### PR TITLE
roachtest: add native libraries to test specification and verify

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -186,6 +186,36 @@ func findBinaryOrLibrary(binOrLib string, name string) (string, error) {
 	return filepathAbs(path)
 }
 
+// VerifyLibraries verifies that the required libraries, specified by name, are
+// available for the target environment.
+func VerifyLibraries(requiredLibs []string) error {
+	for _, requiredLib := range requiredLibs {
+		if !contains(libraryFilePaths, libraryNameFromPath, requiredLib) {
+			return errors.Wrap(errors.Errorf("missing required library %s", requiredLib), "cluster.VerifyLibraries")
+		}
+	}
+	return nil
+}
+
+// libraryNameFromPath returns the name of a library without the extension, for a
+// given path.
+func libraryNameFromPath(path string) string {
+	filename := filepath.Base(path)
+	return strings.TrimSuffix(filename, filepath.Ext(filename))
+}
+
+func contains(list []string, transformString func(s string) string, str string) bool {
+	if transformString == nil {
+		transformString = func(s string) string { return s }
+	}
+	for _, element := range list {
+		if transformString(element) == str {
+			return true
+		}
+	}
+	return false
+}
+
 func initBinariesAndLibraries() {
 	// If we're running against an existing "local" cluster, force the local flag
 	// to true in order to get the "local" test configurations.
@@ -1648,13 +1678,14 @@ func (c *clusterImpl) PutE(
 	return errors.Wrap(roachprod.Put(ctx, l, c.MakeNodes(nodes...), src, dest, true /* useTreeDist */), "cluster.PutE")
 }
 
-// PutLibraries inserts all available library files into all nodes on the cluster
+// PutLibraries inserts the specified libraries, by name, into all nodes on the cluster
 // at the specified location.
-func (c *clusterImpl) PutLibraries(ctx context.Context, libraryDir string) error {
+func (c *clusterImpl) PutLibraries(
+	ctx context.Context, libraryDir string, libraries []string,
+) error {
 	if ctx.Err() != nil {
 		return errors.Wrap(ctx.Err(), "cluster.Put")
 	}
-
 	c.status("uploading library files")
 	defer c.status("")
 
@@ -1662,6 +1693,9 @@ func (c *clusterImpl) PutLibraries(ctx context.Context, libraryDir string) error
 		return err
 	}
 	for _, libraryFilePath := range libraryFilePaths {
+		if !contains(libraries, nil, libraryNameFromPath(libraryFilePath)) {
+			continue
+		}
 		putPath := filepath.Join(libraryDir, filepath.Base(libraryFilePath))
 		if err := c.PutE(
 			ctx,

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1683,6 +1683,9 @@ func (c *clusterImpl) PutE(
 func (c *clusterImpl) PutLibraries(
 	ctx context.Context, libraryDir string, libraries []string,
 ) error {
+	if len(libraries) == 0 {
+		return nil
+	}
 	if ctx.Err() != nil {
 		return errors.Wrap(ctx.Err(), "cluster.Put")
 	}

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -41,7 +41,7 @@ type Cluster interface {
 	Get(ctx context.Context, l *logger.Logger, src, dest string, opts ...option.Option) error
 	Put(ctx context.Context, src, dest string, opts ...option.Option)
 	PutE(ctx context.Context, l *logger.Logger, src, dest string, opts ...option.Option) error
-	PutLibraries(ctx context.Context, libraryDir string) error
+	PutLibraries(ctx context.Context, libraryDir string, libraries []string) error
 	Stage(
 		ctx context.Context, l *logger.Logger, application, versionOrSHA, dir string, opts ...option.Option,
 	) error
@@ -71,6 +71,7 @@ type Cluster interface {
 	ExternalPGUrl(ctx context.Context, l *logger.Logger, node option.NodeListOption) ([]string, error)
 
 	// SQL clients to nodes.
+
 	Conn(ctx context.Context, l *logger.Logger, node int) *gosql.DB
 	ConnE(ctx context.Context, l *logger.Logger, node int) (*gosql.DB, error)
 	ConnEAsUser(ctx context.Context, l *logger.Logger, node int, user string) (*gosql.DB, error)

--- a/pkg/cmd/roachtest/cluster_test.go
+++ b/pkg/cmd/roachtest/cluster_test.go
@@ -181,6 +181,8 @@ func TestCmdLogFileName(t *testing.T) {
 }
 
 func TestVerifyLibraries(t *testing.T) {
+	originalLibraryPaths := libraryFilePaths
+	defer func() { libraryFilePaths = originalLibraryPaths }()
 	testCases := []struct {
 		name             string
 		verifyLibs       []string

--- a/pkg/cmd/roachtest/cluster_test.go
+++ b/pkg/cmd/roachtest/cluster_test.go
@@ -19,7 +19,9 @@ import (
 	test2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/util/version"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestClusterNodes(t *testing.T) {
@@ -176,4 +178,58 @@ func TestCmdLogFileName(t *testing.T) {
 		exp,
 		cmdLogFileName(ts, nodes, "./cockroach bla --foo bar"),
 	)
+}
+
+func TestVerifyLibraries(t *testing.T) {
+	testCases := []struct {
+		name             string
+		verifyLibs       []string
+		libraryFilePaths []string
+		expectedError    error
+	}{
+		{
+			name:             "valid nil input",
+			verifyLibs:       nil,
+			libraryFilePaths: []string{"/some/path/lib.so"},
+			expectedError:    nil,
+		},
+		{
+			name:             "no match",
+			verifyLibs:       []string{"required_c"},
+			libraryFilePaths: []string{"/some/path/lib.so"},
+			expectedError: errors.Wrap(errors.Errorf("missing required library %s",
+				"required_c"), "cluster.VerifyLibraries"),
+		},
+		{
+			name:             "no match on nil libs",
+			verifyLibs:       []string{"required_b"},
+			libraryFilePaths: nil,
+			expectedError: errors.Wrap(errors.Errorf("missing required library %s",
+				"required_b"), "cluster.VerifyLibraries"),
+		},
+		{
+			name:             "single match",
+			verifyLibs:       []string{"geos"},
+			libraryFilePaths: []string{"/lib/geos.so"},
+			expectedError:    nil,
+		},
+		{
+			name:             "multiple matches",
+			verifyLibs:       []string{"lib", "ltwo", "geos"},
+			libraryFilePaths: []string{"ltwo.so", "a/geos.so", "/some/path/to/lib.so"},
+			expectedError:    nil,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			libraryFilePaths = tc.libraryFilePaths
+			actualError := VerifyLibraries(tc.verifyLibs)
+			if tc.expectedError == nil {
+				require.NoError(t, actualError)
+			} else {
+				require.NotNil(t, actualError)
+				require.EqualError(t, actualError, tc.expectedError.Error())
+			}
+		})
+	}
 }

--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -20,6 +20,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 )
 
+// LibGEOS is a list of native libraries for libgeos.
+var LibGEOS = []string{"libgeos", "libgeos_c"}
+
 // TestSpec is a spec for a roachtest.
 type TestSpec struct {
 	Skip string // if non-empty, test will be skipped
@@ -43,6 +46,9 @@ type TestSpec struct {
 	Tags []string
 	// Cluster provides the specification for the cluster to use for the test.
 	Cluster spec.ClusterSpec
+	// NativeLibs specifies the native libraries required to be present on
+	// the cluster during execution.
+	NativeLibs []string
 
 	// UseIOBarrier controls the local-ssd-no-ext4-barrier flag passed to
 	// roachprod when creating a cluster. If set, the flag is not passed, and so

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -629,12 +629,7 @@ func (r *testRunner) runWorker(
 			t.spec.Owner = oldOwner
 		} else {
 			c.setTest(t)
-			c.status("copying libraries")
-			if len(t.spec.NativeLibs) != 0 {
-				if err = c.PutLibraries(ctx, "./lib", t.spec.NativeLibs); err != nil {
-					shout(ctx, l, stdout, "Unable to put native libraries due to: %s", err)
-				}
-			}
+			err = c.PutLibraries(ctx, "./lib", t.spec.NativeLibs)
 
 			if err == nil {
 				// Tell the cluster that, from now on, it will be run "on behalf of this

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -553,6 +553,13 @@ func (r *testRunner) runWorker(
 				testToRun.canReuseCluster = false
 			}
 		}
+
+		// Verify that required native libraries are available.
+		if err = VerifyLibraries(testToRun.spec.NativeLibs); err != nil {
+			shout(ctx, l, stdout, "Library verification failed: %s", err)
+			return err
+		}
+
 		var clusterCreateErr error
 
 		if !testToRun.canReuseCluster {
@@ -621,28 +628,37 @@ func (r *testRunner) runWorker(
 			t.spec.Name = oldName
 			t.spec.Owner = oldOwner
 		} else {
-			// Tell the cluster that, from now on, it will be run "on behalf of this
-			// test".
-			c.status("running test")
 			c.setTest(t)
-
-			switch t.Spec().(*registry.TestSpec).EncryptionSupport {
-			case registry.EncryptionAlwaysEnabled:
-				c.encAtRest = true
-			case registry.EncryptionAlwaysDisabled:
-				c.encAtRest = false
-			case registry.EncryptionMetamorphic:
-				// when tests opted-in to metamorphic testing, encryption will
-				// be enabled according to the probability passed to
-				// --metamorphic-encryption-probability
-				c.encAtRest = prng.Float64() < encryptionProbability
+			c.status("copying libraries")
+			if len(t.spec.NativeLibs) != 0 {
+				if err = c.PutLibraries(ctx, "./lib", t.spec.NativeLibs); err != nil {
+					shout(ctx, l, stdout, "Unable to put native libraries due to: %s", err)
+				}
 			}
 
-			wStatus.SetCluster(c)
-			wStatus.SetTest(t, testToRun)
-			wStatus.SetStatus("running test")
+			if err == nil {
+				// Tell the cluster that, from now on, it will be run "on behalf of this
+				// test".
+				c.status("running test")
 
-			err = r.runTest(ctx, t, testToRun.runNum, testToRun.runCount, c, stdout, testL)
+				switch t.Spec().(*registry.TestSpec).EncryptionSupport {
+				case registry.EncryptionAlwaysEnabled:
+					c.encAtRest = true
+				case registry.EncryptionAlwaysDisabled:
+					c.encAtRest = false
+				case registry.EncryptionMetamorphic:
+					// when tests opted-in to metamorphic testing, encryption will
+					// be enabled according to the probability passed to
+					// --metamorphic-encryption-probability
+					c.encAtRest = prng.Float64() < encryptionProbability
+				}
+
+				wStatus.SetCluster(c)
+				wStatus.SetTest(t, testToRun)
+				wStatus.SetStatus("running test")
+
+				err = r.runTest(ctx, t, testToRun.runNum, testToRun.runCount, c, stdout, testL)
+			}
 		}
 
 		if err != nil {

--- a/pkg/cmd/roachtest/tests/activerecord.go
+++ b/pkg/cmd/roachtest/tests/activerecord.go
@@ -44,9 +44,6 @@ func registerActiveRecord(r registry.Registry) {
 		node := c.Node(1)
 		t.Status("setting up cockroach")
 		c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
-		if err := c.PutLibraries(ctx, "./lib"); err != nil {
-			t.Fatal(err)
-		}
 		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.All())
 
 		version, err := fetchCockroachVersion(ctx, t.L(), c, node[0])
@@ -254,10 +251,11 @@ func registerActiveRecord(r registry.Registry) {
 	}
 
 	r.Add(registry.TestSpec{
-		Name:    "activerecord",
-		Owner:   registry.OwnerSQLExperience,
-		Cluster: r.MakeClusterSpec(1),
-		Tags:    []string{`default`, `orm`},
-		Run:     runActiveRecord,
+		Name:       "activerecord",
+		Owner:      registry.OwnerSQLExperience,
+		Cluster:    r.MakeClusterSpec(1),
+		NativeLibs: registry.LibGEOS,
+		Tags:       []string{`default`, `orm`},
+		Run:        runActiveRecord,
 	})
 }

--- a/pkg/cmd/roachtest/tests/costfuzz.go
+++ b/pkg/cmd/roachtest/tests/costfuzz.go
@@ -35,7 +35,7 @@ func registerCostFuzz(r registry.Registry) {
 		RequiresLicense:   true,
 		Tags:              nil,
 		Cluster:           r.MakeClusterSpec(1),
-		NativeLibs:      registry.LibGEOS,
+		NativeLibs:        registry.LibGEOS,
 		Run:               runCostFuzz,
 	})
 }

--- a/pkg/cmd/roachtest/tests/costfuzz.go
+++ b/pkg/cmd/roachtest/tests/costfuzz.go
@@ -35,6 +35,7 @@ func registerCostFuzz(r registry.Registry) {
 		RequiresLicense:   true,
 		Tags:              nil,
 		Cluster:           r.MakeClusterSpec(1),
+		NativeLibs:      registry.LibGEOS,
 		Run:               runCostFuzz,
 	})
 }

--- a/pkg/cmd/roachtest/tests/hibernate.go
+++ b/pkg/cmd/roachtest/tests/hibernate.go
@@ -80,9 +80,6 @@ func registerHibernate(r registry.Registry, opt hibernateOptions) {
 		node := c.Node(1)
 		t.Status("setting up cockroach")
 		c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
-		if err := c.PutLibraries(ctx, "./lib"); err != nil {
-			t.Fatal(err)
-		}
 		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.All())
 
 		if opt.dbSetupFunc != nil {
@@ -237,10 +234,11 @@ func registerHibernate(r registry.Registry, opt hibernateOptions) {
 	}
 
 	r.Add(registry.TestSpec{
-		Name:    opt.testName,
-		Owner:   registry.OwnerSQLExperience,
-		Cluster: r.MakeClusterSpec(1),
-		Tags:    []string{`default`, `orm`},
+		Name:       opt.testName,
+		Owner:      registry.OwnerSQLExperience,
+		Cluster:    r.MakeClusterSpec(1),
+		NativeLibs: registry.LibGEOS,
+		Tags:       []string{`default`, `orm`},
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runHibernate(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/knex.go
+++ b/pkg/cmd/roachtest/tests/knex.go
@@ -38,9 +38,6 @@ func registerKnex(r registry.Registry) {
 		node := c.Node(1)
 		t.Status("setting up cockroach")
 		c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
-		if err := c.PutLibraries(ctx, "./lib"); err != nil {
-			t.Fatal(err)
-		}
 		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.All())
 
 		version, err := fetchCockroachVersion(ctx, t.L(), c, node[0])
@@ -120,10 +117,11 @@ func registerKnex(r registry.Registry) {
 	}
 
 	r.Add(registry.TestSpec{
-		Name:    "knex",
-		Owner:   registry.OwnerSQLExperience,
-		Cluster: r.MakeClusterSpec(1),
-		Tags:    []string{`default`, `orm`},
+		Name:       "knex",
+		Owner:      registry.OwnerSQLExperience,
+		Cluster:    r.MakeClusterSpec(1),
+		NativeLibs: registry.LibGEOS,
+		Tags:       []string{`default`, `orm`},
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runKnex(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/query_comparison_util.go
+++ b/pkg/cmd/roachtest/tests/query_comparison_util.go
@@ -56,9 +56,6 @@ func runQueryComparison(
 	}
 
 	c.Put(ctx, t.Cockroach(), "./cockroach")
-	if err := c.PutLibraries(ctx, "./lib"); err != nil {
-		t.Fatalf("could not initialize libraries: %v", err)
-	}
 
 	for i := 0; ; i++ {
 		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings())

--- a/pkg/cmd/roachtest/tests/ruby_pg.go
+++ b/pkg/cmd/roachtest/tests/ruby_pg.go
@@ -45,9 +45,6 @@ func registerRubyPG(r registry.Registry) {
 		node := c.Node(1)
 		t.Status("setting up cockroach")
 		c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
-		if err := c.PutLibraries(ctx, "./lib"); err != nil {
-			t.Fatal(err)
-		}
 		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.All())
 
 		version, err := fetchCockroachVersion(ctx, t.L(), c, node[0])
@@ -234,10 +231,11 @@ func registerRubyPG(r registry.Registry) {
 	}
 
 	r.Add(registry.TestSpec{
-		Name:    "ruby-pg",
-		Owner:   registry.OwnerSQLExperience,
-		Cluster: r.MakeClusterSpec(1),
-		Tags:    []string{`default`, `orm`},
+		Name:       "ruby-pg",
+		Owner:      registry.OwnerSQLExperience,
+		Cluster:    r.MakeClusterSpec(1),
+		NativeLibs: registry.LibGEOS,
+		Tags:       []string{`default`, `orm`},
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runRubyPGTest(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/schemachange_random_load.go
+++ b/pkg/cmd/roachtest/tests/schemachange_random_load.go
@@ -45,6 +45,7 @@ func registerSchemaChangeRandomLoad(r registry.Registry) {
 			spec.Geo(),
 			spec.Zones(geoZonesStr),
 		),
+		NativeLibs: registry.LibGEOS,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			maxOps := 5000
 			concurrency := 20
@@ -81,10 +82,11 @@ func registerRandomLoadBenchSpec(r registry.Registry, b randomLoadBenchSpec) {
 	name := strings.Join(nameParts, "/")
 
 	r.Add(registry.TestSpec{
-		Name:    name,
-		Owner:   registry.OwnerSQLSchema,
-		Cluster: r.MakeClusterSpec(b.Nodes),
-		Skip:    "https://github.com/cockroachdb/cockroach/issues/56230",
+		Name:       name,
+		Owner:      registry.OwnerSQLSchema,
+		Cluster:    r.MakeClusterSpec(b.Nodes),
+		NativeLibs: registry.LibGEOS,
+		Skip:       "https://github.com/cockroachdb/cockroach/issues/56230",
 		// This is set while development is still happening on the workload and we
 		// fix (or bypass) minor schema change bugs that are discovered.
 		NonReleaseBlocker: true,
@@ -133,9 +135,6 @@ func runSchemaChangeRandomLoad(
 	t.Status("copying binaries")
 	c.Put(ctx, t.Cockroach(), "./cockroach", roachNodes)
 	c.Put(ctx, t.DeprecatedWorkload(), "./workload", loadNode)
-	if err := c.PutLibraries(ctx, "./lib"); err != nil {
-		t.Fatal(err)
-	}
 
 	t.Status("starting cockroach nodes")
 	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), roachNodes)

--- a/pkg/cmd/roachtest/tests/sequelize.go
+++ b/pkg/cmd/roachtest/tests/sequelize.go
@@ -39,9 +39,6 @@ func registerSequelize(r registry.Registry) {
 		node := c.Node(1)
 		t.Status("setting up cockroach")
 		c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
-		if err := c.PutLibraries(ctx, "./lib"); err != nil {
-			t.Fatal(err)
-		}
 		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.All())
 
 		version, err := fetchCockroachVersion(ctx, t.L(), c, node[0])
@@ -153,10 +150,11 @@ func registerSequelize(r registry.Registry) {
 	}
 
 	r.Add(registry.TestSpec{
-		Name:    "sequelize",
-		Owner:   registry.OwnerSQLExperience,
-		Cluster: r.MakeClusterSpec(1),
-		Tags:    []string{`default`, `orm`},
+		Name:       "sequelize",
+		Owner:      registry.OwnerSQLExperience,
+		Cluster:    r.MakeClusterSpec(1),
+		NativeLibs: registry.LibGEOS,
+		Tags:       []string{`default`, `orm`},
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runSequelize(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/sqlsmith.go
+++ b/pkg/cmd/roachtest/tests/sqlsmith.go
@@ -92,9 +92,6 @@ func registerSQLSmith(r registry.Registry) {
 		rng, seed := randutil.NewTestRand()
 		t.L().Printf("seed: %d", seed)
 
-		if err := c.PutLibraries(ctx, "./lib"); err != nil {
-			t.Fatalf("could not initialize libraries: %v", err)
-		}
 		// With 50% chance use the cockroach-short binary that was compiled with
 		// --crdb_test build tag.
 		maybeUseBuildWithEnabledAssertions(ctx, t, c, rng, 0.5 /* eaProb */)
@@ -316,6 +313,7 @@ INSERT INTO seed_mr_table DEFAULT VALUES;`, regionList[0]),
 			Name:            fmt.Sprintf("sqlsmith/setup=%s/setting=%s", setup, setting),
 			Owner:           registry.OwnerSQLQueries,
 			Cluster:         clusterSpec,
+			NativeLibs:      registry.LibGEOS,
 			Timeout:         time.Minute * 20,
 			RequiresLicense: true,
 			// NB: sqlsmith failures should never block a release.

--- a/pkg/cmd/roachtest/tests/tlp.go
+++ b/pkg/cmd/roachtest/tests/tlp.go
@@ -42,6 +42,7 @@ func registerTLP(r registry.Registry) {
 		RequiresLicense: true,
 		Tags:            nil,
 		Cluster:         r.MakeClusterSpec(1),
+		NativeLibs:      registry.LibGEOS,
 		Run:             runTLP,
 	})
 }
@@ -64,9 +65,6 @@ func runTLP(ctx context.Context, t test.Test, c cluster.Cluster) {
 	}
 
 	c.Put(ctx, t.Cockroach(), "./cockroach")
-	if err := c.PutLibraries(ctx, "./lib"); err != nil {
-		t.Fatalf("could not initialize libraries: %v", err)
-	}
 
 	for i := 0; ; i++ {
 		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings())


### PR DESCRIPTION
This commit adds native libraries to the test specifications.
Each native library that is required should be specified by
name.

The spec is verified in the test runner and uses the existing
logic that populates libraryFilePaths to confirm that libraries
are present. Note was taken on this change that findLibrary
might need to be revised at a later stage to ensure it only
provides libraries compatible with the target cluster.

Verification happens before the cluster is provisioned. The test
will fail quickly if libraries are not present to support the
planned execution.

Resolves: #81081

Release justification: test-only change.
Release note: None.Backport 2/2 commits from #86451.

/cc @cockroachdb/release

---

This commit adds native libraries to the test specifications.
Each native library that is required should be specified by
filename.

The spec is verified in the test runner and also takes into account
whether the test is running locally or remotely. For local tests
the lib directory is verified, and for remote tests the docker lib
(amd64) directory is verified.

Verification happens before the cluster is provisioned. The test
will fail quickly if libraries are not present to support the
planned execution.

Resolves: #81081

Release justification: test-only change.
Release note: None.
