### PR TITLE
colexec: re-enable GCAssert linter

### DIFF
--- a/pkg/sql/colexec/hash_aggregator.eg.go
+++ b/pkg/sql/colexec/hash_aggregator.eg.go
@@ -254,8 +254,6 @@ func getNext_true(op *hashAggregator) coldata.Batch {
 									start int = op.bufferingState.unprocessedIdx
 									end   int = op.bufferingState.pendingBatch.Length() - 1
 								)
-								_ = op.distinctOutput[start]
-								_ = op.distinctOutput[end]
 								for i := start; i <= end; i++ {
 									if op.distinctOutput[i] {
 										{
@@ -356,7 +354,6 @@ func getNext_true(op *hashAggregator) coldata.Batch {
 								end   int = lowerBound
 							)
 							for i := start; i >= end; i-- {
-								//gcassert:bce
 								idx := sel[i]
 								if op.distinctOutput[idx] {
 									{
@@ -385,10 +382,7 @@ func getNext_true(op *hashAggregator) coldata.Batch {
 								start int = toBuffer - 1
 								end   int = lowerBound
 							)
-							_ = op.distinctOutput[start]
-							_ = op.distinctOutput[end]
 							for i := start; i >= end; i-- {
-								//gcassert:bce
 								if op.distinctOutput[i] {
 									{
 										__retval_0 = true

--- a/pkg/sql/colexec/hash_aggregator_tmpl.go
+++ b/pkg/sql/colexec/hash_aggregator_tmpl.go
@@ -128,10 +128,6 @@ func (op *hashAggregator) populateEqChains(
 func findSplit(
 	op *hashAggregator, start int, end int, sel []int, useSel bool, ascending bool,
 ) (bool, int) {
-	if !useSel {
-		_ = op.distinctOutput[start]
-		_ = op.distinctOutput[end]
-	}
 	if ascending {
 		for i := start; i <= end; i++ {
 			if useSel {
@@ -148,13 +144,11 @@ func findSplit(
 	} else {
 		for i := start; i >= end; i-- {
 			if useSel {
-				//gcassert:bce
 				idx := sel[i]
 				if op.distinctOutput[idx] {
 					return true, i
 				}
 			} else {
-				//gcassert:bce
 				if op.distinctOutput[i] {
 					return true, i
 				}

--- a/pkg/sql/colexec/sort.eg.go
+++ b/pkg/sql/colexec/sort.eg.go
@@ -339,7 +339,6 @@ func (s *sortBoolAscWithNullsOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortBoolAscWithNullsOp) Less(i, j int) bool {
 	n1 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[i])
 	n2 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[j])
@@ -433,7 +432,6 @@ func (s *sortBytesAscWithNullsOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortBytesAscWithNullsOp) Less(i, j int) bool {
 	n1 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[i])
 	n2 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[j])
@@ -520,7 +518,6 @@ func (s *sortDecimalAscWithNullsOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortDecimalAscWithNullsOp) Less(i, j int) bool {
 	n1 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[i])
 	n2 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[j])
@@ -598,7 +595,6 @@ func (s *sortInt16AscWithNullsOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortInt16AscWithNullsOp) Less(i, j int) bool {
 	n1 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[i])
 	n2 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[j])
@@ -687,7 +683,6 @@ func (s *sortInt32AscWithNullsOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortInt32AscWithNullsOp) Less(i, j int) bool {
 	n1 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[i])
 	n2 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[j])
@@ -776,7 +771,6 @@ func (s *sortInt64AscWithNullsOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortInt64AscWithNullsOp) Less(i, j int) bool {
 	n1 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[i])
 	n2 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[j])
@@ -865,7 +859,6 @@ func (s *sortFloat64AscWithNullsOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortFloat64AscWithNullsOp) Less(i, j int) bool {
 	n1 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[i])
 	n2 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[j])
@@ -962,7 +955,6 @@ func (s *sortTimestampAscWithNullsOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortTimestampAscWithNullsOp) Less(i, j int) bool {
 	n1 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[i])
 	n2 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[j])
@@ -1047,7 +1039,6 @@ func (s *sortIntervalAscWithNullsOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortIntervalAscWithNullsOp) Less(i, j int) bool {
 	n1 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[i])
 	n2 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[j])
@@ -1125,7 +1116,6 @@ func (s *sortJSONAscWithNullsOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortJSONAscWithNullsOp) Less(i, j int) bool {
 	n1 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[i])
 	n2 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[j])
@@ -1209,7 +1199,6 @@ func (s *sortDatumAscWithNullsOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortDatumAscWithNullsOp) Less(i, j int) bool {
 	n1 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[i])
 	n2 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[j])
@@ -1289,7 +1278,6 @@ func (s *sortBoolDescWithNullsOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortBoolDescWithNullsOp) Less(i, j int) bool {
 	n1 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[i])
 	n2 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[j])
@@ -1383,7 +1371,6 @@ func (s *sortBytesDescWithNullsOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortBytesDescWithNullsOp) Less(i, j int) bool {
 	n1 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[i])
 	n2 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[j])
@@ -1470,7 +1457,6 @@ func (s *sortDecimalDescWithNullsOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortDecimalDescWithNullsOp) Less(i, j int) bool {
 	n1 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[i])
 	n2 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[j])
@@ -1548,7 +1534,6 @@ func (s *sortInt16DescWithNullsOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortInt16DescWithNullsOp) Less(i, j int) bool {
 	n1 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[i])
 	n2 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[j])
@@ -1637,7 +1622,6 @@ func (s *sortInt32DescWithNullsOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortInt32DescWithNullsOp) Less(i, j int) bool {
 	n1 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[i])
 	n2 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[j])
@@ -1726,7 +1710,6 @@ func (s *sortInt64DescWithNullsOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortInt64DescWithNullsOp) Less(i, j int) bool {
 	n1 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[i])
 	n2 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[j])
