### PR TITLE
opt: format return-mapping and update passthrough columns

### DIFF
--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -622,6 +622,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 				tp.Child("columns: <none>")
 			}
 			f.formatMutationCols(e, tp, "insert-mapping:", t.InsertCols, t.Table)
+			f.formatMutationCols(e, tp, "return-mapping:", t.ReturnCols, t.Table)
 			f.formatOptionalColList(e, tp, "check columns:", t.CheckCols)
 			f.formatOptionalColList(e, tp, "partial index put columns:", t.PartialIndexPutCols)
 			f.formatMutationCommon(tp, &t.MutationPrivate)
@@ -633,7 +634,9 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 				tp.Child("columns: <none>")
 			}
 			f.formatOptionalColList(e, tp, "fetch columns:", t.FetchCols)
+			f.formatOptionalColList(e, tp, "passthrough columns:", opt.OptionalColList(t.PassthroughCols))
 			f.formatMutationCols(e, tp, "update-mapping:", t.UpdateCols, t.Table)
+			f.formatMutationCols(e, tp, "return-mapping:", t.ReturnCols, t.Table)
 			f.formatOptionalColList(e, tp, "check columns:", t.CheckCols)
 			f.formatOptionalColList(e, tp, "partial index put columns:", t.PartialIndexPutCols)
 			f.formatOptionalColList(e, tp, "partial index del columns:", t.PartialIndexDelCols)
@@ -668,6 +671,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 				tp.Child("columns: <none>")
 			}
 			f.formatOptionalColList(e, tp, "fetch columns:", t.FetchCols)
+			f.formatMutationCols(e, tp, "return-mapping:", t.ReturnCols, t.Table)
 			f.formatOptionalColList(e, tp, "partial index del columns:", t.PartialIndexDelCols)
 			f.formatMutationCommon(tp, &t.MutationPrivate)
 		}

--- a/pkg/sql/opt/memo/testdata/logprops/delete
+++ b/pkg/sql/opt/memo/testdata/logprops/delete
@@ -61,6 +61,12 @@ project
  └── delete abcde
       ├── columns: a:1(int!null) b:2(int) c:3(int!null) d:4(int) rowid:5(int!null)
       ├── fetch columns: a:9(int) b:10(int) c:11(int) d:12(int) rowid:13(int) e:14(int)
+      ├── return-mapping:
+      │    ├── a:9 => a:1
+      │    ├── b:10 => b:2
+      │    ├── c:11 => c:3
+      │    ├── d:12 => d:4
+      │    └── rowid:13 => rowid:5
       ├── volatile, mutations
       ├── key: (5)
       ├── fd: ()-->(1), (5)-->(2-4), (2,3)-->(4)
@@ -102,6 +108,12 @@ project
  └── delete abcde
       ├── columns: a:1(int!null) b:2(int) c:3(int!null) d:4(int) rowid:5(int!null)
       ├── fetch columns: a:9(int) b:10(int) c:11(int) d:12(int) rowid:13(int) e:14(int)
+      ├── return-mapping:
+      │    ├── a:9 => a:1
+      │    ├── b:10 => b:2
+      │    ├── c:11 => c:3
+      │    ├── d:12 => d:4
+      │    └── rowid:13 => rowid:5
       ├── cardinality: [0 - 1]
       ├── volatile, mutations
       ├── key: ()
@@ -142,6 +154,12 @@ project
  └── delete abcde
       ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int) rowid:5(int!null)
       ├── fetch columns: a:9(int) b:10(int) c:11(int) d:12(int) rowid:13(int) e:14(int)
+      ├── return-mapping:
+      │    ├── a:9 => a:1
+      │    ├── b:10 => b:2
+      │    ├── c:11 => c:3
+      │    ├── d:12 => d:4
+      │    └── rowid:13 => rowid:5
       ├── volatile, mutations
       ├── key: (5)
       ├── fd: (2)==(3), (3)==(2), (5)-->(1-4), (2)-->(4)

--- a/pkg/sql/opt/memo/testdata/logprops/insert
+++ b/pkg/sql/opt/memo/testdata/logprops/insert
@@ -96,6 +96,12 @@ project
       │    ├── d_comp:17 => d:4
       │    ├── rowid_default:15 => rowid:5
       │    └── e_default:16 => e:6
+      ├── return-mapping:
+      │    ├── y:10 => a:1
+      │    ├── y:10 => b:2
+      │    ├── c_default:14 => c:3
+      │    ├── d_comp:17 => d:4
+      │    └── rowid_default:15 => rowid:5
       ├── cardinality: [0 - 10]
       ├── volatile, mutations
       ├── fd: ()-->(3), (1)==(2), (2)==(1), (1)-->(4)
@@ -163,6 +169,12 @@ project
       │    ├── d_comp:17 => d:4
       │    ├── rowid_default:15 => rowid:5
       │    └── e_default:16 => e:6
+      ├── return-mapping:
+      │    ├── y:10 => a:1
+      │    ├── y:10 => b:2
+      │    ├── c_default:14 => c:3
+      │    ├── d_comp:17 => d:4
+      │    └── rowid_default:15 => rowid:5
       ├── volatile, mutations
       ├── fd: ()-->(3), (1)==(2), (2)==(1), (1)-->(4)
       └── project
@@ -209,6 +221,12 @@ insert abcde
  │    ├── d_comp:14 => d:4
  │    ├── rowid_default:12 => rowid:5
  │    └── e_default:13 => e:6
+ ├── return-mapping:
+ │    ├── column1:9 => a:1
+ │    ├── column2:10 => b:2
+ │    ├── c_default:11 => c:3
+ │    ├── d_comp:14 => d:4
+ │    └── rowid_default:12 => rowid:5
  ├── cardinality: [1 - 1]
  ├── volatile, mutations
  ├── key: ()
@@ -266,6 +284,12 @@ project
       │    ├── d_comp:18 => d:4
       │    ├── rowid_default:16 => rowid:5
       │    └── e_default:17 => e:6
+      ├── return-mapping:
+      │    ├── y:10 => a:1
+      │    ├── int8:14 => b:2
+      │    ├── c_default:15 => c:3
+      │    ├── d_comp:18 => d:4
+      │    └── rowid_default:16 => rowid:5
       ├── volatile, mutations
       ├── fd: ()-->(1,3), (2)-->(4)
       └── project

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -1727,6 +1727,10 @@ with &1
  │         │    ├── column1:11 => uv.u:6
  │         │    ├── column2:12 => uv.v:7
  │         │    └── rowid_default:13 => rowid:8
+ │         ├── return-mapping:
+ │         │    ├── column1:11 => uv.u:6
+ │         │    ├── column2:12 => uv.v:7
+ │         │    └── rowid_default:13 => rowid:8
  │         ├── cardinality: [1 - 1]
  │         ├── volatile, mutations
  │         ├── key: ()

--- a/pkg/sql/opt/memo/testdata/logprops/update
+++ b/pkg/sql/opt/memo/testdata/logprops/update
@@ -98,6 +98,12 @@ project
       │    ├── b_new:17 => b:2
       │    ├── d_comp:19 => d:4
       │    └── e_default:18 => e:6
+      ├── return-mapping:
+      │    ├── a:9 => a:1
+      │    ├── b_new:17 => b:2
+      │    ├── c:11 => c:3
+      │    ├── d_comp:19 => d:4
+      │    └── rowid:13 => rowid:5
       ├── volatile, mutations
       ├── key: (5)
       ├── fd: ()-->(1,2), (5)-->(3,4), (3)-->(4)
@@ -172,6 +178,12 @@ project
       │    ├── b_new:17 => b:2
       │    ├── d_comp:19 => d:4
       │    └── e_default:18 => e:6
+      ├── return-mapping:
+      │    ├── a:9 => a:1
+      │    ├── b_new:17 => b:2
+      │    ├── c:11 => c:3
+      │    ├── d_comp:19 => d:4
+      │    └── rowid:13 => rowid:5
       ├── cardinality: [0 - 1]
       ├── volatile, mutations
       ├── key: ()
@@ -244,6 +256,12 @@ project
       ├── update-mapping:
       │    ├── a_new:17 => a:1
       │    └── e_default:18 => e:6
+      ├── return-mapping:
+      │    ├── a_new:17 => a:1
+      │    ├── b:10 => b:2
+      │    ├── c:11 => c:3
+      │    ├── d:12 => d:4
+      │    └── rowid:13 => rowid:5
       ├── volatile, mutations
       ├── key: (5)
       ├── fd: ()-->(1), (2)==(3), (3)==(2), (5)-->(2-4), (2)-->(4)

--- a/pkg/sql/opt/memo/testdata/logprops/upsert
+++ b/pkg/sql/opt/memo/testdata/logprops/upsert
@@ -227,6 +227,11 @@ project
       │    ├── y:8 => b:2
       │    ├── c_comp:13 => c:3
       │    └── rowid_default:12 => rowid:4
+      ├── return-mapping:
+      │    ├── x:7 => a:1
+      │    ├── y:8 => b:2
+      │    ├── c_comp:13 => c:3
+      │    └── rowid_default:12 => rowid:4
       ├── volatile, mutations
       ├── key: (1)
       ├── fd: (1)-->(2-4), (2)-->(3), (4)~~>(1-3), (2,3)~~>(1,4)

--- a/pkg/sql/opt/memo/testdata/stats/delete
+++ b/pkg/sql/opt/memo/testdata/stats/delete
@@ -47,6 +47,10 @@ with &1
  ├── delete xyz
  │    ├── columns: xyz.x:1(string!null) xyz.y:2(int!null) xyz.z:3(float!null)
  │    ├── fetch columns: xyz.x:6(string) xyz.y:7(int) xyz.z:8(float)
+ │    ├── return-mapping:
+ │    │    ├── xyz.x:6 => xyz.x:1
+ │    │    ├── xyz.y:7 => xyz.y:2
+ │    │    └── xyz.z:8 => xyz.z:3
  │    ├── volatile, mutations
  │    ├── stats: [rows=10, distinct(1)=10, null(1)=0, distinct(2)=9.56179, null(2)=0, distinct(3)=1, null(3)=0]
  │    ├── key: (1)
@@ -87,6 +91,10 @@ DELETE FROM xyz WHERE False RETURNING *
 delete xyz
  ├── columns: x:1(string!null) y:2(int!null) z:3(float)
  ├── fetch columns: x:6(string) y:7(int) z:8(float)
+ ├── return-mapping:
+ │    ├── x:6 => x:1
+ │    ├── y:7 => y:2
+ │    └── z:8 => z:3
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── stats: [rows=0]

--- a/pkg/sql/opt/memo/testdata/stats/insert
+++ b/pkg/sql/opt/memo/testdata/stats/insert
@@ -49,6 +49,10 @@ with &1
  │    │    ├── b:7 => xyz.x:1
  │    │    ├── a:6 => xyz.y:2
  │    │    └── c:8 => xyz.z:3
+ │    ├── return-mapping:
+ │    │    ├── b:7 => xyz.x:1
+ │    │    ├── a:6 => xyz.y:2
+ │    │    └── c:8 => xyz.z:3
  │    ├── volatile, mutations
  │    ├── stats: [rows=200, distinct(1)=1, null(1)=0, distinct(2)=200, null(2)=0, distinct(3)=130.264, null(3)=2]
  │    ├── fd: ()-->(1), (2)-->(3)
@@ -93,6 +97,10 @@ INSERT INTO xyz (x, y, z) SELECT b, a, c FROM abc WHERE False RETURNING *
 insert xyz
  ├── columns: x:1(string!null) y:2(int!null) z:3(float)
  ├── insert-mapping:
+ │    ├── b:7 => x:1
+ │    ├── a:6 => y:2
+ │    └── c:8 => z:3
+ ├── return-mapping:
  │    ├── b:7 => x:1
  │    ├── a:6 => y:2
  │    └── c:8 => z:3

--- a/pkg/sql/opt/memo/testdata/stats/update
+++ b/pkg/sql/opt/memo/testdata/stats/update
@@ -49,6 +49,10 @@ with &1
  │    ├── fetch columns: xyz.x:6(string) xyz.y:7(int) xyz.z:8(float)
  │    ├── update-mapping:
  │    │    └── y_new:11 => xyz.y:2
+ │    ├── return-mapping:
+ │    │    ├── xyz.x:6 => xyz.x:1
+ │    │    ├── y_new:11 => xyz.y:2
+ │    │    └── xyz.z:8 => xyz.z:3
  │    ├── volatile, mutations
  │    ├── stats: [rows=10, distinct(1)=10, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0]
  │    ├── key: (1)
