### PR TITLE
sql: fix logic test option typos

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/grant_schema
+++ b/pkg/sql/logictest/testdata/logic_test/grant_schema
@@ -108,7 +108,7 @@ testuser2  test           s                   CREATE          NO
 testuser   test           s                   ALL             YES
 
 # Check grants for testuser2, which should inherit from the public role.
-query TBB colnames rowsort
+query TBB colnames,rowsort
 WITH schema_names(schema_name) AS (
    SELECT n.nspname AS schema_name
      FROM pg_catalog.pg_namespace n

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -2740,7 +2740,7 @@ root      other_db       public              ALL             YES
 ## information_schema.table_privileges and information_schema.role_table_grants
 
 # root can see everything
-query TTTTTTTT colnames rowsort
+query TTTTTTTT colnames,rowsort
 SELECT * FROM system.information_schema.table_privileges ORDER BY table_schema, table_name, table_schema, grantee, privilege_type
 ----
 grantor  grantee  table_catalog  table_schema        table_name                             privilege_type  is_grantable  with_hierarchy

--- a/pkg/sql/logictest/testdata/logic_test/statement_statistics
+++ b/pkg/sql/logictest/testdata/logic_test/statement_statistics
@@ -248,10 +248,11 @@ SELECT z FROM test where y=2;
 statement ok
 SELECT x FROM test where y=1;
 
-query TB colnames rowsort
+query TB colnames
 SELECT key, implicit_txn
   FROM crdb_internal.node_statement_statistics
- WHERE application_name = 'implicit_txn_test' ORDER BY key, implicit_txn;
+ WHERE application_name = 'implicit_txn_test'
+ORDER BY key, implicit_txn;
 ----
 key                             implicit_txn
 SELECT _                        false

--- a/pkg/sql/logictest/testdata/logic_test/subquery_correlated
+++ b/pkg/sql/logictest/testdata/logic_test/subquery_correlated
@@ -949,7 +949,7 @@ c_c_id  bill  rownum
 4       TX    2
 6       FL    1
 
-query TI colnames rowsort
+query TI colnames,rowsort
 SELECT
     *
 FROM

--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -716,7 +716,7 @@ subtest visible_returning_columns
 statement ok
 BEGIN; ALTER TABLE tc DROP COLUMN y
 
-query I colnames rowsort
+query I colnames,rowsort
 UPSERT INTO tc VALUES (1), (2) RETURNING *
 ----
 x


### PR DESCRIPTION
This commit fixes a few tests that incorrectly separated test options with a space instead of a comma.

Release note: None