### PR TITLE
opt: fix UPDATE .. FROM with hidden PK columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/update_from
+++ b/pkg/sql/logictest/testdata/logic_test/update_from
@@ -169,3 +169,14 @@ a  b    c    a  b    a  c
 # Make sure the FROM clause cannot reference the target table.
 statement error no data source matches prefix: abc
 UPDATE abc SET a = other.a FROM (SELECT abc.a FROM abc AS x) AS other WHERE abc.a=other.a
+
+# Regression test for #89779. Do not update the same row twice when the target
+# table has a hidden PK column.
+statement ok
+CREATE TABLE t89779 (a INT);
+INSERT INTO t89779 VALUES (1)
+
+query I
+UPDATE t89779 SET a = 2 FROM (VALUES (1), (1)) v(i) WHERE a = i RETURNING a
+----
+2

--- a/pkg/sql/opt/exec/execbuilder/testdata/unique
+++ b/pkg/sql/opt/exec/execbuilder/testdata/unique
@@ -1862,17 +1862,20 @@ vectorized: true
 │   └── • buffer
 │       │ label: buffer 1
 │       │
-│       └── • cross join
+│       └── • distinct
+│           │ distinct on: rowid
 │           │
-│           ├── • scan
-│           │     missing stats
-│           │     table: uniq_hidden_pk@uniq_hidden_pk_pkey
-│           │     spans: FULL SCAN
-│           │
-│           └── • scan
-│                 missing stats
-│                 table: other@other_pkey
-│                 spans: FULL SCAN
+│           └── • cross join
+│               │
+│               ├── • scan
+│               │     missing stats
+│               │     table: uniq_hidden_pk@uniq_hidden_pk_pkey
+│               │     spans: FULL SCAN
+│               │
+│               └── • scan
+│                     missing stats
+│                     table: other@other_pkey
+│                     spans: FULL SCAN
 │
 ├── • constraint-check
 │   │

--- a/pkg/sql/opt/memo/testdata/stats/update
+++ b/pkg/sql/opt/memo/testdata/stats/update
@@ -149,12 +149,12 @@ WITH q AS (UPDATE child SET c = p FROM parent WHERE p = 1 RETURNING p) SELECT * 
 with &2 (q)
  ├── columns: p:18(int!null)
  ├── volatile, mutations
- ├── stats: [rows=1000, distinct(18)=1, null(18)=0]
+ ├── stats: [rows=1, distinct(18)=1, null(18)=0]
  ├── fd: ()-->(18)
  ├── project
  │    ├── columns: parent.p:11(int)
  │    ├── volatile, mutations
- │    ├── stats: [rows=1000, distinct(11)=1, null(11)=0]
+ │    ├── stats: [rows=632.3046, distinct(11)=632.305, null(11)=0]
  │    ├── fd: ()-->(11)
  │    └── update child
  │         ├── columns: x:1(int) child.c:2(int!null) rowid:3(int!null) parent.p:11(int) parent.crdb_internal_mvcc_timestamp:12(decimal) parent.tableoid:13(oid)
@@ -168,32 +168,53 @@ with &2 (q)
  │         │    └── rowid:8 => rowid:3
  │         ├── input binding: &1
  │         ├── volatile, mutations
- │         ├── stats: [rows=1000, distinct(11)=1, null(11)=0]
+ │         ├── stats: [rows=632.3046, distinct(11)=632.305, null(11)=0]
  │         ├── key: (3)
  │         ├── fd: ()-->(2,11-13), (2)==(11), (11)==(2), (3)-->(1)
- │         ├── select
+ │         ├── distinct-on
  │         │    ├── columns: x:6(int) child.c:7(int) rowid:8(int!null) child.crdb_internal_mvcc_timestamp:9(decimal) child.tableoid:10(oid) parent.p:11(int!null) parent.crdb_internal_mvcc_timestamp:12(decimal) parent.tableoid:13(oid)
