### PR TITLE
release-21.2: roachtest: use highmem instances for some tests

### DIFF
--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -41,6 +41,7 @@ type ClusterSpec struct {
 	NodeCount    int
 	// CPUs is the number of CPUs per node.
 	CPUs           int
+	HighMem        bool
 	SSDs           int
 	VolumeSize     int
 	PreferLocalSSD bool
@@ -77,6 +78,9 @@ func ClustersCompatible(s1, s2 ClusterSpec) bool {
 // String implements fmt.Stringer.
 func (s ClusterSpec) String() string {
 	str := fmt.Sprintf("n%dcpu%d", s.NodeCount, s.CPUs)
+	if s.HighMem {
+		str += "m"
+	}
 	if s.Geo {
 		str += "-Geo"
 	}
@@ -111,11 +115,11 @@ func (s *ClusterSpec) Args(extra ...string) ([]string, error) {
 			// based on the cloud and CPU count.
 			switch s.Cloud {
 			case AWS:
-				machineType = AWSMachineType(s.CPUs)
+				machineType = AWSMachineType(s.CPUs, s.HighMem)
 			case GCE:
-				machineType = GCEMachineType(s.CPUs)
+				machineType = GCEMachineType(s.CPUs, s.HighMem)
 			case Azure:
-				machineType = AzureMachineType(s.CPUs)
+				machineType = AzureMachineType(s.CPUs, s.HighMem)
 			case Local:
 			// Don't need to set machineType.
 			default:

--- a/pkg/cmd/roachtest/spec/machine_type.go
+++ b/pkg/cmd/roachtest/spec/machine_type.go
@@ -37,11 +37,11 @@ func AWSMachineType(cpus int) string {
 
 // GCEMachineType selects a machine type given the desired number of CPUs.
 func GCEMachineType(cpus int) string {
-	// TODO(peter): This is awkward: below 16 cpus, use n1-standard so that the
-	// machines have a decent amount of RAM. We could use customer machine
+	// TODO(peter): This is awkward: at or below 16 cpus, use n1-standard so that
+	// the machines have a decent amount of RAM. We could use custom machine
 	// configurations, but the rules for the amount of RAM per CPU need to be
 	// determined (you can't request any arbitrary amount of RAM).
-	if cpus < 16 {
+	if cpus <= 16 {
 		return fmt.Sprintf("n1-standard-%d", cpus)
 	}
 	return fmt.Sprintf("n1-highcpu-%d", cpus)

--- a/pkg/cmd/roachtest/spec/option.go
+++ b/pkg/cmd/roachtest/spec/option.go
@@ -28,6 +28,17 @@ func CPU(n int) Option {
 	return nodeCPUOption(n)
 }
 
+type nodeHighMemOption bool
+
+func (o nodeHighMemOption) apply(spec *ClusterSpec) {
+	spec.HighMem = bool(o)
+}
+
+// HighMem requests nodes with additional memory per CPU.
+func HighMem(enabled bool) Option {
+	return nodeHighMemOption(enabled)
+}
+
 type volumeSizeOption int
 
 func (o volumeSizeOption) apply(spec *ClusterSpec) {

--- a/pkg/cmd/roachtest/spec/testdata/collected_specs.txt
+++ b/pkg/cmd/roachtest/spec/testdata/collected_specs.txt
@@ -1,438 +1,438 @@
 print-args-for-all
 ----
-1: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:9, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+1: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:9, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
-2: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:3, CPUs:2, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+2: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:3, CPUs:2, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-2 --lifetime=12h0m0s
-3: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:6, CPUs:2, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-east1-b,us-east1-b,us-east1-b,us-west1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+3: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:6, CPUs:2, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-east1-b,us-east1-b,us-east1-b,us-west1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-2 --gce-zones=us-east1-b,us-east1-b,us-east1-b,us-west1-b,us-west1-b,europe-west2-b --geo --lifetime=12h0m0s
-4: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:9, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+4: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:9, CPUs:8, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-8 --lifetime=12h0m0s
-5: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:7, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-central1-a,us-central1-b,us-central1-c", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+5: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:7, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-central1-a,us-central1-b,us-central1-c", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-16 --gce-zones=us-central1-a,us-central1-b,us-central1-c --geo --lifetime=12h0m0s
-6: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:32, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+6: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:32, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-highcpu-32 --lifetime=12h0m0s
-7: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:1, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyTagged{Tag:"offset-injector"}, FileSystem:0, RandomlyUseZfs:false}
+7: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:1, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyTagged{Tag:"offset-injector"}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
-8: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:32, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+8: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:32, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
-9: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:6, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyTagged{Tag:"jepsen"}, FileSystem:0, RandomlyUseZfs:false}
+9: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:6, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyTagged{Tag:"jepsen"}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
-10: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:2, CPUs:32, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+10: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:2, CPUs:32, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-highcpu-32 --lifetime=12h0m0s
-11: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:5, CPUs:96, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+11: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:5, CPUs:96, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-highcpu-96 --lifetime=12h0m0s
-12: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:6, CPUs:16, SSDs:0, VolumeSize:2500, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+12: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:6, CPUs:16, HighMem:false, SSDs:0, VolumeSize:2500, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-16 --gce-pd-volume-size=2500 --lifetime=12h0m0s
-13: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:9, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-central1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+13: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:9, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-central1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-4 --gce-zones=us-central1-b,us-west1-b,europe-west2-b --geo --lifetime=12h0m0s
-14: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+14: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-16 --lifetime=12h0m0s
-15: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:1, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+15: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:1, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-16 --lifetime=12h0m0s
-16: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:8, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"europe-west2-b,europe-west4-b,asia-northeast1-b,us-west1-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+16: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:8, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"europe-west2-b,europe-west4-b,asia-northeast1-b,us-west1-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-16 --gce-zones=europe-west2-b,europe-west4-b,asia-northeast1-b,us-west1-b --geo --lifetime=12h0m0s
-17: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+17: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:8, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-8 --lifetime=12h0m0s
-18: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:33, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+18: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:33, CPUs:8, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-8 --lifetime=12h0m0s
-19: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:7, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+19: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:7, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
-20: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:3, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-east1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+20: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:3, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-east1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-4 --gce-zones=us-east1-b,us-west1-b,europe-west2-b --geo --lifetime=12h0m0s
-21: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:10, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+21: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:10, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
-22: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:5, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+22: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:5, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-16 --lifetime=12h0m0s
-23: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:11, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+23: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:11, CPUs:8, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-8 --lifetime=12h0m0s
-24: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:9, CPUs:1, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+24: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:9, CPUs:1, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-1 --lifetime=12h0m0s
-25: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:6, CPUs:32, SSDs:2, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+25: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:6, CPUs:32, HighMem:false, SSDs:2, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-highcpu-32 --gce-local-ssd-count=2 --gce-enable-multiple-stores=true --lifetime=12h0m0s
-26: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:10, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+26: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:10, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-16 --lifetime=12h0m0s
-27: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:96, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+27: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:96, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-highcpu-96 --lifetime=12h0m0s
-28: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:4, SSDs:1, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+28: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:4, HighMem:false, SSDs:1, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-4 --gce-local-ssd-count=1 --gce-enable-multiple-stores=true --lifetime=12h0m0s
-29: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:2, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+29: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:2, CPUs:8, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-8 --lifetime=12h0m0s
-30: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:8, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+30: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:8, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
-31: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:5, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+31: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:5, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
-32: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:13, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+32: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:13, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-16 --lifetime=12h0m0s
-33: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+33: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
-34: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:3, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+34: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:3, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
-35: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:12, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-east1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+35: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:12, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-east1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-4 --gce-zones=us-east1-b,us-west1-b,europe-west2-b --geo --lifetime=12h0m0s
-36: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:6, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+36: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:6, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
-37: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:7, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-east1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+37: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:7, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-east1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-16 --gce-zones=us-east1-b,us-west1-b,europe-west2-b --geo --lifetime=12h0m0s
-38: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:21, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+38: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:21, CPUs:8, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-8 --lifetime=12h0m0s
-39: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:6, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+39: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:6, CPUs:8, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-8 --lifetime=12h0m0s
-40: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:2, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+40: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:2, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
-41: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:1, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+41: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:1, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
-42: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:10, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-east1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+42: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:10, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-east1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-4 --gce-zones=us-east1-b,us-west1-b,europe-west2-b --geo --lifetime=12h0m0s
-43: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:1, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyNone{}, FileSystem:0, RandomlyUseZfs:false}
+43: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:1, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyNone{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
-44: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:4, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+44: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:4, CPUs:8, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.2xlarge --lifetime=12h0m0s
-45: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:21, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+45: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:21, CPUs:8, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.2xlarge --lifetime=12h0m0s
-46: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:7, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+46: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:7, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.xlarge --lifetime=12h0m0s
-47: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:1, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyNone{}, FileSystem:0, RandomlyUseZfs:false}
+47: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:1, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyNone{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.xlarge --lifetime=12h0m0s
-48: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:1, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+48: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:1, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.xlarge --lifetime=12h0m0s
-49: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:4, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+49: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:4, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.4xlarge --lifetime=12h0m0s
-50: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:9, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+50: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:9, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.xlarge --lifetime=12h0m0s
-51: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:8, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"europe-west2-b,europe-west4-b,asia-northeast1-b,us-west1-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+51: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:8, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"europe-west2-b,europe-west4-b,asia-northeast1-b,us-west1-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.4xlarge --aws-zones=europe-west2-b,europe-west4-b,asia-northeast1-b,us-west1-b --geo --lifetime=12h0m0s
-52: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:33, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+52: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:33, CPUs:8, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.2xlarge --lifetime=12h0m0s
-53: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:10, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-east1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+53: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:10, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-east1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.xlarge --aws-zones=us-east1-b,us-west1-b,europe-west2-b --geo --lifetime=12h0m0s
-54: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:6, CPUs:32, SSDs:2, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+54: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:6, CPUs:32, HighMem:false, SSDs:2, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   specifying SSD count is not yet supported on aws
-55: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:1, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+55: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:1, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.4xlarge --lifetime=12h0m0s
-56: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:2, CPUs:32, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+56: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:2, CPUs:32, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.9xlarge --lifetime=12h0m0s
-57: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:5, CPUs:96, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+57: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:5, CPUs:96, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=m5d.24xlarge --lifetime=12h0m0s
-58: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:2, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+58: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:2, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.xlarge --lifetime=12h0m0s
-59: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:9, CPUs:1, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+59: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:9, CPUs:1, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.large --lifetime=12h0m0s
-60: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:11, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+60: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:11, CPUs:8, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.2xlarge --lifetime=12h0m0s
-61: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:5, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+61: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:5, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.4xlarge --lifetime=12h0m0s
-62: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:9, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-central1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+62: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:9, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-central1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.xlarge --aws-zones=us-central1-b,us-west1-b,europe-west2-b --geo --lifetime=12h0m0s
-63: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:1, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyTagged{Tag:"offset-injector"}, FileSystem:0, RandomlyUseZfs:false}
+63: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:1, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyTagged{Tag:"offset-injector"}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.xlarge --lifetime=12h0m0s
-64: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:3, CPUs:2, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+64: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:3, CPUs:2, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.large --lifetime=12h0m0s
-65: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:32, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+65: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:32, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.xlarge --lifetime=12h0m0s
-66: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:6, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyTagged{Tag:"jepsen"}, FileSystem:0, RandomlyUseZfs:false}
+66: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:6, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyTagged{Tag:"jepsen"}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.xlarge --lifetime=12h0m0s
-67: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:2, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+67: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:2, CPUs:8, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.2xlarge --lifetime=12h0m0s
-68: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:13, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+68: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:13, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.4xlarge --lifetime=12h0m0s
-69: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:6, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+69: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:6, CPUs:8, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.2xlarge --lifetime=12h0m0s
-70: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:7, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-central1-a,us-central1-b,us-central1-c", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+70: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:7, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-central1-a,us-central1-b,us-central1-c", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.4xlarge --aws-zones=us-central1-a,us-central1-b,us-central1-c --geo --lifetime=12h0m0s
-71: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:8, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+71: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:8, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.xlarge --lifetime=12h0m0s
-72: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:5, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+72: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:5, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.xlarge --lifetime=12h0m0s
-73: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:3, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+73: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:3, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.xlarge --lifetime=12h0m0s
-74: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:6, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+74: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:6, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.xlarge --lifetime=12h0m0s
-75: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:4, CPUs:96, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+75: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:4, CPUs:96, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=m5d.24xlarge --lifetime=12h0m0s
-76: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:4, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+76: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:4, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.xlarge --lifetime=12h0m0s
-77: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:6, CPUs:2, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-east1-b,us-east1-b,us-east1-b,us-west1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+77: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:6, CPUs:2, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-east1-b,us-east1-b,us-east1-b,us-west1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.large --aws-zones=us-east1-b,us-east1-b,us-east1-b,us-west1-b,us-west1-b,europe-west2-b --geo --lifetime=12h0m0s
-78: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:4, CPUs:32, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+78: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:4, CPUs:32, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.9xlarge --lifetime=12h0m0s
-79: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:12, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-east1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+79: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:12, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-east1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.xlarge --aws-zones=us-east1-b,us-west1-b,europe-west2-b --geo --lifetime=12h0m0s
-80: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:6, CPUs:16, SSDs:0, VolumeSize:2500, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+80: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:6, CPUs:16, HighMem:false, SSDs:0, VolumeSize:2500, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   specifying volume size is not yet supported on aws
-81: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:3, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-east-2b,us-west-1a,eu-west-1a", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+81: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:3, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-east-2b,us-west-1a,eu-west-1a", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.xlarge --aws-zones=us-east-2b,us-west-1a,eu-west-1a --geo --lifetime=12h0m0s
-82: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:10, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+82: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:10, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.xlarge --lifetime=12h0m0s
-83: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:10, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+83: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:10, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.4xlarge --lifetime=12h0m0s
-84: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:7, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-east-2b,us-west-1a,eu-west-1a", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+84: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:7, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-east-2b,us-west-1a,eu-west-1a", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.4xlarge --aws-zones=us-east-2b,us-west-1a,eu-west-1a --geo --lifetime=12h0m0s
-85: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:9, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+85: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:9, CPUs:8, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=true --aws-machine-type-ssd=c5d.2xlarge --lifetime=12h0m0s
-86: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:4, CPUs:4, SSDs:1, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+86: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:4, CPUs:4, HighMem:false, SSDs:1, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   specifying SSD count is not yet supported on aws
-87: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:9, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+87: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:9, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
-88: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:3, CPUs:2, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+88: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:3, CPUs:2, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-2 --lifetime=12h0m0s
-89: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:6, CPUs:2, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"us-east1-b,us-east1-b,us-east1-b,us-west1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+89: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:6, CPUs:2, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"us-east1-b,us-east1-b,us-east1-b,us-west1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-2 --gce-zones=us-east1-b,us-east1-b,us-east1-b,us-west1-b,us-west1-b,europe-west2-b --geo --lifetime=12h0m0s
-90: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:9, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+90: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:9, CPUs:8, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-8 --lifetime=12h0m0s
-91: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:7, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"us-central1-a,us-central1-b,us-central1-c", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+91: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:7, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"us-central1-a,us-central1-b,us-central1-c", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-16 --gce-zones=us-central1-a,us-central1-b,us-central1-c --geo --lifetime=12h0m0s
-92: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:32, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+92: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:32, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-highcpu-32 --lifetime=12h0m0s
-93: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:1, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyTagged{Tag:"offset-injector"}, FileSystem:0, RandomlyUseZfs:false}
+93: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:1, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyTagged{Tag:"offset-injector"}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
-94: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:32, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+94: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:32, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
-95: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:6, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyTagged{Tag:"jepsen"}, FileSystem:0, RandomlyUseZfs:false}
+95: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:6, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyTagged{Tag:"jepsen"}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
-96: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:2, CPUs:32, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+96: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:2, CPUs:32, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-highcpu-32 --lifetime=12h0m0s
-97: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:5, CPUs:96, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+97: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:5, CPUs:96, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-highcpu-96 --lifetime=12h0m0s
-98: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:6, CPUs:16, SSDs:0, VolumeSize:2500, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+98: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:6, CPUs:16, HighMem:false, SSDs:0, VolumeSize:2500, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-16 --gce-pd-volume-size=2500 --lifetime=12h0m0s
-99: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:9, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"us-central1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+99: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:9, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"us-central1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-4 --gce-zones=us-central1-b,us-west1-b,europe-west2-b --geo --lifetime=12h0m0s
-100: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+100: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-16 --lifetime=12h0m0s
-101: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:1, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+101: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:1, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-16 --lifetime=12h0m0s
-102: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:8, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"europe-west2-b,europe-west4-b,asia-northeast1-b,us-west1-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+102: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:8, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"europe-west2-b,europe-west4-b,asia-northeast1-b,us-west1-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-16 --gce-zones=europe-west2-b,europe-west4-b,asia-northeast1-b,us-west1-b --geo --lifetime=12h0m0s
-103: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+103: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:8, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-8 --lifetime=12h0m0s
-104: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:33, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+104: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:33, CPUs:8, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-8 --lifetime=12h0m0s
-105: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:7, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+105: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:7, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
-106: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:3, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"us-east1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+106: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:3, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"us-east1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-4 --gce-zones=us-east1-b,us-west1-b,europe-west2-b --geo --lifetime=12h0m0s
-107: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:10, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+107: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:10, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
-108: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:5, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+108: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:5, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-16 --lifetime=12h0m0s
-109: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:11, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+109: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:11, CPUs:8, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-8 --lifetime=12h0m0s
-110: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:9, CPUs:1, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+110: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:9, CPUs:1, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-1 --lifetime=12h0m0s
-111: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:6, CPUs:32, SSDs:2, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+111: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:6, CPUs:32, HighMem:false, SSDs:2, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-highcpu-32 --lifetime=12h0m0s
-112: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:10, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+112: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:10, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-16 --lifetime=12h0m0s
-113: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:96, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+113: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:96, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-highcpu-96 --lifetime=12h0m0s
-114: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:4, SSDs:1, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+114: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:4, HighMem:false, SSDs:1, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
-115: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:2, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+115: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:2, CPUs:8, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-8 --lifetime=12h0m0s
-116: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:8, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+116: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:8, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
-117: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:5, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+117: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:5, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
-118: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:13, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+118: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:13, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-16 --lifetime=12h0m0s
-119: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+119: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
-120: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:3, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+120: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:3, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
-121: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:12, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"us-east1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+121: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:12, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"us-east1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-4 --gce-zones=us-east1-b,us-west1-b,europe-west2-b --geo --lifetime=12h0m0s
-122: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:6, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+122: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:6, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
-123: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:7, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"us-east1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+123: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:7, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"us-east1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-16 --gce-zones=us-east1-b,us-west1-b,europe-west2-b --geo --lifetime=12h0m0s
-124: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:21, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+124: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:21, CPUs:8, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-8 --lifetime=12h0m0s
-125: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:6, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+125: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:6, CPUs:8, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-8 --lifetime=12h0m0s
-126: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:2, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+126: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:2, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
-127: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:1, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+127: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:1, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
-128: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:10, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"us-east1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+128: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:10, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"us-east1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-4 --gce-zones=us-east1-b,us-west1-b,europe-west2-b --geo --lifetime=12h0m0s
-129: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:1, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyNone{}, FileSystem:0, RandomlyUseZfs:false}
+129: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:1, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyNone{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
-130: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:4, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+130: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:4, CPUs:8, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.2xlarge --lifetime=12h0m0s
-131: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:21, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+131: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:21, CPUs:8, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.2xlarge --lifetime=12h0m0s
-132: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:7, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+132: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:7, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.xlarge --lifetime=12h0m0s
-133: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:1, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyNone{}, FileSystem:0, RandomlyUseZfs:false}
+133: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:1, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyNone{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.xlarge --lifetime=12h0m0s
-134: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:1, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+134: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:1, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.xlarge --lifetime=12h0m0s
-135: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:4, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+135: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:4, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.4xlarge --lifetime=12h0m0s
-136: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:9, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+136: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:9, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.xlarge --lifetime=12h0m0s
-137: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:8, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"europe-west2-b,europe-west4-b,asia-northeast1-b,us-west1-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+137: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:8, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"europe-west2-b,europe-west4-b,asia-northeast1-b,us-west1-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.4xlarge --aws-zones=europe-west2-b,europe-west4-b,asia-northeast1-b,us-west1-b --geo --lifetime=12h0m0s
-138: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:33, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+138: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:33, CPUs:8, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.2xlarge --lifetime=12h0m0s
-139: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:10, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"us-east1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+139: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:10, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"us-east1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.xlarge --aws-zones=us-east1-b,us-west1-b,europe-west2-b --geo --lifetime=12h0m0s
-140: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:6, CPUs:32, SSDs:2, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+140: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:6, CPUs:32, HighMem:false, SSDs:2, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.9xlarge --lifetime=12h0m0s
-141: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:1, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+141: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:1, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.4xlarge --lifetime=12h0m0s
-142: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:2, CPUs:32, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+142: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:2, CPUs:32, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.9xlarge --lifetime=12h0m0s
-143: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:5, CPUs:96, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+143: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:5, CPUs:96, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=m5d.24xlarge --lifetime=12h0m0s
-144: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:2, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+144: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:2, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.xlarge --lifetime=12h0m0s
-145: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:9, CPUs:1, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+145: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:9, CPUs:1, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.large --lifetime=12h0m0s
-146: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:11, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+146: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:11, CPUs:8, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.2xlarge --lifetime=12h0m0s
-147: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:5, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+147: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:5, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.4xlarge --lifetime=12h0m0s
-148: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:9, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"us-central1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+148: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:9, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"us-central1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.xlarge --aws-zones=us-central1-b,us-west1-b,europe-west2-b --geo --lifetime=12h0m0s
-149: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:1, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyTagged{Tag:"offset-injector"}, FileSystem:0, RandomlyUseZfs:false}
+149: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:1, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyTagged{Tag:"offset-injector"}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.xlarge --lifetime=12h0m0s
-150: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:3, CPUs:2, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+150: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:3, CPUs:2, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.large --lifetime=12h0m0s
-151: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:32, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+151: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:32, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.xlarge --lifetime=12h0m0s
-152: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:6, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyTagged{Tag:"jepsen"}, FileSystem:0, RandomlyUseZfs:false}
+152: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:6, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyTagged{Tag:"jepsen"}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.xlarge --lifetime=12h0m0s
-153: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:2, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+153: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:2, CPUs:8, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.2xlarge --lifetime=12h0m0s
-154: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:13, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+154: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:13, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.4xlarge --lifetime=12h0m0s
-155: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:6, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+155: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:6, CPUs:8, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.2xlarge --lifetime=12h0m0s
-156: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:7, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"us-central1-a,us-central1-b,us-central1-c", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+156: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:7, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"us-central1-a,us-central1-b,us-central1-c", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.4xlarge --aws-zones=us-central1-a,us-central1-b,us-central1-c --geo --lifetime=12h0m0s
-157: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:8, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+157: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:8, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.xlarge --lifetime=12h0m0s
-158: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:5, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+158: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:5, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.xlarge --lifetime=12h0m0s
-159: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:3, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+159: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:3, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.xlarge --lifetime=12h0m0s
-160: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:6, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+160: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:6, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.xlarge --lifetime=12h0m0s
-161: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:4, CPUs:96, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+161: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:4, CPUs:96, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=m5d.24xlarge --lifetime=12h0m0s
-162: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:4, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+162: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:4, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.xlarge --lifetime=12h0m0s
-163: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:6, CPUs:2, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"us-east1-b,us-east1-b,us-east1-b,us-west1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+163: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:6, CPUs:2, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"us-east1-b,us-east1-b,us-east1-b,us-west1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.large --aws-zones=us-east1-b,us-east1-b,us-east1-b,us-west1-b,us-west1-b,europe-west2-b --geo --lifetime=12h0m0s
-164: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:4, CPUs:32, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+164: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:4, CPUs:32, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.9xlarge --lifetime=12h0m0s
-165: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:12, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"us-east1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+165: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:12, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"us-east1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.xlarge --aws-zones=us-east1-b,us-west1-b,europe-west2-b --geo --lifetime=12h0m0s
-166: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:6, CPUs:16, SSDs:0, VolumeSize:2500, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+166: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:6, CPUs:16, HighMem:false, SSDs:0, VolumeSize:2500, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   specifying volume size is not yet supported on aws
-167: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:3, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"us-east-2b,us-west-1a,eu-west-1a", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+167: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:3, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"us-east-2b,us-west-1a,eu-west-1a", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.xlarge --aws-zones=us-east-2b,us-west-1a,eu-west-1a --geo --lifetime=12h0m0s
-168: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:10, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+168: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:10, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.xlarge --lifetime=12h0m0s
-169: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:10, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+169: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:10, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.4xlarge --lifetime=12h0m0s
-170: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:7, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"us-east-2b,us-west-1a,eu-west-1a", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+170: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:7, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"us-east-2b,us-west-1a,eu-west-1a", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.4xlarge --aws-zones=us-east-2b,us-west-1a,eu-west-1a --geo --lifetime=12h0m0s
-171: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:9, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+171: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:9, CPUs:8, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.2xlarge --lifetime=12h0m0s
-172: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:4, CPUs:4, SSDs:1, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+172: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:4, CPUs:4, HighMem:false, SSDs:1, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=aws --local-ssd=false --aws-machine-type=c5d.xlarge --lifetime=12h0m0s
-173: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:9, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+173: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:9, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --lifetime=12h0m0s
-174: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:3, CPUs:2, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+174: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:3, CPUs:2, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --lifetime=12h0m0s
-175: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:6, CPUs:2, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-east1-b,us-east1-b,us-east1-b,us-west1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+175: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:6, CPUs:2, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-east1-b,us-east1-b,us-east1-b,us-west1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --geo --lifetime=12h0m0s
-176: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:9, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+176: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:9, CPUs:8, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --lifetime=12h0m0s
-177: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:7, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-central1-a,us-central1-b,us-central1-c", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+177: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:7, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-central1-a,us-central1-b,us-central1-c", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --geo --lifetime=12h0m0s
-178: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:4, CPUs:32, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+178: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:4, CPUs:32, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --lifetime=12h0m0s
-179: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:1, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyTagged{Tag:"offset-injector"}, FileSystem:0, RandomlyUseZfs:false}
+179: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:1, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyTagged{Tag:"offset-injector"}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --lifetime=12h0m0s
-180: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:32, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+180: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:32, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --lifetime=12h0m0s
-181: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:6, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyTagged{Tag:"jepsen"}, FileSystem:0, RandomlyUseZfs:false}
+181: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:6, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyTagged{Tag:"jepsen"}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --lifetime=12h0m0s
-182: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:2, CPUs:32, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+182: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:2, CPUs:32, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --lifetime=12h0m0s
-183: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:5, CPUs:96, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+183: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:5, CPUs:96, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --lifetime=12h0m0s
-184: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:6, CPUs:16, SSDs:0, VolumeSize:2500, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+184: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:6, CPUs:16, HighMem:false, SSDs:0, VolumeSize:2500, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --lifetime=12h0m0s
-185: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:9, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-central1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+185: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:9, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-central1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --geo --lifetime=12h0m0s
-186: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:4, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+186: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:4, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --lifetime=12h0m0s
-187: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:1, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+187: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:1, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --lifetime=12h0m0s
-188: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:8, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"europe-west2-b,europe-west4-b,asia-northeast1-b,us-west1-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+188: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:8, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"europe-west2-b,europe-west4-b,asia-northeast1-b,us-west1-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --geo --lifetime=12h0m0s
-189: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:4, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+189: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:4, CPUs:8, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --lifetime=12h0m0s
-190: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:33, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+190: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:33, CPUs:8, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --lifetime=12h0m0s
-191: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:7, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+191: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:7, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --lifetime=12h0m0s
-192: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:3, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-east1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+192: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:3, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-east1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --geo --lifetime=12h0m0s
-193: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:10, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+193: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:10, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --lifetime=12h0m0s
-194: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:5, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+194: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:5, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --lifetime=12h0m0s
-195: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:11, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+195: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:11, CPUs:8, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --lifetime=12h0m0s
-196: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:9, CPUs:1, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+196: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:9, CPUs:1, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --lifetime=12h0m0s
-197: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:6, CPUs:32, SSDs:2, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+197: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:6, CPUs:32, HighMem:false, SSDs:2, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --lifetime=12h0m0s
-198: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:10, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+198: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:10, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --lifetime=12h0m0s
-199: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:4, CPUs:96, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+199: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:4, CPUs:96, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --lifetime=12h0m0s
-200: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:4, CPUs:4, SSDs:1, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+200: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:4, CPUs:4, HighMem:false, SSDs:1, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --lifetime=12h0m0s
-201: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:2, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+201: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:2, CPUs:8, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --lifetime=12h0m0s
-202: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:8, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+202: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:8, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --lifetime=12h0m0s
-203: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:5, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+203: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:5, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --lifetime=12h0m0s
-204: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:13, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+204: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:13, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --lifetime=12h0m0s
-205: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:4, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+205: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:4, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --lifetime=12h0m0s
-206: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:3, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+206: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:3, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --lifetime=12h0m0s
-207: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:12, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-east1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+207: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:12, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-east1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --geo --lifetime=12h0m0s
-208: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:6, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+208: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:6, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --lifetime=12h0m0s
-209: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:7, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-east1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+209: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:7, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-east1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --geo --lifetime=12h0m0s
-210: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:21, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+210: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:21, CPUs:8, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --lifetime=12h0m0s
-211: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:6, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+211: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:6, CPUs:8, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --lifetime=12h0m0s
-212: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:2, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+212: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:2, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --lifetime=12h0m0s
-213: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:1, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+213: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:1, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --lifetime=12h0m0s
-214: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:10, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-east1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
+214: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:10, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-east1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --geo --lifetime=12h0m0s
-215: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:1, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyNone{}, FileSystem:0, RandomlyUseZfs:false}
+215: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:1, CPUs:4, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyNone{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --lifetime=12h0m0s
-216: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:7, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:1, RandomlyUseZfs:false}
+216: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:7, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:1, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-16 --filesystem=zfs --geo --lifetime=12h0m0s
-217: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:7, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:1, RandomlyUseZfs:false}
+217: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:7, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:1, RandomlyUseZfs:false}
   node creation with zfs file system not yet supported on aws
