### PR TITLE
kvserver: flush WAL on writing storage checkpoints

### DIFF
--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1762,7 +1762,7 @@ func (p *Pebble) Stat(name string) (os.FileInfo, error) {
 
 // CreateCheckpoint implements the Engine interface.
 func (p *Pebble) CreateCheckpoint(dir string) error {
-	return p.db.Checkpoint(dir)
+	return p.db.Checkpoint(dir, pebble.WithFlushedWAL())
 }
 
 // SetMinVersion implements the Engine interface.


### PR DESCRIPTION
If a consistency check fails, it saves checkpoints on all replicas, to help with further investigation. Flushing WAL was disabled, so some checkpoints could be slightly out of date. This commit fixes that.

Fixes #89287

Release justification: important bug fix
Release note (bug fix): flush WAL when writing storage checkpoints on consistency checker failures