### PR TITLE
changefeedccl: avoid extra internal retry for buffered emits

### DIFF
--- a/pkg/ccl/changefeedccl/sink_kafka.go
+++ b/pkg/ccl/changefeedccl/sink_kafka.go
@@ -499,7 +499,7 @@ func (s *kafkaSink) workerLoop() {
 		}
 		s.mu.inflight--
 
-		if !isRetrying() && s.isInternalRetryable(ackError) {
+		if !isRetrying() && s.mu.flushErr == nil && s.isInternalRetryable(ackError) {
 			startInternalRetry(ackError)
 		}
 


### PR DESCRIPTION
With the new parallel event consumer changes even when the sink errors, storing a value in flushErr, there can be many more emits with no flush, which on this test would result in constant internal retries occuring. This change just makes internal retries only occur if no flushErr has occured, since we've already errored and all we want is to let everything flush out.  This fixes a flake in TestChangefeedKafkaMessageTooLarge.

Release note: None