### PR TITLE
scbuildstmt:fix constraintID of tempIndex of secdonaryIndex in AddColumn

### DIFF
--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_column.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_column.go
@@ -658,6 +658,7 @@ func addSecondaryIndexTargetsForAddColumn(
 			"assumed temporary index ID %d != %d", tempIndexID, temp.IndexID,
 		))
 	}
+	temp.ConstraintID = index.ConstraintID + 1
 	var tempIndexColumns []*scpb.IndexColumn
 	scpb.ForEachIndexColumn(b.QueryByID(tbl.TableID), func(
 		_ scpb.Status, _ scpb.TargetStatus, e *scpb.IndexColumn,

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_add_column
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_add_column
@@ -1781,7 +1781,7 @@ PostCommitPhase stage 8 of 15 with 12 MutationType ops
     [[SecondaryIndex:{DescID: 109, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, PUBLIC], ABSENT] -> BACKFILL_ONLY
     [[IndexColumn:{DescID: 109, ColumnID: 2, IndexID: 5}, PUBLIC], ABSENT] -> PUBLIC
     [[IndexColumn:{DescID: 109, ColumnID: 1, IndexID: 5}, PUBLIC], ABSENT] -> PUBLIC
-    [[TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
+    [[TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
   ops:
     *scop.MakePublicPrimaryIndexWriteOnly
       IndexID: 1
@@ -1817,7 +1817,7 @@ PostCommitPhase stage 8 of 15 with 12 MutationType ops
       IsSecondaryIndex: true
     *scop.MakeAbsentTempIndexDeleteOnly
       Index:
-        ConstraintID: 4
+        ConstraintID: 5
         IndexID: 5
         IsUnique: true
         SourceIndexID: 2
@@ -1847,7 +1847,7 @@ PostCommitPhase stage 8 of 15 with 12 MutationType ops
       JobID: 1
 PostCommitPhase stage 9 of 15 with 3 MutationType ops
   transitions:
-    [[TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}, TRANSIENT_ABSENT], DELETE_ONLY] -> WRITE_ONLY
+    [[TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, TRANSIENT_ABSENT], DELETE_ONLY] -> WRITE_ONLY
   ops:
     *scop.MakeDeleteOnlyIndexWriteOnly
       IndexID: 5
@@ -1922,7 +1922,7 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 9 MutationType ops
     [[IndexColumn:{DescID: 109, ColumnID: 2, IndexID: 3}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
     [[SecondaryIndex:{DescID: 109, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, PUBLIC], VALIDATED] -> PUBLIC
     [[IndexName:{DescID: 109, Name: baz_g_key, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
-    [[TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}, TRANSIENT_ABSENT], WRITE_ONLY] -> TRANSIENT_DELETE_ONLY
+    [[TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, TRANSIENT_ABSENT], WRITE_ONLY] -> TRANSIENT_DELETE_ONLY
   ops:
     *scop.MakeWriteOnlyColumnPublic
       ColumnID: 2
@@ -1963,7 +1963,7 @@ PostCommitNonRevertiblePhase stage 2 of 2 with 8 MutationType ops
   transitions:
     [[PrimaryIndex:{DescID: 109, IndexID: 1, ConstraintID: 1}, ABSENT], DELETE_ONLY] -> ABSENT
     [[TemporaryIndex:{DescID: 109, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
-    [[TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
+    [[TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
   ops:
     *scop.CreateGCJobForIndex
       IndexID: 1
@@ -2062,7 +2062,7 @@ ALTER TABLE defaultdb.baz ADD g INT UNIQUE DEFAULT 1
   kind: Precedence
   rule: column existence precedes temp index existence
 - from: [Column:{DescID: 109, ColumnID: 2}, DELETE_ONLY]
-  to:   [TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}, DELETE_ONLY]
+  to:   [TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, DELETE_ONLY]
   kind: Precedence
   rule: column existence precedes temp index existence
 - from: [Column:{DescID: 109, ColumnID: 2}, WRITE_ONLY]
@@ -2074,7 +2074,7 @@ ALTER TABLE defaultdb.baz ADD g INT UNIQUE DEFAULT 1
   kind: Precedence
   rule: column is WRITE_ONLY before temporary index is WRITE_ONLY
 - from: [Column:{DescID: 109, ColumnID: 2}, WRITE_ONLY]
-  to:   [TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}, WRITE_ONLY]
+  to:   [TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, WRITE_ONLY]
   kind: Precedence
   rule: column is WRITE_ONLY before temporary index is WRITE_ONLY
 - from: [ColumnDefaultExpression:{DescID: 109, ColumnID: 2}, PUBLIC]
@@ -2242,7 +2242,7 @@ ALTER TABLE defaultdb.baz ADD g INT UNIQUE DEFAULT 1
   kind: Precedence
   rule: primary index with new columns should exist before secondary indexes
 - from: [PrimaryIndex:{DescID: 109, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC]
-  to:   [TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}, DELETE_ONLY]
+  to:   [TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, DELETE_ONLY]
   kind: Precedence
   rule: primary index with new columns should exist before temp indexes
 - from: [PrimaryIndex:{DescID: 109, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, VALIDATED]
@@ -2325,31 +2325,31 @@ ALTER TABLE defaultdb.baz ADD g INT UNIQUE DEFAULT 1
   to:   [TemporaryIndex:{DescID: 109, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_DELETE_ONLY]
   kind: PreviousTransactionPrecedence
   rule: TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: WRITE_ONLY->TRANSIENT_DELETE_ONLY
-- from: [TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}, ABSENT]
-  to:   [TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}, DELETE_ONLY]
+- from: [TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, ABSENT]
+  to:   [TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, DELETE_ONLY]
   kind: PreviousTransactionPrecedence
   rule: TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: ABSENT->DELETE_ONLY
-- from: [TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}, DELETE_ONLY]
+- from: [TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, DELETE_ONLY]
   to:   [IndexColumn:{DescID: 109, ColumnID: 1, IndexID: 5}, PUBLIC]
   kind: Precedence
   rule: temp index existence precedes index dependents
-- from: [TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}, DELETE_ONLY]
+- from: [TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, DELETE_ONLY]
   to:   [IndexColumn:{DescID: 109, ColumnID: 2, IndexID: 5}, PUBLIC]
   kind: Precedence
   rule: temp index existence precedes index dependents
-- from: [TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}, DELETE_ONLY]
-  to:   [TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}, WRITE_ONLY]
+- from: [TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, DELETE_ONLY]
+  to:   [TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, WRITE_ONLY]
   kind: PreviousTransactionPrecedence
   rule: TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: DELETE_ONLY->WRITE_ONLY
-- from: [TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}, TRANSIENT_DELETE_ONLY]
-  to:   [TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}, TRANSIENT_ABSENT]
+- from: [TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, TRANSIENT_DELETE_ONLY]
+  to:   [TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, TRANSIENT_ABSENT]
   kind: PreviousTransactionPrecedence
   rule: TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: TRANSIENT_DELETE_ONLY->TRANSIENT_ABSENT
-- from: [TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}, WRITE_ONLY]
+- from: [TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, WRITE_ONLY]
   to:   [SecondaryIndex:{DescID: 109, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, BACKFILLED]
   kind: Precedence
   rule: temp index is WRITE_ONLY before backfill
-- from: [TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}, WRITE_ONLY]
-  to:   [TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}, TRANSIENT_DELETE_ONLY]
+- from: [TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, WRITE_ONLY]
+  to:   [TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, TRANSIENT_DELETE_ONLY]
   kind: PreviousTransactionPrecedence
   rule: TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: WRITE_ONLY->TRANSIENT_DELETE_ONLY

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique
@@ -320,7 +320,7 @@ upsert descriptor #106
   +    state: BACKFILLING
   +  - direction: ADD
   +    index:
-  +      constraintId: 4
+  +      constraintId: 5
   +      createdExplicitly: true
   +      foreignKey: {}
   +      geoConfig: {}
@@ -347,7 +347,7 @@ upsert descriptor #106
      name: tbl
      nextColumnId: 3
   -  nextConstraintId: 4
-  +  nextConstraintId: 5
+  +  nextConstraintId: 6
      nextFamilyId: 1
   -  nextIndexId: 4
   +  nextIndexId: 6
@@ -541,11 +541,11 @@ upsert descriptor #106
   +    state: DELETE_ONLY
   +  - direction: DROP
        index:
-         constraintId: 4
+  -      constraintId: 4
   -      createdAtNanos: "1640998800000000000"
-         createdExplicitly: true
-         foreignKey: {}
-         geoConfig: {}
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
   -      id: 4
   -      interleave: {}
   -      keyColumnDirections:
@@ -566,12 +566,8 @@ upsert descriptor #106
   -    state: WRITE_ONLY
   -  - direction: ADD
   -    index:
-  -      constraintId: 4
-  -      createdExplicitly: true
-  -      foreignKey: {}
-  -      geoConfig: {}
-         id: 5
-         interleave: {}
+         constraintId: 5
+         createdExplicitly: true
   ...
          version: 4
        mutationId: 1
@@ -664,7 +660,7 @@ upsert descriptor #106
   -    state: DELETE_ONLY
   -  - direction: DROP
   -    index:
-  -      constraintId: 4
+  -      constraintId: 5
   -      createdExplicitly: true
   -      foreignKey: {}
   -      geoConfig: {}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_unique
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_unique
@@ -94,7 +94,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}
  │    │    │    └── ABSENT    → PUBLIC        IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
  │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── ABSENT    → DELETE_ONLY   TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+ │    │    │    └── ABSENT    → DELETE_ONLY   TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
  │    │    ├── 2 elements transitioning toward ABSENT
  │    │    │    ├── PUBLIC    → VALIDATED     PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
  │    │    │    └── PUBLIC    → ABSENT        IndexName:{DescID: 106, Name: tbl_pkey, IndexID: 1}
@@ -113,7 +113,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    ├── Stage 9 of 15 in PostCommitPhase
  │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+ │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
  │    │    └── 3 Mutation operations
  │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":5,"TableID":106}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
@@ -164,7 +164,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
       │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
       │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
-      │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+      │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
       │    ├── 2 elements transitioning toward ABSENT
       │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 1}
       │    │    └── VALIDATED  → DELETE_ONLY           PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
@@ -181,7 +181,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 2 elements transitioning toward TRANSIENT_ABSENT
            │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
            ├── 1 element transitioning toward ABSENT
            │    └── DELETE_ONLY           → ABSENT           PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
            └── 8 Mutation operations

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_10_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_10_of_15
@@ -27,7 +27,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
-      │    │    └── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+      │    │    └── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
       │    └── 13 Mutation operations
       │         ├── SetIndexName {"IndexID":1,"Name":"tbl_pkey","TableID":106}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
@@ -46,7 +46,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    ├── 3 elements transitioning toward ABSENT
       │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
       │    └── 7 Mutation operations
       │         ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_11_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_11_of_15
@@ -27,7 +27,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
-      │    │    └── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+      │    │    └── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
       │    └── 13 Mutation operations
       │         ├── SetIndexName {"IndexID":1,"Name":"tbl_pkey","TableID":106}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
@@ -46,7 +46,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    ├── 3 elements transitioning toward ABSENT
       │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
       │    └── 7 Mutation operations
       │         ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_12_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_12_of_15
@@ -27,7 +27,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
-      │    │    └── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+      │    │    └── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
       │    └── 13 Mutation operations
       │         ├── SetIndexName {"IndexID":1,"Name":"tbl_pkey","TableID":106}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
@@ -46,7 +46,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    ├── 3 elements transitioning toward ABSENT
       │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
       │    └── 7 Mutation operations
       │         ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_13_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_13_of_15
@@ -27,7 +27,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
-      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
       │    └── 11 Mutation operations
       │         ├── SetIndexName {"IndexID":1,"Name":"tbl_pkey","TableID":106}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
@@ -45,7 +45,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
       │    └── 10 Mutation operations
       │         ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_14_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_14_of_15
@@ -27,7 +27,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
-      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
       │    └── 11 Mutation operations
       │         ├── SetIndexName {"IndexID":1,"Name":"tbl_pkey","TableID":106}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
@@ -45,7 +45,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
       │    └── 10 Mutation operations
       │         ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_15_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_15_of_15
@@ -27,7 +27,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── WRITE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
-      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
       │    └── 11 Mutation operations
       │         ├── SetIndexName {"IndexID":1,"Name":"tbl_pkey","TableID":106}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
@@ -45,7 +45,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
       │    └── 10 Mutation operations
       │         ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_9_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_9_of_15
@@ -27,7 +27,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
-      │    │    └── DELETE_ONLY   → ABSENT      TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+      │    │    └── DELETE_ONLY   → ABSENT      TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
       │    └── 14 Mutation operations
       │         ├── SetIndexName {"IndexID":1,"Name":"tbl_pkey","TableID":106}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique
@@ -436,18 +436,18 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_r
 │   │   │   │   ├── • Precedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 2}
 │   │   │   │   │     rule: "column existence precedes column dependents"
 │   │   │   │   │
-│   │   │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+│   │   │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
 │   │   │   │         rule: "temp index existence precedes index dependents"
 │   │   │   │
 │   │   │   └── • IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
 │   │   │       │ ABSENT → PUBLIC
 │   │   │       │
-│   │   │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+│   │   │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
 │   │   │             rule: "temp index existence precedes index dependents"
 │   │   │
 │   │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
 │   │   │   │
-│   │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+│   │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
 │   │   │       │ ABSENT → DELETE_ONLY
 │   │   │       │
 │   │   │       ├── • Precedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 2}
@@ -456,7 +456,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_r
 │   │   │       ├── • Precedence dependency from PUBLIC PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
 │   │   │       │     rule: "primary index with new columns should exist before temp indexes"
 │   │   │       │
-│   │   │       └── • PreviousTransactionPrecedence dependency from ABSENT TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+│   │   │       └── • PreviousTransactionPrecedence dependency from ABSENT TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
 │   │   │             rule: "TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: ABSENT->DELETE_ONLY"
 │   │   │
 │   │   ├── • 2 elements transitioning toward ABSENT
@@ -513,7 +513,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_r
 │   │       │
 │   │       ├── • MakeAbsentTempIndexDeleteOnly
 │   │       │     Index:
-│   │       │       ConstraintID: 4
+│   │       │       ConstraintID: 5
 │   │       │       IndexID: 5
 │   │       │       IsUnique: true
 │   │       │       SourceIndexID: 2
@@ -553,13 +553,13 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_r
 │   │   │
 │   │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
 │   │   │   │
-│   │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+│   │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
 │   │   │       │ DELETE_ONLY → WRITE_ONLY
 │   │   │       │
 │   │   │       ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
 │   │   │       │     rule: "column is WRITE_ONLY before temporary index is WRITE_ONLY"
 │   │   │       │
-│   │   │       └── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+│   │   │       └── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
 │   │   │             rule: "TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: DELETE_ONLY->WRITE_ONLY"
 │   │   │
 │   │   └── • 3 Mutation operations
@@ -591,7 +591,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_r
 │   │   │       ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY SecondaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
 │   │   │       │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: BACKFILL_ONLY->BACKFILLED"
 │   │   │       │
-│   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+│   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
 │   │   │             rule: "temp index is WRITE_ONLY before backfill"
 │   │   │
 │   │   └── • 1 Backfill operation
@@ -781,10 +781,10 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_r
     │   │   │   └── • skip PUBLIC → TRANSIENT_ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+    │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
     │   │       │ WRITE_ONLY → TRANSIENT_DELETE_ONLY
     │   │       │
-    │   │       └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+    │   │       └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
     │   │             rule: "TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: WRITE_ONLY->TRANSIENT_DELETE_ONLY"
     │   │
     │   ├── • 2 elements transitioning toward ABSENT
@@ -866,10 +866,10 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_r
         │   │   └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+        │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
         │       │ TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
         │       │
-        │       └── • PreviousTransactionPrecedence dependency from TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+        │       └── • PreviousTransactionPrecedence dependency from TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
         │             rule: "TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: TRANSIENT_DELETE_ONLY->TRANSIENT_ABSENT"
         │
         ├── • 1 element transitioning toward ABSENT

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_10_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_10_of_15
@@ -146,10 +146,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+    │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
     │   │       │ WRITE_ONLY → DELETE_ONLY
     │   │       │
-    │   │       └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+    │   │       └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
     │   │             rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │
     │   └── • 13 Mutation operations
@@ -258,7 +258,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+    │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
     │   │       │ DELETE_ONLY → ABSENT
     │   │       │
     │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}
@@ -267,7 +267,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
     │   │       │     rule: "dependents removed before index"
     │   │       │
-    │   │       └── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+    │   │       └── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
     │   │             rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
     │   │
     │   └── • 7 Mutation operations

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_11_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_11_of_15
@@ -146,10 +146,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+    │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
     │   │       │ WRITE_ONLY → DELETE_ONLY
     │   │       │
-    │   │       └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+    │   │       └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
     │   │             rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │
     │   └── • 13 Mutation operations
@@ -258,7 +258,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+    │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
     │   │       │ DELETE_ONLY → ABSENT
     │   │       │
     │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}
@@ -267,7 +267,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
     │   │       │     rule: "dependents removed before index"
     │   │       │
-    │   │       └── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+    │   │       └── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
     │   │             rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
     │   │
     │   └── • 7 Mutation operations

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_12_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_12_of_15
@@ -146,10 +146,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+    │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
     │   │       │ WRITE_ONLY → DELETE_ONLY
     │   │       │
-    │   │       └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+    │   │       └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
     │   │             rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │
     │   └── • 13 Mutation operations
@@ -258,7 +258,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+    │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
     │   │       │ DELETE_ONLY → ABSENT
     │   │       │
     │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}
@@ -267,7 +267,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
     │   │       │     rule: "dependents removed before index"
     │   │       │
-    │   │       └── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+    │   │       └── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
     │   │             rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
     │   │
     │   └── • 7 Mutation operations

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_13_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_13_of_15
@@ -137,10 +137,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+    │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
     │   │       │ WRITE_ONLY → DELETE_ONLY
     │   │       │
-    │   │       └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+    │   │       └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
     │   │             rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │
     │   └── • 11 Mutation operations
@@ -237,7 +237,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 106, Name: tbl_j_key, IndexID: 4}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+    │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
     │   │       │ DELETE_ONLY → ABSENT
     │   │       │
     │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}
