### PR TITLE
changefeedccl: Release overhead allocation

### DIFF
--- a/pkg/ccl/changefeedccl/event_processing.go
+++ b/pkg/ccl/changefeedccl/event_processing.go
@@ -319,9 +319,14 @@ func (c *kvEventToRowConsumer) ConsumeEvent(ctx context.Context, ev kvevent.Even
 			return err
 		}
 	}
+
+	// Since we're done processing/converting this event, and will not use much more
+	// than len(key)+len(bytes) worth of resources, adjust allocation to match.
+	a := ev.DetachAlloc()
+	a.AdjustBytesToTarget(ctx, int64(len(keyCopy)+len(valueCopy)))
+
 	if err := c.sink.EmitRow(
-		ctx, topic,
-		keyCopy, valueCopy, schemaTimestamp, mvccTimestamp, ev.DetachAlloc(),
+		ctx, topic, keyCopy, valueCopy, schemaTimestamp, mvccTimestamp, a,
 	); err != nil {
 		return err
 	}

--- a/pkg/ccl/changefeedccl/kvevent/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/kvevent/BUILD.bazel
@@ -63,6 +63,7 @@ go_test(
         "//pkg/util/quotapool",
         "//pkg/util/randutil",
         "//pkg/util/syncutil",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/ccl/changefeedccl/kvevent/alloc.go
+++ b/pkg/ccl/changefeedccl/kvevent/alloc.go
@@ -46,6 +46,17 @@ func (a *Alloc) Release(ctx context.Context) {
 	a.clear()
 }
 
+// AdjustBytesToTarget adjust byte allocation to the specified target.
+// Target bytes cannot be adjusted to the higher level than the current allocation.
+func (a *Alloc) AdjustBytesToTarget(ctx context.Context, targetBytes int64) {
+	if a.isZero() || targetBytes <= 0 || targetBytes >= a.bytes {
+		return
+	}
+	toRelease := a.bytes - targetBytes
+	a.bytes = targetBytes
+	a.ap.Release(ctx, toRelease, 0)
+}
+
 // Bytes returns the size of this alloc in bytes.
 func (a *Alloc) Bytes() int64 {
 	return a.bytes


### PR DESCRIPTION
To account for the overhead during the encoding stage, we allocate more memory resources than needed
(`changefeed.event_memory_multiplier`).

Those resources are released when they are amitted by the sink.  Some sinks, such as file based sinks, batch many such events (to generate files of target size). This batching, when combined with compression, could result in a situation where maximum of allowed resources, `changefeed.memory.per_changefeed_limit` are all batched, making it impossible to ingest additional events without forcing a sink flush.

The only way to avoid premature forced flush, is to increase the memory limit for changefeed -- but doing so is not without the costs (i.e. more events batched, more pressure on Go GC, etc).

This PR adjust event resources to match the final size of the data that will be emitted into the sink -- that is, we release the overhead back into the pool, once the event processing is done.

Release note: none