### PR TITLE
backupccl: exclude dropped descriptors from user-descriptor check

### DIFF
--- a/pkg/ccl/backupccl/datadriven_test.go
+++ b/pkg/ccl/backupccl/datadriven_test.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -370,6 +371,9 @@ func (d *datadrivenTestState) getSQLDB(t *testing.T, server string, user string)
 //     Creates a symlink from the testdata path to the file IO path, so that we
 //     can restore precreated backup. src-path and dest-path are comma seperated
 //     paths that will be joined.
+//
+//   - "sleep ms=TIME"
+//     Sleep for TIME milliseconds.
 func TestDataDriven(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -646,6 +650,20 @@ func TestDataDriven(t *testing.T) {
 				}
 				require.NoError(t, err)
 
+				return ""
+
+			case "sleep":
+				var msStr string
+				if d.HasArg("ms") {
+					d.ScanArgs(t, "ms", &msStr)
+				} else {
+					t.Fatalf("must specify sleep time in ms")
+				}
+				ms, err := strconv.ParseInt(msStr, 10, 64)
+				if err != nil {
+					t.Fatalf("invalid sleep time: %v", err)
+				}
+				time.Sleep(time.Duration(ms) * time.Millisecond)
 				return ""
 
 			case "backup":

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1653,6 +1653,17 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 	if err := sql.DescsTxn(ctx, p.ExecCfg(), publishDescriptors); err != nil {
 		return err
 	}
+
+	if err := p.ExecCfg().JobRegistry.CheckPausepoint(
+		"restore.after_publishing_descriptors"); err != nil {
+		return err
+	}
+	if fn := r.testingKnobs.afterPublishingDescriptors; fn != nil {
+		if err := fn(); err != nil {
+			return err
+		}
+	}
+
 	// Reload the details as we may have updated the job.
 	details = r.job.Details().(jobspb.RestoreDetails)
 	p.ExecCfg().JobRegistry.NotifyToAdoptJobs()
@@ -1678,16 +1689,6 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 		details = r.job.Details().(jobspb.RestoreDetails)
 
 		if err := r.cleanupTempSystemTables(ctx); err != nil {
-			return err
-		}
-	}
-
-	if err := p.ExecCfg().JobRegistry.CheckPausepoint(
-		"restore.after_publishing_descriptors"); err != nil {
-		return err
-	}
-	if fn := r.testingKnobs.afterPublishingDescriptors; fn != nil {
-		if err := fn(); err != nil {
 			return err
 		}
 	}

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1354,6 +1354,14 @@ func doRestorePlan(
 		return errors.Errorf("RESTORE FROM ... IN can only by used against a single collection path (per-locality)")
 	}
 
+	if restoreStmt.DescriptorCoverage == tree.AllDescriptors {
+		// We do this before resolving the backup manifest since resolving the
+		// backup manifest can take a while.
+		if err := checkForConflictingDescriptors(ctx, p.ExecCfg()); err != nil {
+			return err
+		}
+	}
+
 	var fullyResolvedSubdir string
 
 	if strings.EqualFold(subdir, backupbase.LatestFileName) {
@@ -1518,31 +1526,6 @@ func doRestorePlan(
 		clusterVersion := p.ExecCfg().Settings.Version.ActiveVersion(ctx).Version
 		if clusterVersion.Less(binaryVersion) {
 			return clusterRestoreDuringUpgradeErr(clusterVersion, binaryVersion)
-		}
-
-		// Ensure that no user descriptors exist for a full cluster restore.
-		var allDescs []catalog.Descriptor
-		if err := sql.DescsTxn(ctx, p.ExecCfg(), func(ctx context.Context, txn *kv.Txn, col *descs.Collection) (err error) {
-			txn.SetDebugName("count-user-descs")
-			all, err := col.GetAllDescriptors(ctx, txn)
-			allDescs = all.OrderedDescriptors()
-			return err
-		}); err != nil {
-			return errors.Wrap(err, "looking up user descriptors during restore")
-		}
-		if allUserDescs := filteredUserCreatedDescriptors(allDescs); len(allUserDescs) > 0 {
-			userDescriptorNames := make([]string, 0, 20)
-			for i, desc := range allUserDescs {
-				if i == 20 {
-					userDescriptorNames = append(userDescriptorNames, "...")
-					break
-				}
-				userDescriptorNames = append(userDescriptorNames, desc.GetName())
-			}
-			return errors.Errorf(
-				"full cluster restore can only be run on a cluster with no tables or databases but found %d descriptors: %s",
-				len(allUserDescs), strings.Join(userDescriptorNames, ", "),
-			)
 		}
 	}
 
@@ -1941,6 +1924,40 @@ func collectRestoreTelemetry(
 		descsByTablePattern, restoreDBs, debugPauseOn, applicationName)
 }
 
