### PR TITLE
release-22.1: backupccl: decrease log chattiness

### DIFF
--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -331,6 +331,8 @@ func runBackupProcessor(
 		//  *2). See #49798.
 		numSenders := int(kvserver.ExportRequestsLimit.Get(&clusterSettings.SV)) * 2
 
+		logExport := log.Every(1 * time.Minute)
+
 		return ctxgroup.GroupWorkers(ctx, numSenders, func(ctx context.Context, _ int) error {
 			readTime := spec.BackupEndTime.GoTime()
 
@@ -415,8 +417,13 @@ func runBackupProcessor(
 						Source:                   roachpb.AdmissionHeader_FROM_SQL,
 						NoMemoryReservedAtSource: true,
 					}
-					log.Infof(ctx, "sending ExportRequest for span %s (attempt %d, priority %s)",
-						span.span, span.attempts+1, header.UserPriority.String())
+					if span.attempts > 0 || logExport.ShouldLog() {
+						log.Infof(ctx, "sending ExportRequest for span %s (attempt %d, priority %s)",
+							span.span, span.attempts+1, header.UserPriority.String())
+					} else {
+						log.VEventf(ctx, 1, "sending ExportRequest for span %s (attempt %d, priority %s)",
+							span.span, span.attempts+1, header.UserPriority.String())
+					}
 					var rawRes roachpb.Response
 					var pErr *roachpb.Error
 					var reqSentTime time.Time


### PR DESCRIPTION
The "sending ExportRequest for span" log message was the 5th most voluminous log event source in CC.

This commit makes it less verbose, by importing a one-line change from another merged PR #84043 from v22.2.

Release justification: reduce splunk costs