-218: spec.ClusterSpec{Cloud:"azure", InstanceType:"", NodeCount:7, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:1, RandomlyUseZfs:false}
+218: spec.ClusterSpec{Cloud:"azure", InstanceType:"", NodeCount:7, CPUs:16, HighMem:false, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:1, RandomlyUseZfs:false}
   node creation with zfs file system not yet supported on azure

--- a/pkg/cmd/roachtest/spec/testdata/collected_specs.txt
+++ b/pkg/cmd/roachtest/spec/testdata/collected_specs.txt
@@ -9,7 +9,7 @@ print-args-for-all
 4: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:9, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-8 --lifetime=12h0m0s
 5: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:7, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-central1-a,us-central1-b,us-central1-c", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
-  --clouds=gce --local-ssd=true --gce-machine-type=n1-highcpu-16 --gce-zones=us-central1-a,us-central1-b,us-central1-c --geo --lifetime=12h0m0s
+  --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-16 --gce-zones=us-central1-a,us-central1-b,us-central1-c --geo --lifetime=12h0m0s
 6: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:32, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-highcpu-32 --lifetime=12h0m0s
 7: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:1, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyTagged{Tag:"offset-injector"}, FileSystem:0, RandomlyUseZfs:false}
@@ -23,15 +23,15 @@ print-args-for-all
 11: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:5, CPUs:96, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-highcpu-96 --lifetime=12h0m0s
 12: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:6, CPUs:16, SSDs:0, VolumeSize:2500, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
