### PR TITLE
release-21.2: opt: check for nulls before attempting to fold binary operators

### DIFF
--- a/pkg/sql/opt/norm/comp_funcs.go
+++ b/pkg/sql/opt/norm/comp_funcs.go
@@ -82,6 +82,9 @@ func (c *CustomFuncs) FoldBinaryCheckOverflow(
 	}
 
 	lDatum, rDatum := memo.ExtractConstDatum(left), memo.ExtractConstDatum(right)
+	if lDatum == tree.DNull || rDatum == tree.DNull {
+		return nil, false
+	}
 	result, err := o.Fn(c.f.evalCtx, lDatum, rDatum)
 	if err != nil {
 		return nil, false

--- a/pkg/sql/opt/norm/testdata/rules/comp
+++ b/pkg/sql/opt/norm/testdata/rules/comp
@@ -207,6 +207,17 @@ select
       ├── (s:4::TIME + '05:00:00') < '01:00:00' [outer=(4), stable]
       └── (s:4::TIME + '-05:00:00') < '23:00:00' [outer=(4), stable]
 
+# Regression test for #89024 - don't attempt to evaluate op for NULL values.
+norm expect-not=(NormalizeCmpPlusConst,NormalizeCmpMinusConst,NormalizeCmpConstMinus)
+SELECT 1
+WHERE (parse_time(e'D~<\x0bjN"@y')::TIME - '50 years'::INTERVAL)::TIME <= NULL::TIME
+----
+values
+ ├── columns: "?column?":1!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1)
+
 # --------------------------------------------------
 # NormalizeCmpMinusConst
 # --------------------------------------------------


### PR DESCRIPTION
Backport 1/1 commits from #89047.

/cc @cockroachdb/release

---

This commit adds a check before the call to `eval.BinaryOp` to ensure that the operands are non-null before attempting to fold a plus or minus expression. This prevents a panic that would occur down the stack due to a type assertion that doesn't expect NULL values.

Fixes #89024

Release note: None

Release justification: low-risk bug fix for recent backport