@@ -1815,7 +1798,6 @@ func (s *sortFloat64DescWithNullsOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortFloat64DescWithNullsOp) Less(i, j int) bool {
 	n1 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[i])
 	n2 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[j])
@@ -1912,7 +1894,6 @@ func (s *sortTimestampDescWithNullsOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortTimestampDescWithNullsOp) Less(i, j int) bool {
 	n1 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[i])
 	n2 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[j])
@@ -1997,7 +1978,6 @@ func (s *sortIntervalDescWithNullsOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortIntervalDescWithNullsOp) Less(i, j int) bool {
 	n1 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[i])
 	n2 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[j])
@@ -2075,7 +2055,6 @@ func (s *sortJSONDescWithNullsOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortJSONDescWithNullsOp) Less(i, j int) bool {
 	n1 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[i])
 	n2 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[j])
@@ -2159,7 +2138,6 @@ func (s *sortDatumDescWithNullsOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortDatumDescWithNullsOp) Less(i, j int) bool {
 	n1 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[i])
 	n2 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[j])
@@ -2239,7 +2217,6 @@ func (s *sortBoolAscOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortBoolAscOp) Less(i, j int) bool {
 
 	var lt bool
@@ -2323,7 +2300,6 @@ func (s *sortBytesAscOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortBytesAscOp) Less(i, j int) bool {
 
 	// If the type can be abbreviated as a uint64, compare the abbreviated
@@ -2400,7 +2376,6 @@ func (s *sortDecimalAscOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortDecimalAscOp) Less(i, j int) bool {
 
 	var lt bool
@@ -2468,7 +2443,7 @@ func (s *sortInt16AscOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
+// gcassert:inline
 func (s *sortInt16AscOp) Less(i, j int) bool {
 
 	var lt bool
@@ -2547,7 +2522,7 @@ func (s *sortInt32AscOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
+// gcassert:inline
 func (s *sortInt32AscOp) Less(i, j int) bool {
 
 	var lt bool
@@ -2626,7 +2601,7 @@ func (s *sortInt64AscOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
+// gcassert:inline
 func (s *sortInt64AscOp) Less(i, j int) bool {
 
 	var lt bool
@@ -2705,7 +2680,6 @@ func (s *sortFloat64AscOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortFloat64AscOp) Less(i, j int) bool {
 
 	var lt bool
@@ -2792,7 +2766,6 @@ func (s *sortTimestampAscOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortTimestampAscOp) Less(i, j int) bool {
 
 	var lt bool
@@ -2867,7 +2840,6 @@ func (s *sortIntervalAscOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortIntervalAscOp) Less(i, j int) bool {
 
 	var lt bool
@@ -2935,7 +2907,6 @@ func (s *sortJSONAscOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortJSONAscOp) Less(i, j int) bool {
 
 	var lt bool
@@ -3009,7 +2980,6 @@ func (s *sortDatumAscOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortDatumAscOp) Less(i, j int) bool {
 
 	var lt bool
@@ -3079,7 +3049,6 @@ func (s *sortBoolDescOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortBoolDescOp) Less(i, j int) bool {
 
 	var lt bool
@@ -3163,7 +3132,6 @@ func (s *sortBytesDescOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortBytesDescOp) Less(i, j int) bool {
 
 	// If the type can be abbreviated as a uint64, compare the abbreviated
@@ -3240,7 +3208,6 @@ func (s *sortDecimalDescOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortDecimalDescOp) Less(i, j int) bool {
 
 	var lt bool
@@ -3308,7 +3275,7 @@ func (s *sortInt16DescOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
+// gcassert:inline
 func (s *sortInt16DescOp) Less(i, j int) bool {
 
 	var lt bool
@@ -3387,7 +3354,7 @@ func (s *sortInt32DescOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
+// gcassert:inline
 func (s *sortInt32DescOp) Less(i, j int) bool {
 
 	var lt bool
@@ -3466,7 +3433,7 @@ func (s *sortInt64DescOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
+// gcassert:inline
 func (s *sortInt64DescOp) Less(i, j int) bool {
 
 	var lt bool
@@ -3545,7 +3512,6 @@ func (s *sortFloat64DescOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortFloat64DescOp) Less(i, j int) bool {
 
 	var lt bool
@@ -3632,7 +3598,6 @@ func (s *sortTimestampDescOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortTimestampDescOp) Less(i, j int) bool {
 
 	var lt bool
@@ -3707,7 +3672,6 @@ func (s *sortIntervalDescOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortIntervalDescOp) Less(i, j int) bool {
 
 	var lt bool
@@ -3775,7 +3739,6 @@ func (s *sortJSONDescOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortJSONDescOp) Less(i, j int) bool {
 
 	var lt bool
@@ -3849,7 +3812,6 @@ func (s *sortDatumDescOp) sortPartitions(partitions []int) {
 	}
 }
 
-//gcassert:inline
 func (s *sortDatumDescOp) Less(i, j int) bool {
 
 	var lt bool

--- a/pkg/sql/colexec/sort_tmpl.go
+++ b/pkg/sql/colexec/sort_tmpl.go
@@ -163,12 +163,8 @@ func (s *sort_TYPE_DIR_HANDLES_NULLSOp) sortPartitions(partitions []int) {
 // TODO(yuzefovich): think through how we can inline more implementations of
 // Less method - this has non-trivial performance improvements.
 // */}}
-// {{$isInt := or (eq .VecMethod "Int16") (eq .VecMethod "Int32")}}
-// {{$isInt = or ($isInt) (eq .VecMethod "Int64")}}
-// {{if and ($isInt) (not $nulls)}}
-// {{end}}
-//
-//gcassert:inline
+// {{$isInt := or (or (eq .VecMethod "Int16") (eq .VecMethod "Int32")) (eq .VecMethod "Int64")}}
+// {{if and ($isInt) (not $nulls)}}gcassert:inline{{end}}
 func (s *sort_TYPE_DIR_HANDLES_NULLSOp) Less(i, j int) bool {
 	// {{if $nulls}}
 	n1 := s.nulls.MaybeHasNulls() && s.nulls.NullAt(s.order[i])

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -2034,7 +2034,6 @@ func TestLint(t *testing.T) {
 	})
 
 	t.Run("TestGCAssert", func(t *testing.T) {
-		skip.WithIssue(t, 86714)
 		skip.UnderShort(t)
 		skip.UnderBazelWithIssue(t, 65485, "Doesn't work in Bazel -- not really sure why yet")
 


### PR DESCRIPTION
This commit addresses a couple of spots where the GCAssert comments have
become stale (which prompted the corresponding linter to be disabled
when we switched to go 1.19):
- in the sort template we can only inline `Less` function for integers.
The problem here was that `//gcassert` comment was being moved outside
of the template conditional block by the updated formatter. The fix is
to inline the template conditional and the `gcassert` directive.
- in the hash aggregator template we no longer are getting bounds check
eliminations for some reason. The function is not that super important
(it is used only when we have a partial ordering), so this commit just
removes the assertions.

This allows us to re-enable the linter.

Fixes: #86714.

Epic: CRDB-20535

Release note: None