- │         │    ├── stats: [rows=1000, distinct(11)=1, null(11)=0]
+ │         │    ├── grouping columns: rowid:8(int!null)
+ │         │    ├── stats: [rows=632.3046, distinct(8)=632.305, null(8)=0, distinct(11)=632.305, null(11)=0]
  │         │    ├── key: (8)
- │         │    ├── fd: ()-->(11-13), (8)-->(6,7,9,10)
- │         │    ├── inner-join (cross)
+ │         │    ├── fd: ()-->(11-13), (8)-->(6,7,9-13)
+ │         │    ├── select
  │         │    │    ├── columns: x:6(int) child.c:7(int) rowid:8(int!null) child.crdb_internal_mvcc_timestamp:9(decimal) child.tableoid:10(oid) parent.p:11(int!null) parent.crdb_internal_mvcc_timestamp:12(decimal) parent.tableoid:13(oid)
- │         │    │    ├── stats: [rows=1000000, distinct(8)=1000, null(8)=0, distinct(11)=1000, null(11)=0]
- │         │    │    ├── key: (8,11)
- │         │    │    ├── fd: (8)-->(6,7,9,10), (11)-->(12,13)
- │         │    │    ├── scan child
- │         │    │    │    ├── columns: x:6(int) child.c:7(int) rowid:8(int!null) child.crdb_internal_mvcc_timestamp:9(decimal) child.tableoid:10(oid)
- │         │    │    │    ├── stats: [rows=1000, distinct(8)=1000, null(8)=0]
- │         │    │    │    ├── key: (8)
- │         │    │    │    └── fd: (8)-->(6,7,9,10)
- │         │    │    ├── scan parent
- │         │    │    │    ├── columns: parent.p:11(int!null) parent.crdb_internal_mvcc_timestamp:12(decimal) parent.tableoid:13(oid)
- │         │    │    │    ├── stats: [rows=1000, distinct(11)=1000, null(11)=0]
- │         │    │    │    ├── key: (11)
- │         │    │    │    └── fd: (11)-->(12,13)
- │         │    │    └── filters (true)
- │         │    └── filters
- │         │         └── parent.p:11 = 1 [type=bool, outer=(11), constraints=(/11: [/1 - /1]; tight), fd=()-->(11)]
+ │         │    │    ├── stats: [rows=1000, distinct(8)=632.305, null(8)=0, distinct(11)=1, null(11)=0]
+ │         │    │    ├── key: (8)
+ │         │    │    ├── fd: ()-->(11-13), (8)-->(6,7,9,10)
+ │         │    │    ├── inner-join (cross)
+ │         │    │    │    ├── columns: x:6(int) child.c:7(int) rowid:8(int!null) child.crdb_internal_mvcc_timestamp:9(decimal) child.tableoid:10(oid) parent.p:11(int!null) parent.crdb_internal_mvcc_timestamp:12(decimal) parent.tableoid:13(oid)
+ │         │    │    │    ├── stats: [rows=1000000, distinct(8)=1000, null(8)=0, distinct(11)=1000, null(11)=0]
+ │         │    │    │    ├── key: (8,11)
+ │         │    │    │    ├── fd: (8)-->(6,7,9,10), (11)-->(12,13)
+ │         │    │    │    ├── scan child
+ │         │    │    │    │    ├── columns: x:6(int) child.c:7(int) rowid:8(int!null) child.crdb_internal_mvcc_timestamp:9(decimal) child.tableoid:10(oid)
+ │         │    │    │    │    ├── stats: [rows=1000, distinct(8)=1000, null(8)=0]
+ │         │    │    │    │    ├── key: (8)
+ │         │    │    │    │    └── fd: (8)-->(6,7,9,10)
+ │         │    │    │    ├── scan parent
+ │         │    │    │    │    ├── columns: parent.p:11(int!null) parent.crdb_internal_mvcc_timestamp:12(decimal) parent.tableoid:13(oid)
+ │         │    │    │    │    ├── stats: [rows=1000, distinct(11)=1000, null(11)=0]
+ │         │    │    │    │    ├── key: (11)
+ │         │    │    │    │    └── fd: (11)-->(12,13)
+ │         │    │    │    └── filters (true)
+ │         │    │    └── filters
+ │         │    │         └── parent.p:11 = 1 [type=bool, outer=(11), constraints=(/11: [/1 - /1]; tight), fd=()-->(11)]
+ │         │    └── aggregations
+ │         │         ├── first-agg [as=x:6, type=int, outer=(6)]
+ │         │         │    └── x:6 [type=int]
+ │         │         ├── first-agg [as=child.c:7, type=int, outer=(7)]
+ │         │         │    └── child.c:7 [type=int]
+ │         │         ├── first-agg [as=child.crdb_internal_mvcc_timestamp:9, type=decimal, outer=(9)]
+ │         │         │    └── child.crdb_internal_mvcc_timestamp:9 [type=decimal]
+ │         │         ├── first-agg [as=child.tableoid:10, type=oid, outer=(10)]
+ │         │         │    └── child.tableoid:10 [type=oid]
+ │         │         ├── first-agg [as=parent.p:11, type=int, outer=(11)]
+ │         │         │    └── parent.p:11 [type=int]
+ │         │         ├── first-agg [as=parent.crdb_internal_mvcc_timestamp:12, type=decimal, outer=(12)]
+ │         │         │    └── parent.crdb_internal_mvcc_timestamp:12 [type=decimal]
+ │         │         └── first-agg [as=parent.tableoid:13, type=oid, outer=(13)]
+ │         │              └── parent.tableoid:13 [type=oid]
  │         └── f-k-checks
  │              └── f-k-checks-item: child(c) -> parent(p)
  │                   └── anti-join (hash)
