### PR TITLE
storage: add test for IsEmpty

### DIFF
--- a/pkg/storage/enginepb/BUILD.bazel
+++ b/pkg/storage/enginepb/BUILD.bazel
@@ -57,13 +57,15 @@ go_test(
     size = "small",
     srcs = [
         "decode_test.go",
+        "mvcc3_test.go",
         "mvcc_test.go",
     ],
     args = ["-test.timeout=55s"],
+    embed = [":enginepb"],
     deps = [
-        ":enginepb",
         "//pkg/roachpb",
         "//pkg/storage",
+        "//pkg/testutils/zerofields",
         "//pkg/util/hlc",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_redact//:redact",

--- a/pkg/storage/enginepb/mvcc3_test.go
+++ b/pkg/storage/enginepb/mvcc3_test.go
@@ -1,0 +1,29 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+//
+
+package enginepb
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils/zerofields"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMVCCValueHeader_IsEmpty(t *testing.T) {
+	allFieldsSet := MVCCValueHeader{
+		LocalTimestamp: hlc.ClockTimestamp{WallTime: 1, Logical: 1, Synthetic: true},
+	}
+	require.NoError(t, zerofields.NoZeroField(allFieldsSet), "make sure you update the IsEmpty method")
+	require.True(t, MVCCValueHeader{}.IsEmpty())
+	require.False(t, allFieldsSet.IsEmpty())
+}

--- a/pkg/util/hlc/BUILD.bazel
+++ b/pkg/util/hlc/BUILD.bazel
@@ -37,6 +37,7 @@ go_test(
     embed = [":hlc"],
     deps = [
         "//pkg/cli/exit",
+        "//pkg/testutils/zerofields",
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/protoutil",

--- a/pkg/util/hlc/timestamp_test.go
+++ b/pkg/util/hlc/timestamp_test.go
@@ -14,6 +14,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/testutils/zerofields"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -127,6 +128,10 @@ func TestIsEmpty(t *testing.T) {
 	assert.False(t, a.IsEmpty())
 	a = makeSynTS(0, 0)
 	assert.False(t, a.IsEmpty())
+
+	nonZero := makeTS(1, 1)
+	nonZero.Synthetic = true
+	require.NoError(t, zerofields.NoZeroField(nonZero), "please update IsEmpty as well")
 }
 
 func TestTimestampNext(t *testing.T) {


### PR DESCRIPTION
In particular, this test will fail if someone adds a
new field to MVCCValueHeader, and will alert them to
the need to check the field in IsEmpty().

Release note: None
