### PR TITLE
cli: skip TestTenantZip

### DIFF
--- a/pkg/cli/zip_tenant_test.go
+++ b/pkg/cli/zip_tenant_test.go
@@ -30,6 +30,7 @@ var _ = kvtenantccl.Connector{}
 // TestTenantZip tests the operation of zip for a tenant server.
 func TestTenantZip(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 89192, "flaky test")
 
 	skip.UnderRace(t, "test too slow under race")
 	tenantDir, tenantDirCleanupFn := testutils.TempDir(t)


### PR DESCRIPTION
Refs: #89192

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None