-  --clouds=gce --local-ssd=false --gce-machine-type=n1-highcpu-16 --gce-pd-volume-size=2500 --lifetime=12h0m0s
+  --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-16 --gce-pd-volume-size=2500 --lifetime=12h0m0s
 13: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:9, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-central1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-4 --gce-zones=us-central1-b,us-west1-b,europe-west2-b --geo --lifetime=12h0m0s
 14: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
-  --clouds=gce --local-ssd=true --gce-machine-type=n1-highcpu-16 --lifetime=12h0m0s
+  --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-16 --lifetime=12h0m0s
 15: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:1, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
-  --clouds=gce --local-ssd=true --gce-machine-type=n1-highcpu-16 --lifetime=12h0m0s
+  --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-16 --lifetime=12h0m0s
 16: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:8, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"europe-west2-b,europe-west4-b,asia-northeast1-b,us-west1-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
-  --clouds=gce --local-ssd=true --gce-machine-type=n1-highcpu-16 --gce-zones=europe-west2-b,europe-west4-b,asia-northeast1-b,us-west1-b --geo --lifetime=12h0m0s
+  --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-16 --gce-zones=europe-west2-b,europe-west4-b,asia-northeast1-b,us-west1-b --geo --lifetime=12h0m0s
 17: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-8 --lifetime=12h0m0s
 18: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:33, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
