### PR TITLE
sql: avoid some overhead due to error construction on common paths

### DIFF
--- a/pkg/sql/colexec/builtin_funcs.go
+++ b/pkg/sql/colexec/builtin_funcs.go
@@ -103,6 +103,12 @@ func (b *defaultBuiltinFuncOperator) Release() {
 	b.toDatumConverter.Release()
 }
 
+// errFnWithExprsNotSupported is returned from NewBuiltinFunctionOperator
+// when the function in question uses FnWithExprs, which is not supported.
+var errFnWithExprsNotSupported = errors.New(
+	"builtins with FnWithExprs are not supported in the vectorized engine",
+)
+
 // NewBuiltinFunctionOperator returns an operator that applies builtin functions.
 func NewBuiltinFunctionOperator(
 	allocator *colmem.Allocator,
@@ -115,7 +121,7 @@ func NewBuiltinFunctionOperator(
 ) (colexecop.Operator, error) {
 	overload := funcExpr.ResolvedOverload()
 	if overload.FnWithExprs != nil {
-		return nil, errors.New("builtins with FnWithExprs are not supported in the vectorized engine")
+		return nil, errFnWithExprsNotSupported
 	}
 	outputType := funcExpr.ResolvedType()
 	input = colexecutils.NewVectorTypeEnforcer(allocator, input, outputType, outputIdx)

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -1440,6 +1440,12 @@ var SynthesizeRegionConfigOptionUseCache SynthesizeRegionConfigOption = func(o *
 	o.useCache = true
 }
 
+// errNotMultiRegionDatabase is returned from SynthesizeRegionConfig when the
+// requested database is not a multi-region database.
+var errNotMultiRegionDatabase = errors.New(
+	"database is not a multi-region database",
+)
+
 // SynthesizeRegionConfig returns a RegionConfig representing the user
 // configured state of a multi-region database by coalescing state from both
 // the database descriptor and multi-region type descriptor. By default, it
@@ -1466,7 +1472,10 @@ func SynthesizeRegionConfig(
 		IncludeOffline: o.includeOffline,
 	})
 	if err != nil {
-		return regionConfig, err
+		return multiregion.RegionConfig{}, err
+	}
+	if !dbDesc.IsMultiRegion() {
+		return multiregion.RegionConfig{}, errNotMultiRegionDatabase
 	}
 
 	regionEnumID, err := dbDesc.MultiRegionEnumID()


### PR DESCRIPTION
These paths amount for about .5% of CPU time and almost as much in terms of allocated objects in tpcc.

Epic: None

Release note: None