### PR TITLE
kvserver: rm consistency check diff report in tests

### DIFF
--- a/pkg/kv/kvserver/client_test.go
+++ b/pkg/kv/kvserver/client_test.go
@@ -46,14 +46,11 @@ func getArgs(key roachpb.Key) *roachpb.GetRequest {
 	}
 }
 
-// putArgs returns a PutRequest and PutResponse pair addressed to
-// the default replica for the specified key / value.
+// putArgs returns a PutRequest for the specified key / value.
 func putArgs(key roachpb.Key, value []byte) *roachpb.PutRequest {
 	return &roachpb.PutRequest{
-		RequestHeader: roachpb.RequestHeader{
-			Key: key,
-		},
-		Value: roachpb.MakeValueFromBytes(value),
+		RequestHeader: roachpb.RequestHeader{Key: key},
+		Value:         roachpb.MakeValueFromBytes(value),
 	}
 }
 

--- a/pkg/kv/kvserver/replica_consistency_diff.go
+++ b/pkg/kv/kvserver/replica_consistency_diff.go
@@ -79,8 +79,8 @@ func (rsds ReplicaSnapshotDiffSlice) String() string {
 	return redact.StringWithoutMarkers(rsds)
 }
 
-// diffs the two kv dumps between the lease holder and the replica.
-func diffRange(l, r *roachpb.RaftSnapshotData) ReplicaSnapshotDiffSlice {
+// DiffRange diffs the two KV dumps between the leaseholder and the replica.
+func DiffRange(l, r *roachpb.RaftSnapshotData) ReplicaSnapshotDiffSlice {
 	if l == nil || r == nil {
 		return nil
 	}

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -7559,7 +7559,7 @@ func TestDiffRange(t *testing.T) {
 	// TODO(tschottdorf): this test should really pass the data through a
 	// RocksDB engine to verify that the original snapshots sort correctly.
 
-	require.Empty(t, diffRange(nil, nil))
+	require.Empty(t, DiffRange(nil, nil))
 
 	timestamp := hlc.Timestamp{WallTime: 1729, Logical: 1}
 	value := []byte("foo")
@@ -7598,7 +7598,7 @@ func TestDiffRange(t *testing.T) {
 	}
 
 	// No diff works.
-	require.Empty(t, diffRange(leaderSnapshot, leaderSnapshot))
+	require.Empty(t, DiffRange(leaderSnapshot, leaderSnapshot))
 
 	replicaSnapshot := &roachpb.RaftSnapshotData{
 		KV: []roachpb.RaftSnapshotData_KeyValue{
@@ -7650,7 +7650,7 @@ func TestDiffRange(t *testing.T) {
 		{LeaseHolder: false, Key: []byte("X"), EndKey: []byte("Z"), Timestamp: timestamp.Add(0, 1)},
 		{LeaseHolder: true, Key: []byte("X"), EndKey: []byte("Z"), Timestamp: timestamp},
 	}
-	diff := diffRange(leaderSnapshot, replicaSnapshot)
+	diff := DiffRange(leaderSnapshot, replicaSnapshot)
 	require.Equal(t, eDiff, diff)
 
 	// Assert the stringifed output. This is what the consistency checker

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1133,9 +1133,7 @@ type ConsistencyTestingKnobs struct {
 	// If non-nil, OnBadChecksumFatal is called by CheckConsistency() (instead of
 	// calling log.Fatal) on a checksum mismatch.
 	OnBadChecksumFatal func(roachpb.StoreIdent)
-	// If non-nil, BadChecksumReportDiff is called by CheckConsistency() on a
-	// checksum mismatch to report the diff between snapshots.
-	BadChecksumReportDiff      func(roachpb.StoreIdent, ReplicaSnapshotDiffSlice)
+
 	ConsistencyQueueResultHook func(response roachpb.CheckConsistencyResponse)
 }
 


### PR DESCRIPTION
This change removes the `BadChecksumReportDiff` testing knob.

Previously, a node that runs a consistency check would report any diffs through this callback to tests. However, now the plan is to move away from computing the diff, and instead leave storage engine checkpoints on each replica so that later they can be analysed/diffed by tooling.

When this plan is implemented, the initiating node will no longer be able to report diffs into the testing knob. This commit proactively refactors a test in such a way that it doesn't need the knob, and verifies the diff by reading from the storage directly. This approximates what we will do with tooling too.

Touches #21128

Release note: None