### PR TITLE
kvserver: decrease verbosity of replicate queue trace logging

### DIFF
--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -814,7 +814,7 @@ func (rq *replicateQueue) processOneChangeWithTracing(
 		}
 
 		if err != nil {
-			log.KvDistribution.Warningf(ctx, "error processing replica: %v%s", err, traceOutput)
+			log.KvDistribution.Infof(ctx, "error processing replica: %v%s", err, traceOutput)
 		} else if exceededDuration {
 			log.KvDistribution.Infof(ctx, "processing replica took %s, exceeding threshold of %s%s",
 				processDuration, loggingThreshold, traceOutput)


### PR DESCRIPTION
While logging of traces on replicate queue errors was recently added, logging these traces at the `WARNING` level appears to be too high, causing noisy logs. This change decreases the verbosity of these logs to the `INFO` level.

Release note: None