### PR TITLE
memo: better selectivity estimates on single-table ORed predicates

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index_query_plan
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index_query_plan
@@ -384,7 +384,7 @@ vectorized: true
                     │
                     └── • distinct
                         │ columns: (crdb_internal_id_shard_16, id, part)
-                        │ estimated row count: 7 (missing stats)
+                        │ estimated row count: 6 (missing stats)
                         │ distinct on: id, part
                         │
                         └── • union all
@@ -1027,7 +1027,7 @@ vectorized: true
                     │
                     └── • distinct
                         │ columns: (id, email, part)
-                        │ estimated row count: 7 (missing stats)
+                        │ estimated row count: 6 (missing stats)
                         │ distinct on: id, part
                         │
                         └── • union all

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index_query_plan
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index_query_plan
@@ -403,7 +403,7 @@ vectorized: true
                     │
                     └── • filter
                         │ columns: (crdb_internal_id_shard_16, id, crdb_region)
-                        │ estimated row count: 7 (missing stats)
+                        │ estimated row count: 6 (missing stats)
                         │ filter: (crdb_internal_id_shard_16 != 9) OR (crdb_region != 'ap-southeast-2')
                         │
                         └── • union all
@@ -1093,7 +1093,7 @@ vectorized: true
                     │
                     └── • distinct
                         │ columns: (id, email, crdb_region)
-                        │ estimated row count: 7 (missing stats)
+                        │ estimated row count: 6 (missing stats)
                         │ distinct on: id, crdb_region
                         │
                         └── • union all

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_merge_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_merge_join
@@ -465,7 +465,7 @@ vectorized: true
     └── • filter
         │ columns: (pid1, pa1)
         │ ordering: +pid1
-        │ estimated row count: 342 (missing stats)
+        │ estimated row count: 339 (missing stats)
         │ filter: ((((pid1 >= 11) AND (pid1 <= 13)) OR ((pid1 >= 19) AND (pid1 <= 21))) OR ((pid1 >= 31) AND (pid1 <= 33))) OR (pa1 > 0)
         │
         └── • scan
@@ -536,7 +536,7 @@ vectorized: true
     └── • filter
         │ columns: (pid1, pa1)
         │ ordering: +pid1
-        │ estimated row count: 342 (missing stats)
+        │ estimated row count: 339 (missing stats)
         │ filter: ((((pid1 >= 11) AND (pid1 <= 13)) OR ((pid1 >= 19) AND (pid1 <= 21))) OR ((pid1 >= 31) AND (pid1 <= 33))) OR (pa1 > 0)
         │
         └── • scan

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -742,7 +742,7 @@ vectorized: true
 ·
 • filter
 │ columns: (a, b, n, sq)
-│ estimated row count: 115 (missing stats)
+│ estimated row count: 116 (missing stats)
 │ filter: ((n IS NULL) OR (n > 1)) AND ((n IS NULL) OR (a < sq))
 │
 └── • hash join (left outer)
@@ -784,7 +784,7 @@ vectorized: true
 ·
 • filter
 │ columns: (a, b, n, sq)
-│ estimated row count: 42 (missing stats)
+│ estimated row count: 44 (missing stats)
 │ filter: ((a IS NULL) OR (a > 2)) AND ((a IS NULL) OR (a < sq))
 │
 └── • hash join (left outer)
@@ -827,7 +827,7 @@ vectorized: true
 │
 ├── • filter
 │   │ columns: (a, b)
-│   │ estimated row count: 111 (missing stats)
+│   │ estimated row count: 113 (missing stats)
 │   │ filter: ((a > 1) AND ((a IS NULL) OR (a > 2))) AND ((a IS NULL) OR (a < b))
 │   │
 │   └── • scan

--- a/pkg/sql/opt/indexrec/testdata/index
+++ b/pkg/sql/opt/indexrec/testdata/index
@@ -215,10 +215,10 @@ creation: CREATE INDEX ON t1 (f) STORING (k, i);
 optimal plan:
 project
  ├── columns: i:2
- ├── cost: 816.218448
+ ├── cost: 814.144374
  └── project
       ├── columns: k:1 i:2 f:3
-      ├── cost: 809.754004
+      ├── cost: 808.716967
       └── distinct-on
            ├── columns: k:1 i:2 f:3 rowid:5!null
            ├── grouping columns: rowid:5!null

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -3192,29 +3192,31 @@ func (sb *statisticsBuilder) applyFiltersItem(
 				numUnappliedConjuncts++
 			}
 		}
