### PR TITLE
builtins: gracefully error on crdb_internal.lease_holder in default vals

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -2673,3 +2673,17 @@ CREATE TABLE t1_non_indexable (n INT8);
 
 statement error pq: unimplemented: column x is of type char\[\] and thus is not indexable
 ALTER TABLE t1_non_indexable ADD COLUMN x CHAR(256)[] UNIQUE;
+
+subtest regression_89025
+
+statement ok
+CREATE TABLE t_89025 (i int primary key);
+
+statement ok
+INSERT INTO t_89025 VALUES (1)
+
+statement error pgcode 0A000 cannot use crdb_internal\.lease_holder in this context
+ALTER TABLE t_89025 ADD COLUMN j INT DEFAULT (crdb_internal.lease_holder('a'));
+
+statement ok
+DROP TABLE t_89025

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -5177,6 +5177,10 @@ value if you rely on the HLC for accuracy.`,
 						Key: key,
 					},
 				})
+				if ctx.Txn == nil { // can occur during backfills
+					return nil, pgerror.Newf(pgcode.FeatureNotSupported,
+						"cannot use crdb_internal.lease_holder in this context")
+				}
 				if err := ctx.Txn.Run(ctx.Context, b); err != nil {
 					return nil, pgerror.Wrap(err, pgcode.InvalidParameterValue, "error fetching leaseholder")
 				}


### PR DESCRIPTION
The txn is nil in the index backfiller.

Fixes #89025

Release note: None