### PR TITLE
kvserver: update storepool after relocate range

### DIFF
--- a/pkg/kv/kvserver/asim/storerebalancer/store_rebalancer.go
+++ b/pkg/kv/kvserver/asim/storerebalancer/store_rebalancer.go
@@ -57,6 +57,7 @@ type storeRebalancerState struct {
 
 	pendingRelocate, pendingTransfer kvserver.CandidateReplica
 	pendingRelocateTargets           []roachpb.ReplicationTarget
+	pendingRelocateExistingVoters    []roachpb.ReplicaDescriptor
 	pendingTransferTarget            roachpb.ReplicaDescriptor
 
 	pendingTicket op.DispatchedTicket
@@ -304,6 +305,9 @@ func (src *storeRebalancerControl) checkPendingRangeRebalance() bool {
 			src.rebalancerState.rctx,
 			src.rebalancerState.pendingRelocate,
 			src.rebalancerState.pendingRelocateTargets,
+			[]roachpb.ReplicationTarget{}, /* non-voter targets */
+			src.rebalancerState.pendingRelocateExistingVoters,
+			[]roachpb.ReplicaDescriptor{}, /* old non-voters */
 		)
 	}
 
@@ -335,6 +339,7 @@ func (src *storeRebalancerControl) applyRangeRebalance(
 	ticket := src.controller.Dispatch(ctx, tick, s, relocateOp)
 	src.rebalancerState.pendingRelocate = candidateReplica
 	src.rebalancerState.pendingRelocateTargets = voterTargets
+	src.rebalancerState.pendingRelocateExistingVoters = candidateReplica.Desc().Replicas().VoterDescriptors()
 	src.rebalancerState.pendingTicket = ticket
 }
 


### PR DESCRIPTION
Previously, after a range relocation via the store rebalancer, no update to the storepool would be made. It was therefore possible to have conflicting views of the cluster capacity between the allocator, picking targets and the store rebalancer loop.

This patch adds updates to the storepool on a store rebalancer relocate range. This also updates the store rebalancer to "refresh" the rebalance context with the latest storepool values, rather than maintain custom logic locally.

resolves: #89397

Release note: None