### PR TITLE
backupccl, changefeedccl, importer: log (sanitized) destination URIs

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -17,6 +17,7 @@ import (
 	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -58,6 +59,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // DistSQLPlanner is used to generate distributed plans from logical
@@ -4079,6 +4081,10 @@ func (dsp *DistSQLPlanner) createPlanForExport(
 		return nil, err
 	}
 
+	if err = logAndSanitizeExportDestination(ctx, n.destination); err != nil {
+		return nil, err
+	}
+
 	var core execinfrapb.ProcessorCoreUnion
 	core.Exporter = &execinfrapb.ExportSpec{
 		Destination: n.destination,
@@ -4101,6 +4107,15 @@ func (dsp *DistSQLPlanner) createPlanForExport(
 	// The CSVWriter produces the same columns as the EXPORT statement.
 	plan.PlanToStreamColMap = identityMap(plan.PlanToStreamColMap, len(colinfo.ExportColumns))
 	return plan, nil
+}
+
+func logAndSanitizeExportDestination(ctx context.Context, dest string) error {
+	clean, err := cloud.SanitizeExternalStorageURI(dest, nil)
+	if err != nil {
+		return err
+	}
+	log.Ops.Infof(ctx, "export planning to connect to destination %v", redact.Safe(clean))
+	return nil
 }
 
 // checkScanParallelizationIfLocal returns whether the plan contains scanNodes

--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -116,6 +116,7 @@ go_library(
         "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_fraugster_parquet_go//:parquet-go",
         "@com_github_fraugster_parquet_go//parquet",
         "@com_github_fraugster_parquet_go//parquetschema",

--- a/pkg/sql/importer/exportcsv_test.go
+++ b/pkg/sql/importer/exportcsv_test.go
@@ -455,11 +455,11 @@ func TestExportFeatureFlag(t *testing.T) {
 	sqlDB.Exec(t, `SET CLUSTER SETTING feature.export.enabled = FALSE`)
 	sqlDB.Exec(t, `CREATE TABLE feature_flags (a INT PRIMARY KEY)`)
 	sqlDB.ExpectErr(t, `feature EXPORT was disabled by the database administrator`,
-		`EXPORT INTO CSV 'nodelocal://0/%s/' FROM TABLE feature_flags`)
+		`EXPORT INTO CSV 'nodelocal://0/foo/' FROM TABLE feature_flags`)
 
 	// Feature flag is on — test that EXPORT does not error.
 	sqlDB.Exec(t, `SET CLUSTER SETTING feature.export.enabled = TRUE`)
-	sqlDB.Exec(t, `EXPORT INTO CSV 'nodelocal://0/%s/' FROM TABLE feature_flags`)
+	sqlDB.Exec(t, `EXPORT INTO CSV 'nodelocal://0/foo/' FROM TABLE feature_flags`)
 }
 
 func TestExportPrivileges(t *testing.T) {

--- a/pkg/sql/importer/import_planning.go
+++ b/pkg/sql/importer/import_planning.go
@@ -55,6 +55,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 const (
@@ -223,7 +224,11 @@ func validateFormatOptions(
 }
 
 func importJobDescription(
-	p sql.PlanHookState, orig *tree.Import, files []string, opts map[string]string,
+	ctx context.Context,
+	p sql.PlanHookState,
+	orig *tree.Import,
+	files []string,
+	opts map[string]string,
 ) (string, error) {
 	stmt := *orig
 	stmt.Files = nil
@@ -232,6 +237,7 @@ func importJobDescription(
 		if err != nil {
 			return "", err
 		}
+		logSanitizedImportDestination(ctx, clean)
 		stmt.Files = append(stmt.Files, tree.NewDString(clean))
 	}
 	stmt.Options = nil
@@ -247,6 +253,10 @@ func importJobDescription(
 	sort.Slice(stmt.Options, func(i, j int) bool { return stmt.Options[i].Key < stmt.Options[j].Key })
 	ann := p.ExtendedEvalContext().Annotations
 	return tree.AsStringWithFQNames(&stmt, ann), nil
+}
+
+func logSanitizedImportDestination(ctx context.Context, destination string) {
+	log.Ops.Infof(ctx, "import planning to connect to destination %v", redact.Safe(destination))
 }
 
 func ensureRequiredPrivileges(
@@ -794,7 +804,7 @@ func importPlanHook(
 
 		var tableDetails []jobspb.ImportDetails_Table
 		var typeDetails []jobspb.ImportDetails_Type
-		jobDesc, err := importJobDescription(p, importStmt, filenamePatterns, opts)
+		jobDesc, err := importJobDescription(ctx, p, importStmt, filenamePatterns, opts)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes: https://github.com/cockroachdb/cockroach/issues/86408
Epic: https://cockroachlabs.atlassian.net/browse/CC-5615

Previously, there were no logs that indicated the destinations CRDB was attempting to connect to during egress enabled jobs (BACKUP,IMPORT, CHANGEFEED, RESTORE).

This needed to change because security teams want the ability to analyze egress traffic coming out of a CRDB cluster. These logs allow them to determine which traffic is actually user initiated (network egress logs align with CRDB logs). And furthermore, if that traffic is initiated by a malicious user (comparing with historical logs indicating unexpected destinations).

To address this, jobs that leverage egress have been modified to include additional logging. Note that we mark the logged destinations as redact safe since we ensure to log only sanitized URIs.
While there may be other ways to manipulate CRDB to make egress calls, these jobs (BACKUP, IMPORT, CHANGEFEED, RESTORE) are the most likely targets for egress manipulation.

Release Note (general change): Bulk operations now log the (sanitized) destinations they are connecting to. For example "backup planning to connect to destination gs://test/backupadhoc?AUTH=specified&CREDENTIALS=redacted"