### PR TITLE
sql: disable persisted stats flush in rsg tests, fix nil type assertions

### DIFF
--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -185,14 +185,16 @@ func (n *scrubNode) startScrubDatabase(ctx context.Context, p *planner, name *tr
 		if err != nil {
 			return err
 		}
-		tableDesc := objDesc.(catalog.TableDescriptor)
-		// Skip non-tables and don't throw an error if we encounter one.
-		if !tableDesc.IsTable() {
-			continue
+		if tableDesc, ok := objDesc.(catalog.TableDescriptor); ok {
+			// Skip non-tables and don't throw an error if we encounter one.
+			if !tableDesc.IsTable() {
+				continue
+			}
+			if err := n.startScrubTable(ctx, p, tableDesc, tableName); err != nil {
+				return err
+			}
 		}
-		if err := n.startScrubTable(ctx, p, tableDesc, tableName); err != nil {
-			return err
-		}
+		continue
 	}
 	return nil
 }

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -119,8 +119,10 @@ func CanModifySchema(stmt Statement) bool {
 	if stmt.StatementReturnType() == DDL {
 		return true
 	}
-	scm, ok := stmt.(canModifySchema)
-	return ok && scm.modifiesSchema()
+	if scm, ok := stmt.(canModifySchema); ok {
+		return scm.modifiesSchema()
+	}
+	return false
 }
 
 // CanWriteData returns true if the statement can modify data.

--- a/pkg/sql/tests/BUILD.bazel
+++ b/pkg/sql/tests/BUILD.bazel
@@ -95,6 +95,7 @@ go_test(
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondatapb",
+        "//pkg/sql/sqlstats/persistedsqlstats",
         "//pkg/sql/stats",
         "//pkg/sql/types",
         "//pkg/testutils",

--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/internal/rsg"
 	"github.com/cockroachdb/cockroach/pkg/internal/sqlsmith"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -35,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins/builtinsregistry"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -775,6 +777,9 @@ func testRandomSyntax(
 	params.Knobs.PGWireTestingKnobs = &sql.PGWireTestingKnobs{
 		CatchPanics: true,
 	}
+	st := cluster.MakeTestingClusterSettings()
+	persistedsqlstats.SQLStatsFlushEnabled.Override(ctx, &st.SV, false)
+	params.Settings = st
 	s, rawDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(ctx)
 	db := &verifyFormatDB{db: rawDB}


### PR DESCRIPTION
This commit disables persisted stats flushing in the rsg testing server config. The commit also properly handles two failed nil type assertions.

Fixes #87673.

Release note: None