### PR TITLE
release-22.1: memo: fix zigzag join stats and costs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/zigzag_join
+++ b/pkg/sql/logictest/testdata/logic_test/zigzag_join
@@ -186,6 +186,9 @@ INSERT INTO d VALUES (30,  '{"a": []}')
 statement ok
 INSERT INTO d VALUES (31,  '{"a": {"b": "c", "d": "e"}, "f": "g"}')
 
+statement ok
+ANALYZE d;
+
 ## Multi-path contains queries with zigzag joins enabled.
 
 query IT

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_inverted_index
@@ -53,6 +53,9 @@ INSERT INTO json_tab VALUES
   (33, '[1, "bar"]')
 
 statement ok
+ANALYZE json_tab
+
+statement ok
 ALTER TABLE json_tab SPLIT AT VALUES (10), (20)
 
 statement ok
@@ -76,15 +79,18 @@ distribution: local
 vectorized: true
 ·
 • sort
+│ estimated row count: 0
 │ order: +a
 │
 └── • lookup join
+    │ estimated row count: 0
     │ table: json_tab@json_tab_pkey
     │ equality: (a) = (a)
     │ equality cols are key
     │ pred: b @> '[1, 2]'
     │
     └── • zigzag join
+          estimated row count: 0
           left table: json_tab@foo_inv
           left columns: (a)
           left fixed values: 1 column
@@ -104,15 +110,18 @@ distribution: local
 vectorized: true
 ·
 • sort
+│ estimated row count: 0
 │ order: +a
 │
 └── • lookup join
+    │ estimated row count: 0
     │ table: json_tab@json_tab_pkey
     │ equality: (a) = (a)
     │ equality cols are key
     │ pred: (b @> '[1]') AND (b @> '[2]')
     │
     └── • zigzag join
+          estimated row count: 0
           left table: json_tab@foo_inv
           left columns: (a)
           left fixed values: 1 column
@@ -132,15 +141,18 @@ distribution: local
 vectorized: true
 ·
 • sort
+│ estimated row count: 0
 │ order: +a
 │
 └── • lookup join
+    │ estimated row count: 0
     │ table: json_tab@json_tab_pkey
     │ equality: (a) = (a)
     │ equality cols are key
     │ pred: b @> '[[1, 2]]'
     │
     └── • zigzag join
+          estimated row count: 0
           left table: json_tab@foo_inv
           left columns: (a)
           left fixed values: 1 column
@@ -171,6 +183,9 @@ INSERT INTO array_tab VALUES
   (5, '{1, 2, 3, 4}')
 
 statement ok
+ANALYZE array_tab
+
+statement ok
 ALTER TABLE array_tab SPLIT AT VALUES (3), (3)
 
 statement ok
@@ -193,15 +208,18 @@ distribution: local
 vectorized: true
 ·
 • sort
+│ estimated row count: 0
 │ order: +a
 │
 └── • lookup join
+    │ estimated row count: 0
     │ table: array_tab@array_tab_pkey
     │ equality: (a) = (a)
     │ equality cols are key
     │ pred: b @> ARRAY[1,2]
     │
     └── • zigzag join
+          estimated row count: 0
           left table: array_tab@foo_inv
           left columns: (a)
           left fixed values: 1 column

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -936,6 +936,70 @@ vectorized: true
               table: d@foo_inv
               spans: /"a"/{}-/"a"/{}/PrefixEnd /???-/??? /"b"/{}-/"b"/{}/PrefixEnd /???-/???
 
+# Stats reflect the following, with some histogram buckets removed:
+# insert into d select g, '[1,2]' from generate_series(1,1000) g(g);
+# insert into d select g, '[[1, 2]]' from generate_series(1001,50000) g(g);
+# insert into d select g, '[1,3]' from generate_series(100001,200000) g(g);
+# analyze d;
+
+statement ok
+ALTER TABLE d INJECT STATISTICS '[
+    {
+        "avg_size": 4,
+        "columns": [
+            "a"
+        ],
+        "created_at": "2022-10-04 15:11:25.779551",
+        "distinct_count": 101000,
+        "null_count": 0,
+        "row_count": 101000
+    },
+    {
+        "avg_size": 26,
+        "columns": [
+            "b"
+        ],
+        "created_at": "2022-10-04 15:11:25.779551",
+        "distinct_count": 3,
+        "histo_buckets": [
+            {
+                "distinct_range": 0,
+                "num_eq": 100680,
+                "num_range": 0,
+                "upper_bound": "\\x37000300012a0200"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 1020,
+                "num_range": 0,
+                "upper_bound": "\\x37000300012a0400"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 99900,
+                "num_range": 0,
+                "upper_bound": "\\x37000300012a0600"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 49980,
+                "num_range": 0,
+                "upper_bound": "\\x370003000300012a0200"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 48420,
+                "num_range": 0,
+                "upper_bound": "\\x370003000300012a0400"
+            }
+        ],
+        "histo_col_type": "BYTES",
+        "histo_version": 2,
+        "null_count": 0,
+        "row_count": 101000
+    }
+]';
+
 # Filter with a fully-specified array. This should use a zigzag join.
 query T
 EXPLAIN SELECT a FROM d WHERE b @> '[1, 2]' ORDER BY a
@@ -944,15 +1008,18 @@ distribution: local
 vectorized: true
 ·
 • sort
+│ estimated row count: 1,247
 │ order: +a
 │
 └── • lookup join
+    │ estimated row count: 1,247
     │ table: d@d_pkey
     │ equality: (a) = (a)
     │ equality cols are key
     │ pred: b @> '[1, 2]'
     │
     └── • zigzag join
+          estimated row count: 1,247
           left table: d@foo_inv
           left columns: (a)
           left fixed values: 1 column
@@ -969,15 +1036,18 @@ distribution: local
 vectorized: true
 ·
 • sort
+│ estimated row count: 1,247
 │ order: +a
 │
 └── • lookup join
+    │ estimated row count: 1,247
     │ table: d@d_pkey
     │ equality: (a) = (a)
     │ equality cols are key
     │ pred: (b @> '[1]') AND (b @> '[2]')
     │
     └── • zigzag join
+          estimated row count: 1,247
           left table: d@foo_inv
           left columns: (a)
           left fixed values: 1 column
@@ -994,15 +1064,18 @@ distribution: local
 vectorized: true
 ·
 • sort
+│ estimated row count: 1,247
 │ order: +a
 │
 └── • lookup join
+    │ estimated row count: 1,247
     │ table: d@d_pkey
     │ equality: (a) = (a)
     │ equality cols are key
     │ pred: b @> '[[1, 2]]'
     │
     └── • zigzag join
+          estimated row count: 1,247
           left table: d@foo_inv
           left columns: (a)
           left fixed values: 1 column