@@ -43,7 +43,7 @@ print-args-for-all
 21: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:10, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
 22: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:5, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
-  --clouds=gce --local-ssd=true --gce-machine-type=n1-highcpu-16 --lifetime=12h0m0s
+  --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-16 --lifetime=12h0m0s
 23: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:11, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-8 --lifetime=12h0m0s
 24: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:9, CPUs:1, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
@@ -51,7 +51,7 @@ print-args-for-all
 25: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:6, CPUs:32, SSDs:2, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-highcpu-32 --gce-local-ssd-count=2 --gce-enable-multiple-stores=true --lifetime=12h0m0s
 26: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:10, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
-  --clouds=gce --local-ssd=true --gce-machine-type=n1-highcpu-16 --lifetime=12h0m0s
+  --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-16 --lifetime=12h0m0s
 27: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:96, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-highcpu-96 --lifetime=12h0m0s
 28: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:4, SSDs:1, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
@@ -63,7 +63,7 @@ print-args-for-all
 31: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:5, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
 32: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:13, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
-  --clouds=gce --local-ssd=true --gce-machine-type=n1-highcpu-16 --lifetime=12h0m0s
+  --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-16 --lifetime=12h0m0s
 33: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
 34: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:3, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
@@ -73,7 +73,7 @@ print-args-for-all
 36: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:6, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
 37: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:7, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"us-east1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
