### PR TITLE
release-22.1: cdc: use highwater, if set, to get table descriptors in alter changefeed.

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
@@ -109,9 +109,23 @@ func alterChangefeedPlanHook(
 		}
 		newChangefeedStmt.SinkURI = tree.NewDString(newSinkURI)
 
+		// We validate that all the tables are resolvable at the
+		// resolveTime below in validateNewTargets. resolveTime is also
+		// the time from which changefeed will resume. Therefore we
+		// will override with this time in createChangefeedJobRecord
+		// when we get table descriptors.
+		var resolveTime hlc.Timestamp
+		highWater := newProgress.GetHighWater()
+		if highWater != nil && !highWater.IsEmpty() {
+			resolveTime = *highWater
+		} else {
+			resolveTime = newStatementTime
+		}
+
 		annotatedStmt := &annotatedChangefeedStatement{
-			CreateChangefeed: newChangefeedStmt,
-			originalSpecs:    originalSpecs,
+			CreateChangefeed:    newChangefeedStmt,
+			originalSpecs:       originalSpecs,
+			alterChangefeedAsOf: resolveTime,
 		}
 
 		jobRecord, err := createChangefeedJobRecord(

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -75,7 +75,8 @@ func init() {
 
 type annotatedChangefeedStatement struct {
 	*tree.CreateChangefeed
-	originalSpecs map[tree.ChangefeedTarget]jobspb.ChangefeedTargetSpecification
+	originalSpecs       map[tree.ChangefeedTarget]jobspb.ChangefeedTargetSpecification
+	alterChangefeedAsOf hlc.Timestamp
 }
 
 func getChangefeedStatement(stmt tree.Statement) *annotatedChangefeedStatement {
@@ -324,6 +325,10 @@ func createChangefeedJobRecord(
 		}
 		initialHighWater = asOf.Timestamp
 		statementTime = initialHighWater
+	}
+
+	if !changefeedStmt.alterChangefeedAsOf.IsEmpty() {
+		statementTime = changefeedStmt.alterChangefeedAsOf
 	}
 
 	endTime := hlc.Timestamp{}

--- a/pkg/ccl/changefeedccl/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/testing_knobs.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeeddist"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvfeed"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 )
 
@@ -41,6 +42,7 @@ type TestingKnobs struct {
 	// not accounted but it is useful to treat it as accounted in
 	// tests.
 	NullSinkIsExternalIOAccounted bool
+	OverrideCursor                func(currentTime *hlc.Timestamp) string
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
Backport 1/1 commits from https://github.com/cockroachdb/cockroach/pull/88402
/cc https://github.com/orgs/cockroachdb/teams/release

---

When the changefeed is started with cursor option, and then runs for a while (>gcttl time -- say 25 hours), the attempts to alter changefeed will fail due to the fact that createChangefeedJobRecord uses cursor (which is now very old) to set the time at which targets are resolved

To fix this, we will use the highwater timestamp to get the table descriptors. Targets will always be valid at highwater. Since createChangefeedJobRecord is called both during create changefeed and alter changefeed, we use cursor/statement time if highwater is not avaliable (which indicates that currently create changefeed is executing)

Resolves: #88050

Release note (bug fix): Fixed a bug which causes alter changefeed to fail if the changefeed was created with cursor option and had been running for more than gc.ttlseconds

Release justification: bug fix