### PR TITLE
sql: Make `tree.ParseJSON` faster

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -99,6 +99,7 @@ require (
 	github.com/jaegertracing/jaeger v1.18.1
 	github.com/jordan-wright/email v4.0.1-0.20210109023952-943e75fe5223+incompatible
 	github.com/jordanlewis/gcassert v0.0.0-20210709222130-81f5df3faab8
+	github.com/json-iterator/go v1.1.12
 	github.com/kevinburke/go-bindata v3.13.0+incompatible
 	github.com/kisielk/errcheck v1.6.1-0.20210625163953-8ddee489636a
 	github.com/kisielk/gotool v1.0.0
@@ -275,7 +276,6 @@ require (
 	github.com/jhump/protoreflect v1.9.1-0.20210817181203-db1a327a393e // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
-	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
 	github.com/lestrrat-go/backoff/v2 v2.0.8 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.1 // indirect

--- a/pkg/sql/logictest/testdata/logic_test/json
+++ b/pkg/sql/logictest/testdata/logic_test/json
@@ -20,7 +20,7 @@ SELECT '1.00'::JSON
 ----
 1.00
 
-statement error unexpected EOF
+statement error could not parse JSON
 SELECT '{'::JSON
 
 query T

--- a/pkg/util/json/BUILD.bazel
+++ b/pkg/util/json/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/util/unique",
         "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_json_iterator_go//:go",
     ],
 )
 

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math/big"
 	"reflect"
 	"sort"
@@ -33,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	uniq "github.com/cockroachdb/cockroach/pkg/util/unique"
 	"github.com/cockroachdb/errors"
+	jsoniter "github.com/json-iterator/go"
 )
 
 // Type represents a JSON type.
@@ -840,8 +842,52 @@ func (j jsonObject) Size() uintptr {
 	return valSize
 }
 
