### PR TITLE
release-22.2: sql: delete function name key from schema if no overload left after drop

### DIFF
--- a/pkg/sql/catalog/schemadesc/schema_desc.go
+++ b/pkg/sql/catalog/schemadesc/schema_desc.go
@@ -425,6 +425,10 @@ func (desc *Mutable) RemoveFunction(name string, id descpb.ID) {
 				updated = append(updated, ol)
 			}
 		}
+		if len(updated) == 0 {
+			delete(desc.Functions, name)
+			return
+		}
 		desc.Functions[name] = descpb.SchemaDescriptor_Function{
 			Name:      name,
 			Overloads: updated,

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -5388,7 +5388,7 @@ SELECT public.ST_AsText('POINT(10.5 20.25)'::geometry)
 ----
 POINT (10.5 20.25)
 
-statement error unknown function: public.log\(\), but log\(\) exists
+statement error pq: unknown function: public.log\(\): function undefined
 SELECT public.log(10)
 
 query TT

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -454,7 +454,7 @@ $$
 statement ok
 DROP FUNCTION f_test_drop(INT), f_test_drop(INT);
 
-statement error pq: function public.f_test_drop does not exist
+statement error pq: unknown function: public.f_test_drop\(\): function undefined
 SELECT @2 FROM [SHOW CREATE FUNCTION public.f_test_drop];
 
 query T
@@ -473,7 +473,7 @@ $$
 statement ok
 DROP FUNCTION f_test_drop(INT);
 
-statement error pq: function sc1.f_test_drop does not exist
+statement error pq: unknown function: sc1.f_test_drop\(\): function undefined
 SELECT @2 FROM [SHOW CREATE FUNCTION sc1.f_test_drop];
 
 # If there are identical function signatures in different schemas, multiple drop
@@ -514,10 +514,10 @@ DROP FUNCTION f_test_drop();
 DROP FUNCTION f_test_drop();
 COMMIT;
 
-statement error pq: function public.f_test_drop does not exist
+statement error pq: unknown function: public.f_test_drop\(\): function undefined
 SELECT @2 FROM [SHOW CREATE FUNCTION public.f_test_drop];
 
-statement error pq: function sc1.f_test_drop does not exist
+statement error pq: unknown function: sc1.f_test_drop\(\): function undefined
 SELECT @2 FROM [SHOW CREATE FUNCTION sc1.f_test_drop];
 
 statement ok
@@ -1044,7 +1044,7 @@ ALTER FUNCTION f_test_alter_name RENAME TO f_test_alter_name_same_in
 statement ok
 ALTER FUNCTION f_test_alter_name RENAME TO f_test_alter_name_new
 
-statement error pq: function f_test_alter_name does not exist
+statement error pq: unknown function: f_test_alter_name\(\): function undefined
 SELECT @2 FROM [SHOW CREATE FUNCTION f_test_alter_name];
 
 query T
@@ -1063,7 +1063,7 @@ $$
 statement ok
 ALTER FUNCTION f_test_alter_name_new RENAME to f_test_alter_name_diff_in
 
-statement error pq: function f_test_alter_name_new does not exist
+statement error pq: unknown function: f_test_alter_name_new\(\): function undefined
 SELECT @2 FROM [SHOW CREATE FUNCTION f_test_alter_name_new];
 
 query T
@@ -2463,3 +2463,19 @@ subtest subqueries
 # UDFs with subqueries are not currently supported.
 statement error pgcode 0A000 unimplemented: subquery usage inside a function definition
 CREATE FUNCTION rec(i INT) RETURNS INT LANGUAGE SQL AS 'SELECT * FROM t WHERE a = (SELECT max(i) FROM s)'
+
+subtest execute_dropped_function
+
+statement ok
+CREATE FUNCTION f_test_exec_dropped(a int) RETURNS INT LANGUAGE SQL AS $$ SELECT a $$;
+
+query I
+SELECT f_test_exec_dropped(123);
+----
+123
+
+statement ok
+DROP FUNCTION f_test_exec_dropped;
+
+statement error pq: unknown function: f_test_exec_dropped\(\): function undefined
+SELECT f_test_exec_dropped(321);

--- a/pkg/sql/schema_resolver.go
+++ b/pkg/sql/schema_resolver.go
@@ -425,7 +425,12 @@ func (sr *schemaResolver) ResolveFunction(
 		// name which is not lowercase. So here we try to lowercase the given
 		// function name and find a suggested function name if possible.
 		extraMsg := ""
-		lowerName := tree.MakeUnresolvedName(strings.ToLower(name.Parts[0]))
+		var lowerName tree.UnresolvedName
+		if fn.ExplicitSchema {
+			lowerName = tree.MakeUnresolvedName(strings.ToLower(name.Parts[0]), strings.ToLower(name.Parts[1]))
+		} else {
+			lowerName = tree.MakeUnresolvedName(strings.ToLower(name.Parts[0]))
+		}
 		if lowerName != *name {
 			alternative, err := sr.ResolveFunction(ctx, &lowerName, path)
 			if err == nil && alternative != nil {


### PR DESCRIPTION
Backport 1/1 commits from #89184.

/cc @cockroachdb/release

---

Backport fixes: #89046
Previously we just remove an overload from the slice when dropping a function. This is problematic if there's zero overloads left after the drop because it pretends that there is some function with the name but actually nothing. So we need to delete the key if there is not overload for the name.

Release note: None
Release justification: GA blocker bug fix.
