### PR TITLE
kvserver: remove leftover code from the RaftAppliedIndexTerm migration

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -1139,24 +1139,9 @@ func splitTriggerHelper(
 		if err != nil {
 			return enginepb.MVCCStats{}, result.Result{}, errors.Wrap(err, "unable to load replica version")
 		}
-		// The RHS should populate RaftAppliedIndexTerm if the LHS is doing so.
-		// Alternatively, we could be more aggressive and also look at the cluster
-		// version, but this is simpler -- if the keyspace occupied by the
-		// original unsplit range has not been migrated yet, by an ongoing
-		// migration, both LHS and RHS will be migrated later.
-		rangeAppliedState, err := sl.LoadRangeAppliedState(ctx, batch)
-		if err != nil {
-			return enginepb.MVCCStats{}, result.Result{},
-				errors.Wrap(err, "unable to load range applied state")
-		}
-		writeRaftAppliedIndexTerm := false
-		if rangeAppliedState.RaftAppliedIndexTerm > 0 {
-			writeRaftAppliedIndexTerm = true
-		}
 		*h.AbsPostSplitRight(), err = stateloader.WriteInitialReplicaState(
 			ctx, batch, *h.AbsPostSplitRight(), split.RightDesc, rightLease,
-			*gcThreshold, *gcHint, replicaVersion, writeRaftAppliedIndexTerm,
-			split.WriteGCHint,
+			*gcThreshold, *gcHint, replicaVersion, split.WriteGCHint,
 		)
 		if err != nil {
 			return enginepb.MVCCStats{}, result.Result{}, errors.Wrap(err, "unable to write initial Replica state")

--- a/pkg/kv/kvserver/batcheval/result/BUILD.bazel
+++ b/pkg/kv/kvserver/batcheval/result/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
     deps = [
         "//pkg/kv/kvserver/concurrency/lock",
         "//pkg/kv/kvserver/kvserverpb",
-        "//pkg/kv/kvserver/stateloader",
         "//pkg/roachpb",
         "//pkg/util/log",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/kv/kvserver/batcheval/result/result.go
+++ b/pkg/kv/kvserver/batcheval/result/result.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -206,20 +205,7 @@ func (p *Result) MergeAndDestroy(q Result) error {
 			p.Replicated.State = &kvserverpb.ReplicaState{}
 		}
 		if q.Replicated.State.RaftAppliedIndexTerm != 0 {
-			if q.Replicated.State.RaftAppliedIndexTerm ==
-				stateloader.RaftLogTermSignalForAddRaftAppliedIndexTermMigration {
-				if p.Replicated.State.RaftAppliedIndexTerm != 0 &&
-					p.Replicated.State.RaftAppliedIndexTerm !=
-						stateloader.RaftLogTermSignalForAddRaftAppliedIndexTermMigration {
-					return errors.AssertionFailedf("invalid term value %d",
-						p.Replicated.State.RaftAppliedIndexTerm)
-				}
-				p.Replicated.State.RaftAppliedIndexTerm = q.Replicated.State.RaftAppliedIndexTerm
-				q.Replicated.State.RaftAppliedIndexTerm = 0
-			} else {
-				return errors.AssertionFailedf("invalid term value %d",
-					q.Replicated.State.RaftAppliedIndexTerm)
-			}
+			return errors.AssertionFailedf("must not specify RaftAppliedIndexTerm")
 		}
 		if p.Replicated.State.Desc == nil {
 			p.Replicated.State.Desc = q.Replicated.State.Desc

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -2075,17 +2075,6 @@ func init() {
 	tracing.RegisterTagRemapping("r", "range")
 }
 
-// LockRaftMuForTesting is for use only by tests in other packages that are
-// trying to avoid a race with concurrent raft application. For tests in the
-// kvserver package, use Replica.{RaftLock,RaftUnlock} that are defined in
-// helpers_test.go.
-func (r *Replica) LockRaftMuForTesting() (unlockFunc func()) {
-	r.raftMu.Lock()
-	return func() {
-		r.raftMu.Unlock()
-	}
-}
-
 // ReadProtectedTimestampsForTesting is for use only by tests to read and update
 // the Replicas' cached protected timestamp state.
 func (r *Replica) ReadProtectedTimestampsForTesting(ctx context.Context) (err error) {

--- a/pkg/kv/kvserver/replica_application_result.go
+++ b/pkg/kv/kvserver/replica_application_result.go
@@ -92,8 +92,6 @@ func clearTrivialReplicatedEvalResultFields(r *kvserverpb.ReplicatedEvalResult) 
 	// replica state for this batch.
 	if haveState := r.State != nil; haveState {
 		r.State.Stats = nil
-		// Reset the signal used to execute the AddRaftAppliedIndexTermMigration.
-		r.State.RaftAppliedIndexTerm = 0
 		if *r.State == (kvserverpb.ReplicaState{}) {
 			r.State = nil
 		}

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -1352,7 +1352,6 @@ func SendEmptySnapshot(
 		hlc.Timestamp{}, // gcThreshold
 		roachpb.GCHint{},
 		st.Version.ActiveVersionOrEmpty(ctx).Version,
-		true,            /* 22.1:AddRaftAppliedIndexTermMigration */
 		supportsGCHints, /* 22.2: GCHintInReplicaState */
 	)
 	if err != nil {

--- a/pkg/storage/enginepb/mvcc3.proto
+++ b/pkg/storage/enginepb/mvcc3.proto
@@ -262,11 +262,9 @@ message RangeAppliedState {
 
   // raft_applied_index_term is the term corresponding to raft_applied_index.
   // The serialized proto will not contain this field until code starts
-  // setting it to a value > 0. This is desirable since we don't want a mixed
-  // version cluster to have divergent replica state simply because we have
-  // introduced this field. An explicit migration,
-  // AddRaftAppliedIndexTermMigration, will cause this field to start being
-  // populated.
+  // setting it to a value > 0 (in v22.1). This is desirable since we don't
+  // want a mixed version cluster (v21.2 and v22.1) to have divergent replica
+  // state simply because we have introduced this field.
   uint64 raft_applied_index_term = 5;
 }
 


### PR DESCRIPTION
The migration itself was already removed, but various supporting code still existed.

Release note: None