### PR TITLE
sql,tree: improve function resolution efficiency

### DIFF
--- a/pkg/sql/catalog/resolver/resolver_bench_test.go
+++ b/pkg/sql/catalog/resolver/resolver_bench_test.go
@@ -106,7 +106,7 @@ func BenchmarkResolveExistingObject(b *testing.B) {
 			require.NoError(b, err)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				desc, _, err := resolver.ResolveExistingObject(ctx, rs, uon, tc.flags)
+				desc, _, err := resolver.ResolveExistingObject(ctx, rs, &uon, tc.flags)
 				require.NoError(b, err)
 				require.NotNil(b, desc)
 			}

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -13665,7 +13665,6 @@ typed_literal:
         // types, return an unimplemented error message.
         var typ tree.ResolvableTypeReference
         var ok bool
-        var err error
         var unimp int
         typ, ok, unimp = types.TypeForNonKeywordTypeName(typName)
         if !ok {
@@ -13674,8 +13673,9 @@ typed_literal:
               // In this case, we don't think this type is one of our
               // known unsupported types, so make a type reference for it.
               aIdx := sqllex.(*lexer).NewAnnotation()
-              typ, err = name.ToUnresolvedObjectName(aIdx)
+              un, err := name.ToUnresolvedObjectName(aIdx)
               if err != nil { return setErr(sqllex, err) }
+              typ = &un
             case -1:
               return unimplemented(sqllex, "type name " + typName)
             default:
@@ -13688,7 +13688,7 @@ typed_literal:
       aIdx := sqllex.(*lexer).NewAnnotation()
       res, err := name.ToUnresolvedObjectName(aIdx)
       if err != nil { return setErr(sqllex, err) }
-      $$.val = &tree.CastExpr{Expr: tree.NewStrVal($2), Type: res, SyntaxMode: tree.CastPrepend}
+      $$.val = &tree.CastExpr{Expr: tree.NewStrVal($2), Type: &res, SyntaxMode: tree.CastPrepend}
     }
   }
 | const_typename SCONST

