### PR TITLE
storage: omit unnecessary seek in `MVCCDelete`

### DIFF
--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -1281,7 +1281,11 @@ func (*IncrementRequest) flags() flag {
 }
 
 func (*DeleteRequest) flags() flag {
-	return isWrite | isTxn | isLocking | isIntentWrite | appliesTSCache | canBackpressure
+	// isRead because of the FoundKey boolean in the response, indicating whether
+	// an existing key was deleted at the read timestamp. isIntentWrite allows
+	// omitting needsRefresh. For background, see:
+	// https://github.com/cockroachdb/cockroach/pull/89375
+	return isRead | isWrite | isTxn | isLocking | isIntentWrite | appliesTSCache | canBackpressure
 }
 
 func (drr *DeleteRangeRequest) flags() flag {

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -1075,11 +1075,15 @@ func cmdDelete(e *evalCtx) error {
 	localTs := hlc.ClockTimestamp(e.getTsWithName("localTs"))
 	resolve, resolveStatus := e.getResolve()
 	return e.withWriter("del", func(rw storage.ReadWriter) error {
-		deletedKey, err := storage.MVCCDelete(e.ctx, rw, e.ms, key, ts, localTs, txn)
+		foundKey, err := storage.MVCCDelete(e.ctx, rw, e.ms, key, ts, localTs, txn)
+		if err == nil || errors.HasType(err, &roachpb.WriteTooOldError{}) {
+			// We want to output foundKey even if a WriteTooOldError is returned,
+			// since the error may be swallowed/deferred during evaluation.
+			e.results.buf.Printf("del: %v: found key %v\n", key, foundKey)
+		}
 		if err != nil {
 			return err
 		}
-		e.results.buf.Printf("del: %v: found key %v\n", key, deletedKey)
 		if resolve {
 			return e.resolveIntent(rw, key, txn, resolveStatus, hlc.ClockTimestamp{})
 		}

--- a/pkg/storage/testdata/mvcc_histories/deletes
+++ b/pkg/storage/testdata/mvcc_histories/deletes
@@ -84,3 +84,161 @@ data: "a"/47.000000000,0 -> /<empty>
 data: "a"/46.000000000,0 -> /BYTES/abc
 data: "a"/44.000000000,0 -> /<empty>
 data: "b"/49.000000000,0 -> /<empty>
+
+
+# Try deleting historical versions using a txn with an old read timestamp, and
+# ensure "found key" is reported correctly for various timestamps along with the
+# WriteTooOldError (which may be deferred).
+run error
+with t=A
+  txn_begin ts=43
+  txn_advance ts=50
+  del k=a
+----
+del: "a": found key false
+>> at end:
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=43.000000000,0 wto=false gul=0,0
+meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} ts=50.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/50.000000000,0 -> /<empty>
+data: "a"/48.000000000,0 -> /<empty>
+data: "a"/47.000000000,0 -> /<empty>
+data: "a"/46.000000000,0 -> /BYTES/abc
+data: "a"/44.000000000,0 -> /<empty>
+data: "b"/49.000000000,0 -> /<empty>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "a" at timestamp 43.000000000,0 too old; wrote at 50.000000000,0
+
+run ok
+with t=A
+  resolve_intent k=a status=ABORTED
+  txn_remove
+----
+>> at end:
+data: "a"/48.000000000,0 -> /<empty>
+data: "a"/47.000000000,0 -> /<empty>
+data: "a"/46.000000000,0 -> /BYTES/abc
+data: "a"/44.000000000,0 -> /<empty>
+data: "b"/49.000000000,0 -> /<empty>
+
+run error
+with t=A
+  txn_begin ts=44
+  txn_advance ts=50
+  del k=a
+----
+del: "a": found key false
+>> at end:
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=44.000000000,0 wto=false gul=0,0
+meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} ts=50.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/50.000000000,0 -> /<empty>
+data: "a"/48.000000000,0 -> /<empty>
+data: "a"/47.000000000,0 -> /<empty>
+data: "a"/46.000000000,0 -> /BYTES/abc
+data: "a"/44.000000000,0 -> /<empty>
+data: "b"/49.000000000,0 -> /<empty>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "a" at timestamp 44.000000000,0 too old; wrote at 50.000000000,0
+
+run ok
+with t=A
+  resolve_intent k=a status=ABORTED
+  txn_remove
+----
+>> at end:
+data: "a"/48.000000000,0 -> /<empty>
+data: "a"/47.000000000,0 -> /<empty>
+data: "a"/46.000000000,0 -> /BYTES/abc
+data: "a"/44.000000000,0 -> /<empty>
+data: "b"/49.000000000,0 -> /<empty>
+
+run error
+with t=A
+  txn_begin ts=46
+  txn_advance ts=50
+  del k=a
+----
+del: "a": found key true
+>> at end:
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=46.000000000,0 wto=false gul=0,0
+meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} ts=50.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/50.000000000,0 -> /<empty>
+data: "a"/48.000000000,0 -> /<empty>
+data: "a"/47.000000000,0 -> /<empty>
+data: "a"/46.000000000,0 -> /BYTES/abc
+data: "a"/44.000000000,0 -> /<empty>
+data: "b"/49.000000000,0 -> /<empty>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "a" at timestamp 46.000000000,0 too old; wrote at 50.000000000,0
+
+run ok
+with t=A
+  resolve_intent k=a status=ABORTED
+  txn_remove
+----
+>> at end:
+data: "a"/48.000000000,0 -> /<empty>
+data: "a"/47.000000000,0 -> /<empty>
+data: "a"/46.000000000,0 -> /BYTES/abc
+data: "a"/44.000000000,0 -> /<empty>
+data: "b"/49.000000000,0 -> /<empty>
+
+run error
+with t=A
+  txn_begin ts=47
+  txn_advance ts=50
+  del k=a
+----
+del: "a": found key false
+>> at end:
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=47.000000000,0 wto=false gul=0,0
+meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} ts=50.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/50.000000000,0 -> /<empty>
+data: "a"/48.000000000,0 -> /<empty>
+data: "a"/47.000000000,0 -> /<empty>
+data: "a"/46.000000000,0 -> /BYTES/abc
+data: "a"/44.000000000,0 -> /<empty>
+data: "b"/49.000000000,0 -> /<empty>
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "a" at timestamp 47.000000000,0 too old; wrote at 50.000000000,0
+
+run ok
+with t=A
+  resolve_intent k=a status=ABORTED
+  txn_remove
+----
+>> at end:
+data: "a"/48.000000000,0 -> /<empty>
+data: "a"/47.000000000,0 -> /<empty>
+data: "a"/46.000000000,0 -> /BYTES/abc
+data: "a"/44.000000000,0 -> /<empty>
+data: "b"/49.000000000,0 -> /<empty>
+
+run ok
+with t=A
+  txn_begin ts=49
+  txn_advance ts=50
+  del k=a
+----
+del: "a": found key false
+>> at end:
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=49.000000000,0 wto=false gul=0,0
+meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} ts=50.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/50.000000000,0 -> /<empty>
+data: "a"/48.000000000,0 -> /<empty>
+data: "a"/47.000000000,0 -> /<empty>
+data: "a"/46.000000000,0 -> /BYTES/abc
+data: "a"/44.000000000,0 -> /<empty>
+data: "b"/49.000000000,0 -> /<empty>
+
+# Delete an inline value, both missing and existing.
+run ok
+del k=i
+put k=i v=inline
+del k=i
+----
+del: "i": found key false
+del: "i": found key true
+>> at end:
+meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} ts=50.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/50.000000000,0 -> /<empty>
+data: "a"/48.000000000,0 -> /<empty>
+data: "a"/47.000000000,0 -> /<empty>
+data: "a"/46.000000000,0 -> /BYTES/abc
+data: "a"/44.000000000,0 -> /<empty>
+data: "b"/49.000000000,0 -> /<empty>

