### PR TITLE
sql: don't collect a verbose recording when a structured one suffices

### DIFF
--- a/pkg/sql/execstats/stats.go
+++ b/pkg/sql/execstats/stats.go
@@ -87,7 +87,7 @@ func PopulateKVMVCCStats(kvStats *execinfrapb.KVStats, ss *ScanStats) {
 // context.
 func GetScanStats(ctx context.Context, recording tracingpb.Recording) (ss ScanStats) {
 	if recording == nil {
-		recording = tracing.SpanFromContext(ctx).GetConfiguredRecording()
+		recording = tracing.SpanFromContext(ctx).GetRecording(tracingpb.RecordingStructured)
 	}
 	var ev roachpb.ScanStats
 	for i := range recording {


### PR DESCRIPTION
GetScanStats() needs to look through the structured logs. In order to do that, it was collecting a verbose recording, where a cheaper, structured one suffices. This patch switches to collecting the structured recording only.
Some callers of GetScanStats() pass in the recording. A similar optimization may apply to them, although these callers want to collect a verbose recording for other reasons. I haven't touched them.

Release note: None