### PR TITLE
scop, scdep: Rename `IndexValidator` to `Validator`

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -968,7 +968,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	jobRegistry.SetInternalExecutorFactory(ieFactory)
 	execCfg.IndexBackfiller = sql.NewIndexBackfiller(execCfg)
 	execCfg.IndexMerger = sql.NewIndexBackfillerMergePlanner(execCfg)
-	execCfg.IndexValidator = scdeps.NewIndexValidator(
+	execCfg.Validator = scdeps.NewValidator(
 		execCfg.DB,
 		execCfg.Codec,
 		execCfg.Settings,

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1257,8 +1257,8 @@ type ExecutorConfig struct {
 	// IndexMerger is also used to backfill indexes and is also rather circular.
 	IndexMerger *IndexBackfillerMergePlanner
 
-	// IndexValidator is used to validate indexes.
-	IndexValidator scexec.IndexValidator
+	// Validator is used to validate indexes and check constraints.
+	Validator scexec.Validator
 
 	// ContentionRegistry is a node-level registry of contention events used for
 	// contention observability.

--- a/pkg/sql/schema_change_plan_node.go
+++ b/pkg/sql/schema_change_plan_node.go
@@ -269,7 +269,7 @@ func newSchemaChangerTxnRunDependencies(
 		// nothing to save because nobody will ever try to resume.
 		scdeps.NewNoOpBackfillerTracker(execCfg.Codec),
 		scdeps.NewNoopPeriodicProgressFlusher(),
-		execCfg.IndexValidator,
+		execCfg.Validator,
 		scdeps.NewConstantClock(evalContext.GetTxnTimestamp(time.Microsecond).Time),
 		metaDataUpdater,
 		NewSchemaChangerEventLogger(txn, execCfg, 1),

--- a/pkg/sql/schemachanger/scdeps/BUILD.bazel
+++ b/pkg/sql/schemachanger/scdeps/BUILD.bazel
@@ -6,8 +6,8 @@ go_library(
     srcs = [
         "build_deps.go",
         "exec_deps.go",
-        "index_validator.go",
         "run_deps.go",
+        "validator.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scdeps",
     visibility = ["//visibility:public"],

--- a/pkg/sql/schemachanger/scdeps/exec_deps.go
+++ b/pkg/sql/schemachanger/scdeps/exec_deps.go
@@ -63,7 +63,7 @@ func NewExecutorDependencies(
 	merger scexec.Merger,
 	backfillTracker scexec.BackfillerTracker,
 	backfillFlusher scexec.PeriodicProgressFlusher,
-	indexValidator scexec.IndexValidator,
+	validator scexec.Validator,
 	clock scmutationexec.Clock,
 	metadataUpdater scexec.DescriptorMetadataUpdater,
 	eventLogger scexec.EventLogger,
@@ -79,7 +79,7 @@ func NewExecutorDependencies(
 			codec:              codec,
 			descsCollection:    descsCollection,
 			jobRegistry:        jobRegistry,
-			indexValidator:     indexValidator,
+			validator:          validator,
 			eventLogger:        eventLogger,
 			statsRefresher:     statsRefresher,
 			schemaChangerJobID: schemaChangerJobID,
@@ -105,7 +105,7 @@ type txnDeps struct {
 	descsCollection     *descs.Collection
 	jobRegistry         JobRegistry
 	createdJobs         []jobspb.JobID
-	indexValidator      scexec.IndexValidator
+	validator           scexec.Validator
 	statsRefresher      scexec.StatsRefresher
 	tableStatsToRefresh []descpb.ID
 	eventLogger         scexec.EventLogger
@@ -395,8 +395,8 @@ func (d *execDeps) PeriodicProgressFlusher() scexec.PeriodicProgressFlusher {
 	return d.periodicProgressFlusher
 }
 
-func (d *execDeps) IndexValidator() scexec.IndexValidator {
-	return d.indexValidator
+func (d *execDeps) Validator() scexec.Validator {
+	return d.validator
 }
 
 // IndexSpanSplitter implements the scexec.Dependencies interface.

--- a/pkg/sql/schemachanger/scdeps/run_deps.go
+++ b/pkg/sql/schemachanger/scdeps/run_deps.go
@@ -43,7 +43,7 @@ func NewJobRunDependencies(
 	job *jobs.Job,
 	codec keys.SQLCodec,
 	settings *cluster.Settings,
-	indexValidator scexec.IndexValidator,
+	indexValidator scexec.Validator,
 	metadataUpdaterFactory MetadataUpdaterFactory,
 	statsRefresher scexec.StatsRefresher,
 	testingKnobs *scexec.TestingKnobs,
@@ -87,7 +87,7 @@ type jobExecutionDeps struct {
 	job                     *jobs.Job
 	kvTrace                 bool
 
-	indexValidator scexec.IndexValidator
+	indexValidator scexec.Validator
 
 	codec        keys.SQLCodec
 	settings     *cluster.Settings
@@ -117,7 +117,7 @@ func (d *jobExecutionDeps) WithTxnInJob(ctx context.Context, fn scrun.JobTxnFunc
 				codec:              d.codec,
 				descsCollection:    descriptors,
 				jobRegistry:        d.jobRegistry,
-				indexValidator:     d.indexValidator,
+				validator:          d.indexValidator,
 				eventLogger:        d.eventLoggerFactory(txn),
 				statsRefresher:     d.statsRefresher,
 				schemaChangerJobID: d.job.ID(),

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -935,7 +935,7 @@ func (s *TestState) WithTxnInJob(ctx context.Context, fn scrun.JobTxnFunc) (err 
 	return err
 }
 
-// ValidateForwardIndexes implements the index validator interface.
+// ValidateForwardIndexes implements the validator interface.
 func (s *TestState) ValidateForwardIndexes(
 	_ context.Context,
 	tbl catalog.TableDescriptor,
@@ -950,7 +950,7 @@ func (s *TestState) ValidateForwardIndexes(
 	return nil
 }
 
-// ValidateInvertedIndexes implements the index validator interface.
+// ValidateInvertedIndexes implements the validator interface.
 func (s *TestState) ValidateInvertedIndexes(
 	_ context.Context,
 	tbl catalog.TableDescriptor,
@@ -965,8 +965,8 @@ func (s *TestState) ValidateInvertedIndexes(
 	return nil
 }
 
-// IndexValidator implements the scexec.Dependencies interface.
-func (s *TestState) IndexValidator() scexec.IndexValidator {
+// Validator implements the scexec.Dependencies interface.
+func (s *TestState) Validator() scexec.Validator {
 	return s
 }
 

--- a/pkg/sql/schemachanger/scexec/dependencies.go
+++ b/pkg/sql/schemachanger/scexec/dependencies.go
@@ -37,7 +37,7 @@ type Dependencies interface {
 	IndexMerger() Merger
 	BackfillProgressTracker() BackfillerTracker
 	PeriodicProgressFlusher() PeriodicProgressFlusher
-	IndexValidator() IndexValidator
+	Validator() Validator
 	IndexSpanSplitter() IndexSpanSplitter
 	EventLogger() EventLogger
 	DescriptorMetadataUpdater(ctx context.Context) DescriptorMetadataUpdater
@@ -196,8 +196,8 @@ type Merger interface {
 	) error
 }
 
-// IndexValidator provides interfaces that allow indexes to be validated.
-type IndexValidator interface {
+// Validator provides interfaces that allow indexes and check constraints to be validated.
+type Validator interface {
 	ValidateForwardIndexes(
 		ctx context.Context,
 		tbl catalog.TableDescriptor,

--- a/pkg/sql/schemachanger/scexec/exec_validation.go
+++ b/pkg/sql/schemachanger/scexec/exec_validation.go
@@ -43,9 +43,9 @@ func executeValidateUniqueIndex(
 		User: username.RootUserName(),
 	}
 	if index.GetType() == descpb.IndexDescriptor_FORWARD {
-		err = deps.IndexValidator().ValidateForwardIndexes(ctx, table, []catalog.Index{index}, execOverride)
+		err = deps.Validator().ValidateForwardIndexes(ctx, table, []catalog.Index{index}, execOverride)
 	} else {
-		err = deps.IndexValidator().ValidateInvertedIndexes(ctx, table, []catalog.Index{index}, execOverride)
+		err = deps.Validator().ValidateInvertedIndexes(ctx, table, []catalog.Index{index}, execOverride)
 	}
 	if err != nil {
 		return scerrors.SchemaChangerUserError(err)

--- a/pkg/sql/schemachanger/scexec/executor_external_test.go
+++ b/pkg/sql/schemachanger/scexec/executor_external_test.go
@@ -75,7 +75,7 @@ func (ti testInfra) newExecDeps(
 		noopMerger{},
 		scdeps.NewNoOpBackfillerTracker(ti.lm.Codec()),
 		scdeps.NewNoopPeriodicProgressFlusher(),
-		noopIndexValidator{},
+		noopValidator{},
 		scdeps.NewConstantClock(timeutil.Now()),
 		noopMetadataUpdater{},
 		noopEventLogger{},
@@ -461,11 +461,11 @@ func (n noopMerger) MergeIndexes(
 	return nil
 }
 
-type noopIndexValidator struct{}
+type noopValidator struct{}
 
-var _ scexec.IndexValidator = noopIndexValidator{}
+var _ scexec.Validator = noopValidator{}
 
-func (noopIndexValidator) ValidateForwardIndexes(
+func (noopValidator) ValidateForwardIndexes(
 	ctx context.Context,
 	tableDesc catalog.TableDescriptor,
 	indexes []catalog.Index,
@@ -474,7 +474,7 @@ func (noopIndexValidator) ValidateForwardIndexes(
 	return nil
 }
 
-func (noopIndexValidator) ValidateInvertedIndexes(
+func (noopValidator) ValidateInvertedIndexes(
 	ctx context.Context,
 	tableDesc catalog.TableDescriptor,
 	indexes []catalog.Index,
@@ -571,7 +571,7 @@ func (noopMetadataUpdater) UpsertZoneConfig(
 }
 
 var _ scexec.Backfiller = noopBackfiller{}
-var _ scexec.IndexValidator = noopIndexValidator{}
+var _ scexec.Validator = noopValidator{}
 var _ scexec.EventLogger = noopEventLogger{}
 var _ scexec.StatsRefresher = noopStatsReferesher{}
 var _ scexec.DescriptorMetadataUpdater = noopMetadataUpdater{}

--- a/pkg/sql/schemachanger/scexec/mocks_generated_test.go
+++ b/pkg/sql/schemachanger/scexec/mocks_generated_test.go
@@ -264,20 +264,6 @@ func (mr *MockDependenciesMockRecorder) IndexSpanSplitter() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IndexSpanSplitter", reflect.TypeOf((*MockDependencies)(nil).IndexSpanSplitter))
 }
 
-// IndexValidator mocks base method.
-func (m *MockDependencies) IndexValidator() scexec.IndexValidator {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IndexValidator")
-	ret0, _ := ret[0].(scexec.IndexValidator)
-	return ret0
-}
-
-// IndexValidator indicates an expected call of IndexValidator.
-func (mr *MockDependenciesMockRecorder) IndexValidator() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IndexValidator", reflect.TypeOf((*MockDependencies)(nil).IndexValidator))
-}
-
 // PeriodicProgressFlusher mocks base method.
 func (m *MockDependencies) PeriodicProgressFlusher() scexec.PeriodicProgressFlusher {
 	m.ctrl.T.Helper()
@@ -360,6 +346,20 @@ func (m *MockDependencies) User() username.SQLUsername {
 func (mr *MockDependenciesMockRecorder) User() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "User", reflect.TypeOf((*MockDependencies)(nil).User))
+}
+
+// Validator mocks base method.
+func (m *MockDependencies) Validator() scexec.Validator {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Validator")
+	ret0, _ := ret[0].(scexec.Validator)
+	return ret0
+}
+
+// Validator indicates an expected call of Validator.
+func (mr *MockDependenciesMockRecorder) Validator() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validator", reflect.TypeOf((*MockDependencies)(nil).Validator))
 }
 
 // MockBackfiller is a mock of Backfiller interface.

--- a/pkg/sql/schemachanger/scjob/job.go
+++ b/pkg/sql/schemachanger/scjob/job.go
@@ -81,7 +81,7 @@ func (n *newSchemaChangeResumer) run(ctx context.Context, execCtxI interface{}) 
 		n.job,
 		execCfg.Codec,
 		execCfg.Settings,
-		execCfg.IndexValidator,
+		execCfg.Validator,
 		func(ctx context.Context, descriptors *descs.Collection, txn *kv.Txn) scexec.DescriptorMetadataUpdater {
 			return descmetadata.NewMetadataUpdater(ctx,
 				execCfg.InternalExecutorFactory,

--- a/pkg/sql/schemachanger/scop/validation.go
+++ b/pkg/sql/schemachanger/scop/validation.go
@@ -31,8 +31,8 @@ type ValidateIndex struct {
 // ValidateCheckConstraint validates a check constraint on a table's columns.
 type ValidateCheckConstraint struct {
 	validationOp
-	TableID descpb.ID
-	Name    string
+	TableID      descpb.ID
+	ConstraintID descpb.ConstraintID
 }
 
 // Make sure baseOp is used for linter.


### PR DESCRIPTION
I've recently done work to enable adding/dropping check constraints in the declarative
schema changer. It is a big PR with many commits. I think it's nicer to separate them
further into multiple PRs. 

This is the first PR in that effort, which is merely renaming and should be easy to review:
commit 1: ValidateCheckConstraint now uses ConstraintID, instead of constraint name;

commit 2: Rename `IndexValidator` to `Validator`.
We previously had a file under scdep called `index_validator.go` where we implement
logic for validating an index. Now that we are going to validate a check constraint, we 
renamed them so they will also validate check constraints.

Informs #89665
Release note: None