### PR TITLE
opt: add tests for FK delete cascade fast-path with UDF

### DIFF
--- a/pkg/sql/opt/optbuilder/fk_cascade.go
+++ b/pkg/sql/opt/optbuilder/fk_cascade.go
@@ -190,7 +190,6 @@ func tryNewOnDeleteFastCascadeBuilder(
 		if memo.CanBeCompositeSensitive(md, &sel.Filters) {
 			return nil, false
 		}
-		// TODO(mgartner): Disallow this fast path if there is a UDF invocation.
 		if sel.Relational().HasSubquery {
 			return nil, false
 		}

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-delete-cascade
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-delete-cascade
@@ -6,6 +6,14 @@ exec-ddl
 CREATE TABLE child (c INT PRIMARY KEY, p INT NOT NULL REFERENCES parent(p) ON DELETE CASCADE)
 ----
 
+exec-ddl
+CREATE FUNCTION one_volatile() RETURNS INT VOLATILE LANGUAGE SQL AS 'SELECT 1'
+----
+
+exec-ddl
+CREATE FUNCTION one_immutable() RETURNS INT IMMUTABLE LANGUAGE SQL AS 'SELECT 1'
+----
+
 # Simple cascade; fast path (the filter gets transferred over to the cascade).
 build-cascades
 DELETE FROM parent WHERE p > 1
@@ -103,6 +111,67 @@ root
                 │         └──  parent.p:4 => p:18
                 └── filters
                      └── child.p:15 = p:18
+
+# Delete with volatile UDF; no fast path.
+build-cascades
+DELETE FROM parent WHERE p > one_volatile()
+----
+root
+ ├── delete parent
+ │    ├── columns: <none>
+ │    ├── fetch columns: p:4
+ │    ├── input binding: &1
+ │    ├── cascades
+ │    │    └── child_p_fkey
+ │    └── select
+ │         ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         ├── scan parent
+ │         │    └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         └── filters
+ │              └── p:4 > one_volatile()
+ └── cascade
+      └── delete child
+           ├── columns: <none>
+           ├── fetch columns: c:12 child.p:13
+           └── semi-join (hash)
+                ├── columns: c:12!null child.p:13!null
+                ├── scan child
+                │    ├── columns: c:12!null child.p:13!null
+                │    └── flags: disabled not visible index feature
+                ├── with-scan &1
+                │    ├── columns: p:16!null
+                │    └── mapping:
+                │         └──  parent.p:4 => p:16
+                └── filters
+                     └── child.p:13 = p:16
+
+# Delete with immutable UDF; fast path.
+build-cascades
+DELETE FROM parent WHERE p > one_immutable()
+----
+root
+ ├── delete parent
+ │    ├── columns: <none>
+ │    ├── fetch columns: p:4
+ │    ├── cascades
+ │    │    └── child_p_fkey
+ │    └── select
+ │         ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         ├── scan parent
+ │         │    └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         └── filters
+ │              └── p:4 > one_immutable()
+ └── cascade
+      └── delete child
+           ├── columns: <none>
+           ├── fetch columns: c:12 child.p:13
+           └── select
+                ├── columns: c:12!null child.p:13!null
+                ├── scan child
+                │    ├── columns: c:12!null child.p:13!null
+                │    └── flags: disabled not visible index feature
+                └── filters
+                     └── child.p:13 > one_immutable()
 
 # Delete everything.
 build-cascades


### PR DESCRIPTION
The FK delete cascade fast-path remaps the `DELETE` filter into a filter on child table, avoiding buffering the parent's deleted rows like in the non-fast-path plan. It is possible to plan this fast-path if the filters contain UDF invocations, as long as they are immutable or stable. (Of course, if the user creates a UDF with mislabeled volatility, data corruption is possible. To mitigate this and other corruption from mislabeled UDF volatility in the future, we're considering performing some analysis during `CREATE FUNCTION` to prevent users from incorrectly assigning volatility.)

This commit adds tests for FK delete cascades with UDFs and removes an unnecessary TODO.

Release note: None