@@ -204,7 +225,7 @@ with &2 (q)
  │                        │    ├── columns: c:14(int!null)
  │                        │    ├── mapping:
  │                        │    │    └──  parent.p:11(int) => c:14(int)
- │                        │    ├── stats: [rows=1000, distinct(14)=1, null(14)=0]
+ │                        │    ├── stats: [rows=632.3046, distinct(14)=632.305, null(14)=0]
  │                        │    └── fd: ()-->(14)
  │                        ├── scan parent
  │                        │    ├── columns: parent.p:15(int!null)
@@ -214,13 +235,13 @@ with &2 (q)
  │                             └── c:14 = parent.p:15 [type=bool, outer=(14,15), constraints=(/14: (/NULL - ]; /15: (/NULL - ]), fd=(14)==(15), (15)==(14)]
  └── select
       ├── columns: p:18(int!null)
-      ├── stats: [rows=1000, distinct(18)=1, null(18)=0]
+      ├── stats: [rows=1, distinct(18)=1, null(18)=0]
       ├── fd: ()-->(18)
       ├── with-scan &2 (q)
       │    ├── columns: p:18(int)
       │    ├── mapping:
       │    │    └──  parent.p:11(int) => p:18(int)
-      │    ├── stats: [rows=1000, distinct(18)=1, null(18)=0]
+      │    ├── stats: [rows=632.3046, distinct(18)=632.305, null(18)=0]
       │    └── fd: ()-->(18)
       └── filters
            └── p:18 = 1 [type=bool, outer=(18), constraints=(/18: [/1 - /1]; tight), fd=()-->(18)]

--- a/pkg/sql/opt/optbuilder/testdata/partial-indexes
+++ b/pkg/sql/opt/optbuilder/testdata/partial-indexes
@@ -573,21 +573,33 @@ project
            ├── columns: partial_index_put1:11!null partial_index_del1:12!null a:5!null rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8 column1:9!null a_cast:10!null
            ├── project
            │    ├── columns: a_cast:10!null a:5!null rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8 column1:9!null
-           │    ├── select
+           │    ├── distinct-on
            │    │    ├── columns: a:5!null rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8 column1:9!null
