### PR TITLE
roachtest: skip cdc/bank on ARM64

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -25,6 +25,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -309,6 +310,9 @@ func cdcBasicTest(ctx context.Context, t test.Test, c cluster.Cluster, args cdcT
 }
 
 func runCDCBank(ctx context.Context, t test.Test, c cluster.Cluster) {
+	if runtime.GOARCH == "arm64" {
+		t.Skip("Skipping cdc/bank under ARM64.")
+	}
 	// Make the logs dir on every node to work around the `roachprod get logs`
 	// spam.
 	c.Run(ctx, c.All(), `mkdir -p logs`)


### PR DESCRIPTION
This code change skips `cdc/bank` on ARM64 because Confluent CLI is not available on `linux/arm64`.

Release note: None