### PR TITLE
opt: avoid looking up MultiregionConfig for non-multiregion tables

### DIFF
--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -162,6 +162,10 @@ type Table interface {
 	// BY ROW.
 	IsRegionalByRow() bool
 
+	// IsMultiregion returns true if the table is a Multiregion table, defined
+	// with one of the LOCALITY clauses.
+	IsMultiregion() bool
+
 	// HomeRegionColName returns the name of the crdb_internal_region column name
 	// specifying the home region of each row in the table, if this table is a
 	// REGIONAL BY ROW TABLE, otherwise "", false is returned.

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -596,6 +596,11 @@ func (u *unknownTable) IsRegionalByRow() bool {
 	return false
 }
 
+// IsMultiregion is part of the cat.Table interface.
+func (u *unknownTable) IsMultiregion() bool {
+	return false
+}
+
 // HomeRegionColName is part of the cat.Table interface.
 func (u *unknownTable) HomeRegionColName() (colName string, ok bool) {
 	return "", false

--- a/pkg/sql/opt/metadata_test.go
+++ b/pkg/sql/opt/metadata_test.go
@@ -427,6 +427,7 @@ func TestTableMeta_GetRegionsInDatabase(t *testing.T) {
 	tab.DatabaseID = 1 // must be non-zero to trigger the region lookup
 	a := md.AddTable(tab, tn)
 	tabMeta := md.TableMeta(a)
+	tab.SetMultiRegion(true)
 
 	p := &fakeGetMultiregionConfigPlanner{}
 	// Call the function once, make sure our planner method gets invoked.

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -693,6 +693,8 @@ type Table struct {
 	// partitionBy is the partitioning clause that corresponds to the primary
 	// index. Used to initialize the partitioning for the primary index.
 	partitionBy *tree.PartitionBy
+
+	multiRegion bool
 }
 
 var _ cat.Table = &Table{}
@@ -701,6 +703,13 @@ func (tt *Table) String() string {
 	tp := treeprinter.New()
 	cat.FormatTable(tt.Catalog, tt, tp)
 	return tp.String()
+}
+
+// SetMultiRegion can make a table in the test catalog appear to be a
+// multiregion table, in that it can cause cat.Table.IsMultiregion() to return
+// true after SetMultiRegion(true) has been called.
+func (tt *Table) SetMultiRegion(val bool) {
+	tt.multiRegion = val
 }
 
 // ID is part of the cat.DataSource interface.
@@ -861,6 +870,11 @@ func (tt *Table) IsGlobalTable() bool {
 // IsRegionalByRow is part of the cat.Table interface.
 func (tt *Table) IsRegionalByRow() bool {
 	return false
+}
+
+// IsMultiregion is part of the cat.Table interface.
+func (tt *Table) IsMultiregion() bool {
+	return tt.multiRegion
 }
 
 // HomeRegionColName is part of the cat.Table interface.

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -1306,6 +1306,12 @@ func (ot *optTable) IsRegionalByRow() bool {
 	return localityConfig.GetRegionalByRow() != nil
 }
 
+// IsMultiregion is part of the cat.Table interface.
+func (ot *optTable) IsMultiregion() bool {
+	localityConfig := ot.desc.GetLocalityConfig()
+	return localityConfig != nil
+}
+
 // HomeRegionColName is part of the cat.Table interface.
 func (ot *optTable) HomeRegionColName() (colName string, ok bool) {
 	localityConfig := ot.desc.GetLocalityConfig()
@@ -2282,6 +2288,11 @@ func (ot *optVirtualTable) IsGlobalTable() bool {
 
 // IsRegionalByRow is part of the cat.Table interface.
 func (ot *optVirtualTable) IsRegionalByRow() bool {
+	return false
+}
+
+// IsMultiregion is part of the cat.Table interface.
+func (ot *optVirtualTable) IsMultiregion() bool {
 	return false
 }
 


### PR DESCRIPTION
This avoids expensive lookups of the regions in a table's parent database for non-multiregion tables.

Epic: CRDB-18645

Release note: None