### PR TITLE
release-21.2: rpc: don't leak shared, poisoned RPC connections

### DIFF
--- a/pkg/rpc/BUILD.bazel
+++ b/pkg/rpc/BUILD.bazel
@@ -123,6 +123,7 @@ go_test(
         "@org_golang_google_grpc//peer",
         "@org_golang_google_grpc//stats",
         "@org_golang_google_grpc//status",
+        "@org_golang_x_sync//errgroup",
     ],
 )
 

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -526,10 +527,64 @@ func TestConnectionRemoveNodeIDZero(t *testing.T) {
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
 	clientCtx := newTestContext(uuid.MakeV4(), clock, stopper)
 	// Provoke an error.
-	_, err := clientCtx.GRPCDialNode("127.0.0.1:notaport", 1, DefaultClass).Connect(context.Background())
+	_, err := clientCtx.GRPCDialNode("127.0.0.1:notaport", 1, DefaultClass).Connect(ctx)
 	if err == nil {
 		t.Fatal("expected some kind of error, got nil")
 	}
+
+	// NB: this takes a moment because GRPCDialRaw only gives up on the initial
+	// connection after 1s (more precisely, the redialChan gets closed only after
+	// 1s), which seems difficult to configure ad-hoc.
+	testutils.SucceedsSoon(t, func() error {
+		var keys []connKey
+		clientCtx.conns.Range(func(k, v interface{}) bool {
+			keys = append(keys, k.(connKey))
+			return true
+		})
+		if len(keys) > 0 {
+			return errors.Errorf("still have connections %v", keys)
+		}
+		return nil
+	})
+}
+
+// TestConnectionSharingDoesNotLeak attempts to create race conditions between
+// multiple dial attempts which are allowed to share the same underlying RPC
+// connection. It verifies that if the shared connection fails, all references
+// to the connection are cleaned up and none are leaked.
+func TestConnectionSharingDoesNotLeak(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+
+	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
+	clientCtx := newTestContext(uuid.MakeV4(), clock, stopper)
+
+	// Launch three goroutines, two of which use the same node ID and one of which
+	// uses node ID 0. All three point at the same address, so they are eligible to
+	// share a gRPC connection (if the timing works out).
+	addr := "127.0.0.1:notaport"
+	nodeIDs := []roachpb.NodeID{7, 7, 0}
+	var g errgroup.Group
+	for _, nodeID := range nodeIDs {
+		nodeID := nodeID // copy for goroutine
+		g.Go(func() error {
+			var conn *Connection
+			if nodeID == 0 {
+				conn = clientCtx.GRPCUnvalidatedDial(addr)
+			} else {
+				conn = clientCtx.GRPCDialNode(addr, nodeID, SystemClass)
+			}
+			_, err := conn.Connect(ctx)
+			if err == nil {
+				return errors.Errorf("expected some kind of error, got nil")
+			}
+			return nil
+		})
+	}
+	require.NoError(t, g.Wait())
 
 	// NB: this takes a moment because GRPCDialRaw only gives up on the initial
 	// connection after 1s (more precisely, the redialChan gets closed only after


### PR DESCRIPTION
Backport 1/1 commits from #89539.

/cc @cockroachdb/release

---

Informs cockroachlabs/support#1833.

This commit resolves a pair of sibling bugs, each hazardous in their own way and each having to do with an optimization we use to share TCP connections between nodes. The bugs have been around for four years and permit a race condition that can lead to leaked RPC connections. The leaked RPC connections can get stuck without a heartbeat, as we saw in a recent support issue, stalling any attempt to contact a certain node.

The buggy code attempts to point two different RPC connection keys (`{<addr>, <nodeid>}` and `{<addr>, 0}`) at the same RPC connection. Two different races are possible if the initial attempt to establish a connection fails rapidly (like we might see with a `no route to host` error).

#### Race 1: leaking the `{<addr>, 0}` conn

```
goroutine 1                                           | goroutine 2
------------------------------------------------------+--------------------------------------
grpcDialNodeInternal(remoteNodeID=2)                  |
thisConnKeys = [{target, 2}]                          |
conns.Load(2) -> false                                |
conns.LoadOrStore(2, new(conn)) -> (conn, true)       |
                                                      | grpcDialNodeInternal(remoteNodeID=2)
                                                      | thisConnKeys = [{target, 2}]
                                                      | conns.Load(2) -> (conn, true)
                                                      | conn.initOnce.Do(...)
                                                      | connection error!
                                                      | removeConn(2)
                                                      | conn.initOnce.Do(...) exits
conns.LoadOrStore(0, new(conn)) -> true               |
thisConnKeys = [{target, 2}, {target, 0}]             |
                                                      |
...                                                   |
future calls to conns.Load(0) return leaked conn!     |
```

#### Race 2: leaking the `{<addr>, <nodeid>}` conn

```
goroutine 1                                           | goroutine 2
------------------------------------------------------+--------------------------------------
grpcDialNodeInternal(remoteNodeID=2)                  |
thisConnKeys = [{target, 2}]                          |
conns.Load(2) -> false                                |
conns.LoadOrStore(2, new(conn)) -> (conn, true)       |
conns.LoadOrStore(0, new(conn)) -> true               |
thisConnKeys = [{target, 2}, {target, 0}]             |
                                                      | grpcDialNodeInternal(remoteNodeID=0)
                                                      | thisConnKeys = [{target, 0}]
                                                      | conns.Load(0) -> (conn, true)
                                                      | conn.initOnce.Do(...)
                                                      | connection error!
                                                      | removeConn(0)
                                                      | conn.initOnce.Do(...) exits
                                                      |
...                                                   |
future calls to conns.Load(2) return leaked conn!     |
```

In the support ticket, we saw that if the leaked connection was stuck in the "initial connection heartbeat failed" state, it would remain there forever, returning the same error to clients indefinitely.

This commit resolves the bug by ensuring that the goroutine which stores the connection under the second connKey is the same one that will remove the connection from the conns map on disconnect. If a separate goroutine were to remove the conn, it may only do so for one of the two connKeys, leaking the other. We ensure this by running the logic to share connections inside the sync.Once function. In doing so, we ensure that the goroutine removing the conn from the map is aware of all keys that it is stored under.

Release note (bug fix): Avoid a source of internal connectivity problems that would resolve after restarting the affected node.

Release justification: Low risk bug fix.
