### PR TITLE
roachtest: decrease the starting estimate for tpccbench on gce a tad

### DIFF
--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -748,7 +748,7 @@ func registerTPCC(r registry.Registry) {
 		CPUs:  16,
 
 		LoadWarehouses: gceOrAws(cloud, 3500, 3900),
-		EstimatedMax:   gceOrAws(cloud, 3000, 3500),
+		EstimatedMax:   gceOrAws(cloud, 2900, 3500),
 	})
 	registerTPCCBenchSpec(r, tpccBenchSpec{
 		Nodes: 12,


### PR DESCRIPTION
The first run needs to be under-loaded because splitting and rebalancing happens during that run. This is something of a flaw in the test. Perhaps we should do a really long ramp on the initial warehouse count and then kick it off. I don't quite know.

Release note: None

Epic: None