### PR TITLE
sql: clean up some udf TODOs

### DIFF
--- a/pkg/sql/function_resolver_test.go
+++ b/pkg/sql/function_resolver_test.go
@@ -176,6 +176,7 @@ CREATE FUNCTION sc1.lower() RETURNS INT IMMUTABLE LANGUAGE SQL AS $$ SELECT 3 $$
 		testName       string
 		funName        tree.UnresolvedName
 		searchPath     []string
+		expectUDF      []bool
 		expectedBody   []string
 		expectedSchema []string
 		expectedErr    string
@@ -206,6 +207,7 @@ CREATE FUNCTION sc1.lower() RETURNS INT IMMUTABLE LANGUAGE SQL AS $$ SELECT 3 $$
 			testName:       "function with explicit schema skip first schema in path",
 			funName:        tree.UnresolvedName{NumParts: 2, Parts: tree.NameParts{"f", "sc2", "", ""}},
 			searchPath:     []string{"sc1", "sc2"},
+			expectUDF:      []bool{true},
 			expectedBody:   []string{"SELECT 2;"},
 			expectedSchema: []string{"sc2"},
 		},
@@ -213,8 +215,25 @@ CREATE FUNCTION sc1.lower() RETURNS INT IMMUTABLE LANGUAGE SQL AS $$ SELECT 3 $$
 			testName:       "use functions from search path",
 			funName:        tree.UnresolvedName{NumParts: 1, Parts: tree.NameParts{"f", "", "", ""}},
 			searchPath:     []string{"sc1", "sc2"},
+			expectUDF:      []bool{true, true},
 			expectedBody:   []string{"SELECT 1;", "SELECT 2;"},
 			expectedSchema: []string{"sc1", "sc2"},
+		},
+		{
+			testName:       "builtin function schema is respected",
+			funName:        tree.UnresolvedName{NumParts: 1, Parts: tree.NameParts{"lower", "", "", ""}},
+			searchPath:     []string{"sc1", "sc2"},
+			expectUDF:      []bool{false, true},
+			expectedBody:   []string{"", "SELECT 3;"},
+			expectedSchema: []string{"pg_catalog", "sc1"},
+		},
+		{
+			testName:       "explicit builtin function schema",
+			funName:        tree.UnresolvedName{NumParts: 2, Parts: tree.NameParts{"lower", "pg_catalog", "", ""}},
+			searchPath:     []string{"sc1", "sc2"},
+			expectUDF:      []bool{false},
+			expectedBody:   []string{""},
+			expectedSchema: []string{"pg_catalog"},
 		},
 		{
 			testName:    "unsupported builtin function",
@@ -222,8 +241,6 @@ CREATE FUNCTION sc1.lower() RETURNS INT IMMUTABLE LANGUAGE SQL AS $$ SELECT 3 $$
 			searchPath:  []string{"sc1", "sc2"},
 			expectedErr: `querytree\(\): unimplemented: this function is not yet supported`,
 		},
-		// TODO(Chengxiong): add test case for builtin function names when builtin
-		// OIDs are changed to fixed IDs.
 	}
 
 	var sessionData sessiondatapb.SessionData
@@ -246,25 +263,31 @@ CREATE FUNCTION sc1.lower() RETURNS INT IMMUTABLE LANGUAGE SQL AS $$ SELECT 3 $$
 		funcResolver := planner.(tree.FunctionReferenceResolver)
 
 		for _, tc := range testCases {
-			path := sessiondata.MakeSearchPath(tc.searchPath)
-			funcDef, err := funcResolver.ResolveFunction(ctx, &tc.funName, &path)
-			if tc.expectedErr != "" {
-				require.Regexp(t, tc.expectedErr, err.Error())
-				continue
-			}
-			require.NoError(t, err)
-
-			require.Equal(t, len(tc.expectedBody), len(funcDef.Overloads))
-			bodies := make([]string, len(funcDef.Overloads))
-			schemas := make([]string, len(funcDef.Overloads))
-			for i, o := range funcDef.Overloads {
-				_, overload, err := funcResolver.ResolveFunctionByOID(ctx, o.Oid)
+			t.Run(tc.testName, func(t *testing.T) {
+				path := sessiondata.MakeSearchPath(tc.searchPath)
+				funcDef, err := funcResolver.ResolveFunction(ctx, &tc.funName, &path)
+				if tc.expectedErr != "" {
+					require.Regexp(t, tc.expectedErr, err.Error())
+					return
+				}
 				require.NoError(t, err)
-				bodies[i] = overload.Body
-				schemas[i] = o.Schema
-			}
-			require.Equal(t, tc.expectedBody, bodies)
-			require.Equal(t, tc.expectedSchema, schemas)
+
+				require.Equal(t, len(tc.expectUDF), len(funcDef.Overloads))
+				require.Equal(t, len(tc.expectedBody), len(funcDef.Overloads))
+				bodies := make([]string, len(funcDef.Overloads))
+				schemas := make([]string, len(funcDef.Overloads))
+				isUDF := make([]bool, len(funcDef.Overloads))
+				for i, o := range funcDef.Overloads {
+					_, overload, err := funcResolver.ResolveFunctionByOID(ctx, o.Oid)
+					require.NoError(t, err)
+					bodies[i] = overload.Body
+					schemas[i] = o.Schema
+					isUDF[i] = o.IsUDF
+				}
+				require.Equal(t, tc.expectedBody, bodies)
+				require.Equal(t, tc.expectedSchema, schemas)
+				require.Equal(t, tc.expectUDF, isUDF)
+			})
 		}
 		return nil
 	})
