### PR TITLE
cluster-ui: correct comment in insightsApi

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/insightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/insightsApi.ts
@@ -30,7 +30,8 @@ import moment from "moment";
 // Transaction insight events.
 
 // There are three transaction contention event insight queries:
-// 1. A query that selects transaction contention events from crdb_internal.cluster_contention_events.
+// 1. A query that selects transaction contention events from crdb_internal.transaction_contention_events
+// and joins on transaction ids from crdb_internal.cluster_execution_insights.
 // 2. A query that selects statement fingerprint IDS from crdb_internal.transaction_statistics, filtering on the
 // fingerprint IDs recorded in the contention events.
 // 3. A query that selects statement queries from crdb_internal.statement_statistics, filtering on the fingerprint IDs


### PR DESCRIPTION
Nit change to correct a comment in `insightsApi` that mentioned a query from `crdb_internal.cluster_contention_events`, when it intended to mention `crdb_internal.transaction_contention_events`.

Release note: None