### PR TITLE
sql: Add server-side transaction timeout

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1850,6 +1850,7 @@ func (ex *connExecutor) run(
 			return err
 		}
 	}
+
 }
 
 // errDrainingComplete is returned by execCmd when the connExecutor previously got
@@ -1920,6 +1921,7 @@ func (ex *connExecutor) execCmd() error {
 			ev, payload, err = ex.execStmt(
 				ctx, tcmd.Statement, nil /* prepared */, nil /* pinfo */, stmtRes, canAutoCommit,
 			)
+
 			return err
 		}()
 		// Note: we write to ex.statsCollector.PhaseTimes, instead of ex.phaseTimes,

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -297,10 +297,15 @@ func (ex *connExecutor) execStmtInOpenState(
 		st.mu.stmtCount++
 	}(&ex.state)
 
-	var timeoutTicker *time.Timer
+	var queryTimeoutTicker *time.Timer
+	var txnTimeoutTicker *time.Timer
 	queryTimedOut := false
-	// doneAfterFunc will be allocated only when timeoutTicker is non-nil.
-	var doneAfterFunc chan struct{}
+	txnTimedOut := false
+
+	// queryDoneAfterFunc and txnDoneAfterFunc will be allocated only when
+	// queryTimeoutTicker or txnTimeoutTicker is non-nil.
+	var queryDoneAfterFunc chan struct{}
+	var txnDoneAfterFunc chan struct{}
 
 	// Early-associate placeholder info with the eval context,
 	// so that we can fill in placeholder values in our call to addActiveQuery, below.