@@ -280,8 +303,6 @@ func TestFuncExprTypeCheck(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 	tDB := sqlutils.MakeSQLRunner(sqlDB)
 
-	// TODO(Chengxiong): add test cases with builtin function when builtin
-	// function OIDs are changed to fixed IDs.
 	tDB.Exec(t, `
 CREATE SCHEMA sc1;
 CREATE SCHEMA sc2;
@@ -346,6 +367,7 @@ CREATE FUNCTION sc1.lower(a STRING) RETURNS STRING IMMUTABLE LANGUAGE SQL AS $$ 
 			exprStr:          "lower('HI')",
 			searchPath:       []string{"sc1", "sc2"},
 			expectedFuncBody: "",
+			expectedFuncOID:  827,
 			desiredType:      types.String,
 		},
 		{
@@ -404,11 +426,8 @@ CREATE FUNCTION sc1.lower(a STRING) RETURNS STRING IMMUTABLE LANGUAGE SQL AS $$ 
 					require.False(t, funcExpr.ResolvedOverload().IsUDF)
 				}
 				require.False(t, funcExpr.ResolvedOverload().UDFContainsOnlySignature)
-				if tc.expectedFuncOID > 0 {
-					require.Equal(t, tc.expectedFuncOID, int(funcExpr.ResolvedOverload().Oid))
-				} else {
-					require.False(t, funcdesc.IsOIDUserDefinedFunc(funcExpr.ResolvedOverload().Oid))
-				}
+				require.Equal(t, tc.expectedFuncOID, int(funcExpr.ResolvedOverload().Oid))
+				require.Equal(t, funcExpr.ResolvedOverload().IsUDF, funcdesc.IsOIDUserDefinedFunc(funcExpr.ResolvedOverload().Oid))
 				require.Equal(t, tc.expectedFuncBody, funcExpr.ResolvedOverload().Body)
 			})
 		}

--- a/pkg/sql/grant_revoke.go
+++ b/pkg/sql/grant_revoke.go
@@ -419,7 +419,6 @@ func (n *changeDescriptorBackedPrivilegesNode) startExec(params runParams) error
 					FuncName:                       d.Name, // FIXME
 				})
 			}
-			// TODO(chengxiong): add eventlog for function privilege changes.
 		}
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4697,21 +4697,6 @@ query T
 SELECT proname FROM pg_catalog.pg_proc WHERE oid = 0
 ----
 
-let $cur_max_builtin_oid
-SELECT cur_max_builtin_oid FROM [SELECT max(oid) as cur_max_builtin_oid FROM pg_catalog.pg_proc]
-
-## If this test failed (proname is the same, but oid increased), it's likely that a
-## new builtin function is implemented and  it's somewhere in the middle of the
-## existing functions at init time. Though the changes to builtin function OID is
-## generally ok, it's still better if we could move the new implement to end of the
-## list at init time (see all_builtins.go)
-## TODO(chengxiong): consider to have a deterministic list of builtin function oids
-## so that new implementations can just be added to it.
-query TT
-SELECT proname, oid FROM pg_catalog.pg_proc WHERE oid = $cur_max_builtin_oid
-----
-pg_get_functiondef  2035
-
 ## Ensure that unnest works with oid wrapper arrays
 
 query O

--- a/pkg/sql/parser/help.go
+++ b/pkg/sql/parser/help.go
@@ -102,8 +102,7 @@ func helpWithFunction(sqllex sqlLexer, f tree.ResolvableFunctionReference) int {
 	if err != nil {
 		return 1
 	}
-	// TODO(Chengxiong): Consider how to produce proper help message for
-	// UDFs.
+
 	props, _ := builtinsregistry.GetBuiltinProperties(d.Name)
 	msg := HelpMessage{
 		Function: f.String(),

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -416,8 +416,8 @@ func GetBuiltinFuncDefinition(
 	}
 
 	// First try that if we can get function directly with the function name.
-	// There is a case where the part[0] of the name is a qualified string.
-	// TODO(Chengxiong): figure out why that could be an input.
+	// There is a case where the part[0] of the name is a qualified string when
+	// the qualified name is double quoted as a single name like "schema.fn".
 	if def, ok := ResolvedBuiltinFuncDefs[fName.Object()]; ok {
 		return def, nil
 	}


### PR DESCRIPTION
Clean up some udf TODOs which are actually done or a not-to-do. Also resolve two TODOs in tests.

Release note: None
Release justification: low risk comment and test only change.