### PR TITLE
release-22.1: roachtest: wait for a 5x replication instead of 3x

### DIFF
--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -160,7 +160,7 @@ func runDrainAndDecommission(
 		run(`SET CLUSTER SETTING kv.snapshot_recovery.max_rate='2GiB'`)
 
 		// Wait for initial up-replication.
-		err := WaitFor3XReplication(ctx, t, db)
+		err := WaitForReplication(ctx, t, db, defaultReplicationFactor)
 		require.NoError(t, err)
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #84392.

Fixes #88901.

Release Justification: Test-only bug fix.

/cc @cockroachdb/release

---

Flaky test: we wait for a 3x replication and then drain 3 nodes. Then we
sometimes have ranges with all 3 replicas on those 3 nodes, stuck forever.

Instead the test should wait for a 5x replication before starting the drain.

Fixes #84128.

Release note: None