--- a/pkg/storage/testdata/mvcc_histories/write_too_old
+++ b/pkg/storage/testdata/mvcc_histories/write_too_old
@@ -19,6 +19,7 @@ with t=A
   txn_begin  ts=33
   del   k=a
 ----
+del: "a": found key false
 >> at end:
 txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=33.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=33.000000000,0 wto=false gul=0,0
 meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=44.000000000,1 min=0,0 seq=0} ts=44.000000000,1 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true


### PR DESCRIPTION
**roachpb: set `isRead` for `DeleteRequest`**

`DeleteRequest` performs a read to determine whether an existing, live
key was deleted, in order to populate the `DeleteResponse.FoundKey`
field. It must therefore have the `isRead` flag in order to avoid
deferring the `WriteTooOldError` and returning a possibly incorrect
value in the case of a write-write conflict (if the delete was submitted
below a newer key).

This has no externally visible effect on KV callers, because the
`WriteTooOldError` is retried on the client side (in
`txnSpanRefresher`), but it does violate the server contract. The flag
may also avoid an unnecessary Raft round trip to lay down an intent that
would be replaced later anyway.

Release note: None

**storage: omit unnecessary seek in `MVCCDelete`**

Recently, `MVCCDelete` was extended to return a boolean indicating
whether an existing, live key was deleted. This relied on passing a
`valueFn` callback to `mvccPutInternal()` which inspected the existing
value. Unfortunately, this incurs an additional, expensive seek. In the
common case when writing above the latest version, `mvccPutInternal`
has already read the existing value when synthesizing the meta record,
making this additional seek unnecessary.

