### PR TITLE
release-22.1: kvserver: don't allow VOTER_DEMOTING to acquire lease after transfer

### DIFF
--- a/pkg/kv/kvclient/kvcoord/replica_slice.go
+++ b/pkg/kv/kvclient/kvcoord/replica_slice.go
@@ -81,7 +81,14 @@ func NewReplicaSlice(
 		}
 	}
 	canReceiveLease := func(rDesc roachpb.ReplicaDescriptor) bool {
-		if err := roachpb.CheckCanReceiveLease(rDesc, desc.Replicas(), true /* leaseHolderRemovalAllowed */); err != nil {
+		// NOTE: This logic is client-side and it’s trying to determine the set of
+		// all replicas that could potentially be leaseholders. We pass
+		// wasLastLeaseholder = true because we don't know who the
+		// leaseholder is, so it's possible that a VOTER_DEMOTING still holds on to
+		// the lease.
+		if err := roachpb.CheckCanReceiveLease(
+			rDesc, desc.Replicas(), true /* lhRemovalAllowed */, true, /* wasLastLeaseholder */
+		); err != nil {
 			return false
 		}
 		return true

--- a/pkg/kv/kvserver/allocator.go
+++ b/pkg/kv/kvserver/allocator.go
@@ -1391,11 +1391,11 @@ func (a Allocator) rebalanceTarget(
 //
 // The return values are, in order:
 //
-// 1. The target on which to add a new replica,
-// 2. An existing replica to remove,
-// 3. a JSON string for use in the range log, and
-// 4. a boolean indicationg whether 1-3 were populated (i.e. whether a rebalance
-//    opportunity was found).
+//  1. The target on which to add a new replica,
+//  2. An existing replica to remove,
+//  3. a JSON string for use in the range log, and
+//  4. a boolean indicationg whether 1-3 were populated (i.e. whether a rebalance
+//     opportunity was found).
 func (a Allocator) RebalanceVoter(
 	ctx context.Context,
 	conf roachpb.SpanConfig,
@@ -1501,7 +1501,8 @@ func (a *Allocator) ValidLeaseTargets(
 	replDescs := roachpb.MakeReplicaSet(existing)
 	lhRemovalAllowed := a.storePool.st.Version.IsActive(ctx, clusterversion.EnableLeaseHolderRemoval)
 	for i := range existing {
-		if err := roachpb.CheckCanReceiveLease(existing[i], replDescs, lhRemovalAllowed); err != nil {
+		if err := roachpb.CheckCanReceiveLease(existing[i], replDescs, lhRemovalAllowed,
+			false /* wasLastLeaseholder */); err != nil {
 			continue
 		}
 		// If we're not allowed to include the current replica, remove it from
@@ -2055,22 +2056,22 @@ func (a Allocator) shouldTransferLeaseForAccessLocality(
 // #13232 or the leaseholder_locality.md RFC for more details), but the general
 // logic behind each part of the formula is as follows:
 //
-// * LeaseRebalancingAggressiveness: Allow the aggressiveness to be tuned via
-//   a cluster setting.
-// * 0.1: Constant factor to reduce aggressiveness by default
-// * math.Log10(remoteWeight/sourceWeight): Comparison of the remote replica's
-//   weight to the local replica's weight. Taking the log of the ratio instead
-//   of using the ratio directly makes things symmetric -- i.e. r1 comparing
-//   itself to r2 will come to the same conclusion as r2 comparing itself to r1.
-// * math.Log1p(remoteLatencyMillis): This will be 0 if there's no latency,
-//   removing the weight/latency factor from consideration. Otherwise, it grows
-//   the aggressiveness for stores that are farther apart. Note that Log1p grows
-//   faster than Log10 as its argument gets larger, which is intentional to
-//   increase the importance of latency.
-// * overfullScore and underfullScore: rebalanceThreshold helps us get an idea
-//   of the ideal number of leases on each store. We then calculate these to
-//   compare how close each node is to its ideal state and use the differences
-//   from the ideal state on each node to compute a final score.
+//   - LeaseRebalancingAggressiveness: Allow the aggressiveness to be tuned via
+//     a cluster setting.
+//   - 0.1: Constant factor to reduce aggressiveness by default
+//   - math.Log10(remoteWeight/sourceWeight): Comparison of the remote replica's
+//     weight to the local replica's weight. Taking the log of the ratio instead
+//     of using the ratio directly makes things symmetric -- i.e. r1 comparing
+//     itself to r2 will come to the same conclusion as r2 comparing itself to r1.
+//   - math.Log1p(remoteLatencyMillis): This will be 0 if there's no latency,
+//     removing the weight/latency factor from consideration. Otherwise, it grows
+//     the aggressiveness for stores that are farther apart. Note that Log1p grows
+//     faster than Log10 as its argument gets larger, which is intentional to
+//     increase the importance of latency.
+//   - overfullScore and underfullScore: rebalanceThreshold helps us get an idea
+//     of the ideal number of leases on each store. We then calculate these to
+//     compare how close each node is to its ideal state and use the differences
+//     from the ideal state on each node to compute a final score.
 //
 // Returns a total score for the replica that takes into account the number of
 // leases already on each store. Also returns the raw "adjustment" value that's

--- a/pkg/kv/kvserver/batcheval/cmd_lease_transfer.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease_transfer.go
@@ -82,7 +82,7 @@ func TransferLease(
 	// If this check is removed at some point, the filtering of learners on the
 	// sending side would have to be removed as well.
 	if err := roachpb.CheckCanReceiveLease(
-		newLease.Replica, cArgs.EvalCtx.Desc().Replicas(), lhRemovalAllowed,
+		newLease.Replica, cArgs.EvalCtx.Desc().Replicas(), lhRemovalAllowed, false, /* wasLastLeaseholder */
 	); err != nil {
 		return newFailedLeaseTrigger(true /* isTransfer */), err
 	}

--- a/pkg/kv/kvserver/client_lease_test.go
+++ b/pkg/kv/kvserver/client_lease_test.go
@@ -395,10 +395,10 @@ func TestCannotTransferLeaseToVoterDemoting(t *testing.T) {
 	})
 }
 
-// TestTransferLeaseToVoterOutgoingWithIncoming ensures that the evaluation of lease
-// requests for nodes which are already in the VOTER_DEMOTING_LEARNER state succeeds
-// when there is a VOTER_INCOMING node.
-func TestTransferLeaseToVoterDemotingWithIncoming(t *testing.T) {
+// TestTransferLeaseToVoterDemotingFails ensures that the evaluation of lease
+// requests for nodes which are already in the VOTER_DEMOTING_LEARNER state fails
+// if they weren't previously holding the lease, even if there is a VOTER_INCOMING..
+func TestTransferLeaseToVoterDemotingFails(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
@@ -448,8 +448,8 @@ func TestTransferLeaseToVoterDemotingWithIncoming(t *testing.T) {
 	//  - Send an AdminChangeReplicasRequest to remove n3 and add n4
 	//  - Block the step that moves n3 to VOTER_DEMOTING_LEARNER on changeReplicasChan
 	//  - Send an AdminLeaseTransfer to make n3 the leaseholder
-	//  - Try really hard to make sure that the lease transfer at least gets to
-	//    latch acquisition before unblocking the ChangeReplicas.
+	//  - Make sure that this request fails (since n3 is VOTER_DEMOTING_LEARNER and
+	//    wasn't previously leaseholder)
 	//  - Unblock the ChangeReplicas.
 	//  - Make sure the lease transfer succeeds.
 
@@ -476,15 +476,17 @@ func TestTransferLeaseToVoterDemotingWithIncoming(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tc.Target(0), leaseHolder,
 				errors.Errorf("Leaseholder supposed to be on n1."))
-			// Move the lease to n3, the VOTER_DEMOTING_LEARNER.
+			// Try to move the lease to n3, the VOTER_DEMOTING_LEARNER.
+			// This should fail since the last leaseholder wasn't n3
+			// (wasLastLeaseholder = false in CheckCanReceiveLease).
 			err = tc.Server(0).DB().AdminTransferLease(context.Background(),
 				scratchStartKey, tc.Target(2).StoreID)
-			require.NoError(t, err)
-			// Make sure the lease moved to n3.
+			require.EqualError(t, err, `replica cannot hold lease`)
+			// Make sure the lease is still on n1.
 			leaseHolder, err = tc.FindRangeLeaseHolder(desc, nil)
 			require.NoError(t, err)
-			require.Equal(t, tc.Target(2), leaseHolder,
-				errors.Errorf("Leaseholder supposed to be on n3."))
+			require.Equal(t, tc.Target(0), leaseHolder,
+				errors.Errorf("Leaseholder supposed to be on n1."))
 		}()
 		// Try really hard to make sure that our request makes it past the
 		// sanity check error to the evaluation error.
@@ -497,26 +499,25 @@ func TestTransferLeaseToVoterDemotingWithIncoming(t *testing.T) {
 	})
 }
 
-// TestTransferLeaseFailureDuringJointConfig reproduces
+// internalTransferLeaseFailureDuringJointConfig reproduces
 // https://github.com/cockroachdb/cockroach/issues/83687
 // and makes sure that if lease transfer fails during a joint configuration
 // the previous leaseholder will successfully re-aquire the lease.
 // The test proceeds as follows:
-// - Creates a range with 3 replicas n1, n2, n3, and makes sure the lease is on n1
-// - Makes sure lease transfers on this range fail from now on
-// - Invokes AdminChangeReplicas to remove n1 and add n4
-// - This causes the range to go into a joint configuration. A lease transfer
-//   is attempted to move the lease from n1 to n4 before exiting the joint config,
-//   but that fails, causing us to remain in the joint configuration with the original
-//   leaseholder having revoked its lease, but everyone else thinking it's still
-//   the leaseholder. In this situation, only n1 can re-aquire the lease as long as it is live.
-// - We re-enable lease transfers on this range.
-// - n1 is able to re-aquire the lease, due to the fix in #83686 which enables a
-//   VOTER_DEMOTING_LEARNER (n1) replica to get the lease if there's also a VOTER_INCOMING
-//   which is the case here (n4).
-// - n1 transfers the lease away and the range leaves the joint configuration.
-func TestTransferLeaseFailureDuringJointConfig(t *testing.T) {
-	defer leaktest.AfterTest(t)()
+//   - Creates a range with 3 replicas n1, n2, n3, and makes sure the lease is on n1
+//   - Makes sure lease transfers on this range fail from now on
+//   - Invokes AdminChangeReplicas to remove n1 and add n4
+//   - This causes the range to go into a joint configuration. A lease transfer
+//     is attempted to move the lease from n1 to n4 before exiting the joint config,
+//     but that fails, causing us to remain in the joint configuration with the original
+//     leaseholder having revoked its lease, but everyone else thinking it's still
+//     the leaseholder. In this situation, only n1 can re-aquire the lease as long as it is live.
+//   - We re-enable lease transfers on this range.
+//   - n1 is able to re-aquire the lease, due to the fix in #83686 which enables a
+//     VOTER_DEMOTING_LEARNER (n1) replica to get the lease if there's also a VOTER_INCOMING
+//     which is the case here (n4) and since n1 was the last leaseholder.
+//   - n1 transfers the lease away and the range leaves the joint configuration.
+func internalTransferLeaseFailureDuringJointConfig(t *testing.T, isManual bool) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
@@ -567,7 +568,22 @@ func TestTransferLeaseFailureDuringJointConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, desc.Replicas().InAtomicReplicationChange())
 
-	// Further lease transfers should succeed, allowing the atomic replication change to complete.
+	// Allow further lease transfers to succeed.
+	atomic.StoreInt64(&scratchRangeID, 0)
+
+	if isManual {
+		// Manually transfer the lease to n1 (VOTER_DEMOTING_LEARNER).
+		err = tc.Server(0).DB().AdminTransferLease(context.Background(),
+			scratchStartKey, tc.Target(0).StoreID)
+		require.NoError(t, err)
+		// Make sure n1 has the lease
+		leaseHolder, err := tc.FindRangeLeaseHolder(desc, nil)
+		require.NoError(t, err)
+		require.Equal(t, tc.Target(0), leaseHolder,
+			errors.Errorf("Leaseholder supposed to be on n1."))
+	}
+
+	// Complete the replication change.
 	atomic.StoreInt64(&scratchRangeID, 0)
 	store := tc.GetFirstStoreFromServer(t, 0)
 	repl := store.LookupReplica(roachpb.RKey(scratchStartKey))
@@ -578,6 +594,24 @@ func TestTransferLeaseFailureDuringJointConfig(t *testing.T) {
 	desc, err = tc.LookupRange(scratchStartKey)
 	require.NoError(t, err)
 	require.False(t, desc.Replicas().InAtomicReplicationChange())
+}
+
+// TestTransferLeaseFailureDuringJointConfig is using
+// internalTransferLeaseFailureDuringJointConfig and
+// completes the lease transfer to n1 “automatically”
+// by relying on replicate queue.
+func TestTransferLeaseFailureDuringJointConfigAuto(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	internalTransferLeaseFailureDuringJointConfig(t, false)
+}
+
+// TestTransferLeaseFailureDuringJointConfigManual is using
+// internalTransferLeaseFailureDuringJointConfig and
+// completes the lease transfer to n1 “manually” using
+// AdminTransferLease.
+func TestTransferLeaseFailureDuringJointConfigManual(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	internalTransferLeaseFailureDuringJointConfig(t, true)
 }
 
 // TestStoreLeaseTransferTimestampCacheRead verifies that the timestamp cache on

--- a/pkg/kv/kvserver/replica_proposal_buf_test.go
+++ b/pkg/kv/kvserver/replica_proposal_buf_test.go
@@ -184,7 +184,7 @@ func (t *testProposer) leaderStatusRLocked(
 			rngDesc := roachpb.RangeDescriptor{
 				InternalReplicas: []roachpb.ReplicaDescriptor{repDesc},
 			}
-			err := roachpb.CheckCanReceiveLease(repDesc, rngDesc.Replicas(), true)
+			err := roachpb.CheckCanReceiveLease(repDesc, rngDesc.Replicas(), true, true)
 			leaderEligibleForLease = err == nil
 		} else {
 			// This matches replicaProposed.leaderStatusRLocked().

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -92,14 +92,14 @@ func makeIDKey() kvserverbase.CmdIDKey {
 // would violate the locking order specified for Store.mu.
 //
 // Return values:
-// - a channel which receives a response or error upon application
-// - a closure used to attempt to abandon the command. When called, it unbinds
-//   the command's context from its Raft proposal. The client is then free to
-//   terminate execution, although it is given no guarantee that the proposal
-//   won't still go on to commit and apply at some later time.
-// - the proposal's ID.
-// - any error obtained during the creation or proposal of the command, in
-//   which case the other returned values are zero.
+//   - a channel which receives a response or error upon application
+//   - a closure used to attempt to abandon the command. When called, it unbinds
+//     the command's context from its Raft proposal. The client is then free to
+//     terminate execution, although it is given no guarantee that the proposal
+//     won't still go on to commit and apply at some later time.
+//   - the proposal's ID.
+//   - any error obtained during the creation or proposal of the command, in
+//     which case the other returned values are zero.
 func (r *Replica) evalAndPropose(
 	ctx context.Context,
 	ba *roachpb.BatchRequest,
@@ -388,7 +388,7 @@ func (r *Replica) propose(
 		// transferred away. The previous leaseholder is a LEARNER in the target config,
 		// and therefore shouldn't continue holding the lease.
 		if err := roachpb.CheckCanReceiveLease(
-			lhDesc, proposedDesc.Replicas(), lhRemovalAllowed,
+			lhDesc, proposedDesc.Replicas(), lhRemovalAllowed, true, /* wasLastLeaseholder */
 		); err != nil {
 			e := errors.Mark(errors.Wrapf(err, "%v received invalid ChangeReplicasTrigger %s to "+
 				"remove self (leaseholder); lhRemovalAllowed: %v; current desc: %v; proposed desc: %v",


### PR DESCRIPTION
Backport commits from https://github.com/cockroachdb/cockroach/pull/89564.

This PR restricts the case when a VOTER_DEMOTING_LEARNER can aquire the lease in a joint configuration to only the case where it was the last leaseholder. Since it is being removed, we only want it to get the lease if no other replica can aquire it, the scenario described in https://github.com/cockroachdb/cockroach/issues/83687

This fix solves a potential starvation scenario where a VOTER_DEMOTING_LEARNER keeps transferring the lease to the VOTER_INCOMING, succeeding, but then re-acquiring because the VOTER_INCOMING is dead and the lease expires. In this case, we would want another replica to pick up the lease, which would allow us to exit the joint configuration.

Release note (bug fix): narrows down the conditions under which a VOTER_DEMOTING_LEARNER can acquire the lease in a joint configuration to a) there has to be an VOTER_INCOMING in the configuration and b) the VOTER_DEMOTING_LEARNER was the last leaseholder. This prevents it from acquiring the lease unless it is the only one that can acquire it, because transferring the lease away is necessary before exiting the joint config (without the fix the system can be stuck in a joint configuration in some rare situations).

Release justification: solves a serious bug.

Fixes: https://github.com/cockroachdb/cockroach/issues/88667 See also https://github.com/cockroachdb/cockroach/pull/89340