### PR TITLE
backupccl: add dropping incremental backup schedule when dropping full backup schedule

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/alter-schedule/missing-schedule
+++ b/pkg/ccl/backupccl/testdata/backup-restore/alter-schedule/missing-schedule
@@ -21,22 +21,6 @@ exec-sql
 drop schedule $fullID
 ----
 
-# The schedule is now in an invalid state.
-
-query-sql
-with schedules as (show schedules) select id, state, recurrence, owner, command from schedules where label='datatest' order by command->>'backup_type' asc;
-----
-$incID Waiting for initial backup to complete @daily root {"backup_statement": "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH detached", "backup_type": 1, "chain_protected_timestamp_records": true}
-
-exec-sql expect-error-regex=(pq: incremental backup schedule \d* has no corresponding full backup schedule; drop schedule \d* and recreate)
-alter backup schedule $incID set recurring '@hourly';
-----
-regex matches error
-
-exec-sql
-drop schedule $incID
-----
-
 # Test that dropping the incremental backup is not an issue.
 
 exec-sql

--- a/pkg/ccl/backupccl/testdata/backup-restore/drop-schedule-backup
+++ b/pkg/ccl/backupccl/testdata/backup-restore/drop-schedule-backup
@@ -1,0 +1,31 @@
+# These tests validate the DROP SCHEDULE command for dropping the incremental scheduled
+# backup when the full scheduled backup is dropped.
+
+new-server name=s1
+----
+
+exec-sql
+CREATE DATABASE foo;
+CREATE TABLE foo.t (x INT);
+INSERT INTO foo.t VALUES (1), (2), (3);
+----
+
+exec-sql
+CREATE SCHEDULE 'hello' FOR BACKUP DATABASE foo INTO 'userfile:///newbackup' WITH revision_history RECURRING '@daily';
+----
+
+query-sql
+SELECT recurrence FROM [SHOW SCHEDULES] WHERE label='hello';
+----
+@daily
+@weekly
+
+exec-sql
+DROP SCHEDULES WITH x AS (SHOW SCHEDULES) SELECT id FROM x WHERE label='hello' AND recurrence='@weekly';
+----
+
+query-sql
+SELECT * FROM [SHOW SCHEDULES] WHERE label='hello';
+----
+
+

--- a/pkg/ccl/backupccl/testdata/backup-restore/schedule-privileges
+++ b/pkg/ccl/backupccl/testdata/backup-restore/schedule-privileges
@@ -126,14 +126,23 @@ query-sql
 with schedules as (SHOW SCHEDULES FOR BACKUP) SELECT label,command,owner FROM schedules WHERE id IN
 ($fullID, $incID) ORDER BY next_run;
 ----
-foocluster_admin BACKUP INTO LATEST IN 'external://foo/cluster' WITH detached root
 
 exec-sql
 REVOKE ADMIN FROM testuser
 ----
 
+# create new admin scheduled backup
+exec-sql
+CREATE SCHEDULE foocluster_admin_revoke FOR BACKUP INTO 'external://foo/cluster2' RECURRING '@hourly';
+----
+
+# Save the schedule IDs for the schedules created by admin root.
+let $otherFullID $otherIncID
+with schedules as (show schedules) select id from schedules where label='foocluster_admin_revoke' order by command->>'backup_type' asc;
+----
+
 exec-sql expect-error-regex=(must be admin or owner of the schedule [0-9]+ to DROP it) user=testuser
-DROP SCHEDULE $incID
+DROP SCHEDULE $otherFullID
 ----
 regex matches error
 
@@ -172,22 +181,17 @@ DROP SCHEDULE $testuserIncID;
 
 # But testuser can't drop, alter, resume or pause the root owned schedules.
 exec-sql expect-error-regex=(must be admin or owner of the schedule [0-9]+ to PAUSE it) user=testuser
-PAUSE SCHEDULE $incID
+PAUSE SCHEDULE $otherFullID
 ----
 regex matches error
 
 exec-sql expect-error-regex=(must be admin or owner of the schedule [0-9]+ to RESUME it) user=testuser
