### PR TITLE
ui/cluster-ui: show active statement explain plan

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementUtils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementUtils.ts
@@ -121,6 +121,7 @@ export function getActiveExecutionsFromSessions(
           user: session.username,
           clientAddress: session.client_address,
           isFullScan: query.is_full_scan || false, // Or here is for conversion in case the field is null.
+          planGist: query.plan_gist,
         };
 
         statements.push(activeStmt);

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/types.ts
@@ -41,6 +41,7 @@ export type ActiveStatement = ActiveExecution &
     user: string;
     clientAddress: string;
     isFullScan: boolean;
+    planGist?: string;
   };
 
 export type ActiveTransaction = ActiveExecution & {

--- a/pkg/ui/workspaces/cluster-ui/src/api/decodePlanGistApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/decodePlanGistApi.ts
@@ -1,0 +1,68 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { SqlExecutionRequest, executeInternalSql } from "./sqlApi";
+
+export type DecodePlanGistResponse = {
+  explainPlan?: string;
+  error?: string;
+};
+
+export type DecodePlanGistRequest = {
+  planGist: string;
+};
+
+type DecodePlanGistColumns = {
+  plan_row: string;
+};
+
+/**
+ * getExplainPlanFromGist decodes the provided planGist into the logical
+ * plan string.
+ * @param req the request providing the planGist
+ */
+export function getExplainPlanFromGist(
+  req: DecodePlanGistRequest,
+): Promise<DecodePlanGistResponse> {
+  const request: SqlExecutionRequest = {
+    statements: [
+      {
+        sql: `SELECT crdb_internal.decode_plan_gist('${req.planGist}') as plan_row`,
+      },
+    ],
+    execute: true,
+    timeout: "10s",
+  };
+
+  return executeInternalSql<DecodePlanGistColumns>(request).then(result => {
+    if (
+      result.execution.txn_results.length === 0 ||
+      !result.execution.txn_results[0].rows
+    ) {
+      return {
+        error: result.execution.txn_results
+          ? result.execution.txn_results[0].error?.message
+          : null,
+      };
+    }
+
+    if (result.execution.txn_results[0].error) {
+      return {
+        error: result.execution.txn_results[0].error.message,
+      };
+    }
+
+    const explainPlan = result.execution.txn_results[0].rows
+      .map(col => col.plan_row)
+      .join("\n");
+
+    return { explainPlan };
+  });
+}

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/activeStatementDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/activeStatementDetailsConnected.tsx
@@ -22,6 +22,7 @@ import {
   selectActiveStatement,
   selectContentionDetailsForStatement,
 } from "src/selectors/activeExecutions.selectors";
+import { selectIsTenant } from "src/store/uiConfig";
 
 // For tenant cases, we don't show information about node, regions and
 // diagnostics.
@@ -33,6 +34,7 @@ const mapStateToProps = (
     contentionDetails: selectContentionDetailsForStatement(state, props),
     statement: selectActiveStatement(state, props),
     match: props.match,
+    isTenant: selectIsTenant(state),
   };
 };
 

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/activeStatementDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/activeStatementDetailsOverviewTab.tsx
@@ -1,0 +1,132 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import classNames from "classnames/bind";
+import { Link } from "react-router-dom";
+import { Col, Row } from "antd";
+import { SummaryCard, SummaryCardItem } from "src/summaryCard";
+import {
+  ActiveStatement,
+  ExecutionContentionDetails,
+} from "src/activeExecutions";
+import { WaitTimeInsightsPanel } from "src/detailsPanels/waitTimeInsightsPanel";
+import { StatusIcon } from "src/activeExecutions/statusIcon";
+import { DATE_FORMAT_24_UTC, Duration } from "src/util";
+
+import "antd/lib/col/style";
+import "antd/lib/row/style";
+import summaryCardStyles from "src/summaryCard/summaryCard.module.scss";
+
+const summaryCardStylesCx = classNames.bind(summaryCardStyles);
+
+import styles from "./statementDetails.module.scss";
+const cx = classNames.bind(styles);
+
+type Props = {
+  statement?: ActiveStatement;
+  contentionDetails?: ExecutionContentionDetails;
+};
+
+export const ActiveStatementDetailsOverviewTab = ({
+  statement,
+  contentionDetails,
+}: Props): React.ReactElement => {
+  if (!statement) return null;
+
+  return (
+    <>
+      <section className={cx("section", "section--container")}>
+        <Row gutter={24}>
+          <Col className="gutter-row" span={12}>
+            <SummaryCard className={cx("summary-card")}>
+              <Row>
+                <Col>
+                  <SummaryCardItem
+                    label="Start Time (UTC)"
+                    value={statement.start.format(DATE_FORMAT_24_UTC)}
+                  />
+                  <SummaryCardItem
+                    label="Elapsed Time"
+                    value={Duration(
+                      statement.elapsedTime.asMilliseconds() * 1e6,
+                    )}
+                  />
+                  <SummaryCardItem
+                    label="Status"
+                    value={
+                      <>
+                        <StatusIcon status={statement.status} />
+                        {statement.status}
+                      </>
+                    }
+                  />
+                  <SummaryCardItem
+                    label="Full Scan"
+                    value={statement.isFullScan.toString()}
+                  />
+                </Col>
+              </Row>
+            </SummaryCard>
+          </Col>
+          <Col className="gutter-row" span={12}>
+            <SummaryCard className={cx("summary-card")}>
+              <SummaryCardItem
+                label="Application Name"
+                value={statement.application}
+              />
+              <SummaryCardItem label="User Name" value={statement.user} />
+              <SummaryCardItem
+                label="Client Address"
+                value={statement.clientAddress}
+              />
+              <p className={summaryCardStylesCx("summary--card__divider")} />
+              <SummaryCardItem
+                label="Session ID"
+                value={
+                  <Link
+                    className={cx("text-link")}
+                    to={`/session/${statement.sessionID}`}
+                  >
+                    {statement.sessionID}
+                  </Link>
+                }
+              />
+              <SummaryCardItem
+                label="Transaction Execution ID"
+                value={
+                  <Link
+                    className={cx("text-link")}
+                    to={`/execution/transaction/${statement.transactionID}`}
+                  >
+                    {statement.transactionID}
+                  </Link>
+                }
+              />
+            </SummaryCard>
+          </Col>
+        </Row>
+      </section>
+      {contentionDetails && (
+        <WaitTimeInsightsPanel
+          execType="statement"
+          executionID={statement.statementID}
+          schemaName={contentionDetails.waitInsights?.schemaName}
+          tableName={contentionDetails.waitInsights?.tableName}
+          indexName={contentionDetails.waitInsights?.indexName}
+          databaseName={contentionDetails.waitInsights?.databaseName}
+          waitTime={contentionDetails.waitInsights?.waitTime}
+          waitingExecutions={contentionDetails.waitingExecutions}
+          blockingExecutions={contentionDetails.blockingExecutions}
+        />
+      )}
+    </>
+  );
+};


### PR DESCRIPTION
Closes #79128

This commit splits the active statment details page into 2 tab views:
1. Overview - the active stmt details information that was already being displayed prior to this commit
2. Explain Tab - newly added as of this commit. The explain plan for this active statement.

The explain plan for the active statement being viewed will be retrieved when the tab is clicked by making a req to decode the plan gist of the stmt.

The explain tab is currently disabled for tenants until the sql http api is available.

Release note (ui change): new tabs in active statement details page:
1. Overview - (previous page info of stmt details)
2. Explain Plan - the explain plan of the stmt, available if the returned plan gist is non-empty


https://www.loom.com/share/64ea19a2f45c4a709e396b89fadfc7c4