### PR TITLE
sql: fix BenchmarkGetZoneConfig

### DIFF
--- a/pkg/sql/zone_config_test.go
+++ b/pkg/sql/zone_config_test.go
@@ -657,9 +657,9 @@ func BenchmarkGetZoneConfig(b *testing.B) {
 	s := srv.(*server.TestServer)
 	cfg := forceNewConfig(b, s)
 
+	key := roachpb.RKey(keys.SystemSQLCodec.TablePrefix(bootstrap.TestingUserDescID(0)))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		key := roachpb.RKey(keys.SystemSQLCodec.TablePrefix(bootstrap.TestingUserDescID(0)))
 		_, _, err := config.TestingGetSystemTenantZoneConfigForKey(cfg, key)
 		if err != nil {
 			b.Fatal(err)


### PR DESCRIPTION
Some of the test setup was in the loop and all of the cost was in that setup. After this change, the benchmark takes 90ns and no allocations.

Fixes #89410

Release note: None