### PR TITLE
release-22.1: norm: do not fold floor division with unit denominator

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/float
+++ b/pkg/sql/logictest/testdata/logic_test/float
@@ -174,3 +174,17 @@ query BB
 SELECT 'nan'::decimal IS NAN, 'nan'::decimal IS NOT NAN
 ----
 true  false
+
+statement ok
+CREATE TABLE t87605 (col2 FLOAT8 NULL)
+
+statement ok
+insert into t87605 values (1.234567890123456e+13), (1.234567890123456e+6)
+
+# Regression test for issue #87605.
+# The floor division operator `//` should not be folded away.
+query F
+SELECT ((col2::FLOAT8 // 1.0:::FLOAT8::FLOAT8)::FLOAT8) FROM t87605@[0] ORDER BY 1
+----
+1.234567e+06
+1.2345678901234e+13

--- a/pkg/sql/opt/norm/general_funcs.go
+++ b/pkg/sql/opt/norm/general_funcs.go
@@ -64,6 +64,12 @@ func (c *CustomFuncs) IsTimestampTZ(scalar opt.ScalarExpr) bool {
 	return scalar.DataType().Family() == types.TimestampTZFamily
 }
 
+// IsInt returns true if the given scalar expression is of one of the
+// integer types.
+func (c *CustomFuncs) IsInt(scalar opt.ScalarExpr) bool {
+	return scalar.DataType().Family() == types.IntFamily
+}
+
 // BoolType returns the boolean SQL type.
 func (c *CustomFuncs) BoolType() *types.T {
 	return types.Bool
@@ -328,7 +334,7 @@ func (c *CustomFuncs) OuterCols(e opt.Expr) opt.ColSet {
 // column, or in other words, a reference to a variable that is not bound within
 // its own scope. For example:
 //
-//   SELECT * FROM a WHERE EXISTS(SELECT * FROM b WHERE b.x = a.x)
+//	SELECT * FROM a WHERE EXISTS(SELECT * FROM b WHERE b.x = a.x)
 //
 // The a.x variable in the EXISTS subquery references a column outside the scope
 // of the subquery. It is an "outer column" for the subquery (see the comment on
@@ -339,11 +345,12 @@ func (c *CustomFuncs) HasOuterCols(input opt.Expr) bool {
 
 // IsCorrelated returns true if any variable in the source expression references
 // a column from the given set of output columns. For example:
-//   (InnerJoin
-//     (Scan a)
-//     (Scan b)
-//     [ ... (FiltersItem $item:(Eq (Variable a.x) (Const 1))) ... ]
-//   )
+//
+//	(InnerJoin
+//	  (Scan a)
+//	  (Scan b)
+//	  [ ... (FiltersItem $item:(Eq (Variable a.x) (Const 1))) ... ]
+//	)
 //
 // The $item expression is correlated with the (Scan a) expression because it
 // references one of its columns. But the $item expression is not correlated
@@ -355,11 +362,11 @@ func (c *CustomFuncs) IsCorrelated(src memo.RelExpr, cols opt.ColSet) bool {
 // IsBoundBy returns true if all outer references in the source expression are
 // bound by the given columns. For example:
 //
-//   (InnerJoin
-//     (Scan a)
-//     (Scan b)
-//     [ ... $item:(FiltersItem (Eq (Variable a.x) (Const 1))) ... ]
-//   )
+//	(InnerJoin
+//	  (Scan a)
+//	  (Scan b)
+//	  [ ... $item:(FiltersItem (Eq (Variable a.x) (Const 1))) ... ]
+//	)
 //
 // The $item expression is fully bound by the output columns of the (Scan a)
 // expression because all of its outer references are satisfied by the columns
@@ -412,11 +419,11 @@ func (c *CustomFuncs) FilterOuterCols(filters memo.FiltersExpr) opt.ColSet {
 // FiltersBoundBy returns true if all outer references in any of the filter
 // conditions are bound by the given columns. For example:
 //
-//   (InnerJoin
-//     (Scan a)
-//     (Scan b)
-//     $filters:[ (FiltersItem (Eq (Variable a.x) (Const 1))) ]
-//   )
+//	(InnerJoin
+//	  (Scan a)
+//	  (Scan b)
+//	  $filters:[ (FiltersItem (Eq (Variable a.x) (Const 1))) ]
+//	)
 //
 // The $filters expression is fully bound by the output columns of the (Scan a)
 // expression because all of its outer references are satisfied by the columns
@@ -713,14 +720,14 @@ func (c *CustomFuncs) ReplaceFiltersItem(
 // from the given list that are fully bound by the given columns (i.e. all
 // outer references are to one of these columns). For example:
 //
-//   (InnerJoin
-//     (Scan a)
-//     (Scan b)
-//     (Filters [
-//       (Eq (Variable a.x) (Variable b.x))
-//       (Gt (Variable a.x) (Const 1))
-//     ])
-//   )
+//	(InnerJoin
+//	  (Scan a)
+//	  (Scan b)
+//	  (Filters [
+//	    (Eq (Variable a.x) (Variable b.x))
+//	    (Gt (Variable a.x) (Const 1))
+//	  ])
+//	)
 //
 // Calling ExtractBoundConditions with the filter conditions list and the output
 // columns of (Scan a) would extract the (Gt) expression, since its outer
@@ -907,11 +914,10 @@ func (c *CustomFuncs) AppendAggCols(
 // function of the given operator type for each of column in the given set. For
 // example, for ConstAggOp and columns (1,2), this expression is returned:
 //
-//   (Aggregations
-//     [(ConstAgg (Variable 1)) (ConstAgg (Variable 2))]
-//     [1,2]
-//   )
-//
+//	(Aggregations
+//	  [(ConstAgg (Variable 1)) (ConstAgg (Variable 2))]
+//	  [1,2]
+//	)
 func (c *CustomFuncs) MakeAggCols(aggOp opt.Operator, cols opt.ColSet) memo.AggregationsExpr {
 	colsLen := cols.Len()
 	aggs := make(memo.AggregationsExpr, colsLen)
@@ -981,8 +987,7 @@ func (c *CustomFuncs) IsPositiveInt(datum tree.Datum) bool {
 // For example, NormalizeCmpTimeZoneFunction uses this function implicitly to
 // match a specific function, like so:
 //
-//   (Function $args:* (FunctionPrivate "timezone"))
-//
+//	(Function $args:* (FunctionPrivate "timezone"))
 func (c *CustomFuncs) EqualsString(left string, right string) bool {
 	return left == right
 }

--- a/pkg/sql/opt/norm/rules/numeric.opt
+++ b/pkg/sql/opt/norm/rules/numeric.opt
@@ -44,7 +44,13 @@
 
 # FoldDivOne folds $left / 1 for numeric types.
 [FoldDivOne, Normalize]
-(Div | FloorDiv $left:* $right:(Const 1))
+(Div $left:* $right:(Const 1))
+=>
+(Cast $left (BinaryType (OpName) $left $right))
+
+# FoldFloorDivOne folds $left // 1 for integer types.
+[FoldFloorDivOne, Normalize]
+(FloorDiv $left:* $right:(Const 1) & (IsInt $left))
 =>
 (Cast $left (BinaryType (OpName) $left $right))
 

--- a/pkg/sql/opt/norm/testdata/rules/fold_constants
+++ b/pkg/sql/opt/norm/testdata/rules/fold_constants
@@ -441,6 +441,27 @@ values
  ├── fd: ()-->(1)
  └── (NULL,)
 
+# Regression test for issue #87605.
+norm expect=FoldBinary
+SELECT 1.333 // 1.0
+----
+values
+ ├── columns: "?column?":1!null
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (1,)
+
+norm expect=FoldBinary
+SELECT 2::INT // 1.0
+----
+values
+ ├── columns: "?column?":1!null
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (2,)
+
 # --------------------------------------------------
 # FoldUnary
 # --------------------------------------------------

--- a/pkg/sql/opt/norm/testdata/rules/numeric
+++ b/pkg/sql/opt/norm/testdata/rules/numeric
@@ -189,6 +189,30 @@ project
       └── i:2::DECIMAL [as="?column?":8, outer=(2), immutable]
 
 # --------------------------------------------------
+# FoldFloorDivOne
+# --------------------------------------------------
+
+# Regression test for issue #87605.
+# The floor division operator `//` should only be folded when the numerator is
+# an integer.
+norm expect=FoldFloorDivOne
+SELECT
+    a.i // 1 AS r,
+    a.f // 1 AS s,
+    a.d // 1 AS t
+FROM a
+----
+project
+ ├── columns: r:8 s:9 t:10
+ ├── immutable
+ ├── scan a
+ │    └── columns: i:2 f:3 d:4
+ └── projections
+      ├── i:2 [as=r:8, outer=(2)]
+      ├── f:3 // 1.0 [as=s:9, outer=(3), immutable]
+      └── d:4 // 1 [as=t:10, outer=(4), immutable]
+
+# --------------------------------------------------
 # InvertMinus
 # --------------------------------------------------
 norm expect=InvertMinus


### PR DESCRIPTION
Backport 1/1 commits from #87808.

/cc @cockroachdb/release

---

Fixes #87605

The floor division operator `//` is like division but drops the
fractional portion of the result. Normalization rule FoldDivOne
rewrites `(column // 1)` as `(column)` which is incorrect if the
data in `column` has fractional digits, as those digits should be
dropped.

The solution is to only fold `(column // 1)` when `column` is one of
the integer types.

Release note (bug fix): This patch fixes incorrect results from
the floor division operator, `//`, when the numerator is non-constant
and the denominator is the constant 1.

Release justification: low risk fix for incorrect results on divide by 1