-  --clouds=gce --local-ssd=true --gce-machine-type=n1-highcpu-16 --gce-zones=us-east1-b,us-west1-b,europe-west2-b --geo --lifetime=12h0m0s
+  --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-16 --gce-zones=us-east1-b,us-west1-b,europe-west2-b --geo --lifetime=12h0m0s
 38: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:21, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-8 --lifetime=12h0m0s
 39: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:6, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
@@ -181,7 +181,7 @@ print-args-for-all
 90: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:9, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-8 --lifetime=12h0m0s
 91: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:7, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"us-central1-a,us-central1-b,us-central1-c", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
-  --clouds=gce --local-ssd=false --gce-machine-type=n1-highcpu-16 --gce-zones=us-central1-a,us-central1-b,us-central1-c --geo --lifetime=12h0m0s
+  --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-16 --gce-zones=us-central1-a,us-central1-b,us-central1-c --geo --lifetime=12h0m0s
 92: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:32, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-highcpu-32 --lifetime=12h0m0s
 93: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:1, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyTagged{Tag:"offset-injector"}, FileSystem:0, RandomlyUseZfs:false}
@@ -195,15 +195,15 @@ print-args-for-all
 97: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:5, CPUs:96, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-highcpu-96 --lifetime=12h0m0s
 98: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:6, CPUs:16, SSDs:0, VolumeSize:2500, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
