### PR TITLE
sctest: deflake backup test

### DIFF
--- a/pkg/sql/schemachanger/scrun/scrun.go
+++ b/pkg/sql/schemachanger/scrun/scrun.go
@@ -158,13 +158,15 @@ func executeStage(
 	stageIdx int,
 	stage scplan.Stage,
 ) (err error) {
+
+	log.Infof(ctx, "executing %s (rollback=%v)", stage, p.InRollback)
+
 	if knobs != nil && knobs.BeforeStage != nil {
 		if err := knobs.BeforeStage(p, stageIdx); err != nil {
 			return err
 		}
 	}
 
-	log.Infof(ctx, "executing %s (rollback=%v)", stage, p.InRollback)
 	start := timeutil.Now()
 	defer func() {
 		if log.ExpensiveLogEnabled(ctx, 2) {

--- a/pkg/sql/schemachanger/sctest/cumulative.go
+++ b/pkg/sql/schemachanger/sctest/cumulative.go
@@ -534,6 +534,10 @@ func Backup(t *testing.T, path string, newCluster NewClusterFunc) {
 			if s.p.InRollback {
 				rollbackStage++
 			}
+			if done {
+				t.Logf("reached final stage, waiting for completion")
+				stageChan = nil // allow the restored jobs to proceed
+			}
 			if shouldFail {
 				s.resume <- errors.Newf("boom %d", i)
 			} else {
@@ -545,7 +549,7 @@ func Backup(t *testing.T, path string, newCluster NewClusterFunc) {
 		} else {
 			require.NoError(t, err)
 		}
-		stageChan = nil // allow the restored jobs to proceed
+
 		t.Logf("finished")
 
 		for i, b := range backups {


### PR DESCRIPTION
The bug was that we might have a transaction restart in the last stage which would result in the test being unable to finish. To fix this, we allow restarts of the last stage to proceeed.

Fixes #88577

Release note: None