### PR TITLE
sql/schemachanger: address bugs that can lead to hanging declarative schema change jobs

### DIFF
--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/create_index
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/create_index
@@ -424,6 +424,8 @@ write *eventpb.FinishSchemaChange to event log
 create job #2 (non-cancelable: true): "GC for "
   descriptor IDs: [104]
 update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
 commit transaction #11
 notified job registry to adopt jobs: [2]
 # end PostCommitPhase

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_database_multiregion_primary_region
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_database_multiregion_primary_region
@@ -255,6 +255,8 @@ write *eventpb.DropDatabase to event log: DROP DATABASE â€¹multi_region_test_dbâ
 create job #2 (non-cancelable: true): "GC for DROP DATABASE multi_region_test_db CASCADE"
   descriptor IDs: [108 104]
 update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
 commit transaction #3
 notified job registry to adopt jobs: [2]
 # end PostCommitPhase

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_table_multiregion
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_table_multiregion
@@ -201,6 +201,8 @@ write *eventpb.DropTable to event log: DROP TABLE ‹multi_region_test_db›.‹
 create job #2 (non-cancelable: true): "GC for DROP TABLE multi_region_test_db.public.table_regional_by_row"
   descriptor IDs: [108]
 update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
 commit transaction #3
 notified job registry to adopt jobs: [2]
 # end PostCommitPhase

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_table_multiregion_primary_region
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_table_multiregion_primary_region
@@ -163,6 +163,8 @@ write *eventpb.DropTable to event log: DROP TABLE ‹multi_region_test_db›.‹
 create job #2 (non-cancelable: true): "GC for DROP TABLE multi_region_test_db.public.table_regional_by_table CASCADE"
   descriptor IDs: [108]
 update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
 commit transaction #3
 notified job registry to adopt jobs: [2]
 # end PostCommitPhase

--- a/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index
+++ b/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index
@@ -432,6 +432,8 @@ EXPLAIN (ddl, verbose) CREATE INDEX id1
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_1_of_7
+++ b/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_1_of_7
@@ -142,6 +142,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_2_of_7
+++ b/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_2_of_7
@@ -166,6 +166,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_3_of_7
+++ b/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_3_of_7
@@ -166,6 +166,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_4_of_7
+++ b/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_4_of_7
@@ -166,6 +166,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_5_of_7
+++ b/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_5_of_7
@@ -176,6 +176,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_6_of_7
+++ b/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_6_of_7
@@ -176,6 +176,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_7_of_7
+++ b/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_7_of_7
@@ -176,6 +176,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/ccl/schemachangerccl/testdata/explain_verbose/drop_database_multiregion_primary_region
+++ b/pkg/ccl/schemachangerccl/testdata/explain_verbose/drop_database_multiregion_primary_region
@@ -893,6 +893,12 @@ EXPLAIN (ddl, verbose) DROP DATABASE multi_region_test_db CASCADE;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
+                  - 105
+                  - 106
+                  - 107
+                  - 108
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/ccl/schemachangerccl/testdata/explain_verbose/drop_table_multiregion
+++ b/pkg/ccl/schemachangerccl/testdata/explain_verbose/drop_table_multiregion
@@ -538,6 +538,10 @@ EXPLAIN (ddl, verbose) DROP TABLE multi_region_test_db.public.table_regional_by_
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 105
+                  - 107
+                  - 108
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/ccl/schemachangerccl/testdata/explain_verbose/drop_table_multiregion_primary_region
+++ b/pkg/ccl/schemachangerccl/testdata/explain_verbose/drop_table_multiregion_primary_region
@@ -410,6 +410,9 @@ EXPLAIN (ddl, verbose) DROP TABLE multi_region_test_db.public.table_regional_by_
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 105
+                  - 108
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -987,3 +987,16 @@ func IsSystemDescriptor(desc Descriptor) bool {
 	}
 	return false
 }
+
+// HasConcurrentDeclarativeSchemaChange returns true iff the descriptors has
+// a concurrent declarative schema change. This declarative schema changer is
+// extremely disciplined and only writes state information during the pre-commit
+// phase, so if a descriptor has a declarative state, we know an ongoing
+// declarative schema change active. The legacy schema changer will tag descriptors
+// with job IDs even during the statement phase, so we cannot rely on similar
+// checks to block concurrent schema changes. Hence, Descriptor.HasConcurrentSchemaChanges
+// is not equivalent to this operation (the former can lead to false positives
+// for the legacy schema changer).
+func HasConcurrentDeclarativeSchemaChange(desc Descriptor) bool {
+	return desc.GetDeclarativeSchemaChangerState() != nil
+}

