### PR TITLE
ci: fix TeamCity artifact publishing for weekly roachtest

### DIFF
--- a/build/teamcity/cockroach/nightlies/roachtest_weekly.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_weekly.sh
@@ -7,5 +7,5 @@ dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
 source "$dir/teamcity-support.sh"  # For $root
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
-BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e BUILD_TAG -e BUILD_VCS_NUMBER -e CLOUD -e COCKROACH_DEV_LICENSE -e COUNT -e GITHUB_API_TOKEN -e GITHUB_ORG -e GITHUB_REPO -e GOOGLE_EPHEMERAL_CREDENTIALS -e SLACK_TOKEN -e TC_BUILDTYPE_ID -e TC_BUILD_BRANCH -e TC_BUILD_ID -e TC_SERVER_URL" \
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e LITERAL_ARTIFACTS_DIR=$root/artifacts -e BUILD_TAG -e BUILD_VCS_NUMBER -e CLOUD -e COCKROACH_DEV_LICENSE -e COUNT -e GITHUB_API_TOKEN -e GITHUB_ORG -e GITHUB_REPO -e GOOGLE_EPHEMERAL_CREDENTIALS -e SLACK_TOKEN -e TC_BUILDTYPE_ID -e TC_BUILD_BRANCH -e TC_BUILD_ID -e TC_SERVER_URL" \
 			       run_bazel build/teamcity/cockroach/nightlies/roachtest_weekly_impl.sh

--- a/build/teamcity/cockroach/nightlies/roachtest_weekly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_weekly_impl.sh
@@ -1,33 +1,19 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
-
-google_credentials="$GOOGLE_EPHEMERAL_CREDENTIALS"
+set -exuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
+
 source "$dir/teamcity-support.sh"
 
-log_into_gcloud
-export ROACHPROD_USER=teamcity
-
-set -x
-
-generate_ssh_key
-
-export PATH=$PATH:$(go env GOPATH)/bin
-
-build_tag=$(git describe --abbrev=0 --tags --match=v[0-9]*)
-git checkout master
-git pull origin master
-
-git rev-parse HEAD
+if [[ ! -f ~/.ssh/id_rsa.pub ]]; then
+  ssh-keygen -q -C "roachtest-weekly-bazel $(date)" -N "" -f ~/.ssh/id_rsa
+fi
 
 source $root/build/teamcity/cockroach/nightlies/roachtest_compile_bits.sh
 
-artifacts_subdir=bazel-$(date +"%Y%m%d")-${TC_BUILD_ID}
-artifacts=$PWD/artifacts/$artifacts_subdir
-mkdir -p "$artifacts"
-chmod o+rwx "${artifacts}"
+artifacts=/artifacts
+source $root/build/teamcity/util/roachtest_util.sh
 
 # NB: Teamcity has a 7920 minute timeout that, when reached,
 # kills the process without a stack trace (probably SIGKILL).
@@ -41,32 +27,14 @@ chmod o+rwx "${artifacts}"
 #
 # NB(3): If you make changes here, you should probably make the same change in
 # build/teamcity-weekly-roachtest.sh
-exit_status=0
-timeout -s INT $((7800*60)) bin/roachtest run \
+timeout -s INT $((7800*60)) build/teamcity-roachtest-invoke.sh \
   tag:weekly \
-  --build-tag "${build_tag}" \
+  --build-tag="${BUILD_TAG}" \
   --cluster-id "${TC_BUILD_ID}" \
   --zones "us-central1-b,us-west1-b,europe-west2-b" \
   --cockroach "$PWD/bin/cockroach" \
-  --workload "$PWD/bin/workload" \
-  --artifacts "/artifacts/${artifacts_subdir}" \
-  --artifacts-literal="${artifacts}" \
+  --artifacts=/artifacts \
+  --artifacts-literal="${LITERAL_ARTIFACTS_DIR:-}" \
   --parallelism 5 \
   --metamorphic-encryption-probability=0.5 \
-  --teamcity || exit_status=$?
-
-if [[ ${exit_status} -eq 10 ]]; then
-  # Exit code 10 indicates that some tests failed, but that roachtest
-  # as a whole passed. We want to exit zero in this case so that we
-  # can let TeamCity report failing tests without also failing the
-  # build. That way, build failures can be used to notify about serious
-  # problems that prevent tests from being invoked in the first place.
-  exit_status=0
-fi
-
-# Upload any stats.json files to the cockroach-nightly bucket.
-for file in $(find ${artifacts#${PWD}/} -name stats.json); do
-    gsutil cp ${file} gs://cockroach-nightly/${file}
-done
-
-exit "$exit_status"
+  --slack-token="${SLACK_TOKEN}"


### PR DESCRIPTION
Resolves: #82899

Correctly pass literal artifacts directory in order that artifacts can be published successfully. Add an SSH key check and more explicit generation if it is not present. Add Slack token to the passed arguments. Clean up unused variables, arguments and instructions in the bash scripts.

Release justification: CI improvement/weekly test fix
Release note: None