### PR TITLE
storage: avoid unnecessary `MVCCFindSplitKey` key comparisons

### DIFF
--- a/pkg/storage/pebble_iterator.go
+++ b/pkg/storage/pebble_iterator.go
@@ -794,10 +794,10 @@ func findSplitKeyUsingIterator(
 
 	// We only have to consider no-split spans if our minimum split key possibly
 	// lies before them. Note that the no-split spans are ordered by end-key.
-	noSplitSpans := keys.NoSplitSpans
-	for i := range noSplitSpans {
-		if minSplitKey.Compare(noSplitSpans[i].EndKey) <= 0 {
-			noSplitSpans = noSplitSpans[i:]
+	var noSplitSpans []roachpb.Span
+	for i := range keys.NoSplitSpans {
+		if minSplitKey.Compare(keys.NoSplitSpans[i].EndKey) <= 0 {
+			noSplitSpans = keys.NoSplitSpans[i:]
 			break
 		}
 	}


### PR DESCRIPTION
`findSplitKeyUsingIterator()` incorrectly adjusted `NoSplitSpans`: it was supposed to only consider spans with end keys after the minimum possible split key, but it did not handle the case where _no_ spans matched and instead considered _all_ spans. This is the common case, and incurs a ton of additional key comparisons in the hot path. This patch correctly handles this case.

```
name                                     old time/op   new time/op   delta
MVCCFindSplitKey_Pebble/valueSize=32-24    105ms ± 4%     73ms ± 3%  -30.48%  (p=0.000 n=9+10)
```

Touches #89171.

Release note: None