### PR TITLE
release-22.1: release-22.2: only check for introduced spans for online tables in restore

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/in-progress-import-missing-data
+++ b/pkg/ccl/backupccl/testdata/backup-restore/in-progress-import-missing-data
@@ -169,6 +169,22 @@ SELECT * FROM d.silly_view;
 ----
 0
 
+# Start and pause another import to ensure the restore checker doesn't spuriously fail on
+# descriptors with an in-progress import.
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = 'import.after_ingest';
+----
+
+exec-sql
+CREATE TABLE foo_offline (i INT PRIMARY KEY, s STRING);
+----
+
+import expect-pausepoint tag=b
+IMPORT INTO foo_offline (i,s) CSV DATA ('nodelocal://0/export1/export*-n*.0.csv')
+----
+job paused at pausepoint
+
+
 # Because BackupRestoreTestingKnobs.SkipDescriptorChangeIntroduction is turned on,
 # this backup will be unable to introduce foo, foofoo, and goodfoo.
 exec-sql


### PR DESCRIPTION
Backport 1/2 commits from #89102.

/cc @cockroachdb/release

This small patch refines the introduced span corruption checker to
ensure that only _online_ tables in a given backup are checked, as oppose to
all tables included in manifest.Descriptors. This is necessary for checking
cluster backups which currently include offline descriptors in
manifest.Descriptors, which should not be checked, as they will not get
restored. If the table was online at some point in the backup's interval,
the check on each DescriptorChange that brought the table online already covers
this case.

Release note (bug fix): refnes a check conducted during restore that ensures
that all previously offline tables were properly introduced.

Release justification: bug fix