### PR TITLE
roachtest: add `backup/mvcc-range-tombstones`

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -191,6 +191,7 @@ go_library(
         "//pkg/security/username",
         "//pkg/server",
         "//pkg/server/serverpb",
+        "//pkg/sql",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/testutils",


### PR DESCRIPTION
This patch adds a roachtest to ensure backup and restore works as expected in the presence of MVCC range tombstones. It uses data from TPCH's order table, 16 GB across 8 CSV files.

1. Import half of the `tpch.orders` table (odd-numbered files).
2. Take fingerprint, time 'initial'.
3. Take a full database backup.
4. Import the other half (even-numbered files), but cancel the import and roll the data back using MVCC range tombstones. Done twice.
5. Take fingerprint, time 'canceled'.
6. Successfully import the other half.
7. Take fingerprint, time 'completed'.
8. Drop the table and wait for deletion with MVCC range tombstone.
9. Take an incremental database backup with revision history.

It then does point-in-time restores of the database at times 'initial', 'canceled', 'completed', and the latest time, and compares the fingerprints to the original data.

Resolves #89644.

Release note: None