@@ -98,6 +102,10 @@ update xyz
  ├── fetch columns: x:6(string) y:7(int) z:8(float)
  ├── update-mapping:
  │    └── x_new:11 => x:1
+ ├── return-mapping:
+ │    ├── x_new:11 => x:1
+ │    ├── y:7 => y:2
+ │    └── z:8 => z:3
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── stats: [rows=0]
@@ -151,8 +159,13 @@ with &2 (q)
  │    └── update child
  │         ├── columns: x:1(int) child.c:2(int!null) rowid:3(int!null) parent.p:11(int) parent.crdb_internal_mvcc_timestamp:12(decimal) parent.tableoid:13(oid)
  │         ├── fetch columns: x:6(int) child.c:7(int) rowid:8(int)
+ │         ├── passthrough columns: parent.p:11(int) parent.crdb_internal_mvcc_timestamp:12(decimal) parent.tableoid:13(oid)
  │         ├── update-mapping:
  │         │    └── parent.p:11 => child.c:2
+ │         ├── return-mapping:
+ │         │    ├── x:6 => x:1
+ │         │    ├── parent.p:11 => child.c:2
+ │         │    └── rowid:8 => rowid:3
  │         ├── input binding: &1
  │         ├── volatile, mutations
  │         ├── stats: [rows=1000, distinct(11)=1, null(11)=0]

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -2071,6 +2071,9 @@ DELETE FROM a RETURNING k, s
 delete a
  ├── columns: k:1!null s:4
  ├── fetch columns: k:7 s:10
+ ├── return-mapping:
+ │    ├── k:7 => k:1
+ │    └── s:10 => s:4
  ├── volatile, mutations
  ├── key: (1)
  ├── fd: (1)-->(4)
@@ -3052,6 +3055,9 @@ project
       ├── fetch columns: a:8 b:9 c:10 d:11
       ├── update-mapping:
       │    └── c_new:15 => c:3
+      ├── return-mapping:
+      │    ├── a:8 => a:1
+      │    └── b:9 => b:2
       ├── volatile, mutations
       ├── key: (1)
       ├── fd: (1)-->(2)
@@ -4066,6 +4072,9 @@ project
  └── delete virt
       ├── columns: a:1!null v:3
       ├── fetch columns: a:6 v:8
+      ├── return-mapping:
+      │    ├── a:6 => a:1
+      │    └── v:8 => v:3
       ├── volatile, mutations
       ├── key: (1)
       ├── fd: (1)-->(3)
@@ -4306,6 +4315,15 @@ project
       ├── fetch columns: a:11 b:12 c:13 d:14 e:15 f:16 g:17 rowid:18
       ├── update-mapping:
       │    └── a_new:21 => a:1
+      ├── return-mapping:
+      │    ├── a_new:21 => a:1
+      │    ├── b:12 => b:2
+      │    ├── c:13 => c:3
+      │    ├── d:14 => d:4
+      │    ├── e:15 => e:5
+      │    ├── f:16 => f:6
+      │    ├── g:17 => g:7
+      │    └── rowid:18 => rowid:8
       ├── volatile, mutations
       ├── key: (8)
       ├── fd: (8)-->(1-7)
@@ -4336,6 +4354,10 @@ project
       ├── fetch columns: a:11 d:14 e:15 f:16 g:17 rowid:18
       ├── update-mapping:
       │    └── d_new:21 => d:4
+      ├── return-mapping:
+      │    ├── a:11 => a:1
+      │    ├── d_new:21 => d:4
+      │    └── rowid:18 => rowid:8
       ├── volatile, mutations
       ├── key: (8)
       ├── fd: (8)-->(1,4), (1)~~>(4,8)
@@ -4363,6 +4385,9 @@ project
       ├── fetch columns: a:11 rowid:18
       ├── update-mapping:
       │    └── a_new:21 => a:1
+      ├── return-mapping:
+      │    ├── a_new:21 => a:1
+      │    └── rowid:18 => rowid:8
       ├── volatile, mutations
       ├── key: (8)
       ├── fd: (8)-->(1)
@@ -4393,6 +4418,11 @@ project
       ├── update-mapping:
       │    ├── a_new:21 => a:1
       │    └── a:11 => b:2
+      ├── return-mapping:
+      │    ├── a_new:21 => a:1
+      │    ├── a:11 => b:2
+      │    ├── c:13 => c:3
+      │    └── rowid:18 => rowid:8
       ├── volatile, mutations
       ├── key: (8)
       ├── fd: (8)-->(1-3), (2)~~>(1,3,8)
@@ -4426,6 +4456,11 @@ with &1
  │         ├── fetch columns: returning_test.a:11 returning_test.b:12 returning_test.c:13 rowid:18
  │         ├── update-mapping:
  │         │    └── a_new:21 => returning_test.a:1
+ │         ├── return-mapping:
+ │         │    ├── a_new:21 => returning_test.a:1
+ │         │    ├── returning_test.b:12 => returning_test.b:2
+ │         │    ├── returning_test.c:13 => returning_test.c:3
+ │         │    └── rowid:18 => rowid:8
  │         ├── volatile, mutations
  │         ├── key: (8)
  │         ├── fd: (8)-->(1-3)
@@ -4467,6 +4502,11 @@ with &1
  │         ├── fetch columns: returning_test.a:11 returning_test.b:12 returning_test.c:13 rowid:18
  │         ├── update-mapping:
  │         │    └── a_new:21 => returning_test.a:1
+ │         ├── return-mapping:
+ │         │    ├── a_new:21 => returning_test.a:1
+ │         │    ├── returning_test.b:12 => returning_test.b:2
+ │         │    ├── returning_test.c:13 => returning_test.c:3
+ │         │    └── rowid:18 => rowid:8
  │         ├── volatile, mutations
  │         ├── key: (8)
  │         ├── fd: (8)-->(1-3)
@@ -4514,6 +4554,11 @@ with &2
  │         ├── fetch columns: returning_test.a:23 returning_test.b:24 returning_test.c:25 rowid:30
  │         ├── update-mapping:
  │         │    └── a_new:33 => returning_test.a:13
+ │         ├── return-mapping:
+ │         │    ├── a_new:33 => returning_test.a:13
+ │         │    ├── returning_test.b:24 => returning_test.b:14
+ │         │    ├── returning_test.c:25 => returning_test.c:15
+ │         │    └── rowid:30 => rowid:20
  │         ├── volatile, mutations
  │         ├── key: (20)
  │         ├── fd: (20)-->(13-15)
@@ -4642,6 +4687,11 @@ project
  └── delete returning_test
       ├── columns: a:1!null b:2 d:4 rowid:8!null
       ├── fetch columns: a:11 b:12 d:14 rowid:18
+      ├── return-mapping:
+      │    ├── a:11 => a:1
+      │    ├── b:12 => b:2
+      │    ├── d:14 => d:4
+      │    └── rowid:18 => rowid:8
       ├── volatile, mutations
       ├── key: (8)
       ├── fd: (8)-->(1,2,4), (1)-->(2,4,8)
@@ -4756,9 +4806,12 @@ RETURNING
 update abcde
  ├── columns: a:1!null b:16 c:17
  ├── fetch columns: abcde.a:8 abcde.b:9 abcde.c:10 abcde.d:11 abcde.e:12
+ ├── passthrough columns: "family".b:16 "family".c:17
  ├── update-mapping:
  │    ├── "family".b:16 => abcde.b:2
  │    └── "family".c:17 => abcde.c:3
+ ├── return-mapping:
+ │    └── abcde.a:8 => abcde.a:1
  ├── volatile, mutations
  ├── key: (1)
  ├── fd: (1)-->(16,17)

--- a/pkg/sql/opt/norm/testdata/rules/with
+++ b/pkg/sql/opt/norm/testdata/rules/with
@@ -407,6 +407,12 @@ with &1 (foo)
  │    │    ├── f_default:10 => a.f:3
  │    │    ├── s_default:11 => a.s:4
  │    │    └── j_default:12 => a.j:5
+ │    ├── return-mapping:
+ │    │    ├── column1:8 => a.k:1
+ │    │    ├── i_default:9 => a.i:2
+ │    │    ├── f_default:10 => a.f:3
+ │    │    ├── s_default:11 => a.s:4
+ │    │    └── j_default:12 => a.j:5
  │    ├── cardinality: [1 - 1]
  │    ├── volatile, mutations
  │    ├── key: ()
@@ -558,6 +564,8 @@ with &2 (cte)
  │    ├── insert-mapping:
  │    │    ├── column1:5 => t.public.child.c:1
  │    │    └── column2:6 => t.public.child.p:2
+ │    ├── return-mapping:
+ │    │    └── column1:5 => t.public.child.c:1
  │    ├── input binding: &1
  │    ├── cardinality: [1 - 1]
  │    ├── volatile, mutations

--- a/pkg/sql/opt/optbuilder/testdata/delete
+++ b/pkg/sql/opt/optbuilder/testdata/delete
@@ -245,6 +245,10 @@ with &1
  ├── delete xyz
  │    ├── columns: xyz.x:1!null xyz.y:2 xyz.z:3!null
  │    ├── fetch columns: xyz.x:6 xyz.y:7 xyz.z:8
+ │    ├── return-mapping:
+ │    │    ├── xyz.x:6 => xyz.x:1
+ │    │    ├── xyz.y:7 => xyz.y:2
+ │    │    └── xyz.z:8 => xyz.z:3
  │    └── select
  │         ├── columns: xyz.x:6!null xyz.y:7 xyz.z:8!null xyz.crdb_internal_mvcc_timestamp:9 xyz.tableoid:10
  │         ├── scan xyz
@@ -300,6 +304,13 @@ project
  └── delete abcde
       ├── columns: a:1!null b:2 c:3 d:4 e:5 rowid:6!null
       ├── fetch columns: a:9 b:10 c:11 d:12 e:13 rowid:14
+      ├── return-mapping:
+      │    ├── a:9 => a:1
+      │    ├── b:10 => b:2
+      │    ├── c:11 => c:3
+      │    ├── d:12 => d:4
+      │    ├── e:13 => e:5
+      │    └── rowid:14 => rowid:6
       └── select
            ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
            ├── scan abcde
@@ -321,6 +332,13 @@ project
  ├── delete abcde [as=foo]
  │    ├── columns: a:1!null b:2 c:3 d:4 e:5 rowid:6!null
  │    ├── fetch columns: a:9 b:10 c:11 d:12 e:13 rowid:14
+ │    ├── return-mapping:
+ │    │    ├── a:9 => a:1
+ │    │    ├── b:10 => b:2
+ │    │    ├── c:11 => c:3
+ │    │    ├── d:12 => d:4
+ │    │    ├── e:13 => e:5
+ │    │    └── rowid:14 => rowid:6
  │    └── select
  │         ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
  │         ├── scan abcde [as=foo]
@@ -347,6 +365,13 @@ with &1
  │    └── delete abcde
  │         ├── columns: abcde.a:1!null abcde.b:2 abcde.c:3 abcde.d:4 abcde.e:5 rowid:6!null
  │         ├── fetch columns: abcde.a:9 abcde.b:10 abcde.c:11 abcde.d:12 abcde.e:13 rowid:14
+ │         ├── return-mapping:
+ │         │    ├── abcde.a:9 => abcde.a:1
+ │         │    ├── abcde.b:10 => abcde.b:2
+ │         │    ├── abcde.c:11 => abcde.c:3
+ │         │    ├── abcde.d:12 => abcde.d:4
+ │         │    ├── abcde.e:13 => abcde.e:5
+ │         │    └── rowid:14 => rowid:6
  │         └── limit
  │              ├── columns: abcde.a:9!null abcde.b:10 abcde.c:11 abcde.d:12 abcde.e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
  │              ├── internal-ordering: +10
@@ -402,6 +427,9 @@ DELETE FROM mutation WHERE m=1 RETURNING *
 delete mutation
  ├── columns: m:1!null n:2
  ├── fetch columns: m:7 n:8 o:9 p:10
+ ├── return-mapping:
+ │    ├── m:7 => m:1
+ │    └── n:8 => n:2
  └── select
       ├── columns: m:7!null n:8 o:9 p:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       ├── scan mutation

--- a/pkg/sql/opt/optbuilder/testdata/insert
+++ b/pkg/sql/opt/optbuilder/testdata/insert
@@ -344,6 +344,13 @@ project
       │    ├── d_comp:13 => d:4
       │    ├── "?column?":9 => e:5
       │    └── rowid_default:12 => rowid:6
