### PR TITLE
opt: assert that inverted scans have inverted constraints

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -724,6 +724,12 @@ func (b *Builder) buildScan(scan *memo.ScanExpr) (execPlan, error) {
 		}
 	}
 
+	idx := tab.Index(scan.Index)
+	if idx.IsInverted() && len(scan.InvertedConstraint) == 0 {
+		return execPlan{},
+			errors.AssertionFailedf("expected inverted index scan to have an inverted constraint")
+	}
+
 	// Save if we planned a full table/index scan on the builder so that the
 	// planner can be made aware later. We only do this for non-virtual tables.
 	stats := scan.Relational().Statistics()


### PR DESCRIPTION
This commit adds an assertion to ensure that inverted index scans have inverted constraints. If they do not, there is a likely a bug that can cause incorrect query results (e.g., #88047). This assertion is made in release builds,not just test builds, because it is cheap to perform.

Fixes #89440

Release note: None