### PR TITLE
roachtest: disable decimal columns in costfuzz and unoptimized tests

### DIFF
--- a/pkg/internal/sqlsmith/type.go
+++ b/pkg/internal/sqlsmith/type.go
@@ -43,6 +43,10 @@ func (s *Smither) pickAnyType(typ *types.T) *types.T {
 		if typ.ArrayContents().Family() == types.AnyFamily {
 			typ = randgen.RandArrayContentsType(s.rnd)
 		}
+	case types.DecimalFamily:
+		if s.disableDecimals {
+			typ = s.randType()
+		}
 	}
 	return typ
 }


### PR DESCRIPTION
This commit fixes an oversight from #89200 which failed to disable decimals in one case that was making costfuzz and unoptimized-query-oracle tests flaky.

Fixes #89303

Release note: None