### PR TITLE
storage: refactor and generalize benchmark MVCC data caching

### DIFF
--- a/pkg/storage/.gitignore
+++ b/pkg/storage/.gitignore
@@ -1,3 +1,7 @@
 # Do not add environment-specific entries here (see the top-level .gitignore
 # for reasoning and alternatives).
+#
+# Old benchmark data:
 mvcc_data_*
+# New benchmark data:
+testdata/initial

--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -104,6 +104,7 @@ go_test(
     srcs = [
         "ballast_test.go",
         "batch_test.go",
+        "bench_data_test.go",
         "bench_pebble_test.go",
         "bench_test.go",
         "disk_map_test.go",
@@ -159,7 +160,6 @@ go_test(
         "//pkg/util",
         "//pkg/util/admission",
         "//pkg/util/encoding",
-        "//pkg/util/fileutil",
         "//pkg/util/hlc",
         "//pkg/util/iterutil",
         "//pkg/util/leaktest",

--- a/pkg/storage/bench_data_test.go
+++ b/pkg/storage/bench_data_test.go
@@ -1,0 +1,419 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package storage
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/errors/oserror"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
+)
+
+type initialState interface {
+	// Base may return an initialState to extend. If Base is non-nil, Build will
+	// be supplied an engine with the initial state Base. This allows initial
+	// states to be layered, ensuring that lower layers are computed once and
+	// cached.
+	Base() initialState
+
+	// Key returns a unique sequence of strings that uniquely identifies the
+	// represented initial condtions. Key is used as the cache key for reusing
+	// databases computed by previous runs, so all configuration must be fully
+	// represented in Key's return value.
+	Key() []string
+
+	// ConfigOptions reutrns additional configuration options that should be
+	// supplied to Open.
+	ConfigOptions() []ConfigOption
+
+	// Build is called when no cached version of the engine state exists yet.
+	// Build must populate the provided engine appropriately. Build must produce
+	// equivalent engine state across initialConditions with equal Key() values.
+	Build(context.Context, *testing.B, Engine) error
+}
+
+type engineWithLocation struct {
+	Engine
+	Location
+}
+
+// getInitialStateEngine constructs an Engine with an initial database
+// state necessary for a benchmark. The initial states are cached on the
+// filesystem to avoid expensive reconstruction when possible. The return value
+// of Key() must be unique for each unique initial database configuration,
+// because the Key() value is used to key cached intial databases.
+//
+// TODO(jackson): Initial states are NOT cached across ./dev bench invocations,
+// because the initial states are written to the temporary bazel sandbox and not
+// copied out. See #83599.
+func getInitialStateEngine(
+	ctx context.Context, b *testing.B, initial initialState, inMemory bool,
+) engineWithLocation {
+	const initialStatesDir = `testdata/initial`
+
+	require.NoError(b, os.MkdirAll(initialStatesDir, os.ModePerm))
+	dir := filepath.Join(append([]string{initialStatesDir}, initial.Key()...)...)
+	dataDir := filepath.Join(dir, "data")
+	completedFile := filepath.Join(dir, "completed")
+
+	var buildFS vfs.FS
+	if _, err := os.Stat(completedFile); oserror.IsNotExist(err) {
+		// There's no completed existing engine state for these initial
+		// condtions.  Produce it.
+		b.Logf("%q does not exist; building initial state first", completedFile)
+		buildFS = buildInitialState(ctx, b, initial, dir)
+	} else if err != nil {
+		b.Fatal(err)
+	}
+
+	opts := append([]ConfigOption{
+		MustExist,
+		LatestReleaseFormatMajorVersion,
+	}, initial.ConfigOptions()...)
+
+	if !inMemory {
+		// The callers wants a durable engine. Copy the seed data to a temporary
+		// directory on the filesystem.
+		testRunDir := b.TempDir()
+		ok, err := vfs.Clone(vfs.Default, vfs.Default, dataDir, testRunDir, vfs.CloneSync)
+		require.NoError(b, err)
+		require.True(b, ok)
+
+		// Load all the files into the OS buffer cache for better determinism.
+		testutils.ReadAllFiles(filepath.Join(testRunDir, "*"))
+
+		loc := Filesystem(testRunDir)
+		e, err := Open(ctx, loc, opts...)
+		require.NoError(b, err)
+		return engineWithLocation{Engine: e, Location: loc}
+	}
+
+	var fs vfs.FS
+
+	// If the caller requests an in-memory engine and we just built the initial
+	// state using an in-memory filesystem, use the existing filesystem already
+	// ready.
+	if buildFS != nil {
+		fs = buildFS
+	} else {
+		// Load the initial state off the filesystem.
+		fs = vfs.NewMem()
+		ok, err := vfs.Clone(vfs.Default, fs, dataDir, "")
+		require.NoError(b, err)
+		require.True(b, ok)
+	}
+
+	loc := Location{fs: fs}
+	e, err := Open(ctx, loc, opts...)
+	require.NoError(b, err)
+	return engineWithLocation{Engine: e, Location: loc}
+}
+
+func buildInitialState(
+	ctx context.Context, b *testing.B, initial initialState, dir string,
+) (buildFS vfs.FS) {
+	dataDir := filepath.Join(dir, "data")
+	// The data directory might exist and be non-empty if the previous run did
+	// not complete successfully. Remove it.
+	require.NoError(b, vfs.Default.RemoveAll(dataDir))
+	require.NoError(b, os.MkdirAll(dataDir, os.ModePerm))
+
+	// If the initial conditions specify a base, we can compute the initial
+	// conditions recursively. For example, if we have two variants of an
+	// initial state, f(A) and g(A), we can compute and persist A. Then f(A) and
+	// g(A) may be computed starting from A's state.
+	if base := initial.Base(); base != nil {
+		e := getInitialStateEngine(ctx, b, base, true /* inMemory */)
+		require.NoError(b, initial.Build(ctx, b, e))
+		e.Close()
+		buildFS = e.Location.fs
+	} else {
+		opts := append([]ConfigOption{LatestReleaseFormatMajorVersion}, initial.ConfigOptions()...)
+
+		// Regardless of whether the initial conditions specify an in-memory engine
+		// or not, we build the conditions using an in-memory engine for
+		// performance.
+		buildFS = vfs.NewMem()
+
+		var err error
+		e, err := Open(ctx, Location{fs: buildFS}, opts...)
+		require.NoError(b, err)
+
+		require.NoError(b, initial.Build(ctx, b, e))
+		e.Close()
+	}
+
+	// Write the initial state out to disk.
+	ok, err := vfs.Clone(buildFS, vfs.Default, "", dataDir, vfs.CloneSync)
+	require.NoError(b, err)
+	require.True(b, ok)
+
+	// Create a marker file signalling that the persisted state is complete.
+	f, err := vfs.Default.Create(filepath.Join(dir, "completed"))
+	require.NoError(b, err)
+	require.NoError(b, f.Close())
+
+	return buildFS
+}
+
+type buildFunc func(ctx context.Context, b *testing.B, eng Engine) error
+
+func extendInitialConditions(base initialState, apply buildFunc, key ...string) initialState {
+	return extendedInitial{
+		base:  base,
+		apply: apply,
+		keys:  key,
+	}
+}
+
+// extendedInitial wraps another initialConditions, layering on a buildFunc.
+type extendedInitial struct {
+	base  initialState
+	apply buildFunc
+	keys  []string
+}
+
+func (e extendedInitial) Base() initialState            { return e.base }
+func (e extendedInitial) Key() []string                 { return append(e.base.Key(), e.keys...) }
+func (e extendedInitial) ConfigOptions() []ConfigOption { return e.base.ConfigOptions() }
+func (e extendedInitial) Build(ctx context.Context, b *testing.B, eng Engine) error {
+	return e.apply(ctx, b, eng)
+}
+
+func withCompactedDB(base initialState) initialState {
+	return extendInitialConditions(base,
+		func(ctx context.Context, b *testing.B, eng Engine) error {
+			return eng.Compact()
+		}, "compacted")
+}
+
+// mvccBenchData implements initialConditions, initializing a database with a
+// configurable count of MVCC keys.
+type mvccBenchData struct {
+	numVersions       int
+	numKeys           int
+	valueBytes        int
+	numColumnFamilies int
+	numRangeKeys      int // MVCC range tombstones, 1=global
+
+	// If garbage is enabled, point keys will be tombstones rather than values.
+	// Furthermore, range keys (controlled by numRangeKeys) will be written above
+	// the point keys rather than below them.
+	garbage bool
+
+	// In transactional mode, data is written by writing and later resolving
+	// intents. In non-transactional mode, data is written directly, without
+	// leaving intents. Transactional mode notably stresses RocksDB deletion
+	// tombstones, as the metadata key is repeatedly written and deleted.
+	//
+	// Both modes are reflective of real workloads. Transactional mode simulates
+	// data that has recently been INSERTed into a table, while non-transactional
+	// mode simulates data that has been RESTOREd or is old enough to have been
+	// fully compacted.
+	transactional bool
+}
+
+var _ initialState = mvccBenchData{}
+
+func (d mvccBenchData) Key() []string {
+	key := []string{
+		"mvcc",
+		fmt.Sprintf("numKeys_%d", d.numKeys),
+		fmt.Sprintf("numVersions_%d", d.numVersions),
+		fmt.Sprintf("valueBytes_%d", d.valueBytes),
+		fmt.Sprintf("numColFams_%d", d.numColumnFamilies),
+		fmt.Sprintf("numRangeKeys_%d", d.numRangeKeys),
+	}
+	if d.garbage {
+		key = append(key, fmt.Sprintf("garbage_%t", d.garbage))
+	}
+	if d.transactional {
+		key = append(key, fmt.Sprintf("transactional_%t", d.transactional))
+	}
+	return key
+}
+func (d mvccBenchData) ConfigOptions() []ConfigOption { return nil }
+func (d mvccBenchData) Base() initialState            { return nil }
+func (d mvccBenchData) Build(ctx context.Context, b *testing.B, eng Engine) error {
+	// Writes up to numVersions values at each of numKeys keys. The number of
+	// versions written for each key is chosen randomly according to a uniform
+	// distribution. Each successive version is written starting at 5ns and then
+	// in 5ns increments. This allows scans at various times, starting at t=5ns,
+	// and continuing to t=5ns*(numVersions+1). A version for each key will be
+	// read on every such scan, but the dynamics of the scan will change
+	// depending on the historical timestamp. Earlier timestamps mean scans
+	// which must skip more historical versions; later timestamps mean scans
+	// which skip fewer.
+	//
+	// MVCC range keys are written below all point keys unless garbage=true.
+	// They're always written with random start/end bounds, at increasing
+	// logical timestamps (WallTime 0).
+	//
+	// The creation of the database is time consuming, especially for larger
+	// numbers of versions. The database is persisted between runs and stored in
+	// a directory with the path elements returned by Key().
+
+	// Generate the same data every time.
+	rng := rand.New(rand.NewSource(1449168817))
+
+	// Write MVCC range keys. If garbage is enabled, they will be written on top
+	// of the point keys, otherwise they will be written below them.
+	writeRangeKeys := func(b testing.TB, wallTime int) {
+		batch := eng.NewBatch()
+		defer batch.Close()
+		for i := 0; i < d.numRangeKeys; i++ {
+			ts := hlc.Timestamp{WallTime: int64(wallTime), Logical: int32(i + 1)}
+			start := rng.Intn(d.numKeys)
+			end := start + rng.Intn(d.numKeys-start) + 1
+			// As a special case, if we're only writing one range key, write it across
+			// the entire span.
+			if d.numRangeKeys == 1 {
+				start = 0
+				end = d.numKeys + 1
+			}
+			startKey := roachpb.Key(encoding.EncodeUvarintAscending([]byte("key-"), uint64(start)))
+			endKey := roachpb.Key(encoding.EncodeUvarintAscending([]byte("key-"), uint64(end)))
+			require.NoError(b, MVCCDeleteRangeUsingTombstone(
+				ctx, batch, nil, startKey, endKey, ts, hlc.ClockTimestamp{}, nil, nil, false, 0, nil))
+		}
+		require.NoError(b, batch.Commit(false /* sync */))
+	}
+	if !d.garbage {
+		writeRangeKeys(b, 0 /* wallTime */)
+	}
+
+	// Generate point keys.
+	keySlice := make([]roachpb.Key, d.numKeys)
+	var order []int
+	var cf uint32
+	for i := 0; i < d.numKeys; i++ {
+		if d.numColumnFamilies > 0 {
+			keySlice[i] = makeBenchRowKey(b, nil, i/d.numColumnFamilies, cf)
+			cf = (cf + 1) % uint32(d.numColumnFamilies)
+		} else {
+			keySlice[i] = roachpb.Key(encoding.EncodeUvarintAscending([]byte("key-"), uint64(i)))
+		}
+		keyVersions := rng.Intn(d.numVersions) + 1
+		for j := 0; j < keyVersions; j++ {
+			order = append(order, i)
+		}
+	}
+
+	// Randomize the order in which the keys are written.
+	for i, n := 0, len(order); i < n-1; i++ {
+		j := i + rng.Intn(n-i)
+		order[i], order[j] = order[j], order[i]
+	}
+
+	counts := make([]int, d.numKeys)
+
+	var txn *roachpb.Transaction
+	if d.transactional {
+		txnCopy := *txn1Commit
+		txn = &txnCopy
+	}
+
+	writeKey := func(batch Batch, idx int) {
+		key := keySlice[idx]
+		var value roachpb.Value
+		if !d.garbage {
+			value = roachpb.MakeValueFromBytes(randutil.RandBytes(rng, d.valueBytes))
+			value.InitChecksum(key)
+		}
+		counts[idx]++
+		ts := hlc.Timestamp{WallTime: int64(counts[idx] * 5)}
+		if txn != nil {
+			txn.ReadTimestamp = ts
+			txn.WriteTimestamp = ts
+		}
+		require.NoError(b, MVCCPut(ctx, batch, nil, key, ts, hlc.ClockTimestamp{}, value, txn))
+	}
+
+	resolveLastIntent := func(batch Batch, idx int) {
+		key := keySlice[idx]
+		txnMeta := txn.TxnMeta
+		txnMeta.WriteTimestamp = hlc.Timestamp{WallTime: int64(counts[idx]) * 5}
+		if _, err := MVCCResolveWriteIntent(ctx, batch, nil /* ms */, roachpb.LockUpdate{
+			Span:   roachpb.Span{Key: key},
+			Status: roachpb.COMMITTED,
+			Txn:    txnMeta,
+		}); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	batch := eng.NewBatch()
+	for i, idx := range order {
+		// Output the keys in ~20 batches. If we used a single batch to output all
+		// of the keys rocksdb would create a single sstable. We want multiple
+		// sstables in order to exercise filtering of which sstables are examined
+		// during iterator seeking. We fix the number of batches we output so that
+		// optimizations which change the data size result in the same number of
+		// sstables.
+		if scaled := len(order) / 20; i > 0 && (i%scaled) == 0 {
+			log.Infof(ctx, "committing (%d/~%d)", i/scaled, 20)
+			if err := batch.Commit(false /* sync */); err != nil {
+				return err
+			}
+			batch.Close()
+			batch = eng.NewBatch()
+			if err := eng.Flush(); err != nil {
+				return err
+			}
+		}
+
+		if d.transactional {
+			// If we've previously written this key transactionally, we need to
+			// resolve the intent we left. We don't do this immediately after writing
+			// the key to introduce the possibility that the intent's resolution ends
+			// up in a different batch than writing the intent itself. Note that the
+			// first time through this loop for any given key we'll attempt to resolve
+			// a non-existent intent, but that's OK.
+			resolveLastIntent(batch, idx)
+		}
+		writeKey(batch, idx)
+	}
+	if d.transactional {
+		// If we were writing transactionally, we need to do one last round of
+		// intent resolution. Just stuff it all into the last batch.
+		for idx := range keySlice {
+			resolveLastIntent(batch, idx)
+		}
+	}
+	if err := batch.Commit(false /* sync */); err != nil {
+		return err
+	}
+	batch.Close()
+
+	// If we're writing garbage, write MVCC range tombstones on top of the
+	// point keys.
+	if d.garbage {
+		writeRangeKeys(b, 10*d.numVersions)
+	}
+
+	if err := eng.Flush(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/storage/bench_pebble_test.go
+++ b/pkg/storage/bench_pebble_test.go
@@ -85,8 +85,8 @@ func BenchmarkMVCCScan_Pebble(b *testing.B) {
 						b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
 							for _, numRangeKeys := range []int{0, 1, 100} {
 								b.Run(fmt.Sprintf("numRangeKeys=%d", numRangeKeys), func(b *testing.B) {
-									runMVCCScan(ctx, b, setupMVCCPebble, benchScanOptions{
-										benchDataOptions: benchDataOptions{
+									runMVCCScan(ctx, b, benchScanOptions{
+										mvccBenchData: mvccBenchData{
 											numVersions:  numVersions,
 											valueBytes:   valueSize,
 											numRangeKeys: numRangeKeys,
@@ -114,8 +114,8 @@ func BenchmarkMVCCScanGarbage_Pebble(b *testing.B) {
 				b.Run(fmt.Sprintf("versions=%d", numVersions), func(b *testing.B) {
 					for _, numRangeKeys := range []int{0, 1, 100} {
 						b.Run(fmt.Sprintf("numRangeKeys=%d", numRangeKeys), func(b *testing.B) {
-							runMVCCScan(ctx, b, setupMVCCPebble, benchScanOptions{
-								benchDataOptions: benchDataOptions{
+							runMVCCScan(ctx, b, benchScanOptions{
+								mvccBenchData: mvccBenchData{
 									numVersions:  numVersions,
 									numRangeKeys: numRangeKeys,
 									garbage:      true,
@@ -145,8 +145,8 @@ func BenchmarkMVCCScanSQLRows_Pebble(b *testing.B) {
 								b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
 									for _, wholeRows := range []bool{false, true} {
 										b.Run(fmt.Sprintf("wholeRows=%t", wholeRows), func(b *testing.B) {
-											runMVCCScan(ctx, b, setupMVCCPebble, benchScanOptions{
-												benchDataOptions: benchDataOptions{
+											runMVCCScan(ctx, b, benchScanOptions{
+												mvccBenchData: mvccBenchData{
 													numColumnFamilies: numColumnFamilies,
 													numVersions:       numVersions,
 													valueBytes:        valueSize,
@@ -179,8 +179,8 @@ func BenchmarkMVCCReverseScan_Pebble(b *testing.B) {
 						b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
 							for _, numRangeKeys := range []int{0, 1, 100} {
 								b.Run(fmt.Sprintf("numRangeKeys=%d", numRangeKeys), func(b *testing.B) {
-									runMVCCScan(ctx, b, setupMVCCPebble, benchScanOptions{
-										benchDataOptions: benchDataOptions{
+									runMVCCScan(ctx, b, benchScanOptions{
+										mvccBenchData: mvccBenchData{
 											numVersions:  numVersions,
 											valueBytes:   valueSize,
 											numRangeKeys: numRangeKeys,
@@ -201,9 +201,9 @@ func BenchmarkMVCCReverseScan_Pebble(b *testing.B) {
 func BenchmarkMVCCScanTransactionalData_Pebble(b *testing.B) {
 	ctx := context.Background()
 	defer log.Scope(b).Close(b)
-	runMVCCScan(ctx, b, setupMVCCPebble, benchScanOptions{
+	runMVCCScan(ctx, b, benchScanOptions{
 		numRows: 10000,
-		benchDataOptions: benchDataOptions{
+		mvccBenchData: mvccBenchData{
 			numVersions:   2,
 			valueBytes:    8,
 			transactional: true,
@@ -223,7 +223,7 @@ func BenchmarkMVCCGet_Pebble(b *testing.B) {
 						b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
 							for _, numRangeKeys := range []int{0, 1, 100} {
 								b.Run(fmt.Sprintf("numRangeKeys=%d", numRangeKeys), func(b *testing.B) {
-									runMVCCGet(ctx, b, setupMVCCPebble, benchDataOptions{
+									runMVCCGet(ctx, b, mvccBenchData{
 										numVersions:  numVersions,
 										valueBytes:   valueSize,
 										numRangeKeys: numRangeKeys,
@@ -246,7 +246,7 @@ func BenchmarkMVCCComputeStats_Pebble(b *testing.B) {
 		b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
 			for _, numRangeKeys := range []int{0, 1, 100} {
 				b.Run(fmt.Sprintf("numRangeKeys=%d", numRangeKeys), func(b *testing.B) {
-					runMVCCComputeStats(ctx, b, setupMVCCPebble, valueSize, numRangeKeys)
+					runMVCCComputeStats(ctx, b, valueSize, numRangeKeys)
 				})
 			}
 		})
@@ -258,7 +258,7 @@ func BenchmarkMVCCFindSplitKey_Pebble(b *testing.B) {
 	ctx := context.Background()
 	for _, valueSize := range []int{32} {
 		b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
-			runMVCCFindSplitKey(ctx, b, setupMVCCPebble, valueSize)
+			runMVCCFindSplitKey(ctx, b, valueSize)
 		})
 	}
 }
@@ -418,7 +418,7 @@ func BenchmarkMVCCDeleteRange_Pebble(b *testing.B) {
 	ctx := context.Background()
 	for _, valueSize := range []int{8, 32, 256} {
 		b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
-			runMVCCDeleteRange(ctx, b, setupMVCCPebble, valueSize)
+			runMVCCDeleteRange(ctx, b, valueSize)
 		})
 	}
 }
@@ -433,7 +433,7 @@ func BenchmarkMVCCDeleteRangeUsingTombstone_Pebble(b *testing.B) {
 				b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
 					for _, entireRange := range []bool{false, true} {
 						b.Run(fmt.Sprintf("entireRange=%t", entireRange), func(b *testing.B) {
-							runMVCCDeleteRangeUsingTombstone(ctx, b, setupMVCCPebble, numKeys, valueSize, entireRange)
+							runMVCCDeleteRangeUsingTombstone(ctx, b, numKeys, valueSize, entireRange)
 						})
 					}
 				})
@@ -446,7 +446,7 @@ func BenchmarkClearMVCCVersions_Pebble(b *testing.B) {
 	skip.UnderShort(b)
 	defer log.Scope(b).Close(b)
 	ctx := context.Background()
-	runClearRange(ctx, b, setupMVCCPebble, func(eng Engine, batch Batch, start, end MVCCKey) error {
+	runClearRange(ctx, b, func(eng Engine, batch Batch, start, end MVCCKey) error {
 		return batch.ClearMVCCVersions(start, end)
 	})
 }
@@ -454,7 +454,7 @@ func BenchmarkClearMVCCVersions_Pebble(b *testing.B) {
 func BenchmarkClearMVCCIteratorRange_Pebble(b *testing.B) {
 	ctx := context.Background()
 	defer log.Scope(b).Close(b)
-	runClearRange(ctx, b, setupMVCCPebble, func(eng Engine, batch Batch, start, end MVCCKey) error {
+	runClearRange(ctx, b, func(eng Engine, batch Batch, start, end MVCCKey) error {
 		return batch.ClearMVCCIteratorRange(start.Key, end.Key, true, true)
 	})
 }

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -1474,10 +1474,9 @@ func collectMatchingWithMVCCIterator(
 	return expectedKVs
 }
 
-func runIncrementalBenchmark(
-	b *testing.B, emk engineMaker, ts hlc.Timestamp, opts benchDataOptions,
-) {
-	eng, _ := setupMVCCData(context.Background(), b, emk, opts)
+func runIncrementalBenchmark(b *testing.B, ts hlc.Timestamp, opts mvccBenchData) {
+	eng := getInitialStateEngine(context.Background(), b, opts, false /* inMemory */)
+	defer eng.Close()
 	{
 		// Pull all of the sstables into the cache.  This
 		// probably defeats a lot of the benefits of the
@@ -1487,7 +1486,6 @@ func runIncrementalBenchmark(
 			b.Fatalf("stats failed: %s", err)
 		}
 	}
-	defer eng.Close()
 
 	startKey := roachpb.Key(encoding.EncodeUvarintAscending([]byte("key-"), uint64(0)))
 	endKey := roachpb.Key(encoding.EncodeUvarintAscending([]byte("key-"), uint64(opts.numKeys)))
@@ -1517,26 +1515,11 @@ func BenchmarkMVCCIncrementalIterator(b *testing.B) {
 	numKeys := 1000
 	valueBytes := 1000
 
-	setupMVCCPebbleWithBlockProperties := func(b testing.TB, dir string) Engine {
-		peb, err := Open(
-			context.Background(),
-			Filesystem(dir),
-			CacheSize(testCacheSize),
-			func(cfg *engineConfig) error {
-				cfg.Opts.FormatMajorVersion = pebble.FormatBlockPropertyCollector
-				return nil
-			})
-
-		if err != nil {
-			b.Fatalf("could not create new pebble instance at %s: %+v", dir, err)
-		}
-		return peb
-	}
 	for _, tsExcludePercent := range []float64{0, 0.95} {
 		wallTime := int64((5 * (float64(numVersions)*tsExcludePercent + 1)))
 		ts := hlc.Timestamp{WallTime: wallTime}
 		b.Run(fmt.Sprintf("ts=%d", ts.WallTime), func(b *testing.B) {
-			runIncrementalBenchmark(b, setupMVCCPebbleWithBlockProperties, ts, benchDataOptions{
+			runIncrementalBenchmark(b, ts, mvccBenchData{
 				numVersions: numVersions,
 				numKeys:     numKeys,
 				valueBytes:  valueBytes,

--- a/pkg/storage/open.go
+++ b/pkg/storage/open.go
@@ -181,6 +181,14 @@ func Hook(hookFunc func(*base.StorageConfig) error) ConfigOption {
 	}
 }
 
+// LatestReleaseFormatMajorVersion opens the database already upgraded to the
+// latest release's format major version.
+var LatestReleaseFormatMajorVersion ConfigOption = func(cfg *engineConfig) error {
+	// TODO(jackson): Tie the below to the mapping in SetMinVersion.
+	cfg.PebbleConfig.Opts.FormatMajorVersion = pebble.FormatPrePebblev1Marked // v22.2
+	return nil
+}
+
 // If enables the given option if enable is true.
 func If(enable bool, opt ConfigOption) ConfigOption {
 	if enable {


### PR DESCRIPTION
The MVCC benchmarks in the storage package persist the databases containing the initial test data on the filesystem. This allows subsequent runs of the benchmarks to avoid reconstructing the initial state.

This commit refactors the way this caching works, generalizing it through a getInitialStateEngine function which returns the appropriate engine seeded with the initial database state. It supports defining initial states in terms of one another, avoiding reconstruction of the intermediary states when possible.

Release note: None
Epic: None