+      ├── return-mapping:
+      │    ├── "?column?":9 => a:1
+      │    ├── b_default:10 => b:2
+      │    ├── c_default:11 => c:3
+      │    ├── d_comp:13 => d:4
+      │    ├── "?column?":9 => e:5
+      │    └── rowid_default:12 => rowid:6
       └── project
            ├── columns: d_comp:13 "?column?":9!null b_default:10 c_default:11!null rowid_default:12
            ├── project
@@ -370,6 +377,13 @@ project
  ├── insert abcde [as=foo]
  │    ├── columns: a:1!null b:2 c:3!null d:4 e:5!null rowid:6!null
  │    ├── insert-mapping:
+ │    │    ├── "?column?":9 => a:1
+ │    │    ├── b_default:10 => b:2
+ │    │    ├── c_default:11 => c:3
+ │    │    ├── d_comp:13 => d:4
+ │    │    ├── "?column?":9 => e:5
+ │    │    └── rowid_default:12 => rowid:6
+ │    ├── return-mapping:
  │    │    ├── "?column?":9 => a:1
  │    │    ├── b_default:10 => b:2
  │    │    ├── c_default:11 => c:3
@@ -407,6 +421,13 @@ with &1
  │    └── insert abcde
  │         ├── columns: abcde.a:1!null abcde.b:2 abcde.c:3!null abcde.d:4 abcde.e:5!null rowid:6!null
  │         ├── insert-mapping:
+ │         │    ├── column1:9 => abcde.a:1
+ │         │    ├── b_default:10 => abcde.b:2
+ │         │    ├── c_default:11 => abcde.c:3
+ │         │    ├── d_comp:13 => abcde.d:4
+ │         │    ├── column1:9 => abcde.e:5
+ │         │    └── rowid_default:12 => rowid:6
+ │         ├── return-mapping:
  │         │    ├── column1:9 => abcde.a:1
  │         │    ├── b_default:10 => abcde.b:2
  │         │    ├── c_default:11 => abcde.c:3
@@ -556,6 +577,13 @@ with &1
  │         │    ├── d_comp:13 => abcde.d:4
  │         │    ├── column1:9 => abcde.e:5
  │         │    └── rowid_default:12 => rowid:6
+ │         ├── return-mapping:
+ │         │    ├── column1:9 => abcde.a:1
+ │         │    ├── b_default:10 => abcde.b:2
+ │         │    ├── c_default:11 => abcde.c:3
+ │         │    ├── d_comp:13 => abcde.d:4
+ │         │    ├── column1:9 => abcde.e:5
+ │         │    └── rowid_default:12 => rowid:6
  │         └── project
  │              ├── columns: d_comp:13 column1:9!null b_default:10 c_default:11!null rowid_default:12
  │              ├── project
@@ -686,6 +714,13 @@ project
       │    ├── d_comp:13 => d:4
       │    ├── column1:9 => e:5
       │    └── column2:10 => rowid:6
+      ├── return-mapping:
+      │    ├── column1:9 => a:1
+      │    ├── b_default:11 => b:2
+      │    ├── c_default:12 => c:3
+      │    ├── d_comp:13 => d:4
+      │    ├── column1:9 => e:5
+      │    └── column2:10 => rowid:6
       └── project
            ├── columns: d_comp:13 column1:9!null column2:10!null b_default:11 c_default:12!null
            ├── project
@@ -708,6 +743,13 @@ RETURNING *, rowid
 insert abcde
  ├── columns: a:1!null b:2 c:3!null d:4 e:5!null rowid:6!null
  ├── insert-mapping:
+ │    ├── column3:11 => a:1
+ │    ├── column2:10 => b:2
+ │    ├── column1:9 => c:3
+ │    ├── d_comp:13 => d:4
+ │    ├── column3:11 => e:5
+ │    └── column4:12 => rowid:6
+ ├── return-mapping:
  │    ├── column3:11 => a:1
  │    ├── column2:10 => b:2
  │    ├── column1:9 => c:3
@@ -827,6 +869,13 @@ project
       │    ├── d_comp:17 => d:4
       │    ├── y:10 => e:5
       │    └── rowid_default:16 => rowid:6
+      ├── return-mapping:
+      │    ├── y:10 => a:1
+      │    ├── x:14 => b:2
+      │    ├── c_default:15 => c:3
+      │    ├── d_comp:17 => d:4
+      │    ├── y:10 => e:5
+      │    └── rowid_default:16 => rowid:6
       └── project
            ├── columns: d_comp:17!null y:10 x:14!null c_default:15!null rowid_default:16
            ├── project
@@ -850,6 +899,13 @@ INSERT INTO abcde (rowid, a) VALUES (1, 2) RETURNING *, rowid
 insert abcde
  ├── columns: a:1!null b:2 c:3!null d:4 e:5!null rowid:6!null
  ├── insert-mapping:
+ │    ├── column2:10 => a:1
+ │    ├── b_default:11 => b:2
+ │    ├── c_default:12 => c:3
+ │    ├── d_comp:13 => d:4
+ │    ├── column2:10 => e:5
+ │    └── column1:9 => rowid:6
+ ├── return-mapping:
  │    ├── column2:10 => a:1
  │    ├── b_default:11 => b:2
  │    ├── c_default:12 => c:3
@@ -880,6 +936,13 @@ with &1
  │    └── insert abcde
  │         ├── columns: abcde.a:1!null abcde.b:2 abcde.c:3!null abcde.d:4 abcde.e:5 rowid:6!null
  │         ├── insert-mapping:
+ │         │    ├── "?column?":14 => abcde.a:1
+ │         │    ├── y:10 => abcde.b:2
+ │         │    ├── c_default:15 => abcde.c:3
+ │         │    ├── d_comp:17 => abcde.d:4
+ │         │    ├── "?column?":14 => abcde.e:5
+ │         │    └── rowid_default:16 => rowid:6
+ │         ├── return-mapping:
  │         │    ├── "?column?":14 => abcde.a:1
  │         │    ├── y:10 => abcde.b:2
  │         │    ├── c_default:15 => abcde.c:3
@@ -1085,6 +1148,9 @@ insert mutation
  │    ├── column2:9 => n:2
  │    ├── o_default:10 => o:3
  │    └── p_comp:11 => p:4
+ ├── return-mapping:
+ │    ├── column1:8 => m:1
+ │    └── column2:9 => n:2
  ├── check columns: check1:12
  └── project
       ├── columns: check1:12!null column1:8!null column2:9!null o_default:10!null p_comp:11!null

--- a/pkg/sql/opt/optbuilder/testdata/partial-indexes
+++ b/pkg/sql/opt/optbuilder/testdata/partial-indexes
@@ -325,6 +325,10 @@ update partial_indexes
  ├── fetch columns: a:6 b:7 c:8
  ├── update-mapping:
  │    └── a_new:11 => a:1
+ ├── return-mapping:
+ │    ├── a_new:11 => a:1
+ │    ├── b:7 => b:2
+ │    └── c:8 => c:3
  ├── partial index put columns: partial_index_put1:12 partial_index_put2:13 partial_index_put3:15 partial_index_put4:16
  ├── partial index del columns: partial_index_put1:12 partial_index_del2:14 partial_index_put3:15 partial_index_put4:16
  └── project
@@ -357,6 +361,7 @@ UPDATE partial_indexes SET a = v.a FROM (VALUES (1), (2)) AS v(a) WHERE partial_
 update partial_indexes
  ├── columns: <none>
  ├── fetch columns: a:6 b:7 c:8
+ ├── passthrough columns: column1:11
  ├── update-mapping:
  │    └── column1:11 => a:1
  ├── partial index put columns: partial_index_put1:12 partial_index_put2:13 partial_index_put3:15 partial_index_put4:16
@@ -556,8 +561,12 @@ project
  └── update t61520 [as=t]
       ├── columns: a:1!null rowid:2!null column1:9
       ├── fetch columns: a:5 rowid:6
+      ├── passthrough columns: column1:9
       ├── update-mapping:
       │    └── a_cast:10 => a:1
+      ├── return-mapping:
+      │    ├── a_cast:10 => a:1
+      │    └── rowid:6 => rowid:2
       ├── partial index put columns: partial_index_put1:11
       ├── partial index del columns: partial_index_del1:12
       └── project

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -1263,6 +1263,10 @@ with &1
  │    │    ├── column1:6 => abc.a:1
  │    │    ├── b_default:7 => abc.b:2
  │    │    └── b_default:7 => abc.c:3
+ │    ├── return-mapping:
+ │    │    ├── column1:6 => abc.a:1
+ │    │    ├── b_default:7 => abc.b:2
+ │    │    └── b_default:7 => abc.c:3
  │    └── project
  │         ├── columns: b_default:7 column1:6!null
  │         ├── values
@@ -1317,6 +1321,10 @@ with &1
  │    └── insert abc
  │         ├── columns: abc.a:1!null b:2!null c:3!null
  │         ├── insert-mapping:
+ │         │    ├── column1:6 => abc.a:1
+ │         │    ├── column2:7 => b:2
+ │         │    └── column3:8 => c:3
+ │         ├── return-mapping:
  │         │    ├── column1:6 => abc.a:1
  │         │    ├── column2:7 => b:2
  │         │    └── column3:8 => c:3

--- a/pkg/sql/opt/optbuilder/testdata/unique-checks-update
+++ b/pkg/sql/opt/optbuilder/testdata/unique-checks-update
@@ -222,6 +222,7 @@ UPDATE uniq SET w = other.w, x = other.x FROM other
 update uniq
  ├── columns: <none>
  ├── fetch columns: uniq.k:8 uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12
+ ├── passthrough columns: other.k:15 other.v:16 other.w:17 other.x:18 other.y:19 rowid:20 other.crdb_internal_mvcc_timestamp:21 other.tableoid:22
  ├── update-mapping:
  │    ├── other.w:17 => uniq.w:3
  │    └── other.x:18 => uniq.x:4
@@ -416,6 +417,7 @@ UPDATE uniq_overlaps_pk SET a = k, d = v FROM other
 update uniq_overlaps_pk
  ├── columns: <none>
  ├── fetch columns: uniq_overlaps_pk.a:7 uniq_overlaps_pk.b:8 uniq_overlaps_pk.c:9 uniq_overlaps_pk.d:10
+ ├── passthrough columns: k:13 v:14 w:15 x:16 y:17 rowid:18 other.crdb_internal_mvcc_timestamp:19 other.tableoid:20
  ├── update-mapping:
  │    ├── k:13 => uniq_overlaps_pk.a:1
  │    └── v:14 => uniq_overlaps_pk.d:4
@@ -575,6 +577,7 @@ UPDATE uniq_hidden_pk SET a = k FROM other
 update uniq_hidden_pk
  ├── columns: <none>
  ├── fetch columns: uniq_hidden_pk.a:8 uniq_hidden_pk.b:9 uniq_hidden_pk.c:10 uniq_hidden_pk.d:11 uniq_hidden_pk.rowid:12
+ ├── passthrough columns: k:15 v:16 w:17 x:18 y:19 other.rowid:20 other.crdb_internal_mvcc_timestamp:21 other.tableoid:22
  ├── update-mapping:
  │    └── k:15 => uniq_hidden_pk.a:1
  ├── input binding: &1
@@ -775,6 +778,7 @@ UPDATE uniq_partial SET a = other.w, b = other.x FROM other
 update uniq_partial
  ├── columns: <none>
  ├── fetch columns: uniq_partial.k:7 uniq_partial.a:8 uniq_partial.b:9 uniq_partial.c:10
+ ├── passthrough columns: other.k:13 v:14 w:15 x:16 y:17 rowid:18 other.crdb_internal_mvcc_timestamp:19 other.tableoid:20
  ├── update-mapping:
  │    ├── w:15 => uniq_partial.a:2
  │    └── x:16 => uniq_partial.b:3
@@ -958,6 +962,7 @@ UPDATE uniq_partial_overlaps_pk SET a = k FROM other
 update uniq_partial_overlaps_pk
  ├── columns: <none>
  ├── fetch columns: uniq_partial_overlaps_pk.a:7 uniq_partial_overlaps_pk.b:8 uniq_partial_overlaps_pk.c:9 uniq_partial_overlaps_pk.d:10
+ ├── passthrough columns: k:13 v:14 w:15 x:16 y:17 rowid:18 other.crdb_internal_mvcc_timestamp:19 other.tableoid:20
  ├── update-mapping:
  │    └── k:13 => uniq_partial_overlaps_pk.a:1
  ├── input binding: &1