@@ -1260,22 +1333,23 @@ vectorized: true
 ·
 • filter
 │ columns: (a, b)
-│ estimated row count: 333 (missing stats)
+│ estimated row count: 33,667
 │ filter: b <@ '[]'
 │
 └── • index join
     │ columns: (a, b)
-    │ estimated row count: 111 (missing stats)
+    │ estimated row count: 0
     │ table: d@d_pkey
     │ key columns: a
     │
     └── • scan
           columns: (a)
-          estimated row count: 111 (missing stats)
+          estimated row count: 0 (<0.01% of the table; stats collected <hidden> ago)
           table: d@foo_inv
           spans: /[]-/{}
 
-
+# Stats now include many entries with column b value '[[1, 2]]', so full scan
+# is cheaper.
 query T
 EXPLAIN (VERBOSE) SELECT * FROM d WHERE b <@ '[1, 2]'
 ----
@@ -1284,29 +1358,14 @@ vectorized: true
 ·
 • filter
 │ columns: (a, b)
-│ estimated row count: 333 (missing stats)
+│ estimated row count: 33,667
 │ filter: b <@ '[1, 2]'
 │
-└── • index join
-    │ columns: (a, b)
-    │ estimated row count: 111 (missing stats)
-    │ table: d@d_pkey
-    │ key columns: a
-    │
-    └── • project
-        │ columns: (a)
-        │ estimated row count: 111 (missing stats)
-        │
-        └── • inverted filter
-            │ columns: (a, b_inverted_key)
-            │ inverted column: b_inverted_key
-            │ num spans: 5
-            │
-            └── • scan
-                  columns: (a, b_inverted_key)
-                  estimated row count: 111 (missing stats)
-                  table: d@foo_inv
-                  spans: /1-/1/PrefixEnd /2-/2/PrefixEnd /[]-/{} /Arr/1-/Arr/1/PrefixEnd /Arr/2-/Arr/2/PrefixEnd
+└── • scan
+      columns: (a, b)
+      estimated row count: 101,000 (100% of the table; stats collected <hidden> ago)
+      table: d@d_pkey
+      spans: FULL SCAN
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM d WHERE b <@ '{}'
@@ -1316,18 +1375,18 @@ vectorized: true
 ·
 • filter
 │ columns: (a, b)
-│ estimated row count: 333 (missing stats)
+│ estimated row count: 33,667
 │ filter: b <@ '{}'
 │
 └── • index join
     │ columns: (a, b)
-    │ estimated row count: 111 (missing stats)
+    │ estimated row count: 0
     │ table: d@d_pkey
     │ key columns: a
     │
     └── • scan
           columns: (a)
-          estimated row count: 111 (missing stats)
+          estimated row count: 0 (<0.01% of the table; stats collected <hidden> ago)
           table: d@foo_inv
           spans: /{}-/{}/PrefixEnd
 
@@ -1339,18 +1398,18 @@ vectorized: true
 ·
 • filter
 │ columns: (a, b)
-│ estimated row count: 333 (missing stats)
+│ estimated row count: 33,667
 │ filter: b <@ '{"a": "b"}'
 │
 └── • index join
     │ columns: (a, b)
-    │ estimated row count: 111 (missing stats)
+    │ estimated row count: 0
     │ table: d@d_pkey
     │ key columns: a
     │
     └── • project
         │ columns: (a)
-        │ estimated row count: 111 (missing stats)
+        │ estimated row count: 0
         │
         └── • inverted filter
             │ columns: (a, b_inverted_key)
@@ -1359,7 +1418,7 @@ vectorized: true
             │
             └── • scan
                   columns: (a, b_inverted_key)
-                  estimated row count: 111 (missing stats)
+                  estimated row count: 0 (<0.01% of the table; stats collected <hidden> ago)
                   table: d@foo_inv
                   spans: /{}-/{}/PrefixEnd /"a"/"b"-/"a"/"b"/PrefixEnd
 
@@ -1371,18 +1430,18 @@ vectorized: true
 ·
 • filter
 │ columns: (a, b)
-│ estimated row count: 333 (missing stats)
+│ estimated row count: 33,667
 │ filter: b <@ '[{"a": "b"}, {"c": {"d": ["e"]}}, "f"]'
 │
 └── • index join
     │ columns: (a, b)
-    │ estimated row count: 111 (missing stats)
+    │ estimated row count: 0
     │ table: d@d_pkey
     │ key columns: a
     │
     └── • project
         │ columns: (a)
-        │ estimated row count: 111 (missing stats)
+        │ estimated row count: 0
         │
         └── • inverted filter
             │ columns: (a, b_inverted_key)
@@ -1391,7 +1450,7 @@ vectorized: true
             │
             └── • scan
                   columns: (a, b_inverted_key)
-                  estimated row count: 111 (missing stats)
+                  estimated row count: 0 (<0.01% of the table; stats collected <hidden> ago)
                   table: d@foo_inv
                   spans: /"f"-/"f"/PrefixEnd /[]-/{} /Arr/"f"-/Arr/"f"/PrefixEnd /Arr/{}-/Arr/{}/PrefixEnd /Arr/"a"/"b"-/Arr/"a"/"b"/PrefixEnd /Arr/"c"/{}-/Arr/"c"/{}/PrefixEnd /Arr/"c"/"d"/[]-/Arr/"c"/"d"/{} /Arr/"c"/"d"/Arr/"e"-/Arr/"c"/"d"/Arr/"e"/PrefixEnd
 

--- a/pkg/sql/opt/indexrec/testdata/index-candidates-recommendations
+++ b/pkg/sql/opt/indexrec/testdata/index-candidates-recommendations
@@ -629,23 +629,16 @@ t1:
 index-recommendations
 SELECT k, i FROM t1 WHERE k = 1 AND i = 2
 ----
-index recommendations: 2
+index recommendations: 1
 1. type: index creation
-   SQL command: CREATE INDEX ON t1 (k) STORING (i);
-2. type: index creation
-   SQL command: CREATE INDEX ON t1 (i) STORING (k);
+   SQL command: CREATE INDEX ON t1 (k, i);
 --
 Optimal Plan.
-inner-join (zigzag t1@_hyp_1 t1@_hyp_2)
+scan t1@_hyp_3
  ├── columns: k:1!null i:2!null
- ├── eq columns: [5] = [5]
- ├── left fixed columns: [1] = [1]
- ├── right fixed columns: [2] = [2]
- ├── cost: 11.9982432
- ├── fd: ()-->(1,2)
- └── filters
-      ├── k:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
-      └── i:2 = 2 [outer=(2), constraints=(/2: [/2 - /2]; tight), fd=()-->(2)]
+ ├── constraint: /1/2/5: [/1/2 - /1/2]
+ ├── cost: 14.9945676
+ └── fd: ()-->(1,2)
 
 # Multi-column combinations used: EQ + R.
 index-candidates
