### PR TITLE
changefeedccl: ignore add column schema change for non-target columns

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1262,6 +1262,46 @@ func TestChangefeedColumnDropsOnTheSameTableWithMultipleFamilies(t *testing.T) {
 	cdcTest(t, testFn)
 }
 
+func TestNoStopAfterNonTargetAddColumnWithBackfill(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+
+		sqlDB.Exec(t, `CREATE TABLE hasfams (id INT PRIMARY KEY, a STRING, b STRING, c STRING, FAMILY id_a (id, a), FAMILY b_and_c (b, c))`)
+		sqlDB.Exec(t, `INSERT INTO hasfams values (0, 'a', 'b', 'c')`)
+
+		// Open up the changefeed.
+		cf := feed(t, f, `CREATE CHANGEFEED FOR TABLE hasfams FAMILY b_and_c WITH schema_change_policy='stop'`)
+
+		defer closeFeed(t, cf)
+		assertPayloads(t, cf, []string{
+			`hasfams.b_and_c: [0]->{"after": {"b": "b", "c": "c"}}`,
+		})
+
+		// Adding a column with a backfill to the default column family does not stop the changefeed.
+		sqlDB.Exec(t, `ALTER TABLE hasfams ADD COLUMN d STRING DEFAULT 'default'`)
+		sqlDB.Exec(t, `INSERT INTO hasfams VALUES (1, 'a1', 'b1', 'c1', 'd1')`)
+		assertPayloads(t, cf, []string{
+			`hasfams.b_and_c: [1]->{"after": {"b": "b1", "c": "c1"}}`,
+		})
+
+		// Adding a column with a backfill to a non-target column family does not stop the changefeed.
+		sqlDB.Exec(t, `ALTER TABLE hasfams ADD COLUMN e STRING DEFAULT 'default' FAMILY id_a`)
+		sqlDB.Exec(t, `INSERT INTO hasfams VALUES (2, 'a2', 'b2', 'c2', 'd2', 'e2')`)
+		assertPayloads(t, cf, []string{
+			`hasfams.b_and_c: [2]->{"after": {"b": "b2", "c": "c2"}}`,
+		})
+
+		// Check that adding a column to a watched family stops the changefeed.
+		sqlDB.Exec(t, `ALTER TABLE hasfams ADD COLUMN f INT DEFAULT 0 FAMILY b_and_c`)
+		if _, err := cf.Next(); !testutils.IsError(err, `schema change occurred at`) {
+			t.Errorf(`expected "schema change occurred at ..." got: %+v`, err.Error())
+		}
+	}
+
+	cdcTest(t, testFn)
+}
+
 func TestChangefeedExternalIODisabled(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
@@ -109,7 +109,7 @@ func Run(ctx context.Context, cfg Config) error {
 		cfg.InitialHighWater, cfg.EndTime,
 		cfg.Codec,
 		cfg.SchemaFeed,
-		sc, pff, bf, cfg.UseMux, cfg.Knobs)
+		sc, pff, bf, cfg.UseMux, cfg.Targets, cfg.Knobs)
 	f.onBackfillCallback = cfg.OnBackfillCallback
 
 	g := ctxgroup.WithContext(ctx)
@@ -181,6 +181,8 @@ type kvFeed struct {
 
 	useMux bool
 
+	targets changefeedbase.Targets
+
 	// These dependencies are made available for test injection.
 	bufferFactory func() kvevent.Buffer
 	tableFeed     schemafeed.SchemaFeed
@@ -206,6 +208,7 @@ func newKVFeed(
 	pff physicalFeedFactory,
 	bf func() kvevent.Buffer,
 	useMux bool,
+	targets changefeedbase.Targets,
 	knobs TestingKnobs,
 ) *kvFeed {
 	return &kvFeed{
@@ -225,6 +228,7 @@ func newKVFeed(
 		physicalFeed:        pff,
 		bufferFactory:       bf,
 		useMux:              useMux,
+		targets:             targets,
 		knobs:               knobs,
 	}
 }
@@ -306,7 +310,7 @@ func (f *kvFeed) run(ctx context.Context) (err error) {
 		// If is no change in the primary key columns, then a primary key change
 		// should not trigger a failure in the `stop` policy because this change is
 		// effectively invisible to consumers.
-		primaryIndexChange, noColumnChanges := isPrimaryKeyChange(events)
+		primaryIndexChange, noColumnChanges := isPrimaryKeyChange(events, f.targets)
 		if primaryIndexChange && (noColumnChanges ||
 			f.schemaChangePolicy != changefeedbase.OptSchemaChangePolicyStop) {
 			boundaryType = jobspb.ResolvedSpan_RESTART
@@ -330,11 +334,11 @@ func (f *kvFeed) run(ctx context.Context) (err error) {
 }
 
 func isPrimaryKeyChange(
-	events []schemafeed.TableEvent,
+	events []schemafeed.TableEvent, targets changefeedbase.Targets,
 ) (isPrimaryIndexChange, hasNoColumnChanges bool) {
 	hasNoColumnChanges = true
 	for _, ev := range events {
-		if ok, noColumnChange := schemafeed.IsPrimaryIndexChange(ev); ok {
+		if ok, noColumnChange := schemafeed.IsPrimaryIndexChange(ev, targets); ok {
 			isPrimaryIndexChange = true
 			hasNoColumnChanges = hasNoColumnChanges && noColumnChange
 		}

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
@@ -128,6 +128,7 @@ func TestKVFeed(t *testing.T) {
 			keys.SystemSQLCodec,
 			tf, sf, rangefeedFactory(ref.run), bufferFactory,
 			util.ConstantWithMetamorphicTestBool("use_mux", true),
+			changefeedbase.Targets{},
 			TestingKnobs{})
 		ctx, cancel := context.WithCancel(context.Background())
 		g := ctxgroup.WithContext(ctx)

--- a/pkg/ccl/changefeedccl/schemafeed/table_event_filter_datadriven_test.go
+++ b/pkg/ccl/changefeedccl/schemafeed/table_event_filter_datadriven_test.go
@@ -154,7 +154,7 @@ func TestDataDriven(t *testing.T) {
 						ev.After.GetName(), ev.Before.GetVersion(), ev.After.GetVersion(),
 						schemafeed.ClassifyEvent(ev),
 					)
-					if _, noColumnChanges := schemafeed.IsPrimaryIndexChange(ev); noColumnChanges {
+					if _, noColumnChanges := schemafeed.IsPrimaryIndexChange(ev, changefeedbase.Targets{}); noColumnChanges {
 						buf.WriteString(" (no column changes)")
 					}
 				}

--- a/pkg/ccl/changefeedccl/schemafeed/table_event_filter_test.go
+++ b/pkg/ccl/changefeedccl/schemafeed/table_event_filter_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/schemafeed/schematestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
@@ -146,7 +147,7 @@ func TestTableEventIsPrimaryIndexChange(t *testing.T) {
 		},
 	} {
 		t.Run(c.name, func(t *testing.T) {
-			got, _ := IsPrimaryIndexChange(c.e)
+			got, _ := IsPrimaryIndexChange(c.e, changefeedbase.Targets{})
 			require.Equalf(t, c.exp, got, "event %v", c.e)
 		})
 	}


### PR DESCRIPTION
Previously, if you created a changefeed which targeted specific column families and used the option `schema_change_policy='stop'`, the changefeed would stop even if a column was added to a non-target column family.

This change updates changefeeds to ignore add column schema changes unless a column is being added to a target column family.

Fixes: https://github.com/cockroachdb/cockroach/issues/85009

Release note: None