### PR TITLE
Revert "roachpb: remove deprecated field from AmbiguousResultError"

### DIFF
--- a/pkg/roachpb/ambiguous_result_error.go
+++ b/pkg/roachpb/ambiguous_result_error.go
@@ -28,13 +28,14 @@ func NewAmbiguousResultErrorf(format string, args ...interface{}) *AmbiguousResu
 // errors.Wrapper) the supplied error.
 func NewAmbiguousResultError(err error) *AmbiguousResultError {
 	return &AmbiguousResultError{
-		EncodedError: errors.EncodeError(context.Background(), err),
+		EncodedError:      errors.EncodeError(context.Background(), err),
+		DeprecatedMessage: err.Error(),
 	}
 }
 
 var _ errors.SafeFormatter = (*AmbiguousResultError)(nil)
 var _ fmt.Formatter = (*AmbiguousResultError)(nil)
-var _ = func() errors.Wrapper {
+var _ errors.Wrapper = func() errors.Wrapper {
 	aErr := (*AmbiguousResultError)(nil)
 	typeKey := errors.GetTypeKey(aErr)
 	errors.RegisterWrapperEncoder(typeKey, func(ctx context.Context, err error) (msgPrefix string, safeDetails []string, payload proto.Message) {

--- a/pkg/roachpb/errors.proto
+++ b/pkg/roachpb/errors.proto
@@ -377,7 +377,11 @@ message LeaseRejectedError {
 // An AmbiguousResultError indicates that a request may have succeeded or
 // failed, but the response was not received and the final result is ambiguous.
 message AmbiguousResultError {
-  // The error that caused the ambiguous result.
+  // DEPRECATED: remove in 22.2.
+  optional string deprecated_message = 1 [(gogoproto.nullable) = false];
+  // Optionally provides a cause for the AmbiguousResultError. We do not
+  // implement Causer to avoid accidentally ignoring ambiguous results;
+  // the error must be inspected directly.
   optional errorspb.EncodedError encoded_error = 3 [(gogoproto.nullable) = false];
   reserved 2;
 }


### PR DESCRIPTION
This reverts commit f3d5b24cdcdb23b5124459e385dc073f83b51880.

We need to remain compatible with 22.1.

Release note: None
