### PR TITLE
roachtest/schemachange: fix tmp directory leak in error path

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_decl_schemachange_compat.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_decl_schemachange_compat.go
@@ -56,8 +56,8 @@ func fetchCorpusToTmpDir(
 			versionNumber,
 			corpusFilePath))
 	if err != nil {
-		t.Fatalf("Missing validation corpus for %v (%v)", versionNumber, err)
 		cleanupFn()
+		t.Fatalf("Missing validation corpus for %v (%v)", versionNumber, err)
 	}
 	t.L().Printf("Fetched validation corpus for %v", versionNumber)
 	return corpusFilePath, cleanupFn


### PR DESCRIPTION
Fixes: https://github.com/cockroachdb/cockroach/issues/89141

Previously, if we failed to fetch any corpus for a
given release we would leave the temporary directory
for storing it behind. This patch cleans up the directory
in a error path.

Release note: None
Release justification: No real risk only fixes a bug in a test.