### PR TITLE
release-22.2: sql: clean up some udf TODOs

### DIFF
--- a/pkg/sql/grant_revoke.go
+++ b/pkg/sql/grant_revoke.go
@@ -419,7 +419,6 @@ func (n *changeDescriptorBackedPrivilegesNode) startExec(params runParams) error
 					FuncName:                       d.Name, // FIXME
 				})
 			}
-			// TODO(chengxiong): add eventlog for function privilege changes.
 		}
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4705,8 +4705,6 @@ SELECT cur_max_builtin_oid FROM [SELECT max(oid) as cur_max_builtin_oid FROM pg_
 ## existing functions at init time. Though the changes to builtin function OID is
 ## generally ok, it's still better if we could move the new implement to end of the
 ## list at init time (see all_builtins.go)
-## TODO(chengxiong): consider to have a deterministic list of builtin function oids
-## so that new implementations can just be added to it.
 query TT
 SELECT proname, oid FROM pg_catalog.pg_proc WHERE oid = $cur_max_builtin_oid
 ----

--- a/pkg/sql/parser/help.go
+++ b/pkg/sql/parser/help.go
@@ -102,8 +102,7 @@ func helpWithFunction(sqllex sqlLexer, f tree.ResolvableFunctionReference) int {
 	if err != nil {
 		return 1
 	}
-	// TODO(Chengxiong): Consider how to produce proper help message for
-	// UDFs.
+
 	props, _ := builtinsregistry.GetBuiltinProperties(d.Name)
 	msg := HelpMessage{
 		Function: f.String(),

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -416,8 +416,8 @@ func GetBuiltinFuncDefinition(
 	}
 
 	// First try that if we can get function directly with the function name.
-	// There is a case where the part[0] of the name is a qualified string.
-	// TODO(Chengxiong): figure out why that could be an input.
+	// There is a case where the part[0] of the name is a qualified string when
+	// the qualified name is double quoted as a single name like "schema.fn".
 	if def, ok := ResolvedBuiltinFuncDefs[fName.Object()]; ok {
 		return def, nil
 	}


### PR DESCRIPTION
Backport 1/1 commits from #89007.

/cc @cockroachdb/release

---

Clean up some udf TODOs which are actually done or a not-to-do. Also resolve two TODOs in tests.

Release note: None
Release justification: low risk comment and test only change.
