### PR TITLE
serverutils: fix and simplify the tenant server configuration

### DIFF
--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
-	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logflags"
 	"github.com/cockroachdb/cockroach/pkg/util/netutil/addr"
@@ -306,8 +305,7 @@ func init() {
 			flag.Hidden = true
 		}
 		if flag.Name == logflags.ShowLogsName ||
-			flag.Name == logflags.TestLogConfigName ||
-			flag.Name == serverutils.TenantModeFlagName {
+			flag.Name == logflags.TestLogConfigName {
 			// test-only flag
 			flag.Hidden = true
 		}

--- a/pkg/testutils/serverutils/BUILD.bazel
+++ b/pkg/testutils/serverutils/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//pkg/testutils",
         "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
+        "//pkg/util",
         "//pkg/util/envutil",
         "//pkg/util/hlc",
         "//pkg/util/httputil",

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -123,16 +123,30 @@ func ConstantWithMetamorphicTestRange(name string, defaultValue, min, max int) i
 //
 // The given name is used for logging.
 func ConstantWithMetamorphicTestBool(name string, defaultValue bool) bool {
+	return constantWithMetamorphicTestBoolInternal(name, defaultValue, true /* doLog */)
+}
+
+func constantWithMetamorphicTestBoolInternal(name string, defaultValue bool, doLog bool) bool {
 	if metamorphicBuild {
 		rng.Lock()
 		defer rng.Unlock()
 		if rng.r.Float64() < metamorphicBoolProbability {
 			ret := !defaultValue
-			logMetamorphicValue(name, ret)
+			if doLog {
+				logMetamorphicValue(name, ret)
+			}
 			return ret
 		}
 	}
 	return defaultValue
+}
+
+// ConstantWithMetamorphicTestBoolWithoutLogging is like ConstantWithMetamorphicTestBool
+// except it does not log the value. This is necessary to work around this issue:
+// https://github.com/cockroachdb/cockroach/issues/106667
+// TODO(test-eng): Remove this variant when the issue above is addressed.
+func ConstantWithMetamorphicTestBoolWithoutLogging(name string, defaultValue bool) bool {
+	return constantWithMetamorphicTestBoolInternal(name, defaultValue, false /* doLog */)
 }
 
 // ConstantWithMetamorphicTestChoice is like ConstantWithMetamorphicTestValue except


### PR DESCRIPTION
This commit contains a couple separate changes.

**Random selection**

Prior to this commit, the selection of whether or not to redirect a
unit test to a secondary tenant / virtual cluster was using the global
PRNG in package `rand`, which has a fixed seed. The result was that in
most cases the assignment of the "random choice" was always the same
for a given test.

This commit fixes that by using a test PRNG (the one from the
metamorphic framework) initialized with a variable seed.

Fixes #106666 

**Messaging**

Before:
```
Running test with the default test tenant. If you are only seeing a
test case failure when this message appears, there may be a problem
with your test case running within tenants.
```

After:
```
Test server was configured to route SQL queries to a secondary
tenant (virtual cluster). If you are only seeing a
test case failure when this message appears, there may be a problem
specific to cluster virtualization or multi-tenancy.

To investigate, consider using "COCKROACH_TEST_TENANT=true" to
force-enable just the secondary tenant in all runs (or, alternatively,
"false" to force-disable), or use
"COCKROACH_INTERNAL_DISABLE_METAMORPHIC_TESTING=false" to disable all
random test variables altogether.
```

**Configuration**

Prior to this commit, there was a flag `-tenantMode` with 3 possible
values: `forceTenant`, `forceNoTenant` and `disable`.
The env var COCKROACH_TEST_TENANT_MODE was also accepting the same
string values.

This was cumbersome in multiple ways:

- this was the only flag using CamelCase, whereas all our other
  command-line flags are snake-case.
- its values were also using CamelCase, whereas we're using
  snake-case for all flag/env/setting values elsewhere.
- its values were case-sensitive, which made it harder
  to remember what precise strings to type in.
- the word "tenant" was present in both the flag name and
  the value, creating redundancy and uncertainty.
- the rule as to the compatibility between the command-line flag
  and the env var was unclear.
- it wasn't following the framework we already had available for
  metamorphic configurations.

This commit simplifies the situation by using a simpler boolean env
var `COCKROACH_TEST_TENANT` to override.

Release note: None

Epic: CRDB-18499