### PR TITLE
diagrams: Diagrams job no longer fails when no diagrams change

### DIFF
--- a/build/teamcity-diagram-generation.sh
+++ b/build/teamcity-diagram-generation.sh
@@ -34,6 +34,14 @@ tc_end_block "Generate Diagrams"
 tc_start_block "Push Diagrams to Git"
 cd generated-diagrams
 
+changed_diagrams=$(git status --porcelain)
+if [ -z "$changed_diagrams" ]
+then
+	echo "No diagrams changed. Exiting."
+  tc_end_block "Push Diagrams to Git"
+	exit 0
+fi
+
 git add .
 git commit -m "Snapshot $cockroach_ref"
 


### PR DESCRIPTION
If there are PRs that don't affect the diagrams or their related files, the Publish SQL Grammar Diagrams job will fail, because `git commit` produces a non-zero exit code if there are no files changed in the working directory. This fixes that problem.

Release note: None

Fixes DOC-5642