--- a/pkg/sql/drop_function.go
+++ b/pkg/sql/drop_function.go
@@ -173,7 +173,7 @@ func (p *planner) dropFunctionImpl(ctx context.Context, fnMutable *funcdesc.Muta
 	// Exit early with an error if the function is undergoing a declarative schema
 	// change, before we try to get job IDs and update job statuses later. See
 	// createOrUpdateSchemaChangeJob.
-	if fnMutable.GetDeclarativeSchemaChangerState() != nil {
+	if catalog.HasConcurrentDeclarativeSchemaChange(fnMutable) {
 		return scerrors.ConcurrentSchemaChangeError(fnMutable)
 	}
 

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -344,7 +344,7 @@ func (p *planner) initiateDropTable(
 	// Exit early with an error if the table is undergoing a declarative schema
 	// change, before we try to get job IDs and update job statuses later. See
 	// createOrUpdateSchemaChangeJob.
-	if tableDesc.GetDeclarativeSchemaChangerState() != nil {
+	if catalog.HasConcurrentDeclarativeSchemaChange(tableDesc) {
 		return scerrors.ConcurrentSchemaChangeError(tableDesc)
 	}
 

--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -212,11 +212,9 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 	// TODO (lucy): Maybe this test API should use an offset starting
 	// from the most recent job instead.
 	if err := jobutils.VerifySystemJob(t, sqlRun, 0, jobspb.TypeNewSchemaChange, jobs.StatusSucceeded, jobs.Record{
-		Username:    username.RootUserName(),
-		Description: "DROP DATABASE t CASCADE",
-		DescriptorIDs: descpb.IDs{
-			tbDesc.GetID(), dbDesc.GetID(), dbDesc.GetSchemaID(tree.PublicSchema),
-		},
+		Username:      username.RootUserName(),
+		Description:   "DROP DATABASE t CASCADE",
+		DescriptorIDs: nil,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -647,11 +645,9 @@ func TestDropTable(t *testing.T) {
 	sqlRun := sqlutils.MakeSQLRunner(sqlDB)
 	if err := jobutils.VerifySystemJob(t, sqlRun, 0,
 		jobspb.TypeNewSchemaChange, jobs.StatusSucceeded, jobs.Record{
-			Username:    username.RootUserName(),
-			Description: `DROP TABLE t.public.kv`,
-			DescriptorIDs: descpb.IDs{
-				tableDesc.GetID(),
-			},
+			Username:      username.RootUserName(),
+			Description:   `DROP TABLE t.public.kv`,
+			DescriptorIDs: nil,
 		}); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/schemachanger/scjob/job.go
+++ b/pkg/sql/schemachanger/scjob/job.go
@@ -97,6 +97,11 @@ func (n *newSchemaChangeResumer) run(ctx context.Context, execCtxI interface{}) 
 		execCtx.ExtendedEvalContext().Tracing.KVTracingEnabled(),
 	)
 
+	// If there are no descriptors left, then we can short circuit here.
+	if len(payload.DescriptorIDs) == 0 {
+		return nil
+	}
+
 	err := scrun.RunSchemaChangesInJob(
 		ctx,
 		execCfg.DeclarativeSchemaChangerTestingKnobs,

--- a/pkg/sql/schemachanger/scplan/internal/scstage/build.go
+++ b/pkg/sql/schemachanger/scplan/internal/scstage/build.go
@@ -583,6 +583,10 @@ func (bc buildContext) updateJobProgressOp(
 	var toRemove catalog.DescriptorIDSet
 	if next != nil {
 		toRemove = descIDsPresentBefore.Difference(descIDsPresentAfter)
+	} else {
+		// If the next stage is nil, simply remove al the descriptors, we are
+		// done processing
+		toRemove = descIDsPresentBefore
 	}
 	return &scop.UpdateSchemaChangerJob{
 		JobID:                 bc.scJobID,

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_add_column
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_add_column
@@ -128,6 +128,10 @@ PostCommitPhase stage 2 of 2 with 6 MutationType ops
       DescriptorID: 106
       JobID: 1
     *scop.UpdateSchemaChangerJob
+      DescriptorIDsToRemove:
+      - 104
+      - 105
+      - 106
       IsNonCancelable: true
       JobID: 1
 
@@ -410,6 +414,8 @@ PostCommitNonRevertiblePhase stage 3 of 3 with 4 MutationType ops
       DescriptorID: 104
       JobID: 1
     *scop.UpdateSchemaChangerJob
+      DescriptorIDsToRemove:
+      - 104
       IsNonCancelable: true
       JobID: 1
 
@@ -772,6 +778,8 @@ PostCommitNonRevertiblePhase stage 3 of 3 with 4 MutationType ops
       DescriptorID: 104
       JobID: 1
     *scop.UpdateSchemaChangerJob
+      DescriptorIDsToRemove:
+      - 104
       IsNonCancelable: true
       JobID: 1
 
@@ -1052,6 +1060,8 @@ PostCommitNonRevertiblePhase stage 3 of 3 with 4 MutationType ops
       DescriptorID: 104
       JobID: 1
     *scop.UpdateSchemaChangerJob
+      DescriptorIDsToRemove:
+      - 104
       IsNonCancelable: true
       JobID: 1
 
@@ -1235,6 +1245,9 @@ PostCommitPhase stage 2 of 2 with 7 MutationType ops
       DescriptorID: 107
       JobID: 1
     *scop.UpdateSchemaChangerJob
+      DescriptorIDsToRemove:
+      - 104
+      - 107
       IsNonCancelable: true
       JobID: 1
 
@@ -1548,6 +1561,8 @@ PostCommitNonRevertiblePhase stage 3 of 3 with 4 MutationType ops
       DescriptorID: 108
       JobID: 1
     *scop.UpdateSchemaChangerJob
+      DescriptorIDsToRemove:
+      - 108
       IsNonCancelable: true
       JobID: 1
 
@@ -1962,6 +1977,8 @@ PostCommitNonRevertiblePhase stage 2 of 2 with 8 MutationType ops
       DescriptorID: 109
       JobID: 1
     *scop.UpdateSchemaChangerJob
+      DescriptorIDsToRemove:
+      - 109
       IsNonCancelable: true
       JobID: 1
 

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_alter_primary_key
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_alter_primary_key
@@ -463,6 +463,8 @@ PostCommitNonRevertiblePhase stage 4 of 4 with 6 MutationType ops
       DescriptorID: 104
       JobID: 1
     *scop.UpdateSchemaChangerJob
+      DescriptorIDsToRemove:
+      - 104
       IsNonCancelable: true
       JobID: 1
 

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_drop_column
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_drop_column
@@ -511,6 +511,10 @@ PostCommitNonRevertiblePhase stage 3 of 3 with 9 MutationType ops
       DescriptorID: 107
       JobID: 1
     *scop.UpdateSchemaChangerJob
+      DescriptorIDsToRemove:
+      - 104
+      - 105
+      - 107
       IsNonCancelable: true
       JobID: 1
 
@@ -1458,6 +1462,11 @@ PostCommitNonRevertiblePhase stage 3 of 3 with 10 MutationType ops
       DescriptorID: 107
       JobID: 1
     *scop.UpdateSchemaChangerJob
+      DescriptorIDsToRemove:
+      - 104
+      - 105
+      - 106
+      - 107
       IsNonCancelable: true
       JobID: 1
 

--- a/pkg/sql/schemachanger/scplan/testdata/create_index
+++ b/pkg/sql/schemachanger/scplan/testdata/create_index
@@ -177,6 +177,8 @@ PostCommitNonRevertiblePhase stage 2 of 2 with 4 MutationType ops
       DescriptorID: 104
       JobID: 1
     *scop.UpdateSchemaChangerJob
+      DescriptorIDsToRemove:
+      - 104
       IsNonCancelable: true
       JobID: 1
 
@@ -472,6 +474,8 @@ PostCommitNonRevertiblePhase stage 2 of 2 with 4 MutationType ops
       DescriptorID: 104
       JobID: 1
     *scop.UpdateSchemaChangerJob
+      DescriptorIDsToRemove:
+      - 104
       IsNonCancelable: true
       JobID: 1
 

--- a/pkg/sql/schemachanger/scplan/testdata/drop_database
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_database
@@ -1257,6 +1257,21 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 74 MutationType ops
       DescriptorID: 117
       JobID: 1
     *scop.UpdateSchemaChangerJob
+      DescriptorIDsToRemove:
+      - 104
+      - 105
+      - 106
+      - 107
+      - 108
+      - 109
+      - 110
+      - 111
+      - 112
+      - 113
+      - 114
+      - 115
+      - 116
+      - 117
       IsNonCancelable: true
       JobID: 1
 

--- a/pkg/sql/schemachanger/scplan/testdata/drop_index
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_index
@@ -90,6 +90,8 @@ PostCommitNonRevertiblePhase stage 2 of 2 with 5 MutationType ops
       DescriptorID: 104
       JobID: 1
     *scop.UpdateSchemaChangerJob
+      DescriptorIDsToRemove:
+      - 104
       IsNonCancelable: true
       JobID: 1
 
@@ -257,6 +259,8 @@ PostCommitNonRevertiblePhase stage 2 of 2 with 7 MutationType ops
       DescriptorID: 104
       JobID: 1
     *scop.UpdateSchemaChangerJob
+      DescriptorIDsToRemove:
+      - 104
       IsNonCancelable: true
       JobID: 1
 
@@ -486,6 +490,8 @@ PostCommitNonRevertiblePhase stage 2 of 2 with 6 MutationType ops
       DescriptorID: 104
       JobID: 1
     *scop.UpdateSchemaChangerJob
+      DescriptorIDsToRemove:
+      - 104
       IsNonCancelable: true
       JobID: 1
 
@@ -765,6 +771,8 @@ PostCommitNonRevertiblePhase stage 2 of 2 with 5 MutationType ops
       DescriptorID: 104
       JobID: 1
     *scop.UpdateSchemaChangerJob
+      DescriptorIDsToRemove:
+      - 104
       IsNonCancelable: true
       JobID: 1
 

--- a/pkg/sql/schemachanger/scplan/testdata/drop_owned_by
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_owned_by
@@ -794,5 +794,17 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 47 MutationType ops
       DescriptorID: 113
       JobID: 1
     *scop.UpdateSchemaChangerJob
+      DescriptorIDsToRemove:
+      - 100
+      - 104
+      - 105
+      - 106
+      - 107
+      - 108
+      - 109
+      - 110
+      - 111
+      - 112
+      - 113
       IsNonCancelable: true
       JobID: 1

--- a/pkg/sql/schemachanger/scplan/testdata/drop_schema
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_schema
@@ -2108,5 +2108,17 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 57 MutationType ops
       DescriptorID: 113
       JobID: 1
     *scop.UpdateSchemaChangerJob
+      DescriptorIDsToRemove:
+      - 100
+      - 104
+      - 105
+      - 106
+      - 107
+      - 108
+      - 109
+      - 110
+      - 111
+      - 112
+      - 113
       IsNonCancelable: true
       JobID: 1

--- a/pkg/sql/schemachanger/scplan/testdata/drop_sequence
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_sequence
@@ -70,6 +70,8 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 4 MutationType ops
       DescriptorID: 104
       JobID: 1
     *scop.UpdateSchemaChangerJob
+      DescriptorIDsToRemove:
+      - 104
       IsNonCancelable: true
       JobID: 1
 
@@ -178,6 +180,10 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 6 MutationType ops
       DescriptorID: 106
       JobID: 1
     *scop.UpdateSchemaChangerJob
+      DescriptorIDsToRemove:
+      - 104
+      - 105
+      - 106
       IsNonCancelable: true
       JobID: 1
 

--- a/pkg/sql/schemachanger/scplan/testdata/drop_table
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_table
@@ -479,6 +479,15 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 26 MutationType ops
       DescriptorID: 111
       JobID: 1
     *scop.UpdateSchemaChangerJob
+      DescriptorIDsToRemove:
+      - 104
+      - 105
+      - 106
+      - 107
+      - 108
+      - 109
+      - 110
+      - 111
       IsNonCancelable: true
       JobID: 1
 
@@ -1424,5 +1433,9 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 11 MutationType ops
       DescriptorID: 114
       JobID: 1
     *scop.UpdateSchemaChangerJob
+      DescriptorIDsToRemove:
+      - 112
+      - 113
+      - 114
       IsNonCancelable: true
       JobID: 1

--- a/pkg/sql/schemachanger/scplan/testdata/drop_type
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_type
@@ -122,6 +122,9 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 7 MutationType ops
       DescriptorID: 105
       JobID: 1
     *scop.UpdateSchemaChangerJob
+      DescriptorIDsToRemove:
+      - 104
+      - 105
       IsNonCancelable: true
       JobID: 1
 

--- a/pkg/sql/schemachanger/scplan/testdata/drop_view
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_view
@@ -134,6 +134,9 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 8 MutationType ops
       DescriptorID: 105
       JobID: 1
     *scop.UpdateSchemaChangerJob
+      DescriptorIDsToRemove:
+      - 104
+      - 105
       IsNonCancelable: true
       JobID: 1
 
@@ -903,6 +906,15 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 39 MutationType ops
       DescriptorID: 111
       JobID: 1
     *scop.UpdateSchemaChangerJob
+      DescriptorIDsToRemove:
+      - 104
+      - 105
+      - 106
+      - 107
+      - 108
+      - 109
+      - 110
+      - 111
       IsNonCancelable: true
       JobID: 1
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column
@@ -519,6 +519,8 @@ write *eventpb.FinishSchemaChange to event log
 create job #3 (non-cancelable: true): "GC for ALTER TABLE db.public.tbl ADD COLUMN j INT8 NOT NULL DEFAULT 42"
   descriptor IDs: [106]
 update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
 commit transaction #12
 notified job registry to adopt jobs: [3]
 # end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_seq
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_seq
@@ -673,6 +673,8 @@ write *eventpb.FinishSchemaChange to event log
 create job #3 (non-cancelable: true): "GC for ALTER TABLE db.public.tbl ADD COLUMN l INT8 NOT NULL DEFAULT nextval('db.public.sq1')"
   descriptor IDs: [106]
 update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
 commit transaction #12
 notified job registry to adopt jobs: [3]
 # end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_no_default
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_no_default
@@ -184,5 +184,6 @@ write *eventpb.FinishSchemaChange to event log
 adding table for stats refresh: 106
 update progress of schema change job #1: "all stages completed"
 set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
 commit transaction #4
 # end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid
@@ -879,6 +879,8 @@ write *eventpb.FinishSchemaChange to event log
 create job #3 (non-cancelable: true): "GC for ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)"
   descriptor IDs: [104]
 update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
 commit transaction #21
 notified job registry to adopt jobs: [3]
 # end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid
@@ -881,6 +881,8 @@ write *eventpb.FinishSchemaChange to event log
 create job #3 (non-cancelable: true): "GC for ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)"
   descriptor IDs: [104]
 update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
 commit transaction #21
 notified job registry to adopt jobs: [3]
 # end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla
@@ -634,6 +634,8 @@ write *eventpb.FinishSchemaChange to event log
 create job #3 (non-cancelable: true): "GC for ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)"
   descriptor IDs: [104]
 update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
 commit transaction #12
 notified job registry to adopt jobs: [3]
 # end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_index
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_index
@@ -370,6 +370,8 @@ write *eventpb.FinishSchemaChange to event log
 create job #2 (non-cancelable: true): "GC for "
   descriptor IDs: [106]
 update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
 commit transaction #11
 notified job registry to adopt jobs: [2]
 # end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_basic
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_basic
@@ -512,6 +512,8 @@ write *eventpb.FinishSchemaChange to event log
 create job #3 (non-cancelable: true): "GC for ALTER TABLE defaultdb.public.t DROP COLUMN j"
   descriptor IDs: [104]
 update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
 commit transaction #12
 notified job registry to adopt jobs: [3]
 # end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_computed_index
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_computed_index
@@ -629,6 +629,8 @@ write *eventpb.FinishSchemaChange to event log
 create job #3 (non-cancelable: true): "GC for ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE"
   descriptor IDs: [104]
 update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
 commit transaction #12
 notified job registry to adopt jobs: [3]
 # end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements
@@ -951,6 +951,8 @@ write *eventpb.DropIndex to event log: ALTER TABLE ‹defaultdb›.‹public›.
 create job #2 (non-cancelable: true): "GC for ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE"
   descriptor IDs: [104]
 update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
 commit transaction #19
 notified job registry to adopt jobs: [2]
 # end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_unique_index
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_unique_index
@@ -545,6 +545,8 @@ write *eventpb.FinishSchemaChange to event log
 create job #3 (non-cancelable: true): "GC for ALTER TABLE t.public.test DROP COLUMN pi"
   descriptor IDs: [106]
 update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
 commit transaction #12
 notified job registry to adopt jobs: [3]
 # end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_index
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_index
@@ -595,6 +595,8 @@ write *eventpb.FinishSchemaChange to event log
 create job #3 (non-cancelable: true): "GC for ALTER TABLE defaultdb.public.t DROP COLUMN j"
   descriptor IDs: [104]
 update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
 commit transaction #12
 notified job registry to adopt jobs: [3]
 # end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_index_hash_sharded_index
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_index_hash_sharded_index
@@ -280,6 +280,8 @@ write *eventpb.DropIndex to event log: DROP INDEX ‹defaultdb›.‹public›.�
 create job #2 (non-cancelable: true): "GC for DROP INDEX defaultdb.public.t@idx CASCADE"
   descriptor IDs: [104]
 update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
 commit transaction #4
 notified job registry to adopt jobs: [2]
 # end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_index_partial_expression_index
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_index_partial_expression_index
@@ -236,6 +236,8 @@ write *eventpb.DropIndex to event log: DROP INDEX ‹defaultdb›.‹public›.�
 create job #2 (non-cancelable: true): "GC for DROP INDEX defaultdb.public.t@idx CASCADE"
   descriptor IDs: [104]
 update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
 commit transaction #4
 notified job registry to adopt jobs: [2]
 # end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_index_vanilla_index
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_index_vanilla_index
@@ -187,6 +187,8 @@ write *eventpb.DropIndex to event log: DROP INDEX ‹defaultdb›.‹public›.�
 create job #2 (non-cancelable: true): "GC for DROP INDEX defaultdb.public.t@idx CASCADE"
   descriptor IDs: [104]
 update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
 commit transaction #4
 notified job registry to adopt jobs: [2]
 # end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_multiple_columns_separate_statements
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_multiple_columns_separate_statements
@@ -768,6 +768,8 @@ write *eventpb.FinishSchemaChange to event log
 create job #3 (non-cancelable: true): "GC for ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE"
   descriptor IDs: [104]
 update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
 commit transaction #12
 notified job registry to adopt jobs: [3]
 # end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_schema
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_schema
@@ -101,6 +101,8 @@ upsert descriptor #104
 delete descriptor #106
 write *eventpb.DropSchema to event log: DROP SCHEMA ‹db›.‹sc›
 update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
 commit transaction #3
 # end PostCommitPhase
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_table
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_table
@@ -111,6 +111,8 @@ write *eventpb.DropTable to event log: DROP TABLE ‹db›.‹sc›.‹t›
 create job #2 (non-cancelable: true): "GC for DROP TABLE db.sc.t"
   descriptor IDs: [107]
 update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
 commit transaction #3
 notified job registry to adopt jobs: [2]
 # end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column
@@ -619,6 +619,8 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 106
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_1_of_7
@@ -158,6 +158,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 106
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_2_of_7
@@ -207,6 +207,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 106
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_3_of_7
@@ -207,6 +207,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 106
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_4_of_7
@@ -207,6 +207,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 106
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_5_of_7
@@ -217,6 +217,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 106
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_6_of_7
@@ -217,6 +217,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 106
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_7_of_7
@@ -217,6 +217,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 106
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq
@@ -654,6 +654,9 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN l INT NOT NULL DEFAU
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 106
+                  - 107
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_1_of_7
@@ -168,6 +168,9 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 106
+                  - 107
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_2_of_7
@@ -220,6 +220,9 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 106
+                  - 107
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_3_of_7
@@ -220,6 +220,9 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 106
+                  - 107
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_4_of_7
@@ -220,6 +220,9 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 106
+                  - 107
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_5_of_7
@@ -230,6 +230,9 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 106
+                  - 107
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_6_of_7
@@ -230,6 +230,9 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 106
+                  - 107
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_7_of_7
@@ -230,6 +230,9 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 106
+                  - 107
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_no_default
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_no_default
@@ -173,6 +173,8 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 106
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_no_default.rollback_1_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_no_default.rollback_1_of_2
@@ -69,6 +69,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 2;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 106
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_no_default.rollback_2_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_no_default.rollback_2_of_2
@@ -102,6 +102,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 2;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 106
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid
@@ -1000,6 +1000,8 @@ EXPLAIN (ddl, verbose) alter table t add primary key (a);
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_10_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_10_of_15
@@ -325,6 +325,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_11_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_11_of_15
@@ -325,6 +325,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_12_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_12_of_15
@@ -325,6 +325,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_13_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_13_of_15
@@ -335,6 +335,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_14_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_14_of_15
@@ -335,6 +335,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_15_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_15_of_15
@@ -335,6 +335,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_1_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_1_of_15
@@ -178,6 +178,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_2_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_2_of_15
@@ -202,6 +202,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_3_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_3_of_15
@@ -202,6 +202,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_4_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_4_of_15
@@ -202,6 +202,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_5_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_5_of_15
@@ -212,6 +212,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_6_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_6_of_15
@@ -212,6 +212,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_7_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_7_of_15
@@ -212,6 +212,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_8_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_8_of_15
@@ -212,6 +212,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 8 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_9_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_9_of_15
@@ -315,6 +315,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid
@@ -1007,6 +1007,8 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_10_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_10_of_15
@@ -325,6 +325,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_11_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_11_of_15
@@ -325,6 +325,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_12_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_12_of_15
@@ -325,6 +325,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_13_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_13_of_15
@@ -335,6 +335,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_14_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_14_of_15
@@ -335,6 +335,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_15_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_15_of_15
@@ -335,6 +335,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_1_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_1_of_15
@@ -178,6 +178,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_2_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_2_of_15
@@ -202,6 +202,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_3_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_3_of_15
@@ -202,6 +202,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_4_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_4_of_15
@@ -202,6 +202,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_5_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_5_of_15
@@ -212,6 +212,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_6_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_6_of_15
@@ -212,6 +212,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_7_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_7_of_15
@@ -212,6 +212,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_8_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_8_of_15
@@ -212,6 +212,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 8 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_9_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_9_of_15
@@ -315,6 +315,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla
@@ -701,6 +701,8 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_1_of_7
@@ -187,6 +187,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_2_of_7
@@ -221,6 +221,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_3_of_7
@@ -221,6 +221,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_4_of_7
@@ -221,6 +221,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_5_of_7
@@ -241,6 +241,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_6_of_7
@@ -241,6 +241,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_7_of_7
@@ -241,6 +241,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/create_index
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/create_index
@@ -350,6 +350,8 @@ EXPLAIN (ddl, verbose) CREATE INDEX idx1 ON t (v) WHERE (v = 'a');
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 106
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_1_of_7
@@ -108,6 +108,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 106
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_2_of_7
@@ -132,6 +132,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 106
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_3_of_7
@@ -132,6 +132,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 106
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_4_of_7
@@ -132,6 +132,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 106
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_5_of_7
@@ -142,6 +142,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 106
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_6_of_7
@@ -142,6 +142,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 106
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_7_of_7
@@ -142,6 +142,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 106
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic
@@ -532,6 +532,8 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_1_of_7
@@ -120,6 +120,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_2_of_7
@@ -144,6 +144,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_3_of_7
@@ -144,6 +144,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_4_of_7
@@ -144,6 +144,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_5_of_7
@@ -154,6 +154,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_6_of_7
@@ -154,6 +154,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_7_of_7
@@ -154,6 +154,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index
@@ -712,6 +712,8 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_1_of_7
@@ -189,6 +189,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_2_of_7
@@ -213,6 +213,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_3_of_7
@@ -213,6 +213,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_4_of_7
@@ -213,6 +213,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_5_of_7
@@ -223,6 +223,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_6_of_7
@@ -223,6 +223,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_7_of_7
@@ -223,6 +223,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_10_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_10_of_15
@@ -429,6 +429,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_11_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_11_of_15
@@ -429,6 +429,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_12_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_12_of_15
@@ -429,6 +429,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_13_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_13_of_15
@@ -439,6 +439,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_14_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_14_of_15
@@ -439,6 +439,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_15_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_15_of_15
@@ -439,6 +439,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_1_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_1_of_15
@@ -211,6 +211,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_2_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_2_of_15
@@ -235,6 +235,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_3_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_3_of_15
@@ -235,6 +235,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_4_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_4_of_15
@@ -235,6 +235,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_5_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_5_of_15
@@ -245,6 +245,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_6_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_6_of_15
@@ -245,6 +245,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_7_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_7_of_15
@@ -245,6 +245,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_8_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_8_of_15
@@ -245,6 +245,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 8 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_9_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_9_of_15
@@ -419,6 +419,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.statement_1_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.statement_1_of_2
@@ -778,6 +778,8 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.statement_2_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.statement_2_of_2
@@ -889,6 +889,8 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index
@@ -661,6 +661,8 @@ EXPLAIN (ddl, verbose) ALTER TABLE t.test DROP pi;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 106
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_1_of_7
@@ -162,6 +162,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 106
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_2_of_7
@@ -186,6 +186,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 106
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_3_of_7
@@ -186,6 +186,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 106
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_4_of_7
@@ -186,6 +186,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 106
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_5_of_7
@@ -196,6 +196,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 106
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_6_of_7
@@ -196,6 +196,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 106
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_7_of_7
@@ -196,6 +196,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 106
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index
@@ -633,6 +633,8 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_1_of_7
@@ -151,6 +151,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_2_of_7
@@ -175,6 +175,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_3_of_7
@@ -175,6 +175,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_4_of_7
@@ -175,6 +175,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_5_of_7
@@ -185,6 +185,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_6_of_7
@@ -185,6 +185,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_7_of_7
@@ -185,6 +185,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_index_hash_sharded_index
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_index_hash_sharded_index
@@ -282,6 +282,8 @@ EXPLAIN (ddl, verbose) DROP INDEX idx CASCADE;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_index_partial_expression_index
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_index_partial_expression_index
@@ -262,6 +262,8 @@ EXPLAIN (ddl, verbose) DROP INDEX idx CASCADE;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_index_vanilla_index
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_index_vanilla_index
@@ -157,6 +157,8 @@ EXPLAIN (ddl, verbose) DROP INDEX idx CASCADE;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_1_of_7
@@ -253,6 +253,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_2_of_7
@@ -277,6 +277,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_3_of_7
@@ -277,6 +277,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_4_of_7
@@ -277,6 +277,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_5_of_7
@@ -287,6 +287,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_6_of_7
@@ -287,6 +287,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_7_of_7
@@ -287,6 +287,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.statement_1_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.statement_1_of_2
@@ -778,6 +778,8 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.statement_2_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.statement_2_of_2
@@ -749,6 +749,8 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN k CASCADE;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_schema
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_schema
@@ -150,6 +150,9 @@ EXPLAIN (ddl, verbose) DROP SCHEMA db.sc;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
+                  - 106
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_table
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_table
@@ -562,6 +562,8 @@ EXPLAIN (ddl, verbose) DROP TABLE db.sc.t;
             │     JobID: 1
             │
             └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 107
                   IsNonCancelable: true
                   JobID: 1
                   RunningStatus: all stages completed

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descbuilder"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
@@ -110,7 +111,7 @@ func (p *planner) createOrUpdateSchemaChangeJob(
 	// changer, then we must fail and wait for that schema change to conclude.
 	// The error here will be dealt with in
 	// (*connExecutor).handleWaitingForConcurrentSchemaChanges().
-	if tableDesc.GetDeclarativeSchemaChangerState() != nil {
+	if catalog.HasConcurrentDeclarativeSchemaChange(tableDesc) {
 		return scerrors.ConcurrentSchemaChangeError(tableDesc)
 	}
 

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
@@ -176,7 +177,7 @@ func (p *planner) truncateTable(ctx context.Context, id descpb.ID, jobDesc strin
 	// Exit early with an error if the table is undergoing a declarative schema
 	// change, before we try to get job IDs and update job statuses later. See
 	// createOrUpdateSchemaChangeJob.
-	if tableDesc.GetDeclarativeSchemaChangerState() != nil {
+	if catalog.HasConcurrentDeclarativeSchemaChange(tableDesc) {
 		return scerrors.ConcurrentSchemaChangeError(tableDesc)
 	}
 


### PR DESCRIPTION
This PR addresses two separate issues that lead to similar problems, where we can hang because the schema changer state is no longer constructible.

1. There is a small window in the declarative schema changer in drop scenarios where if the job succeeds, but the status cannot be updated we may re-attempt the run phase. When we do this we will try to get the declarative schema changer state based on the descriptor list, if any descriptor is dropped then we will no longer be able to construct the state. This PR will check the status to see if all stages are completed and treat this scenario as a no-op.
2. When running a DROP OWNED BY (declarative) and DROP DATABASE (legacy) concurrently we could run into a hang since the DROP DATABASE would not wait for the declarative schema change to complete properly. This PR will add concurrent schema change checks for DROP DATABASE/ DROP SCHEMA/ DROP TYPE.