### PR TITLE
release-22.1: sql: remove unneeded open txn check

### DIFF
--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -398,7 +398,7 @@ func MemberOfWithAdminOption(
 	txn *kv.Txn,
 	member security.SQLUsername,
 ) (map[security.SQLUsername]bool, error) {
-	if txn == nil || !txn.IsOpen() {
+	if txn == nil {
 		return nil, errors.AssertionFailedf("cannot use MemberOfWithAdminoption without a txn")
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #89664.

/cc @cockroachdb/release

Release justification: fix an assertion error

---

fixes #89530

This was missed as part of 9fff27f330062e41ef179632e059180c74b6d436

Ever since c00ea84 was merged, the KV layer has disallowed use of an aborted txn. Therefore, the check here is no longer necessary. This should actually help with debugging, since now if the aborted txn is used, we should get back an error that has the reason for the abort (or restart), instead of an assertion error that does not have that info.

Release note: None
