### PR TITLE
sql: require `CREATE` privilege on a schema to create udf

### DIFF
--- a/pkg/sql/create_function.go
+++ b/pkg/sql/create_function.go
@@ -60,6 +60,12 @@ func (n *createFunctionNode) startExec(params runParams) error {
 		return unimplemented.NewWithIssue(85144, "CREATE FUNCTION...sql_body unimplemented")
 	}
 
+	if err := params.p.canCreateOnSchema(
+		params.ctx, n.scDesc.GetID(), n.dbDesc.GetID(), params.p.User(), skipCheckPublicSchema,
+	); err != nil {
+		return err
+	}
+
 	for _, dep := range n.planDeps {
 		if dbID := dep.desc.GetParentID(); dbID != n.dbDesc.GetID() && dbID != keys.SystemDatabaseID {
 			return pgerror.Newf(pgcode.FeatureNotSupported, "the function cannot refer to other databases")

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -1849,6 +1849,18 @@ test           sc_test_show_grants  f_test_show_grants(int8, text, oid)  u_test_
 statement ok
 SET search_path = public;
 
+subtest udf_create_privilege
+
+statement ok
+CREATE SCHEMA sc_test_priv;
+
+user testuser
+
+statement error pq: user testuser does not have CREATE privilege on schema sc_test_priv
+CREATE FUNCTION sc_test_priv.f() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
+
+user root
+
 subtest execution
 
 statement ok


### PR DESCRIPTION
A user must have `CREATE` privilege on a schema to create a user-defined function. Funny that I took it for granted while reviewing the udf doc PR :(

Release note: None
Release justification: necessary bug fix and low risk.