### PR TITLE
sql: add tracing spans for each statement executed within a UDF

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -1946,6 +1946,37 @@ SELECT one_nth(0)
 statement error pgcode 22012 division by zero
 SELECT int_identity((1/0)::INT)
 
+# Test that tracing spans are created for each UDF invocation and for each
+# statement in the UDF body.
+statement ok
+CREATE TABLE trace_tab (
+  a INT PRIMARY KEY
+);
+INSERT INTO trace_tab VALUES (1), (2), (3);
+CREATE FUNCTION trace_fn(i INT) RETURNS INT LANGUAGE SQL AS $$
+  SELECT 'no-op';
+  SELECT i;
+$$
+
+statement ok
+SET tracing = on
+
+statement ok
+SELECT trace_fn(a) FROM trace_tab
+
+statement ok
+SET tracing = off
+
+query T
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message ~ 'udf'
+----
+=== SPAN START: udf-stmt-trace_fn-0 ===
+=== SPAN START: udf-stmt-trace_fn-1 ===
+=== SPAN START: udf-stmt-trace_fn-0 ===
+=== SPAN START: udf-stmt-trace_fn-1 ===
+=== SPAN START: udf-stmt-trace_fn-0 ===
+=== SPAN START: udf-stmt-trace_fn-1 ===
+
 
 subtest args
 

--- a/pkg/sql/sem/tree/routine.go
+++ b/pkg/sql/sem/tree/routine.go
@@ -39,6 +39,10 @@ type RoutineExecFactory interface{}
 // function. It is only created by execbuilder - it is never constructed during
 // parsing.
 type RoutineExpr struct {
+	// Name is a string name that describes the RoutineExpr, e.g., the name of
+	// the UDF that the RoutineExpr is built from.
+	Name string
+
 	// Input contains the input expressions to the routine.
 	Input TypedExprs
 
@@ -63,8 +67,6 @@ type RoutineExpr struct {
 	// its inputs are NULL. If false, the function will not be evaluated in the
 	// presence of null inputs, and will instead evaluate directly to NULL.
 	CalledOnNullInput bool
-
-	name string
 }
 
 // NewTypedRoutineExpr returns a new RoutineExpr that is well-typed.
@@ -84,7 +86,7 @@ func NewTypedRoutineExpr(
 		Typ:               typ,
 		Volatility:        v,
 		CalledOnNullInput: calledOnNullInput,
-		name:              name,
+		Name:              name,
 	}
 }
 
@@ -102,7 +104,7 @@ func (node *RoutineExpr) ResolvedType() *types.T {
 
 // Format is part of the Expr interface.
 func (node *RoutineExpr) Format(ctx *FmtCtx) {
-	ctx.Printf("%s(", node.name)
+	ctx.Printf("%s(", node.Name)
 	for i := range node.Input {
 		node.Input[i].Format(ctx)
 		if i > 0 {


### PR DESCRIPTION
This commit creates a separate tracing span for each statement executed during evaluation of a UDF.

Release note: None