### PR TITLE
release: Pick SHA should work for prereleases

### DIFF
--- a/build/teamcity/internal/cockroach/release/process/pick_sha.sh
+++ b/build/teamcity/internal/cockroach/release/process/pick_sha.sh
@@ -8,6 +8,6 @@ source "$dir/teamcity-support.sh"  # For $root
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
 tc_start_block "Run Pick SHA Release Phase"
-BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e DRY_RUN -e JIRA_TOKEN -e JIRA_USERNAME -e METADATA_PUBLISHER_GOOGLE_CREDENTIALS_DEV -e METADATA_PUBLISHER_GOOGLE_CREDENTIALS_PROD -e RELEASE_SERIES -e SMTP_PASSWORD -e SMTP_USER" \
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e DRY_RUN -e JIRA_TOKEN -e JIRA_USERNAME -e METADATA_PUBLISHER_GOOGLE_CREDENTIALS_DEV -e METADATA_PUBLISHER_GOOGLE_CREDENTIALS_PROD -e RELEASE_SERIES -e RELEASE_TYPE -e SMTP_PASSWORD -e SMTP_USER" \
   run_bazel build/teamcity/internal/cockroach/release/process/pick_sha_impl.sh
 tc_end_block "Run Pick SHA Release Phase"

--- a/build/teamcity/internal/cockroach/release/process/pick_sha_impl.sh
+++ b/build/teamcity/internal/cockroach/release/process/pick_sha_impl.sh
@@ -31,6 +31,7 @@ $(bazel info --config=crosslinux bazel-bin)/pkg/cmd/release/release_/release \
   ${DRY_RUN:+--dry-run} \
   --template-dir=pkg/cmd/release/templates \
   --release-series="$RELEASE_SERIES" \
+  --release-type="$RELEASE_TYPE" \
   --smtp-user=cronjob@cockroachlabs.com \
   --smtp-host=smtp.gmail.com \
   --smtp-port=587 \