-	} else if constraintUnion := sb.buildDisjunctionConstraints(filter); len(constraintUnion) > 0 {
-		// The filters are one or more disjunctions and tight constraint sets
-		// could be built for each.
-		var tmpStats, unionStats props.Statistics
-		unionStats.CopyFrom(s)
+	} else if constraintUnion, numUnappliedDisjuncts := sb.buildDisjunctionConstraints(filter); len(constraintUnion) > 0 {
+		// The filters are one or more disjuncts and tight constraint sets could be
+		// built for at least one disjunct. numUnappliedDisjuncts contains the count
+		// of disjuncts which are not tight constraints.
+		var tmpStats props.Statistics
 
+		selectivities := make([]props.Selectivity, 0, len(constraintUnion)+numUnappliedDisjuncts)
 		// Get the stats for each constraint set, apply the selectivity to a
-		// temporary stats struct, and union the selectivity and row counts.
-		sb.constrainExpr(e, constraintUnion[0], relProps, &unionStats)
-		for i := 1; i < len(constraintUnion); i++ {
+		// temporary stats struct, and combine the disjunct selectivities.
+		// union the selectivity and row counts.
+		for i := 0; i < len(constraintUnion); i++ {
 			tmpStats.CopyFrom(s)
 			sb.constrainExpr(e, constraintUnion[i], relProps, &tmpStats)
-			unionStats.UnionWith(&tmpStats)
+			selectivities = append(selectivities, tmpStats.Selectivity)
+		}
+		defaultSelectivity := props.MakeSelectivity(unknownFilterSelectivity)
+		for i := 0; i < numUnappliedDisjuncts; i++ {
+			selectivities = append(selectivities, defaultSelectivity)
 		}
 
-		// The stats are unioned naively; the selectivity may be greater than 1
-		// and the row count may be greater than the row count of the input
-		// stats. We use the minimum selectivity and row count of the unioned
-		// stats and the input stats.
 		// TODO(mgartner): Calculate and set the column statistics based on
 		// constraintUnion.
-		s.Selectivity = props.MinSelectivity(s.Selectivity, unionStats.Selectivity)
-		s.RowCount = min(s.RowCount, unionStats.RowCount)
+		disjunctionSelectivity := combineOredSelectivities(selectivities)
+		s.RowCount *= disjunctionSelectivity.AsFloat()
+		s.Selectivity.Multiply(disjunctionSelectivity)
 	} else {
 		numUnappliedConjuncts++
 	}
@@ -3225,20 +3227,22 @@ func (sb *statisticsBuilder) applyFiltersItem(
 // buildDisjunctionConstraints returns a slice of tight constraint sets that are
 // built from one or more adjacent Or expressions in filter. This allows more
 // accurate stats to be calculated for disjunctions. If any adjacent Or cannot
-// be tightly constrained, then nil is returned.
-func (sb *statisticsBuilder) buildDisjunctionConstraints(filter *FiltersItem) []*constraint.Set {
+// be tightly constrained, then numUnappliedDisjuncts is incremented, indicating
+// unknownFilterSelectivity should be used for that disjunct.
+func (sb *statisticsBuilder) buildDisjunctionConstraints(
+	filter *FiltersItem,
+) (constraintSet []*constraint.Set, numUnappliedDisjuncts int) {
 	expr := filter.Condition
 
 	// If the expression is not an Or, we cannot build disjunction constraint
 	// sets.
 	or, ok := expr.(*OrExpr)
 	if !ok {
-		return nil
+		return nil, 0
 	}
 
 	cb := constraintsBuilder{md: sb.md, evalCtx: sb.evalCtx}
 
-	unconstrained := false
 	var constraints []*constraint.Set
 	var collectConstraints func(opt.ScalarExpr)
 	collectConstraints = func(e opt.ScalarExpr) {
@@ -3253,8 +3257,8 @@ func (sb *statisticsBuilder) buildDisjunctionConstraints(filter *FiltersItem) []
 		innerOr, ok := e.(*OrExpr)
 		if !ok {
 			// If a tight constraint could not be built and the expression is
-			// not an Or, set unconstrained so we can return nil.
-			unconstrained = true
+			// not an Or, bump the number of unapplied disjuncts.
+			numUnappliedDisjuncts++
 			return
 		}
 
@@ -3274,11 +3278,7 @@ func (sb *statisticsBuilder) buildDisjunctionConstraints(filter *FiltersItem) []
 	collectConstraints(or.Left)
 	collectConstraints(or.Right)
 
-	if unconstrained {
-		return nil
-	}
-
-	return constraints
+	return constraints, numUnappliedDisjuncts
 }
 
 // constrainExpr calculates the stats for a relational expression based on the
@@ -4292,25 +4292,16 @@ func (sb *statisticsBuilder) selectivityFromOredEquivalencies(
 // https://www.thoughtco.com/probability-union-of-three-sets-more-3126263
 // https://stats.stackexchange.com/questions/87533/whats-the-general-disjunction-rule-for-n-events
 //
-// Q: Does the iterative approach do a good enough job of approximating
-//
-//	the non-iterative textbook solution?
-//
+// The iterative approach seems to be equivalent to textbook solutions which
+// expand into a large number of terms.
 // In the formula we assume A and B are independent, so:
 //
 //	P(A and B) = P(A) * P(B)
 //
 // The independence assumption may not be correct in all cases.
-// Would using the full formula lead to more errors since the independence
-// assumption is used in more terms in that formula?
-// In any case, the runtime of computing the full formula for filters with
-// many predicates may be excessive due to combinatorial explosion.
-// That shouldn't apply to the ON clause because typically it would not have
-// hundreds of disjuncts, but may apply if this method were used for
-// single-table filter selectivity estimation.
 //
-// Possible improvement: Use multicolumn stats to estimate P(A and B)
-// instead of assuming full independence.
+//	TODO(msirek): Use multicolumn stats and column correlations to get better
+//								estimates of P(A and B).
 func combineOredSelectivities(selectivities []props.Selectivity) props.Selectivity {
 	totalSelectivity := selectivities[0]
 	var combinedSel props.Selectivity

--- a/pkg/sql/opt/memo/testdata/stats/inverted-geo
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-geo
@@ -293,7 +293,7 @@ SELECT * FROM t WHERE g IS NULL OR st_intersects('LINESTRING(100 100, 150 150)',
 select
  ├── columns: i:1(int) g:2(geometry)
  ├── immutable
- ├── stats: [rows=666.6667, distinct(1)=555.556, null(1)=16.6667, distinct(2)=7, null(2)=33.3333]
+ ├── stats: [rows=733.3333, distinct(1)=598.889, null(1)=18.3333, distinct(2)=7, null(2)=36.6667]
  ├── scan t
  │    ├── columns: i:1(int) g:2(geometry)
  │    └── stats: [rows=2000, distinct(1)=1000, null(1)=50, distinct(2)=7, null(2)=100]

--- a/pkg/sql/opt/memo/testdata/stats/join
+++ b/pkg/sql/opt/memo/testdata/stats/join
@@ -1750,7 +1750,7 @@ left-join (cross)
  │    └── stats: [rows=1000]
  ├── scan classrequest
  │    ├── columns: studentid:6(int!null) firstchoiceclassid:7(int) secondchoiceclassid:8(int) thirdchoiceclassid:9(int)
- │    ├── stats: [rows=1000]
+ │    ├── stats: [rows=1000, distinct(8)=100, null(8)=10]
  │    ├── key: (6)
  │    └── fd: (6)-->(7-9)
  └── filters
@@ -1823,7 +1823,7 @@ semi-join (cross)
  │    └── stats: [rows=1000]
  ├── scan classrequest
  │    ├── columns: firstchoiceclassid:7(int) secondchoiceclassid:8(int)
- │    └── stats: [rows=1000]
+ │    └── stats: [rows=1000, distinct(8)=100, null(8)=10]
  └── filters
       └── (firstchoiceclassid:7 = classid:1) OR (secondchoiceclassid:8 = 5) [type=bool, outer=(1,7,8)]
 

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -2568,14 +2568,14 @@ SELECT * FROM disjunction WHERE a = 'foo' OR b = 'foo' LIMIT 5
 limit
  ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string)
  ├── cardinality: [0 - 5]
- ├── stats: [rows=2]
+ ├── stats: [rows=1.9995]
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  ├── distinct-on
  │    ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string)
  │    ├── grouping columns: k:1(int!null)
  │    ├── internal-ordering: +1
- │    ├── stats: [rows=2]
+ │    ├── stats: [rows=1.9995]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4)
  │    ├── limit hint: 5.00
@@ -2627,14 +2627,14 @@ SELECT * FROM disjunction WHERE a = 'foo' OR b = 'foo' OR c = 'foo' LIMIT 5
 limit
  ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string)
  ├── cardinality: [0 - 5]
- ├── stats: [rows=3.000001]
+ ├── stats: [rows=2.998501]
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  ├── distinct-on
  │    ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string)
  │    ├── grouping columns: k:1(int!null)
  │    ├── internal-ordering: +1
- │    ├── stats: [rows=3.000001]
+ │    ├── stats: [rows=2.998501]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4)
  │    ├── limit hint: 5.00
@@ -2642,7 +2642,7 @@ limit
  │    │    ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string)
  │    │    ├── left columns: k:7(int) a:8(string) b:9(string) c:10(string)
  │    │    ├── right columns: k:13(int) a:14(string) b:15(string) c:16(string)
