### PR TITLE
storage,kvserver: support lazy value fetching in SimpleMVCCIterator

### DIFF
--- a/pkg/kv/kvserver/gc/gc_iterator.go
+++ b/pkg/kv/kvserver/gc/gc_iterator.go
@@ -33,6 +33,9 @@ type gcIterator struct {
 	cachedRangeTombstoneKey roachpb.Key
 }
 
+// TODO(sumeer): change gcIterator to use MVCCValueLenAndIsTombstone(). It
+// needs to get the value only for intents.
+
 func makeGCIterator(
 	desc *roachpb.RangeDescriptor,
 	snap storage.Reader,

--- a/pkg/kv/kvserver/rangefeed/task_test.go
+++ b/pkg/kv/kvserver/rangefeed/task_test.go
@@ -190,6 +190,16 @@ func (s *testIterator) UnsafeValue() []byte {
 	return s.curKV().Value
 }
 
+func (s *testIterator) MVCCValueLenAndIsTombstone() (int, bool, error) {
+	rawV := s.curKV().Value
+	v, err := storage.DecodeMVCCValue(rawV)
+	return len(rawV), v.IsTombstone(), err
+}
+
+func (s *testIterator) ValueLen() int {
+	return len(s.curKV().Value)
+}
+
 func (s *testIterator) curKV() storage.MVCCKeyValue {
 	return s.kvs[s.cur]
 }

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -174,6 +174,16 @@ func (i *MVCCIterator) UnsafeValue() []byte {
 	return i.i.UnsafeValue()
 }
 
+// MVCCValueLenAndIsTombstone implements the MVCCIterator interface.
+func (i *MVCCIterator) MVCCValueLenAndIsTombstone() (int, bool, error) {
+	return i.i.MVCCValueLenAndIsTombstone()
+}
+
+// ValueLen implements the MVCCIterator interface.
+func (i *MVCCIterator) ValueLen() int {
+	return i.i.ValueLen()
+}
+
 // HasPointAndRange implements SimpleMVCCIterator.
 func (i *MVCCIterator) HasPointAndRange() (bool, bool) {
 	return i.i.HasPointAndRange()

--- a/pkg/storage/intent_interleaving_iter.go
+++ b/pkg/storage/intent_interleaving_iter.go
@@ -895,6 +895,20 @@ func (i *intentInterleavingIter) UnsafeValue() []byte {
 	return i.iter.UnsafeValue()
 }
 
+func (i *intentInterleavingIter) MVCCValueLenAndIsTombstone() (int, bool, error) {
+	if i.isCurAtIntentIter() {
+		return 0, false, errors.Errorf("not at MVCC value")
+	}
+	return i.iter.MVCCValueLenAndIsTombstone()
+}
+
+func (i *intentInterleavingIter) ValueLen() int {
+	if i.isCurAtIntentIter() {
+		return i.intentIter.ValueLen()
+	}
+	return i.iter.ValueLen()
+}
+
 func (i *intentInterleavingIter) Key() MVCCKey {
 	key := i.UnsafeKey()
 	keyCopy := make([]byte, len(key.Key))

--- a/pkg/storage/multi_iterator.go
+++ b/pkg/storage/multi_iterator.go
@@ -98,6 +98,16 @@ func (f *multiIterator) UnsafeValue() []byte {
 	return f.iters[f.currentIdx].UnsafeValue()
 }
 
+// MVCCValueLenAndIsTombstone implements the SimpleMVCCIterator interface.
+func (f *multiIterator) MVCCValueLenAndIsTombstone() (int, bool, error) {
+	return f.iters[f.currentIdx].MVCCValueLenAndIsTombstone()
+}
+
+// ValueLen implements the SimpleMVCCIterator interface.
+func (f *multiIterator) ValueLen() int {
+	return f.iters[f.currentIdx].ValueLen()
+}
+
 // HasPointAndRange implements SimpleMVCCIterator.
 func (f *multiIterator) HasPointAndRange() (bool, bool) {
 	panic("not implemented")

--- a/pkg/storage/mvcc_history_metamorphic_iterator_test.go
+++ b/pkg/storage/mvcc_history_metamorphic_iterator_test.go
@@ -320,6 +320,14 @@ func (m *metamorphicIterator) UnsafeValue() []byte {
 	return m.it.UnsafeValue()
 }
 
+func (m *metamorphicIterator) MVCCValueLenAndIsTombstone() (int, bool, error) {
+	return m.it.MVCCValueLenAndIsTombstone()
+}
+
+func (m *metamorphicIterator) ValueLen() int {
+	return m.it.ValueLen()
+}
+
 func (m *metamorphicIterator) HasPointAndRange() (bool, bool) {
 	return m.it.HasPointAndRange()
 }

--- a/pkg/storage/mvcc_incremental_iterator.go
+++ b/pkg/storage/mvcc_incremental_iterator.go
@@ -653,6 +653,16 @@ func (i *MVCCIncrementalIterator) UnsafeValue() []byte {
 	return i.iter.UnsafeValue()
 }
 
+// MVCCValueLenAndIsTombstone implements the SimpleMVCCIterator interface.
+func (i *MVCCIncrementalIterator) MVCCValueLenAndIsTombstone() (int, bool, error) {
+	return i.iter.MVCCValueLenAndIsTombstone()
+}
+
+// ValueLen implements the SimpleMVCCIterator interface.
+func (i *MVCCIncrementalIterator) ValueLen() int {
+	return i.iter.ValueLen()
+}
+
 // updateIgnoreTime updates the iterator's metadata and handles intents depending on the iterator's
 // intent policy.
 func (i *MVCCIncrementalIterator) updateIgnoreTime() {

--- a/pkg/storage/point_synthesizing_iter.go
+++ b/pkg/storage/point_synthesizing_iter.go
@@ -643,6 +643,31 @@ func (i *PointSynthesizingIter) UnsafeValue() []byte {
 	return i.rangeKeys[i.rangeKeysIdx].Value
 }
 
+// MVCCValueLenAndIsTombstone implements the MVCCIterator interface.
+func (i *PointSynthesizingIter) MVCCValueLenAndIsTombstone() (int, bool, error) {
+	if i.atPoint {
+		return i.iter.MVCCValueLenAndIsTombstone()
+	}
+	if i.rangeKeysIdx >= len(i.rangeKeys) || i.rangeKeysIdx < 0 {
+		return 0, false, errors.Errorf("iter is not Valid")
+	}
+	val := i.rangeKeys[i.rangeKeysIdx].Value
+	// All range keys are tombstones
+	return len(val), true, nil
+}
+
+// ValueLen implements the MVCCIterator interface.
+func (i *PointSynthesizingIter) ValueLen() int {
+	if i.atPoint {
+		return i.iter.ValueLen()
+	}
+	if i.rangeKeysIdx >= len(i.rangeKeys) || i.rangeKeysIdx < 0 {
+		// Caller has violated invariant!
+		return 0
+	}
+	return len(i.rangeKeys[i.rangeKeysIdx].Value)
+}
+
 // ValueProto implements MVCCIterator.
 func (i *PointSynthesizingIter) ValueProto(msg protoutil.Message) error {
 	return protoutil.Unmarshal(i.UnsafeValue(), msg)

--- a/pkg/storage/read_as_of_iterator.go
+++ b/pkg/storage/read_as_of_iterator.go
@@ -109,6 +109,16 @@ func (f *ReadAsOfIterator) UnsafeValue() []byte {
 	return f.iter.UnsafeValue()
 }
 
+// MVCCValueLenAndIsTombstone implements the SimpleMVCCIterator interface.
+func (f *ReadAsOfIterator) MVCCValueLenAndIsTombstone() (int, bool, error) {
+	return f.iter.MVCCValueLenAndIsTombstone()
+}
+
+// ValueLen implements the SimpleMVCCIterator interface.
+func (f *ReadAsOfIterator) ValueLen() int {
+	return f.iter.ValueLen()
+}
+
 // HasPointAndRange implements SimpleMVCCIterator.
 func (f *ReadAsOfIterator) HasPointAndRange() (bool, bool) {
 	return true, false


### PR DESCRIPTION
SimpleMVCCIterator already separates the methods to retrieve the key and value, and callers who do not need any information about the value do not call UnsafeValue(). However, there are callers (like stats calculation) who need to know the length of the value and in some cases whether an MVCC value is a tombstone. The MVCCValueLenAndIsTombstone() and ValueLen() methods are introduced for these cases. This is preparation for the near future where retrieving the value in Pebble will have actual additional cost, since the value may be in a different part of the file or a different file.

Non-test callers that can use these new interfaces have been modified. There are some todos to modify some non-trivial callers, related to deciding what to GC, and checking sstable conflicts, which will happen in future PRs.

When new methods are introduced to retrieve these value attributes in pebble.Iterator, only pebbleIterator.{MVCCValueLenAndIsTombstone, ValueLen} will need to be modified to make use of them.

Informs https://github.com/cockroachdb/pebble/issues/1170

Release note: None