### PR TITLE
sql: track CPU time on gateway node

### DIFF
--- a/pkg/roachpb/app_stats.go
+++ b/pkg/roachpb/app_stats.go
@@ -156,6 +156,7 @@ func (s *StatementStatistics) Add(other *StatementStatistics) {
 	s.Nodes = util.CombineUniqueInt64(s.Nodes, other.Nodes)
 	s.PlanGists = util.CombineUniqueString(s.PlanGists, other.PlanGists)
 	s.IndexRecommendations = other.IndexRecommendations
+	s.CpuTime.Add(other.CpuTime, s.Count, other.Count)
 
 	s.ExecStats.Add(other.ExecStats)
 
@@ -189,7 +190,8 @@ func (s *StatementStatistics) AlmostEqual(other *StatementStatistics, eps float6
 		s.SensitiveInfo.Equal(other.SensitiveInfo) &&
 		s.BytesRead.AlmostEqual(other.BytesRead, eps) &&
 		s.RowsRead.AlmostEqual(other.RowsRead, eps) &&
-		s.RowsWritten.AlmostEqual(other.RowsWritten, eps)
+		s.RowsWritten.AlmostEqual(other.RowsWritten, eps) &&
+		s.CpuTime.AlmostEqual(other.CpuTime, eps)
 	// s.ExecStats are deliberately ignored since they are subject to sampling
 	// probability and are not fully deterministic (e.g. the number of network
 	// messages depends on the range cache state).

--- a/pkg/roachpb/app_stats.proto
+++ b/pkg/roachpb/app_stats.proto
@@ -113,6 +113,9 @@ message StatementStatistics {
   // index_recommendations is the list of index recommendations generated for the statement fingerprint.
   repeated string index_recommendations = 27;
 
+  // cpu_time is the amount of CPU time spent (in seconds) by this query.
+  optional NumericStat cpu_time = 28 [(gogoproto.nullable) = false];
+
   // Note: be sure to update `sql/app_stats.go` when adding/removing fields here!
 
   reserved 13, 14, 17, 18, 19, 20;

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -472,6 +472,7 @@ go_library(
         "//pkg/util/errorutil/unimplemented",
         "//pkg/util/fsm",
         "//pkg/util/grpcutil",
+        "//pkg/util/grunning",
         "//pkg/util/hlc",
         "//pkg/util/humanizeutil",
         "//pkg/util/interval",

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1094,6 +1094,8 @@ CREATE TABLE crdb_internal.node_statement_statistics (
   service_lat_var     FLOAT NOT NULL,
   overhead_lat_avg    FLOAT NOT NULL,
   overhead_lat_var    FLOAT NOT NULL,
+  cpu_time_avg        FLOAT NOT NULL,
+  cpu_time_var        FLOAT NOT NULL,
   bytes_read_avg      FLOAT NOT NULL,
   bytes_read_var      FLOAT NOT NULL,
   rows_read_avg       FLOAT NOT NULL,
@@ -1197,6 +1199,8 @@ CREATE TABLE crdb_internal.node_statement_statistics (
 				tree.NewDFloat(tree.DFloat(stats.Stats.ServiceLat.GetVariance(stats.Stats.Count))),  // service_lat_var
 				tree.NewDFloat(tree.DFloat(stats.Stats.OverheadLat.Mean)),                           // overhead_lat_avg
 				tree.NewDFloat(tree.DFloat(stats.Stats.OverheadLat.GetVariance(stats.Stats.Count))), // overhead_lat_var
+				tree.NewDFloat(tree.DFloat(stats.Stats.CpuTime.Mean)),                               // cpu_time_avg
+				tree.NewDFloat(tree.DFloat(stats.Stats.CpuTime.GetVariance(stats.Stats.Count))),     // cpu_time_var
 				tree.NewDFloat(tree.DFloat(stats.Stats.BytesRead.Mean)),                             // bytes_read_avg
 				tree.NewDFloat(tree.DFloat(stats.Stats.BytesRead.GetVariance(stats.Stats.Count))),   // bytes_read_var
 				tree.NewDFloat(tree.DFloat(stats.Stats.RowsRead.Mean)),                              // rows_read_avg

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -131,6 +131,7 @@ func (ex *connExecutor) recordStatementSummary(
 	// We want to exclude any overhead to reduce possible confusion.
 	svcLatRaw := phaseTimes.GetServiceLatencyNoOverhead()
 	svcLat := svcLatRaw.Seconds()
+	cpuTime := phaseTimes.GetServiceCPUTimeTotal().Seconds()
 
 	// processing latency: contributing towards SQL results.
 	processingLat := parseLat + planLat + runLat
@@ -192,6 +193,7 @@ func (ex *connExecutor) recordStatementSummary(
 		RunLatency:           runLat,
 		ServiceLatency:       svcLat,
 		OverheadLatency:      execOverhead,
+		ServiceCPUTime:       cpuTime,
 		BytesRead:            stats.bytesRead,
 		RowsRead:             stats.rowsRead,
 		RowsWritten:          stats.rowsWritten,

--- a/pkg/sql/pgwire/BUILD.bazel
+++ b/pkg/sql/pgwire/BUILD.bazel
@@ -54,6 +54,7 @@ go_library(
         "//pkg/util/duration",
         "//pkg/util/envutil",
         "//pkg/util/errorutil/unimplemented",
+        "//pkg/util/grunning",
         "//pkg/util/humanizeutil",
         "//pkg/util/ipaddr",
         "//pkg/util/json",

--- a/pkg/sql/sessionphase/session_phase.go
+++ b/pkg/sql/sessionphase/session_phase.go
@@ -33,6 +33,8 @@ const (
 
 	// Executor phases.
 
+	SessionQueryReceivedCPUTime
+
 	// SessionQueryReceived is the SessionPhase when a query is received.
 	SessionQueryReceived
 
@@ -53,6 +55,8 @@ const (
 
 	// PlannerEndExecStmt is the SessionPhase when execution ends.
 	PlannerEndExecStmt
+
+	PlannerEndExecStmtCpuTime
 
 	// SessionQueryServiced is the SessionPhase when a query is serviced.
 	// Note: we compute this even for empty queries or  "special" statements that
@@ -164,6 +168,13 @@ func (t *Times) GetServiceLatencyNoOverhead() time.Duration {
 // NOTE: SessionQueryServiced phase must have been set.
 func (t *Times) GetServiceLatencyTotal() time.Duration {
 	return t.times[SessionQueryServiced].Sub(t.times[SessionQueryReceived])
+}
+
+// GetServiceCPUTimeTotal returns the total CPU time of serving a query
+// including any overhead like internal retries.
+// NOTE: SessionQueryServicedCPUTime phase must have been set.
+func (t *Times) GetServiceCPUTimeTotal() time.Duration {
+	return t.times[PlannerEndExecStmtCpuTime].Sub(t.times[SessionQueryReceivedCPUTime])
 }
 
 // GetRunLatency returns the time between a query execution starting and

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
@@ -286,6 +286,7 @@ func (s *innerStmtStats) jsonFields() jsonFields {
 		{"runLat", (*numericStats)(&s.RunLat)},
 		{"svcLat", (*numericStats)(&s.ServiceLat)},
 		{"ovhLat", (*numericStats)(&s.OverheadLat)},
+		{"cpuTime", (*numericStats)(&s.CpuTime)},
 		{"bytesRead", (*numericStats)(&s.BytesRead)},
 		{"rowsRead", (*numericStats)(&s.RowsRead)},
 		{"rowsWritten", (*numericStats)(&s.RowsWritten)},

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
@@ -129,6 +129,7 @@ func (s *Container) RecordStatement(
 	stats.mu.data.RunLat.Record(stats.mu.data.Count, value.RunLatency)
 	stats.mu.data.ServiceLat.Record(stats.mu.data.Count, value.ServiceLatency)
 	stats.mu.data.OverheadLat.Record(stats.mu.data.Count, value.OverheadLatency)
+	stats.mu.data.CpuTime.Record(stats.mu.data.Count, value.ServiceCPUTime)
 	stats.mu.data.BytesRead.Record(stats.mu.data.Count, float64(value.BytesRead))
 	stats.mu.data.RowsRead.Record(stats.mu.data.Count, float64(value.RowsRead))
 	stats.mu.data.RowsWritten.Record(stats.mu.data.Count, float64(value.RowsWritten))

--- a/pkg/sql/sqlstats/ssprovider.go
+++ b/pkg/sql/sqlstats/ssprovider.go
@@ -201,6 +201,7 @@ type RecordedStmtStats struct {
 	RunLatency           float64
 	ServiceLatency       float64
 	OverheadLatency      float64
+	ServiceCPUTime       float64
 	BytesRead            int64
 	RowsRead             int64
 	RowsWritten          int64


### PR DESCRIPTION
Updates #87213

This commit adds a new field to the statement_statistics, which is the number of CPU seconds spent (on the gateway node only) processing a particular SQL query.

It uses the new "grunning" CPU seconds tracker to calculate this quantity.

Release note (sql change): add the cpu_time_avg and cpu_time_var fields to crdb_internal.node_statement_statistics, and the cpu_time field to the statistics JSON in system.statement_statistics.