### PR TITLE
release-21.2: cloud: don't write empty buffer to s3

### DIFF
--- a/pkg/cloud/amazon/s3_storage.go
+++ b/pkg/cloud/amazon/s3_storage.go
@@ -426,7 +426,7 @@ func (s *s3Storage) putUploader(ctx context.Context, basename string) (io.WriteC
 		return nil, err
 	}
 
-	buf := bytes.NewBuffer(make([]byte, 4<<20))
+	buf := bytes.NewBuffer(make([]byte, 0, 4<<20))
 
 	return &putUploader{
 		b: buf,


### PR DESCRIPTION
Backport 1/1 commits from #89643.

/cc @cockroachdb/release

---

When using

   cloudstorage.s3.buffer_and_put_uploads.enabled

a bug meant that 4MB of empty data was written at the beginning of files written to S3.

This would have been caught by our unit tests had they run in this
configuration. I've added a test case for this configuration
specifically and made it possible to run the S3 tests against an
alternate S3 endpoint to make it easier to test locally against
something like minio.

Fixes #89645

Release note (bug fix): Fix bug that resulted in additional empty bytes being written to files in S3 when the non-public cloudstorage.s3.buffer_and_put_uploads.enabled was set to true.

Release justification: Critical bug fix.