-RESUME SCHEDULE $incID
-----
-regex matches error
-
-exec-sql user=testuser expect-error-regex=(incremental backup schedule [0-9]+ has no corresponding full backup schedule)
-ALTER BACKUP SCHEDULE $incID SET WITH revision_history = false;
+RESUME SCHEDULE $otherFullID
 ----
 regex matches error
 
 exec-sql expect-error-regex=(must be admin or owner of the schedule [0-9]+ to DROP it) user=testuser
-DROP SCHEDULE $incID;
+DROP SCHEDULE $otherFullID;
 ----
 regex matches error
 

--- a/pkg/jobs/scheduled_job_executor.go
+++ b/pkg/jobs/scheduled_job_executor.go
@@ -69,7 +69,8 @@ type ScheduledJobExecutor interface {
 // when controlling a scheduled job.
 type ScheduledJobController interface {
 	// OnDrop runs before the passed in `schedule` is dropped as part of a `DROP
-	// SCHEDULE` query.
+	// SCHEDULE` query. OnDrop may drop the schedule's dependent schedules and will
+	// return the number of additional schedules it drops.
 	OnDrop(
 		ctx context.Context,
 		scheduleControllerEnv scheduledjobs.ScheduleControllerEnv,
@@ -77,7 +78,7 @@ type ScheduledJobController interface {
 		schedule *ScheduledJob,
 		txn *kv.Txn,
 		descsCol *descs.Collection,
-	) error
+	) (int, error)
 }
 
 // ScheduledJobExecutorFactory is a callback to create a ScheduledJobExecutor.

--- a/pkg/sql/catalog/schematelemetry/scheduled_job_executor.go
+++ b/pkg/sql/catalog/schematelemetry/scheduled_job_executor.go
@@ -51,8 +51,8 @@ func (s schemaTelemetryExecutor) OnDrop(
 	schedule *jobs.ScheduledJob,
 	txn *kv.Txn,
 	descsCol *descs.Collection,
-) error {
-	return errScheduleUndroppable
+) (int, error) {
+	return 0, errScheduleUndroppable
 }
 
 var errScheduleUndroppable = errors.New("SQL schema telemetry schedule cannot be dropped")

--- a/pkg/sql/compact_sql_stats.go
+++ b/pkg/sql/compact_sql_stats.go
@@ -167,8 +167,8 @@ func (e *scheduledSQLStatsCompactionExecutor) OnDrop(
 	schedule *jobs.ScheduledJob,
 	txn *kv.Txn,
 	descsCol *descs.Collection,
-) error {
-	return persistedsqlstats.ErrScheduleUndroppable
+) (int, error) {
+	return 0, persistedsqlstats.ErrScheduleUndroppable
 }
 
 // ExecuteJob implements the jobs.ScheduledJobExecutor interface.

--- a/pkg/sql/ttl/ttlschedule/ttlschedule.go
+++ b/pkg/sql/ttl/ttlschedule/ttlschedule.go
@@ -58,24 +58,24 @@ func (s rowLevelTTLExecutor) OnDrop(
 	schedule *jobs.ScheduledJob,
 	txn *kv.Txn,
 	descsCol *descs.Collection,
-) error {
+) (int, error) {
 
 	var args catpb.ScheduledRowLevelTTLArgs
 	if err := pbtypes.UnmarshalAny(schedule.ExecutionArgs().Args, &args); err != nil {
-		return err
+		return 0, err
 	}
 
 	canDrop, err := canDropTTLSchedule(ctx, txn, descsCol, schedule, args)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	if !canDrop {
 		tn, err := descs.GetTableNameByID(ctx, txn, descsCol, args.TableID)
 		if err != nil {
-			return err
+			return 0, err
 		}
-		return errors.WithHintf(
+		return 0, errors.WithHintf(
 			pgerror.Newf(
 				pgcode.InvalidTableDefinition,
 				"cannot drop a row level TTL schedule",
@@ -84,7 +84,7 @@ func (s rowLevelTTLExecutor) OnDrop(
 			tn.FQString(),
 		)
 	}
-	return nil
+	return 0, nil
 }
 
 // canDropTTLSchedule determines whether we can drop a given row-level TTL


### PR DESCRIPTION
Fixes #87435

Release note (sql change): Previously, whenever a user dropped a scheduled full backup, the corresponding scheduled incremental backup would not be dropped. This change drops the associated scheduled incremental backup when `DROP SCHEDULE` or `DROP SCHEDULES` is called.