### PR TITLE
sql: rename some planner internal executor methods

### DIFF
--- a/pkg/sql/drop_role.go
+++ b/pkg/sql/drop_role.go
@@ -584,7 +584,7 @@ func addDependentPrivilegesFromSystemPrivileges(
 	for i, username := range usernames {
 		names[i] = username.Normalized()
 	}
-	rows, err := p.QueryIteratorEx(ctx, `drop-role-get-system-privileges`, sessiondata.NodeUserSessionDataOverride,
+	rows, err := p.QueryIterator(ctx, `drop-role-get-system-privileges`, sessiondata.NodeUserSessionDataOverride,
 		`SELECT DISTINCT username, path, privileges FROM system.privileges WHERE username = ANY($1) ORDER BY 1, 2`, names)
 	if err != nil {
 		return err

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -420,7 +420,7 @@ func (ep *DummyEvalPlanner) ResolveType(
 }
 
 // QueryRowEx is part of the eval.Planner interface.
-func (ep *DummyEvalPlanner) QueryRowEx(
+func (ep *DummyEvalPlanner) QueryRow(
 	ctx context.Context,
 	opName string,
 	session sessiondata.InternalExecutorOverride,
@@ -431,7 +431,7 @@ func (ep *DummyEvalPlanner) QueryRowEx(
 }
 
 // QueryIteratorEx is part of the eval.Planner interface.
-func (ep *DummyEvalPlanner) QueryIteratorEx(
+func (ep *DummyEvalPlanner) QueryIterator(
 	ctx context.Context,
 	opName string,
 	override sessiondata.InternalExecutorOverride,

--- a/pkg/sql/grant_revoke_system.go
+++ b/pkg/sql/grant_revoke_system.go
@@ -280,7 +280,7 @@ func (p *planner) SynthesizePrivilegeDescriptor(
 			catconstants.SystemPrivilegeTableName,
 			privilegeObjectPath)
 
-		it, err := p.QueryIteratorEx(ctx, `get-system-privileges`,
+		it, err := p.QueryIterator(ctx, `get-system-privileges`,
 			sessiondata.NodeUserSessionDataOverride, query)
 		if err != nil {
 			return nil, err

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -915,12 +915,12 @@ func initInternalExecutor(ctx context.Context, p *planner) sqlutil.InternalExecu
 	return ie
 }
 
-// QueryRowEx executes the supplied SQL statement and returns a single row, or
+// QueryRow executes the supplied SQL statement and returns a single row, or
 // nil if no row is found, or an error if more that one row is returned.
 //
 // The fields set in session that are set override the respective fields if
 // they have previously been set through SetSessionData().
-func (p *planner) QueryRowEx(
+func (p *planner) QueryRow(
 	ctx context.Context,
 	opName string,
 	override sessiondata.InternalExecutorOverride,
@@ -931,9 +931,11 @@ func (p *planner) QueryRowEx(
 	return ie.QueryRowEx(ctx, opName, p.Txn(), override, stmt, qargs...)
 }
 
-// ExecEx is like Exec, but allows the caller to override some session data
-// fields (e.g. the user).
-func (p *planner) ExecEx(
+// Exec executes the supplied SQL statement and returns the number of rows
+// affected (not like the full results; see QueryIterator()). If no user has
+// been previously set through SetSessionData, the statement is executed as
+// the root user.
+func (p *planner) Exec(
 	ctx context.Context,
 	opName string,
 	override sessiondata.InternalExecutorOverride,
@@ -944,13 +946,13 @@ func (p *planner) ExecEx(
 	return ie.ExecEx(ctx, opName, p.Txn(), override, stmt, qargs...)
 }
 
-// QueryIteratorEx executes the query, returning an iterator that can be used
+// QueryIterator executes the query, returning an iterator that can be used
 // to get the results. If the call is successful, the returned iterator
 // *must* be closed.
 //
 // The fields set in session that are set override the respective fields if they
 // have previously been set through SetSessionData().
-func (p *planner) QueryIteratorEx(
+func (p *planner) QueryIterator(
 	ctx context.Context,
 	opName string,
 	override sessiondata.InternalExecutorOverride,
@@ -962,11 +964,11 @@ func (p *planner) QueryIteratorEx(
 	return rows.(eval.InternalRows), err
 }
 
-// QueryBufferedEx executes the supplied SQL statement and returns the resulting
+// QueryBuffered executes the supplied SQL statement and returns the resulting
 // rows (meaning all of them are buffered at once).
 // The fields set in session that are set override the respective fields if they
 // have previously been set through SetSessionData().
-func (p *planner) QueryBufferedEx(
+func (p *planner) QueryBuffered(
 	ctx context.Context,
 	opName string,
 	session sessiondata.InternalExecutorOverride,
@@ -977,9 +979,9 @@ func (p *planner) QueryBufferedEx(
 	return ie.QueryBufferedEx(ctx, opName, p.Txn(), session, stmt, qargs...)
 }
 
-// QueryRowExWithCols is like QueryRowEx, additionally returning the computed
+// QueryRowWithCols is like QueryRowEx, additionally returning the computed
 // ResultColumns of the input query.
-func (p *planner) QueryRowExWithCols(
+func (p *planner) QueryRowWithCols(
 	ctx context.Context,
 	opName string,
 	session sessiondata.InternalExecutorOverride,
@@ -990,9 +992,9 @@ func (p *planner) QueryRowExWithCols(
 	return ie.QueryRowExWithCols(ctx, opName, p.Txn(), session, stmt, qargs...)
 }
 
-// QueryBufferedExWithCols is like QueryBufferedEx, additionally returning the
+// QueryBufferedWithCols is like QueryBuffered, additionally returning the
 // computed ResultColumns of the input query.
-func (p *planner) QueryBufferedExWithCols(
+func (p *planner) QueryBufferedWithCols(
 	ctx context.Context,
 	opName string,
 	session sessiondata.InternalExecutorOverride,

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -3240,7 +3240,7 @@ func isCurrentMutationDiscarded(
 func (p *planner) CanPerformDropOwnedBy(
 	ctx context.Context, role username.SQLUsername,
 ) (bool, error) {
-	row, err := p.QueryRowEx(ctx, `role-has-synthetic-privileges`, sessiondata.NodeUserSessionDataOverride,
+	row, err := p.QueryRow(ctx, `role-has-synthetic-privileges`, sessiondata.NodeUserSessionDataOverride,
 		`SELECT count(1) FROM system.privileges WHERE username = $1`, role.Normalized())
 
 	return tree.MustBeDInt(row[0]) == 0, err

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -2342,7 +2342,7 @@ func makePayloadsForTraceGenerator(
 									) SELECT *
 										FROM spans, LATERAL crdb_internal.payloads_for_span(spans.span_id)`
 
-	it, err := ctx.Planner.QueryIteratorEx(
+	it, err := ctx.Planner.QueryIterator(
 		ctx.Ctx(),
 		"crdb_internal.payloads_for_trace",
 		sessiondata.NoSessionDataOverride,

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -212,7 +212,7 @@ func makePGGetIndexDef(argTypes tree.ArgTypes) tree.Overload {
 			if len(args) == 3 {
 				colNumber = *args[1].(*tree.DInt)
 			}
-			r, err := ctx.Planner.QueryRowEx(
+			r, err := ctx.Planner.QueryRow(
 				ctx.Ctx(), "pg_get_indexdef",
 				sessiondata.NoSessionDataOverride,
 				"SELECT indexdef FROM pg_catalog.pg_indexes WHERE crdb_oid = $1", args[0])
@@ -228,7 +228,7 @@ func makePGGetIndexDef(argTypes tree.ArgTypes) tree.Overload {
 				return r[0], nil
 			}
 			// The 3 argument variant for column number other than 0 returns the column name.
-			r, err = ctx.Planner.QueryRowEx(
+			r, err = ctx.Planner.QueryRow(
 				ctx.Ctx(), "pg_get_indexdef",
 				sessiondata.NoSessionDataOverride,
 				`SELECT ischema.column_name as pg_get_indexdef 
@@ -262,7 +262,7 @@ func makePGGetViewDef(argTypes tree.ArgTypes) tree.Overload {
 		Types:      argTypes,
 		ReturnType: tree.FixedReturnType(types.String),
 		Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-			r, err := ctx.Planner.QueryRowEx(
+			r, err := ctx.Planner.QueryRow(
 				ctx.Ctx(), "pg_get_viewdef",
 				sessiondata.NoSessionDataOverride,
 				`SELECT definition
@@ -293,7 +293,7 @@ func makePGGetConstraintDef(argTypes tree.ArgTypes) tree.Overload {
 		Types:      argTypes,
 		ReturnType: tree.FixedReturnType(types.String),
 		Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-			r, err := ctx.Planner.QueryRowEx(
+			r, err := ctx.Planner.QueryRow(
 				ctx.Ctx(), "pg_get_constraintdef",
 				sessiondata.NoSessionDataOverride,
 				"SELECT condef FROM pg_catalog.pg_constraint WHERE oid=$1", args[0])
@@ -446,7 +446,7 @@ func getNameForArg(ctx *eval.Context, arg tree.Datum, pgTable, pgCol string) (st
 	default:
 		return "", errors.AssertionFailedf("unexpected arg type %T", t)
 	}
-	r, err := ctx.Planner.QueryRowEx(ctx.Ctx(), "get-name-for-arg",
+	r, err := ctx.Planner.QueryRow(ctx.Ctx(), "get-name-for-arg",
 		sessiondata.NoSessionDataOverride, query, arg)
 	if err != nil || r == nil {
 		return "", err
@@ -664,7 +664,7 @@ var pgBuiltins = map[string]builtinDefinition{
 						return nil, err
 					}
 				}
-				results, err := ctx.Planner.QueryRowEx(
+				results, err := ctx.Planner.QueryRow(
 					ctx.Ctx(), "pg_get_functiondef",
 					sessiondata.NoSessionDataOverride,
 					getFuncQuery,
@@ -695,7 +695,7 @@ var pgBuiltins = map[string]builtinDefinition{
 			ReturnType: tree.FixedReturnType(types.String),
 			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				funcOid := tree.MustBeDOid(args[0])
-				t, err := ctx.Planner.QueryRowEx(
+				t, err := ctx.Planner.QueryRow(
 					ctx.Ctx(), "pg_get_function_result",
 					sessiondata.NoSessionDataOverride,
 					`SELECT prorettype::REGTYPE::TEXT FROM pg_proc WHERE oid=$1`, funcOid.Oid)
@@ -723,7 +723,7 @@ var pgBuiltins = map[string]builtinDefinition{
 			ReturnType: tree.FixedReturnType(types.String),
 			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				funcOid := tree.MustBeDOid(args[0])
-				t, err := ctx.Planner.QueryRowEx(
+				t, err := ctx.Planner.QueryRow(
 					ctx.Ctx(), "pg_get_function_identity_arguments",
 					sessiondata.NoSessionDataOverride,
 					`SELECT array_agg(unnest(proargtypes)::REGTYPE::TEXT) FROM pg_proc WHERE oid=$1`, funcOid.Oid)
@@ -919,7 +919,7 @@ var pgBuiltins = map[string]builtinDefinition{
 			ReturnType: tree.FixedReturnType(types.String),
 			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				oid := args[0]
-				t, err := ctx.Planner.QueryRowEx(
+				t, err := ctx.Planner.QueryRow(
 					ctx.Ctx(), "pg_get_userbyid",
 					sessiondata.NoSessionDataOverride,
 					"SELECT rolname FROM pg_catalog.pg_roles WHERE oid=$1", oid)
@@ -947,7 +947,7 @@ var pgBuiltins = map[string]builtinDefinition{
 			Types:      tree.ArgTypes{{"sequence_oid", types.Oid}},
 			ReturnType: tree.FixedReturnType(types.String),
 			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				r, err := ctx.Planner.QueryRowEx(
+				r, err := ctx.Planner.QueryRow(
 					ctx.Ctx(), "pg_sequence_parameters",
 					sessiondata.NoSessionDataOverride,
 					`SELECT seqstart, seqmin, seqmax, seqincrement, seqcycle, seqcache, seqtypid `+
@@ -1034,7 +1034,7 @@ var pgBuiltins = map[string]builtinDefinition{
 				//
 				// TODO(jordanlewis): Really we'd like to query this directly
 				// on pg_description and let predicate push-down do its job.
-				r, err := ctx.Planner.QueryRowEx(
+				r, err := ctx.Planner.QueryRow(
 					ctx.Ctx(), "pg_get_coldesc",
 					sessiondata.NoSessionDataOverride,
 					`
@@ -1106,7 +1106,7 @@ WHERE c.type=$1::int AND c.object_id=$2::int AND c.sub_id=$3::int LIMIT 1
 					return tree.DNull, nil
 				}
 
-				r, err := ctx.Planner.QueryRowEx(
+				r, err := ctx.Planner.QueryRow(
 					ctx.Ctx(), "pg_get_shobjdesc",
 					sessiondata.NoSessionDataOverride,
 					fmt.Sprintf(`
@@ -1180,7 +1180,7 @@ SELECT description
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				oid := tree.MustBeDOid(args[0])
-				t, err := ctx.Planner.QueryRowEx(
+				t, err := ctx.Planner.QueryRow(
 					ctx.Ctx(), "pg_function_is_visible",
 					sessiondata.NoSessionDataOverride,
 					"SELECT * from pg_proc WHERE oid=$1 LIMIT 1", oid.Oid)
@@ -2037,7 +2037,7 @@ SELECT description
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				r, err := ctx.Planner.QueryRowEx(
+				r, err := ctx.Planner.QueryRow(
 					ctx.Ctx(), "information_schema._pg_index_position",
 					sessiondata.NoSessionDataOverride,
 					`SELECT (ss.a).n FROM
@@ -2204,7 +2204,7 @@ func getPgObjDesc(ctx *eval.Context, catalogName string, oidVal oid.Oid) (tree.D
 		}
 		classOidFilter = fmt.Sprintf("AND classoid = %d", classOid)
 	}
-	r, err := ctx.Planner.QueryRowEx(
+	r, err := ctx.Planner.QueryRow(
 		ctx.Ctx(), "pg_get_objdesc",
 		sessiondata.NoSessionDataOverride,
 		fmt.Sprintf(`

--- a/pkg/sql/sem/builtins/show_create_all_schemas_builtin.go
+++ b/pkg/sql/sem/builtins/show_create_all_schemas_builtin.go
@@ -33,7 +33,7 @@ func getSchemaIDs(
 		FROM %s.crdb_internal.create_schema_statements
 		WHERE database_name = $1
 		`, dbName)
-	it, err := evalPlanner.QueryIteratorEx(
+	it, err := evalPlanner.QueryIterator(
 		ctx,
 		"crdb_internal.show_create_all_schemas",
 		sessiondata.NoSessionDataOverride,
@@ -74,7 +74,7 @@ func getSchemaCreateStatement(
 		FROM %s.crdb_internal.create_schema_statements
 		WHERE descriptor_id = $1
 	`, dbName)
-	row, err := evalPlanner.QueryRowEx(
+	row, err := evalPlanner.QueryRow(
 		ctx,
 		"crdb_internal.show_create_all_schemas",
 		sessiondata.NoSessionDataOverride,

--- a/pkg/sql/sem/builtins/show_create_all_tables_builtin.go
+++ b/pkg/sql/sem/builtins/show_create_all_tables_builtin.go
@@ -71,7 +71,7 @@ func getTopologicallySortedTableIDs(
 		FROM %s.crdb_internal.backward_dependencies
 		WHERE descriptor_id = $1
 		`, dbName)
-		it, err := evalPlanner.QueryIteratorEx(
+		it, err := evalPlanner.QueryIterator(
 			ctx,
 			"crdb_internal.show_create_all_tables",
 			sessiondata.NoSessionDataOverride,
@@ -160,7 +160,7 @@ func getTableIDs(
 		AND is_virtual = FALSE
 		AND is_temporary = FALSE
 		`, dbName)
-	it, err := evalPlanner.QueryIteratorEx(
+	it, err := evalPlanner.QueryIterator(
 		ctx,
 		"crdb_internal.show_create_all_tables",
 		sessiondata.NoSessionDataOverride,
@@ -249,7 +249,7 @@ func getCreateStatement(
 		FROM %s.crdb_internal.create_statements
 		WHERE descriptor_id = $1
 	`, dbName)
-	row, err := evalPlanner.QueryRowEx(
+	row, err := evalPlanner.QueryRow(
 		ctx,
 		"crdb_internal.show_create_all_tables",
 		sessiondata.NoSessionDataOverride,
@@ -279,7 +279,7 @@ func getAlterStatements(
 		FROM %s.crdb_internal.create_statements
 		WHERE descriptor_id = $1
 	`, statementType, dbName)
-	row, err := evalPlanner.QueryRowEx(
+	row, err := evalPlanner.QueryRow(
 		ctx,
 		"crdb_internal.show_create_all_tables",
 		sessiondata.NoSessionDataOverride,

--- a/pkg/sql/sem/builtins/show_create_all_types_builtin.go
+++ b/pkg/sql/sem/builtins/show_create_all_types_builtin.go
@@ -33,7 +33,7 @@ func getTypeIDs(
 		FROM %s.crdb_internal.create_type_statements
 		WHERE database_name = $1
 		`, dbName)
-	it, err := evalPlanner.QueryIteratorEx(
+	it, err := evalPlanner.QueryIterator(
 		ctx,
 		"crdb_internal.show_create_all_types",
 		sessiondata.NoSessionDataOverride,
@@ -74,7 +74,7 @@ func getTypeCreateStatement(
 		FROM %s.crdb_internal.create_type_statements
 		WHERE descriptor_id = $1
 	`, dbName)
-	row, err := evalPlanner.QueryRowEx(
+	row, err := evalPlanner.QueryRow(
 		ctx,
 		"crdb_internal.show_create_all_types",
 		sessiondata.NoSessionDataOverride,

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -330,7 +330,7 @@ type Planner interface {
 	//
 	// The fields set in session that are set override the respective fields if
 	// they have previously been set through SetSessionData().
-	QueryRowEx(
+	QueryRow(
 		ctx context.Context,
 		opName string,
 		override sessiondata.InternalExecutorOverride,
@@ -343,7 +343,7 @@ type Planner interface {
 	//
 	// The fields set in session that are set override the respective fields if they
 	// have previously been set through SetSessionData().
-	QueryIteratorEx(ctx context.Context, opName string, override sessiondata.InternalExecutorOverride, stmt string, qargs ...interface{}) (InternalRows, error)
+	QueryIterator(ctx context.Context, opName string, override sessiondata.InternalExecutorOverride, stmt string, qargs ...interface{}) (InternalRows, error)
 
 	// IsActive returns if the version specified by key is active.
 	IsActive(ctx context.Context, key clusterversion.Key) bool
@@ -369,7 +369,7 @@ type Planner interface {
 // executor. It provides access to the rows from a query.
 // InternalRows is a copy of the one in sql/internal.go excluding the
 // Types function - we don't need the Types function for use cases where
-// QueryIteratorEx is used from the InternalExecutor on the Planner.
+// QueryIterator is used from the InternalExecutor on the Planner.
 // Furthermore, we cannot include the Types function due to a cyclic
 // dependency on colinfo.ResultColumns - we cannot import colinfo in tree.
 type InternalRows interface {


### PR DESCRIPTION
Some planner methods that call into the InternalExecutor had `...Ex()` in their name, seemingly copying that from the underlying internal executor. There's no need for these Ex(tended) markers, since there's no "non-Extended" interface in the planner. This patch drops the Ex's.

Release note: None