### PR TITLE
sql: improve func expression type checking performance

### DIFF
--- a/pkg/ccl/changefeedccl/cdceval/expr_eval.go
+++ b/pkg/ccl/changefeedccl/cdceval/expr_eval.go
@@ -627,9 +627,9 @@ func checkFunctionSupported(
 	} else {
 		// Pick highest volatility overload.
 		for i := range funcDef.Overloads {
-			overload := funcDef.Overloads[i].Overload
-			if overload.Volatility > fnVolatility {
-				fnVolatility = overload.Volatility
+			v := funcDef.Overloads[i].GetVolatility()
+			if v > fnVolatility {
+				fnVolatility = v
 			}
 		}
 	}

--- a/pkg/ccl/changefeedccl/cdceval/func_resolver_test.go
+++ b/pkg/ccl/changefeedccl/cdceval/func_resolver_test.go
@@ -69,7 +69,7 @@ func TestResolveFunction(t *testing.T) {
 			}
 			require.NoError(t, err)
 			for _, o := range funcDef.Overloads {
-				require.Equal(t, tc.expectedSchema, o.Schema)
+				require.Equal(t, tc.expectedSchema, o.GetSchema())
 			}
 		})
 	}

--- a/pkg/sql/catalog/schemadesc/schema_desc.go
+++ b/pkg/sql/catalog/schemadesc/schema_desc.go
@@ -492,7 +492,7 @@ func (desc *immutable) GetResolvedFuncDefinition(
 	}
 	funcDef := &tree.ResolvedFunctionDefinition{
 		Name:      name,
-		Overloads: make([]tree.QualifiedOverload, 0, len(funcDescPb.Overloads)),
+		Overloads: make([]*tree.QualifiedOverload, 0, len(funcDescPb.Overloads)),
 	}
 	for i := range funcDescPb.Overloads {
 		retType := funcDescPb.Overloads[i].ReturnType

--- a/pkg/sql/catalog/schemadesc/schema_desc.go
+++ b/pkg/sql/catalog/schemadesc/schema_desc.go
@@ -492,7 +492,7 @@ func (desc *immutable) GetResolvedFuncDefinition(
 	}
 	funcDef := &tree.ResolvedFunctionDefinition{
 		Name:      name,
-		Overloads: make([]*tree.QualifiedOverload, 0, len(funcDescPb.Overloads)),
+		Overloads: make([]tree.OverloadImpl, 0, len(funcDescPb.Overloads)),
 	}
 	for i := range funcDescPb.Overloads {
 		retType := funcDescPb.Overloads[i].ReturnType

--- a/pkg/sql/catalog/seqexpr/sequence.go
+++ b/pkg/sql/catalog/seqexpr/sequence.go
@@ -70,16 +70,17 @@ func GetSequenceFromFunc(funcExpr *tree.FuncExpr) (*SeqIdentifier, error) {
 		found := false
 		for i := range def.Overloads {
 			// Find the overload that matches funcExpr.
-			if len(funcExpr.Exprs) == def.Overloads[i].Types.Length() {
+			ol := def.Overloads[i].(*tree.QualifiedOverload)
+			if len(funcExpr.Exprs) == ol.Types.Length() {
 				found = true
-				argTypes, ok := def.Overloads[i].Types.(tree.ArgTypes)
+				argTypes, ok := ol.Types.(tree.ArgTypes)
 				if !ok {
 					panic(pgerror.Newf(
 						pgcode.InvalidFunctionDefinition,
 						"%s has invalid argument types", funcExpr.Func.String(),
 					))
 				}
-				for i := 0; i < def.Overloads[i].Types.Length(); i++ {
+				for i := 0; i < ol.Types.Length(); i++ {
 					// Find the sequence name arg.
 					argName := argTypes[i].Name
 					if argName == builtinconstants.SequenceNameArg {

--- a/pkg/sql/delegate/show_function.go
+++ b/pkg/sql/delegate/show_function.go
@@ -39,8 +39,9 @@ AND function_name = %[2]s
 
 	var udfSchema string
 	for _, o := range fn.Overloads {
-		if o.IsUDF {
-			udfSchema = o.Schema
+		ol := o.(*tree.QualifiedOverload)
+		if ol.IsUDF {
+			udfSchema = ol.Schema
 		}
 	}
 	if udfSchema == "" {

--- a/pkg/sql/drop_function.go
+++ b/pkg/sql/drop_function.go
@@ -131,7 +131,7 @@ func (p *planner) matchUDF(
 			fnDef.Name, ol.Signature(true /*Simplify*/),
 		)
 	}
-	return &ol, nil
+	return ol, nil
 }
 
 func (p *planner) checkPrivilegesForDropFunction(

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -1179,7 +1179,7 @@ func isOrderedSetAggregate(
 	unsetPrivate := func(def *tree.ResolvedFunctionDefinition) {
 		for i := range def.Overloads {
 			newOverload := def.Overloads[i]
-			newOverload.Private = false
+			newOverload.(*tree.QualifiedOverload).Private = false
 			def.Overloads[i] = newOverload
 		}
 	}

--- a/pkg/sql/opt/testutils/testcat/function.go
+++ b/pkg/sql/opt/testutils/testcat/function.go
@@ -104,7 +104,7 @@ func (tc *Catalog) CreateFunction(c *tree.CreateFunction) {
 		Name: name,
 		// TODO(mgartner): Consider setting Class and CompositeInsensitive fo
 		// overloads.
-		Overloads: []tree.QualifiedOverload{prefixedOverload},
+		Overloads: []tree.OverloadImpl{prefixedOverload},
 	}
 	tc.udfs[name] = def
 }
@@ -174,13 +174,16 @@ func formatFunction(fn *tree.ResolvedFunctionDefinition) string {
 	o := fn.Overloads[0]
 	tp := treeprinter.New()
 	nullStr := ""
-	if !o.CalledOnNullInput {
+	if !o.(*tree.QualifiedOverload).CalledOnNullInput {
 		nullStr = ", called-on-null-input=false"
 	}
 	child := tp.Childf(
 		"FUNCTION %s%s [%s%s]",
-		fn.Name, o.Signature(false /* simplify */), o.Volatility, nullStr,
+		fn.Name,
+		o.(*tree.QualifiedOverload).Signature(false /* simplify */),
+		o.(*tree.QualifiedOverload).Volatility,
+		nullStr,
 	)
-	child.Child(o.Body)
+	child.Child(o.(*tree.QualifiedOverload).Body)
 	return tp.String()
 }

--- a/pkg/sql/parser/help.go
+++ b/pkg/sql/parser/help.go
@@ -121,17 +121,17 @@ func helpWithFunction(sqllex sqlLexer, f tree.ResolvableFunctionReference) int {
 	// together.
 	lastInfo := ""
 	for i, b := range d.Overloads {
-		if b.Info != "" && b.Info != lastInfo {
+		if b.GetInfo() != "" && b.GetInfo() != lastInfo {
 			if i > 0 {
 				fmt.Fprintln(w, "---")
 			}
-			fmt.Fprintf(w, "\n%s\n\n", b.Info)
+			fmt.Fprintf(w, "\n%s\n\n", b.GetInfo())
 			fmt.Fprintln(w, "Signature")
 		}
-		lastInfo = b.Info
+		lastInfo = b.GetInfo()
 
-		simplifyRet := b.Class == tree.GeneratorClass
-		fmt.Fprintf(w, "%s%s\n", d.Name, b.Signature(simplifyRet))
+		simplifyRet := b.GetClass() == tree.GeneratorClass
+		fmt.Fprintf(w, "%s%s\n", d.Name, b.(*tree.QualifiedOverload).Signature(simplifyRet))
 	}
 	_ = w.Flush()
 	msg.Text = buf.String()

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -4304,7 +4304,7 @@ https://www.postgresql.org/docs/9.6/catalog-pg-aggregate.html`,
 					}
 					_, overloads := builtinsregistry.GetBuiltinProperties(name)
 					for _, overload := range overloads {
-						params, _ := tree.GetParamsAndReturnType(overload)
+						params, _ := tree.GetParamsAndReturnType(&overload)
 						sortOperatorOid := oidZero
 						aggregateKind := tree.NewDString("n")
 						aggNumDirectArgs := zeroVal

--- a/pkg/sql/sem/eval/parse_doid.go
+++ b/pkg/sql/sem/eval/parse_doid.go
@@ -79,7 +79,7 @@ func ParseDOid(ctx context.Context, evalCtx *Context, s string, t *types.T) (*tr
 				"more than one function named '%s'", funcDef.Name)
 		}
 		overload := funcDef.Overloads[0]
-		return tree.NewDOidWithTypeAndName(overload.Oid, t, funcDef.Name), nil
+		return tree.NewDOidWithTypeAndName(overload.GetOID(), t, funcDef.Name), nil
 	case oid.T_regprocedure:
 		// Fake a ALTER FUNCTION statement to extract the function signature.
 		// We're kinda being lazy here to rely on the parser to determine if the
@@ -110,7 +110,7 @@ func ParseDOid(ctx context.Context, evalCtx *Context, s string, t *types.T) (*tr
 			// short-circuit it to return the oid. For example, `array_in` is defined
 			// to take in a `Any` type, but some ORM sends
 			// `'array_in(cstring,oid,integer)'::REGPROCEDURE` for introspection.
-			ol := fd.Overloads[0]
+			ol := fd.Overloads[0].(*tree.QualifiedOverload)
 			if !catid.IsOIDUserDefined(ol.Oid) &&
 				ol.Types.Length() == 1 &&
 				ol.Types.GetAt(0).Identical(types.Any) {

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -84,6 +84,51 @@ func (*UnaryOp) preferred() bool {
 	return false
 }
 
+// GetClass implements the OverloadImpl interface.
+func (op *UnaryOp) GetClass() FunctionClass {
+	panic(errors.AssertionFailedf("unimplemented"))
+}
+
+// GetReturnLabels implements the OverloadImpl interface.
+func (op *UnaryOp) GetReturnLabels() []string {
+	panic(errors.AssertionFailedf("unimplemented"))
+}
+
+// GetHasSequenceArguments implements the OverloadImpl interface.
+func (op *UnaryOp) GetHasSequenceArguments() bool {
+	panic(errors.AssertionFailedf("unimplemented"))
+}
+
+// GetSchema implements the OverloadImpl interface.
+func (op *UnaryOp) GetSchema() string {
+	panic(errors.AssertionFailedf("unimplemented"))
+}
+
+// GetInfo implements the OverloadImpl interface.
+func (op *UnaryOp) GetInfo() string {
+	panic(errors.AssertionFailedf("unimplemented"))
+}
+
+// GetOID implements the OverloadImpl interface.
+func (op *UnaryOp) GetOID() oid.Oid {
+	panic(errors.AssertionFailedf("unimplemented"))
+}
+
+// GetVolatility implements the OverloadImpl interface.
+func (op *UnaryOp) GetVolatility() volatility.V {
+	panic(errors.AssertionFailedf("unimplemented"))
+}
+
+// GetIsUDF implements the OverloadImpl interface.
+func (op *UnaryOp) GetIsUDF() bool {
+	panic(errors.AssertionFailedf("unimplemented"))
+}
+
+// GetCalledOnNullInput implements the OverloadImpl interface.
+func (op *UnaryOp) GetCalledOnNullInput() bool {
+	panic(errors.AssertionFailedf("unimplemented"))
+}
+
 func unaryOpFixups(
 	ops map[UnaryOperatorSymbol]unaryOpOverload,
 ) map[UnaryOperatorSymbol]unaryOpOverload {
@@ -99,7 +144,7 @@ func unaryOpFixups(
 }
 
 // unaryOpOverload is an overloaded set of unary operator implementations.
-type unaryOpOverload []overloadImpl
+type unaryOpOverload []OverloadImpl
 
 // UnaryOps contains the unary operations indexed by operation type.
 var UnaryOps = unaryOpFixups(map[UnaryOperatorSymbol]unaryOpOverload{
@@ -239,6 +284,51 @@ func (op *BinOp) returnType() ReturnTyper {
 
 func (op *BinOp) preferred() bool {
 	return op.PreferredOverload
+}
+
+// GetClass implements the OverloadImpl interface.
+func (op *BinOp) GetClass() FunctionClass {
+	panic(errors.AssertionFailedf("unimplemented"))
+}
+
+// GetReturnLabels implements the OverloadImpl interface.
+func (op *BinOp) GetReturnLabels() []string {
+	panic(errors.AssertionFailedf("unimplemented"))
+}
+
+// GetHasSequenceArguments implements the OverloadImpl interface.
+func (op *BinOp) GetHasSequenceArguments() bool {
+	panic(errors.AssertionFailedf("unimplemented"))
+}
+
+// GetSchema implements the OverloadImpl interface.
+func (op *BinOp) GetSchema() string {
+	panic(errors.AssertionFailedf("unimplemented"))
+}
+
+// GetInfo implements the OverloadImpl interface.
+func (op *BinOp) GetInfo() string {
+	panic(errors.AssertionFailedf("unimplemented"))
+}
+
+// GetOID implements the OverloadImpl interface.
+func (op *BinOp) GetOID() oid.Oid {
+	panic(errors.AssertionFailedf("unimplemented"))
+}
+
+// GetVolatility implements the OverloadImpl interface.
+func (op *BinOp) GetVolatility() volatility.V {
+	panic(errors.AssertionFailedf("unimplemented"))
+}
+
+// GetIsUDF implements the OverloadImpl interface.
+func (op *BinOp) GetIsUDF() bool {
+	panic(errors.AssertionFailedf("unimplemented"))
+}
+
+// GetCalledOnNullInput implements the OverloadImpl interface.
+func (op *BinOp) GetCalledOnNullInput() bool {
+	panic(errors.AssertionFailedf("unimplemented"))
 }
 
 // AppendToMaybeNullArray appends an element to an array. If the first
@@ -453,7 +543,7 @@ func init() {
 }
 
 // binOpOverload is an overloaded set of binary operator implementations.
-type binOpOverload []overloadImpl
+type binOpOverload []OverloadImpl
 
 func (o binOpOverload) LookupImpl(left, right *types.T) (*BinOp, bool) {
 	for _, fn := range o {
@@ -1323,6 +1413,51 @@ func (op *CmpOp) preferred() bool {
 	return op.PreferredOverload
 }
 
+// GetClass implements the OverloadImpl interface.
+func (op *CmpOp) GetClass() FunctionClass {
+	panic(errors.AssertionFailedf("unimplemented"))
+}
+
+// GetReturnLabels implements the OverloadImpl interface.
+func (op *CmpOp) GetReturnLabels() []string {
+	panic(errors.AssertionFailedf("unimplemented"))
+}
+
+// GetHasSequenceArguments implements the OverloadImpl interface.
+func (op *CmpOp) GetHasSequenceArguments() bool {
+	panic(errors.AssertionFailedf("unimplemented"))
+}
+
+// GetSchema implements the OverloadImpl interface.
+func (op *CmpOp) GetSchema() string {
+	panic(errors.AssertionFailedf("unimplemented"))
+}
+
+// GetInfo implements the OverloadImpl interface.
+func (op *CmpOp) GetInfo() string {
+	panic(errors.AssertionFailedf("unimplemented"))
+}
+
+// GetOID implements the OverloadImpl interface.
+func (op *CmpOp) GetOID() oid.Oid {
+	panic(errors.AssertionFailedf("unimplemented"))
+}
+
+// GetVolatility implements the OverloadImpl interface.
+func (op *CmpOp) GetVolatility() volatility.V {
+	panic(errors.AssertionFailedf("unimplemented"))
+}
+
+// GetIsUDF implements the OverloadImpl interface.
+func (op *CmpOp) GetIsUDF() bool {
+	panic(errors.AssertionFailedf("unimplemented"))
+}
+
+// GetCalledOnNullInput implements the OverloadImpl interface.
+func (op *CmpOp) GetCalledOnNullInput() bool {
+	panic(errors.AssertionFailedf("unimplemented"))
+}
+
 func cmpOpFixups(
 	cmpOps map[treecmp.ComparisonOperatorSymbol]cmpOpOverload,
 ) map[treecmp.ComparisonOperatorSymbol]cmpOpOverload {
@@ -1378,7 +1513,7 @@ func cmpOpFixups(
 }
 
 // cmpOpOverload is an overloaded set of comparison operator implementations.
-type cmpOpOverload []overloadImpl
+type cmpOpOverload []OverloadImpl
 
 func (o cmpOpOverload) LookupImpl(left, right *types.T) (*CmpOp, bool) {
 	for _, fn := range o {

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -45,7 +45,7 @@ type ResolvedFunctionDefinition struct {
 	// not qualified.
 	Name string
 
-	Overloads []*QualifiedOverload
+	Overloads []OverloadImpl
 }
 
 // QualifiedOverload is a wrapper of Overload prefixed with a schema name.
@@ -53,6 +53,11 @@ type ResolvedFunctionDefinition struct {
 type QualifiedOverload struct {
 	Schema string
 	*Overload
+}
+
+// GetSchema implements the OverloadImpl interface.
+func (b QualifiedOverload) GetSchema() string {
+	return b.Schema
 }
 
 // MakeQualifiedOverload creates a new QualifiedOverload.
@@ -265,8 +270,8 @@ func (fd *ResolvedFunctionDefinition) MergeWith(
 func (fd *ResolvedFunctionDefinition) MatchOverload(
 	argTypes []*types.T, explicitSchema string, searchPath SearchPath,
 ) (*QualifiedOverload, error) {
-	matched := func(ol *QualifiedOverload, schema string) bool {
-		return schema == ol.Schema && (argTypes == nil || ol.params().Match(argTypes))
+	matched := func(ol OverloadImpl, schema string) bool {
+		return schema == ol.GetSchema() && (argTypes == nil || ol.params().Match(argTypes))
 	}
 	typeNames := func() string {
 		ns := make([]string, len(argTypes))
@@ -277,7 +282,7 @@ func (fd *ResolvedFunctionDefinition) MatchOverload(
 	}
 
 	found := false
-	ret := make([]*QualifiedOverload, 0, len(fd.Overloads))
+	ret := make([]OverloadImpl, 0, len(fd.Overloads))
 
 	findMatches := func(schema string) {
 		for i := range fd.Overloads {
@@ -306,11 +311,11 @@ func (fd *ResolvedFunctionDefinition) MatchOverload(
 	if len(ret) > 1 {
 		return nil, errors.Errorf("function name %q is not unique", fd.Name)
 	}
-	return ret[0], nil
+	return ret[0].(*QualifiedOverload), nil
 }
 
-func combineOverloads(a, b []*QualifiedOverload) []*QualifiedOverload {
-	return append(append(make([]*QualifiedOverload, 0, len(a)+len(b)), a...), b...)
+func combineOverloads(a, b []OverloadImpl) []OverloadImpl {
+	return append(append(make([]OverloadImpl, 0, len(a)+len(b)), a...), b...)
 }
 
 // GetClass returns function class by checking each overload's Class and returns
@@ -321,9 +326,9 @@ func combineOverloads(a, b []*QualifiedOverload) []*QualifiedOverload {
 // method, function is resolved to one overload, so that we can get rid of this
 // function and similar methods below.
 func (fd *ResolvedFunctionDefinition) GetClass() (FunctionClass, error) {
-	ret := fd.Overloads[0].Class
+	ret := fd.Overloads[0].GetClass()
 	for i := range fd.Overloads {
-		if fd.Overloads[i].Class != ret {
+		if fd.Overloads[i].GetClass() != ret {
 			return 0, pgerror.Newf(pgcode.AmbiguousFunction, "ambiguous function class on %s", fd.Name)
 		}
 	}
@@ -336,9 +341,9 @@ func (fd *ResolvedFunctionDefinition) GetClass() (FunctionClass, error) {
 // different length. This is good enough since we don't create UDF with
 // ReturnLabel.
 func (fd *ResolvedFunctionDefinition) GetReturnLabel() ([]string, error) {
-	ret := fd.Overloads[0].ReturnLabels
+	ret := fd.Overloads[0].GetReturnLabels()
 	for i := range fd.Overloads {
-		if len(ret) != len(fd.Overloads[i].ReturnLabels) {
+		if len(ret) != len(fd.Overloads[i].GetReturnLabels()) {
 			return nil, pgerror.Newf(pgcode.AmbiguousFunction, "ambiguous function return label on %s", fd.Name)
 		}
 	}
@@ -349,9 +354,9 @@ func (fd *ResolvedFunctionDefinition) GetReturnLabel() ([]string, error) {
 // checking each overload's HasSequenceArguments flag. Ambiguous error is
 // returned if there is any overload has a different flag.
 func (fd *ResolvedFunctionDefinition) GetHasSequenceArguments() (bool, error) {
-	ret := fd.Overloads[0].HasSequenceArguments
+	ret := fd.Overloads[0].GetHasSequenceArguments()
 	for i := range fd.Overloads {
-		if ret != fd.Overloads[i].HasSequenceArguments {
+		if ret != fd.Overloads[i].GetHasSequenceArguments() {
 			return false, pgerror.Newf(pgcode.AmbiguousFunction, "ambiguous function sequence argument on %s", fd.Name)
 		}
 	}
@@ -366,7 +371,7 @@ func QualifyBuiltinFunctionDefinition(
 ) *ResolvedFunctionDefinition {
 	ret := &ResolvedFunctionDefinition{
 		Name:      def.Name,
-		Overloads: make([]*QualifiedOverload, 0, len(def.Definition)),
+		Overloads: make([]OverloadImpl, 0, len(def.Definition)),
 	}
 	for _, o := range def.Definition {
 		ret.Overloads = append(

--- a/pkg/sql/sem/tree/function_definition_test.go
+++ b/pkg/sql/sem/tree/function_definition_test.go
@@ -82,7 +82,7 @@ func TestBuiltinFunctionResolver(t *testing.T) {
 				return
 			}
 			for _, o := range funcDef.Overloads {
-				require.Equal(t, tc.expectedSchema, o.Schema)
+				require.Equal(t, tc.expectedSchema, o.GetSchema())
 			}
 		})
 	}
@@ -94,20 +94,20 @@ func TestMatchOverload(t *testing.T) {
 
 	fd := &tree.ResolvedFunctionDefinition{
 		Name: "f",
-		Overloads: []tree.QualifiedOverload{
-			{
+		Overloads: []tree.OverloadImpl{
+			&tree.QualifiedOverload{
 				Schema:   "pg_catalog",
 				Overload: &tree.Overload{Oid: 1, IsUDF: false, Types: tree.ArgTypes{tree.ArgType{Typ: types.Int}}},
 			},
-			{
+			&tree.QualifiedOverload{
 				Schema:   "sc1",
 				Overload: &tree.Overload{Oid: 2, IsUDF: true, Types: tree.ArgTypes{tree.ArgType{Typ: types.Int}}},
 			},
-			{
+			&tree.QualifiedOverload{
 				Schema:   "sc1",
 				Overload: &tree.Overload{Oid: 3, IsUDF: true, Types: tree.ArgTypes{}},
 			},
-			{
+			&tree.QualifiedOverload{
 				Schema:   "sc2",
 				Overload: &tree.Overload{Oid: 4, IsUDF: true, Types: tree.ArgTypes{tree.ArgType{Typ: types.Int}}},
 			},

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -191,18 +191,63 @@ type Overload struct {
 	ReturnSet bool
 }
 
-// params implements the overloadImpl interface.
-func (b Overload) params() TypeList { return b.Types }
+// params implements the OverloadImpl interface.
+func (b *Overload) params() TypeList { return b.Types }
 
-// returnType implements the overloadImpl interface.
-func (b Overload) returnType() ReturnTyper { return b.ReturnType }
+// returnType implements the OverloadImpl interface.
+func (b *Overload) returnType() ReturnTyper { return b.ReturnType }
 
-// preferred implements the overloadImpl interface.
-func (b Overload) preferred() bool { return b.PreferredOverload }
+// preferred implements the OverloadImpl interface.
+func (b *Overload) preferred() bool { return b.PreferredOverload }
+
+// GetClass implements the OverloadImpl interface.
+func (b *Overload) GetClass() FunctionClass {
+	return b.Class
+}
+
+// GetReturnLabels implements the OverloadImpl interface.
+func (b *Overload) GetReturnLabels() []string {
+	return b.ReturnLabels
+}
+
+// GetHasSequenceArguments implements the OverloadImpl interface.
+func (b *Overload) GetHasSequenceArguments() bool {
+	return b.HasSequenceArguments
+}
+
+// GetSchema implements the OverloadImpl interface.
+func (b *Overload) GetSchema() string {
+	panic(errors.AssertionFailedf("unimplemented"))
+}
+
+// GetInfo implements the OverloadImpl interface.
+func (b *Overload) GetInfo() string {
+	return b.Info
+}
+
+// GetOID implements the OverloadImpl interface.
+func (b *Overload) GetOID() oid.Oid {
+	return b.Oid
+}
+
+// GetVolatility implements the OverloadImpl interface.
+func (b *Overload) GetVolatility() volatility.V {
+	return b.Volatility
+}
+
+// GetIsUDF implements the OverloadImpl interface.
+func (b *Overload) GetIsUDF() bool {
+	return b.IsUDF
+}
+
+// GetCalledOnNullInput implements the OverloadImpl interface.
+func (b *Overload) GetCalledOnNullInput() bool {
+	return b.CalledOnNullInput
+}
 
 // FixedReturnType returns a fixed type that the function returns, returning Any
 // if the return type is based on the function's arguments.
-func (b Overload) FixedReturnType() *types.T {
+func (b *Overload) FixedReturnType() *types.T {
 	if b.ReturnType == nil {
 		return nil
 	}
@@ -211,7 +256,7 @@ func (b Overload) FixedReturnType() *types.T {
 
 // InferReturnTypeFromInputArgTypes returns the type that the function returns,
 // inferring the type based on the function's inputTypes if necessary.
-func (b Overload) InferReturnTypeFromInputArgTypes(inputTypes []*types.T) *types.T {
+func (b *Overload) InferReturnTypeFromInputArgTypes(inputTypes []*types.T) *types.T {
 	retTyp := b.FixedReturnType()
 	// If the output type of the function depends on its inputs, then
 	// the output of FixedReturnType will be ambiguous. In the ambiguous
@@ -235,14 +280,14 @@ func (b Overload) InferReturnTypeFromInputArgTypes(inputTypes []*types.T) *types
 }
 
 // IsGenerator returns true if the function is a set returning function (SRF).
-func (b Overload) IsGenerator() bool {
+func (b *Overload) IsGenerator() bool {
 	return b.Generator != nil || b.GeneratorWithExprs != nil
 }
 
 // Signature returns a human-readable signature.
 // If simplify is bool, tuple-returning functions with just
 // 1 tuple element unwrap the return type in the signature.
-func (b Overload) Signature(simplify bool) string {
+func (b *Overload) Signature(simplify bool) string {
 	retType := b.FixedReturnType()
 	if simplify {
 		if retType.Family() == types.TupleFamily && len(retType.TupleContents()) == 1 {
@@ -252,26 +297,52 @@ func (b Overload) Signature(simplify bool) string {
 	return fmt.Sprintf("(%s) -> %s", b.Types.String(), retType)
 }
 
-// overloadImpl is an implementation of an overloaded function. It provides
+// OverloadImpl is an implementation of an overloaded function. It provides
 // access to the parameter type list and the return type of the implementation.
 //
 // This is a more general type than Overload defined above, because it also
 // works with the built-in binary and unary operators.
-type overloadImpl interface {
+//
+// The exported methods of this interface are all implemented only by Overload
+// (the actual function overload) at the moment. Operators only have dummy
+// panicing implementation. This is only to allow us to share the
+// `typeCheckOverloadedExprs` function across different overload types and
+// access actual function properties without too much type assertions to avoid
+// performance regress.
+type OverloadImpl interface {
 	params() TypeList
 	returnType() ReturnTyper
 	// allows manually resolving preference between multiple compatible overloads.
 	preferred() bool
+
+	// GetClass returns function class property of an overload.
+	GetClass() FunctionClass
+	// GetReturnLabels returns ReturnLabels property of an overload.
+	GetReturnLabels() []string
+	// GetHasSequenceArguments returns HasSequenceArguments property of an overload.
+	GetHasSequenceArguments() bool
+	// GetInfo returns Info property of an overload.
+	GetInfo() string
+	// GetVolatility returns volatility property of an overload.
+	GetVolatility() volatility.V
+	// GetCalledOnNullInput returns CalledOnNullInput property of an overload.
+	GetCalledOnNullInput() bool
+	// GetIsUDF returns IsUDF property of an overload.
+	GetIsUDF() bool
+	// GetOID returns OID of an overload.
+	GetOID() oid.Oid
+	// GetSchema returns parent schema of an overload.
+	GetSchema() string
 }
 
-var _ overloadImpl = &Overload{}
-var _ overloadImpl = &UnaryOp{}
-var _ overloadImpl = &BinOp{}
-var _ overloadImpl = &CmpOp{}
+var _ OverloadImpl = &Overload{}
+var _ OverloadImpl = &UnaryOp{}
+var _ OverloadImpl = &BinOp{}
+var _ OverloadImpl = &CmpOp{}
 
 // GetParamsAndReturnType gets the parameters and return type of an
-// overloadImpl.
-func GetParamsAndReturnType(impl overloadImpl) (TypeList, ReturnTyper) {
+// OverloadImpl.
+func GetParamsAndReturnType(impl OverloadImpl) (TypeList, ReturnTyper) {
 	return impl.params(), impl.returnType()
 }
 
@@ -563,7 +634,7 @@ func returnTypeToFixedType(s ReturnTyper, inputTyps []TypedExpr) *types.T {
 }
 
 type typeCheckOverloadState struct {
-	overloads       []overloadImpl
+	overloads       []OverloadImpl
 	overloadIdxs    []uint8 // index into overloads
 	exprs           []Expr
 	typedExprs      []TypedExpr
@@ -588,10 +659,10 @@ func typeCheckOverloadedExprs(
 	ctx context.Context,
 	semaCtx *SemaContext,
 	desired *types.T,
-	overloads []overloadImpl,
+	overloads []OverloadImpl,
 	inBinOp bool,
 	exprs ...Expr,
-) ([]TypedExpr, []overloadImpl, error) {
+) ([]TypedExpr, []OverloadImpl, error) {
 	if len(overloads) > math.MaxUint8 {
 		return nil, nil, errors.AssertionFailedf("too many overloads (%d > 255)", len(overloads))
 	}
@@ -644,7 +715,7 @@ func typeCheckOverloadedExprs(
 
 	// Filter out incorrect parameter length overloads.
 	s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs,
-		func(o overloadImpl) bool {
+		func(o OverloadImpl) bool {
 			return o.params().MatchLen(len(exprs))
 		})
 
@@ -652,7 +723,7 @@ func typeCheckOverloadedExprs(
 	for _, i := range s.constIdxs {
 		constExpr := exprs[i].(Constant)
 		s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs,
-			func(o overloadImpl) bool {
+			func(o OverloadImpl) bool {
 				return canConstantBecome(constExpr, o.params().GetAt(i))
 			})
 	}
@@ -687,7 +758,7 @@ func typeCheckOverloadedExprs(
 		}
 		s.typedExprs[i] = typ
 		s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs,
-			func(o overloadImpl) bool {
+			func(o OverloadImpl) bool {
 				return o.params().MatchAt(typ.ResolvedType(), i)
 			})
 	}
@@ -704,7 +775,7 @@ func typeCheckOverloadedExprs(
 	// if a desired type was provided.
 	if desired.Family() != types.AnyFamily {
 		s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs,
-			func(o overloadImpl) bool {
+			func(o OverloadImpl) bool {
 				// For now, we only filter on the return type for overloads with
 				// fixed return types. This could be improved, but is not currently
 				// critical because we have no cases of functions with multiple
@@ -748,7 +819,7 @@ func typeCheckOverloadedExprs(
 				if allConstantsAreHomogenous {
 					for _, i := range s.constIdxs {
 						s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs,
-							func(o overloadImpl) bool {
+							func(o OverloadImpl) bool {
 								return o.params().GetAt(i).Equivalent(homogeneousTyp)
 							})
 					}
@@ -765,7 +836,7 @@ func typeCheckOverloadedExprs(
 				natural := naturalConstantType(exprs[i].(Constant))
 				if natural != nil {
 					s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs,
-						func(o overloadImpl) bool {
+						func(o OverloadImpl) bool {
 							return o.params().GetAt(i).Equivalent(natural)
 						})
 				}
@@ -828,7 +899,7 @@ func typeCheckOverloadedExprs(
 		for _, i := range s.constIdxs {
 			constExpr := exprs[i].(Constant)
 			s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs,
-				func(o overloadImpl) bool {
+				func(o OverloadImpl) bool {
 					semaCtx := MakeSemaContext()
 					_, err := constExpr.ResolveAsType(ctx, &semaCtx, o.params().GetAt(i))
 					return err == nil
@@ -847,13 +918,13 @@ func typeCheckOverloadedExprs(
 			prevOverloadIdxs := s.overloadIdxs
 			for _, i := range s.constIdxs {
 				s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs,
-					func(o overloadImpl) bool {
+					func(o OverloadImpl) bool {
 						return o.params().GetAt(i).Equivalent(bestConstType)
 					})
 			}
 			if ok, typedExprs, fns, err := checkReturn(ctx, semaCtx, &s); ok {
 				if len(fns) == 0 {
-					var overloadImpls []overloadImpl
+					var overloadImpls []OverloadImpl
 					for i := range prevOverloadIdxs {
 						overloadImpls = append(overloadImpls, s.overloads[i])
 					}
@@ -874,7 +945,7 @@ func typeCheckOverloadedExprs(
 	// The fifth heuristic is to defer to preferred candidates, if one has been
 	// specified in the overload list.
 	if ok, typedExprs, fns, err := filterAttempt(ctx, semaCtx, &s, func() {
-		s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs, func(o overloadImpl) bool {
+		s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs, func(o OverloadImpl) bool {
 			return o.preferred()
 		})
 	}); ok {
@@ -895,7 +966,7 @@ func typeCheckOverloadedExprs(
 				return nil, nil, err
 			}
 			s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs,
-				func(o overloadImpl) bool {
+				func(o OverloadImpl) bool {
 					return o.params().GetAt(i).Equivalent(homogeneousTyp)
 				})
 		}
@@ -999,7 +1070,7 @@ func typeCheckOverloadedExprs(
 					rightType = leftType
 				}
 				s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs,
-					func(o overloadImpl) bool {
+					func(o OverloadImpl) bool {
 						return o.params().GetAt(0).Equivalent(leftType) &&
 							o.params().GetAt(1).Equivalent(rightType)
 					})
@@ -1042,7 +1113,7 @@ func typeCheckOverloadedExprs(
 					rightType = types.String
 				}
 				s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs,
-					func(o overloadImpl) bool {
+					func(o OverloadImpl) bool {
 						return o.params().GetAt(0).Equivalent(leftType) &&
 							o.params().GetAt(1).Equivalent(rightType)
 					})
@@ -1056,7 +1127,7 @@ func typeCheckOverloadedExprs(
 		return nil, nil, err
 	}
 
-	possibleOverloads := make([]overloadImpl, len(s.overloadIdxs))
+	possibleOverloads := make([]OverloadImpl, len(s.overloadIdxs))
 	for i, o := range s.overloadIdxs {
 		possibleOverloads[i] = s.overloads[o]
 	}
@@ -1069,7 +1140,7 @@ func typeCheckOverloadedExprs(
 // undo any filtering performed during the attempt.
 func filterAttempt(
 	ctx context.Context, semaCtx *SemaContext, s *typeCheckOverloadState, attempt func(),
-) (ok bool, _ []TypedExpr, _ []overloadImpl, _ error) {
+) (ok bool, _ []TypedExpr, _ []OverloadImpl, _ error) {
 	before := s.overloadIdxs
 	attempt()
 	if len(s.overloadIdxs) == 1 {
@@ -1087,7 +1158,7 @@ func filterAttempt(
 
 // filterOverloads filters overloads which do not satisfy the predicate.
 func filterOverloads(
-	overloads []overloadImpl, overloadIdxs []uint8, fn func(overloadImpl) bool,
+	overloads []OverloadImpl, overloadIdxs []uint8, fn func(OverloadImpl) bool,
 ) []uint8 {
 	for i := 0; i < len(overloadIdxs); {
 		if fn(overloads[overloadIdxs[i]]) {
@@ -1135,7 +1206,7 @@ func defaultTypeCheck(
 // immediately return, so any mutations to s are irrelevant.
 func checkReturn(
 	ctx context.Context, semaCtx *SemaContext, s *typeCheckOverloadState,
-) (ok bool, _ []TypedExpr, _ []overloadImpl, _ error) {
+) (ok bool, _ []TypedExpr, _ []OverloadImpl, _ error) {
 	switch len(s.overloadIdxs) {
 	case 0:
 		if err := defaultTypeCheck(ctx, semaCtx, s, false); err != nil {
@@ -1177,7 +1248,7 @@ func checkReturn(
 // as checkReturn.
 func checkReturnPlaceholdersAtIdx(
 	ctx context.Context, semaCtx *SemaContext, s *typeCheckOverloadState, idx int,
-) (bool, []TypedExpr, []overloadImpl, error) {
+) (bool, []TypedExpr, []OverloadImpl, error) {
 	o := s.overloads[idx]
 	p := o.params()
 	for _, i := range s.placeholderIdxs {
@@ -1194,7 +1265,7 @@ func checkReturnPlaceholdersAtIdx(
 	return true, s.typedExprs, s.overloads[idx : idx+1], nil
 }
 
-func formatCandidates(prefix string, candidates []overloadImpl) string {
+func formatCandidates(prefix string, candidates []OverloadImpl) string {
 	var buf bytes.Buffer
 	for _, candidate := range candidates {
 		buf.WriteString(prefix)

--- a/pkg/sql/sem/tree/overload_test.go
+++ b/pkg/sql/sem/tree/overload_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treebin"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/volatility"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -126,6 +127,42 @@ func (to *testOverload) String() string {
 	return fmt.Sprintf("func(%s) %s", strings.Join(typeNames, ","), to.retType)
 }
 
+func (to *testOverload) GetClass() FunctionClass {
+	panic("unimplemented")
+}
+
+func (to *testOverload) GetReturnLabels() []string {
+	panic("unimplemented")
+}
+
+func (to *testOverload) GetHasSequenceArguments() bool {
+	panic("unimplemented")
+}
+
+func (to *testOverload) GetSchema() string {
+	panic("unimplemented")
+}
+
+func (to *testOverload) GetInfo() string {
+	panic("unimplemented")
+}
+
+func (to *testOverload) GetOID() oid.Oid {
+	panic("unimplemented")
+}
+
+func (to *testOverload) GetVolatility() volatility.V {
+	panic("unimplemented")
+}
+
+func (to *testOverload) GetIsUDF() bool {
+	panic("unimplemented")
+}
+
+func (to *testOverload) GetCalledOnNullInput() bool {
+	panic("unimplemented")
+}
+
 func makeTestOverload(retType *types.T, params ...*types.T) *testOverload {
 	t := make(ArgTypes, len(params))
 	for i := range params {
@@ -182,88 +219,88 @@ func TestTypeCheckOverloadedExprs(t *testing.T) {
 	testData := []struct {
 		desired          *types.T
 		exprs            []Expr
-		overloads        []overloadImpl
-		expectedOverload overloadImpl
+		overloads        []OverloadImpl
+		expectedOverload OverloadImpl
 		inBinOp          bool
 	}{
 		// Unary constants.
-		{nil, []Expr{intConst("1")}, []overloadImpl{unaryIntFn, unaryIntFn}, ambiguous, false},
-		{nil, []Expr{intConst("1")}, []overloadImpl{unaryIntFn, unaryFloatFn}, unaryIntFn, false},
-		{nil, []Expr{decConst("1.0")}, []overloadImpl{unaryIntFn, unaryDecimalFn}, unaryDecimalFn, false},
-		{nil, []Expr{decConst("1.0")}, []overloadImpl{unaryIntFn, unaryFloatFn}, ambiguous, false},
-		{nil, []Expr{intConst("1")}, []overloadImpl{unaryIntFn, binaryIntFn}, unaryIntFn, false},
-		{nil, []Expr{intConst("1")}, []overloadImpl{unaryFloatFn, unaryStringFn}, unaryFloatFn, false},
-		{nil, []Expr{intConst("1")}, []overloadImpl{unaryStringFn, binaryIntFn}, unsupported, false},
-		{nil, []Expr{strConst("PT12H2M")}, []overloadImpl{unaryIntervalFn}, unaryIntervalFn, false},
-		{nil, []Expr{strConst("PT12H2M")}, []overloadImpl{unaryIntervalFn, unaryStringFn}, unaryStringFn, false},
-		{nil, []Expr{strConst("PT12H2M")}, []overloadImpl{unaryIntervalFn, unaryTimestampFn}, unaryIntervalFn, false},
-		{nil, []Expr{intConst("1")}, []overloadImpl{unaryIntFn, unaryIntFnPref}, unaryIntFnPref, false},
-		{nil, []Expr{intConst("1")}, []overloadImpl{unaryIntFnPref, unaryIntFnPref}, ambiguous, false},
-		{nil, []Expr{strConst("PT12H2M")}, []overloadImpl{unaryIntervalFn, unaryIntFn}, unaryIntervalFn, false},
+		{nil, []Expr{intConst("1")}, []OverloadImpl{unaryIntFn, unaryIntFn}, ambiguous, false},
+		{nil, []Expr{intConst("1")}, []OverloadImpl{unaryIntFn, unaryFloatFn}, unaryIntFn, false},
+		{nil, []Expr{decConst("1.0")}, []OverloadImpl{unaryIntFn, unaryDecimalFn}, unaryDecimalFn, false},
+		{nil, []Expr{decConst("1.0")}, []OverloadImpl{unaryIntFn, unaryFloatFn}, ambiguous, false},
+		{nil, []Expr{intConst("1")}, []OverloadImpl{unaryIntFn, binaryIntFn}, unaryIntFn, false},
+		{nil, []Expr{intConst("1")}, []OverloadImpl{unaryFloatFn, unaryStringFn}, unaryFloatFn, false},
+		{nil, []Expr{intConst("1")}, []OverloadImpl{unaryStringFn, binaryIntFn}, unsupported, false},
+		{nil, []Expr{strConst("PT12H2M")}, []OverloadImpl{unaryIntervalFn}, unaryIntervalFn, false},
+		{nil, []Expr{strConst("PT12H2M")}, []OverloadImpl{unaryIntervalFn, unaryStringFn}, unaryStringFn, false},
+		{nil, []Expr{strConst("PT12H2M")}, []OverloadImpl{unaryIntervalFn, unaryTimestampFn}, unaryIntervalFn, false},
+		{nil, []Expr{intConst("1")}, []OverloadImpl{unaryIntFn, unaryIntFnPref}, unaryIntFnPref, false},
+		{nil, []Expr{intConst("1")}, []OverloadImpl{unaryIntFnPref, unaryIntFnPref}, ambiguous, false},
+		{nil, []Expr{strConst("PT12H2M")}, []OverloadImpl{unaryIntervalFn, unaryIntFn}, unaryIntervalFn, false},
 		// Unary unresolved Placeholders.
-		{nil, []Expr{placeholder(0)}, []overloadImpl{unaryStringFn, unaryIntFn}, shouldError, false},
-		{nil, []Expr{placeholder(0)}, []overloadImpl{unaryStringFn, binaryIntFn}, unaryStringFn, false},
-		{nil, []Expr{placeholder(0)}, []overloadImpl{unaryStringFn, unaryIntFnPref}, unaryIntFnPref, false},
+		{nil, []Expr{placeholder(0)}, []OverloadImpl{unaryStringFn, unaryIntFn}, shouldError, false},
+		{nil, []Expr{placeholder(0)}, []OverloadImpl{unaryStringFn, binaryIntFn}, unaryStringFn, false},
+		{nil, []Expr{placeholder(0)}, []OverloadImpl{unaryStringFn, unaryIntFnPref}, unaryIntFnPref, false},
 		// Unary values (not constants).
-		{nil, []Expr{NewDInt(1)}, []overloadImpl{unaryIntFn, unaryFloatFn}, unaryIntFn, false},
-		{nil, []Expr{NewDFloat(1)}, []overloadImpl{unaryIntFn, unaryFloatFn}, unaryFloatFn, false},
-		{nil, []Expr{NewDInt(1)}, []overloadImpl{unaryIntFn, binaryIntFn}, unaryIntFn, false},
-		{nil, []Expr{NewDInt(1)}, []overloadImpl{unaryFloatFn, unaryStringFn}, unsupported, false},
-		{nil, []Expr{NewDString("a")}, []overloadImpl{unaryIntFn, unaryFloatFn}, unsupported, false},
-		{nil, []Expr{NewDString("a")}, []overloadImpl{unaryIntFn, unaryStringFn}, unaryStringFn, false},
+		{nil, []Expr{NewDInt(1)}, []OverloadImpl{unaryIntFn, unaryFloatFn}, unaryIntFn, false},
+		{nil, []Expr{NewDFloat(1)}, []OverloadImpl{unaryIntFn, unaryFloatFn}, unaryFloatFn, false},
+		{nil, []Expr{NewDInt(1)}, []OverloadImpl{unaryIntFn, binaryIntFn}, unaryIntFn, false},
+		{nil, []Expr{NewDInt(1)}, []OverloadImpl{unaryFloatFn, unaryStringFn}, unsupported, false},
+		{nil, []Expr{NewDString("a")}, []OverloadImpl{unaryIntFn, unaryFloatFn}, unsupported, false},
+		{nil, []Expr{NewDString("a")}, []OverloadImpl{unaryIntFn, unaryStringFn}, unaryStringFn, false},
 		// Binary constants.
-		{nil, []Expr{intConst("1"), intConst("1")}, []overloadImpl{binaryIntFn, binaryFloatFn, unaryIntFn}, binaryIntFn, false},
-		{nil, []Expr{intConst("1"), decConst("1.0")}, []overloadImpl{binaryIntFn, binaryDecimalFn, unaryDecimalFn}, binaryDecimalFn, false},
-		{nil, []Expr{strConst("2010-09-28"), strConst("2010-09-29")}, []overloadImpl{binaryTimestampFn}, binaryTimestampFn, false},
-		{nil, []Expr{strConst("2010-09-28"), strConst("2010-09-29")}, []overloadImpl{binaryTimestampFn, binaryStringFn}, binaryStringFn, false},
-		{nil, []Expr{strConst("2010-09-28"), strConst("2010-09-29")}, []overloadImpl{binaryTimestampFn, binaryIntFn}, binaryTimestampFn, false},
-		{nil, []Expr{intConst("1"), intConst("1")}, []overloadImpl{binaryIntFn, binaryFloatFn, binaryIntFnPref}, binaryIntFnPref, false},
-		{nil, []Expr{intConst("1"), intConst("1")}, []overloadImpl{binaryIntFn, binaryIntFnPref, binaryIntFnPref}, ambiguous, false},
+		{nil, []Expr{intConst("1"), intConst("1")}, []OverloadImpl{binaryIntFn, binaryFloatFn, unaryIntFn}, binaryIntFn, false},
+		{nil, []Expr{intConst("1"), decConst("1.0")}, []OverloadImpl{binaryIntFn, binaryDecimalFn, unaryDecimalFn}, binaryDecimalFn, false},
+		{nil, []Expr{strConst("2010-09-28"), strConst("2010-09-29")}, []OverloadImpl{binaryTimestampFn}, binaryTimestampFn, false},
+		{nil, []Expr{strConst("2010-09-28"), strConst("2010-09-29")}, []OverloadImpl{binaryTimestampFn, binaryStringFn}, binaryStringFn, false},
+		{nil, []Expr{strConst("2010-09-28"), strConst("2010-09-29")}, []OverloadImpl{binaryTimestampFn, binaryIntFn}, binaryTimestampFn, false},
+		{nil, []Expr{intConst("1"), intConst("1")}, []OverloadImpl{binaryIntFn, binaryFloatFn, binaryIntFnPref}, binaryIntFnPref, false},
+		{nil, []Expr{intConst("1"), intConst("1")}, []OverloadImpl{binaryIntFn, binaryIntFnPref, binaryIntFnPref}, ambiguous, false},
 		// Binary unresolved Placeholders.
-		{nil, []Expr{placeholder(0), placeholder(1)}, []overloadImpl{binaryIntFn, binaryFloatFn}, shouldError, false},
-		{nil, []Expr{placeholder(0), placeholder(1)}, []overloadImpl{binaryIntFn, unaryStringFn}, binaryIntFn, false},
-		{nil, []Expr{placeholder(0), placeholder(1)}, []overloadImpl{binaryIntFnPref, binaryFloatFn}, binaryIntFnPref, false},
-		{nil, []Expr{placeholder(0), NewDString("a")}, []overloadImpl{binaryIntFn, binaryStringFn}, binaryStringFn, false},
-		{nil, []Expr{placeholder(0), intConst("1")}, []overloadImpl{binaryIntFn, binaryFloatFn}, binaryIntFn, false},
-		{nil, []Expr{placeholder(0), intConst("1")}, []overloadImpl{binaryStringFn, binaryFloatFn}, binaryFloatFn, false},
+		{nil, []Expr{placeholder(0), placeholder(1)}, []OverloadImpl{binaryIntFn, binaryFloatFn}, shouldError, false},
+		{nil, []Expr{placeholder(0), placeholder(1)}, []OverloadImpl{binaryIntFn, unaryStringFn}, binaryIntFn, false},
+		{nil, []Expr{placeholder(0), placeholder(1)}, []OverloadImpl{binaryIntFnPref, binaryFloatFn}, binaryIntFnPref, false},
+		{nil, []Expr{placeholder(0), NewDString("a")}, []OverloadImpl{binaryIntFn, binaryStringFn}, binaryStringFn, false},
+		{nil, []Expr{placeholder(0), intConst("1")}, []OverloadImpl{binaryIntFn, binaryFloatFn}, binaryIntFn, false},
+		{nil, []Expr{placeholder(0), intConst("1")}, []OverloadImpl{binaryStringFn, binaryFloatFn}, binaryFloatFn, false},
 		// Binary values.
-		{nil, []Expr{NewDString("a"), NewDString("b")}, []overloadImpl{binaryStringFn, binaryFloatFn, unaryFloatFn}, binaryStringFn, false},
-		{nil, []Expr{NewDString("a"), intConst("1")}, []overloadImpl{binaryStringFn, binaryFloatFn, binaryStringFloatFn1}, binaryStringFloatFn1, false},
-		{nil, []Expr{NewDString("a"), NewDInt(1)}, []overloadImpl{binaryStringFn, binaryFloatFn, binaryStringFloatFn1}, unsupported, false},
-		{nil, []Expr{NewDString("a"), NewDFloat(1)}, []overloadImpl{binaryStringFn, binaryFloatFn, binaryStringFloatFn1}, binaryStringFloatFn1, false},
-		{nil, []Expr{NewDString("a"), NewDFloat(1)}, []overloadImpl{binaryStringFn, binaryFloatFn, binaryStringFloatFn2}, binaryStringFloatFn2, false},
-		{nil, []Expr{NewDFloat(1), NewDString("a")}, []overloadImpl{binaryStringFn, binaryFloatFn, binaryStringFloatFn1}, unsupported, false},
-		{nil, []Expr{NewDString("a"), NewDFloat(1)}, []overloadImpl{binaryStringFn, binaryFloatFn, binaryStringFloatFn1, binaryStringFloatFn2}, ambiguous, false},
+		{nil, []Expr{NewDString("a"), NewDString("b")}, []OverloadImpl{binaryStringFn, binaryFloatFn, unaryFloatFn}, binaryStringFn, false},
+		{nil, []Expr{NewDString("a"), intConst("1")}, []OverloadImpl{binaryStringFn, binaryFloatFn, binaryStringFloatFn1}, binaryStringFloatFn1, false},
+		{nil, []Expr{NewDString("a"), NewDInt(1)}, []OverloadImpl{binaryStringFn, binaryFloatFn, binaryStringFloatFn1}, unsupported, false},
+		{nil, []Expr{NewDString("a"), NewDFloat(1)}, []OverloadImpl{binaryStringFn, binaryFloatFn, binaryStringFloatFn1}, binaryStringFloatFn1, false},
+		{nil, []Expr{NewDString("a"), NewDFloat(1)}, []OverloadImpl{binaryStringFn, binaryFloatFn, binaryStringFloatFn2}, binaryStringFloatFn2, false},
+		{nil, []Expr{NewDFloat(1), NewDString("a")}, []OverloadImpl{binaryStringFn, binaryFloatFn, binaryStringFloatFn1}, unsupported, false},
+		{nil, []Expr{NewDString("a"), NewDFloat(1)}, []OverloadImpl{binaryStringFn, binaryFloatFn, binaryStringFloatFn1, binaryStringFloatFn2}, ambiguous, false},
 		// Desired type with ambiguity.
-		{types.Int, []Expr{intConst("1"), decConst("1.0")}, []overloadImpl{binaryIntFn, binaryDecimalFn, unaryDecimalFn}, binaryIntFn, false},
-		{types.Int, []Expr{intConst("1"), NewDFloat(1)}, []overloadImpl{binaryIntFn, binaryFloatFn, unaryFloatFn}, binaryFloatFn, false},
-		{types.Int, []Expr{NewDString("a"), NewDFloat(1)}, []overloadImpl{binaryStringFn, binaryFloatFn, binaryStringFloatFn1, binaryStringFloatFn2}, binaryStringFloatFn1, false},
-		{types.Float, []Expr{NewDString("a"), NewDFloat(1)}, []overloadImpl{binaryStringFn, binaryFloatFn, binaryStringFloatFn1, binaryStringFloatFn2}, binaryStringFloatFn2, false},
-		{types.Float, []Expr{placeholder(0), placeholder(1)}, []overloadImpl{binaryIntFn, binaryFloatFn}, binaryFloatFn, false},
+		{types.Int, []Expr{intConst("1"), decConst("1.0")}, []OverloadImpl{binaryIntFn, binaryDecimalFn, unaryDecimalFn}, binaryIntFn, false},
+		{types.Int, []Expr{intConst("1"), NewDFloat(1)}, []OverloadImpl{binaryIntFn, binaryFloatFn, unaryFloatFn}, binaryFloatFn, false},
+		{types.Int, []Expr{NewDString("a"), NewDFloat(1)}, []OverloadImpl{binaryStringFn, binaryFloatFn, binaryStringFloatFn1, binaryStringFloatFn2}, binaryStringFloatFn1, false},
+		{types.Float, []Expr{NewDString("a"), NewDFloat(1)}, []OverloadImpl{binaryStringFn, binaryFloatFn, binaryStringFloatFn1, binaryStringFloatFn2}, binaryStringFloatFn2, false},
+		{types.Float, []Expr{placeholder(0), placeholder(1)}, []OverloadImpl{binaryIntFn, binaryFloatFn}, binaryFloatFn, false},
 		// Sub-expressions.
-		{nil, []Expr{decConst("1.0"), plus(intConst("1"), intConst("2"))}, []overloadImpl{binaryIntFn, binaryDecimalFn}, binaryIntFn, false},
-		{nil, []Expr{decConst("1.1"), plus(intConst("1"), intConst("2"))}, []overloadImpl{binaryIntFn, binaryDecimalFn}, shouldError, false},
-		{nil, []Expr{NewDFloat(1.1), plus(intConst("1"), intConst("2"))}, []overloadImpl{binaryIntFn, binaryDecimalFn, binaryFloatFn}, binaryFloatFn, false},
-		{types.Decimal, []Expr{decConst("1.0"), plus(intConst("1"), intConst("2"))}, []overloadImpl{binaryIntFn, binaryDecimalFn}, binaryIntFn, false},              // Limitation.
-		{nil, []Expr{plus(intConst("1"), intConst("2")), plus(decConst("1.1"), decConst("2.2"))}, []overloadImpl{binaryIntFn, binaryDecimalFn}, shouldError, false}, // Limitation.
-		{nil, []Expr{plus(decConst("1.1"), decConst("2.2")), plus(intConst("1"), intConst("2"))}, []overloadImpl{binaryIntFn, binaryDecimalFn}, shouldError, false},
-		{nil, []Expr{plus(NewDFloat(1.1), NewDFloat(2.2)), plus(intConst("1"), intConst("2"))}, []overloadImpl{binaryIntFn, binaryFloatFn}, binaryFloatFn, false},
+		{nil, []Expr{decConst("1.0"), plus(intConst("1"), intConst("2"))}, []OverloadImpl{binaryIntFn, binaryDecimalFn}, binaryIntFn, false},
+		{nil, []Expr{decConst("1.1"), plus(intConst("1"), intConst("2"))}, []OverloadImpl{binaryIntFn, binaryDecimalFn}, shouldError, false},
+		{nil, []Expr{NewDFloat(1.1), plus(intConst("1"), intConst("2"))}, []OverloadImpl{binaryIntFn, binaryDecimalFn, binaryFloatFn}, binaryFloatFn, false},
+		{types.Decimal, []Expr{decConst("1.0"), plus(intConst("1"), intConst("2"))}, []OverloadImpl{binaryIntFn, binaryDecimalFn}, binaryIntFn, false},              // Limitation.
+		{nil, []Expr{plus(intConst("1"), intConst("2")), plus(decConst("1.1"), decConst("2.2"))}, []OverloadImpl{binaryIntFn, binaryDecimalFn}, shouldError, false}, // Limitation.
+		{nil, []Expr{plus(decConst("1.1"), decConst("2.2")), plus(intConst("1"), intConst("2"))}, []OverloadImpl{binaryIntFn, binaryDecimalFn}, shouldError, false},
+		{nil, []Expr{plus(NewDFloat(1.1), NewDFloat(2.2)), plus(intConst("1"), intConst("2"))}, []OverloadImpl{binaryIntFn, binaryFloatFn}, binaryFloatFn, false},
 		// Homogenous preference.
-		{nil, []Expr{NewDInt(1), placeholder(1)}, []overloadImpl{binaryIntFn, binaryIntDateFn}, binaryIntFn, false},
-		{nil, []Expr{NewDFloat(1), placeholder(1)}, []overloadImpl{binaryIntFn, binaryIntDateFn}, unsupported, false},
-		{nil, []Expr{intConst("1"), placeholder(1)}, []overloadImpl{binaryIntFn, binaryIntDateFn}, binaryIntFn, false},
-		{nil, []Expr{decConst("1.0"), placeholder(1)}, []overloadImpl{binaryIntFn, binaryIntDateFn}, ambiguous, false}, // Limitation.
-		{types.Date, []Expr{NewDInt(1), placeholder(1)}, []overloadImpl{binaryIntFn, binaryIntDateFn}, binaryIntDateFn, false},
-		{types.Date, []Expr{NewDFloat(1), placeholder(1)}, []overloadImpl{binaryIntFn, binaryIntDateFn}, unsupported, false},
-		{types.Date, []Expr{intConst("1"), placeholder(1)}, []overloadImpl{binaryIntFn, binaryIntDateFn}, binaryIntDateFn, false},
-		{types.Date, []Expr{decConst("1.0"), placeholder(1)}, []overloadImpl{binaryIntFn, binaryIntDateFn}, binaryIntDateFn, false},
+		{nil, []Expr{NewDInt(1), placeholder(1)}, []OverloadImpl{binaryIntFn, binaryIntDateFn}, binaryIntFn, false},
+		{nil, []Expr{NewDFloat(1), placeholder(1)}, []OverloadImpl{binaryIntFn, binaryIntDateFn}, unsupported, false},
+		{nil, []Expr{intConst("1"), placeholder(1)}, []OverloadImpl{binaryIntFn, binaryIntDateFn}, binaryIntFn, false},
+		{nil, []Expr{decConst("1.0"), placeholder(1)}, []OverloadImpl{binaryIntFn, binaryIntDateFn}, ambiguous, false}, // Limitation.
+		{types.Date, []Expr{NewDInt(1), placeholder(1)}, []OverloadImpl{binaryIntFn, binaryIntDateFn}, binaryIntDateFn, false},
+		{types.Date, []Expr{NewDFloat(1), placeholder(1)}, []OverloadImpl{binaryIntFn, binaryIntDateFn}, unsupported, false},
+		{types.Date, []Expr{intConst("1"), placeholder(1)}, []OverloadImpl{binaryIntFn, binaryIntDateFn}, binaryIntDateFn, false},
+		{types.Date, []Expr{decConst("1.0"), placeholder(1)}, []OverloadImpl{binaryIntFn, binaryIntDateFn}, binaryIntDateFn, false},
 		// BinOps
-		{nil, []Expr{NewDInt(1), DNull}, []overloadImpl{binaryIntFn, binaryIntDateFn}, ambiguous, false},
-		{nil, []Expr{NewDInt(1), DNull}, []overloadImpl{binaryIntFn, binaryIntDateFn}, binaryIntFn, true},
+		{nil, []Expr{NewDInt(1), DNull}, []OverloadImpl{binaryIntFn, binaryIntDateFn}, ambiguous, false},
+		{nil, []Expr{NewDInt(1), DNull}, []OverloadImpl{binaryIntFn, binaryIntDateFn}, binaryIntFn, true},
 		// Verify that we don't return uninitialized typedExprs for a function like
 		// array_length where the array argument is a placeholder (#36153).
-		{nil, []Expr{placeholder(0), intConst("1")}, []overloadImpl{binaryArrayIntFn}, unsupported, false},
-		{nil, []Expr{placeholder(0), intConst("1")}, []overloadImpl{binaryArrayIntFn}, unsupported, true},
+		{nil, []Expr{placeholder(0), intConst("1")}, []OverloadImpl{binaryArrayIntFn}, unsupported, false},
+		{nil, []Expr{placeholder(0), intConst("1")}, []OverloadImpl{binaryArrayIntFn}, unsupported, true},
 	}
 	ctx := context.Background()
 	for i, d := range testData {
@@ -328,20 +365,20 @@ func TestGetMostSignificantOverload(t *testing.T) {
 		return &path
 	}
 	returnTyper := FixedReturnType(types.Int)
-	newOverload := func(schema string, oid oid.Oid) QualifiedOverload {
-		return QualifiedOverload{Schema: schema, Overload: &Overload{Oid: oid, Types: ArgTypes{}, ReturnType: returnTyper}}
+	newOverload := func(schema string, oid oid.Oid) *QualifiedOverload {
+		return &QualifiedOverload{Schema: schema, Overload: &Overload{Oid: oid, Types: ArgTypes{}, ReturnType: returnTyper}}
 	}
 
 	testCases := []struct {
 		testName    string
-		overloads   []overloadImpl
+		overloads   []OverloadImpl
 		searchPath  SearchPath
 		expectedOID int
 		expectedErr string
 	}{
 		{
 			testName: "empty search path",
-			overloads: []overloadImpl{
+			overloads: []OverloadImpl{
 				newOverload("sc1", 1),
 			},
 			searchPath:  EmptySearchPath,
@@ -349,113 +386,113 @@ func TestGetMostSignificantOverload(t *testing.T) {
 		},
 		{
 			testName: "empty search path but ambiguous",
-			overloads: []overloadImpl{
-				QualifiedOverload{Schema: "sc1", Overload: &Overload{Oid: 1, Types: ArgTypes{}, ReturnType: returnTyper}},
-				QualifiedOverload{Schema: "sc1", Overload: &Overload{Oid: 2, Types: ArgTypes{}, ReturnType: returnTyper}},
+			overloads: []OverloadImpl{
+				&QualifiedOverload{Schema: "sc1", Overload: &Overload{Oid: 1, Types: ArgTypes{}, ReturnType: returnTyper}},
+				&QualifiedOverload{Schema: "sc1", Overload: &Overload{Oid: 2, Types: ArgTypes{}, ReturnType: returnTyper}},
 			},
 			searchPath:  EmptySearchPath,
 			expectedErr: "ambiguous call",
 		},
 		{
 			testName: "no udf overload",
-			overloads: []overloadImpl{
-				QualifiedOverload{Schema: "pg_catalog", Overload: &Overload{Oid: 1, Types: ArgTypes{}, ReturnType: returnTyper}},
+			overloads: []OverloadImpl{
+				&QualifiedOverload{Schema: "pg_catalog", Overload: &Overload{Oid: 1, Types: ArgTypes{}, ReturnType: returnTyper}},
 			},
 			searchPath:  makeSearchPath([]string{"sc3", "sc2", "sc1", "pg_catalog"}),
 			expectedOID: 1,
 		},
 		{
 			testName: "no udf overload but ambiguous",
-			overloads: []overloadImpl{
-				QualifiedOverload{Schema: "pg_catalog", Overload: &Overload{Oid: 1, Types: ArgTypes{}, ReturnType: returnTyper}},
-				QualifiedOverload{Schema: "pg_catalog", Overload: &Overload{Oid: 2, Types: ArgTypes{}, ReturnType: returnTyper}},
+			overloads: []OverloadImpl{
+				&QualifiedOverload{Schema: "pg_catalog", Overload: &Overload{Oid: 1, Types: ArgTypes{}, ReturnType: returnTyper}},
+				&QualifiedOverload{Schema: "pg_catalog", Overload: &Overload{Oid: 2, Types: ArgTypes{}, ReturnType: returnTyper}},
 			},
 			searchPath:  makeSearchPath([]string{"sc3", "sc2", "sc1", "pg_catalog"}),
 			expectedErr: "ambiguous call",
 		},
 		{
 			testName: "overloads from all schemas in path",
-			overloads: []overloadImpl{
-				QualifiedOverload{Schema: "sc1", Overload: &Overload{Oid: 1, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
-				QualifiedOverload{Schema: "sc2", Overload: &Overload{Oid: 2, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
-				QualifiedOverload{Schema: "sc3", Overload: &Overload{Oid: 3, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
+			overloads: []OverloadImpl{
+				&QualifiedOverload{Schema: "sc1", Overload: &Overload{Oid: 1, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
+				&QualifiedOverload{Schema: "sc2", Overload: &Overload{Oid: 2, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
+				&QualifiedOverload{Schema: "sc3", Overload: &Overload{Oid: 3, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
 			},
 			searchPath:  makeSearchPath([]string{"sc3", "sc2", "sc1"}),
 			expectedOID: 3,
 		},
 		{
 			testName: "overloads from all schemas in path but ambiguous",
-			overloads: []overloadImpl{
-				QualifiedOverload{Schema: "sc1", Overload: &Overload{Oid: 1, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
-				QualifiedOverload{Schema: "sc2", Overload: &Overload{Oid: 2, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
-				QualifiedOverload{Schema: "sc3", Overload: &Overload{Oid: 3, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
-				QualifiedOverload{Schema: "sc3", Overload: &Overload{Oid: 4, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
+			overloads: []OverloadImpl{
+				&QualifiedOverload{Schema: "sc1", Overload: &Overload{Oid: 1, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
+				&QualifiedOverload{Schema: "sc2", Overload: &Overload{Oid: 2, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
+				&QualifiedOverload{Schema: "sc3", Overload: &Overload{Oid: 3, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
+				&QualifiedOverload{Schema: "sc3", Overload: &Overload{Oid: 4, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
 			},
 			searchPath:  makeSearchPath([]string{"sc3", "sc2", "sc1"}),
 			expectedErr: "ambiguous call",
 		},
 		{
 			testName: "overloads from some schemas in path",
-			overloads: []overloadImpl{
-				QualifiedOverload{Schema: "sc1", Overload: &Overload{Oid: 1, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
-				QualifiedOverload{Schema: "sc2", Overload: &Overload{Oid: 2, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
-				QualifiedOverload{Schema: "sc2", Overload: &Overload{Oid: 3, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
+			overloads: []OverloadImpl{
+				&QualifiedOverload{Schema: "sc1", Overload: &Overload{Oid: 1, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
+				&QualifiedOverload{Schema: "sc2", Overload: &Overload{Oid: 2, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
+				&QualifiedOverload{Schema: "sc2", Overload: &Overload{Oid: 3, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
 			},
 			searchPath:  makeSearchPath([]string{"sc3", "sc1", "sc2"}),
 			expectedOID: 1,
 		},
 		{
 			testName: "overloads from some schemas in path but ambiguous",
-			overloads: []overloadImpl{
-				QualifiedOverload{Schema: "sc1", Overload: &Overload{Oid: 1, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
-				QualifiedOverload{Schema: "sc2", Overload: &Overload{Oid: 2, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
-				QualifiedOverload{Schema: "sc2", Overload: &Overload{Oid: 3, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
+			overloads: []OverloadImpl{
+				&QualifiedOverload{Schema: "sc1", Overload: &Overload{Oid: 1, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
+				&QualifiedOverload{Schema: "sc2", Overload: &Overload{Oid: 2, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
+				&QualifiedOverload{Schema: "sc2", Overload: &Overload{Oid: 3, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
 			},
 			searchPath:  makeSearchPath([]string{"sc3", "sc2", "sc1"}),
 			expectedErr: "ambiguous call",
 		},
 		{
 			testName: "implicit pg_catalog in path",
-			overloads: []overloadImpl{
-				QualifiedOverload{Schema: "sc1", Overload: &Overload{Oid: 1, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
-				QualifiedOverload{Schema: "sc3", Overload: &Overload{Oid: 2, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
-				QualifiedOverload{Schema: "pg_catalog", Overload: &Overload{Oid: 3}},
+			overloads: []OverloadImpl{
+				&QualifiedOverload{Schema: "sc1", Overload: &Overload{Oid: 1, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
+				&QualifiedOverload{Schema: "sc3", Overload: &Overload{Oid: 2, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
+				&QualifiedOverload{Schema: "pg_catalog", Overload: &Overload{Oid: 3}},
 			},
 			searchPath:  makeSearchPath([]string{"sc3", "sc2", "sc1"}),
 			expectedOID: 3,
 		},
 		{
 			testName: "explicit pg_catalog in path",
-			overloads: []overloadImpl{
-				QualifiedOverload{Schema: "sc1", Overload: &Overload{Oid: 1, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
-				QualifiedOverload{Schema: "sc3", Overload: &Overload{Oid: 2, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
-				QualifiedOverload{Schema: "pg_catalog", Overload: &Overload{Oid: 3}},
+			overloads: []OverloadImpl{
+				&QualifiedOverload{Schema: "sc1", Overload: &Overload{Oid: 1, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
+				&QualifiedOverload{Schema: "sc3", Overload: &Overload{Oid: 2, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
+				&QualifiedOverload{Schema: "pg_catalog", Overload: &Overload{Oid: 3}},
 			},
 			searchPath:  makeSearchPath([]string{"sc3", "sc2", "sc1", "pg_catalog"}),
 			expectedOID: 2,
 		},
 		{
 			testName: "unique schema not in path",
-			overloads: []overloadImpl{
-				QualifiedOverload{Schema: "sc1", Overload: &Overload{Oid: 1, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
+			overloads: []OverloadImpl{
+				&QualifiedOverload{Schema: "sc1", Overload: &Overload{Oid: 1, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
 			},
 			searchPath:  makeSearchPath([]string{"sc3", "sc2"}),
 			expectedOID: 1,
 		},
 		{
 			testName: "unique schema not in path but ambiguous",
-			overloads: []overloadImpl{
-				QualifiedOverload{Schema: "sc1", Overload: &Overload{Oid: 1, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
-				QualifiedOverload{Schema: "sc1", Overload: &Overload{Oid: 2, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
+			overloads: []OverloadImpl{
+				&QualifiedOverload{Schema: "sc1", Overload: &Overload{Oid: 1, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
+				&QualifiedOverload{Schema: "sc1", Overload: &Overload{Oid: 2, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
 			},
 			searchPath:  makeSearchPath([]string{"sc3", "sc2"}),
 			expectedErr: "ambiguous call",
 		},
 		{
 			testName: "not unique schema and schema not in path",
-			overloads: []overloadImpl{
-				QualifiedOverload{Schema: "sc1", Overload: &Overload{Oid: 1, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
-				QualifiedOverload{Schema: "sc2", Overload: &Overload{Oid: 2, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
+			overloads: []OverloadImpl{
+				&QualifiedOverload{Schema: "sc1", Overload: &Overload{Oid: 1, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
+				&QualifiedOverload{Schema: "sc2", Overload: &Overload{Oid: 2, IsUDF: true, Types: ArgTypes{}, ReturnType: returnTyper}},
 			},
 			searchPath:  makeSearchPath([]string{"sc3"}),
 			expectedErr: "unknown signature",

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1084,7 +1084,7 @@ func (expr *FuncExpr) TypeCheck(
 	var calledOnNullInputFns []overloadImpl
 	var notCalledOnNullInputFns []overloadImpl
 	for _, f := range fns {
-		if f.(QualifiedOverload).CalledOnNullInput {
+		if f.(*QualifiedOverload).CalledOnNullInput {
 			calledOnNullInputFns = append(calledOnNullInputFns, f)
 		} else {
 			notCalledOnNullInputFns = append(notCalledOnNullInputFns, f)
@@ -2936,7 +2936,7 @@ func (stripFuncsVisitor) VisitPost(expr Expr) Expr { return expr }
 // of QualifiedOverload. Also, the input should not be empty.
 func getMostSignificantOverload(
 	overloads []overloadImpl, searchPath SearchPath, expr *FuncExpr, getFuncSig func() string,
-) (QualifiedOverload, error) {
+) (*QualifiedOverload, error) {
 	ambiguousError := func() error {
 		return pgerror.Newf(
 			pgcode.AmbiguousFunction,
@@ -2947,13 +2947,13 @@ func getMostSignificantOverload(
 			formatCandidates(expr.Func.String(), overloads),
 		)
 	}
-	checkAmbiguity := func(oImpls []overloadImpl) (QualifiedOverload, error) {
+	checkAmbiguity := func(oImpls []overloadImpl) (*QualifiedOverload, error) {
 		if len(oImpls) > 1 {
 			// Throw ambiguity error if there are more than one candidate overloads from
 			// same schema.
-			return QualifiedOverload{}, ambiguousError()
+			return nil, ambiguousError()
 		}
-		return oImpls[0].(QualifiedOverload), nil
+		return oImpls[0].(*QualifiedOverload), nil
 	}
 
 	if searchPath == nil || searchPath == EmptySearchPath {
@@ -2963,10 +2963,10 @@ func getMostSignificantOverload(
 	udfFound := false
 	uniqueSchema := true
 	for i, o := range overloads {
-		if o.(QualifiedOverload).IsUDF {
+		if o.(*QualifiedOverload).IsUDF {
 			udfFound = true
 		}
-		if i > 0 && o.(QualifiedOverload).Schema != overloads[i-1].(QualifiedOverload).Schema {
+		if i > 0 && o.(*QualifiedOverload).Schema != overloads[i-1].(*QualifiedOverload).Schema {
 			uniqueSchema = false
 		}
 	}
@@ -2987,16 +2987,16 @@ func getMostSignificantOverload(
 	}
 
 	found := false
-	var ret QualifiedOverload
+	var ret *QualifiedOverload
 	for i, n := 0, searchPath.NumElements(); i < n; i++ {
 		schema := searchPath.GetSchema(i)
 		for i := range overloads {
-			if overloads[i].(QualifiedOverload).Schema == schema {
+			if overloads[i].(*QualifiedOverload).Schema == schema {
 				if found {
-					return QualifiedOverload{}, ambiguousError()
+					return nil, ambiguousError()
 				}
 				found = true
-				ret = overloads[i].(QualifiedOverload)
+				ret = overloads[i].(*QualifiedOverload)
 			}
 		}
 		if found {
@@ -3007,7 +3007,7 @@ func getMostSignificantOverload(
 		// This should never happen. Otherwise, it means we get function from a
 		// schema no on the given search path or we try to resolve a function on an
 		// explicit schema, but get some function from other schemas are fetched.
-		return QualifiedOverload{}, pgerror.Newf(pgcode.UndefinedFunction, "unknown signature: %s", getFuncSig())
+		return nil, pgerror.Newf(pgcode.UndefinedFunction, "unknown signature: %s", getFuncSig())
 	}
 	return ret, nil
 }


### PR DESCRIPTION
2 commits:
(1) change overloads returned from function resolver to pointers to avoid value copying.
(2) expand the `overloadImpl` interface to allow accessing function overload properties without type casting. This allows us to get rid of the slice allocation in type checking.

All these would be able to improve the type checking performance by 20% cpu time overall:
```
name                                                       old time/op    new time/op    delta
FuncExprTypeCheck/builtin_called_on_null_input-24            1.05µs ± 1%    0.68µs ± 1%  -35.53%  (p=0.000 n=10+10)
FuncExprTypeCheck/builtin_not_called_on_null_input-24        1.00µs ± 1%    0.66µs ± 1%  -34.04%  (p=0.000 n=9+10)
FuncExprTypeCheck/builtin_aggregate-24                       2.17µs ± 0%    1.06µs ± 0%  -51.07%  (p=0.000 n=10+10)
FuncExprTypeCheck/builtin_aggregate_not_called_on_null-24    1.23µs ± 1%    0.80µs ± 1%  -35.02%  (p=0.000 n=10+9)
FuncExprTypeCheck/udf_same_name_as_builtin-24                1.50µs ± 0%    0.91µs ± 1%  -39.53%  (p=0.000 n=10+9)
FuncExprTypeCheck/udf_across_different_schemas-24            2.43µs ± 0%    1.80µs ± 1%  -25.90%  (p=0.000 n=8+10)
FuncExprTypeCheck/unary_operator-24                           344ns ± 2%     349ns ± 2%     ~     (p=0.065 n=10+10)
FuncExprTypeCheck/binary_operator-24                         1.36µs ± 0%    1.35µs ± 0%   -0.72%  (p=0.000 n=10+10)
FuncExprTypeCheck/comparison_operator-24                     2.16µs ± 0%    2.18µs ± 0%   +0.81%  (p=0.000 n=10+10)
FuncExprTypeCheck/tuple_comparison_operator-24               6.45µs ± 0%    6.47µs ± 1%     ~     (p=0.239 n=10+10)
FuncExprTypeCheck/tuple_in_operator-24                       1.13µs ± 1%    1.14µs ± 0%   +1.21%  (p=0.000 n=10+9)

name                                                       old alloc/op   new alloc/op   delta
FuncExprTypeCheck/builtin_called_on_null_input-24              132B ± 6%       34B ±10%  -74.53%  (p=0.000 n=10+10)
FuncExprTypeCheck/builtin_not_called_on_null_input-24          129B ± 0%       33B ± 2%  -74.81%  (p=0.000 n=8+8)
FuncExprTypeCheck/builtin_aggregate-24                         467B ± 0%       73B ± 0%  -84.37%  (p=0.000 n=9+8)
FuncExprTypeCheck/builtin_aggregate_not_called_on_null-24      145B ± 0%       32B ± 0%  -77.93%  (p=0.000 n=8+8)
FuncExprTypeCheck/udf_same_name_as_builtin-24                  273B ± 0%       64B ± 1%  -76.53%  (p=0.000 n=9+8)
FuncExprTypeCheck/udf_across_different_schemas-24              674B ± 0%      465B ± 0%  -30.90%  (p=0.000 n=8+9)
FuncExprTypeCheck/unary_operator-24                           0.00B          0.00B          ~     (all equal)
FuncExprTypeCheck/binary_operator-24                           113B ± 0%      113B ± 1%     ~     (p=0.214 n=6+9)
FuncExprTypeCheck/comparison_operator-24                       153B ± 0%      155B ± 4%     ~     (p=0.793 n=9+9)
FuncExprTypeCheck/tuple_comparison_operator-24                 894B ± 0%      892B ± 0%     ~     (p=0.057 n=9+8)
FuncExprTypeCheck/tuple_in_operator-24                         400B ± 0%      400B ± 0%     ~     (p=1.161 n=8+9)

name                                                       old allocs/op  new allocs/op  delta
FuncExprTypeCheck/builtin_called_on_null_input-24              7.00 ± 0%      3.00 ± 0%  -57.14%  (p=0.000 n=10+10)
FuncExprTypeCheck/builtin_not_called_on_null_input-24          7.00 ± 0%      3.00 ± 0%  -57.14%  (p=0.000 n=10+10)
FuncExprTypeCheck/builtin_aggregate-24                         16.0 ± 0%       4.0 ± 0%  -75.00%  (p=0.000 n=10+10)
FuncExprTypeCheck/builtin_aggregate_not_called_on_null-24      8.00 ± 0%      3.00 ± 0%  -62.50%  (p=0.000 n=10+10)
FuncExprTypeCheck/udf_same_name_as_builtin-24                  11.0 ± 0%       4.0 ± 0%  -63.64%  (p=0.000 n=10+10)
FuncExprTypeCheck/udf_across_different_schemas-24              16.0 ± 0%       9.0 ± 0%  -43.75%  (p=0.002 n=8+10)
FuncExprTypeCheck/unary_operator-24                            0.00           0.00          ~     (all equal)
FuncExprTypeCheck/binary_operator-24                           5.00 ± 0%      5.00 ± 0%     ~     (all equal)
FuncExprTypeCheck/comparison_operator-24                       5.00 ± 0%      5.00 ± 0%     ~     (all equal)
FuncExprTypeCheck/tuple_comparison_operator-24                 19.0 ± 0%      19.0 ± 0%     ~     (all equal)
FuncExprTypeCheck/tuple_in_operator-24                         7.00 ± 0%      7.00 ± 0%     ~     (all equal)
```