### PR TITLE
gc: switch gc to use MVCCValueLenAndIsTombstone

### DIFF
--- a/pkg/kv/kvserver/rditer/replica_data_iter.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter.go
@@ -357,6 +357,12 @@ func (ri *ReplicaMVCCDataIterator) UnsafeValue() []byte {
 	return ri.it.UnsafeValue()
 }
 
+// MVCCValueLenAndIsTombstone has the same behavior as
+// SimpleMVCCIterator.MVCCValueLenAndIsTombstone.
+func (ri *ReplicaMVCCDataIterator) MVCCValueLenAndIsTombstone() (int, bool, error) {
+	return ri.it.MVCCValueLenAndIsTombstone()
+}
+
 // RangeKeys exposes RangeKeys from underlying iterator. See
 // storage.SimpleMVCCIterator for details.
 func (ri *ReplicaMVCCDataIterator) RangeKeys() storage.MVCCRangeKeyStack {


### PR DESCRIPTION
The GC scan to identify garbage does not need the value of MVCC data, and only needs the length and whether the value is a tombstone. This change switches it to use ReplicaMVCCDataIterator.MVCCValueLenAndIsTombstone which passes through to the underlying MVCCIterator.

Informs https://github.com/cockroachdb/pebble/issues/1170

Release note: None