### PR TITLE
sql: show hash check constraints if set NOT VALID

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -606,6 +606,7 @@ go_test(
         "session_migration_test.go",
         "set_zone_config_test.go",
         "show_create_all_tables_builtin_test.go",
+        "show_create_table_test.go",
         "show_fingerprints_test.go",
         "show_ranges_test.go",
         "show_stats_test.go",

--- a/pkg/sql/show_create_clauses.go
+++ b/pkg/sql/show_create_clauses.go
@@ -697,7 +697,7 @@ func showConstraintClause(
 	f *tree.FmtCtx,
 ) error {
 	for _, e := range desc.AllActiveAndInactiveChecks() {
-		if e.FromHashShardedColumn {
+		if e.FromHashShardedColumn && e.Validity != descpb.ConstraintValidity_Unvalidated {
 			continue
 		}
 		f.WriteString(",\n\t")


### PR DESCRIPTION
If check constraints that accompanies hash shared index are accidentally
set `NOT VALID`, it should show up in the `SHOW CREATE TABLE`'s output.

Informs: #89012

Release note (sql change): show hash shared check constraint in `SHOW CREATE TABLE`if
it is set NOT VALID