### PR TITLE
backupccl: use klauspost gzip library

### DIFF
--- a/pkg/ccl/backupccl/backupinfo/BUILD.bazel
+++ b/pkg/ccl/backupccl/backupinfo/BUILD.bazel
@@ -50,6 +50,7 @@ go_library(
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_klauspost_compress//gzip",
     ],
 )
 

--- a/pkg/ccl/backupccl/backupinfo/manifest_handling.go
+++ b/pkg/ccl/backupccl/backupinfo/manifest_handling.go
@@ -10,7 +10,6 @@ package backupinfo
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -55,6 +54,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
+	gzip "github.com/klauspost/compress/gzip"
 )
 
 // Files that may appear in a backup directory.
@@ -189,7 +189,10 @@ func DecompressData(ctx context.Context, mem *mon.BoundAccount, descBytes []byte
 	if err != nil {
 		return nil, err
 	}
-	defer r.Close()
+	defer func() {
+		// Swallow any errors, this is only a read operation.
+		_ = r.Close()
+	}()
 	return mon.ReadAll(ctx, ioctx.ReaderAdapter(r), mem)
 }
 


### PR DESCRIPTION
Expect some degree of speedup in manifest reading/writing, as in https://github.com/cockroachdb/cockroach/pull/88632.

Release note: None