### PR TITLE
schemachanger: verify statement pretty roundtrip in schema changer tests

### DIFF
--- a/pkg/sql/schemachanger/scbuild/builder_test.go
+++ b/pkg/sql/schemachanger/scbuild/builder_test.go
@@ -114,6 +114,7 @@ func run(
 	tdb *sqlutils.SQLRunner,
 	withDependencies func(*testing.T, serverutils.TestServerInterface, *sqlutils.SQLRunner, func(scbuild.Dependencies)),
 ) string {
+	sqlutils.VerifyStatementPrettyRoundtrip(t, d.Input)
 	switch d.Cmd {
 	case "setup":
 		stmts, err := parser.Parse(d.Input)

--- a/pkg/sql/schemachanger/scplan/plan_test.go
+++ b/pkg/sql/schemachanger/scplan/plan_test.go
@@ -58,6 +58,7 @@ func TestPlanDataDriven(t *testing.T) {
 
 		tdb := sqlutils.MakeSQLRunner(sqlDB)
 		run := func(t *testing.T, d *datadriven.TestData) string {
+			sqlutils.VerifyStatementPrettyRoundtrip(t, d.Input)
 			switch d.Cmd {
 			case "setup":
 				stmts, err := parser.Parse(d.Input)

--- a/pkg/sql/schemachanger/sctest/decomp.go
+++ b/pkg/sql/schemachanger/sctest/decomp.go
@@ -57,6 +57,7 @@ func runDecomposeTest(
 ) string {
 	switch d.Cmd {
 	case "setup":
+		sqlutils.VerifyStatementPrettyRoundtrip(t, d.Input)
 		stmts, err := parser.Parse(d.Input)
 		require.NoError(t, err)
 		require.NotEmpty(t, stmts, "missing statement(s) for setup command")

--- a/pkg/sql/schemachanger/sctest/end_to_end.go
+++ b/pkg/sql/schemachanger/sctest/end_to_end.go
@@ -126,6 +126,7 @@ func EndToEndSideEffects(t *testing.T, relPath string, newCluster NewClusterFunc
 	numTestStatementsObserved := 0
 	var setupStmts parser.Statements
 	datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
+		sqlutils.VerifyStatementPrettyRoundtrip(t, d.Input)
 		stmts, err := parser.Parse(d.Input)
 		require.NoError(t, err)
 		require.NotEmpty(t, stmts)


### PR DESCRIPTION
We added the function that verifies sql statement pretty round trip to our end-to-end and build test suites in the declarative schema changer, which is already done for every stmt in logic test.

Fix #84908

Release note: None