+// checkForConflictingDescriptors checks for user-created descriptors that would
+// create a conflict when doing a full cluster restore.
+//
+// Because we remap all descriptors, we only care about namespace conflicts.
+func checkForConflictingDescriptors(ctx context.Context, execCfg *sql.ExecutorConfig) error {
+	var allDescs []catalog.Descriptor
+	if err := sql.DescsTxn(ctx, execCfg, func(ctx context.Context, txn *kv.Txn, col *descs.Collection) (err error) {
+		txn.SetDebugName("count-user-descs")
+		all, err := col.GetAllDescriptors(ctx, txn)
+		if err != nil {
+			return err
+		}
+		allDescs = all.OrderedDescriptors()
+		return err
+	}); err != nil {
+		return errors.Wrap(err, "looking up user descriptors during restore")
+	}
+	if allUserDescs := filteredUserCreatedDescriptors(allDescs); len(allUserDescs) > 0 {
+		userDescriptorNames := make([]string, 0, 20)
+		for i, desc := range allUserDescs {
+			if i == 20 {
+				userDescriptorNames = append(userDescriptorNames, "...")
+				break
+			}
+			userDescriptorNames = append(userDescriptorNames, desc.GetName())
+		}
+		return errors.Errorf(
+			"full cluster restore can only be run on a cluster with no tables or databases but found %d descriptors: %s",
+			len(allUserDescs), strings.Join(userDescriptorNames, ", "),
+		)
+	}
+	return nil
+}
+
 func filteredUserCreatedDescriptors(
 	allDescs []catalog.Descriptor,
 ) (userDescs []catalog.Descriptor) {
@@ -1961,6 +1978,11 @@ func filteredUserCreatedDescriptors(
 
 	userDescs = make([]catalog.Descriptor, 0, len(allDescs))
 	for _, desc := range allDescs {
+		if desc.Dropped() {
+			// Exclude dropped descriptors since they should no longer have namespace
+			// entries.
+			continue
+		}
 		if catalog.IsSystemDescriptor(desc) {
 			// Exclude system descriptors.
 			continue

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-on-fail-or-cancel-retry
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-on-fail-or-cancel-retry
@@ -1,0 +1,64 @@
+new-server name=s1 nodes=1
+----
+
+subtest restore-retry
+
+exec-sql
+CREATE DATABASE restore;
+CREATE SCHEMA restore.myschema;
+CREATE TABLE foobar (pk int primary key);
+CREATE TABLE restore.myschema.table1 (pk int primary key);
+INSERT INTO restore.myschema.table1 VALUES (1);
+CREATE TYPE data.myenum AS ENUM ('hello');
+----
+
+exec-sql
+BACKUP INTO 'nodelocal://1/cluster_backup';
+----
+
+new-server name=s2 nodes=1 share-io-dir=s1
+----
+
+exec-sql
+SET CLUSTER SETTING storage.mvcc.range_tombstones.enabled = true;
+----
+
+exec-sql
+SELECT crdb_internal.set_vmodule('lease=3');
+----
+
+# Restore's OnFailOrCancel deletes descriptors which requires us to wait for no
+# versions of that descriptor to be leased before proceeding. Since our test fails
+# the job after the descriptors have been published, it's possible for them to be leased
+# somewhere.
+exec-sql
+SET CLUSTER SETTING sql.catalog.descriptor_lease_duration = '1s';
+----
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = 'restore.after_publishing_descriptors';
+----
+
+restore expect-pausepoint tag=a
+RESTORE FROM LATEST IN 'nodelocal://0/cluster_backup';
+----
+job paused at pausepoint
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = '';
+----
+
+# Cancel the job so that the cleanup hook runs.
+job cancel=a
+----
+
+# TODO(ssd): We sleep via the test runner and not via SQL using pg_sleep because if we try to
+# execute a query too quickly we see failures. https://github.com/cockroachdb/cockroach/issues/88913
+sleep ms=2000
+----
+
+restore
+RESTORE FROM LATEST IN 'nodelocal://0/cluster_backup';
+----
+
+subtest end


### PR DESCRIPTION
During a full cluster restore, we check for user created descriptors. Previously, this check would fail on any user-defined descriptor because we restored most descriptors as-is without any rewriting. However, we now rewrite all descriptors during restore.

Because of this, we can limit our check to descriptors that are not dropped and thus might produce namespace conflicts with descriptors we are going to restore.

This allows us to more quickly retry a failed or cancelled backup since the user does not have to wait for descriptor to be completely deleted by the GC job.

Release note: None