### PR TITLE
util/log: separate kv distribution log channel in tests

### DIFF
--- a/pkg/util/log/test_log_scope.go
+++ b/pkg/util/log/test_log_scope.go
@@ -227,10 +227,10 @@ func getTestConfig(fileDir *string, mostlyInline bool) (testConfig logconfig.Con
 		// We have two desired cases: -show-logs (mostlyInline = true)
 		// and without -show-logs (default, mostlyInline = false).
 
-		// In both cases, we emit output to files, with the STORAGE and
-		// HEALTH channels split into separate files.  We do keep a copy
-		// of HEALTH and STORAGE warning and errors on the main file
-		// though.
+		// In both cases, we emit output to files, with the STORAGE, HEALTH, and
+		// KV_DISTRIBUTION channels split into separate files.  We do keep a copy
+		// of HEALTH, STORAGE, and KV_DISTRIBUTION warning and errors on the main
+		// file though.
 		testConfig.Sinks.FileGroups = map[string]*logconfig.FileSinkConfig{
 			"storage": {
 				Channels: logconfig.SelectChannels(channel.STORAGE),
@@ -238,12 +238,16 @@ func getTestConfig(fileDir *string, mostlyInline bool) (testConfig logconfig.Con
 			"health": {
 				Channels: logconfig.SelectChannels(channel.HEALTH),
 			},
-			// Also add the WARNING+ events from STORAGE and CHANNEL into the
+			"kv-distribution": {
+				Channels: logconfig.SelectChannels(channel.KV_DISTRIBUTION),
+			},
+			// Also add the WARNING+ events from the separated channels into the
 			// default file group.
 			"default": {
 				Channels: logconfig.ChannelFilters{
 					Filters: map[logpb.Severity]logconfig.ChannelList{
-						severity.WARNING: {Channels: []logpb.Channel{channel.STORAGE, channel.HEALTH}},
+						severity.WARNING: {Channels: []logpb.Channel{channel.STORAGE, channel.HEALTH,
+							channel.KV_DISTRIBUTION}},
 					},
 				},
 			},
@@ -253,12 +257,13 @@ func getTestConfig(fileDir *string, mostlyInline bool) (testConfig logconfig.Con
 		if mostlyInline {
 			// User requested -show-logs.
 			//
-			// Include everything on stderr except STORAGE and HEALTH at
-			// severity below WARNING.
+			// Include everything on stderr except STORAGE, HEALTH, and
+			// KV_DISTRIBUTION at severity below WARNING.
 			testConfig.Sinks.Stderr.Filter = severity.INFO
 			testConfig.Sinks.Stderr.Channels.Filters = map[logpb.Severity]logconfig.ChannelList{
-				logpb.Severity_INFO:    {Channels: selectAllChannelsExceptStorageAndHealth()},
-				logpb.Severity_WARNING: {Channels: []logpb.Channel{channel.HEALTH, channel.STORAGE}},
+				logpb.Severity_INFO: {Channels: selectAllChannelsExceptSeparated()},
+				logpb.Severity_WARNING: {Channels: []logpb.Channel{channel.HEALTH, channel.STORAGE,
+					channel.KV_DISTRIBUTION}},
 			}
 		} else {
 			// Preferring file output only.
@@ -291,11 +296,11 @@ func getTestConfig(fileDir *string, mostlyInline bool) (testConfig logconfig.Con
 	return testConfig
 }
 
-func selectAllChannelsExceptStorageAndHealth() []logpb.Channel {
+func selectAllChannelsExceptSeparated() []logpb.Channel {
 	res := logconfig.AllChannels()
 	k := 0
 	for _, ch := range res {
-		if ch == channel.HEALTH || ch == channel.STORAGE {
+		if ch == channel.HEALTH || ch == channel.STORAGE || ch == channel.KV_DISTRIBUTION {
 			continue
 		}
 		res[k] = ch

--- a/pkg/util/log/test_log_scope_test.go
+++ b/pkg/util/log/test_log_scope_test.go
@@ -51,10 +51,11 @@ func TestDefaultTestLogConfig(t *testing.T) {
 
 				if mostlyInline {
 					// Test configs that prefer stderr send all channels to
-					// stderr at severity INFO, except for HEALTH and STORAGE.
+					// stderr at severity INFO, except for HEALTH, STORAGE, and
+					// KV_DISTRIBUTION.
 					for _, c := range logconfig.AllChannels() {
 						require.True(t, testConfig.Sinks.Stderr.Channels.AllChannels.HasChannel(c))
-						if c == channel.HEALTH || c == channel.STORAGE {
+						if c == channel.HEALTH || c == channel.STORAGE || c == channel.KV_DISTRIBUTION {
 							require.Equal(t, severity.WARNING, testConfig.Sinks.Stderr.Channels.ChannelFilters[c])
 						} else {
 							require.Equal(t, severity.INFO, testConfig.Sinks.Stderr.Channels.ChannelFilters[c])
@@ -72,7 +73,7 @@ func TestDefaultTestLogConfig(t *testing.T) {
 				require.False(t, *testConfig.Sinks.Stderr.Redactable)
 
 				// Output to files enabled, with just 1 file sink for all channels at severity INFO.
-				require.Equal(t, 3, len(testConfig.Sinks.FileGroups))
+				require.Equal(t, 4, len(testConfig.Sinks.FileGroups))
 				fc1, ok := testConfig.Sinks.FileGroups["health"]
 				require.True(t, ok)
 				require.Equal(t, 1, len(fc1.Channels.ChannelFilters))
@@ -83,12 +84,17 @@ func TestDefaultTestLogConfig(t *testing.T) {
 				require.Equal(t, 1, len(fc2.Channels.ChannelFilters))
 				require.Equal(t, severity.INFO, fc2.Channels.ChannelFilters[channel.STORAGE])
 				require.Equal(t, fakeDir, *fc2.Dir)
+				fc3, ok := testConfig.Sinks.FileGroups["kv-distribution"]
+				require.True(t, ok)
+				require.Equal(t, 1, len(fc3.Channels.ChannelFilters))
+				require.Equal(t, severity.INFO, fc3.Channels.ChannelFilters[channel.KV_DISTRIBUTION])
+				require.Equal(t, fakeDir, *fc3.Dir)
 				def, ok := testConfig.Sinks.FileGroups["default"]
 				require.True(t, ok)
 				require.Equal(t, fakeDir, *def.Dir)
 				for _, c := range logconfig.AllChannels() {
 					require.True(t, def.Channels.AllChannels.HasChannel(c), "channel %v", c)
-					if c == channel.HEALTH || c == channel.STORAGE {
+					if c == channel.HEALTH || c == channel.STORAGE || c == channel.KV_DISTRIBUTION {
 						// These two have been selected at severity WARNING.
 						require.Equal(t, severity.WARNING, def.Channels.ChannelFilters[c], "channel %v", c)
 					} else {


### PR DESCRIPTION
While the `KV_DISTRIBUTION` log channel was introduced recently, it was not separated out into a separate file in the test logging config like it was in the default production logging config. This change rectifies that, placing the `KV_DISTRIBUTION` log channel into a separate file, while retaining the messages at level `WARNING` or above in the main log file.

Fixes #87452.

Release note: None