### PR TITLE
opt: do not commute LIKE when building trigram index spans

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/trigram_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/trigram_builtins
@@ -91,6 +91,24 @@ SELECT similarity(a, b) FROM (VALUES
 0.16666666666666666
 0
 
+# Similarity is commutative.
+query F
+SELECT similarity(a, b) FROM (VALUES
+    ('foo', 'foobar'),
+    ('foobar', 'foo'),
+    ('FOO', 'foo'),
+    ('foo', 'FOO'),
+    ('blorp', 'z'),
+    ('z', 'blorp')
+  ) tbl(a, b)
+----
+0.375
+0.375
+1
+1
+0
+0
+
 query T
 SHOW pg_trgm.similarity_threshold
 ----

--- a/pkg/sql/logictest/testdata/logic_test/trigram_indexes
+++ b/pkg/sql/logictest/testdata/logic_test/trigram_indexes
@@ -236,3 +236,18 @@ CREATE TABLE public.t86614 (
    INVERTED INDEX t86614_a_s_idx (a ASC, s gin_trgm_ops),
    FAMILY fam_0_a_s_rowid (a, s, rowid)
 )
+
+# Regression test for #88925. Return correct result with a variable on the RHS
+# of LIKE.
+statement ok
+CREATE TABLE t88558 (
+  a INT PRIMARY KEY,
+  b TEXT,
+  INVERTED INDEX (b gin_trgm_ops)
+);
+INSERT INTO t88558 VALUES (1, '%');
+
+query IT
+SELECT * FROM t88558 WHERE 'aab':::STRING LIKE b;
+----
+1  %

--- a/pkg/sql/opt/exec/execbuilder/testdata/trigram_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/trigram_index
@@ -298,3 +298,19 @@ vectorized: true
               missing stats
               table: b@b_a_idx
               spans: 2 spans
+
+# Regression test for #88925.
+statement ok
+CREATE TABLE t88925 (
+  a INT PRIMARY KEY,
+  b TEXT NOT NULL,
+  INVERTED INDEX t88925_b_idx (b gin_trgm_ops)
+)
+
+# The secondary index cannot be used because LIKE is not commutative.
+statement error pgcode 42809 index "t88925_b_idx" is inverted and cannot be used for this query
+SELECT * FROM t88925@t88925_b_idx WHERE 'aab' LIKE b
+
+# The secondary index cannot be used because ILIKE is not commutative.
+statement error pgcode 42809 index "t88925_b_idx" is inverted and cannot be used for this query
+SELECT * FROM t88925@t88925_b_idx WHERE 'aab' ILIKE b

--- a/pkg/sql/opt/invertedidx/trigram_test.go
+++ b/pkg/sql/opt/invertedidx/trigram_test.go
@@ -52,7 +52,7 @@ func TestTryFilterTrigram(t *testing.T) {
 		ok      bool
 		unique  bool
 	}{
-		// Test LIKE with percents on both sides
+		// Test LIKE with percents on both sides.
 		// TODO(jordan): we could make expressions with just a single trigram
 		// tight, because we would know for sure that we wouldn't need to recheck
 		// the condition once the row is returned. But, it's probably not that
@@ -71,6 +71,12 @@ func TestTryFilterTrigram(t *testing.T) {
 		// AND and OR for two LIKE queries behave as expected.
 		{filters: "s LIKE '%lkj%' AND s LIKE '%bla%'", ok: true, unique: true},
 		{filters: "s LIKE '%lkj%' OR s LIKE '%bla%'", ok: true, unique: false},
+
+		// LIKE with variables on the right-hand side.
+		{filters: "'abc' LIKE s", ok: false},
+		{filters: "'abc' ILIKE s", ok: false},
+		{filters: "'abc%' LIKE s", ok: false},
+		{filters: "'%abc' LIKE s", ok: false},
 
 		// Similarity queries.
 		{filters: "s % 'lkjsdlkj'", ok: true, unique: false},


### PR DESCRIPTION
This commit fixes a bug in the creation of trigram index spans that was caused by the incorrect assumption that `LIKE` and `ILIKE` are commutative. Trigram index spans would be built for expressions such as `'foo' LIKE col` where `col` is included in a trigram index. The spans would be the same as spans built for `col LIKE 'foo'`, but these expressions are not equivalent:

    'foo' LIKE '%' => true
    '%' LIKE 'foo' => false

The bug is fixed by only generating trigram index spans when the right-hand side of the `LIKE` operator is a constant. We lose the ability to index accelerate queries that have a constant on the left-hand side of `LIKE`. It may be possible to regain this acceleration in the future, but we'd have to write some value to the trigram index when the column's value is `'%'`; we currently add no entries to the index. I've left a TODO for this.

Fixes #88925

Release note (bug fix): A bug has been fixed that caused queries with expressions like `'foo' LIKE col` to return incorrect values. The bug only occurs when an inverted trigram index exists on `col`. The bug is only present in previous beta versions of v22.2.