### PR TITLE
release-22.2: check whether adoption is disabled before resuming a job

### DIFF
--- a/pkg/jobs/wait.go
+++ b/pkg/jobs/wait.go
@@ -46,7 +46,9 @@ func (r *Registry) NotifyToResume(ctx context.Context, jobs ...jobspb.JobID) {
 	_ = r.stopper.RunAsyncTask(ctx, "resume-jobs", func(ctx context.Context) {
 		r.withSession(ctx, func(ctx context.Context, s sqlliveness.Session) {
 			r.filterAlreadyRunningAndCancelFromPreviousSessions(ctx, s, m)
-			r.resumeClaimedJobs(ctx, s, m)
+			if !r.adoptionDisabled(ctx) {
+				r.resumeClaimedJobs(ctx, s, m)
+			}
 		})
 	})
 }

--- a/pkg/upgrade/upgrades/wait_for_schema_changes_test.go
+++ b/pkg/upgrade/upgrades/wait_for_schema_changes_test.go
@@ -254,7 +254,6 @@ func TestWaitForSchemaChangeMigrationSynthetic(t *testing.T) {
 			var waitCount int32
 			var secondWaitChan chan struct{}
 			params.Knobs.JobsTestingKnobs = &jobs.TestingKnobs{
-				DisableAdoptions: true,
 				BeforeWaitForJobsQuery: func() {
 					if secondWaitChan != nil {
 						if atomic.AddInt32(&waitCount, 1) == 2 {


### PR DESCRIPTION
Backport 1/2 commits from #89348.

/cc @cockroachdb/release

---

There is one place where we resume a job without first checking whether 
adoption on that registry is disabled. This commit fixes that.

Fixes: #89091

Release note: None
Release justification: GA blocker bug fix