-  --clouds=gce --local-ssd=false --gce-machine-type=n1-highcpu-16 --gce-pd-volume-size=2500 --lifetime=12h0m0s
+  --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-16 --gce-pd-volume-size=2500 --lifetime=12h0m0s
 99: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:9, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"us-central1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-4 --gce-zones=us-central1-b,us-west1-b,europe-west2-b --geo --lifetime=12h0m0s
 100: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
-  --clouds=gce --local-ssd=false --gce-machine-type=n1-highcpu-16 --lifetime=12h0m0s
+  --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-16 --lifetime=12h0m0s
 101: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:1, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
-  --clouds=gce --local-ssd=false --gce-machine-type=n1-highcpu-16 --lifetime=12h0m0s
+  --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-16 --lifetime=12h0m0s
 102: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:8, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"europe-west2-b,europe-west4-b,asia-northeast1-b,us-west1-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
-  --clouds=gce --local-ssd=false --gce-machine-type=n1-highcpu-16 --gce-zones=europe-west2-b,europe-west4-b,asia-northeast1-b,us-west1-b --geo --lifetime=12h0m0s
+  --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-16 --gce-zones=europe-west2-b,europe-west4-b,asia-northeast1-b,us-west1-b --geo --lifetime=12h0m0s
 103: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-8 --lifetime=12h0m0s
 104: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:33, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