This patch takes a conservative approach, by modifying `mvccPutInternal`
to return a boolean indicating whether an existing value was replaced by
the put. This is motivated by backport concerns. It does, however, incur
an additional read for all write-write conflicts, not just `MVCCDelete`,
but this cost is expected to be negligible considering the cost of a
transaction refresh.

A better solution might be to remove the need for an additional seek
with `valueFn` in the common case, which would also benefit e.g.
`MVCCConditionalPut` and `MVCCIncrement`, and avoid the read for
non-delete writes. This is left for the future.

```
name                     old time/op  new time/op  delta
MVCCPutDelete_Pebble-24  20.0µs ± 7%  15.5µs ± 3%  -22.43%  (p=0.008 n=5+5)

name                            old time/op  new time/op  delta
KV/Delete/Native/rows=1-24       153µs ± 6%   146µs ± 6%   -4.41%  (p=0.009 n=10+10)
KV/Delete/Native/rows=10-24      278µs ± 3%   227µs ± 4%  -18.22%  (p=0.000 n=10+10)
KV/Delete/Native/rows=100-24    1.28ms ± 3%  0.86ms ± 4%  -33.01%  (p=0.000 n=10+10)
KV/Delete/Native/rows=1000-24   10.8ms ± 4%   6.0ms ± 6%  -44.98%  (p=0.000 n=10+10)
KV/Delete/Native/rows=10000-24   110ms ± 4%    62ms ± 5%  -43.88%  (p=0.000 n=10+10)
KV/Delete/SQL/rows=1-24          598µs ± 2%   588µs ± 2%   -1.62%  (p=0.009 n=10+10)
KV/Delete/SQL/rows=10-24         753µs ± 3%   701µs ± 2%   -6.90%  (p=0.000 n=10+10)
KV/Delete/SQL/rows=100-24       2.34ms ± 2%  1.77ms ± 1%  -24.42%  (p=0.000 n=10+9)
KV/Delete/SQL/rows=1000-24      26.0ms ± 4%  18.5ms ± 1%  -29.08%  (p=0.000 n=10+9)
KV/Delete/SQL/rows=10000-24      248ms ± 8%   185ms ± 4%  -25.40%  (p=0.000 n=10+10)
```

Resolves #89253.

Release note: None