### PR TITLE
batcheval: set default `AddSSTable` SST rewrite concurrency to 4

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -76,7 +76,7 @@ var AddSSTableRewriteConcurrency = settings.RegisterIntSetting(
 	settings.SystemOnly,
 	"kv.bulk_io_write.sst_rewrite_concurrency.per_call",
 	"concurrency to use when rewriting sstable timestamps by block, or 0 to use a loop",
-	int64(util.ConstantWithMetamorphicTestRange("addsst-rewrite-concurrency", 0, 0, 16)),
+	int64(util.ConstantWithMetamorphicTestRange("addsst-rewrite-concurrency", 4, 0, 16)),
 	settings.NonNegativeInt,
 )
 


### PR DESCRIPTION
@dt Uhm, looks like we never enabled the optimized SST rewriter by default. Frankly not sure how we missed that. I think we should flip it before we ship 22.2, wdyt?

---

This has higher constant costs, and is thus slower for small SSTs, but
is significantly faster for large ones.

```
name                                   old time/op    new time/op     delta
UpdateSSTTimestamps/numKeys=1-24          132µs ± 1%      313µs ± 1%  +138.25%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=10-24         138µs ± 2%      319µs ± 1%  +130.96%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=100-24        174µs ± 4%      383µs ± 1%  +120.64%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=1000-24       467µs ± 1%      868µs ± 2%   +85.95%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=10000-24     3.38ms ± 0%     2.30ms ± 1%   -32.05%  (p=0.008 n=5+5)
UpdateSSTTimestamps/numKeys=100000-24    32.6ms ± 1%      7.2ms ± 3%   -77.80%  (p=0.008 n=5+5)
```

Resolves #89646.

Release note: None