-// ParseJSON takes a string of JSON and returns a JSON value.
-func ParseJSON(s string) (JSON, error) {
+// ParseJSONImplType is the implementation library
+// used to parse JSON.
+type ParseJSONImplType int
+
+const (
+	// UseStdGoJSON : encoding/json
+	UseStdGoJSON ParseJSONImplType = iota
+	// UseJSONIter :json-iterator
+	UseJSONIter
+
+	// Note: Other libraries tested and rejected include:
+	//  * go-json: universally slower, worse (allocation) than either
+	//    standard or json-iter for larger inputs.
+	//  * simdjson-go: too restrictive; doesn't work on all platforms,
+	//    does not parse raw json literals (true/false, etc); and is not
+	//    a drop in replacement.
+	//  * ffjson, easyjson: not appropriate since these library use code
+	//    generation, and cannot parse arbitrary JSON.
+)
+
+var parseJSONImpl = util.ConstantWithMetamorphicTestChoice(
+	"parse-json-impl", UseJSONIter, UseStdGoJSON)
+
+// TestingSetParseJSONImpl configures ParseJSON to use specified implementation.
+func TestingSetParseJSONImpl(impl ParseJSONImplType) func() {
+	old := parseJSONImpl
+	parseJSONImpl = impl
+	return func() {
+		parseJSONImpl = old
+	}
+}
+
+func (impl ParseJSONImplType) String() string {
+	switch impl {
+	case UseStdGoJSON:
+		return "stdgo"
+	case UseJSONIter:
+		return "jsoniter"
+	default:
+		return "unknown"
+	}
+}
+
+// parseJSONGoStd parses json using encoding/json library.
+// TODO(yevgeniy): Remove this code once we get more confidence in json-iter implementation.
+func parseJSONGoStd(s string) (JSON, error) {
 	// This goes in two phases - first it parses the string into raw interface{}s
 	// using the Go encoding/json package, then it transforms that into a JSON.
 	// This could be faster if we wrote a parser to go directly into the JSON.
@@ -853,15 +899,134 @@ func ParseJSON(s string) (JSON, error) {
 	decoder.UseNumber()
 	err := decoder.Decode(&result)
 	if err != nil {
-		err = errors.Handled(err)
-		err = errors.Wrap(err, "unable to decode JSON")
-		err = pgerror.WithCandidateCode(err, pgcode.InvalidTextRepresentation)
-		return nil, err
+		return nil, jsonDecodeError(err)
 	}
 	if decoder.More() {
 		return nil, errTrailingCharacters
 	}
 	return MakeJSON(result)
+}
+
+var parseCfg = jsoniter.Config{
+	EscapeHTML:             true,
+	SortMapKeys:            false, // We'll sort when we build JSONb object.
+	ValidateJsonRawMessage: true,
+	UseNumber:              true,
+}.Froze()
+
+// readNumber reads json.Number from the iterator and checks to see if
+// json.Number has leading 0's -- which is not allowed.
+// TODO(yevgeniy): jsoniter.Iterator should handle this directly in the it.ReadNumber().
+func readNumber(it *jsoniter.Iterator) json.Number {
+	n := it.ReadNumber()
+
+	pos := 0
+	if pos < len(n) && n[0] == '-' {
+		pos++
+	}
+
+	if pos+1 < len(n) && n[pos] == '0' {
+		switch n[pos+1] {
+		case 'e', 'E', '.':
+			return n
+		default:
+			it.ReportError("readNumber", "leading 0 not allowed")
+			return n[:pos+1]
+		}
+	}
+	return n
+}
+
+// jsonIterToJSON converts json iterator to JSON.
+// Indicates error via it.Error field.
+func jsonIterToJSON(it *jsoniter.Iterator) JSON {
+	switch next := it.WhatIsNext(); next {
+	case jsoniter.StringValue:
+		return FromString(it.ReadString())
+	case jsoniter.NumberValue:
+		n, err := FromNumber(readNumber(it))
+		if err != nil {
+			it.ReportError("parse-num", err.Error())
+			return nil
+		}
+		return n
+	case jsoniter.NilValue:
+		if it.ReadNil() {
+			return NullJSONValue
+		}
+		it.ReportError("parse", "failed to read expected 'null'")
+		return nil
+	case jsoniter.BoolValue:
+		return FromBool(it.ReadBool())
+	case jsoniter.ArrayValue:
+		b := NewArrayBuilder(0)
+		for it.ReadArray() && it.Error == nil {
+			if v := jsonIterToJSON(it); it.Error == nil {
+				b.Add(v)
+			}
+		}
+		return b.Build()
+	case jsoniter.ObjectValue:
+		b := NewObjectBuilder(0)
+		// Use ReadObjectCB since ReadObject does not distinguish between
+		// end of object (returned as empty key field), and an empty key
+		// (i.e. ReadObject cannot handle `{"": ""}`).
+		it.ReadObjectCB(func(pos *jsoniter.Iterator, key string) bool {
+			if v := jsonIterToJSON(pos); pos.Error == nil {
+				b.Add(key, v)
+			}
+			return true
+		})
+		if it.Error != nil {
+			return nil
+		}
+		return b.Build()
+	default:
+		it.ReportError("parse", "unexpected JSON value type")
+		return nil
+	}
+}
+
+// iterHasMoreData returns true if iterator has more data.
+// This is similar to encoder/json More() check.
+func iterHasMoreData(it *jsoniter.Iterator) bool {
+	buf := bytes.TrimSpace(it.SkipAndReturnBytes())
+	return !(len(buf) == 0 || buf[0] == ']' || buf[0] == '}')
+}
+
+func jsonDecodeError(err error) error {
+	return pgerror.Wrapf(
+		errors.Handled(err), pgcode.InvalidTextRepresentation, "unable to decode JSON")
+}
+
+func parseUsingJSONIter(s string) (JSON, error) {
+	it := parseCfg.BorrowIterator([]byte(s))
+	defer parseCfg.ReturnIterator(it)
+	j := jsonIterToJSON(it)
+
+	// Errors indicated via it.Error.
+	if it.Error != nil && it.Error != io.EOF {
+		return nil, jsonDecodeError(it.Error)
+	}
+
+	// This check is similar to encoder/json More() check.
+	if iterHasMoreData(it) {
+		return nil, errTrailingCharacters
+	}
+
+	return j, nil
+}
+
+// ParseJSON takes a string of JSON and returns a JSON value.
+func ParseJSON(s string) (JSON, error) {
+	switch parseJSONImpl {
+	case UseStdGoJSON:
+		return parseJSONGoStd(s)
+	case UseJSONIter:
+		return parseUsingJSONIter(s)
+	default:
+		return nil, errors.AssertionFailedf("invalid JSON impl")
+	}
 }
 
 // EncodeInvertedIndexKeys takes in a key prefix and returns a slice of inverted index keys,

--- a/pkg/util/json/random.go
+++ b/pkg/util/json/random.go
@@ -29,18 +29,67 @@ var staticStrings = []string{
 	"foobar",
 }
 
-// Random generates a random JSON value.
-func Random(complexity int, rng *rand.Rand) (JSON, error) {
-	return MakeJSON(doRandomJSON(complexity, rng))
+type randConfig struct {
+	strLen     int
+	complexity int
 }
 
-func randomJSONString(rng *rand.Rand) interface{} {
-	if rng.Intn(2) == 0 {
+// RandOption is an option to control generation of random json.
+type RandOption interface {
+	apply(*randConfig)
+}
+
+type funcOpt func(cfg *randConfig)
+
+func (fn funcOpt) apply(cfg *randConfig) {
+	fn(cfg)
+}
+
+// WithMaxStrLen returns an option to set maximum length of random JSON string objects.
+func WithMaxStrLen(l int) RandOption {
+	return funcOpt(func(cfg *randConfig) {
+		cfg.strLen = l
+	})
+}
+
+// WithComplexity returns an option to set maximum complexity of JSON objects.
+func WithComplexity(c int) RandOption {
+	return funcOpt(func(cfg *randConfig) {
+		cfg.complexity = c
+	})
+}
+
+func defaultRandConfig(complexity int) randConfig {
+	return randConfig{
+		strLen:     defaultRandStrLen,
+		complexity: complexity,
+	}
+}
+
+// RandGen generates a random JSON value configured with specified options.
+func RandGen(rng *rand.Rand, opts ...RandOption) (JSON, error) {
+	cfg := defaultRandConfig(20)
+	for _, opt := range opts {
+		opt.apply(&cfg)
+	}
+	return MakeJSON(doRandomJSON(rng, &cfg))
+}
+
+// Random generates a random JSON value.
+func Random(complexity int, rng *rand.Rand) (JSON, error) {
+	cfg := defaultRandConfig(complexity)
+	return MakeJSON(doRandomJSON(rng, &cfg))
+}
+
+const defaultRandStrLen = 10
+
+func randomJSONString(rng *rand.Rand, maxLen int) interface{} {
+	if maxLen <= defaultRandStrLen && rng.Intn(2) == 0 {
 		return staticStrings[rng.Intn(len(staticStrings))]
 	}
 	result := make([]byte, 0)
-	l := rng.Intn(10) + 3
-	for i := 0; i < l; i++ {
+	l := rng.Intn(maxLen) + 3
+	for i := 0; i < l+maxLen/4 && i < maxLen; i++ { // Bias to generate larger strings.
 		result = append(result, byte(rng.Intn(0x7f-0x20)+0x20))
 	}
 	return string(result)
@@ -50,11 +99,11 @@ func randomJSONNumber(rng *rand.Rand) interface{} {
 	return json.Number(fmt.Sprintf("%v", rng.ExpFloat64()))
 }
 
-func doRandomJSON(complexity int, rng *rand.Rand) interface{} {
-	if complexity <= 0 || rng.Intn(10) == 0 {
+func doRandomJSON(rng *rand.Rand, cfg *randConfig) interface{} {
+	if cfg.complexity <= 0 || rng.Intn(cfg.complexity) == 0 {
 		switch rng.Intn(5) {
 		case 0:
-			return randomJSONString(rng)
+			return randomJSONString(rng, cfg.strLen)
 		case 1:
 			return randomJSONNumber(rng)
 		case 2:
@@ -65,26 +114,26 @@ func doRandomJSON(complexity int, rng *rand.Rand) interface{} {
 			return nil
 		}
 	}
-	complexity--
+	cfg.complexity--
 	switch rng.Intn(3) {
 	case 0:
 		result := make([]interface{}, 0)
-		for complexity > 0 {
-			amount := 1 + rng.Intn(complexity)
-			complexity -= amount
-			result = append(result, doRandomJSON(amount, rng))
+		for cfg.complexity > 0 {
+			amount := 1 + rng.Intn(cfg.complexity)
+			cfg.complexity -= amount
+			result = append(result, doRandomJSON(rng, cfg))
 		}
 		return result
 	case 1:
 		result := make(map[string]interface{})
-		for complexity > 0 {
-			amount := 1 + rng.Intn(complexity)
-			complexity -= amount
-			result[randomJSONString(rng).(string)] = doRandomJSON(amount, rng)
+		for cfg.complexity > 0 {
+			amount := 1 + rng.Intn(cfg.complexity)
+			cfg.complexity -= amount
+			result[randomJSONString(rng, defaultRandStrLen).(string)] = doRandomJSON(rng, cfg)
 		}
 		return result
 	default:
-		j, _ := Random(complexity, rng)
+		j, _ := Random(cfg.complexity, rng)
 		encoding, _ := EncodeJSON(nil, j)
 		encoded, _ := newEncodedFromRoot(encoding)
 		return encoded


### PR DESCRIPTION
Switch `tree.ParseJSON` to use `json-iterator` library to convert input string directly into `tree.JSON`, without extra conversion to go native type.

The change is a drop in replacement for standard `encoding/json` library.  Allmost all metrics (speed per op, throughput, allocations/op) are improved significantly.  The new implementation tends to allocate more when encoding very large strings (256KB or larger).

This change should help for any insert query that converts strings to JSON -- including, large scale imports of JSON data.

Release note (performance improvement): Signficantly speed up conversion of strings to JSONb.