### PR TITLE
server: Thread storeID through stickyInMemEngine

### DIFF
--- a/pkg/server/sticky_engine.go
+++ b/pkg/server/sticky_engine.go
@@ -86,6 +86,13 @@ func (e *stickyInMemEngine) Closed() bool {
 	return e.closed
 }
 
+// SetStoreID implements the StoreIDSetter interface.
+func (e *stickyInMemEngine) SetStoreID(ctx context.Context, storeID int32) {
+	if storeIDSetter, ok := e.Engine.(storage.StoreIDSetter); ok {
+		storeIDSetter.SetStoreID(ctx, storeID)
+	}
+}
+
 // stickyInMemEnginesRegistryImpl is the bookkeeper for all active
 // sticky engines, keyed by their id. It implements the
 // StickyInMemEnginesRegistry interface.

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -846,11 +846,11 @@ func NewPebble(ctx context.Context, cfg PebbleConfig) (p *Pebble, err error) {
 	// The context dance here is done so that we have a clean context without
 	// timeouts that has a copy of the log tags.
 	logCtx := logtags.WithTags(context.Background(), logtags.FromContext(ctx))
-	logCtx = logtags.AddTag(logCtx, "pebble", nil)
 	// The store id, could not necessarily be determined when this function
 	// is called. Therefore, we use a container for the store id.
 	storeIDContainer := &base.StoreIDContainer{}
 	logCtx = logtags.AddTag(logCtx, "s", storeIDContainer)
+	logCtx = logtags.AddTag(logCtx, "pebble", nil)
 
 	if cfg.Opts.Logger == nil {
 		cfg.Opts.Logger = pebbleLogger{


### PR DESCRIPTION
The stickyInMemEngine that's used by the test cluster as well as by `cockroach demo` did not implement the `SetStoreID` call implemented in `storage.Pebble`. This change implements that to bring about store
IDs in log entries emitted by demo/test clusters.

Fixes #72701.

Release note: None