### PR TITLE
sql: split out planning and execution monitors

### DIFF
--- a/pkg/ccl/backupccl/backup_processor_planning.go
+++ b/pkg/ccl/backupccl/backup_processor_planning.go
@@ -209,6 +209,6 @@ func distBackup(
 	defer close(progCh)
 	// Copy the evalCtx, as dsp.Run() might change it.
 	evalCtxCopy := *evalCtx
-	dsp.Run(ctx, planCtx, noTxn, p, recv, &evalCtxCopy, nil /* finishedSetupFn */)()
+	dsp.Run(ctx, planCtx, noTxn, p, recv, &evalCtxCopy, nil /* finishedSetupFn */)
 	return rowResultWriter.Err()
 }

--- a/pkg/ccl/backupccl/restore_processor_planning.go
+++ b/pkg/ccl/backupccl/restore_processor_planning.go
@@ -278,7 +278,7 @@ func distRestore(
 
 		// Copy the evalCtx, as dsp.Run() might change it.
 		evalCtxCopy := *evalCtx
-		dsp.Run(ctx, planCtx, noTxn, p, recv, &evalCtxCopy, nil /* finishedSetupFn */)()
+		dsp.Run(ctx, planCtx, noTxn, p, recv, &evalCtxCopy, nil /* finishedSetupFn */)
 		return rowResultWriter.Err()
 	})
 

--- a/pkg/ccl/backupccl/split_and_scatter_processor_test.go
+++ b/pkg/ccl/backupccl/split_and_scatter_processor_test.go
@@ -237,6 +237,7 @@ func TestSplitAndScatterProcessor(t *testing.T) {
 					Stopper:  tc.Stopper(),
 				},
 				EvalCtx:     &evalCtx,
+				Mon:         evalCtx.TestingMon,
 				DiskMonitor: testDiskMonitor,
 			}
 

--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -300,7 +300,7 @@ func startDistChangefeed(
 		// Copy the evalCtx, as dsp.Run() might change it.
 		evalCtxCopy := *evalCtx
 		// p is the physical plan, recv is the distsqlreceiver
-		dsp.Run(ctx, planCtx, noTxn, p, recv, &evalCtxCopy, finishedSetupFn)()
+		dsp.Run(ctx, planCtx, noTxn, p, recv, &evalCtxCopy, finishedSetupFn)
 		return resultRows.Err()
 	}
 

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -133,7 +133,7 @@ func newChangeAggregatorProcessor(
 	post *execinfrapb.PostProcessSpec,
 	output execinfra.RowReceiver,
 ) (execinfra.Processor, error) {
-	memMonitor := execinfra.NewMonitor(ctx, flowCtx.EvalCtx.Mon, "changeagg-mem")
+	memMonitor := execinfra.NewMonitor(ctx, flowCtx.Mon, "changeagg-mem")
 	ca := &changeAggregator{
 		flowCtx: flowCtx,
 		spec:    spec,
@@ -822,7 +822,7 @@ func newChangeFrontierProcessor(
 	post *execinfrapb.PostProcessSpec,
 	output execinfra.RowReceiver,
 ) (execinfra.Processor, error) {
-	memMonitor := execinfra.NewMonitor(ctx, flowCtx.EvalCtx.Mon, "changefntr-mem")
+	memMonitor := execinfra.NewMonitor(ctx, flowCtx.Mon, "changefntr-mem")
 	sf, err := makeSchemaChangeFrontier(hlc.Timestamp{}, spec.TrackedSpans...)
 	if err != nil {
 		return nil, err

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor_test.go
@@ -77,6 +77,7 @@ func TestStreamIngestionFrontierProcessor(t *testing.T) {
 			BulkSenderLimiter: limit.MakeConcurrentRequestLimiter("test", math.MaxInt),
 		},
 		EvalCtx:     &evalCtx,
+		Mon:         evalCtx.TestingMon,
 		DiskMonitor: testDiskMonitor,
 	}
 

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_planning.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_planning.go
@@ -154,6 +154,6 @@ func distStreamIngest(
 
 	// Copy the evalCtx, as dsp.Run() might change it.
 	evalCtxCopy := *evalCtx
-	dsp.Run(ctx, planCtx, noTxn, p, recv, &evalCtxCopy, nil /* finishedSetupFn */)()
+	dsp.Run(ctx, planCtx, noTxn, p, recv, &evalCtxCopy, nil /* finishedSetupFn */)
 	return rw.Err()
 }

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
@@ -602,6 +602,7 @@ func getStreamIngestionProcessor(
 			BulkSenderLimiter: limit.MakeConcurrentRequestLimiter("test", math.MaxInt),
 		},
 		EvalCtx:     &evalCtx,
+		Mon:         evalCtx.TestingMon,
 		DiskMonitor: testDiskMonitor,
 	}
 

--- a/pkg/ccl/streamingccl/streamproducer/event_stream.go
+++ b/pkg/ccl/streamingccl/streamproducer/event_stream.go
@@ -543,6 +543,6 @@ func streamPartition(
 		spec:            spec,
 		subscribedSpans: subscribedSpans,
 		execCfg:         execCfg,
-		mon:             evalCtx.Mon,
+		mon:             evalCtx.Planner.Mon(),
 	}, nil
 }

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1212,7 +1212,7 @@ func (sc *SchemaChanger) distIndexBackfill(
 			nil, /* txn - the processors manage their own transactions */
 			p, recv, &evalCtxCopy,
 			nil, /* finishedSetupFn */
-		)()
+		)
 		return cbw.Err()
 	})
 
