### PR TITLE
backupccl: speed up restore-permissions test

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-permissions
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-permissions
@@ -180,6 +180,16 @@ subtest cluster-restore
 new-server name=s2 allow-implicit-access share-io-dir=s1
 ----
 
+# The cluster restore below needs to drop the defaultdb table and can end up
+# waiting up to 5 minutes by default for that to happen.
+#
+# TODO(ssd): We could move this into our test setup code in the driver. But, for
+# reasons that aren't clear to me, other tests that also do cluster retores are
+# not impacted by this.
+exec-sql
+SET CLUSTER SETTING sql.catalog.descriptor_lease_duration = '1s'
+----
+
 exec-sql
 CREATE USER testuser;
 ----


### PR DESCRIPTION
This test does a cluster restore needs to drop the defaultdb. This test was slowed down by having to wait 5m for a lease on defaultdb to expire.

Why doesn't _every_ data-driven test that does a cluster restore hit this same problem? I'm not sure.

I've also increased the rate at which we log that we are waiting on descriptors.

Release note: None