### PR TITLE
ttl: Remove ttl_range_concurrency config

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -288,7 +288,6 @@ sql.trace.stmt.enable_threshold	duration	0s	enables tracing on all statements; s
 sql.trace.txn.enable_threshold	duration	0s	enables tracing on all transactions; transactions open for longer than this duration will have their trace logged (set to 0 to disable); note that enabling this may have a negative performance impact; this setting is coarser-grained than sql.trace.stmt.enable_threshold because it applies to all statements within a transaction as well as client communication (e.g. retries)
 sql.ttl.default_delete_batch_size	integer	100	default amount of rows to delete in a single query during a TTL job
 sql.ttl.default_delete_rate_limit	integer	0	default delete rate limit for all TTL jobs. Use 0 to signify no rate limit.
-sql.ttl.default_range_concurrency	integer	1	default amount of ranges to process at once during a TTL delete
 sql.ttl.default_select_batch_size	integer	500	default amount of rows to select in a single query during a TTL job
 sql.ttl.job.enabled	boolean	true	whether the TTL job is enabled
 sql.txn_fingerprint_id_cache.capacity	integer	100	the maximum number of txn fingerprint IDs stored

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -222,7 +222,6 @@
 <tr><td><code>sql.trace.txn.enable_threshold</code></td><td>duration</td><td><code>0s</code></td><td>enables tracing on all transactions; transactions open for longer than this duration will have their trace logged (set to 0 to disable); note that enabling this may have a negative performance impact; this setting is coarser-grained than sql.trace.stmt.enable_threshold because it applies to all statements within a transaction as well as client communication (e.g. retries)</td></tr>
 <tr><td><code>sql.ttl.default_delete_batch_size</code></td><td>integer</td><td><code>100</code></td><td>default amount of rows to delete in a single query during a TTL job</td></tr>
 <tr><td><code>sql.ttl.default_delete_rate_limit</code></td><td>integer</td><td><code>0</code></td><td>default delete rate limit for all TTL jobs. Use 0 to signify no rate limit.</td></tr>
