### PR TITLE
jobs: Clear out claim info when pausing

### DIFF
--- a/pkg/jobs/adopt.go
+++ b/pkg/jobs/adopt.go
@@ -432,7 +432,9 @@ const pauseAndCancelUpdate = `
 						 ELSE status
           END,
 					num_runs = 0,
-					last_run = NULL
+					last_run = NULL,
+          claim_session_id = NULL,
+          claim_instance_id = NULL
     WHERE (status IN ('` + string(StatusPauseRequested) + `', '` + string(StatusCancelRequested) + `'))
       AND ((claim_session_id = $1) AND (claim_instance_id = $2))
 RETURNING id, status


### PR DESCRIPTION
Clear out job claim information when job is paused. Clearing out claim information is beneficial since it allows operator to pause/resume job if they want to try to move job coordinator to another node.

Addresses #82698

Release note: none