### PR TITLE
sql: don't cache uncommitted privileges

### DIFF
--- a/pkg/sql/cacheutil/cache.go
+++ b/pkg/sql/cacheutil/cache.go
@@ -55,10 +55,10 @@ func (c *Cache) GetValueLocked(key interface{}) (interface{}, bool) {
 	return val, ok
 }
 
-// LoadValueOutsideOfCache loads the value for the given requestKey using the provided
+// LoadValueOutsideOfCacheSingleFlight loads the value for the given requestKey using the provided
 // function. It ensures that there is only at most one in-flight request for
 // each key at any time.
-func (c *Cache) LoadValueOutsideOfCache(
+func (c *Cache) LoadValueOutsideOfCacheSingleFlight(
 	ctx context.Context, requestKey string, fn func(loadCtx context.Context) (interface{}, error),
 ) (interface{}, error) {
 	ch, _ := c.populateCacheGroup.DoChan(requestKey, func() (interface{}, error) {

--- a/pkg/sql/cacheutil/cache_test.go
+++ b/pkg/sql/cacheutil/cache_test.go
@@ -53,12 +53,12 @@ func TestCache(t *testing.T) {
 	require.Equal(t, isEligible, true)
 
 	// In theory, only one call should happen to the func passed into
-	// LoadValueOutsideOfCache due to singleflight.
+	// LoadValueOutsideOfCacheSingleFlight due to singleflight.
 	// Testing that only one call happens is hard to synchronize, we would
 	// have to add a test hook into `DoChan` to make synchronize our calls.
 	for i := 0; i < 5; i++ {
 		go func() {
-			val, err := cache.LoadValueOutsideOfCache(ctx, "test", func(loadCtx context.Context) (interface{}, error) {
+			val, err := cache.LoadValueOutsideOfCacheSingleFlight(ctx, "test", func(loadCtx context.Context) (interface{}, error) {
 				return "val", nil
 			})
 			require.NoError(t, err)

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -308,10 +308,7 @@ func (*DummyEvalPlanner) ExecutorConfig() interface{} {
 
 // SynthesizePrivilegeDescriptor is part of the Planner interface.
 func (*DummyEvalPlanner) SynthesizePrivilegeDescriptor(
-	ctx context.Context,
-	privilegeObjectName string,
-	privilegeObjectPath string,
-	privilegeObjectType privilege.ObjectType,
+	ctx context.Context, privilegeObjectPath string, privilegeObjectType privilege.ObjectType,
 ) (privileges *catpb.PrivilegeDescriptor, retErr error) {
 	return nil, nil
 }

--- a/pkg/sql/logictest/testdata/logic_test/synthetic_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/synthetic_privileges
@@ -283,3 +283,60 @@ ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES TO testuser3
 
 statement error pq: role testuser3 cannot be dropped because some objects depend on it\nprivileges for default privileges on new relations belonging to role root in database test\ntestuser3 has global 'EXTERNALCONNECTION' privilege\ntestuser3 has global 'MODIFYCLUSTERSETTING' privilege
 DROP USER testuser3
+
+# Do not cache privileges if the system.privileges table is uncommitted.
+statement ok
+CREATE USER testuser4
+
+statement ok
+REVOKE SELECT ON crdb_internal.tables FROM public
+
+query B
+SELECT has_table_privilege('testuser4', 'crdb_internal.tables', 'SELECT')
+----
+false
+
+statement ok
+BEGIN
+
+statement ok
+GRANT SELECT ON crdb_internal.tables TO testuser4
+
+query TTTT
+SELECT * FROM system.privileges ORDER BY 1,2
+----
+public     /vtable/crdb_internal/tables  {}                                         {}
+root       /global/                      {MODIFYCLUSTERSETTING}                     {}
+testuser   /externalconn/foo             {USAGE}                                    {}
+testuser   /global/                      {MODIFYCLUSTERSETTING}                     {}
+testuser   /vtable/crdb_internal/tables  {SELECT}                                   {}
+testuser2  /externalconn/foo             {USAGE}                                    {}
+testuser2  /global/                      {MODIFYCLUSTERSETTING}                     {}
+testuser3  /global/                      {EXTERNALCONNECTION,MODIFYCLUSTERSETTING}  {}
+testuser4  /vtable/crdb_internal/tables  {SELECT}                                   {}
+
+# This should not cache the uncommitted privilege.
+query B
+SELECT has_table_privilege('testuser4', 'crdb_internal.tables', 'SELECT')
+----
+true
+
+statement ok
+ROLLBACK
+
+query TTTT
+SELECT * FROM system.privileges ORDER BY 1,2
+----
+public     /vtable/crdb_internal/tables  {}                                         {}
+root       /global/                      {MODIFYCLUSTERSETTING}                     {}
+testuser   /externalconn/foo             {USAGE}                                    {}
+testuser   /global/                      {MODIFYCLUSTERSETTING}                     {}
+testuser   /vtable/crdb_internal/tables  {SELECT}                                   {}
+testuser2  /externalconn/foo             {USAGE}                                    {}
+testuser2  /global/                      {MODIFYCLUSTERSETTING}                     {}
+testuser3  /global/                      {EXTERNALCONNECTION,MODIFYCLUSTERSETTING}  {}
+
+query B
+SELECT has_table_privilege('testuser4', 'crdb_internal.tables', 'SELECT')
+----
+false

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -353,7 +353,6 @@ type Planner interface {
 	// from system.privileges.
 	SynthesizePrivilegeDescriptor(
 		ctx context.Context,
-		privilegeObjectName string,
 		privilegeObjectPath string,
 		privilegeObjectType privilege.ObjectType,
 	) (*catpb.PrivilegeDescriptor, error)

--- a/pkg/sql/syntheticprivilege/external_connection_privilege.go
+++ b/pkg/sql/syntheticprivilege/external_connection_privilege.go
@@ -40,7 +40,7 @@ func (e *ExternalConnectionPrivilege) GetPrivilegeDescriptor(
 	ctx context.Context, planner eval.Planner,
 ) (*catpb.PrivilegeDescriptor, error) {
 	if planner.IsActive(ctx, clusterversion.SystemPrivilegesTable) {
-		return planner.SynthesizePrivilegeDescriptor(ctx, e.GetName(), e.GetPath(),
+		return planner.SynthesizePrivilegeDescriptor(ctx, e.GetPath(),
 			e.GetObjectType())
 	}
 	return catpb.NewPrivilegeDescriptor(

--- a/pkg/sql/syntheticprivilege/global_privilege.go
+++ b/pkg/sql/syntheticprivilege/global_privilege.go
@@ -41,7 +41,7 @@ var GlobalPrivilegeObject = &GlobalPrivilege{}
 func (p *GlobalPrivilege) GetPrivilegeDescriptor(
 	ctx context.Context, planner eval.Planner,
 ) (*catpb.PrivilegeDescriptor, error) {
-	return planner.SynthesizePrivilegeDescriptor(ctx, p.GetName(), p.GetPath(), p.GetObjectType())
+	return planner.SynthesizePrivilegeDescriptor(ctx, p.GetPath(), p.GetObjectType())
 }
 
 // GetObjectType implements the PrivilegeObject interface.

--- a/pkg/sql/syntheticprivilege/vtable_privilege.go
+++ b/pkg/sql/syntheticprivilege/vtable_privilege.go
@@ -42,7 +42,7 @@ func (p *VirtualTablePrivilege) GetPrivilegeDescriptor(
 	ctx context.Context, planner eval.Planner,
 ) (*catpb.PrivilegeDescriptor, error) {
 	if planner.IsActive(ctx, clusterversion.SystemPrivilegesTable) {
-		return planner.SynthesizePrivilegeDescriptor(ctx, p.GetName(), p.GetPath(), p.GetObjectType())
+		return planner.SynthesizePrivilegeDescriptor(ctx, p.GetPath(), p.GetObjectType())
 	}
 	return catpb.NewPrivilegeDescriptor(
 		username.PublicRoleName(), privilege.List{privilege.SELECT}, privilege.List{}, username.NodeUserName(),


### PR DESCRIPTION
Release note (sql change): Previously, uncommitted privileges could be cached if the txn is rolled back. This is now fixed. This has not made it into GA and is a GA blocker. Example:

```
BEGIN;
GRANT SELECT ON crdb_internal.tables TO testuser;
SELECT has_table_privilege('testuser', 'crdb_internal.tables', 'SELECT'); --- this caches the privilege ---
ROLLBACK;
--- SELECT IS STILL CACHED UNTIL ANOTHER GRANT/REVOKE HAPPENS TO INVALIDATE THE CACHE---
```

Fixes: #89001