@@ -696,7 +689,7 @@ inner-join (zigzag t1@_hyp_1 t1@_hyp_2)
  ├── eq columns: [5] = [5]
  ├── left fixed columns: [1] = [1]
  ├── right fixed columns: [2] = [2]
- ├── cost: 10.6474054
+ ├── cost: 13.4131712
  ├── fd: ()-->(1,2)
  └── filters
       ├── k:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
@@ -754,34 +747,27 @@ t2:
 index-recommendations
 SELECT t1.i, t1.s FROM t1 JOIN t2 ON t1.k != t2.k WHERE t1.i = 2 AND t1.s = 'NG'
 ----
-index recommendations: 2
+index recommendations: 1
 1. type: index creation
-   SQL command: CREATE INDEX ON t1 (i) STORING (k, s);
-2. type: index creation
-   SQL command: CREATE INDEX ON t1 (s) STORING (k, i);
+   SQL command: CREATE INDEX ON t1 (i, s) STORING (k);
 --
 Optimal Plan.
 project
  ├── columns: i:2!null s:4!null
- ├── cost: 1111.17702
+ ├── cost: 1114.17334
  ├── fd: ()-->(2,4)
  └── inner-join (cross)
       ├── columns: t1.k:1!null t1.i:2!null t1.s:4!null t2.k:8!null
-      ├── cost: 1108.1814
+      ├── cost: 1111.17772
       ├── fd: ()-->(2,4)
       ├── scan t2
       │    ├── columns: t2.k:8
       │    └── cost: 1074.52
-      ├── inner-join (zigzag t1@_hyp_1 t1@_hyp_2)
+      ├── scan t1@_hyp_4
       │    ├── columns: t1.k:1 t1.i:2!null t1.s:4!null
-      │    ├── eq columns: [5] = [5]
-      │    ├── left fixed columns: [2] = [2]
-      │    ├── right fixed columns: [4] = ['NG']
-      │    ├── cost: 12.0073514
-      │    ├── fd: ()-->(2,4)
-      │    └── filters
-      │         ├── t1.i:2 = 2 [outer=(2), constraints=(/2: [/2 - /2]; tight), fd=()-->(2)]
-      │         └── t1.s:4 = 'NG' [outer=(4), constraints=(/4: [/'NG' - /'NG']; tight), fd=()-->(4)]
+      │    ├── constraint: /2/4/5: [/2/'NG' - /2/'NG']
+      │    ├── cost: 15.0036757
+      │    └── fd: ()-->(2,4)
       └── filters
            └── t1.k:1 != t2.k:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ])]
 
@@ -1314,13 +1300,13 @@ inner-join (lookup t4)
  ├── key columns: [6] = [6]
  ├── lookup columns are key
  ├── immutable
- ├── cost: 110.790741
+ ├── cost: 234.247531
  ├── inner-join (zigzag t4@_hyp_1 t4@_hyp_1)
  │    ├── columns: rowid:6!null
  │    ├── eq columns: [6] = [6]
  │    ├── left fixed columns: [9] = ['\x37626172000112320001']
  │    ├── right fixed columns: [9] = ['\x37666f6f000112310001']
- │    ├── cost: 35.6990123
+ │    ├── cost: 159.155802
  │    └── filters (true)
  └── filters
       └── j:4 @> '{"bar": "2", "foo": "1"}' [outer=(4), immutable, constraints=(/4: (/NULL - ])]
@@ -1401,7 +1387,7 @@ Optimal Plan.
 project
  ├── columns: k:1!null f:3
  ├── immutable
- ├── cost: 10.7379279
+ ├── cost: 13.773964
  ├── fd: ()-->(1)
  └── inner-join (zigzag t4@_hyp_1 t4@_hyp_2)
       ├── columns: k:1!null i:2!null f:3 j:4
@@ -1409,7 +1395,7 @@ project
       ├── left fixed columns: [1] = [1]
       ├── right fixed columns: [2] = [2]
       ├── immutable
-      ├── cost: 10.7148919
+      ├── cost: 13.7509279
       ├── fd: ()-->(1,2)
       └── filters
            ├── j:4 <@ '{"foo": "1"}' [outer=(4), immutable]

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -2075,6 +2075,10 @@ select
  └── filters
       └── f:6 = 0.0 [type=bool, outer=(6), constraints=(/6: [/0.0 - /0.0]; tight), fd=()-->(6)]
 
+# Without stats with histograms, zig-zag join may not be chosen.
+# This is OK because it can be expensive when many rows are qualified.
+# This case shows less than 1 qualified row in the constrained scan of
+# multi_col@bef_idx, so it should beat zig-zag join.
 opt
 SELECT * FROM multi_col
 WHERE a = '37685f26-4b07-40ba-9bbf-42916ed9bc61'
@@ -2083,34 +2087,29 @@ AND d = 'foo'
 AND e = 5
 AND f = 0
 ----
-inner-join (lookup multi_col)
+select
  ├── columns: a:1(uuid!null) b:2(bool!null) c:3(int) d:4(string!null) e:5(int!null) f:6(float!null)
- ├── key columns: [7] = [7]
- ├── lookup columns are key
  ├── stats: [rows=0.9000001, distinct(1)=0.9, null(1)=0, avgsize(1)=1, distinct(2)=0.9, null(2)=0, avgsize(2)=2, distinct(4)=0.9, null(4)=0, avgsize(4)=4, distinct(5)=0.9, null(5)=0, avgsize(5)=5, distinct(6)=0.9, null(6)=0, avgsize(6)=6, distinct(1,2,4-6)=0.9, null(1,2,4-6)=0, avgsize(1,2,4-6)=18]
  │   histogram(2)=  0   0.9
  │                <--- false
  │   histogram(4)=  0   0.9
  │                <--- 'foo'
  ├── fd: ()-->(1,2,4-6)
