### PR TITLE
workload/schemachange: enhance logging to be more consumable

### DIFF
--- a/pkg/workload/schemachange/error_code_set.go
+++ b/pkg/workload/schemachange/error_code_set.go
@@ -44,6 +44,15 @@ func (set errorCodeSet) contains(code pgcode.Code) bool {
 	return ok
 }
 
+func (set errorCodeSet) StringSlice() []string {
+	var codes []string
+	for code := range set {
+		codes = append(codes, code.String())
+	}
+	sort.Strings(codes)
+	return codes
+}
+
 func (set errorCodeSet) String() string {
 	var codes []string
 	for code := range set {

--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -82,8 +82,9 @@ func (og *operationGenerator) scanInt(
 	err = tx.QueryRow(ctx, query, args...).Scan(&i)
 	if err == nil {
 		og.LogQueryResults(
-			fmt.Sprintf("%q %q", query, args),
-			fmt.Sprintf("%d", i),
+			query,
+			i,
+			args...,
 		)
 	}
 	return i, errors.Wrapf(err, "scanBool: %q %q", query, args)
@@ -95,8 +96,9 @@ func (og *operationGenerator) scanBool(
 	err = tx.QueryRow(ctx, query, args...).Scan(&b)
 	if err == nil {
 		og.LogQueryResults(
-			fmt.Sprintf("%q %q", query, args),
-			fmt.Sprintf("%t", b),
+			query,
+			b,
+			args...,
 		)
 	}
 	return b, errors.Wrapf(err, "scanBool: %q %q", query, args)
@@ -855,8 +857,9 @@ func (og *operationGenerator) scanStringArrayNullableRows(
 			humanReadableResults = append(humanReadableResults, humanReadableRes)
 		}
 		og.LogQueryResults(
-			fmt.Sprintf("%q %q", query, args),
-			fmt.Sprintf("%q", humanReadableResults))
+			query,
+			humanReadableResults,
+			args...)
 	}
 	return results, nil
 }
@@ -885,8 +888,9 @@ func (og *operationGenerator) scanStringArrayRows(
 	}
 
 	og.LogQueryResults(
-		fmt.Sprintf("%q %q", query, args),
-		fmt.Sprintf("%q", results))
+		query,
+		results,
+		args...)
 	return results, nil
 }
 
