### PR TITLE
release-22.1: kv: update kvprober with quarantine pool

### DIFF
--- a/pkg/kv/kvprober/BUILD.bazel
+++ b/pkg/kv/kvprober/BUILD.bazel
@@ -38,6 +38,7 @@ go_test(
         "kvprober_test.go",
         "main_test.go",
         "planner_test.go",
+        "quarantine_pool_test.go",
     ],
     embed = [":kvprober"],
     deps = [

--- a/pkg/kv/kvprober/BUILD.bazel
+++ b/pkg/kv/kvprober/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/util/metric",
         "//pkg/util/randutil",
         "//pkg/util/stop",
+        "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/kv/kvprober/BUILD.bazel
+++ b/pkg/kv/kvprober/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "kvprober.go",
         "planner.go",
+        "quarantine_pool.go",
         "settings.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvprober",

--- a/pkg/kv/kvprober/helpers_test.go
+++ b/pkg/kv/kvprober/helpers_test.go
@@ -29,11 +29,11 @@ var (
 )
 
 func (p *Prober) ReadProbe(ctx context.Context, db *kv.DB) {
-	p.readProbe(ctx, db, p.readPlanner)
+	p.readProbe(ctx, p.readPlanner)
 }
 
 func (p *Prober) WriteProbe(ctx context.Context, db *kv.DB) {
-	p.writeProbe(ctx, db, p.writePlanner)
+	p.writeProbe(ctx, p.writePlanner)
 }
 
 type recordingPlanner struct {
@@ -50,7 +50,7 @@ func (rp *recordingPlanner) next(ctx context.Context) (Step, error) {
 func (p *Prober) WriteProbeReturnLastStep(ctx context.Context, db *kv.DB) *Step {
 	rp := &recordingPlanner{}
 	rp.pl = p.writePlanner
-	p.writeProbe(ctx, db, rp)
+	p.writeProbe(ctx, rp)
 	return &rp.last
 }
 

--- a/pkg/kv/kvprober/kvprober.go
+++ b/pkg/kv/kvprober/kvprober.go
@@ -287,6 +287,9 @@ func (p *Prober) Start(ctx context.Context, stopper *stop.Stopper) error {
 	if err := startLoop(ctx, "write probe loop", p.writeProbe, p.writePlanner, writeInterval); err != nil {
 		return err
 	}
+	// The purpose of the quarantine pool is to detect outages affecting a small number
+	// of ranges but at a high confidence. The quarantine pool does this by repeatedly
+	// probing ranges that are in the pool.
 	return startLoop(ctx, "quarantine write probe loop", p.quarantineProbe, p.quarantineWritePool, quarantineWriteInterval)
 }
 
@@ -305,6 +308,9 @@ func (p *Prober) readProbeImpl(ctx context.Context, ops proberOpsI, txns proberT
 	p.metrics.ProbePlanAttempts.Inc(1)
 
 	step, err := pl.next(ctx)
+	if err == nil && step.RangeID == 0 {
+		return
+	}
 	if err != nil {
 		log.Health.Errorf(ctx, "can't make a plan: %v", err)
 		p.metrics.ProbePlanFailures.Inc(1)
@@ -363,6 +369,11 @@ func (p *Prober) writeProbeImpl(ctx context.Context, ops proberOpsI, txns prober
 	p.metrics.ProbePlanAttempts.Inc(1)
 
 	step, err := pl.next(ctx)
+	// In the case where the quarantine pool is empty don't record a planning failure since
+	// it isn't an actual plan failure.
+	if err == nil && step.RangeID == 0 {
+		return
+	}
 	if err != nil {
 		log.Health.Errorf(ctx, "can't make a plan: %v", err)
 		p.metrics.ProbePlanFailures.Inc(1)

--- a/pkg/kv/kvprober/kvprober.go
+++ b/pkg/kv/kvprober/kvprober.go
@@ -53,6 +53,9 @@ type Prober struct {
 	// goal of the prober IS to populate these metrics.
 	metrics Metrics
 	tracer  *tracing.Tracer
+	// quarantine pools keep track of ranges that timed/errored when probing and
+	// continually probe those ranges until killed/probe is succesful.
+	quarantineWritePool *quarantinePool
 }
 
 // Opts provides knobs to control kvprober.Prober.
@@ -120,6 +123,13 @@ var (
 		Measurement: "Runs",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaWriteProbeQuarantineOldestDuration = metric.Metadata{
+		Name: "kv.prober.write.quarantine.oldest_duration",
+		Help: "The duration that the oldest range in the " +
+			"write quarantine pool has remained",
+		Measurement: "Seconds",
+		Unit:        metric.Unit_SECONDS,
+	}
 	// TODO(josh): Add a histogram that captures where in the "rangespace" errors
 	// are occurring. This will allow operators to see at a glance what percentage
 	// of ranges are affected.
@@ -127,14 +137,15 @@ var (
 
 // Metrics groups together the metrics that kvprober exports.
 type Metrics struct {
-	ReadProbeAttempts  *metric.Counter
-	ReadProbeFailures  *metric.Counter
-	ReadProbeLatency   *metric.Histogram
-	WriteProbeAttempts *metric.Counter
-	WriteProbeFailures *metric.Counter
-	WriteProbeLatency  *metric.Histogram
-	ProbePlanAttempts  *metric.Counter
-	ProbePlanFailures  *metric.Counter
+	ReadProbeAttempts                  *metric.Counter
+	ReadProbeFailures                  *metric.Counter
+	ReadProbeLatency                   *metric.Histogram
+	WriteProbeAttempts                 *metric.Counter
+	WriteProbeFailures                 *metric.Counter
+	WriteProbeLatency                  *metric.Histogram
+	ProbePlanAttempts                  *metric.Counter
+	ProbePlanFailures                  *metric.Counter
+	WriteProbeQuarantineOldestDuration *metric.Gauge
 }
 
 // proberOpsI is an interface that the prober will use to run ops against some
@@ -217,8 +228,11 @@ func NewProber(opts Opts) *Prober {
 			WriteProbeLatency:  metric.NewLatency(metaWriteProbeLatency, opts.HistogramWindowInterval),
 			ProbePlanAttempts:  metric.NewCounter(metaProbePlanAttempts),
 			ProbePlanFailures:  metric.NewCounter(metaProbePlanFailures),
+			WriteProbeQuarantineOldestDuration: metric.NewGauge(metaWriteProbeQuarantineOldestDuration),
+
 		},
-		tracer: opts.Tracer,
+		tracer:              opts.Tracer,
+		quarantineWritePool: newQuarantinePool(opts.Settings),
 	}
 }
 
@@ -266,7 +280,10 @@ func (p *Prober) Start(ctx context.Context, stopper *stop.Stopper) error {
 	if err := startLoop(ctx, "read probe loop", p.readProbe, p.readPlanner, readInterval); err != nil {
 		return err
 	}
-	return startLoop(ctx, "write probe loop", p.writeProbe, p.writePlanner, writeInterval)
+	if err := startLoop(ctx, "write probe loop", p.writeProbe, p.writePlanner, writeInterval); err != nil {
+		return err
+	}
+	return startLoop(ctx, "quarantine write probe loop", p.quarantineProbe, p.quarantineWritePool, quarantineWriteInterval)
 }
 
 // Doesn't return an error. Instead increments error type specific metrics.
@@ -363,14 +380,35 @@ func (p *Prober) writeProbeImpl(ctx context.Context, ops proberOpsI, txns prober
 	if err != nil {
 		log.Health.Errorf(ctx, "kv.Txn(Put(%s); Del(-)), r=%v failed with: %v", step.Key, step.RangeID, err)
 		p.metrics.WriteProbeFailures.Inc(1)
+		// Add to quarantine pool if not in the entry map.
+		if _, ok := p.quarantineWritePool.entryTimeMap[step.RangeID]; !ok {
+			p.quarantineWritePool.add(ctx, step)
+		} else {
+			duration := int64(timeutil.Since(p.quarantineWritePool.entryTimeMap[step.RangeID]).Seconds())
+			longestDuration := p.metrics.WriteProbeQuarantineOldestDuration.Value()
+			if duration > longestDuration {
+				p.metrics.WriteProbeQuarantineOldestDuration.Update(duration)
+			}
+		}
 		return
 	}
+	// This will no-op if not in the quarantine pool.
+	p.quarantineWritePool.remove(ctx, step)
 
 	d := timeutil.Since(start)
 	log.Health.Infof(ctx, "kv.Txn(Put(%s); Del(-)), r=%v returned success in %v", step.Key, step.RangeID, d)
 
 	// Latency of failures is not recorded. They are counted as failures tho.
 	p.metrics.WriteProbeLatency.RecordValue(d.Nanoseconds())
+}
+
+// Wrapper function for probing the quarantine pool.
+func (p *Prober) quarantineProbe(ctx context.Context, db *kv.DB, pl planner) {
+	if !quarantineWriteEnabled.Get(&p.settings.SV) {
+		return
+	}
+
+	p.writeProbe(ctx, db, pl)
 }
 
 // Returns a random duration pulled from the uniform distribution given below:

--- a/pkg/kv/kvprober/kvprober.go
+++ b/pkg/kv/kvprober/kvprober.go
@@ -53,8 +53,8 @@ type Prober struct {
 	// goal of the prober IS to populate these metrics.
 	metrics Metrics
 	tracer  *tracing.Tracer
-	// quarantine pools keep track of ranges that timed/errored when probing and
-	// continually probe those ranges until killed/probe is succesful.
+	// quarantineWritePool pool keeps track of ranges that timed out/errored when
+	// probing and repeatedly probes those ranges until a probe succeeds.
 	quarantineWritePool *quarantinePool
 }
 
@@ -107,6 +107,14 @@ var (
 		Measurement: "Latency",
 		Unit:        metric.Unit_NANOSECONDS,
 	}
+	metaWriteProbeQuarantineOldestDuration = metric.Metadata{
+		Name: "kv.prober.write.quarantine.oldest_duration",
+		Help: "The duration that the oldest range in the " +
+			"write quarantine pool has remained",
+		Measurement: "Seconds",
+		Unit:        metric.Unit_SECONDS,
+	}
+
 	metaProbePlanAttempts = metric.Metadata{
 		Name: "kv.prober.planning_attempts",
 		Help: "Number of attempts at planning out probes made; " +
@@ -123,13 +131,6 @@ var (
 		Measurement: "Runs",
 		Unit:        metric.Unit_COUNT,
 	}
-	metaWriteProbeQuarantineOldestDuration = metric.Metadata{
-		Name: "kv.prober.write.quarantine.oldest_duration",
-		Help: "The duration that the oldest range in the " +
-			"write quarantine pool has remained",
-		Measurement: "Seconds",
-		Unit:        metric.Unit_SECONDS,
-	}
 	// TODO(josh): Add a histogram that captures where in the "rangespace" errors
 	// are occurring. This will allow operators to see at a glance what percentage
 	// of ranges are affected.
@@ -143,9 +144,9 @@ type Metrics struct {
 	WriteProbeAttempts                 *metric.Counter
 	WriteProbeFailures                 *metric.Counter
 	WriteProbeLatency                  *metric.Histogram
+	WriteProbeQuarantineOldestDuration *metric.Gauge
 	ProbePlanAttempts                  *metric.Counter
 	ProbePlanFailures                  *metric.Counter
-	WriteProbeQuarantineOldestDuration *metric.Gauge
 }
 
 // proberOpsI is an interface that the prober will use to run ops against some
@@ -212,6 +213,7 @@ func (p *proberTxnImpl) TxnRootKV(
 
 // NewProber creates a Prober from Opts.
 func NewProber(opts Opts) *Prober {
+	qPool := newQuarantinePool(opts.Settings)
 	return &Prober{
 		db:       opts.DB,
 		settings: opts.Settings,
@@ -226,13 +228,15 @@ func NewProber(opts Opts) *Prober {
 			WriteProbeAttempts: metric.NewCounter(metaWriteProbeAttempts),
 			WriteProbeFailures: metric.NewCounter(metaWriteProbeFailures),
 			WriteProbeLatency:  metric.NewLatency(metaWriteProbeLatency, opts.HistogramWindowInterval),
-			ProbePlanAttempts:  metric.NewCounter(metaProbePlanAttempts),
-			ProbePlanFailures:  metric.NewCounter(metaProbePlanFailures),
-			WriteProbeQuarantineOldestDuration: metric.NewGauge(metaWriteProbeQuarantineOldestDuration),
-
+			WriteProbeQuarantineOldestDuration: metric.NewFunctionalGauge(
+				metaWriteProbeQuarantineOldestDuration,
+				func() int64 { return qPool.oldestDuration().Nanoseconds() },
+			),
+			ProbePlanAttempts: metric.NewCounter(metaProbePlanAttempts),
+			ProbePlanFailures: metric.NewCounter(metaProbePlanFailures),
 		},
 		tracer:              opts.Tracer,
-		quarantineWritePool: newQuarantinePool(opts.Settings),
+		quarantineWritePool: qPool,
 	}
 }
 
@@ -286,7 +290,9 @@ func (p *Prober) Start(ctx context.Context, stopper *stop.Stopper) error {
 	return startLoop(ctx, "quarantine write probe loop", p.quarantineProbe, p.quarantineWritePool, quarantineWriteInterval)
 }
 
-// Doesn't return an error. Instead increments error type specific metrics.
+// Doesn't return an error. Instead, increments error type specific metrics.
+//
+// TODO(tbg): db parameter is unused, remove it.
 func (p *Prober) readProbe(ctx context.Context, db *kv.DB, pl planner) {
 	p.readProbeImpl(ctx, &ProberOps{}, &proberTxnImpl{db: p.db}, pl)
 }
@@ -378,22 +384,15 @@ func (p *Prober) writeProbeImpl(ctx context.Context, ops proberOpsI, txns prober
 		return txns.TxnRootKV(ctx, f)
 	})
 	if err != nil {
-		log.Health.Errorf(ctx, "kv.Txn(Put(%s); Del(-)), r=%v failed with: %v", step.Key, step.RangeID, err)
+		added := p.quarantineWritePool.maybeAdd(ctx, step)
+		log.Health.Errorf(
+			ctx, "kv.Txn(Put(%s); Del(-)), r=%v failed with: %v [quarantined=%t]", step.Key, step.RangeID, err, added,
+		)
 		p.metrics.WriteProbeFailures.Inc(1)
-		// Add to quarantine pool if not in the entry map.
-		if _, ok := p.quarantineWritePool.entryTimeMap[step.RangeID]; !ok {
-			p.quarantineWritePool.add(ctx, step)
-		} else {
-			duration := int64(timeutil.Since(p.quarantineWritePool.entryTimeMap[step.RangeID]).Seconds())
-			longestDuration := p.metrics.WriteProbeQuarantineOldestDuration.Value()
-			if duration > longestDuration {
-				p.metrics.WriteProbeQuarantineOldestDuration.Update(duration)
-			}
-		}
 		return
 	}
 	// This will no-op if not in the quarantine pool.
-	p.quarantineWritePool.remove(ctx, step)
+	p.quarantineWritePool.maybeRemove(ctx, step)
 
 	d := timeutil.Since(start)
 	log.Health.Infof(ctx, "kv.Txn(Put(%s); Del(-)), r=%v returned success in %v", step.Key, step.RangeID, d)

--- a/pkg/kv/kvprober/kvprober.go
+++ b/pkg/kv/kvprober/kvprober.go
@@ -249,7 +249,7 @@ func (p *Prober) Metrics() Metrics {
 // returns an error only if stopper.RunAsyncTask returns an error.
 func (p *Prober) Start(ctx context.Context, stopper *stop.Stopper) error {
 	ctx = logtags.AddTag(ctx, "kvprober", nil /* value */)
-	startLoop := func(ctx context.Context, opName string, probe func(context.Context, *kv.DB, planner), pl planner, interval *settings.DurationSetting) error {
+	startLoop := func(ctx context.Context, opName string, probe func(context.Context, planner), pl planner, interval *settings.DurationSetting) error {
 		return stopper.RunAsyncTaskEx(ctx, stop.TaskOpts{TaskName: opName, SpanOpt: stop.SterileRootSpan}, func(ctx context.Context) {
 			defer logcrash.RecoverAndReportNonfatalPanic(ctx, &p.settings.SV)
 
@@ -275,7 +275,7 @@ func (p *Prober) Start(ctx context.Context, stopper *stop.Stopper) error {
 				}
 
 				probeCtx, sp := tracing.EnsureChildSpan(ctx, p.tracer, opName+" - probe")
-				probe(probeCtx, p.db, pl)
+				probe(probeCtx, pl)
 				sp.Finish()
 			}
 		})
@@ -293,7 +293,7 @@ func (p *Prober) Start(ctx context.Context, stopper *stop.Stopper) error {
 // Doesn't return an error. Instead, increments error type specific metrics.
 //
 // TODO(tbg): db parameter is unused, remove it.
-func (p *Prober) readProbe(ctx context.Context, db *kv.DB, pl planner) {
+func (p *Prober) readProbe(ctx context.Context, pl planner) {
 	p.readProbeImpl(ctx, &ProberOps{}, &proberTxnImpl{db: p.db}, pl)
 }
 
@@ -351,7 +351,7 @@ func (p *Prober) readProbeImpl(ctx context.Context, ops proberOpsI, txns proberT
 }
 
 // Doesn't return an error. Instead increments error type specific metrics.
-func (p *Prober) writeProbe(ctx context.Context, db *kv.DB, pl planner) {
+func (p *Prober) writeProbe(ctx context.Context, pl planner) {
 	p.writeProbeImpl(ctx, &ProberOps{}, &proberTxnImpl{db: p.db}, pl)
 }
 
@@ -402,12 +402,12 @@ func (p *Prober) writeProbeImpl(ctx context.Context, ops proberOpsI, txns prober
 }
 
 // Wrapper function for probing the quarantine pool.
-func (p *Prober) quarantineProbe(ctx context.Context, db *kv.DB, pl planner) {
+func (p *Prober) quarantineProbe(ctx context.Context, pl planner) {
 	if !quarantineWriteEnabled.Get(&p.settings.SV) {
 		return
 	}
 
-	p.writeProbe(ctx, db, pl)
+	p.writeProbe(ctx, pl)
 }
 
 // Returns a random duration pulled from the uniform distribution given below:

--- a/pkg/kv/kvprober/quarantine_pool.go
+++ b/pkg/kv/kvprober/quarantine_pool.go
@@ -24,59 +24,100 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
 
 type quarantinePool struct {
-	steps        []Step
-	size         int64
-	entryTimeMap map[roachpb.RangeID]time.Time
+	size func() int64 // can change over time
+	mu   struct {
+		syncutil.Mutex
+		steps        []Step
+		size         int64
+		entryTimeMap map[roachpb.RangeID]time.Time
+	}
 }
 
 func newQuarantinePool(settings *cluster.Settings) *quarantinePool {
-	poolSize := quarantinePoolSize.Get(&settings.SV)
 	return &quarantinePool{
-		size:         poolSize,
-		entryTimeMap: make(map[roachpb.RangeID]time.Time),
-		steps:        make([]Step, poolSize),
+		size: func() int64 { return quarantinePoolSize.Get(&settings.SV) },
 	}
 }
 
-func (qp *quarantinePool) add(ctx context.Context, step Step) {
-	if int64(len(qp.steps)) >= qp.size-1 {
-		log.Health.Errorf(ctx, "cannot add range %s to quarantine pool, at capacity", step.RangeID.String())
-	} else {
-		qp.steps = append(qp.steps, step)
-		qp.entryTimeMap[step.RangeID] = timeutil.Now()
+func (qp *quarantinePool) maybeAdd(ctx context.Context, step Step) (added bool) {
+	qp.mu.Lock()
+	defer qp.mu.Unlock()
+	if _, ok := qp.mu.entryTimeMap[step.RangeID]; ok {
+		// Already in the pool.
+		return false
 	}
+
+	size := qp.size()
+
+	if int64(len(qp.mu.steps)) >= size {
+		// The pool is full. Note that we don't log, as we have a full pool of
+		// failing ranges, and it should thus be clear that the cluster is likely
+		// experiencing a widespread outage.
+		//
+		// Truncate slice in case size() got lowered.
+		qp.mu.steps = qp.mu.steps[:size]
+		return false
+	}
+	qp.mu.steps = append(qp.mu.steps, step)
+	if qp.mu.entryTimeMap == nil {
+		qp.mu.entryTimeMap = map[roachpb.RangeID]time.Time{}
+	}
+	qp.mu.entryTimeMap[step.RangeID] = timeutil.Now()
+	return true
 }
 
-func (qp *quarantinePool) remove(ctx context.Context, step Step) {
-	if len(qp.steps) < 1 {
-		log.Health.Errorf(ctx, "cannot remove range %s from quarantine pool, pool is empty", step.RangeID.String())
+func (qp *quarantinePool) oldestDuration() time.Duration {
+	qp.mu.Lock()
+	defer qp.mu.Unlock()
+
+	now := timeutil.Now()
+	var max time.Duration
+	for _, then := range qp.mu.entryTimeMap {
+		dur := now.Sub(then)
+		if dur > max {
+			max = dur
+		}
+	}
+	return max
+}
+
+func (qp *quarantinePool) maybeRemove(ctx context.Context, step Step) {
+	qp.mu.Lock()
+	defer qp.mu.Unlock()
+	if _, found := qp.mu.entryTimeMap[step.RangeID]; !found {
 		return
 	}
+	delete(qp.mu.entryTimeMap, step.RangeID)
 	idx := -1
-	for k, v := range qp.steps {
+	for k, v := range qp.mu.steps {
 		if v.RangeID == step.RangeID {
 			idx = k
 			break
 		}
 	}
 	if idx == -1 {
-		log.Health.Errorf(ctx, "cannot remove range %s from quarantine pool, not found", step.RangeID.String())
+		// This is a programming error. We had an entry in entryTimeMap, but can't
+		// find the corresponding step.
+		log.Health.Errorf(ctx, "inconsistent from quarantine pool: %s not found", step.RangeID)
 		return
 	}
-	// Expensive op if pool size is very large.
-	qp.steps = append(qp.steps[:idx], qp.steps[idx+1:]...)
-	delete(qp.entryTimeMap, step.RangeID)
+	qp.mu.steps = append(qp.mu.steps[:idx], qp.mu.steps[idx+1:]...)
 }
 
 func (qp *quarantinePool) next(ctx context.Context) (Step, error) {
-	if len(qp.steps) > 0 {
-		step := qp.steps[0]
-		return step, nil
+	qp.mu.Lock()
+	defer qp.mu.Unlock()
+
+	if len(qp.mu.steps) == 0 {
+		return Step{}, errors.New("quarantine pool is empty")
 	}
-	return Step{}, errors.New("there are no keys in quarantine")
+
+	step := qp.mu.steps[0]
+	return step, nil
 }

--- a/pkg/kv/kvprober/quarantine_pool.go
+++ b/pkg/kv/kvprober/quarantine_pool.go
@@ -1,0 +1,82 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// Package kvprober sends queries to KV in a loop, with configurable sleep
+// times, in order to generate data about the healthiness or unhealthiness of
+// kvclient & below.
+//
+// Prober increments metrics that SRE & other operators can use as alerting
+// signals. It also writes to logs to help narrow down the problem (e.g. which
+// range(s) are acting up).
+package kvprober
+
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
+)
+
+type quarantinePool struct {
+	steps        []Step
+	size         int64
+	entryTimeMap map[roachpb.RangeID]time.Time
+}
+
+func newQuarantinePool(settings *cluster.Settings) *quarantinePool {
+	poolSize := quarantinePoolSize.Get(&settings.SV)
+	return &quarantinePool{
+		size:         poolSize,
+		entryTimeMap: make(map[roachpb.RangeID]time.Time),
+		steps:        make([]Step, poolSize),
+	}
+}
+
+func (qp *quarantinePool) add(ctx context.Context, step Step) {
+	if int64(len(qp.steps)) >= qp.size-1 {
+		log.Health.Errorf(ctx, "cannot add range %s to quarantine pool, at capacity", step.RangeID.String())
+	} else {
+		qp.steps = append(qp.steps, step)
+		qp.entryTimeMap[step.RangeID] = timeutil.Now()
+	}
+}
+
+func (qp *quarantinePool) remove(ctx context.Context, step Step) {
+	if len(qp.steps) < 1 {
+		log.Health.Errorf(ctx, "cannot remove range %s from quarantine pool, pool is empty", step.RangeID.String())
+		return
+	}
+	idx := -1
+	for k, v := range qp.steps {
+		if v.RangeID == step.RangeID {
+			idx = k
+			break
+		}
+	}
+	if idx == -1 {
+		log.Health.Errorf(ctx, "cannot remove range %s from quarantine pool, not found", step.RangeID.String())
+		return
+	}
+	// Expensive op if pool size is very large.
+	qp.steps = append(qp.steps[:idx], qp.steps[idx+1:]...)
+	delete(qp.entryTimeMap, step.RangeID)
+}
+
+func (qp *quarantinePool) next(ctx context.Context) (Step, error) {
+	if len(qp.steps) > 0 {
+		step := qp.steps[0]
+		return step, nil
+	}
+	return Step{}, errors.New("there are no keys in quarantine")
+}

--- a/pkg/kv/kvprober/quarantine_pool_test.go
+++ b/pkg/kv/kvprober/quarantine_pool_test.go
@@ -1,0 +1,82 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kvprober
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQuarantinePool(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("disabled by default", func(t *testing.T) {
+		m := &mock{
+			t:      t,
+			noPlan: true,
+		}
+		p := initTestProber(ctx, m)
+		p.quarantineProbe(ctx, m)
+
+		require.Zero(t, p.Metrics().WriteProbeQuarantineOldestDuration.Value())
+		require.Zero(t, p.Metrics().WriteProbeAttempts.Count())
+	})
+
+	t.Run("add then remove from quarantine pool", func(t *testing.T) {
+		// adds to the quarantine pool
+		m := &mock{t: t, write: true, qWrite: true, writeErr: fmt.Errorf("inject write failure")}
+		p := initTestProber(ctx, m)
+		p.writeProbeImpl(ctx, m, m, m)
+
+		require.Equal(t, 1, len(p.quarantineWritePool.mu.steps))
+		require.Equal(t, 1, len(p.quarantineWritePool.mu.entryTimeMap))
+		require.Equal(t, int64(1), p.Metrics().WriteProbeFailures.Count())
+
+		// removes from the quarantine pool
+		m = &mock{t: t, write: true, qWrite: true}
+		p.writeProbeImpl(ctx, m, m, m)
+
+		require.Zero(t, len(p.quarantineWritePool.mu.steps))
+		require.Empty(t, p.quarantineWritePool.mu.entryTimeMap)
+		require.Equal(t, int64(1), p.Metrics().WriteProbeFailures.Count())
+	})
+
+	t.Run("test maybeAdd false cases", func(t *testing.T) {
+		m := &mock{t: t, write: true, qWrite: true, writeErr: fmt.Errorf("inject write failure")}
+		p := initTestProber(ctx, m)
+		p.writeProbeImpl(ctx, m, m, m)
+
+		step, err := p.quarantineWritePool.next(ctx)
+		require.NoError(t, err)
+
+		// already in pool case
+		added := p.quarantineWritePool.maybeAdd(ctx, step)
+		require.False(t, added)
+
+		// pool full case
+		quarantinePoolSize.Override(ctx, &p.settings.SV, 1)
+		mockStep := Step{RangeID: 1, Key: keys.LocalMax}
+		added = p.quarantineWritePool.maybeAdd(ctx, mockStep)
+		require.False(t, added)
+	})
+
+	t.Run("ensure empty q pool does not cause planning failure", func(t *testing.T) {
+		m := &mock{t: t, write: true, qWrite: true, emptyQPool: true}
+		p := initTestProber(ctx, m)
+		p.writeProbeImpl(ctx, m, m, m)
+
+		require.Zero(t, p.Metrics().ProbePlanFailures.Count())
+	})
+}

--- a/pkg/kv/kvprober/settings.go
+++ b/pkg/kv/kvprober/settings.go
@@ -144,7 +144,10 @@ var quarantinePoolSize = settings.RegisterIntSetting(
 var quarantineWriteEnabled = settings.RegisterBoolSetting(
 	settings.TenantWritable,
 	"kv.prober.quarantine.write.enabled",
-	"whether the KV write prober is enabled for the quaranatine pool",
+	"whether the KV write prober is enabled for the quarantine pool; The "+
+		"quarantine pool holds a separate group of ranges that have previously failed "+
+		"a probe which are continually probed. This helps determine outages for ranges "+
+		" with a high level of confidence",
 	false)
 
 var quarantineWriteInterval = settings.RegisterDurationSetting(

--- a/pkg/kv/kvprober/settings.go
+++ b/pkg/kv/kvprober/settings.go
@@ -126,3 +126,37 @@ var numStepsToPlanAtOnce = settings.RegisterIntSetting(
 		}
 		return nil
 	})
+
+var quarantinePoolSize = settings.RegisterIntSetting(
+	settings.TenantWritable,
+	"kv.prober.quarantine_pool_size",
+	"the maximum size of the kv prober quarantine pool, where the quarantine "+
+		"pool holds Steps for ranges that have been probed and timed out; If "+
+		"the quarantine pool is full, probes that fail will not be added to "+
+		" the pool",
+	100, func(i int64) error {
+		if i <= 0 {
+			return errors.New("param must be >0")
+		}
+		return nil
+	})
+
+var quarantineWriteEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
+	"kv.prober.quarantine.write.enabled",
+	"whether the KV write prober is enabled for the quaranatine pool",
+	false)
+
+var quarantineWriteInterval = settings.RegisterDurationSetting(
+	settings.TenantWritable,
+	"kv.prober.quarantine.write.interval",
+	"how often each node sends a write probe for the quarantine pool to the KV layer "+
+		"on average (jitter is added); "+
+		"note that a very slow read can block kvprober from sending additional probes; "+
+		"kv.prober.write.timeout controls the max time kvprober can be blocked",
+	10*time.Second, func(duration time.Duration) error {
+		if duration <= 0 {
+			return errors.New("param must be >0")
+		}
+		return nil
+	})

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -762,6 +762,12 @@ var charts = []sectionDescription{
 					"kv.prober.write.latency",
 				},
 			},
+			{
+				Title: "Duration",
+				Metrics: []string{
+					"kv.prober.write.quarantine.oldest_duration",
+				},
+			},
 		},
 	},
 	{


### PR DESCRIPTION
Backport 4/4 commits from #87436.

/cc @cockroachdb/release

---

These changes update the kvprober to add ranges that
fail probing into a quarantine pool where they are
continuously probed. A metric which indicates the
duration of the longest tenured range has also been
added.

Resolves #74407

Release justification: low risk, high benefit changes to
existing functionality.

Release note: None
