### PR TITLE
changefeedccl: fast path csv encoding when escaping isn't necessary

### DIFF
--- a/pkg/ccl/changefeedccl/encoder_csv.go
+++ b/pkg/ccl/changefeedccl/encoder_csv.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcevent"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding/csv"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/errors"
@@ -55,7 +56,7 @@ func (e *csvEncoder) EncodeValue(
 	if err := updatedRow.ForEachColumn().Datum(func(d tree.Datum, col cdcevent.ResultColumn) error {
 		e.formatter.Reset()
 		e.formatter.FormatNode(d)
-		return e.writer.WriteField(&e.formatter.Buffer)
+		return e.writer.WriteField(&e.formatter.Buffer, mayNeedCSVEscaping(d.ResolvedType().Family()))
 	}); err != nil {
 		return nil, err
 	}
@@ -65,6 +66,23 @@ func (e *csvEncoder) EncodeValue(
 	}
 	e.writer.Flush()
 	return e.buf.Bytes(), nil
+}
+
+// mayNeedCSVEscaping checks whether the given type is known to encode to a charset that can't contain
+// special characters. For this encoder, special characters are double quotes, commas, leading spaces,
+// and the special 2-byte string "\.".
+func mayNeedCSVEscaping(f types.Family) bool {
+	switch f {
+	case types.BoolFamily, types.IntFamily, types.DecimalFamily, types.FloatFamily, types.BitFamily:
+		// Literals with a limited charset.
+		return false
+	case types.BytesFamily:
+		// Bytes are hex-encoded.
+		return false
+	}
+	// There are definitely more types that could return false here, but probability of error goes up
+	// with each one added so let's add them as needed.
+	return true
 }
 
 // EncodeResolvedTimestamp implements the Encoder interface.

--- a/pkg/util/encoding/csv/writer.go
+++ b/pkg/util/encoding/csv/writer.go
@@ -61,7 +61,7 @@ func (w *Writer) Write(record []string) error {
 	}
 
 	for _, field := range record {
-		if err := w.WriteField(bytes.NewBufferString(field)); err != nil {
+		if err := w.WriteField(bytes.NewBufferString(field), true /*escape*/); err != nil {
 			return err
 		}
 	}
@@ -83,14 +83,19 @@ func (w *Writer) FinishRecord() (err error) {
 	return err
 }
 
-// WriteField writes an individual field.
-func (w *Writer) WriteField(field *bytes.Buffer) (e error) {
+// WriteField writes an individual field. Setting escape to false warrants that the field
+// doesn't contain w.Comma, w.Escape, a leading space, or exactly "\."
+func (w *Writer) WriteField(field *bytes.Buffer, escape bool) (e error) {
 	if w.midRow {
 		if _, err := w.w.WriteRune(w.Comma); err != nil {
 			return err
 		}
 	}
 	w.midRow = true
+	if !escape {
+		_, e = field.WriteTo(w.w)
+		return e
+	}
 	w.i = 0
 	w.currentRecordNeedsQuotes = false
 	w.scratch.Reset()


### PR DESCRIPTION
BYTES export slower than STRINGS due to their more verbose encoding. However, the nice thing about hex encoding is we know it can't contain special characters. So this commit adds a type check to see if we can safely skip the escape step, and now BYTES are faster than they were before, although still not as fast as raw strings.

name                          old time/op    new time/op    delta
CSVEncodeWideRow-16             81.1µs ± 2%    85.1µs ± 2%   +4.98%  (p=0.000 n=10+8)
CSVEncodeWideRowASCII-16        63.5µs ± 3%    66.1µs ± 3%   +4.11%  (p=0.000 n=10+10)
CSVEncodeWideColumnsASCII-16    20.0µs ± 2%    20.2µs ± 5%     ~     (p=0.549 n=10+9)
CSVEncodeWideColumns-16         31.9µs ± 1%    32.0µs ± 1%     ~     (p=0.436 n=10+10)
CSVEncodeWideColumnsBytes-16    95.7µs ± 1%    29.3µs ± 5%  -69.42%  (p=0.000 n=8+9)

name                          old alloc/op   new alloc/op   delta
CSVEncodeWideRow-16               144B ± 1%      155B ±13%   +7.44%  (p=0.000 n=8+8)
CSVEncodeWideRowASCII-16          112B ± 2%      117B ± 3%   +4.54%  (p=0.000 n=10+10)
CSVEncodeWideColumnsASCII-16     35.0B ± 0%     35.9B ± 3%     ~     (p=0.106 n=8+9)
CSVEncodeWideColumns-16          57.7B ± 4%     57.0B ± 0%     ~     (p=0.309 n=10+7)
CSVEncodeWideColumnsBytes-16      174B ± 3%       53B ± 3%  -69.29%  (p=0.000 n=10+8)

name                          old allocs/op  new allocs/op  delta
CSVEncodeWideRow-16               0.00           0.00          ~     (all equal)
CSVEncodeWideRowASCII-16          0.00           0.00          ~     (all equal)
CSVEncodeWideColumnsASCII-16      0.00           0.00          ~     (all equal)
CSVEncodeWideColumns-16           0.00           0.00          ~     (all equal)
CSVEncodeWideColumnsBytes-16      0.00           0.00          ~     (all equal)

Release note: None