@@ -1072,6 +1077,7 @@ UPDATE uniq_partial_hidden_pk SET a = k FROM other
 update uniq_partial_hidden_pk
  ├── columns: <none>
  ├── fetch columns: uniq_partial_hidden_pk.a:6 uniq_partial_hidden_pk.b:7 uniq_partial_hidden_pk.rowid:8
+ ├── passthrough columns: k:11 v:12 w:13 x:14 y:15 other.rowid:16 other.crdb_internal_mvcc_timestamp:17 other.tableoid:18
  ├── update-mapping:
  │    └── k:11 => uniq_partial_hidden_pk.a:1
  ├── input binding: &1

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -567,6 +567,10 @@ with &1
  │    ├── fetch columns: xyz.x:6 xyz.y:7 xyz.z:8
  │    ├── update-mapping:
  │    │    └── y_new:11 => xyz.y:2
+ │    ├── return-mapping:
+ │    │    ├── xyz.x:6 => xyz.x:1
+ │    │    ├── y_new:11 => xyz.y:2
+ │    │    └── xyz.z:8 => xyz.z:3
  │    └── project
  │         ├── columns: y_new:11 xyz.x:6!null xyz.y:7 xyz.z:8 xyz.crdb_internal_mvcc_timestamp:9 xyz.tableoid:10
  │         ├── scan xyz
@@ -629,6 +633,13 @@ project
       ├── update-mapping:
       │    ├── a_new:17 => a:1
       │    └── a_new:17 => e:5
+      ├── return-mapping:
+      │    ├── a_new:17 => a:1
+      │    ├── b:10 => b:2
+      │    ├── c:11 => c:3
+      │    ├── d:12 => d:4
+      │    ├── a_new:17 => e:5
+      │    └── rowid:14 => rowid:6
       └── project
            ├── columns: d_comp:18 a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16 a_new:17!null
            ├── project
@@ -661,6 +672,13 @@ project
  │    ├── update-mapping:
  │    │    ├── a_new:17 => a:1
  │    │    └── a_new:17 => e:5
+ │    ├── return-mapping:
+ │    │    ├── a_new:17 => a:1
+ │    │    ├── b:10 => b:2
+ │    │    ├── c:11 => c:3
+ │    │    ├── d:12 => d:4
+ │    │    ├── a_new:17 => e:5
+ │    │    └── rowid:14 => rowid:6
  │    └── project
  │         ├── columns: d_comp:18 a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16 a_new:17!null
  │         ├── project
@@ -698,6 +716,13 @@ with &1
  │         ├── update-mapping:
  │         │    ├── a_new:17 => abcde.a:1
  │         │    └── a_new:17 => abcde.e:5
+ │         ├── return-mapping:
+ │         │    ├── a_new:17 => abcde.a:1
+ │         │    ├── abcde.b:10 => abcde.b:2
+ │         │    ├── abcde.c:11 => abcde.c:3
+ │         │    ├── abcde.d:12 => abcde.d:4
+ │         │    ├── a_new:17 => abcde.e:5
+ │         │    └── rowid:14 => rowid:6
  │         └── project
  │              ├── columns: d_comp:18 abcde.a:9!null abcde.b:10 abcde.c:11 abcde.d:12 abcde.e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16 a_new:17!null
  │              ├── project
@@ -746,6 +771,13 @@ project
       ├── columns: a:1!null b:2 c:3 d:4 e:5 rowid:6!null
       ├── fetch columns: a:9 b:10 c:11 d:12 e:13 rowid:14
       ├── update-mapping:
+      │    └── rowid_new:17 => rowid:6
+      ├── return-mapping:
+      │    ├── a:9 => a:1
+      │    ├── b:10 => b:2
+      │    ├── c:11 => c:3
+      │    ├── d:12 => d:4
+      │    ├── e:13 => e:5
       │    └── rowid_new:17 => rowid:6
       └── project
            ├── columns: d_comp:18 a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16 rowid_new:17!null
@@ -1230,6 +1262,13 @@ project
       ├── update-mapping:
       │    ├── b_new:25 => abcde1.b:2
       │    └── d_comp:26 => abcde1.d:4
+      ├── return-mapping:
+      │    ├── abcde1.a:9 => abcde1.a:1
+      │    ├── b_new:25 => abcde1.b:2
+      │    ├── abcde1.c:11 => abcde1.c:3
+      │    ├── d_comp:26 => abcde1.d:4
+      │    ├── abcde1.e:13 => abcde1.e:5
+      │    └── abcde1.rowid:14 => abcde1.rowid:6
       └── project
            ├── columns: d_comp:26 abcde1.a:9!null abcde1.b:10 abcde1.c:11 abcde1.d:12 abcde1.e:13 abcde1.rowid:14!null abcde1.crdb_internal_mvcc_timestamp:15 abcde1.tableoid:16 b_new:25
            ├── project

--- a/pkg/sql/opt/optbuilder/testdata/update_from
+++ b/pkg/sql/opt/optbuilder/testdata/update_from
@@ -17,6 +17,7 @@ UPDATE abc SET b = other.b + 1, c = other.c + 1 FROM abc AS other WHERE abc.a = 
 update abc
  ├── columns: <none>
  ├── fetch columns: abc.a:6 abc.b:7 abc.c:8
+ ├── passthrough columns: other.a:11 other.b:12 other.c:13 other.crdb_internal_mvcc_timestamp:14 other.tableoid:15
  ├── update-mapping:
  │    ├── b_new:16 => abc.b:2
  │    └── c_new:17 => abc.c:3
@@ -44,6 +45,7 @@ UPDATE abc SET b = other.b, c = other.c FROM new_abc AS other WHERE abc.a = othe
 update abc
  ├── columns: <none>
  ├── fetch columns: abc.a:6 abc.b:7 abc.c:8
+ ├── passthrough columns: other.a:11 other.b:12 other.c:13 rowid:14 other.crdb_internal_mvcc_timestamp:15 other.tableoid:16
  ├── update-mapping:
  │    ├── other.b:12 => abc.b:2
  │    └── other.c:13 => abc.c:3
@@ -91,7 +93,12 @@ RETURNING
 update abc
  ├── columns: a:1!null new_b:2 old_b:12 new_c:3 old_c:13
  ├── fetch columns: abc.a:6 abc.b:7 abc.c:8
+ ├── passthrough columns: old.b:12 old.c:13
  ├── update-mapping:
+ │    ├── b_new:16 => abc.b:2
+ │    └── c_new:17 => abc.c:3
+ ├── return-mapping:
+ │    ├── abc.a:6 => abc.a:1
  │    ├── b_new:16 => abc.b:2
  │    └── c_new:17 => abc.c:3
  └── project
@@ -118,7 +125,12 @@ UPDATE abc SET b = old.b + 1, c = old.c + 2 FROM abc AS old WHERE abc.a = old.a 
 update abc
  ├── columns: a:1!null b:2 c:3 a:11 b:12 c:13
  ├── fetch columns: abc.a:6 abc.b:7 abc.c:8
+ ├── passthrough columns: old.a:11 old.b:12 old.c:13
  ├── update-mapping:
+ │    ├── b_new:16 => abc.b:2
+ │    └── c_new:17 => abc.c:3
+ ├── return-mapping:
+ │    ├── abc.a:6 => abc.a:1
  │    ├── b_new:16 => abc.b:2
  │    └── c_new:17 => abc.c:3
  └── project
@@ -145,6 +157,7 @@ UPDATE abc SET b = old.b + 1, c = old.c + 2 FROM abc AS old WHERE abc.a = old.a 
 update abc
  ├── columns: <none>
  ├── fetch columns: abc.a:6 abc.b:7 abc.c:8
+ ├── passthrough columns: old.a:11 old.b:12 old.c:13 old.crdb_internal_mvcc_timestamp:14 old.tableoid:15
  ├── update-mapping:
  │    ├── b_new:16 => abc.b:2
  │    └── c_new:17 => abc.c:3
@@ -170,6 +183,7 @@ UPDATE abc SET b = other.b, c = other.c FROM (values (1, 2, 3), (2, 3, 4)) as ot
 update abc
  ├── columns: <none>
  ├── fetch columns: a:6 b:7 c:8
+ ├── passthrough columns: column1:11 column2:12 column3:13
  ├── update-mapping:
  │    ├── column2:12 => b:2
  │    └── column3:13 => c:3
@@ -212,6 +226,7 @@ UPDATE abc SET b = ab.b, c = ac.c FROM ab, ac WHERE abc.a = ab.a AND abc.a = ac.
 update abc
  ├── columns: <none>
  ├── fetch columns: abc.a:6 abc.b:7 abc.c:8
+ ├── passthrough columns: ab.a:11 ab.b:12 ab.rowid:13 ab.crdb_internal_mvcc_timestamp:14 ab.tableoid:15 ac.a:16 ac.c:17 ac.rowid:18 ac.crdb_internal_mvcc_timestamp:19 ac.tableoid:20
  ├── update-mapping:
  │    ├── ab.b:12 => abc.b:2
  │    └── ac.c:17 => abc.c:3
@@ -274,7 +289,12 @@ RETURNING
 update abc
  ├── columns: a:1!null b:2 c:3 a:11 b:12 a:16 c:17
  ├── fetch columns: abc.a:6 abc.b:7 abc.c:8
+ ├── passthrough columns: ab.a:11 ab.b:12 ac.a:16 ac.c:17
  ├── update-mapping:
+ │    ├── ab.b:12 => abc.b:2
+ │    └── ac.c:17 => abc.c:3
+ ├── return-mapping:
+ │    ├── abc.a:6 => abc.a:1
  │    ├── ab.b:12 => abc.b:2
  │    └── ac.c:17 => abc.c:3
  └── distinct-on
@@ -323,7 +343,12 @@ RETURNING
 update abc
  ├── columns: a:1!null b:2 c:3 a:11 b:12 a:16 c:17 rowid:13 rowid:18
  ├── fetch columns: abc.a:6 abc.b:7 abc.c:8
+ ├── passthrough columns: ab.a:11 ab.b:12 ab.rowid:13 ac.a:16 ac.c:17 ac.rowid:18
  ├── update-mapping:
+ │    ├── ab.b:12 => abc.b:2
+ │    └── ac.c:17 => abc.c:3
+ ├── return-mapping:
+ │    ├── abc.a:6 => abc.a:1
  │    ├── ab.b:12 => abc.b:2
  │    └── ac.c:17 => abc.c:3
  └── distinct-on
@@ -367,6 +392,7 @@ UPDATE abc SET b = other.d FROM dec AS other WHERE abc.a = other.k
 update abc
  ├── columns: <none>
  ├── fetch columns: a:6 b:7 c:8
+ ├── passthrough columns: k:11 d:12 other.crdb_internal_mvcc_timestamp:13 other.tableoid:14
  ├── update-mapping:
  │    └── b_cast:15 => b:2
  └── project
@@ -405,8 +431,12 @@ project
  └── update t61520 [as=t]
       ├── columns: a:1!null rowid:2!null column1:9
       ├── fetch columns: a:5 rowid:6
+      ├── passthrough columns: column1:9
       ├── update-mapping:
       │    └── a_cast:10 => a:1
+      ├── return-mapping:
+      │    ├── a_cast:10 => a:1
+      │    └── rowid:6 => rowid:2
       ├── check columns: check1:11
       └── project
            ├── columns: check1:11!null a:5!null rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8 column1:9!null a_cast:10!null

--- a/pkg/sql/opt/optbuilder/testdata/virtual-columns
+++ b/pkg/sql/opt/optbuilder/testdata/virtual-columns
@@ -143,6 +143,10 @@ project
       │    ├── column1:6 => a:1
       │    ├── column2:7 => b:2
       │    └── v_comp:8 => v:3
+      ├── return-mapping:
+      │    ├── column1:6 => a:1
+      │    ├── column2:7 => b:2
+      │    └── v_comp:8 => v:3
       └── project
            ├── columns: v_comp:8!null column1:6!null column2:7!null
            ├── values
@@ -223,6 +227,10 @@ project
  └── delete t
       ├── columns: a:1!null b:2 v:3
       ├── fetch columns: a:6 b:7 v:8
+      ├── return-mapping:
+      │    ├── a:6 => a:1
+      │    ├── b:7 => b:2
+      │    └── v:8 => v:3
       └── select
            ├── columns: a:6!null b:7 v:8 crdb_internal_mvcc_timestamp:9 tableoid:10
            ├── project
