### PR TITLE
insights: stop retaining sibling statements

### DIFF
--- a/pkg/sql/sqlstats/insights/BUILD.bazel
+++ b/pkg/sql/sqlstats/insights/BUILD.bazel
@@ -45,6 +45,7 @@ go_test(
         "//pkg/roachpb",
         "//pkg/settings/cluster",
         "//pkg/sql/clusterunique",
+        "//pkg/testutils/skip",
         "//pkg/util/stop",
         "//pkg/util/uint128",
         "//pkg/util/uuid",

--- a/pkg/sql/sqlstats/insights/integration/insights_test.go
+++ b/pkg/sql/sqlstats/insights/integration/insights_test.go
@@ -124,6 +124,8 @@ func TestInsightsIntegration(t *testing.T) {
 }
 
 func TestInsightsPriorityIntegration(t *testing.T) {
+	skip.WithIssue(t, 89398, "retaining sibling statements may consume too much memory")
+
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -328,6 +330,8 @@ func TestInsightsIntegrationForContention(t *testing.T) {
 // Testing that the index recommendation is included
 // in the insights table
 func TestInsightsIndexRecommendationIntegration(t *testing.T) {
+	skip.WithIssue(t, 89398, "retaining sibling statements may consume too much memory")
+
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 

--- a/pkg/sql/sqlstats/insights/registry_test.go
+++ b/pkg/sql/sqlstats/insights/registry_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/clusterunique"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/uint128"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/stretchr/testify/require"
@@ -180,6 +181,8 @@ func TestRegistry(t *testing.T) {
 	})
 
 	t.Run("sibling statements without problems", func(t *testing.T) {
+		skip.WithIssue(t, 89398, "retaining sibling statements may consume too much memory")
+
 		siblingStatment := &Statement{
 			ID:            clusterunique.IDFromBytes([]byte("dddddddddddddddddddddddddddddddd")),
 			FingerprintID: roachpb.StmtFingerprintID(101),


### PR DESCRIPTION
We've observed large lateral joins consuming unreasonable amounts of memory, due to the insights subsystem's behavior of reporting all statements in a transaction with one problematic statement.

This patch removes that sibling retention altogether, holding onto only statements that we've already determined to be problematic.

This patch is a work in progress. Before landing, we'll want to get input from product and possibly consider less severe restrictions, including buffering N statements per transaction instead of all of them. We also want to fix up the skipped tests.