### PR TITLE
sqlitelogictest: increase timeout from 1h to 2h

### DIFF
--- a/pkg/ccl/sqlitelogictestccl/tests/3node-tenant/BUILD.bazel
+++ b/pkg/ccl/sqlitelogictestccl/tests/3node-tenant/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     name = "3node-tenant_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = ["-test.timeout=7195s"],
     data = [
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep

--- a/pkg/cmd/generate-bazel-extra/main_test.go
+++ b/pkg/cmd/generate-bazel-extra/main_test.go
@@ -46,3 +46,55 @@ func TestParseQueryXML(t *testing.T) {
 		require.ElementsMatch(t, expectedDataMap[size], sizeToTargets[size])
 	}
 }
+
+func TestExcludeSqliteLogicTests(t *testing.T) {
+	for _, tc := range []struct {
+		in  []string
+		out []string
+	}{
+		{
+			in: []string{
+				"//pkg/jobs:jobs_test",
+				"//pkg/sql/sem/eval:eval_test",
+				"//pkg/sql/sqlitelogictest:sqlitelogictest_test",
+			},
+			out: []string{
+				"//pkg/jobs:jobs_test",
+				"//pkg/sql/sem/eval:eval_test",
+			},
+		},
+		{
+			in: []string{
+				"//pkg/sql/colexec:colexec_test",
+				"//pkg/sql/sem/eval:eval_test",
+			},
+			out: []string{
+				"//pkg/sql/colexec:colexec_test",
+				"//pkg/sql/sem/eval:eval_test",
+			},
+		},
+		{
+			in: []string{
+				"//pkg/ccl/sqlitelogictestccl:sqlitelogictestccl_test",
+				"//pkg/sql/sqlitelogictest:sqlitelogictest_test",
+			},
+			out: []string{},
+		},
+		{
+			in: []string{
+				"//pkg/ccl/sqlitelogictestccl:sqlitelogictestccl_test",
+				"//pkg/jobs:jobs_test",
+				"//pkg/sql/colexec:colexec_test",
+				"//pkg/sql/sem/eval:eval_test",
+				"//pkg/sql/sqlitelogictest:sqlitelogictest_test",
+			},
+			out: []string{
+				"//pkg/jobs:jobs_test",
+				"//pkg/sql/colexec:colexec_test",
+				"//pkg/sql/sem/eval:eval_test",
+			},
+		},
+	} {
+		require.Equal(t, tc.out, excludeSqliteLogicTests(tc.in))
+	}
+}

--- a/pkg/cmd/generate-logictest/templates.go
+++ b/pkg/cmd/generate-logictest/templates.go
@@ -247,8 +247,9 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 go_test(
     name = "{{ .TestRuleName }}_test",
     size = "enormous",
-    srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    srcs = ["generated_test.go"],{{ if .SqliteLogicTest }}
+    args = ["-test.timeout=7195s"],{{ else }}
+    args = ["-test.timeout=3595s"],{{ end }}
     data = [
         "//c-deps:libgeos",  # keep{{ if .SqliteLogicTest }}
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep{{ end }}{{ if .CclLogicTest }}

--- a/pkg/sql/sqlitelogictest/tests/fakedist-disk/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/fakedist-disk/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     name = "fakedist-disk_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = ["-test.timeout=7195s"],
     data = [
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep

--- a/pkg/sql/sqlitelogictest/tests/fakedist-vec-off/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/fakedist-vec-off/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     name = "fakedist-vec-off_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = ["-test.timeout=7195s"],
     data = [
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep

--- a/pkg/sql/sqlitelogictest/tests/fakedist/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/fakedist/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     name = "fakedist_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = ["-test.timeout=7195s"],
     data = [
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep

--- a/pkg/sql/sqlitelogictest/tests/local-legacy-schema-changer/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/local-legacy-schema-changer/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     name = "local-legacy-schema-changer_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = ["-test.timeout=7195s"],
     data = [
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep

--- a/pkg/sql/sqlitelogictest/tests/local-vec-off/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/local-vec-off/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     name = "local-vec-off_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = ["-test.timeout=7195s"],
     data = [
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep

--- a/pkg/sql/sqlitelogictest/tests/local/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/local/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     name = "local_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = ["-test.timeout=7195s"],
     data = [
         "//c-deps:libgeos",  # keep
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep


### PR DESCRIPTION
sqlitelogic tests have been timing out lately, mostly on `local-legacy-schema-changer` config. It's possible that `workmem` randomizations make the tests run slower, but before removing that or changing the range of values for that variable, this commit increases the timeout from 1h to 2h. This should be ok since the tests are run on a nightly basis and, thus, are not on the hot CI path.

Informs: #88123.

Release note: None