### PR TITLE
sql: avoid using "rune" in COPY error message

### DIFF
--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -219,7 +219,7 @@ func newCopyMachine(
 		if len(s) != 1 {
 			return nil, pgerror.Newf(
 				pgcode.FeatureNotSupported,
-				"ESCAPE must be a single rune",
+				"ESCAPE must be a single one-byte character",
 			)
 		}
 


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/88521

Rune is a go concept, not a SQL concept.

Release note: None