### PR TITLE
[DNM] opt: Eliminate LIMIT and scans with contradiction during planning

### DIFF
--- a/pkg/sql/opt/norm/general_funcs.go
+++ b/pkg/sql/opt/norm/general_funcs.go
@@ -793,6 +793,23 @@ func (c *CustomFuncs) ConstructEmptyValues(cols opt.ColSet) memo.RelExpr {
 	})
 }
 
+// ConstructEmptyValues builds a Values expression with no rows, but does not
+// add it to the memo.
+func (c *CustomFuncs) GenerateEmptyValues(cols opt.ColSet) *memo.ValuesExpr {
+	colList := make(opt.ColList, 0, cols.Len())
+	for i, ok := cols.Next(0); ok; i, ok = cols.Next(i + 1) {
+		colList = append(colList, i)
+	}
+	valuesExpr := &memo.ValuesExpr{
+		Rows:          memo.EmptyScalarListExpr,
+		ValuesPrivate: memo.ValuesPrivate{
+			Cols: colList,
+			ID:   c.mem.Metadata().NextUniqueID(),
+		},
+	}
+	return valuesExpr
+}
+
 // ----------------------------------------------------------------------
 //
 // Grouping functions

--- a/pkg/sql/opt/optgen/cmd/optgen/rule_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/rule_gen.go
@@ -743,7 +743,8 @@ func (g *newRuleGen) genExploreReplace(define *lang.DefineExpr, rule *lang.RuleE
 		opTyp := g.md.typeOf(opDef)
 
 		g.genBoundStatements(t)
-		g.w.nestIndent("_expr := &%s{\n", opTyp.name)
+		g.w.writeIndent("var _expr, _interned memo.RelExpr\n")
+		g.w.nestIndent("_expr = &%s{\n", opTyp.name)
 		for i, arg := range t.Args {
 			field := opDef.Fields[i]
 
@@ -753,7 +754,31 @@ func (g *newRuleGen) genExploreReplace(define *lang.DefineExpr, rule *lang.RuleE
 			g.w.write(",\n")
 		}
 		g.w.unnest("}\n")
-		g.w.writeIndent("_interned := _e.mem.Add%sToGroup(_expr, _root)\n", opDef.Name)
+
+		// Post-transformation normalization
+		//g.w.nestIndent("if _e.f.HasZeroCardinalityInput(_expr) {\n")
+		//g.w.writeIndent("_typedExpr, _ := _expr.(*%s)\n", opTyp.name)
+		//g.w.nestIndent("_expr = %s.Construct%s(\n", g.factoryVar, name)
+		//numArgs := len(t.Args)
+		//for i := range t.Args {
+		//	field := opDef.Fields[i]
+		//	if i == numArgs - 1 && strings.Contains(g.md.typeOf(field).name, "Private") {
+		//		g.w.writeIndent("&")
+		//	} else {
+		//		g.w.writeIndent("")
+		//	}
+		//	g.w.write("_typedExpr.%s", g.md.fieldName(field))
+		//	g.w.write(",\n")
+		//}
+		//g.w.unnest(")\n")
+		//
+		//g.w.writeIndent("_expr = _e.f.OnTransformRelational(_expr, _root)\n")
+		//g.w.writeIndent("_interned = _expr\n")
+		//g.w.unnest("}\n")
+		//g.w.nestIndent("if _interned == (memo.RelExpr)(nil) {\n")
+		//g.w.writeIndent("_typedExpr, _ := _expr.(*%s)\n", opTyp.name)
+		//g.w.writeIndent("_interned = _e.mem.Add%sToGroup(_typedExpr, _root)\n", opDef.Name)
+		//g.w.unnest("}\n")  // msirek-temp
 
 		// Notify listeners that rule was applied. If the expression was already
 		// part of the memo, then _interned != _expr, and this rule is a no-op.

--- a/pkg/sql/opt/xform/general_funcs.go
+++ b/pkg/sql/opt/xform/general_funcs.go
@@ -845,3 +845,8 @@ func (c *CustomFuncs) getKnownScanConstraint(
 	}
 	return cons, !cons.IsUnconstrained()
 }
+
+// AddExprToGroup adds any generic RelExpr `expr` to group `grp`.
+func (c *CustomFuncs) AddExprToGroup(grp, expr memo.RelExpr) memo.RelExpr {
+	return c.e.mem.AddExprToGroup(expr, grp.FirstExpr())
+}

--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -539,6 +539,11 @@ func (o *Optimizer) optimizeGroup(grp memo.RelExpr, required *physical.Required)
 
 		if fullyOptimized {
 			state.fullyOptimized = true
+			if state.best.Op() == opt.LimitOp {
+				i := 0
+				i++ // msirek-temp
+			}
+			state.best = o.f.OnTransformRelational(state.best, grp)
 			break
 		}
 	}

--- a/pkg/sql/opt/xform/select_funcs.go
+++ b/pkg/sql/opt/xform/select_funcs.go
@@ -444,6 +444,12 @@ func (c *CustomFuncs) GenerateConstrainedScans(
 			); !ok {
 			return
 		}
+		relational := grp.Relational()
+		if combinedConstraint.IsContradiction() && grp.Relational().VolatilitySet.IsLeakproof() {
+			values := c.GenerateEmptyValues(relational.OutputCols)
+			c.e.mem.AddValuesToGroup(values, grp)
+			return
+		}
 
 		// Construct new constrained ScanPrivate.
 		newScanPrivate := *scanPrivate


### PR DESCRIPTION
This converts a scan with filter contradictions into an empty values expression and implements the EliminateLimit normalization rule in the post-normalization query planning phase.

Epic: None

Release note: None