### PR TITLE
release-22.1: ui: reduce frequent Metrics page re-rendering

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/clusterOverview/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/clusterOverview/index.tsx
@@ -16,7 +16,7 @@ import { connect } from "react-redux";
 import { createSelector } from "reselect";
 
 import { AdminUIState } from "src/redux/state";
-import { nodesSummarySelector, NodesSummary } from "src/redux/nodes";
+import { nodeSumsSelector } from "src/redux/nodes";
 import { Bytes as formatBytes } from "src/util/format";
 import createChartComponent from "src/views/shared/util/d3-react";
 import capacityChart from "./capacity";
@@ -81,9 +81,9 @@ function renderCapacityUsage(props: CapacityUsageProps) {
 }
 
 const mapStateToCapacityUsageProps = createSelector(
-  nodesSummarySelector,
-  function(nodesSummary: NodesSummary) {
-    const { capacityUsed, capacityUsable } = nodesSummary.nodeSums;
+  nodeSumsSelector,
+  nodeSums => {
+    const { capacityUsed, capacityUsable } = nodeSums;
     return {
       usedCapacity: capacityUsed,
       usableCapacity: capacityUsable,
@@ -149,9 +149,9 @@ function renderNodeLiveness(props: NodeLivenessProps) {
 }
 
 const mapStateToNodeLivenessProps = createSelector(
-  nodesSummarySelector,
-  function(nodesSummary: NodesSummary) {
-    const { nodeCounts } = nodesSummary.nodeSums;
+  nodeSumsSelector,
+  nodeSums => {
+    const { nodeCounts } = nodeSums;
     return {
       liveNodes: nodeCounts.healthy,
       suspectNodes: nodeCounts.suspect,
@@ -220,13 +220,9 @@ function renderReplicationStatus(props: ReplicationStatusProps) {
 }
 
 const mapStateToReplicationStatusProps = createSelector(
-  nodesSummarySelector,
-  function(nodesSummary: NodesSummary) {
-    const {
-      totalRanges,
-      underReplicatedRanges,
-      unavailableRanges,
-    } = nodesSummary.nodeSums;
+  nodeSumsSelector,
+  nodeSums => {
+    const { totalRanges, underReplicatedRanges, unavailableRanges } = nodeSums;
     return {
       totalRanges: totalRanges,
       underReplicatedRanges: underReplicatedRanges,

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/dashboardUtils.ts
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/dashboardUtils.ts
@@ -8,17 +8,11 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { NodesSummary } from "src/redux/nodes";
-
 /**
  * GraphDashboardProps are the properties accepted by the renderable component
  * of each graph dashboard.
  */
 export interface GraphDashboardProps {
-  /**
-   * Summary of nodes data.
-   */
-  nodesSummary: NodesSummary;
   /**
    * List of node IDs which should be used in graphs which display a series per
    * node.
@@ -40,21 +34,26 @@ export interface GraphDashboardProps {
    * all nodes" or "on node X".
    */
   tooltipSelection: string;
+
+  nodeDisplayNameByID: {
+    [key: string]: string;
+  };
+
+  storeIDsByNodeID: {
+    [key: string]: string[];
+  };
 }
 
-export function nodeDisplayName(nodesSummary: NodesSummary, nid: string) {
-  const ns = nodesSummary.nodeStatusByID[nid];
-  if (!ns) {
-    // This should only happen immediately after loading a page, and
-    // associated graphs should display no data.
-    return "unknown node";
-  }
-  return nodesSummary.nodeDisplayNameByID[ns.desc.node_id];
+export function nodeDisplayName(
+  nodeDisplayNameByID: { [nodeId: string]: string },
+  nid: string,
+): string {
+  return nodeDisplayNameByID[nid] || "unknown node";
 }
 
 export function storeIDsForNode(
-  nodesSummary: NodesSummary,
+  storeIDsByNodeID: { [key: string]: string[] },
   nid: string,
 ): string[] {
-  return nodesSummary.storeIDsByNodeID[nid] || [];
+  return storeIDsByNodeID[nid] || [];
 }

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/distributed.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/distributed.tsx
@@ -18,7 +18,7 @@ import { AxisUnits } from "@cockroachlabs/cluster-ui";
 import { GraphDashboardProps, nodeDisplayName } from "./dashboardUtils";
 
 export default function(props: GraphDashboardProps) {
-  const { nodeIDs, nodesSummary, nodeSources } = props;
+  const { nodeIDs, nodeSources, nodeDisplayNameByID } = props;
 
   return [
     <LineGraph title="Batches" sources={nodeSources}>
@@ -93,7 +93,7 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={node}
             name="cr.node.txn.durations-p99"
-            title={nodeDisplayName(nodesSummary, node)}
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
             downsampleMax
           />
@@ -111,7 +111,7 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={node}
             name="cr.node.txn.durations-p90"
-            title={nodeDisplayName(nodesSummary, node)}
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
             downsampleMax
           />
@@ -129,7 +129,7 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={node}
             name="cr.node.liveness.heartbeatlatency-p99"
-            title={nodeDisplayName(nodesSummary, node)}
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
             downsampleMax
           />
@@ -147,7 +147,7 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={node}
             name="cr.node.liveness.heartbeatlatency-p90"
-            title={nodeDisplayName(nodesSummary, node)}
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
             downsampleMax
           />

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
@@ -26,7 +26,8 @@ import { AxisUnits } from "@cockroachlabs/cluster-ui";
 export default function(props: GraphDashboardProps) {
   const {
     nodeIDs,
-    nodesSummary,
+    nodeDisplayNameByID,
+    storeIDsByNodeID,
     nodeSources,
     storeSources,
     tooltipSelection,
@@ -38,7 +39,7 @@ export default function(props: GraphDashboardProps) {
         {nodeIDs.map(nid => (
           <Metric
             name="cr.node.sys.cpu.combined.percent-normalized"
-            title={nodeDisplayName(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
             sources={[nid]}
           />
         ))}
@@ -54,7 +55,7 @@ export default function(props: GraphDashboardProps) {
         {nodeIDs.map(nid => (
           <Metric
             name="cr.node.sys.rss"
-            title={nodeDisplayName(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
             sources={[nid]}
           />
         ))}
@@ -66,7 +67,7 @@ export default function(props: GraphDashboardProps) {
         {nodeIDs.map(nid => (
           <Metric
             name="cr.node.sys.host.disk.read.bytes"
-            title={nodeDisplayName(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
             sources={[nid]}
             nonNegativeRate
           />
@@ -79,7 +80,7 @@ export default function(props: GraphDashboardProps) {
         {nodeIDs.map(nid => (
           <Metric
             name="cr.node.sys.host.disk.write.bytes"
-            title={nodeDisplayName(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
             sources={[nid]}
             nonNegativeRate
           />
@@ -92,7 +93,7 @@ export default function(props: GraphDashboardProps) {
         {nodeIDs.map(nid => (
           <Metric
             name="cr.node.sys.host.disk.read.count"
-            title={nodeDisplayName(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
             sources={[nid]}
             nonNegativeRate
           />
@@ -105,7 +106,7 @@ export default function(props: GraphDashboardProps) {
         {nodeIDs.map(nid => (
           <Metric
             name="cr.node.sys.host.disk.write.count"
-            title={nodeDisplayName(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
             sources={[nid]}
             nonNegativeRate
           />
@@ -118,7 +119,7 @@ export default function(props: GraphDashboardProps) {
         {nodeIDs.map(nid => (
           <Metric
             name="cr.node.sys.host.disk.iopsinprogress"
-            title={nodeDisplayName(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
             sources={[nid]}
           />
         ))}
@@ -134,8 +135,8 @@ export default function(props: GraphDashboardProps) {
         {nodeIDs.map(nid => (
           <Metric
             name="cr.store.capacity.available"
-            sources={storeIDsForNode(nodesSummary, nid)}
-            title={nodeDisplayName(nodesSummary, nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
           />
         ))}
       </Axis>
@@ -146,7 +147,7 @@ export default function(props: GraphDashboardProps) {
         {nodeIDs.map(nid => (
           <Metric
             name="cr.node.sys.host.net.recv.bytes"
-            title={nodeDisplayName(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
             sources={[nid]}
             nonNegativeRate
           />
@@ -159,7 +160,7 @@ export default function(props: GraphDashboardProps) {
         {nodeIDs.map(nid => (
           <Metric
             name="cr.node.sys.host.net.send.bytes"
-            title={nodeDisplayName(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
             sources={[nid]}
             nonNegativeRate
           />

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overload.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overload.tsx
@@ -9,7 +9,6 @@
 // licenses/APL.txt.
 
 import React from "react";
-import _ from "lodash";
 
 import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis } from "src/views/shared/components/metricQuery";
@@ -22,7 +21,13 @@ import {
 } from "./dashboardUtils";
 
 export default function(props: GraphDashboardProps) {
-  const { nodeIDs, nodesSummary, nodeSources, storeSources } = props;
+  const {
+    nodeIDs,
+    nodeSources,
+    storeSources,
+    nodeDisplayNameByID,
+    storeIDsByNodeID,
+  } = props;
 
   return [
     <LineGraph title="CPU Percent" sources={nodeSources}>
@@ -30,7 +35,7 @@ export default function(props: GraphDashboardProps) {
         {nodeIDs.map(nid => (
           <Metric
             name="cr.node.sys.cpu.combined.percent-normalized"
-            title={nodeDisplayName(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
             sources={[nid]}
           />
         ))}
@@ -46,7 +51,7 @@ export default function(props: GraphDashboardProps) {
         {nodeIDs.map(nid => (
           <Metric
             name="cr.node.sys.runnable.goroutines.per.cpu"
-            title={nodeDisplayName(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
             sources={[nid]}
           />
         ))}
@@ -64,14 +69,16 @@ export default function(props: GraphDashboardProps) {
             <Metric
               key={nid}
               name="cr.store.storage.l0-sublevels"
-              title={"L0 Sublevels " + nodeDisplayName(nodesSummary, nid)}
-              sources={storeIDsForNode(nodesSummary, nid)}
+              title={
+                "L0 Sublevels " + nodeDisplayName(nodeDisplayNameByID, nid)
+              }
+              sources={storeIDsForNode(storeIDsByNodeID, nid)}
             />
             <Metric
               key={nid}
               name="cr.store.storage.l0-num-files"
-              title={"L0 Files " + nodeDisplayName(nodesSummary, nid)}
-              sources={storeIDsForNode(nodesSummary, nid)}
+              title={"L0 Files " + nodeDisplayName(nodeDisplayNameByID, nid)}
+              sources={storeIDsForNode(storeIDsByNodeID, nid)}
             />
           </>
         ))}
@@ -85,13 +92,13 @@ export default function(props: GraphDashboardProps) {
             <Metric
               key={nid}
               name="cr.node.admission.granter.total_slots.kv"
-              title={"Total Slots " + nodeDisplayName(nodesSummary, nid)}
+              title={"Total Slots " + nodeDisplayName(nodeDisplayNameByID, nid)}
               sources={[nid]}
             />
             <Metric
               key={nid}
               name="cr.node.admission.granter.used_slots.kv"
-              title={"Used Slots " + nodeDisplayName(nodesSummary, nid)}
+              title={"Used Slots " + nodeDisplayName(nodeDisplayNameByID, nid)}
               sources={[nid]}
             />
           </>
@@ -108,7 +115,7 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.node.admission.granter.io_tokens_exhausted_duration.kv"
-            title={"IO Exhausted " + nodeDisplayName(nodesSummary, nid)}
+            title={"IO Exhausted " + nodeDisplayName(nodeDisplayNameByID, nid)}
             sources={[nid]}
             nonNegativeRate
           />
@@ -123,7 +130,9 @@ export default function(props: GraphDashboardProps) {
             <Metric
               key={nid}
               name="cr.node.admission.admitted.kv"
-              title={"KV request rate " + nodeDisplayName(nodesSummary, nid)}
+              title={
+                "KV request rate " + nodeDisplayName(nodeDisplayNameByID, nid)
+              }
               sources={[nid]}
               nonNegativeRate
             />
@@ -131,7 +140,8 @@ export default function(props: GraphDashboardProps) {
               key={nid}
               name="cr.node.admission.admitted.kv-stores"
               title={
-                "KV write request rate " + nodeDisplayName(nodesSummary, nid)
+                "KV write request rate " +
+                nodeDisplayName(nodeDisplayNameByID, nid)
               }
               sources={[nid]}
               nonNegativeRate
@@ -140,7 +150,8 @@ export default function(props: GraphDashboardProps) {
               key={nid}
               name="cr.node.admission.admitted.sql-kv-response"
               title={
-                "SQL-KV response rate " + nodeDisplayName(nodesSummary, nid)
+                "SQL-KV response rate " +
+                nodeDisplayName(nodeDisplayNameByID, nid)
               }
               sources={[nid]}
               nonNegativeRate
@@ -149,7 +160,8 @@ export default function(props: GraphDashboardProps) {
               key={nid}
               name="cr.node.admission.admitted.sql-sql-response"
               title={
-                "SQL-SQL response rate " + nodeDisplayName(nodesSummary, nid)
+                "SQL-SQL response rate " +
+                nodeDisplayName(nodeDisplayNameByID, nid)
               }
               sources={[nid]}
               nonNegativeRate
@@ -166,28 +178,32 @@ export default function(props: GraphDashboardProps) {
             <Metric
               key={nid}
               name="cr.node.admission.wait_sum.kv"
-              title={"KV " + nodeDisplayName(nodesSummary, nid)}
+              title={"KV " + nodeDisplayName(nodeDisplayNameByID, nid)}
               sources={[nid]}
               nonNegativeRate
             />
             <Metric
               key={nid}
               name="cr.node.admission.wait_sum.kv-stores"
-              title={"KV write " + nodeDisplayName(nodesSummary, nid)}
+              title={"KV write " + nodeDisplayName(nodeDisplayNameByID, nid)}
               sources={[nid]}
               nonNegativeRate
             />
             <Metric
               key={nid}
               name="cr.node.admission.wait_sum.sql-kv-response"
-              title={"SQL-KV response " + nodeDisplayName(nodesSummary, nid)}
+              title={
+                "SQL-KV response " + nodeDisplayName(nodeDisplayNameByID, nid)
+              }
               sources={[nid]}
               nonNegativeRate
             />
             <Metric
               key={nid}
               name="cr.node.admission.wait_sum.sql-sql-response"
-              title={"SQL-SQL response " + nodeDisplayName(nodesSummary, nid)}
+              title={
+                "SQL-SQL response " + nodeDisplayName(nodeDisplayNameByID, nid)
+              }
               sources={[nid]}
               nonNegativeRate
             />
@@ -203,28 +219,32 @@ export default function(props: GraphDashboardProps) {
             <Metric
               key={nid}
               name="cr.node.admission.wait_durations.kv-p75"
-              title={"KV " + nodeDisplayName(nodesSummary, nid)}
+              title={"KV " + nodeDisplayName(nodeDisplayNameByID, nid)}
               sources={[nid]}
               downsampleMax
             />
             <Metric
               key={nid}
               name="cr.node.admission.wait_durations.kv-stores-p75"
-              title={"KV write " + nodeDisplayName(nodesSummary, nid)}
+              title={"KV write " + nodeDisplayName(nodeDisplayNameByID, nid)}
               sources={[nid]}
               downsampleMax
             />
             <Metric
               key={nid}
               name="cr.node.admission.wait_durations.sql-kv-response-p75"
-              title={"SQL-KV response " + nodeDisplayName(nodesSummary, nid)}
+              title={
+                "SQL-KV response " + nodeDisplayName(nodeDisplayNameByID, nid)
+              }
               sources={[nid]}
               downsampleMax
             />
             <Metric
               key={nid}
               name="cr.node.admission.wait_durations.sql-sql-response-p75"
-              title={"SQL-SQL response " + nodeDisplayName(nodesSummary, nid)}
+              title={
+                "SQL-SQL response " + nodeDisplayName(nodeDisplayNameByID, nid)
+              }
               sources={[nid]}
               downsampleMax
             />

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
@@ -25,10 +25,11 @@ import { AxisUnits } from "@cockroachlabs/cluster-ui";
 export default function(props: GraphDashboardProps) {
   const {
     nodeIDs,
-    nodesSummary,
     nodeSources,
     storeSources,
     tooltipSelection,
+    nodeDisplayNameByID,
+    storeIDsByNodeID,
   } = props;
 
   return [
@@ -82,7 +83,7 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={node}
             name="cr.node.sql.service.latency-p99"
-            title={nodeDisplayName(nodesSummary, node)}
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
             downsampleMax
           />
@@ -123,8 +124,8 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.store.replicas"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={storeIDsForNode(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
           />
         ))}
       </Axis>

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
@@ -29,7 +29,12 @@ import { cockroach } from "src/js/protos";
 import TimeSeriesQueryAggregator = cockroach.ts.tspb.TimeSeriesQueryAggregator;
 
 export default function(props: GraphDashboardProps) {
-  const { nodeIDs, nodesSummary, storeSources } = props;
+  const {
+    nodeIDs,
+    storeSources,
+    nodeDisplayNameByID,
+    storeIDsByNodeID,
+  } = props;
 
   return [
     <LineGraph title="Ranges" sources={storeSources}>
@@ -59,8 +64,8 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.store.replicas"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={storeIDsForNode(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
           />
         ))}
       </Axis>
@@ -76,8 +81,8 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.store.replicas.leaseholders"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={storeIDsForNode(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
           />
         ))}
       </Axis>
@@ -92,8 +97,8 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.store.rebalancing.queriespersecond"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={storeIDsForNode(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
           />
         ))}
       </Axis>
@@ -108,8 +113,8 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.store.totalbytes"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={storeIDsForNode(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
           />
         ))}
       </Axis>
@@ -182,8 +187,8 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.store.range.snapshots.rcvd-bytes"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={storeIDsForNode(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
             nonNegativeRate
           />
         ))}
@@ -199,8 +204,8 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.store.kv.replica_circuit_breaker.num_tripped_replicas"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={storeIDsForNode(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
             downsampler={TimeSeriesQueryAggregator.SUM}
           />
         ))}
@@ -216,8 +221,8 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.store.kv.replica_circuit_breaker.num_tripped_events"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={storeIDsForNode(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
             downsampler={TimeSeriesQueryAggregator.MAX}
           />
         ))}

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/runtime.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/runtime.tsx
@@ -18,7 +18,7 @@ import { AxisUnits } from "@cockroachlabs/cluster-ui";
 import { GraphDashboardProps, nodeDisplayName } from "./dashboardUtils";
 
 export default function(props: GraphDashboardProps) {
-  const { nodeIDs, nodesSummary, nodeSources, tooltipSelection } = props;
+  const { nodeIDs, nodeSources, tooltipSelection, nodeDisplayNameByID } = props;
 
   return [
     <LineGraph
@@ -85,7 +85,7 @@ export default function(props: GraphDashboardProps) {
         {nodeIDs.map(nid => (
           <Metric
             name="cr.node.sys.runnable.goroutines.per.cpu"
-            title={nodeDisplayName(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
             sources={[nid]}
           />
         ))}
@@ -150,7 +150,7 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.node.clock-offset.meannanos"
-            title={nodeDisplayName(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
             sources={[nid]}
           />
         ))}

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -22,7 +22,7 @@ import {
 } from "src/views/cluster/containers/nodeGraphs/dashboards/graphTooltips";
 
 export default function(props: GraphDashboardProps) {
-  const { nodeIDs, nodesSummary, nodeSources, tooltipSelection } = props;
+  const { nodeIDs, nodeSources, tooltipSelection, nodeDisplayNameByID } = props;
 
   return [
     <LineGraph
@@ -35,7 +35,7 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={node}
             name="cr.node.sql.conns"
-            title={nodeDisplayName(nodesSummary, node)}
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
             downsampleMax
           />
@@ -152,7 +152,7 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={node}
             name="cr.node.sql.full.scan.count"
-            title={nodeDisplayName(nodesSummary, node)}
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
             downsampleMax
           />
@@ -169,7 +169,7 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={node}
             name="cr.node.sql.distsql.flows.active"
-            title={nodeDisplayName(nodesSummary, node)}
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
           />
         ))}
@@ -185,7 +185,7 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={node}
             name="cr.node.sql.conn.latency-p99"
-            title={nodeDisplayName(nodesSummary, node)}
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
             downsampleMax
           />
@@ -202,7 +202,7 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={node}
             name="cr.node.sql.conn.latency-p90"
-            title={nodeDisplayName(nodesSummary, node)}
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
             downsampleMax
           />
@@ -228,7 +228,7 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={node}
             name="cr.node.sql.service.latency-p99"
-            title={nodeDisplayName(nodesSummary, node)}
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
             downsampleMax
           />
@@ -254,7 +254,7 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={node}
             name="cr.node.sql.service.latency-p90"
-            title={nodeDisplayName(nodesSummary, node)}
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
             downsampleMax
           />
@@ -272,7 +272,7 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={node}
             name="cr.node.exec.latency-p99"
-            title={nodeDisplayName(nodesSummary, node)}
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
             downsampleMax
           />
@@ -290,7 +290,7 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={node}
             name="cr.node.exec.latency-p90"
-            title={nodeDisplayName(nodesSummary, node)}
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
             downsampleMax
           />
@@ -397,7 +397,7 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={node}
             name="cr.node.sql.txn.latency-p99"
-            title={nodeDisplayName(nodesSummary, node)}
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
             downsampleMax
           />
@@ -423,7 +423,7 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={node}
             name="cr.node.sql.txn.latency-p90"
-            title={nodeDisplayName(nodesSummary, node)}
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
             downsampleMax
           />
@@ -441,7 +441,7 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={node}
             name="cr.node.sql.mem.root.current"
-            title={nodeDisplayName(nodesSummary, node)}
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
             downsampleMax
           />

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
@@ -28,11 +28,15 @@ import { AxisUnits } from "@cockroachlabs/cluster-ui";
 export default function(props: GraphDashboardProps) {
   const {
     nodeIDs,
-    nodesSummary,
     nodeSources,
     storeSources,
     tooltipSelection,
+    storeIDsByNodeID,
+    nodeDisplayNameByID,
   } = props;
+
+  const getNodeNameById = (id: string) =>
+    nodeDisplayName(nodeDisplayNameByID, id);
 
   return [
     <LineGraph
@@ -69,8 +73,8 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.store.raft.process.logcommit.latency-p99"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={storeIDsForNode(nodesSummary, nid)}
+            title={getNodeNameById(nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
           />
         ))}
       </Axis>
@@ -87,8 +91,8 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.store.raft.process.logcommit.latency-p50"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={storeIDsForNode(nodesSummary, nid)}
+            title={getNodeNameById(nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
           />
         ))}
       </Axis>
@@ -106,8 +110,8 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.store.raft.process.commandcommit.latency-p99"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={storeIDsForNode(nodesSummary, nid)}
+            title={getNodeNameById(nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
           />
         ))}
       </Axis>
@@ -125,8 +129,8 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.store.raft.process.commandcommit.latency-p50"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={storeIDsForNode(nodesSummary, nid)}
+            title={getNodeNameById(nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
           />
         ))}
       </Axis>
@@ -142,8 +146,8 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.store.rocksdb.read-amplification"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={storeIDsForNode(nodesSummary, nid)}
+            title={getNodeNameById(nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
           />
         ))}
       </Axis>
@@ -159,8 +163,8 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.store.rocksdb.num-sstables"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={storeIDsForNode(nodesSummary, nid)}
+            title={getNodeNameById(nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
           />
         ))}
       </Axis>
@@ -188,8 +192,8 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.store.rocksdb.flushed-bytes"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={storeIDsForNode(nodesSummary, nid)}
+            title={getNodeNameById(nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
             nonNegativeRate
           />
         ))}
@@ -206,8 +210,8 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.store.rocksdb.compacted-bytes-written"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={storeIDsForNode(nodesSummary, nid)}
+            title={getNodeNameById(nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
             nonNegativeRate
           />
         ))}
@@ -224,8 +228,8 @@ export default function(props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.store.rocksdb.ingested-bytes"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={storeIDsForNode(nodesSummary, nid)}
+            title={getNodeNameById(nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
             nonNegativeRate
           />
         ))}

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/summaryBar.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/summaryBar.spec.tsx
@@ -15,13 +15,38 @@ import { MemoryRouter as Router } from "react-router-dom";
 
 import { ClusterNodeTotalsComponent } from "./summaryBar";
 import { SummaryStatBreakdown } from "src/views/shared/components/summaryBar";
+import { NodeSummaryStats } from "src/redux/nodes";
 
 describe("<ClusterNodeTotals>", () => {
+  let nodeSumsSelectorStubReturn: NodeSummaryStats;
+
+  beforeEach(() => {
+    nodeSumsSelectorStubReturn = {
+      capacityAvailable: 0,
+      capacityTotal: 0,
+      capacityUsable: 0,
+      capacityUsed: 0,
+      replicas: 0,
+      totalRanges: 0,
+      unavailableRanges: 0,
+      underReplicatedRanges: 0,
+      usedBytes: 0,
+      usedMem: 0,
+      nodeCounts: {
+        total: 0,
+        healthy: 0,
+        suspect: 0,
+        dead: 0,
+        decommissioned: 0,
+      },
+    };
+  });
+
   it("hidden when no data", () => {
     const wrapper = shallow(
       <Router>
         <ClusterNodeTotalsComponent
-          nodesSummary={null}
+          nodeSums={nodeSumsSelectorStubReturn}
           nodesSummaryEmpty={true}
         />
       </Router>,
@@ -30,21 +55,20 @@ describe("<ClusterNodeTotals>", () => {
   });
 
   it("renders", () => {
-    const nodesSummary = {
-      nodeSums: {
-        nodeCounts: {
-          total: 1,
-          healthy: 1,
-          suspect: 0,
-          dead: 0,
-          decommissioned: 0,
-        },
+    const nodeSums = {
+      ...nodeSumsSelectorStubReturn,
+      nodeCounts: {
+        total: 1,
+        healthy: 1,
+        suspect: 0,
+        dead: 0,
+        decommissioned: 0,
       },
     };
     const wrapper = shallow(
       <Router>
         <ClusterNodeTotalsComponent
-          nodesSummary={nodesSummary as any}
+          nodeSums={nodeSums}
           nodesSummaryEmpty={false}
         />
       </Router>,
@@ -53,21 +77,20 @@ describe("<ClusterNodeTotals>", () => {
   });
 
   it("renders dead nodes", () => {
-    const nodesSummary = {
-      nodeSums: {
-        nodeCounts: {
-          total: 2,
-          healthy: 0,
-          suspect: 1,
-          dead: 1,
-          decommissioned: 0,
-        },
+    const nodeSums = {
+      ...nodeSumsSelectorStubReturn,
+      nodeCounts: {
+        total: 2,
+        healthy: 0,
+        suspect: 1,
+        dead: 1,
+        decommissioned: 0,
       },
     };
     const wrapper = mount(
       <Router>
         <ClusterNodeTotalsComponent
-          nodesSummary={nodesSummary as any}
+          nodeSums={nodeSums}
           nodesSummaryEmpty={false}
         />
       </Router>,

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/summaryBar.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/summaryBar.tsx
@@ -9,11 +9,15 @@
 // licenses/APL.txt.
 
 import React from "react";
-import { connect } from "react-redux";
+import { connect, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 import * as d3 from "d3";
 
-import { NodesSummary } from "src/redux/nodes";
+import {
+  nodeStatusesSelector,
+  NodeSummaryStats,
+  nodeSumsSelector,
+} from "src/redux/nodes";
 import { Bytes } from "src/util/format";
 import { util } from "@cockroachlabs/cluster-ui";
 
@@ -31,25 +35,25 @@ import {
 import { Tooltip, Anchor } from "src/components";
 import { howAreCapacityMetricsCalculated } from "src/util/docs";
 import { AdminUIState } from "src/redux/state";
+import { createSelector } from "reselect";
+
+export interface ClusterNodeTotalsProps {
+  nodeSums: NodeSummaryStats;
+  nodesSummaryEmpty: boolean;
+}
 
 /**
  * ClusterNodeTotals displays a high-level breakdown of the nodes on the cluster
  * and their current liveness status.
  */
-
-export interface ClusterNodeTotalsProps {
-  nodesSummary: NodesSummary;
-  nodesSummaryEmpty: boolean;
-}
-
 export const ClusterNodeTotalsComponent: React.FC<ClusterNodeTotalsProps> = ({
-  nodesSummary,
+  nodeSums,
   nodesSummaryEmpty,
 }) => {
   if (nodesSummaryEmpty) {
     return null;
   }
-  const { nodeCounts } = nodesSummary.nodeSums;
+  const { nodeCounts } = nodeSums;
   let children: React.ReactNode;
   if (nodeCounts.dead > 0 || nodeCounts.suspect > 0) {
     children = (
@@ -86,12 +90,14 @@ export const ClusterNodeTotalsComponent: React.FC<ClusterNodeTotalsProps> = ({
   );
 };
 
-export function selectNodesSummaryEmpty(state: AdminUIState) {
-  return !state.cachedData.nodes.data;
-}
+export const selectNodesSummaryEmpty = createSelector(
+  nodeStatusesSelector,
+  nodes => !nodes,
+);
 
-const mapStateToProps = (state: AdminUIState) => ({
+const mapStateToProps = (state: AdminUIState): ClusterNodeTotalsProps => ({
   nodesSummaryEmpty: selectNodesSummaryEmpty(state),
+  nodeSums: nodeSumsSelector(state),
 });
 
 const ClusterNodeTotals = connect(
@@ -110,19 +116,19 @@ function formatNanosAsMillis(n: number) {
  */
 export interface ClusterSummaryProps {
   nodeSources: string[];
-  nodesSummary: NodesSummary;
 }
 
 export default function(props: ClusterSummaryProps) {
+  const nodeSums = useSelector(nodeSumsSelector);
   // Capacity math used in the summary status section.
-  const { capacityUsed, capacityUsable } = props.nodesSummary.nodeSums;
+  const { capacityUsed, capacityUsable } = nodeSums;
   const capacityPercent =
     capacityUsable !== 0 ? capacityUsed / capacityUsable : null;
   return (
     <div>
       <SummaryBar>
         <SummaryLabel>Summary</SummaryLabel>
-        <ClusterNodeTotals nodesSummary={props.nodesSummary} />
+        <ClusterNodeTotals />
         <SummaryStat
           title={
             <Tooltip
@@ -153,7 +159,7 @@ export default function(props: ClusterSummaryProps) {
         </SummaryStat>
         <SummaryStat
           title="Unavailable ranges"
-          value={props.nodesSummary.nodeSums.unavailableRanges}
+          value={nodeSums.unavailableRanges}
         />
         <SummaryMetricStat
           id="qps"

--- a/pkg/ui/workspaces/db-console/src/views/devtools/containers/raftMessages/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/devtools/containers/raftMessages/index.tsx
@@ -21,7 +21,12 @@ import {
   hoverStateSelector,
   HoverState,
 } from "src/redux/hover";
-import { NodesSummary, nodesSummarySelector } from "src/redux/nodes";
+import {
+  nodeDisplayNameByIDSelector,
+  nodeIDsStringifiedSelector,
+  selectStoreIDsByNodeID,
+  nodeIDsSelector,
+} from "src/redux/nodes";
 import { AdminUIState } from "src/redux/state";
 import { setGlobalTimeScaleAction } from "src/redux/statements";
 import { nodeIDAttr } from "src/util/constants";
@@ -52,10 +57,18 @@ interface NodeGraphsOwnProps {
   hoverOff: typeof hoverOffAction;
   nodesQueryValid: boolean;
   livenessQueryValid: boolean;
-  nodesSummary: NodesSummary;
+  nodeDropdownOptions: ReturnType<
+    typeof nodeDropdownOptionsSelector.resultFunc
+  >;
+  storeIDsByNodeID: ReturnType<typeof selectStoreIDsByNodeID.resultFunc>;
   hoverState: HoverState;
   setMetricsFixedWindow: (tw: TimeWindow) => PayloadAction<TimeWindow>;
   setTimeScale: (ts: TimeScale) => PayloadAction<TimeScale>;
+
+  nodeIds: string[];
+  nodeDisplayNameByID: ReturnType<
+    typeof nodeDisplayNameByIDSelector.resultFunc
+  >;
 }
 
 type RaftMessagesProps = NodeGraphsOwnProps & RouteComponentProps;
@@ -65,21 +78,6 @@ export class RaftMessages extends React.Component<RaftMessagesProps> {
    * Selector to compute node dropdown options from the current node summary
    * collection.
    */
-  private nodeDropdownOptions = createSelector(
-    (summary: NodesSummary) => summary.nodeStatuses,
-    (summary: NodesSummary) => summary.nodeDisplayNameByID,
-    (nodeStatuses, nodeDisplayNameByID): DropdownOption[] => {
-      const base = [{ value: "", label: "Cluster" }];
-      return base.concat(
-        _.map(nodeStatuses, ns => {
-          return {
-            value: ns.desc.node_id.toString(),
-            label: nodeDisplayNameByID[ns.desc.node_id],
-          };
-        }),
-      );
-    },
-  );
 
   refresh(props = this.props) {
     if (!props.nodesQueryValid) {
@@ -112,7 +110,15 @@ export class RaftMessages extends React.Component<RaftMessagesProps> {
   }
 
   render() {
-    const { match, nodesSummary, hoverState, hoverOn, hoverOff } = this.props;
+    const {
+      match,
+      hoverState,
+      hoverOn,
+      hoverOff,
+      storeIDsByNodeID,
+      nodeIds,
+      nodeDisplayNameByID,
+    } = this.props;
 
     const selectedNode = getMatchParamByName(match, nodeIDAttr) || "";
     const nodeSources = selectedNode !== "" ? [selectedNode] : null;
@@ -121,13 +127,13 @@ export class RaftMessages extends React.Component<RaftMessagesProps> {
     // node in the cluster using the nodeIDs collection. However, if a specific
     // node is already selected, these per-node graphs should only display data
     // only for the selected node.
-    const nodeIDs = nodeSources ? nodeSources : nodesSummary.nodeIDs;
+    const nodeIDs = nodeSources ? nodeSources : nodeIds;
 
     // If a single node is selected, we need to restrict the set of stores
     // queried for per-store metrics (only stores that belong to that node will
     // be queried).
     const storeSources = nodeSources
-      ? storeIDsForNode(nodesSummary, nodeSources[0])
+      ? storeIDsForNode(storeIDsByNodeID, nodeSources[0])
       : null;
 
     // tooltipSelection is a string used in tooltips to reference the currently
@@ -140,10 +146,11 @@ export class RaftMessages extends React.Component<RaftMessagesProps> {
 
     const dashboardProps: GraphDashboardProps = {
       nodeIDs,
-      nodesSummary,
       nodeSources,
       storeSources,
       tooltipSelection,
+      nodeDisplayNameByID,
+      storeIDsByNodeID,
     };
 
     // Generate graphs for the current dashboard, wrapping each one in a
@@ -172,7 +179,7 @@ export class RaftMessages extends React.Component<RaftMessagesProps> {
           <PageConfigItem>
             <Dropdown
               title="Graph"
-              options={this.nodeDropdownOptions(this.props.nodesSummary)}
+              options={this.props.nodeDropdownOptions}
               selected={selectedNode}
               onChange={this.nodeChange}
             />
@@ -189,12 +196,30 @@ export class RaftMessages extends React.Component<RaftMessagesProps> {
   }
 }
 
+const nodeDropdownOptionsSelector = createSelector(
+  nodeIDsSelector,
+  nodeDisplayNameByIDSelector,
+  (nodeIds, nodeDisplayNameByID): DropdownOption[] => {
+    const base = [{ value: "", label: "Cluster" }];
+    return base.concat(
+      _.map(nodeIds, id => {
+        return {
+          value: id.toString(),
+          label: nodeDisplayNameByID[id],
+        };
+      }),
+    );
+  },
+);
+
 const mapStateToProps = (state: AdminUIState) => ({
-  // RootState contains declaration for whole state
-  nodesSummary: nodesSummarySelector(state),
   nodesQueryValid: state.cachedData.nodes.valid,
   livenessQueryValid: state.cachedData.nodes.valid,
   hoverState: hoverStateSelector(state),
+  nodeIds: nodeIDsStringifiedSelector(state),
+  storeIDsByNodeID: selectStoreIDsByNodeID(state),
+  nodeDropdownOptions: nodeDropdownOptionsSelector(state),
+  nodeDisplayNameByID: nodeDisplayNameByIDSelector(state),
 });
 
 const mapDispatchToProps = {

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
@@ -25,7 +25,7 @@ import {
 import "./debug.styl";
 import { connect } from "react-redux";
 import { AdminUIState } from "src/redux/state";
-import { nodeIDsSelector } from "src/redux/nodes";
+import { nodeIDsStringifiedSelector } from "src/redux/nodes";
 import { refreshNodes, refreshUserSQLRoles } from "src/redux/apiReducers";
 import { selectHasViewActivityRedactedRole } from "src/redux/user";
 
@@ -142,7 +142,7 @@ function NodeIDSelector(props: {
 const NodeIDSelectorConnected = connect(
   (state: AdminUIState) => {
     return {
-      nodeIDs: nodeIDsSelector(state),
+      nodeIDs: nodeIDsStringifiedSelector(state),
     };
   },
   {

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/nodes/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/nodes/index.tsx
@@ -21,9 +21,11 @@ import { InlineAlert } from "src/components";
 import * as protos from "src/js/protos";
 import { refreshLiveness, refreshNodes } from "src/redux/apiReducers";
 import {
-  nodesSummarySelector,
-  NodesSummary,
   LivenessStatus,
+  nodeIDsStringifiedSelector,
+  selectNodesLastError,
+  nodeStatusByIDSelector,
+  livenessStatusByNodeIDSelector,
 } from "src/redux/nodes";
 import { AdminUIState } from "src/redux/state";
 import { util } from "@cockroachlabs/cluster-ui";
@@ -38,8 +40,14 @@ import {
   PageConfigItem,
 } from "src/views/shared/components/pageconfig";
 import Dropdown, { DropdownOption } from "src/views/shared/components/dropdown";
+
 interface NodesOwnProps {
-  nodesSummary: NodesSummary;
+  nodeIds: ReturnType<typeof nodeIDsStringifiedSelector.resultFunc>;
+  nodeLastError: ReturnType<typeof selectNodesLastError.resultFunc>;
+  nodeStatusByID: ReturnType<typeof nodeStatusByIDSelector.resultFunc>;
+  livenessStatusByNodeID: ReturnType<
+    typeof livenessStatusByNodeIDSelector.resultFunc
+  >;
   refreshNodes: typeof refreshNodes;
   refreshLiveness: typeof refreshLiveness;
 }
@@ -317,7 +325,7 @@ export class Nodes extends React.Component<NodesProps, LocalNodeState> {
     const inconsistent =
       !_.isNil(equality) &&
       _.chain(orderedNodeIDs)
-        .map(nodeID => this.props.nodesSummary.nodeStatusByID[nodeID])
+        .map(nodeID => this.props.nodeStatusByID[nodeID])
         .map(status => equality(status))
         .uniq()
         .value().length > 1;
@@ -331,7 +339,7 @@ export class Nodes extends React.Component<NodesProps, LocalNodeState> {
       <tr className="nodes-table__row" key={key}>
         <th className={headerClassName}>{title}</th>
         {_.map(orderedNodeIDs, nodeID => {
-          const status = this.props.nodesSummary.nodeStatusByID[nodeID];
+          const status = this.props.nodeStatusByID[nodeID];
           return (
             <NodeTableCell
               key={nodeID}
@@ -345,29 +353,27 @@ export class Nodes extends React.Component<NodesProps, LocalNodeState> {
   }
 
   requiresAdmin() {
-    const {
-      nodesSummary: { nodeLastError },
-    } = this.props;
-
-    return nodeLastError?.message === "this operation requires admin privilege";
+    return (
+      this.props.nodeLastError?.message ===
+      "this operation requires admin privilege"
+    );
   }
 
   render() {
-    const { nodesSummary } = this.props;
-    const { nodeStatusByID, livenessStatusByNodeID } = nodesSummary;
+    const { nodeStatusByID, livenessStatusByNodeID, nodeIds } = this.props;
     if (this.requiresAdmin()) {
       return (
         <InlineAlert title="" message="This page requires admin privileges." />
       );
     }
 
-    if (_.isEmpty(nodesSummary.nodeIDs)) {
+    if (_.isEmpty(nodeIds)) {
       return loading;
     }
 
     const filters = getFilters(this.props.location);
 
-    let nodeIDsContext = _.chain(nodesSummary.nodeIDs).map((nodeID: string) =>
+    let nodeIDsContext = _.chain(nodeIds).map((nodeID: string) =>
       Number.parseInt(nodeID, 10),
     );
     if (!_.isNil(filters.nodeIDs) && filters.nodeIDs.size > 0) {
@@ -479,7 +485,10 @@ export class Nodes extends React.Component<NodesProps, LocalNodeState> {
 }
 
 const mapStateToProps = (state: AdminUIState) => ({
-  nodesSummary: nodesSummarySelector(state),
+  nodeIds: nodeIDsStringifiedSelector(state),
+  nodeLastError: selectNodesLastError(state),
+  nodeStatusByID: nodeStatusByIDSelector(state),
+  livenessStatusByNodeID: livenessStatusByNodeIDSelector(state),
 });
 
 const mapDispatchToProps = {


### PR DESCRIPTION
Backport 1/1 commits from #88707.

/cc @cockroachdb/release

---

Before, many components on Metrics page relied on
`nodesSummarySelector` selector that in turn relies on `NodeStatus` that change constantly with every request (and we request it periodically every 10 seconds). `NodeStatus` include lots of unnecessary data for Metrics page (ie. node's and stores last metrics that aren't used on charts) but these changes forces react components to be re-rendered.

This patch refactors selectors that are used by metrics page in a way to provide only relevant subset of NodeStatus's info
to Graph components and reduce propagation of `props` passing from parent to child components. Instead, use selectors 
in child components if necessary.

Release note: None

Release justification: low risk, high benefit changes to existing functionality

Resolves #65030


Video that shows how often components were re-rendered **before** this fix - regardless of timewindow, it always
updates every 10 seconds:

https://user-images.githubusercontent.com/3106437/192295619-9b2da8bd-2fdb-4f5e-96db-688048fc54cf.mov

and here's after fix. Components re-render every 10 second for 10 minutes interval and it is not re-rendered 
for timewindows like 2 weeks or 1 month:

https://user-images.githubusercontent.com/3106437/192296089-13103781-6632-46a5-85aa-80ad8b20dd02.mov