-           │    │    ├── inner-join (cross)
-           │    │    │    ├── columns: a:5 rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8 column1:9!null
-           │    │    │    ├── scan t61520 [as=t]
-           │    │    │    │    ├── columns: a:5 rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
-           │    │    │    │    └── partial index predicates
-           │    │    │    │         └── t61520_a_idx: filters
-           │    │    │    │              └── a:5 > 0
-           │    │    │    ├── values
-           │    │    │    │    ├── columns: column1:9!null
-           │    │    │    │    └── (1.0,)
-           │    │    │    └── filters (true)
-           │    │    └── filters
-           │    │         └── a:5 = column1:9
+           │    │    ├── grouping columns: rowid:6!null
+           │    │    ├── select
+           │    │    │    ├── columns: a:5!null rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8 column1:9!null
+           │    │    │    ├── inner-join (cross)
+           │    │    │    │    ├── columns: a:5 rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8 column1:9!null
+           │    │    │    │    ├── scan t61520 [as=t]
+           │    │    │    │    │    ├── columns: a:5 rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
+           │    │    │    │    │    └── partial index predicates
+           │    │    │    │    │         └── t61520_a_idx: filters
+           │    │    │    │    │              └── a:5 > 0
+           │    │    │    │    ├── values
+           │    │    │    │    │    ├── columns: column1:9!null
+           │    │    │    │    │    └── (1.0,)
+           │    │    │    │    └── filters (true)
+           │    │    │    └── filters
+           │    │    │         └── a:5 = column1:9
+           │    │    └── aggregations
+           │    │         ├── first-agg [as=a:5]
+           │    │         │    └── a:5
+           │    │         ├── first-agg [as=crdb_internal_mvcc_timestamp:7]
+           │    │         │    └── crdb_internal_mvcc_timestamp:7
+           │    │         ├── first-agg [as=tableoid:8]
+           │    │         │    └── tableoid:8
+           │    │         └── first-agg [as=column1:9]
+           │    │              └── column1:9
            │    └── projections
            │         └── assignment-cast: DECIMAL(10,2) [as=a_cast:10]
            │              └── column1:9

--- a/pkg/sql/opt/optbuilder/testdata/unique-checks-update
+++ b/pkg/sql/opt/optbuilder/testdata/unique-checks-update
@@ -581,13 +581,45 @@ update uniq_hidden_pk
  ├── update-mapping:
  │    └── k:15 => uniq_hidden_pk.a:1
  ├── input binding: &1
- ├── inner-join (cross)
+ ├── distinct-on
  │    ├── columns: uniq_hidden_pk.a:8 uniq_hidden_pk.b:9 uniq_hidden_pk.c:10 uniq_hidden_pk.d:11 uniq_hidden_pk.rowid:12!null uniq_hidden_pk.crdb_internal_mvcc_timestamp:13 uniq_hidden_pk.tableoid:14 k:15 v:16 w:17!null x:18 y:19 other.rowid:20!null other.crdb_internal_mvcc_timestamp:21 other.tableoid:22
