### PR TITLE
sqlstats: always enable tracing first time fingerprint is seen

### DIFF
--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -121,8 +121,8 @@ type instrumentationHelper struct {
 
 	queryLevelStatsWithErr *execstats.QueryLevelStatsWithErr
 
-	// If savePlanForStats is true, the explainPlan will be collected and returned
-	// via PlanForStats().
+	// If savePlanForStats is true and the explainPlan was collected, the
+	// serialized version of the plan will be returned via PlanForStats().
 	savePlanForStats bool
 
 	explainPlan  *explain.Plan
@@ -255,8 +255,8 @@ func (ih *instrumentationHelper) Setup(
 	ih.stmtDiagnosticsRecorder = stmtDiagnosticsRecorder
 	ih.withStatementTrace = cfg.TestingKnobs.WithStatementTrace
 
-	ih.savePlanForStats =
-		statsCollector.ShouldSaveLogicalPlanDesc(fingerprint, implicitTxn, p.SessionData().Database)
+	var previouslySampled bool
+	previouslySampled, ih.savePlanForStats = statsCollector.ShouldSample(fingerprint, implicitTxn, p.SessionData().Database)
 
 	defer func() {
 		if ih.ShouldBuildExplainPlan() {
@@ -289,7 +289,7 @@ func (ih *instrumentationHelper) Setup(
 
 	ih.collectExecStats = collectTxnExecStats
 
-	if !collectTxnExecStats && ih.savePlanForStats {
+	if !collectTxnExecStats && !previouslySampled {
 		// We don't collect the execution stats for statements in this txn, but
 		// this is the first time we see this statement ever, so we'll collect
 		// its execution stats anyway (unless the user disabled txn stats
@@ -439,7 +439,7 @@ func (ih *instrumentationHelper) ShouldUseJobForCreateStats() bool {
 // ShouldBuildExplainPlan returns true if we should build an explain plan and
 // call RecordExplainPlan.
 func (ih *instrumentationHelper) ShouldBuildExplainPlan() bool {
-	return ih.collectBundle || ih.collectExecStats || ih.savePlanForStats ||
+	return ih.collectBundle || ih.collectExecStats ||
 		ih.outputMode == explainAnalyzePlanOutput ||
 		ih.outputMode == explainAnalyzeDistSQLOutput
 }
@@ -472,7 +472,7 @@ func (ih *instrumentationHelper) RecordPlanInfo(
 // collected (nil otherwise). It should be called after RecordExplainPlan() and
 // RecordPlanInfo().
 func (ih *instrumentationHelper) PlanForStats(ctx context.Context) *roachpb.ExplainTreePlanNode {
-	if ih.explainPlan == nil {
+	if ih.explainPlan == nil || !ih.savePlanForStats {
 		return nil
 	}
 

--- a/pkg/sql/sqlstats/persistedsqlstats/appStats.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/appStats.go
@@ -44,11 +44,11 @@ func (s *ApplicationStats) RecordStatement(
 	return fingerprintID, err
 }
 
-// ShouldSaveLogicalPlanDesc implements sqlstats.ApplicationStats interface.
-func (s *ApplicationStats) ShouldSaveLogicalPlanDesc(
+// ShouldSample implements sqlstats.ApplicationStats interface.
+func (s *ApplicationStats) ShouldSample(
 	fingerprint string, implicitTxn bool, database string,
-) bool {
-	return s.ApplicationStats.ShouldSaveLogicalPlanDesc(fingerprint, implicitTxn, database)
+) (bool, bool) {
+	return s.ApplicationStats.ShouldSample(fingerprint, implicitTxn, database)
 }
 
 // RecordTransaction implements sqlstats.ApplicationStats interface and saves

--- a/pkg/sql/sqlstats/persistedsqlstats/datadriven_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/datadriven_test.go
@@ -61,7 +61,7 @@ const (
 //     system table.
 //   - set-time: this changes the clock time perceived by SQL Stats subsystem.
 //     This is useful when unit tests need to manipulate times.
-//   - should-sample-logical-plan: this checks if the given tuple of
+//   - should-sample: this checks if the given tuple of
 //     (db, implicitTxn, fingerprint) will be sampled
 //     next time it is being executed.
 func TestSQLStatsDataDriven(t *testing.T) {
@@ -129,7 +129,7 @@ func TestSQLStatsDataDriven(t *testing.T) {
 			}
 			stubTime.setTime(tm)
 			return stubTime.Now().String()
-		case "should-sample-logical-plan":
+		case "should-sample":
 			mustHaveArgsOrFatal(t, d, fingerprintArgs, implicitTxnArgs, dbNameArgs)
 
 			var dbName string
@@ -145,13 +145,12 @@ func TestSQLStatsDataDriven(t *testing.T) {
 			// them.
 			fingerprint = strings.Replace(fingerprint, "%", " ", -1)
 
-			return fmt.Sprintf("%t",
-				appStats.ShouldSaveLogicalPlanDesc(
-					fingerprint,
-					implicitTxn,
-					dbName,
-				),
+			previouslySampled, savePlanForStats := appStats.ShouldSample(
+				fingerprint,
+				implicitTxn,
+				dbName,
 			)
+			return fmt.Sprintf("%t, %t", previouslySampled, savePlanForStats)
 		}
 
 		return ""

--- a/pkg/sql/sqlstats/persistedsqlstats/testdata/logical_plan_sampling_for_explicit_txn
+++ b/pkg/sql/sqlstats/persistedsqlstats/testdata/logical_plan_sampling_for_explicit_txn
@@ -14,9 +14,9 @@ set-time time=2021-09-20T15:00:00Z
 
 # Logical plan should be sampled here, since we have not collected logical plan
 # at all.
-should-sample-logical-plan db=defaultdb implicitTxn=true fingerprint=SELECT%_
+should-sample db=defaultdb implicitTxn=true fingerprint=SELECT%_
 ----
-true
+false, true
 
 # Execute the query to trigger a collection of logical plan.
 # (db_name=defaultdb implicitTxn=true fingerprint=SELECT _)
@@ -26,15 +26,15 @@ SELECT 1
 
 # Ensure that if a query is to be subsequently executed, it will not cause
 # logical plan sampling.
-should-sample-logical-plan db=defaultdb implicitTxn=true fingerprint=SELECT%_
+should-sample db=defaultdb implicitTxn=true fingerprint=SELECT%_
 ----
-false
+true, false
 
 # However, if we are to execute the same statement but under explicit
 # transaction, the plan will still need to be sampled.
-should-sample-logical-plan db=defaultdb implicitTxn=false fingerprint=SELECT%_
+should-sample db=defaultdb implicitTxn=false fingerprint=SELECT%_
 ----
-true
+false, true
 
 # Execute the statement under explicit transaction.
 # (db_name=defaultdb implicitTxn=false fingerprint=SELECT _)
@@ -46,9 +46,9 @@ COMMIT
 
 # Ensure that the subsequent execution of the query will not cause logical plan
 # collection.
-should-sample-logical-plan db=defaultdb implicitTxn=false fingerprint=SELECT%_
+should-sample db=defaultdb implicitTxn=false fingerprint=SELECT%_
 ----
-false
+true, false
 
 # Set the time to the future and ensure we will resample the logical plan.
 set-time time=2021-09-20T15:05:01Z
@@ -56,22 +56,22 @@ set-time time=2021-09-20T15:05:01Z
 2021-09-20 15:05:01 +0000 UTC
 
 
-should-sample-logical-plan db=defaultdb implicitTxn=true fingerprint=SELECT%_
+should-sample db=defaultdb implicitTxn=true fingerprint=SELECT%_
 ----
-true
+true, true
 
 # implicit txn
 exec-sql
 SELECT 1
 ----
 
-should-sample-logical-plan db=defaultdb implicitTxn=true fingerprint=SELECT%_
+should-sample db=defaultdb implicitTxn=true fingerprint=SELECT%_
 ----
-false
+true, true
 
-should-sample-logical-plan db=defaultdb implicitTxn=false fingerprint=SELECT%_
+should-sample db=defaultdb implicitTxn=false fingerprint=SELECT%_
 ----
-true
+true, true
 
 # explicit txn
 exec-sql
@@ -80,6 +80,6 @@ SELECT 1
 COMMIT
 ----
 
-should-sample-logical-plan db=defaultdb implicitTxn=false fingerprint=SELECT%_
+should-sample db=defaultdb implicitTxn=false fingerprint=SELECT%_
 ----
-false
+true, true

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
@@ -692,7 +692,7 @@ func (s *Container) MergeApplicationStatementStats(
 			defer stmtStats.mu.Unlock()
 
 			stmtStats.mergeStatsLocked(statistics)
-			planLastSampled := s.getLogicalPlanLastSampled(key.sampledPlanKey)
+			planLastSampled, _ := s.getLogicalPlanLastSampled(key.sampledPlanKey)
 			if planLastSampled.Before(stmtStats.mu.data.SensitiveInfo.MostRecentPlanTimestamp) {
 				s.setLogicalPlanLastSampled(key.sampledPlanKey, stmtStats.mu.data.SensitiveInfo.MostRecentPlanTimestamp)
 			}
@@ -922,16 +922,13 @@ func (s *transactionCounts) recordTransactionCounts(
 	}
 }
 
-func (s *Container) getLogicalPlanLastSampled(key sampledPlanKey) time.Time {
+func (s *Container) getLogicalPlanLastSampled(
+	key sampledPlanKey,
+) (lastSampled time.Time, found bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-
-	lastSampled, found := s.mu.sampledPlanMetadataCache[key]
-	if !found {
-		return time.Time{}
-	}
-
-	return lastSampled
+	lastSampled, found = s.mu.sampledPlanMetadataCache[key]
+	return lastSampled, found
 }
 
 func (s *Container) setLogicalPlanLastSampled(key sampledPlanKey, time time.Time) {

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
@@ -227,16 +227,17 @@ func (s *Container) RecordStatementExecStats(
 	return nil
 }
 
-// ShouldSaveLogicalPlanDesc implements sqlstats.Writer interface.
-func (s *Container) ShouldSaveLogicalPlanDesc(
+// ShouldSample implements sqlstats.Writer interface.
+func (s *Container) ShouldSample(
 	fingerprint string, implicitTxn bool, database string,
-) bool {
-	lastSampled := s.getLogicalPlanLastSampled(sampledPlanKey{
+) (previouslySampled, savePlanForStats bool) {
+	lastSampled, previouslySampled := s.getLogicalPlanLastSampled(sampledPlanKey{
 		stmtNoConstants: fingerprint,
 		implicitTxn:     implicitTxn,
 		database:        database,
 	})
-	return s.shouldSaveLogicalPlanDescription(lastSampled)
+	savePlanForStats = s.shouldSaveLogicalPlanDescription(lastSampled)
+	return previouslySampled, savePlanForStats
 }
 
 // RecordTransaction implements sqlstats.Writer interface and saves

--- a/pkg/sql/sqlstats/ssprovider.go
+++ b/pkg/sql/sqlstats/ssprovider.go
@@ -37,9 +37,11 @@ type Writer interface {
 	// This is sampled and not recorded for every single statement.
 	RecordStatementExecStats(key roachpb.StatementStatisticsKey, stats execstats.QueryLevelStats) error
 
-	// ShouldSaveLogicalPlanDesc returns whether we should save the logical plan
-	// description for a given combination of statement metadata.
-	ShouldSaveLogicalPlanDesc(fingerprint string, implicitTxn bool, database string) bool
+	// ShouldSample returns two booleans, the first one indicates whether we
+	// ever sampled (i.e. collected statistics for) the given combination of
+	// statement metadata, and the second one whether we should save the logical
+	// plan description for it.
+	ShouldSample(fingerprint string, implicitTxn bool, database string) (previouslySampled, savePlanForStats bool)
 
 	// RecordTransaction records statistics for a transaction.
 	RecordTransaction(ctx context.Context, key roachpb.TransactionFingerprintID, value RecordedTxnStats) error


### PR DESCRIPTION
Fixes: #89185

The first time a fingerprint is seen tracing should be enabled. This currently is broken if
sql.metrics.statement_details.plan_collection.enabled is set to false. This can cause crdb_internal.transaction_contention_events to be empty because tracing was never enabled to the contention event was never recorded.

To properly fix this a new value needs to be returned on ShouldSample to tell if it is the first time a fingerprint is seen. This will remove the dependency on plan_collection feature switch.

Release justification: Bug fixes and low-risk updates to new functionality.

Release note (bug fix): Always enable tracing the frist time a fingerprint is seen.