- │    │    ├── stats: [rows=3.000001]
+ │    │    ├── stats: [rows=2.999501]
  │    │    ├── ordering: +1
  │    │    ├── index-join disjunction
  │    │    │    ├── columns: k:7(int!null) a:8(string!null) b:9(string) c:10(string)
@@ -2660,7 +2660,7 @@ limit
  │    │    └── distinct-on
  │    │         ├── columns: k:13(int!null) a:14(string) b:15(string) c:16(string)
  │    │         ├── grouping columns: k:13(int!null)
- │    │         ├── stats: [rows=2]
+ │    │         ├── stats: [rows=1.9995]
  │    │         ├── key: (13)
  │    │         ├── fd: (13)-->(14-16)
  │    │         ├── ordering: +13
@@ -2718,12 +2718,12 @@ SELECT * FROM disjunction WHERE (a = 'foo' OR b = 'foo') AND c = 'foo' LIMIT 5
 limit
  ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string!null)
  ├── cardinality: [0 - 5]
- ├── stats: [rows=0.001]
+ ├── stats: [rows=0.0009997504]
  ├── key: (1)
  ├── fd: ()-->(4), (1)-->(2,3)
  ├── select
  │    ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string!null)
- │    ├── stats: [rows=0.001, distinct(4)=0.001, null(4)=0]
+ │    ├── stats: [rows=0.0009997504, distinct(4)=0.00099975, null(4)=0]
  │    ├── key: (1)
  │    ├── fd: ()-->(4), (1)-->(2,3)
  │    ├── limit hint: 5.00
@@ -2799,7 +2799,7 @@ limit
  ├── distinct-on
  │    ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string)
  │    ├── grouping columns: k:1(int!null)
- │    ├── stats: [rows=40]
+ │    ├── stats: [rows=39.96]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4)
  │    ├── limit hint: 5.00
