### PR TITLE
opt: fix WithScan errors in apply-joins

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/apply_join
+++ b/pkg/sql/logictest/testdata/logic_test/apply_join
@@ -604,3 +604,23 @@ LEFT JOIN LATERAL (
 ) ON true;
 ----
 NULL
+
+subtest regression_89601
+
+statement ok
+CREATE TABLE t89601 (i INT4);
+INSERT INTO t89601 VALUES (0)
+
+# Regression test for #89601. All with bindings should be added to the new
+# metadata when planning the RHS of an apply-join.
+statement ok
+SELECT NULL
+FROM t89601 t1, t89601 t2
+WHERE EXISTS(
+  SELECT NULL
+  FROM t89601 t3, t89601 t4
+  WHERE t3.i IN (
+     WITH w AS (SELECT NULL)
+     SELECT t4.i::INT8 FROM w
+  )
+)

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -1121,10 +1121,9 @@ func (b *Builder) buildApplyJoin(join memo.RelExpr) (execPlan, error) {
 				// because the call to Factory.CopyAndReplace below clears With
 				// expressions in the metadata.
 				if !addedWithBindings {
-					for i, n := opt.WithID(1), b.mem.MaxWithID(); i <= n; i++ {
-						memoExpr := b.mem.Metadata().WithBinding(i)
-						f.Metadata().AddWithBinding(i, memoExpr)
-					}
+					b.mem.Metadata().ForEachWithBinding(func(id opt.WithID, expr opt.Expr) {
+						f.Metadata().AddWithBinding(id, expr)
+					})
 					addedWithBindings = true
 				}
 				// Fall through.

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -469,12 +469,6 @@ func (m *Memo) NextWithID() opt.WithID {
 	return m.curWithID
 }
 
-// MaxWithID returns the current maximum assigned identifier for a WITH
-// expression.
-func (m *Memo) MaxWithID() opt.WithID {
-	return m.curWithID
-}
-
 // Detach is used when we detach a memo that is to be reused later (either for
 // execbuilding or with AssignPlaceholders). New expressions should no longer be
 // constructed in this memo.

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -775,3 +775,11 @@ func (md *Metadata) WithBinding(id WithID) Expr {
 	}
 	return res
 }
+
+// ForEachWithBinding calls fn with each bound (WithID, Expr) pair in the
+// metadata.
+func (md *Metadata) ForEachWithBinding(fn func(WithID, Expr)) {
+	for id, expr := range md.withBindings {
+		fn(id, expr)
+	}
+}


### PR DESCRIPTION
In #88396, we updated the planning logic for the RHS of apply-joins so that all With expressions in the original memo's metadata are added to the metadata of the new, temporary memo. This change was brittle. It relied on the memo's `curWithID` to enumerate all With expressions in the metadata, but it did not propagate the same `curWithID` to the new temporary memo. This caused internal errors with nested apply-joins, because the With expression would not propagate to the inner-most memo's metadata.

This commit fixes the issue by removing the dependence on `curWithID`, and directly iterating over all With expressions to add them to the new metadata for the RHS of apply-joins.

Fixes #89601

Release note (bug fix): A bug has been fixed that caused internal errors in rare cases when running CTEs (statements with WITH clauses). This bug is only present in v22.2.0-beta.2, v22.2.0-beta.3, v21.2.16, and v22.1.9.