### PR TITLE
cloud: don't write empty buffer to s3

### DIFF
--- a/pkg/ccl/backupccl/backup_cloud_test.go
+++ b/pkg/ccl/backupccl/backup_cloud_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cloud/azure"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -48,6 +49,42 @@ func InitManualReplication(tc *testcluster.TestCluster) {
 func TestCloudBackupRestoreS3(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	creds, bucket := requiredS3CredsAndBucket(t)
+
+	// TODO(dan): Actually invalidate the descriptor cache and delete this line.
+	defer lease.TestingDisableTableLeases()()
+	const numAccounts = 1000
+
+	ctx := context.Background()
+	tc, db, _, cleanupFn := backupRestoreTestSetup(t, 1, numAccounts, InitManualReplication)
+	defer cleanupFn()
+	prefix := fmt.Sprintf("TestBackupRestoreS3-%d", timeutil.Now().UnixNano())
+	uri := setupS3URI(t, db, bucket, prefix, creds)
+	backupAndRestore(ctx, t, tc, []string{uri.String()}, []string{uri.String()}, numAccounts)
+}
+
+// TestCloudBackupRestoreS3WithLegacyPut tests that backup/restore works when
+// cloudstorage.s3.buffer_and_put_uploads.enabled=true is set.
+func TestCloudBackupRestoreS3WithLegacyPut(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	creds, bucket := requiredS3CredsAndBucket(t)
+
+	// TODO(dan): Actually invalidate the descriptor cache and delete this line.
+	defer lease.TestingDisableTableLeases()()
+	const numAccounts = 1000
+
+	ctx := context.Background()
+	tc, db, _, cleanupFn := backupRestoreTestSetup(t, 1, numAccounts, InitManualReplication)
+	defer cleanupFn()
+	prefix := fmt.Sprintf("TestBackupRestoreS3-%d", timeutil.Now().UnixNano())
+	db.Exec(t, "SET CLUSTER SETTING cloudstorage.s3.buffer_and_put_uploads.enabled=true")
+	uri := setupS3URI(t, db, bucket, prefix, creds)
+	backupAndRestore(ctx, t, tc, []string{uri.String()}, []string{uri.String()}, numAccounts)
+}
+
+func requiredS3CredsAndBucket(t *testing.T) (credentials.Value, string) {
+	t.Helper()
 	creds, err := credentials.NewEnvCredentials().Get()
 	if err != nil {
 		skip.IgnoreLintf(t, "No AWS env keys (%v)", err)
@@ -56,22 +93,28 @@ func TestCloudBackupRestoreS3(t *testing.T) {
 	if bucket == "" {
 		skip.IgnoreLint(t, "AWS_S3_BUCKET env var must be set")
 	}
+	return creds, bucket
+}
 
-	// TODO(dan): Actually invalidate the descriptor cache and delete this line.
-	defer lease.TestingDisableTableLeases()()
-	const numAccounts = 1000
+func setupS3URI(
+	t *testing.T, db *sqlutils.SQLRunner, bucket string, prefix string, creds credentials.Value,
+) url.URL {
+	t.Helper()
+	endpoint := os.Getenv("AWS_ENDPOINT")
+	customCACert := os.Getenv("AWS_CUSTOM_CA_CERT")
+	if customCACert != "" {
+		db.Exec(t, fmt.Sprintf("SET CLUSTER SETTING cloudstorage.http.custom_ca='%s'", customCACert))
+	}
 
-	ctx := context.Background()
-	tc, _, _, cleanupFn := backupRestoreTestSetup(t, 1, numAccounts, InitManualReplication)
-	defer cleanupFn()
-	prefix := fmt.Sprintf("TestBackupRestoreS3-%d", timeutil.Now().UnixNano())
 	uri := url.URL{Scheme: "s3", Host: bucket, Path: prefix}
 	values := uri.Query()
 	values.Add(amazon.AWSAccessKeyParam, creds.AccessKeyID)
 	values.Add(amazon.AWSSecretParam, creds.SecretAccessKey)
+	if endpoint != "" {
+		values.Add(amazon.AWSEndpointParam, endpoint)
+	}
 	uri.RawQuery = values.Encode()
-
-	backupAndRestore(ctx, t, tc, []string{uri.String()}, []string{uri.String()}, numAccounts)
+	return uri
 }
 
 // TestBackupRestoreGoogleCloudStorage hits the real GCS and so could

--- a/pkg/cloud/amazon/s3_storage.go
+++ b/pkg/cloud/amazon/s3_storage.go
@@ -595,7 +595,7 @@ func (s *s3Storage) putUploader(ctx context.Context, basename string) (io.WriteC
 		return nil, err
 	}
 
-	buf := bytes.NewBuffer(make([]byte, 4<<20))
+	buf := bytes.NewBuffer(make([]byte, 0, 4<<20))
 
 	return &putUploader{
 		b: buf,


### PR DESCRIPTION
When using

   cloudstorage.s3.buffer_and_put_uploads.enabled

a bug meant that 4MB of empty data was written at the beginning of files written to S3.

This would have been caught by our unit tests had they run in this
configuration. I've added a test case for this configuration
specifically and made it possible to run the S3 tests against an
alternate S3 endpoint to make it easier to test locally against
something like minio.

Fixes #89645

Release note (bug fix): Fix bug that resulted in additional empty bytes being written to files in S3 when the non-public cloudstorage.s3.buffer_and_put_uploads.enabled was set to true.