### PR TITLE
kvserver: do not report diff in consistency checks

### DIFF
--- a/pkg/kv/kvserver/api.proto
+++ b/pkg/kv/kvserver/api.proto
@@ -36,22 +36,14 @@ message CollectChecksumRequest {
   bytes checksum_id = 3 [(gogoproto.nullable) = false,
       (gogoproto.customname) = "ChecksumID",
       (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/uuid.UUID"];
-  reserved 4;
-  // If true then the response must include the snapshot of the data from which
-  // the checksum is computed.
-  bool with_snapshot = 5;
+  reserved 4, 5;
 }
 
 message CollectChecksumResponse {
   // The checksum is the sha512 hash of the requested computation. It is empty
   // if the computation failed.
   bytes checksum = 1;
-  // snapshot is set if the with_snapshot in CollectChecksumRequest is true. For
-  // example, it can be set by the caller when it has detected an inconsistency.
-  //
-  // TODO(tschottdorf): with larger ranges, this is no longer tenable.
-  // See https://github.com/cockroachdb/cockroach/issues/21128.
-  roachpb.RaftSnapshotData snapshot = 2;
+  reserved 2;
   // delta carries the stats of the range minus the recomputed stats.
   storage.enginepb.MVCCStatsDelta delta = 3 [(gogoproto.nullable) = false];
   // persisted carries the persisted stats of the replica.

--- a/pkg/kv/kvserver/batcheval/cmd_compute_checksum.go
+++ b/pkg/kv/kvserver/batcheval/cmd_compute_checksum.go
@@ -63,12 +63,11 @@ func ComputeChecksum(
 
 	var pd result.Result
 	pd.Replicated.ComputeChecksum = &kvserverpb.ComputeChecksum{
-		Version:      args.Version,
-		ChecksumID:   reply.ChecksumID,
-		SaveSnapshot: args.Snapshot,
-		Mode:         args.Mode,
-		Checkpoint:   args.Checkpoint,
-		Terminate:    args.Terminate,
+		Version:    args.Version,
+		ChecksumID: reply.ChecksumID,
+		Mode:       args.Mode,
+		Checkpoint: args.Checkpoint,
+		Terminate:  args.Terminate,
 	}
 	return pd, nil
 }

--- a/pkg/kv/kvserver/consistency_queue_test.go
+++ b/pkg/kv/kvserver/consistency_queue_test.go
@@ -222,10 +222,12 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	// TODO(pavelkalinnikov): not if we remove TestingSetRedactable below?
 	skip.UnderRaceWithIssue(t, 81819, "slow test, and TestingSetRedactable triggers race detector")
 
 	// This test prints a consistency checker diff, so it's
 	// good to make sure we're overly redacting said diff.
+	// TODO(pavelkalinnikov): remove this since we don't print diffs anymore?
 	defer log.TestingSetRedactable(true)()
 
 	// Test expects simple MVCC value encoding.

--- a/pkg/kv/kvserver/kvserverpb/proposer_kv.proto
+++ b/pkg/kv/kvserver/kvserverpb/proposer_kv.proto
@@ -75,9 +75,7 @@ message ComputeChecksum {
   // that hardcoded in the binary will a computation be carried out.
   uint32 version = 5;
 
-  // SaveSnapshot indicates that the snapshot used to compute the checksum
-  // should be saved so that a diff of divergent replicas can later be computed.
-  bool save_snapshot = 2;
+  reserved 2;
   roachpb.ChecksumMode mode = 3;
   // If set, a checkpoint (i.e. cheap backup) of the engine will be taken. This
   // is expected to be set only if we already know that there is an

--- a/pkg/kv/kvserver/stores_server.go
+++ b/pkg/kv/kvserver/stores_server.go
@@ -64,9 +64,6 @@ func (is Server) CollectChecksum(
 			if err != nil {
 				return err
 			}
-			if !req.WithSnapshot {
-				ccr.Snapshot = nil
-			}
 			resp = &ccr
 			return nil
 		})

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -1419,10 +1419,7 @@ message ComputeChecksumRequest {
   // The version used to pick the checksum method. It allows us to use a
   // consistent checksumming method across replicas.
   uint32 version = 2;
-  reserved 3;
-  // Compute a checksum along with a snapshot of the entire range, that will be
-  // used in logging a diff during checksum verification.
-  bool snapshot = 4;
+  reserved 3, 4;
   // The type of checksum to compute. See ChecksumMode.
   ChecksumMode mode = 5;
   // If set, a checkpoint (i.e. cheap backup) of the storage engine will be


### PR DESCRIPTION
This commit removes reporting of the diff between replicas in case of consistency check failures. With the increased range sizes the previous approach has become infeasible.

One possible way to inspect an inconsistency after this change is:
1. Run `cockroach debug range-data` tool to extract the range data from each replica's checkpoint.
2. Use standard OS tools like `diff` to analyse them.

In the meantime, we are researching the UX of this alternative approach, and seeing if there can be a better tooling support.

Part of #21128
Epic: none

Release note (sql change): The `crdb_internal.check_consistency` function now does not include the diff between inconsistent replicas, should they occur. If an inconsistency occurs, the storage engine checkpoints should be inspected. This change is made because previously the range size limit has been increased from 64 MiB to O(GiB), so inlining diffs in consistency checks does not scale.