### PR TITLE
opgen: ensure GC jobs for temp indexes have proper description

### DIFF
--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/create_index
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/create_index
@@ -385,7 +385,7 @@ upsert descriptor #104
   -  version: "7"
   +  version: "8"
 write *eventpb.FinishSchemaChange to event log
-create job #2 (non-cancelable: true): "GC for "
+create job #2 (non-cancelable: true): "GC for removed temporary index; CREATE INDEX id1 ON defaultdb.public.t1 (id, name) STORING (money) PARTITION BY LIST (id) (PARTITION p1 VALUES IN (1))"
   descriptor IDs: [104]
 update progress of schema change job #1: "all stages completed"
 set schema change job #1 to non-cancellable

--- a/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index
+++ b/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index
@@ -421,6 +421,9 @@ EXPLAIN (ddl, verbose) CREATE INDEX id1
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Statement: removed temporary index; CREATE INDEX id1 ON defaultdb.public.t1 (id,
+            │         name) STORING (money) PARTITION BY LIST (id) (PARTITION p1 VALUES IN (1))
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_1_of_7
+++ b/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_1_of_7
@@ -121,8 +121,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: CREATE INDEX id1 ON defaultdb.public.t1 (id, name) STORING (money) PARTITION
-            │         BY LIST (id) (PARTITION p1 VALUES IN (1))
+            │       Statement: removed secondary index; CREATE INDEX id1 ON defaultdb.public.t1 (id,
+            │         name) STORING (money) PARTITION BY LIST (id) (PARTITION p1 VALUES IN (1))
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -131,6 +131,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; CREATE INDEX id1 ON defaultdb.public.t1 (id,
+            │         name) STORING (money) PARTITION BY LIST (id) (PARTITION p1 VALUES IN (1))
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_2_of_7
+++ b/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_2_of_7
@@ -113,8 +113,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │       │     IndexID: 2
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: CREATE INDEX id1 ON defaultdb.public.t1 (id, name) STORING (money) PARTITION
-    │       │         BY LIST (id) (PARTITION p1 VALUES IN (1))
+    │       │       Statement: removed secondary index; CREATE INDEX id1 ON defaultdb.public.t1 (id,
+    │       │         name) STORING (money) PARTITION BY LIST (id) (PARTITION p1 VALUES IN (1))
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -155,6 +155,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; CREATE INDEX id1 ON defaultdb.public.t1 (id,
+            │         name) STORING (money) PARTITION BY LIST (id) (PARTITION p1 VALUES IN (1))
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_3_of_7
+++ b/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_3_of_7
@@ -113,8 +113,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │       │     IndexID: 2
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: CREATE INDEX id1 ON defaultdb.public.t1 (id, name) STORING (money) PARTITION
-    │       │         BY LIST (id) (PARTITION p1 VALUES IN (1))
+    │       │       Statement: removed secondary index; CREATE INDEX id1 ON defaultdb.public.t1 (id,
+    │       │         name) STORING (money) PARTITION BY LIST (id) (PARTITION p1 VALUES IN (1))
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -155,6 +155,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; CREATE INDEX id1 ON defaultdb.public.t1 (id,
+            │         name) STORING (money) PARTITION BY LIST (id) (PARTITION p1 VALUES IN (1))
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_4_of_7
+++ b/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_4_of_7
@@ -113,8 +113,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │       │     IndexID: 2
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: CREATE INDEX id1 ON defaultdb.public.t1 (id, name) STORING (money) PARTITION
-    │       │         BY LIST (id) (PARTITION p1 VALUES IN (1))
+    │       │       Statement: removed secondary index; CREATE INDEX id1 ON defaultdb.public.t1 (id,
+    │       │         name) STORING (money) PARTITION BY LIST (id) (PARTITION p1 VALUES IN (1))
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -155,6 +155,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; CREATE INDEX id1 ON defaultdb.public.t1 (id,
+            │         name) STORING (money) PARTITION BY LIST (id) (PARTITION p1 VALUES IN (1))
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_5_of_7
+++ b/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_5_of_7
@@ -155,8 +155,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: CREATE INDEX id1 ON defaultdb.public.t1 (id, name) STORING (money) PARTITION
-            │         BY LIST (id) (PARTITION p1 VALUES IN (1))
+            │       Statement: removed secondary index; CREATE INDEX id1 ON defaultdb.public.t1 (id,
+            │         name) STORING (money) PARTITION BY LIST (id) (PARTITION p1 VALUES IN (1))
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -165,6 +165,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; CREATE INDEX id1 ON defaultdb.public.t1 (id,
+            │         name) STORING (money) PARTITION BY LIST (id) (PARTITION p1 VALUES IN (1))
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_6_of_7
+++ b/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_6_of_7
@@ -155,8 +155,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: CREATE INDEX id1 ON defaultdb.public.t1 (id, name) STORING (money) PARTITION
-            │         BY LIST (id) (PARTITION p1 VALUES IN (1))
+            │       Statement: removed secondary index; CREATE INDEX id1 ON defaultdb.public.t1 (id,
+            │         name) STORING (money) PARTITION BY LIST (id) (PARTITION p1 VALUES IN (1))
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -165,6 +165,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; CREATE INDEX id1 ON defaultdb.public.t1 (id,
+            │         name) STORING (money) PARTITION BY LIST (id) (PARTITION p1 VALUES IN (1))
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_7_of_7
+++ b/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_7_of_7
@@ -155,8 +155,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: CREATE INDEX id1 ON defaultdb.public.t1 (id, name) STORING (money) PARTITION
-            │         BY LIST (id) (PARTITION p1 VALUES IN (1))
+            │       Statement: removed secondary index; CREATE INDEX id1 ON defaultdb.public.t1 (id,
+            │         name) STORING (money) PARTITION BY LIST (id) (PARTITION p1 VALUES IN (1))
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -165,6 +165,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; CREATE INDEX id1 ON defaultdb.public.t1 (id,
+            │         name) STORING (money) PARTITION BY LIST (id) (PARTITION p1 VALUES IN (1))
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_temporary_index.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_temporary_index.go
@@ -49,10 +49,11 @@ func init() {
 				}),
 			),
 			to(scpb.Status_ABSENT,
-				emit(func(this *scpb.TemporaryIndex) *scop.CreateGCJobForIndex {
+				emit(func(this *scpb.TemporaryIndex, md *targetsWithElementMap) *scop.CreateGCJobForIndex {
 					return &scop.CreateGCJobForIndex{
-						TableID: this.TableID,
-						IndexID: this.IndexID,
+						TableID:             this.TableID,
+						IndexID:             this.IndexID,
+						StatementForDropJob: statementForDropJob(this, md),
 					}
 				}),
 				emit(func(this *scpb.TemporaryIndex) *scop.MakeIndexAbsent {

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_add_column
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_add_column
@@ -377,6 +377,9 @@ PostCommitNonRevertiblePhase stage 2 of 3 with 5 MutationType ops
   ops:
     *scop.CreateGCJobForIndex
       IndexID: 3
+      StatementForDropJob:
+        Statement: removed temporary index; ALTER TABLE defaultdb.public.foo ADD COLUMN
+          j INT8 NOT NULL DEFAULT 123
       TableID: 104
     *scop.MakeIndexAbsent
       IndexID: 3
@@ -396,7 +399,8 @@ PostCommitNonRevertiblePhase stage 3 of 3 with 4 MutationType ops
     *scop.CreateGCJobForIndex
       IndexID: 1
       StatementForDropJob:
-        Statement: ALTER TABLE defaultdb.public.foo ADD COLUMN j INT8 NOT NULL DEFAULT 123
+        Statement: removed primary index; ALTER TABLE defaultdb.public.foo ADD COLUMN j
+          INT8 NOT NULL DEFAULT 123
       TableID: 104
     *scop.MakeIndexAbsent
       EventBase:
@@ -742,6 +746,9 @@ PostCommitNonRevertiblePhase stage 2 of 3 with 5 MutationType ops
   ops:
     *scop.CreateGCJobForIndex
       IndexID: 3
+      StatementForDropJob:
+        Statement: removed temporary index; ALTER TABLE defaultdb.public.foo ADD COLUMN
+          j INT8 DEFAULT 123
       TableID: 104
     *scop.MakeIndexAbsent
       IndexID: 3
@@ -761,7 +768,8 @@ PostCommitNonRevertiblePhase stage 3 of 3 with 4 MutationType ops
     *scop.CreateGCJobForIndex
       IndexID: 1
       StatementForDropJob:
-        Statement: ALTER TABLE defaultdb.public.foo ADD COLUMN j INT8 DEFAULT 123
+        Statement: removed primary index; ALTER TABLE defaultdb.public.foo ADD COLUMN j
+          INT8 DEFAULT 123
       TableID: 104
     *scop.MakeIndexAbsent
       EventBase:
@@ -1023,6 +1031,9 @@ PostCommitNonRevertiblePhase stage 2 of 3 with 5 MutationType ops
   ops:
     *scop.CreateGCJobForIndex
       IndexID: 3
+      StatementForDropJob:
+        Statement: removed temporary index; ALTER TABLE defaultdb.public.foo ADD COLUMN
+          a INT8 AS (i + 1) STORED
       TableID: 104
     *scop.MakeIndexAbsent
       IndexID: 3
@@ -1042,7 +1053,8 @@ PostCommitNonRevertiblePhase stage 3 of 3 with 4 MutationType ops
     *scop.CreateGCJobForIndex
       IndexID: 1
       StatementForDropJob:
-        Statement: ALTER TABLE defaultdb.public.foo ADD COLUMN a INT8 AS (i + 1) STORED
+        Statement: removed primary index; ALTER TABLE defaultdb.public.foo ADD COLUMN a
+          INT8 AS (i + 1) STORED
       TableID: 104
     *scop.MakeIndexAbsent
       EventBase:
@@ -1519,12 +1531,18 @@ PostCommitNonRevertiblePhase stage 2 of 3 with 7 MutationType ops
   ops:
     *scop.CreateGCJobForIndex
       IndexID: 3
+      StatementForDropJob:
+        Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+          KEY USING COLUMNS (j)
       TableID: 108
     *scop.MakeIndexAbsent
       IndexID: 3
       TableID: 108
     *scop.CreateGCJobForIndex
       IndexID: 5
+      StatementForDropJob:
+        Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+          KEY USING COLUMNS (j)
       TableID: 108
     *scop.MakeIndexAbsent
       IndexID: 5
@@ -1544,7 +1562,8 @@ PostCommitNonRevertiblePhase stage 3 of 3 with 4 MutationType ops
     *scop.CreateGCJobForIndex
       IndexID: 1
       StatementForDropJob:
-        Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)
+        Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+          USING COLUMNS (j)
       TableID: 108
     *scop.MakeIndexAbsent
       EventBase:
@@ -1947,7 +1966,8 @@ PostCommitNonRevertiblePhase stage 2 of 2 with 8 MutationType ops
     *scop.CreateGCJobForIndex
       IndexID: 1
       StatementForDropJob:
-        Statement: ALTER TABLE defaultdb.public.baz ADD COLUMN g INT8 UNIQUE DEFAULT 1
+        Statement: removed primary index; ALTER TABLE defaultdb.public.baz ADD COLUMN g
+          INT8 UNIQUE DEFAULT 1
       TableID: 109
     *scop.MakeIndexAbsent
       EventBase:
@@ -1963,12 +1983,18 @@ PostCommitNonRevertiblePhase stage 2 of 2 with 8 MutationType ops
       TableID: 109
     *scop.CreateGCJobForIndex
       IndexID: 3
+      StatementForDropJob:
+        Statement: removed temporary index; ALTER TABLE defaultdb.public.baz ADD COLUMN
+          g INT8 UNIQUE DEFAULT 1
       TableID: 109
     *scop.MakeIndexAbsent
       IndexID: 3
       TableID: 109
     *scop.CreateGCJobForIndex
       IndexID: 5
+      StatementForDropJob:
+        Statement: removed temporary index; ALTER TABLE defaultdb.public.baz ADD COLUMN
+          g INT8 UNIQUE DEFAULT 1
       TableID: 109
     *scop.MakeIndexAbsent
       IndexID: 5

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_alter_primary_key
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_alter_primary_key
@@ -358,7 +358,8 @@ PostCommitNonRevertiblePhase stage 2 of 4 with 12 MutationType ops
     *scop.CreateGCJobForIndex
       IndexID: 1
       StatementForDropJob:
-        Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (k)
+        Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+          USING COLUMNS (k)
       TableID: 104
     *scop.MakeIndexAbsent
       EventBase:
@@ -380,6 +381,9 @@ PostCommitNonRevertiblePhase stage 2 of 4 with 12 MutationType ops
       TableID: 104
     *scop.CreateGCJobForIndex
       IndexID: 3
+      StatementForDropJob:
+        Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+          KEY USING COLUMNS (k)
       TableID: 104
     *scop.MakeIndexAbsent
       IndexID: 3
@@ -390,6 +394,9 @@ PostCommitNonRevertiblePhase stage 2 of 4 with 12 MutationType ops
       TableID: 104
     *scop.CreateGCJobForIndex
       IndexID: 5
+      StatementForDropJob:
+        Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+          KEY USING COLUMNS (k)
       TableID: 104
     *scop.MakeIndexAbsent
       IndexID: 5
@@ -432,7 +439,8 @@ PostCommitNonRevertiblePhase stage 4 of 4 with 6 MutationType ops
     *scop.CreateGCJobForIndex
       IndexID: 2
       StatementForDropJob:
-        Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (k)
+        Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+          USING COLUMNS (k)
       TableID: 104
     *scop.MakeIndexAbsent
       EventBase:

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_drop_column
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_drop_column
@@ -355,7 +355,8 @@ PostCommitNonRevertiblePhase stage 2 of 3 with 17 MutationType ops
     *scop.CreateGCJobForIndex
       IndexID: 2
       StatementForDropJob:
-        Statement: ALTER TABLE defaultdb.public.foo DROP COLUMN v1 CASCADE
+        Statement: removed secondary index; ALTER TABLE defaultdb.public.foo DROP COLUMN
+          v1 CASCADE
       TableID: 107
     *scop.MakeIndexAbsent
       IndexID: 2
@@ -442,6 +443,9 @@ PostCommitNonRevertiblePhase stage 2 of 3 with 17 MutationType ops
       TableID: 108
     *scop.CreateGCJobForIndex
       IndexID: 4
+      StatementForDropJob:
+        Statement: removed temporary index; ALTER TABLE defaultdb.public.foo DROP COLUMN
+          v1 CASCADE
       TableID: 107
     *scop.MakeIndexAbsent
       IndexID: 4
@@ -469,7 +473,8 @@ PostCommitNonRevertiblePhase stage 3 of 3 with 9 MutationType ops
     *scop.CreateGCJobForIndex
       IndexID: 1
       StatementForDropJob:
-        Statement: ALTER TABLE defaultdb.public.foo DROP COLUMN v1 CASCADE
+        Statement: removed primary index; ALTER TABLE defaultdb.public.foo DROP COLUMN v1
+          CASCADE
       TableID: 107
     *scop.MakeIndexAbsent
       EventBase:
@@ -1300,7 +1305,8 @@ PostCommitNonRevertiblePhase stage 2 of 3 with 18 MutationType ops
     *scop.CreateGCJobForIndex
       IndexID: 2
       StatementForDropJob:
-        Statement: ALTER TABLE defaultdb.public.foo DROP COLUMN v2 CASCADE
+        Statement: removed secondary index; ALTER TABLE defaultdb.public.foo DROP COLUMN
+          v2 CASCADE
       TableID: 107
     *scop.MakeIndexAbsent
       IndexID: 2
@@ -1387,6 +1393,9 @@ PostCommitNonRevertiblePhase stage 2 of 3 with 18 MutationType ops
       TableID: 108
     *scop.CreateGCJobForIndex
       IndexID: 4
+      StatementForDropJob:
+        Statement: removed temporary index; ALTER TABLE defaultdb.public.foo DROP COLUMN
+          v2 CASCADE
       TableID: 107
     *scop.MakeIndexAbsent
       IndexID: 4
@@ -1417,7 +1426,8 @@ PostCommitNonRevertiblePhase stage 3 of 3 with 10 MutationType ops
     *scop.CreateGCJobForIndex
       IndexID: 1
       StatementForDropJob:
-        Statement: ALTER TABLE defaultdb.public.foo DROP COLUMN v2 CASCADE
+        Statement: removed primary index; ALTER TABLE defaultdb.public.foo DROP COLUMN v2
+          CASCADE
       TableID: 107
     *scop.MakeIndexAbsent
       EventBase:

--- a/pkg/sql/schemachanger/scplan/testdata/create_index
+++ b/pkg/sql/schemachanger/scplan/testdata/create_index
@@ -169,6 +169,9 @@ PostCommitNonRevertiblePhase stage 2 of 2 with 4 MutationType ops
   ops:
     *scop.CreateGCJobForIndex
       IndexID: 3
+      StatementForDropJob:
+        Statement: removed temporary index; CREATE INDEX id1 ON defaultdb.public.t1 (id,
+          name) STORING (money)
       TableID: 104
     *scop.MakeIndexAbsent
       IndexID: 3
@@ -466,6 +469,9 @@ PostCommitNonRevertiblePhase stage 2 of 2 with 4 MutationType ops
   ops:
     *scop.CreateGCJobForIndex
       IndexID: 3
+      StatementForDropJob:
+        Statement: removed temporary index; CREATE INVERTED INDEX CONCURRENTLY id1 ON defaultdb.public.t1
+          (id, name) STORING (money)
       TableID: 104
     *scop.MakeIndexAbsent
       IndexID: 3

--- a/pkg/sql/schemachanger/scplan/testdata/drop_index
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_index
@@ -81,7 +81,7 @@ PostCommitNonRevertiblePhase stage 2 of 2 with 5 MutationType ops
     *scop.CreateGCJobForIndex
       IndexID: 2
       StatementForDropJob:
-        Statement: DROP INDEX defaultdb.public.t1@idx1 CASCADE
+        Statement: removed secondary index; DROP INDEX defaultdb.public.t1@idx1 CASCADE
       TableID: 104
     *scop.MakeIndexAbsent
       IndexID: 2
@@ -239,7 +239,7 @@ PostCommitNonRevertiblePhase stage 2 of 2 with 7 MutationType ops
     *scop.CreateGCJobForIndex
       IndexID: 4
       StatementForDropJob:
-        Statement: DROP INDEX defaultdb.public.t1@idx2 CASCADE
+        Statement: removed secondary index; DROP INDEX defaultdb.public.t1@idx2 CASCADE
       TableID: 104
     *scop.MakeIndexAbsent
       IndexID: 4
@@ -470,7 +470,7 @@ PostCommitNonRevertiblePhase stage 2 of 2 with 6 MutationType ops
     *scop.CreateGCJobForIndex
       IndexID: 6
       StatementForDropJob:
-        Statement: DROP INDEX defaultdb.public.t1@idx3 CASCADE
+        Statement: removed secondary index; DROP INDEX defaultdb.public.t1@idx3 CASCADE
       TableID: 104
     *scop.MakeIndexAbsent
       IndexID: 6
@@ -762,7 +762,7 @@ PostCommitNonRevertiblePhase stage 2 of 2 with 5 MutationType ops
     *scop.CreateGCJobForIndex
       IndexID: 8
       StatementForDropJob:
-        Statement: DROP INDEX defaultdb.public.t1@idx4 CASCADE
+        Statement: removed secondary index; DROP INDEX defaultdb.public.t1@idx4 CASCADE
       TableID: 104
     *scop.MakeIndexAbsent
       IndexID: 8

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column
@@ -412,7 +412,7 @@ upsert descriptor #106
      unexposedParentSchemaId: 105
   -  version: "7"
   +  version: "8"
-create job #2 (non-cancelable: true): "GC for "
+create job #2 (non-cancelable: true): "GC for removed temporary index; ALTER TABLE db.public.tbl ADD COLUMN j INT8 NOT NULL DEFAULT 42"
   descriptor IDs: [106]
 update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 3 of 3 with 2 MutationType ops pending"
 commit transaction #11
@@ -473,7 +473,7 @@ upsert descriptor #106
   -  version: "8"
   +  version: "9"
 write *eventpb.FinishSchemaChange to event log
-create job #3 (non-cancelable: true): "GC for ALTER TABLE db.public.tbl ADD COLUMN j INT8 NOT NULL DEFAULT 42"
+create job #3 (non-cancelable: true): "GC for removed primary index; ALTER TABLE db.public.tbl ADD COLUMN j INT8 NOT NULL DEFAULT 42"
   descriptor IDs: [106]
 update progress of schema change job #1: "all stages completed"
 set schema change job #1 to non-cancellable

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_seq
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_seq
@@ -491,7 +491,7 @@ upsert descriptor #107
      unexposedParentSchemaId: 105
   -  version: "7"
   +  version: "8"
-create job #2 (non-cancelable: true): "GC for "
+create job #2 (non-cancelable: true): "GC for removed temporary index; ALTER TABLE db.public.tbl ADD COLUMN l INT8 NOT NULL DEFAULT nextval('db.public.sq1')"
   descriptor IDs: [106]
 update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 3 of 3 with 2 MutationType ops pending"
 commit transaction #11
@@ -567,7 +567,7 @@ upsert descriptor #107
   -  version: "8"
   +  version: "9"
 write *eventpb.FinishSchemaChange to event log
-create job #3 (non-cancelable: true): "GC for ALTER TABLE db.public.tbl ADD COLUMN l INT8 NOT NULL DEFAULT nextval('db.public.sq1')"
+create job #3 (non-cancelable: true): "GC for removed primary index; ALTER TABLE db.public.tbl ADD COLUMN l INT8 NOT NULL DEFAULT nextval('db.public.sq1')"
   descriptor IDs: [106]
 update progress of schema change job #1: "all stages completed"
 set schema change job #1 to non-cancellable

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid
@@ -680,7 +680,7 @@ upsert descriptor #104
      unexposedParentSchemaId: 101
   -  version: "12"
   +  version: "13"
-create job #2 (non-cancelable: true): "GC for ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)"
+create job #2 (non-cancelable: true): "GC for removed primary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)"
   descriptor IDs: [104]
 update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 3 of 4 with 1 MutationType op pending"
 commit transaction #19
@@ -780,7 +780,7 @@ upsert descriptor #104
   -  version: "14"
   +  version: "15"
 write *eventpb.FinishSchemaChange to event log
-create job #3 (non-cancelable: true): "GC for ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)"
+create job #3 (non-cancelable: true): "GC for removed primary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)"
   descriptor IDs: [104]
 update progress of schema change job #1: "all stages completed"
 set schema change job #1 to non-cancellable

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid
@@ -681,7 +681,7 @@ upsert descriptor #104
      unexposedParentSchemaId: 101
   -  version: "12"
   +  version: "13"
-create job #2 (non-cancelable: true): "GC for ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)"
+create job #2 (non-cancelable: true): "GC for removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)"
   descriptor IDs: [104]
 update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 3 of 4 with 1 MutationType op pending"
 commit transaction #19
@@ -782,7 +782,7 @@ upsert descriptor #104
   -  version: "14"
   +  version: "15"
 write *eventpb.FinishSchemaChange to event log
-create job #3 (non-cancelable: true): "GC for ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)"
+create job #3 (non-cancelable: true): "GC for removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)"
   descriptor IDs: [104]
 update progress of schema change job #1: "all stages completed"
 set schema change job #1 to non-cancellable

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla
@@ -524,7 +524,7 @@ upsert descriptor #104
      unexposedParentSchemaId: 101
   -  version: "7"
   +  version: "8"
-create job #2 (non-cancelable: true): "GC for "
+create job #2 (non-cancelable: true): "GC for removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)"
   descriptor IDs: [104]
 update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 3 of 3 with 2 MutationType ops pending"
 commit transaction #11
@@ -589,7 +589,7 @@ upsert descriptor #104
   -  version: "8"
   +  version: "9"
 write *eventpb.FinishSchemaChange to event log
-create job #3 (non-cancelable: true): "GC for ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)"
+create job #3 (non-cancelable: true): "GC for removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)"
   descriptor IDs: [104]
 update progress of schema change job #1: "all stages completed"
 set schema change job #1 to non-cancellable

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_index
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_index
@@ -331,7 +331,7 @@ upsert descriptor #106
   -  version: "7"
   +  version: "8"
 write *eventpb.FinishSchemaChange to event log
-create job #2 (non-cancelable: true): "GC for "
+create job #2 (non-cancelable: true): "GC for removed temporary index; CREATE INDEX idx1 ON defaultdb.public.t (v) WHERE (v = 'a')"
   descriptor IDs: [106]
 update progress of schema change job #1: "all stages completed"
 set schema change job #1 to non-cancellable

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_basic
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_basic
@@ -379,7 +379,7 @@ upsert descriptor #104
      unexposedParentSchemaId: 101
   -  version: "7"
   +  version: "8"
-create job #2 (non-cancelable: true): "GC for "
+create job #2 (non-cancelable: true): "GC for removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j"
   descriptor IDs: [104]
 update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 3 of 3 with 3 MutationType ops pending"
 commit transaction #11
@@ -461,7 +461,7 @@ upsert descriptor #104
   -  version: "8"
   +  version: "9"
 write *eventpb.FinishSchemaChange to event log
-create job #3 (non-cancelable: true): "GC for ALTER TABLE defaultdb.public.t DROP COLUMN j"
+create job #3 (non-cancelable: true): "GC for removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j"
   descriptor IDs: [104]
 update progress of schema change job #1: "all stages completed"
 set schema change job #1 to non-cancellable

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_computed_index
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_computed_index
@@ -495,7 +495,7 @@ upsert descriptor #104
   -  version: "7"
   +  version: "8"
 write *eventpb.DropIndex to event log: ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COLUMN ‹j› CASCADE
-create job #2 (non-cancelable: true): "GC for ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE"
+create job #2 (non-cancelable: true): "GC for removed secondary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE"
   descriptor IDs: [104]
 update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 3 of 3 with 3 MutationType ops pending"
 commit transaction #11
@@ -577,7 +577,7 @@ upsert descriptor #104
   -  version: "8"
   +  version: "9"
 write *eventpb.FinishSchemaChange to event log
-create job #3 (non-cancelable: true): "GC for ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE"
+create job #3 (non-cancelable: true): "GC for removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE"
   descriptor IDs: [104]
 update progress of schema change job #1: "all stages completed"
 set schema change job #1 to non-cancellable

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements
@@ -872,7 +872,7 @@ upsert descriptor #104
   -  version: "12"
   +  version: "13"
 write *eventpb.DropIndex to event log: ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COLUMN ‹j› CASCADE
-create job #2 (non-cancelable: true): "GC for ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE"
+create job #2 (non-cancelable: true): "GC for removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE; removed temporary index; CREATE UNIQUE INDEX idx ON defaultdb.public.t (k)"
   descriptor IDs: [104]
 update progress of schema change job #1: "all stages completed"
 set schema change job #1 to non-cancellable

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_unique_index
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_unique_index
@@ -403,7 +403,7 @@ upsert descriptor #106
      unexposedParentSchemaId: 105
   -  version: "17"
   +  version: "18"
-create job #2 (non-cancelable: true): "GC for "
+create job #2 (non-cancelable: true): "GC for removed temporary index; ALTER TABLE t.public.test DROP COLUMN pi"
   descriptor IDs: [106]
 update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 3 of 3 with 4 MutationType ops pending"
 commit transaction #11
@@ -492,7 +492,7 @@ upsert descriptor #106
   -  version: "18"
   +  version: "19"
 write *eventpb.FinishSchemaChange to event log
-create job #3 (non-cancelable: true): "GC for ALTER TABLE t.public.test DROP COLUMN pi"
+create job #3 (non-cancelable: true): "GC for removed primary index; ALTER TABLE t.public.test DROP COLUMN pi"
   descriptor IDs: [106]
 update progress of schema change job #1: "all stages completed"
 set schema change job #1 to non-cancellable

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_index
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_index
@@ -465,7 +465,7 @@ upsert descriptor #104
   -  version: "7"
   +  version: "8"
 write *eventpb.DropIndex to event log: ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COLUMN ‹j›
-create job #2 (non-cancelable: true): "GC for ALTER TABLE defaultdb.public.t DROP COLUMN j"
+create job #2 (non-cancelable: true): "GC for removed secondary index; ALTER TABLE defaultdb.public.t DROP COLUMN j"
   descriptor IDs: [104]
 update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 3 of 3 with 3 MutationType ops pending"
 commit transaction #11
@@ -547,7 +547,7 @@ upsert descriptor #104
   -  version: "8"
   +  version: "9"
 write *eventpb.FinishSchemaChange to event log
-create job #3 (non-cancelable: true): "GC for ALTER TABLE defaultdb.public.t DROP COLUMN j"
+create job #3 (non-cancelable: true): "GC for removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j"
   descriptor IDs: [104]
 update progress of schema change job #1: "all stages completed"
 set schema change job #1 to non-cancellable

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_index_hash_sharded_index
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_index_hash_sharded_index
@@ -269,7 +269,7 @@ upsert descriptor #104
   -  version: "10"
   +  version: "11"
 write *eventpb.DropIndex to event log: DROP INDEX ‹defaultdb›.‹public›.‹t›@‹idx› CASCADE
-create job #2 (non-cancelable: true): "GC for DROP INDEX defaultdb.public.t@idx CASCADE"
+create job #2 (non-cancelable: true): "GC for removed secondary index; DROP INDEX defaultdb.public.t@idx CASCADE"
   descriptor IDs: [104]
 update progress of schema change job #1: "all stages completed"
 set schema change job #1 to non-cancellable

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_index_partial_expression_index
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_index_partial_expression_index
@@ -224,7 +224,7 @@ upsert descriptor #104
   -  version: "9"
   +  version: "10"
 write *eventpb.DropIndex to event log: DROP INDEX ‹defaultdb›.‹public›.‹t›@‹idx› CASCADE
-create job #2 (non-cancelable: true): "GC for DROP INDEX defaultdb.public.t@idx CASCADE"
+create job #2 (non-cancelable: true): "GC for removed secondary index; DROP INDEX defaultdb.public.t@idx CASCADE"
   descriptor IDs: [104]
 update progress of schema change job #1: "all stages completed"
 set schema change job #1 to non-cancellable

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_index_vanilla_index
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_index_vanilla_index
@@ -175,7 +175,7 @@ upsert descriptor #104
   +  version: "10"
 write *eventpb.FinishSchemaChange to event log
 write *eventpb.DropIndex to event log: DROP INDEX ‹defaultdb›.‹public›.‹t›@‹idx› CASCADE
-create job #2 (non-cancelable: true): "GC for DROP INDEX defaultdb.public.t@idx CASCADE"
+create job #2 (non-cancelable: true): "GC for removed secondary index; DROP INDEX defaultdb.public.t@idx CASCADE"
   descriptor IDs: [104]
 update progress of schema change job #1: "all stages completed"
 set schema change job #1 to non-cancellable

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_multiple_columns_separate_statements
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_multiple_columns_separate_statements
@@ -617,7 +617,7 @@ upsert descriptor #104
   -  version: "7"
   +  version: "8"
 write *eventpb.DropIndex to event log: ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COLUMN ‹j› CASCADE
-create job #2 (non-cancelable: true): "GC for ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE"
+create job #2 (non-cancelable: true): "GC for removed secondary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE"
   descriptor IDs: [104]
 update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 3 of 3 with 6 MutationType ops pending"
 commit transaction #11
@@ -721,7 +721,7 @@ upsert descriptor #104
   -  version: "8"
   +  version: "9"
 write *eventpb.FinishSchemaChange to event log
-create job #3 (non-cancelable: true): "GC for ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE"
+create job #3 (non-cancelable: true): "GC for removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE"
   descriptor IDs: [104]
 update progress of schema change job #1: "all stages completed"
 set schema change job #1 to non-cancellable

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column
@@ -559,6 +559,9 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 3
+    │       │     StatementForDropJob:
+    │       │       Statement: removed temporary index; ALTER TABLE db.public.tbl ADD COLUMN j INT8
+    │       │         NOT NULL DEFAULT 42
     │       │     TableID: 106
     │       │
     │       ├── • MakeIndexAbsent
@@ -598,7 +601,8 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
             ├── • CreateGCJobForIndex
             │     IndexID: 1
             │     StatementForDropJob:
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 NOT NULL DEFAULT 42
+            │       Statement: removed primary index; ALTER TABLE db.public.tbl ADD COLUMN j INT8 NOT
+            │         NULL DEFAULT 42
             │     TableID: 106
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_1_of_7
@@ -114,7 +114,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 NOT NULL DEFAULT 42
+            │       Statement: removed primary index; ALTER TABLE db.public.tbl ADD COLUMN j INT8 NOT
+            │         NULL DEFAULT 42
             │     TableID: 106
             │
             ├── • MakeIndexAbsent
@@ -131,6 +132,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE db.public.tbl ADD COLUMN j INT8
+            │         NOT NULL DEFAULT 42
             │     TableID: 106
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_2_of_7
@@ -97,7 +97,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │       │     IndexID: 2
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 NOT NULL DEFAULT 42
+    │       │       Statement: removed primary index; ALTER TABLE db.public.tbl ADD COLUMN j INT8 NOT
+    │       │         NULL DEFAULT 42
     │       │     TableID: 106
     │       │
     │       ├── • MakeIndexAbsent
@@ -184,6 +185,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE db.public.tbl ADD COLUMN j INT8
+            │         NOT NULL DEFAULT 42
             │     TableID: 106
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_3_of_7
@@ -97,7 +97,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │       │     IndexID: 2
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 NOT NULL DEFAULT 42
+    │       │       Statement: removed primary index; ALTER TABLE db.public.tbl ADD COLUMN j INT8 NOT
+    │       │         NULL DEFAULT 42
     │       │     TableID: 106
     │       │
     │       ├── • MakeIndexAbsent
@@ -184,6 +185,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE db.public.tbl ADD COLUMN j INT8
+            │         NOT NULL DEFAULT 42
             │     TableID: 106
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_4_of_7
@@ -97,7 +97,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │       │     IndexID: 2
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 NOT NULL DEFAULT 42
+    │       │       Statement: removed primary index; ALTER TABLE db.public.tbl ADD COLUMN j INT8 NOT
+    │       │         NULL DEFAULT 42
     │       │     TableID: 106
     │       │
     │       ├── • MakeIndexAbsent
@@ -184,6 +185,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE db.public.tbl ADD COLUMN j INT8
+            │         NOT NULL DEFAULT 42
             │     TableID: 106
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_5_of_7
@@ -173,7 +173,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 NOT NULL DEFAULT 42
+            │       Statement: removed primary index; ALTER TABLE db.public.tbl ADD COLUMN j INT8 NOT
+            │         NULL DEFAULT 42
             │     TableID: 106
             │
             ├── • MakeIndexAbsent
@@ -190,6 +191,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE db.public.tbl ADD COLUMN j INT8
+            │         NOT NULL DEFAULT 42
             │     TableID: 106
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_6_of_7
@@ -173,7 +173,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 NOT NULL DEFAULT 42
+            │       Statement: removed primary index; ALTER TABLE db.public.tbl ADD COLUMN j INT8 NOT
+            │         NULL DEFAULT 42
             │     TableID: 106
             │
             ├── • MakeIndexAbsent
@@ -190,6 +191,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE db.public.tbl ADD COLUMN j INT8
+            │         NOT NULL DEFAULT 42
             │     TableID: 106
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_7_of_7
@@ -173,7 +173,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 NOT NULL DEFAULT 42
+            │       Statement: removed primary index; ALTER TABLE db.public.tbl ADD COLUMN j INT8 NOT
+            │         NULL DEFAULT 42
             │     TableID: 106
             │
             ├── • MakeIndexAbsent
@@ -190,6 +191,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE db.public.tbl ADD COLUMN j INT8
+            │         NOT NULL DEFAULT 42
             │     TableID: 106
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq
@@ -587,6 +587,9 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN l INT NOT NULL DEFAU
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 3
+    │       │     StatementForDropJob:
+    │       │       Statement: removed temporary index; ALTER TABLE db.public.tbl ADD COLUMN l INT8
+    │       │         NOT NULL DEFAULT nextval('db.public.sq1')
     │       │     TableID: 106
     │       │
     │       ├── • MakeIndexAbsent
@@ -629,7 +632,8 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN l INT NOT NULL DEFAU
             ├── • CreateGCJobForIndex
             │     IndexID: 1
             │     StatementForDropJob:
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN l INT8 NOT NULL DEFAULT nextval('db.public.sq1')
+            │       Statement: removed primary index; ALTER TABLE db.public.tbl ADD COLUMN l INT8 NOT
+            │         NULL DEFAULT nextval('db.public.sq1')
             │     TableID: 106
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_1_of_7
@@ -114,7 +114,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN l INT8 NOT NULL DEFAULT nextval('db.public.sq1')
+            │       Statement: removed primary index; ALTER TABLE db.public.tbl ADD COLUMN l INT8 NOT
+            │         NULL DEFAULT nextval('db.public.sq1')
             │     TableID: 106
             │
             ├── • MakeIndexAbsent
@@ -131,6 +132,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE db.public.tbl ADD COLUMN l INT8
+            │         NOT NULL DEFAULT nextval('db.public.sq1')
             │     TableID: 106
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_2_of_7
@@ -97,7 +97,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │       │     IndexID: 2
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE db.public.tbl ADD COLUMN l INT8 NOT NULL DEFAULT nextval('db.public.sq1')
+    │       │       Statement: removed primary index; ALTER TABLE db.public.tbl ADD COLUMN l INT8 NOT
+    │       │         NULL DEFAULT nextval('db.public.sq1')
     │       │     TableID: 106
     │       │
     │       ├── • MakeIndexAbsent
@@ -193,6 +194,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE db.public.tbl ADD COLUMN l INT8
+            │         NOT NULL DEFAULT nextval('db.public.sq1')
             │     TableID: 106
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_3_of_7
@@ -97,7 +97,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │       │     IndexID: 2
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE db.public.tbl ADD COLUMN l INT8 NOT NULL DEFAULT nextval('db.public.sq1')
+    │       │       Statement: removed primary index; ALTER TABLE db.public.tbl ADD COLUMN l INT8 NOT
+    │       │         NULL DEFAULT nextval('db.public.sq1')
     │       │     TableID: 106
     │       │
     │       ├── • MakeIndexAbsent
@@ -193,6 +194,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE db.public.tbl ADD COLUMN l INT8
+            │         NOT NULL DEFAULT nextval('db.public.sq1')
             │     TableID: 106
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_4_of_7
@@ -97,7 +97,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │       │     IndexID: 2
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE db.public.tbl ADD COLUMN l INT8 NOT NULL DEFAULT nextval('db.public.sq1')
+    │       │       Statement: removed primary index; ALTER TABLE db.public.tbl ADD COLUMN l INT8 NOT
+    │       │         NULL DEFAULT nextval('db.public.sq1')
     │       │     TableID: 106
     │       │
     │       ├── • MakeIndexAbsent
@@ -193,6 +194,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE db.public.tbl ADD COLUMN l INT8
+            │         NOT NULL DEFAULT nextval('db.public.sq1')
             │     TableID: 106
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_5_of_7
@@ -176,7 +176,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN l INT8 NOT NULL DEFAULT nextval('db.public.sq1')
+            │       Statement: removed primary index; ALTER TABLE db.public.tbl ADD COLUMN l INT8 NOT
+            │         NULL DEFAULT nextval('db.public.sq1')
             │     TableID: 106
             │
             ├── • MakeIndexAbsent
@@ -193,6 +194,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE db.public.tbl ADD COLUMN l INT8
+            │         NOT NULL DEFAULT nextval('db.public.sq1')
             │     TableID: 106
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_6_of_7
@@ -176,7 +176,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN l INT8 NOT NULL DEFAULT nextval('db.public.sq1')
+            │       Statement: removed primary index; ALTER TABLE db.public.tbl ADD COLUMN l INT8 NOT
+            │         NULL DEFAULT nextval('db.public.sq1')
             │     TableID: 106
             │
             ├── • MakeIndexAbsent
@@ -193,6 +194,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE db.public.tbl ADD COLUMN l INT8
+            │         NOT NULL DEFAULT nextval('db.public.sq1')
             │     TableID: 106
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_7_of_7
@@ -176,7 +176,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN l INT8 NOT NULL DEFAULT nextval('db.public.sq1')
+            │       Statement: removed primary index; ALTER TABLE db.public.tbl ADD COLUMN l INT8 NOT
+            │         NULL DEFAULT nextval('db.public.sq1')
             │     TableID: 106
             │
             ├── • MakeIndexAbsent
@@ -193,6 +194,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE db.public.tbl ADD COLUMN l INT8
+            │         NOT NULL DEFAULT nextval('db.public.sq1')
             │     TableID: 106
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid
@@ -803,7 +803,8 @@ EXPLAIN (ddl, verbose) alter table t add primary key (a);
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 1
     │       │     StatementForDropJob:
-    │       │       Statement: ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+    │       │         (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -829,6 +830,9 @@ EXPLAIN (ddl, verbose) alter table t add primary key (a);
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 3
+    │       │     StatementForDropJob:
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+    │       │         (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -842,6 +846,9 @@ EXPLAIN (ddl, verbose) alter table t add primary key (a);
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 5
+    │       │     StatementForDropJob:
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+    │       │         (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -964,7 +971,8 @@ EXPLAIN (ddl, verbose) alter table t add primary key (a);
             ├── • CreateGCJobForIndex
             │     IndexID: 2
             │     StatementForDropJob:
-            │       Statement: ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+            │         (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_10_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_10_of_15
@@ -196,7 +196,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │       │     IndexID: 4
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+    │       │         (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -254,6 +255,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 3
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+    │       │         (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -262,6 +267,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 5
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+    │       │         (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -305,7 +314,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+            │         (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_11_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_11_of_15
@@ -196,7 +196,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │       │     IndexID: 4
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+    │       │         (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -254,6 +255,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 3
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+    │       │         (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -262,6 +267,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 5
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+    │       │         (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -305,7 +314,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+            │         (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_12_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_12_of_15
@@ -196,7 +196,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │       │     IndexID: 4
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+    │       │         (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -254,6 +255,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 3
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+    │       │         (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -262,6 +267,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 5
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+    │       │         (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -305,7 +314,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+            │         (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_13_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_13_of_15
@@ -245,6 +245,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 3
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+    │       │         (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -255,7 +259,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
     │       │     IndexID: 4
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+    │       │         (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -272,6 +277,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 5
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+    │       │         (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -315,7 +324,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+            │         (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_14_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_14_of_15
@@ -245,6 +245,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 3
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+    │       │         (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -255,7 +259,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
     │       │     IndexID: 4
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+    │       │         (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -272,6 +277,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 5
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+    │       │         (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -315,7 +324,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+            │         (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_15_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_15_of_15
@@ -245,6 +245,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 3
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+    │       │         (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -255,7 +259,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
     │       │     IndexID: 4
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+    │       │         (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -272,6 +277,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 5
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+    │       │         (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -315,7 +324,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+            │         (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_1_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_1_of_15
@@ -131,7 +131,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+            │         (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -148,6 +149,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 15;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+            │         (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -158,7 +163,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 15;
             │     IndexID: 4
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+            │         (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_2_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_2_of_15
@@ -129,7 +129,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 15;
     │       │     IndexID: 2
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+    │       │         (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -148,7 +149,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 15;
     │       │     IndexID: 4
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+    │       │         (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -191,6 +193,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 15;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+            │         (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_3_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_3_of_15
@@ -129,7 +129,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 15;
     │       │     IndexID: 2
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+    │       │         (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -148,7 +149,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 15;
     │       │     IndexID: 4
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+    │       │         (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -191,6 +193,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 15;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+            │         (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_4_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_4_of_15
@@ -129,7 +129,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 15;
     │       │     IndexID: 2
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+    │       │         (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -148,7 +149,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 15;
     │       │     IndexID: 4
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+    │       │         (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -191,6 +193,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 15;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+            │         (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_5_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_5_of_15
@@ -124,7 +124,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 15;
     │       │     IndexID: 4
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+    │       │         (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -184,7 +185,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+            │         (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -201,6 +203,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 15;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+            │         (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_6_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_6_of_15
@@ -124,7 +124,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 15;
     │       │     IndexID: 4
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+    │       │         (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -184,7 +185,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+            │         (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -201,6 +203,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 15;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+            │         (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_7_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_7_of_15
@@ -124,7 +124,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 15;
     │       │     IndexID: 4
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+    │       │         (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -184,7 +185,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+            │         (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -201,6 +203,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 15;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+            │         (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_8_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_8_of_15
@@ -124,7 +124,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 8 of 15;
     │       │     IndexID: 4
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+    │       │         (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -184,7 +185,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 8 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+            │         (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -201,6 +203,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 8 of 15;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+            │         (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_9_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_9_of_15
@@ -195,7 +195,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
     │       │     IndexID: 4
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+    │       │         (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -212,6 +213,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 5
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+    │       │         (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -252,6 +257,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 3
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+    │       │         (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -295,7 +304,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ADD PRIMARY KEY
+            │         (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid
@@ -806,7 +806,8 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 1
     │       │     StatementForDropJob:
-    │       │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+    │       │         USING COLUMNS (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -833,6 +834,9 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 3
+    │       │     StatementForDropJob:
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -846,6 +850,9 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 5
+    │       │     StatementForDropJob:
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -969,7 +976,8 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
             ├── • CreateGCJobForIndex
             │     IndexID: 2
             │     StatementForDropJob:
-            │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+            │         USING COLUMNS (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_10_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_10_of_15
@@ -196,7 +196,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │       │     IndexID: 4
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+    │       │         USING COLUMNS (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -254,6 +255,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 3
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -262,6 +267,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 5
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -305,7 +314,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+            │         USING COLUMNS (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_11_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_11_of_15
@@ -196,7 +196,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │       │     IndexID: 4
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+    │       │         USING COLUMNS (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -254,6 +255,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 3
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -262,6 +267,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 5
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -305,7 +314,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+            │         USING COLUMNS (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_12_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_12_of_15
@@ -196,7 +196,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │       │     IndexID: 4
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+    │       │         USING COLUMNS (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -254,6 +255,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 3
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -262,6 +267,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 5
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -305,7 +314,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+            │         USING COLUMNS (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_13_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_13_of_15
@@ -245,6 +245,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 3
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -255,7 +259,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
     │       │     IndexID: 4
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+    │       │         USING COLUMNS (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -272,6 +277,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 5
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -315,7 +324,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+            │         USING COLUMNS (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_14_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_14_of_15
@@ -245,6 +245,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 3
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -255,7 +259,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
     │       │     IndexID: 4
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+    │       │         USING COLUMNS (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -272,6 +277,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 5
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -315,7 +324,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+            │         USING COLUMNS (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_15_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_15_of_15
@@ -245,6 +245,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 3
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -255,7 +259,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
     │       │     IndexID: 4
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+    │       │         USING COLUMNS (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -272,6 +277,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 5
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -315,7 +324,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+            │         USING COLUMNS (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_1_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_1_of_15
@@ -131,7 +131,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+            │         USING COLUMNS (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -148,6 +149,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 15;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+            │         KEY USING COLUMNS (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -158,7 +163,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 15;
             │     IndexID: 4
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+            │         USING COLUMNS (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_2_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_2_of_15
@@ -129,7 +129,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 15;
     │       │     IndexID: 2
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+    │       │         USING COLUMNS (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -148,7 +149,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 15;
     │       │     IndexID: 4
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+    │       │         USING COLUMNS (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -191,6 +193,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 15;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+            │         KEY USING COLUMNS (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_3_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_3_of_15
@@ -129,7 +129,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 15;
     │       │     IndexID: 2
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+    │       │         USING COLUMNS (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -148,7 +149,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 15;
     │       │     IndexID: 4
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+    │       │         USING COLUMNS (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -191,6 +193,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 15;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+            │         KEY USING COLUMNS (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_4_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_4_of_15
@@ -129,7 +129,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 15;
     │       │     IndexID: 2
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+    │       │         USING COLUMNS (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -148,7 +149,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 15;
     │       │     IndexID: 4
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+    │       │         USING COLUMNS (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -191,6 +193,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 15;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+            │         KEY USING COLUMNS (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_5_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_5_of_15
@@ -124,7 +124,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 15;
     │       │     IndexID: 4
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+    │       │         USING COLUMNS (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -184,7 +185,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+            │         USING COLUMNS (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -201,6 +203,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 15;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+            │         KEY USING COLUMNS (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_6_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_6_of_15
@@ -124,7 +124,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 15;
     │       │     IndexID: 4
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+    │       │         USING COLUMNS (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -184,7 +185,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+            │         USING COLUMNS (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -201,6 +203,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 15;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+            │         KEY USING COLUMNS (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_7_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_7_of_15
@@ -124,7 +124,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 15;
     │       │     IndexID: 4
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+    │       │         USING COLUMNS (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -184,7 +185,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+            │         USING COLUMNS (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -201,6 +203,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 15;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+            │         KEY USING COLUMNS (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_8_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_8_of_15
@@ -124,7 +124,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 8 of 15;
     │       │     IndexID: 4
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+    │       │         USING COLUMNS (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -184,7 +185,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 8 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+            │         USING COLUMNS (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -201,6 +203,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 8 of 15;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+            │         KEY USING COLUMNS (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_9_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_9_of_15
@@ -195,7 +195,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
     │       │     IndexID: 4
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+    │       │         USING COLUMNS (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -212,6 +213,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 5
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -252,6 +257,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 3
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -295,7 +304,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+            │         USING COLUMNS (a)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla
@@ -630,6 +630,9 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 3
+    │       │     StatementForDropJob:
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (j)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -638,6 +641,9 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 5
+    │       │     StatementForDropJob:
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (j)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -680,7 +686,8 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
             ├── • CreateGCJobForIndex
             │     IndexID: 1
             │     StatementForDropJob:
-            │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+            │         USING COLUMNS (j)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_1_of_7
@@ -121,7 +121,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+            │         USING COLUMNS (j)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -138,6 +139,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+            │         KEY USING COLUMNS (j)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -167,7 +172,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │     IndexID: 4
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)
+            │       Statement: removed secondary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+            │         KEY USING COLUMNS (j)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -176,6 +182,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 5
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+            │         KEY USING COLUMNS (j)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_2_of_7
@@ -117,7 +117,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │       │     IndexID: 2
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+    │       │         USING COLUMNS (j)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -155,7 +156,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │       │     IndexID: 4
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)
+    │       │       Statement: removed secondary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (j)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -202,6 +204,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+            │         KEY USING COLUMNS (j)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -210,6 +216,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 5
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+            │         KEY USING COLUMNS (j)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_3_of_7
@@ -117,7 +117,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │       │     IndexID: 2
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+    │       │         USING COLUMNS (j)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -155,7 +156,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │       │     IndexID: 4
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)
+    │       │       Statement: removed secondary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (j)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -202,6 +204,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+            │         KEY USING COLUMNS (j)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -210,6 +216,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 5
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+            │         KEY USING COLUMNS (j)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_4_of_7
@@ -117,7 +117,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │       │     IndexID: 2
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+    │       │         USING COLUMNS (j)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -155,7 +156,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │       │     IndexID: 4
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)
+    │       │       Statement: removed secondary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (j)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -202,6 +204,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+            │         KEY USING COLUMNS (j)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -210,6 +216,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 5
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+            │         KEY USING COLUMNS (j)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_5_of_7
@@ -175,7 +175,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+            │         USING COLUMNS (j)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -192,6 +193,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+            │         KEY USING COLUMNS (j)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -221,7 +226,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             │     IndexID: 4
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)
+            │       Statement: removed secondary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+            │         KEY USING COLUMNS (j)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -230,6 +236,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 5
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+            │         KEY USING COLUMNS (j)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_6_of_7
@@ -175,7 +175,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+            │         USING COLUMNS (j)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -192,6 +193,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+            │         KEY USING COLUMNS (j)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -221,7 +226,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             │     IndexID: 4
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)
+            │       Statement: removed secondary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+            │         KEY USING COLUMNS (j)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -230,6 +236,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 5
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+            │         KEY USING COLUMNS (j)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_7_of_7
@@ -175,7 +175,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
+            │         USING COLUMNS (j)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -192,6 +193,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+            │         KEY USING COLUMNS (j)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -221,7 +226,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             │     IndexID: 4
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)
+            │       Statement: removed secondary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+            │         KEY USING COLUMNS (j)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -230,6 +236,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 5
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+            │         KEY USING COLUMNS (j)
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/create_index
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/create_index
@@ -339,6 +339,9 @@ EXPLAIN (ddl, verbose) CREATE INDEX idx1 ON t (v) WHERE (v = 'a');
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Statement: removed temporary index; CREATE INDEX idx1 ON defaultdb.public.t (v)
+            │         WHERE (v = 'a')
             │     TableID: 106
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_1_of_7
@@ -88,7 +88,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: CREATE INDEX idx1 ON defaultdb.public.t (v) WHERE (v = 'a')
+            │       Statement: removed secondary index; CREATE INDEX idx1 ON defaultdb.public.t (v)
+            │         WHERE (v = 'a')
             │     TableID: 106
             │
             ├── • MakeIndexAbsent
@@ -97,6 +98,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; CREATE INDEX idx1 ON defaultdb.public.t (v)
+            │         WHERE (v = 'a')
             │     TableID: 106
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_2_of_7
@@ -86,7 +86,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │       │     IndexID: 2
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: CREATE INDEX idx1 ON defaultdb.public.t (v) WHERE (v = 'a')
+    │       │       Statement: removed secondary index; CREATE INDEX idx1 ON defaultdb.public.t (v)
+    │       │         WHERE (v = 'a')
     │       │     TableID: 106
     │       │
     │       ├── • MakeIndexAbsent
@@ -121,6 +122,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; CREATE INDEX idx1 ON defaultdb.public.t (v)
+            │         WHERE (v = 'a')
             │     TableID: 106
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_3_of_7
@@ -86,7 +86,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │       │     IndexID: 2
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: CREATE INDEX idx1 ON defaultdb.public.t (v) WHERE (v = 'a')
+    │       │       Statement: removed secondary index; CREATE INDEX idx1 ON defaultdb.public.t (v)
+    │       │         WHERE (v = 'a')
     │       │     TableID: 106
     │       │
     │       ├── • MakeIndexAbsent
@@ -121,6 +122,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; CREATE INDEX idx1 ON defaultdb.public.t (v)
+            │         WHERE (v = 'a')
             │     TableID: 106
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_4_of_7
@@ -82,7 +82,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │       │     IndexID: 2
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: CREATE INDEX idx1 ON defaultdb.public.t (v) WHERE (v = 'a')
+    │       │       Statement: removed secondary index; CREATE INDEX idx1 ON defaultdb.public.t (v)
+    │       │         WHERE (v = 'a')
     │       │     TableID: 106
     │       │
     │       ├── • MakeIndexAbsent
@@ -121,6 +122,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; CREATE INDEX idx1 ON defaultdb.public.t (v)
+            │         WHERE (v = 'a')
             │     TableID: 106
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_5_of_7
@@ -122,7 +122,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: CREATE INDEX idx1 ON defaultdb.public.t (v) WHERE (v = 'a')
+            │       Statement: removed secondary index; CREATE INDEX idx1 ON defaultdb.public.t (v)
+            │         WHERE (v = 'a')
             │     TableID: 106
             │
             ├── • MakeIndexAbsent
@@ -131,6 +132,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; CREATE INDEX idx1 ON defaultdb.public.t (v)
+            │         WHERE (v = 'a')
             │     TableID: 106
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_6_of_7
@@ -122,7 +122,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: CREATE INDEX idx1 ON defaultdb.public.t (v) WHERE (v = 'a')
+            │       Statement: removed secondary index; CREATE INDEX idx1 ON defaultdb.public.t (v)
+            │         WHERE (v = 'a')
             │     TableID: 106
             │
             ├── • MakeIndexAbsent
@@ -131,6 +132,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; CREATE INDEX idx1 ON defaultdb.public.t (v)
+            │         WHERE (v = 'a')
             │     TableID: 106
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_7_of_7
@@ -122,7 +122,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: CREATE INDEX idx1 ON defaultdb.public.t (v) WHERE (v = 'a')
+            │       Statement: removed secondary index; CREATE INDEX idx1 ON defaultdb.public.t (v)
+            │         WHERE (v = 'a')
             │     TableID: 106
             │
             ├── • MakeIndexAbsent
@@ -131,6 +132,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; CREATE INDEX idx1 ON defaultdb.public.t (v)
+            │         WHERE (v = 'a')
             │     TableID: 106
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic
@@ -433,6 +433,8 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 3
+    │       │     StatementForDropJob:
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -500,7 +502,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
             ├── • CreateGCJobForIndex
             │     IndexID: 1
             │     StatementForDropJob:
-            │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_1_of_7
@@ -92,7 +92,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -109,6 +109,9 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_2_of_7
@@ -93,7 +93,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │       │     IndexID: 2
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -133,6 +133,9 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_3_of_7
@@ -93,7 +93,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │       │     IndexID: 2
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -133,6 +133,9 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_4_of_7
@@ -93,7 +93,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │       │     IndexID: 2
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -133,6 +133,9 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_5_of_7
@@ -126,7 +126,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -143,6 +143,9 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_6_of_7
@@ -126,7 +126,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -143,6 +143,9 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_7_of_7
@@ -126,7 +126,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -143,6 +143,9 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index
@@ -592,7 +592,8 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 2
     │       │     StatementForDropJob:
-    │       │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+    │       │       Statement: removed secondary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+    │       │         CASCADE
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -601,6 +602,9 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 4
+    │       │     StatementForDropJob:
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+    │       │         CASCADE
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -680,7 +684,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
             ├── • CreateGCJobForIndex
             │     IndexID: 1
             │     StatementForDropJob:
-            │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_1_of_7
@@ -161,7 +161,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -178,6 +178,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+            │         CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_2_of_7
@@ -162,7 +162,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │       │     IndexID: 3
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -202,6 +202,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+            │         CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_3_of_7
@@ -162,7 +162,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │       │     IndexID: 3
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -202,6 +202,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+            │         CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_4_of_7
@@ -162,7 +162,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │       │     IndexID: 3
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -202,6 +202,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+            │         CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_5_of_7
@@ -195,7 +195,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -212,6 +212,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+            │         CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_6_of_7
@@ -195,7 +195,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -212,6 +212,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+            │         CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_7_of_7
@@ -195,7 +195,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -212,6 +212,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+            │         CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_10_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_10_of_15
@@ -304,7 +304,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │       │     IndexID: 5
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: CREATE UNIQUE INDEX idx ON defaultdb.public.t (k)
+    │       │       Statement: removed secondary index; CREATE UNIQUE INDEX idx ON defaultdb.public.t
+    │       │         (k)
     │       │       StatementID: 1
     │       │     TableID: 104
     │       │
@@ -358,6 +359,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 4
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+    │       │         CASCADE
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -366,6 +371,11 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 6
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; CREATE UNIQUE INDEX idx ON defaultdb.public.t
+    │       │         (k)
+    │       │       StatementID: 1
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -409,7 +419,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_11_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_11_of_15
@@ -304,7 +304,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │       │     IndexID: 5
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: CREATE UNIQUE INDEX idx ON defaultdb.public.t (k)
+    │       │       Statement: removed secondary index; CREATE UNIQUE INDEX idx ON defaultdb.public.t
+    │       │         (k)
     │       │       StatementID: 1
     │       │     TableID: 104
     │       │
@@ -358,6 +359,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 4
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+    │       │         CASCADE
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -366,6 +371,11 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 6
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; CREATE UNIQUE INDEX idx ON defaultdb.public.t
+    │       │         (k)
+    │       │       StatementID: 1
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -409,7 +419,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_12_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_12_of_15
@@ -254,7 +254,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │       │     IndexID: 5
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: CREATE UNIQUE INDEX idx ON defaultdb.public.t (k)
+    │       │       Statement: removed secondary index; CREATE UNIQUE INDEX idx ON defaultdb.public.t
+    │       │         (k)
     │       │       StatementID: 1
     │       │     TableID: 104
     │       │
@@ -358,6 +359,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 4
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+    │       │         CASCADE
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -366,6 +371,11 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 6
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; CREATE UNIQUE INDEX idx ON defaultdb.public.t
+    │       │         (k)
+    │       │       StatementID: 1
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -409,7 +419,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_13_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_13_of_15
@@ -336,6 +336,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 4
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+    │       │         CASCADE
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -366,7 +370,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
     │       │     IndexID: 5
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: CREATE UNIQUE INDEX idx ON defaultdb.public.t (k)
+    │       │       Statement: removed secondary index; CREATE UNIQUE INDEX idx ON defaultdb.public.t
+    │       │         (k)
     │       │       StatementID: 1
     │       │     TableID: 104
     │       │
@@ -376,6 +381,11 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 6
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; CREATE UNIQUE INDEX idx ON defaultdb.public.t
+    │       │         (k)
+    │       │       StatementID: 1
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -419,7 +429,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_14_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_14_of_15
@@ -336,6 +336,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 4
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+    │       │         CASCADE
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -366,7 +370,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
     │       │     IndexID: 5
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: CREATE UNIQUE INDEX idx ON defaultdb.public.t (k)
+    │       │       Statement: removed secondary index; CREATE UNIQUE INDEX idx ON defaultdb.public.t
+    │       │         (k)
     │       │       StatementID: 1
     │       │     TableID: 104
     │       │
@@ -376,6 +381,11 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 6
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; CREATE UNIQUE INDEX idx ON defaultdb.public.t
+    │       │         (k)
+    │       │       StatementID: 1
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -419,7 +429,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_15_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_15_of_15
@@ -336,6 +336,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 4
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+    │       │         CASCADE
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -366,7 +370,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
     │       │     IndexID: 5
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: CREATE UNIQUE INDEX idx ON defaultdb.public.t (k)
+    │       │       Statement: removed secondary index; CREATE UNIQUE INDEX idx ON defaultdb.public.t
+    │       │         (k)
     │       │       StatementID: 1
     │       │     TableID: 104
     │       │
@@ -376,6 +381,11 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 6
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; CREATE UNIQUE INDEX idx ON defaultdb.public.t
+    │       │         (k)
+    │       │       StatementID: 1
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -419,7 +429,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_1_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_1_of_15
@@ -147,6 +147,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 15;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+            │         CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -191,7 +195,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 15;
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_2_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_2_of_15
@@ -181,7 +181,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 15;
     │       │     IndexID: 3
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -224,6 +224,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 15;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+            │         CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_3_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_3_of_15
@@ -181,7 +181,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 15;
     │       │     IndexID: 3
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -224,6 +224,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 15;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+            │         CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_4_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_4_of_15
@@ -143,7 +143,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 15;
     │       │     IndexID: 3
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -224,6 +224,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 15;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+            │         CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_5_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_5_of_15
@@ -217,7 +217,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 15;
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -234,6 +234,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 15;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+            │         CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_6_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_6_of_15
@@ -217,7 +217,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 15;
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -234,6 +234,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 15;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+            │         CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_7_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_7_of_15
@@ -217,7 +217,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 15;
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -234,6 +234,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 15;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+            │         CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_8_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_8_of_15
@@ -217,7 +217,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 8 of 15;
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -234,6 +234,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 8 of 15;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+            │         CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_9_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_9_of_15
@@ -306,7 +306,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
     │       │     IndexID: 5
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: CREATE UNIQUE INDEX idx ON defaultdb.public.t (k)
+    │       │       Statement: removed secondary index; CREATE UNIQUE INDEX idx ON defaultdb.public.t
+    │       │         (k)
     │       │       StatementID: 1
     │       │     TableID: 104
     │       │
@@ -316,6 +317,11 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 6
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; CREATE UNIQUE INDEX idx ON defaultdb.public.t
+    │       │         (k)
+    │       │       StatementID: 1
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -356,6 +362,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 4
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+    │       │         CASCADE
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -399,7 +409,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.statement_1_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.statement_1_of_2
@@ -655,7 +655,8 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 2
     │       │     StatementForDropJob:
-    │       │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+    │       │       Statement: removed secondary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+    │       │         CASCADE
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -664,6 +665,9 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 4
+    │       │     StatementForDropJob:
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+    │       │         CASCADE
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -746,7 +750,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
             ├── • CreateGCJobForIndex
             │     IndexID: 1
             │     StatementForDropJob:
-            │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.statement_2_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.statement_2_of_2
@@ -804,7 +804,7 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
             ├── • CreateGCJobForIndex
             │     IndexID: 1
             │     StatementForDropJob:
-            │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -837,7 +837,8 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
             ├── • CreateGCJobForIndex
             │     IndexID: 2
             │     StatementForDropJob:
-            │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+            │       Statement: removed secondary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+            │         CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -846,6 +847,9 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
+            │     StatementForDropJob:
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+            │         CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -854,6 +858,10 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 6
+            │     StatementForDropJob:
+            │       Statement: removed temporary index; CREATE UNIQUE INDEX idx ON defaultdb.public.t
+            │         (k)
+            │       StatementID: 1
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index
@@ -540,6 +540,8 @@ EXPLAIN (ddl, verbose) ALTER TABLE t.test DROP pi;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 5
+    │       │     StatementForDropJob:
+    │       │       Statement: removed temporary index; ALTER TABLE t.public.test DROP COLUMN pi
     │       │     TableID: 106
     │       │
     │       ├── • MakeIndexAbsent
@@ -625,7 +627,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t.test DROP pi;
             ├── • CreateGCJobForIndex
             │     IndexID: 1
             │     StatementForDropJob:
-            │       Statement: ALTER TABLE t.public.test DROP COLUMN pi
+            │       Statement: removed primary index; ALTER TABLE t.public.test DROP COLUMN pi
             │     TableID: 106
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_1_of_7
@@ -134,7 +134,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │     IndexID: 4
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE t.public.test DROP COLUMN pi
+            │       Statement: removed primary index; ALTER TABLE t.public.test DROP COLUMN pi
             │     TableID: 106
             │
             ├── • MakeIndexAbsent
@@ -151,6 +151,9 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 5
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE t.public.test DROP COLUMN pi
             │     TableID: 106
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_2_of_7
@@ -129,7 +129,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │       │     IndexID: 4
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE t.public.test DROP COLUMN pi
+    │       │       Statement: removed primary index; ALTER TABLE t.public.test DROP COLUMN pi
     │       │     TableID: 106
     │       │
     │       ├── • MakeIndexAbsent
@@ -175,6 +175,9 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 5
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE t.public.test DROP COLUMN pi
             │     TableID: 106
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_3_of_7
@@ -129,7 +129,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │       │     IndexID: 4
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE t.public.test DROP COLUMN pi
+    │       │       Statement: removed primary index; ALTER TABLE t.public.test DROP COLUMN pi
     │       │     TableID: 106
     │       │
     │       ├── • MakeIndexAbsent
@@ -175,6 +175,9 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 5
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE t.public.test DROP COLUMN pi
             │     TableID: 106
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_4_of_7
@@ -129,7 +129,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │       │     IndexID: 4
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE t.public.test DROP COLUMN pi
+    │       │       Statement: removed primary index; ALTER TABLE t.public.test DROP COLUMN pi
     │       │     TableID: 106
     │       │
     │       ├── • MakeIndexAbsent
@@ -175,6 +175,9 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 5
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE t.public.test DROP COLUMN pi
             │     TableID: 106
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_5_of_7
@@ -168,7 +168,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             │     IndexID: 4
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE t.public.test DROP COLUMN pi
+            │       Statement: removed primary index; ALTER TABLE t.public.test DROP COLUMN pi
             │     TableID: 106
             │
             ├── • MakeIndexAbsent
@@ -185,6 +185,9 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 5
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE t.public.test DROP COLUMN pi
             │     TableID: 106
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_6_of_7
@@ -168,7 +168,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             │     IndexID: 4
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE t.public.test DROP COLUMN pi
+            │       Statement: removed primary index; ALTER TABLE t.public.test DROP COLUMN pi
             │     TableID: 106
             │
             ├── • MakeIndexAbsent
@@ -185,6 +185,9 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 5
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE t.public.test DROP COLUMN pi
             │     TableID: 106
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_7_of_7
@@ -168,7 +168,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             │     IndexID: 4
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE t.public.test DROP COLUMN pi
+            │       Statement: removed primary index; ALTER TABLE t.public.test DROP COLUMN pi
             │     TableID: 106
             │
             ├── • MakeIndexAbsent
@@ -185,6 +185,9 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 5
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE t.public.test DROP COLUMN pi
             │     TableID: 106
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index
@@ -519,7 +519,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 2
     │       │     StatementForDropJob:
-    │       │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j
+    │       │       Statement: removed secondary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -528,6 +528,8 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 4
+    │       │     StatementForDropJob:
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -601,7 +603,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
             ├── • CreateGCJobForIndex
             │     IndexID: 1
             │     StatementForDropJob:
-            │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_1_of_7
@@ -123,7 +123,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -140,6 +140,9 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_2_of_7
@@ -124,7 +124,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │       │     IndexID: 3
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -164,6 +164,9 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_3_of_7
@@ -124,7 +124,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │       │     IndexID: 3
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -164,6 +164,9 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_4_of_7
@@ -124,7 +124,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │       │     IndexID: 3
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -164,6 +164,9 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_5_of_7
@@ -157,7 +157,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -174,6 +174,9 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_6_of_7
@@ -157,7 +157,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -174,6 +174,9 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_7_of_7
@@ -157,7 +157,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -174,6 +174,9 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_index_hash_sharded_index
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_index_hash_sharded_index
@@ -258,7 +258,7 @@ EXPLAIN (ddl, verbose) DROP INDEX idx CASCADE;
             ├── • CreateGCJobForIndex
             │     IndexID: 2
             │     StatementForDropJob:
-            │       Statement: DROP INDEX defaultdb.public.t@idx CASCADE
+            │       Statement: removed secondary index; DROP INDEX defaultdb.public.t@idx CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_index_partial_expression_index
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_index_partial_expression_index
@@ -238,7 +238,7 @@ EXPLAIN (ddl, verbose) DROP INDEX idx CASCADE;
             ├── • CreateGCJobForIndex
             │     IndexID: 2
             │     StatementForDropJob:
-            │       Statement: DROP INDEX defaultdb.public.t@idx CASCADE
+            │       Statement: removed secondary index; DROP INDEX defaultdb.public.t@idx CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_index_vanilla_index
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_index_vanilla_index
@@ -145,7 +145,7 @@ EXPLAIN (ddl, verbose) DROP INDEX idx CASCADE;
             ├── • CreateGCJobForIndex
             │     IndexID: 2
             │     StatementForDropJob:
-            │       Statement: DROP INDEX defaultdb.public.t@idx CASCADE
+            │       Statement: removed secondary index; DROP INDEX defaultdb.public.t@idx CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_1_of_7
@@ -173,6 +173,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+            │         CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -202,7 +206,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_2_of_7
@@ -195,7 +195,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │       │     IndexID: 3
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -266,6 +266,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+            │         CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_3_of_7
@@ -195,7 +195,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │       │     IndexID: 3
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -266,6 +266,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+            │         CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_4_of_7
@@ -172,7 +172,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │       │     IndexID: 3
     │       │     StatementForDropJob:
     │       │       Rollback: true
-    │       │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+    │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -266,6 +266,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+            │         CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_5_of_7
@@ -259,7 +259,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -276,6 +276,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+            │         CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_6_of_7
@@ -259,7 +259,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -276,6 +276,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+            │         CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_7_of_7
@@ -259,7 +259,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
@@ -276,6 +276,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
+            │     StatementForDropJob:
+            │       Rollback: true
+            │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+            │         CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.statement_1_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.statement_1_of_2
@@ -655,7 +655,8 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 2
     │       │     StatementForDropJob:
-    │       │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+    │       │       Statement: removed secondary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+    │       │         CASCADE
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -664,6 +665,9 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 4
+    │       │     StatementForDropJob:
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+    │       │         CASCADE
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -746,7 +750,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
             ├── • CreateGCJobForIndex
             │     IndexID: 1
             │     StatementForDropJob:
-            │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.statement_2_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.statement_2_of_2
@@ -544,7 +544,8 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN k CASCADE;
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 2
     │       │     StatementForDropJob:
-    │       │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+    │       │       Statement: removed secondary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+    │       │         CASCADE
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -553,6 +554,9 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN k CASCADE;
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 4
+    │       │     StatementForDropJob:
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t DROP COLUMN j
+    │       │         CASCADE
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
@@ -696,7 +700,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN k CASCADE;
             ├── • CreateGCJobForIndex
             │     IndexID: 1
             │     StatementForDropJob:
-            │       Statement: ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
+            │       Statement: removed primary index; ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE
             │     TableID: 104
             │
             ├── • MakeIndexAbsent


### PR DESCRIPTION
Fixes #82169.

Release note: None