### PR TITLE
storage: add EngineKeyEqual lock table fast path

### DIFF
--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -157,7 +157,8 @@ func EngineKeyEqual(a, b []byte) bool {
 	// need to split the "user key" from the version suffix before comparing to
 	// compute equality. Instead, we can check for byte equality immediately.
 	const withWall = mvccEncodedTimeSentinelLen + mvccEncodedTimeWallLen
-	if aVerLen <= withWall && bVerLen <= withWall {
+	const withLockTableLen = mvccEncodedTimeSentinelLen + engineKeyVersionLockTableLen
+	if (aVerLen <= withWall && bVerLen <= withWall) || (aVerLen == withLockTableLen && bVerLen == withLockTableLen) {
 		return bytes.Equal(a, b)
 	}
 


### PR DESCRIPTION
Apply the EngineKeyEqual fast path to lock table keys too.

Thanks @sumeerbhola for the suggestion.

```
name                                          old time/op  new time/op  delta
IntentScan/versions=400/percent-flushed=0-24  54.2µs ± 1%  47.2µs ± 1%  -12.94%  (p=0.016 n=5+4)
```

Informs #89153.
Epic: CRDB-2624

Release note: None