### PR TITLE
backupccl: enable `restore_span.target_size`

### DIFF
--- a/pkg/ccl/backupccl/restore_span_covering.go
+++ b/pkg/ccl/backupccl/restore_span_covering.go
@@ -50,7 +50,7 @@ var targetRestoreSpanSize = settings.RegisterByteSizeSetting(
 	settings.TenantWritable,
 	"backup.restore_span.target_size",
 	"target size to which base spans of a restore are merged to produce a restore span (0 disables)",
-	0, //TODO(dt): make this something like 384 << 20,
+	384<<20,
 )
 
 // makeSimpleImportSpans partitions the spans of requiredSpans into a covering


### PR DESCRIPTION
This setting was previously disabled because of timeouts being observed when restoring our TPCCInc fixtures. The cause of those timeouts has been identified as
https://github.com/cockroachdb/cockroach/issues/88329 making it safe to re-enable merging of spans during restore. This settings prevents restore from over-splitting and leaving the cluster with a merge hangover post restore.

Informs: #86470

Release note (sql change): Sets `backup.restore_span.target_size` to default to 384 MiB so that restore merges upto that size of spans when reading from the backup before actually ingesting data. This should reduce the number of ranges created during restore and thereby reduce the merging of ranges that needs to occur post restore.