- ├── inner-join (zigzag multi_col@bad_idx multi_col@bef_idx)
- │    ├── columns: a:1(uuid!null) b:2(bool!null) d:4(string!null) e:5(int!null) f:6(float!null) rowid:7(int!null)
- │    ├── eq columns: [7] = [7]
- │    ├── left fixed columns: [2 1 4] = [false '37685f26-4b07-40ba-9bbf-42916ed9bc61' 'foo']
- │    ├── right fixed columns: [2 5 6] = [false 5 0.0]
- │    ├── stats: [rows=0.9000001, distinct(1)=0.9, null(1)=0, avgsize(1)=1, distinct(2)=0.9, null(2)=0, avgsize(2)=2, distinct(4)=0.9, null(4)=0, avgsize(4)=4, distinct(5)=0.9, null(5)=0, avgsize(5)=5, distinct(6)=0.9, null(6)=0, avgsize(6)=6, distinct(1,2,4-6)=0.9, null(1,2,4-6)=0, avgsize(1,2,4-6)=18]
- │    │   histogram(2)=  0   0.9
- │    │                <--- false
- │    │   histogram(4)=  0   0.9
- │    │                <--- 'foo'
- │    ├── fd: ()-->(1,2,4-6)
- │    └── filters
- │         ├── a:1 = '37685f26-4b07-40ba-9bbf-42916ed9bc61' [type=bool, outer=(1), constraints=(/1: [/'37685f26-4b07-40ba-9bbf-42916ed9bc61' - /'37685f26-4b07-40ba-9bbf-42916ed9bc61']; tight), fd=()-->(1)]
- │         ├── NOT b:2 [type=bool, outer=(2), constraints=(/2: [/false - /false]; tight), fd=()-->(2)]
- │         ├── d:4 = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
- │         ├── e:5 = 5 [type=bool, outer=(5), constraints=(/5: [/5 - /5]; tight), fd=()-->(5)]
- │         └── f:6 = 0.0 [type=bool, outer=(6), constraints=(/6: [/0.0 - /0.0]; tight), fd=()-->(6)]
- └── filters (true)
+ ├── index-join multi_col
+ │    ├── columns: a:1(uuid) b:2(bool) c:3(int) d:4(string) e:5(int) f:6(float)
+ │    ├── stats: [rows=0.501576]
+ │    ├── fd: ()-->(2,5,6)
+ │    └── scan multi_col@bef_idx
+ │         ├── columns: b:2(bool!null) e:5(int!null) f:6(float!null) rowid:7(int!null)
+ │         ├── constraint: /2/5/6/7: [/false/5/0.0 - /false/5/0.0]
+ │         ├── stats: [rows=0.501576, distinct(2)=0.501576, null(2)=0, avgsize(2)=2, distinct(5)=0.501576, null(5)=0, avgsize(5)=5, distinct(6)=0.501576, null(6)=0, avgsize(6)=6, distinct(2,5,6)=0.501576, null(2,5,6)=0, avgsize(2,5,6)=12]
+ │         │   histogram(2)=  0 0.50158
+ │         │                <--- false
+ │         ├── key: (7)
+ │         └── fd: ()-->(2,5,6)
+ └── filters
+      ├── a:1 = '37685f26-4b07-40ba-9bbf-42916ed9bc61' [type=bool, outer=(1), constraints=(/1: [/'37685f26-4b07-40ba-9bbf-42916ed9bc61' - /'37685f26-4b07-40ba-9bbf-42916ed9bc61']; tight), fd=()-->(1)]
+      └── d:4 = 'foo' [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
 
 # Regression test for #50409.
 exec-ddl

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -3266,3 +3266,249 @@ union
       ├── columns: t85499.rowid:6(int!null)
       ├── stats: [rows=1000, distinct(6)=1000, null(6)=0, avgsize(6)=4]
       └── key: (6)
+
+# Regression test for support issue #1821
+exec-ddl
+CREATE TABLE t1821 (
+    n INT8 NOT NULL,
+    a INT8 NULL,
+    b INT8 NULL,
+    c STRING NULL,
+    CONSTRAINT t1_pkey PRIMARY KEY (n ASC),
+    INDEX a_idx (a ASC),
+    INDEX b_idx (b ASC)
+)
+----
+
+exec-ddl
+ALTER TABLE t1821 INJECT STATISTICS '[
+    {
+        "avg_size": 4,
+        "columns": [
+            "n"
+        ],
+        "created_at": "2022-09-28 15:29:12.909895",
+        "distinct_count": 199241,
+        "null_count": 0,
+        "row_count": 200000
+    },
+    {
+        "avg_size": 3,
+        "columns": [
+            "a"
+        ],
+        "created_at": "2022-09-28 15:29:12.909895",
+        "distinct_count": 100000,
+        "histo_buckets": [
+            {
+                "distinct_range": 0,
+                "num_eq": 0,
+                "num_range": 0,
+                "upper_bound": "-9223372036854775808"
+            },
+            {
+                "distinct_range": 7.275957614183426E-12,
+                "num_eq": 50000,
+                "num_range": 0,
+                "upper_bound": "1"
+            },
+            {
+                "distinct_range": 417.004372929906,
+                "num_eq": 16,
+                "num_range": 150000,
+                "upper_bound": "200000"
+            },
+            {
+                "distinct_range": 7.275957614183426E-12,
+                "num_eq": 0,
+                "num_range": 0,
+                "upper_bound": "9223372036854775807"
+            }
+        ],
+        "histo_col_type": "INT8",
+        "histo_version": 2,
+        "null_count": 0,
+        "row_count": 200000
+    },
+    {
+        "avg_size": 3,
+        "columns": [
+            "b"
+        ],
+        "created_at": "2022-09-28 15:29:12.909895",
+        "distinct_count": 100000,
+        "histo_buckets": [
+            {
+                "distinct_range": 0,
+                "num_eq": 0,
+                "num_range": 0,
+                "upper_bound": "-9223372036854775808"
+            },
+            {
+                "distinct_range": 7.275957614183426E-12,
+                "num_eq": 50000,
+                "num_range": 0,
+                "upper_bound": "1"
+            },
+            {
+                "distinct_range": 417.004372929906,
+                "num_eq": 16,
+                "num_range": 150000,
+                "upper_bound": "200000"
+            },
+            {
+                "distinct_range": 7.275957614183426E-12,
+                "num_eq": 0,
+                "num_range": 0,
+                "upper_bound": "9223372036854775807"
+            }
+        ],
+        "histo_col_type": "INT8",
+        "histo_version": 2,
+        "null_count": 0,
+        "row_count": 200000
+    },
+    {
+        "avg_size": 3,
+        "columns": [
+            "c"
+        ],
+        "created_at": "2022-09-28 15:29:12.909895",
+        "distinct_count": 1,
+        "histo_buckets": [
+            {
+                "distinct_range": 0,
+                "num_eq": 200000,
+                "num_range": 0,
+                "upper_bound": "a"
+            }
+        ],
+        "histo_col_type": "STRING",
+        "histo_version": 2,
+        "null_count": 0,
+        "row_count": 200000
+    }
+]';
+----
+
+# Zig-zag join should not be picked due to high selectivity.
+opt
+SELECT count(*) FROM t1821 WHERE a = 1 AND b = 1
+----
+scalar-group-by
+ ├── columns: count:7(int!null)
+ ├── cardinality: [1 - 1]
+ ├── stats: [rows=1]
+ ├── key: ()
+ ├── fd: ()-->(7)
+ ├── select
+ │    ├── columns: a:2(int!null) b:3(int!null)
+ │    ├── stats: [rows=29371.93, distinct(2)=1, null(2)=0, avgsize(2)=3, distinct(3)=1, null(3)=0, avgsize(3)=3, distinct(2,3)=1, null(2,3)=0, avgsize(2,3)=6]
+ │    │   histogram(2)=  0 29372
+ │    │                <---- 1 -
+ │    │   histogram(3)=  0 29372
+ │    │                <---- 1 -
+ │    ├── fd: ()-->(2,3)
+ │    ├── scan t1821
+ │    │    ├── columns: a:2(int) b:3(int)
+ │    │    └── stats: [rows=200000, distinct(2)=100000, null(2)=0, avgsize(2)=3, distinct(3)=100000, null(3)=0, avgsize(3)=3, distinct(2,3)=200000, null(2,3)=0, avgsize(2,3)=6]
+ │    │        histogram(2)=  0           0            0 49996 1.4999e+05  15.999  0           0
+ │    │                     <--- -9223372036854775808 ---- 1 ------------- 200000 --- 9223372036854775807
+ │    │        histogram(3)=  0           0            0 49996 1.4999e+05  15.999  0           0
+ │    │                     <--- -9223372036854775808 ---- 1 ------------- 200000 --- 9223372036854775807
+ │    └── filters
+ │         ├── a:2 = 1 [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
+ │         └── b:3 = 1 [type=bool, outer=(3), constraints=(/3: [/1 - /1]; tight), fd=()-->(3)]
+ └── aggregations
+      └── count-rows [as=count_rows:7, type=int]
+
+# Zig-zag join plus index join should not be picked due to high selectivity.
+opt
+SELECT count(c) FROM t1821 WHERE a = 1 AND b = 1
+----
+scalar-group-by
+ ├── columns: count:7(int!null)
+ ├── cardinality: [1 - 1]
+ ├── stats: [rows=1]
+ ├── key: ()
+ ├── fd: ()-->(7)
+ ├── select
+ │    ├── columns: a:2(int!null) b:3(int!null) c:4(string)
+ │    ├── stats: [rows=29371.93, distinct(2)=1, null(2)=0, avgsize(2)=3, distinct(3)=1, null(3)=0, avgsize(3)=3, distinct(2,3)=1, null(2,3)=0, avgsize(2,3)=6]
+ │    │   histogram(2)=  0 29372
+ │    │                <---- 1 -
+ │    │   histogram(3)=  0 29372
+ │    │                <---- 1 -
+ │    ├── fd: ()-->(2,3)
+ │    ├── scan t1821
+ │    │    ├── columns: a:2(int) b:3(int) c:4(string)
+ │    │    └── stats: [rows=200000, distinct(2)=100000, null(2)=0, avgsize(2)=3, distinct(3)=100000, null(3)=0, avgsize(3)=3, distinct(2,3)=200000, null(2,3)=0, avgsize(2,3)=6]
+ │    │        histogram(2)=  0           0            0 49996 1.4999e+05  15.999  0           0
+ │    │                     <--- -9223372036854775808 ---- 1 ------------- 200000 --- 9223372036854775807
+ │    │        histogram(3)=  0           0            0 49996 1.4999e+05  15.999  0           0
+ │    │                     <--- -9223372036854775808 ---- 1 ------------- 200000 --- 9223372036854775807
+ │    └── filters
+ │         ├── a:2 = 1 [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
+ │         └── b:3 = 1 [type=bool, outer=(3), constraints=(/3: [/1 - /1]; tight), fd=()-->(3)]
+ └── aggregations
+      └── count [as=count:7, type=int, outer=(4)]
+           └── c:4 [type=string]
+
+# When the zig-zag join is covering, stats come from the Select group.
+opt
+SELECT 1 FROM t1821@{FORCE_ZIGZAG} WHERE a = 1 AND b = 1
+----
+project
+ ├── columns: "?column?":7(int!null)
+ ├── stats: [rows=29371.93]
+ ├── fd: ()-->(7)
+ ├── inner-join (zigzag t1821@a_idx t1821@b_idx)
+ │    ├── columns: a:2(int!null) b:3(int!null)
+ │    ├── eq columns: [1] = [1]
+ │    ├── left fixed columns: [2] = [1]
+ │    ├── right fixed columns: [3] = [1]
+ │    ├── stats: [rows=29371.93, distinct(2)=1, null(2)=0, avgsize(2)=3, distinct(3)=1, null(3)=0, avgsize(3)=3, distinct(2,3)=1, null(2,3)=0, avgsize(2,3)=6]
+ │    │   histogram(2)=  0 29372
+ │    │                <---- 1 -
+ │    │   histogram(3)=  0 29372
+ │    │                <---- 1 -
+ │    ├── fd: ()-->(2,3)
+ │    └── filters
+ │         ├── a:2 = 1 [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
+ │         └── b:3 = 1 [type=bool, outer=(3), constraints=(/3: [/1 - /1]; tight), fd=()-->(3)]
+ └── projections
+      └── 1 [as="?column?":7, type=int]
+
+# When the zig-zag join is not covering and the stats come from memoizing the
+# zig-zag join, verify that the row count is the same as above.
+opt
+SELECT c FROM t1821@{FORCE_ZIGZAG} WHERE a = 1 AND b = 1
+----
+project
+ ├── columns: c:4(string)
+ ├── stats: [rows=29371.93]
+ └── inner-join (lookup t1821)
+      ├── columns: a:2(int!null) b:3(int!null) c:4(string)
+      ├── key columns: [1] = [1]
+      ├── lookup columns are key
+      ├── stats: [rows=29371.93, distinct(2)=1, null(2)=0, avgsize(2)=3, distinct(3)=1, null(3)=0, avgsize(3)=3, distinct(2,3)=1, null(2,3)=0, avgsize(2,3)=6]
+      │   histogram(2)=  0 29372
+      │                <---- 1 -
+      │   histogram(3)=  0 29372
+      │                <---- 1 -
+      ├── fd: ()-->(2,3)
+      ├── inner-join (zigzag t1821@a_idx t1821@b_idx)
+      │    ├── columns: n:1(int!null) a:2(int!null) b:3(int!null)
+      │    ├── eq columns: [1] = [1]
+      │    ├── left fixed columns: [2] = [1]
+      │    ├── right fixed columns: [3] = [1]
+      │    ├── stats: [rows=29371.93, distinct(2)=1, null(2)=0, avgsize(2)=3, distinct(3)=1, null(3)=0, avgsize(3)=3, distinct(2,3)=1, null(2,3)=0, avgsize(2,3)=6]
+      │    │   histogram(2)=  0 29372
+      │    │                <---- 1 -
+      │    │   histogram(3)=  0 29372
+      │    │                <---- 1 -
+      │    ├── fd: ()-->(2,3)
+      │    └── filters
+      │         ├── a:2 = 1 [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
+      │         └── b:3 = 1 [type=bool, outer=(3), constraints=(/3: [/1 - /1]; tight), fd=()-->(3)]
+      └── filters (true)

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -1141,9 +1141,27 @@ func (c *coster) computeZigzagJoinCost(join *memo.ZigzagJoinExpr) memo.Cost {
 
 	filterSetup, filterPerRow := c.computeFiltersCost(join.On, util.FastIntMap{})
 
+	// It is much more expensive to do a seek in zigzag join vs. lookup join
+	// because zigzag join starts a new scan for every seek via
+	// `Fetcher.StartScan`. Instead of using `seqIOCostFactor`, bump seek costs to
+	// be similar to lookup join, though more fine-tuning is needed.
+	// TODO(msirek): Refine zigzag join costs and try out changes to execution to
+	//               do a point lookup for a match in the other index before
+	//               starting a new scan. Lookup join and inverted join add a
+	//               cost of 5 * randIOCostFactor per row to account for not
+	//               running non-key lookups in parallel. This may be applicable
+	//               here too.
+	//               Explore dynamically detecting selection of a bad zigzag join
+	//               during execution and switching to merge join on-the-fly.
+	// Seek costs should be at least as expensive as lookup join.
+	// See `indexLookupJoinPerLookupCost` and `computeIndexLookupJoinCost`.
+	// Increased zigzag join costs mean that accurate selectivity estimation is
+	// needed to ensure this index access path can be picked.
+	seekCost := memo.Cost(randIOCostFactor + lookupJoinRetrieveRowCost)
+
 	// Double the cost of emitting rows as well as the cost of seeking rows,
 	// given two indexes will be accessed.
-	cost := memo.Cost(rowCount) * (2*(cpuCostFactor+seqIOCostFactor) + scanCost + filterPerRow)
+	cost := memo.Cost(rowCount) * (2*(cpuCostFactor+seekCost) + scanCost + filterPerRow)
 	cost += filterSetup
 
 	// Add a penalty if the cardinality exceeds the row count estimate. Adding a

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -5410,7 +5410,7 @@ memo (optimized, ~16KB, required=[presentation: q:2,r:3])
  ├── G1: (select G2 G3) (select G4 G5) (select G6 G7) (select G8 G7) (zigzag-join G3 pqr@q pqr@r)
  │    └── [presentation: q:2,r:3]
  │         ├── best: (zigzag-join G3 pqr@q pqr@r)
- │         └── cost: 11.94
+ │         └── cost: 21.04
  ├── G2: (scan pqr,cols=(2,3))
  │    └── []
  │         ├── best: (scan pqr,cols=(2,3))
@@ -5491,7 +5491,7 @@ memo (optimized, ~18KB, required=[presentation: q:2,r:3,s:4])
  ├── G1: (select G2 G3) (select G4 G5) (select G6 G7) (select G8 G7) (lookup-join G9 G10 pqr,keyCols=[1],outCols=(2-4))
  │    └── [presentation: q:2,r:3,s:4]
  │         ├── best: (lookup-join G9 G10 pqr,keyCols=[1],outCols=(2-4))
- │         └── cost: 17.51
+ │         └── cost: 26.61
  ├── G2: (scan pqr,cols=(2-4))
  │    └── []
  │         ├── best: (scan pqr,cols=(2-4))
@@ -5514,7 +5514,7 @@ memo (optimized, ~18KB, required=[presentation: q:2,r:3,s:4])
  ├── G9: (zigzag-join G3 pqr@q pqr@r)
  │    └── []
  │         ├── best: (zigzag-join G3 pqr@q pqr@r)
- │         └── cost: 11.95
+ │         └── cost: 21.05
  ├── G10: (filters)
  ├── G11: (eq G16 G17)
  ├── G12: (eq G18 G19)
@@ -5556,7 +5556,7 @@ memo (optimized, ~13KB, required=[presentation: q:2,s:4])
  ├── G1: (select G2 G3) (select G4 G5) (select G6 G7) (zigzag-join G3 pqr@q pqr@s)
  │    └── [presentation: q:2,s:4]
  │         ├── best: (zigzag-join G3 pqr@q pqr@s)
- │         └── cost: 12.14
+ │         └── cost: 22.13
  ├── G2: (scan pqr,cols=(2,4))
  │    └── []
  │         ├── best: (scan pqr,cols=(2,4))
@@ -6059,7 +6059,7 @@ memo (optimized, ~37KB, required=[presentation: p:1,q:2,r:3,s:4])
  ├── G1: (select G2 G3) (select G4 G5) (select G6 G7) (select G8 G9) (select G10 G9) (lookup-join G11 G12 pqr,keyCols=[1],outCols=(1-4)) (zigzag-join G3 pqr@q pqr@s) (zigzag-join G3 pqr@q pqr@rs) (lookup-join G13 G9 pqr,keyCols=[1],outCols=(1-4))
  │    └── [presentation: p:1,q:2,r:3,s:4]
  │         ├── best: (zigzag-join G3 pqr@q pqr@s)
- │         └── cost: 11.96
+ │         └── cost: 20.97
  ├── G2: (scan pqr,cols=(1-4))
  │    └── []
  │         ├── best: (scan pqr,cols=(1-4))
@@ -6087,12 +6087,12 @@ memo (optimized, ~37KB, required=[presentation: p:1,q:2,r:3,s:4])
  ├── G11: (zigzag-join G21 pqr@q pqr@r)
  │    └── []
  │         ├── best: (zigzag-join G21 pqr@q pqr@r)
- │         └── cost: 11.95
+ │         └── cost: 21.05
  ├── G12: (filters G16)
  ├── G13: (zigzag-join G5 pqr@r pqr@s)
  │    └── []
  │         ├── best: (zigzag-join G5 pqr@r pqr@s)
- │         └── cost: 31.14
+ │         └── cost: 131.14
  ├── G14: (eq G22 G23)
  ├── G15: (eq G24 G23)
  ├── G16: (eq G25 G26)
@@ -6347,6 +6347,104 @@ select
 # GenerateInvertedIndexZigzagJoins
 # --------------------------------------------------
 
+# Stats on table b created via:
+# insert into b select g,g,g,'{"a": "b"}'
+#                      from generate_series(10,100000) g(g);
+# insert into b select g,g,g,'{"f": "g"}'
+#                      from generate_series(100001,200000) g(g);
+# insert into b select g,g,g,'{"a":[{"b":"c"}, 5]}'
+#                      from generate_series(200001,300000) g(g);
+# insert into b select g,g,g,'{"a":1}'
+#                      from generate_series(300001,400000) g(g);
+# insert into b select g,g,g,'{"b":2}'
+#                      from generate_series(400001,500000) g(g);
+# analyze b;
+# Only histogram buckets on column j are preserved.
+exec-ddl
+ALTER TABLE b INJECT STATISTICS '[
+    {
+        "avg_size": 4,
+        "columns": [
+            "k"
+        ],
+        "created_at": "2022-10-03 22:22:47.76982",
+        "distinct_count": 496512,
+        "null_count": 0,
+        "row_count": 499991
+    },
+    {
+        "avg_size": 4,
+        "columns": [
+            "u"
+        ],
+        "created_at": "2022-10-03 22:22:47.76982",
+        "distinct_count": 496512,
+        "null_count": 0,
+        "row_count": 499991
+    },
+    {
+        "avg_size": 4,
+        "columns": [
+            "v"
+        ],
+        "created_at": "2022-10-03 22:22:47.76982",
+        "distinct_count": 496512,
+        "null_count": 0,
+        "row_count": 499991
+    },
+    {
+        "avg_size": 25,
+        "columns": [
+            "j"
+        ],
+        "created_at": "2022-10-03 22:22:47.76982",
+        "distinct_count": 5,
+        "histo_buckets": [
+            {
+                "distinct_range": 0,
+                "num_eq": 103378,
+                "num_range": 0,
+                "upper_bound": "\\x3761000112620001"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 102478,
+                "num_range": 0,
+                "upper_bound": "\\x376100012a0200"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 101998,
+                "num_range": 0,
+                "upper_bound": "\\x37610002000300012a0a00"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 96659,
+                "num_range": 0,
+                "upper_bound": "\\x37610002000362000112630001"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 96119,
+                "num_range": 0,
+                "upper_bound": "\\x376200012a0400"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 99359,
+                "num_range": 0,
+                "upper_bound": "\\x3766000112670001"
+            }
+        ],
+        "histo_col_type": "BYTES",
+        "histo_version": 2,
+        "null_count": 0,
+        "row_count": 499991
+    }
+]';
+----
+
 # Query only the primary key with a remaining filter. 2+ paths in containment
 # query should favor zigzag joins.
 opt expect=GenerateInvertedIndexZigzagJoins
@@ -6431,6 +6529,62 @@ inner-join (lookup b)
  │    └── filters (true)
  └── filters
       └── j:4 @> '{"a": [{"b": "c", "d": 3}, 5]}' [outer=(4), immutable, constraints=(/4: (/NULL - ])]
+
+# Stats on table b created via:
+# insert into c select g, ARRAY[1,3], g
+#                      from generate_series(1,100000) g(g);
+# analyze c;
+# Only histogram buckets on column a are preserved.
+exec-ddl
+ALTER TABLE c INJECT STATISTICS '[
+    {
+        "avg_size": 4,
+        "columns": [
+            "k"
+        ],
+        "created_at": "2022-10-03 22:41:56.480168",
+        "distinct_count": 99658,
+        "null_count": 0,
+        "row_count": 100000
+    },
+    {
+        "avg_size": 7,
+        "columns": [
+            "a"
+        ],
+        "created_at": "2022-10-03 22:41:56.480168",
+        "distinct_count": 1,
+        "histo_buckets": [
+            {
+                "distinct_range": 0,
+                "num_eq": 101040,
+                "num_range": 0,
+                "upper_bound": "\\x89"
+            },
+            {
+                "distinct_range": 0,
+                "num_eq": 98960,
+                "num_range": 0,
+                "upper_bound": "\\x8b"
+            }
+        ],
+        "histo_col_type": "BYTES",
+        "histo_version": 2,
+        "null_count": 0,
+        "row_count": 100000
+    },
+    {
+        "avg_size": 4,
+        "columns": [
+            "u"
+        ],
+        "created_at": "2022-10-03 22:41:56.480168",
+        "distinct_count": 99658,
+        "null_count": 0,
+        "row_count": 100000
+    }
+]';
+----
 
 opt expect=GenerateInvertedIndexZigzagJoins
 SELECT k FROM c WHERE a @> ARRAY[1,3,1,5]
@@ -7027,6 +7181,7 @@ project
  └── distinct-on
       ├── columns: k:1!null j:4
       ├── grouping columns: k:1!null
+      ├── internal-ordering: +1
       ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(4)
@@ -7035,6 +7190,7 @@ project
       │    ├── left columns: k:10 j:13
       │    ├── right columns: k:19 j:22
       │    ├── immutable
+      │    ├── ordering: +1
       │    ├── scan b
       │    │    ├── columns: k:10!null j:13
       │    │    ├── constraint: /10: [/1 - /1]
@@ -7046,11 +7202,16 @@ project
       │         ├── immutable
       │         ├── key: (19)
       │         ├── fd: (19)-->(22)
-      │         └── scan b@j_inv_idx
+      │         ├── ordering: +19
+      │         └── sort
       │              ├── columns: k:19!null
-      │              ├── inverted constraint: /27/19
-      │              │    └── spans: ["7foo\x00\x01\x12bar\x00\x01", "7foo\x00\x01\x12bar\x00\x01"]
-      │              └── key: (19)
+      │              ├── key: (19)
+      │              ├── ordering: +19
+      │              └── scan b@j_inv_idx
+      │                   ├── columns: k:19!null
+      │                   ├── inverted constraint: /27/19
+      │                   │    └── spans: ["7foo\x00\x01\x12bar\x00\x01", "7foo\x00\x01\x12bar\x00\x01"]
+      │                   └── key: (19)
       └── aggregations
            └── const-agg [as=j:4, outer=(4)]
                 └── j:4
@@ -7066,6 +7227,7 @@ project
  └── distinct-on
       ├── columns: k:1!null a:2
       ├── grouping columns: k:1!null
+      ├── internal-ordering: +1
       ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(2)
@@ -7074,6 +7236,7 @@ project
       │    ├── left columns: k:9 a:10
       │    ├── right columns: k:17 a:18
       │    ├── immutable
+      │    ├── ordering: +1
       │    ├── scan c
       │    │    ├── columns: k:9!null a:10
       │    │    ├── constraint: /9: [/1 - /1]
@@ -7085,11 +7248,16 @@ project
       │         ├── immutable
       │         ├── key: (17)
       │         ├── fd: (17)-->(18)
-      │         └── scan c@a_inv_idx
+      │         ├── ordering: +17
+      │         └── sort
       │              ├── columns: k:17!null
-      │              ├── inverted constraint: /24/17
-      │              │    └── spans: ["\x8a", "\x8a"]
-      │              └── key: (17)
+      │              ├── key: (17)
+      │              ├── ordering: +17
+      │              └── scan c@a_inv_idx
+      │                   ├── columns: k:17!null
+      │                   ├── inverted constraint: /24/17
+      │                   │    └── spans: ["\x8a", "\x8a"]
+      │                   └── key: (17)
       └── aggregations
            └── const-agg [as=a:2, outer=(2)]
                 └── a:2
@@ -8518,6 +8686,7 @@ project
  └── distinct-on
       ├── columns: k:1!null u:2 j:4
       ├── grouping columns: k:1!null
+      ├── internal-ordering: +1
       ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(2,4)
@@ -8526,25 +8695,33 @@ project
       │    ├── left columns: k:10 u:11 j:13
       │    ├── right columns: k:19 u:20 j:22
       │    ├── immutable
+      │    ├── ordering: +1
       │    ├── index-join b
       │    │    ├── columns: k:10!null u:11!null j:13
       │    │    ├── key: (10)
       │    │    ├── fd: ()-->(11), (10)-->(13)
+      │    │    ├── ordering: +10 opt(11) [actual: +10]
       │    │    └── scan b@u
       │    │         ├── columns: k:10!null u:11!null
       │    │         ├── constraint: /11/10: [/1 - /1]
       │    │         ├── key: (10)
-      │    │         └── fd: ()-->(11)
+      │    │         ├── fd: ()-->(11)
+      │    │         └── ordering: +10 opt(11) [actual: +10]
       │    └── index-join b
       │         ├── columns: k:19!null u:20 j:22!null
       │         ├── immutable
       │         ├── key: (19)
       │         ├── fd: (19)-->(20,22)
-      │         └── scan b@j_inv_idx
+      │         ├── ordering: +19
+      │         └── sort
       │              ├── columns: k:19!null
-      │              ├── inverted constraint: /27/19
-      │              │    └── spans: ["7foo\x00\x01\x12bar\x00\x01", "7foo\x00\x01\x12bar\x00\x01"]
-      │              └── key: (19)
+      │              ├── key: (19)
+      │              ├── ordering: +19
+      │              └── scan b@j_inv_idx
+      │                   ├── columns: k:19!null
+      │                   ├── inverted constraint: /27/19
+      │                   │    └── spans: ["7foo\x00\x01\x12bar\x00\x01", "7foo\x00\x01\x12bar\x00\x01"]
+      │                   └── key: (19)
       └── aggregations
            ├── const-agg [as=u:2, outer=(2)]
            │    └── u:2
@@ -8561,6 +8738,7 @@ project
  └── distinct-on
       ├── columns: k:1!null a:2 u:3
       ├── grouping columns: k:1!null
+      ├── internal-ordering: +1
       ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(2,3)
@@ -8569,25 +8747,33 @@ project
       │    ├── left columns: k:9 a:10 u:11
       │    ├── right columns: k:17 a:18 u:19
       │    ├── immutable
+      │    ├── ordering: +1
       │    ├── index-join c
       │    │    ├── columns: k:9!null a:10 u:11!null
       │    │    ├── key: (9)
       │    │    ├── fd: ()-->(11), (9)-->(10)
+      │    │    ├── ordering: +9 opt(11) [actual: +9]
       │    │    └── scan c@u
       │    │         ├── columns: k:9!null u:11!null
       │    │         ├── constraint: /11/9: [/1 - /1]
       │    │         ├── key: (9)
-      │    │         └── fd: ()-->(11)
+      │    │         ├── fd: ()-->(11)
+      │    │         └── ordering: +9 opt(11) [actual: +9]
       │    └── index-join c
       │         ├── columns: k:17!null a:18!null u:19
       │         ├── immutable
       │         ├── key: (17)
       │         ├── fd: (17)-->(18,19)
-      │         └── scan c@a_inv_idx
+      │         ├── ordering: +17
+      │         └── sort
       │              ├── columns: k:17!null
-      │              ├── inverted constraint: /24/17
-      │              │    └── spans: ["\x8a", "\x8a"]
-      │              └── key: (17)
+      │              ├── key: (17)
+      │              ├── ordering: +17
+      │              └── scan c@a_inv_idx
+      │                   ├── columns: k:17!null
+      │                   ├── inverted constraint: /24/17
+      │                   │    └── spans: ["\x8a", "\x8a"]
+      │                   └── key: (17)
       └── aggregations
            ├── const-agg [as=a:2, outer=(2)]
            │    └── a:2


### PR DESCRIPTION
Backport 1/1 commits from #89261.

/cc @cockroachdb/release

---

Fixes https://github.com/cockroachlabs/support/issues/1821

Non-covering zigzag join can have a selectivity estimate orders of
magnitude lower than competing plans, causing its cost to be
underestimated. This can make the optimizer choose zigzag join when
there are many qualified rows, which is known to perform poorly.

Also, the per-row cost of zigzag join is underestimated so that even
if selectivity estimates are accurate, the optimizer may still plan
a query using a slow zigzag join.

The selectivity issue is due to a difference between how `buildSelect`
and `buildZigZagJoin` in the `statisticsBuilder` treat constraints
(A filtered Select from the base table should have the same selectivity
as the zigzag join). In `buildSelect`, `filterRelExpr` builds a
filtered histogram via `applyFilters` with new `DistinctCount`s,
then calculates selectivity on the constrained columns, taking into
account which `histCols` already adjusted `DistinctCount`.
```
numUnappliedConjuncts, constrainedCols, histCols :=
sb.applyFilters(filters, e, relProps, false /* skipOrTermAccounting */)
...
corr := sb.correlationFromMultiColDistinctCounts(constrainedCols, e, s)
s.ApplySelectivity(sb.
 selectivityFromConstrainedCols(constrainedCols, histCols, e, s, corr))
```
In `buildZigZagJoin`, `applyFilters` is also called, but the
information about which columns adjusted stats is not considered:
```
multiColSelectivity, _ :=
    sb.selectivityFromMultiColDistinctCounts(constrainedCols, zigzag, s)
s.ApplySelectivity(multiColSelectivity)
```
The solution is to update `buildZigZagJoin` to match the logic in
`filterRelExpr`. This can't be done for zigzag join on inverted indexes
because the constraints aren't pushed into the ON clause. Validating
zigzag join stats on inverted indexes is left for future work.

The costing issue is simply that seek costs are using `seqIOCostFactor`
instead of `randIOCostFactor` like lookup join and inverted join use:
```
cost := memo.Cost(rowCount) * (2*(cpuCostFactor+seqIOCostFactor)
                                       + scanCost + filterPerRow)
```
Every time zigzag join zigs or zags and starts a new scan, that initial
read is like a random IO and incurs some startup overhead. In fact,
profiling has shown it to be quite expensive. The solution is to make
the seek cost be at least on par with lookup join by replacing
`seqIOCostFactor` with `randIOCostFactor + lookupJoinRetrieveRowCost`.
Further fine-tuning may be needed. It may be possible to speed up zigzag
join by trying a point lookup to find a match in the other index before
starting a new scan. This improvement and refinement of costs could be
done simultaneously.

Release note (bug fix): This patch fixes optimizer selectivity and cost
estimates of zigzag join in order to prevent query plans from using it
when it would perform poorly (when many rows are qualified).

Release justification: low risk fix to avoid poor-performing zigzag joins