### PR TITLE
ci: add SessionCreate to MacOS TeamCity agents

### DIFF
--- a/build/packer/teamcity-agent-macos.sh
+++ b/build/packer/teamcity-agent-macos.sh
@@ -22,6 +22,8 @@ write_plist_file() {
 	<string>agent</string>
 	<key>WorkingDirectory</key>
 	<string>/Users/agent/teamcity</string>
+	<key>SessionCreate</key>
+	<true/>
 	<key>Label</key>
 	<string>jetbrains.teamcity.BuildAgent</string>
 	<key>OnDemand</key>


### PR DESCRIPTION
Previously, the TeamCity agent process was started by launchd, but there was no security session created, so the process could not interact with the keychain.

This change adds a parameter to the launchd configuration file to start the TeamCity agent process inside a security session.

Release note: None