@@ -215,7 +215,7 @@ print-args-for-all
 107: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:10, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
 108: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:5, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
-  --clouds=gce --local-ssd=false --gce-machine-type=n1-highcpu-16 --lifetime=12h0m0s
+  --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-16 --lifetime=12h0m0s
 109: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:11, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-8 --lifetime=12h0m0s
 110: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:9, CPUs:1, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
@@ -223,7 +223,7 @@ print-args-for-all
 111: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:6, CPUs:32, SSDs:2, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-highcpu-32 --lifetime=12h0m0s
 112: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:10, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
-  --clouds=gce --local-ssd=false --gce-machine-type=n1-highcpu-16 --lifetime=12h0m0s
+  --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-16 --lifetime=12h0m0s
 113: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:96, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-highcpu-96 --lifetime=12h0m0s
 114: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:4, SSDs:1, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
@@ -235,7 +235,7 @@ print-args-for-all
 117: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:5, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
 118: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:13, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
-  --clouds=gce --local-ssd=false --gce-machine-type=n1-highcpu-16 --lifetime=12h0m0s
+  --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-16 --lifetime=12h0m0s
 119: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:4, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
 120: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:3, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
@@ -245,7 +245,7 @@ print-args-for-all
 122: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:6, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-4 --lifetime=12h0m0s
 123: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:7, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"us-east1-b,us-west1-b,europe-west2-b", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
