### PR TITLE
cli: fix possible crash with debug statement-bundle recreate

### DIFF
--- a/pkg/cli/statement_bundle.go
+++ b/pkg/cli/statement_bundle.go
@@ -292,6 +292,12 @@ func getExplainCombinations(
 				return nil, nil, errors.Wrapf(err, "unable to parse type %s for col %s", typ, col)
 			}
 			colType := tree.MustBeStaticallyKnownType(colTypeRef)
+			if stat["histo_buckets"] == nil {
+				// There might not be any histogram buckets if the stats were
+				// collected when the table was empty or all values in the
+				// column were NULL.
+				continue
+			}
 			buckets := stat["histo_buckets"].([]interface{})
 			var maxUpperBound tree.Datum
 			for _, b := range buckets {

--- a/pkg/cli/testdata/explain-bundle/bundle/stats-defaultdb.public.a.sql
+++ b/pkg/cli/testdata/explain-bundle/bundle/stats-defaultdb.public.a.sql
@@ -1,6 +1,28 @@
 ALTER TABLE public.a INJECT STATISTICS '[
     {
         "columns": [
+            "b"
+        ],
+        "created_at": "2021-06-23 21:17:16.83267",
+        "distinct_count": 0,
+        "histo_col_type": "INT8",
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 0
+    },
+    {
+        "columns": [
+            "b"
+        ],
+        "created_at": "2021-06-23 22:17:16.83267",
+        "distinct_count": 0,
+        "histo_col_type": "INT8",
+        "name": "__auto__",
+        "null_count": 100,
+        "row_count": 100
+    },
+    {
+        "columns": [
             "a"
         ],
         "created_at": "2021-04-30 21:09:56.854553",


### PR DESCRIPTION
Previously, when using `debug statement-bundle recreate` with
`--placeholder` arguments we could run into an interface conversion
crash if the stats files had a statistic with no `histo_buckets`
attribute. Such situation can occur when the table was empty when those
stats were collected or the column only had NULL values, and the crash
is now fixed.

Epic: CRDB-14510

Release note: None