@@ -285,6 +293,10 @@ project
  └── delete t
       ├── columns: a:1!null b:2 v:3!null
       ├── fetch columns: a:6 b:7 v:8
+      ├── return-mapping:
+      │    ├── a:6 => a:1
+      │    ├── b:7 => b:2
+      │    └── v:8 => v:3
       └── select
            ├── columns: a:6!null b:7 v:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
            ├── project
@@ -327,6 +339,10 @@ project
  └── delete t_idx
       ├── columns: a:1!null b:2 v:3
       ├── fetch columns: a:6 b:7 v:8
+      ├── return-mapping:
+      │    ├── a:6 => a:1
+      │    ├── b:7 => b:2
+      │    └── v:8 => v:3
       └── select
            ├── columns: a:6!null b:7 v:8 crdb_internal_mvcc_timestamp:9 tableoid:10
            ├── project
@@ -389,6 +405,10 @@ project
  └── delete t_idx
       ├── columns: a:1!null b:2 v:3!null
       ├── fetch columns: a:6 b:7 v:8
+      ├── return-mapping:
+      │    ├── a:6 => a:1
+      │    ├── b:7 => b:2
+      │    └── v:8 => v:3
       └── select
            ├── columns: a:6!null b:7 v:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
            ├── project
@@ -601,6 +621,10 @@ project
       ├── update-mapping:
       │    ├── b_new:11 => b:2
       │    └── v_comp:12 => v:3
+      ├── return-mapping:
+      │    ├── a:6 => a:1
+      │    ├── b_new:11 => b:2
+      │    └── v_comp:12 => v:3
       └── project
            ├── columns: v_comp:12 a:6!null b:7 v:8 crdb_internal_mvcc_timestamp:9 tableoid:10 b_new:11
            ├── project
@@ -630,6 +654,12 @@ project
       ├── update-mapping:
       │    ├── b_new:15 => b:2
       │    └── v_comp:16 => v:4
+      ├── return-mapping:
+      │    ├── a:8 => a:1
+      │    ├── b_new:15 => b:2
+      │    ├── c:10 => c:3
+      │    ├── v_comp:16 => v:4
+      │    └── w:12 => w:5
       └── project
            ├── columns: v_comp:16 w_comp:17 a:8!null b:9 c:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14 b_new:15
            ├── project
@@ -823,6 +853,10 @@ project
       ├── columns: a:1!null b:2!null v:3!null
       ├── arbiter indexes: t_pkey
       ├── insert-mapping:
+      │    ├── column1:6 => a:1
+      │    ├── column2:7 => b:2
+      │    └── v_comp:8 => v:3
+      ├── return-mapping:
       │    ├── column1:6 => a:1
       │    ├── column2:7 => b:2
       │    └── v_comp:8 => v:3

--- a/pkg/sql/opt/optbuilder/testdata/with
+++ b/pkg/sql/opt/optbuilder/testdata/with
@@ -663,6 +663,10 @@ with &1 (t)
            │    ├── "?column?":12 => x.a:6
            │    ├── b_default:13 => b:7
            │    └── rowid_default:14 => rowid:8
+           ├── return-mapping:
+           │    ├── "?column?":12 => x.a:6
+           │    ├── b_default:13 => b:7
+           │    └── rowid_default:14 => rowid:8
            └── project
                 ├── columns: b_default:13 rowid_default:14 "?column?":12
                 ├── project
@@ -693,6 +697,10 @@ with &1 (t)
            ├── fetch columns: x.a:11 b:12 rowid:13
            ├── update-mapping:
            │    └── a_new:17 => x.a:6
+           ├── return-mapping:
+           │    ├── a_new:17 => x.a:6
+           │    ├── b:12 => b:7
+           │    └── rowid:13 => rowid:8
            └── project
                 ├── columns: a_new:17 x.a:11 b:12 rowid:13!null crdb_internal_mvcc_timestamp:14 tableoid:15
                 ├── scan x
@@ -720,6 +728,10 @@ with &1 (t)
       └── delete x
            ├── columns: x.a:6!null b:7 rowid:8!null
            ├── fetch columns: x.a:11 b:12 rowid:13
+           ├── return-mapping:
+           │    ├── x.a:11 => x.a:6
+           │    ├── b:12 => b:7
+           │    └── rowid:13 => rowid:8
            └── select
                 ├── columns: x.a:11!null b:12 rowid:13!null crdb_internal_mvcc_timestamp:14 tableoid:15
                 ├── scan x
@@ -1444,6 +1456,10 @@ with &2
  │         │    ├── column1:12 => x.a:7
  │         │    ├── column2:13 => x.b:8
  │         │    └── rowid_default:14 => rowid:9
+ │         ├── return-mapping:
+ │         │    ├── column1:12 => x.a:7
+ │         │    ├── column2:13 => x.b:8
+ │         │    └── rowid_default:14 => rowid:9
  │         └── project
  │              ├── columns: rowid_default:14 column1:12!null column2:13!null
  │              ├── values
@@ -1667,6 +1683,9 @@ explain
       │    └── insert y
       │         ├── columns: y.a:1!null rowid:2!null
       │         ├── insert-mapping:
+      │         │    ├── column1:5 => y.a:1
+      │         │    └── rowid_default:6 => rowid:2
+      │         ├── return-mapping:
       │         │    ├── column1:5 => y.a:1
       │         │    └── rowid_default:6 => rowid:2
       │         └── project

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -32,6 +32,11 @@ project
       ├── fetch columns: d_id:14 d_w_id:15 d_name:16 d_street_1:17 d_street_2:18 d_city:19 d_state:20 d_zip:21 d_tax:22 d_ytd:23 d_next_o_id:24
       ├── update-mapping:
       │    └── d_next_o_id_new:27 => d_next_o_id:11
+      ├── return-mapping:
+      │    ├── d_id:14 => d_id:1
+      │    ├── d_w_id:15 => d_w_id:2
+      │    ├── d_tax:22 => d_tax:9
+      │    └── d_next_o_id_new:27 => d_next_o_id:11
       ├── cardinality: [0 - 1]
       ├── volatile, mutations
       ├── key: ()
@@ -439,6 +444,14 @@ project
       ├── fetch columns: w_id:12 w_name:13 w_street_1:14 w_street_2:15 w_city:16 w_state:17 w_zip:18 w_tax:19 w_ytd:20
       ├── update-mapping:
       │    └── w_ytd_cast:24 => w_ytd:9
+      ├── return-mapping:
+      │    ├── w_id:12 => w_id:1
+      │    ├── w_name:13 => w_name:2
+      │    ├── w_street_1:14 => w_street_1:3
+      │    ├── w_street_2:15 => w_street_2:4
+      │    ├── w_city:16 => w_city:5
+      │    ├── w_state:17 => w_state:6
+      │    └── w_zip:18 => w_zip:7
       ├── cardinality: [0 - 1]
       ├── volatile, mutations
       ├── key: ()
@@ -474,6 +487,15 @@ project
       ├── fetch columns: d_id:14 d_w_id:15 d_name:16 d_street_1:17 d_street_2:18 d_city:19 d_state:20 d_zip:21 d_tax:22 d_ytd:23 d_next_o_id:24
       ├── update-mapping:
       │    └── d_ytd_cast:28 => d_ytd:10
+      ├── return-mapping:
+      │    ├── d_id:14 => d_id:1
+      │    ├── d_w_id:15 => d_w_id:2
+      │    ├── d_name:16 => d_name:3
+      │    ├── d_street_1:17 => d_street_1:4
+      │    ├── d_street_2:18 => d_street_2:5
+      │    ├── d_city:19 => d_city:6
+      │    ├── d_state:20 => d_state:7
+      │    └── d_zip:21 => d_zip:8
       ├── cardinality: [0 - 1]
       ├── volatile, mutations
       ├── key: ()
@@ -566,6 +588,25 @@ project
  │    │    ├── c_balance_cast:51 => c_balance:17
  │    │    ├── c_ytd_payment_cast:52 => c_ytd_payment:18
  │    │    ├── c_payment_cnt_new:49 => c_payment_cnt:19
+ │    │    └── c_data_cast:53 => c_data:21
+ │    ├── return-mapping:
+ │    │    ├── c_id:24 => c_id:1
+ │    │    ├── c_d_id:25 => c_d_id:2
+ │    │    ├── c_w_id:26 => c_w_id:3
+ │    │    ├── c_first:27 => c_first:4
+ │    │    ├── c_middle:28 => c_middle:5
+ │    │    ├── c_last:29 => c_last:6
+ │    │    ├── c_street_1:30 => c_street_1:7
+ │    │    ├── c_street_2:31 => c_street_2:8
+ │    │    ├── c_city:32 => c_city:9
+ │    │    ├── c_state:33 => c_state:10
+ │    │    ├── c_zip:34 => c_zip:11
+ │    │    ├── c_phone:35 => c_phone:12
+ │    │    ├── c_since:36 => c_since:13
+ │    │    ├── c_credit:37 => c_credit:14
+ │    │    ├── c_credit_lim:38 => c_credit_lim:15
+ │    │    ├── c_discount:39 => c_discount:16
+ │    │    ├── c_balance_cast:51 => c_balance:17
  │    │    └── c_data_cast:53 => c_data:21
  │    ├── cardinality: [0 - 1]
  │    ├── volatile, mutations
@@ -822,6 +863,11 @@ project
       ├── fetch columns: o_id:11 o_d_id:12 o_w_id:13 o_c_id:14 o_entry_d:15 o_carrier_id:16 o_ol_cnt:17 o_all_local:18
       ├── update-mapping:
       │    └── o_carrier_id_new:21 => o_carrier_id:6
+      ├── return-mapping:
+      │    ├── o_id:11 => o_id:1
+      │    ├── o_d_id:12 => o_d_id:2
+      │    ├── o_w_id:13 => o_w_id:3
+      │    └── o_c_id:14 => o_c_id:4
       ├── cardinality: [0 - 10]
       ├── volatile, mutations
       ├── key: (2)

--- a/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
@@ -35,6 +35,11 @@ project
       ├── fetch columns: d_id:14 d_w_id:15 d_name:16 d_street_1:17 d_street_2:18 d_city:19 d_state:20 d_zip:21 d_tax:22 d_ytd:23 d_next_o_id:24
       ├── update-mapping:
       │    └── d_next_o_id_new:27 => d_next_o_id:11
+      ├── return-mapping:
+      │    ├── d_id:14 => d_id:1
+      │    ├── d_w_id:15 => d_w_id:2
+      │    ├── d_tax:22 => d_tax:9
+      │    └── d_next_o_id_new:27 => d_next_o_id:11
       ├── cardinality: [0 - 1]
       ├── volatile, mutations
       ├── key: ()
@@ -442,6 +447,14 @@ project
       ├── fetch columns: w_id:12 w_name:13 w_street_1:14 w_street_2:15 w_city:16 w_state:17 w_zip:18 w_tax:19 w_ytd:20
       ├── update-mapping:
       │    └── w_ytd_cast:24 => w_ytd:9
+      ├── return-mapping:
+      │    ├── w_id:12 => w_id:1
+      │    ├── w_name:13 => w_name:2
+      │    ├── w_street_1:14 => w_street_1:3
+      │    ├── w_street_2:15 => w_street_2:4
+      │    ├── w_city:16 => w_city:5
+      │    ├── w_state:17 => w_state:6
+      │    └── w_zip:18 => w_zip:7
       ├── cardinality: [0 - 1]
       ├── volatile, mutations
       ├── key: ()
@@ -477,6 +490,15 @@ project
       ├── fetch columns: d_id:14 d_w_id:15 d_name:16 d_street_1:17 d_street_2:18 d_city:19 d_state:20 d_zip:21 d_tax:22 d_ytd:23 d_next_o_id:24
       ├── update-mapping:
       │    └── d_ytd_cast:28 => d_ytd:10
+      ├── return-mapping:
+      │    ├── d_id:14 => d_id:1
+      │    ├── d_w_id:15 => d_w_id:2
+      │    ├── d_name:16 => d_name:3
+      │    ├── d_street_1:17 => d_street_1:4
+      │    ├── d_street_2:18 => d_street_2:5
+      │    ├── d_city:19 => d_city:6
+      │    ├── d_state:20 => d_state:7
+      │    └── d_zip:21 => d_zip:8
       ├── cardinality: [0 - 1]
       ├── volatile, mutations
       ├── key: ()
