### PR TITLE
kvserver: skip TestLeasePreferencesDuringOutage

### DIFF
--- a/pkg/kv/kvserver/client_lease_test.go
+++ b/pkg/kv/kvserver/client_lease_test.go
@@ -780,6 +780,7 @@ func gossipLiveness(t *testing.T, tc *testcluster.TestCluster) {
 // lease in a single cycle of the replicate_queue.
 func TestLeasePreferencesDuringOutage(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 88769, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	stickyRegistry := server.NewStickyInMemEnginesRegistry()


### PR DESCRIPTION
See #88769.

Release note: None