- │    ├── scan uniq_hidden_pk
- │    │    └── columns: uniq_hidden_pk.a:8 uniq_hidden_pk.b:9 uniq_hidden_pk.c:10 uniq_hidden_pk.d:11 uniq_hidden_pk.rowid:12!null uniq_hidden_pk.crdb_internal_mvcc_timestamp:13 uniq_hidden_pk.tableoid:14
- │    ├── scan other
- │    │    └── columns: k:15 v:16 w:17!null x:18 y:19 other.rowid:20!null other.crdb_internal_mvcc_timestamp:21 other.tableoid:22
- │    └── filters (true)
+ │    ├── grouping columns: uniq_hidden_pk.rowid:12!null
+ │    ├── inner-join (cross)
+ │    │    ├── columns: uniq_hidden_pk.a:8 uniq_hidden_pk.b:9 uniq_hidden_pk.c:10 uniq_hidden_pk.d:11 uniq_hidden_pk.rowid:12!null uniq_hidden_pk.crdb_internal_mvcc_timestamp:13 uniq_hidden_pk.tableoid:14 k:15 v:16 w:17!null x:18 y:19 other.rowid:20!null other.crdb_internal_mvcc_timestamp:21 other.tableoid:22
+ │    │    ├── scan uniq_hidden_pk
+ │    │    │    └── columns: uniq_hidden_pk.a:8 uniq_hidden_pk.b:9 uniq_hidden_pk.c:10 uniq_hidden_pk.d:11 uniq_hidden_pk.rowid:12!null uniq_hidden_pk.crdb_internal_mvcc_timestamp:13 uniq_hidden_pk.tableoid:14
+ │    │    ├── scan other
+ │    │    │    └── columns: k:15 v:16 w:17!null x:18 y:19 other.rowid:20!null other.crdb_internal_mvcc_timestamp:21 other.tableoid:22
+ │    │    └── filters (true)
+ │    └── aggregations
+ │         ├── first-agg [as=uniq_hidden_pk.a:8]
+ │         │    └── uniq_hidden_pk.a:8
+ │         ├── first-agg [as=uniq_hidden_pk.b:9]
+ │         │    └── uniq_hidden_pk.b:9
+ │         ├── first-agg [as=uniq_hidden_pk.c:10]
+ │         │    └── uniq_hidden_pk.c:10
+ │         ├── first-agg [as=uniq_hidden_pk.d:11]
+ │         │    └── uniq_hidden_pk.d:11
+ │         ├── first-agg [as=uniq_hidden_pk.crdb_internal_mvcc_timestamp:13]
+ │         │    └── uniq_hidden_pk.crdb_internal_mvcc_timestamp:13
+ │         ├── first-agg [as=uniq_hidden_pk.tableoid:14]
+ │         │    └── uniq_hidden_pk.tableoid:14
+ │         ├── first-agg [as=k:15]
+ │         │    └── k:15
+ │         ├── first-agg [as=v:16]
+ │         │    └── v:16
+ │         ├── first-agg [as=w:17]
+ │         │    └── w:17
+ │         ├── first-agg [as=x:18]
+ │         │    └── x:18
+ │         ├── first-agg [as=y:19]
+ │         │    └── y:19
+ │         ├── first-agg [as=other.rowid:20]
+ │         │    └── other.rowid:20
+ │         ├── first-agg [as=other.crdb_internal_mvcc_timestamp:21]
+ │         │    └── other.crdb_internal_mvcc_timestamp:21
+ │         └── first-agg [as=other.tableoid:22]
+ │              └── other.tableoid:22
  └── unique-checks
       ├── unique-checks-item: uniq_hidden_pk(a,b,d)
       │    └── project
@@ -1081,13 +1113,41 @@ update uniq_partial_hidden_pk
  ├── update-mapping:
  │    └── k:11 => uniq_partial_hidden_pk.a:1
  ├── input binding: &1
- ├── inner-join (cross)
+ ├── distinct-on
  │    ├── columns: uniq_partial_hidden_pk.a:6 uniq_partial_hidden_pk.b:7 uniq_partial_hidden_pk.rowid:8!null uniq_partial_hidden_pk.crdb_internal_mvcc_timestamp:9 uniq_partial_hidden_pk.tableoid:10 k:11 v:12 w:13!null x:14 y:15 other.rowid:16!null other.crdb_internal_mvcc_timestamp:17 other.tableoid:18
