### PR TITLE
 keys: refactor PrettyPrint function to use safeFormatInternal

### DIFF
--- a/pkg/ccl/partitionccl/BUILD.bazel
+++ b/pkg/ccl/partitionccl/BUILD.bazel
@@ -91,6 +91,7 @@ go_test(
         "//pkg/util/uuid",
         "@com_github_cockroachdb_cockroach_go_v2//crdb",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_gogo_protobuf//proto",
         "@com_github_stretchr_testify//require",
         "@in_gopkg_yaml_v2//:yaml_v2",

--- a/pkg/ccl/partitionccl/zone_test.go
+++ b/pkg/ccl/partitionccl/zone_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/redact"
 	"github.com/stretchr/testify/require"
 )
 
@@ -330,20 +331,26 @@ func TestGenerateSubzoneSpans(t *testing.T) {
 				}
 
 				// Verify that we're always doing the space savings when we can.
+				var buf redact.StringBuilder
+				var buf2 redact.StringBuilder
 				if span.Key.PrefixEnd().Equal(span.EndKey) {
+					encoding.PrettyPrintValue(&buf, directions, span.Key, "/")
+					encoding.PrettyPrintValue(&buf2, directions, span.EndKey, "/")
 					t.Errorf("endKey should be omitted when equal to key.PrefixEnd [%s, %s)",
-						encoding.PrettyPrintValue(directions, span.Key, "/"),
-						encoding.PrettyPrintValue(directions, span.EndKey, "/"))
+						buf.String(),
+						buf2.String())
 				}
 				if len(span.EndKey) == 0 {
 					span.EndKey = span.Key.PrefixEnd()
 				}
 
 				// TODO(dan): Check that spans are sorted.
