### PR TITLE
builtins: allow null in enum_* functions

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -144,6 +144,23 @@ SELECT enum_first('mysql'::dbs), enum_last('spanner'::dbs)
 postgres cockroach
 
 query T
+SELECT enum_first(null::dbs)
+----
+postgres
+
+query T
+SELECT enum_first(val) FROM unnest(array_append(enum_range(null::dbs),null)) val
+----
+postgres
+postgres
+postgres
+postgres
+postgres
+
+statement error input expression must always resolve to the same enum type
+SELECT enum_first(null)
+
+query T
 SELECT enum_range('cockroach'::dbs)
 ----
 {postgres,mysql,spanner,cockroach}


### PR DESCRIPTION
Our enum functions don't quite have parity with their Postgres equivalents. Even though all they need is the type of their argument, they still evaluate it and error if the result is null. This PR fixes that, not in the ambitious way suggested in #78358 of persisting type info on nulls, but in the more limited way of changing the function implementations to act on their arguments after type resolution but before evaluation.

Informs #78358

Release note (sql change): enum_first, enum_last, and enum_range may now take null arguments as long as their type can be inferred from the expression.
Example: select num_first(null::switch);