@@ -2866,7 +2866,7 @@ limit
  ├── distinct-on
  │    ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string)
  │    ├── grouping columns: k:1(int!null)
- │    ├── stats: [rows=60]
+ │    ├── stats: [rows=59.88008]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4)
  │    ├── limit hint: 5.00
@@ -2874,7 +2874,7 @@ limit
  │    │    ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string)
  │    │    ├── left columns: k:7(int) a:8(string) b:9(string) c:10(string)
  │    │    ├── right columns: k:13(int) a:14(string) b:15(string) c:16(string)
- │    │    ├── stats: [rows=60]
+ │    │    ├── stats: [rows=59.96]
  │    │    ├── limit hint: 6.28
  │    │    ├── index-join disjunction
  │    │    │    ├── columns: k:7(int!null) a:8(string!null) b:9(string) c:10(string)
@@ -2896,7 +2896,7 @@ limit
  │    │    └── distinct-on
  │    │         ├── columns: k:13(int!null) a:14(string) b:15(string) c:16(string)
  │    │         ├── grouping columns: k:13(int!null)
- │    │         ├── stats: [rows=40]
+ │    │         ├── stats: [rows=39.96]
  │    │         ├── key: (13)
  │    │         ├── fd: (13)-->(14-16)
  │    │         ├── limit hint: 6.28
@@ -2963,14 +2963,14 @@ SELECT * FROM disjunction WHERE (a LIKE 'foo%' OR b LIKE 'foo%') AND c LIKE 'foo
 limit
  ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string!null)
  ├── cardinality: [0 - 5]
- ├── stats: [rows=0.08000001]
+ ├── stats: [rows=0.07992001]
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  ├── select
  │    ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string!null)
- │    ├── stats: [rows=0.08000001, distinct(4)=0.08, null(4)=0]
- │    │   histogram(4)=  0  0.04   0.04    0
- │    │                <--- 'foo' ------ 'fop'
+ │    ├── stats: [rows=0.07992001, distinct(4)=0.07992, null(4)=0]
+ │    │   histogram(4)=  0 0.03996 0.03996    0
+ │    │                <--- 'foo' --------- 'fop'
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4)
  │    ├── limit hint: 5.00
@@ -3004,7 +3004,7 @@ limit
  ├── fd: (1)-->(2-4)
  ├── select
  │    ├── columns: k:1(int!null) a:2(string) b:3(string) c:4(string)
- │    ├── stats: [rows=10000]
+ │    ├── stats: [rows=9920]
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4)
  │    ├── limit hint: 5.00
@@ -3019,7 +3019,7 @@ limit
  │    │    │                <--- 'aaa' ----- 'foo' ---- 'fop' ------ 'zoo'
  │    │    ├── key: (1)
  │    │    ├── fd: (1)-->(2-4)
- │    │    └── limit hint: 5.00
+ │    │    └── limit hint: 5.04
  │    └── filters
  │         └── ((a:2 > 'fop') OR (b:3 > 'fop')) OR (c:4 > 'fop') [type=bool, outer=(2-4)]
  └── 5 [type=int]