+				encoding.PrettyPrintValue(&buf, directions, span.Key, "/")
+				encoding.PrettyPrintValue(&buf2, directions, span.EndKey, "/")
 
 				actual = append(actual, fmt.Sprintf("%s %s-%s", subzoneShort,
-					encoding.PrettyPrintValue(directions, span.Key, "/"),
-					encoding.PrettyPrintValue(directions, span.EndKey, "/")))
+					buf.String(),
+					buf2.String()))
 			}
 
 			if len(actual) != len(test.parsed.generatedSpans) {

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/multitenant/basic
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/multitenant/basic
@@ -26,8 +26,8 @@ state offset=47
 /Table/5{0-1}                              database system (host)
 /Table/5{1-2}                              database system (host)
 /Table/5{2-3}                              database system (host)
-/Tenant/10{-"\x00"}                        database system (tenant)
-/Tenant/11{-"\x00"}                        database system (tenant)
+/Tenant/10{-\x00}                          database system (tenant)
+/Tenant/11{-\x00}                          database system (tenant)
 
 # Start the reconciliation loop for the secondary tenant.
 reconcile tenant=10
@@ -35,7 +35,7 @@ reconcile tenant=10
 
 mutations tenant=10
 ----
-delete /Tenant/10{-"\x00"}
+delete /Tenant/10{-\x00}
 upsert /Tenant/10{-/Table/4}               database system (tenant)
 upsert /Tenant/10/Table/{4-5}              database system (tenant)
 upsert /Tenant/10/Table/{5-6}              database system (tenant)
@@ -120,7 +120,7 @@ state offset=47
 /Tenant/10/Table/5{0-1}                    database system (tenant)
 /Tenant/10/Table/5{1-2}                    database system (tenant)
 /Tenant/10/Table/5{2-3}                    database system (tenant)
-/Tenant/11{-"\x00"}                        database system (tenant)
+/Tenant/11{-\x00}                          database system (tenant)
 
 exec-sql tenant=10
 CREATE DATABASE db;
@@ -155,4 +155,4 @@ state offset=81
 /Tenant/10/Table/10{7-8}                   range default
 /Tenant/10/Table/11{2-3}                   range default
 /Tenant/10/Table/11{3-4}                   range default
-/Tenant/11{-"\x00"}                        database system (tenant)
+/Tenant/11{-\x00}                          database system (tenant)

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/multitenant/protectedts
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/multitenant/protectedts
@@ -23,7 +23,7 @@ state offset=47
 /Table/5{0-1}                              database system (host)
 /Table/5{1-2}                              database system (host)
 /Table/5{2-3}                              database system (host)
-/Tenant/10{-"\x00"}                        database system (tenant)
+/Tenant/10{-\x00}                          database system (tenant)
 
 # Write a protected timestamp record on the system tenant cluster.
 protect record-id=1 ts=1
@@ -51,7 +51,7 @@ upsert {source=1,target=10}                protection_policies=[{ts: 2}]
 # tenant.
 mutations tenant=10
 ----
-delete /Tenant/10{-"\x00"}
+delete /Tenant/10{-\x00}
 upsert /Tenant/10{-/Table/4}               database system (tenant)
 upsert /Tenant/10/Table/{4-5}              database system (tenant)
 upsert /Tenant/10/Table/{5-6}              database system (tenant)

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/multitenant/range_tenants
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/multitenant/range_tenants
@@ -42,8 +42,8 @@ state offset=47
 /Table/5{0-1}                              database system (host)
 /Table/5{1-2}                              database system (host)
 /Table/5{2-3}                              database system (host)
-/Tenant/10{-"\x00"}                        database system (tenant)
-/Tenant/11{-"\x00"}                        ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/10{-\x00}                          database system (tenant)
+/Tenant/11{-\x00}                          ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
 
 # Start the reconciliation loop for the tenant=10. It should have the vanilla
 # RANGE DEFAULT. Check against the underlying KV state, the SQL view of the
@@ -99,7 +99,7 @@ state offset=47
 /Tenant/10/Table/5{0-1}                    database system (tenant)
 /Tenant/10/Table/5{1-2}                    database system (tenant)
 /Tenant/10/Table/5{2-3}                    database system (tenant)
-/Tenant/11{-"\x00"}                        ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11{-\x00}                          ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
 
 query-sql tenant=10
 SHOW ZONE CONFIGURATION FOR RANGE DEFAULT

--- a/pkg/keys/printer_test.go
+++ b/pkg/keys/printer_test.go
@@ -69,7 +69,7 @@ func TestSafeFormatKey_SystemTenant(t *testing.T) {
 		{
 			"namespace table handled as standard system tenant table",
 			keys.NamespaceTableMin,
-			"/Table/30",
+			"/NamespaceTable/30",
 		},
 		{
 			"table index without index key",
@@ -105,6 +105,14 @@ func TestSafeFormatKey_SystemTenant(t *testing.T) {
 			makeKey(tenSysCodec.TablePrefix(42), []byte{0x12, 'a', 0x00, 0x03}),
 			`/Table/42/‹???›`,
 		},
+		{
+			"marks safe reserved key prefix",
+			makeKey(keys.Meta1Prefix,
+				tenSysCodec.TablePrefix(42),
+				encoding.EncodeStringAscending(nil, "California"),
+				encoding.EncodeStringAscending(nil, "Los Angeles")),
+			`/Meta1/Table/42/‹"California"›/‹"Los Angeles"›`,
+		},
 	}
 
 	for _, test := range testCases {
@@ -114,17 +122,16 @@ func TestSafeFormatKey_SystemTenant(t *testing.T) {
 	}
 }
 
-func TestSafeFormatKey_UnsupportedKeyspace(t *testing.T) {
-	ten5Codec := keys.MakeSQLCodec(roachpb.MakeTenantID(5))
+func TestSafeFormatKey_Basic(t *testing.T) {
 	testCases := []struct {
 		name string
 		key  roachpb.Key
 		exp  string
 	}{
 		{
-			"key-spaces without a safe format function implementation are fully redacted",
-			keys.MakeRangeKeyPrefix(roachpb.RKey(ten5Codec.TablePrefix(42))),
-			`‹/Local/Range/Tenant/5/Table/42›`,
+			"ensure constants get redacted",
+			makeKey(keys.Meta2Prefix, roachpb.Key("foo")),
+			`/Meta2/‹"foo"›`,
 		},
 	}
 

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -155,7 +155,9 @@ func (rk RKey) String() string {
 
 // StringWithDirs - see Key.StringWithDirs.
 func (rk RKey) StringWithDirs(valDirs []encoding.Direction) string {
-	return Key(rk).StringWithDirs(valDirs)
+	var buf redact.StringBuilder
+	Key(rk).StringWithDirs(&buf, valDirs)
+	return buf.String()
 }
 
 // Key is a custom type for a byte string in proto
@@ -237,14 +239,12 @@ func (k Key) String() string {
 //	encoding direction.
 //
 //	returned, plus a "..." suffix.
-func (k Key) StringWithDirs(valDirs []encoding.Direction) string {
-	var s string
+func (k Key) StringWithDirs(buf *redact.StringBuilder, valDirs []encoding.Direction) {
 	if PrettyPrintKey != nil {
-		s = PrettyPrintKey(valDirs, k)
+		buf.Print(PrettyPrintKey(valDirs, k))
 	} else {
-		s = fmt.Sprintf("%q", []byte(k))
+		buf.Printf("%q", []byte(k))
 	}
-	return s
 }
 
 // Format implements the fmt.Formatter interface.

--- a/pkg/rpc/auth_test.go
+++ b/pkg/rpc/auth_test.go
@@ -242,7 +242,7 @@ func TestTenantAuthRequest(t *testing.T) {
 				req: &roachpb.BatchRequest{Requests: makeReqs(
 					makeReq(prefix(5, "a"), prefix(5, "b")),
 				)},
-				expErr: `requested key span /Tenant/5"{a"-b"} not fully contained in tenant keyspace /Tenant/1{0-1}`,
+				expErr: `requested key span /Tenant/5{a-b} not fully contained in tenant keyspace /Tenant/1{0-1}`,
 			},
 			{
 				req: &roachpb.BatchRequest{Requests: makeReqs(
@@ -254,33 +254,33 @@ func TestTenantAuthRequest(t *testing.T) {
 				req: &roachpb.BatchRequest{Requests: makeReqs(
 					makeReq(prefix(50, "a"), prefix(50, "b")),
 				)},
-				expErr: `requested key span /Tenant/50"{a"-b"} not fully contained in tenant keyspace /Tenant/1{0-1}`,
+				expErr: `requested key span /Tenant/50{a-b} not fully contained in tenant keyspace /Tenant/1{0-1}`,
 			},
 			{
 				req: &roachpb.BatchRequest{Requests: makeReqs(
 					makeReq("a", "b"),
 					makeReq(prefix(5, "a"), prefix(5, "b")),
 				)},
-				expErr: `requested key span {a-/Tenant/5"b"} not fully contained in tenant keyspace /Tenant/1{0-1}`,
+				expErr: `requested key span {a-/Tenant/5b} not fully contained in tenant keyspace /Tenant/1{0-1}`,
 			},
 			{
 				req: &roachpb.BatchRequest{Requests: makeReqs(
 					makeReq(prefix(5, "a"), prefix(5, "b")),
 					makeReq(prefix(10, "a"), prefix(10, "b")),
 				)},
-				expErr: `requested key span /Tenant/{5"a"-10"b"} not fully contained in tenant keyspace /Tenant/1{0-1}`,
+				expErr: `requested key span /Tenant/{5a-10b} not fully contained in tenant keyspace /Tenant/1{0-1}`,
 			},
 			{
 				req: &roachpb.BatchRequest{Requests: makeReqs(
 					makeReq("a", prefix(10, "b")),
 				)},
-				expErr: `requested key span {a-/Tenant/10"b"} not fully contained in tenant keyspace /Tenant/1{0-1}`,
+				expErr: `requested key span {a-/Tenant/10b} not fully contained in tenant keyspace /Tenant/1{0-1}`,
 			},
 			{
 				req: &roachpb.BatchRequest{Requests: makeReqs(
 					makeReq(prefix(10, "a"), prefix(20, "b")),
 				)},
-				expErr: `requested key span /Tenant/{10"a"-20"b"} not fully contained in tenant keyspace /Tenant/1{0-1}`,
+				expErr: `requested key span /Tenant/{10a-20b} not fully contained in tenant keyspace /Tenant/1{0-1}`,
 			},
 			{
 				req: &roachpb.BatchRequest{Requests: makeReqs(
@@ -330,7 +330,7 @@ func TestTenantAuthRequest(t *testing.T) {
 				req: &roachpb.BatchRequest{Requests: makeReqs(
 					makeAdminSplitReq(prefix(50, "a")),
 				)},
-				expErr: `requested key span /Tenant/50"a{"-\\x00"} not fully contained in tenant keyspace /Tenant/1{0-1}`,
+				expErr: `requested key span /Tenant/50a{-\\x00} not fully contained in tenant keyspace /Tenant/1{0-1}`,
 			},
 			{
 				req: &roachpb.BatchRequest{Requests: makeReqs(
@@ -362,7 +362,7 @@ func TestTenantAuthRequest(t *testing.T) {
 				req: &roachpb.BatchRequest{Requests: makeReqs(
 					makeAdminScatterReq(prefix(50, "a")),
 				)},
-				expErr: `requested key span /Tenant/50"a{"-\\x00"} not fully contained in tenant keyspace /Tenant/1{0-1}`,
+				expErr: `requested key span /Tenant/50a{-\\x00} not fully contained in tenant keyspace /Tenant/1{0-1}`,
 			},
 			{
 				req: &roachpb.BatchRequest{Requests: makeReqs(
@@ -421,7 +421,7 @@ func TestTenantAuthRequest(t *testing.T) {
 			},
 			{
 				req:    &roachpb.RangeFeedRequest{Span: makeSpan(prefix(5, "a"), prefix(5, "b"))},
-				expErr: `requested key span /Tenant/5"{a"-b"} not fully contained in tenant keyspace /Tenant/1{0-1}`,
+				expErr: `requested key span /Tenant/5{a-b} not fully contained in tenant keyspace /Tenant/1{0-1}`,
 			},
 			{
 				req:    &roachpb.RangeFeedRequest{Span: makeSpan(prefix(10, "a"), prefix(10, "b"))},
@@ -429,15 +429,15 @@ func TestTenantAuthRequest(t *testing.T) {
 			},
 			{
 				req:    &roachpb.RangeFeedRequest{Span: makeSpan(prefix(50, "a"), prefix(50, "b"))},
-				expErr: `requested key span /Tenant/50"{a"-b"} not fully contained in tenant keyspace /Tenant/1{0-1}`,
+				expErr: `requested key span /Tenant/50{a-b} not fully contained in tenant keyspace /Tenant/1{0-1}`,
 			},
 			{
 				req:    &roachpb.RangeFeedRequest{Span: makeSpan("a", prefix(10, "b"))},
-				expErr: `requested key span {a-/Tenant/10"b"} not fully contained in tenant keyspace /Tenant/1{0-1}`,
+				expErr: `requested key span {a-/Tenant/10b} not fully contained in tenant keyspace /Tenant/1{0-1}`,
 			},
 			{
 				req:    &roachpb.RangeFeedRequest{Span: makeSpan(prefix(10, "a"), prefix(20, "b"))},
-				expErr: `requested key span /Tenant/{10"a"-20"b"} not fully contained in tenant keyspace /Tenant/1{0-1}`,
+				expErr: `requested key span /Tenant/{10a-20b} not fully contained in tenant keyspace /Tenant/1{0-1}`,
 			},
 		},
 		"/cockroach.roachpb.Internal/GossipSubscription": {
@@ -497,7 +497,7 @@ func TestTenantAuthRequest(t *testing.T) {
 				req: makeGetSpanConfigsReq(
 					makeSpanTarget(makeSpan(prefix(5, "a"), prefix(5, "b"))),
 				),
-				expErr: `requested key span /Tenant/5"{a"-b"} not fully contained in tenant keyspace /Tenant/1{0-1}`,
+				expErr: `requested key span /Tenant/5{a-b} not fully contained in tenant keyspace /Tenant/1{0-1}`,
 			},
 			{
 				req: makeGetSpanConfigsReq(
@@ -509,19 +509,19 @@ func TestTenantAuthRequest(t *testing.T) {
 				req: makeGetSpanConfigsReq(
 					makeSpanTarget(makeSpan(prefix(50, "a"), prefix(50, "b"))),
 				),
-				expErr: `requested key span /Tenant/50"{a"-b"} not fully contained in tenant keyspace /Tenant/1{0-1}`,
+				expErr: `requested key span /Tenant/50{a-b} not fully contained in tenant keyspace /Tenant/1{0-1}`,
 			},
 			{
 				req: makeGetSpanConfigsReq(
 					makeSpanTarget(makeSpan("a", prefix(10, "b"))),
 				),
-				expErr: `requested key span {a-/Tenant/10"b"} not fully contained in tenant keyspace /Tenant/1{0-1}`,
+				expErr: `requested key span {a-/Tenant/10b} not fully contained in tenant keyspace /Tenant/1{0-1}`,
 			},
 			{
 				req: makeGetSpanConfigsReq(
 					makeSpanTarget(makeSpan(prefix(10, "a"), prefix(20, "b"))),
 				),
-				expErr: `requested key span /Tenant/{10"a"-20"b"} not fully contained in tenant keyspace /Tenant/1{0-1}`,
+				expErr: `requested key span /Tenant/{10a-20b} not fully contained in tenant keyspace /Tenant/1{0-1}`,
 			},
 			{
 				req:    makeGetSpanConfigsReq(makeSystemSpanConfigTarget(10, 10)),
@@ -577,7 +577,7 @@ func TestTenantAuthRequest(t *testing.T) {
 					makeSpanTarget(makeSpan(prefix(5, "a"), prefix(5, "b"))),
 					true,
 				),
-				expErr: `requested key span /Tenant/5"{a"-b"} not fully contained in tenant keyspace /Tenant/1{0-1}`,
+				expErr: `requested key span /Tenant/5{a-b} not fully contained in tenant keyspace /Tenant/1{0-1}`,
 			},
 			{
 				req: makeUpdateSpanConfigsReq(
@@ -591,21 +591,21 @@ func TestTenantAuthRequest(t *testing.T) {
 					makeSpanTarget(makeSpan(prefix(50, "a"), prefix(50, "b"))),
 					true,
 				),
-				expErr: `requested key span /Tenant/50"{a"-b"} not fully contained in tenant keyspace /Tenant/1{0-1}`,
+				expErr: `requested key span /Tenant/50{a-b} not fully contained in tenant keyspace /Tenant/1{0-1}`,
 			},
 			{
 				req: makeUpdateSpanConfigsReq(
 					makeSpanTarget(makeSpan("a", prefix(10, "b"))),
 					true,
 				),
-				expErr: `requested key span {a-/Tenant/10"b"} not fully contained in tenant keyspace /Tenant/1{0-1}`,
+				expErr: `requested key span {a-/Tenant/10b} not fully contained in tenant keyspace /Tenant/1{0-1}`,
 			},
 			{
 				req: makeUpdateSpanConfigsReq(
 					makeSpanTarget(makeSpan(prefix(10, "a"), prefix(20, "b"))),
 					true,
 				),
-				expErr: `requested key span /Tenant/{10"a"-20"b"} not fully contained in tenant keyspace /Tenant/1{0-1}`,
+				expErr: `requested key span /Tenant/{10a-20b} not fully contained in tenant keyspace /Tenant/1{0-1}`,
 			},
 			{
 				req: makeUpdateSpanConfigsReq(
@@ -619,7 +619,7 @@ func TestTenantAuthRequest(t *testing.T) {
 					makeSpanTarget(makeSpan(prefix(5, "a"), prefix(5, "b"))),
 					false,
 				),
-				expErr: `requested key span /Tenant/5"{a"-b"} not fully contained in tenant keyspace /Tenant/1{0-1}`,
+				expErr: `requested key span /Tenant/5{a-b} not fully contained in tenant keyspace /Tenant/1{0-1}`,
 			},
 			{
 				req: makeUpdateSpanConfigsReq(
@@ -633,21 +633,21 @@ func TestTenantAuthRequest(t *testing.T) {
 					makeSpanTarget(makeSpan(prefix(50, "a"), prefix(50, "b"))),
 					false,
 				),
-				expErr: `requested key span /Tenant/50"{a"-b"} not fully contained in tenant keyspace /Tenant/1{0-1}`,
+				expErr: `requested key span /Tenant/50{a-b} not fully contained in tenant keyspace /Tenant/1{0-1}`,
 			},
 			{
 				req: makeUpdateSpanConfigsReq(
 					makeSpanTarget(makeSpan("a", prefix(10, "b"))),
 					false,
 				),
-				expErr: `requested key span {a-/Tenant/10"b"} not fully contained in tenant keyspace /Tenant/1{0-1}`,
+				expErr: `requested key span {a-/Tenant/10b} not fully contained in tenant keyspace /Tenant/1{0-1}`,
 			},
 			{
 				req: makeUpdateSpanConfigsReq(
 					makeSpanTarget(makeSpan(prefix(10, "a"), prefix(20, "b"))),
 					false,
 				),
-				expErr: `requested key span /Tenant/{10"a"-20"b"} not fully contained in tenant keyspace /Tenant/1{0-1}`,
+				expErr: `requested key span /Tenant/{10a-20b} not fully contained in tenant keyspace /Tenant/1{0-1}`,
 			},
 			{
 				req:    makeUpdateSpanConfigsReq(makeSystemSpanConfigTarget(10, 10), false),

--- a/pkg/sql/catalog/catalogkeys/BUILD.bazel
+++ b/pkg/sql/catalog/catalogkeys/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/sql/sem/catconstants",
         "//pkg/util/encoding",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/sql/catalog/catalogkeys/keys.go
+++ b/pkg/sql/catalog/catalogkeys/keys.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 const (
@@ -84,7 +85,9 @@ func IndexKeyValDirs(index catalog.Index) []encoding.Direction {
 // currently true for the fields we care about stripping (the table and index
 // ID).
 func PrettyKey(valDirs []encoding.Direction, key roachpb.Key, skip int) string {
-	p := key.StringWithDirs(valDirs)
+	var buf redact.StringBuilder
+	key.StringWithDirs(&buf, valDirs)
+	p := buf.String()
 	for i := 0; i <= skip; i++ {
 		n := strings.IndexByte(p[1:], '/')
 		if n == -1 {

--- a/pkg/ts/BUILD.bazel
+++ b/pkg/ts/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
         "//pkg/util/stop",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_grpc_ecosystem_grpc_gateway//runtime:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes",

--- a/pkg/util/encoding/BUILD.bazel
+++ b/pkg/util/encoding/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/util/uuid",
         "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 
@@ -58,6 +59,7 @@ go_test(
         "//pkg/util/uuid",
         "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/util/encoding/encoding_test.go
+++ b/pkg/util/encoding/encoding_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -912,7 +913,9 @@ func TestPrettyPrintValue(t *testing.T) {
 			dirStr = "Desc"
 		}
 		t.Run(test.exp[1:]+"/"+dirStr, func(t *testing.T) {
-			got := PrettyPrintValue([]Direction{test.dir}, test.key, "/")
+			var buf redact.StringBuilder
+			PrettyPrintValue(&buf, []Direction{test.dir}, test.key, "/")
+			got := buf.String()
 			if got != test.exp {
 				t.Errorf("expected %q, got %q", test.exp, got)
 			}

--- a/pkg/util/json/BUILD.bazel
+++ b/pkg/util/json/BUILD.bazel
@@ -51,6 +51,7 @@ go_test(
         "//pkg/util/timeutil",
         "//pkg/util/unique",
         "@com_github_cockroachdb_apd_v3//:apd",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/util/json/json_test.go
+++ b/pkg/util/json/json_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/unique"
+	"github.com/cockroachdb/redact"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1275,7 +1276,9 @@ func TestEncodeDecodeJSONInvertedIndex(t *testing.T) {
 		}
 
 		for j, path := range enc {
-			str := encoding.PrettyPrintValue(nil, path, "/")
+			var buf redact.StringBuilder
+			encoding.PrettyPrintValue(&buf, nil, path, "/")
+			str := buf.String()
 			if str != c.expEnc[j] {
 				t.Errorf("unexpected encoding mismatch for %v. expected [%s], got [%s]",
 					c.value, c.expEnc[j], str)

--- a/pkg/util/keysutil/keys.go
+++ b/pkg/util/keysutil/keys.go
@@ -117,7 +117,7 @@ outer:
 	for len(input) > 0 {
 		if entries != nil {
 			for _, v := range entries {
-				if strings.HasPrefix(input, v.Name) {
+				if strings.HasPrefix(input, string(v.Name)) {
 					input = input[len(v.Name):]
 					if v.PSFunc == nil {
 						return mkErr(nil)
@@ -134,14 +134,14 @@ outer:
 			}
 		}
 		for _, v := range keys.ConstKeyOverrides {
-			if strings.HasPrefix(input, v.Name) {
+			if strings.HasPrefix(input, string(v.Name)) {
 				output = append(output, v.Value...)
 				input = input[len(v.Name):]
 				continue outer
 			}
 		}
 		for _, v := range s.keyComprehension {
-			if strings.HasPrefix(input, v.Name) {
+			if strings.HasPrefix(input, string(v.Name)) {
 				// No appending to output yet, the dictionary will take care of
 				// it.
 				input = input[len(v.Name):]


### PR DESCRIPTION
Previously the PrettyPrint function called the prettyPrintInternal
function which had similar logic to safeFormatInternal. This patch
modifies safeFormatInternal such that PrettyPrint can use it and
prettyPrintInternal has been removed. As part of this refactor,
all ppFunc functions have been updated to return
redact.RedactableString. Changes from https://github.com/cockroachdb/cockroach/pull/87952 are also included.

Resolves https://github.com/cockroachdb/cockroach/issues/88060

Release note: None