- │    ├── scan uniq_partial_hidden_pk
- │    │    └── columns: uniq_partial_hidden_pk.a:6 uniq_partial_hidden_pk.b:7 uniq_partial_hidden_pk.rowid:8!null uniq_partial_hidden_pk.crdb_internal_mvcc_timestamp:9 uniq_partial_hidden_pk.tableoid:10
- │    ├── scan other
- │    │    └── columns: k:11 v:12 w:13!null x:14 y:15 other.rowid:16!null other.crdb_internal_mvcc_timestamp:17 other.tableoid:18
- │    └── filters (true)
+ │    ├── grouping columns: uniq_partial_hidden_pk.rowid:8!null
+ │    ├── inner-join (cross)
+ │    │    ├── columns: uniq_partial_hidden_pk.a:6 uniq_partial_hidden_pk.b:7 uniq_partial_hidden_pk.rowid:8!null uniq_partial_hidden_pk.crdb_internal_mvcc_timestamp:9 uniq_partial_hidden_pk.tableoid:10 k:11 v:12 w:13!null x:14 y:15 other.rowid:16!null other.crdb_internal_mvcc_timestamp:17 other.tableoid:18
+ │    │    ├── scan uniq_partial_hidden_pk
+ │    │    │    └── columns: uniq_partial_hidden_pk.a:6 uniq_partial_hidden_pk.b:7 uniq_partial_hidden_pk.rowid:8!null uniq_partial_hidden_pk.crdb_internal_mvcc_timestamp:9 uniq_partial_hidden_pk.tableoid:10
+ │    │    ├── scan other
+ │    │    │    └── columns: k:11 v:12 w:13!null x:14 y:15 other.rowid:16!null other.crdb_internal_mvcc_timestamp:17 other.tableoid:18
+ │    │    └── filters (true)
+ │    └── aggregations
+ │         ├── first-agg [as=uniq_partial_hidden_pk.a:6]
+ │         │    └── uniq_partial_hidden_pk.a:6
+ │         ├── first-agg [as=uniq_partial_hidden_pk.b:7]
+ │         │    └── uniq_partial_hidden_pk.b:7
+ │         ├── first-agg [as=uniq_partial_hidden_pk.crdb_internal_mvcc_timestamp:9]
+ │         │    └── uniq_partial_hidden_pk.crdb_internal_mvcc_timestamp:9
+ │         ├── first-agg [as=uniq_partial_hidden_pk.tableoid:10]
+ │         │    └── uniq_partial_hidden_pk.tableoid:10
+ │         ├── first-agg [as=k:11]
+ │         │    └── k:11
+ │         ├── first-agg [as=v:12]
+ │         │    └── v:12
+ │         ├── first-agg [as=w:13]
+ │         │    └── w:13
+ │         ├── first-agg [as=x:14]
+ │         │    └── x:14
+ │         ├── first-agg [as=y:15]
+ │         │    └── y:15
+ │         ├── first-agg [as=other.rowid:16]
+ │         │    └── other.rowid:16
+ │         ├── first-agg [as=other.crdb_internal_mvcc_timestamp:17]
+ │         │    └── other.crdb_internal_mvcc_timestamp:17
+ │         └── first-agg [as=other.tableoid:18]
+ │              └── other.tableoid:18
  └── unique-checks
       └── unique-checks-item: uniq_partial_hidden_pk(a)
            └── project

--- a/pkg/sql/opt/optbuilder/testdata/update_from
+++ b/pkg/sql/opt/optbuilder/testdata/update_from
@@ -442,20 +442,81 @@ project
            ├── columns: check1:11!null a:5!null rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8 column1:9!null a_cast:10!null
            ├── project
            │    ├── columns: a_cast:10!null a:5!null rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8 column1:9!null
-           │    ├── select
+           │    ├── distinct-on
            │    │    ├── columns: a:5!null rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8 column1:9!null
