### PR TITLE
catalog/descs: remove an allocation due to logging

### DIFF
--- a/pkg/sql/catalog/descs/descriptor.go
+++ b/pkg/sql/catalog/descs/descriptor.go
@@ -89,7 +89,9 @@ func (tc *Collection) getDescriptorsByID(
 ) (descs []catalog.Descriptor, err error) {
 	// Override flags.
 	flags.Required = true
-	log.VEventf(ctx, 2, "looking up descriptors for ids %v", ids)
+	if log.ExpensiveLogEnabled(ctx, 2) {
+		log.VEventf(ctx, 2, "looking up descriptors for ids %v", ids)
+	}
 	descs = make([]catalog.Descriptor, len(ids))
 	vls := make([]catalog.ValidationLevel, len(ids))
 	{


### PR DESCRIPTION
This commit removes an allocation that we incurred due to a logging message - constructing the log message wasn't free in this case, so we hide it behind an "expensive logging enabled" check.

```
name                                         old time/op    new time/op    delta
SQL/MultinodeCockroach/Upsert/count=1000-24    25.5ms ± 4%    24.1ms ± 5%  -5.15%  (p=0.000 n=10+10)

name                                         old alloc/op   new alloc/op   delta
SQL/MultinodeCockroach/Upsert/count=1000-24    10.7MB ±13%    10.6MB ±18%    ~     (p=0.497 n=9+10)

name                                         old allocs/op  new allocs/op  delta
SQL/MultinodeCockroach/Upsert/count=1000-24     79.1k ± 6%     73.2k ± 6%  -7.50%  (p=0.007 n=10+10)
```

Addresses: #87685.

Release note: None