### PR TITLE
bazel: fix segfault

### DIFF
--- a/pkg/ccl/changefeedccl/sink_cloudstorage.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage.go
@@ -314,6 +314,8 @@ type cloudStorageSink struct {
 
 var cloudStorageSinkIDAtomic int64
 
+const sinkCompressionGzip compressionAlgo = "gzip"
+
 // Files that are emitted can be partitioned by their earliest event time,
 // for example being emitted to topic/date/file.ndjson, or further split by hour.
 // Note that a file may contain events with timestamps that would normally

--- a/pkg/cmd/bazci/bazci.go
+++ b/pkg/cmd/bazci/bazci.go
@@ -184,6 +184,9 @@ func processBuildEventProtocolLog(action, bepLoc string) error {
 			outputDir = strings.ReplaceAll(outputDir, ":", "/")
 			outputDir = filepath.Join("bazel-testlogs", outputDir)
 			summary := event.GetTestSummary()
+			if summary == nil {
+				summary = &bes.TestSummary{}
+			}
 			for _, testResult := range testResults[label] {
 				outputDir := outputDir
 				if testResult.run > 1 {
@@ -216,6 +219,9 @@ func processBuildEventProtocolLog(action, bepLoc string) error {
 
 	if action == "build" {
 		for _, target := range builtTargets {
+			if target == nil {
+				continue
+			}
 			for _, outputGroup := range target.OutputGroup {
 				if outputGroup.Incomplete {
 					continue


### PR DESCRIPTION
It looks like it's possible to get an event with the ID EventCompleted but that is not an EventCompleted, in which case we don't surface the underlying error very well. Curious if this fixes it or just swallows it more thoroughly.

Release note: None