### PR TITLE
release-22.2: kvserver: don't log "local QPS is below max threshold" by default

### DIFF
--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -222,7 +222,7 @@ func (sr *StoreRebalancer) rebalanceStore(
 	// cluster-level overfull threshold of QPS.
 	qpsMaxThreshold := allocatorimpl.OverfullQPSThreshold(options, allStoresList.CandidateQueriesPerSecond.Mean)
 	if !(localDesc.Capacity.QueriesPerSecond > qpsMaxThreshold) {
-		log.KvDistribution.Infof(ctx, "local QPS %.2f is below max threshold %.2f (mean=%.2f); no rebalancing needed",
+		log.KvDistribution.VEventf(ctx, 1, "local QPS %.2f is below max threshold %.2f (mean=%.2f); no rebalancing needed",
 			localDesc.Capacity.QueriesPerSecond, qpsMaxThreshold, allStoresList.CandidateQueriesPerSecond.Mean)
 		return
 	}


### PR DESCRIPTION
Backport 1/1 commits from #89077.

/cc @cockroachdb/release

---

Context: #89075

This log message is the 9th most voluminous across the CC fleet. It's not surprising since most stores are idle.
There's no good reason to have it logged by default - it doesn't say anything interesting.
Let's just keep it in traces.

Release justification: reduce splunk costs