-           │    │    ├── inner-join (cross)
-           │    │    │    ├── columns: a:5 rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8 column1:9!null
-           │    │    │    ├── scan t61520 [as=t]
-           │    │    │    │    └── columns: a:5 rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
-           │    │    │    ├── values
-           │    │    │    │    ├── columns: column1:9!null
-           │    │    │    │    └── (1.0,)
-           │    │    │    └── filters (true)
-           │    │    └── filters
-           │    │         └── a:5 = column1:9
+           │    │    ├── grouping columns: rowid:6!null
+           │    │    ├── select
+           │    │    │    ├── columns: a:5!null rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8 column1:9!null
+           │    │    │    ├── inner-join (cross)
+           │    │    │    │    ├── columns: a:5 rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8 column1:9!null
+           │    │    │    │    ├── scan t61520 [as=t]
+           │    │    │    │    │    └── columns: a:5 rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
+           │    │    │    │    ├── values
+           │    │    │    │    │    ├── columns: column1:9!null
+           │    │    │    │    │    └── (1.0,)
+           │    │    │    │    └── filters (true)
+           │    │    │    └── filters
+           │    │    │         └── a:5 = column1:9
+           │    │    └── aggregations
+           │    │         ├── first-agg [as=a:5]
+           │    │         │    └── a:5
+           │    │         ├── first-agg [as=crdb_internal_mvcc_timestamp:7]
+           │    │         │    └── crdb_internal_mvcc_timestamp:7
+           │    │         ├── first-agg [as=tableoid:8]
+           │    │         │    └── tableoid:8
+           │    │         └── first-agg [as=column1:9]
+           │    │              └── column1:9
            │    └── projections
            │         └── assignment-cast: DECIMAL(10,2) [as=a_cast:10]
            │              └── column1:9
            └── projections
                 └── a_cast:10 > 0 [as=check1:11]
+
+# Regression test for #89779. Do not should not omit hidden PK columns from the
+# distinct-on operator the deduplicates rows from the target table.
+exec-ddl
+CREATE TABLE t89779 (a INT)
+----
+
+build
+UPDATE t89779 SET a = 2 FROM (VALUES (1)) v(i) WHERE a = i RETURNING rowid, a
+----
+project
+ ├── columns: rowid:2!null a:1!null
+ └── update t89779
+      ├── columns: a:1!null rowid:2!null column1:9
+      ├── fetch columns: a:5 rowid:6
+      ├── passthrough columns: column1:9
+      ├── update-mapping:
+      │    └── a_new:10 => a:1
+      ├── return-mapping:
+      │    ├── a_new:10 => a:1
+      │    └── rowid:6 => rowid:2
+      └── project
+           ├── columns: a_new:10!null a:5!null rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8 column1:9!null
+           ├── distinct-on
+           │    ├── columns: a:5!null rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8 column1:9!null
+           │    ├── grouping columns: rowid:6!null
+           │    ├── select
+           │    │    ├── columns: a:5!null rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8 column1:9!null
+           │    │    ├── inner-join (cross)
+           │    │    │    ├── columns: a:5 rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8 column1:9!null
+           │    │    │    ├── scan t89779
+           │    │    │    │    └── columns: a:5 rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
+           │    │    │    ├── values
+           │    │    │    │    ├── columns: column1:9!null
+           │    │    │    │    └── (1,)
+           │    │    │    └── filters (true)
+           │    │    └── filters
+           │    │         └── a:5 = column1:9
+           │    └── aggregations
+           │         ├── first-agg [as=a:5]
+           │         │    └── a:5
+           │         ├── first-agg [as=crdb_internal_mvcc_timestamp:7]
+           │         │    └── crdb_internal_mvcc_timestamp:7
+           │         ├── first-agg [as=tableoid:8]
+           │         │    └── tableoid:8
+           │         └── first-agg [as=column1:9]
+           │              └── column1:9
+           └── projections
+                └── 2 [as=a_new:10]


### PR DESCRIPTION
An `UPDATE .. FROM` statement allows joining the target table with other tables. A distinct-on operator is added above the joins to ensure that at most one row is output for every row in the target table. Previously, hidden PK columns were omitted from the distinct-on columns, which could cause the same row to be updated multiple times.

Fixes #89779

Release note (bug fix): A bug has been fixed that could cause `UPDATE .. FROM` clauses to update the same row multiple times, resulting in incorrect `UPDATED` row counts and duplicate output rows for statements with a `RETURNING` clause. The bug only presented when the target table had a hidden primary key column (e.g., an implicit `rowid` primary key column). The bug has been present since support for `UPDATE .. FROM` was added in version 19.0.