### PR TITLE
roachtest: pause changefeed during upgrade in mixed-versions test

### DIFF
--- a/pkg/ccl/changefeedccl/cdctest/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/cdctest/BUILD.bazel
@@ -31,7 +31,6 @@ go_library(
         "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/randutil",
-        "//pkg/util/retry",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/ccl/changefeedccl/cdctest/nemeses.go
+++ b/pkg/ccl/changefeedccl/cdctest/nemeses.go
@@ -173,7 +173,8 @@ func RunNemesis(f TestFeedFactory, db *gosql.DB, isSinkless bool) (Validator, er
 	if err != nil {
 		return nil, err
 	}
-	fprintV, err := NewFingerprintValidator(db, `foo`, scratchTableName, foo.Partitions(), ns.maxTestColumnCount, false)
+	withSQLDB := WithDBConnection(db)
+	fprintV, err := NewFingerprintValidator(withSQLDB, `foo`, scratchTableName, foo.Partitions(), ns.maxTestColumnCount)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/changefeedccl/cdctest/validator_test.go
+++ b/pkg/ccl/changefeedccl/cdctest/validator_test.go
@@ -289,17 +289,18 @@ func TestFingerprintValidator(t *testing.T) {
 		return fmt.Sprintf(`CREATE TABLE %s (k INT PRIMARY KEY, v INT)`, tableName)
 	}
 	testColumns := 0
+	withSQLDB := WithDBConnection(sqlDBRaw)
 
 	t.Run(`empty`, func(t *testing.T) {
 		sqlDB.Exec(t, createTableStmt(`empty`))
-		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `empty`, []string{`p`}, testColumns, false)
+		v, err := NewFingerprintValidator(withSQLDB, `foo`, `empty`, []string{`p`}, testColumns)
 		require.NoError(t, err)
 		noteResolved(t, v, `p`, ts[0])
 		assertValidatorFailures(t, v)
 	})
 	t.Run(`wrong data`, func(t *testing.T) {
 		sqlDB.Exec(t, createTableStmt(`wrong_data`))
-		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `wrong_data`, []string{`p`}, testColumns, false)
+		v, err := NewFingerprintValidator(withSQLDB, `foo`, `wrong_data`, []string{`p`}, testColumns)
 		require.NoError(t, err)
 		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":10}}`, ts[1])
 		noteResolved(t, v, `p`, ts[1])
@@ -310,7 +311,7 @@ func TestFingerprintValidator(t *testing.T) {
 	})
 	t.Run(`all resolved`, func(t *testing.T) {
 		sqlDB.Exec(t, createTableStmt(`all_resolved`))
-		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `all_resolved`, []string{`p`}, testColumns, false)
+		v, err := NewFingerprintValidator(withSQLDB, `foo`, `all_resolved`, []string{`p`}, testColumns)
 		require.NoError(t, err)
 		if err := v.NoteResolved(`p`, ts[0]); err != nil {
 			t.Fatal(err)
@@ -329,7 +330,7 @@ func TestFingerprintValidator(t *testing.T) {
 	})
 	t.Run(`rows unsorted`, func(t *testing.T) {
 		sqlDB.Exec(t, createTableStmt(`rows_unsorted`))
-		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `rows_unsorted`, []string{`p`}, testColumns, false)
+		v, err := NewFingerprintValidator(withSQLDB, `foo`, `rows_unsorted`, []string{`p`}, testColumns)
 		require.NoError(t, err)
 		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":3}}`, ts[3])
 		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":2}}`, ts[2])
@@ -341,7 +342,7 @@ func TestFingerprintValidator(t *testing.T) {
 	})
 	t.Run(`missed initial`, func(t *testing.T) {
 		sqlDB.Exec(t, createTableStmt(`missed_initial`))
-		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `missed_initial`, []string{`p`}, testColumns, false)
+		v, err := NewFingerprintValidator(withSQLDB, `foo`, `missed_initial`, []string{`p`}, testColumns)
 		require.NoError(t, err)
 		noteResolved(t, v, `p`, ts[0])
 		// Intentionally missing {"k":1,"v":1} at ts[1].
@@ -357,7 +358,7 @@ func TestFingerprintValidator(t *testing.T) {
 	})
 	t.Run(`missed middle`, func(t *testing.T) {
 		sqlDB.Exec(t, createTableStmt(`missed_middle`))
-		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `missed_middle`, []string{`p`}, testColumns, false)
+		v, err := NewFingerprintValidator(withSQLDB, `foo`, `missed_middle`, []string{`p`}, testColumns)
 		require.NoError(t, err)
 		noteResolved(t, v, `p`, ts[0])
 		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1])
@@ -375,7 +376,7 @@ func TestFingerprintValidator(t *testing.T) {
 	})
 	t.Run(`missed end`, func(t *testing.T) {
 		sqlDB.Exec(t, createTableStmt(`missed_end`))
-		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `missed_end`, []string{`p`}, testColumns, false)
+		v, err := NewFingerprintValidator(withSQLDB, `foo`, `missed_end`, []string{`p`}, testColumns)
 		require.NoError(t, err)
 		noteResolved(t, v, `p`, ts[0])
 		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1])
