### PR TITLE
backupccl: refine span introduction checker

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/in-progress-import-missing-data
+++ b/pkg/ccl/backupccl/testdata/backup-restore/in-progress-import-missing-data
@@ -156,6 +156,18 @@ SELECT count(*) FROM d.goodfoo;
 ----
 3
 
+# Create a view to ensure the restore checker passes even though no spans are introduced for the
+# view.
+exec-sql
+CREATE VIEW d.silly_view (foo_count)
+AS SELECT count(*)
+FROM d.foo;
+----
+
+query-sql
+SELECT * FROM d.silly_view;
+----
+0
 
 # Because BackupRestoreTestingKnobs.SkipDescriptorChangeIntroduction is turned on,
 # this backup will be unable to introduce foo, foofoo, and goodfoo.


### PR DESCRIPTION
This patch fixes two bugs in restore's span introduction checker:

Previously, the checker would return an error if an incremental backup observed a new view. Because we back up a view's descriptor but not its span, the restore checker previously expected the backup to contain an introduced span for the new view, causing the checker to spuriously fail. This patch filters views out of the checker.

Previously, the checker only checked for introduced spans for table descriptors that were online at manfiest.Endtime. Now, in the spirit of getReintroducedSpans(), the checker also checks
descriptors that may have been offline at manifest.Endtime, but may have been online between manifest.StartTime and manifest.Endtime.

Release note (bug fix): prevents restore from spuriously failing