@@ -569,6 +591,25 @@ project
  │    │    ├── c_balance_cast:51 => c_balance:17
  │    │    ├── c_ytd_payment_cast:52 => c_ytd_payment:18
  │    │    ├── c_payment_cnt_new:49 => c_payment_cnt:19
+ │    │    └── c_data_cast:53 => c_data:21
+ │    ├── return-mapping:
+ │    │    ├── c_id:24 => c_id:1
+ │    │    ├── c_d_id:25 => c_d_id:2
+ │    │    ├── c_w_id:26 => c_w_id:3
+ │    │    ├── c_first:27 => c_first:4
+ │    │    ├── c_middle:28 => c_middle:5
+ │    │    ├── c_last:29 => c_last:6
+ │    │    ├── c_street_1:30 => c_street_1:7
+ │    │    ├── c_street_2:31 => c_street_2:8
+ │    │    ├── c_city:32 => c_city:9
+ │    │    ├── c_state:33 => c_state:10
+ │    │    ├── c_zip:34 => c_zip:11
+ │    │    ├── c_phone:35 => c_phone:12
+ │    │    ├── c_since:36 => c_since:13
+ │    │    ├── c_credit:37 => c_credit:14
+ │    │    ├── c_credit_lim:38 => c_credit_lim:15
+ │    │    ├── c_discount:39 => c_discount:16
+ │    │    ├── c_balance_cast:51 => c_balance:17
  │    │    └── c_data_cast:53 => c_data:21
  │    ├── cardinality: [0 - 1]
  │    ├── volatile, mutations
@@ -825,6 +866,11 @@ project
       ├── fetch columns: o_id:11 o_d_id:12 o_w_id:13 o_c_id:14 o_entry_d:15 o_carrier_id:16 o_ol_cnt:17 o_all_local:18
       ├── update-mapping:
       │    └── o_carrier_id_new:21 => o_carrier_id:6
+      ├── return-mapping:
+      │    ├── o_id:11 => o_id:1
+      │    ├── o_d_id:12 => o_d_id:2
+      │    ├── o_w_id:13 => o_w_id:3
+      │    └── o_c_id:14 => o_c_id:4
       ├── cardinality: [0 - 10]
       ├── volatile, mutations
       ├── key: (2)

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -29,6 +29,11 @@ project
       ├── fetch columns: d_id:14 d_w_id:15 d_name:16 d_street_1:17 d_street_2:18 d_city:19 d_state:20 d_zip:21 d_tax:22 d_ytd:23 d_next_o_id:24
       ├── update-mapping:
       │    └── d_next_o_id_new:27 => d_next_o_id:11
+      ├── return-mapping:
+      │    ├── d_id:14 => d_id:1
+      │    ├── d_w_id:15 => d_w_id:2
+      │    ├── d_tax:22 => d_tax:9
+      │    └── d_next_o_id_new:27 => d_next_o_id:11
       ├── cardinality: [0 - 1]
       ├── volatile, mutations
       ├── key: ()
@@ -436,6 +441,14 @@ project
       ├── fetch columns: w_id:12 w_name:13 w_street_1:14 w_street_2:15 w_city:16 w_state:17 w_zip:18 w_tax:19 w_ytd:20
       ├── update-mapping:
       │    └── w_ytd_cast:24 => w_ytd:9
+      ├── return-mapping:
+      │    ├── w_id:12 => w_id:1
+      │    ├── w_name:13 => w_name:2
+      │    ├── w_street_1:14 => w_street_1:3
+      │    ├── w_street_2:15 => w_street_2:4
+      │    ├── w_city:16 => w_city:5
+      │    ├── w_state:17 => w_state:6
+      │    └── w_zip:18 => w_zip:7
       ├── cardinality: [0 - 1]
       ├── volatile, mutations
       ├── key: ()
@@ -471,6 +484,15 @@ project
       ├── fetch columns: d_id:14 d_w_id:15 d_name:16 d_street_1:17 d_street_2:18 d_city:19 d_state:20 d_zip:21 d_tax:22 d_ytd:23 d_next_o_id:24
       ├── update-mapping:
       │    └── d_ytd_cast:28 => d_ytd:10
+      ├── return-mapping:
+      │    ├── d_id:14 => d_id:1
+      │    ├── d_w_id:15 => d_w_id:2
+      │    ├── d_name:16 => d_name:3
+      │    ├── d_street_1:17 => d_street_1:4
+      │    ├── d_street_2:18 => d_street_2:5
+      │    ├── d_city:19 => d_city:6
+      │    ├── d_state:20 => d_state:7
+      │    └── d_zip:21 => d_zip:8
       ├── cardinality: [0 - 1]
       ├── volatile, mutations
       ├── key: ()
@@ -563,6 +585,25 @@ project
  │    │    ├── c_balance_cast:51 => c_balance:17
  │    │    ├── c_ytd_payment_cast:52 => c_ytd_payment:18
  │    │    ├── c_payment_cnt_new:49 => c_payment_cnt:19
+ │    │    └── c_data_cast:53 => c_data:21
+ │    ├── return-mapping:
+ │    │    ├── c_id:24 => c_id:1
+ │    │    ├── c_d_id:25 => c_d_id:2
+ │    │    ├── c_w_id:26 => c_w_id:3
+ │    │    ├── c_first:27 => c_first:4
+ │    │    ├── c_middle:28 => c_middle:5
+ │    │    ├── c_last:29 => c_last:6
+ │    │    ├── c_street_1:30 => c_street_1:7
+ │    │    ├── c_street_2:31 => c_street_2:8
+ │    │    ├── c_city:32 => c_city:9
+ │    │    ├── c_state:33 => c_state:10
+ │    │    ├── c_zip:34 => c_zip:11
+ │    │    ├── c_phone:35 => c_phone:12
+ │    │    ├── c_since:36 => c_since:13
+ │    │    ├── c_credit:37 => c_credit:14
+ │    │    ├── c_credit_lim:38 => c_credit_lim:15
+ │    │    ├── c_discount:39 => c_discount:16
+ │    │    ├── c_balance_cast:51 => c_balance:17
  │    │    └── c_data_cast:53 => c_data:21
  │    ├── cardinality: [0 - 1]
  │    ├── volatile, mutations
@@ -823,6 +864,11 @@ project
       ├── fetch columns: o_id:11 o_d_id:12 o_w_id:13 o_c_id:14 o_entry_d:15 o_carrier_id:16 o_ol_cnt:17 o_all_local:18
       ├── update-mapping:
       │    └── o_carrier_id_new:21 => o_carrier_id:6
+      ├── return-mapping:
+      │    ├── o_id:11 => o_id:1
+      │    ├── o_d_id:12 => o_d_id:2
+      │    ├── o_w_id:13 => o_w_id:3
+      │    └── o_c_id:14 => o_c_id:4
       ├── cardinality: [0 - 10]
       ├── volatile, mutations
       ├── key: (2)

--- a/pkg/sql/opt/xform/testdata/external/tpce
+++ b/pkg/sql/opt/xform/testdata/external/tpce
@@ -569,6 +569,8 @@ with &1 (update_last_trade)
  │    │    │    ├── lt_dts_new:17 => lt_dts:2
  │    │    │    ├── lt_price_cast:18 => lt_price:3
  │    │    │    └── lt_vol_new:15 => lt_vol:5
+ │    │    ├── return-mapping:
+ │    │    │    └── lt_s_symb:8 => lt_s_symb:1
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── volatile, mutations
  │    │    ├── key: ()
@@ -633,6 +635,8 @@ with &1 (update_last_trade)
            │    ├── delete trade_request
            │    │    ├── columns: trade_request.tr_t_id:29!null
            │    │    ├── fetch columns: trade_request.tr_t_id:37 tr_s_symb:39 tr_b_id:42
+           │    │    ├── return-mapping:
+           │    │    │    └── trade_request.tr_t_id:37 => trade_request.tr_t_id:29
            │    │    ├── partial index del columns: partial_index_del1:49
            │    │    ├── volatile, mutations
            │    │    ├── key: (29)
@@ -674,6 +678,9 @@ with &1 (update_last_trade)
                 │    │    ├── insert-mapping:
                 │    │    │    ├── tr_t_id:56 => trade_history.th_t_id:51
                 │    │    │    ├── timestamp:61 => th_dts:52
+                │    │    │    └── th_st_id_cast:62 => trade_history.th_st_id:53
+                │    │    ├── return-mapping:
+                │    │    │    ├── tr_t_id:56 => trade_history.th_t_id:51
                 │    │    │    └── th_st_id_cast:62 => trade_history.th_st_id:53
                 │    │    ├── input binding: &4
                 │    │    ├── volatile, mutations
@@ -733,6 +740,8 @@ with &1 (update_last_trade)
                      │    │    ├── update-mapping:
                      │    │    │    ├── t_dts_new:126 => t_dts:88
                      │    │    │    └── t_st_id_cast:127 => trade.t_st_id:89
+                     │    │    ├── return-mapping:
+                     │    │    │    └── t_id:104 => t_id:87
                      │    │    ├── input binding: &6
                      │    │    ├── volatile, mutations
                      │    │    ├── key: (87)
@@ -2950,6 +2959,8 @@ with &2 (insert_trade)
  │    │    │    ├── t_comm_cast:40 => t_comm:13
  │    │    │    ├── t_tax_cast:41 => t_tax:14
  │    │    │    └── column15:32 => t_lifo:15
+ │    │    ├── return-mapping:
+ │    │    │    └── column1:18 => t_id:1
  │    │    ├── check columns: check1:42 check2:43 check3:44 check4:45 check5:46
  │    │    ├── input binding: &1
  │    │    ├── cardinality: [1 - 1]
@@ -3046,6 +3057,9 @@ with &2 (insert_trade)
       │    │    ├── insert-mapping:
       │    │    │    ├── column1:93 => trade_history.th_t_id:88
       │    │    │    ├── column2:94 => th_dts:89
+      │    │    │    └── th_st_id_cast:96 => trade_history.th_st_id:90
+      │    │    ├── return-mapping:
+      │    │    │    ├── column1:93 => trade_history.th_t_id:88
       │    │    │    └── th_st_id_cast:96 => trade_history.th_st_id:90
       │    │    ├── input binding: &3
       │    │    ├── cardinality: [1 - 1]
@@ -3200,6 +3214,8 @@ with &2 (insert_trade)
  │    │    │    ├── t_comm_cast:40 => t_comm:13
  │    │    │    ├── t_tax_cast:41 => t_tax:14
  │    │    │    └── column15:32 => t_lifo:15
+ │    │    ├── return-mapping:
+ │    │    │    └── column1:18 => t_id:1
  │    │    ├── check columns: check1:42 check2:43 check3:44 check4:45 check5:46
  │    │    ├── input binding: &1
  │    │    ├── cardinality: [1 - 1]
@@ -3297,6 +3313,9 @@ with &2 (insert_trade)
       │    │    │    ├── column1:93 => trade_history.th_t_id:88
       │    │    │    ├── column2:94 => th_dts:89
       │    │    │    └── th_st_id_cast:96 => trade_history.th_st_id:90
+      │    │    ├── return-mapping:
+      │    │    │    ├── column1:93 => trade_history.th_t_id:88
+      │    │    │    └── th_st_id_cast:96 => trade_history.th_st_id:90
       │    │    ├── input binding: &3
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── volatile, mutations
@@ -3364,6 +3383,8 @@ with &2 (insert_trade)
            │    │    │    ├── tr_qty_cast:137 => tr_qty:124
            │    │    │    ├── tr_bid_price_cast:138 => tr_bid_price:125
            │    │    │    └── column6:134 => trade_request.tr_b_id:126
+           │    │    ├── return-mapping:
+           │    │    │    └── column1:129 => trade_request.tr_t_id:121
            │    │    ├── check columns: check1:139 check2:140
            │    │    ├── partial index put columns: partial_index_put1:141
            │    │    ├── input binding: &5
@@ -3945,6 +3966,9 @@ project
  │    ├── fetch columns: t_id:18 trade.t_tax:31
  │    ├── update-mapping:
  │    │    └── t_tax_cast:46 => trade.t_tax:14
+ │    ├── return-mapping:
+ │    │    ├── t_id:18 => t_id:1
+ │    │    └── t_tax_cast:46 => trade.t_tax:14
  │    ├── check columns: check5:51
  │    ├── cardinality: [0 - 1]
  │    ├── volatile, mutations
