### PR TITLE
roachtest: ignore duplicated events in fingerprint validator

### DIFF
--- a/pkg/ccl/changefeedccl/cdctest/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/cdctest/BUILD.bazel
@@ -31,7 +31,6 @@ go_library(
         "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/randutil",
-        "//pkg/util/retry",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/ccl/changefeedccl/cdctest/nemeses.go
+++ b/pkg/ccl/changefeedccl/cdctest/nemeses.go
@@ -173,7 +173,7 @@ func RunNemesis(f TestFeedFactory, db *gosql.DB, isSinkless bool) (Validator, er
 	if err != nil {
 		return nil, err
 	}
-	fprintV, err := NewFingerprintValidator(db, `foo`, scratchTableName, foo.Partitions(), ns.maxTestColumnCount, false)
+	fprintV, err := NewFingerprintValidator(db, `foo`, scratchTableName, foo.Partitions(), ns.maxTestColumnCount)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/changefeedccl/cdctest/validator.go
+++ b/pkg/ccl/changefeedccl/cdctest/validator.go
@@ -319,6 +319,13 @@ type validatorRow struct {
 	updated    hlc.Timestamp
 }
 
+// eventKey returns a key that encodes the key and timestamp of a row
+// received from a changefeed. Can be used to keep track of which
+// updates have been seen before in a validator.
+func (row validatorRow) eventKey() string {
+	return fmt.Sprintf("%s|%s", row.key, row.updated.AsOfSystemTime())
+}
+
 // FingerprintValidator verifies that recreating a table from its changefeed
 // will fingerprint the same at all "interesting" points in time.
 type FingerprintValidator struct {
@@ -342,6 +349,7 @@ type FingerprintValidator struct {
 	fprintOrigColumns int
 	fprintTestColumns int
 	buffer            []validatorRow
+	previouslySeen    map[string]struct{}
 
 	failures []string
 }
@@ -423,6 +431,16 @@ func (v *FingerprintValidator) DBFunc(
 	return v
 }
 
+// ValidateDuplicatedEvents enables the validation of duplicated
+// messages in the fingerprint validator. Whenever a row is received
+// with a timestamp lower than the last `resolved` timestamp seen, we
+// verify that the event has been seen before (if it hasn't, that
+// would be a violation of the changefeed guarantees)
+func (v *FingerprintValidator) ValidateDuplicatedEvents() *FingerprintValidator {
+	v.previouslySeen = make(map[string]struct{})
+	return v
+}
+
 // NoteRow implements the Validator interface.
 func (v *FingerprintValidator) NoteRow(
 	ignoredPartition string, key, value string, updated hlc.Timestamp,
@@ -430,11 +448,20 @@ func (v *FingerprintValidator) NoteRow(
 	if v.firstRowTimestamp.IsEmpty() || updated.Less(v.firstRowTimestamp) {
 		v.firstRowTimestamp = updated
 	}
-	v.buffer = append(v.buffer, validatorRow{
-		key:     key,
-		value:   value,
-		updated: updated,
-	})
+
+	row := validatorRow{key: key, value: value, updated: updated}
+	if err := v.maybeValidateDuplicatedEvent(row); err != nil {
+		return err
+	}
+
+	// if this row's timestamp is earlier than the last resolved
+	// timestamp we processed, we can skip it as it is a duplicate
+	if row.updated.Less(v.resolved) {
+		return nil
+	}
+
+	v.buffer = append(v.buffer, row)
+	v.maybeAddSeenEvent(row)
 	return nil
 }
 
@@ -595,6 +622,42 @@ func (v *FingerprintValidator) NoteResolved(partition string, resolved hlc.Times
 		lastFingerprintedAt != resolved {
 		return v.fingerprint(resolved)
 	}
+	return nil
+}
+
+// maybeAddSeenEvent is a no-op if the caller did not call
+// ValidateDuplicatedEvents. Otherwise, we keep a reference to the row
+// key and MVCC timestamp for later validation
+func (v *FingerprintValidator) maybeAddSeenEvent(row validatorRow) {
+	if v.previouslySeen == nil {
+		return
+	}
+
+	v.previouslySeen[row.eventKey()] = struct{}{}
+}
+
+// maybeValidateDuplicatedEvent is a no-op if the caller did not call
+// ValidateDuplicatedEvents. Otherwise, it returns an error if the
+// row's timestamp is earlier than the validator's `resolved`
+// timestamp *and* it has not been seen before; that would be a
+// violation of the changefeed's guarantees.
+func (v *FingerprintValidator) maybeValidateDuplicatedEvent(row validatorRow) error {
+	if v.previouslySeen == nil {
+		return nil
+	}
+
+	// row's timestamp is after the last resolved timestamp; no problem
+	if v.resolved.LessEq(row.updated) {
+		return nil
+	}
+
+	// row's timestamp is earlier than resolved timestamp *and* it
+	// hasn't been seen before; that shouldn't happen
+	if _, seen := v.previouslySeen[row.eventKey()]; !seen {
+		return fmt.Errorf("unexpected out-of-order event at timestamp %s prior to resolved timestamp %s",
+			row.updated.AsOfSystemTime(), v.resolved.AsOfSystemTime())
+	}
+
 	return nil
 }
 

--- a/pkg/ccl/changefeedccl/cdctest/validator.go
+++ b/pkg/ccl/changefeedccl/cdctest/validator.go
@@ -15,11 +15,9 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/errors"
 )
 
@@ -64,8 +62,6 @@ var NoOpValidator = &noOpValidator{}
 var _ Validator = &orderValidator{}
 var _ Validator = &noOpValidator{}
 var _ StreamValidator = &orderValidator{}
-
-var retryDuration = 2 * time.Minute
 
 type noOpValidator struct{}
 
@@ -323,16 +319,16 @@ type validatorRow struct {
 	updated    hlc.Timestamp
 }
 
-// fingerprintValidator verifies that recreating a table from its changefeed
+// FingerprintValidator verifies that recreating a table from its changefeed
 // will fingerprint the same at all "interesting" points in time.
-type fingerprintValidator struct {
-	sqlDB                  *gosql.DB
+type FingerprintValidator struct {
+	sqlDBFunc              func(func(*gosql.DB) error) error
 	origTable, fprintTable string
 	primaryKeyCols         []string
 	partitionResolved      map[string]hlc.Timestamp
 	resolved               hlc.Timestamp
 	// It's possible to get a resolved timestamp from before the table even
-	// exists, which is valid but complicates the way fingerprintValidator works.
+	// exists, which is valid but complicates the way FingerprintValidator works.
 	// Don't create a fingerprint earlier than the first seen row.
 	firstRowTimestamp hlc.Timestamp
 	// previousRowUpdateTs keeps track of the timestamp of the most recently processed row
@@ -347,12 +343,16 @@ type fingerprintValidator struct {
 	fprintTestColumns int
 	buffer            []validatorRow
 
-	// shouldRetry indicates whether row updates should be retried (for
-	// a fixed duration). Typically used when the transient errors are
-	// expected (e.g., if performing an upgrade)
-	shouldRetry bool
-
 	failures []string
+}
+
+// defaultSQLDBFunc is the default function passed the FingerprintValidator's
+// `sqlDBFunc`. It is sufficient in cases when the database is not expected to
+// fail while the validator is using it.
+func defaultSQLDBFunc(db *gosql.DB) func(func(*gosql.DB) error) error {
+	return func(f func(*gosql.DB) error) error {
+		return f(db)
+	}
 }
 
 // NewFingerprintValidator returns a new FingerprintValidator that uses `fprintTable` as
@@ -362,23 +362,19 @@ type fingerprintValidator struct {
 // will modify `fprint`'s schema to add `maxTestColumnCount` columns to avoid having to
 // accommodate schema changes on the fly.
 func NewFingerprintValidator(
-	sqlDB *gosql.DB,
-	origTable, fprintTable string,
-	partitions []string,
-	maxTestColumnCount int,
-	shouldRetry bool,
-) (Validator, error) {
+	db *gosql.DB, origTable, fprintTable string, partitions []string, maxTestColumnCount int,
+) (*FingerprintValidator, error) {
 	// Fetch the primary keys though information_schema schema inspections so we
 	// can use them to construct the SQL for DELETEs and also so we can verify
 	// that the key in a message matches what's expected for the value.
-	primaryKeyCols, err := fetchPrimaryKeyCols(sqlDB, fprintTable)
+	primaryKeyCols, err := fetchPrimaryKeyCols(db, fprintTable)
 	if err != nil {
 		return nil, err
 	}
 
 	// Record the non-test%d columns in `fprint`.
 	var fprintOrigColumns int
-	if err := sqlDB.QueryRow(`
+	if err := db.QueryRow(`
 		SELECT count(column_name)
 		FROM information_schema.columns
 		WHERE table_name=$1
@@ -396,19 +392,19 @@ func NewFingerprintValidator(
 			}
 			fmt.Fprintf(&addColumnStmt, `ADD COLUMN test%d STRING`, i)
 		}
-		if _, err := sqlDB.Exec(addColumnStmt.String()); err != nil {
+		_, err = db.Exec(addColumnStmt.String())
+		if err != nil {
 			return nil, err
 		}
 	}
 
-	v := &fingerprintValidator{
-		sqlDB:             sqlDB,
+	v := &FingerprintValidator{
+		sqlDBFunc:         defaultSQLDBFunc(db),
 		origTable:         origTable,
 		fprintTable:       fprintTable,
 		primaryKeyCols:    primaryKeyCols,
 		fprintOrigColumns: fprintOrigColumns,
 		fprintTestColumns: maxTestColumnCount,
-		shouldRetry:       shouldRetry,
 	}
 	v.partitionResolved = make(map[string]hlc.Timestamp)
 	for _, partition := range partitions {
@@ -417,8 +413,18 @@ func NewFingerprintValidator(
 	return v, nil
 }
 
+// DBFunc sets the database function used when the validator needs to
+// perform database operations (updating the scratch table, computing
+// fingerprints, etc)
+func (v *FingerprintValidator) DBFunc(
+	dbFunc func(func(*gosql.DB) error) error,
+) *FingerprintValidator {
+	v.sqlDBFunc = dbFunc
+	return v
+}
+
 // NoteRow implements the Validator interface.
-func (v *fingerprintValidator) NoteRow(
+func (v *FingerprintValidator) NoteRow(
 	ignoredPartition string, key, value string, updated hlc.Timestamp,
 ) error {
 	if v.firstRowTimestamp.IsEmpty() || updated.Less(v.firstRowTimestamp) {
@@ -433,9 +439,9 @@ func (v *fingerprintValidator) NoteRow(
 }
 
 // applyRowUpdate applies the update represented by `row` to the scratch table.
-func (v *fingerprintValidator) applyRowUpdate(row validatorRow) (_err error) {
+func (v *FingerprintValidator) applyRowUpdate(row validatorRow) (_err error) {
 	defer func() {
-		_err = errors.Wrap(_err, "fingerprintValidator failed")
+		_err = errors.Wrap(_err, "FingerprintValidator failed")
 	}()
 
 	var args []interface{}
@@ -512,14 +518,14 @@ func (v *fingerprintValidator) applyRowUpdate(row validatorRow) (_err error) {
 		}
 	}
 
-	return v.maybeRetry(func() error {
-		_, err := v.sqlDB.Exec(stmtBuf.String(), args...)
+	return v.sqlDBFunc(func(db *gosql.DB) error {
+		_, err := db.Exec(stmtBuf.String(), args...)
 		return err
 	})
 }
 
 // NoteResolved implements the Validator interface.
-func (v *fingerprintValidator) NoteResolved(partition string, resolved hlc.Timestamp) error {
+func (v *FingerprintValidator) NoteResolved(partition string, resolved hlc.Timestamp) error {
 	if r, ok := v.partitionResolved[partition]; !ok {
 		return errors.Errorf(`unknown partition: %s`, partition)
 	} else if resolved.LessEq(r) {
@@ -557,8 +563,8 @@ func (v *fingerprintValidator) NoteResolved(partition string, resolved hlc.Times
 		}
 		row := v.buffer[0]
 		// NOTE: changes to the validator's state before `applyRowUpdate`
-		// are safe because, if the operation can fail, the caller should
-		// be setting the `shouldRetry` field accordingly
+		// are safe because if database calls can fail, they should be
+		// retried by passing a custom function to DBFunction
 		v.buffer = v.buffer[1:]
 
 		// If we've processed all row updates belonging to the previous row's timestamp,
@@ -592,18 +598,18 @@ func (v *fingerprintValidator) NoteResolved(partition string, resolved hlc.Times
 	return nil
 }
 
-func (v *fingerprintValidator) fingerprint(ts hlc.Timestamp) error {
+func (v *FingerprintValidator) fingerprint(ts hlc.Timestamp) error {
 	var orig string
-	if err := v.maybeRetry(func() error {
-		return v.sqlDB.QueryRow(`SELECT IFNULL(fingerprint, 'EMPTY') FROM [
+	if err := v.sqlDBFunc(func(db *gosql.DB) error {
+		return db.QueryRow(`SELECT IFNULL(fingerprint, 'EMPTY') FROM [
 		SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE ` + v.origTable + `
 	] AS OF SYSTEM TIME '` + ts.AsOfSystemTime() + `'`).Scan(&orig)
 	}); err != nil {
 		return err
 	}
 	var check string
-	if err := v.maybeRetry(func() error {
-		return v.sqlDB.QueryRow(`SELECT IFNULL(fingerprint, 'EMPTY') FROM [
+	if err := v.sqlDBFunc(func(db *gosql.DB) error {
+		return db.QueryRow(`SELECT IFNULL(fingerprint, 'EMPTY') FROM [
 		SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE ` + v.fprintTable + `
 	]`).Scan(&check)
 	}); err != nil {
@@ -617,19 +623,8 @@ func (v *fingerprintValidator) fingerprint(ts hlc.Timestamp) error {
 }
 
 // Failures implements the Validator interface.
-func (v *fingerprintValidator) Failures() []string {
+func (v *FingerprintValidator) Failures() []string {
 	return v.failures
-}
-
-// maybeRetry will retry the function passed if the fingerprint was
-// created with `shouldRetry` set to `true`. Every access to `sqlDB`
-// should be made my closures passed to this function
-func (v *fingerprintValidator) maybeRetry(f func() error) error {
-	if v.shouldRetry {
-		return retry.ForDuration(retryDuration, f)
-	}
-
-	return f()
 }
 
 // Validators abstracts over running multiple `Validator`s at once on the same

--- a/pkg/ccl/changefeedccl/cdctest/validator_test.go
+++ b/pkg/ccl/changefeedccl/cdctest/validator_test.go
@@ -292,14 +292,14 @@ func TestFingerprintValidator(t *testing.T) {
 
 	t.Run(`empty`, func(t *testing.T) {
 		sqlDB.Exec(t, createTableStmt(`empty`))
-		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `empty`, []string{`p`}, testColumns, false)
+		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `empty`, []string{`p`}, testColumns)
 		require.NoError(t, err)
 		noteResolved(t, v, `p`, ts[0])
 		assertValidatorFailures(t, v)
 	})
 	t.Run(`wrong data`, func(t *testing.T) {
 		sqlDB.Exec(t, createTableStmt(`wrong_data`))
-		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `wrong_data`, []string{`p`}, testColumns, false)
+		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `wrong_data`, []string{`p`}, testColumns)
 		require.NoError(t, err)
 		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":10}}`, ts[1])
 		noteResolved(t, v, `p`, ts[1])
@@ -310,7 +310,7 @@ func TestFingerprintValidator(t *testing.T) {
 	})
 	t.Run(`all resolved`, func(t *testing.T) {
 		sqlDB.Exec(t, createTableStmt(`all_resolved`))
-		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `all_resolved`, []string{`p`}, testColumns, false)
+		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `all_resolved`, []string{`p`}, testColumns)
 		require.NoError(t, err)
 		if err := v.NoteResolved(`p`, ts[0]); err != nil {
 			t.Fatal(err)
@@ -329,7 +329,7 @@ func TestFingerprintValidator(t *testing.T) {
 	})
 	t.Run(`rows unsorted`, func(t *testing.T) {
 		sqlDB.Exec(t, createTableStmt(`rows_unsorted`))
-		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `rows_unsorted`, []string{`p`}, testColumns, false)
+		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `rows_unsorted`, []string{`p`}, testColumns)
 		require.NoError(t, err)
 		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":3}}`, ts[3])
 		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":2}}`, ts[2])
@@ -341,7 +341,7 @@ func TestFingerprintValidator(t *testing.T) {
 	})
 	t.Run(`missed initial`, func(t *testing.T) {
 		sqlDB.Exec(t, createTableStmt(`missed_initial`))
-		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `missed_initial`, []string{`p`}, testColumns, false)
+		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `missed_initial`, []string{`p`}, testColumns)
 		require.NoError(t, err)
 		noteResolved(t, v, `p`, ts[0])
 		// Intentionally missing {"k":1,"v":1} at ts[1].
@@ -357,7 +357,7 @@ func TestFingerprintValidator(t *testing.T) {
 	})
 	t.Run(`missed middle`, func(t *testing.T) {
 		sqlDB.Exec(t, createTableStmt(`missed_middle`))
-		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `missed_middle`, []string{`p`}, testColumns, false)
+		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `missed_middle`, []string{`p`}, testColumns)
 		require.NoError(t, err)
 		noteResolved(t, v, `p`, ts[0])
 		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1])
@@ -375,7 +375,7 @@ func TestFingerprintValidator(t *testing.T) {
 	})
 	t.Run(`missed end`, func(t *testing.T) {
 		sqlDB.Exec(t, createTableStmt(`missed_end`))
-		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `missed_end`, []string{`p`}, testColumns, false)
+		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `missed_end`, []string{`p`}, testColumns)
 		require.NoError(t, err)
 		noteResolved(t, v, `p`, ts[0])
 		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1])
@@ -390,7 +390,7 @@ func TestFingerprintValidator(t *testing.T) {
 	})
 	t.Run(`initial scan`, func(t *testing.T) {
 		sqlDB.Exec(t, createTableStmt(`initial_scan`))
-		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `initial_scan`, []string{`p`}, testColumns, false)
+		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `initial_scan`, []string{`p`}, testColumns)
 		require.NoError(t, err)
 		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":3}}`, ts[3])
 		noteRow(t, v, ignored, `[2]`, `{"after": {"k":2,"v":2}}`, ts[3])
@@ -399,7 +399,7 @@ func TestFingerprintValidator(t *testing.T) {
 	})
 	t.Run(`unknown partition`, func(t *testing.T) {
 		sqlDB.Exec(t, createTableStmt(`unknown_partition`))
-		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `unknown_partition`, []string{`p`}, testColumns, false)
+		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `unknown_partition`, []string{`p`}, testColumns)
 		require.NoError(t, err)
 		if err := v.NoteResolved(`nope`, ts[1]); !testutils.IsError(err, `unknown partition`) {
 			t.Fatalf(`expected "unknown partition" error got: %+v`, err)
@@ -407,7 +407,7 @@ func TestFingerprintValidator(t *testing.T) {
 	})
 	t.Run(`resolved unsorted`, func(t *testing.T) {
 		sqlDB.Exec(t, createTableStmt(`resolved_unsorted`))
-		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `resolved_unsorted`, []string{`p`}, testColumns, false)
+		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `resolved_unsorted`, []string{`p`}, testColumns)
 		require.NoError(t, err)
 		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1])
 		noteResolved(t, v, `p`, ts[1])
@@ -417,7 +417,7 @@ func TestFingerprintValidator(t *testing.T) {
 	})
 	t.Run(`two partitions`, func(t *testing.T) {
 		sqlDB.Exec(t, createTableStmt(`two_partitions`))
-		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `two_partitions`, []string{`p0`, `p1`}, testColumns, false)
+		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `two_partitions`, []string{`p0`, `p1`}, testColumns)
 		require.NoError(t, err)
 		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1])
 		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":2}}`, ts[2])

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -417,7 +417,7 @@ func runCDCBank(ctx context.Context, t test.Test, c cluster.Cluster) {
 			return errors.Wrap(err, "CREATE TABLE failed")
 		}
 
-		fprintV, err := cdctest.NewFingerprintValidator(db, `bank.bank`, `fprint`, tc.partitions, 0, false)
+		fprintV, err := cdctest.NewFingerprintValidator(db, `bank.bank`, `fprint`, tc.partitions, 0)
 		if err != nil {
 			return errors.Wrap(err, "error creating validator")
 		}

--- a/pkg/cmd/roachtest/tests/mixed_version_cdc.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_cdc.go
@@ -12,6 +12,7 @@ package tests
 
 import (
 	"context"
+	gosql "database/sql"
 	"fmt"
 	"strconv"
 	"strings"
@@ -74,9 +75,12 @@ type cdcMixedVersionTester struct {
 		syncutil.Mutex
 		C chan struct{}
 	}
-	kafka     kafkaManager
-	validator *cdctest.CountValidator
-	cleanup   func()
+	crdbUpgrading syncutil.Mutex
+	kafka         kafkaManager
+	validator     *cdctest.CountValidator
+	validatorDone chan struct{} // validator is no longer waiting for messages
+	validatorStop bool          // used  to tell the validator to stop validating messages
+	cleanup       func()
 }
 
 func newCDCMixedVersionTester(
@@ -94,6 +98,7 @@ func newCDCMixedVersionTester(
 		workloadNodes: lastNode,
 		kafkaNodes:    lastNode,
 		monitor:       c.NewMonitor(ctx, crdbNodes),
+		validatorDone: make(chan struct{}),
 	}
 }
 
@@ -165,6 +170,17 @@ func (cmvt *cdcMixedVersionTester) waitForResolvedTimestamps() versionStep {
 	}
 }
 
+// waitForValidator sets the `validatorStop` flag and waits for the
+// validator to finish. This should be done right before the test
+// finishes, to ensure that we won't try to close the database
+// connection while the validator is still trying to use it
+func (cmvt *cdcMixedVersionTester) waitForValidator() versionStep {
+	return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
+		cmvt.validatorStop = true
+		<-cmvt.validatorDone
+	}
+}
+
 // setupVerifier creates a CDC validator to validate that a changefeed
 // created on the `target` table is able to re-create the table
 // somewhere else. It also verifies CDC's ordering guarantees. This
@@ -192,17 +208,19 @@ func (cmvt *cdcMixedVersionTester) setupVerifier(node int) versionStep {
 				t.Fatal(err)
 			}
 
-			fprintV, err := cdctest.NewFingerprintValidator(db, tableName, `fprint`, consumer.partitions, 0, true)
+			getConn := func(node int) *gosql.DB { return u.conn(ctx, t, node) }
+			fprintV, err := cdctest.NewFingerprintValidator(db, tableName, `fprint`, consumer.partitions, 0)
 			if err != nil {
 				t.Fatal(err)
 			}
+			fprintV.DBFunc(cmvt.cdcDBConn(getConn))
 			validators := cdctest.Validators{
 				cdctest.NewOrderValidator(tableName),
 				fprintV,
 			}
 			cmvt.validator = cdctest.MakeCountValidator(validators)
 
-			for {
+			for !cmvt.validatorStop {
 				m := consumer.Next(ctx)
 				if m == nil {
 					t.L().Printf("end of changefeed")
@@ -229,6 +247,9 @@ func (cmvt *cdcMixedVersionTester) setupVerifier(node int) versionStep {
 					cmvt.timestampResolved()
 				}
 			}
+
+			close(cmvt.validatorDone)
+			return nil
 		})
 	}
 }
@@ -241,6 +262,35 @@ func (cmvt *cdcMixedVersionTester) timestampResolved() {
 
 	if cmvt.timestampsResolved.C != nil {
 		cmvt.timestampsResolved.C <- struct{}{}
+	}
+}
+
+// cdcDBConn is the wrapper passed to the FingerprintValidator. The
+// goal is to ensure that database checks by the validator do not
+// happen while we are running an upgrade. We used to retry database
+// calls in the validator, but that logic adds complexity and does not
+// help in testing the changefeed's correctness
+func (cmvt *cdcMixedVersionTester) cdcDBConn(
+	getConn func(int) *gosql.DB,
+) func(func(*gosql.DB) error) error {
+	return func(f func(*gosql.DB) error) error {
+		cmvt.crdbUpgrading.Lock()
+		defer cmvt.crdbUpgrading.Unlock()
+
+		node := cmvt.crdbNodes.RandNode()[0]
+		return f(getConn(node))
+	}
+}
+
+// crdbUpgradeStep is a wrapper to steps that upgrade the cockroach
+// binary running in the cluster. It makes sure we hold exclusive
+// access to the `crdbUpgrading` lock while the upgrade is in process
+func (cmvt *cdcMixedVersionTester) crdbUpgradeStep(step versionStep) versionStep {
+	return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
+		cmvt.crdbUpgrading.Lock()
+		defer cmvt.crdbUpgrading.Unlock()
+
+		step(ctx, t, u)
 	}
 }
 
@@ -312,7 +362,7 @@ func runCDCMixedVersions(
 
 		tester.waitForResolvedTimestamps(),
 		// Roll the nodes into the new version one by one in random order
-		binaryUpgradeStep(tester.crdbNodes, mainVersion),
+		tester.crdbUpgradeStep(binaryUpgradeStep(tester.crdbNodes, mainVersion)),
 		// let the workload run in the new version for a while
 		tester.waitForResolvedTimestamps(),
 
@@ -320,19 +370,20 @@ func runCDCMixedVersions(
 
 		// Roll back again, which ought to be fine because the cluster upgrade was
 		// not finalized.
-		binaryUpgradeStep(tester.crdbNodes, predecessorVersion),
+		tester.crdbUpgradeStep(binaryUpgradeStep(tester.crdbNodes, predecessorVersion)),
 		tester.waitForResolvedTimestamps(),
 
 		tester.assertValid(),
 
 		// Roll nodes forward and finalize upgrade.
-		binaryUpgradeStep(tester.crdbNodes, mainVersion),
+		tester.crdbUpgradeStep(binaryUpgradeStep(tester.crdbNodes, mainVersion)),
 
 		// allow cluster version to update
 		allowAutoUpgradeStep(sqlNode()),
 		waitForUpgradeStep(tester.crdbNodes),
 
 		tester.waitForResolvedTimestamps(),
+		tester.waitForValidator(),
 		tester.assertValid(),
 	).run(ctx, t)
 }

--- a/pkg/cmd/roachtest/tests/mixed_version_cdc.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_cdc.go
@@ -46,6 +46,15 @@ var (
 	targetTable = "bank"
 
 	timeout = 30 * time.Minute
+	// set a fixed number of operations to be performed by the
+	// workload. Since we are validating events emitted by the
+	// changefeed in this test (ValidateDuplicatedEvents() call),
+	// enforcing a maximum number of operations sets a boundary on the
+	// validator's memory usage. The current value represents enough
+	// operations to allow for the validator to receive the desired
+	// amount of resolved events at different points of the upgrade
+	// process while staying within the current timeout.
+	maxOps = 12000
 )
 
 func registerCDCMixedVersions(r registry.Registry) {
@@ -78,8 +87,7 @@ type cdcMixedVersionTester struct {
 	crdbUpgrading syncutil.Mutex
 	kafka         kafkaManager
 	validator     *cdctest.CountValidator
-	validatorDone chan struct{} // validator is no longer waiting for messages
-	validatorStop bool          // used  to tell the validator to stop validating messages
+	workloadDone  bool
 	cleanup       func()
 }
 
@@ -98,7 +106,6 @@ func newCDCMixedVersionTester(
 		workloadNodes: lastNode,
 		kafkaNodes:    lastNode,
 		monitor:       c.NewMonitor(ctx, crdbNodes),
-		validatorDone: make(chan struct{}),
 	}
 }
 
@@ -126,10 +133,12 @@ func (cmvt *cdcMixedVersionTester) installAndStartWorkload() versionStep {
 		t.Status("installing and running workload")
 		u.c.Run(ctx, cmvt.workloadNodes, "./workload init bank {pgurl:1}")
 		cmvt.monitor.Go(func(ctx context.Context) error {
+			defer func() { cmvt.workloadDone = true }()
 			return u.c.RunE(
 				ctx,
 				cmvt.workloadNodes,
-				fmt.Sprintf("./workload run bank {pgurl%s} --max-rate=10 --tolerate-errors", cmvt.crdbNodes),
+				fmt.Sprintf("./workload run bank {pgurl%s} --max-rate=10 --max-ops %d --tolerate-errors",
+					cmvt.crdbNodes, maxOps),
 			)
 		})
 	}
@@ -170,14 +179,12 @@ func (cmvt *cdcMixedVersionTester) waitForResolvedTimestamps() versionStep {
 	}
 }
 
-// waitForValidator sets the `validatorStop` flag and waits for the
-// validator to finish. This should be done right before the test
-// finishes, to ensure that we won't try to close the database
-// connection while the validator is still trying to use it
-func (cmvt *cdcMixedVersionTester) waitForValidator() versionStep {
+// waitForWorkload waits for the workload to finish
+func (cmvt *cdcMixedVersionTester) waitForWorkload() versionStep {
 	return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
-		cmvt.validatorStop = true
-		<-cmvt.validatorDone
+		t.L().Printf("waiting for workload to finish...")
+		cmvt.monitor.Wait()
+		t.L().Printf("workload finished")
 	}
 }
 
@@ -213,17 +220,17 @@ func (cmvt *cdcMixedVersionTester) setupVerifier(node int) versionStep {
 			if err != nil {
 				t.Fatal(err)
 			}
-			fprintV.DBFunc(cmvt.cdcDBConn(getConn))
+			fprintV.DBFunc(cmvt.cdcDBConn(getConn)).ValidateDuplicatedEvents()
 			validators := cdctest.Validators{
 				cdctest.NewOrderValidator(tableName),
 				fprintV,
 			}
 			cmvt.validator = cdctest.MakeCountValidator(validators)
 
-			for !cmvt.validatorStop {
+			for !cmvt.workloadDone {
 				m := consumer.Next(ctx)
 				if m == nil {
-					t.L().Printf("end of changefeed")
+					t.Fatal("unexpected end of changefeed")
 					return nil
 				}
 
@@ -247,8 +254,6 @@ func (cmvt *cdcMixedVersionTester) setupVerifier(node int) versionStep {
 					cmvt.timestampResolved()
 				}
 			}
-
-			close(cmvt.validatorDone)
 			return nil
 		})
 	}
@@ -383,7 +388,7 @@ func runCDCMixedVersions(
 		waitForUpgradeStep(tester.crdbNodes),
 
 		tester.waitForResolvedTimestamps(),
-		tester.waitForValidator(),
+		tester.waitForWorkload(),
 		tester.assertValid(),
 	).run(ctx, t)
 }


### PR DESCRIPTION
This commit updates the fingerprint validator (and its use in the
`cdc/mixed-versions` test) to ignore duplicated events received by the
validator.

A previously implicit assumption of the validator is that any events
that it receives are either not duplicated, or -- if they are
duplicated -- they are within the previous resolved timestamp and the
current resolved timestamp. However, that assumption is not justified
by the changefeed guarantees and depends on how frequently `resolved`
events are emitted and how often the changefeed checkpoints.

In the specific case of the `cdc/mixed-versions` roachtest, it was
possible for the changefeed to start from an old checkpoint (older
than the last received `resolved` timestamp), causing it to re-emit
old events that happened way before the previously observed resolved
event. As a consequence, when the validator applies the update
associated with that event, there is a mismatch with state of the
original table as of the update's timestamp, as the fingerprint
validator relies on the fact that updates are applied in order.

To fix the issue, we now skip events that happen before the timestamp
of the previous `resolved` event received. In addition, the caller can
also tell the validator to verify that such out-of-order messages
received by the validator have indeed been previously seen; if not,
that would represent a violation of the changefeed's guarantees.

Fixes: https://github.com/cockroachdb/cockroach/issues/87251.

Release note: None