@@ -3580,3 +3580,337 @@ project
       │         ├── a:2 = 1 [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
       │         └── b:3 = 1 [type=bool, outer=(3), constraints=(/3: [/1 - /1]; tight), fd=()-->(3)]
       └── filters (true)
+
+# Tests for selectivity of disjunctions
+
+exec-ddl
+CREATE TABLE t00 (c0 INT, c1 INT, c2 INT, c3 INT, c4 INT, c5 INT)
+----
+
+# 6 columns with identical stats histograms
+exec-ddl
+ALTER TABLE t00 INJECT STATISTICS '[
+  {
+    "columns": ["c0"],
+    "created_at": "2019-02-08 04:10:40.001179+00:00",
+    "row_count": 10,
+    "distinct_count": 10,
+    "histo_buckets": [
+        {
+            "distinct_range": 0,
+            "num_eq": 0,
+            "num_range": 0,
+            "upper_bound": "0"
+        },
+        {
+            "distinct_range": 9,
+            "num_eq": 1,
+            "num_range": 9,
+            "upper_bound": "10"
+        }
+    ],
+    "histo_col_type": "INT8",
+    "histo_version": 2,
+    "null_count": 0,
+    "avg_size": 3
+  },
+  {
+    "columns": ["c1"],
+    "created_at": "2019-02-08 04:10:40.001179+00:00",
+    "row_count": 10,
+    "distinct_count": 10,
+    "histo_buckets": [
+        {
+            "distinct_range": 0,
+            "num_eq": 0,
+            "num_range": 0,
+            "upper_bound": "0"
+        },
+        {
+            "distinct_range": 9,
+            "num_eq": 1,
+            "num_range": 9,
+            "upper_bound": "10"
+        }
+    ],
+    "histo_col_type": "INT8",
+    "histo_version": 2,
+    "null_count": 0,
+    "avg_size": 3
+  },
+  {
+    "columns": ["c2"],
+    "created_at": "2019-02-08 04:10:40.001179+00:00",
+    "row_count": 10,
+    "distinct_count": 10,
+    "histo_buckets": [
+        {
+            "distinct_range": 0,
+            "num_eq": 0,
+            "num_range": 0,
+            "upper_bound": "0"
+        },
+        {
+            "distinct_range": 9,
+            "num_eq": 1,
+            "num_range": 9,
+            "upper_bound": "10"
+        }
+    ],
+    "histo_col_type": "INT8",
+    "histo_version": 2,
+    "null_count": 0,
+    "avg_size": 3
+  },
+  {
+    "columns": ["c3"],
+    "created_at": "2019-02-08 04:10:40.001179+00:00",
+    "row_count": 10,
+    "distinct_count": 10,
+    "histo_buckets": [
+        {
+            "distinct_range": 0,
+            "num_eq": 0,
+            "num_range": 0,
+            "upper_bound": "0"
+        },
+        {
+            "distinct_range": 9,
+            "num_eq": 1,
+            "num_range": 9,
+            "upper_bound": "10"
+        }
+    ],
+    "histo_col_type": "INT8",
+    "histo_version": 2,
+    "null_count": 0,
+    "avg_size": 3
+  },
+  {
+    "columns": ["c4"],
+    "created_at": "2019-02-08 04:10:40.001179+00:00",
+    "row_count": 10,
+    "distinct_count": 10,
+    "histo_buckets": [
+        {
+            "distinct_range": 0,
+            "num_eq": 0,
+            "num_range": 0,
+            "upper_bound": "0"
+        },
+        {
+            "distinct_range": 9,
+            "num_eq": 1,
+            "num_range": 9,
+            "upper_bound": "10"
+        }
+    ],
+    "histo_col_type": "INT8",
+    "histo_version": 2,
+    "null_count": 0,
+    "avg_size": 3
+  },
+  {
+    "columns": ["c5"],
+    "created_at": "2019-02-08 04:10:40.001179+00:00",
+    "row_count": 10,
+    "distinct_count": 10,
+    "histo_buckets": [
+        {
+            "distinct_range": 0,
+            "num_eq": 0,
+            "num_range": 0,
+            "upper_bound": "0"
+        },
+        {
+            "distinct_range": 9,
+            "num_eq": 1,
+            "num_range": 9,
+            "upper_bound": "10"
+        }
+    ],
+    "histo_col_type": "INT8",
+    "histo_version": 2,
+    "null_count": 0,
+    "avg_size": 3
+  }
+]'
+----
+
+# Expect estimate of 10 rows.
+opt
+SELECT c0 FROM t00 WHERE (c0 IS NOT NULL) OR (1 < ALL (c0, c0))
+----
+select
+ ├── columns: c0:1(int)
+ ├── stats: [rows=10]
+ ├── scan t00
+ │    ├── columns: c0:1(int)
+ │    └── stats: [rows=10, distinct(1)=10, null(1)=0]
+ │        histogram(1)=  0  0  9  1
+ │                     <--- 0 --- 10
+ └── filters
+      └── (c0:1 IS NOT NULL) OR (NOT (1 >= ANY (c0:1, c0:1))) [type=bool, outer=(1)]
+
+# ORed predicate selectivity should be approximately additive.
+opt
+SELECT c0 FROM t00 WHERE (c0 = 1) OR (c1 = 3)
+----
+project
+ ├── columns: c0:1(int)
+ ├── stats: [rows=1.9]
+ └── select
+      ├── columns: c0:1(int) c1:2(int)
+      ├── stats: [rows=1.9]
+      ├── scan t00
+      │    ├── columns: c0:1(int) c1:2(int)
+      │    └── stats: [rows=10, distinct(1)=10, null(1)=0, distinct(2)=10, null(2)=0]
+      │        histogram(1)=  0  0  9  1
+      │                     <--- 0 --- 10
+      │        histogram(2)=  0  0  9  1
+      │                     <--- 0 --- 10
+      └── filters
+           └── (c0:1 = 1) OR (c1:2 = 3) [type=bool, outer=(1,2)]
+
+# ORed predicate selectivity when ANDed with a predicate which selects all rows
+# should not change.
+opt
+SELECT c0 FROM t00 WHERE (c0 BETWEEN 1 AND 10) AND (c0 = 1 OR c1 = 3)
+----
+project
+ ├── columns: c0:1(int!null)
+ ├── stats: [rows=1.9]
+ └── select
+      ├── columns: c0:1(int!null) c1:2(int)
+      ├── stats: [rows=1.9, distinct(1)=1.9, null(1)=0]
+      │   histogram(1)=  0  0  1.71 0.19
+      │                <--- 0 ------ 10
+      ├── scan t00
+      │    ├── columns: c0:1(int) c1:2(int)
+      │    └── stats: [rows=10, distinct(1)=10, null(1)=0, distinct(2)=10, null(2)=0]
+      │        histogram(1)=  0  0  9  1
+      │                     <--- 0 --- 10
+      │        histogram(2)=  0  0  9  1
+      │                     <--- 0 --- 10
+      └── filters
+           ├── (c0:1 >= 1) AND (c0:1 <= 10) [type=bool, outer=(1), constraints=(/1: [/1 - /10]; tight)]
+           └── (c0:1 = 1) OR (c1:2 = 3) [type=bool, outer=(1,2)]
+
+# Extra zero-cardinality terms should not reduce estimated row count.
+opt
+SELECT c0 FROM t00 WHERE (c0 = 1) OR (c1 = 3) OR
+                         (c0 = -1) OR (c1 = -1)
+----
+project
+ ├── columns: c0:1(int)
+ ├── stats: [rows=1.9]
+ └── select
+      ├── columns: c0:1(int) c1:2(int)
+      ├── stats: [rows=1.9]
+      ├── scan t00
+      │    ├── columns: c0:1(int) c1:2(int)
+      │    └── stats: [rows=10, distinct(1)=10, null(1)=0, distinct(2)=10, null(2)=0]
+      │        histogram(1)=  0  0  9  1
+      │                     <--- 0 --- 10
+      │        histogram(2)=  0  0  9  1
+      │                     <--- 0 --- 10
+      └── filters
+           └── (((c0:1 = 1) OR (c1:2 = 3)) OR (c0:1 = -1)) OR (c1:2 = -1) [type=bool, outer=(1,2)]
+
+# Selectivity should not exceed 1.
+opt
+SELECT c0 FROM t00 WHERE (c0 between 0 and 10) OR (c1 between 0 and 10)
+----
+project
+ ├── columns: c0:1(int)
+ ├── stats: [rows=10]
+ └── select
+      ├── columns: c0:1(int) c1:2(int)
+      ├── stats: [rows=10]
+      ├── scan t00
+      │    ├── columns: c0:1(int) c1:2(int)
+      │    └── stats: [rows=10, distinct(1)=10, null(1)=0, distinct(2)=10, null(2)=0]
+      │        histogram(1)=  0  0  9  1
+      │                     <--- 0 --- 10
+      │        histogram(2)=  0  0  9  1
+      │                     <--- 0 --- 10
+      └── filters
+           └── ((c0:1 >= 0) AND (c0:1 <= 10)) OR ((c1:2 >= 0) AND (c1:2 <= 10)) [type=bool, outer=(1,2)]
+
+# Selectivity of ORed terms on multiple different columns is roughly additive.
+opt
+SELECT c0 FROM t00 WHERE
+(c0 = 1) OR (c1 = 1) OR (c2 = 1) OR (c3 = 1) OR (c4 = 1) OR (c5 = 1)
+----
+project
+ ├── columns: c0:1(int)
+ ├── stats: [rows=4.68559]
+ └── select
+      ├── columns: c0:1(int) c1:2(int) c2:3(int) c3:4(int) c4:5(int) c5:6(int)
+      ├── stats: [rows=4.68559]
+      ├── scan t00
+      │    ├── columns: c0:1(int) c1:2(int) c2:3(int) c3:4(int) c4:5(int) c5:6(int)
+      │    └── stats: [rows=10, distinct(1)=10, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0, distinct(4)=10, null(4)=0, distinct(5)=10, null(5)=0, distinct(6)=10, null(6)=0]
+      │        histogram(1)=  0  0  9  1
+      │                     <--- 0 --- 10
+      │        histogram(2)=  0  0  9  1
+      │                     <--- 0 --- 10
+      │        histogram(3)=  0  0  9  1
+      │                     <--- 0 --- 10
+      │        histogram(4)=  0  0  9  1
+      │                     <--- 0 --- 10
+      │        histogram(5)=  0  0  9  1
+      │                     <--- 0 --- 10
+      │        histogram(6)=  0  0  9  1
+      │                     <--- 0 --- 10
+      └── filters
+           └── (((((c0:1 = 1) OR (c1:2 = 1)) OR (c2:3 = 1)) OR (c3:4 = 1)) OR (c4:5 = 1)) OR (c5:6 = 1) [type=bool, outer=(1-6)]
+
+# Expected row count 0.19
+opt
+SELECT c0 FROM t00 WHERE (c0 = 1 AND (c1 = 1 OR c2 = 1))
+----
+project
+ ├── columns: c0:1(int!null)
+ ├── stats: [rows=0.19]
+ ├── fd: ()-->(1)
+ └── select
+      ├── columns: c0:1(int!null) c1:2(int) c2:3(int)
+      ├── stats: [rows=0.19, distinct(1)=0.19, null(1)=0]
+      │   histogram(1)=  0 0.19
+      │                <--- 1 -
+      ├── fd: ()-->(1)
+      ├── scan t00
+      │    ├── columns: c0:1(int) c1:2(int) c2:3(int)
+      │    └── stats: [rows=10, distinct(1)=10, null(1)=0, distinct(2)=10, null(2)=0, distinct(3)=10, null(3)=0]
+      │        histogram(1)=  0  0  9  1
+      │                     <--- 0 --- 10
+      │        histogram(2)=  0  0  9  1
+      │                     <--- 0 --- 10
+      │        histogram(3)=  0  0  9  1
+      │                     <--- 0 --- 10
+      └── filters
+           ├── c0:1 = 1 [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+           └── (c1:2 = 1) OR (c2:3 = 1) [type=bool, outer=(2,3)]
+
+# The estimated row count here should be approximately twice that of the above
+# query, but the optimizer is currently unable to handle more complex
+# predicates and ends up using the default 1/3 selectivity.
+# TODO(msirek): More work is needed for nested ANDs and ORs.
+opt
+SELECT c0 FROM t00 WHERE (c0 = 1 AND (c1 = 1 OR c2 = 1)) OR
+                         (c3 = 2 AND (c4 = 2 OR c5 = 2))
+----
+project
+ ├── columns: c0:1(int)
+ ├── stats: [rows=3.333333]
+ └── select
+      ├── columns: c0:1(int) c1:2(int) c2:3(int) c3:4(int) c4:5(int) c5:6(int)
+      ├── stats: [rows=3.333333]
+      ├── scan t00
+      │    ├── columns: c0:1(int) c1:2(int) c2:3(int) c3:4(int) c4:5(int) c5:6(int)
+      │    └── stats: [rows=10]
+      └── filters
+           └── ((c0:1 = 1) AND ((c1:2 = 1) OR (c2:3 = 1))) OR ((c3:4 = 2) AND ((c4:5 = 2) OR (c5:6 = 2))) [type=bool, outer=(1-6)]
+
+# End tests for selectivity of disjunctions

--- a/pkg/sql/opt/memo/testdata/stats_quality/tpcc
+++ b/pkg/sql/opt/memo/testdata/stats_quality/tpcc
@@ -1649,7 +1649,7 @@ scalar-group-by
  ├── select
  │    ├── save-table-name: consistency_12_select_2
  │    ├── columns: o_id:1(int) o_d_id:2(int) o_w_id:3(int) ol_o_id:11(int) ol_d_id:12(int) ol_w_id:13(int)
- │    ├── stats: [rows=629603.7, distinct(1)=2999, null(1)=440660, distinct(2)=10, null(2)=440660, distinct(3)=10, null(3)=440660, distinct(11)=2999, null(11)=0, distinct(12)=10, null(12)=0, distinct(13)=10, null(13)=0]
+ │    ├── stats: [rows=629393.8, distinct(1)=2999, null(1)=440513, distinct(2)=10, null(2)=440513, distinct(3)=10, null(3)=440513, distinct(11)=2999, null(11)=0, distinct(12)=10, null(12)=0, distinct(13)=10, null(13)=0]
  │    ├── full-join (merge)
  │    │    ├── save-table-name: consistency_12_merge_join_3
  │    │    ├── columns: o_id:1(int) o_d_id:2(int) o_w_id:3(int) ol_o_id:11(int) ol_d_id:12(int) ol_w_id:13(int)
@@ -1739,12 +1739,12 @@ column_names  row_count  distinct_count  null_count
 {ol_w_id}     0          0               0
 ~~~~
 column_names  row_count_est  row_count_err  distinct_count_est  distinct_count_err  null_count_est  null_count_err
-{o_d_id}      629604.00      +Inf <==       10.00               +Inf <==            440660.00       +Inf <==
-{o_id}        629604.00      +Inf <==       2999.00             +Inf <==            440660.00       +Inf <==
-{o_w_id}      629604.00      +Inf <==       10.00               +Inf <==            440660.00       +Inf <==
-{ol_d_id}     629604.00      +Inf <==       10.00               +Inf <==            0.00            1.00
-{ol_o_id}     629604.00      +Inf <==       2999.00             +Inf <==            0.00            1.00
-{ol_w_id}     629604.00      +Inf <==       10.00               +Inf <==            0.00            1.00
+{o_d_id}      629394.00      +Inf <==       10.00               +Inf <==            440513.00       +Inf <==
+{o_id}        629394.00      +Inf <==       2999.00             +Inf <==            440513.00       +Inf <==
+{o_w_id}      629394.00      +Inf <==       10.00               +Inf <==            440513.00       +Inf <==
+{ol_d_id}     629394.00      +Inf <==       10.00               +Inf <==            0.00            1.00
+{ol_o_id}     629394.00      +Inf <==       2999.00             +Inf <==            0.00            1.00
+{ol_w_id}     629394.00      +Inf <==       10.00               +Inf <==            0.00            1.00
 
 ----Stats for consistency_12_merge_join_3----
 column_names  row_count  distinct_count  null_count

--- a/pkg/sql/opt/xform/testdata/coster/join
+++ b/pkg/sql/opt/xform/testdata/coster/join
@@ -168,7 +168,7 @@ inner-join (cross)
  ├── fd: (1)-->(2), (6)-->(7)
  ├── scan g [as=g1]
  │    ├── columns: g1.k:1!null g1.geom:2
- │    ├── stats: [rows=1000]
+ │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0]
  │    ├── cost: 1064.42
  │    ├── key: (1)
  │    └── fd: (1)-->(2)

