### PR TITLE
changefeedccl: fix shutdown deadlock on kafka internal retry

### DIFF
--- a/pkg/ccl/changefeedccl/sink_kafka.go
+++ b/pkg/ccl/changefeedccl/sink_kafka.go
@@ -475,6 +475,8 @@ func (s *kafkaSink) workerLoop() {
 		var ackError error
 
 		select {
+		case <-s.ctx.Done():
+			return
 		case <-s.stopWorkerCh:
 			return
 		case m := <-s.producer.Successes():
@@ -553,6 +555,7 @@ func (s *kafkaSink) finishProducerMessage(ackMsg *sarama.ProducerMessage, ackErr
 func (s *kafkaSink) handleBufferedRetries(msgs []*sarama.ProducerMessage, retryErr error) error {
 	lastSendErr := retryErr
 	activeConfig := s.kafkaCfg
+	log.Infof(s.ctx, "kafka sink handling %d buffered messages for internal retry", len(msgs))
 
 	// Ensure memory for messages are always cleaned up
 	defer func() {


### PR DESCRIPTION
This fixes a test flake where if the changefeed was cancelled right after registering an inflight message to be sent, the message wouldn't send but the kafka sink worker would remain blocked expecting one to arrive. stopWorkerCh was never closed since kafkaSink is only closed after eventConsumer is closed, but eventConsumer was blocked on sending a message.

Release note (bug fix): changefeeds no longer deadlock when cancelling during an internal kafka sink retry.