@@ -316,11 +321,18 @@ func (ex *connExecutor) execStmtInOpenState(
 	// overwriting res.Error to a more user-friendly message in case of query
 	// cancellation.
 	defer func(ctx context.Context, res RestrictedCommandResult) {
-		if timeoutTicker != nil {
-			if !timeoutTicker.Stop() {
+		if queryTimeoutTicker != nil {
+			if !queryTimeoutTicker.Stop() {
 				// Wait for the timer callback to complete to avoid a data race on
 				// queryTimedOut.
-				<-doneAfterFunc
+				<-queryDoneAfterFunc
+			}
+		}
+		if txnTimeoutTicker != nil {
+			if !txnTimeoutTicker.Stop() {
+				// Wait for the timer callback to complete to avoid a data race on
+				// txnTimedOut.
+				<-txnDoneAfterFunc
 			}
 		}
 
@@ -365,6 +377,12 @@ func (ex *connExecutor) execStmtInOpenState(
 			}
 			res.SetError(sqlerrors.QueryTimeoutError)
 			retPayload = eventNonRetriableErrPayload{err: sqlerrors.QueryTimeoutError}
+		} else if txnTimedOut {
+			retEv = eventNonRetriableErr{
+				IsCommit: fsm.FromBool(isCommit(ast)),
+			}
+			res.SetError(sqlerrors.TxnTimeoutError)
+			retPayload = eventNonRetriableErrPayload{err: sqlerrors.TxnTimeoutError}
 		}
 	}(ctx, res)
 
@@ -475,6 +493,34 @@ func (ex *connExecutor) execStmtInOpenState(
 		}()
 	}
 
+	if ex.sessionData().TransactionTimeout > 0 && !ex.implicitTxn() {
+		timerDuration :=
+			ex.sessionData().TransactionTimeout - timeutil.Since(ex.phaseTimes.GetSessionPhaseTime(sessionphase.SessionTransactionStarted))
+
+		// If the timer already expired, but the transaction is not yet aborted,
+		// we should error immediately without executing. If the timer
+		// expired but the transaction already is aborted, then we should still
+		// proceed with executing the statement in order to get a
+		// TransactionAbortedError.
+		_, txnAborted := ex.machine.CurState().(stateAborted)
+
+		if timerDuration < 0 && !txnAborted {
+			txnTimedOut = true
+			return makeErrEvent(sqlerrors.TxnTimeoutError)
+		}
+
+		if timerDuration > 0 {
+			txnDoneAfterFunc = make(chan struct{}, 1)
+			txnTimeoutTicker = time.AfterFunc(
+				timerDuration,
+				func() {
+					cancelQuery()
+					txnTimedOut = true
+					txnDoneAfterFunc <- struct{}{}
+				})
+		}
+	}
+
 	// We exempt `SET` statements from the statement timeout, particularly so as
 	// not to block the `SET statement_timeout` command itself.
 	if ex.sessionData().StmtTimeout > 0 && ast.StatementTag() != "SET" {
@@ -485,13 +531,13 @@ func (ex *connExecutor) execStmtInOpenState(
 			queryTimedOut = true
 			return makeErrEvent(sqlerrors.QueryTimeoutError)
 		}
-		doneAfterFunc = make(chan struct{}, 1)
-		timeoutTicker = time.AfterFunc(
+		queryDoneAfterFunc = make(chan struct{}, 1)
+		queryTimeoutTicker = time.AfterFunc(
 			timerDuration,
 			func() {
 				cancelQuery()
 				queryTimedOut = true
-				doneAfterFunc <- struct{}{}
+				queryDoneAfterFunc <- struct{}{}
 			})
 	}
 

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3119,6 +3119,10 @@ func (m *sessionDataMutator) SetIdleInTransactionSessionTimeout(timeout time.Dur
 	m.data.IdleInTransactionSessionTimeout = timeout
 }
 
+func (m *sessionDataMutator) SetTransactionTimeout(timeout time.Duration) {
+	m.data.TransactionTimeout = timeout
+}
+
 func (m *sessionDataMutator) SetAllowPrepareAsOptPlan(val bool) {
 	m.data.AllowPrepareAsOptPlan = val
 }

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4800,6 +4800,7 @@ transaction_rows_read_log                             0
 transaction_rows_written_err                          0
 transaction_rows_written_log                          0
 transaction_status                                    NoTxn
+transaction_timeout                                   0
 troubleshooting_mode                                  off
 unconstrained_non_covering_index_scan_enabled         off
 variable_inequality_lookup_join_enabled               on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4270,6 +4270,7 @@ transaction_rows_read_log                             0                   NULL  
 transaction_rows_written_err                          0                   NULL      NULL        NULL        string
 transaction_rows_written_log                          0                   NULL      NULL        NULL        string
 transaction_status                                    NoTxn               NULL      NULL        NULL        string
+transaction_timeout                                   0                   NULL      NULL        NULL        string
 troubleshooting_mode                                  off                 NULL      NULL        NULL        string
 unconstrained_non_covering_index_scan_enabled         off                 NULL      NULL        NULL        string
 use_declarative_schema_changer                        on                  NULL      NULL        NULL        string
@@ -4404,6 +4405,7 @@ transaction_rows_read_log                             0                   NULL  
 transaction_rows_written_err                          0                   NULL  user     NULL      0                   0
 transaction_rows_written_log                          0                   NULL  user     NULL      0                   0
 transaction_status                                    NoTxn               NULL  user     NULL      NoTxn               NoTxn
+transaction_timeout                                   0                   NULL  user     NULL      0                   0
 troubleshooting_mode                                  off                 NULL  user     NULL      off                 off
 unconstrained_non_covering_index_scan_enabled         off                 NULL  user     NULL      off                 off
 use_declarative_schema_changer                        on                  NULL  user     NULL      on                  on
@@ -4537,6 +4539,7 @@ transaction_rows_read_log                             NULL    NULL     NULL     
 transaction_rows_written_err                          NULL    NULL     NULL     NULL        NULL
 transaction_rows_written_log                          NULL    NULL     NULL     NULL        NULL
 transaction_status                                    NULL    NULL     NULL     NULL        NULL
+transaction_timeout                                   NULL    NULL     NULL     NULL        NULL
 troubleshooting_mode                                  NULL    NULL     NULL     NULL        NULL
 unconstrained_non_covering_index_scan_enabled         NULL    NULL     NULL     NULL        NULL
 use_declarative_schema_changer                        NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -143,6 +143,7 @@ transaction_rows_read_log                             0
 transaction_rows_written_err                          0
 transaction_rows_written_log                          0
 transaction_status                                    NoTxn
+transaction_timeout                                   0
 troubleshooting_mode                                  off
 unconstrained_non_covering_index_scan_enabled         off
 use_declarative_schema_changer                        on

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -295,6 +295,9 @@ message LocalOnlySessionData {
   // be allowed to consider lookup joins with inequality conditions, in
   // addition to the other restrictions on when they are planned.
   bool variable_inequality_lookup_join_enabled = 80;
+  // TransactionSessionTimeout is the duration a transaction is permitted to
+  // run before the transaction is canceled. If set to 0, there is no timeout.
+  int64 transaction_timeout = 81 [(gogoproto.casttype) = "time.Duration"];
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/set_var.go
+++ b/pkg/sql/set_var.go
@@ -438,6 +438,20 @@ func idleInSessionTimeoutVarSet(ctx context.Context, m sessionDataMutator, s str
 	return nil
 }
 
+func transactionTimeoutVarSet(ctx context.Context, m sessionDataMutator, s string) error {
+	timeout, err := validateTimeoutVar(
+		m.data.GetIntervalStyle(),
+		s,
+		"transaction_timeout",
+	)
+	if err != nil {
+		return err
+	}
+
+	m.SetTransactionTimeout(timeout)
+	return nil
+}
+
 func idleInTransactionSessionTimeoutVarSet(
 	ctx context.Context, m sessionDataMutator, s string,
 ) error {

--- a/pkg/sql/sqlerrors/errors.go
+++ b/pkg/sql/sqlerrors/errors.go
@@ -304,6 +304,10 @@ func NewAggInAggError() error {
 var QueryTimeoutError = pgerror.New(
 	pgcode.QueryCanceled, "query execution canceled due to statement timeout")
 
+// TxnTimeoutError is an error representing a query timeout.
+var TxnTimeoutError = pgerror.New(
+	pgcode.QueryCanceled, "query execution canceled due to transaction timeout")
+
 // IsOutOfMemoryError checks whether this is an out of memory error.
 func IsOutOfMemoryError(err error) bool {
 	return errHasCode(err, pgcode.OutOfMemory)

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -1218,6 +1218,18 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalFalse,
 	},
+	// CockroachDB extension.
+	`transaction_timeout`: {
+		GetStringVal: makeTimeoutVarGetter(`transaction_timeout`),
+		Set:          transactionTimeoutVarSet,
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			ms := evalCtx.SessionData().TransactionTimeout.Nanoseconds() / int64(time.Millisecond)
+			return strconv.FormatInt(ms, 10), nil
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return strconv.FormatInt(0, 10)
+		},
+	},
 
 	// This is read-only in Postgres also.
 	// See https://www.postgresql.org/docs/14/sql-show.html and


### PR DESCRIPTION
Resolves #61102

This commit adds the session variable `transation_timeout`

Release note (sql change): `transaction_timeout` cancels an explicit transaction when it runs longer than the timer set. When the timer times out, the current statement is allowed to finish and from then the transaction enters an aborted state. Because the timer needs a statement to finish before it aborts a transaction `transaction_timeout` should be used with `idle_in_transaction` for the best results.