-<tr><td><code>sql.ttl.default_range_concurrency</code></td><td>integer</td><td><code>1</code></td><td>default amount of ranges to process at once during a TTL delete</td></tr>
 <tr><td><code>sql.ttl.default_select_batch_size</code></td><td>integer</td><td><code>500</code></td><td>default amount of rows to select in a single query during a TTL job</td></tr>
 <tr><td><code>sql.ttl.job.enabled</code></td><td>boolean</td><td><code>true</code></td><td>whether the TTL job is enabled</td></tr>
 <tr><td><code>sql.txn_fingerprint_id_cache.capacity</code></td><td>integer</td><td><code>100</code></td><td>the maximum number of txn fingerprint IDs stored</td></tr>

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -1019,12 +1019,18 @@ message RowLevelTTLDetails {
 }
 
 message RowLevelTTLProgress {
+
   // JobRowCount is the number of deleted rows for the entire TTL job.
   int64 job_row_count = 1;
+
   // ProcessorProgresses is the progress per DistSQL processor.
   repeated RowLevelTTLProcessorProgress processor_progresses = 2 [(gogoproto.nullable)=false];
 
+  // UseDistSQL is true if the TTL job distributed the work to DistSQL processors (requires cluster v22.2).
   bool use_dist_sql = 3 [(gogoproto.customname) = "UseDistSQL"];
+
+  // JobSpanCount is the number of spans for the entire TTL job.
+  int64 job_span_count = 4;
 }
 
 message RowLevelTTLProcessorProgress {
@@ -1041,6 +1047,12 @@ message RowLevelTTLProcessorProgress {
 
   // ProcessorRowCount is the row count of the DistSQL processor.
   int64 processor_row_count = 3;
+
+  // ProcessorSpanCount is the number of spans of the DistSQL processor;
+  int64 processor_span_count = 4;
+
+  // ProcessorConcurrency is the number parallel tasks the processor will do at once.
+  int64 processor_concurrency = 5;
 }
 
 message SchemaTelemetryDetails {

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -145,6 +145,9 @@ var retiredSettings = map[string]struct{}{
 	"kv.refresh_range.time_bound_iterators.enabled":             {},
 	"sql.defaults.datestyle.enabled":                            {},
 	"sql.defaults.intervalstyle.enabled":                        {},
+
+	// removed as of 22.2.1
+	"sql.ttl.default_range_concurrency": {},
 }
 
 // sqlDefaultSettings is the list of "grandfathered" existing sql.defaults

--- a/pkg/sql/catalog/catpb/catalog.proto
+++ b/pkg/sql/catalog/catpb/catalog.proto
@@ -204,8 +204,8 @@ message RowLevelTTL {
   optional string deletion_cron = 4 [(gogoproto.nullable)=false];
   // ScheduleID is the ID of the row-level TTL job schedules.
   optional int64 schedule_id = 5 [(gogoproto.customname)="ScheduleID",(gogoproto.nullable)=false];
-  // RangeConcurrency is the number of ranges to process at a time.
-  optional int64 range_concurrency = 6 [(gogoproto.nullable)=false];
+  // RangeConcurrency is based on the number of spans and is no longer configurable.
+  reserved 6;
   // DeleteRateLimit is the maximum amount of rows to delete per second.
   optional int64 delete_rate_limit = 7 [(gogoproto.nullable)=false];
   // Pause is set if the TTL job should not run.

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -2627,9 +2627,6 @@ func (desc *wrapper) GetStorageParams(spaceBetweenEqual bool) []string {
 		if bs := ttl.DeleteBatchSize; bs != 0 {
 			appendStorageParam(`ttl_delete_batch_size`, fmt.Sprintf(`%d`, bs))
 		}
-		if rc := ttl.RangeConcurrency; rc != 0 {
-			appendStorageParam(`ttl_range_concurrency`, fmt.Sprintf(`%d`, rc))
-		}
 		if rl := ttl.DeleteRateLimit; rl != 0 {
 			appendStorageParam(`ttl_delete_rate_limit`, fmt.Sprintf(`%d`, rl))
 		}

--- a/pkg/sql/catalog/tabledesc/ttl.go
+++ b/pkg/sql/catalog/tabledesc/ttl.go
@@ -51,11 +51,6 @@ func ValidateRowLevelTTL(ttl *catpb.RowLevelTTL) error {
 			return err
 		}
 	}
-	if ttl.RangeConcurrency != 0 {
-		if err := ValidateTTLRangeConcurrency("ttl_range_concurrency", ttl.RangeConcurrency); err != nil {
-			return err
-		}
-	}
 	if ttl.DeleteRateLimit != 0 {
 		if err := ValidateTTLRateLimit("ttl_delete_rate_limit", ttl.DeleteRateLimit); err != nil {
 			return err
@@ -145,18 +140,6 @@ func ValidateTTLExpirationColumn(desc catalog.TableDescriptor) error {
 
 // ValidateTTLBatchSize validates the batch size of a TTL.
 func ValidateTTLBatchSize(key string, val int64) error {
-	if val <= 0 {
-		return pgerror.Newf(
-			pgcode.InvalidParameterValue,
-			`"%s" must be at least 1`,
-			key,
-		)
-	}
-	return nil
-}
-
-// ValidateTTLRangeConcurrency validates the batch size of a TTL.
-func ValidateTTLRangeConcurrency(key string, val int64) error {
 	if val <= 0 {
 		return pgerror.Newf(
 			pgcode.InvalidParameterValue,

--- a/pkg/sql/execinfrapb/processors_ttl.proto
+++ b/pkg/sql/execinfrapb/processors_ttl.proto
@@ -59,9 +59,8 @@ message TTLSpec {
   // flow.
   repeated roachpb.Span spans = 5 [(gogoproto.nullable) = false];
 
-  // RangeConcurrency controls how many ranges a single ttlProcessor processes
-  // in parallel.
-  optional int64 range_concurrency = 6 [(gogoproto.nullable) = false];
+  // RangeConcurrency is based on the number of spans and is no longer configurable.
+  reserved 6;
 
   // SelectBatchSize controls the batch size for SELECTs.
   optional int64 select_batch_size = 7 [(gogoproto.nullable) = false];

--- a/pkg/sql/logictest/testdata/logic_test/row_level_ttl
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_ttl
@@ -40,7 +40,7 @@ CREATE TABLE tbl (id INT PRIMARY KEY, text TEXT) WITH (ttl = 'on')
 
 subtest end
 
-subtest todo_add_subtests
+subtest ttl_automatic_column_notice
 
 query T noticetrace
 CREATE TABLE tbl_ttl_automatic_column (id INT PRIMARY KEY, text TEXT) WITH (ttl_automatic_column = 'on')
@@ -51,6 +51,24 @@ query T noticetrace
 ALTER TABLE tbl_ttl_automatic_column RESET (ttl_automatic_column)
 ----
 NOTICE: ttl_automatic_column is no longer used. Setting ttl_expire_after automatically creates a TTL column. Resetting ttl_expire_after removes the automatically created column.
+
+subtest end
+
+subtest ttl_range_concurrency_notice
+
+query T noticetrace
+CREATE TABLE tbl_ttl_range_concurrency (id INT PRIMARY KEY, text TEXT) WITH (ttl_range_concurrency = 2)
+----
+NOTICE: ttl_range_concurrency is no longer configurable.
+
+query T noticetrace
+ALTER TABLE tbl_ttl_range_concurrency RESET (ttl_range_concurrency)
+----
+NOTICE: ttl_range_concurrency is no longer configurable.
+
+subtest end
+
+subtest todo_add_subtests
 
 statement error expected DEFAULT expression of crdb_internal_expiration to be current_timestamp\(\):::TIMESTAMPTZ \+ '00:10:00':::INTERVAL
 CREATE TABLE tbl (
@@ -432,12 +450,12 @@ CREATE TABLE tbl (
   id INT PRIMARY KEY,
   text TEXT,
   FAMILY (id, text)
-) WITH (ttl_expire_after = '10 minutes', ttl_select_batch_size = 50, ttl_range_concurrency = 2, ttl_delete_rate_limit = 100, ttl_pause = true, ttl_row_stats_poll_interval = '1 minute', ttl_label_metrics = true)
+) WITH (ttl_expire_after = '10 minutes', ttl_select_batch_size = 50, ttl_delete_rate_limit = 100, ttl_pause = true, ttl_row_stats_poll_interval = '1 minute', ttl_label_metrics = true)
 
 query T
 SELECT reloptions FROM pg_class WHERE relname = 'tbl'
 ----
-{ttl='on',ttl_expire_after='00:10:00':::INTERVAL,ttl_job_cron='@hourly',ttl_select_batch_size=50,ttl_range_concurrency=2,ttl_delete_rate_limit=100,ttl_pause=true,ttl_row_stats_poll_interval='1m0s',ttl_label_metrics=true}
+{ttl='on',ttl_expire_after='00:10:00':::INTERVAL,ttl_job_cron='@hourly',ttl_select_batch_size=50,ttl_delete_rate_limit=100,ttl_pause=true,ttl_row_stats_poll_interval='1m0s',ttl_label_metrics=true}
 
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl]
@@ -448,7 +466,7 @@ CREATE TABLE public.tbl (
                                                                                                                                                                                                                                                                                             crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
                                                                                                                                                                                                                                                                                             CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
                                                                                                                                                                                                                                                                                             FAMILY fam_0_id_text_crdb_internal_expiration (id, text, crdb_internal_expiration)
-) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@hourly', ttl_select_batch_size = 50, ttl_range_concurrency = 2, ttl_delete_rate_limit = 100, ttl_pause = true, ttl_row_stats_poll_interval = '1m0s', ttl_label_metrics = true)
+) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@hourly', ttl_select_batch_size = 50, ttl_delete_rate_limit = 100, ttl_pause = true, ttl_row_stats_poll_interval = '1m0s', ttl_label_metrics = true)
 
 statement ok
 ALTER TABLE tbl SET (ttl_delete_batch_size = 100)
@@ -462,16 +480,13 @@ CREATE TABLE public.tbl (
                                                                                                                                                                                                                                                                                                                          crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
                                                                                                                                                                                                                                                                                                                          CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
                                                                                                                                                                                                                                                                                                                          FAMILY fam_0_id_text_crdb_internal_expiration (id, text, crdb_internal_expiration)
-) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@hourly', ttl_select_batch_size = 50, ttl_delete_batch_size = 100, ttl_range_concurrency = 2, ttl_delete_rate_limit = 100, ttl_pause = true, ttl_row_stats_poll_interval = '1m0s', ttl_label_metrics = true)
+) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@hourly', ttl_select_batch_size = 50, ttl_delete_batch_size = 100, ttl_delete_rate_limit = 100, ttl_pause = true, ttl_row_stats_poll_interval = '1m0s', ttl_label_metrics = true)
 
 statement error "ttl_select_batch_size" must be at least 1
 ALTER TABLE tbl SET (ttl_select_batch_size = -1)
 
 statement error "ttl_delete_batch_size" must be at least 1
 ALTER TABLE tbl SET (ttl_delete_batch_size = -1)
-
-statement error "ttl_range_concurrency" must be at least 1
-ALTER TABLE tbl SET (ttl_range_concurrency = -1)
 
 statement error "ttl_delete_rate_limit" must be at least 1
 ALTER TABLE tbl SET (ttl_delete_rate_limit = -1)
@@ -480,7 +495,7 @@ statement error "ttl_row_stats_poll_interval" must be at least 1
 ALTER TABLE tbl SET (ttl_row_stats_poll_interval = '-1 second')
 
 statement ok
-ALTER TABLE tbl RESET (ttl_delete_batch_size, ttl_select_batch_size, ttl_range_concurrency, ttl_delete_rate_limit, ttl_pause, ttl_row_stats_poll_interval)
+ALTER TABLE tbl RESET (ttl_delete_batch_size, ttl_select_batch_size, ttl_delete_rate_limit, ttl_pause, ttl_row_stats_poll_interval)
 
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl]

--- a/pkg/sql/ttl/ttljob/ttljob_query_builder_test.go
+++ b/pkg/sql/ttl/ttljob/ttljob_query_builder_test.go
@@ -45,7 +45,7 @@ func TestSelectQueryBuilder(t *testing.T) {
 				mockTime,
 				[]string{"col1", "col2"},
 				"relation_name",
-				rangeToProcess{
+				spanToProcess{
 					startPK: tree.Datums{tree.NewDInt(100), tree.NewDInt(5)},
 					endPK:   tree.Datums{tree.NewDInt(200), tree.NewDInt(15)},
 				},
@@ -111,7 +111,7 @@ LIMIT 2`,
 				mockTime,
 				[]string{"col1", "col2"},
 				"table_name",
-				rangeToProcess{},
+				spanToProcess{},
 				mockTime,
 				2,
 				colinfo.TTLDefaultExpirationColumnName,
@@ -170,7 +170,7 @@ LIMIT 2`,
 				mockTime,
 				[]string{"col1", "col2"},
 				"table_name",
-				rangeToProcess{
+				spanToProcess{
 					startPK: tree.Datums{tree.NewDInt(100)},
 					endPK:   tree.Datums{tree.NewDInt(181)},
 				},
@@ -236,7 +236,7 @@ LIMIT 2`,
 				mockTime,
 				[]string{"col1", "col2"},
 				"table_name",
-				rangeToProcess{
+				spanToProcess{
 					endPK: tree.Datums{tree.NewDInt(200), tree.NewDInt(15)},
 				},
 				mockTime,
@@ -300,7 +300,7 @@ LIMIT 2`,
 				mockTime,
 				[]string{"col1", "col2"},
 				"table_name",
-				rangeToProcess{
+				spanToProcess{
 					startPK: tree.Datums{tree.NewDInt(100), tree.NewDInt(5)},
 				},
 				mockTime,


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/89393

see https://github.com/cockroachdb/cockroach/pull/89392 for benchmarking

To simplify TTL setup, range concurrency is set to min(num_spans, num_cpus)
in each processor instead of letting the user set it.

Release note (sql change): Cluster setting sql.ttl.default_range_concurrency
and table storage param ttl_range_concurrency are no longer configurable.