### PR TITLE
release-22.2: build: support running extra checks on ARM

### DIFF
--- a/build/teamcity/cockroach/ci/tests/bench_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/bench_impl.sh
@@ -5,6 +5,12 @@ set -euo pipefail
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
 source "$dir/teamcity/util.sh"
 
+if [[ "$(uname -m)" =~ (arm64|aarch64)$ ]]; then
+  export CROSSLINUX_CONFIG="crosslinuxarm"
+else
+  export CROSSLINUX_CONFIG="crosslinux"
+fi
+
 # Enumerate test targets that have benchmarks.
 all_tests=$(bazel query 'kind(go_test, //pkg/...)' --output=label)
 pkgs=$(git grep -l '^func Benchmark' -- 'pkg/*_test.go' | rev | cut -d/ -f2- | rev | sort | uniq)
@@ -21,7 +27,7 @@ do
     tc_start_block "Bench $target"
     # We need the `test_sharding_strategy` flag or else the benchmarks will
     # fail to run sharded tests like //pkg/sql/importer:importer_test.
-    bazel run --config=test --config=crosslinux --config=ci --test_sharding_strategy=disabled $target -- \
+    bazel run --config=test --config=$CROSSLINUX_CONFIG --config=ci --test_sharding_strategy=disabled $target -- \
           -test.bench=. -test.benchtime=1ns -test.short -test.run=-
     tc_end_block "Bench $target"
 done

--- a/build/teamcity/cockroach/ci/tests/local_roachtest_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/local_roachtest_impl.sh
@@ -2,11 +2,17 @@
 
 set -euo pipefail
 
-bazel build --config=crosslinux --config=ci //pkg/cmd/cockroach-short \
+if [[ "$(uname -m)" =~ (arm64|aarch64)$ ]]; then
+  export CROSSLINUX_CONFIG="crosslinuxarm"
+else
+  export CROSSLINUX_CONFIG="crosslinux"
+fi
+
+bazel build --config=$CROSSLINUX_CONFIG --config=ci //pkg/cmd/cockroach-short \
       //pkg/cmd/roachtest \
       //pkg/cmd/workload
 
-BAZEL_BIN=$(bazel info bazel-bin --config=crosslinux --config=ci)
+BAZEL_BIN=$(bazel info bazel-bin --config=$CROSSLINUX_CONFIG --config=ci)
 $BAZEL_BIN/pkg/cmd/roachtest/roachtest_/roachtest run acceptance kv/splits cdc/bank \
   --local \
   --parallelism=1 \


### PR DESCRIPTION
Backport 1/1 commits from #88966.

/cc @cockroachdb/release

---

This code change changes CI scripts for acceptance, bench,
and roachtest to be runnable on ARM machines.

Release note: None
Release justification: test-only change.