@@ -246,7 +246,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
     │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
     │   │       │     rule: "dependents removed before index"
     │   │       │
-    │   │       └── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+    │   │       └── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
     │   │             rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
     │   │
     │   └── • 10 Mutation operations

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_14_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_14_of_15
@@ -137,10 +137,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+    │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
     │   │       │ WRITE_ONLY → DELETE_ONLY
     │   │       │
-    │   │       └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+    │   │       └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
     │   │             rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │
     │   └── • 11 Mutation operations
@@ -237,7 +237,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 106, Name: tbl_j_key, IndexID: 4}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+    │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
     │   │       │ DELETE_ONLY → ABSENT
     │   │       │
     │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}
@@ -246,7 +246,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
     │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
     │   │       │     rule: "dependents removed before index"
     │   │       │
-    │   │       └── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+    │   │       └── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
     │   │             rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
     │   │
     │   └── • 10 Mutation operations

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_15_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_15_of_15
@@ -137,10 +137,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+    │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
     │   │       │ WRITE_ONLY → DELETE_ONLY
     │   │       │
-    │   │       └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+    │   │       └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
     │   │             rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │
     │   └── • 11 Mutation operations
@@ -237,7 +237,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 106, Name: tbl_j_key, IndexID: 4}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+    │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
     │   │       │ DELETE_ONLY → ABSENT
     │   │       │
     │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}
@@ -246,7 +246,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
     │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
     │   │       │     rule: "dependents removed before index"
     │   │       │
-    │   │       └── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+    │   │       └── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
     │   │             rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
     │   │
     │   └── • 10 Mutation operations

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_9_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_9_of_15
@@ -146,7 +146,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+    │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
     │   │       │ DELETE_ONLY → ABSENT
     │   │       │
     │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}
@@ -155,7 +155,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
     │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
     │   │       │     rule: "dependents removed before index"
     │   │       │
-    │   │       └── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 4, SourceIndexID: 2}
+    │   │       └── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
     │   │             rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
     │   │
     │   └── • 14 Mutation operations


### PR DESCRIPTION
Previously, when we `ADD COLUMN UNIQUE`, the TemporaryIndex element has the same constraintID as its associated unique SecondaryIndex element. We'd like it to have a different constraint ID, just like what we did for the new primary index and its temp index. This one-line PR does that; the remaining are just test output changes.

Release note: None