### PR TITLE
rewrite: rewrite UniqueWithoutIndexConstraint on restore

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/unique_without_index_constraint
+++ b/pkg/ccl/backupccl/testdata/backup-restore/unique_without_index_constraint
@@ -1,0 +1,45 @@
+new-server name=s1
+----
+
+exec-sql
+SET experimental_enable_unique_without_index_constraints = true;
+----
+
+exec-sql
+CREATE TABLE uwi(a INT UNIQUE WITHOUT INDEX);
+----
+
+exec-sql
+CREATE EXTERNAL CONNECTION foo AS 'nodelocal://1/foo';
+----
+
+exec-sql
+BACKUP INTO 'external://foo/cluster';
+----
+
+exec-sql
+BACKUP DATABASE defaultdb INTO 'external://foo/database';
+----
+
+exec-sql
+BACKUP TABLE uwi INTO 'external://foo/table';
+----
+
+new-server name=s2 share-io-dir=s1
+----
+
+exec-sql
+RESTORE FROM LATEST IN 'nodelocal://1/foo/cluster';
+----
+
+exec-sql
+RESTORE DATABASE defaultdb FROM LATEST IN 'nodelocal://1/foo/database' WITH new_db_name='newdefaultdb';
+----
+
+exec-sql
+CREATE DATABASE bar;
+----
+
+exec-sql
+RESTORE TABLE uwi FROM LATEST IN 'nodelocal://1/foo/table' WITH into_db='bar';
+----


### PR DESCRIPTION
If a table with `UniqueWithoutIndexConstraint` is captured as part of the backup, then on restore the tableIDs in the `UniqueWithoutIndexConstraint` slice on the table descriptor need to be remapped to the new tableIDs that will be assigned to the descriptors post restore.

Fixes: #88860

Release note (bug fix): Restoring a backup with a table containing `UniqueWithoutIndexConstraints` would fail because of incorrect tableIDs being referenced in the constraints stored on the restored table.