### PR TITLE
build/nightlies: enable crdb_test on sqllite logic tests

### DIFF
--- a/build/teamcity/cockroach/nightlies/sqlite_logic_test_impl.sh
+++ b/build/teamcity/cockroach/nightlies/sqlite_logic_test_impl.sh
@@ -7,7 +7,7 @@ dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
 bazel build //pkg/cmd/bazci --config=ci
 BAZEL_BIN=$(bazel info bazel-bin --config=ci)
 exit_status=0
-$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- test --config=ci --config=crdb_test_off \
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- test --config=ci \
     //pkg/sql/sqlitelogictest/tests/... \
     --test_arg -bigtest --test_arg -flex-types --test_timeout 86400 \
     || exit_status=$?


### PR DESCRIPTION
I believe we have fixed all of the known issues with `crdb_test`
randomizations on the sqlite logic tests, and I got a passing run on my
gceworker, so I think we can try re-enabling them.

Fixes: #58089.

Release note: None