### PR TITLE
sql: remove no longer needed closure of subqueries on error

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -1350,14 +1350,6 @@ func (dsp *DistSQLPlanner) PlanAndRunSubqueries(
 			skipDistSQLDiagramGeneration,
 		); err != nil {
 			recv.SetError(err)
-			// Usually we leave the closure of subqueries to occur when the
-			// whole plan is being closed (i.e. planTop.close); however, since
-			// we've encountered an error, we might never get to the point of
-			// closing the whole plan, so we choose to defensively close the
-			// subqueries here.
-			for i := range subqueryPlans {
-				subqueryPlans[i].plan.Close(ctx)
-			}
 			return false
 		}
 	}


### PR DESCRIPTION
With the recent cleanup of the closing code for the plans we no longer need to explicitly close the subqueries if an error is encountered.

Release note: None