@@ -907,9 +911,10 @@ func (og *operationGenerator) scanStringArray(
 ) (b []string, err error) {
 	err = tx.QueryRow(ctx, query, args...).Scan(&b)
 	if err == nil {
-		og.LogQueryResultArray(
-			fmt.Sprintf("%q %q", query, args),
+		og.LogQueryResults(
+			query,
 			b,
+			args...,
 		)
 	}
 	return b, errors.Wrapf(err, "scanStringArray %q %q", query, args)
@@ -1129,7 +1134,7 @@ func (og *operationGenerator) checkAndAdjustForUnknownSchemaErrors(err error) er
 	if pgErr := new(pgconn.PgError); errors.As(err, &pgErr) &&
 		pgcode.MakeCode(pgErr.Code) == pgcode.InvalidSchemaName {
 		if regexpUnknownSchemaErr.MatchString(pgErr.Message) {
-			og.opGenLog.WriteString(fmt.Sprintf("Rolling back due to unknown schema error %v",
+			og.LogMessage(fmt.Sprintf("Rolling back due to unknown schema error %v",
 				err))
 			// Force a rollback and log inside the operation generator.
 			return errors.Mark(err, errRunInTxnRbkSentinel)

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -12,6 +12,7 @@ package schemachange
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"strconv"
@@ -73,30 +74,52 @@ type operationGenerator struct {
 	stmtsInTxt []*opStmt
 
 	// opGenLog log of statement used to generate the current statement.
-	opGenLog strings.Builder
+	opGenLog []interface{}
+}
+
+// OpGenLogQuery a query with a single value result.
+type OpGenLogQuery struct {
+	Query     string      `json:"query"`
+	QueryArgs interface{} `json:"queryArgs,omitempty"`
+	Result    interface{} `json:"result,omitempty"`
+}
+
+// OpGenLogMessage an informational message directly written into the OpGen log.
+type OpGenLogMessage struct {
+	Message string `json:"message"`
 }
 
 // LogQueryResults logs a string query result.
-func (og *operationGenerator) LogQueryResults(queryName string, result string) {
-	og.opGenLog.WriteString(fmt.Sprintf("QUERY [%s] :", queryName))
-	og.opGenLog.WriteString(result)
-	og.opGenLog.WriteString("\n")
-}
-
-// LogQueryResultArray logs a query result that is a strng array.
-func (og *operationGenerator) LogQueryResultArray(queryName string, results []string) {
-	og.opGenLog.WriteString(fmt.Sprintf("QUERY [%s] : ", queryName))
-	for _, result := range results {
-		og.opGenLog.WriteString(result)
-		og.opGenLog.WriteString(",")
+func (og *operationGenerator) LogQueryResults(
+	queryName string, result interface{}, queryArgs ...interface{},
+) {
+	formattedQuery := queryName
+	parsedQuery, err := parser.Parse(queryName)
+	if err == nil {
+		formattedQuery = parsedQuery.String()
 	}
 
-	og.opGenLog.WriteString("\n")
+	query := &OpGenLogQuery{
+		Query:  formattedQuery,
+		Result: result,
+	}
+	if len(queryArgs) != 0 {
+		query.QueryArgs = queryArgs
+	}
+	og.opGenLog = append(og.opGenLog, query)
+}
+
+// LogMessage logs an information mesage into the OpGen log.
+func (og *operationGenerator) LogMessage(message string) {
+	query := &OpGenLogMessage{
+		Message: message,
+	}
+	og.opGenLog = append(og.opGenLog, query)
 }
 
 // GetOpGenLog fetches the generated log entries.
-func (og *operationGenerator) GetOpGenLog() string {
-	return og.opGenLog.String()
+func (og *operationGenerator) GetOpGenLog() []interface{} {
+	return og.opGenLog
 }
 
 func makeOperationGenerator(params *operationGeneratorParams) *operationGenerator {
@@ -113,7 +136,6 @@ func makeOperationGenerator(params *operationGeneratorParams) *operationGenerato
 func (og *operationGenerator) resetOpState() {
 	og.candidateExpectedCommitErrors.reset()
 	og.potentialExecErrors.reset()
-	og.opGenLog = strings.Builder{}
 }
 
 // Reset internal state used per transaction
@@ -658,7 +680,7 @@ func (og *operationGenerator) scanRegionNames(
 	if rows.Err() != nil {
 		return nil, errors.Wrapf(rows.Err(), "failed to get regions: %s", query)
 	}
-	og.LogQueryResultArray(query, regionNamesForLog)
+	og.LogQueryResults(query, regionNamesForLog)
 	return regionNames, nil
 }
 
@@ -2573,6 +2595,18 @@ func (s *opStmt) String() string {
 		s.potentialExecErrors)
 }
 
+func (s *opStmt) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		SQL              string `json:"sql"`
+		ExpectedExecErr  string `json:"expectedExecErr,omitempty"`
+		PotentialExecErr string `json:"potentialExecErr,omitempty"`
+	}{
+		SQL:              s.sql,
+		ExpectedExecErr:  s.expectedExecErrors.String(),
+		PotentialExecErr: s.potentialExecErrors.String(),
+	})
+}
+
 // makeOpStmtForSingleError constructs a statement that will only produce
 // an error.
 func makeOpStmtForSingleError(queryType opStmtType, sql string, codes ...pgcode.Code) *opStmt {
@@ -2593,23 +2627,41 @@ func makeOpStmt(queryType opStmtType) *opStmt {
 	}
 }
 
-// getErrorState dumps the object state when an error is hit
-func (og *operationGenerator) getErrorState(op *opStmt) string {
-	return fmt.Sprintf("Dumping state before death:\n"+
-		"Expected errors: %s\n"+
-		"Potential errors: %s\n"+
-		"Expected commit errors: %s\n"+
-		"Potential commit errors: %s\n"+
-		"===========================\n"+
-		"Executed queries for generating errors: %s\n"+
-		"===========================\n"+
-		"Previous statements %s\n",
-		op.expectedExecErrors,
-		op.potentialExecErrors,
-		og.expectedCommitErrors.String(),
-		og.potentialCommitErrors.String(),
-		og.GetOpGenLog(),
-		og.stmtsInTxt)
+// ErrorState wraps schemachange workload errors to have state information for
+// the purpose of dumping in our JSON log.
+type ErrorState struct {
+	cause                      error
+	ExpectedErrors             []string      `json:"expectedErrors,omitempty"`
+	PotentialErrors            []string      `json:"potentialErrors,omitempty"`
+	ExpectedCommitErrors       []string      `json:"expectedCommitErrors,omitempty"`
+	PotentialCommitErrors      []string      `json:"potentialCommitErrors,omitempty"`
+	QueriesForGeneratingErrors []interface{} `json:"queriesForGeneratingErrors,omitempty"`
+	PreviousStatements         []string      `json:"previousStatements,omitempty"`
+}
+
+func (es *ErrorState) Unwrap() error {
+	return es.cause
+}
+
+func (es *ErrorState) Error() string {
+	return es.cause.Error()
+}
+
+// WrapWithErrorState dumps the object state when an error is hit
+func (og *operationGenerator) WrapWithErrorState(err error, op *opStmt) error {
+	previousStmts := make([]string, 0, len(og.stmtsInTxt))
+	for _, stmt := range og.stmtsInTxt {
+		previousStmts = append(previousStmts, stmt.sql)
+	}
+	return &ErrorState{
+		cause:                      err,
+		ExpectedErrors:             op.expectedExecErrors.StringSlice(),
+		PotentialErrors:            op.potentialExecErrors.StringSlice(),
+		ExpectedCommitErrors:       og.expectedCommitErrors.StringSlice(),
+		PotentialCommitErrors:      og.potentialCommitErrors.StringSlice(),
+		QueriesForGeneratingErrors: og.GetOpGenLog(),
+		PreviousStatements:         previousStmts,
+	}
 }
 
 // executeStmt executes the given operation statement, and validates the result
@@ -2629,8 +2681,7 @@ func (s *opStmt) executeStmt(ctx context.Context, tx pgx.Tx, og *operationGenera
 		pgErr := new(pgconn.PgError)
 		if !errors.As(err, &pgErr) {
 			return errors.Mark(
-				errors.Wrapf(err, "***UNEXPECTED ERROR; Received a non pg error.\n %s",
-					og.getErrorState(s)),
+				og.WrapWithErrorState(errors.Wrap(err, "***UNEXPECTED ERROR; Received a non pg error."), s),
 				errRunInTxnFatalSentinel,
 			)
 		}
@@ -2640,21 +2691,23 @@ func (s *opStmt) executeStmt(ctx context.Context, tx pgx.Tx, og *operationGenera
 		if !s.expectedExecErrors.contains(pgcode.MakeCode(pgErr.Code)) &&
 			!s.potentialExecErrors.contains(pgcode.MakeCode(pgErr.Code)) {
 			return errors.Mark(
-				errors.Wrapf(err, "***UNEXPECTED ERROR; Received an unexpected execution error.\n %s",
-					og.getErrorState(s)),
+				og.WrapWithErrorState(errors.Wrap(err, "***UNEXPECTED ERROR; Received an unexpected execution error."),
+					s),
 				errRunInTxnFatalSentinel,
 			)
 		}
-		return errors.Mark(
-			errors.Wrapf(err, "ROLLBACK; Successfully got expected execution error.\n %s",
-				og.getErrorState(s)),
+		return errors.Mark(errors.Wrap(err, "ROLLBACK; Successfully got expected execution error."),
 			errRunInTxnRbkSentinel,
 		)
 	}
 	if !s.expectedExecErrors.empty() {
+		// Clean up the result set, if we didn't encounter an expected error.
+		if rows != nil {
+			rows.Close()
+		}
 		return errors.Mark(
-			errors.Newf("***FAIL; Failed to receive an execution error when errors were expected. %s",
-				og.getErrorState(s)),
+			og.WrapWithErrorState(errors.New("***FAIL; Failed to receive an execution error when errors were expected"),
+				s),
 			errRunInTxnFatalSentinel,
 		)
 	}
@@ -3527,7 +3580,7 @@ func (og *operationGenerator) pctExisting(shouldAlreadyExist bool) int {
 	return og.params.errorRate
 }
 
-func (og operationGenerator) alwaysExisting() int {
+func (og *operationGenerator) alwaysExisting() int {
 	return 100
 }
 

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -285,13 +285,14 @@ var (
 
 // LogEntry and its fields must be public so that the json package can encode this struct.
 type LogEntry struct {
-	WorkerID             int      `json:"workerId"`
-	ClientTimestamp      string   `json:"clientTimestamp"`
-	Ops                  []string `json:"ops"`
-	ExpectedExecErrors   string   `json:"expectedExecErrors"`
-	ExpectedCommitErrors string   `json:"expectedCommitErrors"`
+	WorkerID             int           `json:"workerId"`
+	ClientTimestamp      string        `json:"clientTimestamp"`
+	Ops                  []interface{} `json:"ops"`
+	ExpectedExecErrors   string        `json:"expectedExecErrors"`
+	ExpectedCommitErrors string        `json:"expectedCommitErrors"`
 	// Optional message for errors or if a hook was called.
-	Message string `json:"message"`
+	Message    string      `json:"message"`
+	ErrorState *ErrorState `json:"errorState,omitempty"`
 }
 
 type histBin int
@@ -311,23 +312,19 @@ func (w *schemaChangeWorker) recordInHist(elapsed time.Duration, bin histBin) {
 	w.hists.Get(bin.String()).Record(elapsed)
 }
 
-func (w *schemaChangeWorker) getErrorState() string {
-	return fmt.Sprintf("Dumping state before death:\n"+
-		"Expected errors: %s"+
-		"Potential exec errors: %s"+
-		"Expected commit errors: %s"+
-		"Potential commit errors: %s"+
-		"==========================="+
-		"Executed queries for generating errors: %s"+
-		"==========================="+
-		"Previous statements %s",
-		"",
-		//	w.opGen.expectedExecErrors.String(),
-		w.opGen.potentialExecErrors.String(),
-		w.opGen.expectedCommitErrors.String(),
-		w.opGen.potentialCommitErrors.String(),
-		w.opGen.GetOpGenLog(),
-		w.opGen.stmtsInTxt)
+func (w *schemaChangeWorker) WrapWithErrorState(err error) error {
+	previousStmts := make([]string, 0, len(w.opGen.stmtsInTxt))
+	for _, stmt := range w.opGen.stmtsInTxt {
+		previousStmts = append(previousStmts, stmt.sql)
+	}
+	return &ErrorState{
+		cause:                      err,
+		PotentialErrors:            w.opGen.potentialExecErrors.StringSlice(),
+		PotentialCommitErrors:      w.opGen.potentialCommitErrors.StringSlice(),
+		ExpectedCommitErrors:       w.opGen.expectedCommitErrors.StringSlice(),
+		QueriesForGeneratingErrors: w.opGen.GetOpGenLog(),
+		PreviousStatements:         previousStmts,
+	}
 }
 
 func (w *schemaChangeWorker) runInTxn(ctx context.Context, tx pgx.Tx) error {
@@ -359,16 +356,14 @@ func (w *schemaChangeWorker) runInTxn(ctx context.Context, tx pgx.Tx) error {
 			return errors.Mark(err, errRunInTxnRbkSentinel)
 		} else if err != nil {
 			return errors.Mark(
-				errors.Wrapf(err, "***UNEXPECTED ERROR; Failed to generate a random operation\n OpGen log: \n%s\nStmts: \n%s\n",
-					w.opGen.GetOpGenLog(),
-					w.opGen.stmtsInTxt,
-				),
+				w.WrapWithErrorState(
+					errors.Wrap(err, "***UNEXPECTED ERROR; Failed to generate a random operation")),
 				errRunInTxnFatalSentinel,
 			)
 		}
 
 		w.logger.addExpectedErrors(op.expectedExecErrors, w.opGen.expectedCommitErrors)
-		w.logger.writeLog(op.String())
+		w.logger.writeLogOp(op)
 		if !w.dryRun {
 			start := timeutil.Now()
 			err := op.executeStmt(ctx, tx, w.opGen)
@@ -425,7 +420,7 @@ func (w *schemaChangeWorker) run(ctx context.Context) error {
 			)
 		}
 
-		w.logger.flushLog(tx, err.Error())
+		w.logger.flushLogWithError(tx, err)
 		switch {
 		case errors.Is(err, errRunInTxnFatalSentinel):
 			w.preErrorHook()
@@ -448,7 +443,7 @@ func (w *schemaChangeWorker) run(ctx context.Context) error {
 				errors.Wrap(err, "***UNEXPECTED COMMIT ERROR; Received a non pg error"),
 				errRunInTxnFatalSentinel,
 			)
-			w.logger.flushLog(tx, err.Error())
+			w.logger.flushLogWithError(tx, err)
 			w.preErrorHook()
 			return err
 		}
@@ -475,10 +470,11 @@ func (w *schemaChangeWorker) run(ctx context.Context) error {
 		if !w.opGen.expectedCommitErrors.contains(pgcode.MakeCode(pgErr.Code)) &&
 			!w.opGen.potentialCommitErrors.contains(pgcode.MakeCode(pgErr.Code)) {
 			err = errors.Mark(
-				errors.Wrapf(err, "***UNEXPECTED COMMIT ERROR; Received an unexpected commit error %s", w.getErrorState()),
+				w.WrapWithErrorState(
+					errors.Wrapf(err, "***UNEXPECTED COMMIT ERROR; Received an unexpected commit error")),
 				errRunInTxnFatalSentinel,
 			)
-			w.logger.flushLog(tx, err.Error())
+			w.logger.flushLogWithError(tx, err)
 			w.preErrorHook()
 			return err
 		}
@@ -489,8 +485,8 @@ func (w *schemaChangeWorker) run(ctx context.Context) error {
 		return nil
 	}
 	if !w.opGen.expectedCommitErrors.empty() {
-		err := errors.Newf("***FAIL; Failed to receive a commit error when at least one commit error was expected %s", w.getErrorState())
-		w.logger.flushLog(tx, err.Error())
+		err := w.WrapWithErrorState(errors.Newf("***FAIL; Failed to receive a commit error when at least one commit error was expected"))
+		w.logger.flushLogWithError(tx, err)
 		w.preErrorHook()
 		return errors.Mark(err, errRunInTxnFatalSentinel)
 	}
@@ -559,6 +555,19 @@ func (l *logger) writeLog(op string) {
 	}
 }
 
+// writeLog appends an op statement to the currentLogEntry of the schemaChangeWorker.
+// It is a noop if l.verbose < 1.
+func (l *logger) writeLogOp(op *opStmt) {
+	if l.verbose < 1 {
+		return
+	}
+	l.currentLogEntry.mu.Lock()
+	defer l.currentLogEntry.mu.Unlock()
+	if l.currentLogEntry.mu.entry != nil {
+		l.currentLogEntry.mu.entry.Ops = append(l.currentLogEntry.mu.entry.Ops, op)
+	}
+}
+
 // addExpectedErrors sets the expected errors in the currentLogEntry of the schemaChangeWorker.
 // It is a noop if l.verbose < 1.
 func (l *logger) addExpectedErrors(execErrors errorCodeSet, commitErrors errorCodeSet) {
@@ -571,6 +580,30 @@ func (l *logger) addExpectedErrors(execErrors errorCodeSet, commitErrors errorCo
 		l.currentLogEntry.mu.entry.ExpectedExecErrors = execErrors.String()
 		l.currentLogEntry.mu.entry.ExpectedCommitErrors = commitErrors.String()
 	}
+}
+
+// flushLogWithError outputs the currentLogEntry of the schemaChangeWorker, with
+// an error message (any available error state information is also added).
+// It is a noop if l.verbose < 0.
+func (l *logger) flushLogWithError(tx pgx.Tx, err error) {
+	if l.verbose < 1 {
+		return
+	}
+
+	// Fetch and apply the error state to the log entry.
+	func() {
+		l.currentLogEntry.mu.Lock()
+		defer l.currentLogEntry.mu.Unlock()
+		if l.currentLogEntry.mu.entry != nil {
+			var state *ErrorState
+			if errors.As(err, &state) {
+				l.currentLogEntry.mu.entry.ErrorState = state
+			}
+		}
+	}()
+
+	l.flushLogAndLock(tx, err.Error(), true)
+	l.currentLogEntry.mu.Unlock()
 }
 
 // flushLog outputs the currentLogEntry of the schemaChangeWorker.


### PR DESCRIPTION
These changes modify the logging inside the schema changer workload to do the following:

Fixes: #89284

1) Generate more easily consumable error state information that is kept was JSON. This works by adding an new error wrapper to help propagate errors.
2) Turn the opGenLog into a structured log for more easy consume ability.
3) Eliminate unnecessary fields in the output by omitting empty optional fields from the JSON log.
4) Eliminate unnecessary state information dumps, where successful operations were also dumping this information out.

Release note: None


As an example, the new logging during a failure in the JSON format we currently generate the following output on master:
```
{
  "workerId": 0,
  "clientTimestamp": "03:23:30.14084",
  "ops": [
    "BEGIN",
    "QUERY: SELECT 'validating all objects', crdb_internal.validate_multi_region_zone_configs(), Expected Errors: , Potential Errors: ",
    "QUERY: CREATE TABLE public.table8 (col8_9 GEOMETRY NOT NULL, col8_10 BOX2D NOT NULL, col8_11 FLOAT4 NOT NULL, col8_12 TIMETZ NOT NULL, col8_13 \"char\" NOT NULL, col8_14 NAME NOT NULL, col8_15 DECIMAL NOT NULL, col8_16 INET NOT NULL, col8_17 INT8 NO
T NULL, col8_18 STRING NOT NULL AS (lower(col8_13)) STORED, col8_19 FLOAT8 NOT NULL AS (col8_11 + 0.05183445289731026:::FLOAT8) VIRTUAL, PRIMARY KEY (col8_10, col8_18 DESC, col8_17 DESC, col8_19, col8_15 DESC, col8_11 ASC, col8_13 DESC, col8_14, col8_16
DESC), UNIQUE (col8_17 ASC, col8_12 DESC, col8_19, col8_18) PARTITION BY LIST (col8_17, col8_12, col8_19, col8_18) (PARTITION table8_part_0 VALUES IN ((1112324545982352417:::INT8, '08:25:58.380905+00:58:00':::TIMETZ, 2.308196400279898:::FLOAT8, e' >\\t\\
bp\\x02\\x047':::STRING)), PARTITION table8_part_1 VALUES IN (((-4169758796321653179):::INT8, '12:59:18.130563-10:24:00':::TIMETZ, (-0.7093454254464202):::FLOAT8, e'k\\x1a#`!#c\\x7fY':::STRING)), PARTITION table8_part_2 VALUES IN (((-5076717300105623401)
:::INT8, '07:12:07.412407-07:06:00':::TIMETZ, (-0.7914235188323253):::FLOAT8, e'KIn3#\\rAk':::STRING)), PARTITION table8_part_3 VALUES IN ((2147483647:::INT8, '18:07:00.223705+03:00:00':::TIMETZ, 1.4698528925964642:::FLOAT8, e'S\\x047\\x03\\x02VW\\x0e'::
:STRING)), PARTITION table8_part_4 VALUES IN (((-5362989756654691582):::INT8, '01:31:00.271577+14:32:00':::TIMETZ, (-0.3369973678230378):::FLOAT8, '/fKW':::STRING)), PARTITION table8_part_5 VALUES IN (((-6629264169873001169):::INT8, '02:01:58.855859-02:5
8:00':::TIMETZ, (-0.8050523865991726):::FLOAT8, '':::STRING)), PARTITION table8_part_6 VALUES IN (((-5722173834231977500):::INT8, '17:00:12.308808-06:17:00':::TIMETZ, (-0.9479345049607424):::FLOAT8, '':::STRING)), PARTITION table8_part_7 VALUES IN (((-83
7799042489541168):::INT8, '06:37:23.35124+07:43:00':::TIMETZ, (-1.0469263893545366):::FLOAT8, e'\\x03\\x01l(n\\x1cv9':::STRING)), PARTITION table8_part_8 VALUES IN ((3264035864940073454:::INT8, '11:23:56.130029+12:36:00':::TIMETZ, 0.6868497639211962:::FL
OAT8, '':::STRING)), PARTITION \"DEFAULT\" VALUES IN ((DEFAULT, DEFAULT, DEFAULT, DEFAULT))), INDEX (lower(CAST(col8_9 AS STRING)) ASC, lower(CAST(col8_16 AS STRING))), INDEX (col8_15 ASC, col8_13 ASC, col8_19, col8_16 ASC, lower(CAST(col8_16 AS STRING))
 ASC, col8_10, col8_14 ASC, col8_18 ASC), INDEX (lower(col8_14) DESC, col8_13 DESC, col8_14 ASC), INDEX (col8_19, (col8_11 + (-0.5048524141311646):::FLOAT8) ASC, col8_18, col8_13, lower(CAST(col8_10 AS STRING)) DESC, col8_12 ASC) STORING (col8_9) NOT VIS
IBLE, UNIQUE (col8_18 ASC, col8_19, col8_15 ASC, col8_10, col8_14, col8_17 ASC, col8_16 ASC) STORING (col8_9, col8_12), FAMILY (col8_18, col8_16, col8_13), FAMILY (col8_11, col8_12, col8_15), FAMILY (col8_10), FAMILY (col8_14), FAMILY (col8_9), FAMILY (c
ol8_17)), Expected Errors: , Potential Errors: "
  ],
  "expectedExecErrors": "",
  "expectedCommitErrors": "",
  "message": "***UNEXPECTED ERROR; Failed to generate a random operation\n OpGen log: \nQUERY [\"SELECT EXISTS (\\n\\tSELECT table_name\\n    FROM information_schema.tables \\n   WHERE table_schema = $1\\n     AND table_name = $2\\n   )\" [\"public\" \"t
able8\"]] :true\nStmts: \n[QUERY: SELECT 'validating all objects', crdb_internal.validate_multi_region_zone_configs(), Expected Errors: , Potential Errors: QUERY: CREATE TABLE public.table8 (col8_9 GEOMETRY NOT NULL, col8_10 BOX2D NOT NULL, col8_11 FLOAT
4 NOT NULL, col8_12 TIMETZ NOT NULL, col8_13 \"char\" NOT NULL, col8_14 NAME NOT NULL, col8_15 DECIMAL NOT NULL, col8_16 INET NOT NULL, col8_17 INT8 NOT NULL, col8_18 STRING NOT NULL AS (lower(col8_13)) STORED, col8_19 FLOAT8 NOT NULL AS (col8_11 + 0.051
83445289731026:::FLOAT8) VIRTUAL, PRIMARY KEY (col8_10, col8_18 DESC, col8_17 DESC, col8_19, col8_15 DESC, col8_11 ASC, col8_13 DESC, col8_14, col8_16 DESC), UNIQUE (col8_17 ASC, col8_12 DESC, col8_19, col8_18) PARTITION BY LIST (col8_17, col8_12, col8_1
9, col8_18) (PARTITION table8_part_0 VALUES IN ((1112324545982352417:::INT8, '08:25:58.380905+00:58:00':::TIMETZ, 2.308196400279898:::FLOAT8, e' >\\t\\bp\\x02\\x047':::STRING)), PARTITION table8_part_1 VALUES IN (((-4169758796321653179):::INT8, '12:59:18
.130563-10:24:00':::TIMETZ, (-0.7093454254464202):::FLOAT8, e'k\\x1a#`!#c\\x7fY':::STRING)), PARTITION table8_part_2 VALUES IN (((-5076717300105623401):::INT8, '07:12:07.412407-07:06:00':::TIMETZ, (-0.7914235188323253):::FLOAT8, e'KIn3#\\rAk':::STRING)),
 PARTITION table8_part_3 VALUES IN ((2147483647:::INT8, '18:07:00.223705+03:00:00':::TIMETZ, 1.4698528925964642:::FLOAT8, e'S\\x047\\x03\\x02VW\\x0e':::STRING)), PARTITION table8_part_4 VALUES IN (((-5362989756654691582):::INT8, '01:31:00.271577+14:32:00
':::TIMETZ, (-0.3369973678230378):::FLOAT8, '/fKW':::STRING)), PARTITION table8_part_5 VALUES IN (((-6629264169873001169):::INT8, '02:01:58.855859-02:58:00':::TIMETZ, (-0.8050523865991726):::FLOAT8, '':::STRING)), PARTITION table8_part_6 VALUES IN (((-57
22173834231977500):::INT8, '17:00:12.308808-06:17:00':::TIMETZ, (-0.9479345049607424):::FLOAT8, '':::STRING)), PARTITION table8_part_7 VALUES IN (((-837799042489541168):::INT8, '06:37:23.35124+07:43:00':::TIMETZ, (-1.0469263893545366):::FLOAT8, e'\\x03\\
x01l(n\\x1cv9':::STRING)), PARTITION table8_part_8 VALUES IN ((3264035864940073454:::INT8, '11:23:56.130029+12:36:00':::TIMETZ, 0.6868497639211962:::FLOAT8, '':::STRING)), PARTITION \"DEFAULT\" VALUES IN ((DEFAULT, DEFAULT, DEFAULT, DEFAULT))), INDEX (lo
wer(CAST(col8_9 AS STRING)) ASC, lower(CAST(col8_16 AS STRING))), INDEX (col8_15 ASC, col8_13 ASC, col8_19, col8_16 ASC, lower(CAST(col8_16 AS STRING)) ASC, col8_10, col8_14 ASC, col8_18 ASC), INDEX (lower(col8_14) DESC, col8_13 DESC, col8_14 ASC), INDEX
 (col8_19, (col8_11 + (-0.5048524141311646):::FLOAT8) ASC, col8_18, col8_13, lower(CAST(col8_10 AS STRING)) DESC, col8_12 ASC) STORING (col8_9) NOT VISIBLE, UNIQUE (col8_18 ASC, col8_19, col8_15 ASC, col8_10, col8_14, col8_17 ASC, col8_16 ASC) STORING (c
ol8_9, col8_12), FAMILY (col8_18, col8_16, col8_13), FAMILY (col8_11, col8_12, col8_15), FAMILY (col8_10), FAMILY (col8_14), FAMILY (col8_9), FAMILY (col8_17)), Expected Errors: , Potential Errors:]\n: Blah"
}
{
```

With these changes, we will get more readable output (note the scenarios are not same, but we can see readability in general from them):
```
{
  "workerId": 0,
  "clientTimestamp": "03:19:26.209338",
  "ops": [
    "BEGIN",
    {
      "sql": "SELECT t1.col47_54 AS col0,t1.col47_52 AS col1,t1.col47_50 AS col2,t1.col47_56 AS col3,t1.col47_53 AS col4,t1.col47_55 AS col5 FROM public.table57 AS t0 ,public.table47 AS t1  FETCH FIRST 1 ROWS ONLY"
    }
  ],
  "expectedExecErrors": "",
  "expectedCommitErrors": "",
  "message": "***UNEXPECTED ERROR; Received an unexpected execution error.: ERROR: relation \"public.table57\" does not exist (SQLSTATE 42P01)",
  "errorState": {
    "queriesForGeneratingErrors": [
      {
        "query": "SELECT EXISTS (SELECT schema_name FROM information_schema.schemata WHERE schema_name = $1)",
        "queryArgs": [
          "public"
        ],
        "result": true
      },
      {
        "query": "SELECT EXISTS (SELECT sequence_name FROM information_schema.sequences WHERE (sequence_schema = $1) AND (sequence_name = $2))",
        "queryArgs": [
          "public",
          "seq1"
        ],
        "result": false
      },
      {
        "query": "SELECT EXISTS (SELECT schema_name FROM information_schema.schemata WHERE schema_name = $1)",
        "queryArgs": [
          "public"
        ],
        "result": true
      },
      {
        "query": "SELECT EXISTS (SELECT * FROM [SHOW REGIONS FROM DATABASE])",
        "result": false
      },
      {
        "query": "SELECT EXISTS (SELECT table_name FROM information_schema.tables WHERE (table_schema = $1) AND (table_name = $2))",
        "queryArgs": [
          "public",
          "table5"
        ],
        "result": false
      },
      {
        "query": "SELECT EXISTS (SELECT schema_name FROM information_schema.schemata WHERE schema_name = $1)",
        "queryArgs": [
          "public"
        ],
        "result": true
      },
      {
        "query": "SELECT EXISTS (SELECT table_name FROM information_schema.tables WHERE (table_schema = $1) AND (table_name = $2))",
        "queryArgs": [
          "public",
          "table5"
        ],
        "result": true
      },
      {
        "query": "SELECT EXISTS (SELECT table_name FROM information_schema.tables WHERE (table_schema = $1) AND (table_name = $2))",
        "queryArgs": [
          "public",
          "table5"
        ],
        "result": true
      },
      {
        "query": "SELECT EXISTS (SELECT table_name FROM information_schema.tables WHERE (table_schema = $1) AND (table_name = $2))",
        "queryArgs": [
          "public",
          "table5"
        ],
        "result": true
      },
      {
        "query": "SELECT EXISTS (SELECT schema_name FROM information_schema.schemata WHERE schema_name = $1)",
        "queryArgs": [
          "public"
        ],
        "result": true
      },
      {
        "query": "SELECT EXISTS (SELECT table_name FROM information_schema.tables WHERE (table_schema = $1) AND (table_name = $2))",
        "queryArgs": [
          "public",
          "table13"
        ],
        "result": false
      },
      {
        "query": "SELECT EXISTS (SELECT sequence_name FROM information_schema.sequences WHERE (sequence_schema = $1) AND (sequence_name = $2))",
        "queryArgs": [
          "public",
          "seq1"
        ],
        "result": true
      },
      {
        "query": "SELECT EXISTS (SELECT table_name FROM information_schema.tables WHERE (table_schema = $1) AND (table_name = $2))",
        "queryArgs": [
          "public",
          "table14"
        ],
        "result": false
      },
      {
        "query": "SELECT EXISTS (SELECT schema_name FROM information_schema.schemata WHERE schema_name = $1)",
        "queryArgs": [
          "public"
        ],
        "result": true
      },
      {
        "query": "SELECT EXISTS (SELECT sequence_name FROM information_schema.sequences WHERE (sequence_schema = $1) AND (sequence_name = $2))",
        "queryArgs": [
          "public",
          "seq15"
        ],
        "result": false
      },
      {
        "query": "SELECT EXISTS (SELECT sequence_name FROM information_schema.sequences WHERE (sequence_schema = $1) AND (sequence_name = $2))",
        "queryArgs": [
          "public",
          "seq15"
        ],
        "result": true
      },
      {
        "query": "SELECT EXISTS (SELECT table_name FROM information_schema.tables WHERE (table_schema = $1) AND (table_name = $2))",
        "queryArgs": [
          "public",
          "table39"
        ],
        "result": false
      },
      {
        "query": "SELECT EXISTS (SELECT sequence_name FROM information_schema.sequences WHERE (sequence_schema = $1) AND (sequence_name = $2))",
        "queryArgs": [
          "public",
          "seq42"
        ],
        "result": false
      },
      {
        "query": "SELECT EXISTS (SELECT table_name FROM information_schema.tables WHERE (table_schema = $1) AND (table_name = $2))",
        "queryArgs": [
          "public",
          "table43"
        ],
        "result": false
      },
      {
        "query": "SELECT EXISTS (SELECT schema_name FROM information_schema.schemata WHERE schema_name = $1)",
        "queryArgs": [
          "schema41"
        ],
        "result": true
      },
      {
        "query": "WITH database_id AS (SELECT id FROM system.namespace WHERE ((\"parentID\" = 0) AND (\"parentSchemaID\" = 0)) AND (name = current_database())), schema_id AS (SELECT nsp.id FROM system.namespace AS nsp JOIN database_id ON ((\"parentID\" = database_id.id) AND (\"parentSchemaID\" = 0)) AND (name = $1)), descriptor_ids AS (SELECT nsp.id FROM system.namespace AS nsp, schema_id, database_id WHERE (nsp.\"parentID\" = database_id.id) AND (nsp.\"parentSchemaID\" = schema_id.id)), descriptors AS (SELECT crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor) AS descriptor FROM system.descriptor AS descriptors JOIN descriptor_ids ON descriptors.id = descriptor_ids.id), types AS (SELECT descriptor FROM descriptors WHERE (descriptor->'type') IS NOT NULL), table_references AS (SELECT json_array_elements((descriptor->'table')->'dependedOnBy') AS ref FROM descriptors WHERE (descriptor->'table') IS NOT NULL), dependent AS (SELECT (ref->>'id')::INT8 AS id FROM table_references), referenced_descriptors AS (SELECT json_array_elements_text((descriptor->'type')->'referencingDescriptorIds')::INT8 AS id FROM types) SELECT EXISTS (SELECT * FROM system.namespace WHERE ((id IN (SELECT id FROM referenced_descriptors)) AND (\"parentSchemaID\" NOT IN (SELECT id FROM schema_id))) AND (id NOT IN (SELECT id FROM dependent)))",
        "queryArgs": [
          "schema41"
        ],
        "result": false
      },
      {
        "query": "SELECT EXISTS (SELECT schema_name FROM information_schema.schemata WHERE schema_name = $1)",
        "queryArgs": [
          "public"
        ],
        "result": true
      },
      {
        "query": "SELECT EXISTS (SELECT * FROM [SHOW REGIONS FROM DATABASE])",
        "queryArgs": null,
        "result": false
      },
      {
        "query": "SELECT EXISTS (SELECT table_name FROM information_schema.tables WHERE (table_schema = $1) AND (table_name = $2))",
        "queryArgs": [
          "public",
          "table47"
        ],
        "result": false
      },
      {
        "query": "SELECT EXISTS (SELECT schema_name FROM information_schema.schemata WHERE schema_name = $1)",
        "queryArgs": [
          "public"
        ],
        "result": true
      },
      {
        "query": "SELECT EXISTS (SELECT table_name FROM information_schema.tables WHERE (table_schema = $1) AND (table_name = $2))",
        "queryArgs": [
          "public",
          "table57"
        ],
        "result": false
      },
      {
        "query": "SELECT EXISTS (SELECT table_name FROM information_schema.tables WHERE (table_schema = $1) AND (table_name = $2))",
        "queryArgs": [
          "public",
          "table47"
        ],
        "result": true
      }
    ],
    "previousStatements": [
      "SELECT t1.col47_54 AS col0,t1.col47_52 AS col1,t1.col47_50 AS col2,t1.col47_56 AS col3,t1.col47_53 AS col4,t1.col47_55 AS col5 FROM public.table57 AS t0 ,public.table47 AS t1  FETCH FIRST 1 ROWS ONLY"
    ]
  }
}
````