@@ -4182,6 +4206,8 @@ with &2 (update_trade_commission)
  │    │    │    ├── t_st_id_cast:39 => trade.t_st_id:3
  │    │    │    ├── t_trade_price_cast:40 => t_trade_price:11
  │    │    │    └── t_comm_cast:41 => t_comm:13
+ │    │    ├── return-mapping:
+ │    │    │    └── t_id:18 => t_id:1
  │    │    ├── check columns: check4:45
  │    │    ├── input binding: &1
  │    │    ├── cardinality: [0 - 1]
@@ -4242,6 +4268,8 @@ with &2 (update_trade_commission)
       │    │    ├── update-mapping:
       │    │    │    ├── b_num_trades_new:68 => b_num_trades:56
       │    │    │    └── b_comm_total_cast:69 => b_comm_total:57
+      │    │    ├── return-mapping:
+      │    │    │    └── b_id:60 => b_id:53
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── volatile, mutations
       │    │    ├── key: ()
@@ -4281,6 +4309,9 @@ with &2 (update_trade_commission)
            │    │    ├── insert-mapping:
            │    │    │    ├── column1:76 => trade_history.th_t_id:71
            │    │    │    ├── column2:77 => th_dts:72
+           │    │    │    └── th_st_id_cast:79 => trade_history.th_st_id:73
+           │    │    ├── return-mapping:
+           │    │    │    ├── column1:76 => trade_history.th_t_id:71
            │    │    │    └── th_st_id_cast:79 => trade_history.th_st_id:73
            │    │    ├── input binding: &4
            │    │    ├── cardinality: [1 - 1]
@@ -4380,6 +4411,8 @@ with &2 (insert_settlement)
  │    │    │    ├── se_cash_type_cast:11 => se_cash_type:2
  │    │    │    ├── column3:9 => se_cash_due_date:3
  │    │    │    └── se_amt_cast:12 => se_amt:4
+ │    │    ├── return-mapping:
+ │    │    │    └── column1:7 => settlement.se_t_id:1
  │    │    ├── input binding: &1
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── volatile, mutations
@@ -4429,6 +4462,8 @@ with &2 (insert_settlement)
       │    │    │    ├── column2:39 => ct_dts:33
       │    │    │    ├── ct_amt_cast:42 => ct_amt:34
       │    │    │    └── ct_name_cast:43 => ct_name:35
+      │    │    ├── return-mapping:
+      │    │    │    └── column1:38 => cash_transaction.ct_t_id:32
       │    │    ├── input binding: &3
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── volatile, mutations
@@ -4469,6 +4504,9 @@ with &2 (insert_settlement)
            │    ├── columns: ca_id:63!null customer_account.ca_bal:68!null
            │    ├── fetch columns: ca_id:71 ca_b_id:72 ca_c_id:73 ca_name:74 ca_tax_st:75 customer_account.ca_bal:76
            │    ├── update-mapping:
+           │    │    └── ca_bal_cast:80 => customer_account.ca_bal:68
+           │    ├── return-mapping:
+           │    │    ├── ca_id:71 => ca_id:63
            │    │    └── ca_bal_cast:80 => customer_account.ca_bal:68
            │    ├── cardinality: [0 - 1]
            │    ├── volatile, mutations
@@ -4522,6 +4560,8 @@ with &2 (insert_settlement)
  │    │    │    ├── se_cash_type_cast:11 => se_cash_type:2
  │    │    │    ├── column3:9 => se_cash_due_date:3
  │    │    │    └── se_amt_cast:12 => se_amt:4
+ │    │    ├── return-mapping:
+ │    │    │    └── column1:7 => settlement.se_t_id:1
  │    │    ├── input binding: &1
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── volatile, mutations
@@ -5244,6 +5284,7 @@ UPDATE settlement
 update settlement
  ├── columns: <none>
  ├── fetch columns: se_t_id:7 se_cash_type:8 se_cash_due_date:9 se_amt:10
+ ├── passthrough columns: unnest:13 unnest:14
  ├── update-mapping:
  │    └── se_cash_type_cast:16 => se_cash_type:2
  ├── cardinality: [0 - 0]
@@ -5506,6 +5547,7 @@ UPDATE cash_transaction
 update cash_transaction
  ├── columns: <none>
  ├── fetch columns: ct_t_id:7 ct_dts:8 ct_amt:9 ct_name:10
+ ├── passthrough columns: unnest:13 unnest:14 unnest:15 unnest:16
  ├── update-mapping:
  │    └── ct_name_cast:18 => ct_name:4
  ├── cardinality: [0 - 0]
@@ -6107,6 +6149,7 @@ UPDATE watch_item
 update watch_item
  ├── columns: <none>
  ├── fetch columns: wi_wl_id:5 watch_item.wi_s_symb:6
+ ├── passthrough columns: wl_id:9 wl_c_id:10 watch_list.crdb_internal_mvcc_timestamp:11 watch_list.tableoid:12
  ├── update-mapping:
  │    └── wi_s_symb_cast:14 => watch_item.wi_s_symb:2
  ├── input binding: &1
@@ -6287,6 +6330,8 @@ with &1 (empty_trade_requests)
  ├── delete trade_request
  │    ├── columns: trade_request.tr_t_id:1!null
  │    ├── fetch columns: trade_request.tr_t_id:9 tr_s_symb:11 tr_b_id:14
+ │    ├── return-mapping:
+ │    │    └── trade_request.tr_t_id:9 => trade_request.tr_t_id:1
  │    ├── partial index del columns: partial_index_del1:17
  │    ├── cardinality: [0 - 20]
  │    ├── volatile, mutations

--- a/pkg/sql/opt/xform/testdata/external/tpce-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpce-no-stats
@@ -587,6 +587,8 @@ with &1 (update_last_trade)
  │    │    │    ├── lt_dts_new:17 => lt_dts:2
  │    │    │    ├── lt_price_cast:18 => lt_price:3
  │    │    │    └── lt_vol_new:15 => lt_vol:5
+ │    │    ├── return-mapping:
+ │    │    │    └── lt_s_symb:8 => lt_s_symb:1
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── volatile, mutations
  │    │    ├── key: ()
@@ -651,6 +653,8 @@ with &1 (update_last_trade)
            │    ├── delete trade_request
            │    │    ├── columns: trade_request.tr_t_id:29!null
            │    │    ├── fetch columns: trade_request.tr_t_id:37 tr_s_symb:39 tr_b_id:42
+           │    │    ├── return-mapping:
+           │    │    │    └── trade_request.tr_t_id:37 => trade_request.tr_t_id:29
            │    │    ├── partial index del columns: partial_index_del1:49
            │    │    ├── volatile, mutations
            │    │    ├── key: (29)
@@ -692,6 +696,9 @@ with &1 (update_last_trade)
                 │    │    ├── insert-mapping:
                 │    │    │    ├── tr_t_id:56 => trade_history.th_t_id:51
                 │    │    │    ├── timestamp:61 => th_dts:52
+                │    │    │    └── th_st_id_cast:62 => trade_history.th_st_id:53
+                │    │    ├── return-mapping:
+                │    │    │    ├── tr_t_id:56 => trade_history.th_t_id:51
                 │    │    │    └── th_st_id_cast:62 => trade_history.th_st_id:53
                 │    │    ├── input binding: &4
                 │    │    ├── volatile, mutations
@@ -751,6 +758,8 @@ with &1 (update_last_trade)
                      │    │    ├── update-mapping:
                      │    │    │    ├── t_dts_new:126 => t_dts:88
                      │    │    │    └── t_st_id_cast:127 => trade.t_st_id:89
+                     │    │    ├── return-mapping:
+                     │    │    │    └── t_id:104 => t_id:87
                      │    │    ├── input binding: &6
                      │    │    ├── volatile, mutations
                      │    │    ├── key: (87)
@@ -2981,6 +2990,8 @@ with &2 (insert_trade)
  │    │    │    ├── t_comm_cast:40 => t_comm:13
  │    │    │    ├── t_tax_cast:41 => t_tax:14
  │    │    │    └── column15:32 => t_lifo:15
+ │    │    ├── return-mapping:
+ │    │    │    └── column1:18 => t_id:1
  │    │    ├── check columns: check1:42 check2:43 check3:44 check4:45 check5:46
  │    │    ├── input binding: &1
  │    │    ├── cardinality: [1 - 1]
@@ -3077,6 +3088,9 @@ with &2 (insert_trade)
       │    │    ├── insert-mapping:
       │    │    │    ├── column1:93 => trade_history.th_t_id:88
       │    │    │    ├── column2:94 => th_dts:89
+      │    │    │    └── th_st_id_cast:96 => trade_history.th_st_id:90
+      │    │    ├── return-mapping:
+      │    │    │    ├── column1:93 => trade_history.th_t_id:88
       │    │    │    └── th_st_id_cast:96 => trade_history.th_st_id:90
       │    │    ├── input binding: &3
       │    │    ├── cardinality: [1 - 1]
@@ -3231,6 +3245,8 @@ with &2 (insert_trade)
  │    │    │    ├── t_comm_cast:40 => t_comm:13
  │    │    │    ├── t_tax_cast:41 => t_tax:14
  │    │    │    └── column15:32 => t_lifo:15
+ │    │    ├── return-mapping:
+ │    │    │    └── column1:18 => t_id:1
  │    │    ├── check columns: check1:42 check2:43 check3:44 check4:45 check5:46
  │    │    ├── input binding: &1
  │    │    ├── cardinality: [1 - 1]
@@ -3328,6 +3344,9 @@ with &2 (insert_trade)
       │    │    │    ├── column1:93 => trade_history.th_t_id:88
       │    │    │    ├── column2:94 => th_dts:89
       │    │    │    └── th_st_id_cast:96 => trade_history.th_st_id:90
+      │    │    ├── return-mapping:
+      │    │    │    ├── column1:93 => trade_history.th_t_id:88
+      │    │    │    └── th_st_id_cast:96 => trade_history.th_st_id:90
       │    │    ├── input binding: &3
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── volatile, mutations
@@ -3395,6 +3414,8 @@ with &2 (insert_trade)
            │    │    │    ├── tr_qty_cast:137 => tr_qty:124
            │    │    │    ├── tr_bid_price_cast:138 => tr_bid_price:125
            │    │    │    └── column6:134 => trade_request.tr_b_id:126
+           │    │    ├── return-mapping:
+           │    │    │    └── column1:129 => trade_request.tr_t_id:121
            │    │    ├── check columns: check1:139 check2:140
            │    │    ├── partial index put columns: partial_index_put1:141
            │    │    ├── input binding: &5
@@ -3976,6 +3997,9 @@ project
  │    ├── fetch columns: t_id:18 trade.t_tax:31
  │    ├── update-mapping:
  │    │    └── t_tax_cast:46 => trade.t_tax:14
+ │    ├── return-mapping:
+ │    │    ├── t_id:18 => t_id:1
+ │    │    └── t_tax_cast:46 => trade.t_tax:14
  │    ├── check columns: check5:51
  │    ├── cardinality: [0 - 1]
  │    ├── volatile, mutations
@@ -4207,6 +4231,8 @@ with &2 (update_trade_commission)
  │    │    │    ├── t_st_id_cast:39 => trade.t_st_id:3
  │    │    │    ├── t_trade_price_cast:40 => t_trade_price:11
  │    │    │    └── t_comm_cast:41 => t_comm:13
+ │    │    ├── return-mapping:
+ │    │    │    └── t_id:18 => t_id:1
  │    │    ├── check columns: check4:45
  │    │    ├── input binding: &1
  │    │    ├── cardinality: [0 - 1]
@@ -4267,6 +4293,8 @@ with &2 (update_trade_commission)
       │    │    ├── update-mapping:
       │    │    │    ├── b_num_trades_new:68 => b_num_trades:56
       │    │    │    └── b_comm_total_cast:69 => b_comm_total:57
+      │    │    ├── return-mapping:
+      │    │    │    └── b_id:60 => b_id:53
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── volatile, mutations
       │    │    ├── key: ()
@@ -4306,6 +4334,9 @@ with &2 (update_trade_commission)
            │    │    ├── insert-mapping:
            │    │    │    ├── column1:76 => trade_history.th_t_id:71
            │    │    │    ├── column2:77 => th_dts:72
+           │    │    │    └── th_st_id_cast:79 => trade_history.th_st_id:73
+           │    │    ├── return-mapping:
+           │    │    │    ├── column1:76 => trade_history.th_t_id:71
            │    │    │    └── th_st_id_cast:79 => trade_history.th_st_id:73
            │    │    ├── input binding: &4
            │    │    ├── cardinality: [1 - 1]