--- a/pkg/sql/opt/xform/testdata/rules/disjunction_in_join
+++ b/pkg/sql/opt/xform/testdata/rules/disjunction_in_join
@@ -716,7 +716,7 @@ select
                 │    ├── limit hint: 1.00
                 │    ├── scan d
                 │    │    ├── columns: d1:7 d2:8
-                │    │    └── limit hint: 50.00
+                │    │    └── limit hint: 50.25
                 │    └── filters
                 │         └── (d1:7 = 4) OR (d2:8 = 50) [outer=(7,8)]
                 └── 1

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -8304,7 +8304,7 @@ memo (optimized, ~22KB, required=[presentation: k:1,a:2,b:3,c:4])
  ├── G4: (scan t58390@t58390_c_idx,partial,cols=(1,4))
  │    └── []
  │         ├── best: (scan t58390@t58390_c_idx,partial,cols=(1,4))
- │         └── cost: 707.35
+ │         └── cost: 591.80
  ├── G5: (union-all G8 G9)
  │    ├── [ordering: +1]
  │    │    ├── best: (union-all G8="[ordering: +7]" G9="[ordering: +13]")
@@ -8344,10 +8344,10 @@ memo (optimized, ~22KB, required=[presentation: k:1,a:2,b:3,c:4])
  ├── G17: (index-join G26 t58390,cols=(7-10))
  │    ├── [ordering: +7]
  │    │    ├── best: (index-join G26="[ordering: +7]" t58390,cols=(7-10))