--- a/pkg/cmd/release/BUILD.bazel
+++ b/pkg/cmd/release/BUILD.bazel
@@ -42,6 +42,7 @@ go_test(
     name = "release_test",
     srcs = [
         "blockers_test.go",
+        "git_test.go",
         "sender_test.go",
         "versionmap_test.go",
     ],

--- a/pkg/cmd/release/blockers.go
+++ b/pkg/cmd/release/blockers.go
@@ -140,7 +140,8 @@ func cancelReleaseSeriesPublishDate(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("%s is not parseable into %s date layout", blockersFlags.nextPublishDate, dateFormatCommandLine)
 	}
-	nextVersion, err := findNextVersion(blockersFlags.releaseSeries)
+	// TODO(rail): we can use releaseType to guess tne next version for preleases too
+	nextVersion, err := findNextVersion(blockersFlags.releaseSeries, releaseTypeStable)
 	if err != nil {
 		return fmt.Errorf("cannot find next release version: %w", err)
 	}
@@ -202,9 +203,10 @@ func fetchReleaseSeriesBlockers(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("%s is not parseable into %s date layout", blockersFlags.publishDate, dateFormatCommandLine)
 	}
+	// TODO(rail): instead of passing an explicit version, we can guess it using reelaseSeries and releaseTypeOpt.
 	if blockersFlags.nextVersion == "" {
 		var err error
-		blockersFlags.nextVersion, err = findNextVersion(blockersFlags.releaseSeries)
+		blockersFlags.nextVersion, err = findNextVersion(blockersFlags.releaseSeries, releaseTypeStable)
 		if err != nil {
 			return fmt.Errorf("cannot find next release version: %w", err)
 		}

--- a/pkg/cmd/release/git_test.go
+++ b/pkg/cmd/release/git_test.go
@@ -1,0 +1,179 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package main
+
+import "testing"
+
+func Test_bumpVersion(t *testing.T) {
+	type args struct {
+		version     string
+		releaseType releaseTypeOpt
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "stable",
+			args: args{
+				version:     "v22.1.2",
+				releaseType: releaseTypeStable,
+			},
+			want:    "v22.1.3",
+			wantErr: false,
+		},
+		{
+			name: "stable 2",
+			args: args{
+				version:     "v22.1.0",
+				releaseType: releaseTypeStable,
+			},
+			want:    "v22.1.1",
+			wantErr: false,
+		},
+		{
+			name: "alpha 0",
+			args: args{
+				version:     "v22.1.0-alpha.0",
+				releaseType: releaseTypeAlpha,
+			},
+			want:    "v22.1.0-alpha.1",
+			wantErr: false,
+		},
+		{
+			name: "alpha 3",
+			args: args{
+				version:     "v22.1.0-alpha.3",
+				releaseType: releaseTypeAlpha,
+			},
+			want:    "v22.1.0-alpha.4",
+			wantErr: false,
+		},
+		{
+			name: "beta 2",
+			args: args{
+				version:     "v22.1.0-beta.2",
+				releaseType: releaseTypeBeta,
+			},
+			want:    "v22.1.0-beta.3",
+			wantErr: false,
+		},
+		{
+			name: "alpha to beta",
+			args: args{
+				version:     "v22.1.0-alpha.3",
+				releaseType: releaseTypeBeta,
+			},
+			want:    "v22.1.0-beta.1",
+			wantErr: false,
+		},
+		{
+			name: "rc 2",
+			args: args{
+				version:     "v22.1.0-rc.2",
+				releaseType: releaseTypeRC,
+			},
+			want:    "v22.1.0-rc.3",
+			wantErr: false,
+		},
+		{
+			name: "alpha to rc",
+			args: args{
+				version:     "v22.1.0-alpha.3",
+				releaseType: releaseTypeRC,
+			},
+			want:    "v22.1.0-rc.1",
+			wantErr: false,
+		},
+		{
+			name: "beta to rc",
+			args: args{
+				version:     "v22.1.0-beta.3",
+				releaseType: releaseTypeRC,
+			},
+			want:    "v22.1.0-rc.1",
+			wantErr: false,
+		},
+		{
+			name: "rc to beta",
+			args: args{
+				version:     "v22.1.0-rc.33",
+				releaseType: releaseTypeBeta,
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "rc to alpha",
+			args: args{
+				version:     "v22.1.0-rc.44",
+				releaseType: releaseTypeAlpha,
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "beta to alpha",
+			args: args{
+				version:     "v22.1.0-beta.4",
+				releaseType: releaseTypeAlpha,
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := bumpVersion(tt.args.version, tt.args.releaseType)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("bumpVersion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("bumpVersion() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_bumpPrerelease(t *testing.T) {
+	tests := []struct {
+		prerelease string
+		want       string
+		wantErr    bool
+	}{
+		{prerelease: "alpha.0", want: "alpha.1", wantErr: false},
+		{prerelease: "alpha.1", want: "alpha.2", wantErr: false},
+		{prerelease: "alpha.22", want: "alpha.23", wantErr: false},
+		{prerelease: "beta.0", want: "beta.1", wantErr: false},
+		{prerelease: "beta.1", want: "beta.2", wantErr: false},
+		{prerelease: "beta.5", want: "beta.6", wantErr: false},
+		{prerelease: "rc.0", want: "rc.1", wantErr: false},
+		{prerelease: "rc.59", want: "rc.60", wantErr: false},
+		{prerelease: "rc", want: "", wantErr: true},
+		{prerelease: "rc.11.12", want: "", wantErr: true},
+		{prerelease: "rc.one", want: "", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.prerelease, func(t *testing.T) {
+			got, err := bumpPrerelease(tt.prerelease)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("bumpPrerelease() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("bumpPrerelease() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/cmd/release/main.go
+++ b/pkg/cmd/release/main.go
@@ -19,6 +19,7 @@ const (
 	envSMTPPassword = "SMTP_PASSWORD"
 	envGithubToken  = "GITHUB_TOKEN"
 	releaseSeries   = "release-series"
+	releaseType     = "release-type"
 	templatesDir    = "template-dir"
 	smtpUser        = "smtp-user"
 	smtpHost        = "smtp-host"


### PR DESCRIPTION
Previously, the logic used in the Pick SHA step worked for stable releases only.

This PR adds ability to specify release type (alpha, beta, rc, stable) and logic to find the next available version for a release.

Release note: None
