### PR TITLE
release-22.2: ui: some hot ranges may not back SQL tables

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRangesTable.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRangesTable.tsx
@@ -179,11 +179,17 @@ const HotRangesTable = ({
             Table
           </Tooltip>
         ),
-        cell: val => (
-          <Link to={`/database/${val.database_name}/table/${val.table_name}`}>
-            {val.table_name}
-          </Link>
-        ),
+        cell: val =>
+          // A hot range may not necessarily back a SQL table. If we see a
+          // "table name" that starts with a slash, it is not a table name but
+          // instead the start key of the range, and we should not link it.
+          val.table_name.startsWith("/") ? (
+            val.table_name
+          ) : (
+            <Link to={`/database/${val.database_name}/table/${val.table_name}`}>
+              {val.table_name}
+            </Link>
+          ),
         sort: val => val.table_name,
       },
       {


### PR DESCRIPTION
Backport 1/1 commits from #88853.

/cc @cockroachdb/release

---

So it doesn't make sense to link from them to the table details page.

Fixes #81542.

Release note: None

---

Release justification: Bug fixes and low-risk updates to new functionality