### PR TITLE
sql: fix panic in DROP ROLE when schemas have the same name

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/drop_user
+++ b/pkg/sql/logictest/testdata/logic_test/drop_user
@@ -177,3 +177,33 @@ INSERT INTO system.scheduled_jobs (schedule_name, owner, executor_type,execution
 
 statement error pq: cannot drop role/user user1; it owns 1 scheduled jobs.
 DROP USER user1
+
+# Verify that schemas are fully qualified in the error message.
+subtest same_schema_name
+
+statement ok
+CREATE ROLE schema_owner
+
+statement ok
+GRANT admin TO schema_owner
+
+statement ok
+SET ROLE schema_owner
+
+statement ok
+CREATE SCHEMA the_schema
+
+statement ok
+USE defaultdb
+
+statement ok
+CREATE SCHEMA the_schema
+
+statement ok
+RESET ROLE;
+RESET DATABASE
+
+statement error role schema_owner cannot be dropped because some objects depend on it\nowner of schema defaultdb.the_schema\nowner of schema test.the_schema
+DROP ROLE schema_owner
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/owner
+++ b/pkg/sql/logictest/testdata/logic_test/owner
@@ -253,5 +253,5 @@ REVOKE ALL ON TABLE d.s.t FROM testuser;
 
 user testuser
 
-statement error pq: role testuser cannot be dropped because some objects depend on it\nowner of database d\nowner of schema s
+statement error pq: role testuser cannot be dropped because some objects depend on it\nowner of database d\nowner of schema d.s
 DROP ROLE testuser

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -1179,6 +1179,22 @@ func getTypeNameFromTypeDescriptor(
 	return typeName, nil
 }
 
+func getSchemaNameFromSchemaDescriptor(
+	l simpleSchemaResolver, sc catalog.SchemaDescriptor,
+) (tree.ObjectNamePrefix, error) {
+	var scName tree.ObjectNamePrefix
+	db, err := l.getDatabaseByID(sc.GetParentID())
+	if err != nil {
+		return scName, err
+	}
+	return tree.ObjectNamePrefix{
+		CatalogName:     tree.Name(db.GetName()),
+		SchemaName:      tree.Name(sc.GetName()),
+		ExplicitCatalog: true,
+		ExplicitSchema:  true,
+	}, nil
+}
+
 func getFunctionNameFromFunctionDescriptor(
 	l simpleSchemaResolver, fn catalog.FunctionDescriptor,
 ) (tree.FunctionName, error) {


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/89486

Release note (bug fix): Fix a crash that could occur when dropping a role that owned two schemas with the same name in different databases. The bug was introduced in v22.1.0.