### PR TITLE
kvserver: fix allocator determinism

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_scorer.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_scorer.go
@@ -1396,7 +1396,18 @@ func rankedCandidateListForRebalancing(
 
 	var equivalenceClasses []equivalenceClass
 	var needRebalanceTo bool
-	for _, existing := range existingStores {
+	existingStoreList := []roachpb.StoreID{}
+	for storeID := range existingStores {
+		existingStoreList = append(existingStoreList, storeID)
+	}
+	if options.deterministicForTesting() {
+		sort.Slice(
+			existingStoreList,
+			func(i, j int) bool { return existingStoreList[i] < existingStoreList[j] },
+		)
+	}
+	for _, storeID := range existingStoreList {
+		existing := existingStores[storeID]
 		var comparableCands candidateList
 		for _, store := range allStores.Stores {
 			// Only process replacement candidates, not existing stores.


### PR DESCRIPTION
Previously, the allocator when running in deterministic mode, would not be deterministic under all scenarios due to iteration over an unordered map. This patch fixes this by first sorting entries, before iterating.

resolves: cockroachdb#89394

Release note: None