### PR TITLE
sql: correctly reset the planner in the copy shim

### DIFF
--- a/pkg/sql/copyshim.go
+++ b/pkg/sql/copyshim.go
@@ -98,6 +98,7 @@ func RunCopyFrom(
 		p.cancelChecker.Reset(ctx)
 		p.optPlanningCtx.init(p)
 		p.resetPlanner(ctx, txn, stmtTS, p.sessionDataMutatorIterator.sds.Top())
+		p.extendedEvalCtx.Context.Txn = txn
 	}
 	p, cleanup := newInternalPlanner("copytest",
 		txn,


### PR DESCRIPTION
Previously, we forgot to update the txn of the eval context of the planner.

Release note: None