### PR TITLE
release-22.1: sqlproxyccl: validate tenant certs common name and org

### DIFF
--- a/pkg/ccl/sqlproxyccl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//pkg/ccl/sqlproxyccl/tenantdirsvr",
         "//pkg/ccl/sqlproxyccl/throttler",
         "//pkg/roachpb",
+        "//pkg/security",
         "//pkg/security/certmgr",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgwirebase",

--- a/pkg/ccl/sqlproxyccl/backend_dialer_test.go
+++ b/pkg/ccl/sqlproxyccl/backend_dialer_test.go
@@ -11,9 +11,14 @@ package sqlproxyccl
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
+	"path/filepath"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -21,31 +26,101 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBackendDialTLS(t *testing.T) {
+func TestBackendDialTLSInsecure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	startupMsg := &pgproto3.StartupMessage{ProtocolVersion: pgproto3.ProtocolVersionNumber}
-	tlsConfig := &tls.Config{InsecureSkipVerify: true}
 
-	t.Run("insecure server", func(t *testing.T) {
-		sql, _, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: true})
-		defer sql.Stopper().Stop(ctx)
+	sql, _, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: true})
+	defer sql.Stopper().Stop(ctx)
 
-		conn, err := BackendDial(startupMsg, sql.ServingSQLAddr(), tlsConfig)
-		require.Error(t, err)
-		require.Regexp(t, "target server refused TLS connection", err)
-		require.Nil(t, conn)
+	conn, err := BackendDial(startupMsg, sql.ServingSQLAddr(), &tls.Config{})
+	require.Error(t, err)
+	require.Regexp(t, "target server refused TLS connection", err)
+	require.Nil(t, conn)
+}
+
+func TestBackendDialTLS(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	startupMsg := &pgproto3.StartupMessage{ProtocolVersion: pgproto3.ProtocolVersionNumber}
+
+	tenantCA, err := securitytest.Asset(filepath.Join(security.EmbeddedCertsDir, security.EmbeddedTenantCACert))
+	require.NoError(t, err)
+
+	ca := x509.NewCertPool()
+	require.True(t, ca.AppendCertsFromPEM(tenantCA))
+	tlsConfig := &tls.Config{
+		RootCAs: ca,
+	}
+
+	ctx := context.Background()
+
+	storageServer, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Insecure: false,
 	})
+	defer storageServer.Stopper().Stop(ctx)
 
-	t.Run("secure server", func(t *testing.T) {
-		sql, _, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: false})
-		defer sql.Stopper().Stop(ctx)
+	tenant10 := roachpb.MakeTenantID(10)
+	sql10, _ := serverutils.StartTenant(t, storageServer, base.TestTenantArgs{TenantID: tenant10})
+	defer sql10.Stopper().Stop(ctx)
 
-		conn, err := BackendDial(startupMsg, sql.ServingSQLAddr(), tlsConfig)
+	tenant11 := roachpb.MakeTenantID(11)
+	sql11, _ := serverutils.StartTenant(t, storageServer, base.TestTenantArgs{TenantID: tenant11})
+	defer sql11.Stopper().Stop(ctx)
 
-		require.NoError(t, err)
-		require.NotNil(t, conn)
-	})
+	tests := []struct {
+		name     string
+		addr     string
+		tenantID uint64
+		err      bool
+	}{{
+		name:     "tenant10",
+		addr:     sql10.SQLAddr(),
+		tenantID: 10,
+	}, {
+		name:     "tenant11",
+		addr:     sql11.SQLAddr(),
+		tenantID: 11,
+	}, {
+		name:     "tenant10To11",
+		addr:     sql11.SQLAddr(),
+		tenantID: 10,
+		err:      true,
+	}, {
+		name:     "tenant11To10",
+		addr:     sql10.SQLAddr(),
+		tenantID: 11,
+		err:      true,
+	}, {
+		name:     "tenant10ToStorage",
+		addr:     storageServer.ServingSQLAddr(),
+		tenantID: 10,
+		err:      true,
+	}, {
+		name:     "tenantWithNodeIDToStoage",
+		addr:     storageServer.ServingSQLAddr(),
+		tenantID: uint64(storageServer.NodeID()),
+		err:      true,
+	}}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tenantID := roachpb.MakeTenantID(tc.tenantID)
+
+			tenantConfig, err := tlsConfigForTenant(tenantID, tc.addr, tlsConfig)
+			require.NoError(t, err)
+
+			conn, err := BackendDial(startupMsg, tc.addr, tenantConfig)
+
+			if tc.err {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, conn)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #89587.

/cc @cockroachdb/release

---

Currently the sqlproxy only validates the tenant cert's DNS name. The
tenant cert also contains a specific common name and organization.
Validating the common name and organization is useful, because the dns
name for k8s pod is the pod's IP address and IP addresses are reused by
the cluster.

Fixes: [CC-7532](https://cockroachlabs.atlassian.net/browse/CC-7532)

Release justification: Fixes CC-7532
