### PR TITLE
insights: ignore internal executions

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -365,7 +365,7 @@ func NewServer(cfg *ExecutorConfig, pool *mon.BytesMonitor) *Server {
 		sqlstats.MaxMemReportedSQLStatsTxnFingerprints,
 		serverMetrics.StatsMetrics.ReportedSQLStatsMemoryCurBytesCount,
 		serverMetrics.StatsMetrics.ReportedSQLStatsMemoryMaxBytesHist,
-		insightsProvider.Writer(),
+		insightsProvider.Writer,
 		pool,
 		nil, /* reportedProvider */
 		cfg.SQLStatsTestingKnobs,
@@ -378,7 +378,7 @@ func NewServer(cfg *ExecutorConfig, pool *mon.BytesMonitor) *Server {
 		sqlstats.MaxMemSQLStatsTxnFingerprints,
 		serverMetrics.StatsMetrics.SQLStatsMemoryCurBytesCount,
 		serverMetrics.StatsMetrics.SQLStatsMemoryMaxBytesHist,
-		insightsProvider.Writer(),
+		insightsProvider.Writer,
 		pool,
 		reportedSQLStats,
 		cfg.SQLStatsTestingKnobs,
@@ -737,7 +737,7 @@ func (s *Server) SetupConn(
 
 	ex := s.newConnExecutor(
 		ctx, sdMutIterator, stmtBuf, clientComm, memMetrics, &s.Metrics,
-		s.sqlStats.GetApplicationStats(sd.ApplicationName),
+		s.sqlStats.GetApplicationStats(sd.ApplicationName, false /* internal */),
 		nil, /* postSetupFn */
 	)
 	return ConnectionHandler{ex}, nil
@@ -991,7 +991,7 @@ func (s *Server) newConnExecutor(
 	)
 	ex.dataMutatorIterator.onApplicationNameChange = func(newName string) {
 		ex.applicationName.Store(newName)
-		ex.applicationStats = ex.server.sqlStats.GetApplicationStats(newName)
+		ex.applicationStats = ex.server.sqlStats.GetApplicationStats(newName, false /* internal */)
 	}
 
 	ex.phaseTimes.SetSessionPhaseTime(sessionphase.SessionInit, timeutil.Now())

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -225,7 +225,7 @@ func (ie *InternalExecutor) initConnEx(
 		// If this is already an "internal app", don't put more prefix.
 		appStatsBucketName = sd.ApplicationName
 	}
-	applicationStats := ie.s.sqlStats.GetApplicationStats(appStatsBucketName)
+	applicationStats := ie.s.sqlStats.GetApplicationStats(appStatsBucketName, true /* internal */)
 
 	sds := sessiondata.NewStack(sd)
 	sdMutIterator := ie.s.makeSessionDataMutatorIterator(sds, nil /* sessionDefaults */)

--- a/pkg/sql/sqlstats/insights/ingester.go
+++ b/pkg/sql/sqlstats/insights/ingester.go
@@ -108,7 +108,13 @@ func (i *concurrentBufferIngester) Reader() Reader {
 	return i.registry
 }
 
-func (i *concurrentBufferIngester) Writer() Writer {
+var nullWriterInstance Writer = &nullWriter{}
+
+func (i *concurrentBufferIngester) Writer(internal bool) Writer {
+	// We ignore statements and transactions run by the internal executor.
+	if internal {
+		return nullWriterInstance
+	}
 	return i
 }
 
@@ -165,4 +171,12 @@ func newConcurrentBufferIngester(registry *lockingRegistry) *concurrentBufferIng
 		},
 	)
 	return i
+}
+
+type nullWriter struct{}
+
+func (n *nullWriter) ObserveStatement(_ clusterunique.ID, _ *Statement) {
+}
+
+func (n *nullWriter) ObserveTransaction(_ clusterunique.ID, _ *Transaction) {
 }

--- a/pkg/sql/sqlstats/insights/insights.go
+++ b/pkg/sql/sqlstats/insights/insights.go
@@ -143,6 +143,10 @@ type Writer interface {
 	ObserveTransaction(sessionID clusterunique.ID, transaction *Transaction)
 }
 
+// WriterProvider offers a Writer.
+// Pass true for internal when called by the internal executor.
+type WriterProvider func(internal bool) Writer
+
 // Reader offers access to the currently retained set of insights.
 type Reader interface {
 	// IterateInsights calls visitor with each of the currently retained set of insights.
@@ -155,7 +159,8 @@ type Provider interface {
 	Start(ctx context.Context, stopper *stop.Stopper)
 
 	// Writer returns an object that observes statement and transaction executions.
-	Writer() Writer
+	// Pass true for internal when called by the internal executor.
+	Writer(internal bool) Writer
 
 	// Reader returns an object that offers read access to any detected insights.
 	Reader() Reader

--- a/pkg/sql/sqlstats/insights/insights_test.go
+++ b/pkg/sql/sqlstats/insights/insights_test.go
@@ -54,7 +54,7 @@ func BenchmarkInsights(b *testing.B) {
 			numTransactionsPerSession := b.N / numSessions
 			var sessions sync.WaitGroup
 			sessions.Add(numSessions)
-			writer := provider.Writer()
+			writer := provider.Writer(false /* internal */)
 
 			for i := 0; i < numSessions; i++ {
 				sessionID := clusterunique.ID{Uint128: uint128.FromInts(0, uint64(i))}

--- a/pkg/sql/sqlstats/persistedsqlstats/datadriven_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/datadriven_test.go
@@ -85,7 +85,7 @@ func TestSQLStatsDataDriven(t *testing.T) {
 	server := cluster.Server(0 /* idx */)
 	sqlStats := server.SQLServer().(*sql.Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats)
 
-	appStats := sqlStats.GetApplicationStats("app1")
+	appStats := sqlStats.GetApplicationStats("app1", false)
 
 	// Open two connections so that we can run statements without messing up
 	// the SQL stats.

--- a/pkg/sql/sqlstats/persistedsqlstats/provider.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/provider.go
@@ -202,8 +202,10 @@ func (s *PersistedSQLStats) jitterInterval(interval time.Duration) time.Duration
 }
 
 // GetApplicationStats implements sqlstats.Provider interface.
-func (s *PersistedSQLStats) GetApplicationStats(appName string) sqlstats.ApplicationStats {
-	appStats := s.SQLStats.GetApplicationStats(appName)
+func (s *PersistedSQLStats) GetApplicationStats(
+	appName string, internal bool,
+) sqlstats.ApplicationStats {
+	appStats := s.SQLStats.GetApplicationStats(appName, internal)
 	return &ApplicationStats{
 		ApplicationStats:     appStats,
 		memoryPressureSignal: s.memoryPressureSignal,

--- a/pkg/sql/sqlstats/sslocal/sql_stats.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats.go
@@ -67,7 +67,7 @@ type SQLStats struct {
 
 	knobs *sqlstats.TestingKnobs
 
-	insights insights.Writer
+	insights insights.WriterProvider
 }
 
 func newSQLStats(
@@ -76,7 +76,7 @@ func newSQLStats(
 	uniqueTxnFingerprintLimit *settings.IntSetting,
 	curMemBytesCount *metric.Gauge,
 	maxMemBytesHist *metric.Histogram,
-	insightsWriter insights.Writer,
+	insightsWriter insights.WriterProvider,
 	parentMon *mon.BytesMonitor,
 	flushTarget Sink,
 	knobs *sqlstats.TestingKnobs,
@@ -134,7 +134,7 @@ func (s *SQLStats) getStatsForApplication(appName string) *ssmemstorage.Containe
 		s.mu.mon,
 		appName,
 		s.knobs,
-		s.insights,
+		s.insights(false /* internal */),
 	)
 	s.mu.apps[appName] = a
 	return a

--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -445,13 +445,13 @@ func TestExplicitTxnFingerprintAccounting(t *testing.T) {
 		sqlstats.MaxMemSQLStatsTxnFingerprints,
 		nil, /* curMemoryBytesCount */
 		nil, /* maxMemoryBytesHist */
-		insights.New(st, insights.NewMetrics()).Writer(),
+		insights.New(st, insights.NewMetrics()).Writer,
 		monitor,
 		nil, /* reportingSink */
 		nil, /* knobs */
 	)
 
-	appStats := sqlStats.GetApplicationStats("" /* appName */)
+	appStats := sqlStats.GetApplicationStats("" /* appName */, false /* internal */)
 	statsCollector := sslocal.NewStatsCollector(
 		st,
 		appStats,
@@ -563,12 +563,12 @@ func TestAssociatingStmtStatsWithTxnFingerprint(t *testing.T) {
 			sqlstats.MaxMemSQLStatsTxnFingerprints,
 			nil,
 			nil,
-			insights.New(st, insights.NewMetrics()).Writer(),
+			insights.New(st, insights.NewMetrics()).Writer,
 			monitor,
 			nil,
 			nil,
 		)
-		appStats := sqlStats.GetApplicationStats("" /* appName */)
+		appStats := sqlStats.GetApplicationStats("" /* appName */, false /* internal */)
 		statsCollector := sslocal.NewStatsCollector(
 			st,
 			appStats,

--- a/pkg/sql/sqlstats/sslocal/sslocal_provider.go
+++ b/pkg/sql/sqlstats/sslocal/sslocal_provider.go
@@ -38,7 +38,7 @@ func New(
 	maxTxnFingerprints *settings.IntSetting,
 	curMemoryBytesCount *metric.Gauge,
 	maxMemoryBytesHist *metric.Histogram,
-	insightsWriter insights.Writer,
+	insightsWriter insights.WriterProvider,
 	pool *mon.BytesMonitor,
 	reportingSink Sink,
 	knobs *sqlstats.TestingKnobs,
@@ -93,7 +93,7 @@ func (s *SQLStats) Start(ctx context.Context, stopper *stop.Stopper) {
 }
 
 // GetApplicationStats implements sqlstats.Provider interface.
-func (s *SQLStats) GetApplicationStats(appName string) sqlstats.ApplicationStats {
+func (s *SQLStats) GetApplicationStats(appName string, internal bool) sqlstats.ApplicationStats {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if a, ok := s.mu.apps[appName]; ok {
@@ -108,7 +108,7 @@ func (s *SQLStats) GetApplicationStats(appName string) sqlstats.ApplicationStats
 		s.mu.mon,
 		appName,
 		s.knobs,
-		s.insights,
+		s.insights(internal),
 	)
 	s.mu.apps[appName] = a
 	return a

--- a/pkg/sql/sqlstats/ssprovider.go
+++ b/pkg/sql/sqlstats/ssprovider.go
@@ -175,7 +175,7 @@ type Storage interface {
 
 	// GetApplicationStats returns an ApplicationStats instance for the given
 	// application name.
-	GetApplicationStats(appName string) ApplicationStats
+	GetApplicationStats(appName string, internal bool) ApplicationStats
 
 	// Reset resets all the statistics stored in-memory in the current Storage.
 	Reset(context.Context) error


### PR DESCRIPTION
This change passes a no-op `insights.Writer` into the internal executor. Many built-in functions are implemented in SQL, calling through the internal executor. These executions are uninteresting from an insights perspective, and tracking them needlessly consumes available memory.

Here's a representative flame graph of the heap *after* running a large lateral join repeatedly calling out to `pg_catalog.col_description()`. Something's different enough about the way the internal executor records stats (perhaps its "implicit transaction is done" path flows a different way?) that we leaked tons of memory, both in the statement observations themselves (left) and in buffering them for eventual examination (right):

| ssmemstorage.(*Container).RecordStatement | insights.(*lockingRegistry).ObserveStatement |
|--|--|
|<img width="1372" alt="Before - RecordStatement" src="https://user-images.githubusercontent.com/5261/194400752-4e5635e8-fb14-42b6-91cc-8279ec0dfc0c.png">|<img width="1372" alt="Before - ObserveStatement" src="https://user-images.githubusercontent.com/5261/194400900-784f6f43-9f16-4d2e-90e4-a87b8a10ab01.png">|

After this change, the heap is far healthier:

<img width="1372" alt="Screen Shot 2022-10-06 at 3 27 22 PM" src="https://user-images.githubusercontent.com/5261/194401746-3b549bb3-ed57-44b5-99c1-2cfabaa2b779.png">

Release justification: Fixes for high-priority or high-severity bugs in existing functionality

Release note: None