### PR TITLE
roachtest: disable decimal columns in costfuzz and unoptimized tests

### DIFF
--- a/pkg/cmd/roachtest/tests/query_comparison_util.go
+++ b/pkg/cmd/roachtest/tests/query_comparison_util.go
@@ -177,7 +177,7 @@ func runOneRoundQueryComparison(
 		sqlsmith.DisableMutations(), sqlsmith.DisableNondeterministicFns(), sqlsmith.DisableLimits(),
 		sqlsmith.UnlikelyConstantPredicate(), sqlsmith.FavorCommonData(),
 		sqlsmith.UnlikelyRandomNulls(), sqlsmith.DisableCrossJoins(),
-		sqlsmith.DisableIndexHints(), sqlsmith.DisableWith(),
+		sqlsmith.DisableIndexHints(), sqlsmith.DisableWith(), sqlsmith.DisableDecimals(),
 		sqlsmith.LowProbabilityWhereClauseWithJoinTables(),
 		sqlsmith.SetComplexity(.3),
 		sqlsmith.SetScalarComplexity(.1),

--- a/pkg/cmd/smith/main.go
+++ b/pkg/cmd/smith/main.go
@@ -73,6 +73,7 @@ var (
 		"CompareMode":                             sqlsmith.CompareMode(),
 		"PostgresMode":                            sqlsmith.PostgresMode(),
 		"MutatingMode":                            sqlsmith.MutatingMode(),
+		"DisableDecimals":                         sqlsmith.DisableDecimals(),
 	}
 	smitherOpts []string
 )

--- a/pkg/internal/sqlsmith/scalar.go
+++ b/pkg/internal/sqlsmith/scalar.go
@@ -223,6 +223,9 @@ func getColRef(s *Smither, typ *types.T, refs colRefs) (tree.TypedExpr, *colRef,
 		return nil, nil, false
 	}
 	col := cols[s.rnd.Intn(len(cols))]
+	if s.disableDecimals && col.typ.Family() == types.DecimalFamily {
+		return nil, nil, false
+	}
 	return col.typedExpr(), col, true
 }
 

--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -98,6 +98,7 @@ type Smither struct {
 	lowProbWhereWithJoinTables bool
 	disableInsertSelect        bool
 	disableDivision            bool
+	disableDecimals            bool
 
 	bulkSrv     *httptest.Server
 	bulkFiles   map[string][]byte
@@ -442,6 +443,11 @@ var DisableInsertSelect = simpleOption("disable insert select", func(s *Smither)
 // TODO(mgartner): Remove this once #86790 is addressed.
 var DisableDivision = simpleOption("disable division", func(s *Smither) {
 	s.disableDivision = true
+})
+
+// DisableDecimals disables use of decimal type columns in the query.
+var DisableDecimals = simpleOption("disable decimals", func(s *Smither) {
+	s.disableDecimals = true
 })
 
 // CompareMode causes the Smither to generate statements that have

--- a/pkg/internal/sqlsmith/type.go
+++ b/pkg/internal/sqlsmith/type.go
@@ -54,7 +54,13 @@ func (s *Smither) randScalarType() *types.T {
 	if s.types != nil {
 		scalarTypes = s.types.scalarTypes
 	}
-	return randgen.RandTypeFromSlice(s.rnd, scalarTypes)
+	typ := randgen.RandTypeFromSlice(s.rnd, scalarTypes)
+	if s.disableDecimals {
+		for typ.Family() == types.DecimalFamily {
+			typ = randgen.RandTypeFromSlice(s.rnd, scalarTypes)
+		}
+	}
+	return typ
 }
 
 // isScalarType returns true if t is a member of types.Scalar, or a user defined
@@ -81,7 +87,13 @@ func (s *Smither) randType() *types.T {
 	if s.types != nil {
 		seedTypes = s.types.seedTypes
 	}
-	return randgen.RandTypeFromSlice(s.rnd, seedTypes)
+	typ := randgen.RandTypeFromSlice(s.rnd, seedTypes)
+	if s.disableDecimals {
+		for typ.Family() == types.DecimalFamily {
+			typ = randgen.RandTypeFromSlice(s.rnd, seedTypes)
+		}
+	}
+	return typ
 }
 
 func (s *Smither) makeDesiredTypes() []*types.T {


### PR DESCRIPTION
The use of decimal columns was making costfuzz and unoptimized-query-oracle tests flaky. This commit disables generation of decimal columns as a temporary mitigation for these flakes.

Fixes #88547

Release note: None