### PR TITLE
sql/covering: make OverlapCoveringMerge benchmark deterministic

### DIFF
--- a/pkg/sql/covering/BUILD.bazel
+++ b/pkg/sql/covering/BUILD.bazel
@@ -20,7 +20,6 @@ go_test(
     embed = [":covering"],
     deps = [
         "//pkg/util/leaktest",
-        "//pkg/util/timeutil",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/covering/bench_test.go
+++ b/pkg/sql/covering/bench_test.go
@@ -16,7 +16,6 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,7 +24,7 @@ func BenchmarkOverlapCoveringMerge(b *testing.B) {
 		name   string
 		inputs []Covering
 	}
-	rand.Seed(timeutil.Now().Unix())
+	rand.Seed(0)
 
 	for _, numLayers := range []int{
 		1,      // single backup


### PR DESCRIPTION
Previously we seeded RNG with time and benchmark results varied widely.
In order to make sure this doesn't make noise when comparing different
versions make the seed a constant.

Fixes: #88919

Release note: None
