### PR TITLE
kvserver: add storage checkpoints metric

### DIFF
--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3303,11 +3303,15 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 	return nil
 }
 
+func (s *Store) checkpointsDir() string {
+	return filepath.Join(s.engine.GetAuxiliaryDir(), "checkpoints")
+}
+
 // checkpoint creates a RocksDB checkpoint in the auxiliary directory with the
 // provided tag used in the filepath. The filepath for the checkpoint directory
 // is returned.
 func (s *Store) checkpoint(ctx context.Context, tag string) (string, error) {
-	checkpointBase := filepath.Join(s.engine.GetAuxiliaryDir(), "checkpoints")
+	checkpointBase := s.checkpointsDir()
 	_ = s.engine.MkdirAll(checkpointBase)
 
 	checkpointDir := filepath.Join(checkpointBase, tag)
@@ -3343,6 +3347,14 @@ func (s *Store) ComputeMetrics(ctx context.Context, tick int) error {
 		return err
 	}
 	s.metrics.updateEnvStats(*envStats)
+
+	{
+		dirs, err := s.engine.List(s.checkpointsDir())
+		if err != nil { // skip NotFound or any other error
+			dirs = nil
+		}
+		s.metrics.RdbCheckpoints.Update(int64(len(dirs)))
+	}
 
 	// Log this metric infrequently (with current configurations,
 	// every 10 minutes). Trigger on tick 1 instead of tick 0 so that

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -3035,6 +3035,11 @@ var charts = []sectionDescription{
 				AxisLabel: "Duration (nanos)",
 			},
 			{
+				Title:     "Checkpoints",
+				Metrics:   []string{"storage.checkpoints"},
+				AxisLabel: "Directories",
+			},
+			{
 				Title: "Bytes Used Per Level",
 				Metrics: []string{
 					"storage.l0-level-size",


### PR DESCRIPTION
When an inconsistency between range's replicas is found, every replica's node leaves behind a storage checkpoint which can be used for finding the cause of the inconsistency. The checkpoints are cheap to make if hard links are used. However, the cost of a checkpoint on a live node increases over time because the state keeps diverging from it. Effectively it becomes a full copy of the old state, and consumes that much of disk capacity.

It is important to act on the checkpoints and reclaim the space. This commit adds a store metric which exposes the number of checkpoints found, so that admins/SREs can be alerted and act on it.

Touches #21128

Added a test, and also tested manually: tricked one replica to think that there is an inconsistency, this triggered all replicas to store a checkpoint and one crash; the metric on the other 2 replicas increased to 1, and I saw the corresponding directories in storage.

Release note: None