### PR TITLE
tests: Skip a roachtest test until master is on 23.1

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_job_compatibility_in_declarative_schema_changer.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_job_compatibility_in_declarative_schema_changer.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/stretchr/testify/require"
 )
 
@@ -84,6 +85,9 @@ func registerDeclarativeSchemaChangerJobCompatibilityInMixedVersion(r registry.R
 		Owner:   registry.OwnerSQLSchema,
 		Cluster: r.MakeClusterSpec(4),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			// Skip this roachtest until master is on 23.1
+			skip.WithIssue(t, 89345)
+
 			if runtime.GOARCH == "arm64" {
 				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/89268")
 			}

--- a/pkg/jobs/wait.go
+++ b/pkg/jobs/wait.go
@@ -46,7 +46,9 @@ func (r *Registry) NotifyToResume(ctx context.Context, jobs ...jobspb.JobID) {
 	_ = r.stopper.RunAsyncTask(ctx, "resume-jobs", func(ctx context.Context) {
 		r.withSession(ctx, func(ctx context.Context, s sqlliveness.Session) {
 			r.filterAlreadyRunningAndCancelFromPreviousSessions(ctx, s, m)
-			r.resumeClaimedJobs(ctx, s, m)
+			if !r.adoptionDisabled(ctx) {
+				r.resumeClaimedJobs(ctx, s, m)
+			}
 		})
 	})
 }

--- a/pkg/upgrade/upgrades/wait_for_schema_changes_test.go
+++ b/pkg/upgrade/upgrades/wait_for_schema_changes_test.go
@@ -254,7 +254,6 @@ func TestWaitForSchemaChangeMigrationSynthetic(t *testing.T) {
 			var waitCount int32
 			var secondWaitChan chan struct{}
 			params.Knobs.JobsTestingKnobs = &jobs.TestingKnobs{
-				DisableAdoptions: true,
 				BeforeWaitForJobsQuery: func() {
 					if secondWaitChan != nil {
 						if atomic.AddInt32(&waitCount, 1) == 2 {


### PR DESCRIPTION
Commit 1: Fixed a bug where we forgot to check whether
job adoption is disabled before resuming a job. It also uncovered
a flaw in another test which we fix.

Commit 2: Skip a roachtest that we recently see failure until
master is on 23.1. The reason is detailed in issue https://github.com/cockroachdb/cockroach/issues/89345.

Fixes: #88921
Backport commit 1 will also fix #89091

Release note: None