- │    │    └── cost: 4905.87
+ │    │    └── cost: 4087.63
  │    └── []
  │         ├── best: (index-join G26 t58390,cols=(7-10))
- │         └── cost: 4754.04
+ │         └── cost: 3964.04
  ├── G18: (scan t58390,cols=(13-16))
  │    ├── [ordering: +13]
  │    │    ├── best: (scan t58390,cols=(13-16))
@@ -8359,10 +8359,10 @@ memo (optimized, ~22KB, required=[presentation: k:1,a:2,b:3,c:4])
  ├── G20: (index-join G28 t58390,cols=(13-16))
  │    ├── [ordering: +13]
  │    │    ├── best: (index-join G28="[ordering: +13]" t58390,cols=(13-16))
- │    │    └── cost: 4905.87
+ │    │    └── cost: 4087.63
  │    └── []
  │         ├── best: (index-join G28 t58390,cols=(13-16))
- │         └── cost: 4754.04
+ │         └── cost: 3964.04
  ├── G21: (variable a)
  ├── G22: (variable b)
  ├── G23: (variable c)
@@ -8371,18 +8371,18 @@ memo (optimized, ~22KB, required=[presentation: k:1,a:2,b:3,c:4])
  ├── G26: (scan t58390@t58390_c_idx,partial,cols=(7,10))
  │    ├── [ordering: +7]
  │    │    ├── best: (sort G26)
