### PR TITLE
gc: tombstone with extended encoding should be marked as garbage

### DIFF
--- a/pkg/kv/kvserver/gc/data_distribution_test.go
+++ b/pkg/kv/kvserver/gc/data_distribution_test.go
@@ -68,7 +68,7 @@ func (ds dataDistribution) setupTest(
 			if kv.Key.Timestamp.IsEmpty() {
 				require.NoError(t, eng.PutUnversioned(kv.Key.Key, kv.Value))
 			} else {
-				require.NoError(t, eng.PutRawMVCC(kv.Key, kv.Value))
+				require.NoError(t, eng.PutMVCC(kv.Key, storage.MVCCValue{Value: roachpb.Value{RawBytes: kv.Value}}))
 			}
 		} else {
 			// TODO(ajwerner): Decide if using MVCCPut is worth it.


### PR DESCRIPTION
The current code would never GC a tombstone written with the extended encoding, since it would not realize that it is a tombstone. This would cause a leak, though is expected to be rare since most tombstones will not have a local timestamp.

Resolves #89238.

Release note: None