@@ -390,7 +391,7 @@ func TestFingerprintValidator(t *testing.T) {
 	})
 	t.Run(`initial scan`, func(t *testing.T) {
 		sqlDB.Exec(t, createTableStmt(`initial_scan`))
-		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `initial_scan`, []string{`p`}, testColumns, false)
+		v, err := NewFingerprintValidator(withSQLDB, `foo`, `initial_scan`, []string{`p`}, testColumns)
 		require.NoError(t, err)
 		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":3}}`, ts[3])
 		noteRow(t, v, ignored, `[2]`, `{"after": {"k":2,"v":2}}`, ts[3])
@@ -399,7 +400,7 @@ func TestFingerprintValidator(t *testing.T) {
 	})
 	t.Run(`unknown partition`, func(t *testing.T) {
 		sqlDB.Exec(t, createTableStmt(`unknown_partition`))
-		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `unknown_partition`, []string{`p`}, testColumns, false)
+		v, err := NewFingerprintValidator(withSQLDB, `foo`, `unknown_partition`, []string{`p`}, testColumns)
 		require.NoError(t, err)
 		if err := v.NoteResolved(`nope`, ts[1]); !testutils.IsError(err, `unknown partition`) {
 			t.Fatalf(`expected "unknown partition" error got: %+v`, err)
@@ -407,7 +408,7 @@ func TestFingerprintValidator(t *testing.T) {
 	})
 	t.Run(`resolved unsorted`, func(t *testing.T) {
 		sqlDB.Exec(t, createTableStmt(`resolved_unsorted`))
-		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `resolved_unsorted`, []string{`p`}, testColumns, false)
+		v, err := NewFingerprintValidator(withSQLDB, `foo`, `resolved_unsorted`, []string{`p`}, testColumns)
 		require.NoError(t, err)
 		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1])
 		noteResolved(t, v, `p`, ts[1])
@@ -417,7 +418,7 @@ func TestFingerprintValidator(t *testing.T) {
 	})
 	t.Run(`two partitions`, func(t *testing.T) {
 		sqlDB.Exec(t, createTableStmt(`two_partitions`))
-		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `two_partitions`, []string{`p0`, `p1`}, testColumns, false)
+		v, err := NewFingerprintValidator(withSQLDB, `foo`, `two_partitions`, []string{`p0`, `p1`}, testColumns)
 		require.NoError(t, err)
 		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1])
 		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":2}}`, ts[2])

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -413,7 +413,8 @@ func runCDCBank(ctx context.Context, t test.Test, c cluster.Cluster) {
 			return errors.Wrap(err, "CREATE TABLE failed")
 		}
 
-		fprintV, err := cdctest.NewFingerprintValidator(db, `bank.bank`, `fprint`, tc.partitions, 0, false)
+		withSQLDB := cdctest.WithDBConnection(db)
+		fprintV, err := cdctest.NewFingerprintValidator(withSQLDB, `bank.bank`, `fprint`, tc.partitions, 0)
 		if err != nil {
 			return errors.Wrap(err, "error creating validator")
 		}

