### PR TITLE
*: Implement check constraint validation for new schema changer

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1785,10 +1785,10 @@ func revalidateIndexes(
 
 	// We don't actually need the 'historical' read the way the schema change does
 	// since our table is offline.
-	var runner sqlutil.HistoricalInternalExecTxnRunner = func(ctx context.Context, fn sqlutil.InternalExecFn) error {
+	var runner descs.HistoricalInternalExecTxnRunner = func(ctx context.Context, fn descs.InternalExecFn) error {
 		return execCfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 			ie := job.MakeSessionBoundInternalExecutor(sql.NewFakeSessionData(execCfg.SV())).(*sql.InternalExecutor)
-			return fn(ctx, txn, ie)
+			return fn(ctx, txn, ie, nil /* descriptors */)
 		})
 	}
 

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -975,6 +975,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		ieFactory,
 		sql.ValidateForwardIndexes,
 		sql.ValidateInvertedIndexes,
+		sql.ValidateCheckConstraint,
 		sql.NewFakeSessionData,
 	)
 	execCfg.InternalExecutorFactory = ieFactory

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -165,14 +165,14 @@ func (sc *SchemaChanger) makeFixedTimestampRunner(readAsOf hlc.Timestamp) histor
 // makeFixedTimestampRunner creates a HistoricalTxnRunner suitable for use by the helpers.
 func (sc *SchemaChanger) makeFixedTimestampInternalExecRunner(
 	readAsOf hlc.Timestamp,
-) sqlutil.HistoricalInternalExecTxnRunner {
-	runner := func(ctx context.Context, retryable sqlutil.InternalExecFn) error {
+) descs.HistoricalInternalExecTxnRunner {
+	runner := func(ctx context.Context, retryable descs.InternalExecFn) error {
 		return sc.fixedTimestampTxn(ctx, readAsOf, func(
 			ctx context.Context, txn *kv.Txn, descriptors *descs.Collection,
 		) error {
 			// We need to re-create the evalCtx since the txn may retry.
 			ie := sc.ieFactory.NewInternalExecutor(NewFakeSessionData(sc.execCfg.SV()))
-			return retryable(ctx, txn, ie)
+			return retryable(ctx, txn, ie, nil /* descriptors */)
 		})
 	}
 	return runner
@@ -1527,7 +1527,7 @@ func ValidateInvertedIndexes(
 	codec keys.SQLCodec,
 	tableDesc catalog.TableDescriptor,
 	indexes []catalog.Index,
-	runHistoricalTxn sqlutil.HistoricalInternalExecTxnRunner,
+	runHistoricalTxn descs.HistoricalInternalExecTxnRunner,
 	withFirstMutationPublic bool,
 	gatherAllInvalid bool,
 	execOverride sessiondata.InternalExecutorOverride,
@@ -1553,7 +1553,9 @@ func ValidateInvertedIndexes(
 			span := tableDesc.IndexSpan(codec, idx.GetID())
 			key := span.Key
 			endKey := span.EndKey
-			if err := runHistoricalTxn(ctx, func(ctx context.Context, txn *kv.Txn, _ sqlutil.InternalExecutor) error {
+			if err := runHistoricalTxn(ctx, func(
+				ctx context.Context, txn *kv.Txn, _ sqlutil.InternalExecutor, _ *descs.Collection,
+			) error {
 				for {
 					kvs, err := txn.Scan(ctx, key, endKey, 1000000)
 					if err != nil {
@@ -1620,7 +1622,7 @@ func countExpectedRowsForInvertedIndex(
 	ctx context.Context,
 	tableDesc catalog.TableDescriptor,
 	idx catalog.Index,
-	runHistoricalTxn sqlutil.HistoricalInternalExecTxnRunner,
+	runHistoricalTxn descs.HistoricalInternalExecTxnRunner,
 	withFirstMutationPublic bool,
 	execOverride sessiondata.InternalExecutorOverride,
 ) (int64, error) {
@@ -1659,7 +1661,9 @@ func countExpectedRowsForInvertedIndex(
 	}
 
 	var expectedCount int64
-	if err := runHistoricalTxn(ctx, func(ctx context.Context, txn *kv.Txn, ie sqlutil.InternalExecutor) error {
+	if err := runHistoricalTxn(ctx, func(
+		ctx context.Context, txn *kv.Txn, ie sqlutil.InternalExecutor, _ *descs.Collection,
+	) error {
 		var stmt string
 		geoConfig := idx.GetGeoConfig()
 		if geoConfig.IsEmpty() {
@@ -1714,7 +1718,7 @@ func ValidateForwardIndexes(
 	ctx context.Context,
 	tableDesc catalog.TableDescriptor,
 	indexes []catalog.Index,
-	runHistoricalTxn sqlutil.HistoricalInternalExecTxnRunner,
+	runHistoricalTxn descs.HistoricalInternalExecTxnRunner,
 	withFirstMutationPublic bool,
 	gatherAllInvalid bool,
 	execOverride sessiondata.InternalExecutorOverride,
@@ -1816,7 +1820,7 @@ func populateExpectedCounts(
 	indexes []catalog.Index,
 	partialIndexExpectedCounts map[descpb.IndexID]int64,
 	withFirstMutationPublic bool,
-	runHistoricalTxn sqlutil.HistoricalInternalExecTxnRunner,
+	runHistoricalTxn descs.HistoricalInternalExecTxnRunner,
 	execOverride sessiondata.InternalExecutorOverride,
 ) (int64, error) {
 	desc := tableDesc
@@ -1834,7 +1838,9 @@ func populateExpectedCounts(
 		desc = fakeDesc
 	}
 	var tableRowCount int64
-	if err := runHistoricalTxn(ctx, func(ctx context.Context, txn *kv.Txn, ie sqlutil.InternalExecutor) error {
+	if err := runHistoricalTxn(ctx, func(
+		ctx context.Context, txn *kv.Txn, ie sqlutil.InternalExecutor, _ *descs.Collection,
+	) error {
 		var s strings.Builder
 		for _, idx := range indexes {
 			// For partial indexes, count the number of rows in the table
@@ -1880,7 +1886,7 @@ func countIndexRowsAndMaybeCheckUniqueness(
 	tableDesc catalog.TableDescriptor,
 	idx catalog.Index,
 	withFirstMutationPublic bool,
-	runHistoricalTxn sqlutil.HistoricalInternalExecTxnRunner,
+	runHistoricalTxn descs.HistoricalInternalExecTxnRunner,
 	execOverride sessiondata.InternalExecutorOverride,
 ) (int64, error) {
 	// If we are doing a REGIONAL BY ROW locality change, we can
@@ -1945,7 +1951,9 @@ func countIndexRowsAndMaybeCheckUniqueness(
 
 	// Retrieve the row count in the index.
 	var idxLen int64
-	if err := runHistoricalTxn(ctx, func(ctx context.Context, txn *kv.Txn, ie sqlutil.InternalExecutor) error {
+	if err := runHistoricalTxn(ctx, func(
+		ctx context.Context, txn *kv.Txn, ie sqlutil.InternalExecutor, _ *descs.Collection,
+	) error {
 		query := fmt.Sprintf(`SELECT count(1) FROM [%d AS t]@[%d]`, desc.GetID(), idx.GetID())
 		// If the index is a partial index the predicate must be added
 		// as a filter to the query to force scanning the index.

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1618,6 +1618,19 @@ func ValidateInvertedIndexes(
 	return nil
 }
 
+// ValidateCheckConstraint checks all rows satisfy the check constraint.
+func ValidateCheckConstraint(
+	ctx context.Context,
+	tableDesc catalog.TableDescriptor,
+	constraint *descpb.ConstraintDetail,
+	sessionData *sessiondata.SessionData,
+	runHistoricalTxn descs.HistoricalInternalExecTxnRunner,
+	execOverride sessiondata.InternalExecutorOverride,
+) (err error) {
+	// TODO (xiang): implement this.
+	return nil
+}
+
 func countExpectedRowsForInvertedIndex(
 	ctx context.Context,
 	tableDesc catalog.TableDescriptor,

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -611,3 +612,11 @@ func MakeTestCollection(ctx context.Context, leaseManager *lease.Manager) Collec
 		leased:   makeLeasedDescriptors(leaseManager),
 	}
 }
+
+// InternalExecFn is the type of functions that operates using an internalExecutor.
+type InternalExecFn func(ctx context.Context, txn *kv.Txn, ie sqlutil.InternalExecutor, descriptors *Collection) error
+
+// HistoricalInternalExecTxnRunner is like historicalTxnRunner except it only
+// passes the fn the exported InternalExecutor and *Collection, instead of
+// the whole unexported extendedEvalContenxt, so it can be implemented outside pkg/sql.
+type HistoricalInternalExecTxnRunner func(ctx context.Context, fn InternalExecFn) error

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -970,6 +970,17 @@ func (s *TestState) Validator() scexec.Validator {
 	return s
 }
 
+// ValidateCheckConstraint implements the validator interface.
+func (s *TestState) ValidateCheckConstraint(
+	ctx context.Context,
+	tbl catalog.TableDescriptor,
+	constraint *descpb.ConstraintDetail,
+	override sessiondata.InternalExecutorOverride,
+) error {
+	s.LogSideEffectf("validate check constraint %v in table #%d", constraint.GetConstraintName(), tbl.GetID())
+	return nil
+}
+
 // LogEvent implements scexec.EventLogger.
 func (s *TestState) LogEvent(
 	_ context.Context, details eventpb.CommonSQLEventDetails, event logpb.EventPayload,

--- a/pkg/sql/schemachanger/scexec/dependencies.go
+++ b/pkg/sql/schemachanger/scexec/dependencies.go
@@ -211,6 +211,13 @@ type Validator interface {
 		indexes []catalog.Index,
 		override sessiondata.InternalExecutorOverride,
 	) error
+
+	ValidateCheckConstraint(
+		ctx context.Context,
+		tbl catalog.TableDescriptor,
+		constraint *descpb.ConstraintDetail,
+		override sessiondata.InternalExecutorOverride,
+	) error
 }
 
 // IndexSpanSplitter can try to split an index span in the current transaction

--- a/pkg/sql/schemachanger/scexec/executor_external_test.go
+++ b/pkg/sql/schemachanger/scexec/executor_external_test.go
@@ -483,6 +483,15 @@ func (noopValidator) ValidateInvertedIndexes(
 	return nil
 }
 
+func (noopValidator) ValidateCheckConstraint(
+	ctx context.Context,
+	tbl catalog.TableDescriptor,
+	constraint *descpb.ConstraintDetail,
+	override sessiondata.InternalExecutorOverride,
+) error {
+	return nil
+}
+
 type noopEventLogger struct{}
 
 var _ scexec.EventLogger = noopEventLogger{}

--- a/pkg/sql/sqlutil/internal_executor.go
+++ b/pkg/sql/sqlutil/internal_executor.go
@@ -232,14 +232,6 @@ type InternalExecutorFactory interface {
 	TxnWithExecutor(context.Context, *kv.DB, *sessiondata.SessionData, func(context.Context, *kv.Txn, InternalExecutor) error, ...TxnOption) error
 }
 
-// InternalExecFn is the type of functions that operates using an internalExecutor.
-type InternalExecFn func(ctx context.Context, txn *kv.Txn, ie InternalExecutor) error
-
-// HistoricalInternalExecTxnRunner is like historicalTxnRunner except it only
-// passes the fn the exported InternalExecutor instead of the whole unexported
-// extendedEvalContenxt, so it can be implemented outside pkg/sql.
-type HistoricalInternalExecTxnRunner func(ctx context.Context, fn InternalExecFn) error
-
 // TxnOption is used to configure a Txn or TxnWithExecutor.
 type TxnOption interface {
 	Apply(*TxnConfig)


### PR DESCRIPTION
See each commit message for details.

Commit 1: preparation work where we augmented an existing type definition.

Commit 2: add a `ValidateCheckConstraint` method to interface `Validator`
with empty implementations.

Commit 3: actually implement the logic for validating check constraint.

Informs #89665