@@ -1351,7 +1351,7 @@ func (sc *SchemaChanger) distColumnBackfill(
 				nil, /* txn - the processors manage their own transactions */
 				plan, recv, &evalCtx,
 				nil, /* finishedSetupFn */
-			)()
+			)
 			return cbw.Err()
 		}); err != nil {
 			return err
@@ -2673,9 +2673,8 @@ func columnBackfillInTxn(
 		return nil
 	}
 	var columnBackfillerMon *mon.BytesMonitor
-	// This is the planner's memory monitor.
-	if evalCtx.Mon != nil {
-		columnBackfillerMon = execinfra.NewMonitor(ctx, evalCtx.Mon, "local-column-backfill-mon")
+	if evalCtx.Planner.Mon() != nil {
+		columnBackfillerMon = execinfra.NewMonitor(ctx, evalCtx.Planner.Mon(), "local-column-backfill-mon")
 	}
 
 	rowMetrics := execCfg.GetRowMetrics(evalCtx.SessionData().Internal)
@@ -2717,9 +2716,8 @@ func indexBackfillInTxn(
 	traceKV bool,
 ) error {
 	var indexBackfillerMon *mon.BytesMonitor
-	// This is the planner's memory monitor.
-	if evalCtx.Mon != nil {
-		indexBackfillerMon = execinfra.NewMonitor(ctx, evalCtx.Mon, "local-index-backfill-mon")
+	if evalCtx.Planner.Mon() != nil {
+		indexBackfillerMon = execinfra.NewMonitor(ctx, evalCtx.Planner.Mon(), "local-index-backfill-mon")
 	}
 
 	var backfiller backfill.IndexBackfiller

--- a/pkg/sql/buffer_util.go
+++ b/pkg/sql/buffer_util.go
@@ -82,7 +82,7 @@ func (c *rowContainerHelper) initMonitors(
 ) {
 	distSQLCfg := &evalContext.DistSQLPlanner.distSQLSrv.ServerConfig
 	c.memMonitor = execinfra.NewLimitedMonitorNoFlowCtx(
-		ctx, evalContext.Mon, distSQLCfg, evalContext.SessionData(),
+		ctx, evalContext.Planner.Mon(), distSQLCfg, evalContext.SessionData(),
 		redact.Sprintf("%s-limited", opName),
 	)
 	c.diskMonitor = execinfra.NewMonitor(

--- a/pkg/sql/colexec/aggregators_test.go
+++ b/pkg/sql/colexec/aggregators_test.go
@@ -1003,7 +1003,7 @@ func benchmarkAggregateFunction(
 	ctx := context.Background()
 	evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(ctx)
-	aggMemAcc := evalCtx.Mon.MakeBoundAccount()
+	aggMemAcc := evalCtx.TestingMon.MakeBoundAccount()
 	defer aggMemAcc.Close(ctx)
 	evalCtx.SingleDatumAggMemAccount = &aggMemAcc
 	const bytesFixedLength = 8

--- a/pkg/sql/colexec/and_or_projection_test.go
+++ b/pkg/sql/colexec/and_or_projection_test.go
@@ -167,6 +167,7 @@ func TestAndOrOps(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},
@@ -228,6 +229,7 @@ func benchmarkLogicalProjOp(
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},

--- a/pkg/sql/colexec/builtin_funcs_test.go
+++ b/pkg/sql/colexec/builtin_funcs_test.go
@@ -44,6 +44,7 @@ func TestBasicBuiltinFunctions(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},
@@ -129,6 +130,7 @@ func benchmarkBuiltinFunctions(b *testing.B, useSelectionVector bool, hasNulls b
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},

--- a/pkg/sql/colexec/case_test.go
+++ b/pkg/sql/colexec/case_test.go
@@ -40,6 +40,7 @@ func TestCaseOp(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},
@@ -106,6 +107,7 @@ func TestCaseOpRandomized(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},

--- a/pkg/sql/colexec/coalesce_test.go
+++ b/pkg/sql/colexec/coalesce_test.go
@@ -40,6 +40,7 @@ func TestCoalesceBasic(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},
@@ -107,6 +108,7 @@ func TestCoalesceRandomized(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},

--- a/pkg/sql/colexec/colbuilder/execplan_test.go
+++ b/pkg/sql/colexec/colbuilder/execplan_test.go
@@ -77,6 +77,7 @@ func TestNewColOperatorExpectedTypeSchema(t *testing.T) {
 	txn := kv.NewTxn(ctx, s.DB(), s.NodeID())
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},
@@ -84,7 +85,7 @@ func TestNewColOperatorExpectedTypeSchema(t *testing.T) {
 		NodeID: evalCtx.NodeID,
 	}
 
-	streamingMemAcc := evalCtx.Mon.MakeBoundAccount()
+	streamingMemAcc := evalCtx.TestingMon.MakeBoundAccount()
 	defer streamingMemAcc.Close(ctx)
 
 	desc := desctestutils.TestingGetPublicTableDescriptor(kvDB, keys.SystemSQLCodec, "test", "t")

--- a/pkg/sql/colexec/colexecargs/monitor_registry.go
+++ b/pkg/sql/colexec/colexecargs/monitor_registry.go
@@ -36,7 +36,7 @@ func (r *MonitorRegistry) GetMonitors() []*mon.BytesMonitor {
 // NewStreamingMemAccount creates a new memory account bound to the monitor in
 // flowCtx.
 func (r *MonitorRegistry) NewStreamingMemAccount(flowCtx *execinfra.FlowCtx) *mon.BoundAccount {
-	streamingMemAccount := flowCtx.EvalCtx.Mon.MakeBoundAccount()
+	streamingMemAccount := flowCtx.Mon.MakeBoundAccount()
 	r.accounts = append(r.accounts, &streamingMemAccount)
 	return &streamingMemAccount
 }
@@ -63,7 +63,7 @@ func (r *MonitorRegistry) CreateMemAccountForSpillStrategy(
 ) (*mon.BoundAccount, redact.RedactableString) {
 	monitorName := r.getMemMonitorName(opName, processorID, "limited" /* suffix */)
 	bufferingOpMemMonitor := execinfra.NewLimitedMonitor(
-		ctx, flowCtx.EvalCtx.Mon, flowCtx, monitorName,
+		ctx, flowCtx.Mon, flowCtx, monitorName,
 	)
 	r.monitors = append(r.monitors, bufferingOpMemMonitor)
 	bufferingMemAccount := bufferingOpMemMonitor.MakeBoundAccount()
@@ -90,8 +90,8 @@ func (r *MonitorRegistry) CreateMemAccountForSpillStrategyWithLimit(
 		}
 	}
 	monitorName := r.getMemMonitorName(opName, processorID, "limited" /* suffix */)
-	bufferingOpMemMonitor := mon.NewMonitorInheritWithLimit(monitorName, limit, flowCtx.EvalCtx.Mon)
-	bufferingOpMemMonitor.StartNoReserved(ctx, flowCtx.EvalCtx.Mon)
+	bufferingOpMemMonitor := mon.NewMonitorInheritWithLimit(monitorName, limit, flowCtx.Mon)
+	bufferingOpMemMonitor.StartNoReserved(ctx, flowCtx.Mon)
 	r.monitors = append(r.monitors, bufferingOpMemMonitor)
 	bufferingMemAccount := bufferingOpMemMonitor.MakeBoundAccount()
 	r.accounts = append(r.accounts, &bufferingMemAccount)
@@ -163,7 +163,7 @@ func (r *MonitorRegistry) createUnlimitedMemAccounts(
 	numAccounts int,
 ) (*mon.BytesMonitor, []*mon.BoundAccount) {
 	bufferingOpUnlimitedMemMonitor := execinfra.NewMonitor(
-		ctx, flowCtx.EvalCtx.Mon, monitorName,
+		ctx, flowCtx.Mon, monitorName,
 	)
 	r.monitors = append(r.monitors, bufferingOpUnlimitedMemMonitor)
 	oldLen := len(r.accounts)

--- a/pkg/sql/colexec/colexecbase/const_test.go
+++ b/pkg/sql/colexec/colexecbase/const_test.go
@@ -33,6 +33,7 @@ func TestConst(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},
@@ -70,6 +71,7 @@ func TestConstNull(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},

--- a/pkg/sql/colexec/colexecbase/ordinality_test.go
+++ b/pkg/sql/colexec/colexecbase/ordinality_test.go
@@ -37,6 +37,7 @@ func TestOrdinality(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},
@@ -83,6 +84,7 @@ func BenchmarkOrdinality(b *testing.B) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},

--- a/pkg/sql/colexec/colexecdisk/external_sort_test.go
+++ b/pkg/sql/colexec/colexecdisk/external_sort_test.go
@@ -56,6 +56,7 @@ func TestExternalSortMemoryAccounting(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},

--- a/pkg/sql/colexec/colexecproj/default_cmp_op_test.go
+++ b/pkg/sql/colexec/colexecproj/default_cmp_op_test.go
@@ -36,6 +36,7 @@ func TestDefaultCmpProjOps(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},
@@ -127,6 +128,7 @@ func BenchmarkDefaultCmpProjOp(b *testing.B) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},

--- a/pkg/sql/colexec/colexecproj/projection_ops_test.go
+++ b/pkg/sql/colexec/colexecproj/projection_ops_test.go
@@ -46,6 +46,7 @@ func TestProjPlusInt64Int64ConstOp(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},
@@ -68,6 +69,7 @@ func TestProjPlusInt64Int64Op(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},
@@ -90,6 +92,7 @@ func TestProjDivFloat64Float64Op(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},
@@ -115,6 +118,7 @@ func TestRandomComparisons(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},
@@ -292,6 +296,7 @@ func BenchmarkProjOp(b *testing.B) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},

--- a/pkg/sql/colexec/colexecwindow/window_functions_test.go
+++ b/pkg/sql/colexec/colexecwindow/window_functions_test.go
@@ -53,6 +53,7 @@ func TestWindowFunctions(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},

--- a/pkg/sql/colexec/columnarizer_test.go
+++ b/pkg/sql/colexec/columnarizer_test.go
@@ -49,6 +49,7 @@ func TestColumnarizerResetsInternalBatch(t *testing.T) {
 	flowCtx := &execinfra.FlowCtx{
 		Cfg:     &execinfra.ServerConfig{Settings: st},
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 	}
 
 	c := NewBufferingColumnarizerForTests(testAllocator, flowCtx, 0, input)
@@ -80,6 +81,7 @@ func TestColumnarizerDrainsAndClosesInput(t *testing.T) {
 	flowCtx := &execinfra.FlowCtx{
 		Cfg:     &execinfra.ServerConfig{Settings: st},
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 	}
 
 	for _, tc := range []struct {
@@ -139,6 +141,7 @@ func BenchmarkColumnarize(b *testing.B) {
 	flowCtx := &execinfra.FlowCtx{
 		Cfg:     &execinfra.ServerConfig{Settings: st},
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 	}
 
 	b.SetBytes(int64(nRows * nCols * int(memsize.Int64)))

--- a/pkg/sql/colexec/crossjoiner_test.go
+++ b/pkg/sql/colexec/crossjoiner_test.go
@@ -373,6 +373,7 @@ func TestCrossJoiner(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},
@@ -417,6 +418,7 @@ func BenchmarkCrossJoiner(b *testing.B) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},

--- a/pkg/sql/colexec/default_agg_test.go
+++ b/pkg/sql/colexec/default_agg_test.go
@@ -133,7 +133,7 @@ func TestDefaultAggregateFunc(t *testing.T) {
 
 	evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(context.Background())
-	aggMemAcc := evalCtx.Mon.MakeBoundAccount()
+	aggMemAcc := evalCtx.TestingMon.MakeBoundAccount()
 	defer aggMemAcc.Close(context.Background())
 	evalCtx.SingleDatumAggMemAccount = &aggMemAcc
 	semaCtx := tree.MakeSemaContext()

--- a/pkg/sql/colexec/external_distinct_test.go
+++ b/pkg/sql/colexec/external_distinct_test.go
@@ -45,6 +45,7 @@ func TestExternalDistinct(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},
@@ -110,6 +111,7 @@ func TestExternalDistinctSpilling(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},
@@ -264,6 +266,7 @@ func BenchmarkExternalDistinct(b *testing.B) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},

--- a/pkg/sql/colexec/external_hash_aggregator_test.go
+++ b/pkg/sql/colexec/external_hash_aggregator_test.go
@@ -43,6 +43,7 @@ func TestExternalHashAggregator(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},
@@ -171,6 +172,7 @@ func BenchmarkExternalHashAggregator(b *testing.B) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},

--- a/pkg/sql/colexec/external_hash_joiner_test.go
+++ b/pkg/sql/colexec/external_hash_joiner_test.go
@@ -44,6 +44,7 @@ func TestExternalHashJoiner(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},
@@ -119,6 +120,7 @@ func TestExternalHashJoinerFallbackToSortMergeJoin(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 			TestingKnobs: execinfra.TestingKnobs{
@@ -198,6 +200,7 @@ func BenchmarkExternalHashJoiner(b *testing.B) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},

--- a/pkg/sql/colexec/external_sort_test.go
+++ b/pkg/sql/colexec/external_sort_test.go
@@ -44,6 +44,7 @@ func TestExternalSort(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},
@@ -126,6 +127,7 @@ func TestExternalSortRandomized(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},
@@ -226,6 +228,7 @@ func BenchmarkExternalSort(b *testing.B) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},

--- a/pkg/sql/colexec/hashjoiner_test.go
+++ b/pkg/sql/colexec/hashjoiner_test.go
@@ -1015,6 +1015,7 @@ func TestHashJoiner(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg:     &execinfra.ServerConfig{Settings: st},
 	}
 	var monitorRegistry colexecargs.MonitorRegistry
@@ -1141,6 +1142,7 @@ func TestHashJoinerProjection(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},

--- a/pkg/sql/colexec/if_expr_test.go
+++ b/pkg/sql/colexec/if_expr_test.go
@@ -39,6 +39,7 @@ func TestIfExprBasic(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},
@@ -103,6 +104,7 @@ func TestIfExprRandomized(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},

--- a/pkg/sql/colexec/is_null_ops_test.go
+++ b/pkg/sql/colexec/is_null_ops_test.go
@@ -36,6 +36,7 @@ func TestIsNullProjOp(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},
@@ -142,6 +143,7 @@ func TestIsNullSelOp(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},

--- a/pkg/sql/colexec/materializer_test.go
+++ b/pkg/sql/colexec/materializer_test.go
@@ -56,6 +56,7 @@ func TestColumnarizeMaterialize(t *testing.T) {
 	flowCtx := &execinfra.FlowCtx{
 		Cfg:     &execinfra.ServerConfig{Settings: st},
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 	}
 	c := NewBufferingColumnarizerForTests(testAllocator, flowCtx, 0, input)
 
@@ -100,6 +101,7 @@ func BenchmarkMaterializer(b *testing.B) {
 	flowCtx := &execinfra.FlowCtx{
 		Cfg:     &execinfra.ServerConfig{Settings: st},
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 	}
 
 	rng, _ := randutil.NewTestRand()
@@ -183,6 +185,7 @@ func TestMaterializerNextErrorAfterConsumerDone(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 	}
 
 	m := NewMaterializer(
@@ -224,6 +227,7 @@ func BenchmarkColumnarizeMaterialize(b *testing.B) {
 	flowCtx := &execinfra.FlowCtx{
 		Cfg:     &execinfra.ServerConfig{Settings: st},
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 	}
 	c := NewBufferingColumnarizerForTests(testAllocator, flowCtx, 0, input)
 

--- a/pkg/sql/colexec/mergejoiner_test.go
+++ b/pkg/sql/colexec/mergejoiner_test.go
@@ -1663,6 +1663,7 @@ func TestMergeJoiner(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},

--- a/pkg/sql/colexec/select_in_test.go
+++ b/pkg/sql/colexec/select_in_test.go
@@ -164,6 +164,7 @@ func TestProjectInInt64(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},

--- a/pkg/sql/colexec/types_integration_test.go
+++ b/pkg/sql/colexec/types_integration_test.go
@@ -51,6 +51,7 @@ func TestSQLTypesIntegration(t *testing.T) {
 	defer diskMonitor.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},

--- a/pkg/sql/colexec/values_test.go
+++ b/pkg/sql/colexec/values_test.go
@@ -136,6 +136,7 @@ func BenchmarkValues(b *testing.B) {
 	flowCtx := execinfra.FlowCtx{
 		Cfg:     &execinfra.ServerConfig{Settings: st},
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 	}
 	post := execinfrapb.PostProcessSpec{}
 

--- a/pkg/sql/colflow/colbatch_scan_test.go
+++ b/pkg/sql/colflow/colbatch_scan_test.go
@@ -66,6 +66,7 @@ func TestColBatchScanMeta(t *testing.T) {
 	leafTxn := kv.NewLeafTxn(ctx, s.DB(), s.NodeID(), leafInputState)
 	flowCtx := execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},
@@ -160,6 +161,7 @@ func BenchmarkColBatchScan(b *testing.B) {
 
 			flowCtx := execinfra.FlowCtx{
 				EvalCtx: &evalCtx,
+				Mon:     evalCtx.TestingMon,
 				Cfg:     &execinfra.ServerConfig{Settings: s.ClusterSettings()},
 				Txn:     kv.NewTxn(ctx, s.DB(), s.NodeID()),
 				NodeID:  evalCtx.NodeID,

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -492,7 +492,7 @@ func (s *vectorizedFlowCreator) makeGetStatsFnForOutbox(
 			result = append(result, &execinfrapb.ComponentStats{
 				Component: execinfrapb.FlowComponentID(originSQLInstanceID, flowCtx.ID),
 				FlowStats: execinfrapb.FlowStats{
-					MaxMemUsage:  optional.MakeUint(uint64(flowCtx.EvalCtx.Mon.MaximumBytes())),
+					MaxMemUsage:  optional.MakeUint(uint64(flowCtx.Mon.MaximumBytes())),
 					MaxDiskUsage: optional.MakeUint(uint64(flowCtx.DiskMonitor.MaximumBytes())),
 				},
 			})

--- a/pkg/sql/colflow/vectorized_flow_shutdown_test.go
+++ b/pkg/sql/colflow/vectorized_flow_shutdown_test.go
@@ -154,6 +154,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 				defer evalCtx.Stop(ctxLocal)
 				flowCtx := &execinfra.FlowCtx{
 					EvalCtx: &evalCtx,
+					Mon:     evalCtx.TestingMon,
 					Cfg:     &execinfra.ServerConfig{Settings: st},
 				}
 				rng, _ := randutil.NewTestRand()

--- a/pkg/sql/colflow/vectorized_flow_space_test.go
+++ b/pkg/sql/colflow/vectorized_flow_space_test.go
@@ -45,6 +45,7 @@ func TestVectorizeInternalMemorySpaceError(t *testing.T) {
 		},
 		DiskMonitor: testDiskMonitor,
 		EvalCtx:     &evalCtx,
+		Mon:         evalCtx.TestingMon,
 	}
 
 	oneInput := []execinfrapb.InputSyncSpec{
@@ -121,6 +122,7 @@ func TestVectorizeAllocatorSpaceError(t *testing.T) {
 		},
 		DiskMonitor: testDiskMonitor,
 		EvalCtx:     &evalCtx,
+		Mon:         evalCtx.TestingMon,
 	}
 	var monitorRegistry colexecargs.MonitorRegistry
 	defer monitorRegistry.Close(ctx)

--- a/pkg/sql/colflow/vectorized_flow_test.go
+++ b/pkg/sql/colflow/vectorized_flow_test.go
@@ -231,6 +231,7 @@ func TestDrainOnlyInputDAG(t *testing.T) {
 		FlowCtx: execinfra.FlowCtx{
 			Cfg:     &execinfra.ServerConfig{},
 			EvalCtx: &evalCtx,
+			Mon:     evalCtx.TestingMon,
 			NodeID:  base.TestingIDContainer,
 		},
 	}
@@ -281,6 +282,7 @@ func TestVectorizedFlowTempDirectory(t *testing.T) {
 						},
 					},
 					EvalCtx:     &evalCtx,
+					Mon:         evalCtx.TestingMon,
 					NodeID:      base.TestingIDContainer,
 					DiskMonitor: execinfra.NewTestDiskMonitor(ctx, st),
 				},

--- a/pkg/sql/colflow/vectorized_meta_propagation_test.go
+++ b/pkg/sql/colflow/vectorized_meta_propagation_test.go
@@ -64,6 +64,7 @@ func TestVectorizedMetaPropagation(t *testing.T) {
 
 	flowCtx := execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg:     &execinfra.ServerConfig{Settings: cluster.MakeTestingClusterSettings()},
 	}
 

--- a/pkg/sql/colflow/vectorized_panic_propagation_test.go
+++ b/pkg/sql/colflow/vectorized_panic_propagation_test.go
@@ -43,6 +43,7 @@ func TestVectorizedInternalPanic(t *testing.T) {
 
 	flowCtx := execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg:     &execinfra.ServerConfig{Settings: cluster.MakeTestingClusterSettings()},
 	}
 
@@ -79,6 +80,7 @@ func TestNonVectorizedPanicPropagation(t *testing.T) {
 
 	flowCtx := execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg:     &execinfra.ServerConfig{Settings: cluster.MakeTestingClusterSettings()},
 	}
 

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2815,7 +2815,6 @@ func (ex *connExecutor) resetEvalCtx(evalCtx *extendedEvalContext, txn *kv.Txn, 
 	evalCtx.IVarContainer = nil
 	evalCtx.Context.Context = ex.Ctx()
 	evalCtx.Txn = txn
-	evalCtx.Mon = ex.state.mon
 	evalCtx.PrepareOnly = false
 	evalCtx.SkipNormalize = false
 	evalCtx.SchemaChangerState = ex.extraTxnState.schemaChangerState
@@ -2881,7 +2880,7 @@ func (ex *connExecutor) initPlanner(ctx context.Context, p *planner) {
 func (ex *connExecutor) resetPlanner(
 	ctx context.Context, p *planner, txn *kv.Txn, stmtTS time.Time,
 ) {
-	p.resetPlanner(ctx, txn, stmtTS, ex.sessionData())
+	p.resetPlanner(ctx, txn, stmtTS, ex.sessionData(), ex.state.mon)
 	ex.resetEvalCtx(&p.extendedEvalCtx, txn, stmtTS)
 }
 

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -4933,7 +4933,7 @@ CREATE TABLE crdb_internal.invalid_objects (
 		}
 		descs := c.OrderedDescriptors()
 		// Collect all marshaled job metadata and account for its memory usage.
-		acct := p.EvalContext().Mon.MakeBoundAccount()
+		acct := p.Mon().MakeBoundAccount()
 		defer acct.Close(ctx)
 		jmg, err := collectMarshaledJobMetadataMap(ctx, p, &acct, descs)
 		if err != nil {
@@ -5548,7 +5548,7 @@ CREATE TABLE crdb_internal.cluster_statement_statistics (
 	generator: func(ctx context.Context, p *planner, db catalog.DatabaseDescriptor, stopper *stop.Stopper) (virtualTableGenerator, cleanupFunc, error) {
 		// TODO(azhng): we want to eventually implement memory accounting within the
 		//  RPC handlers. See #69032.
-		acc := p.extendedEvalCtx.Mon.MakeBoundAccount()
+		acc := p.Mon().MakeBoundAccount()
 		defer acc.Close(ctx)
 
 		// Perform RPC fanout.
@@ -5779,7 +5779,7 @@ CREATE TABLE crdb_internal.cluster_transaction_statistics (
 	generator: func(ctx context.Context, p *planner, db catalog.DatabaseDescriptor, stopper *stop.Stopper) (virtualTableGenerator, cleanupFunc, error) {
 		// TODO(azhng): we want to eventually implement memory accounting within the
 		//  RPC handlers. See #69032.
-		acc := p.extendedEvalCtx.Mon.MakeBoundAccount()
+		acc := p.Mon().MakeBoundAccount()
 		defer acc.Close(ctx)
 
 		// Perform RPC fanout.
@@ -5987,7 +5987,7 @@ CREATE TABLE crdb_internal.transaction_contention_events (
 		}
 
 		// Account for memory used by the RPC fanout.
-		acc := p.extendedEvalCtx.Mon.MakeBoundAccount()
+		acc := p.Mon().MakeBoundAccount()
 		defer acc.Close(ctx)
 
 		resp, err := p.extendedEvalCtx.SQLStatusServer.TransactionContentionEvents(

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -70,7 +70,7 @@ func (d *deleteNode) startExec(params runParams) error {
 
 	if d.run.rowsNeeded {
 		d.run.td.rows = rowcontainer.NewRowContainer(
-			params.EvalContext().Mon.MakeBoundAccount(),
+			params.p.Mon().MakeBoundAccount(),
 			colinfo.ColTypeInfoFromResCols(d.columns))
 	}
 	return d.run.td.init(params.ctx, params.p.txn, params.EvalContext(), &params.EvalContext().Settings.SV)

--- a/pkg/sql/distsql/columnar_utils_test.go
+++ b/pkg/sql/distsql/columnar_utils_test.go
@@ -98,6 +98,7 @@ func verifyColOperator(t *testing.T, args verifyColOperatorArgs) error {
 	defer diskMonitor.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings:    st,
 			TempStorage: tempEngine,
@@ -127,7 +128,7 @@ func verifyColOperator(t *testing.T, args verifyColOperatorArgs) error {
 		return errors.New("processor is unexpectedly not a RowSource")
 	}
 
-	acc := evalCtx.Mon.MakeBoundAccount()
+	acc := evalCtx.TestingMon.MakeBoundAccount()
 	defer acc.Close(ctx)
 	testAllocator := colmem.NewAllocator(ctx, &acc, coldataext.NewExtendedColumnFactory(&evalCtx))
 	columnarizers := make([]colexecop.Operator, len(args.inputs))

--- a/pkg/sql/distsql/vectorized_panic_propagation_test.go
+++ b/pkg/sql/distsql/vectorized_panic_propagation_test.go
@@ -40,6 +40,7 @@ func TestNonVectorizedPanicDoesntHangServer(t *testing.T) {
 
 	flowCtx := execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg:     &execinfra.ServerConfig{Settings: cluster.MakeTestingClusterSettings()},
 	}
 	base := flowinfra.NewFlowBase(

--- a/pkg/sql/distsql_plan_ctas.go
+++ b/pkg/sql/distsql_plan_ctas.go
@@ -55,5 +55,5 @@ func PlanAndRunCTAS(
 	// Make copy of evalCtx as Run might modify it.
 	evalCtxCopy := planner.ExtendedEvalContextCopy()
 	dsp.FinalizePlan(planCtx, physPlan)
-	dsp.Run(ctx, planCtx, txn, physPlan, recv, evalCtxCopy, nil /* finishedSetupFn */)()
+	dsp.Run(ctx, planCtx, txn, physPlan, recv, evalCtxCopy, nil /* finishedSetupFn */)
 }

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -307,6 +307,6 @@ func (dsp *DistSQLPlanner) planAndRunCreateStats(
 	)
 	defer recv.Release()
 
-	dsp.Run(ctx, planCtx, txn, physPlan, recv, evalCtx, nil /* finishedSetupFn */)()
+	dsp.Run(ctx, planCtx, txn, physPlan, recv, evalCtx, nil /* finishedSetupFn */)
 	return resultWriter.Err()
 }

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -170,6 +170,7 @@ func TestDistSQLRunningInAbortedTxn(t *testing.T) {
 		if err := p.makeOptimizerPlan(ctx); err != nil {
 			t.Fatal(err)
 		}
+		defer p.curPlan.close(ctx)
 
 		evalCtx := p.ExtendedEvalContext()
 		// We need distribute = true so that executing the plan involves marshaling
@@ -181,7 +182,7 @@ func TestDistSQLRunningInAbortedTxn(t *testing.T) {
 
 		execCfg.DistSQLPlanner.PlanAndRun(
 			ctx, evalCtx, planCtx, txn, p.curPlan.main, recv,
-		)()
+		)
 		return rw.Err()
 	})
 	if err != nil {

--- a/pkg/sql/execinfra/flow_context.go
+++ b/pkg/sql/execinfra/flow_context.go
@@ -50,6 +50,8 @@ type FlowCtx struct {
 	// cores of the processors that need it.
 	EvalCtx *eval.Context
 
+	Mon *mon.BytesMonitor
+
 	// The transaction in which kv operations performed by processors in the flow
 	// must be performed. Processors in the Flow will use this txn concurrently.
 	// This field is generally not nil, except for flows that don't run in a

--- a/pkg/sql/faketreeeval/BUILD.bazel
+++ b/pkg/sql/faketreeeval/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/sql/sessiondatapb",
         "//pkg/sql/types",
         "//pkg/util/errorutil/unimplemented",
+        "//pkg/util/mon",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_lib_pq//oid",
     ],

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/errors"
 	"github.com/lib/pq/oid"
 )
@@ -157,7 +158,9 @@ func (so *DummyRegionOperator) ResetMultiRegionZoneConfigsForDatabase(
 
 // DummyEvalPlanner implements the eval.Planner interface by returning
 // errors.
-type DummyEvalPlanner struct{}
+type DummyEvalPlanner struct {
+	Monitor *mon.BytesMonitor
+}
 
 // ResolveOIDFromString is part of the Planner interface.
 func (ep *DummyEvalPlanner) ResolveOIDFromString(
@@ -291,6 +294,11 @@ func (*DummyEvalPlanner) ValidateTTLScheduledJobsInCurrentDB(ctx context.Context
 // RepairTTLScheduledJobForTable is part of the Planner interface.
 func (*DummyEvalPlanner) RepairTTLScheduledJobForTable(ctx context.Context, tableID int64) error {
 	return errors.WithStack(errEvalPlanner)
+}
+
+// Mon is part of the eval.Planner interface.
+func (ep *DummyEvalPlanner) Mon() *mon.BytesMonitor {
+	return ep.Monitor
 }
 
 // ExecutorConfig is part of the Planner interface.

--- a/pkg/sql/flowinfra/outbox.go
+++ b/pkg/sql/flowinfra/outbox.go
@@ -288,7 +288,7 @@ func (m *Outbox) mainLoop(ctx context.Context) error {
 						// since it's a flow level stat. However, due to the row exec engine infrastructure, it is too
 						// complicated to attach this to a flow level span. If the row exec engine gets removed, getting
 						// maxMemUsage from streamStats should be removed as well.
-						m.stats.FlowStats.MaxMemUsage.Set(uint64(m.flowCtx.EvalCtx.Mon.MaximumBytes()))
+						m.stats.FlowStats.MaxMemUsage.Set(uint64(m.flowCtx.Mon.MaximumBytes()))
 						m.stats.FlowStats.MaxDiskUsage.Set(uint64(m.flowCtx.DiskMonitor.MaximumBytes()))
 					}
 					span.RecordStructured(&m.stats)

--- a/pkg/sql/flowinfra/outbox_test.go
+++ b/pkg/sql/flowinfra/outbox_test.go
@@ -72,6 +72,7 @@ func TestOutbox(t *testing.T) {
 	dialer := nodedialer.New(clientRPC, staticAddressResolver(addr))
 	flowCtx := execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		ID:      execinfrapb.FlowID{UUID: uuid.MakeV4()},
 		Cfg: &execinfra.ServerConfig{
 			Settings:      st,
@@ -237,6 +238,7 @@ func TestOutboxInitializesStreamBeforeReceivingAnyRows(t *testing.T) {
 	dialer := nodedialer.New(clientRPC, staticAddressResolver(addr))
 	flowCtx := execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		ID:      execinfrapb.FlowID{UUID: uuid.MakeV4()},
 		Cfg: &execinfra.ServerConfig{
 			Settings:      st,
@@ -309,6 +311,7 @@ func TestOutboxClosesWhenConsumerCloses(t *testing.T) {
 			dialer := nodedialer.New(clientRPC, staticAddressResolver(addr))
 			flowCtx := execinfra.FlowCtx{
 				EvalCtx: &evalCtx,
+				Mon:     evalCtx.TestingMon,
 				ID:      execinfrapb.FlowID{UUID: uuid.MakeV4()},
 				Cfg: &execinfra.ServerConfig{
 					Settings:      st,
@@ -386,6 +389,7 @@ func TestOutboxCancelsFlowOnError(t *testing.T) {
 	dialer := nodedialer.New(clientRPC, staticAddressResolver(addr))
 	flowCtx := execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		ID:      execinfrapb.FlowID{UUID: uuid.MakeV4()},
 		Cfg: &execinfra.ServerConfig{
 			Settings:      st,
@@ -441,6 +445,7 @@ func TestOutboxUnblocksProducers(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		ID:      execinfrapb.FlowID{UUID: uuid.MakeV4()},
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
@@ -516,6 +521,7 @@ func BenchmarkOutbox(b *testing.B) {
 			dialer := nodedialer.New(clientRPC, staticAddressResolver(addr))
 			flowCtx := execinfra.FlowCtx{
 				EvalCtx: &evalCtx,
+				Mon:     evalCtx.TestingMon,
 				ID:      execinfrapb.FlowID{UUID: uuid.MakeV4()},
 				Cfg: &execinfra.ServerConfig{
 					Settings:      st,

--- a/pkg/sql/flowinfra/server_test.go
+++ b/pkg/sql/flowinfra/server_test.go
@@ -169,7 +169,7 @@ func runLocalFlow(
 	evalCtx := eval.MakeTestingEvalContext(s.ClusterSettings())
 	defer evalCtx.Stop(ctx)
 	var rowBuf distsqlutils.RowBuffer
-	flowCtx, flow, _, err := s.DistSQLServer().(*distsql.ServerImpl).SetupLocalSyncFlow(ctx, evalCtx.Mon, req, &rowBuf, nil /* batchOutput */, distsql.LocalState{})
+	flowCtx, flow, _, err := s.DistSQLServer().(*distsql.ServerImpl).SetupLocalSyncFlow(ctx, evalCtx.TestingMon, req, &rowBuf, nil /* batchOutput */, distsql.LocalState{})
 	if err != nil {
 		return nil, err
 	}
@@ -206,7 +206,7 @@ func runLocalFlowTenant(
 	evalCtx := eval.MakeTestingEvalContext(s.ClusterSettings())
 	defer evalCtx.Stop(ctx)
 	var rowBuf distsqlutils.RowBuffer
-	flowCtx, flow, _, err := s.DistSQLServer().(*distsql.ServerImpl).SetupLocalSyncFlow(ctx, evalCtx.Mon, req, &rowBuf, nil /* batchOutput */, distsql.LocalState{})
+	flowCtx, flow, _, err := s.DistSQLServer().(*distsql.ServerImpl).SetupLocalSyncFlow(ctx, evalCtx.TestingMon, req, &rowBuf, nil /* batchOutput */, distsql.LocalState{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/importer/import_processor_planning.go
+++ b/pkg/sql/importer/import_processor_planning.go
@@ -261,7 +261,7 @@ func distImport(
 
 		// Copy the evalCtx, as dsp.Run() might change it.
 		evalCtxCopy := *evalCtx
-		dsp.Run(ctx, planCtx, nil, p, recv, &evalCtxCopy, nil /* finishedSetupFn */)()
+		dsp.Run(ctx, planCtx, nil, p, recv, &evalCtxCopy, nil /* finishedSetupFn */)
 		return rowResultWriter.Err()
 	})
 

--- a/pkg/sql/importer/import_processor_test.go
+++ b/pkg/sql/importer/import_processor_test.go
@@ -236,6 +236,7 @@ func TestImportIgnoresProcessedFiles(t *testing.T) {
 	evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings:        &cluster.Settings{},
 			ExternalStorage: externalStorageFactory,
@@ -336,6 +337,7 @@ func TestImportHonorsResumePosition(t *testing.T) {
 	evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings:        &cluster.Settings{},
 			ExternalStorage: externalStorageFactory,
@@ -463,6 +465,7 @@ func TestImportHandlesDuplicateKVs(t *testing.T) {
 	evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings:        &cluster.Settings{},
 			ExternalStorage: externalStorageFactory,

--- a/pkg/sql/index_backfiller.go
+++ b/pkg/sql/index_backfiller.go
@@ -202,7 +202,7 @@ func (ib *IndexBackfillPlanner) plan(
 		)
 		defer recv.Release()
 		evalCtxCopy := evalCtx
-		ib.execCfg.DistSQLPlanner.Run(ctx, planCtx, nil, p, recv, &evalCtxCopy, nil)()
+		ib.execCfg.DistSQLPlanner.Run(ctx, planCtx, nil, p, recv, &evalCtxCopy, nil)
 		return cbw.Err()
 	}, nil
 }

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -89,7 +89,7 @@ func (r *insertRun) initRowContainer(params runParams, columns colinfo.ResultCol
 		return
 	}
 	r.ti.rows = rowcontainer.NewRowContainer(
-		params.EvalContext().Mon.MakeBoundAccount(),
+		params.p.Mon().MakeBoundAccount(),
 		colinfo.ColTypeInfoFromResCols(columns),
 	)
 

--- a/pkg/sql/mvcc_backfiller.go
+++ b/pkg/sql/mvcc_backfiller.go
@@ -162,7 +162,7 @@ func (im *IndexBackfillerMergePlanner) plan(
 			nil, /* txn - the processors manage their own transactions */
 			p, recv, &evalCtxCopy,
 			nil, /* finishedSetupFn */
-		)()
+		)
 		return cbw.Err()
 	}, nil
 }

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -146,6 +146,12 @@ func TestMemoIsStale(t *testing.T) {
 	// Initialize context with starting values.
 	evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 	evalCtx.SessionData().Database = "t"
+	// MakeTestingEvalContext created a fake planner that can only provide the
+	// memory monitor and will encounter a nil-pointer error when other methods
+	// are accessed. In this test, GetDatabaseSurvivalGoal method will be called
+	// which can handle a case of nil planner but cannot a case when the
+	// planner's GetMultiregionConfig is nil, so we nil out the planner.
+	evalCtx.Planner = nil
 
 	var o xform.Optimizer
 	opttestutils.BuildQuery(t, &o, catalog, &evalCtx, "SELECT a, b+1 FROM abcview WHERE c='foo'")

--- a/pkg/sql/rowcontainer/datum_row_container_test.go
+++ b/pkg/sql/rowcontainer/datum_row_container_test.go
@@ -20,11 +20,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 )
 
 func TestRowContainer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	for _, numCols := range []int{0, 1, 2, 3, 5, 10, 15} {
@@ -78,6 +80,7 @@ func TestRowContainer(t *testing.T) {
 
 func TestRowContainerAtOutOfRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
@@ -105,6 +108,7 @@ func TestRowContainerAtOutOfRange(t *testing.T) {
 
 func TestRowContainerZeroCols(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
@@ -153,6 +157,9 @@ func TestRowContainerZeroCols(t *testing.T) {
 }
 
 func BenchmarkRowContainerAt(b *testing.B) {
+	defer leaktest.AfterTest(b)()
+	defer log.Scope(b).Close(b)
+
 	const numCols = 3
 	const numRows = 1024
 

--- a/pkg/sql/rowcontainer/disk_row_container_test.go
+++ b/pkg/sql/rowcontainer/disk_row_container_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/stretchr/testify/require"
@@ -65,6 +66,7 @@ func compareRows(
 
 func TestDiskRowContainer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
@@ -108,6 +110,7 @@ func TestDiskRowContainer(t *testing.T) {
 	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
 
 	evalCtx := eval.MakeTestingEvalContext(st)
+	defer evalCtx.Stop(ctx)
 	diskMonitor := mon.NewMonitor(
 		"test-disk",
 		mon.DiskResource,
@@ -368,6 +371,7 @@ func makeUniqueRows(
 
 func TestDiskRowContainerDiskFull(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
@@ -406,6 +410,7 @@ func TestDiskRowContainerDiskFull(t *testing.T) {
 
 func TestDiskRowContainerFinalIterator(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
@@ -536,6 +541,7 @@ func TestDiskRowContainerFinalIterator(t *testing.T) {
 
 func TestDiskRowContainerUnsafeReset(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()

--- a/pkg/sql/rowcontainer/hash_row_container_test.go
+++ b/pkg/sql/rowcontainer/hash_row_container_test.go
@@ -28,11 +28,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 )
 
 func TestHashDiskBackedRowContainer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
@@ -318,6 +320,7 @@ func TestHashDiskBackedRowContainer(t *testing.T) {
 
 func TestHashDiskBackedRowContainerPreservesMatchesAndMarks(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()

--- a/pkg/sql/rowcontainer/numbered_row_container_test.go
+++ b/pkg/sql/rowcontainer/numbered_row_container_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/stretchr/testify/require"
@@ -51,6 +52,7 @@ func newTestDiskMonitor(ctx context.Context, st *cluster.Settings) *mon.BytesMon
 // Tests the de-duping functionality of DiskBackedNumberedRowContainer.
 func TestNumberedRowContainerDeDuping(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
@@ -142,6 +144,7 @@ func TestNumberedRowContainerDeDuping(t *testing.T) {
 // elsewhere.
 func TestNumberedRowContainerIteratorCaching(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
@@ -242,6 +245,7 @@ func TestNumberedRowContainerIteratorCaching(t *testing.T) {
 // DiskBackedIndexedRowContainer return the same results.
 func TestCompareNumberedAndIndexedRowContainers(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	rng, _ := randutil.NewTestRand()
 
@@ -553,6 +557,9 @@ func accessPatternForBenchmarkIterations(totalAccesses int, accessPattern [][]in
 }
 
 func BenchmarkNumberedContainerIteratorCaching(b *testing.B) {
+	defer leaktest.AfterTest(b)()
+	defer log.Scope(b).Close(b)
+
 	const numRows = 10000
 
 	ctx := context.Background()

--- a/pkg/sql/rowcontainer/row_container.go
+++ b/pkg/sql/rowcontainer/row_container.go
@@ -158,12 +158,12 @@ type MemRowContainer struct {
 var _ heap.Interface = &MemRowContainer{}
 var _ IndexedRowContainer = &MemRowContainer{}
 
-// Init initializes the MemRowContainer. The MemRowContainer uses evalCtx.Mon
-// to track memory usage.
+// Init initializes the MemRowContainer. The MemRowContainer uses the planner's
+// monitor to track memory usage.
 func (mc *MemRowContainer) Init(
 	ordering colinfo.ColumnOrdering, types []*types.T, evalCtx *eval.Context,
 ) {
-	mc.InitWithMon(ordering, types, evalCtx, evalCtx.Mon)
+	mc.InitWithMon(ordering, types, evalCtx, evalCtx.Planner.Mon())
 }
 
 // InitWithMon initializes the MemRowContainer with an explicit monitor. Only

--- a/pkg/sql/rowcontainer/row_container_test.go
+++ b/pkg/sql/rowcontainer/row_container_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -76,6 +77,7 @@ func verifyRows(
 // the memory accounting.
 func TestRowContainerReplaceMax(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	rng, _ := randutil.NewTestRand()
@@ -131,6 +133,7 @@ func TestRowContainerReplaceMax(t *testing.T) {
 
 func TestRowContainerIterators(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
@@ -187,6 +190,7 @@ func TestRowContainerIterators(t *testing.T) {
 
 func TestDiskBackedRowContainer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
@@ -342,6 +346,7 @@ func TestDiskBackedRowContainer(t *testing.T) {
 
 func TestDiskBackedRowContainerDeDuping(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
@@ -461,6 +466,7 @@ func verifyOrdering(
 
 func TestDiskBackedIndexedRowContainer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
@@ -920,6 +926,9 @@ func generateAccessPattern(numRows int) []int {
 }
 
 func BenchmarkDiskBackedIndexedRowContainer(b *testing.B) {
+	defer leaktest.AfterTest(b)()
+	defer log.Scope(b).Close(b)
+
 	const numCols = 1
 	const numRows = 100000
 

--- a/pkg/sql/rowenc/encoded_datum_test.go
+++ b/pkg/sql/rowenc/encoded_datum_test.go
@@ -735,7 +735,7 @@ func TestEncDatumFingerprintMemory(t *testing.T) {
 	ctx := context.Background()
 	evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(ctx)
-	memAcc := evalCtx.Mon.MakeBoundAccount()
+	memAcc := evalCtx.TestingMon.MakeBoundAccount()
 	defer memAcc.Close(ctx)
 	var da tree.DatumAlloc
 	for _, c := range testCases {

--- a/pkg/sql/rowexec/aggregator.go
+++ b/pkg/sql/rowexec/aggregator.go
@@ -97,7 +97,7 @@ func (ag *aggregatorBase) init(
 	output execinfra.RowReceiver,
 	trailingMetaCallback func() []execinfrapb.ProducerMetadata,
 ) error {
-	memMonitor := execinfra.NewMonitor(ctx, flowCtx.EvalCtx.Mon, "aggregator-mem")
+	memMonitor := execinfra.NewMonitor(ctx, flowCtx.Mon, "aggregator-mem")
 	if execstats.ShouldCollectStats(ctx, flowCtx.CollectStats) {
 		input = newInputStatCollector(input)
 		ag.ExecStatsForTrace = ag.execStatsForTrace

--- a/pkg/sql/rowexec/aggregator_test.go
+++ b/pkg/sql/rowexec/aggregator_test.go
@@ -426,6 +426,7 @@ func BenchmarkAggregation(b *testing.B) {
 	flowCtx := &execinfra.FlowCtx{
 		Cfg:     &execinfra.ServerConfig{Settings: st},
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 	}
 
 	for _, aggFunc := range aggFuncs {
@@ -480,6 +481,7 @@ func BenchmarkCountRows(b *testing.B) {
 	flowCtx := &execinfra.FlowCtx{
 		Cfg:     &execinfra.ServerConfig{Settings: st},
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 	}
 
 	b.SetBytes(int64(8 * numRows * numCols))
@@ -507,6 +509,7 @@ func BenchmarkGrouping(b *testing.B) {
 	flowCtx := &execinfra.FlowCtx{
 		Cfg:     &execinfra.ServerConfig{Settings: st},
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 	}
 	spec := &execinfrapb.AggregatorSpec{
 		GroupCols: []uint32{0},
@@ -558,6 +561,7 @@ func benchmarkAggregationWithGrouping(b *testing.B, numOrderedCols int) {
 	flowCtx := &execinfra.FlowCtx{
 		Cfg:     &execinfra.ServerConfig{Settings: st},
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 	}
 
 	for _, aggFunc := range aggFuncs {

--- a/pkg/sql/rowexec/distinct.go
+++ b/pkg/sql/rowexec/distinct.go
@@ -99,7 +99,7 @@ func newDistinct(
 		}
 	}
 
-	memMonitor := execinfra.NewMonitor(ctx, flowCtx.EvalCtx.Mon, "distinct-mem")
+	memMonitor := execinfra.NewMonitor(ctx, flowCtx.Mon, "distinct-mem")
 	d := &distinct{
 		input:            input,
 		memAcc:           memMonitor.MakeBoundAccount(),

--- a/pkg/sql/rowexec/distinct_test.go
+++ b/pkg/sql/rowexec/distinct_test.go
@@ -278,6 +278,7 @@ func TestDistinct(t *testing.T) {
 			flowCtx := execinfra.FlowCtx{
 				Cfg:     &execinfra.ServerConfig{Settings: st},
 				EvalCtx: &evalCtx,
+				Mon:     evalCtx.TestingMon,
 			}
 
 			d, err := newDistinct(context.Background(), &flowCtx, 0 /* processorID */, &ds, in, &execinfrapb.PostProcessSpec{}, out)
@@ -327,6 +328,7 @@ func benchmarkDistinct(b *testing.B, orderedColumns []uint32) {
 	flowCtx := &execinfra.FlowCtx{
 		Cfg:     &execinfra.ServerConfig{Settings: st},
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 	}
 	spec := &execinfrapb.DistinctSpec{
 		DistinctColumns: []uint32{0, 1},

--- a/pkg/sql/rowexec/filterer_test.go
+++ b/pkg/sql/rowexec/filterer_test.go
@@ -84,6 +84,7 @@ func TestFilterer(t *testing.T) {
 			flowCtx := execinfra.FlowCtx{
 				Cfg:     &execinfra.ServerConfig{Settings: st},
 				EvalCtx: &evalCtx,
+				Mon:     evalCtx.TestingMon,
 			}
 			spec := execinfrapb.FiltererSpec{
 				Filter: execinfrapb.Expression{Expr: c.filter},
@@ -126,6 +127,7 @@ func BenchmarkFilterer(b *testing.B) {
 	flowCtx := &execinfra.FlowCtx{
 		Cfg:     &execinfra.ServerConfig{Settings: st},
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 	}
 	post := &execinfrapb.PostProcessSpec{}
 	disposer := &rowDisposer{}

--- a/pkg/sql/rowexec/hashjoiner.go
+++ b/pkg/sql/rowexec/hashjoiner.go
@@ -144,7 +144,7 @@ func newHashJoiner(
 
 	// Limit the memory use by creating a child monitor with a hard limit.
 	// The hashJoiner will overflow to disk if this limit is not enough.
-	h.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx, "hashjoiner-limited")
+	h.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.Mon, flowCtx, "hashjoiner-limited")
 	h.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor, "hashjoiner-disk")
 	h.hashTable = rowcontainer.NewHashDiskBackedRowContainer(
 		h.EvalCtx, h.MemMonitor, h.diskMonitor, h.FlowCtx.Cfg.TempStorage,

--- a/pkg/sql/rowexec/hashjoiner_test.go
+++ b/pkg/sql/rowexec/hashjoiner_test.go
@@ -1046,6 +1046,7 @@ func TestHashJoiner(t *testing.T) {
 				out := &distsqlutils.RowBuffer{}
 				flowCtx := execinfra.FlowCtx{
 					EvalCtx: &evalCtx,
+					Mon:     evalCtx.TestingMon,
 					Cfg: &execinfra.ServerConfig{
 						Settings:    st,
 						TempStorage: tempEngine,
@@ -1130,6 +1131,7 @@ func TestHashJoinerError(t *testing.T) {
 			out := &distsqlutils.RowBuffer{}
 			flowCtx := execinfra.FlowCtx{
 				EvalCtx: &evalCtx,
+				Mon:     evalCtx.TestingMon,
 				Cfg: &execinfra.ServerConfig{
 					Settings:    st,
 					TempStorage: tempEngine,
@@ -1278,6 +1280,7 @@ func TestHashJoinerDrain(t *testing.T) {
 		},
 		DiskMonitor: diskMonitor,
 		EvalCtx:     &evalCtx,
+		Mon:         evalCtx.TestingMon,
 	}
 
 	post := execinfrapb.PostProcessSpec{Projection: true, OutputColumns: outCols}
@@ -1410,6 +1413,7 @@ func TestHashJoinerDrainAfterBuildPhaseError(t *testing.T) {
 		},
 		DiskMonitor: diskMonitor,
 		EvalCtx:     &evalCtx,
+		Mon:         evalCtx.TestingMon,
 	}
 
 	post := execinfrapb.PostProcessSpec{Projection: true, OutputColumns: outCols}
@@ -1460,6 +1464,7 @@ func BenchmarkHashJoiner(b *testing.B) {
 	defer diskMonitor.Stop(ctx)
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},

--- a/pkg/sql/rowexec/inverted_filterer.go
+++ b/pkg/sql/rowexec/inverted_filterer.go
@@ -110,7 +110,7 @@ func newInvertedFilterer(
 	}
 
 	// Initialize memory monitor and row container for input rows.
-	ifr.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx, "inverted-filterer-limited")
+	ifr.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.Mon, flowCtx, "inverted-filterer-limited")
 	ifr.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor, "inverted-filterer-disk")
 	ifr.rc = rowcontainer.NewDiskBackedNumberedRowContainer(
 		true, /* deDup */

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -297,7 +297,7 @@ func newInvertedJoiner(
 			LockWaitPolicy:             spec.LockingWaitPolicy,
 			LockTimeout:                flowCtx.EvalCtx.SessionData().LockTimeout,
 			Alloc:                      &ij.alloc,
-			MemMonitor:                 flowCtx.EvalCtx.Mon,
+			MemMonitor:                 flowCtx.Mon,
 			Spec:                       &spec.FetchSpec,
 			TraceKV:                    flowCtx.TraceKV,
 			ForceProductionKVBatchSize: flowCtx.EvalCtx.TestingKnobs.ForceProductionValues,
@@ -317,7 +317,7 @@ func newInvertedJoiner(
 	ij.spanBuilder.InitWithFetchSpec(flowCtx.EvalCtx, flowCtx.Codec(), &ij.fetchSpec)
 
 	// Initialize memory monitors and row container for index rows.
-	ij.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx, "invertedjoiner-limited")
+	ij.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.Mon, flowCtx, "invertedjoiner-limited")
 	ij.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor, "invertedjoiner-disk")
 	ij.indexRows = rowcontainer.NewDiskBackedNumberedRowContainer(
 		true, /* deDup */

--- a/pkg/sql/rowexec/inverted_joiner_test.go
+++ b/pkg/sql/rowexec/inverted_joiner_test.go
@@ -636,6 +636,7 @@ func TestInvertedJoiner(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings:    st,
 			TempStorage: tempEngine,
@@ -777,6 +778,7 @@ func TestInvertedJoinerDrain(t *testing.T) {
 	leafTxn := kv.NewLeafTxn(ctx, s.DB(), s.NodeID(), leafInputState)
 	flowCtx := execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings:    st,
 			TempStorage: tempEngine,

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -440,9 +440,9 @@ func newJoinReader(
 
 	// Initialize memory monitors and bound account for data structures in the joinReader.
 	jr.MemMonitor = mon.NewMonitorInheritWithLimit(
-		"joinreader-mem" /* name */, memoryLimit, flowCtx.EvalCtx.Mon,
+		"joinreader-mem" /* name */, memoryLimit, flowCtx.Mon,
 	)
-	jr.MemMonitor.StartNoReserved(ctx, flowCtx.EvalCtx.Mon)
+	jr.MemMonitor.StartNoReserved(ctx, flowCtx.Mon)
 	jr.memAcc = jr.MemMonitor.MakeBoundAccount()
 
 	if err := jr.initJoinReaderStrategy(ctx, flowCtx, rightTypes, readerType); err != nil {
@@ -488,9 +488,9 @@ func newJoinReader(
 		// We need to use an unlimited monitor for the streamer's budget since
 		// the streamer itself is responsible for staying under the limit.
 		jr.streamerInfo.unlimitedMemMonitor = mon.NewMonitorInheritWithLimit(
-			"joinreader-streamer-unlimited" /* name */, math.MaxInt64, flowCtx.EvalCtx.Mon,
+			"joinreader-streamer-unlimited" /* name */, math.MaxInt64, flowCtx.Mon,
 		)
-		jr.streamerInfo.unlimitedMemMonitor.StartNoReserved(ctx, flowCtx.EvalCtx.Mon)
+		jr.streamerInfo.unlimitedMemMonitor.StartNoReserved(ctx, flowCtx.Mon)
 		jr.streamerInfo.budgetAcc = jr.streamerInfo.unlimitedMemMonitor.MakeBoundAccount()
 		jr.streamerInfo.txnKVStreamerMemAcc = jr.streamerInfo.unlimitedMemMonitor.MakeBoundAccount()
 		// The index joiner can rely on the streamer to maintain the input ordering,
@@ -546,7 +546,7 @@ func newJoinReader(
 			LockWaitPolicy:             spec.LockingWaitPolicy,
 			LockTimeout:                flowCtx.EvalCtx.SessionData().LockTimeout,
 			Alloc:                      &jr.alloc,
-			MemMonitor:                 flowCtx.EvalCtx.Mon,
+			MemMonitor:                 flowCtx.Mon,
 			Spec:                       &spec.FetchSpec,
 			TraceKV:                    flowCtx.TraceKV,
 			ForceProductionKVBatchSize: flowCtx.EvalCtx.TestingKnobs.ForceProductionValues,

--- a/pkg/sql/rowexec/joinreader_test.go
+++ b/pkg/sql/rowexec/joinreader_test.go
@@ -1096,6 +1096,7 @@ func TestJoinReader(t *testing.T) {
 							defer evalCtx.Stop(ctx)
 							flowCtx := execinfra.FlowCtx{
 								EvalCtx: &evalCtx,
+								Mon:     evalCtx.TestingMon,
 								Cfg: &execinfra.ServerConfig{
 									Settings:    st,
 									TempStorage: tempEngine,
@@ -1276,6 +1277,7 @@ CREATE TABLE test.t (a INT, s STRING, INDEX (a, s))`); err != nil {
 	defer diskMonitor.Stop(ctx)
 	flowCtx := execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings:    st,
 			TempStorage: tempEngine,
@@ -1391,6 +1393,7 @@ func TestJoinReaderDrain(t *testing.T) {
 
 	flowCtx := execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings:    st,
 			TempStorage: tempEngine,
@@ -1680,6 +1683,7 @@ func benchmarkJoinReader(b *testing.B, bc JRBenchConfig) {
 		diskMonitor = execinfra.NewTestDiskMonitor(ctx, st)
 		flowCtx     = execinfra.FlowCtx{
 			EvalCtx: &evalCtx,
+			Mon:     evalCtx.TestingMon,
 			Cfg: &execinfra.ServerConfig{
 				Settings: st,
 			},
@@ -1944,6 +1948,7 @@ func BenchmarkJoinReaderLookupStress(b *testing.B) {
 		diskMonitor = execinfra.NewTestDiskMonitor(ctx, st)
 		flowCtx     = execinfra.FlowCtx{
 			EvalCtx: &evalCtx,
+			Mon:     evalCtx.TestingMon,
 			Cfg: &execinfra.ServerConfig{
 				Settings: st,
 			},

--- a/pkg/sql/rowexec/mergejoiner.go
+++ b/pkg/sql/rowexec/mergejoiner.go
@@ -88,7 +88,7 @@ func newMergeJoiner(
 		return nil, err
 	}
 
-	m.MemMonitor = execinfra.NewMonitor(ctx, flowCtx.EvalCtx.Mon, "mergejoiner-mem")
+	m.MemMonitor = execinfra.NewMonitor(ctx, flowCtx.Mon, "mergejoiner-mem")
 
 	var err error
 	m.streamMerger, err = makeStreamMerger(

--- a/pkg/sql/rowexec/mergejoiner_test.go
+++ b/pkg/sql/rowexec/mergejoiner_test.go
@@ -725,6 +725,7 @@ func TestMergeJoiner(t *testing.T) {
 			flowCtx := execinfra.FlowCtx{
 				Cfg:     &execinfra.ServerConfig{Settings: st},
 				EvalCtx: &evalCtx,
+				Mon:     evalCtx.TestingMon,
 			}
 
 			post := execinfrapb.PostProcessSpec{Projection: true, OutputColumns: c.outCols}
@@ -831,6 +832,7 @@ func TestConsumerClosed(t *testing.T) {
 			flowCtx := execinfra.FlowCtx{
 				Cfg:     &execinfra.ServerConfig{Settings: st},
 				EvalCtx: &evalCtx,
+				Mon:     evalCtx.TestingMon,
 			}
 			post := execinfrapb.PostProcessSpec{Projection: true, OutputColumns: outCols}
 			m, err := newMergeJoiner(context.Background(), &flowCtx, 0 /* processorID */, &spec, leftInput, rightInput, &post, out)
@@ -856,6 +858,7 @@ func BenchmarkMergeJoiner(b *testing.B) {
 	flowCtx := &execinfra.FlowCtx{
 		Cfg:     &execinfra.ServerConfig{Settings: st},
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 	}
 
 	spec := &execinfrapb.MergeJoinerSpec{

--- a/pkg/sql/rowexec/noop_test.go
+++ b/pkg/sql/rowexec/noop_test.go
@@ -36,6 +36,7 @@ func BenchmarkNoop(b *testing.B) {
 	flowCtx := &execinfra.FlowCtx{
 		Cfg:     &execinfra.ServerConfig{Settings: st},
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 	}
 	post := &execinfrapb.PostProcessSpec{}
 	disposer := &rowDisposer{}

--- a/pkg/sql/rowexec/ordinality_test.go
+++ b/pkg/sql/rowexec/ordinality_test.go
@@ -116,6 +116,7 @@ func TestOrdinality(t *testing.T) {
 			flowCtx := execinfra.FlowCtx{
 				Cfg:     &execinfra.ServerConfig{Settings: st},
 				EvalCtx: &evalCtx,
+				Mon:     evalCtx.TestingMon,
 			}
 
 			d, err := newOrdinalityProcessor(context.Background(), &flowCtx, 0 /* processorID */, &os, in, &execinfrapb.PostProcessSpec{}, out)
@@ -164,6 +165,7 @@ func BenchmarkOrdinality(b *testing.B) {
 	flowCtx := &execinfra.FlowCtx{
 		Cfg:     &execinfra.ServerConfig{Settings: st},
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 	}
 	spec := &execinfrapb.OrdinalitySpec{}
 

--- a/pkg/sql/rowexec/processor_utils_test.go
+++ b/pkg/sql/rowexec/processor_utils_test.go
@@ -45,6 +45,7 @@ func DefaultProcessorTestConfig() ProcessorTestConfig {
 		FlowCtx: &execinfra.FlowCtx{
 			Cfg:     &execinfra.ServerConfig{Settings: st},
 			EvalCtx: &evalCtx,
+			Mon:     evalCtx.TestingMon,
 		},
 	}
 }

--- a/pkg/sql/rowexec/processors_test.go
+++ b/pkg/sql/rowexec/processors_test.go
@@ -323,6 +323,7 @@ func TestProcessorBaseContext(t *testing.T) {
 		flowCtx := &execinfra.FlowCtx{
 			Cfg:     &execinfra.ServerConfig{Settings: st},
 			EvalCtx: &evalCtx,
+			Mon:     evalCtx.TestingMon,
 		}
 		defer flowCtx.EvalCtx.Stop(ctx)
 

--- a/pkg/sql/rowexec/project_set_test.go
+++ b/pkg/sql/rowexec/project_set_test.go
@@ -164,6 +164,7 @@ func BenchmarkProjectSet(b *testing.B) {
 				flowCtx := execinfra.FlowCtx{
 					Cfg:     &execinfra.ServerConfig{Settings: st},
 					EvalCtx: &evalCtx,
+					Mon:     evalCtx.TestingMon,
 				}
 
 				in := distsqlutils.NewRowBuffer(c.inputTypes, c.input, distsqlutils.RowBufferArgs{})

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -111,7 +111,7 @@ func newSampleAggregator(
 	// Limit the memory use by creating a child monitor with a hard limit.
 	// The processor will disable histogram collection if this limit is not
 	// enough.
-	memMonitor := execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx, "sample-aggregator-mem")
+	memMonitor := execinfra.NewLimitedMonitor(ctx, flowCtx.Mon, flowCtx, "sample-aggregator-mem")
 	rankCol := len(input.OutputTypes()) - 8
 	s := &sampleAggregator{
 		spec:         spec,

--- a/pkg/sql/rowexec/sample_aggregator_test.go
+++ b/pkg/sql/rowexec/sample_aggregator_test.go
@@ -70,6 +70,7 @@ func runSampleAggregator(
 ) {
 	flowCtx := execinfra.FlowCtx{
 		EvalCtx: evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 			DB:       kvDB,

--- a/pkg/sql/rowexec/sampler.go
+++ b/pkg/sql/rowexec/sampler.go
@@ -117,7 +117,7 @@ func newSamplerProcessor(
 	// Limit the memory use by creating a child monitor with a hard limit.
 	// The processor will disable histogram collection if this limit is not
 	// enough.
-	memMonitor := execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx, "sampler-mem")
+	memMonitor := execinfra.NewLimitedMonitor(ctx, flowCtx.Mon, flowCtx, "sampler-mem")
 	s := &samplerProcessor{
 		flowCtx:         flowCtx,
 		input:           input,

--- a/pkg/sql/rowexec/sampler_test.go
+++ b/pkg/sql/rowexec/sampler_test.go
@@ -67,6 +67,7 @@ func runSampler(
 	flowCtx := execinfra.FlowCtx{
 		Cfg:     &execinfra.ServerConfig{Settings: st},
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 	}
 	// Override the default memory limit. If memLimitBytes is small but
 	// non-zero, the processor will hit this limit and disable sampling.
@@ -356,6 +357,7 @@ func TestSamplerSketch(t *testing.T) {
 				Settings: st,
 			},
 			EvalCtx: &evalCtx,
+			Mon:     evalCtx.TestingMon,
 		}
 
 		spec := &execinfrapb.SamplerSpec{

--- a/pkg/sql/rowexec/sorter.go
+++ b/pkg/sql/rowexec/sorter.go
@@ -61,7 +61,7 @@ func (s *sorterBase) init(
 
 	// Limit the memory use by creating a child monitor with a hard limit.
 	// The processor will overflow to disk if this limit is not enough.
-	memMonitor := execinfra.NewLimitedMonitor(ctx, flowCtx.EvalCtx.Mon, flowCtx, redact.Sprintf("%s-limited", processorName))
+	memMonitor := execinfra.NewLimitedMonitor(ctx, flowCtx.Mon, flowCtx, redact.Sprintf("%s-limited", processorName))
 	if err := s.ProcessorBase.Init(
 		ctx, self, post, input.OutputTypes(), flowCtx, processorID, output, memMonitor, opts,
 	); err != nil {

--- a/pkg/sql/rowexec/sorter_test.go
+++ b/pkg/sql/rowexec/sorter_test.go
@@ -277,6 +277,7 @@ func TestSorter(t *testing.T) {
 					defer diskMonitor.Stop(ctx)
 					flowCtx := execinfra.FlowCtx{
 						EvalCtx: &evalCtx,
+						Mon:     evalCtx.TestingMon,
 						Cfg: &execinfra.ServerConfig{
 							Settings:    cluster.MakeTestingClusterSettings(),
 							TempStorage: tempEngine,
@@ -351,6 +352,7 @@ func TestSortInvalidLimit(t *testing.T) {
 		defer diskMonitor.Stop(ctx)
 		flowCtx := execinfra.FlowCtx{
 			EvalCtx: &evalCtx,
+			Mon:     evalCtx.TestingMon,
 			Cfg: &execinfra.ServerConfig{
 				Settings: st,
 			},
@@ -400,6 +402,7 @@ func BenchmarkSortAll(b *testing.B) {
 	defer diskMonitor.Stop(ctx)
 	flowCtx := execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},
@@ -443,6 +446,7 @@ func BenchmarkSortLimit(b *testing.B) {
 	defer diskMonitor.Stop(ctx)
 	flowCtx := execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},
@@ -491,6 +495,7 @@ func BenchmarkSortChunks(b *testing.B) {
 	defer diskMonitor.Stop(ctx)
 	flowCtx := execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -156,7 +156,7 @@ func newTableReader(
 			LockWaitPolicy:             spec.LockingWaitPolicy,
 			LockTimeout:                flowCtx.EvalCtx.SessionData().LockTimeout,
 			Alloc:                      &tr.alloc,
-			MemMonitor:                 flowCtx.EvalCtx.Mon,
+			MemMonitor:                 flowCtx.Mon,
 			Spec:                       &spec.FetchSpec,
 			TraceKV:                    flowCtx.TraceKV,
 			ForceProductionKVBatchSize: flowCtx.EvalCtx.TestingKnobs.ForceProductionValues,

--- a/pkg/sql/rowexec/tablereader_test.go
+++ b/pkg/sql/rowexec/tablereader_test.go
@@ -129,6 +129,7 @@ func TestTableReader(t *testing.T) {
 				defer evalCtx.Stop(ctx)
 				flowCtx := execinfra.FlowCtx{
 					EvalCtx: &evalCtx,
+					Mon:     evalCtx.TestingMon,
 					Cfg: &execinfra.ServerConfig{
 						Settings: st,
 						RangeCache: rangecache.NewRangeCache(s.ClusterSettings(), nil,
@@ -224,6 +225,7 @@ ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 1), (ARRAY[1], 2), (ARRAY[
 
 	flowCtx := execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings:   st,
 			RangeCache: tc.Server(0).DistSenderI().(*kvcoord.DistSender).RangeDescriptorCache(),
@@ -329,6 +331,7 @@ func TestTableReaderDrain(t *testing.T) {
 	leafTxn := kv.NewLeafTxn(ctx, s.DB(), s.NodeID(), leafInputState)
 	flowCtx := execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},
@@ -377,6 +380,7 @@ func TestLimitScans(t *testing.T) {
 	evalCtx.TestingKnobs.ForceProductionValues = true
 	flowCtx := execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 			RangeCache: rangecache.NewRangeCache(s.ClusterSettings(), nil,
@@ -490,6 +494,7 @@ func BenchmarkTableReader(b *testing.B) {
 		tableDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, keys.SystemSQLCodec, "test", tableName)
 		flowCtx := execinfra.FlowCtx{
 			EvalCtx: &evalCtx,
+			Mon:     evalCtx.TestingMon,
 			Cfg: &execinfra.ServerConfig{
 				Settings: st,
 				RangeCache: rangecache.NewRangeCache(s.ClusterSettings(), nil,

--- a/pkg/sql/rowexec/utils_test.go
+++ b/pkg/sql/rowexec/utils_test.go
@@ -57,6 +57,7 @@ func runProcessorTest(
 	flowCtx := execinfra.FlowCtx{
 		Cfg:     &execinfra.ServerConfig{Settings: st, Stopper: stopper, DistSender: distSender},
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Txn:     txn,
 	}
 

--- a/pkg/sql/rowexec/values_test.go
+++ b/pkg/sql/rowexec/values_test.go
@@ -49,6 +49,7 @@ func TestValuesProcessor(t *testing.T) {
 				flowCtx := execinfra.FlowCtx{
 					Cfg:     &execinfra.ServerConfig{Settings: st},
 					EvalCtx: evalCtx,
+					Mon:     evalCtx.TestingMon,
 				}
 
 				v, err := newValuesProcessor(context.Background(), &flowCtx, 0 /* processorID */, &spec, &execinfrapb.PostProcessSpec{}, out)
@@ -107,6 +108,7 @@ func BenchmarkValuesProcessor(b *testing.B) {
 	flowCtx := execinfra.FlowCtx{
 		Cfg:     &execinfra.ServerConfig{Settings: st},
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 	}
 	post := execinfrapb.PostProcessSpec{}
 	output := rowDisposer{}

--- a/pkg/sql/rowexec/windower.go
+++ b/pkg/sql/rowexec/windower.go
@@ -123,8 +123,8 @@ func newWindower(
 		// production.
 		limit = memRequiredByWindower
 	}
-	limitedMon := mon.NewMonitorInheritWithLimit("windower-limited", limit, evalCtx.Mon)
-	limitedMon.StartNoReserved(ctx, evalCtx.Mon)
+	limitedMon := mon.NewMonitorInheritWithLimit("windower-limited", limit, flowCtx.Mon)
+	limitedMon.StartNoReserved(ctx, flowCtx.Mon)
 	w.acc = limitedMon.MakeBoundAccount()
 	// If we have aggregate builtins that aggregate a single datum, we want
 	// them to reuse the same shared memory account with the windower. Notably,

--- a/pkg/sql/rowexec/windower_test.go
+++ b/pkg/sql/rowexec/windower_test.go
@@ -61,6 +61,7 @@ func TestWindowerAccountingForResults(t *testing.T) {
 
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings:    st,
 			TempStorage: tempEngine,
@@ -208,6 +209,7 @@ func BenchmarkWindower(b *testing.B) {
 
 	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 		},

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -468,7 +468,7 @@ func (z *zigzagJoiner) setupInfo(
 			LockWaitPolicy:             spec.LockingWaitPolicy,
 			LockTimeout:                flowCtx.EvalCtx.SessionData().LockTimeout,
 			Alloc:                      &info.alloc,
-			MemMonitor:                 flowCtx.EvalCtx.Mon,
+			MemMonitor:                 flowCtx.Mon,
 			Spec:                       &spec.FetchSpec,
 			TraceKV:                    flowCtx.TraceKV,
 			ForceProductionKVBatchSize: flowCtx.EvalCtx.TestingKnobs.ForceProductionValues,

--- a/pkg/sql/rowexec/zigzagjoiner_test.go
+++ b/pkg/sql/rowexec/zigzagjoiner_test.go
@@ -700,6 +700,7 @@ func TestZigzagJoiner(t *testing.T) {
 			defer evalCtx.Stop(ctx)
 			flowCtx := execinfra.FlowCtx{
 				EvalCtx: &evalCtx,
+				Mon:     evalCtx.TestingMon,
 				Cfg:     &execinfra.ServerConfig{Settings: st},
 				Txn:     kv.NewTxn(ctx, s.DB(), s.NodeID()),
 			}
@@ -774,6 +775,7 @@ func TestZigzagJoinerDrain(t *testing.T) {
 	leafTxn := kv.NewLeafTxn(ctx, s.DB(), s.NodeID(), leafInputState)
 	flowCtx := execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg:     &execinfra.ServerConfig{Settings: s.ClusterSettings()},
 		Txn:     leafTxn,
 	}

--- a/pkg/sql/rowflow/routers.go
+++ b/pkg/sql/rowflow/routers.go
@@ -272,7 +272,7 @@ func (rb *routerBase) init(ctx context.Context, flowCtx *execinfra.FlowCtx, type
 		// to take the mutex.
 		evalCtx := flowCtx.NewEvalCtx()
 		rb.outputs[i].memoryMonitor = execinfra.NewLimitedMonitor(
-			ctx, evalCtx.Mon, flowCtx,
+			ctx, flowCtx.Mon, flowCtx,
 			redact.Sprintf("router-limited-%d", rb.outputs[i].streamID),
 		)
 		rb.outputs[i].diskMonitor = execinfra.NewMonitor(
@@ -283,7 +283,7 @@ func (rb *routerBase) init(ctx context.Context, flowCtx *execinfra.FlowCtx, type
 		// to fallback to disk if a memory budget error is encountered when
 		// we're popping rows from the row container into the row buffer.
 		rb.outputs[i].rowBufToPushFromMon = execinfra.NewMonitor(
-			ctx, evalCtx.Mon, redact.Sprintf("router-unlimited-%d", rb.outputs[i].streamID),
+			ctx, flowCtx.Mon, redact.Sprintf("router-unlimited-%d", rb.outputs[i].streamID),
 		)
 		memAcc := rb.outputs[i].rowBufToPushFromMon.MakeBoundAccount()
 		rb.outputs[i].rowBufToPushFromAcc = &memAcc

--- a/pkg/sql/rowflow/routers_test.go
+++ b/pkg/sql/rowflow/routers_test.go
@@ -67,6 +67,7 @@ func setupRouter(
 			Settings: st,
 		},
 		EvalCtx:     evalCtx,
+		Mon:         evalCtx.TestingMon,
 		DiskMonitor: diskMonitor,
 	}
 	r.init(ctx, &flowCtx, inputTypes)
@@ -676,6 +677,7 @@ func TestRouterBlocks(t *testing.T) {
 					Settings: st,
 				},
 				EvalCtx:     &evalCtx,
+				Mon:         evalCtx.TestingMon,
 				DiskMonitor: diskMonitor,
 			}
 			router.init(ctx, &flowCtx, colTypes)
@@ -786,6 +788,7 @@ func TestRouterDiskSpill(t *testing.T) {
 	defer evalCtx.Stop(ctx)
 	flowCtx := execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
+		Mon:     evalCtx.TestingMon,
 		Cfg: &execinfra.ServerConfig{
 			Settings:    st,
 			TempStorage: tempEngine,
@@ -799,10 +802,10 @@ func TestRouterDiskSpill(t *testing.T) {
 	// memErrorWhenConsumingRows indicates whether we expect an OOM error to
 	// occur when we're consuming rows from the row channel. By default, it
 	// will occur because routerOutput derives a memory monitor for the row
-	// buffer from evalCtx.Mon which has a limit, and we're going to consume
-	// rows after the spilling has occurred (meaning that evalCtx.Mon reached
-	// its limit). In order for this to not happen we will create a separate
-	// memory account.
+	// buffer from evalCtx.TestingMon which has a limit, and we're going to
+	// consume rows after the spilling has occurred (meaning that
+	// evalCtx.TestingMon reached its limit). In order for this to not happen we
+	// will create a separate memory account.
 	for _, memErrorWhenConsumingRows := range []bool{false, true} {
 		var (
 			rowChan execinfra.RowChannel

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -340,7 +340,7 @@ func (sc *SchemaChanger) backfillQueryIntoTable(
 				// subqueries. Note that we intentionally defer the closure of
 				// the account until we return from this method (after the main
 				// query is executed).
-				subqueryResultMemAcc := localPlanner.EvalContext().Mon.MakeBoundAccount()
+				subqueryResultMemAcc := localPlanner.Mon().MakeBoundAccount()
 				defer subqueryResultMemAcc.Close(ctx)
 				if !sc.distSQLPlanner.PlanAndRunSubqueries(
 					ctx, localPlanner, localPlanner.ExtendedEvalContextCopy,

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -511,7 +511,7 @@ var aggregates = map[string]builtinDefinition{
 				params []*types.T, evalCtx *eval.Context, arguments tree.Datums,
 			) eval.AggregateFunc {
 				return &stMakeLineAgg{
-					acc: evalCtx.Mon.MakeBoundAccount(),
+					acc: evalCtx.Planner.Mon().MakeBoundAccount(),
 				}
 			},
 			infoBuilder{
@@ -785,7 +785,7 @@ func makeSTUnionBuiltin() builtinDefinition {
 				params []*types.T, evalCtx *eval.Context, arguments tree.Datums,
 			) eval.AggregateFunc {
 				return &stUnionAgg{
-					acc: evalCtx.Mon.MakeBoundAccount(),
+					acc: evalCtx.Planner.Mon().MakeBoundAccount(),
 				}
 			},
 			infoBuilder{
@@ -975,7 +975,7 @@ type stCollectAgg struct {
 
 func newSTCollectAgg(_ []*types.T, evalCtx *eval.Context, _ tree.Datums) eval.AggregateFunc {
 	return &stCollectAgg{
-		acc: evalCtx.Mon.MakeBoundAccount(),
+		acc: evalCtx.Planner.Mon().MakeBoundAccount(),
 	}
 }
 
@@ -1308,7 +1308,7 @@ const (
 // will be used by the new struct which will operate in "shared" mode
 func makeSingleDatumAggregateBase(evalCtx *eval.Context) singleDatumAggregateBase {
 	if evalCtx.SingleDatumAggMemAccount == nil {
-		newAcc := evalCtx.Mon.MakeBoundAccount()
+		newAcc := evalCtx.Planner.Mon().MakeBoundAccount()
 		return singleDatumAggregateBase{
 			mode: nonSharedSingleDatumAggregateBaseMode,
 			acc:  &newAcc,
@@ -1435,7 +1435,7 @@ type arrayAggregate struct {
 func newArrayAggregate(params []*types.T, evalCtx *eval.Context, _ tree.Datums) eval.AggregateFunc {
 	return &arrayAggregate{
 		arr: tree.NewDArray(params[0]),
-		acc: evalCtx.Mon.MakeBoundAccount(),
+		acc: evalCtx.Planner.Mon().MakeBoundAccount(),
 	}
 }
 
@@ -4517,7 +4517,7 @@ func newPercentileDiscAggregate(
 ) eval.AggregateFunc {
 	return &percentileDiscAggregate{
 		arr: tree.NewDArray(params[1]),
-		acc: evalCtx.Mon.MakeBoundAccount(),
+		acc: evalCtx.Planner.Mon().MakeBoundAccount(),
 	}
 }
 
@@ -4615,7 +4615,7 @@ func newPercentileContAggregate(
 ) eval.AggregateFunc {
 	return &percentileContAggregate{
 		arr: tree.NewDArray(params[1]),
-		acc: evalCtx.Mon.MakeBoundAccount(),
+		acc: evalCtx.Planner.Mon().MakeBoundAccount(),
 	}
 }
 

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -2058,7 +2058,7 @@ type spanKeyIterator struct {
 
 func newSpanKeyIterator(evalCtx *eval.Context, span roachpb.Span) *spanKeyIterator {
 	return &spanKeyIterator{
-		acc:  evalCtx.Mon.MakeBoundAccount(),
+		acc:  evalCtx.Planner.Mon().MakeBoundAccount(),
 		span: span,
 	}
 }
@@ -2162,7 +2162,7 @@ func makeRangeKeyIterator(ctx *eval.Context, args tree.Datums) (eval.ValueGenera
 	rangeID := roachpb.RangeID(tree.MustBeDInt(args[0]))
 	return &rangeKeyIterator{
 		spanKeyIterator: spanKeyIterator{
-			acc: ctx.Mon.MakeBoundAccount(),
+			acc: ctx.Planner.Mon().MakeBoundAccount(),
 		},
 		rangeID: rangeID,
 	}, nil
@@ -2475,7 +2475,7 @@ func makeShowCreateAllSchemasGenerator(
 	return &showCreateAllSchemasGenerator{
 		evalPlanner: ctx.Planner,
 		dbName:      dbName,
-		acc:         ctx.Mon.MakeBoundAccount(),
+		acc:         ctx.Planner.Mon().MakeBoundAccount(),
 	}, nil
 }
 
@@ -2631,7 +2631,7 @@ func makeShowCreateAllTablesGenerator(
 	return &showCreateAllTablesGenerator{
 		evalPlanner: ctx.Planner,
 		dbName:      dbName,
-		acc:         ctx.Mon.MakeBoundAccount(),
+		acc:         ctx.Planner.Mon().MakeBoundAccount(),
 		sessionData: ctx.SessionData(),
 	}, nil
 }
@@ -2712,6 +2712,6 @@ func makeShowCreateAllTypesGenerator(
 	return &showCreateAllTypesGenerator{
 		evalPlanner: ctx.Planner,
 		dbName:      dbName,
-		acc:         ctx.Mon.MakeBoundAccount(),
+		acc:         ctx.Planner.Mon().MakeBoundAccount(),
 	}, nil
 }

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -175,7 +175,11 @@ type Context struct {
 
 	TestingKnobs TestingKnobs
 
-	Mon *mon.BytesMonitor
+	// TestingMon is a memory monitor that should be only used in tests. In
+	// production code consider using either the monitor of the planner or of
+	// the flow.
+	// TODO(yuzefovich): remove this.
+	TestingMon *mon.BytesMonitor
 
 	// SingleDatumAggMemAccount is a memory account that all aggregate builtins
 	// that store a single datum will share to account for the memory needed to
@@ -309,12 +313,23 @@ func MakeTestingEvalContextWithMon(st *cluster.Settings, monitor *mon.BytesMonit
 		NodeID:           base.TestingIDContainer,
 	}
 	monitor.Start(context.Background(), nil /* pool */, mon.NewStandaloneBudget(math.MaxInt64))
-	ctx.Mon = monitor
+	ctx.TestingMon = monitor
+	ctx.Planner = &fakePlannerWithMonitor{monitor: monitor}
 	ctx.Context = context.TODO()
 	now := timeutil.Now()
 	ctx.SetTxnTimestamp(now)
 	ctx.SetStmtTimestamp(now)
 	return ctx
+}
+
+type fakePlannerWithMonitor struct {
+	Planner
+	monitor *mon.BytesMonitor
+}
+
+// Mon is part of the Planner interface.
+func (p *fakePlannerWithMonitor) Mon() *mon.BytesMonitor {
+	return p.monitor
 }
 
 // SessionData returns the SessionData the current EvalCtx should use to eval.
@@ -368,10 +383,10 @@ func NewTestingEvalContext(st *cluster.Settings) *Context {
 // Stop closes out the EvalContext and must be called once it is no longer in use.
 func (ec *Context) Stop(c context.Context) {
 	if r := recover(); r != nil {
-		ec.Mon.EmergencyStop(c)
+		ec.TestingMon.EmergencyStop(c)
 		panic(r)
 	} else {
-		ec.Mon.Stop(c)
+		ec.TestingMon.Stop(c)
 	}
 }
 

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/lib/pq/oid"
 )
 
@@ -198,6 +199,9 @@ type Planner interface {
 	DatabaseCatalog
 	TypeResolver
 	tree.FunctionReferenceResolver
+
+	// Mon returns the Planner's monitor.
+	Mon() *mon.BytesMonitor
 
 	// ExecutorConfig returns *ExecutorConfig
 	ExecutorConfig() interface{}

--- a/pkg/sql/sem/eval/eval_test.go
+++ b/pkg/sql/sem/eval/eval_test.go
@@ -193,7 +193,7 @@ func TestTimeConversion(t *testing.T) {
 
 	for _, test := range tests {
 		ctx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
-		defer ctx.Mon.Stop(context.Background())
+		defer ctx.TestingMon.Stop(context.Background())
 		exprStr := fmt.Sprintf("experimental_strptime('%s', '%s')", test.start, test.format)
 		expr, err := parser.ParseExpr(exprStr)
 		if err != nil {

--- a/pkg/sql/sem/eval/eval_test/eval_test.go
+++ b/pkg/sql/sem/eval/eval_test/eval_test.go
@@ -145,6 +145,7 @@ func TestEval(t *testing.T) {
 			flowCtx := &execinfra.FlowCtx{
 				Cfg:     &execinfra.ServerConfig{Settings: st},
 				EvalCtx: evalCtx,
+				Mon:     evalCtx.TestingMon,
 			}
 			memMonitor := execinfra.NewTestMemMonitor(ctx, st)
 			defer memMonitor.Stop(ctx)

--- a/pkg/sql/sem/eval/like_test.go
+++ b/pkg/sql/sem/eval/like_test.go
@@ -171,7 +171,7 @@ func benchmarkLike(b *testing.B, ctx *Context, caseInsensitive bool) {
 func BenchmarkLikeWithCache(b *testing.B) {
 	ctx := NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	ctx.ReCache = tree.NewRegexpCache(len(benchmarkLikePatterns))
-	defer ctx.Mon.Stop(context.Background())
+	defer ctx.TestingMon.Stop(context.Background())
 
 	benchmarkLike(b, ctx, false)
 }
@@ -186,7 +186,7 @@ func BenchmarkLikeWithoutCache(b *testing.B) {
 func BenchmarkILikeWithCache(b *testing.B) {
 	ctx := NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	ctx.ReCache = tree.NewRegexpCache(len(benchmarkLikePatterns))
-	defer ctx.Mon.Stop(context.Background())
+	defer ctx.TestingMon.Stop(context.Background())
 
 	benchmarkLike(b, ctx, true)
 }

--- a/pkg/sql/sem/normalize/constant_eval_test.go
+++ b/pkg/sql/sem/normalize/constant_eval_test.go
@@ -43,7 +43,7 @@ func TestConstantEvalArrayComparison(t *testing.T) {
 	}
 
 	ctx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
-	defer ctx.Mon.Stop(context.Background())
+	defer ctx.TestingMon.Stop(context.Background())
 	c := normalize.MakeConstantEvalVisitor(ctx)
 	expr, _ = tree.WalkExpr(&c, typedExpr)
 	if err := c.Err(); err != nil {

--- a/pkg/sql/sem/normalize/normalize_test.go
+++ b/pkg/sql/sem/normalize/normalize_test.go
@@ -236,7 +236,7 @@ func TestNormalizeExpr(t *testing.T) {
 			}
 			rOrig := typedExpr.String()
 			ctx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
-			defer ctx.Mon.Stop(context.Background())
+			defer ctx.TestingMon.Stop(context.Background())
 			r, err := normalize.Expr(ctx, typedExpr)
 			if err != nil {
 				t.Fatalf("%s: %v", d.expr, err)

--- a/pkg/sql/sem/tree/compare_test.go
+++ b/pkg/sql/sem/tree/compare_test.go
@@ -56,7 +56,7 @@ func TestEvalComparisonExprCaching(t *testing.T) {
 			Right:    tree.NewDString(d.right),
 		}
 		ctx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
-		defer ctx.Mon.Stop(context.Background())
+		defer ctx.TestingMon.Stop(context.Background())
 		ctx.ReCache = tree.NewRegexpCache(8)
 		typedExpr, err := tree.TypeCheck(context.Background(), expr, nil, types.Any)
 		if err != nil {

--- a/pkg/sql/sem/tree/expr_test.go
+++ b/pkg/sql/sem/tree/expr_test.go
@@ -175,7 +175,7 @@ func TestExprString(t *testing.T) {
 		}
 		// Compare the normalized expressions.
 		ctx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
-		defer ctx.Mon.Stop(context.Background())
+		defer ctx.TestingMon.Stop(context.Background())
 		normalized, err := normalize.Expr(ctx, typedExpr)
 		if err != nil {
 			t.Fatalf("%s: %v", exprStr, err)

--- a/pkg/sql/spool.go
+++ b/pkg/sql/spool.go
@@ -45,7 +45,7 @@ func (s *spoolNode) startExec(params runParams) error {
 	}
 
 	s.rows = rowcontainer.NewRowContainer(
-		params.EvalContext().Mon.MakeBoundAccount(),
+		params.p.Mon().MakeBoundAccount(),
 		colinfo.ColTypeInfoFromResCols(planColumns(s.source)),
 	)
 

--- a/pkg/sql/tablewriter_upsert_opt.go
+++ b/pkg/sql/tablewriter_upsert_opt.go
@@ -110,7 +110,7 @@ func (tu *optTableUpserter) init(
 	if tu.rowsNeeded {
 		tu.resultRow = make(tree.Datums, len(tu.returnCols))
 		tu.rows = rowcontainer.NewRowContainer(
-			evalCtx.Mon.MakeBoundAccount(),
+			evalCtx.Planner.Mon().MakeBoundAccount(),
 			colinfo.ColTypeInfoFromColumns(tu.returnCols),
 		)
 

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -131,6 +131,7 @@ func (dsp *DistSQLPlanner) Exec(
 	if err := p.makeOptimizerPlan(ctx); err != nil {
 		return err
 	}
+	defer p.curPlan.close(ctx)
 	rw := NewCallbackResultWriter(func(ctx context.Context, row tree.Datums) error {
 		return nil
 	})
@@ -157,7 +158,7 @@ func (dsp *DistSQLPlanner) Exec(
 		distributionType)
 	planCtx.stmtType = recv.stmtType
 
-	dsp.PlanAndRun(ctx, evalCtx, planCtx, p.txn, p.curPlan.main, recv)()
+	dsp.PlanAndRun(ctx, evalCtx, planCtx, p.txn, p.curPlan.main, recv)
 	return rw.Err()
 }
 

--- a/pkg/sql/ttl/ttljob/ttljob.go
+++ b/pkg/sql/ttl/ttljob/ttljob.go
@@ -313,7 +313,7 @@ func (t rowLevelTTLResumer) Resume(ctx context.Context, execCtx interface{}) err
 
 		// Copy the evalCtx, as dsp.Run() might change it.
 		evalCtxCopy := *evalCtx
-		cleanup := distSQLPlanner.Run(
+		distSQLPlanner.Run(
 			ctx,
 			planCtx,
 			nil, /* txn */
@@ -322,7 +322,6 @@ func (t rowLevelTTLResumer) Resume(ctx context.Context, execCtx interface{}) err
 			&evalCtxCopy,
 			nil, /* finishedSetupFn */
 		)
-		defer cleanup()
 
 		return metadataCallbackWriter.Err()
 	}()

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -127,7 +127,7 @@ func (u *updateNode) startExec(params runParams) error {
 
 	if u.run.rowsNeeded {
 		u.run.tu.rows = rowcontainer.NewRowContainer(
-			params.EvalContext().Mon.MakeBoundAccount(),
+			params.p.Mon().MakeBoundAccount(),
 			colinfo.ColTypeInfoFromResCols(u.columns),
 		)
 	}

--- a/pkg/sql/values.go
+++ b/pkg/sql/values.go
@@ -42,7 +42,7 @@ func (p *planner) newContainerValuesNode(columns colinfo.ResultColumns, capacity
 		columns: columns,
 		valuesRun: valuesRun{
 			rows: rowcontainer.NewRowContainerWithCapacity(
-				p.EvalContext().Mon.MakeBoundAccount(),
+				p.Mon().MakeBoundAccount(),
 				colinfo.ColTypeInfoFromResCols(columns),
 				capacity,
 			),
@@ -68,7 +68,7 @@ func (n *valuesNode) startExec(params runParams) error {
 	// from other planNodes), so its expressions need evaluating.
 	// This may run subqueries.
 	n.rows = rowcontainer.NewRowContainerWithCapacity(
-		params.extendedEvalCtx.Mon.MakeBoundAccount(),
+		params.p.Mon().MakeBoundAccount(),
 		colinfo.ColTypeInfoFromResCols(n.columns),
 		len(n.tuples),
 	)

--- a/pkg/sql/virtual_table.go
+++ b/pkg/sql/virtual_table.go
@@ -258,7 +258,7 @@ var _ rowPusher = &vTableLookupJoinNode{}
 func (v *vTableLookupJoinNode) startExec(params runParams) error {
 	v.run.keyCtx = constraint.KeyContext{EvalCtx: params.EvalContext()}
 	v.run.rows = rowcontainer.NewRowContainer(
-		params.EvalContext().Mon.MakeBoundAccount(),
+		params.p.Mon().MakeBoundAccount(),
 		colinfo.ColTypeInfoFromResCols(v.columns),
 	)
 	v.run.indexKeyDatums = make(tree.Datums, len(v.columns))


### PR DESCRIPTION
This commit cleans up a long standing tech debt of how the "planning"
and "execution" monitors were intertwined which made it so that we had
to put some hacks in place to close things in the correct order. In
particular, previously `DistSQLPlanner.Run` was returning a "cleanup"
function that had to be deferred in some cases (e.g. on the main query
path we had to defer until after the postqueries finished). That cleanup
function closed the plan before cleaning up the execution flow. It had
to happen in this particular order since the memory monitor of the
latter was used to derive some memory accounts for the planNode tree
(part of the former). We also didn't want to return flow objects
explicitly, so we returned this cleanup closure. We also had some hacks
about "ignoring the closure" of the plans for sub- and postqueries.

This commit refactors this whole mess into a much more clear structure.
The main idea is that we now store the "flow" memory monitor explicitly
on the `FlowContext`, and most of the things (like processors and
operators) use it. However, in some cases we need to have access to
a memory monitor that outlives the flow (this is what was previously
intertwined), so we introduce a method to `eval.Planner` interface to
return the "planner" monitor (which is actually a parent of the "flow"
monitor). There are two main users (builtin functions like aggregates
and row containers) that - philosophically speaking - should be using
the flow monitor, but there is no easy way to plumb it there nor are
those things closed on the flow cleanup, so these things access the
"planner" monitor.

This refactor allowed us to remove several cleanup closures, so now the
flow is cleaned up automatically at the end of `Run` method. Several
non-main query paths (like apply joins) that use `PlanAndRun`
infrastructure now explicitly close their plans (previously this was
hidden inside the now-removed cleanup closure).

Epic: CRDB-20535

Release note: None