--- a/pkg/cmd/roachtest/tests/mixed_version_cdc.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_cdc.go
@@ -12,6 +12,7 @@ package tests
 
 import (
 	"context"
+	gosql "database/sql"
 	"fmt"
 	"strconv"
 	"strings"
@@ -74,9 +75,13 @@ type cdcMixedVersionTester struct {
 		syncutil.Mutex
 		C chan struct{}
 	}
-	kafka     kafkaManager
-	validator *cdctest.CountValidator
-	cleanup   func()
+	crdbUpgrading   syncutil.Mutex
+	kafka           kafkaManager
+	changefeedJobID int
+	validator       *cdctest.CountValidator
+	validatorDone   chan struct{} // validator is no longer waiting for messages
+	validatorStop   bool          // used  to tell the validator to stop validating messages
+	cleanup         func()
 }
 
 func newCDCMixedVersionTester(
@@ -94,6 +99,7 @@ func newCDCMixedVersionTester(
 		workloadNodes: lastNode,
 		kafkaNodes:    lastNode,
 		monitor:       c.NewMonitor(ctx, crdbNodes),
+		validatorDone: make(chan struct{}),
 	}
 }
 
@@ -165,6 +171,17 @@ func (cmvt *cdcMixedVersionTester) waitForResolvedTimestamps() versionStep {
 	}
 }
 
+// waitForValidator sets the `validatorStop` flag and waits for the
+// validator to finish. This should be done right before the test
+// finishes, to ensure that we won't try to close the database
+// connection while the validator is still trying to use it
+func (cmvt *cdcMixedVersionTester) waitForValidator() versionStep {
+	return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
+		cmvt.validatorStop = true
+		<-cmvt.validatorDone
+	}
+}
+
 // setupVerifier creates a CDC validator to validate that a changefeed
 // created on the `target` table is able to re-create the table
 // somewhere else. It also verifies CDC's ordering guarantees. This
@@ -192,7 +209,8 @@ func (cmvt *cdcMixedVersionTester) setupVerifier(node int) versionStep {
 				t.Fatal(err)
 			}
 
-			fprintV, err := cdctest.NewFingerprintValidator(db, tableName, `fprint`, consumer.partitions, 0, true)
+			getConn := func(node int) *gosql.DB { return u.conn(ctx, t, node) }
+			fprintV, err := cdctest.NewFingerprintValidator(cmvt.cdcDBConn(getConn), tableName, `fprint`, consumer.partitions, 0)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -202,7 +220,7 @@ func (cmvt *cdcMixedVersionTester) setupVerifier(node int) versionStep {
 			}
 			cmvt.validator = cdctest.MakeCountValidator(validators)
 
-			for {
+			for !cmvt.validatorStop {
 				m := consumer.Next(ctx)
 				if m == nil {
 					t.L().Printf("end of changefeed")
@@ -229,6 +247,9 @@ func (cmvt *cdcMixedVersionTester) setupVerifier(node int) versionStep {
 					cmvt.timestampResolved()
 				}
 			}
+
+			close(cmvt.validatorDone)
+			return nil
 		})
 	}
 }
