### PR TITLE
storage: avoid `EncodeMVCCValue` struct comparison

### DIFF
--- a/pkg/storage/enginepb/mvcc3.go
+++ b/pkg/storage/enginepb/mvcc3.go
@@ -51,3 +51,12 @@ func (op *MVCCLogicalOp) MustSetValue(value interface{}) {
 		panic(errors.AssertionFailedf("%T excludes %T", op, value))
 	}
 }
+
+// IsEmpty returns true if the header is empty.
+// gcassert:inline
+func (h MVCCValueHeader) IsEmpty() bool {
+	// NB: We don't use a struct comparison like h == MVCCValueHeader{} due to a
+	// Go 1.19 performance regression, see:
+	// https://github.com/cockroachdb/cockroach/issues/88818
+	return h.LocalTimestamp.IsEmpty()
+}

--- a/pkg/storage/enginepb/mvcc3.proto
+++ b/pkg/storage/enginepb/mvcc3.proto
@@ -142,6 +142,8 @@ message IgnoredSeqNumRange {
 
 // MVCCValueHeader holds MVCC-level metadata for a versioned value.
 // Used by storage.MVCCValue.
+//
+// NB: Make sure to update MVCCValueHeader.IsEmpty() when adding fields.
 message MVCCValueHeader {
   option (gogoproto.equal) = true;
 

--- a/pkg/storage/mvcc_value.go
+++ b/pkg/storage/mvcc_value.go
@@ -146,42 +146,20 @@ var disableSimpleValueEncoding = util.ConstantWithMetamorphicTestBool(
 	"mvcc-value-disable-simple-encoding", false)
 
 // DisableMetamorphicSimpleValueEncoding disables the disableSimpleValueEncoding
-// metamorphic bool and emptyValueHeader value for the duration of a test,
-// resetting it at the end.
-func DisableMetamorphicSimpleValueEncoding(t *testing.T) {
+// metamorphic bool for the duration of a test, resetting it at the end.
+func DisableMetamorphicSimpleValueEncoding(t testing.TB) {
 	t.Helper()
 	if disableSimpleValueEncoding {
 		disableSimpleValueEncoding = false
-		oldHeader := emptyValueHeader
-		emptyValueHeader = enginepb.MVCCValueHeader{}
-
 		t.Cleanup(func() {
 			disableSimpleValueEncoding = true
-			emptyValueHeader = oldHeader
 		})
 	}
 }
 
-var emptyValueHeader = func() enginepb.MVCCValueHeader {
-	var h enginepb.MVCCValueHeader
-	// Hacky: we don't have room in the mid-stack inlining budget in either
-	// encodedMVCCValueSize or EncodeMVCCValue to add to the simple encoding
-	// condition (e.g. `&& !disableSimpleValueEncoding`). So to have the same
-	// effect, we replace the empty value header with a header we never expect
-	// to see. We never expect LocalTimestamp to be set to MaxClockTimestamp
-	// because if it was set to that value, LocalTimestampNeeded would never
-	// return true.
-	if disableSimpleValueEncoding {
-		h.LocalTimestamp = hlc.MaxClockTimestamp
-	}
-	return h
-}()
-
 // encodedMVCCValueSize returns the size of the MVCCValue when encoded.
-//
-//gcassert:inline
 func encodedMVCCValueSize(v MVCCValue) int {
-	if v.MVCCValueHeader == emptyValueHeader {
+	if v.MVCCValueHeader.IsEmpty() && !disableSimpleValueEncoding {
 		return len(v.Value.RawBytes)
 	}
 	return extendedPreludeSize + v.MVCCValueHeader.Size() + len(v.Value.RawBytes)
@@ -190,22 +168,20 @@ func encodedMVCCValueSize(v MVCCValue) int {
 // EncodeMVCCValue encodes an MVCCValue into its Pebble representation. See the
 // comment on MVCCValue for a description of the encoding scheme.
 //
-//gcassert:inline
+// TODO(erikgrinaker): This could mid-stack inline when we compared
+// v.MVCCValueHeader == enginepb.MVCCValueHeader{} instead of IsEmpty(), but
+// struct comparisons have a significant performance regression in Go 1.19 which
+// negates the inlining gain. Reconsider this with Go 1.20. See:
+// https://github.com/cockroachdb/cockroach/issues/88818
 func EncodeMVCCValue(v MVCCValue) ([]byte, error) {
-	if v.MVCCValueHeader == emptyValueHeader {
+	if v.MVCCValueHeader.IsEmpty() && !disableSimpleValueEncoding {
 		// Simple encoding. Use the roachpb.Value encoding directly with no
 		// modification. No need to re-allocate or copy.
 		return v.Value.RawBytes, nil
 	}
+
 	// Extended encoding. Wrap the roachpb.Value encoding with a header containing
 	// MVCC-level metadata. Requires a re-allocation and copy.
-	return encodeExtendedMVCCValue(v)
-}
-
-// encodeExtendedMVCCValue implements the extended MVCCValue encoding. It is
-// split from EncodeMVCCValue to allow that function to qualify for mid-stack
-// inlining, which avoids a function call for the simple encoding.
-func encodeExtendedMVCCValue(v MVCCValue) ([]byte, error) {
 	headerLen := v.MVCCValueHeader.Size()
 	headerSize := extendedPreludeSize + headerLen
 	valueSize := headerSize + len(v.Value.RawBytes)

--- a/pkg/storage/mvcc_value_test.go
+++ b/pkg/storage/mvcc_value_test.go
@@ -183,6 +183,7 @@ var mvccValueBenchmarkConfigs = struct {
 }
 
 func BenchmarkEncodeMVCCValue(b *testing.B) {
+	DisableMetamorphicSimpleValueEncoding(b)
 	cfg := mvccValueBenchmarkConfigs
 	for hDesc, h := range cfg.headers {
 		for vDesc, v := range cfg.values {


### PR DESCRIPTION
In Go 1.19, struct comparisons saw a significant performance regression, apparently due to the use of `memeqbody`. This patch changes `EncodeMVCCValue` to use field comparisons instead of struct comparisons, which yields a significant performance gain.

Unfortunately, this prevents mid-stack inlining. However, the struct comparison regression is significantly larger than the inlining gains. We should reconsider this once Go 1.20 lands, where the regression has been fixed.

```
name                                                              old time/op  new time/op  delta
EncodeMVCCValue/header=empty/value=tombstone-24                   5.96ns ± 1%  4.66ns ± 0%  -21.85%  (p=0.000 n=9+9)
EncodeMVCCValue/header=empty/value=short-24                       5.93ns ± 0%  4.66ns ± 0%  -21.40%  (p=0.000 n=9+9)
EncodeMVCCValue/header=empty/value=long-24                        5.92ns ± 0%  4.66ns ± 0%  -21.31%  (p=0.000 n=10+10)
EncodeMVCCValue/header=local_walltime/value=tombstone-24          51.9ns ± 1%  49.5ns ± 1%   -4.81%  (p=0.000 n=9+10)
EncodeMVCCValue/header=local_walltime/value=short-24              54.2ns ± 1%  52.5ns ± 1%   -3.25%  (p=0.000 n=10+10)
EncodeMVCCValue/header=local_walltime/value=long-24               1.34µs ± 2%  1.36µs ± 1%   +1.69%  (p=0.001 n=10+9)
EncodeMVCCValue/header=local_walltime+logical/value=tombstone-24  56.3ns ± 0%  53.3ns ± 1%   -5.40%  (p=0.000 n=10+10)
EncodeMVCCValue/header=local_walltime+logical/value=short-24      58.8ns ± 0%  56.3ns ± 2%   -4.18%  (p=0.000 n=10+9)
EncodeMVCCValue/header=local_walltime+logical/value=long-24       1.36µs ± 3%  1.36µs ± 1%     ~     (p=0.269 n=10+9)
```

Resolves #88818.

Release note: None