--- a/pkg/sql/schema_resolver.go
+++ b/pkg/sql/schema_resolver.go
@@ -401,23 +401,23 @@ func (sr *schemaResolver) ResolveFunction(
 		sc := prefix.Schema
 		udfDef, _ = sc.GetResolvedFuncDefinition(fn.Object())
 	} else {
-		if err := path.IterateSearchPath(func(schema string) error {
+		for i, n := 0, path.NumElements(); i < n; i++ {
+			schema := path.GetSchema(i)
 			found, prefix, err := sr.LookupSchema(ctx, sr.CurrentDatabase(), schema)
 			if err != nil {
-				return err
+				return nil, err
 			}
 			if !found {
-				return nil
+				continue
 			}
 			curUdfDef, found := prefix.Schema.GetResolvedFuncDefinition(fn.Object())
 			if !found {
-				return nil
+				continue
 			}
-
 			udfDef, err = udfDef.MergeWith(curUdfDef)
-			return err
-		}); err != nil {
-			return nil, err
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/pkg/sql/schema_resolver.go
+++ b/pkg/sql/schema_resolver.go
@@ -334,7 +334,8 @@ func (sr *schemaResolver) canResolveDescUnderSchema(
 	case catalog.SchemaUserDefined:
 		return sr.authAccessor.CheckPrivilegeForUser(ctx, scDesc, privilege.USAGE, sr.sessionDataStack.Top().User())
 	default:
-		panic(errors.AssertionFailedf("unknown schema kind %d", kind))
+		forLog := kind // prevents kind from escaping
+		panic(errors.AssertionFailedf("unknown schema kind %d", forLog))
 	}
 }
 

--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -146,7 +146,6 @@ go_library(
         "//pkg/util/encoding",
         "//pkg/util/errorutil/unimplemented",
         "//pkg/util/ipaddr",
-        "//pkg/util/iterutil",
         "//pkg/util/json",
         "//pkg/util/pretty",
         "//pkg/util/stringencoding",

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -386,14 +386,15 @@ func QualifyBuiltinFunctionDefinition(
 // GetBuiltinFuncDefinitionOrFail is similar to GetBuiltinFuncDefinition but
 // returns an error if function is not found.
 func GetBuiltinFuncDefinitionOrFail(
-	fName *FunctionName, searchPath SearchPath,
+	fName FunctionName, searchPath SearchPath,
 ) (*ResolvedFunctionDefinition, error) {
 	def, err := GetBuiltinFuncDefinition(fName, searchPath)
 	if err != nil {
 		return nil, err
 	}
 	if def == nil {
-		return nil, errors.Wrapf(ErrFunctionUndefined, "unknown function: %s()", ErrString(fName))
+		forError := fName // prevent fName from escaping
+		return nil, errors.Wrapf(ErrFunctionUndefined, "unknown function: %s()", ErrString(&forError))
 	}
 	return def, nil
 }
@@ -409,7 +410,7 @@ func GetBuiltinFuncDefinitionOrFail(
 // error is still checked and return from the function signature just in case
 // we change the iterating function in the future.
 func GetBuiltinFuncDefinition(
-	fName *FunctionName, searchPath SearchPath,
+	fName FunctionName, searchPath SearchPath,
 ) (*ResolvedFunctionDefinition, error) {
 	if fName.ExplicitSchema {
 		return ResolvedBuiltinFuncDefs[fName.Schema()+"."+fName.Object()], nil

--- a/pkg/sql/sem/tree/name_part.go
+++ b/pkg/sql/sem/tree/name_part.go
@@ -218,11 +218,11 @@ func MakeUnresolvedName(args ...string) UnresolvedName {
 }
 
 // ToUnresolvedObjectName converts an UnresolvedName to an UnresolvedObjectName.
-func (u *UnresolvedName) ToUnresolvedObjectName(idx AnnotationIdx) (*UnresolvedObjectName, error) {
+func (u *UnresolvedName) ToUnresolvedObjectName(idx AnnotationIdx) (UnresolvedObjectName, error) {
 	if u.NumParts == 4 {
-		return nil, pgerror.Newf(pgcode.Syntax, "improper qualified name (too many dotted names): %s", u)
+		return UnresolvedObjectName{}, pgerror.Newf(pgcode.Syntax, "improper qualified name (too many dotted names): %s", u)
 	}
-	return NewUnresolvedObjectName(
+	return MakeUnresolvedObjectName(
 		u.NumParts,
 		[3]string{u.Parts[0], u.Parts[1], u.Parts[2]},
 		idx,
@@ -230,11 +230,10 @@ func (u *UnresolvedName) ToUnresolvedObjectName(idx AnnotationIdx) (*UnresolvedO
 }
 
 // ToFunctionName converts an UnresolvedName to a FunctionName.
-func (u *UnresolvedName) ToFunctionName() (*FunctionName, error) {
+func (u *UnresolvedName) ToFunctionName() (FunctionName, error) {
 	un, err := u.ToUnresolvedObjectName(NoAnnotation)
 	if err != nil {
-		return nil, errors.Newf("invalid function name: %s", u.String())
+		return FunctionName{}, errors.Newf("invalid function name: %s", u.String())
 	}
-	fn := un.ToFunctionName()
-	return &fn, nil
+	return un.ToFunctionName(), nil
 }

--- a/pkg/sql/sem/tree/name_resolution.go
+++ b/pkg/sql/sem/tree/name_resolution.go
@@ -129,12 +129,12 @@ type QualifiedNameResolver interface {
 // SearchPath encapsulates the ordered list of schemas in the current database
 // to search during name resolution.
 type SearchPath interface {
+	// NumElements returns the number of elements in the SearchPath.
+	NumElements() int
 
-	// IterateSearchPath calls the passed function for every element of the
-	// SearchPath in order. If an error is returned, iteration stops. If the
-	// error is iterutil.StopIteration, no error will be returned from the
-	// method.
-	IterateSearchPath(func(schema string) error) error
+	// GetSchema returns the schema at the ord offset in the SearchPath.
+	// Note that it will return the empty string if the ordinal is out of range.
+	GetSchema(ord int) string
 }
 
 // EmptySearchPath is a SearchPath with no members.
@@ -142,9 +142,8 @@ var EmptySearchPath SearchPath = emptySearchPath{}
 
 type emptySearchPath struct{}
 
-func (emptySearchPath) IterateSearchPath(func(string) error) error {
-	return nil
-}
+func (emptySearchPath) NumElements() int       { return 0 }
+func (emptySearchPath) GetSchema(i int) string { return "" }
 
 func newInvColRef(n *UnresolvedName) error {
 	return pgerror.NewWithDepthf(1, pgcode.InvalidColumnReference,

--- a/pkg/sql/sessiondata/BUILD.bazel
+++ b/pkg/sql/sessiondata/BUILD.bazel
@@ -19,7 +19,6 @@ go_library(
         "//pkg/sql/sem/catconstants",
         "//pkg/sql/sessiondatapb",
         "//pkg/util/duration",
-        "//pkg/util/iterutil",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/timeutil/pgdate",


### PR DESCRIPTION
#### sql: prevent allocations by avoiding some name pointers

We don't need pointers for these names. They generally won't escape.

#### sql,tree: change SearchPath to avoid allocations
The closure-oriented interface was forcing the closures and the variables they
referenced to escape to the heap. This change, while not beautiful, ends up being
much more efficient.

```
name                                         old time/op    new time/op    delta
SQL/MultinodeCockroach/Upsert/count=1000-16    20.4ms ±11%    18.9ms ± 8%   -7.47%  (p=0.000 n=20+19)

name                                         old alloc/op   new alloc/op   delta
SQL/MultinodeCockroach/Upsert/count=1000-16    10.1MB ±29%     9.8MB ±29%     ~     (p=0.231 n=20+20)

name                                         old allocs/op  new allocs/op  delta
SQL/MultinodeCockroach/Upsert/count=1000-16     56.3k ± 7%     50.2k ±10%  -10.81%  (p=0.000 n=19+19)
```

Release note: None