@@ -241,6 +262,50 @@ func (cmvt *cdcMixedVersionTester) timestampResolved() {
 
 	if cmvt.timestampsResolved.C != nil {
 		cmvt.timestampsResolved.C <- struct{}{}
+	}
+}
+
+// cdcDBConn is the wrapper passed to the FingerprintValidator. The
+// goal is to ensure that database checks by the validator do not
+// happen while we are running an upgrade. We used to retry database
+// calls in the validator, but that logic adds complexity and does not
+// help in testing the changefeed's correctness
+func (cmvt *cdcMixedVersionTester) cdcDBConn(
+	getConn func(int) *gosql.DB,
+) func(func(*gosql.DB) error) error {
+	return func(f func(*gosql.DB) error) error {
+		cmvt.crdbUpgrading.Lock()
+		defer cmvt.crdbUpgrading.Unlock()
+
+		node := cmvt.crdbNodes.RandNode()[0]
+		return f(getConn(node))
+	}
+}
+
+// crdbUpgradeStep is a wrapper to steps that upgrade the cockroach
+// binary running in the cluster. It makes sure we hold exclusive
+// access to the `crdbUpgrading` lock while the upgrade is in process
+func (cmvt *cdcMixedVersionTester) crdbUpgradeStep(step versionStep) versionStep {
+	return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
+		cmvt.crdbUpgrading.Lock()
+		defer cmvt.crdbUpgrading.Unlock()
+
+		runJobOp := func(db *gosql.DB, op string) {
+			if _, err := db.Exec(fmt.Sprintf("%s JOB $1", op), cmvt.changefeedJobID); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		node := cmvt.crdbNodes.RandNode()[0]
+		db := u.conn(ctx, t, node)
+		// pause the changefeed while the upgrade is in process. Without
+		// this, tests frequently fail with fingerprint mismatch errors
+		// during the test
+		// TODO(renatolabs): remove this once #88948 is resolved
+		runJobOp(db, "PAUSE")
+		defer runJobOp(db, "RESUME")
+
+		step(ctx, t, u)
 	}
 }
 
@@ -265,12 +330,14 @@ func (cmvt *cdcMixedVersionTester) createChangeFeed(node int) versionStep {
 			{"updated", ""},
 			{"resolved", fmt.Sprintf("'%s'", resolvedInterval)},
 		}
-		_, err := newChangefeedCreator(db, fmt.Sprintf("%s.%s", targetDB, targetTable), cmvt.kafka.sinkURL(ctx)).
+		jobID, err := newChangefeedCreator(db, fmt.Sprintf("%s.%s", targetDB, targetTable), cmvt.kafka.sinkURL(ctx)).
 			With(options...).
 			Create()
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		cmvt.changefeedJobID = jobID
 	}
 }
 
@@ -312,7 +379,7 @@ func runCDCMixedVersions(
 
 		tester.waitForResolvedTimestamps(),
 		// Roll the nodes into the new version one by one in random order
-		binaryUpgradeStep(tester.crdbNodes, mainVersion),
+		tester.crdbUpgradeStep(binaryUpgradeStep(tester.crdbNodes, mainVersion)),
 		// let the workload run in the new version for a while
 		tester.waitForResolvedTimestamps(),
 
@@ -320,19 +387,20 @@ func runCDCMixedVersions(
 
 		// Roll back again, which ought to be fine because the cluster upgrade was
 		// not finalized.
-		binaryUpgradeStep(tester.crdbNodes, predecessorVersion),
+		tester.crdbUpgradeStep(binaryUpgradeStep(tester.crdbNodes, predecessorVersion)),
 		tester.waitForResolvedTimestamps(),
 
 		tester.assertValid(),
 
 		// Roll nodes forward and finalize upgrade.
-		binaryUpgradeStep(tester.crdbNodes, mainVersion),
+		tester.crdbUpgradeStep(binaryUpgradeStep(tester.crdbNodes, mainVersion)),
 
 		// allow cluster version to update
 		allowAutoUpgradeStep(sqlNode()),
 		waitForUpgradeStep(tester.crdbNodes),
 
 		tester.waitForResolvedTimestamps(),
+		tester.waitForValidator(),
 		tester.assertValid(),
 	).run(ctx, t)
 }


### PR DESCRIPTION
In #87154, we started gracefully shutting down nodes in mixed-version tests. As a consequence of that change, the `cdc/mixed-versions` roachtest started failing. After some investigation, it was discovered that the issue has nothing to do with upgrades but instead with the the different way nodes are stopped (if we don't use different binaries and just stop and restart the same binaries, running current `master`, the issue is still observed).

In order to stop that test from failing, this commit implements a workaround solution of stopping the changefeed while an upgrade is in process, which makes the test pass reliably. This commit also removes the retry logic from the FingerprintValidator code as it adds a dimension of complexity that is not needed in the tests. The validator will now block if trying to perform a SQL update until the upgrade process is finished.

The actual issue that leads to this failure is being investigated in #88948.

Fixes #87251.

Release note: None.