### PR TITLE
release-22.1: sql: fix recording db names with hyphen for idx usage stats

### DIFF
--- a/pkg/sql/scheduledlogging/captured_index_usage_stats.go
+++ b/pkg/sql/scheduledlogging/captured_index_usage_stats.go
@@ -191,14 +191,14 @@ func captureIndexUsageStats(
 		 last_read,
 		 ti.created_at,
      t.schema_name
-		FROM %s.crdb_internal.index_usage_statistics AS us
-		JOIN %s.crdb_internal.table_indexes ti
+	  FROM %[1]s.crdb_internal.index_usage_statistics AS us
+    JOIN %[1]s.crdb_internal.table_indexes ti
 		ON us.index_id = ti.index_id
 		 AND us.table_id = ti.descriptor_id
-    JOIN %s.crdb_internal.tables t 
+    JOIN %[1]s.crdb_internal.tables t 
     ON ti.descriptor_id = t.table_id
-		ORDER BY total_reads ASC;
-	`, databaseName, databaseName, databaseName)
+		ORDER BY total_reads ASC;`,
+			databaseName.String())
 
 		it, err := ie.QueryIteratorEx(
 			ctx,
@@ -247,7 +247,7 @@ func captureIndexUsageStats(
 				IndexID:        uint32(roachpb.IndexID(indexID)),
 				TotalReadCount: uint64(totalReads),
 				LastRead:       lastRead.String(),
-				DatabaseName:   databaseName,
+				DatabaseName:   databaseName.String(),
 				TableName:      string(tableName),
 				IndexName:      string(indexName),
 				IndexType:      string(indexType),
@@ -294,8 +294,8 @@ func logIndexUsageStatsWithDelay(
 	timer.Stop()
 }
 
-func getAllDatabaseNames(ctx context.Context, ie sqlutil.InternalExecutor) ([]string, error) {
-	var allDatabaseNames []string
+func getAllDatabaseNames(ctx context.Context, ie sqlutil.InternalExecutor) (tree.NameList, error) {
+	var allDatabaseNames tree.NameList
 	var ok bool
 	var expectedNumDatums = 1
 
@@ -307,7 +307,7 @@ func getAllDatabaseNames(ctx context.Context, ie sqlutil.InternalExecutor) ([]st
 		`SELECT database_name FROM [SHOW DATABASES]`,
 	)
 	if err != nil {
-		return []string{}, err
+		return tree.NameList{}, err
 	}
 
 	// We have to make sure to close the iterator since we might return from the
@@ -316,13 +316,13 @@ func getAllDatabaseNames(ctx context.Context, ie sqlutil.InternalExecutor) ([]st
 	for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
 		var row tree.Datums
 		if row = it.Cur(); row == nil {
-			return []string{}, errors.New("unexpected null row while capturing index usage stats")
+			return tree.NameList{}, errors.New("unexpected null row while capturing index usage stats")
 		}
 		if row.Len() != expectedNumDatums {
-			return []string{}, errors.Newf("expected %d columns, received %d while capturing index usage stats", expectedNumDatums, row.Len())
+			return tree.NameList{}, errors.Newf("expected %d columns, received %d while capturing index usage stats", expectedNumDatums, row.Len())
 		}
 
-		databaseName := string(tree.MustBeDString(row[0]))
+		databaseName := tree.Name(tree.MustBeDString(row[0]))
 		allDatabaseNames = append(allDatabaseNames, databaseName)
 	}
 	return allDatabaseNames, nil

--- a/pkg/sql/scheduledlogging/captured_index_usage_stats_test.go
+++ b/pkg/sql/scheduledlogging/captured_index_usage_stats_test.go
@@ -116,6 +116,9 @@ func TestCaptureIndexUsageStats(t *testing.T) {
 	db.Exec(t, "CREATE DATABASE test")
 	db.Exec(t, "CREATE DATABASE test2")
 
+	// Test fix for #85577.
+	db.Exec(t, `CREATE DATABASE "test-hyphen"`)
+
 	// Create a table for each database.
 	db.Exec(t, "CREATE TABLE test.test_table (num INT PRIMARY KEY, letter char)")
 	db.Exec(t, "CREATE TABLE test2.test2_table (num INT PRIMARY KEY, letter char)")


### PR DESCRIPTION
Backport 1/1 commits from #87525.

/cc @cockroachdb/release

---

Fixes #85577

This commit fixes a bug where the query constructed during
index usage stats recording failed for db names containing
a hyphen. The db name placeholder is now converted to string
from the `tree.Name`, which should properly escape hyphen
characters for the query.

Release justification: bug fix

Release note (bug fix): index usage stats are properly captured for database names with hyphens
