### PR TITLE
eval: partial removal of usages of the stored context

### DIFF
--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -119,6 +119,7 @@ var (
 )
 
 func newBackupDataProcessor(
+	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec execinfrapb.BackupDataSpec,
@@ -139,7 +140,7 @@ func newBackupDataProcessor(
 		progCh:  make(chan execinfrapb.RemoteProducerMetadata_BulkProcessorProgress),
 		memAcc:  &ba,
 	}
-	if err := bp.Init(bp, post, backupOutputTypes, flowCtx, processorID, output, nil, /* memMonitor */
+	if err := bp.Init(ctx, bp, post, backupOutputTypes, flowCtx, processorID, output, nil, /* memMonitor */
 		execinfra.ProcStateOpts{
 			// This processor doesn't have any inputs to drain.
 			InputsToDrain: nil,

--- a/pkg/ccl/backupccl/backup_processor_planning.go
+++ b/pkg/ccl/backupccl/backup_processor_planning.go
@@ -46,7 +46,6 @@ func distBackupPlanSpecs(
 ) (map[base.SQLInstanceID]*execinfrapb.BackupDataSpec, error) {
 	var span *tracing.Span
 	ctx, span = tracing.ChildSpan(ctx, "backupccl.distBackupPlanSpecs")
-	_ = ctx // ctx is currently unused, but this new ctx should be used below in the future.
 	defer span.Finish()
 	user := execCtx.User()
 
@@ -78,8 +77,7 @@ func distBackupPlanSpecs(
 			}
 		}()
 
-		encryption.Key, err = kms.Decrypt(planCtx.EvalContext().Context,
-			encryption.KMSInfo.EncryptedDataKey)
+		encryption.Key, err = kms.Decrypt(ctx, encryption.KMSInfo.EncryptedDataKey)
 		if err != nil {
 			return nil, errors.Wrap(err,
 				"failed to decrypt data key before starting BackupDataProcessor")

--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -121,6 +121,7 @@ var numRestoreWorkers = settings.RegisterIntSetting(
 )
 
 func newRestoreDataProcessor(
+	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec execinfrapb.RestoreDataSpec,
@@ -140,7 +141,7 @@ func newRestoreDataProcessor(
 		numWorkers: int(numRestoreWorkers.Get(sv)),
 	}
 
-	if err := rd.Init(rd, post, restoreDataOutputTypes, flowCtx, processorID, output, nil, /* memMonitor */
+	if err := rd.Init(ctx, rd, post, restoreDataOutputTypes, flowCtx, processorID, output, nil, /* memMonitor */
 		execinfra.ProcStateOpts{
 			InputsToDrain: []execinfra.RowSource{input},
 			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {

--- a/pkg/ccl/backupccl/split_and_scatter_processor.go
+++ b/pkg/ccl/backupccl/split_and_scatter_processor.go
@@ -207,6 +207,7 @@ type splitAndScatterProcessor struct {
 var _ execinfra.Processor = &splitAndScatterProcessor{}
 
 func newSplitAndScatterProcessor(
+	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec execinfrapb.SplitAndScatterSpec,
@@ -240,7 +241,7 @@ func newSplitAndScatterProcessor(
 		doneScatterCh:     make(chan entryNode, numEntries),
 		routingDatumCache: make(map[roachpb.NodeID]rowenc.EncDatum),
 	}
-	if err := ssp.Init(ssp, post, splitAndScatterOutputTypes, flowCtx, processorID, output, nil, /* memMonitor */
+	if err := ssp.Init(ctx, ssp, post, splitAndScatterOutputTypes, flowCtx, processorID, output, nil, /* memMonitor */
 		execinfra.ProcStateOpts{
 			InputsToDrain: nil, // there are no inputs to drain
 			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {

--- a/pkg/ccl/backupccl/split_and_scatter_processor_test.go
+++ b/pkg/ccl/backupccl/split_and_scatter_processor_test.go
@@ -246,7 +246,7 @@ func TestSplitAndScatterProcessor(t *testing.T) {
 			require.NoError(t, err)
 
 			post := execinfrapb.PostProcessSpec{}
-			proc, err := newSplitAndScatterProcessor(&flowCtx, 0 /* processorID */, c.procSpec, &post, out)
+			proc, err := newSplitAndScatterProcessor(ctx, &flowCtx, 0 /* processorID */, c.procSpec, &post, out)
 			require.NoError(t, err)
 			ssp, ok := proc.(*splitAndScatterProcessor)
 			if !ok {

--- a/pkg/ccl/changefeedccl/cdceval/expr_eval_test.go
+++ b/pkg/ccl/changefeedccl/cdceval/expr_eval_test.go
@@ -614,7 +614,7 @@ func makeEvaluator(t *testing.T, st *cluster.Settings, selectStr string) (*Evalu
 	require.NoError(t, err)
 	slct := s.AST.(*tree.Select).Select.(*tree.SelectClause)
 	evalCtx := eval.MakeTestingEvalContext(st)
-	return NewEvaluator(&evalCtx, slct)
+	return NewEvaluator(context.Background(), &evalCtx, slct)
 }
 
 func makeExprEval(

--- a/pkg/ccl/changefeedccl/cdceval/validation.go
+++ b/pkg/ccl/changefeedccl/cdceval/validation.go
@@ -110,7 +110,7 @@ func NormalizeAndValidateSelectForTarget(
 
 	// Construct and initialize evaluator.  This performs some static checks,
 	// and (importantly) type checks expressions.
-	evaluator, err := NewEvaluator(evalCtx, sc)
+	evaluator, err := NewEvaluator(ctx, evalCtx, sc)
 	if err != nil {
 		return n, target, err
 	}

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -126,13 +126,13 @@ var _ execinfra.Processor = &changeAggregator{}
 var _ execinfra.RowSource = &changeAggregator{}
 
 func newChangeAggregatorProcessor(
+	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec execinfrapb.ChangeAggregatorSpec,
 	post *execinfrapb.PostProcessSpec,
 	output execinfra.RowReceiver,
 ) (execinfra.Processor, error) {
-	ctx := flowCtx.EvalCtx.Ctx()
 	memMonitor := execinfra.NewMonitor(ctx, flowCtx.EvalCtx.Mon, "changeagg-mem")
 	ca := &changeAggregator{
 		flowCtx: flowCtx,
@@ -140,6 +140,7 @@ func newChangeAggregatorProcessor(
 		memAcc:  memMonitor.MakeBoundAccount(),
 	}
 	if err := ca.Init(
+		ctx,
 		ca,
 		post,
 		changefeedResultTypes,
@@ -813,6 +814,7 @@ var _ execinfra.Processor = &changeFrontier{}
 var _ execinfra.RowSource = &changeFrontier{}
 
 func newChangeFrontierProcessor(
+	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec execinfrapb.ChangeFrontierSpec,
@@ -820,7 +822,6 @@ func newChangeFrontierProcessor(
 	post *execinfrapb.PostProcessSpec,
 	output execinfra.RowReceiver,
 ) (execinfra.Processor, error) {
-	ctx := flowCtx.EvalCtx.Ctx()
 	memMonitor := execinfra.NewMonitor(ctx, flowCtx.EvalCtx.Mon, "changefntr-mem")
 	sf, err := makeSchemaChangeFrontier(hlc.Timestamp{}, spec.TrackedSpans...)
 	if err != nil {
@@ -841,6 +842,7 @@ func newChangeFrontierProcessor(
 	}
 
 	if err := cf.Init(
+		ctx,
 		cf,
 		post,
 		input.OutputTypes(),

--- a/pkg/ccl/changefeedccl/event_processing.go
+++ b/pkg/ccl/changefeedccl/event_processing.go
@@ -166,7 +166,7 @@ func newKVEventToRowConsumer(
 			return nil, err
 		}
 		safeExpr = tree.AsString(expr)
-		evaluator, err = cdceval.NewEvaluator(evalCtx, expr)
+		evaluator, err = cdceval.NewEvaluator(ctx, evalCtx, expr)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor.go
@@ -89,6 +89,7 @@ func init() {
 }
 
 func newStreamIngestionFrontierProcessor(
+	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec execinfrapb.StreamIngestionFrontierSpec,
@@ -106,7 +107,7 @@ func newStreamIngestionFrontierProcessor(
 		}
 	}
 
-	heartbeatSender, err := newHeartbeatSender(flowCtx, spec)
+	heartbeatSender, err := newHeartbeatSender(ctx, flowCtx, spec)
 	if err != nil {
 		return nil, err
 	}
@@ -128,6 +129,7 @@ func newStreamIngestionFrontierProcessor(
 		persistedHighWater: spec.HighWaterAtStart,
 	}
 	if err := sf.Init(
+		ctx,
 		sf,
 		post,
 		input.OutputTypes(),
@@ -169,9 +171,9 @@ type heartbeatSender struct {
 }
 
 func newHeartbeatSender(
-	flowCtx *execinfra.FlowCtx, spec execinfrapb.StreamIngestionFrontierSpec,
+	ctx context.Context, flowCtx *execinfra.FlowCtx, spec execinfrapb.StreamIngestionFrontierSpec,
 ) (*heartbeatSender, error) {
-	streamClient, err := streamclient.GetFirstActiveClient(flowCtx.EvalCtx.Ctx(), spec.StreamAddresses)
+	streamClient, err := streamclient.GetFirstActiveClient(ctx, spec.StreamAddresses)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor_test.go
@@ -239,7 +239,7 @@ func TestStreamIngestionFrontierProcessor(t *testing.T) {
 			}
 			spec.StartTime = tc.frontierStartTime
 			spec.Checkpoint.ResolvedSpans = tc.jobCheckpoint
-			proc, err := newStreamIngestionDataProcessor(&flowCtx, 0 /* processorID */, spec, &post, out)
+			proc, err := newStreamIngestionDataProcessor(ctx, &flowCtx, 0 /* processorID */, spec, &post, out)
 			require.NoError(t, err)
 			sip, ok := proc.(*streamIngestionProcessor)
 			if !ok {
@@ -290,8 +290,10 @@ func TestStreamIngestionFrontierProcessor(t *testing.T) {
 
 			frontierPost := execinfrapb.PostProcessSpec{}
 			frontierOut := distsqlutils.RowBuffer{}
-			frontierProc, err := newStreamIngestionFrontierProcessor(&flowCtx, 0, /* processorID*/
-				frontierSpec, sip, &frontierPost, &frontierOut)
+			frontierProc, err := newStreamIngestionFrontierProcessor(
+				ctx, &flowCtx, 0, /* processorID*/
+				frontierSpec, sip, &frontierPost, &frontierOut,
+			)
 			require.NoError(t, err)
 			fp, ok := frontierProc.(*streamIngestionFrontier)
 			if !ok {

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -210,6 +210,7 @@ var (
 const streamIngestionProcessorName = "stream-ingestion-processor"
 
 func newStreamIngestionDataProcessor(
+	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec execinfrapb.StreamIngestionDataSpec,
@@ -253,7 +254,7 @@ func newStreamIngestionDataProcessor(
 		rekeyer:          rekeyer,
 		rewriteToDiffKey: spec.TenantRekey.NewID != spec.TenantRekey.OldID,
 	}
-	if err := sip.Init(sip, post, streamIngestionResultTypes, flowCtx, processorID, output, nil, /* memMonitor */
+	if err := sip.Init(ctx, sip, post, streamIngestionResultTypes, flowCtx, processorID, output, nil, /* memMonitor */
 		execinfra.ProcStateOpts{
 			InputsToDrain: []execinfra.RowSource{},
 			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
@@ -623,7 +623,7 @@ func getStreamIngestionProcessor(
 	spec.StartTime = startTime
 	spec.Checkpoint.ResolvedSpans = checkpoint
 	processorID := int32(0)
-	proc, err := newStreamIngestionDataProcessor(&flowCtx, processorID, spec, &post, out)
+	proc, err := newStreamIngestionDataProcessor(ctx, &flowCtx, processorID, spec, &post, out)
 	require.NoError(t, err)
 	sip, ok := proc.(*streamIngestionProcessor)
 	if !ok {

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -737,6 +737,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 		case *tree.AlterTableSetStorageParams:
 			setter := tablestorageparam.NewSetter(n.tableDesc)
 			if err := storageparam.Set(
+				params.ctx,
 				params.p.SemaCtx(),
 				params.EvalContext(),
 				t.StorageParams,
@@ -1286,7 +1287,7 @@ func injectTableStats(
 StatsLoop:
 	for i := range jsonStats {
 		s := &jsonStats[i]
-		h, err := s.GetHistogram(&params.p.semaCtx, params.EvalContext())
+		h, err := s.GetHistogram(params.ctx, &params.p.semaCtx, params.EvalContext())
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -114,7 +114,7 @@ func (a *applyJoinNode) startExec(params runParams) error {
 		}
 	}
 	a.run.out = make(tree.Datums, len(a.columns))
-	a.run.rightRows.Init(a.rightTypes, params.extendedEvalCtx, "apply-join" /* opName */)
+	a.run.rightRows.Init(params.ctx, a.rightTypes, params.extendedEvalCtx, "apply-join" /* opName */)
 	return nil
 }
 

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -108,6 +108,7 @@ func (cb *ColumnBackfiller) initCols(desc catalog.TableDescriptor) {
 //
 // txn might be nil, in which case it will need to be set on the fetcher later.
 func (cb *ColumnBackfiller) init(
+	ctx context.Context,
 	txn *kv.Txn,
 	evalCtx *eval.Context,
 	defaultExprs []tree.TypedExpr,
@@ -158,7 +159,7 @@ func (cb *ColumnBackfiller) init(
 	cb.rowMetrics = rowMetrics
 
 	return cb.fetcher.Init(
-		evalCtx.Context,
+		ctx,
 		row.FetcherInitArgs{
 			Txn:        txn,
 			Alloc:      &cb.alloc,
@@ -201,7 +202,7 @@ func (cb *ColumnBackfiller) InitForLocalUse(
 	if err != nil {
 		return err
 	}
-	return cb.init(txn, evalCtx, defaultExprs, computedExprs, desc, mon, rowMetrics, traceKV)
+	return cb.init(ctx, txn, evalCtx, defaultExprs, computedExprs, desc, mon, rowMetrics, traceKV)
 }
 
 // InitForDistributedUse initializes a ColumnBackfiller for use as part of a
@@ -259,7 +260,7 @@ func (cb *ColumnBackfiller) InitForDistributedUse(
 
 	rowMetrics := flowCtx.GetRowMetrics()
 	// The txn will be set on the fetcher in RunColumnBackfillChunk.
-	return cb.init(nil /* txn */, evalCtx, defaultExprs, computedExprs, desc, mon, rowMetrics, flowCtx.TraceKV)
+	return cb.init(ctx, nil /* txn */, evalCtx, defaultExprs, computedExprs, desc, mon, rowMetrics, flowCtx.TraceKV)
 }
 
 // Close frees the resources used by the ColumnBackfiller.
@@ -832,7 +833,7 @@ func (ib *IndexBackfiller) BuildIndexEntriesChunk(
 	}
 	var fetcher row.Fetcher
 	if err := fetcher.Init(
-		ib.evalCtx.Context,
+		ctx,
 		row.FetcherInitArgs{
 			Txn:        txn,
 			Alloc:      &ib.alloc,

--- a/pkg/sql/backfill/mvcc_index_merger.go
+++ b/pkg/sql/backfill/mvcc_index_merger.go
@@ -144,7 +144,7 @@ func (ibm *IndexBackfillMerger) Run(ctx context.Context) {
 	}
 
 	semaCtx := tree.MakeSemaContext()
-	if err := ibm.out.Init(&execinfrapb.PostProcessSpec{}, nil, &semaCtx, ibm.flowCtx.NewEvalCtx()); err != nil {
+	if err := ibm.out.Init(ctx, &execinfrapb.PostProcessSpec{}, nil, &semaCtx, ibm.flowCtx.NewEvalCtx()); err != nil {
 		ibm.output.Push(nil, &execinfrapb.ProducerMetadata{Err: err})
 		return
 	}

--- a/pkg/sql/buffer.go
+++ b/pkg/sql/buffer.go
@@ -36,7 +36,7 @@ type bufferNode struct {
 
 func (n *bufferNode) startExec(params runParams) error {
 	n.typs = planTypes(n.plan)
-	n.rows.Init(n.typs, params.extendedEvalCtx, redact.Sprint(n.label))
+	n.rows.Init(params.ctx, n.typs, params.extendedEvalCtx, redact.Sprint(n.label))
 	return nil
 }
 

--- a/pkg/sql/buffer_util.go
+++ b/pkg/sql/buffer_util.go
@@ -35,9 +35,12 @@ type rowContainerHelper struct {
 }
 
 func (c *rowContainerHelper) Init(
-	typs []*types.T, evalContext *extendedEvalContext, opName redact.RedactableString,
+	ctx context.Context,
+	typs []*types.T,
+	evalContext *extendedEvalContext,
+	opName redact.RedactableString,
 ) {
-	c.initMonitors(evalContext, opName)
+	c.initMonitors(ctx, evalContext, opName)
 	distSQLCfg := &evalContext.DistSQLPlanner.distSQLSrv.ServerConfig
 	c.rows = &rowcontainer.DiskBackedRowContainer{}
 	c.rows.Init(
@@ -50,9 +53,12 @@ func (c *rowContainerHelper) Init(
 // InitWithDedup is a variant of init that is used if row deduplication
 // functionality is needed (see addRowWithDedup).
 func (c *rowContainerHelper) InitWithDedup(
-	typs []*types.T, evalContext *extendedEvalContext, opName redact.RedactableString,
+	ctx context.Context,
+	typs []*types.T,
+	evalContext *extendedEvalContext,
+	opName redact.RedactableString,
 ) {
-	c.initMonitors(evalContext, opName)
+	c.initMonitors(ctx, evalContext, opName)
 	distSQLCfg := &evalContext.DistSQLPlanner.distSQLSrv.ServerConfig
 	c.rows = &rowcontainer.DiskBackedRowContainer{}
 	// The DiskBackedRowContainer can be configured to deduplicate along the
@@ -72,15 +78,15 @@ func (c *rowContainerHelper) InitWithDedup(
 }
 
 func (c *rowContainerHelper) initMonitors(
-	evalContext *extendedEvalContext, opName redact.RedactableString,
+	ctx context.Context, evalContext *extendedEvalContext, opName redact.RedactableString,
 ) {
 	distSQLCfg := &evalContext.DistSQLPlanner.distSQLSrv.ServerConfig
 	c.memMonitor = execinfra.NewLimitedMonitorNoFlowCtx(
-		evalContext.Ctx(), evalContext.Mon, distSQLCfg, evalContext.SessionData(),
+		ctx, evalContext.Mon, distSQLCfg, evalContext.SessionData(),
 		redact.Sprintf("%s-limited", opName),
 	)
 	c.diskMonitor = execinfra.NewMonitor(
-		evalContext.Ctx(), distSQLCfg.ParentDiskMonitor, redact.Sprintf("%s-disk", opName),
+		ctx, distSQLCfg.ParentDiskMonitor, redact.Sprintf("%s-disk", opName),
 	)
 }
 

--- a/pkg/sql/colexec/aggregators_test.go
+++ b/pkg/sql/colexec/aggregators_test.go
@@ -786,7 +786,7 @@ func TestAggregators(t *testing.T) {
 	ctx := context.Background()
 	for _, tc := range aggregatorsTestCases {
 		constructors, constArguments, outputTypes, err := colexecagg.ProcessAggregations(
-			&evalCtx, nil /* semaCtx */, tc.spec.Aggregations, tc.typs,
+			ctx, &evalCtx, nil /* semaCtx */, tc.spec.Aggregations, tc.typs,
 		)
 		require.NoError(t, err)
 		for _, agg := range aggTypes {
@@ -930,7 +930,7 @@ func TestAggregatorRandom(t *testing.T) {
 					}
 					require.NoError(t, tc.init())
 					constructors, constArguments, outputTypes, err := colexecagg.ProcessAggregations(
-						&evalCtx, nil /* semaCtx */, tc.spec.Aggregations, tc.typs,
+						context.Background(), &evalCtx, nil /* semaCtx */, tc.spec.Aggregations, tc.typs,
 					)
 					require.NoError(t, err)
 					a := agg.new(&colexecagg.NewAggregatorArgs{
@@ -1093,7 +1093,7 @@ func benchmarkAggregateFunction(
 	}
 	require.NoError(b, tc.init())
 	constructors, constArguments, outputTypes, err := colexecagg.ProcessAggregations(
-		&evalCtx, nil /* semaCtx */, tc.spec.Aggregations, tc.typs,
+		ctx, &evalCtx, nil /* semaCtx */, tc.spec.Aggregations, tc.typs,
 	)
 	require.NoError(b, err)
 	fName := execinfrapb.AggregatorSpec_Func_name[int32(aggFn)]

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -835,7 +835,7 @@ func NewColOperator(
 				EvalCtx:    evalCtx,
 			}
 			newAggArgs.Constructors, newAggArgs.ConstArguments, newAggArgs.OutputTypes, err = colexecagg.ProcessAggregations(
-				evalCtx, args.ExprHelper.SemaCtx, aggSpec.Aggregations, inputTypes,
+				ctx, evalCtx, args.ExprHelper.SemaCtx, aggSpec.Aggregations, inputTypes,
 			)
 			if err != nil {
 				return r, err
@@ -1419,7 +1419,7 @@ func NewColOperator(
 							ColIdx: colIdx,
 						}}
 						aggArgs.Constructors, aggArgs.ConstArguments, aggArgs.OutputTypes, err =
-							colexecagg.ProcessAggregations(flowCtx.EvalCtx, args.ExprHelper.SemaCtx, aggregations, argTypes)
+							colexecagg.ProcessAggregations(ctx, flowCtx.EvalCtx, args.ExprHelper.SemaCtx, aggregations, argTypes)
 						var toClose colexecop.Closers
 						var aggFnsAlloc *colexecagg.AggregateFuncsAlloc
 						if (aggType != execinfrapb.Min && aggType != execinfrapb.Max) ||
@@ -1693,7 +1693,7 @@ func (r *postProcessResult) planPostProcessSpec(
 		exprs := make([]tree.TypedExpr, len(post.RenderExprs))
 		var err error
 		for i := range exprs {
-			exprs[i], err = args.ExprHelper.ProcessExpr(post.RenderExprs[i], flowCtx.EvalCtx, r.ColumnTypes)
+			exprs[i], err = args.ExprHelper.ProcessExpr(ctx, post.RenderExprs[i], flowCtx.EvalCtx, r.ColumnTypes)
 			if err != nil {
 				return err
 			}
@@ -1810,7 +1810,7 @@ func planFilterExpr(
 	helper *colexecargs.ExprHelper,
 	releasables *[]execreleasable.Releasable,
 ) (colexecop.Operator, error) {
-	expr, err := helper.ProcessExpr(filter, flowCtx.EvalCtx, columnTypes)
+	expr, err := helper.ProcessExpr(ctx, filter, flowCtx.EvalCtx, columnTypes)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/colexec/colexecagg/aggregate_funcs.go
+++ b/pkg/sql/colexec/colexecagg/aggregate_funcs.go
@@ -11,6 +11,7 @@
 package colexecagg
 
 import (
+	"context"
 	"unsafe"
 
 	"github.com/cockroachdb/apd/v3"
@@ -443,6 +444,7 @@ type aggAllocBase struct {
 //
 // evalCtx will not be mutated.
 func ProcessAggregations(
+	ctx context.Context,
 	evalCtx *eval.Context,
 	semaCtx *tree.SemaContext,
 	aggregations []execinfrapb.AggregatorSpec_Aggregation,
@@ -458,7 +460,7 @@ func ProcessAggregations(
 	outputTypes = make([]*types.T, len(aggregations))
 	for i, aggFn := range aggregations {
 		constructors[i], constArguments[i], outputTypes[i], err = execagg.GetAggregateConstructor(
-			evalCtx, semaCtx, &aggFn, inputTypes,
+			ctx, evalCtx, semaCtx, &aggFn, inputTypes,
 		)
 		if err != nil {
 			return

--- a/pkg/sql/colexec/colexecargs/expr.go
+++ b/pkg/sql/colexec/colexecargs/expr.go
@@ -11,6 +11,7 @@
 package colexecargs
 
 import (
+	"context"
 	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -42,12 +43,12 @@ type ExprHelper struct {
 //
 // evalCtx will not be mutated.
 func (h *ExprHelper) ProcessExpr(
-	expr execinfrapb.Expression, evalCtx *eval.Context, typs []*types.T,
+	ctx context.Context, expr execinfrapb.Expression, evalCtx *eval.Context, typs []*types.T,
 ) (tree.TypedExpr, error) {
 	if expr.LocalExpr != nil {
 		return expr.LocalExpr, nil
 	}
 	h.helper.Types = typs
 	tempVars := tree.MakeIndexedVarHelper(&h.helper, len(typs))
-	return execinfrapb.DeserializeExpr(expr.Expr, h.SemaCtx, evalCtx, &tempVars)
+	return execinfrapb.DeserializeExpr(ctx, expr.Expr, h.SemaCtx, evalCtx, &tempVars)
 }

--- a/pkg/sql/colexec/colexecwindow/window_functions_test.go
+++ b/pkg/sql/colexec/colexecwindow/window_functions_test.go
@@ -1054,7 +1054,7 @@ func TestWindowFunctions(t *testing.T) {
 						ColIdx: argIdxs,
 					}}
 					_, _, outputTypes, err :=
-						colexecagg.ProcessAggregations(&evalCtx, &semaCtx, aggregations, ct)
+						colexecagg.ProcessAggregations(ctx, &evalCtx, &semaCtx, aggregations, ct)
 					require.NoError(t, err)
 					resultType = outputTypes[0]
 				}
@@ -1218,7 +1218,7 @@ func BenchmarkWindowFunctions(b *testing.B) {
 				ColIdx: colIdxs,
 			}}
 			aggArgs.Constructors, aggArgs.ConstArguments, aggArgs.OutputTypes, err =
-				colexecagg.ProcessAggregations(&evalCtx, &semaCtx, aggregations, sourceTypes)
+				colexecagg.ProcessAggregations(ctx, &evalCtx, &semaCtx, aggregations, sourceTypes)
 			require.NoError(b, err)
 			aggFnsAlloc, _, toClose, err := colexecagg.NewAggregateFuncsAlloc(
 				&aggArgs, aggregations, 1 /* allocSize */, colexecagg.WindowAggKind,

--- a/pkg/sql/colexec/default_agg_test.go
+++ b/pkg/sql/colexec/default_agg_test.go
@@ -144,7 +144,7 @@ func TestDefaultAggregateFunc(t *testing.T) {
 					t.Fatal(err)
 				}
 				constructors, constArguments, outputTypes, err := colexecagg.ProcessAggregations(
-					&evalCtx, &semaCtx, tc.spec.Aggregations, tc.typs,
+					context.Background(), &evalCtx, &semaCtx, tc.spec.Aggregations, tc.typs,
 				)
 				require.NoError(t, err)
 				colexectestutils.RunTestsWithTyps(t, testAllocator, []colexectestutils.Tuples{tc.input}, [][]*types.T{tc.typs}, tc.expected, colexectestutils.UnorderedVerifier, func(input []colexecop.Operator) (colexecop.Operator, error) {

--- a/pkg/sql/colexec/external_hash_aggregator_test.go
+++ b/pkg/sql/colexec/external_hash_aggregator_test.go
@@ -100,7 +100,7 @@ func TestExternalHashAggregator(t *testing.T) {
 			}
 			log.Infof(ctx, "diskSpillingEnabled=%t/spillForced=%t/memoryLimitBytes=%d/numRepartitions=%d/%s", cfg.diskSpillingEnabled, cfg.spillForced, cfg.memoryLimitBytes, numForcedRepartitions, tc.name)
 			constructors, constArguments, outputTypes, err := colexecagg.ProcessAggregations(
-				&evalCtx, nil /* semaCtx */, tc.spec.Aggregations, tc.typs,
+				ctx, &evalCtx, nil /* semaCtx */, tc.spec.Aggregations, tc.typs,
 			)
 			require.NoError(t, err)
 			verifier := colexectestutils.OrderedVerifier

--- a/pkg/sql/colexec/hash_aggregator_test.go
+++ b/pkg/sql/colexec/hash_aggregator_test.go
@@ -417,7 +417,7 @@ func TestHashAggregator(t *testing.T) {
 	for _, tc := range hashAggregatorTestCases {
 		log.Infof(context.Background(), "%s", tc.name)
 		constructors, constArguments, outputTypes, err := colexecagg.ProcessAggregations(
-			&evalCtx, nil /* semaCtx */, tc.spec.Aggregations, tc.typs,
+			context.Background(), &evalCtx, nil /* semaCtx */, tc.spec.Aggregations, tc.typs,
 		)
 		require.NoError(t, err)
 		var typs [][]*types.T

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3295,6 +3295,7 @@ func (ex *connExecutor) runPreCommitStages(ctx context.Context) error {
 		return nil
 	}
 	deps := newSchemaChangerTxnRunDependencies(
+		ctx,
 		ex.planner.SessionData(),
 		ex.planner.User(),
 		ex.server.cfg,

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -473,8 +473,6 @@ func (ex *connExecutor) execStmtInOpenState(
 				retErr,
 			)
 		}()
-		// TODO(radu): consider removing this if/when #46164 is addressed.
-		p.extendedEvalCtx.Context.Context = ctx
 	}
 
 	// We exempt `SET` statements from the statement timeout, particularly so as
@@ -1532,10 +1530,6 @@ func (ex *connExecutor) execWithDistSQLEngine(
 			ex.resetEvalCtx(&factoryEvalCtx, planner.txn, planner.ExtendedEvalContext().StmtTimestamp)
 			factoryEvalCtx.Placeholders = &planner.semaCtx.Placeholders
 			factoryEvalCtx.Annotations = &planner.semaCtx.Annotations
-			// Query diagnostics can change the Context; make sure we are using the
-			// same one.
-			// TODO(radu): consider removing this if/when #46164 is addressed.
-			factoryEvalCtx.Context = evalCtx.Context
 			return &factoryEvalCtx
 		}
 	}

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -273,6 +273,7 @@ func makeIndexDescriptor(
 	}
 
 	if err := storageparam.Set(
+		params.ctx,
 		params.p.SemaCtx(),
 		params.EvalContext(),
 		n.StorageParams,

--- a/pkg/sql/create_schema.go
+++ b/pkg/sql/create_schema.go
@@ -176,7 +176,7 @@ func CreateSchemaDescriptorWithPrivileges(
 
 func (p *planner) createUserDefinedSchema(params runParams, n *tree.CreateSchema) error {
 	if err := checkSchemaChangeEnabled(
-		p.EvalContext().Context,
+		params.ctx,
 		p.ExecCfg(),
 		"CREATE SCHEMA",
 	); err != nil {

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1326,6 +1326,7 @@ func NewTableDesc(
 
 	setter := tablestorageparam.NewSetter(&desc)
 	if err := storageparam.Set(
+		ctx,
 		semaCtx,
 		evalCtx,
 		n.StorageParams,
@@ -1860,6 +1861,7 @@ func NewTableDesc(
 				idx.Predicate = expr
 			}
 			if err := storageparam.Set(
+				ctx,
 				semaCtx,
 				evalCtx,
 				d.StorageParams,

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -1463,7 +1463,7 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 		typs = subqueryPhysPlan.GetResultTypes()
 	}
 	var rows rowContainerHelper
-	rows.Init(typs, evalCtx, "subquery" /* opName */)
+	rows.Init(ctx, typs, evalCtx, "subquery" /* opName */)
 	defer rows.Close(ctx)
 
 	// TODO(yuzefovich): consider implementing batch receiving result writer.

--- a/pkg/sql/drop_schema.go
+++ b/pkg/sql/drop_schema.go
@@ -173,6 +173,7 @@ func (n *dropSchemaNode) startExec(params runParams) error {
 
 	// Create the job to drop the schema.
 	if err := p.createDropSchemaJob(
+		params.ctx,
 		schemaIDs,
 		n.d.getDroppedTableDetails(),
 		n.d.typesToDelete,
@@ -238,6 +239,7 @@ func (p *planner) dropSchemaImpl(
 }
 
 func (p *planner) createDropSchemaJob(
+	ctx context.Context,
 	schemas []descpb.ID,
 	tableDropDetails []jobspb.DroppedTableDetails,
 	typesToDrop []*typedesc.Mutable,
@@ -248,7 +250,7 @@ func (p *planner) createDropSchemaJob(
 		typeIDs = append(typeIDs, t.ID)
 	}
 
-	_, err := p.extendedEvalCtx.QueueJob(p.EvalContext().Ctx(), jobs.Record{
+	_, err := p.extendedEvalCtx.QueueJob(ctx, jobs.Record{
 		Description:   jobDesc,
 		Username:      p.User(),
 		DescriptorIDs: schemas,

--- a/pkg/sql/execinfra/execagg/base.go
+++ b/pkg/sql/execinfra/execagg/base.go
@@ -11,6 +11,7 @@
 package execagg
 
 import (
+	"context"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -74,6 +75,7 @@ func GetAggregateInfo(
 //
 // evalCtx will not be mutated.
 func GetAggregateConstructor(
+	ctx context.Context,
 	evalCtx *eval.Context,
 	semaCtx *tree.SemaContext,
 	aggInfo *execinfrapb.AggregatorSpec_Aggregation,
@@ -92,7 +94,7 @@ func GetAggregateConstructor(
 	for j, argument := range aggInfo.Arguments {
 		h := execinfrapb.ExprHelper{}
 		// Pass nil types and row - there are no variables in these expressions.
-		if err = h.Init(argument, nil /* types */, semaCtx, evalCtx); err != nil {
+		if err = h.Init(ctx, argument, nil /* types */, semaCtx, evalCtx); err != nil {
 			err = errors.Wrapf(err, "%s", argument)
 			return
 		}

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -160,7 +160,7 @@ func (h *ProcOutputHelper) Init(
 			h.OutputTypes = make([]*types.T, nRenders)
 		}
 		for i, expr := range post.RenderExprs {
-			if err := h.renderExprs[i].Init(expr, coreOutputTypes, semaCtx, evalCtx); err != nil {
+			if err := h.renderExprs[i].Init(evalCtx.Context, expr, coreOutputTypes, semaCtx, evalCtx); err != nil {
 				return err
 			}
 			h.OutputTypes[i] = h.renderExprs[i].Expr.ResolvedType()

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -117,6 +117,7 @@ func (h *ProcOutputHelper) Reset() {
 // Note that the types slice may be stored directly; the caller should not
 // modify it.
 func (h *ProcOutputHelper) Init(
+	ctx context.Context,
 	post *execinfrapb.PostProcessSpec,
 	coreOutputTypes []*types.T,
 	semaCtx *tree.SemaContext,
@@ -160,7 +161,7 @@ func (h *ProcOutputHelper) Init(
 			h.OutputTypes = make([]*types.T, nRenders)
 		}
 		for i, expr := range post.RenderExprs {
-			if err := h.renderExprs[i].Init(evalCtx.Context, expr, coreOutputTypes, semaCtx, evalCtx); err != nil {
+			if err := h.renderExprs[i].Init(ctx, expr, coreOutputTypes, semaCtx, evalCtx); err != nil {
 				return err
 			}
 			h.OutputTypes[i] = h.renderExprs[i].Expr.ResolvedType()
@@ -748,6 +749,7 @@ type ProcStateOpts struct {
 // core (i.e. the "internal schema" of the processor, see
 // execinfrapb.ProcessorSpec for more details).
 func (pb *ProcessorBase) Init(
+	ctx context.Context,
 	self RowSource,
 	post *execinfrapb.PostProcessSpec,
 	coreOutputTypes []*types.T,
@@ -758,7 +760,7 @@ func (pb *ProcessorBase) Init(
 	opts ProcStateOpts,
 ) error {
 	return pb.InitWithEvalCtx(
-		self, post, coreOutputTypes, flowCtx, flowCtx.NewEvalCtx(), processorID, output, memMonitor, opts,
+		ctx, self, post, coreOutputTypes, flowCtx, flowCtx.NewEvalCtx(), processorID, output, memMonitor, opts,
 	)
 }
 
@@ -767,6 +769,7 @@ func (pb *ProcessorBase) Init(
 // core (i.e. the "internal schema" of the processor, see
 // execinfrapb.ProcessorSpec for more details).
 func (pb *ProcessorBase) InitWithEvalCtx(
+	ctx context.Context,
 	self RowSource,
 	post *execinfrapb.PostProcessSpec,
 	coreOutputTypes []*types.T,
@@ -784,13 +787,13 @@ func (pb *ProcessorBase) InitWithEvalCtx(
 
 	// Hydrate all types used in the processor.
 	resolver := flowCtx.NewTypeResolver(flowCtx.Txn)
-	if err := resolver.HydrateTypeSlice(evalCtx.Context, coreOutputTypes); err != nil {
+	if err := resolver.HydrateTypeSlice(ctx, coreOutputTypes); err != nil {
 		return err
 	}
 	pb.SemaCtx = tree.MakeSemaContext()
 	pb.SemaCtx.TypeResolver = &resolver
 
-	return pb.OutputHelper.Init(post, coreOutputTypes, &pb.SemaCtx, pb.EvalCtx)
+	return pb.OutputHelper.Init(ctx, post, coreOutputTypes, &pb.SemaCtx, pb.EvalCtx)
 }
 
 // Init initializes the ProcessorBaseNoHelper.
@@ -958,7 +961,7 @@ func NewLimitedMonitorNoFlowCtx(
 type LocalProcessor interface {
 	RowSourcedProcessor
 	// InitWithOutput initializes this processor.
-	InitWithOutput(flowCtx *FlowCtx, post *execinfrapb.PostProcessSpec, output RowReceiver) error
+	InitWithOutput(ctx context.Context, flowCtx *FlowCtx, post *execinfrapb.PostProcessSpec, output RowReceiver) error
 	// SetInput initializes this LocalProcessor with an input RowSource. Not all
 	// LocalProcessors need inputs, but this needs to be called if a
 	// LocalProcessor expects to get its data from another RowSource.

--- a/pkg/sql/execinfrapb/component_stats.go
+++ b/pkg/sql/execinfrapb/component_stats.go
@@ -11,7 +11,6 @@
 package execinfrapb
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -411,7 +410,7 @@ func ExtractStatsFromSpans(
 
 // ExtractNodesFromSpans extracts a list of node ids from a set of tracing
 // spans.
-func ExtractNodesFromSpans(ctx context.Context, spans []tracingpb.RecordedSpan) util.FastIntSet {
+func ExtractNodesFromSpans(spans []tracingpb.RecordedSpan) util.FastIntSet {
 	var nodes util.FastIntSet
 	// componentStats is only used to check whether a structured payload item is
 	// of ComponentStats type.

--- a/pkg/sql/execinfrapb/expr_test.go
+++ b/pkg/sql/execinfrapb/expr_test.go
@@ -11,6 +11,7 @@
 package execinfrapb
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -46,7 +47,7 @@ func TestProcessExpression(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.MakeTestingEvalContext(st)
 	semaCtx := tree.MakeSemaContext()
-	expr, err := processExpression(e, &evalCtx, &semaCtx, &h)
+	expr, err := processExpression(context.Background(), e, &evalCtx, &semaCtx, &h)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +74,7 @@ func TestProcessExpressionConstantEval(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.MakeTestingEvalContext(st)
 	semaCtx := tree.MakeSemaContext()
-	expr, err := processExpression(e, &evalCtx, &semaCtx, &h)
+	expr, err := processExpression(context.Background(), e, &evalCtx, &semaCtx, &h)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -292,7 +292,7 @@ func getNodesFromPlanner(planner *planner) []int64 {
 	if _, ok := planner.instrumentation.Tracing(); !ok {
 		trace := planner.instrumentation.sp.GetRecording(tracingpb.RecordingStructured)
 		// ForEach returns nodes in order.
-		execinfrapb.ExtractNodesFromSpans(planner.EvalContext().Context, trace).ForEach(func(i int) {
+		execinfrapb.ExtractNodesFromSpans(trace).ForEach(func(i int) {
 			nodes = append(nodes, int64(i))
 		})
 	}

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -241,7 +241,9 @@ func (*DummyEvalPlanner) SerializeSessionState() (*tree.DBytes, error) {
 }
 
 // DeserializeSessionState is part of the Planner interface.
-func (*DummyEvalPlanner) DeserializeSessionState(token *tree.DBytes) (*tree.DBool, error) {
+func (*DummyEvalPlanner) DeserializeSessionState(
+	ctx context.Context, token *tree.DBytes,
+) (*tree.DBool, error) {
 	return nil, errors.WithStack(errEvalPlanner)
 }
 

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -453,7 +453,9 @@ func (ep *DummyEvalPlanner) ResolveFunctionByOID(
 }
 
 // GetMultiregionConfig is part of the eval.Planner interface.
-func (ep *DummyEvalPlanner) GetMultiregionConfig(databaseID descpb.ID) (interface{}, bool) {
+func (ep *DummyEvalPlanner) GetMultiregionConfig(
+	ctx context.Context, databaseID descpb.ID,
+) (interface{}, bool) {
 	return nil /* regionConfig */, false
 }
 

--- a/pkg/sql/importer/exportcsv.go
+++ b/pkg/sql/importer/exportcsv.go
@@ -131,6 +131,7 @@ func newCSVExporter(sp execinfrapb.ExportSpec) *csvExporter {
 }
 
 func newCSVWriterProcessor(
+	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec execinfrapb.ExportSpec,
@@ -145,7 +146,7 @@ func newCSVWriterProcessor(
 		output:      output,
 	}
 	semaCtx := tree.MakeSemaContext()
-	if err := c.out.Init(&execinfrapb.PostProcessSpec{}, c.OutputTypes(), &semaCtx, flowCtx.NewEvalCtx()); err != nil {
+	if err := c.out.Init(ctx, &execinfrapb.PostProcessSpec{}, c.OutputTypes(), &semaCtx, flowCtx.NewEvalCtx()); err != nil {
 		return nil, err
 	}
 	return c, nil

--- a/pkg/sql/importer/exportparquet.go
+++ b/pkg/sql/importer/exportparquet.go
@@ -679,6 +679,7 @@ func newParquetSchema(parquetFields []ParquetColumn) *parquetschema.SchemaDefini
 }
 
 func newParquetWriterProcessor(
+	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec execinfrapb.ExportSpec,
@@ -693,7 +694,7 @@ func newParquetWriterProcessor(
 		output:      output,
 	}
 	semaCtx := tree.MakeSemaContext()
-	if err := c.out.Init(&execinfrapb.PostProcessSpec{}, c.OutputTypes(), &semaCtx, flowCtx.NewEvalCtx()); err != nil {
+	if err := c.out.Init(ctx, &execinfrapb.PostProcessSpec{}, c.OutputTypes(), &semaCtx, flowCtx.NewEvalCtx()); err != nil {
 		return nil, err
 	}
 	return c, nil

--- a/pkg/sql/importer/import_processor.go
+++ b/pkg/sql/importer/import_processor.go
@@ -137,6 +137,7 @@ var (
 )
 
 func newReadImportDataProcessor(
+	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec execinfrapb.ReadImportDataSpec,
@@ -149,7 +150,7 @@ func newReadImportDataProcessor(
 		output:  output,
 		progCh:  make(chan execinfrapb.RemoteProducerMetadata_BulkProcessorProgress),
 	}
-	if err := cp.Init(cp, post, csvOutputTypes, flowCtx, processorID, output, nil, /* memMonitor */
+	if err := cp.Init(ctx, cp, post, csvOutputTypes, flowCtx, processorID, output, nil, /* memMonitor */
 		execinfra.ProcStateOpts{
 			// This processor doesn't have any inputs to drain.
 			InputsToDrain: nil,

--- a/pkg/sql/importer/import_processor_test.go
+++ b/pkg/sql/importer/import_processor_test.go
@@ -308,7 +308,7 @@ func TestImportIgnoresProcessedFiles(t *testing.T) {
 			spec := setInputOffsets(t, testCase.spec.getConverterSpec(), testCase.inputOffsets)
 			post := execinfrapb.PostProcessSpec{}
 
-			processor, err := newReadImportDataProcessor(flowCtx, 0, *spec, &post, &errorReportingRowReceiver{t})
+			processor, err := newReadImportDataProcessor(ctx, flowCtx, 0, *spec, &post, &errorReportingRowReceiver{t})
 			if err != nil {
 				t.Fatalf("Could not create data processor: %v", err)
 			}
@@ -574,11 +574,11 @@ func (r *cancellableImportResumer) OnFailOrCancel(context.Context, interface{}, 
 func setImportReaderParallelism(parallelism int32) func() {
 	factory := rowexec.NewReadImportDataProcessor
 	rowexec.NewReadImportDataProcessor = func(
-		flowCtx *execinfra.FlowCtx, processorID int32,
+		ctx context.Context, flowCtx *execinfra.FlowCtx, processorID int32,
 		spec execinfrapb.ReadImportDataSpec, post *execinfrapb.PostProcessSpec,
 		output execinfra.RowReceiver) (execinfra.Processor, error) {
 		spec.ReaderParallelism = parallelism
-		return factory(flowCtx, processorID, spec, post, output)
+		return factory(ctx, flowCtx, processorID, spec, post, output)
 	}
 
 	return func() {

--- a/pkg/sql/opaque.go
+++ b/pkg/sql/opaque.go
@@ -237,7 +237,7 @@ func planOpaque(ctx context.Context, p *planner, stmt tree.Statement) (planNode,
 	case *tree.SetSessionAuthorizationDefault:
 		return p.SetSessionAuthorizationDefault()
 	case *tree.SetSessionCharacteristics:
-		return p.SetSessionCharacteristics(n)
+		return p.SetSessionCharacteristics(ctx, n)
 	case *tree.ShowClusterSetting:
 		return p.ShowClusterSetting(ctx, n)
 	case *tree.ShowTenantClusterSetting:

--- a/pkg/sql/opt/distribution/distribution_test.go
+++ b/pkg/sql/opt/distribution/distribution_test.go
@@ -11,6 +11,7 @@
 package distribution
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -99,7 +100,7 @@ func TestBuildProvided(t *testing.T) {
 				)
 			}
 
-			res := BuildProvided(evalCtx, expr, &physical.Distribution{})
+			res := BuildProvided(context.Background(), evalCtx, expr, &physical.Distribution{})
 			if res.String() != expected.String() {
 				t.Errorf("expected '%s', got '%s'", expected, res)
 			}

--- a/pkg/sql/opt/invertedidx/geo_test.go
+++ b/pkg/sql/opt/invertedidx/geo_test.go
@@ -11,6 +11,7 @@
 package invertedidx_test
 
 import (
+	"context"
 	"math"
 	"strconv"
 	"testing"
@@ -292,7 +293,7 @@ func TestTryJoinGeoIndex(t *testing.T) {
 		}
 
 		actInvertedExpr := invertedidx.TryJoinInvertedIndex(
-			evalCtx.Context, &f, filters, tab2, md.Table(tab2).Index(tc.indexOrd), inputCols,
+			context.Background(), &f, filters, tab2, md.Table(tab2).Index(tc.indexOrd), inputCols,
 		)
 
 		if actInvertedExpr == nil {

--- a/pkg/sql/opt/invertedidx/json_array_test.go
+++ b/pkg/sql/opt/invertedidx/json_array_test.go
@@ -11,6 +11,7 @@
 package invertedidx_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -196,7 +197,7 @@ func TestTryJoinJsonOrArrayIndex(t *testing.T) {
 		}
 
 		actInvertedExpr := invertedidx.TryJoinInvertedIndex(
-			evalCtx.Context, &f, filters, tab2, md.Table(tab2).Index(tc.indexOrd), inputCols,
+			context.Background(), &f, filters, tab2, md.Table(tab2).Index(tc.indexOrd), inputCols,
 		)
 
 		if actInvertedExpr == nil {

--- a/pkg/sql/opt/metadata_test.go
+++ b/pkg/sql/opt/metadata_test.go
@@ -431,14 +431,14 @@ func TestTableMeta_GetRegionsInDatabase(t *testing.T) {
 	p := &fakeGetMultiregionConfigPlanner{}
 	// Call the function once, make sure our planner method gets invoked.
 	{
-		_, exists := tabMeta.GetRegionsInDatabase(p)
+		_, exists := tabMeta.GetRegionsInDatabase(context.Background(), p)
 		require.False(t, exists)
 		require.Equal(t, 1, p.getMultiregionConfigCalled)
 	}
 	// Call the function again, make sure that our planner method doesn't
 	// get invoked again.
 	{
-		_, exists := tabMeta.GetRegionsInDatabase(p)
+		_, exists := tabMeta.GetRegionsInDatabase(context.Background(), p)
 		require.False(t, exists)
 		require.Equal(t, 1, p.getMultiregionConfigCalled)
 	}
@@ -450,7 +450,7 @@ type fakeGetMultiregionConfigPlanner struct {
 }
 
 func (f *fakeGetMultiregionConfigPlanner) GetMultiregionConfig(
-	databaseID descpb.ID,
+	ctx context.Context, databaseID descpb.ID,
 ) (interface{}, bool) {
 	f.getMultiregionConfigCalled++
 	return nil, false

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -217,7 +217,7 @@ func (b *Builder) Build() (err error) {
 	// Special case for CannedOptPlan.
 	if canned, ok := b.stmt.(*tree.CannedOptPlan); ok {
 		b.factory.DisableOptimizations()
-		_, err := exprgen.Build(b.catalog, b.factory, canned.Plan)
+		_, err := exprgen.Build(b.ctx, b.catalog, b.factory, canned.Plan)
 		return err
 	}
 

--- a/pkg/sql/opt/props/physical/distribution.go
+++ b/pkg/sql/opt/props/physical/distribution.go
@@ -12,6 +12,7 @@ package physical
 
 import (
 	"bytes"
+	"context"
 	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -110,7 +111,11 @@ func (d *Distribution) FromLocality(locality roachpb.Locality) {
 // FromIndexScan sets the Distribution that results from scanning the given
 // index with the given constraint c (c can be nil).
 func (d *Distribution) FromIndexScan(
-	evalCtx *eval.Context, tabMeta *opt.TableMeta, ord cat.IndexOrdinal, c *constraint.Constraint,
+	ctx context.Context,
+	evalCtx *eval.Context,
+	tabMeta *opt.TableMeta,
+	ord cat.IndexOrdinal,
+	c *constraint.Constraint,
 ) {
 	tab := tabMeta.Table
 	index := tab.Index(ord)
@@ -183,7 +188,7 @@ func (d *Distribution) FromIndexScan(
 		if !regionsPopulated {
 			// If the above methods failed to find a distribution, then the
 			// distribution is all regions in the database.
-			regionsNames, ok := tabMeta.GetRegionsInDatabase(evalCtx.Planner)
+			regionsNames, ok := tabMeta.GetRegionsInDatabase(ctx, evalCtx.Planner)
 			if !ok && evalCtx.SessionData().EnforceHomeRegion {
 				err := pgerror.New(pgcode.QueryHasNoHomeRegion,
 					"Query has no home region. Try accessing only tables defined in multi-region databases.")

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -1259,7 +1259,7 @@ func (ot *OptTester) Expr() (opt.Expr, error) {
 	f.Init(&ot.evalCtx, ot.catalog)
 	f.DisableOptimizations()
 
-	return exprgen.Build(ot.catalog, &f, ot.sql)
+	return exprgen.Build(ot.ctx, ot.catalog, &f, ot.sql)
 }
 
 // ExprNorm parses the input directly into an expression and runs
@@ -1283,7 +1283,7 @@ func (ot *OptTester) ExprNorm() (opt.Expr, error) {
 		ot.appliedRules.Add(int(ruleName))
 	})
 
-	return exprgen.Build(ot.catalog, &f, ot.sql)
+	return exprgen.Build(ot.ctx, ot.catalog, &f, ot.sql)
 }
 
 // ExprOpt parses the input directly into an expression and runs normalization
@@ -1304,7 +1304,7 @@ func (ot *OptTester) ExprOpt() (opt.Expr, error) {
 		ot.appliedRules.Add(int(ruleName))
 	})
 
-	return exprgen.Optimize(ot.catalog, o, ot.sql)
+	return exprgen.Optimize(ot.ctx, ot.catalog, o, ot.sql)
 }
 
 // RuleStats performs the optimization and returns statistics about how many

--- a/pkg/sql/opt/xform/physical_props.go
+++ b/pkg/sql/opt/xform/physical_props.go
@@ -11,6 +11,7 @@
 package xform
 
 import (
+	"context"
 	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
@@ -34,12 +35,12 @@ import (
 // method and then pass through that property in the buildChildPhysicalProps
 // method.
 func CanProvidePhysicalProps(
-	evalCtx *eval.Context, e memo.RelExpr, required *physical.Required,
+	ctx context.Context, evalCtx *eval.Context, e memo.RelExpr, required *physical.Required,
 ) bool {
 	// All operators can provide the Presentation and LimitHint properties, so no
 	// need to check for that.
 	canProvideOrdering := e.Op() == opt.SortOp || ordering.CanProvide(e, &required.Ordering)
-	canProvideDistribution := e.Op() == opt.DistributeOp || distribution.CanProvide(evalCtx, e, &required.Distribution)
+	canProvideDistribution := e.Op() == opt.DistributeOp || distribution.CanProvide(ctx, evalCtx, e, &required.Distribution)
 	return canProvideOrdering && canProvideDistribution
 }
 

--- a/pkg/sql/plan_node_to_row_source.go
+++ b/pkg/sql/plan_node_to_row_source.go
@@ -97,9 +97,13 @@ func (p *planNodeToRowSource) MustBeStreaming() bool {
 
 // InitWithOutput implements the LocalProcessor interface.
 func (p *planNodeToRowSource) InitWithOutput(
-	flowCtx *execinfra.FlowCtx, post *execinfrapb.PostProcessSpec, output execinfra.RowReceiver,
+	ctx context.Context,
+	flowCtx *execinfra.FlowCtx,
+	post *execinfrapb.PostProcessSpec,
+	output execinfra.RowReceiver,
 ) error {
 	return p.InitWithEvalCtx(
+		ctx,
 		p,
 		post,
 		p.outputTypes,

--- a/pkg/sql/recursive_cte.go
+++ b/pkg/sql/recursive_cte.go
@@ -68,9 +68,9 @@ type recursiveCTERun struct {
 
 func (n *recursiveCTENode) startExec(params runParams) error {
 	n.typs = planTypes(n.initial)
-	n.workingRows.Init(n.typs, params.extendedEvalCtx, "cte" /* opName */)
+	n.workingRows.Init(params.ctx, n.typs, params.extendedEvalCtx, "cte" /* opName */)
 	if n.deduplicate {
-		n.allRows.InitWithDedup(n.typs, params.extendedEvalCtx, "cte-all" /* opName */)
+		n.allRows.InitWithDedup(params.ctx, n.typs, params.extendedEvalCtx, "cte-all" /* opName */)
 	}
 	return nil
 }
@@ -128,7 +128,7 @@ func (n *recursiveCTENode) Next(params runParams) (bool, error) {
 	defer lastWorkingRows.Close(params.ctx)
 
 	n.workingRows = rowContainerHelper{}
-	n.workingRows.Init(n.typs, params.extendedEvalCtx, "cte" /* opName */)
+	n.workingRows.Init(params.ctx, n.typs, params.extendedEvalCtx, "cte" /* opName */)
 
 	// Set up a bufferNode that can be used as a reference for a scanBufferNode.
 	buf := &bufferNode{

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -2333,10 +2333,12 @@ func (p *planner) checkNoRegionChangeUnderway(
 }
 
 // GetMultiregionConfig is part of the eval.Planner interface.
-func (p *planner) GetMultiregionConfig(databaseID descpb.ID) (interface{}, bool) {
+func (p *planner) GetMultiregionConfig(
+	ctx context.Context, databaseID descpb.ID,
+) (interface{}, bool) {
 
 	regionConfig, err := SynthesizeRegionConfig(
-		p.EvalContext().Ctx(),
+		ctx,
 		p.txn,
 		databaseID,
 		p.Descriptors(),

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -1211,7 +1211,7 @@ func partitionByForRegionalByRow(
 // ValidateAllMultiRegionZoneConfigsInCurrentDatabase is part of the eval.DatabaseCatalog interface.
 func (p *planner) ValidateAllMultiRegionZoneConfigsInCurrentDatabase(ctx context.Context) error {
 	dbDesc, err := p.Descriptors().GetImmutableDatabaseByName(
-		p.EvalContext().Ctx(),
+		ctx,
 		p.txn,
 		p.CurrentDatabase(),
 		tree.DatabaseLookupFlags{
@@ -1289,7 +1289,7 @@ func (p *planner) ResetMultiRegionZoneConfigsForTable(ctx context.Context, id in
 // the multi-region syntax.
 func (p *planner) ResetMultiRegionZoneConfigsForDatabase(ctx context.Context, id int64) error {
 	_, dbDesc, err := p.Descriptors().GetImmutableDatabaseByID(
-		p.EvalContext().Ctx(),
+		ctx,
 		p.txn,
 		descpb.ID(id),
 		tree.DatabaseLookupFlags{
@@ -1388,7 +1388,7 @@ func (p *planner) CurrentDatabaseRegionConfig(
 	ctx context.Context,
 ) (eval.DatabaseRegionConfig, error) {
 	dbDesc, err := p.Descriptors().GetImmutableDatabaseByName(
-		p.EvalContext().Ctx(),
+		ctx,
 		p.txn,
 		p.CurrentDatabase(),
 		tree.DatabaseLookupFlags{

--- a/pkg/sql/routine.go
+++ b/pkg/sql/routine.go
@@ -42,7 +42,7 @@ func (p *planner) EvalRoutineExpr(
 	// of any preceding statements is ignored. We set up a rowResultWriter that
 	// can store the results of the final statement here.
 	var rch rowContainerHelper
-	rch.Init(retTypes, p.ExtendedEvalContext(), "routine" /* opName */)
+	rch.Init(ctx, retTypes, p.ExtendedEvalContext(), "routine" /* opName */)
 	defer rch.Close(ctx)
 	rrw := NewRowResultWriter(&rch)
 

--- a/pkg/sql/rowexec/aggregator.go
+++ b/pkg/sql/rowexec/aggregator.go
@@ -87,6 +87,7 @@ type aggregatorBase struct {
 // trailingMetaCallback is passed as part of ProcStateOpts; the inputs to drain
 // are in aggregatorBase.
 func (ag *aggregatorBase) init(
+	ctx context.Context,
 	self execinfra.RowSource,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
@@ -96,7 +97,6 @@ func (ag *aggregatorBase) init(
 	output execinfra.RowReceiver,
 	trailingMetaCallback func() []execinfrapb.ProducerMetadata,
 ) error {
-	ctx := flowCtx.EvalCtx.Ctx()
 	memMonitor := execinfra.NewMonitor(ctx, flowCtx.EvalCtx.Mon, "aggregator-mem")
 	if execstats.ShouldCollectStats(ctx, flowCtx.CollectStats) {
 		input = newInputStatCollector(input)
@@ -148,7 +148,7 @@ func (ag *aggregatorBase) init(
 	}
 
 	return ag.ProcessorBase.Init(
-		self, post, ag.outputTypes, flowCtx, processorID, output, memMonitor,
+		ctx, self, post, ag.outputTypes, flowCtx, processorID, output, memMonitor,
 		execinfra.ProcStateOpts{
 			InputsToDrain:        []execinfra.RowSource{ag.input},
 			TrailingMetaCallback: trailingMetaCallback,
@@ -251,6 +251,7 @@ const (
 )
 
 func newAggregator(
+	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec *execinfrapb.AggregatorSpec,
@@ -259,10 +260,10 @@ func newAggregator(
 	output execinfra.RowReceiver,
 ) (execinfra.Processor, error) {
 	if spec.IsRowCount() {
-		return newCountAggregator(flowCtx, processorID, input, post, output)
+		return newCountAggregator(ctx, flowCtx, processorID, input, post, output)
 	}
 	if len(spec.OrderedGroupCols) == len(spec.GroupCols) {
-		return newOrderedAggregator(flowCtx, processorID, spec, input, post, output)
+		return newOrderedAggregator(ctx, flowCtx, processorID, spec, input, post, output)
 	}
 
 	ag := &hashAggregator{
@@ -271,6 +272,7 @@ func newAggregator(
 	}
 
 	if err := ag.init(
+		ctx,
 		ag,
 		flowCtx,
 		processorID,
@@ -294,6 +296,7 @@ func newAggregator(
 }
 
 func newOrderedAggregator(
+	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec *execinfrapb.AggregatorSpec,
@@ -304,6 +307,7 @@ func newOrderedAggregator(
 	ag := &orderedAggregator{}
 
 	if err := ag.init(
+		ctx,
 		ag,
 		flowCtx,
 		processorID,

--- a/pkg/sql/rowexec/aggregator.go
+++ b/pkg/sql/rowexec/aggregator.go
@@ -135,7 +135,7 @@ func (ag *aggregatorBase) init(
 			}
 		}
 		constructor, arguments, outputType, err := execagg.GetAggregateConstructor(
-			flowCtx.EvalCtx, semaCtx, &aggInfo, ag.inputTypes,
+			ctx, flowCtx.EvalCtx, semaCtx, &aggInfo, ag.inputTypes,
 		)
 		if err != nil {
 			return err

--- a/pkg/sql/rowexec/aggregator_test.go
+++ b/pkg/sql/rowexec/aggregator_test.go
@@ -445,7 +445,7 @@ func BenchmarkAggregation(b *testing.B) {
 			b.SetBytes(int64(8 * numRows * numCols))
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				d, err := newAggregator(flowCtx, 0 /* processorID */, spec, input, post, disposer)
+				d, err := newAggregator(ctx, flowCtx, 0 /* processorID */, spec, input, post, disposer)
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -485,7 +485,7 @@ func BenchmarkCountRows(b *testing.B) {
 	b.SetBytes(int64(8 * numRows * numCols))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		d, err := newAggregator(flowCtx, 0 /* processorID */, spec, input, post, disposer)
+		d, err := newAggregator(ctx, flowCtx, 0 /* processorID */, spec, input, post, disposer)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -518,7 +518,7 @@ func BenchmarkGrouping(b *testing.B) {
 	b.SetBytes(int64(8 * numRows * numCols))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		d, err := newAggregator(flowCtx, 0 /* processorID */, spec, input, post, disposer)
+		d, err := newAggregator(ctx, flowCtx, 0 /* processorID */, spec, input, post, disposer)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -579,7 +579,7 @@ func benchmarkAggregationWithGrouping(b *testing.B, numOrderedCols int) {
 			b.SetBytes(int64(8 * intPow(groupSize, len(groupedCols)+1) * numCols))
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				d, err := newAggregator(flowCtx, 0 /* processorID */, spec, input, post, disposer)
+				d, err := newAggregator(ctx, flowCtx, 0 /* processorID */, spec, input, post, disposer)
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/pkg/sql/rowexec/backfiller.go
+++ b/pkg/sql/rowexec/backfiller.go
@@ -101,7 +101,7 @@ func (b *backfiller) Run(ctx context.Context) {
 
 func (b *backfiller) doRun(ctx context.Context) *execinfrapb.ProducerMetadata {
 	semaCtx := tree.MakeSemaContext()
-	if err := b.out.Init(&execinfrapb.PostProcessSpec{}, nil, &semaCtx, b.flowCtx.NewEvalCtx()); err != nil {
+	if err := b.out.Init(ctx, &execinfrapb.PostProcessSpec{}, nil, &semaCtx, b.flowCtx.NewEvalCtx()); err != nil {
 		return &execinfrapb.ProducerMetadata{Err: err}
 	}
 	finishedSpans, err := b.mainLoop(ctx)

--- a/pkg/sql/rowexec/bulk_row_writer.go
+++ b/pkg/sql/rowexec/bulk_row_writer.go
@@ -49,6 +49,7 @@ var _ execinfra.Processor = &bulkRowWriter{}
 var _ execinfra.RowSource = &bulkRowWriter{}
 
 func newBulkRowWriterProcessor(
+	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec execinfrapb.BulkRowWriterSpec,
@@ -59,13 +60,13 @@ func newBulkRowWriterProcessor(
 		flowCtx:        flowCtx,
 		processorID:    processorID,
 		batchIdxAtomic: 0,
-		tableDesc:      flowCtx.TableDescriptor(&spec.Table),
+		tableDesc:      flowCtx.TableDescriptor(ctx, &spec.Table),
 		spec:           spec,
 		input:          input,
 		output:         output,
 	}
 	if err := c.Init(
-		c, &execinfrapb.PostProcessSpec{}, CTASPlanResultTypes, flowCtx, processorID, output,
+		ctx, c, &execinfrapb.PostProcessSpec{}, CTASPlanResultTypes, flowCtx, processorID, output,
 		nil /* memMonitor */, execinfra.ProcStateOpts{InputsToDrain: []execinfra.RowSource{input}},
 	); err != nil {
 		return nil, err

--- a/pkg/sql/rowexec/columnbackfiller.go
+++ b/pkg/sql/rowexec/columnbackfiller.go
@@ -66,7 +66,7 @@ func newColumnBackfiller(
 	columnBackfillerMon := execinfra.NewMonitor(ctx, flowCtx.Cfg.BackfillerMonitor,
 		"column-backfill-mon")
 	cb := &columnBackfiller{
-		desc: flowCtx.TableDescriptor(&spec.Table),
+		desc: flowCtx.TableDescriptor(ctx, &spec.Table),
 		backfiller: backfiller{
 			name:        "Column",
 			filter:      backfill.ColumnMutationFilter,

--- a/pkg/sql/rowexec/countrows.go
+++ b/pkg/sql/rowexec/countrows.go
@@ -36,6 +36,7 @@ var _ execinfra.RowSource = &countAggregator{}
 const countRowsProcName = "count rows"
 
 func newCountAggregator(
+	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	input execinfra.RowSource,
@@ -45,12 +46,13 @@ func newCountAggregator(
 	ag := &countAggregator{}
 	ag.input = input
 
-	if execstats.ShouldCollectStats(flowCtx.EvalCtx.Ctx(), flowCtx.CollectStats) {
+	if execstats.ShouldCollectStats(ctx, flowCtx.CollectStats) {
 		ag.input = newInputStatCollector(input)
 		ag.ExecStatsForTrace = ag.execStatsForTrace
 	}
 
 	if err := ag.Init(
+		ctx,
 		ag,
 		post,
 		[]*types.T{types.Int},

--- a/pkg/sql/rowexec/distinct.go
+++ b/pkg/sql/rowexec/distinct.go
@@ -73,6 +73,7 @@ const sortedDistinctProcName = "sorted distinct"
 
 // newDistinct instantiates a new Distinct processor.
 func newDistinct(
+	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec *execinfrapb.DistinctSpec,
@@ -98,7 +99,6 @@ func newDistinct(
 		}
 	}
 
-	ctx := flowCtx.EvalCtx.Ctx()
 	memMonitor := execinfra.NewMonitor(ctx, flowCtx.EvalCtx.Mon, "distinct-mem")
 	d := &distinct{
 		input:            input,
@@ -118,7 +118,7 @@ func newDistinct(
 	}
 
 	if err := d.Init(
-		d, post, d.types, flowCtx, processorID, output, memMonitor, /* memMonitor */
+		ctx, d, post, d.types, flowCtx, processorID, output, memMonitor, /* memMonitor */
 		execinfra.ProcStateOpts{
 			InputsToDrain: []execinfra.RowSource{d.input},
 			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {

--- a/pkg/sql/rowexec/distinct_test.go
+++ b/pkg/sql/rowexec/distinct_test.go
@@ -280,7 +280,7 @@ func TestDistinct(t *testing.T) {
 				EvalCtx: &evalCtx,
 			}
 
-			d, err := newDistinct(&flowCtx, 0 /* processorID */, &ds, in, &execinfrapb.PostProcessSpec{}, out)
+			d, err := newDistinct(context.Background(), &flowCtx, 0 /* processorID */, &ds, in, &execinfrapb.PostProcessSpec{}, out)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -341,7 +341,7 @@ func benchmarkDistinct(b *testing.B, orderedColumns []uint32) {
 			b.SetBytes(int64(8 * numRows * numCols))
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				d, err := newDistinct(flowCtx, 0 /* processorID */, spec, input, post, &rowDisposer{})
+				d, err := newDistinct(ctx, flowCtx, 0 /* processorID */, spec, input, post, &rowDisposer{})
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/pkg/sql/rowexec/filterer.go
+++ b/pkg/sql/rowexec/filterer.go
@@ -58,12 +58,13 @@ func newFiltererProcessor(
 		return nil, err
 	}
 
+	ctx := flowCtx.EvalCtx.Ctx()
+
 	f.filter = &execinfrapb.ExprHelper{}
-	if err := f.filter.Init(spec.Filter, types, &f.SemaCtx, f.EvalCtx); err != nil {
+	if err := f.filter.Init(ctx, spec.Filter, types, &f.SemaCtx, f.EvalCtx); err != nil {
 		return nil, err
 	}
 
-	ctx := flowCtx.EvalCtx.Ctx()
 	if execstats.ShouldCollectStats(ctx, flowCtx.CollectStats) {
 		f.input = newInputStatCollector(f.input)
 		f.ExecStatsForTrace = f.execStatsForTrace

--- a/pkg/sql/rowexec/filterer.go
+++ b/pkg/sql/rowexec/filterer.go
@@ -36,6 +36,7 @@ var _ execopnode.OpNode = &filtererProcessor{}
 const filtererProcName = "filterer"
 
 func newFiltererProcessor(
+	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec *execinfrapb.FiltererSpec,
@@ -46,6 +47,7 @@ func newFiltererProcessor(
 	f := &filtererProcessor{input: input}
 	types := input.OutputTypes()
 	if err := f.Init(
+		ctx,
 		f,
 		post,
 		types,
@@ -57,8 +59,6 @@ func newFiltererProcessor(
 	); err != nil {
 		return nil, err
 	}
-
-	ctx := flowCtx.EvalCtx.Ctx()
 
 	f.filter = &execinfrapb.ExprHelper{}
 	if err := f.filter.Init(ctx, spec.Filter, types, &f.SemaCtx, f.EvalCtx); err != nil {

--- a/pkg/sql/rowexec/filterer_test.go
+++ b/pkg/sql/rowexec/filterer_test.go
@@ -89,7 +89,7 @@ func TestFilterer(t *testing.T) {
 				Filter: execinfrapb.Expression{Expr: c.filter},
 			}
 
-			d, err := newFiltererProcessor(&flowCtx, 0 /* processorID */, &spec, in, &c.post, out)
+			d, err := newFiltererProcessor(context.Background(), &flowCtx, 0 /* processorID */, &spec, in, &c.post, out)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -146,7 +146,7 @@ func BenchmarkFilterer(b *testing.B) {
 			b.SetBytes(int64(8 * numRows * numCols))
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				d, err := newFiltererProcessor(flowCtx, 0 /* processorID */, &spec, input, post, disposer)
+				d, err := newFiltererProcessor(ctx, flowCtx, 0 /* processorID */, &spec, input, post, disposer)
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/pkg/sql/rowexec/hashjoiner.go
+++ b/pkg/sql/rowexec/hashjoiner.go
@@ -100,6 +100,7 @@ const hashJoinerProcName = "hash joiner"
 
 // newHashJoiner creates a new hash join processor.
 func newHashJoiner(
+	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec *execinfrapb.HashJoinerSpec,
@@ -119,6 +120,7 @@ func newHashJoiner(
 	}
 
 	if err := h.joinerBase.init(
+		ctx,
 		h,
 		flowCtx,
 		processorID,
@@ -140,7 +142,6 @@ func newHashJoiner(
 		return nil, err
 	}
 
-	ctx := h.FlowCtx.EvalCtx.Ctx()
 	// Limit the memory use by creating a child monitor with a hard limit.
 	// The hashJoiner will overflow to disk if this limit is not enough.
 	h.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx, "hashjoiner-limited")

--- a/pkg/sql/rowexec/hashjoiner_test.go
+++ b/pkg/sql/rowexec/hashjoiner_test.go
@@ -1063,7 +1063,7 @@ func TestHashJoiner(t *testing.T) {
 					OnExpr:         c.onExpr,
 				}
 				h, err := newHashJoiner(
-					&flowCtx, 0 /* processorID */, spec, leftInput, rightInput, &post, out,
+					ctx, &flowCtx, 0 /* processorID */, spec, leftInput, rightInput, &post, out,
 				)
 				if err != nil {
 					return err
@@ -1145,7 +1145,7 @@ func TestHashJoinerError(t *testing.T) {
 				OnExpr:         c.onExpr,
 			}
 			h, err := newHashJoiner(
-				&flowCtx, 0 /* processorID */, spec, leftInput, rightInput, &post, out,
+				ctx, &flowCtx, 0 /* processorID */, spec, leftInput, rightInput, &post, out,
 			)
 			if err != nil {
 				return err
@@ -1282,7 +1282,7 @@ func TestHashJoinerDrain(t *testing.T) {
 
 	post := execinfrapb.PostProcessSpec{Projection: true, OutputColumns: outCols}
 	h, err := newHashJoiner(
-		&flowCtx, 0 /* processorID */, &spec, leftInput, rightInput, &post, out,
+		ctx, &flowCtx, 0 /* processorID */, &spec, leftInput, rightInput, &post, out,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -1414,7 +1414,7 @@ func TestHashJoinerDrainAfterBuildPhaseError(t *testing.T) {
 
 	post := execinfrapb.PostProcessSpec{Projection: true, OutputColumns: outCols}
 	h, err := newHashJoiner(
-		&flowCtx, 0 /* processorID */, &spec, leftInput, rightInput, &post, out,
+		ctx, &flowCtx, 0 /* processorID */, &spec, leftInput, rightInput, &post, out,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -1500,7 +1500,7 @@ func BenchmarkHashJoiner(b *testing.B) {
 						// TODO(asubiotto): Get rid of uncleared state between
 						// hashJoiner Run()s to omit instantiation time from benchmarks.
 						h, err := newHashJoiner(
-							flowCtx, 0 /* processorID */, spec, leftInput, rightInput, post, &rowDisposer{},
+							ctx, flowCtx, 0 /* processorID */, spec, leftInput, rightInput, post, &rowDisposer{},
 						)
 						if err != nil {
 							b.Fatal(err)

--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -78,7 +78,7 @@ func newIndexBackfiller(
 	indexBackfillerMon := execinfra.NewMonitor(ctx, flowCtx.Cfg.BackfillerMonitor,
 		"index-backfill-mon")
 	ib := &indexBackfiller{
-		desc:    flowCtx.TableDescriptor(&spec.Table),
+		desc:    flowCtx.TableDescriptor(ctx, &spec.Table),
 		spec:    spec,
 		flowCtx: flowCtx,
 		output:  output,
@@ -352,7 +352,7 @@ func (ib *indexBackfiller) Run(ctx context.Context) {
 	progCh := make(chan execinfrapb.RemoteProducerMetadata_BulkProcessorProgress)
 
 	semaCtx := tree.MakeSemaContext()
-	if err := ib.out.Init(&execinfrapb.PostProcessSpec{}, nil, &semaCtx, ib.flowCtx.NewEvalCtx()); err != nil {
+	if err := ib.out.Init(ctx, &execinfrapb.PostProcessSpec{}, nil, &semaCtx, ib.flowCtx.NewEvalCtx()); err != nil {
 		ib.output.Push(nil, &execinfrapb.ProducerMetadata{Err: err})
 		return
 	}

--- a/pkg/sql/rowexec/inverted_filterer.go
+++ b/pkg/sql/rowexec/inverted_filterer.go
@@ -121,7 +121,7 @@ func newInvertedFilterer(
 		ifr.diskMonitor,
 	)
 
-	if execstats.ShouldCollectStats(flowCtx.EvalCtx.Ctx(), flowCtx.CollectStats) {
+	if execstats.ShouldCollectStats(ctx, flowCtx.CollectStats) {
 		ifr.input = newInputStatCollector(ifr.input)
 		ifr.ExecStatsForTrace = ifr.execStatsForTrace
 	}
@@ -130,7 +130,7 @@ func newInvertedFilterer(
 		semaCtx := flowCtx.NewSemaContext(flowCtx.Txn)
 		var exprHelper execinfrapb.ExprHelper
 		colTypes := []*types.T{spec.PreFiltererSpec.Type}
-		if err := exprHelper.Init(spec.PreFiltererSpec.Expression, colTypes, semaCtx, ifr.EvalCtx); err != nil {
+		if err := exprHelper.Init(ctx, spec.PreFiltererSpec.Expression, colTypes, semaCtx, ifr.EvalCtx); err != nil {
 			return nil, err
 		}
 		preFilterer, preFiltererState, err := invertedidx.NewBoundPreFilterer(

--- a/pkg/sql/rowexec/inverted_filterer.go
+++ b/pkg/sql/rowexec/inverted_filterer.go
@@ -69,6 +69,7 @@ var _ execopnode.OpNode = &invertedFilterer{}
 const invertedFiltererProcName = "inverted filterer"
 
 func newInvertedFilterer(
+	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec *execinfrapb.InvertedFiltererSpec,
@@ -96,7 +97,7 @@ func newInvertedFilterer(
 
 	// Initialize ProcessorBase.
 	if err := ifr.ProcessorBase.Init(
-		ifr, post, outputColTypes, flowCtx, processorID, output, nil, /* memMonitor */
+		ctx, ifr, post, outputColTypes, flowCtx, processorID, output, nil, /* memMonitor */
 		execinfra.ProcStateOpts{
 			InputsToDrain: []execinfra.RowSource{ifr.input},
 			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {
@@ -108,7 +109,6 @@ func newInvertedFilterer(
 		return nil, err
 	}
 
-	ctx := flowCtx.EvalCtx.Ctx()
 	// Initialize memory monitor and row container for input rows.
 	ifr.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx, "inverted-filterer-limited")
 	ifr.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor, "inverted-filterer-disk")

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -162,6 +162,7 @@ const invertedJoinerProcName = "inverted joiner"
 // argument is non-nil only for tests. When nil, the invertedJoiner uses
 // the spec to construct an implementation of DatumsToInvertedExpr.
 func newInvertedJoiner(
+	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec *execinfrapb.InvertedJoinerSpec,
@@ -221,8 +222,6 @@ func newInvertedJoiner(
 		}
 	}
 
-	ctx := flowCtx.EvalCtx.Ctx()
-
 	// Make sure the key column types are hydrated. The fetched column types
 	// will be hydrated in ProcessorBase.Init below.
 	resolver := flowCtx.NewTypeResolver(flowCtx.Txn)
@@ -235,7 +234,7 @@ func newInvertedJoiner(
 	}
 
 	if err := ij.ProcessorBase.Init(
-		ij, post, outputColTypes, flowCtx, processorID, output, nil, /* memMonitor */
+		ctx, ij, post, outputColTypes, flowCtx, processorID, output, nil, /* memMonitor */
 		execinfra.ProcStateOpts{
 			InputsToDrain: []execinfra.RowSource{ij.input},
 			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {

--- a/pkg/sql/rowexec/inverted_joiner_test.go
+++ b/pkg/sql/rowexec/inverted_joiner_test.go
@@ -688,6 +688,7 @@ func TestInvertedJoiner(t *testing.T) {
 				}
 
 				ij, err := newInvertedJoiner(
+					ctx,
 					&flowCtx,
 					0, /* processorID */
 					&execinfrapb.InvertedJoinerSpec{
@@ -795,6 +796,7 @@ func TestInvertedJoinerDrain(t *testing.T) {
 			t.Fatal(err)
 		}
 		return newInvertedJoiner(
+			ctx,
 			&flowCtx,
 			0, /* processorID */
 			&execinfrapb.InvertedJoinerSpec{

--- a/pkg/sql/rowexec/joinerbase.go
+++ b/pkg/sql/rowexec/joinerbase.go
@@ -87,7 +87,7 @@ func (jb *joinerBase) init(
 		return err
 	}
 	semaCtx := flowCtx.NewSemaContext(flowCtx.Txn)
-	return jb.onCond.Init(onExpr, onCondTypes, semaCtx, jb.EvalCtx)
+	return jb.onCond.Init(flowCtx.EvalCtx.Ctx(), onExpr, onCondTypes, semaCtx, jb.EvalCtx)
 }
 
 // joinSide is the utility type to distinguish between two sides of the join.

--- a/pkg/sql/rowexec/joinerbase.go
+++ b/pkg/sql/rowexec/joinerbase.go
@@ -11,6 +11,8 @@
 package rowexec
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -36,6 +38,7 @@ type joinerBase struct {
 // opts is passed along to the underlying ProcessorBase. The zero value is used
 // if the processor using the joinerBase is not implementing RowSource.
 func (jb *joinerBase) init(
+	ctx context.Context,
 	self execinfra.RowSource,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
@@ -82,12 +85,12 @@ func (jb *joinerBase) init(
 	}
 
 	if err := jb.ProcessorBase.Init(
-		self, post, outputTypes, flowCtx, processorID, output, nil /* memMonitor */, opts,
+		ctx, self, post, outputTypes, flowCtx, processorID, output, nil /* memMonitor */, opts,
 	); err != nil {
 		return err
 	}
 	semaCtx := flowCtx.NewSemaContext(flowCtx.Txn)
-	return jb.onCond.Init(flowCtx.EvalCtx.Ctx(), onExpr, onCondTypes, semaCtx, jb.EvalCtx)
+	return jb.onCond.Init(ctx, onExpr, onCondTypes, semaCtx, jb.EvalCtx)
 }
 
 // joinSide is the utility type to distinguish between two sides of the join.

--- a/pkg/sql/rowexec/joinreader_test.go
+++ b/pkg/sql/rowexec/joinreader_test.go
@@ -1137,6 +1137,7 @@ func TestJoinReader(t *testing.T) {
 							splitter := span.MakeSplitter(td, index, neededOrds)
 
 							jr, err := newJoinReader(
+								ctx,
 								&flowCtx,
 								0, /* processorID */
 								&execinfrapb.JoinReaderSpec{
@@ -1307,6 +1308,7 @@ CREATE TABLE test.t (a INT, s STRING, INDEX (a, s))`); err != nil {
 
 	out := &distsqlutils.RowBuffer{}
 	jr, err := newJoinReader(
+		ctx,
 		&flowCtx,
 		0, /* processorID */
 		&execinfrapb.JoinReaderSpec{
@@ -1411,6 +1413,7 @@ func TestJoinReaderDrain(t *testing.T) {
 
 	testReaderProcessorDrain(ctx, t, func(out execinfra.RowReceiver) (execinfra.Processor, error) {
 		return newJoinReader(
+			ctx,
 			&flowCtx,
 			0, /* processorID */
 			&execinfrapb.JoinReaderSpec{FetchSpec: fetchSpec},
@@ -1435,7 +1438,7 @@ func TestJoinReaderDrain(t *testing.T) {
 		out.ConsumerDone()
 
 		jr, err := newJoinReader(
-			&flowCtx, 0 /* processorID */, &execinfrapb.JoinReaderSpec{
+			ctx, &flowCtx, 0 /* processorID */, &execinfrapb.JoinReaderSpec{
 				FetchSpec: fetchSpec,
 			}, in, &execinfrapb.PostProcessSpec{},
 			out, lookupJoinReaderType)
@@ -1849,7 +1852,7 @@ func benchmarkJoinReader(b *testing.B, bc JRBenchConfig) {
 								for i := 0; i < b.N; i++ {
 									flowCtx.Cfg.TestingKnobs.MemoryLimitBytes = memoryLimit
 									jr, err := newJoinReader(
-										&flowCtx, 0 /* processorID */, &spec, input, &execinfrapb.PostProcessSpec{}, &output, lookupJoinReaderType,
+										ctx, &flowCtx, 0 /* processorID */, &spec, input, &execinfrapb.PostProcessSpec{}, &output, lookupJoinReaderType,
 									)
 									if err != nil {
 										b.Fatal(err)
@@ -2053,7 +2056,7 @@ func BenchmarkJoinReaderLookupStress(b *testing.B) {
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {
-				jr, err := newJoinReader(&flowCtx, 0 /* processorID */, &spec, input, &post, &output, lookupJoinReaderType)
+				jr, err := newJoinReader(ctx, &flowCtx, 0 /* processorID */, &spec, input, &post, &output, lookupJoinReaderType)
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/pkg/sql/rowexec/mergejoiner_test.go
+++ b/pkg/sql/rowexec/mergejoiner_test.go
@@ -728,7 +728,7 @@ func TestMergeJoiner(t *testing.T) {
 			}
 
 			post := execinfrapb.PostProcessSpec{Projection: true, OutputColumns: c.outCols}
-			m, err := newMergeJoiner(&flowCtx, 0 /* processorID */, &ms, leftInput, rightInput, &post, out)
+			m, err := newMergeJoiner(context.Background(), &flowCtx, 0 /* processorID */, &ms, leftInput, rightInput, &post, out)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -833,7 +833,7 @@ func TestConsumerClosed(t *testing.T) {
 				EvalCtx: &evalCtx,
 			}
 			post := execinfrapb.PostProcessSpec{Projection: true, OutputColumns: outCols}
-			m, err := newMergeJoiner(&flowCtx, 0 /* processorID */, &spec, leftInput, rightInput, &post, out)
+			m, err := newMergeJoiner(context.Background(), &flowCtx, 0 /* processorID */, &spec, leftInput, rightInput, &post, out)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -882,7 +882,7 @@ func BenchmarkMergeJoiner(b *testing.B) {
 			b.SetBytes(int64(8 * inputSize * numCols * 2))
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				m, err := newMergeJoiner(flowCtx, 0 /* processorID */, spec, leftInput, rightInput, post, disposer)
+				m, err := newMergeJoiner(ctx, flowCtx, 0 /* processorID */, spec, leftInput, rightInput, post, disposer)
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -901,7 +901,7 @@ func BenchmarkMergeJoiner(b *testing.B) {
 			b.SetBytes(int64(8 * inputSize * numCols * 2))
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				m, err := newMergeJoiner(flowCtx, 0 /* processorID */, spec, leftInput, rightInput, post, disposer)
+				m, err := newMergeJoiner(ctx, flowCtx, 0 /* processorID */, spec, leftInput, rightInput, post, disposer)
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -921,7 +921,7 @@ func BenchmarkMergeJoiner(b *testing.B) {
 			b.SetBytes(int64(8 * inputSize * numCols * 2))
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				m, err := newMergeJoiner(flowCtx, 0 /* processorID */, spec, leftInput, rightInput, post, disposer)
+				m, err := newMergeJoiner(ctx, flowCtx, 0 /* processorID */, spec, leftInput, rightInput, post, disposer)
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/pkg/sql/rowexec/noop.go
+++ b/pkg/sql/rowexec/noop.go
@@ -46,6 +46,7 @@ var noopPool = sync.Pool{
 }
 
 func newNoopProcessor(
+	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	input execinfra.RowSource,
@@ -55,6 +56,7 @@ func newNoopProcessor(
 	n := noopPool.Get().(*noopProcessor)
 	n.input = input
 	if err := n.Init(
+		ctx,
 		n,
 		post,
 		input.OutputTypes(),
@@ -69,7 +71,6 @@ func newNoopProcessor(
 		return nil, err
 	}
 	n.AddInputToDrain(n.input)
-	ctx := flowCtx.EvalCtx.Ctx()
 	if execstats.ShouldCollectStats(ctx, flowCtx.CollectStats) {
 		n.input = newInputStatCollector(n.input)
 		n.ExecStatsForTrace = n.execStatsForTrace

--- a/pkg/sql/rowexec/noop_test.go
+++ b/pkg/sql/rowexec/noop_test.go
@@ -50,7 +50,7 @@ func BenchmarkNoop(b *testing.B) {
 			b.SetBytes(int64(8 * numRows * numCols))
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				d, err := newNoopProcessor(flowCtx, 0 /* processorID */, input, post, disposer)
+				d, err := newNoopProcessor(ctx, flowCtx, 0 /* processorID */, input, post, disposer)
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/pkg/sql/rowexec/ordinality.go
+++ b/pkg/sql/rowexec/ordinality.go
@@ -36,6 +36,7 @@ var _ execinfra.RowSource = &ordinalityProcessor{}
 const ordinalityProcName = "ordinality"
 
 func newOrdinalityProcessor(
+	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec *execinfrapb.OrdinalitySpec,
@@ -43,13 +44,13 @@ func newOrdinalityProcessor(
 	post *execinfrapb.PostProcessSpec,
 	output execinfra.RowReceiver,
 ) (execinfra.RowSourcedProcessor, error) {
-	ctx := flowCtx.EvalCtx.Ctx()
 	o := &ordinalityProcessor{input: input, curCnt: 1}
 
 	colTypes := make([]*types.T, len(input.OutputTypes())+1)
 	copy(colTypes, input.OutputTypes())
 	colTypes[len(colTypes)-1] = types.Int
 	if err := o.Init(
+		ctx,
 		o,
 		post,
 		colTypes,

--- a/pkg/sql/rowexec/ordinality_test.go
+++ b/pkg/sql/rowexec/ordinality_test.go
@@ -118,7 +118,7 @@ func TestOrdinality(t *testing.T) {
 				EvalCtx: &evalCtx,
 			}
 
-			d, err := newOrdinalityProcessor(&flowCtx, 0 /* processorID */, &os, in, &execinfrapb.PostProcessSpec{}, out)
+			d, err := newOrdinalityProcessor(context.Background(), &flowCtx, 0 /* processorID */, &os, in, &execinfrapb.PostProcessSpec{}, out)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -173,7 +173,7 @@ func BenchmarkOrdinality(b *testing.B) {
 		b.SetBytes(int64(8 * numRows * numCols))
 		b.Run(fmt.Sprintf("rows=%d", numRows), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				o, err := newOrdinalityProcessor(flowCtx, 0 /* processorID */, spec, input, post, &rowDisposer{})
+				o, err := newOrdinalityProcessor(ctx, flowCtx, 0 /* processorID */, spec, input, post, &rowDisposer{})
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/pkg/sql/rowexec/processors.go
+++ b/pkg/sql/rowexec/processors.go
@@ -123,25 +123,25 @@ func NewProcessor(
 		if err := checkNumInOut(inputs, outputs, 1, 1); err != nil {
 			return nil, err
 		}
-		return newNoopProcessor(flowCtx, processorID, inputs[0], post, outputs[0])
+		return newNoopProcessor(ctx, flowCtx, processorID, inputs[0], post, outputs[0])
 	}
 	if core.Values != nil {
 		if err := checkNumInOut(inputs, outputs, 0, 1); err != nil {
 			return nil, err
 		}
-		return newValuesProcessor(flowCtx, processorID, core.Values, post, outputs[0])
+		return newValuesProcessor(ctx, flowCtx, processorID, core.Values, post, outputs[0])
 	}
 	if core.TableReader != nil {
 		if err := checkNumInOut(inputs, outputs, 0, 1); err != nil {
 			return nil, err
 		}
-		return newTableReader(flowCtx, processorID, core.TableReader, post, outputs[0])
+		return newTableReader(ctx, flowCtx, processorID, core.TableReader, post, outputs[0])
 	}
 	if core.Filterer != nil {
 		if err := checkNumInOut(inputs, outputs, 1, 1); err != nil {
 			return nil, err
 		}
-		return newFiltererProcessor(flowCtx, processorID, core.Filterer, inputs[0], post, outputs[0])
+		return newFiltererProcessor(ctx, flowCtx, processorID, core.Filterer, inputs[0], post, outputs[0])
 	}
 	if core.JoinReader != nil {
 		if err := checkNumInOut(inputs, outputs, 1, 1); err != nil {
@@ -149,9 +149,10 @@ func NewProcessor(
 		}
 		if core.JoinReader.IsIndexJoin() {
 			return newJoinReader(
-				flowCtx, processorID, core.JoinReader, inputs[0], post, outputs[0], indexJoinReaderType)
+				ctx, flowCtx, processorID, core.JoinReader, inputs[0], post, outputs[0], indexJoinReaderType,
+			)
 		}
-		return newJoinReader(flowCtx, processorID, core.JoinReader, inputs[0], post, outputs[0], lookupJoinReaderType)
+		return newJoinReader(ctx, flowCtx, processorID, core.JoinReader, inputs[0], post, outputs[0], lookupJoinReaderType)
 	}
 	if core.Sorter != nil {
 		if err := checkNumInOut(inputs, outputs, 1, 1); err != nil {
@@ -163,26 +164,26 @@ func NewProcessor(
 		if err := checkNumInOut(inputs, outputs, 1, 1); err != nil {
 			return nil, err
 		}
-		return newDistinct(flowCtx, processorID, core.Distinct, inputs[0], post, outputs[0])
+		return newDistinct(ctx, flowCtx, processorID, core.Distinct, inputs[0], post, outputs[0])
 	}
 	if core.Ordinality != nil {
 		if err := checkNumInOut(inputs, outputs, 1, 1); err != nil {
 			return nil, err
 		}
-		return newOrdinalityProcessor(flowCtx, processorID, core.Ordinality, inputs[0], post, outputs[0])
+		return newOrdinalityProcessor(ctx, flowCtx, processorID, core.Ordinality, inputs[0], post, outputs[0])
 	}
 	if core.Aggregator != nil {
 		if err := checkNumInOut(inputs, outputs, 1, 1); err != nil {
 			return nil, err
 		}
-		return newAggregator(flowCtx, processorID, core.Aggregator, inputs[0], post, outputs[0])
+		return newAggregator(ctx, flowCtx, processorID, core.Aggregator, inputs[0], post, outputs[0])
 	}
 	if core.MergeJoiner != nil {
 		if err := checkNumInOut(inputs, outputs, 2, 1); err != nil {
 			return nil, err
 		}
 		return newMergeJoiner(
-			flowCtx, processorID, core.MergeJoiner, inputs[0], inputs[1], post, outputs[0],
+			ctx, flowCtx, processorID, core.MergeJoiner, inputs[0], inputs[1], post, outputs[0],
 		)
 	}
 	if core.ZigzagJoiner != nil {
@@ -190,7 +191,7 @@ func NewProcessor(
 			return nil, err
 		}
 		return newZigzagJoiner(
-			flowCtx, processorID, core.ZigzagJoiner, nil, post, outputs[0],
+			ctx, flowCtx, processorID, core.ZigzagJoiner, nil, post, outputs[0],
 		)
 	}
 	if core.HashJoiner != nil {
@@ -198,7 +199,7 @@ func NewProcessor(
 			return nil, err
 		}
 		return newHashJoiner(
-			flowCtx, processorID, core.HashJoiner, inputs[0], inputs[1], post, outputs[0],
+			ctx, flowCtx, processorID, core.HashJoiner, inputs[0], inputs[1], post, outputs[0],
 		)
 	}
 	if core.InvertedJoiner != nil {
@@ -206,7 +207,8 @@ func NewProcessor(
 			return nil, err
 		}
 		return newInvertedJoiner(
-			flowCtx, processorID, core.InvertedJoiner, nil, inputs[0], post, outputs[0])
+			ctx, flowCtx, processorID, core.InvertedJoiner, nil, inputs[0], post, outputs[0],
+		)
 	}
 	if core.Backfiller != nil {
 		if err := checkNumInOut(inputs, outputs, 0, 1); err != nil {
@@ -223,13 +225,13 @@ func NewProcessor(
 		if err := checkNumInOut(inputs, outputs, 1, 1); err != nil {
 			return nil, err
 		}
-		return newSamplerProcessor(flowCtx, processorID, core.Sampler, inputs[0], post, outputs[0])
+		return newSamplerProcessor(ctx, flowCtx, processorID, core.Sampler, inputs[0], post, outputs[0])
 	}
 	if core.SampleAggregator != nil {
 		if err := checkNumInOut(inputs, outputs, 1, 1); err != nil {
 			return nil, err
 		}
-		return newSampleAggregator(flowCtx, processorID, core.SampleAggregator, inputs[0], post, outputs[0])
+		return newSampleAggregator(ctx, flowCtx, processorID, core.SampleAggregator, inputs[0], post, outputs[0])
 	}
 	if core.ReadImport != nil {
 		if err := checkNumInOut(inputs, outputs, 0, 1); err != nil {
@@ -238,7 +240,7 @@ func NewProcessor(
 		if NewReadImportDataProcessor == nil {
 			return nil, errors.New("ReadImportData processor unimplemented")
 		}
-		return NewReadImportDataProcessor(flowCtx, processorID, *core.ReadImport, post, outputs[0])
+		return NewReadImportDataProcessor(ctx, flowCtx, processorID, *core.ReadImport, post, outputs[0])
 	}
 	if core.BackupData != nil {
 		if err := checkNumInOut(inputs, outputs, 0, 1); err != nil {
@@ -247,7 +249,7 @@ func NewProcessor(
 		if NewBackupDataProcessor == nil {
 			return nil, errors.New("BackupData processor unimplemented")
 		}
-		return NewBackupDataProcessor(flowCtx, processorID, *core.BackupData, post, outputs[0])
+		return NewBackupDataProcessor(ctx, flowCtx, processorID, *core.BackupData, post, outputs[0])
 	}
 	if core.SplitAndScatter != nil {
 		if err := checkNumInOut(inputs, outputs, 0, 1); err != nil {
@@ -256,7 +258,7 @@ func NewProcessor(
 		if NewSplitAndScatterProcessor == nil {
 			return nil, errors.New("SplitAndScatter processor unimplemented")
 		}
-		return NewSplitAndScatterProcessor(flowCtx, processorID, *core.SplitAndScatter, post, outputs[0])
+		return NewSplitAndScatterProcessor(ctx, flowCtx, processorID, *core.SplitAndScatter, post, outputs[0])
 	}
 	if core.RestoreData != nil {
 		if err := checkNumInOut(inputs, outputs, 1, 1); err != nil {
@@ -265,7 +267,7 @@ func NewProcessor(
 		if NewRestoreDataProcessor == nil {
 			return nil, errors.New("RestoreData processor unimplemented")
 		}
-		return NewRestoreDataProcessor(flowCtx, processorID, *core.RestoreData, post, inputs[0], outputs[0])
+		return NewRestoreDataProcessor(ctx, flowCtx, processorID, *core.RestoreData, post, inputs[0], outputs[0])
 	}
 	if core.StreamIngestionData != nil {
 		if err := checkNumInOut(inputs, outputs, 0, 1); err != nil {
@@ -274,7 +276,7 @@ func NewProcessor(
 		if NewStreamIngestionDataProcessor == nil {
 			return nil, errors.New("StreamIngestionData processor unimplemented")
 		}
-		return NewStreamIngestionDataProcessor(flowCtx, processorID, *core.StreamIngestionData, post, outputs[0])
+		return NewStreamIngestionDataProcessor(ctx, flowCtx, processorID, *core.StreamIngestionData, post, outputs[0])
 	}
 	if core.Exporter != nil {
 		if err := checkNumInOut(inputs, outputs, 1, 1); err != nil {
@@ -282,28 +284,28 @@ func NewProcessor(
 		}
 
 		if core.Exporter.Format.Format == roachpb.IOFileFormat_Parquet {
-			return NewParquetWriterProcessor(flowCtx, processorID, *core.Exporter, inputs[0], outputs[0])
+			return NewParquetWriterProcessor(ctx, flowCtx, processorID, *core.Exporter, inputs[0], outputs[0])
 		}
-		return NewCSVWriterProcessor(flowCtx, processorID, *core.Exporter, inputs[0], outputs[0])
+		return NewCSVWriterProcessor(ctx, flowCtx, processorID, *core.Exporter, inputs[0], outputs[0])
 	}
 
 	if core.BulkRowWriter != nil {
 		if err := checkNumInOut(inputs, outputs, 1, 1); err != nil {
 			return nil, err
 		}
-		return newBulkRowWriterProcessor(flowCtx, processorID, *core.BulkRowWriter, inputs[0], outputs[0])
+		return newBulkRowWriterProcessor(ctx, flowCtx, processorID, *core.BulkRowWriter, inputs[0], outputs[0])
 	}
 	if core.ProjectSet != nil {
 		if err := checkNumInOut(inputs, outputs, 1, 1); err != nil {
 			return nil, err
 		}
-		return newProjectSetProcessor(flowCtx, processorID, core.ProjectSet, inputs[0], post, outputs[0])
+		return newProjectSetProcessor(ctx, flowCtx, processorID, core.ProjectSet, inputs[0], post, outputs[0])
 	}
 	if core.Windower != nil {
 		if err := checkNumInOut(inputs, outputs, 1, 1); err != nil {
 			return nil, err
 		}
-		return newWindower(flowCtx, processorID, core.Windower, inputs[0], post, outputs[0])
+		return newWindower(ctx, flowCtx, processorID, core.Windower, inputs[0], post, outputs[0])
 	}
 	if core.LocalPlanNode != nil {
 		numInputs := int(core.LocalPlanNode.NumInputs)
@@ -311,7 +313,7 @@ func NewProcessor(
 			return nil, err
 		}
 		processor := localProcessors[core.LocalPlanNode.RowSourceIdx]
-		if err := processor.InitWithOutput(flowCtx, post, outputs[0]); err != nil {
+		if err := processor.InitWithOutput(ctx, flowCtx, post, outputs[0]); err != nil {
 			return nil, err
 		}
 		if numInputs == 1 {
@@ -330,7 +332,7 @@ func NewProcessor(
 		if NewChangeAggregatorProcessor == nil {
 			return nil, errors.New("ChangeAggregator processor unimplemented")
 		}
-		return NewChangeAggregatorProcessor(flowCtx, processorID, *core.ChangeAggregator, post, outputs[0])
+		return NewChangeAggregatorProcessor(ctx, flowCtx, processorID, *core.ChangeAggregator, post, outputs[0])
 	}
 	if core.ChangeFrontier != nil {
 		if err := checkNumInOut(inputs, outputs, 1, 1); err != nil {
@@ -339,19 +341,22 @@ func NewProcessor(
 		if NewChangeFrontierProcessor == nil {
 			return nil, errors.New("ChangeFrontier processor unimplemented")
 		}
-		return NewChangeFrontierProcessor(flowCtx, processorID, *core.ChangeFrontier, inputs[0], post, outputs[0])
+		return NewChangeFrontierProcessor(ctx, flowCtx, processorID, *core.ChangeFrontier, inputs[0], post, outputs[0])
 	}
 	if core.InvertedFilterer != nil {
 		if err := checkNumInOut(inputs, outputs, 1, 1); err != nil {
 			return nil, err
 		}
-		return newInvertedFilterer(flowCtx, processorID, core.InvertedFilterer, inputs[0], post, outputs[0])
+		return newInvertedFilterer(ctx, flowCtx, processorID, core.InvertedFilterer, inputs[0], post, outputs[0])
 	}
 	if core.StreamIngestionFrontier != nil {
 		if err := checkNumInOut(inputs, outputs, 1, 1); err != nil {
 			return nil, err
 		}
-		return NewStreamIngestionFrontierProcessor(flowCtx, processorID, *core.StreamIngestionFrontier, inputs[0], post, outputs[0])
+		if NewStreamIngestionFrontierProcessor == nil {
+			return nil, errors.New("StreamIngestionFrontier processor unimplemented")
+		}
+		return NewStreamIngestionFrontierProcessor(ctx, flowCtx, processorID, *core.StreamIngestionFrontier, inputs[0], post, outputs[0])
 	}
 	if core.IndexBackfillMerger != nil {
 		if err := checkNumInOut(inputs, outputs, 0, 1); err != nil {
@@ -363,40 +368,40 @@ func NewProcessor(
 		if err := checkNumInOut(inputs, outputs, 0, 1); err != nil {
 			return nil, err
 		}
-		return NewTTLProcessor(flowCtx, processorID, *core.Ttl, outputs[0])
+		return NewTTLProcessor(ctx, flowCtx, processorID, *core.Ttl, outputs[0])
 	}
 	return nil, errors.Errorf("unsupported processor core %q", core)
 }
 
 // NewReadImportDataProcessor is implemented in the non-free (CCL) codebase and then injected here via runtime initialization.
-var NewReadImportDataProcessor func(*execinfra.FlowCtx, int32, execinfrapb.ReadImportDataSpec, *execinfrapb.PostProcessSpec, execinfra.RowReceiver) (execinfra.Processor, error)
+var NewReadImportDataProcessor func(context.Context, *execinfra.FlowCtx, int32, execinfrapb.ReadImportDataSpec, *execinfrapb.PostProcessSpec, execinfra.RowReceiver) (execinfra.Processor, error)
 
 // NewBackupDataProcessor is implemented in the non-free (CCL) codebase and then injected here via runtime initialization.
-var NewBackupDataProcessor func(*execinfra.FlowCtx, int32, execinfrapb.BackupDataSpec, *execinfrapb.PostProcessSpec, execinfra.RowReceiver) (execinfra.Processor, error)
+var NewBackupDataProcessor func(context.Context, *execinfra.FlowCtx, int32, execinfrapb.BackupDataSpec, *execinfrapb.PostProcessSpec, execinfra.RowReceiver) (execinfra.Processor, error)
 
 // NewSplitAndScatterProcessor is implemented in the non-free (CCL) codebase and then injected here via runtime initialization.
-var NewSplitAndScatterProcessor func(*execinfra.FlowCtx, int32, execinfrapb.SplitAndScatterSpec, *execinfrapb.PostProcessSpec, execinfra.RowReceiver) (execinfra.Processor, error)
+var NewSplitAndScatterProcessor func(context.Context, *execinfra.FlowCtx, int32, execinfrapb.SplitAndScatterSpec, *execinfrapb.PostProcessSpec, execinfra.RowReceiver) (execinfra.Processor, error)
 
 // NewRestoreDataProcessor is implemented in the non-free (CCL) codebase and then injected here via runtime initialization.
-var NewRestoreDataProcessor func(*execinfra.FlowCtx, int32, execinfrapb.RestoreDataSpec, *execinfrapb.PostProcessSpec, execinfra.RowSource, execinfra.RowReceiver) (execinfra.Processor, error)
+var NewRestoreDataProcessor func(context.Context, *execinfra.FlowCtx, int32, execinfrapb.RestoreDataSpec, *execinfrapb.PostProcessSpec, execinfra.RowSource, execinfra.RowReceiver) (execinfra.Processor, error)
 
 // NewStreamIngestionDataProcessor is implemented in the non-free (CCL) codebase and then injected here via runtime initialization.
-var NewStreamIngestionDataProcessor func(*execinfra.FlowCtx, int32, execinfrapb.StreamIngestionDataSpec, *execinfrapb.PostProcessSpec, execinfra.RowReceiver) (execinfra.Processor, error)
+var NewStreamIngestionDataProcessor func(context.Context, *execinfra.FlowCtx, int32, execinfrapb.StreamIngestionDataSpec, *execinfrapb.PostProcessSpec, execinfra.RowReceiver) (execinfra.Processor, error)
 
 // NewCSVWriterProcessor is implemented in the non-free (CCL) codebase and then injected here via runtime initialization.
-var NewCSVWriterProcessor func(*execinfra.FlowCtx, int32, execinfrapb.ExportSpec, execinfra.RowSource, execinfra.RowReceiver) (execinfra.Processor, error)
+var NewCSVWriterProcessor func(context.Context, *execinfra.FlowCtx, int32, execinfrapb.ExportSpec, execinfra.RowSource, execinfra.RowReceiver) (execinfra.Processor, error)
 
 // NewParquetWriterProcessor is implemented in the non-free (CCL) codebase and then injected here via runtime initialization.
-var NewParquetWriterProcessor func(*execinfra.FlowCtx, int32, execinfrapb.ExportSpec, execinfra.RowSource, execinfra.RowReceiver) (execinfra.Processor, error)
+var NewParquetWriterProcessor func(context.Context, *execinfra.FlowCtx, int32, execinfrapb.ExportSpec, execinfra.RowSource, execinfra.RowReceiver) (execinfra.Processor, error)
 
 // NewChangeAggregatorProcessor is implemented in the non-free (CCL) codebase and then injected here via runtime initialization.
-var NewChangeAggregatorProcessor func(*execinfra.FlowCtx, int32, execinfrapb.ChangeAggregatorSpec, *execinfrapb.PostProcessSpec, execinfra.RowReceiver) (execinfra.Processor, error)
+var NewChangeAggregatorProcessor func(context.Context, *execinfra.FlowCtx, int32, execinfrapb.ChangeAggregatorSpec, *execinfrapb.PostProcessSpec, execinfra.RowReceiver) (execinfra.Processor, error)
 
 // NewChangeFrontierProcessor is implemented in the non-free (CCL) codebase and then injected here via runtime initialization.
-var NewChangeFrontierProcessor func(*execinfra.FlowCtx, int32, execinfrapb.ChangeFrontierSpec, execinfra.RowSource, *execinfrapb.PostProcessSpec, execinfra.RowReceiver) (execinfra.Processor, error)
+var NewChangeFrontierProcessor func(context.Context, *execinfra.FlowCtx, int32, execinfrapb.ChangeFrontierSpec, execinfra.RowSource, *execinfrapb.PostProcessSpec, execinfra.RowReceiver) (execinfra.Processor, error)
 
 // NewStreamIngestionFrontierProcessor is implemented in the non-free (CCL) codebase and then injected here via runtime initialization.
-var NewStreamIngestionFrontierProcessor func(*execinfra.FlowCtx, int32, execinfrapb.StreamIngestionFrontierSpec, execinfra.RowSource, *execinfrapb.PostProcessSpec, execinfra.RowReceiver) (execinfra.Processor, error)
+var NewStreamIngestionFrontierProcessor func(context.Context, *execinfra.FlowCtx, int32, execinfrapb.StreamIngestionFrontierSpec, execinfra.RowSource, *execinfrapb.PostProcessSpec, execinfra.RowReceiver) (execinfra.Processor, error)
 
 // NewTTLProcessor is implemented in the non-free (CCL) codebase and then injected here via runtime initialization.
-var NewTTLProcessor func(*execinfra.FlowCtx, int32, execinfrapb.TTLSpec, execinfra.RowReceiver) (execinfra.Processor, error)
+var NewTTLProcessor func(context.Context, *execinfra.FlowCtx, int32, execinfrapb.TTLSpec, execinfra.RowReceiver) (execinfra.Processor, error)

--- a/pkg/sql/rowexec/processors_test.go
+++ b/pkg/sql/rowexec/processors_test.go
@@ -191,7 +191,7 @@ func TestPostProcess(t *testing.T) {
 			semaCtx := tree.MakeSemaContext()
 			evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 			defer evalCtx.Stop(context.Background())
-			if err := out.Init(&tc.post, inBuf.OutputTypes(), &semaCtx, evalCtx); err != nil {
+			if err := out.Init(context.Background(), &tc.post, inBuf.OutputTypes(), &semaCtx, evalCtx); err != nil {
 				t.Fatal(err)
 			}
 
@@ -327,7 +327,7 @@ func TestProcessorBaseContext(t *testing.T) {
 		defer flowCtx.EvalCtx.Stop(ctx)
 
 		input := execinfra.NewRepeatableRowSource(types.OneIntCol, randgen.MakeIntRows(10, 1))
-		noop, err := newNoopProcessor(flowCtx, 0 /* processorID */, input, &execinfrapb.PostProcessSpec{}, &rowDisposer{})
+		noop, err := newNoopProcessor(ctx, flowCtx, 0 /* processorID */, input, &execinfrapb.PostProcessSpec{}, &rowDisposer{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/sql/rowexec/project_set.go
+++ b/pkg/sql/rowexec/project_set.go
@@ -73,6 +73,7 @@ var _ execopnode.OpNode = &projectSetProcessor{}
 const projectSetProcName = "projectSet"
 
 func newProjectSetProcessor(
+	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec *execinfrapb.ProjectSetSpec,
@@ -91,6 +92,7 @@ func newProjectSetProcessor(
 		done:        make([]bool, len(spec.Exprs)),
 	}
 	if err := ps.Init(
+		ctx,
 		ps,
 		post,
 		outputTypes,
@@ -108,8 +110,6 @@ func newProjectSetProcessor(
 	); err != nil {
 		return nil, err
 	}
-
-	ctx := flowCtx.EvalCtx.Ctx()
 
 	// Initialize exprHelpers.
 	semaCtx := ps.FlowCtx.NewSemaContext(ps.FlowCtx.Txn)

--- a/pkg/sql/rowexec/project_set.go
+++ b/pkg/sql/rowexec/project_set.go
@@ -109,11 +109,13 @@ func newProjectSetProcessor(
 		return nil, err
 	}
 
+	ctx := flowCtx.EvalCtx.Ctx()
+
 	// Initialize exprHelpers.
 	semaCtx := ps.FlowCtx.NewSemaContext(ps.FlowCtx.Txn)
 	for i, expr := range ps.spec.Exprs {
 		var helper execinfrapb.ExprHelper
-		err := helper.Init(expr, ps.input.OutputTypes(), semaCtx, ps.EvalCtx)
+		err := helper.Init(ctx, expr, ps.input.OutputTypes(), semaCtx, ps.EvalCtx)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -85,6 +85,7 @@ const sampleAggregatorProcName = "sample aggregator"
 var SampleAggregatorProgressInterval = 5 * time.Second
 
 func newSampleAggregator(
+	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec *execinfrapb.SampleAggregatorSpec,
@@ -107,7 +108,6 @@ func newSampleAggregator(
 		}
 	}
 
-	ctx := flowCtx.EvalCtx.Ctx()
 	// Limit the memory use by creating a child monitor with a hard limit.
 	// The processor will disable histogram collection if this limit is not
 	// enough.
@@ -170,7 +170,7 @@ func newSampleAggregator(
 	}
 
 	if err := s.Init(
-		nil, post, input.OutputTypes(), flowCtx, processorID, output, memMonitor,
+		ctx, nil, post, input.OutputTypes(), flowCtx, processorID, output, memMonitor,
 		execinfra.ProcStateOpts{
 			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {
 				s.close()

--- a/pkg/sql/rowexec/sample_aggregator_test.go
+++ b/pkg/sql/rowexec/sample_aggregator_test.go
@@ -164,7 +164,7 @@ func runSampleAggregator(
 			Sketches:      sketchSpecs,
 		}
 		p, err := newSamplerProcessor(
-			&flowCtx, 0 /* processorID */, spec, in[i], &execinfrapb.PostProcessSpec{}, outputs[i],
+			context.Background(), &flowCtx, 0 /* processorID */, spec, in[i], &execinfrapb.PostProcessSpec{}, outputs[i],
 		)
 		if err != nil {
 			t.Fatal(err)
@@ -198,7 +198,7 @@ func runSampleAggregator(
 	}
 
 	agg, err := newSampleAggregator(
-		&flowCtx, 0 /* processorID */, spec, samplerResults, &execinfrapb.PostProcessSpec{}, finalOut,
+		context.Background(), &flowCtx, 0 /* processorID */, spec, samplerResults, &execinfrapb.PostProcessSpec{}, finalOut,
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/sql/rowexec/sampler.go
+++ b/pkg/sql/rowexec/sampler.go
@@ -100,6 +100,7 @@ const cpuUsageMaxThrottle = 0.75
 var bytesRowType = []*types.T{types.Bytes}
 
 func newSamplerProcessor(
+	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec *execinfrapb.SamplerSpec,
@@ -113,7 +114,6 @@ func newSamplerProcessor(
 		}
 	}
 
-	ctx := flowCtx.EvalCtx.Ctx()
 	// Limit the memory use by creating a child monitor with a hard limit.
 	// The processor will disable histogram collection if this limit is not
 	// enough.
@@ -204,7 +204,7 @@ func newSamplerProcessor(
 	s.outTypes = outTypes
 
 	if err := s.Init(
-		nil, post, outTypes, flowCtx, processorID, output, memMonitor,
+		ctx, nil, post, outTypes, flowCtx, processorID, output, memMonitor,
 		execinfra.ProcStateOpts{
 			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {
 				s.close()

--- a/pkg/sql/rowexec/sampler_test.go
+++ b/pkg/sql/rowexec/sampler_test.go
@@ -84,7 +84,7 @@ func runSampler(
 		MinSampleSize: uint32(minNumSamples),
 	}
 	p, err := newSamplerProcessor(
-		&flowCtx, 0 /* processorID */, spec, in, &execinfrapb.PostProcessSpec{}, out,
+		context.Background(), &flowCtx, 0 /* processorID */, spec, in, &execinfrapb.PostProcessSpec{}, out,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -381,7 +381,7 @@ func TestSamplerSketch(t *testing.T) {
 				},
 			},
 		}
-		p, err := newSamplerProcessor(&flowCtx, 0 /* processorID */, spec, in, &execinfrapb.PostProcessSpec{}, out)
+		p, err := newSamplerProcessor(context.Background(), &flowCtx, 0 /* processorID */, spec, in, &execinfrapb.PostProcessSpec{}, out)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/sql/rowexec/sorter.go
+++ b/pkg/sql/rowexec/sorter.go
@@ -42,6 +42,7 @@ type sorterBase struct {
 }
 
 func (s *sorterBase) init(
+	ctx context.Context,
 	self execinfra.RowSource,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
@@ -53,7 +54,6 @@ func (s *sorterBase) init(
 	matchLen uint32,
 	opts execinfra.ProcStateOpts,
 ) error {
-	ctx := flowCtx.EvalCtx.Ctx()
 	if execstats.ShouldCollectStats(ctx, flowCtx.CollectStats) {
 		input = newInputStatCollector(input)
 		s.ExecStatsForTrace = s.execStatsForTrace
@@ -63,7 +63,7 @@ func (s *sorterBase) init(
 	// The processor will overflow to disk if this limit is not enough.
 	memMonitor := execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx, redact.Sprintf("%s-limited", processorName))
 	if err := s.ProcessorBase.Init(
-		self, post, input.OutputTypes(), flowCtx, processorID, output, memMonitor, opts,
+		ctx, self, post, input.OutputTypes(), flowCtx, processorID, output, memMonitor, opts,
 	); err != nil {
 		memMonitor.Stop(ctx)
 		return err
@@ -164,7 +164,7 @@ func newSorter(
 		// our sort procedure by maintaining a max-heap populated with only the
 		// smallest k rows seen. It has a worst-case time complexity of
 		// O(n*log(k)) and a worst-case space complexity of O(k).
-		return newSortTopKProcessor(flowCtx, processorID, spec, input, post, output, uint64(spec.Limit))
+		return newSortTopKProcessor(ctx, flowCtx, processorID, spec, input, post, output, uint64(spec.Limit))
 	}
 	// Ordering match length is specified. We will be able to use existing
 	// ordering in order to avoid loading all the rows into memory. If we're
@@ -173,7 +173,7 @@ func newSorter(
 	// chunk and then output.
 	// TODO(irfansharif): Add optimization for case where both ordering match
 	// length and limit is specified.
-	return newSortChunksProcessor(flowCtx, processorID, spec, input, post, output)
+	return newSortChunksProcessor(ctx, flowCtx, processorID, spec, input, post, output)
 }
 
 // sortAllProcessor reads in all values into the wrapped rows and
@@ -201,7 +201,7 @@ func newSortAllProcessor(
 ) (execinfra.Processor, error) {
 	proc := &sortAllProcessor{}
 	if err := proc.sorterBase.init(
-		proc, flowCtx, processorID, sortAllProcName, input, post, out,
+		ctx, proc, flowCtx, processorID, sortAllProcName, input, post, out,
 		execinfrapb.ConvertToColumnOrdering(spec.OutputOrdering),
 		spec.OrderingMatchLen,
 		execinfra.ProcStateOpts{
@@ -297,6 +297,7 @@ const sortTopKProcName = "sortTopK"
 var errSortTopKZeroK = errors.New("invalid value 0 for k")
 
 func newSortTopKProcessor(
+	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec *execinfrapb.SorterSpec,
@@ -312,7 +313,7 @@ func newSortTopKProcessor(
 	ordering := execinfrapb.ConvertToColumnOrdering(spec.OutputOrdering)
 	proc := &sortTopKProcessor{k: k}
 	if err := proc.sorterBase.init(
-		proc, flowCtx, processorID, sortTopKProcName, input, post, out,
+		ctx, proc, flowCtx, processorID, sortTopKProcName, input, post, out,
 		ordering, spec.OrderingMatchLen,
 		execinfra.ProcStateOpts{
 			InputsToDrain: []execinfra.RowSource{input},
@@ -399,6 +400,7 @@ var _ execinfra.RowSource = &sortChunksProcessor{}
 const sortChunksProcName = "sortChunks"
 
 func newSortChunksProcessor(
+	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec *execinfrapb.SorterSpec,
@@ -410,7 +412,7 @@ func newSortChunksProcessor(
 
 	proc := &sortChunksProcessor{}
 	if err := proc.sorterBase.init(
-		proc, flowCtx, processorID, sortChunksProcName, input, post, out, ordering, spec.OrderingMatchLen,
+		ctx, proc, flowCtx, processorID, sortChunksProcName, input, post, out, ordering, spec.OrderingMatchLen,
 		execinfra.ProcStateOpts{
 			InputsToDrain: []execinfra.RowSource{input},
 			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {

--- a/pkg/sql/rowexec/sorter_test.go
+++ b/pkg/sql/rowexec/sorter_test.go
@@ -375,7 +375,7 @@ func TestSortInvalidLimit(t *testing.T) {
 		var k uint64
 		// All arguments apart from spec and post are not necessary.
 		if _, err := newSortTopKProcessor(
-			nil, 0, &spec, nil, nil, nil, k,
+			context.Background(), nil, 0, &spec, nil, nil, nil, k,
 		); !testutils.IsError(err, errSortTopKZeroK.Error()) {
 			t.Fatalf("unexpected error %v, expected %v", err, errSortTopKZeroK)
 		}

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -76,6 +76,7 @@ var trPool = sync.Pool{
 
 // newTableReader creates a tableReader.
 func newTableReader(
+	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec *execinfrapb.TableReaderSpec,
@@ -112,7 +113,7 @@ func newTableReader(
 	resolver := flowCtx.NewTypeResolver(flowCtx.Txn)
 	for i := range spec.FetchSpec.KeyAndSuffixColumns {
 		if err := typedesc.EnsureTypeIsHydrated(
-			flowCtx.EvalCtx.Ctx(), spec.FetchSpec.KeyAndSuffixColumns[i].Type, &resolver,
+			ctx, spec.FetchSpec.KeyAndSuffixColumns[i].Type, &resolver,
 		); err != nil {
 			return nil, err
 		}
@@ -125,6 +126,7 @@ func newTableReader(
 
 	tr.ignoreMisplannedRanges = flowCtx.Local
 	if err := tr.Init(
+		ctx,
 		tr,
 		post,
 		resultTypes,
@@ -143,8 +145,6 @@ func newTableReader(
 	); err != nil {
 		return nil, err
 	}
-
-	ctx := flowCtx.EvalCtx.Ctx()
 
 	var fetcher row.Fetcher
 	if err := fetcher.Init(

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -144,9 +144,11 @@ func newTableReader(
 		return nil, err
 	}
 
+	ctx := flowCtx.EvalCtx.Ctx()
+
 	var fetcher row.Fetcher
 	if err := fetcher.Init(
-		flowCtx.EvalCtx.Context,
+		ctx,
 		row.FetcherInitArgs{
 			Txn:                        flowCtx.Txn,
 			Reverse:                    spec.Reverse,
@@ -170,7 +172,7 @@ func newTableReader(
 		tr.MakeSpansCopy()
 	}
 
-	if execstats.ShouldCollectStats(flowCtx.EvalCtx.Ctx(), flowCtx.CollectStats) {
+	if execstats.ShouldCollectStats(ctx, flowCtx.CollectStats) {
 		tr.fetcher = newRowFetcherStatCollector(&fetcher)
 		tr.ExecStatsForTrace = tr.execStatsForTrace
 	} else {

--- a/pkg/sql/rowexec/tablereader_test.go
+++ b/pkg/sql/rowexec/tablereader_test.go
@@ -144,7 +144,7 @@ func TestTableReader(t *testing.T) {
 					buf = &distsqlutils.RowBuffer{}
 					out = buf
 				}
-				tr, err := newTableReader(&flowCtx, 0 /* processorID */, &ts, &c.post, out)
+				tr, err := newTableReader(ctx, &flowCtx, 0 /* processorID */, &ts, &c.post, out)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -244,7 +244,7 @@ ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 1), (ARRAY[1], 2), (ARRAY[
 			buf = &distsqlutils.RowBuffer{}
 			out = buf
 		}
-		tr, err := newTableReader(&flowCtx, 0 /* processorID */, &spec, &post, out)
+		tr, err := newTableReader(ctx, &flowCtx, 0 /* processorID */, &spec, &post, out)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -343,7 +343,7 @@ func TestTableReaderDrain(t *testing.T) {
 	post := execinfrapb.PostProcessSpec{}
 
 	testReaderProcessorDrain(ctx, t, func(out execinfra.RowReceiver) (execinfra.Processor, error) {
-		return newTableReader(&flowCtx, 0 /* processorID */, &spec, &post, out)
+		return newTableReader(ctx, &flowCtx, 0 /* processorID */, &spec, &post, out)
 	})
 }
 
@@ -397,10 +397,9 @@ func TestLimitScans(t *testing.T) {
 	tracer := s.TracerI().(*tracing.Tracer)
 	sp := tracer.StartSpan("root", tracing.WithRecording(tracingpb.RecordingVerbose))
 	ctx = tracing.ContextWithSpan(ctx, sp)
-	flowCtx.EvalCtx.Context = ctx
 	flowCtx.CollectStats = true
 
-	tr, err := newTableReader(&flowCtx, 0 /* processorID */, &spec, &post, nil /* output */)
+	tr, err := newTableReader(ctx, &flowCtx, 0 /* processorID */, &spec, &post, nil /* output */)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -515,7 +514,7 @@ func BenchmarkTableReader(b *testing.B) {
 				// txnKVFetcher reuses the passed-in slice and destructively
 				// modifies it.
 				spec.Spans = []roachpb.Span{span}
-				tr, err := newTableReader(&flowCtx, 0 /* processorID */, &spec, &post, nil /* output */)
+				tr, err := newTableReader(ctx, &flowCtx, 0 /* processorID */, &spec, &post, nil /* output */)
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/pkg/sql/rowexec/values.go
+++ b/pkg/sql/rowexec/values.go
@@ -42,6 +42,7 @@ var _ execopnode.OpNode = &valuesProcessor{}
 const valuesProcName = "values"
 
 func newValuesProcessor(
+	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec *execinfrapb.ValuesCoreSpec,
@@ -64,7 +65,7 @@ func newValuesProcessor(
 		v.typs[i] = spec.Columns[i].Type
 	}
 	if err := v.Init(
-		v, post, v.typs, flowCtx, processorID, output, nil /* memMonitor */, execinfra.ProcStateOpts{},
+		ctx, v, post, v.typs, flowCtx, processorID, output, nil /* memMonitor */, execinfra.ProcStateOpts{},
 	); err != nil {
 		return nil, err
 	}

--- a/pkg/sql/rowexec/values_test.go
+++ b/pkg/sql/rowexec/values_test.go
@@ -51,7 +51,7 @@ func TestValuesProcessor(t *testing.T) {
 					EvalCtx: evalCtx,
 				}
 
-				v, err := newValuesProcessor(&flowCtx, 0 /* processorID */, &spec, &execinfrapb.PostProcessSpec{}, out)
+				v, err := newValuesProcessor(context.Background(), &flowCtx, 0 /* processorID */, &spec, &execinfrapb.PostProcessSpec{}, out)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -123,7 +123,7 @@ func BenchmarkValuesProcessor(b *testing.B) {
 				b.SetBytes(int64(8 * numRows * numCols))
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					v, err := newValuesProcessor(&flowCtx, 0 /* processorID */, &spec, &post, &output)
+					v, err := newValuesProcessor(ctx, &flowCtx, 0 /* processorID */, &spec, &post, &output)
 					if err != nil {
 						b.Fatal(err)
 					}

--- a/pkg/sql/rowexec/windower.go
+++ b/pkg/sql/rowexec/windower.go
@@ -98,6 +98,7 @@ var _ execopnode.OpNode = &windower{}
 const windowerProcName = "windower"
 
 func newWindower(
+	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec *execinfrapb.WindowerSpec,
@@ -110,7 +111,6 @@ func newWindower(
 	}
 	evalCtx := flowCtx.NewEvalCtx()
 	w.inputTypes = input.OutputTypes()
-	ctx := evalCtx.Ctx()
 
 	// Limit the memory use by creating a child monitor with a hard limit.
 	// windower will overflow to disk if this limit is not enough.
@@ -166,6 +166,7 @@ func newWindower(
 	w.outputRow = make(rowenc.EncDatumRow, len(w.outputTypes))
 
 	if err := w.InitWithEvalCtx(
+		ctx,
 		w,
 		post,
 		w.outputTypes,

--- a/pkg/sql/rowexec/windower_test.go
+++ b/pkg/sql/rowexec/windower_test.go
@@ -94,7 +94,7 @@ func TestWindowerAccountingForResults(t *testing.T) {
 		types.OneIntCol, nil, distsqlutils.RowBufferArgs{},
 	)
 
-	d, err := newWindower(flowCtx, 0 /* processorID */, &spec, input, post, output)
+	d, err := newWindower(ctx, flowCtx, 0 /* processorID */, &spec, input, post, output)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -253,11 +253,11 @@ func BenchmarkWindower(b *testing.B) {
 				b.SetBytes(int64(8 * numRows * numCols))
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					d, err := newWindower(flowCtx, 0 /* processorID */, &spec, input, post, disposer)
+					d, err := newWindower(ctx, flowCtx, 0 /* processorID */, &spec, input, post, disposer)
 					if err != nil {
 						b.Fatal(err)
 					}
-					d.Run(context.Background())
+					d.Run(ctx)
 					input.Reset()
 				}
 				b.StopTimer()

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -272,6 +272,7 @@ const zigzagJoinerProcName = "zigzagJoiner"
 // newZigzagJoiner creates a new zigzag joiner given a spec and an EncDatumRow
 // holding the values of the prefix columns of the index specified in the spec.
 func newZigzagJoiner(
+	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec *execinfrapb.ZigzagJoinerSpec,
@@ -293,7 +294,7 @@ func newZigzagJoiner(
 	for _, fetchSpec := range []descpb.IndexFetchSpec{spec.Sides[0].FetchSpec, spec.Sides[1].FetchSpec} {
 		for i := range fetchSpec.KeyAndSuffixColumns {
 			if err := typedesc.EnsureTypeIsHydrated(
-				flowCtx.EvalCtx.Ctx(), fetchSpec.KeyAndSuffixColumns[i].Type, &resolver,
+				ctx, fetchSpec.KeyAndSuffixColumns[i].Type, &resolver,
 			); err != nil {
 				return nil, err
 			}
@@ -303,6 +304,7 @@ func newZigzagJoiner(
 	leftColumnTypes := spec.Sides[0].FetchSpec.FetchedColumnTypes()
 	rightColumnTypes := spec.Sides[1].FetchSpec.FetchedColumnTypes()
 	err := z.joinerBase.init(
+		ctx,
 		z, /* self */
 		flowCtx,
 		processorID,
@@ -331,7 +333,6 @@ func newZigzagJoiner(
 	z.numTables = len(spec.Sides)
 	z.infos = make([]zigzagJoinerInfo, z.numTables)
 
-	ctx := flowCtx.EvalCtx.Ctx()
 	collectingStats := false
 	if execstats.ShouldCollectStats(ctx, flowCtx.CollectStats) {
 		collectingStats = true

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -331,8 +331,9 @@ func newZigzagJoiner(
 	z.numTables = len(spec.Sides)
 	z.infos = make([]zigzagJoinerInfo, z.numTables)
 
+	ctx := flowCtx.EvalCtx.Ctx()
 	collectingStats := false
-	if execstats.ShouldCollectStats(flowCtx.EvalCtx.Ctx(), flowCtx.CollectStats) {
+	if execstats.ShouldCollectStats(ctx, flowCtx.CollectStats) {
 		collectingStats = true
 		z.ExecStatsForTrace = z.execStatsForTrace
 	}
@@ -353,7 +354,7 @@ func newZigzagJoiner(
 				return nil, err
 			}
 		}
-		if err := z.setupInfo(flowCtx, &spec.Sides[i], &z.infos[i], collectingStats); err != nil {
+		if err := z.setupInfo(ctx, flowCtx, &spec.Sides[i], &z.infos[i], collectingStats); err != nil {
 			return nil, err
 		}
 	}
@@ -420,6 +421,7 @@ type zigzagJoinerInfo struct {
 // number of the curInfo to set up.
 // Side specifies which the spec is associated with.
 func (z *zigzagJoiner) setupInfo(
+	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	spec *execinfrapb.ZigzagJoinerSpec_Side,
 	info *zigzagJoinerInfo,
@@ -458,7 +460,7 @@ func (z *zigzagJoiner) setupInfo(
 	// Setup the Fetcher.
 	var fetcher row.Fetcher
 	if err := fetcher.Init(
-		flowCtx.EvalCtx.Context,
+		ctx,
 		row.FetcherInitArgs{
 			Txn:                        flowCtx.Txn,
 			LockStrength:               spec.LockingStrength,

--- a/pkg/sql/rowexec/zigzagjoiner_test.go
+++ b/pkg/sql/rowexec/zigzagjoiner_test.go
@@ -706,7 +706,7 @@ func TestZigzagJoiner(t *testing.T) {
 
 			out := &distsqlutils.RowBuffer{}
 			post := execinfrapb.PostProcessSpec{Projection: true, OutputColumns: c.outCols}
-			z, err := newZigzagJoiner(&flowCtx, 0 /* processorID */, &c.spec, c.fixedValues, &post, out)
+			z, err := newZigzagJoiner(ctx, &flowCtx, 0 /* processorID */, &c.spec, c.fixedValues, &post, out)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -780,6 +780,7 @@ func TestZigzagJoinerDrain(t *testing.T) {
 
 	testReaderProcessorDrain(ctx, t, func(out execinfra.RowReceiver) (execinfra.Processor, error) {
 		return newZigzagJoiner(
+			ctx,
 			&flowCtx,
 			0, /* processorID */
 			&execinfrapb.ZigzagJoinerSpec{

--- a/pkg/sql/schema_change_plan_node.go
+++ b/pkg/sql/schema_change_plan_node.go
@@ -212,6 +212,7 @@ func (s *schemaChangePlanNode) startExec(params runParams) error {
 	}
 
 	runDeps := newSchemaChangerTxnRunDependencies(
+		params.ctx,
 		p.SessionData(),
 		p.User(),
 		p.ExecCfg(),
@@ -234,6 +235,7 @@ func (s *schemaChangePlanNode) startExec(params runParams) error {
 }
 
 func newSchemaChangerTxnRunDependencies(
+	ctx context.Context,
 	sessionData *sessiondata.SessionData,
 	user username.SQLUsername,
 	execCfg *ExecutorConfig,
@@ -245,7 +247,7 @@ func newSchemaChangerTxnRunDependencies(
 	stmts []string,
 ) scexec.Dependencies {
 	metaDataUpdater := descmetadata.NewMetadataUpdater(
-		evalContext.Context,
+		ctx,
 		execCfg.InternalExecutorFactory,
 		descriptors,
 		&execCfg.Settings.SV,

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -6630,7 +6630,7 @@ table's zone configuration this will return NULL.`,
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				state := tree.MustBeDBytes(args[0])
-				return evalCtx.Planner.DeserializeSessionState(tree.NewDBytes(state))
+				return evalCtx.Planner.DeserializeSessionState(evalCtx.Ctx(), tree.NewDBytes(state))
 			},
 			Info:       `This function deserializes the serialized variables into the current session.`,
 			Volatility: volatility.Volatile,

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -587,7 +587,7 @@ var geoBuiltins = map[string]builtinDefinition{
 				if err != nil {
 					return nil, err
 				}
-				cfg, err := applyGeoindexConfigStorageParams(evalCtx, *startCfg, string(params))
+				cfg, err := applyGeoindexConfigStorageParams(evalCtx.Context, evalCtx, *startCfg, string(params))
 				if err != nil {
 					return nil, err
 				}
@@ -632,7 +632,7 @@ SELECT ST_S2Covering(geometry, 's2_max_level=15,s2_level_mod=3').
 				params := tree.MustBeDString(args[1])
 
 				startCfg := geoindex.DefaultGeographyIndexConfig()
-				cfg, err := applyGeoindexConfigStorageParams(evalCtx, *startCfg, string(params))
+				cfg, err := applyGeoindexConfigStorageParams(evalCtx.Context, evalCtx, *startCfg, string(params))
 				if err != nil {
 					return nil, err
 				}
@@ -7665,7 +7665,7 @@ func makeSTDWithinBuiltin(exclusivity geo.FnExclusivity) builtinDefinition {
 }
 
 func applyGeoindexConfigStorageParams(
-	evalCtx *eval.Context, cfg geoindex.Config, params string,
+	ctx context.Context, evalCtx *eval.Context, cfg geoindex.Config, params string,
 ) (geoindex.Config, error) {
 	indexDesc := &descpb.IndexDescriptor{GeoConfig: cfg}
 	stmt, err := parser.ParseOne(
@@ -7676,6 +7676,7 @@ func applyGeoindexConfigStorageParams(
 	}
 	semaCtx := tree.MakeSemaContext()
 	if err := storageparam.Set(
+		ctx,
 		&semaCtx,
 		evalCtx,
 		stmt.AST.(*tree.CreateIndex).StorageParams,

--- a/pkg/sql/sem/builtins/window_frame_builtins_test.go
+++ b/pkg/sql/sem/builtins/window_frame_builtins_test.go
@@ -81,7 +81,7 @@ func testMin(t *testing.T, evalCtx *eval.Context, wfr *eval.WindowFrameRun) {
 			return -a.Compare(evalCtx, b)
 		})
 		for wfr.RowIdx = 0; wfr.RowIdx < wfr.PartitionSize(); wfr.RowIdx++ {
-			res, err := min.Compute(evalCtx.Ctx(), evalCtx, wfr)
+			res, err := min.Compute(context.Background(), evalCtx, wfr)
 			if err != nil {
 				t.Errorf("Unexpected error received when getting min from sliding window: %+v", err)
 			}
@@ -91,7 +91,7 @@ func testMin(t *testing.T, evalCtx *eval.Context, wfr *eval.WindowFrameRun) {
 				if idx < 0 || idx >= wfr.PartitionSize() {
 					continue
 				}
-				row, err := wfr.Rows.GetRow(evalCtx.Ctx(), idx)
+				row, err := wfr.Rows.GetRow(context.Background(), idx)
 				if err != nil {
 					panic(err)
 				}
@@ -108,7 +108,7 @@ func testMin(t *testing.T, evalCtx *eval.Context, wfr *eval.WindowFrameRun) {
 				t.Errorf("Min sliding window returned wrong result: expected %+v, found %+v", naiveMin, minResult)
 				t.Errorf("partitionSize: %+v idx: %+v offset: %+v", wfr.PartitionSize(), wfr.RowIdx, offset)
 				t.Errorf(min.sw.string())
-				t.Errorf(partitionToString(evalCtx.Ctx(), wfr.Rows))
+				t.Errorf(partitionToString(context.Background(), wfr.Rows))
 				panic("")
 			}
 		}
@@ -124,7 +124,7 @@ func testMax(t *testing.T, evalCtx *eval.Context, wfr *eval.WindowFrameRun) {
 			return a.Compare(evalCtx, b)
 		})
 		for wfr.RowIdx = 0; wfr.RowIdx < wfr.PartitionSize(); wfr.RowIdx++ {
-			res, err := max.Compute(evalCtx.Ctx(), evalCtx, wfr)
+			res, err := max.Compute(context.Background(), evalCtx, wfr)
 			if err != nil {
 				t.Errorf("Unexpected error received when getting max from sliding window: %+v", err)
 			}
@@ -134,7 +134,7 @@ func testMax(t *testing.T, evalCtx *eval.Context, wfr *eval.WindowFrameRun) {
 				if idx < 0 || idx >= wfr.PartitionSize() {
 					continue
 				}
-				row, err := wfr.Rows.GetRow(evalCtx.Ctx(), idx)
+				row, err := wfr.Rows.GetRow(context.Background(), idx)
 				if err != nil {
 					panic(err)
 				}
@@ -151,7 +151,7 @@ func testMax(t *testing.T, evalCtx *eval.Context, wfr *eval.WindowFrameRun) {
 				t.Errorf("Max sliding window returned wrong result: expected %+v, found %+v", naiveMax, maxResult)
 				t.Errorf("partitionSize: %+v idx: %+v offset: %+v", wfr.PartitionSize(), wfr.RowIdx, offset)
 				t.Errorf(max.sw.string())
-				t.Errorf(partitionToString(evalCtx.Ctx(), wfr.Rows))
+				t.Errorf(partitionToString(context.Background(), wfr.Rows))
 				panic("")
 			}
 		}
@@ -165,12 +165,12 @@ func testSumAndAvg(t *testing.T, evalCtx *eval.Context, wfr *eval.WindowFrameRun
 		sum := &slidingWindowSumFunc{agg: &intSumAggregate{}}
 		avg := &avgWindowFunc{sum: newSlidingWindowSumFunc(&intSumAggregate{})}
 		for wfr.RowIdx = 0; wfr.RowIdx < wfr.PartitionSize(); wfr.RowIdx++ {
-			res, err := sum.Compute(evalCtx.Ctx(), evalCtx, wfr)
+			res, err := sum.Compute(context.Background(), evalCtx, wfr)
 			if err != nil {
 				t.Errorf("Unexpected error received when getting sum from sliding window: %+v", err)
 			}
 			sumResult := tree.DDecimal{Decimal: res.(*tree.DDecimal).Decimal}
-			res, err = avg.Compute(evalCtx.Ctx(), evalCtx, wfr)
+			res, err = avg.Compute(context.Background(), evalCtx, wfr)
 			if err != nil {
 				t.Errorf("Unexpected error received when getting avg from sliding window: %+v", err)
 			}
@@ -180,7 +180,7 @@ func testSumAndAvg(t *testing.T, evalCtx *eval.Context, wfr *eval.WindowFrameRun
 				if idx < 0 || idx >= wfr.PartitionSize() {
 					continue
 				}
-				row, err := wfr.Rows.GetRow(evalCtx.Ctx(), idx)
+				row, err := wfr.Rows.GetRow(context.Background(), idx)
 				if err != nil {
 					panic(err)
 				}
@@ -198,21 +198,21 @@ func testSumAndAvg(t *testing.T, evalCtx *eval.Context, wfr *eval.WindowFrameRun
 			if s != naiveSum {
 				t.Errorf("Sum sliding window returned wrong result: expected %+v, found %+v", naiveSum, s)
 				t.Errorf("partitionSize: %+v idx: %+v offset: %+v", wfr.PartitionSize(), wfr.RowIdx, offset)
-				t.Errorf(partitionToString(evalCtx.Ctx(), wfr.Rows))
+				t.Errorf(partitionToString(context.Background(), wfr.Rows))
 				panic("")
 			}
 			a, err := avgResult.Float64()
 			if err != nil {
 				t.Errorf("Unexpected error received when converting avg from DDecimal to float64: %+v", err)
 			}
-			frameSize, err := wfr.FrameSize(evalCtx.Ctx(), evalCtx)
+			frameSize, err := wfr.FrameSize(context.Background(), evalCtx)
 			if err != nil {
 				t.Errorf("Unexpected error when getting FrameSize: %+v", err)
 			}
 			if a != float64(naiveSum)/float64(frameSize) {
 				t.Errorf("Sum sliding window returned wrong result: expected %+v, found %+v", float64(naiveSum)/float64(frameSize), a)
 				t.Errorf("partitionSize: %+v idx: %+v offset: %+v", wfr.PartitionSize(), wfr.RowIdx, offset)
-				t.Errorf(partitionToString(evalCtx.Ctx(), wfr.Rows))
+				t.Errorf(partitionToString(context.Background(), wfr.Rows))
 				panic("")
 			}
 		}

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -358,7 +358,7 @@ type Planner interface {
 	// the multiregion properties of the database identified via databaseID. The
 	// second return value is false if the database doesn't exist or is not
 	// multiregion.
-	GetMultiregionConfig(databaseID descpb.ID) (interface{}, bool)
+	GetMultiregionConfig(ctx context.Context, databaseID descpb.ID) (interface{}, bool)
 }
 
 // InternalRows is an iterator interface that's exposed by the internal

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -280,7 +280,7 @@ type Planner interface {
 
 	// DeserializeSessionState deserializes the state as serialized variables
 	// into the current session.
-	DeserializeSessionState(state *tree.DBytes) (*tree.DBool, error)
+	DeserializeSessionState(ctx context.Context, state *tree.DBytes) (*tree.DBool, error)
 
 	// CreateSessionRevivalToken creates a token that can be used to log in
 	// as the current user, in bytes form.

--- a/pkg/sql/sem/eval/window_funcs_test.go
+++ b/pkg/sql/sem/eval/window_funcs_test.go
@@ -81,16 +81,16 @@ func testStartPreceding(t *testing.T, evalCtx *Context, wfr *WindowFrameRun, off
 		}
 		wfr.StartBoundOffset = typedOffset
 		for wfr.RowIdx = 0; wfr.RowIdx < wfr.PartitionSize(); wfr.RowIdx++ {
-			frameStartIdx, err := wfr.FrameStartIdx(evalCtx.Ctx(), evalCtx)
+			frameStartIdx, err := wfr.FrameStartIdx(context.Background(), evalCtx)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
-			value, err := wfr.getValueByOffset(evalCtx.Ctx(), evalCtx, typedOffset, true /* negative */)
+			value, err := wfr.getValueByOffset(context.Background(), evalCtx, typedOffset, true /* negative */)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
 			for idx := 0; idx <= wfr.RowIdx; idx++ {
-				valueAt, err := wfr.valueAt(evalCtx.Ctx(), idx)
+				valueAt, err := wfr.valueAt(context.Background(), idx)
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)
 				}
@@ -98,7 +98,7 @@ func testStartPreceding(t *testing.T, evalCtx *Context, wfr *WindowFrameRun, off
 					if idx != frameStartIdx {
 						t.Errorf("FrameStartIdx returned wrong result on Preceding: expected %+v, found %+v", idx, frameStartIdx)
 						t.Errorf("Search for %+v when wfr.RowIdx=%+v", value, wfr.RowIdx)
-						t.Errorf(partitionToString(evalCtx.Ctx(), wfr.Rows))
+						t.Errorf(partitionToString(context.Background(), wfr.Rows))
 						t.Fatal("")
 					}
 					break
@@ -129,11 +129,11 @@ func testStartFollowing(t *testing.T, evalCtx *Context, wfr *WindowFrameRun, off
 		}
 		wfr.StartBoundOffset = typedOffset
 		for wfr.RowIdx = 0; wfr.RowIdx < wfr.PartitionSize(); wfr.RowIdx++ {
-			frameStartIdx, err := wfr.FrameStartIdx(evalCtx.Ctx(), evalCtx)
+			frameStartIdx, err := wfr.FrameStartIdx(context.Background(), evalCtx)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
-			value, err := wfr.getValueByOffset(evalCtx.Ctx(), evalCtx, typedOffset, false /* negative */)
+			value, err := wfr.getValueByOffset(context.Background(), evalCtx, typedOffset, false /* negative */)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
@@ -142,12 +142,12 @@ func testStartFollowing(t *testing.T, evalCtx *Context, wfr *WindowFrameRun, off
 					if idx != frameStartIdx {
 						t.Errorf("FrameStartIdx returned wrong result on Following: expected %+v, found %+v", idx, frameStartIdx)
 						t.Errorf("Search for %+v when wfr.RowIdx=%+v", value, wfr.RowIdx)
-						t.Errorf(partitionToString(evalCtx.Ctx(), wfr.Rows))
+						t.Errorf(partitionToString(context.Background(), wfr.Rows))
 						t.Fatal("")
 					}
 					break
 				}
-				valueAt, err := wfr.valueAt(evalCtx.Ctx(), idx)
+				valueAt, err := wfr.valueAt(context.Background(), idx)
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)
 				}
@@ -155,7 +155,7 @@ func testStartFollowing(t *testing.T, evalCtx *Context, wfr *WindowFrameRun, off
 					if idx != frameStartIdx {
 						t.Errorf("FrameStartIdx returned wrong result on Following: expected %+v, found %+v", idx, frameStartIdx)
 						t.Errorf("Search for %+v when wfr.RowIdx=%+v", value, wfr.RowIdx)
-						t.Errorf(partitionToString(evalCtx.Ctx(), wfr.Rows))
+						t.Errorf(partitionToString(context.Background(), wfr.Rows))
 						t.Fatal("")
 					}
 					break
@@ -186,16 +186,16 @@ func testEndPreceding(t *testing.T, evalCtx *Context, wfr *WindowFrameRun, offse
 		}
 		wfr.EndBoundOffset = typedOffset
 		for wfr.RowIdx = 0; wfr.RowIdx < wfr.PartitionSize(); wfr.RowIdx++ {
-			frameEndIdx, err := wfr.FrameEndIdx(evalCtx.Ctx(), evalCtx)
+			frameEndIdx, err := wfr.FrameEndIdx(context.Background(), evalCtx)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
-			value, err := wfr.getValueByOffset(evalCtx.Ctx(), evalCtx, typedOffset, true /* negative */)
+			value, err := wfr.getValueByOffset(context.Background(), evalCtx, typedOffset, true /* negative */)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
 			for idx := wfr.PartitionSize() - 1; idx >= 0; idx-- {
-				valueAt, err := wfr.valueAt(evalCtx.Ctx(), idx)
+				valueAt, err := wfr.valueAt(context.Background(), idx)
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)
 				}
@@ -203,7 +203,7 @@ func testEndPreceding(t *testing.T, evalCtx *Context, wfr *WindowFrameRun, offse
 					if idx+1 != frameEndIdx {
 						t.Errorf("FrameEndIdx returned wrong result on Preceding: expected %+v, found %+v", idx+1, frameEndIdx)
 						t.Errorf("Search for %+v when wfr.RowIdx=%+v", value, wfr.RowIdx)
-						t.Errorf(partitionToString(evalCtx.Ctx(), wfr.Rows))
+						t.Errorf(partitionToString(context.Background(), wfr.Rows))
 						t.Fatal("")
 					}
 					break
@@ -234,16 +234,16 @@ func testEndFollowing(t *testing.T, evalCtx *Context, wfr *WindowFrameRun, offse
 		}
 		wfr.EndBoundOffset = typedOffset
 		for wfr.RowIdx = 0; wfr.RowIdx < wfr.PartitionSize(); wfr.RowIdx++ {
-			frameEndIdx, err := wfr.FrameEndIdx(evalCtx.Ctx(), evalCtx)
+			frameEndIdx, err := wfr.FrameEndIdx(context.Background(), evalCtx)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
-			value, err := wfr.getValueByOffset(evalCtx.Ctx(), evalCtx, typedOffset, false /* negative */)
+			value, err := wfr.getValueByOffset(context.Background(), evalCtx, typedOffset, false /* negative */)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
 			for idx := wfr.PartitionSize() - 1; idx >= wfr.RowIdx; idx-- {
-				valueAt, err := wfr.valueAt(evalCtx.Ctx(), idx)
+				valueAt, err := wfr.valueAt(context.Background(), idx)
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)
 				}
@@ -251,7 +251,7 @@ func testEndFollowing(t *testing.T, evalCtx *Context, wfr *WindowFrameRun, offse
 					if idx+1 != frameEndIdx {
 						t.Errorf("FrameEndIdx returned wrong result on Following: expected %+v, found %+v", idx+1, frameEndIdx)
 						t.Errorf("Search for %+v when wfr.RowIdx=%+v", value, wfr.RowIdx)
-						t.Errorf(partitionToString(evalCtx.Ctx(), wfr.Rows))
+						t.Errorf(partitionToString(context.Background(), wfr.Rows))
 						t.Fatal("")
 					}
 					break

--- a/pkg/sql/set_default_isolation.go
+++ b/pkg/sql/set_default_isolation.go
@@ -11,6 +11,8 @@
 package sql
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/asof"
@@ -18,7 +20,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 )
 
-func (p *planner) SetSessionCharacteristics(n *tree.SetSessionCharacteristics) (planNode, error) {
+func (p *planner) SetSessionCharacteristics(
+	ctx context.Context, n *tree.SetSessionCharacteristics,
+) (planNode, error) {
 	// Note: We also support SET DEFAULT_TRANSACTION_ISOLATION TO ' .... '.
 	switch n.Modes.Isolation {
 	case tree.SerializableIsolation, tree.UnspecifiedIsolation:
@@ -55,7 +59,7 @@ func (p *planner) SetSessionCharacteristics(n *tree.SetSessionCharacteristics) (
 		// the same SET SESSION CHARACTERISTICS AS TRANSACTION mechanism? Currently, the
 		// way to do this is SET DEFAULT_TRANSACTION_USE_FOLLOWER_READS TO FALSE;
 		if n.Modes.AsOf.Expr != nil {
-			if asof.IsFollowerReadTimestampFunction(p.EvalContext().Ctx(), n.Modes.AsOf, p.semaCtx.SearchPath) {
+			if asof.IsFollowerReadTimestampFunction(ctx, n.Modes.AsOf, p.semaCtx.SearchPath) {
 				m.SetDefaultTransactionUseFollowerReads(true)
 			} else {
 				return pgerror.Newf(pgcode.InvalidParameterValue,

--- a/pkg/sql/stats/json.go
+++ b/pkg/sql/stats/json.go
@@ -128,7 +128,7 @@ func (js *JSONStatistic) DecodeAndSetHistogram(
 
 // GetHistogram converts the json histogram into HistogramData.
 func (js *JSONStatistic) GetHistogram(
-	semaCtx *tree.SemaContext, evalCtx *eval.Context,
+	ctx context.Context, semaCtx *tree.SemaContext, evalCtx *eval.Context,
 ) (*HistogramData, error) {
 	if js.HistogramColumnType == "" {
 		return nil, nil
@@ -138,7 +138,7 @@ func (js *JSONStatistic) GetHistogram(
 	if err != nil {
 		return nil, err
 	}
-	colType, err := tree.ResolveType(evalCtx.Context, colTypeRef, semaCtx.GetTypeResolver())
+	colType, err := tree.ResolveType(ctx, colTypeRef, semaCtx.GetTypeResolver())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/storageparam/storage_param.go
+++ b/pkg/sql/storageparam/storage_param.go
@@ -13,6 +13,8 @@
 package storageparam
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/paramparse"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -41,7 +43,11 @@ type Setter interface {
 // Set sets the given storage parameters using the
 // given observer.
 func Set(
-	semaCtx *tree.SemaContext, evalCtx *eval.Context, params tree.StorageParams, setter Setter,
+	ctx context.Context,
+	semaCtx *tree.SemaContext,
+	evalCtx *eval.Context,
+	params tree.StorageParams,
+	setter Setter,
 ) error {
 	for _, sp := range params {
 		key := string(sp.Key)
@@ -55,7 +61,7 @@ func Set(
 		expr := paramparse.UnresolvedNameToStrVal(sp.Value)
 
 		// Convert the expressions to a datum.
-		typedExpr, err := tree.TypeCheck(evalCtx.Context, expr, semaCtx, types.Any)
+		typedExpr, err := tree.TypeCheck(ctx, expr, semaCtx, types.Any)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -190,12 +190,9 @@ func (dsp *DistSQLPlanner) ExecLocalAll(
 		Tracing: &SessionTracing{},
 	}
 	evalCtxFactory = func() *extendedEvalContext {
+		factoryEvalCtx.Context = evalCtx.Context
 		factoryEvalCtx.Placeholders = &p.semaCtx.Placeholders
 		factoryEvalCtx.Annotations = &p.semaCtx.Annotations
-		// Query diagnostics can change the Context; make sure we are using the
-		// same one.
-		// TODO(radu): consider removing this if/when #46164 is addressed.
-		factoryEvalCtx.Context = evalCtx.Context
 		return &factoryEvalCtx
 	}
 	return dsp.PlanAndRunAll(ctx, evalCtx, planCtx, p, recv, evalCtxFactory)

--- a/pkg/sql/ttl/ttljob/ttljob_processor.go
+++ b/pkg/sql/ttl/ttljob/ttljob_processor.go
@@ -425,6 +425,7 @@ func (t *ttlProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata
 }
 
 func newTTLProcessor(
+	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
 	processorID int32,
 	spec execinfrapb.TTLSpec,
@@ -434,6 +435,7 @@ func newTTLProcessor(
 		ttlSpec: spec,
 	}
 	if err := ttlProcessor.Init(
+		ctx,
 		ttlProcessor,
 		&execinfrapb.PostProcessSpec{},
 		[]*types.T{},


### PR DESCRIPTION
This PR contains several commits from #85782 which attempts to remove the stored `context.Context` from `eval.Context` object. I didn't finish that PR since I ran into two very thorny usages, so instead this PR takes some steps towards deprecating the usage of the stored context.

Storing a `context.Context` is an anti-pattern that needs to have a justification for applying, and in case of `eval.Context` I think it was introduced that way specifically for scalar functions evaluations (which should use the same `context.Context`) and that was ok, but over time we introduced many more callsites out of convenience.

Epic: CRDB-20535

Fixes: #46164