### PR TITLE
sql: address minor typos in recent overflow fix

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/overflow
+++ b/pkg/sql/logictest/testdata/logic_test/overflow
@@ -54,6 +54,6 @@ true
 # constant addend to the right side of the comparison when the subtraction would
 # overflow.
 query B
-SELECT i + 1000 > -9223372036854775800 FROM t88128
+SELECT i + (-1000) < 9223372036854775800 FROM t88128
 ----
 true

--- a/pkg/sql/opt/norm/comp_funcs.go
+++ b/pkg/sql/opt/norm/comp_funcs.go
@@ -37,16 +37,16 @@ func (c *CustomFuncs) CommuteInequality(
 
 // FoldBinaryCheckOverflow attempts to evaluate a binary expression with
 // constant inputs. The only operations supported are plus and minus. It returns
-// a constant expression as if all the following criteria are met:
+// a constant expression if all the following criteria are met:
 //
 //  1. The right datum is an integer, float, decimal, or interval. This
 //     restriction can be lifted for any type that we can construct a zero value
 //     of. The zero value of the right type is required in order to check for
-//     overflow/underflow (see #4).
+//     overflow/underflow (see #5).
 //  2. An overload function for the given operator and input types exists and
 //     has an appropriate volatility.
 //  3. The result type of the overload is equivalent to the type of left. This
-//     is required in order to check for overflow/underflow (see #4).
+//     is required in order to check for overflow/underflow (see #5).
 //  4. The evaluation causes no error.
 //  5. The evaluation does not overflow or underflow.
 //

--- a/pkg/sql/opt/norm/rules/comp.opt
+++ b/pkg/sql/opt/norm/rules/comp.opt
@@ -32,11 +32,11 @@
 #   1. $leftRight is an integer, float, decimal, or interval. This restriction
 #      can be lifted for any type that we can construct a zero value of. The
 #      zero value of the right type is required in order to check for
-#      overflow/underflow (see #4).
+#      overflow/underflow (see #5).
 #   2. A Minus overload for the given input types exists and has an appropriate
 #      volatility.
 #   3. The result type of the overload is equivalent to the type of $right. This
-#      is required in order to check for overflow/underflow (see #4).
+#      is required in order to check for overflow/underflow (see #5).
 #   4. The evaluation of the Minus operator causes no error.
 #   5. The evaluation of the Minus operator does not overflow or underflow.
 #

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -3031,7 +3031,7 @@ type DInterval struct {
 	duration.Duration
 }
 
-// DZeroInterval is the zero-valued DTimestamp.
+// DZeroInterval is the zero-valued DInterval.
 var DZeroInterval = &DInterval{}
 
 // AsDInterval attempts to retrieve a DInterval from an Expr, panicking if the


### PR DESCRIPTION
This commit fixes minor typos introduced in #88199.

Release note: None