- │    │    └── cost: 859.18
+ │    │    └── cost: 715.39
  │    └── []
  │         ├── best: (scan t58390@t58390_c_idx,partial,cols=(7,10))
- │         └── cost: 707.35
+ │         └── cost: 591.80
  ├── G27: (gt G30 G24)
  ├── G28: (scan t58390@t58390_c_idx,partial,cols=(13,16))
  │    ├── [ordering: +13]
  │    │    ├── best: (sort G28)
- │    │    └── cost: 859.18
+ │    │    └── cost: 715.39
  │    └── []
  │         ├── best: (scan t58390@t58390_c_idx,partial,cols=(13,16))
- │         └── cost: 707.35
+ │         └── cost: 591.80
  ├── G29: (variable a)
  └── G30: (variable b)
 
@@ -8410,14 +8410,14 @@ memo (optimized, ~33KB, required=[presentation: a:1] [ordering: +2])
  ├── G1: (project G2 G3 a b)
  │    ├── [presentation: a:1] [ordering: +2]
  │    │    ├── best: (sort G1)
- │    │    └── cost: 1094.72
+ │    │    └── cost: 1094.75
  │    └── []
  │         ├── best: (project G2 G3 a b)
- │         └── cost: 1094.68
+ │         └── cost: 1094.69
  ├── G2: (select G4 G5) (select G6 G7) (distinct-on G8 G9 cols=(1)) (distinct-on G8 G9 cols=(1),ordering=+1)
  │    ├── [ordering: +(2|3)]
  │    │    ├── best: (sort G2)
- │    │    └── cost: 1094.70
+ │    │    └── cost: 1094.73
  │    └── []
  │         ├── best: (select G4 G5)
  │         └── cost: 1094.66
@@ -8433,10 +8433,10 @@ memo (optimized, ~33KB, required=[presentation: a:1] [ordering: +2])
  ├── G6: (index-join G12 t61795,cols=(1-3))
  │    ├── [ordering: +2]
  │    │    ├── best: (index-join G12="[ordering: +2]" t61795,cols=(1-3))
- │    │    └── cost: 3050.07
+ │    │    └── cost: 3054.10
  │    └── []
  │         ├── best: (index-join G12 t61795,cols=(1-3))
- │         └── cost: 3050.07
+ │         └── cost: 3054.10
  ├── G7: (filters G10)
  ├── G8: (union-all G13 G14)
  │    ├── [ordering: +(2|3)]


### PR DESCRIPTION
Fixes #75090

Currently, the optimizer only does a good job of estimating the       
selectivity of single-table ORed predicates when all disjuncts are tight  
constraints. Otherwise we give up and go with the default selectivity of    
1/3 for the entire filter. If any of the disjuncts has a selectivity 
above 1/3, then the total selectivity should be at least as high as the 
selectivity of that disjunct. Any failure to find a tight constraint for
a given disjunct should only cause a selectivity of 1/3 to be used for
that disjunct, not the entire filter.  

This is addressed by using the method of combining ORed selectivities
introduced by #74303:
```
   Given predicates A and B and probability function P:

      P(A or B) = P(A) + P(B) - P(A and B)
```
The above formula is applied n-1 times, given n disjuncts.
For each disjunct which is not a tight constraint, 1/3 is used for that
predicate's selectivity in the formula.

Release note (bug fix): This patch fixes incorrect selectivity
estimation for queries with ORed predicates all referencing a
common single table.