@@ -4405,6 +4436,8 @@ with &2 (insert_settlement)
  │    │    │    ├── se_cash_type_cast:11 => se_cash_type:2
  │    │    │    ├── column3:9 => se_cash_due_date:3
  │    │    │    └── se_amt_cast:12 => se_amt:4
+ │    │    ├── return-mapping:
+ │    │    │    └── column1:7 => settlement.se_t_id:1
  │    │    ├── input binding: &1
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── volatile, mutations
@@ -4454,6 +4487,8 @@ with &2 (insert_settlement)
       │    │    │    ├── column2:39 => ct_dts:33
       │    │    │    ├── ct_amt_cast:42 => ct_amt:34
       │    │    │    └── ct_name_cast:43 => ct_name:35
+      │    │    ├── return-mapping:
+      │    │    │    └── column1:38 => cash_transaction.ct_t_id:32
       │    │    ├── input binding: &3
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── volatile, mutations
@@ -4494,6 +4529,9 @@ with &2 (insert_settlement)
            │    ├── columns: ca_id:63!null customer_account.ca_bal:68!null
            │    ├── fetch columns: ca_id:71 ca_b_id:72 ca_c_id:73 ca_name:74 ca_tax_st:75 customer_account.ca_bal:76
            │    ├── update-mapping:
+           │    │    └── ca_bal_cast:80 => customer_account.ca_bal:68
+           │    ├── return-mapping:
+           │    │    ├── ca_id:71 => ca_id:63
            │    │    └── ca_bal_cast:80 => customer_account.ca_bal:68
            │    ├── cardinality: [0 - 1]
            │    ├── volatile, mutations
@@ -4547,6 +4585,8 @@ with &2 (insert_settlement)
  │    │    │    ├── se_cash_type_cast:11 => se_cash_type:2
  │    │    │    ├── column3:9 => se_cash_due_date:3
  │    │    │    └── se_amt_cast:12 => se_amt:4
+ │    │    ├── return-mapping:
+ │    │    │    └── column1:7 => settlement.se_t_id:1
  │    │    ├── input binding: &1
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── volatile, mutations
@@ -5257,6 +5297,7 @@ UPDATE settlement
 update settlement
  ├── columns: <none>
  ├── fetch columns: se_t_id:7 se_cash_type:8 se_cash_due_date:9 se_amt:10
+ ├── passthrough columns: unnest:13 unnest:14
  ├── update-mapping:
  │    └── se_cash_type_cast:16 => se_cash_type:2
  ├── cardinality: [0 - 0]
@@ -5518,6 +5559,7 @@ UPDATE cash_transaction
 update cash_transaction
  ├── columns: <none>
  ├── fetch columns: ct_t_id:7 ct_dts:8 ct_amt:9 ct_name:10
+ ├── passthrough columns: unnest:13 unnest:14 unnest:15 unnest:16
  ├── update-mapping:
  │    └── ct_name_cast:18 => ct_name:4
  ├── cardinality: [0 - 0]
@@ -6119,6 +6161,7 @@ UPDATE watch_item
 update watch_item
  ├── columns: <none>
  ├── fetch columns: wi_wl_id:5 watch_item.wi_s_symb:6
+ ├── passthrough columns: wl_id:9 wl_c_id:10 watch_list.crdb_internal_mvcc_timestamp:11 watch_list.tableoid:12
  ├── update-mapping:
  │    └── wi_s_symb_cast:14 => watch_item.wi_s_symb:2
  ├── input binding: &1
@@ -6298,6 +6341,8 @@ with &1 (empty_trade_requests)
  ├── delete trade_request
  │    ├── columns: trade_request.tr_t_id:1!null
  │    ├── fetch columns: trade_request.tr_t_id:9 tr_s_symb:11 tr_b_id:14
+ │    ├── return-mapping:
+ │    │    └── trade_request.tr_t_id:9 => trade_request.tr_t_id:1
  │    ├── partial index del columns: partial_index_del1:17
  │    ├── cardinality: [0 - 20]
  │    ├── volatile, mutations

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -1445,6 +1445,7 @@ WHERE ci.cardid = Updates.c AND ci.dealerid = 1
 update cardsinfo [as=ci]
  ├── columns: <none>
  ├── fetch columns: ci.dealerid:17 ci.cardid:18 buyprice:19 sellprice:20 discount:21 desiredinventory:22 actualinventory:23 maxinventory:24 ci.version:25
+ ├── passthrough columns: c:28 q:29
  ├── update-mapping:
  │    └── actualinventory_new:39 => actualinventory:12
  ├── cardinality: [0 - 0]

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -1457,6 +1457,7 @@ WHERE ci.cardid = Updates.c AND ci.dealerid = 1
 update cardsinfo [as=ci]
  ├── columns: <none>
  ├── fetch columns: ci.dealerid:21 ci.cardid:22 buyprice:23 sellprice:24 discount:25 desiredinventory:26 actualinventory:27 maxinventory:28 ci.version:29 discountbuyprice:30 notes:31 oldinventory:32 ci.extra:33
+ ├── passthrough columns: c:36 q:37
  ├── update-mapping:
  │    ├── actualinventory_new:49 => actualinventory:12
  │    ├── discountbuyprice_cast:53 => discountbuyprice:15

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -1863,6 +1863,10 @@ sort
       │    │    ├── x:6 => abc.a:1
       │    │    ├── y:7 => abc.b:2
       │    │    └── z:8 => abc.c:3
+      │    ├── return-mapping:
+      │    │    ├── x:6 => abc.a:1
+      │    │    ├── y:7 => abc.b:2
+      │    │    └── z:8 => abc.c:3
       │    ├── cardinality: [0 - 2]
       │    ├── volatile, mutations
       │    ├── key: (1-3)
@@ -1905,6 +1909,10 @@ sort
       │    │    ├── b:7 => xyz.x:1
       │    │    ├── c:8 => xyz.y:2
       │    │    └── d:9 => xyz.z:3
+      │    ├── return-mapping:
+      │    │    ├── b:7 => xyz.x:1
+      │    │    ├── c:8 => xyz.y:2
+      │    │    └── d:9 => xyz.z:3
       │    ├── cardinality: [0 - 2]
       │    ├── volatile, mutations
       │    └── scan abcd@cd
@@ -1943,6 +1951,10 @@ sort
       │    │    ├── b:7 => xyz.x:1
       │    │    ├── c:8 => xyz.y:2
       │    │    └── d:9 => xyz.z:3
+      │    ├── return-mapping:
+      │    │    ├── b:7 => xyz.x:1
+      │    │    ├── c:8 => xyz.y:2
+      │    │    └── d:9 => xyz.z:3
       │    ├── cardinality: [0 - 2]
       │    ├── volatile, mutations
       │    └── scan abcd@cd
@@ -1973,6 +1985,10 @@ with &1
  ├── insert abc
  │    ├── columns: abc.a:1!null abc.b:2!null abc.c:3!null
  │    ├── insert-mapping:
+ │    │    ├── x:6 => abc.a:1
+ │    │    ├── y:7 => abc.b:2
+ │    │    └── z:8 => abc.c:3
+ │    ├── return-mapping:
  │    │    ├── x:6 => abc.a:1
  │    │    ├── y:7 => abc.b:2
  │    │    └── z:8 => abc.c:3
@@ -2016,6 +2032,12 @@ sort
       │         ├── update-mapping:
       │         │    ├── a_new:15 => abcd.a:1
       │         │    └── b_new:16 => abcd.b:2
+      │         ├── return-mapping:
+      │         │    ├── a_new:15 => abcd.a:1
+      │         │    ├── b_new:16 => abcd.b:2
+      │         │    ├── abcd.c:10 => abcd.c:3
+      │         │    ├── abcd.d:11 => abcd.d:4
+      │         │    └── rowid:12 => rowid:5
       │         ├── volatile, mutations
       │         ├── key: (5)
       │         ├── fd: ()-->(1,2), (5)-->(3,4)
@@ -2063,6 +2085,12 @@ sort
       │         ├── fetch columns: abcd.a:8 abcd.b:9 abcd.c:10 abcd.d:11 rowid:12
       │         ├── update-mapping:
       │         │    └── b_new:15 => abcd.b:2
+      │         ├── return-mapping:
+      │         │    ├── abcd.a:8 => abcd.a:1
+      │         │    ├── b_new:15 => abcd.b:2
+      │         │    ├── abcd.c:10 => abcd.c:3
+      │         │    ├── abcd.d:11 => abcd.d:4
+      │         │    └── rowid:12 => rowid:5
       │         ├── cardinality: [0 - 10]
       │         ├── volatile, mutations
       │         ├── key: (5)
@@ -2117,6 +2145,12 @@ sort
       │         ├── fetch columns: abcd.a:8 abcd.b:9 abcd.c:10 abcd.d:11 rowid:12
       │         ├── update-mapping:
       │         │    └── b_new:15 => abcd.b:2
+      │         ├── return-mapping:
+      │         │    ├── abcd.a:8 => abcd.a:1
+      │         │    ├── b_new:15 => abcd.b:2
+      │         │    ├── abcd.c:10 => abcd.c:3
+      │         │    ├── abcd.d:11 => abcd.d:4
+      │         │    └── rowid:12 => rowid:5
       │         ├── cardinality: [0 - 10]
       │         ├── volatile, mutations
       │         ├── key: (5)
@@ -2253,6 +2287,12 @@ sort
       │    └── delete abcd
       │         ├── columns: abcd.a:1 abcd.b:2 abcd.c:3 abcd.d:4 rowid:5!null
       │         ├── fetch columns: abcd.a:8 abcd.b:9 abcd.c:10 abcd.d:11 rowid:12
+      │         ├── return-mapping:
+      │         │    ├── abcd.a:8 => abcd.a:1
+      │         │    ├── abcd.b:9 => abcd.b:2
+      │         │    ├── abcd.c:10 => abcd.c:3
+      │         │    ├── abcd.d:11 => abcd.d:4
+      │         │    └── rowid:12 => rowid:5
       │         ├── volatile, mutations
       │         ├── key: (5)
       │         ├── fd: (5)-->(1-4)
@@ -2290,6 +2330,12 @@ sort
       │    └── delete abcd
       │         ├── columns: abcd.a:1 abcd.b:2 abcd.c:3 abcd.d:4 rowid:5!null
       │         ├── fetch columns: abcd.a:8 abcd.b:9 abcd.c:10 abcd.d:11 rowid:12
+      │         ├── return-mapping:
+      │         │    ├── abcd.a:8 => abcd.a:1
+      │         │    ├── abcd.b:9 => abcd.b:2
+      │         │    ├── abcd.c:10 => abcd.c:3
+      │         │    ├── abcd.d:11 => abcd.d:4
+      │         │    └── rowid:12 => rowid:5
       │         ├── cardinality: [0 - 10]
       │         ├── volatile, mutations
       │         ├── key: (5)
@@ -2334,6 +2380,12 @@ sort
       │    └── delete abcd
       │         ├── columns: abcd.a:1 abcd.b:2 abcd.c:3 abcd.d:4 rowid:5!null
       │         ├── fetch columns: abcd.a:8 abcd.b:9 abcd.c:10 abcd.d:11 rowid:12
+      │         ├── return-mapping:
+      │         │    ├── abcd.a:8 => abcd.a:1
+      │         │    ├── abcd.b:9 => abcd.b:2
+      │         │    ├── abcd.c:10 => abcd.c:3
+      │         │    ├── abcd.d:11 => abcd.d:4
+      │         │    └── rowid:12 => rowid:5
       │         ├── cardinality: [0 - 10]
       │         ├── volatile, mutations
       │         ├── key: (5)

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -10068,6 +10068,8 @@ with &1
  │    │    │    ├── b_default:20 => abc.b:8
  │    │    │    ├── b_default:20 => abc.c:9
  │    │    │    └── rowid_default:21 => abc.rowid:10
+ │    │    ├── return-mapping:
+ │    │    │    └── rowid_default:21 => abc.rowid:10
  │    │    ├── volatile, mutations
  │    │    └── project
  │    │         ├── columns: b_default:20 rowid_default:21 "?column?":19!null


### PR DESCRIPTION
Previously, insert, update, and delete expressions were not displayed with their return column mappings, like upsert expressions were. This made it hard to understand where returning columns originated from in the expression tree. The return mapping is now displayed.

Also, update expressions are displayed with their passthrough columns, which are columns being returned that do not originate from the target table, i.e., columns from tables listed in a `FROM` clause of an `UPDATE`.

Release note: None