### PR TITLE
kvserver: remove unused Protobuf import

### DIFF
--- a/pkg/kv/kvserver/api.proto
+++ b/pkg/kv/kvserver/api.proto
@@ -13,7 +13,6 @@ package cockroach.kv.kvserver;
 option go_package = "kvserver";
 
 import "roachpb/data.proto";
-import "roachpb/internal_raft.proto";
 import "storage/enginepb/mvcc.proto";
 import "storage/enginepb/mvcc3.proto";
 import "gogoproto/gogo.proto";


### PR DESCRIPTION
Resolves the following build error:

```
INFO: From Generating Descriptor Set proto_library //pkg/kv/kvserver:kvserver_proto:
kv/kvserver/api.proto:16:1: warning: Import roachpb/internal_raft.proto but not used.
```

Epic: None

Release note: None