### PR TITLE
sql/sem/builtins: speed up pg_catalog.col_description

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -4754,6 +4754,9 @@ CREATE TABLE crdb_internal.predefined_comments (
 	populate: func(
 		ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error,
 	) error {
+		// NB if ever anyone were to extend this table to carry column
+		// comments, make sure to update pg_catalog.col_description to
+		// retrieve those comments.
 		tableCommentKey := tree.NewDInt(tree.DInt(keys.TableCommentType))
 		vt := p.getVirtualTabler()
 		vEntries := vt.getSchemas()


### PR DESCRIPTION
We do not have column comments on virtual tables. We were doing a ton of work to look them up, both by materializing a whole virtual table and by doing a scan against a system table for IDs we knew were doomed to find nothing.

Release note (performance improvement): pg_catalog.col_description is now much faster when resolving columns for tables in the pg_catalog, crdb_internal, or information_schema namespaces.