### PR TITLE
release-22.2: jobs: make the registry logging less chatty

### DIFF
--- a/pkg/jobs/BUILD.bazel
+++ b/pkg/jobs/BUILD.bazel
@@ -78,7 +78,7 @@ go_library(
 
 go_test(
     name = "jobs_test",
-    size = "medium",
+    size = "large",
     srcs = [
         "delegate_control_test.go",
         "executor_impl_test.go",
@@ -93,7 +93,7 @@ go_test(
         "scheduled_job_test.go",
         "testutils_test.go",
     ],
-    args = ["-test.timeout=295s"],
+    args = ["-test.timeout=895s"],
     embed = [":jobs"],
     shard_count = 16,
     deps = [

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -960,15 +960,18 @@ func (r *Registry) cleanupOldJobsPage(
 
 	log.VEventf(ctx, 2, "read potentially expired jobs: %d", numRows)
 	if len(toDelete.Array) > 0 {
-		log.Infof(ctx, "attempting to clean up %d expired job records", len(toDelete.Array))
+		log.VEventf(ctx, 2, "attempting to clean up %d expired job records", len(toDelete.Array))
 		const stmt = `DELETE FROM system.jobs WHERE id = ANY($1)`
 		var nDeleted int
 		if nDeleted, err = r.ex.Exec(
 			ctx, "gc-jobs", nil /* txn */, stmt, toDelete,
 		); err != nil {
+			log.Warningf(ctx, "error cleaning up %d jobs: %v", len(toDelete.Array), err)
 			return false, 0, errors.Wrap(err, "deleting old jobs")
 		}
-		log.Infof(ctx, "cleaned up %d expired job records", nDeleted)
+		if nDeleted > 0 {
+			log.Infof(ctx, "cleaned up %d expired job records", nDeleted)
+		}
 	}
 	// If we got as many rows as we asked for, there might be more.
 	morePages := numRows == pageSize
@@ -1419,7 +1422,7 @@ func (r *Registry) MarkIdle(job *Job, isIdle bool) {
 		jobType := payload.Type()
 		jm := r.metrics.JobMetrics[jobType]
 		if aj.isIdle != isIdle {
-			log.Infof(r.serverCtx, "%s job %d: toggling idleness to %+v", jobType, job.ID(), isIdle)
+			log.VEventf(r.serverCtx, 2, "%s job %d: toggling idleness to %+v", jobType, job.ID(), isIdle)
 			if isIdle {
 				r.metrics.RunningNonIdleJobs.Dec(1)
 				jm.CurrentlyIdle.Inc(1)


### PR DESCRIPTION
Backport 1/1 commits from #89064.

/cc @cockroachdb/release

---

The "toggling idleness" log message was the 4th most voluminous log event source in CC, logged 4x more frequently than the first next event source in volume.

This commit makes it less verbose.

Release justification: reduce splunk costs