-  --clouds=gce --local-ssd=false --gce-machine-type=n1-highcpu-16 --gce-zones=us-east1-b,us-west1-b,europe-west2-b --geo --lifetime=12h0m0s
+  --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-16 --gce-zones=us-east1-b,us-west1-b,europe-west2-b --geo --lifetime=12h0m0s
 124: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:21, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
   --clouds=gce --local-ssd=false --gce-machine-type=n1-standard-8 --lifetime=12h0m0s
 125: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:6, CPUs:8, SSDs:0, VolumeSize:0, PreferLocalSSD:false, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:0, RandomlyUseZfs:false}
@@ -431,7 +431,7 @@ print-args-for-all
 215: spec.ClusterSpec{Cloud:"local", InstanceType:"", NodeCount:1, CPUs:4, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:false, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyNone{}, FileSystem:0, RandomlyUseZfs:false}
   --local-ssd=false --lifetime=12h0m0s
 216: spec.ClusterSpec{Cloud:"gce", InstanceType:"", NodeCount:7, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:1, RandomlyUseZfs:false}
-  --clouds=gce --local-ssd=true --gce-machine-type=n1-highcpu-16 --filesystem=zfs --geo --lifetime=12h0m0s
+  --clouds=gce --local-ssd=true --gce-machine-type=n1-standard-16 --filesystem=zfs --geo --lifetime=12h0m0s
 217: spec.ClusterSpec{Cloud:"aws", InstanceType:"", NodeCount:7, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:1, RandomlyUseZfs:false}
   node creation with zfs file system not yet supported on aws
 218: spec.ClusterSpec{Cloud:"azure", InstanceType:"", NodeCount:7, CPUs:16, SSDs:0, VolumeSize:0, PreferLocalSSD:true, Zones:"", Geo:true, Lifetime:43200000000000, ReusePolicy:spec.ReusePolicyAny{}, FileSystem:1, RandomlyUseZfs:false}

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -438,6 +438,8 @@ func registerRestore(r registry.Registry) {
 			clusterOpts = append(clusterOpts, spec.VolumeSize(largeVolumeSize))
 			testName += fmt.Sprintf("/pd-volume=%dGB", largeVolumeSize)
 		}
+		// Has been seen to OOM: https://github.com/cockroachdb/cockroach/issues/71805
+		clusterOpts = append(clusterOpts, spec.HighMem(true))
 
 		r.Add(registry.TestSpec{
 			Name:    testName,

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -770,6 +770,7 @@ func registerTPCC(r registry.Registry) {
 	registerTPCCBenchSpec(r, tpccBenchSpec{
 		Nodes:        9,
 		CPUs:         4,
+		HighMem:      true, // can OOM otherwise: https://github.com/cockroachdb/cockroach/issues/73376
 		Distribution: multiRegion,
 		LoadConfig:   multiLoadgen,
 
@@ -853,6 +854,7 @@ func (l tpccBenchLoadConfig) numLoadNodes(d tpccBenchDistribution) int {
 type tpccBenchSpec struct {
 	Nodes                   int
 	CPUs                    int
+	HighMem                 bool
 	Chaos                   bool
 	AdmissionControlEnabled bool
 	Distribution            tpccBenchDistribution
@@ -911,7 +913,7 @@ func registerTPCCBenchSpec(r registry.Registry, b tpccBenchSpec) {
 		nameParts = append(nameParts, "admission")
 	}
 
-	opts := []spec.Option{spec.CPU(b.CPUs)}
+	opts := []spec.Option{spec.CPU(b.CPUs), spec.HighMem(b.HighMem)}
 	switch b.Distribution {
 	case singleZone:
 		// No specifier.


### PR DESCRIPTION
Backport:
  * 1/1 commits from "roachtest: use n1-standard for 16-core GCE machines" (#88346)
  * 2/2 commits from "roachtest: use highmem instances for some tests " (#88444)

Please see individual PRs for details.

Resolves #76824.
Resolves #88986.

/cc @cockroachdb/release

Release justification: deflakes tests.