### PR TITLE
tree: optimize function type checking

### DIFF
--- a/pkg/cmd/docgen/funcs.go
+++ b/pkg/cmd/docgen/funcs.go
@@ -103,17 +103,18 @@ func generateOperators() []byte {
 	ops := make(map[string]operations)
 	for optyp, overloads := range tree.UnaryOps {
 		op := optyp.String()
-		for _, v := range *overloads {
+		_ = overloads.ForEachUnaryOp(func(v *tree.UnaryOp) error {
 			ops[op] = append(ops[op], operation{
 				left: v.Typ.String(),
 				ret:  v.ReturnType.String(),
 				op:   op,
 			})
-		}
+			return nil
+		})
 	}
 	for optyp, overloads := range tree.BinOps {
 		op := optyp.String()
-		for _, v := range *overloads {
+		_ = overloads.ForEachBinOp(func(v *tree.BinOp) error {
 			left := v.LeftType.String()
 			right := v.RightType.String()
 			ops[op] = append(ops[op], operation{
@@ -122,11 +123,12 @@ func generateOperators() []byte {
 				ret:   v.ReturnType.String(),
 				op:    op,
 			})
-		}
+			return nil
+		})
 	}
 	for optyp, overloads := range tree.CmpOps {
 		op := optyp.String()
-		for _, v := range *overloads {
+		_ = overloads.ForEachCmpOp(func(v *tree.CmpOp) error {
 			left := v.LeftType.String()
 			right := v.RightType.String()
 			ops[op] = append(ops[op], operation{
@@ -135,7 +137,8 @@ func generateOperators() []byte {
 				ret:   "bool",
 				op:    op,
 			})
-		}
+			return nil
+		})
 	}
 	var opstrs []string
 	for k, v := range ops {

--- a/pkg/cmd/docgen/funcs.go
+++ b/pkg/cmd/docgen/funcs.go
@@ -103,8 +103,7 @@ func generateOperators() []byte {
 	ops := make(map[string]operations)
 	for optyp, overloads := range tree.UnaryOps {
 		op := optyp.String()
-		for _, untyped := range overloads {
-			v := untyped.(*tree.UnaryOp)
+		for _, v := range *overloads {
 			ops[op] = append(ops[op], operation{
 				left: v.Typ.String(),
 				ret:  v.ReturnType.String(),
@@ -114,8 +113,7 @@ func generateOperators() []byte {
 	}
 	for optyp, overloads := range tree.BinOps {
 		op := optyp.String()
-		for _, untyped := range overloads {
-			v := untyped.(*tree.BinOp)
+		for _, v := range *overloads {
 			left := v.LeftType.String()
 			right := v.RightType.String()
 			ops[op] = append(ops[op], operation{
@@ -128,8 +126,7 @@ func generateOperators() []byte {
 	}
 	for optyp, overloads := range tree.CmpOps {
 		op := optyp.String()
-		for _, untyped := range overloads {
-			v := untyped.(*tree.CmpOp)
+		for _, v := range *overloads {
 			left := v.LeftType.String()
 			right := v.RightType.String()
 			ops[op] = append(ops[op], operation{

--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -472,8 +472,7 @@ type operator struct {
 var operators = func() map[oid.Oid][]operator {
 	m := map[oid.Oid][]operator{}
 	for BinaryOperator, overload := range tree.BinOps {
-		for _, ov := range overload {
-			bo := ov.(*tree.BinOp)
+		for _, bo := range *overload {
 			m[bo.ReturnType.Oid()] = append(m[bo.ReturnType.Oid()], operator{
 				BinOp:    bo,
 				Operator: treebin.MakeBinaryOperator(BinaryOperator),

--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -472,12 +472,13 @@ type operator struct {
 var operators = func() map[oid.Oid][]operator {
 	m := map[oid.Oid][]operator{}
 	for BinaryOperator, overload := range tree.BinOps {
-		for _, bo := range *overload {
+		_ = overload.ForEachBinOp(func(bo *tree.BinOp) error {
 			m[bo.ReturnType.Oid()] = append(m[bo.ReturnType.Oid()], operator{
 				BinOp:    bo,
 				Operator: treebin.MakeBinaryOperator(BinaryOperator),
 			})
-		}
+			return nil
+		})
 	}
 	return m
 }()

--- a/pkg/sql/opt/memo/BUILD.bazel
+++ b/pkg/sql/opt/memo/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
         "//pkg/util/buildutil",
         "//pkg/util/duration",
         "//pkg/util/encoding",
+        "//pkg/util/iterutil",
         "//pkg/util/json",
         "//pkg/util/log",
         "//pkg/util/timeutil/pgdate",

--- a/pkg/sql/opt/memo/typing.go
+++ b/pkg/sql/opt/memo/typing.go
@@ -41,8 +41,7 @@ func InferUnaryType(op opt.Operator, inputType *types.T) *types.T {
 	unaryOp := opt.UnaryOpReverseMap[op]
 
 	// Find the unary op that matches the type of the expression's child.
-	for _, op := range tree.UnaryOps[unaryOp] {
-		o := op.(*tree.UnaryOp)
+	for _, o := range *tree.UnaryOps[unaryOp] {
 		if inputType.Equivalent(o.Typ) {
 			return o.ReturnType
 		}
@@ -405,8 +404,7 @@ func FindBinaryOverload(op opt.Operator, leftType, rightType *types.T) (_ *tree.
 func FindUnaryOverload(op opt.Operator, typ *types.T) (_ *tree.UnaryOp, ok bool) {
 	unary := opt.UnaryOpReverseMap[op]
 
-	for _, unaryOverloads := range tree.UnaryOps[unary] {
-		o := unaryOverloads.(*tree.UnaryOp)
+	for _, o := range *tree.UnaryOps[unary] {
 		if o.Typ.Equivalent(typ) {
 			return o, true
 		}
@@ -436,9 +434,7 @@ func FindComparisonOverload(
 	// right children. No more than one match should ever be found. The
 	// TestTypingComparisonAssumptions test ensures this will be the case even if
 	// new operators or overloads are added.
-	for _, cmpOverloads := range tree.CmpOps[comp] {
-		o := cmpOverloads.(*tree.CmpOp)
-
+	for _, o := range *tree.CmpOps[comp] {
 		if leftType.Family() == types.UnknownFamily {
 			if rightType.Equivalent(o.RightType) {
 				return o, flipped, not, true

--- a/pkg/sql/opt/memo/typing.go
+++ b/pkg/sql/opt/memo/typing.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
 )
@@ -37,16 +38,21 @@ func InferType(mem *Memo, e opt.ScalarExpr) *types.T {
 
 // InferUnaryType infers the return type of a unary operator, given the type of
 // its input.
-func InferUnaryType(op opt.Operator, inputType *types.T) *types.T {
+func InferUnaryType(op opt.Operator, inputType *types.T) (ret *types.T) {
 	unaryOp := opt.UnaryOpReverseMap[op]
 
 	// Find the unary op that matches the type of the expression's child.
-	for _, o := range *tree.UnaryOps[unaryOp] {
+	_ = tree.UnaryOps[unaryOp].ForEachUnaryOp(func(o *tree.UnaryOp) error {
 		if inputType.Equivalent(o.Typ) {
-			return o.ReturnType
+			ret = o.ReturnType
+			return iterutil.StopIteration()
 		}
+		return nil
+	})
+	if ret == nil {
+		panic(errors.AssertionFailedf("could not find type for unary expression %s", redact.Safe(op)))
 	}
-	panic(errors.AssertionFailedf("could not find type for unary expression %s", redact.Safe(op)))
+	return ret
 }
 
 // InferBinaryType infers the return type of a binary expression, given the type
@@ -401,15 +407,17 @@ func FindBinaryOverload(op opt.Operator, leftType, rightType *types.T) (_ *tree.
 // specified unary operator, given the type of its input. If an overload is
 // found, FindUnaryOverload returns true, plus a pointer to the overload.
 // If an overload is not found, FindUnaryOverload returns false.
-func FindUnaryOverload(op opt.Operator, typ *types.T) (_ *tree.UnaryOp, ok bool) {
+func FindUnaryOverload(op opt.Operator, typ *types.T) (ret *tree.UnaryOp, ok bool) {
 	unary := opt.UnaryOpReverseMap[op]
 
-	for _, o := range *tree.UnaryOps[unary] {
-		if o.Typ.Equivalent(typ) {
-			return o, true
+	_ = tree.UnaryOps[unary].ForEachUnaryOp(func(op *tree.UnaryOp) error {
+		if ok = op.Typ.Equivalent(typ); ok {
+			ret = op
+			return iterutil.StopIteration()
 		}
-	}
-	return nil, false
+		return nil
+	})
+	return ret, ok
 }
 
 // FindComparisonOverload finds the correct type signature overload for the
@@ -422,7 +430,7 @@ func FindUnaryOverload(op opt.Operator, typ *types.T) (_ *tree.UnaryOp, ok bool)
 // FindComparisonOverload returns ok=false.
 func FindComparisonOverload(
 	op opt.Operator, leftType, rightType *types.T,
-) (_ *tree.CmpOp, flipped, not, ok bool) {
+) (cmpOp *tree.CmpOp, flipped, not, ok bool) {
 	op, flipped, not = NormalizeComparison(op)
 	comp := opt.ComparisonOpReverseMap[op]
 
@@ -434,22 +442,25 @@ func FindComparisonOverload(
 	// right children. No more than one match should ever be found. The
 	// TestTypingComparisonAssumptions test ensures this will be the case even if
 	// new operators or overloads are added.
-	for _, o := range *tree.CmpOps[comp] {
+	_ = tree.CmpOps[comp].ForEachCmpOp(func(o *tree.CmpOp) error {
 		if leftType.Family() == types.UnknownFamily {
-			if rightType.Equivalent(o.RightType) {
-				return o, flipped, not, true
-			}
+			ok = rightType.Equivalent(o.RightType)
 		} else if rightType.Family() == types.UnknownFamily {
-			if leftType.Equivalent(o.LeftType) {
-				return o, flipped, not, true
-			}
+			ok = leftType.Equivalent(o.LeftType)
 		} else {
-			if leftType.Equivalent(o.LeftType) && rightType.Equivalent(o.RightType) {
-				return o, flipped, not, true
-			}
+			ok = leftType.Equivalent(o.LeftType) && rightType.Equivalent(o.RightType)
 		}
+		if !ok {
+			return nil
+		}
+		cmpOp = o
+		return iterutil.StopIteration()
+	})
+	if !ok {
+		return nil, false, false, false
 	}
-	return nil, false, false, false
+	return cmpOp, flipped, not, true
+
 }
 
 // NormalizeComparison maps a given comparison operator into an equivalent

--- a/pkg/sql/opt/memo/typing_test.go
+++ b/pkg/sql/opt/memo/typing_test.go
@@ -70,23 +70,19 @@ func TestBinaryAllowsNullArgs(t *testing.T) {
 //     types of its operand.
 func TestTypingUnaryAssumptions(t *testing.T) {
 	for name, overloads := range tree.UnaryOps {
-		for i, overload := range overloads {
-			op := overload.(*tree.UnaryOp)
-
-			// Check for basic ambiguity where two different unary op overloads
-			// both allow equivalent operand types.
-			for i2, overload2 := range overloads {
-				if i == i2 {
-					continue
+		_ = overloads.ForEachUnaryOp(func(op *tree.UnaryOp) error {
+			_ = overloads.ForEachUnaryOp(func(op2 *tree.UnaryOp) error {
+				if op == op2 {
+					return nil
 				}
-
-				op2 := overload2.(*tree.UnaryOp)
 				if op.Typ.Equivalent(op2.Typ) {
 					format := "found equivalent operand type ambiguity for %s:\n%+v\n%+v"
 					t.Errorf(format, name, op, op2)
 				}
-			}
-		}
+				return nil
+			})
+			return nil
+		})
 	}
 }
 
@@ -105,23 +101,21 @@ func TestTypingComparisonAssumptions(t *testing.T) {
 		}
 	}
 	for name, overloads := range tree.CmpOps {
-		for i, overload := range overloads {
-			op := overload.(*tree.CmpOp)
-
-			// Check for basic ambiguity where two different comparison op overloads
-			// both allow equivalent operand types.
-			for i2, overload2 := range overloads {
-				if i == i2 {
-					continue
+		_ = overloads.ForEachCmpOp(func(op *tree.CmpOp) error {
+			_ = overloads.ForEachCmpOp(func(op2 *tree.CmpOp) error {
+				// Check for basic ambiguity where two different comparison op overloads
+				// both allow equivalent operand types.
+				if op == op2 {
+					return nil
 				}
-
-				op2 := overload2.(*tree.CmpOp)
 				if op.LeftType.Equivalent(op2.LeftType) && op.RightType.Equivalent(op2.RightType) {
 					format := "found equivalent operand type ambiguity for %s:\n%+v\n%+v"
 					t.Errorf(format, name, op, op2)
 				}
-			}
-		}
+				return nil
+			})
+			return nil
+		})
 	}
 }
 

--- a/pkg/sql/opt/norm/norm_test.go
+++ b/pkg/sql/opt/norm/norm_test.go
@@ -81,11 +81,12 @@ func TestNormRuleProps(t *testing.T) {
 // switched. Patterns like CommuteConst rely on this being possible.
 func TestRuleBinaryAssumption(t *testing.T) {
 	fn := func(op opt.Operator) {
-		for _, binOp := range *tree.BinOps[opt.BinaryOpReverseMap[op]] {
+		_ = tree.BinOps[opt.BinaryOpReverseMap[op]].ForEachBinOp(func(binOp *tree.BinOp) error {
 			if !memo.BinaryOverloadExists(op, binOp.RightType, binOp.LeftType) {
 				t.Errorf("could not find inverse for overload: %+v", op)
 			}
-		}
+			return nil
+		})
 	}
 
 	// Only include commutative binary operators.

--- a/pkg/sql/opt/norm/norm_test.go
+++ b/pkg/sql/opt/norm/norm_test.go
@@ -81,8 +81,7 @@ func TestNormRuleProps(t *testing.T) {
 // switched. Patterns like CommuteConst rely on this being possible.
 func TestRuleBinaryAssumption(t *testing.T) {
 	fn := func(op opt.Operator) {
-		for _, overload := range tree.BinOps[opt.BinaryOpReverseMap[op]] {
-			binOp := overload.(*tree.BinOp)
+		for _, binOp := range *tree.BinOps[opt.BinaryOpReverseMap[op]] {
 			if !memo.BinaryOverloadExists(op, binOp.RightType, binOp.LeftType) {
 				t.Errorf("could not find inverse for overload: %+v", op)
 			}

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -2188,7 +2188,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-operator.html`,
 			if cmpOp == treecmp.In {
 				continue
 			}
-			for _, overload := range overloads {
+			for _, overload := range *overloads {
 				params, returnType := tree.GetParamsAndReturnType(overload)
 				if err := addOp(cmpOp.String(), infixKind, params, returnType); err != nil {
 					return err
@@ -2201,7 +2201,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-operator.html`,
 			}
 		}
 		for binOp, overloads := range tree.BinOps {
-			for _, overload := range overloads {
+			for _, overload := range *overloads {
 				params, returnType := tree.GetParamsAndReturnType(overload)
 				if err := addOp(binOp.String(), infixKind, params, returnType); err != nil {
 					return err
@@ -2209,7 +2209,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-operator.html`,
 			}
 		}
 		for unaryOp, overloads := range tree.UnaryOps {
-			for _, overload := range overloads {
+			for _, overload := range *overloads {
 				params, returnType := tree.GetParamsAndReturnType(overload)
 				if err := addOp(unaryOp.String(), prefixKind, params, returnType); err != nil {
 					return err

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -2188,7 +2188,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-operator.html`,
 			if cmpOp == treecmp.In {
 				continue
 			}
-			for _, overload := range *overloads {
+			if err := overloads.ForEachCmpOp(func(overload *tree.CmpOp) error {
 				params, returnType := tree.GetParamsAndReturnType(overload)
 				if err := addOp(cmpOp.String(), infixKind, params, returnType); err != nil {
 					return err
@@ -2198,22 +2198,25 @@ https://www.postgresql.org/docs/9.5/catalog-pg-operator.html`,
 						return err
 					}
 				}
+				return nil
+			}); err != nil {
+				return err
 			}
 		}
 		for binOp, overloads := range tree.BinOps {
-			for _, overload := range *overloads {
+			if err := overloads.ForEachBinOp(func(overload *tree.BinOp) error {
 				params, returnType := tree.GetParamsAndReturnType(overload)
-				if err := addOp(binOp.String(), infixKind, params, returnType); err != nil {
-					return err
-				}
+				return addOp(binOp.String(), infixKind, params, returnType)
+			}); err != nil {
+				return err
 			}
 		}
 		for unaryOp, overloads := range tree.UnaryOps {
-			for _, overload := range *overloads {
+			if err := overloads.ForEachUnaryOp(func(overload *tree.UnaryOp) error {
 				params, returnType := tree.GetParamsAndReturnType(overload)
-				if err := addOp(unaryOp.String(), prefixKind, params, returnType); err != nil {
-					return err
-				}
+				return addOp(unaryOp.String(), prefixKind, params, returnType)
+			}); err != nil {
+				return err
 			}
 		}
 		return nil

--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -180,6 +180,7 @@ go_test(
         "format_test.go",
         "function_definition_test.go",
         "function_name_test.go",
+        "helpers_test.go",
         "indexed_vars_test.go",
         "interval_test.go",
         "json_test.go",

--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -145,6 +145,7 @@ go_library(
         "//pkg/util/encoding",
         "//pkg/util/errorutil/unimplemented",
         "//pkg/util/ipaddr",
+        "//pkg/util/iterutil",
         "//pkg/util/json",
         "//pkg/util/pretty",
         "//pkg/util/stringencoding",

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treecmp"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/volatility"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/errors"
 	"github.com/lib/pq/oid"
@@ -85,10 +86,10 @@ func (*UnaryOp) preferred() bool {
 }
 
 func unaryOpFixups(
-	ops map[UnaryOperatorSymbol]*unaryOpOverload,
-) map[UnaryOperatorSymbol]*unaryOpOverload {
+	ops map[UnaryOperatorSymbol]*UnaryOpOverloads,
+) map[UnaryOperatorSymbol]*UnaryOpOverloads {
 	for _, overload := range ops {
-		for _, impl := range *overload {
+		for _, impl := range overload.overloads {
 			impl.types = ArgTypes{{"arg", impl.Typ}}
 			impl.retType = FixedReturnType(impl.ReturnType)
 		}
@@ -96,119 +97,134 @@ func unaryOpFixups(
 	return ops
 }
 
-// unaryOpOverload is an overloaded set of unary operator implementations.
+// UnaryOpOverloads is an overloaded set of unary operator implementations.
 // It implements overloadSet.
-type unaryOpOverload []*UnaryOp
+type UnaryOpOverloads struct {
+	overloads []*UnaryOp
+}
 
-func (u *unaryOpOverload) len() int               { return len(*u) }
-func (u *unaryOpOverload) get(i int) overloadImpl { return (*u)[i] }
+func (u *UnaryOpOverloads) len() int               { return len(u.overloads) }
+func (u *UnaryOpOverloads) get(i int) overloadImpl { return u.overloads[i] }
+
+// ForEachUnaryOp iterates the set of overloads.
+func (u *UnaryOpOverloads) ForEachUnaryOp(f func(op *UnaryOp) error) error {
+	if u == nil {
+		return nil
+	}
+	for _, op := range u.overloads {
+		if err := f(op); err != nil {
+			return iterutil.Map(err)
+		}
+	}
+	return nil
+}
 
 // UnaryOps contains the unary operations indexed by operation type.
-var UnaryOps = unaryOpFixups(map[UnaryOperatorSymbol]*unaryOpOverload{
-	UnaryPlus: {
-		&UnaryOp{
+var UnaryOps = unaryOpFixups(map[UnaryOperatorSymbol]*UnaryOpOverloads{
+	UnaryPlus: {overloads: []*UnaryOp{
+		{
 			Typ:        types.Int,
 			ReturnType: types.Int,
 			EvalOp:     &UnaryNoop{},
 			Volatility: volatility.Immutable,
 		},
-		&UnaryOp{
+		{
 			Typ:        types.Float,
 			ReturnType: types.Float,
 			EvalOp:     &UnaryNoop{},
 			Volatility: volatility.Immutable,
 		},
-		&UnaryOp{
+		{
 			Typ:        types.Decimal,
 			ReturnType: types.Decimal,
 			EvalOp:     &UnaryNoop{},
 			Volatility: volatility.Immutable,
 		},
-		&UnaryOp{
+		{
 			Typ:        types.Interval,
 			ReturnType: types.Interval,
 			EvalOp:     &UnaryNoop{},
 			Volatility: volatility.Immutable,
 		},
-	},
+	}},
 
-	UnaryMinus: {
-		&UnaryOp{
+	UnaryMinus: {overloads: []*UnaryOp{
+		{
 			Typ:        types.Int,
 			ReturnType: types.Int,
 			EvalOp:     &UnaryMinusIntOp{},
 			Volatility: volatility.Immutable,
 		},
-		&UnaryOp{
+		{
 			Typ:        types.Float,
 			ReturnType: types.Float,
 			EvalOp:     &UnaryMinusFloatOp{},
 			Volatility: volatility.Immutable,
 		},
-		&UnaryOp{
+		{
 			Typ:        types.Decimal,
 			ReturnType: types.Decimal,
 			EvalOp:     &UnaryMinusDecimalOp{},
 			Volatility: volatility.Immutable,
 		},
-		&UnaryOp{
+		{
 			Typ:        types.Interval,
 			ReturnType: types.Interval,
 			EvalOp:     &UnaryMinusIntervalOp{},
 			Volatility: volatility.Immutable,
 		},
-	},
+	}},
 
-	UnaryComplement: {
-		&UnaryOp{
+	UnaryComplement: {overloads: []*UnaryOp{
+		{
 			Typ:        types.Int,
 			ReturnType: types.Int,
 			EvalOp:     &ComplementIntOp{},
 			Volatility: volatility.Immutable,
 		},
-		&UnaryOp{
+		{
 			Typ:        types.VarBit,
 			ReturnType: types.VarBit,
 			EvalOp:     &ComplementVarBitOp{},
 			Volatility: volatility.Immutable,
 		},
-		&UnaryOp{
+		{
 			Typ:        types.INet,
 			ReturnType: types.INet,
 			EvalOp:     &ComplementINetOp{},
 			Volatility: volatility.Immutable,
 		},
-	},
+	}},
 
-	UnarySqrt: {
-		&UnaryOp{
+	UnarySqrt: {overloads: []*UnaryOp{
+		{
 			Typ:        types.Float,
 			ReturnType: types.Float,
 			EvalOp:     &SqrtFloatOp{},
 			Volatility: volatility.Immutable,
 		},
-		&UnaryOp{
+		{
 			Typ:        types.Decimal,
 			ReturnType: types.Decimal,
 			EvalOp:     &SqrtDecimalOp{},
 			Volatility: volatility.Immutable,
 		},
-	},
+	}},
 
-	UnaryCbrt: {
-		&UnaryOp{
+	UnaryCbrt: {overloads: []*UnaryOp{
+		{
 			Typ:        types.Float,
 			ReturnType: types.Float,
 			EvalOp:     &CbrtFloatOp{},
 			Volatility: volatility.Immutable,
 		},
-		&UnaryOp{
+		{
 			Typ:        types.Decimal,
 			ReturnType: types.Decimal,
 			EvalOp:     &CbrtDecimalOp{},
 			Volatility: volatility.Immutable,
 		},
-	},
+	}},
 })
 
 // BinOp is a binary operator.
@@ -284,12 +300,7 @@ func PrependToMaybeNullArray(typ *types.T, left Datum, right Datum) (Datum, erro
 func initArrayElementConcatenation() {
 	for _, t := range types.Scalar {
 		typ := t
-		s, ok := BinOps[treebin.Concat]
-		if !ok {
-			s = new(binOpOverload)
-			BinOps[treebin.Concat] = s
-		}
-		*s = append(*s, &BinOp{
+		addBinOp(treebin.Concat, &BinOp{
 			LeftType:          types.MakeArray(typ),
 			RightType:         typ,
 			ReturnType:        types.MakeArray(typ),
@@ -396,12 +407,7 @@ func initArrayToArrayConcatenation() {
 	for _, t := range types.Scalar {
 		typ := t
 		at := types.MakeArray(typ)
-		s, ok := BinOps[treebin.Concat]
-		if !ok {
-			s = new(binOpOverload)
-			BinOps[treebin.Concat] = s
-		}
-		*s = append(*s, &BinOp{
+		addBinOp(treebin.Concat, &BinOp{
 			LeftType:          at,
 			RightType:         at,
 			ReturnType:        at,
@@ -416,12 +422,7 @@ func initArrayToArrayConcatenation() {
 // and nonarrayelement + string concatenation.
 func initNonArrayToNonArrayConcatenation() {
 	addConcat := func(leftType, rightType *types.T, volatility volatility.V) {
-		s, ok := BinOps[treebin.Concat]
-		if !ok {
-			s = new(binOpOverload)
-			BinOps[treebin.Concat] = s
-		}
-		*s = append(*s, &BinOp{
+		addBinOp(treebin.Concat, &BinOp{
 			LeftType:          leftType,
 			RightType:         rightType,
 			ReturnType:        types.String,
@@ -458,23 +459,43 @@ func init() {
 
 func init() {
 	for _, overload := range BinOps {
-		for _, impl := range *overload {
+		_ = overload.ForEachBinOp(func(impl *BinOp) error {
 			impl.types = ArgTypes{{"left", impl.LeftType}, {"right", impl.RightType}}
 			impl.retType = FixedReturnType(impl.ReturnType)
-		}
+			return nil
+		})
 	}
 }
 
-// binOpOverload is an overloaded set of binary operator implementations.
+// BinOpOverloads is an overloaded set of binary operator implementations.
 // It implements overloadSet.
-type binOpOverload []*BinOp
+type BinOpOverloads struct {
+	overloads []*BinOp
+}
 
-func (o *binOpOverload) len() int               { return len(*o) }
-func (o *binOpOverload) get(i int) overloadImpl { return (*o)[i] }
+// ForEachBinOp iterates the BinOps in the set.
+func (o *BinOpOverloads) ForEachBinOp(f func(op *BinOp) error) error {
+	if o == nil {
+		return nil
+	}
+	for _, ol := range o.overloads {
+		if err := f(ol); err != nil {
+			return iterutil.Map(err)
+		}
+	}
+	return nil
+}
 
-func (o *binOpOverload) LookupImpl(left, right *types.T) (*BinOp, bool) {
-	for i := range *o {
-		if ol := (*o)[i]; ol.matchParams(left, right) {
+func (o *BinOpOverloads) len() int               { return len(o.overloads) }
+func (o *BinOpOverloads) get(i int) overloadImpl { return o.overloads[i] }
+
+// LookupImpl can be used to look up the overload which match the requested types.
+func (o *BinOpOverloads) LookupImpl(left, right *types.T) (*BinOp, bool) {
+	if o == nil {
+		return nil, false
+	}
+	for _, ol := range o.overloads {
+		if ol.matchParams(left, right) {
 			return ol, true
 		}
 	}
@@ -495,407 +516,416 @@ func GetJSONPath(j json.JSON, ary DArray) (json.JSON, error) {
 	return json.FetchPath(j, path)
 }
 
+func addBinOp(symbol treebin.BinaryOperatorSymbol, ops ...*BinOp) {
+	s, ok := BinOps[symbol]
+	if !ok {
+		s = new(BinOpOverloads)
+		BinOps[symbol] = s
+	}
+	s.overloads = append(s.overloads, ops...)
+}
+
 // BinOps contains the binary operations indexed by operation type.
-var BinOps = map[treebin.BinaryOperatorSymbol]*binOpOverload{
-	treebin.Bitand: {
-		&BinOp{
+var BinOps = map[treebin.BinaryOperatorSymbol]*BinOpOverloads{
+	treebin.Bitand: {overloads: []*BinOp{
+		{
 			LeftType:   types.Int,
 			RightType:  types.Int,
 			ReturnType: types.Int,
 			EvalOp:     &BitAndIntOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.VarBit,
 			RightType:  types.VarBit,
 			ReturnType: types.VarBit,
 			EvalOp:     &BitAndVarBitOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.INet,
 			RightType:  types.INet,
 			ReturnType: types.INet,
 			EvalOp:     &BitAndINetOp{},
 			Volatility: volatility.Immutable,
 		},
-	},
+	}},
 
-	treebin.Bitor: {
-		&BinOp{
+	treebin.Bitor: {overloads: []*BinOp{
+		{
 			LeftType:   types.Int,
 			RightType:  types.Int,
 			ReturnType: types.Int,
 			EvalOp:     &BitOrIntOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.VarBit,
 			RightType:  types.VarBit,
 			ReturnType: types.VarBit,
 			EvalOp:     &BitOrVarBitOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.INet,
 			RightType:  types.INet,
 			ReturnType: types.INet,
 			EvalOp:     &BitOrINetOp{},
 			Volatility: volatility.Immutable,
 		},
-	},
+	}},
 
-	treebin.Bitxor: {
-		&BinOp{
+	treebin.Bitxor: {overloads: []*BinOp{
+		{
 			LeftType:   types.Int,
 			RightType:  types.Int,
 			ReturnType: types.Int,
 			EvalOp:     &BitXorIntOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.VarBit,
 			RightType:  types.VarBit,
 			ReturnType: types.VarBit,
 			EvalOp:     &BitXorVarBitOp{},
 			Volatility: volatility.Immutable,
 		},
-	},
+	}},
 
-	treebin.Plus: {
-		&BinOp{
+	treebin.Plus: {overloads: []*BinOp{
+		{
 			LeftType:   types.Int,
 			RightType:  types.Int,
 			ReturnType: types.Int,
 			EvalOp:     &PlusIntOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Float,
 			RightType:  types.Float,
 			ReturnType: types.Float,
 			EvalOp:     &PlusFloatOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Decimal,
 			RightType:  types.Decimal,
 			ReturnType: types.Decimal,
 			EvalOp:     &PlusDecimalOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Decimal,
 			RightType:  types.Int,
 			ReturnType: types.Decimal,
 			EvalOp:     &PlusDecimalIntOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Int,
 			RightType:  types.Decimal,
 			ReturnType: types.Decimal,
 			EvalOp:     &PlusIntDecimalOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Date,
 			RightType:  types.Int,
 			ReturnType: types.Date,
 			EvalOp:     &PlusDateIntOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Int,
 			RightType:  types.Date,
 			ReturnType: types.Date,
 			EvalOp:     &PlusIntDateOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Date,
 			RightType:  types.Time,
 			ReturnType: types.Timestamp,
 			EvalOp:     &PlusDateTimeOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Time,
 			RightType:  types.Date,
 			ReturnType: types.Timestamp,
 			EvalOp:     &PlusTimeDateOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Date,
 			RightType:  types.TimeTZ,
 			ReturnType: types.TimestampTZ,
 			EvalOp:     &PlusDateTimeTZOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.TimeTZ,
 			RightType:  types.Date,
 			ReturnType: types.TimestampTZ,
 			EvalOp:     &PlusTimeTZDateOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Time,
 			RightType:  types.Interval,
 			ReturnType: types.Time,
 			EvalOp:     &PlusTimeIntervalOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Interval,
 			RightType:  types.Time,
 			ReturnType: types.Time,
 			EvalOp:     &PlusIntervalTimeOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.TimeTZ,
 			RightType:  types.Interval,
 			ReturnType: types.TimeTZ,
 			EvalOp:     &PlusTimeTZIntervalOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Interval,
 			RightType:  types.TimeTZ,
 			ReturnType: types.TimeTZ,
 			EvalOp:     &PlusIntervalTimeTZOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Timestamp,
 			RightType:  types.Interval,
 			ReturnType: types.Timestamp,
 			EvalOp:     &PlusTimestampIntervalOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Interval,
 			RightType:  types.Timestamp,
 			ReturnType: types.Timestamp,
 			EvalOp:     &PlusIntervalTimestampOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.TimestampTZ,
 			RightType:  types.Interval,
 			ReturnType: types.TimestampTZ,
 			EvalOp:     &PlusTimestampTZIntervalOp{},
 			Volatility: volatility.Stable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Interval,
 			RightType:  types.TimestampTZ,
 			ReturnType: types.TimestampTZ,
 			EvalOp:     &PlusIntervalTimestampTZOp{},
 			Volatility: volatility.Stable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Interval,
 			RightType:  types.Interval,
 			ReturnType: types.Interval,
 			EvalOp:     &PlusIntervalOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Date,
 			RightType:  types.Interval,
 			ReturnType: types.Timestamp,
 			EvalOp:     &PlusDateIntervalOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Interval,
 			RightType:  types.Date,
 			ReturnType: types.Timestamp,
 			EvalOp:     &PlusIntervalDateOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.INet,
 			RightType:  types.Int,
 			ReturnType: types.INet,
 			EvalOp:     &PlusINetIntOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Int,
 			RightType:  types.INet,
 			ReturnType: types.INet,
 			EvalOp:     &PlusIntINetOp{},
 			Volatility: volatility.Immutable,
 		},
-	},
+	}},
 
-	treebin.Minus: {
-		&BinOp{
+	treebin.Minus: {overloads: []*BinOp{
+		{
 			LeftType:   types.Int,
 			RightType:  types.Int,
 			ReturnType: types.Int,
 			EvalOp:     &MinusIntOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Float,
 			RightType:  types.Float,
 			ReturnType: types.Float,
 			EvalOp:     &MinusFloatOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Decimal,
 			RightType:  types.Decimal,
 			ReturnType: types.Decimal,
 			EvalOp:     &MinusDecimalOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Decimal,
 			RightType:  types.Int,
 			ReturnType: types.Decimal,
 			EvalOp:     &MinusDecimalIntOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Int,
 			RightType:  types.Decimal,
 			ReturnType: types.Decimal,
 			EvalOp:     &MinusIntDecimalOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Date,
 			RightType:  types.Int,
 			ReturnType: types.Date,
 			EvalOp:     &MinusDateIntOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Date,
 			RightType:  types.Date,
 			ReturnType: types.Int,
 			EvalOp:     &MinusDateOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Date,
 			RightType:  types.Time,
 			ReturnType: types.Timestamp,
 			EvalOp:     &MinusDateTimeOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Time,
 			RightType:  types.Time,
 			ReturnType: types.Interval,
 			EvalOp:     &MinusTimeOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Timestamp,
 			RightType:  types.Timestamp,
 			ReturnType: types.Interval,
 			EvalOp:     &MinusTimestampOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.TimestampTZ,
 			RightType:  types.TimestampTZ,
 			ReturnType: types.Interval,
 			EvalOp:     &MinusTimestampTZOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Timestamp,
 			RightType:  types.TimestampTZ,
 			ReturnType: types.Interval,
 			EvalOp:     &MinusTimestampTimestampTZOp{},
 			Volatility: volatility.Stable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.TimestampTZ,
 			RightType:  types.Timestamp,
 			ReturnType: types.Interval,
 			EvalOp:     &MinusTimestampTZTimestampOp{},
 			Volatility: volatility.Stable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Time,
 			RightType:  types.Interval,
 			ReturnType: types.Time,
 			EvalOp:     &MinusTimeIntervalOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.TimeTZ,
 			RightType:  types.Interval,
 			ReturnType: types.TimeTZ,
 			EvalOp:     &MinusTimeTZIntervalOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Timestamp,
 			RightType:  types.Interval,
 			ReturnType: types.Timestamp,
 			EvalOp:     &MinusTimestampIntervalOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.TimestampTZ,
 			RightType:  types.Interval,
 			ReturnType: types.TimestampTZ,
 			EvalOp:     &MinusTimestampTZIntervalOp{},
 			Volatility: volatility.Stable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Date,
 			RightType:  types.Interval,
 			ReturnType: types.Timestamp,
 			EvalOp:     &MinusDateIntervalOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Interval,
 			RightType:  types.Interval,
 			ReturnType: types.Interval,
 			EvalOp:     &MinusIntervalOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Jsonb,
 			RightType:  types.String,
 			ReturnType: types.Jsonb,
 			EvalOp:     &MinusJsonbStringOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Jsonb,
 			RightType:  types.Int,
 			ReturnType: types.Jsonb,
 			EvalOp:     &MinusJsonbIntOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Jsonb,
 			RightType:  types.MakeArray(types.String),
 			ReturnType: types.Jsonb,
 			EvalOp:     &MinusJsonbStringArrayOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.INet,
 			RightType:  types.INet,
 			ReturnType: types.Int,
 			EvalOp:     &MinusINetOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			// Note: postgres ver 10 does NOT have Int - INet. Throws ERROR: 42883.
 			LeftType:   types.INet,
 			RightType:  types.Int,
@@ -903,24 +933,24 @@ var BinOps = map[treebin.BinaryOperatorSymbol]*binOpOverload{
 			EvalOp:     &MinusINetIntOp{},
 			Volatility: volatility.Immutable,
 		},
-	},
+	}},
 
-	treebin.Mult: {
-		&BinOp{
+	treebin.Mult: {overloads: []*BinOp{
+		{
 			LeftType:   types.Int,
 			RightType:  types.Int,
 			ReturnType: types.Int,
 			EvalOp:     &MultIntOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Float,
 			RightType:  types.Float,
 			ReturnType: types.Float,
 			EvalOp:     &MultFloatOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Decimal,
 			RightType:  types.Decimal,
 			ReturnType: types.Decimal,
@@ -930,191 +960,191 @@ var BinOps = map[treebin.BinaryOperatorSymbol]*binOpOverload{
 		// The following two overloads are needed because DInt/DInt = DDecimal. Due
 		// to this operation, normalization may sometimes create a DInt * DDecimal
 		// operation.
-		&BinOp{
+		{
 			LeftType:   types.Decimal,
 			RightType:  types.Int,
 			ReturnType: types.Decimal,
 			EvalOp:     &MultDecimalIntOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Int,
 			RightType:  types.Decimal,
 			ReturnType: types.Decimal,
 			EvalOp:     &MultIntDecimalOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Int,
 			RightType:  types.Interval,
 			ReturnType: types.Interval,
 			EvalOp:     &MultIntIntervalOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Interval,
 			RightType:  types.Int,
 			ReturnType: types.Interval,
 			EvalOp:     &MultIntervalIntOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Interval,
 			RightType:  types.Float,
 			ReturnType: types.Interval,
 			EvalOp:     &MultIntervalFloatOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Float,
 			RightType:  types.Interval,
 			ReturnType: types.Interval,
 			EvalOp:     &MultFloatIntervalOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Decimal,
 			RightType:  types.Interval,
 			ReturnType: types.Interval,
 			EvalOp:     &MultDecimalIntervalOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Interval,
 			RightType:  types.Decimal,
 			ReturnType: types.Interval,
 			EvalOp:     &MultIntervalDecimalOp{},
 			Volatility: volatility.Immutable,
 		},
-	},
+	}},
 
-	treebin.Div: {
-		&BinOp{
+	treebin.Div: {overloads: []*BinOp{
+		{
 			LeftType:   types.Int,
 			RightType:  types.Int,
 			ReturnType: types.Decimal,
 			EvalOp:     &DivIntOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Float,
 			RightType:  types.Float,
 			ReturnType: types.Float,
 			EvalOp:     &DivFloatOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Decimal,
 			RightType:  types.Decimal,
 			ReturnType: types.Decimal,
 			EvalOp:     &DivDecimalOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Decimal,
 			RightType:  types.Int,
 			ReturnType: types.Decimal,
 			EvalOp:     &DivDecimalIntOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Int,
 			RightType:  types.Decimal,
 			ReturnType: types.Decimal,
 			EvalOp:     &DivIntDecimalOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Interval,
 			RightType:  types.Int,
 			ReturnType: types.Interval,
 			EvalOp:     &DivIntervalIntOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Interval,
 			RightType:  types.Float,
 			ReturnType: types.Interval,
 			EvalOp:     &DivIntervalFloatOp{},
 			Volatility: volatility.Immutable,
 		},
-	},
+	}},
 
-	treebin.FloorDiv: {
-		&BinOp{
+	treebin.FloorDiv: {overloads: []*BinOp{
+		{
 			LeftType:   types.Int,
 			RightType:  types.Int,
 			ReturnType: types.Int,
 			EvalOp:     &FloorDivIntOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Float,
 			RightType:  types.Float,
 			ReturnType: types.Float,
 			EvalOp:     &FloorDivFloatOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Decimal,
 			RightType:  types.Decimal,
 			ReturnType: types.Decimal,
 			EvalOp:     &FloorDivDecimalOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Decimal,
 			RightType:  types.Int,
 			ReturnType: types.Decimal,
 			EvalOp:     &FloorDivDecimalIntOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Int,
 			RightType:  types.Decimal,
 			ReturnType: types.Decimal,
 			EvalOp:     &FloorDivIntDecimalOp{},
 			Volatility: volatility.Immutable,
 		},
-	},
+	}},
 
-	treebin.Mod: {
-		&BinOp{
+	treebin.Mod: {overloads: []*BinOp{
+		{
 			LeftType:   types.Int,
 			RightType:  types.Int,
 			ReturnType: types.Int,
 			EvalOp:     &ModIntOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Float,
 			RightType:  types.Float,
 			ReturnType: types.Float,
 			EvalOp:     &ModFloatOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Decimal,
 			RightType:  types.Decimal,
 			ReturnType: types.Decimal,
 			EvalOp:     &ModDecimalOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Decimal,
 			RightType:  types.Int,
 			ReturnType: types.Decimal,
 			EvalOp:     &ModDecimalIntOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Int,
 			RightType:  types.Decimal,
 			ReturnType: types.Decimal,
 			EvalOp:     &ModIntDecimalOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.String,
 			RightType:  types.String,
 			ReturnType: types.Bool,
@@ -1123,128 +1153,128 @@ var BinOps = map[treebin.BinaryOperatorSymbol]*binOpOverload{
 			// of the pg_trgm.similarity_threshold session setting.
 			Volatility: volatility.Stable,
 		},
-	},
+	}},
 
-	treebin.Concat: {
-		&BinOp{
+	treebin.Concat: {overloads: []*BinOp{
+		{
 			LeftType:   types.String,
 			RightType:  types.String,
 			ReturnType: types.String,
 			EvalOp:     &ConcatStringOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Bytes,
 			RightType:  types.Bytes,
 			ReturnType: types.Bytes,
 			EvalOp:     &ConcatBytesOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.VarBit,
 			RightType:  types.VarBit,
 			ReturnType: types.VarBit,
 			EvalOp:     &ConcatVarBitOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Jsonb,
 			RightType:  types.Jsonb,
 			ReturnType: types.Jsonb,
 			EvalOp:     &ConcatJsonbOp{},
 			Volatility: volatility.Immutable,
 		},
-	},
+	}},
 
 	// TODO(pmattis): Check that the shift is valid.
-	treebin.LShift: {
-		&BinOp{
+	treebin.LShift: {overloads: []*BinOp{
+		{
 			LeftType:   types.Int,
 			RightType:  types.Int,
 			ReturnType: types.Int,
 			EvalOp:     &LShiftIntOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.VarBit,
 			RightType:  types.Int,
 			ReturnType: types.VarBit,
 			EvalOp:     &LShiftVarBitIntOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.INet,
 			RightType:  types.INet,
 			ReturnType: types.Bool,
 			EvalOp:     &LShiftINetOp{},
 			Volatility: volatility.Immutable,
 		},
-	},
+	}},
 
-	treebin.RShift: {
-		&BinOp{
+	treebin.RShift: {overloads: []*BinOp{
+		{
 			LeftType:   types.Int,
 			RightType:  types.Int,
 			ReturnType: types.Int,
 			EvalOp:     &RShiftIntOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.VarBit,
 			RightType:  types.Int,
 			ReturnType: types.VarBit,
 			EvalOp:     &RShiftVarBitIntOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.INet,
 			RightType:  types.INet,
 			ReturnType: types.Bool,
 			EvalOp:     &RShiftINetOp{},
 			Volatility: volatility.Immutable,
 		},
-	},
+	}},
 
-	treebin.Pow: {
-		&BinOp{
+	treebin.Pow: {overloads: []*BinOp{
+		{
 			LeftType:   types.Int,
 			RightType:  types.Int,
 			ReturnType: types.Int,
 			EvalOp:     &PowIntOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Float,
 			RightType:  types.Float,
 			ReturnType: types.Float,
 			EvalOp:     &PowFloatOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Decimal,
 			RightType:  types.Decimal,
 			ReturnType: types.Decimal,
 			EvalOp:     &PowDecimalOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Decimal,
 			RightType:  types.Int,
 			ReturnType: types.Decimal,
 			EvalOp:     &PowDecimalIntOp{},
 			Volatility: volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Int,
 			RightType:  types.Decimal,
 			ReturnType: types.Decimal,
 			EvalOp:     &PowIntDecimalOp{},
 			Volatility: volatility.Immutable,
 		},
-	},
+	}},
 
-	treebin.JSONFetchVal: {
-		&BinOp{
+	treebin.JSONFetchVal: {overloads: []*BinOp{
+		{
 			LeftType:          types.Jsonb,
 			RightType:         types.String,
 			ReturnType:        types.Jsonb,
@@ -1252,27 +1282,27 @@ var BinOps = map[treebin.BinaryOperatorSymbol]*binOpOverload{
 			PreferredOverload: true,
 			Volatility:        volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Jsonb,
 			RightType:  types.Int,
 			ReturnType: types.Jsonb,
 			EvalOp:     &JSONFetchValIntOp{},
 			Volatility: volatility.Immutable,
 		},
-	},
+	}},
 
-	treebin.JSONFetchValPath: {
-		&BinOp{
+	treebin.JSONFetchValPath: {overloads: []*BinOp{
+		{
 			LeftType:   types.Jsonb,
 			RightType:  types.MakeArray(types.String),
 			ReturnType: types.Jsonb,
 			EvalOp:     &JSONFetchValPathOp{},
 			Volatility: volatility.Immutable,
 		},
-	},
+	}},
 
-	treebin.JSONFetchText: {
-		&BinOp{
+	treebin.JSONFetchText: {overloads: []*BinOp{
+		{
 			LeftType:          types.Jsonb,
 			RightType:         types.String,
 			ReturnType:        types.String,
@@ -1280,24 +1310,24 @@ var BinOps = map[treebin.BinaryOperatorSymbol]*binOpOverload{
 			EvalOp:            &JSONFetchTextStringOp{},
 			Volatility:        volatility.Immutable,
 		},
-		&BinOp{
+		{
 			LeftType:   types.Jsonb,
 			RightType:  types.Int,
 			ReturnType: types.String,
 			EvalOp:     &JSONFetchTextIntOp{},
 			Volatility: volatility.Immutable,
 		},
-	},
+	}},
 
-	treebin.JSONFetchTextPath: {
-		&BinOp{
+	treebin.JSONFetchTextPath: {overloads: []*BinOp{
+		{
 			LeftType:   types.Jsonb,
 			RightType:  types.MakeArray(types.String),
 			ReturnType: types.String,
 			EvalOp:     &JSONFetchTextPathOp{},
 			Volatility: volatility.Immutable,
 		},
-	},
+	}},
 }
 
 // CmpOp is a comparison operator.
@@ -1340,10 +1370,10 @@ func (op *CmpOp) preferred() bool {
 }
 
 func cmpOpFixups(
-	cmpOps map[treecmp.ComparisonOperatorSymbol]*cmpOpOverload,
-) map[treecmp.ComparisonOperatorSymbol]*cmpOpOverload {
+	cmpOps map[treecmp.ComparisonOperatorSymbol]*CmpOpOverloads,
+) map[treecmp.ComparisonOperatorSymbol]*CmpOpOverloads {
 	findVolatility := func(op treecmp.ComparisonOperatorSymbol, t *types.T) volatility.V {
-		for _, o := range *cmpOps[treecmp.EQ] {
+		for _, o := range cmpOps[treecmp.EQ].overloads {
 			if o.LeftType.Equivalent(t) && o.RightType.Equivalent(t) {
 				return o.Volatility
 			}
@@ -1356,10 +1386,10 @@ func cmpOpFixups(
 		appendCmpOp := func(sym treecmp.ComparisonOperatorSymbol, cmpOp *CmpOp) {
 			s, ok := cmpOps[sym]
 			if !ok {
-				s = new(cmpOpOverload)
+				s = new(CmpOpOverloads)
 				cmpOps[sym] = s
 			}
-			*s = append(*s, cmpOp)
+			s.overloads = append(s.overloads, cmpOp)
 		}
 		appendCmpOp(treecmp.EQ, &CmpOp{
 			LeftType:   types.MakeArray(t),
@@ -1388,33 +1418,48 @@ func cmpOpFixups(
 		})
 	}
 
-	for _, overload := range cmpOps {
-		for _, impl := range *overload {
-			impl.types = ArgTypes{{"left", impl.LeftType}, {"right", impl.RightType}}
-		}
+	for _, overloads := range cmpOps {
+		_ = overloads.ForEachCmpOp(func(op *CmpOp) error {
+			op.types = ArgTypes{{"left", op.LeftType}, {"right", op.RightType}}
+			return nil
+		})
 	}
 
 	return cmpOps
 }
 
-// cmpOpOverload is an overloaded set of comparison operator implementations.
-type cmpOpOverload []*CmpOp
-
-func (o cmpOpOverload) len() int {
-	return len(o)
+// CmpOpOverloads is an overloaded set of comparison operator implementations.
+type CmpOpOverloads struct {
+	overloads []*CmpOp
 }
 
-func (o cmpOpOverload) get(i int) overloadImpl {
-	return o[i]
-}
+func (o *CmpOpOverloads) len() int               { return len(o.overloads) }
+func (o *CmpOpOverloads) get(i int) overloadImpl { return o.overloads[i] }
 
-func (o cmpOpOverload) LookupImpl(left, right *types.T) (*CmpOp, bool) {
-	for _, fn := range o {
+// LookupImpl is used to look up the overload for a pair of types.
+func (o *CmpOpOverloads) LookupImpl(left, right *types.T) (*CmpOp, bool) {
+	if o == nil {
+		return nil, false
+	}
+	for _, fn := range o.overloads {
 		if fn.matchParams(left, right) {
 			return fn, true
 		}
 	}
 	return nil, false
+}
+
+// ForEachCmpOp iterates the ops in the set.
+func (o *CmpOpOverloads) ForEachCmpOp(f func(op *CmpOp) error) error {
+	if o == nil {
+		return nil
+	}
+	for _, ol := range o.overloads {
+		if err := f(ol); err != nil {
+			return iterutil.Map(err)
+		}
+	}
+	return nil
 }
 
 func makeCmpOpOverload(
@@ -1443,8 +1488,8 @@ func makeIsFn(a, b *types.T, v volatility.V) *CmpOp {
 }
 
 // CmpOps contains the comparison operations indexed by operation type.
-var CmpOps = cmpOpFixups(map[treecmp.ComparisonOperatorSymbol]*cmpOpOverload{
-	treecmp.EQ: {
+var CmpOps = cmpOpFixups(map[treecmp.ComparisonOperatorSymbol]*CmpOpOverloads{
+	treecmp.EQ: {overloads: []*CmpOp{
 		// Single-type comparisons.
 		makeEqFn(types.AnyEnum, types.AnyEnum, volatility.Immutable),
 		makeEqFn(types.Bool, types.Bool, volatility.Leakproof),
@@ -1491,7 +1536,7 @@ var CmpOps = cmpOpFixups(map[treecmp.ComparisonOperatorSymbol]*cmpOpOverload{
 		makeEqFn(types.TimeTZ, types.Time, volatility.Stable),
 
 		// Tuple comparison.
-		&CmpOp{
+		{
 			LeftType:  types.AnyTuple,
 			RightType: types.AnyTuple,
 			EvalOp: &CompareTupleOp{
@@ -1499,9 +1544,9 @@ var CmpOps = cmpOpFixups(map[treecmp.ComparisonOperatorSymbol]*cmpOpOverload{
 			},
 			Volatility: volatility.Immutable,
 		},
-	},
+	}},
 
-	treecmp.LT: {
+	treecmp.LT: {overloads: []*CmpOp{
 		// Single-type comparisons.
 		makeLtFn(types.AnyEnum, types.AnyEnum, volatility.Immutable),
 		makeLtFn(types.Bool, types.Bool, volatility.Leakproof),
@@ -1547,7 +1592,7 @@ var CmpOps = cmpOpFixups(map[treecmp.ComparisonOperatorSymbol]*cmpOpOverload{
 		makeLtFn(types.TimeTZ, types.Time, volatility.Stable),
 
 		// Tuple comparison.
-		&CmpOp{
+		{
 			LeftType:  types.AnyTuple,
 			RightType: types.AnyTuple,
 			EvalOp: &CompareTupleOp{
@@ -1555,9 +1600,9 @@ var CmpOps = cmpOpFixups(map[treecmp.ComparisonOperatorSymbol]*cmpOpOverload{
 			},
 			Volatility: volatility.Immutable,
 		},
-	},
+	}},
 
-	treecmp.LE: {
+	treecmp.LE: {overloads: []*CmpOp{
 		// Single-type comparisons.
 		makeLeFn(types.AnyEnum, types.AnyEnum, volatility.Immutable),
 		makeLeFn(types.Bool, types.Bool, volatility.Leakproof),
@@ -1603,7 +1648,7 @@ var CmpOps = cmpOpFixups(map[treecmp.ComparisonOperatorSymbol]*cmpOpOverload{
 		makeLeFn(types.TimeTZ, types.Time, volatility.Stable),
 
 		// Tuple comparison.
-		&CmpOp{
+		{
 			LeftType:  types.AnyTuple,
 			RightType: types.AnyTuple,
 			EvalOp: &CompareTupleOp{
@@ -1611,10 +1656,10 @@ var CmpOps = cmpOpFixups(map[treecmp.ComparisonOperatorSymbol]*cmpOpOverload{
 			},
 			Volatility: volatility.Immutable,
 		},
-	},
+	}},
 
-	treecmp.IsNotDistinctFrom: {
-		&CmpOp{
+	treecmp.IsNotDistinctFrom: {overloads: []*CmpOp{
+		{
 			LeftType:  types.Unknown,
 			RightType: types.Unknown,
 			EvalOp: &CompareScalarOp{
@@ -1625,7 +1670,7 @@ var CmpOps = cmpOpFixups(map[treecmp.ComparisonOperatorSymbol]*cmpOpOverload{
 			PreferredOverload: true,
 			Volatility:        volatility.Leakproof,
 		},
-		&CmpOp{
+		{
 			LeftType:  types.AnyArray,
 			RightType: types.Unknown,
 			EvalOp: &CompareScalarOp{
@@ -1680,7 +1725,7 @@ var CmpOps = cmpOpFixups(map[treecmp.ComparisonOperatorSymbol]*cmpOpOverload{
 		makeIsFn(types.TimeTZ, types.Time, volatility.Stable),
 
 		// Tuple comparison.
-		&CmpOp{
+		{
 			LeftType:          types.AnyTuple,
 			RightType:         types.AnyTuple,
 			CalledOnNullInput: true,
@@ -1689,9 +1734,9 @@ var CmpOps = cmpOpFixups(map[treecmp.ComparisonOperatorSymbol]*cmpOpOverload{
 			},
 			Volatility: volatility.Immutable,
 		},
-	},
+	}},
 
-	treecmp.In: {
+	treecmp.In: {overloads: []*CmpOp{
 		makeEvalTupleIn(types.AnyEnum, volatility.Leakproof),
 		makeEvalTupleIn(types.Bool, volatility.Leakproof),
 		makeEvalTupleIn(types.Bytes, volatility.Leakproof),
@@ -1715,144 +1760,139 @@ var CmpOps = cmpOpFixups(map[treecmp.ComparisonOperatorSymbol]*cmpOpOverload{
 		makeEvalTupleIn(types.TimestampTZ, volatility.Leakproof),
 		makeEvalTupleIn(types.Uuid, volatility.Leakproof),
 		makeEvalTupleIn(types.VarBit, volatility.Leakproof),
-	},
+	}},
 
-	treecmp.Like: {
-		&CmpOp{
+	treecmp.Like: {overloads: []*CmpOp{
+		{
 			LeftType:   types.String,
 			RightType:  types.String,
 			EvalOp:     &MatchLikeOp{CaseInsensitive: false},
 			Volatility: volatility.Leakproof,
 		},
-	},
+	}},
 
-	treecmp.ILike: {
-		&CmpOp{
+	treecmp.ILike: {overloads: []*CmpOp{
+		{
 			LeftType:   types.String,
 			RightType:  types.String,
 			EvalOp:     &MatchLikeOp{CaseInsensitive: true},
 			Volatility: volatility.Leakproof,
 		},
-	},
+	}},
 
-	treecmp.SimilarTo: {
-		&CmpOp{
+	treecmp.SimilarTo: {overloads: []*CmpOp{
+		{
 			LeftType:   types.String,
 			RightType:  types.String,
 			EvalOp:     &SimilarToOp{Escape: '\\'},
 			Volatility: volatility.Leakproof,
 		},
-	},
+	}},
 
-	treecmp.RegMatch: func() *cmpOpOverload {
-		r := append(cmpOpOverload{
-			{
-				LeftType:   types.String,
-				RightType:  types.String,
-				EvalOp:     &MatchRegexpOp{},
-				Volatility: volatility.Immutable,
-			},
+	treecmp.RegMatch: {overloads: append([]*CmpOp{
+		{
+			LeftType:   types.String,
+			RightType:  types.String,
+			EvalOp:     &MatchRegexpOp{},
+			Volatility: volatility.Immutable,
 		},
-			makeBox2DComparisonOperators(
-				func(lhs, rhs *geo.CartesianBoundingBox) bool {
-					return lhs.Covers(rhs)
-				},
-			)...,
-		)
-		return &r
-	}(),
+	},
+		makeBox2DComparisonOperators(
+			func(lhs, rhs *geo.CartesianBoundingBox) bool {
+				return lhs.Covers(rhs)
+			},
+		)...,
+	)},
 
-	treecmp.RegIMatch: {
-		&CmpOp{
+	treecmp.RegIMatch: {overloads: []*CmpOp{
+		{
 			LeftType:   types.String,
 			RightType:  types.String,
 			EvalOp:     &MatchRegexpOp{CaseInsensitive: true},
 			Volatility: volatility.Immutable,
 		},
-	},
+	}},
 
-	treecmp.JSONExists: {
-		&CmpOp{
+	treecmp.JSONExists: {overloads: []*CmpOp{
+		{
 			LeftType:   types.Jsonb,
 			RightType:  types.String,
 			EvalOp:     &JSONExistsOp{},
 			Volatility: volatility.Immutable,
 		},
-	},
+	}},
 
-	treecmp.JSONSomeExists: {
-		&CmpOp{
+	treecmp.JSONSomeExists: {overloads: []*CmpOp{
+		{
 			LeftType:   types.Jsonb,
 			RightType:  types.StringArray,
 			EvalOp:     &JSONSomeExistsOp{},
 			Volatility: volatility.Immutable,
 		},
-	},
+	}},
 
-	treecmp.JSONAllExists: {
-		&CmpOp{
+	treecmp.JSONAllExists: {overloads: []*CmpOp{
+		{
 			LeftType:   types.Jsonb,
 			RightType:  types.StringArray,
 			EvalOp:     &JSONAllExistsOp{},
 			Volatility: volatility.Immutable,
 		},
-	},
+	}},
 
-	treecmp.Contains: {
-		&CmpOp{
+	treecmp.Contains: {overloads: []*CmpOp{
+		{
 			LeftType:   types.AnyArray,
 			RightType:  types.AnyArray,
 			EvalOp:     &ContainsArrayOp{},
 			Volatility: volatility.Immutable,
 		},
-		&CmpOp{
+		{
 			LeftType:   types.Jsonb,
 			RightType:  types.Jsonb,
 			EvalOp:     &ContainsJsonbOp{},
 			Volatility: volatility.Immutable,
 		},
-	},
+	}},
 
-	treecmp.ContainedBy: {
-		&CmpOp{
+	treecmp.ContainedBy: {overloads: []*CmpOp{
+		{
 			LeftType:   types.AnyArray,
 			RightType:  types.AnyArray,
 			EvalOp:     &ContainedByArrayOp{},
 			Volatility: volatility.Immutable,
 		},
-		&CmpOp{
+		{
 			LeftType:   types.Jsonb,
 			RightType:  types.Jsonb,
 			EvalOp:     &ContainedByJsonbOp{},
 			Volatility: volatility.Immutable,
 		},
+	}},
+	treecmp.Overlaps: {overloads: append([]*CmpOp{
+		{
+			LeftType:   types.AnyArray,
+			RightType:  types.AnyArray,
+			EvalOp:     &OverlapsArrayOp{},
+			Volatility: volatility.Immutable,
+		},
+		{
+			LeftType:   types.INet,
+			RightType:  types.INet,
+			EvalOp:     &OverlapsINetOp{},
+			Volatility: volatility.Immutable,
+		},
+	}, makeBox2DComparisonOperators(
+		func(lhs, rhs *geo.CartesianBoundingBox) bool {
+			return lhs.Intersects(rhs)
+		},
+	)...),
 	},
-	treecmp.Overlaps: func() *cmpOpOverload {
-		r := append(cmpOpOverload{
-			{
-				LeftType:   types.AnyArray,
-				RightType:  types.AnyArray,
-				EvalOp:     &OverlapsArrayOp{},
-				Volatility: volatility.Immutable,
-			},
-			{
-				LeftType:   types.INet,
-				RightType:  types.INet,
-				EvalOp:     &OverlapsINetOp{},
-				Volatility: volatility.Immutable,
-			},
-		}, makeBox2DComparisonOperators(
-			func(lhs, rhs *geo.CartesianBoundingBox) bool {
-				return lhs.Intersects(rhs)
-			},
-		)...)
-		return &r
-	}(),
 })
 
-func makeBox2DComparisonOperators(op func(lhs, rhs *geo.CartesianBoundingBox) bool) cmpOpOverload {
-	return cmpOpOverload{
-		&CmpOp{
+func makeBox2DComparisonOperators(op func(lhs, rhs *geo.CartesianBoundingBox) bool) []*CmpOp {
+	return []*CmpOp{
+		{
 			LeftType:  types.Box2D,
 			RightType: types.Box2D,
 			EvalOp: &CompareBox2DOp{Op: func(left, right Datum) bool {
@@ -1863,7 +1903,7 @@ func makeBox2DComparisonOperators(op func(lhs, rhs *geo.CartesianBoundingBox) bo
 			}},
 			Volatility: volatility.Immutable,
 		},
-		&CmpOp{
+		{
 			LeftType:  types.Box2D,
 			RightType: types.Geometry,
 			EvalOp: &CompareBox2DOp{Op: func(left, right Datum) bool {
@@ -1874,7 +1914,7 @@ func makeBox2DComparisonOperators(op func(lhs, rhs *geo.CartesianBoundingBox) bo
 			}},
 			Volatility: volatility.Immutable,
 		},
-		&CmpOp{
+		{
 			LeftType:  types.Geometry,
 			RightType: types.Box2D,
 			EvalOp: &CompareBox2DOp{Op: func(left, right Datum) bool {
@@ -1885,7 +1925,7 @@ func makeBox2DComparisonOperators(op func(lhs, rhs *geo.CartesianBoundingBox) bo
 			}},
 			Volatility: volatility.Immutable,
 		},
-		&CmpOp{
+		{
 			LeftType:  types.Geometry,
 			RightType: types.Geometry,
 			EvalOp: &CompareBox2DOp{Op: func(left, right Datum) bool {

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treebin"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treecmp"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -1219,13 +1220,18 @@ func NewTypedUnaryExpr(op UnaryOperator, expr TypedExpr, typ *types.T) *UnaryExp
 	node := &UnaryExpr{Operator: op, Expr: expr}
 	node.typ = typ
 	innerType := expr.ResolvedType()
-	for _, o := range *UnaryOps[op.Symbol] {
+
+	_ = UnaryOps[op.Symbol].ForEachUnaryOp(func(o *UnaryOp) error {
 		if innerType.Equivalent(o.Typ) && node.typ.Equivalent(o.ReturnType) {
 			node.op = o
-			return node
+			return iterutil.StopIteration()
 		}
+		return nil
+	})
+	if node.op == nil {
+		panic(errors.AssertionFailedf("invalid TypedExpr with unary op %d: %s", op.Symbol, expr))
 	}
-	panic(errors.AssertionFailedf("invalid TypedExpr with unary op %d: %s", op.Symbol, expr))
+	return node
 }
 
 // FuncExpr represents a function call.

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1219,8 +1219,7 @@ func NewTypedUnaryExpr(op UnaryOperator, expr TypedExpr, typ *types.T) *UnaryExp
 	node := &UnaryExpr{Operator: op, Expr: expr}
 	node.typ = typ
 	innerType := expr.ResolvedType()
-	for _, o := range UnaryOps[op.Symbol] {
-		o := o.(*UnaryOp)
+	for _, o := range *UnaryOps[op.Symbol] {
 		if innerType.Equivalent(o.Typ) && node.typ.Equivalent(o.ReturnType) {
 			node.op = o
 			return node

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -48,6 +48,16 @@ type ResolvedFunctionDefinition struct {
 	Overloads []QualifiedOverload
 }
 
+type qualifiedOverloads []QualifiedOverload
+
+func (qo qualifiedOverloads) len() int {
+	return len(qo)
+}
+
+func (qo qualifiedOverloads) get(i int) overloadImpl {
+	return qo[i].Overload
+}
+
 // QualifiedOverload is a wrapper of Overload prefixed with a schema name.
 // It indicates that the overload is defined with the specified schema.
 type QualifiedOverload struct {

--- a/pkg/sql/sem/tree/helpers_test.go
+++ b/pkg/sql/sem/tree/helpers_test.go
@@ -1,0 +1,14 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tree
+
+// TypeCheckSameTypedExprs is exported for testing.
+var TypeCheckSameTypedExprs = typeCheckSameTypedExprs

--- a/pkg/sql/sem/tree/operators_test.go
+++ b/pkg/sql/sem/tree/operators_test.go
@@ -137,34 +137,25 @@ func TestOperatorVolatilityMatchesPostgres(t *testing.T) {
 	// Check unary ops. We don't just go through the map so we process them in
 	// an orderly fashion.
 	for op := UnaryOperatorSymbol(0); op < NumUnaryOperatorSymbols; op++ {
-		s, ok := UnaryOps[op]
-		if !ok {
-			continue
-		}
-		for _, o := range *s {
+		_ = UnaryOps[op].ForEachUnaryOp(func(o *UnaryOp) error {
 			check(op.String(), nil /* leftType */, o.Typ, o.Volatility)
-		}
+			return nil
+		})
 	}
 
 	// Check comparison ops.
 	for op := treecmp.ComparisonOperatorSymbol(0); op < treecmp.NumComparisonOperatorSymbols; op++ {
-		s, ok := CmpOps[op]
-		if !ok {
-			continue
-		}
-		for _, o := range *s {
+		_ = CmpOps[op].ForEachCmpOp(func(o *CmpOp) error {
 			check(op.String(), o.LeftType, o.RightType, o.Volatility)
-		}
+			return nil
+		})
 	}
 
 	// Check binary ops.
 	for op := treebin.BinaryOperatorSymbol(0); op < treebin.NumBinaryOperatorSymbols; op++ {
-		s, ok := BinOps[op]
-		if !ok {
-			continue
-		}
-		for _, o := range *s {
+		_ = BinOps[op].ForEachBinOp(func(o *BinOp) error {
 			check(op.String(), o.LeftType, o.RightType, o.Volatility)
-		}
+			return nil
+		})
 	}
 }

--- a/pkg/sql/sem/tree/operators_test.go
+++ b/pkg/sql/sem/tree/operators_test.go
@@ -137,24 +137,33 @@ func TestOperatorVolatilityMatchesPostgres(t *testing.T) {
 	// Check unary ops. We don't just go through the map so we process them in
 	// an orderly fashion.
 	for op := UnaryOperatorSymbol(0); op < NumUnaryOperatorSymbols; op++ {
-		for _, impl := range UnaryOps[op] {
-			o := impl.(*UnaryOp)
+		s, ok := UnaryOps[op]
+		if !ok {
+			continue
+		}
+		for _, o := range *s {
 			check(op.String(), nil /* leftType */, o.Typ, o.Volatility)
 		}
 	}
 
 	// Check comparison ops.
 	for op := treecmp.ComparisonOperatorSymbol(0); op < treecmp.NumComparisonOperatorSymbols; op++ {
-		for _, impl := range CmpOps[op] {
-			o := impl.(*CmpOp)
+		s, ok := CmpOps[op]
+		if !ok {
+			continue
+		}
+		for _, o := range *s {
 			check(op.String(), o.LeftType, o.RightType, o.Volatility)
 		}
 	}
 
 	// Check binary ops.
 	for op := treebin.BinaryOperatorSymbol(0); op < treebin.NumBinaryOperatorSymbols; op++ {
-		for _, impl := range BinOps[op] {
-			o := impl.(*BinOp)
+		s, ok := BinOps[op]
+		if !ok {
+			continue
+		}
+		for _, o := range *s {
 			check(op.String(), o.LeftType, o.RightType, o.Volatility)
 		}
 	}

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"math"
 	"strings"
+	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -565,12 +566,70 @@ func returnTypeToFixedType(s ReturnTyper, inputTyps []TypedExpr) *types.T {
 
 type typeCheckOverloadState struct {
 	overloads       []overloadImpl
+	params          []TypeList
 	overloadIdxs    []uint8 // index into overloads
 	exprs           []Expr
 	typedExprs      []TypedExpr
 	resolvableIdxs  util.FastIntSet // index into exprs/typedExprs
 	constIdxs       util.FastIntSet // index into exprs/typedExprs
 	placeholderIdxs util.FastIntSet // index into exprs/typedExprs
+	overloadsIdxArr [16]uint8
+}
+
+var overloadTypeCheckerPool = sync.Pool{
+	New: func() interface{} {
+		var s typeCheckOverloadState
+		s.overloadIdxs = s.overloadsIdxArr[:0]
+		return &s
+	},
+}
+
+func getOverloadTypeChecker(o overloadSet, exprs ...Expr) *typeCheckOverloadState {
+	s := overloadTypeCheckerPool.Get().(*typeCheckOverloadState)
+	n := o.len()
+	if n > cap(s.overloads) {
+		s.overloads = make([]overloadImpl, n)
+		s.params = make([]TypeList, n)
+	} else {
+		s.overloads = s.overloads[:n]
+		s.params = s.params[:n]
+	}
+	for i := 0; i < n; i++ {
+		got := o.get(i)
+		s.overloads[i] = got
+		s.params[i] = got.params()
+	}
+	s.exprs = append(s.exprs, exprs...)
+	return s
+}
+
+func (s *typeCheckOverloadState) release() {
+	for i := range s.overloads {
+		s.overloads[i] = nil
+	}
+	s.overloads = s.overloads[:0]
+	for i := range s.params {
+		s.params[i] = nil
+	}
+	s.params = s.params[:0]
+	for i := range s.exprs {
+		s.exprs[i] = nil
+	}
+	s.exprs = s.exprs[:0]
+	for i := range s.typedExprs {
+		s.typedExprs[i] = nil
+	}
+	s.typedExprs = s.typedExprs[:0]
+	s.overloadIdxs = s.overloadIdxs[:0]
+	s.resolvableIdxs = util.FastIntSet{}
+	s.constIdxs = util.FastIntSet{}
+	s.placeholderIdxs = util.FastIntSet{}
+	overloadTypeCheckerPool.Put(s)
+}
+
+type overloadSet interface {
+	len() int
+	get(i int) overloadImpl
 }
 
 // typeCheckOverloadedExprs determines the correct overload to use for the given set of
@@ -585,77 +644,84 @@ type typeCheckOverloadState struct {
 // The inBinOp parameter denotes whether this type check is occurring within a binary operator,
 // in which case we may need to make a guess that the two parameters are of the same type if one
 // of them is NULL.
-func typeCheckOverloadedExprs(
-	ctx context.Context,
-	semaCtx *SemaContext,
-	desired *types.T,
-	overloads []overloadImpl,
-	inBinOp bool,
-	exprs ...Expr,
-) ([]TypedExpr, []overloadImpl, error) {
-	if len(overloads) > math.MaxUint8 {
-		return nil, nil, errors.AssertionFailedf("too many overloads (%d > 255)", len(overloads))
+func (s *typeCheckOverloadState) typeCheckOverloadedExprs(
+	ctx context.Context, semaCtx *SemaContext, desired *types.T, inBinOp bool,
+) (_ error) {
+	numOverloads := len(s.overloads)
+	if numOverloads > math.MaxUint8 {
+		return errors.AssertionFailedf("too many overloads (%d > 255)", numOverloads)
 	}
-
-	var s typeCheckOverloadState
-	s.exprs = exprs
-	s.overloads = overloads
 
 	// Special-case the HomogeneousType overload. We determine its return type by checking that
 	// all parameters have the same type.
-	for i, overload := range overloads {
+	for i := range s.params {
 		// Only one overload can be provided if it has parameters with HomogeneousType.
-		if _, ok := overload.params().(HomogeneousType); ok {
-			if len(overloads) > 1 {
-				return nil, nil, errors.AssertionFailedf(
+		if _, ok := s.params[i].(HomogeneousType); ok {
+			if numOverloads > 1 {
+				return errors.AssertionFailedf(
 					"only one overload can have HomogeneousType parameters")
 			}
-			typedExprs, _, err := TypeCheckSameTypedExprs(ctx, semaCtx, desired, exprs...)
+			typedExprs, _, err := typeCheckSameTypedExprs(ctx, semaCtx, desired, s.exprs...)
 			if err != nil {
-				return nil, nil, err
+				return err
 			}
-			return typedExprs, overloads[i : i+1], nil
+			s.typedExprs = typedExprs
+			s.overloadIdxs = append(s.overloadIdxs[:0], uint8(i))
+			return nil
 		}
 	}
 
 	// Hold the resolved type expressions of the provided exprs, in order.
-	s.typedExprs = make([]TypedExpr, len(exprs))
-	s.constIdxs, s.placeholderIdxs, s.resolvableIdxs = typeCheckSplitExprs(semaCtx, exprs)
+	if cap(s.typedExprs) >= len(s.exprs) {
+		s.typedExprs = s.typedExprs[:len(s.exprs)]
+	} else {
+		s.typedExprs = make([]TypedExpr, len(s.exprs))
+	}
+	s.constIdxs, s.placeholderIdxs, s.resolvableIdxs = typeCheckSplitExprs(
+		semaCtx, s.exprs,
+	)
 
 	// If no overloads are provided, just type check parameters and return.
-	if len(overloads) == 0 {
+	if numOverloads == 0 {
 		for i, ok := s.resolvableIdxs.Next(0); ok; i, ok = s.resolvableIdxs.Next(i + 1) {
-			typ, err := exprs[i].TypeCheck(ctx, semaCtx, types.Any)
+			typ, err := s.exprs[i].TypeCheck(ctx, semaCtx, types.Any)
 			if err != nil {
-				return nil, nil, pgerror.Wrapf(err, pgcode.InvalidParameterValue,
+				return pgerror.Wrapf(err, pgcode.InvalidParameterValue,
 					"error type checking resolved expression:")
 			}
 			s.typedExprs[i] = typ
 		}
-		if err := defaultTypeCheck(ctx, semaCtx, &s, false); err != nil {
-			return nil, nil, err
+		if err := defaultTypeCheck(ctx, semaCtx, s, false); err != nil {
+			return err
 		}
-		return s.typedExprs, nil, nil
+		s.overloadIdxs = s.overloadIdxs[:0]
+		return nil
 	}
 
-	s.overloadIdxs = make([]uint8, len(overloads))
-	for i := 0; i < len(overloads); i++ {
+	if cap(s.overloadIdxs) < numOverloads {
+		s.overloadIdxs = make([]uint8, 0, numOverloads)
+	}
+	s.overloadIdxs = s.overloadIdxs[:numOverloads]
+	for i := range s.overloadIdxs {
 		s.overloadIdxs[i] = uint8(i)
 	}
 
 	// Filter out incorrect parameter length overloads.
-	s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs,
-		func(o overloadImpl) bool {
-			return o.params().MatchLen(len(exprs))
-		})
+	exprsLen := len(s.exprs)
+	s.overloadIdxs = filterParams(s.overloadIdxs, s.params, func(
+		params TypeList,
+	) bool {
+		return params.MatchLen(exprsLen)
+	})
 
 	// Filter out overloads which constants cannot become.
 	for i, ok := s.constIdxs.Next(0); ok; i, ok = s.constIdxs.Next(i + 1) {
-		constExpr := exprs[i].(Constant)
-		s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs,
-			func(o overloadImpl) bool {
-				return canConstantBecome(constExpr, o.params().GetAt(i))
-			})
+		constExpr := s.exprs[i].(Constant)
+		s.overloadIdxs = filterParams(s.overloadIdxs, s.params, func(
+			params TypeList,
+		) bool {
+			return canConstantBecome(constExpr, params.GetAt(i))
+		})
 	}
 
 	// TODO(nvanbenschoten): We should add a filtering step here to filter
@@ -671,7 +737,8 @@ func typeCheckOverloadedExprs(
 		// Note that this is always the case when we have a single overload left.
 		var sameType *types.T
 		for _, ovIdx := range s.overloadIdxs {
-			typ := s.overloads[ovIdx].params().GetAt(i)
+			ov := s.overloads[ovIdx]
+			typ := ov.params().GetAt(i)
 			if sameType == nil {
 				sameType = typ
 			} else if !typ.Identical(sameType) {
@@ -682,41 +749,44 @@ func typeCheckOverloadedExprs(
 		if sameType != nil {
 			paramDesired = sameType
 		}
-		typ, err := exprs[i].TypeCheck(ctx, semaCtx, paramDesired)
+		typ, err := s.exprs[i].TypeCheck(ctx, semaCtx, paramDesired)
 		if err != nil {
-			return nil, nil, err
+			return err
 		}
 		s.typedExprs[i] = typ
-		s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs,
-			func(o overloadImpl) bool {
-				return o.params().MatchAt(typ.ResolvedType(), i)
-			})
+		rt := typ.ResolvedType()
+		s.overloadIdxs = filterParams(s.overloadIdxs, s.params, func(
+			params TypeList,
+		) bool {
+			return params.MatchAt(rt, i)
+		})
 	}
 
 	// At this point, all remaining overload candidates accept the argument list,
-	// so we begin checking for a single remaining candidate implementation to choose.
+	// so we begin checking for a single remainig candidate implementation to choose.
 	// In case there is more than one candidate remaining, the following code uses
 	// heuristics to find a most preferable candidate.
-	if ok, typedExprs, fns, err := checkReturn(ctx, semaCtx, &s); ok {
-		return typedExprs, fns, err
+	if ok, err := checkReturn(ctx, semaCtx, s); ok {
+		return err
 	}
 
 	// The first heuristic is to prefer candidates that return the desired type,
 	// if a desired type was provided.
 	if desired.Family() != types.AnyFamily {
-		s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs,
-			func(o overloadImpl) bool {
-				// For now, we only filter on the return type for overloads with
-				// fixed return types. This could be improved, but is not currently
-				// critical because we have no cases of functions with multiple
-				// overloads that do not all expose FixedReturnTypes.
-				if t := o.returnType()(nil); t != UnknownReturnType {
-					return t.Equivalent(desired)
-				}
-				return true
-			})
-		if ok, typedExprs, fns, err := checkReturn(ctx, semaCtx, &s); ok {
-			return typedExprs, fns, err
+		s.overloadIdxs = filterOverloads(s.overloadIdxs, s.overloads, func(
+			o overloadImpl,
+		) bool {
+			// For now, we only filter on the return type for overloads with
+			// fixed return types. This could be improved, but is not currently
+			// critical because we have no cases of functions with multiple
+			// overloads that do not all expose FixedReturnTypes.
+			if t := o.returnType()(nil); t != UnknownReturnType {
+				return t.Equivalent(desired)
+			}
+			return true
+		})
+		if ok, err := checkReturn(ctx, semaCtx, s); ok {
+			return err
 		}
 	}
 
@@ -734,7 +804,7 @@ func typeCheckOverloadedExprs(
 
 	if !s.constIdxs.Empty() {
 		allConstantsAreHomogenous := false
-		if ok, typedExprs, fns, err := filterAttempt(ctx, semaCtx, &s, func() {
+		if ok, err := filterAttempt(ctx, semaCtx, s, func() {
 			// The second heuristic is to prefer candidates where all constants can
 			// become a homogeneous type, if all resolvable expressions became one.
 			// This is only possible if resolvable expressions were resolved
@@ -742,38 +812,40 @@ func typeCheckOverloadedExprs(
 			if homogeneousTyp != nil {
 				allConstantsAreHomogenous = true
 				for i, ok := s.constIdxs.Next(0); ok; i, ok = s.constIdxs.Next(i + 1) {
-					if !canConstantBecome(exprs[i].(Constant), homogeneousTyp) {
+					if !canConstantBecome(s.exprs[i].(Constant), homogeneousTyp) {
 						allConstantsAreHomogenous = false
 						break
 					}
 				}
 				if allConstantsAreHomogenous {
 					for i, ok := s.constIdxs.Next(0); ok; i, ok = s.constIdxs.Next(i + 1) {
-						s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs,
-							func(o overloadImpl) bool {
-								return o.params().GetAt(i).Equivalent(homogeneousTyp)
-							})
+						s.overloadIdxs = filterParams(s.overloadIdxs, s.params, func(
+							params TypeList,
+						) bool {
+							return params.GetAt(i).Equivalent(homogeneousTyp)
+						})
 					}
 				}
 			}
 		}); ok {
-			return typedExprs, fns, err
+			return err
 		}
 
-		if ok, typedExprs, fns, err := filterAttempt(ctx, semaCtx, &s, func() {
+		if ok, err := filterAttempt(ctx, semaCtx, s, func() {
 			// The third heuristic is to prefer candidates where all constants can
 			// become their "natural" types.
 			for i, ok := s.constIdxs.Next(0); ok; i, ok = s.constIdxs.Next(i + 1) {
-				natural := naturalConstantType(exprs[i].(Constant))
+				natural := naturalConstantType(s.exprs[i].(Constant))
 				if natural != nil {
-					s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs,
-						func(o overloadImpl) bool {
-							return o.params().GetAt(i).Equivalent(natural)
-						})
+					s.overloadIdxs = filterParams(s.overloadIdxs, s.params, func(
+						params TypeList,
+					) bool {
+						return params.GetAt(i).Equivalent(natural)
+					})
 				}
 			}
 		}); ok {
-			return typedExprs, fns, err
+			return err
 		}
 
 		// At this point, it's worth seeing if we have constants that can't actually
@@ -819,25 +891,26 @@ func typeCheckOverloadedExprs(
 				for i, ok := s.constIdxs.Next(0); ok; i, ok = s.constIdxs.Next(i + 1) {
 					typ, err := s.exprs[i].TypeCheck(ctx, semaCtx, homogeneousTyp)
 					if err != nil {
-						return nil, nil, err
+						return err
 					}
 					s.typedExprs[i] = typ
 				}
-				_, typedExprs, fn, err := checkReturnPlaceholdersAtIdx(ctx, semaCtx, &s, int(s.overloadIdxs[0]))
-				return typedExprs, fn, err
+				_, err := checkReturnPlaceholdersAtIdx(ctx, semaCtx, s, s.overloadIdxs[0])
+				return err
 			}
 		}
 		for i, ok := s.constIdxs.Next(0); ok; i, ok = s.constIdxs.Next(i + 1) {
-			constExpr := exprs[i].(Constant)
-			s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs,
-				func(o overloadImpl) bool {
-					semaCtx := MakeSemaContext()
-					_, err := constExpr.ResolveAsType(ctx, &semaCtx, o.params().GetAt(i))
-					return err == nil
-				})
+			constExpr := s.exprs[i].(Constant)
+			s.overloadIdxs = filterParams(s.overloadIdxs, s.params, func(
+				params TypeList,
+			) bool {
+				semaCtx := MakeSemaContext()
+				_, err := constExpr.ResolveAsType(ctx, &semaCtx, params.GetAt(i))
+				return err == nil
+			})
 		}
-		if ok, typedExprs, fn, err := checkReturn(ctx, semaCtx, &s); ok {
-			return typedExprs, fn, err
+		if ok, err := checkReturn(ctx, semaCtx, s); ok {
+			return err
 		}
 
 		// The fourth heuristic is to prefer candidates that accepts the "best"
@@ -848,20 +921,17 @@ func typeCheckOverloadedExprs(
 			// instead of unsupported error (0 overloads) when applicable.
 			prevOverloadIdxs := s.overloadIdxs
 			for i, ok := s.constIdxs.Next(0); ok; i, ok = s.constIdxs.Next(i + 1) {
-				s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs,
-					func(o overloadImpl) bool {
-						return o.params().GetAt(i).Equivalent(bestConstType)
-					})
+				s.overloadIdxs = filterParams(s.overloadIdxs, s.params, func(
+					params TypeList,
+				) bool {
+					return params.GetAt(i).Equivalent(bestConstType)
+				})
 			}
-			if ok, typedExprs, fns, err := checkReturn(ctx, semaCtx, &s); ok {
-				if len(fns) == 0 {
-					var overloadImpls []overloadImpl
-					for i := range prevOverloadIdxs {
-						overloadImpls = append(overloadImpls, s.overloads[i])
-					}
-					return typedExprs, overloadImpls, err
+			if ok, err := checkReturn(ctx, semaCtx, s); ok {
+				if len(s.overloadIdxs) == 0 {
+					s.overloadIdxs = prevOverloadIdxs
 				}
-				return typedExprs, fns, err
+				return err
 			}
 			if homogeneousTyp != nil {
 				if !homogeneousTyp.Equivalent(bestConstType) {
@@ -875,12 +945,12 @@ func typeCheckOverloadedExprs(
 
 	// The fifth heuristic is to defer to preferred candidates, if one has been
 	// specified in the overload list.
-	if ok, typedExprs, fns, err := filterAttempt(ctx, semaCtx, &s, func() {
-		s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs, func(o overloadImpl) bool {
-			return o.preferred()
-		})
+	if ok, err := filterAttempt(ctx, semaCtx, s, func() {
+		s.overloadIdxs = filterOverloads(
+			s.overloadIdxs, s.overloads, overloadImpl.preferred,
+		)
 	}); ok {
-		return typedExprs, fns, err
+		return err
 	}
 
 	// The sixth heuristic is to prefer candidates where all placeholders can be
@@ -893,16 +963,17 @@ func typeCheckOverloadedExprs(
 		// parameter types are ambiguous (like in the case of tuple-tuple binary
 		// operators).
 		for i, ok := s.placeholderIdxs.Next(0); ok; i, ok = s.placeholderIdxs.Next(i + 1) {
-			if _, err := exprs[i].TypeCheck(ctx, semaCtx, homogeneousTyp); err != nil {
-				return nil, nil, err
+			if _, err := s.exprs[i].TypeCheck(ctx, semaCtx, homogeneousTyp); err != nil {
+				return err
 			}
-			s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs,
-				func(o overloadImpl) bool {
-					return o.params().GetAt(i).Equivalent(homogeneousTyp)
-				})
+			s.overloadIdxs = filterParams(s.overloadIdxs, s.params, func(
+				params TypeList,
+			) bool {
+				return params.GetAt(i).Equivalent(homogeneousTyp)
+			})
 		}
-		if ok, typedExprs, fns, err := checkReturn(ctx, semaCtx, &s); ok {
-			return typedExprs, fns, err
+		if ok, err := checkReturn(ctx, semaCtx, s); ok {
+			return err
 		}
 	}
 
@@ -949,10 +1020,11 @@ func typeCheckOverloadedExprs(
 		// enum's actual type, try type cast the rest.
 		if attemptAnyEnumCast {
 			// Copy exprs to prevent any overwrites of underlying s.exprs array later.
-			sCopy := s
+			sCopy := *s
 			sCopy.exprs = make([]Expr, len(s.exprs))
 			copy(sCopy.exprs, s.exprs)
-			if ok, typedExprs, fns, err := filterAttempt(ctx, semaCtx, &sCopy, func() {
+
+			if ok, err := filterAttempt(ctx, semaCtx, &sCopy, func() {
 				work := func(idx int) {
 					p := params.GetAt(idx)
 					typCast := knownEnum
@@ -968,7 +1040,10 @@ func typeCheckOverloadedExprs(
 					work(i)
 				}
 			}); ok {
-				return typedExprs, fns, err
+				s.exprs = sCopy.exprs
+				s.typedExprs = sCopy.typedExprs
+				s.overloadIdxs = append(s.overloadIdxs[:0], sCopy.overloadIdxs...)
+				return err
 			}
 		}
 	}
@@ -978,7 +1053,7 @@ func typeCheckOverloadedExprs(
 	// other argument. This is used to differentiate the behavior of
 	// STRING[] || NULL and STRING || NULL.
 	if inBinOp && len(s.exprs) == 2 {
-		if ok, typedExprs, fns, err := filterAttempt(ctx, semaCtx, &s, func() {
+		if ok, err := filterAttempt(ctx, semaCtx, s, func() {
 			var err error
 			left := s.typedExprs[0]
 			if left == nil {
@@ -1006,14 +1081,15 @@ func typeCheckOverloadedExprs(
 				if rightIsNull {
 					rightType = leftType
 				}
-				s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs,
-					func(o overloadImpl) bool {
-						return o.params().GetAt(0).Equivalent(leftType) &&
-							o.params().GetAt(1).Equivalent(rightType)
-					})
+				s.overloadIdxs = filterParams(s.overloadIdxs, s.params, func(
+					params TypeList,
+				) bool {
+					return params.GetAt(0).Equivalent(leftType) &&
+						params.GetAt(1).Equivalent(rightType)
+				})
 			}
 		}); ok {
-			return typedExprs, fns, err
+			return err
 		}
 	}
 
@@ -1021,7 +1097,7 @@ func typeCheckOverloadedExprs(
 	// NULL, we prefer overloads where we infer the type of the NULL to be a STRING. This is used
 	// to choose INT || NULL::STRING over INT || NULL::INT[].
 	if inBinOp && len(s.exprs) == 2 {
-		if ok, typedExprs, fns, err := filterAttempt(ctx, semaCtx, &s, func() {
+		if ok, err := filterAttempt(ctx, semaCtx, s, func() {
 			var err error
 			left := s.typedExprs[0]
 			if left == nil {
@@ -1049,26 +1125,23 @@ func typeCheckOverloadedExprs(
 				if rightIsNull {
 					rightType = types.String
 				}
-				s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs,
-					func(o overloadImpl) bool {
-						return o.params().GetAt(0).Equivalent(leftType) &&
-							o.params().GetAt(1).Equivalent(rightType)
-					})
+				s.overloadIdxs = filterParams(s.overloadIdxs, s.params, func(
+					params TypeList,
+				) bool {
+					return params.GetAt(0).Equivalent(leftType) &&
+						params.GetAt(1).Equivalent(rightType)
+				})
 			}
 		}); ok {
-			return typedExprs, fns, err
+			return err
 		}
 	}
 
-	if err := defaultTypeCheck(ctx, semaCtx, &s, len(s.overloads) > 0); err != nil {
-		return nil, nil, err
+	if err := defaultTypeCheck(ctx, semaCtx, s, numOverloads > 0); err != nil {
+		return err
 	}
 
-	possibleOverloads := make([]overloadImpl, len(s.overloadIdxs))
-	for i, o := range s.overloadIdxs {
-		possibleOverloads[i] = s.overloads[o]
-	}
-	return s.typedExprs, possibleOverloads, nil
+	return nil
 }
 
 // filterAttempt attempts to filter the overloads down to a single candidate.
@@ -1077,35 +1150,44 @@ func typeCheckOverloadedExprs(
 // undo any filtering performed during the attempt.
 func filterAttempt(
 	ctx context.Context, semaCtx *SemaContext, s *typeCheckOverloadState, attempt func(),
-) (ok bool, _ []TypedExpr, _ []overloadImpl, _ error) {
+) (ok bool, _ error) {
 	before := s.overloadIdxs
 	attempt()
 	if len(s.overloadIdxs) == 1 {
-		ok, typedExprs, fns, err := checkReturn(ctx, semaCtx, s)
+		ok, err := checkReturn(ctx, semaCtx, s)
 		if err != nil {
-			return false, nil, nil, err
+			return false, err
 		}
 		if ok {
-			return true, typedExprs, fns, err
+			return true, err
 		}
 	}
 	s.overloadIdxs = before
-	return false, nil, nil, nil
+	return false, nil
 }
 
-// filterOverloads filters overloads which do not satisfy the predicate.
-func filterOverloads(
-	overloads []overloadImpl, overloadIdxs []uint8, fn func(overloadImpl) bool,
-) []uint8 {
-	for i := 0; i < len(overloadIdxs); {
-		if fn(overloads[overloadIdxs[i]]) {
+func filterParams(idxs []uint8, params []TypeList, fn func(i TypeList) bool) []uint8 {
+	i, n := 0, len(idxs)
+	for i < n {
+		if fn(params[idxs[i]]) {
 			i++
-		} else {
-			overloadIdxs[i], overloadIdxs[len(overloadIdxs)-1] = overloadIdxs[len(overloadIdxs)-1], overloadIdxs[i]
-			overloadIdxs = overloadIdxs[:len(overloadIdxs)-1]
+		} else if n--; i != n {
+			idxs[i], idxs[n] = idxs[n], idxs[i]
 		}
 	}
-	return overloadIdxs
+	return idxs[:n]
+}
+
+func filterOverloads(idxs []uint8, params []overloadImpl, fn func(overloadImpl) bool) []uint8 {
+	i, n := 0, len(idxs)
+	for i < n {
+		if fn(params[idxs[i]]) {
+			i++
+		} else if n--; i != n {
+			idxs[i], idxs[n] = idxs[n], idxs[i]
+		}
+	}
+	return idxs[:n]
 }
 
 // defaultTypeCheck type checks the constant and placeholder expressions without a preference
@@ -1143,29 +1225,28 @@ func defaultTypeCheck(
 // immediately return, so any mutations to s are irrelevant.
 func checkReturn(
 	ctx context.Context, semaCtx *SemaContext, s *typeCheckOverloadState,
-) (ok bool, _ []TypedExpr, _ []overloadImpl, _ error) {
+) (ok bool, _ error) {
 	switch len(s.overloadIdxs) {
 	case 0:
 		if err := defaultTypeCheck(ctx, semaCtx, s, false); err != nil {
-			return false, nil, nil, err
+			return false, err
 		}
-		return true, s.typedExprs, nil, nil
+		return true, nil
 
 	case 1:
 		idx := s.overloadIdxs[0]
-		o := s.overloads[idx]
-		p := o.params()
+		p := s.params[idx]
 		for i, ok := s.constIdxs.Next(0); ok; i, ok = s.constIdxs.Next(i + 1) {
 			des := p.GetAt(i)
 			typ, err := s.exprs[i].TypeCheck(ctx, semaCtx, des)
 			if err != nil {
-				return false, s.typedExprs, nil, pgerror.Wrapf(
+				return false, pgerror.Wrapf(
 					err, pgcode.InvalidParameterValue,
 					"error type checking constant value",
 				)
 			}
 			if des != nil && !typ.ResolvedType().Equivalent(des) {
-				return false, nil, nil, errors.AssertionFailedf(
+				return false, errors.AssertionFailedf(
 					"desired constant value type %s but set type %s",
 					redact.Safe(des), redact.Safe(typ.ResolvedType()),
 				)
@@ -1173,10 +1254,10 @@ func checkReturn(
 			s.typedExprs[i] = typ
 		}
 
-		return checkReturnPlaceholdersAtIdx(ctx, semaCtx, s, int(idx))
+		return checkReturnPlaceholdersAtIdx(ctx, semaCtx, s, idx)
 
 	default:
-		return false, nil, nil, nil
+		return false, nil
 	}
 }
 
@@ -1184,27 +1265,28 @@ func checkReturn(
 // overload at the input index are valid. It has the same return values
 // as checkReturn.
 func checkReturnPlaceholdersAtIdx(
-	ctx context.Context, semaCtx *SemaContext, s *typeCheckOverloadState, idx int,
-) (bool, []TypedExpr, []overloadImpl, error) {
-	o := s.overloads[idx]
-	p := o.params()
+	ctx context.Context, semaCtx *SemaContext, s *typeCheckOverloadState, idx uint8,
+) (ok bool, _ error) {
+	p := s.params[idx]
 	for i, ok := s.placeholderIdxs.Next(0); ok; i, ok = s.placeholderIdxs.Next(i + 1) {
 		des := p.GetAt(i)
 		typ, err := s.exprs[i].TypeCheck(ctx, semaCtx, des)
 		if err != nil {
 			if des.IsAmbiguous() {
-				return false, nil, nil, nil
+				return false, nil
 			}
-			return false, nil, nil, err
+			return false, err
 		}
 		s.typedExprs[i] = typ
 	}
-	return true, s.typedExprs, s.overloads[idx : idx+1], nil
+	s.overloadIdxs = append(s.overloadIdxs[:0], idx)
+	return true, nil
 }
 
-func formatCandidates(prefix string, candidates []overloadImpl) string {
+func formatCandidates(prefix string, candidates []overloadImpl, filter []uint8) string {
 	var buf bytes.Buffer
-	for _, candidate := range candidates {
+	for _, idx := range filter {
+		candidate := candidates[idx]
 		buf.WriteString(prefix)
 		buf.WriteByte('(')
 		params := candidate.params()

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -330,7 +330,7 @@ func (expr *BinaryExpr) TypeCheck(
 		if len(s.overloadIdxs) > 0 {
 			noneAcceptNull := true
 			for _, idx := range s.overloadIdxs {
-				if (*ops)[idx].CalledOnNullInput {
+				if ops.overloads[idx].CalledOnNullInput {
 					noneAcceptNull = false
 					break
 				}
@@ -361,7 +361,7 @@ func (expr *BinaryExpr) TypeCheck(
 		return nil, err
 	}
 
-	binOp := (*ops)[s.overloadIdxs[0]]
+	binOp := ops.overloads[s.overloadIdxs[0]]
 	if err := semaCtx.checkVolatility(binOp.Volatility); err != nil {
 		return nil, pgerror.Wrapf(err, pgcode.InvalidParameterValue, "%s", expr.Operator)
 	}
@@ -1536,7 +1536,7 @@ func (expr *UnaryExpr) TypeCheck(
 		return nil, err
 	}
 
-	unaryOp := (*ops)[s.overloadIdxs[0]]
+	unaryOp := ops.overloads[s.overloadIdxs[0]]
 	if err := semaCtx.checkVolatility(unaryOp.Volatility); err != nil {
 		return nil, pgerror.Wrapf(err, pgcode.InvalidParameterValue, "%s", expr.Operator)
 	}
@@ -2109,7 +2109,7 @@ func typeCheckComparisonOpWithSubOperator(
 
 // deepCheckValidCmpOp performs extra checks that a given operation is valid
 // when the types are tuples.
-func deepCheckValidCmpOp(ops *cmpOpOverload, leftType, rightType *types.T) bool {
+func deepCheckValidCmpOp(ops *CmpOpOverloads, leftType, rightType *types.T) bool {
 	if leftType.Family() == types.TupleFamily && rightType.Family() == types.TupleFamily {
 		l := leftType.TupleContents()
 		r := rightType.TupleContents()
@@ -2269,7 +2269,7 @@ func typeCheckComparisonOp(
 		if len(s.overloadIdxs) > 0 {
 			noneAcceptNull := true
 			for _, idx := range s.overloadIdxs {
-				e := (*ops)[idx]
+				e := ops.overloads[idx]
 				if e.CalledOnNullInput {
 					noneAcceptNull = false
 					break
@@ -2313,7 +2313,7 @@ func typeCheckComparisonOp(
 		err = errors.WithHintf(err, candidatesHintFmt, fnsStr)
 		return nil, nil, nil, false, err
 	}
-	return leftExpr, rightExpr, (*ops)[s.overloadIdxs[0]], false, nil
+	return leftExpr, rightExpr, ops.overloads[s.overloadIdxs[0]], false, nil
 }
 
 type typeCheckExprsState struct {

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -313,11 +313,13 @@ func (expr *BinaryExpr) TypeCheck(
 ) (TypedExpr, error) {
 	ops := BinOps[expr.Operator.Symbol]
 
-	typedSubExprs, fns, err := typeCheckOverloadedExprs(ctx, semaCtx, desired, ops, true, expr.Left, expr.Right)
-	if err != nil {
+	const inBinOp = true
+	s := getOverloadTypeChecker(ops, expr.Left, expr.Right)
+	defer s.release()
+	if err := s.typeCheckOverloadedExprs(ctx, semaCtx, desired, inBinOp); err != nil {
 		return nil, err
 	}
-
+	typedSubExprs := s.typedExprs
 	leftTyped, rightTyped := typedSubExprs[0], typedSubExprs[1]
 	leftReturn := leftTyped.ResolvedType()
 	rightReturn := rightTyped.ResolvedType()
@@ -325,10 +327,10 @@ func (expr *BinaryExpr) TypeCheck(
 	// Return NULL if at least one overload is possible, NULL is an argument,
 	// and none of the overloads accept NULL.
 	if leftReturn.Family() == types.UnknownFamily || rightReturn.Family() == types.UnknownFamily {
-		if len(fns) > 0 {
+		if len(s.overloadIdxs) > 0 {
 			noneAcceptNull := true
-			for _, e := range fns {
-				if e.(*BinOp).CalledOnNullInput {
+			for _, idx := range s.overloadIdxs {
+				if (*ops)[idx].CalledOnNullInput {
 					noneAcceptNull = false
 					break
 				}
@@ -341,23 +343,25 @@ func (expr *BinaryExpr) TypeCheck(
 
 	// Throw a typing error if overload resolution found either no compatible candidates
 	// or if it found an ambiguity.
-	if len(fns) != 1 {
+	if len(s.overloadIdxs) != 1 {
 		var desStr string
 		if desired.Family() != types.AnyFamily {
 			desStr = fmt.Sprintf(" (desired <%s>)", desired)
 		}
 		sig := fmt.Sprintf("<%s> %s <%s>%s", leftReturn, expr.Operator, rightReturn, desStr)
-		if len(fns) == 0 {
+		if len(s.overloadIdxs) == 0 {
 			return nil,
 				pgerror.Newf(pgcode.InvalidParameterValue, unsupportedBinaryOpErrFmt, sig)
 		}
-		fnsStr := formatCandidates(expr.Operator.String(), fns)
-		err = pgerror.Newf(pgcode.AmbiguousFunction, ambiguousBinaryOpErrFmt, sig)
+		fnsStr := formatCandidates(
+			expr.Operator.String(), s.overloads, s.overloadIdxs,
+		)
+		err := pgerror.Newf(pgcode.AmbiguousFunction, ambiguousBinaryOpErrFmt, sig)
 		err = errors.WithHintf(err, candidatesHintFmt, fnsStr)
 		return nil, err
 	}
 
-	binOp := fns[0].(*BinOp)
+	binOp := (*ops)[s.overloadIdxs[0]]
 	if err := semaCtx.checkVolatility(binOp.Volatility); err != nil {
 		return nil, pgerror.Wrapf(err, pgcode.InvalidParameterValue, "%s", expr.Operator)
 	}
@@ -385,7 +389,7 @@ func (expr *CaseExpr) TypeCheck(
 			tmpExprs = append(tmpExprs, when.Cond)
 		}
 
-		typedSubExprs, _, err := TypeCheckSameTypedExprs(ctx, semaCtx, types.Any, tmpExprs...)
+		typedSubExprs, _, err := typeCheckSameTypedExprs(ctx, semaCtx, types.Any, tmpExprs...)
 		if err != nil {
 			return nil, decorateTypeCheckError(err, "incompatible condition type:")
 		}
@@ -411,7 +415,7 @@ func (expr *CaseExpr) TypeCheck(
 	if expr.Else != nil {
 		tmpExprs = append(tmpExprs, expr.Else)
 	}
-	typedSubExprs, retType, err := TypeCheckSameTypedExprs(ctx, semaCtx, desired, tmpExprs...)
+	typedSubExprs, retType, err := typeCheckSameTypedExprs(ctx, semaCtx, desired, tmpExprs...)
 	if err != nil {
 		return nil, decorateTypeCheckError(err, "incompatible value type")
 	}
@@ -829,7 +833,7 @@ func (expr *ColumnAccessExpr) TypeCheck(
 func (expr *CoalesceExpr) TypeCheck(
 	ctx context.Context, semaCtx *SemaContext, desired *types.T,
 ) (TypedExpr, error) {
-	typedSubExprs, retType, err := TypeCheckSameTypedExprs(ctx, semaCtx, desired, expr.Exprs...)
+	typedSubExprs, retType, err := typeCheckSameTypedExprs(ctx, semaCtx, desired, expr.Exprs...)
 	if err != nil {
 		return nil, decorateTypeCheckError(err, "incompatible %s expressions", redact.Safe(expr.Name))
 	}
@@ -1073,22 +1077,20 @@ func (expr *FuncExpr) TypeCheck(
 		}
 	}
 
-	overloadImpls := make([]overloadImpl, 0, len(def.Overloads))
-	for i := range def.Overloads {
-		overloadImpls = append(overloadImpls, def.Overloads[i])
-	}
-	typedSubExprs, fns, err := typeCheckOverloadedExprs(ctx, semaCtx, desired, overloadImpls, false, expr.Exprs...)
-	if err != nil {
+	s := getOverloadTypeChecker(
+		(*qualifiedOverloads)(&def.Overloads), expr.Exprs...,
+	)
+	defer s.release()
+	if err := s.typeCheckOverloadedExprs(ctx, semaCtx, desired, false); err != nil {
 		return nil, pgerror.Wrapf(err, pgcode.InvalidParameterValue, "%s()", def.Name)
 	}
 
-	var calledOnNullInputFns []overloadImpl
-	var notCalledOnNullInputFns []overloadImpl
-	for _, f := range fns {
-		if f.(QualifiedOverload).CalledOnNullInput {
-			calledOnNullInputFns = append(calledOnNullInputFns, f)
+	var calledOnNullInputFns, notCalledOnNullInputFns util.FastIntSet
+	for _, idx := range s.overloadIdxs {
+		if def.Overloads[idx].CalledOnNullInput {
+			calledOnNullInputFns.Add(int(idx))
 		} else {
-			notCalledOnNullInputFns = append(notCalledOnNullInputFns, f)
+			notCalledOnNullInputFns.Add(int(idx))
 		}
 	}
 
@@ -1103,51 +1105,55 @@ func (expr *FuncExpr) TypeCheck(
 		return nil, err
 	}
 	if funcCls == AggregateClass {
-		for i := range typedSubExprs {
-			if typedSubExprs[i].ResolvedType().Family() == types.UnknownFamily {
-				var filtered []overloadImpl
-				for j := range notCalledOnNullInputFns {
-					if fns[j].params().GetAt(i).Equivalent(types.String) {
-						if filtered == nil {
-							filtered = make([]overloadImpl, 0, len(fns)-j)
-						}
-						filtered = append(filtered, fns[j])
+		for i := range s.typedExprs {
+			if s.typedExprs[i].ResolvedType().Family() == types.UnknownFamily {
+				var filtered util.FastIntSet
+				for j, ok := notCalledOnNullInputFns.Next(0); ok; j, ok = notCalledOnNullInputFns.Next(j + 1) {
+					if def.Overloads[j].params().GetAt(i).Equivalent(types.String) {
+						filtered.Add(j)
 					}
 				}
 
 				// Only use the filtered list if it's not empty.
-				if filtered != nil {
+				if filtered.Len() > 0 {
 					notCalledOnNullInputFns = filtered
 
 					// Cast the expression to a string so the execution engine will find
 					// the correct overload.
-					typedSubExprs[i] = NewTypedCastExpr(typedSubExprs[i], types.String)
+					s.typedExprs[i] = NewTypedCastExpr(s.typedExprs[i], types.String)
 				}
 			}
 		}
-		fns = append(calledOnNullInputFns, notCalledOnNullInputFns...)
+		truncated := s.overloadIdxs[:0]
+		for _, idx := range s.overloadIdxs {
+			if calledOnNullInputFns.Contains(int(idx)) ||
+				notCalledOnNullInputFns.Contains(int(idx)) {
+				truncated = append(truncated, idx)
+			}
+		}
+		s.overloadIdxs = truncated
 	}
 
 	// Return NULL if at least one overload is possible, no overload accepts
 	// NULL arguments, the function isn't a generator or aggregate builtin, and
 	// NULL is given as an argument.
-	if len(fns) > 0 && len(calledOnNullInputFns) == 0 && funcCls != GeneratorClass &&
+	if len(s.overloadIdxs) > 0 && calledOnNullInputFns.Len() == 0 && funcCls != GeneratorClass &&
 		funcCls != AggregateClass {
-		for _, expr := range typedSubExprs {
+		for _, expr := range s.typedExprs {
 			if expr.ResolvedType().Family() == types.UnknownFamily {
 				return DNull, nil
 			}
 		}
 	}
 
-	if len(fns) == 0 {
-		return nil, pgerror.Newf(pgcode.UndefinedFunction, "unknown signature: %s", getFuncSig(expr, typedSubExprs, desired))
+	if len(s.overloadIdxs) == 0 {
+		return nil, pgerror.Newf(pgcode.UndefinedFunction, "unknown signature: %s", getFuncSig(expr, s.typedExprs, desired))
 	}
 
 	// Get overloads from the most significant schema in search path.
 	favoredOverload, err := getMostSignificantOverload(
-		fns, searchPath, expr,
-		func() string { return getFuncSig(expr, typedSubExprs, desired) },
+		def.Overloads, s.overloads, s.overloadIdxs, searchPath, expr,
+		func() string { return getFuncSig(expr, s.typedExprs, desired) },
 	)
 	if err != nil {
 		return nil, err
@@ -1210,15 +1216,15 @@ func (expr *FuncExpr) TypeCheck(
 		}
 	}
 
-	for i, subExpr := range typedSubExprs {
+	for i, subExpr := range s.typedExprs {
 		expr.Exprs[i] = subExpr
 	}
 	expr.fn = overloadImpl
 	expr.fnProps = &overloadImpl.FunctionProperties
-	expr.typ = overloadImpl.returnType()(typedSubExprs)
+	expr.typ = overloadImpl.returnType()(s.typedExprs)
 	if expr.typ == UnknownReturnType {
 		typeNames := make([]string, 0, len(expr.Exprs))
-		for _, expr := range typedSubExprs {
+		for _, expr := range s.typedExprs {
 			typeNames = append(typeNames, expr.ResolvedType().String())
 		}
 		return nil, pgerror.Newf(
@@ -1252,7 +1258,7 @@ func (expr *IfErrExpr) TypeCheck(
 		retType = types.Bool
 	} else {
 		var typedSubExprs []TypedExpr
-		typedSubExprs, retType, err = TypeCheckSameTypedExprs(ctx, semaCtx, desired, expr.Cond, expr.Else)
+		typedSubExprs, retType, err = typeCheckSameTypedExprs(ctx, semaCtx, desired, expr.Cond, expr.Else)
 		if err != nil {
 			return nil, decorateTypeCheckError(err, "incompatible IFERROR expressions")
 		}
@@ -1287,7 +1293,7 @@ func (expr *IfExpr) TypeCheck(
 		return nil, err
 	}
 
-	typedSubExprs, retType, err := TypeCheckSameTypedExprs(ctx, semaCtx, desired, expr.True, expr.Else)
+	typedSubExprs, retType, err := typeCheckSameTypedExprs(ctx, semaCtx, desired, expr.True, expr.Else)
 	if err != nil {
 		return nil, decorateTypeCheckError(err, "incompatible IF expressions")
 	}
@@ -1363,7 +1369,7 @@ func (expr *IsNotNullExpr) TypeCheck(
 func (expr *NullIfExpr) TypeCheck(
 	ctx context.Context, semaCtx *SemaContext, desired *types.T,
 ) (TypedExpr, error) {
-	typedSubExprs, retType, err := TypeCheckSameTypedExprs(ctx, semaCtx, desired, expr.Expr1, expr.Expr2)
+	typedSubExprs, retType, err := typeCheckSameTypedExprs(ctx, semaCtx, desired, expr.Expr1, expr.Expr2)
 	if err != nil {
 		return nil, decorateTypeCheckError(err, "incompatible NULLIF expressions")
 	}
@@ -1492,16 +1498,19 @@ func (expr *UnaryExpr) TypeCheck(
 ) (TypedExpr, error) {
 	ops := UnaryOps[expr.Operator.Symbol]
 
-	typedSubExprs, fns, err := typeCheckOverloadedExprs(ctx, semaCtx, desired, ops, false, expr.Expr)
-	if err != nil {
+	s := getOverloadTypeChecker(ops, expr.Expr)
+	defer s.release()
+	if err := s.typeCheckOverloadedExprs(ctx, semaCtx, desired, false); err != nil {
 		return nil, err
 	}
 
+	typedSubExprs := s.typedExprs
 	exprTyped := typedSubExprs[0]
 	exprReturn := exprTyped.ResolvedType()
 
 	// Return NULL if at least one overload is possible and NULL is an argument.
-	if len(fns) > 0 {
+	numOps := len(s.overloadIdxs)
+	if numOps > 0 {
 		if exprReturn.Family() == types.UnknownFamily {
 			return DNull, nil
 		}
@@ -1509,23 +1518,25 @@ func (expr *UnaryExpr) TypeCheck(
 
 	// Throw a typing error if overload resolution found either no compatible candidates
 	// or if it found an ambiguity.
-	if len(fns) != 1 {
+	if numOps != 1 {
 		var desStr string
 		if desired.Family() != types.AnyFamily {
 			desStr = fmt.Sprintf(" (desired <%s>)", desired)
 		}
 		sig := fmt.Sprintf("%s <%s>%s", expr.Operator, exprReturn, desStr)
-		if len(fns) == 0 {
+		if numOps == 0 {
 			return nil,
 				pgerror.Newf(pgcode.InvalidParameterValue, unsupportedUnaryOpErrFmt, sig)
 		}
-		fnsStr := formatCandidates(expr.Operator.String(), fns)
-		err = pgerror.Newf(pgcode.AmbiguousFunction, ambiguousUnaryOpErrFmt, sig)
+		fnsStr := formatCandidates(
+			expr.Operator.String(), s.overloads, s.overloadIdxs,
+		)
+		err := pgerror.Newf(pgcode.AmbiguousFunction, ambiguousUnaryOpErrFmt, sig)
 		err = errors.WithHintf(err, candidatesHintFmt, fnsStr)
 		return nil, err
 	}
 
-	unaryOp := fns[0].(*UnaryOp)
+	unaryOp := (*ops)[s.overloadIdxs[0]]
 	if err := semaCtx.checkVolatility(unaryOp.Volatility); err != nil {
 		return nil, pgerror.Wrapf(err, pgcode.InvalidParameterValue, "%s", expr.Operator)
 	}
@@ -1630,7 +1641,7 @@ func (expr *Array) TypeCheck(
 		return expr, nil
 	}
 
-	typedSubExprs, typ, err := TypeCheckSameTypedExprs(ctx, semaCtx, desiredParam, expr.Exprs...)
+	typedSubExprs, typ, err := typeCheckSameTypedExprs(ctx, semaCtx, desiredParam, expr.Exprs...)
 	if err != nil {
 		return nil, err
 	}
@@ -2009,7 +2020,7 @@ func typeCheckComparisonOpWithSubOperator(
 		sameTypeExprs[0] = left
 		copy(sameTypeExprs[1:], array.Exprs)
 
-		typedSubExprs, retType, err := TypeCheckSameTypedExprs(ctx, semaCtx, types.Any, sameTypeExprs...)
+		typedSubExprs, retType, err := typeCheckSameTypedExprs(ctx, semaCtx, types.Any, sameTypeExprs...)
 		if err != nil {
 			sigWithErr := fmt.Sprintf(compExprsWithSubOpFmt, left, subOp, op, right, err)
 			return nil, nil, nil, false,
@@ -2098,7 +2109,7 @@ func typeCheckComparisonOpWithSubOperator(
 
 // deepCheckValidCmpOp performs extra checks that a given operation is valid
 // when the types are tuples.
-func deepCheckValidCmpOp(ops cmpOpOverload, leftType, rightType *types.T) bool {
+func deepCheckValidCmpOp(ops *cmpOpOverload, leftType, rightType *types.T) bool {
 	if leftType.Family() == types.TupleFamily && rightType.Family() == types.TupleFamily {
 		l := leftType.TupleContents()
 		r := rightType.TupleContents()
@@ -2156,7 +2167,7 @@ func typeCheckComparisonOp(
 		sameTypeExprs[0] = foldedLeft
 		copy(sameTypeExprs[1:], rightTuple.Exprs)
 
-		typedSubExprs, retType, err := TypeCheckSameTypedExprs(ctx, semaCtx, types.Any, sameTypeExprs...)
+		typedSubExprs, retType, err := typeCheckSameTypedExprs(ctx, semaCtx, types.Any, sameTypeExprs...)
 		if err != nil {
 			sigWithErr := fmt.Sprintf(compExprsFmt, left, op, right, err)
 			return nil, nil, nil, false,
@@ -2234,12 +2245,12 @@ func typeCheckComparisonOp(
 	// defined to return NULL anyways. Should the SQL dialect ever be extended with
 	// comparisons that can return non-NULL on NULL input, the `inBinOp` parameter
 	// may need altering.
-	typedSubExprs, fns, err := typeCheckOverloadedExprs(
-		ctx, semaCtx, types.Any, ops, true /* inBinOp */, foldedLeft, foldedRight,
-	)
-	if err != nil {
+	s := getOverloadTypeChecker(ops, foldedLeft, foldedRight)
+	defer s.release()
+	if err := s.typeCheckOverloadedExprs(ctx, semaCtx, types.Any, true); err != nil {
 		return nil, nil, nil, false, err
 	}
+	typedSubExprs := s.typedExprs
 
 	leftExpr, rightExpr := typedSubExprs[0], typedSubExprs[1]
 	if switched {
@@ -2255,16 +2266,17 @@ func typeCheckComparisonOp(
 	nullComparison := false
 	if leftFamily == types.UnknownFamily || rightFamily == types.UnknownFamily {
 		nullComparison = true
-		if len(fns) > 0 {
+		if len(s.overloadIdxs) > 0 {
 			noneAcceptNull := true
-			for _, e := range fns {
-				if e.(*CmpOp).CalledOnNullInput {
+			for _, idx := range s.overloadIdxs {
+				e := (*ops)[idx]
+				if e.CalledOnNullInput {
 					noneAcceptNull = false
 					break
 				}
 			}
 			if noneAcceptNull {
-				return leftExpr, rightExpr, nil, true /* alwaysNull */, err
+				return leftExpr, rightExpr, nil, true /* alwaysNull */, nil
 			}
 		}
 	}
@@ -2283,9 +2295,9 @@ func typeCheckComparisonOp(
 
 	// Throw a typing error if overload resolution found either no compatible candidates
 	// or if it found an ambiguity.
-	if len(fns) != 1 || typeMismatch {
+	if len(s.overloadIdxs) != 1 || typeMismatch {
 		sig := fmt.Sprintf(compSignatureFmt, leftReturn, op, rightReturn)
-		if len(fns) == 0 || typeMismatch {
+		if len(s.overloadIdxs) == 0 || typeMismatch {
 			// For some typeMismatch errors, we want to emit a more specific error
 			// message than "unknown comparison". In particular, comparison between
 			// two different enum types is invalid, rather than just unsupported.
@@ -2296,13 +2308,12 @@ func typeCheckComparisonOp(
 			return nil, nil, nil, false,
 				pgerror.Newf(pgcode.InvalidParameterValue, unsupportedCompErrFmt, sig)
 		}
-		fnsStr := formatCandidates(op.String(), fns)
-		err = pgerror.Newf(pgcode.AmbiguousFunction, ambiguousCompErrFmt, sig)
+		fnsStr := formatCandidates(op.String(), s.overloads, s.overloadIdxs)
+		err := pgerror.Newf(pgcode.AmbiguousFunction, ambiguousCompErrFmt, sig)
 		err = errors.WithHintf(err, candidatesHintFmt, fnsStr)
 		return nil, nil, nil, false, err
 	}
-
-	return leftExpr, rightExpr, fns[0].(*CmpOp), false, nil
+	return leftExpr, rightExpr, (*ops)[s.overloadIdxs[0]], false, nil
 }
 
 type typeCheckExprsState struct {
@@ -2316,10 +2327,10 @@ type typeCheckExprsState struct {
 	resolvableIdxs  util.FastIntSet // index into exprs/typedExprs
 }
 
-// TypeCheckSameTypedExprs type checks a list of expressions, asserting that all
+// typeCheckSameTypedExprs type checks a list of expressions, asserting that all
 // resolved TypeExprs have the same type. An optional desired type can be provided,
 // which will hint that type which the expressions should resolve to, if possible.
-func TypeCheckSameTypedExprs(
+func typeCheckSameTypedExprs(
 	ctx context.Context, semaCtx *SemaContext, desired *types.T, exprs ...Expr,
 ) ([]TypedExpr, *types.T, error) {
 	switch len(exprs) {
@@ -2620,7 +2631,7 @@ func typeCheckSameTypedTupleExprs(
 		if len(desired.TupleContents()) > elemIdx {
 			desiredElem = desired.TupleContents()[elemIdx]
 		}
-		typedSubExprs, resType, err := TypeCheckSameTypedExprs(ctx, semaCtx, desiredElem, sameTypeExprs...)
+		typedSubExprs, resType, err := typeCheckSameTypedExprs(ctx, semaCtx, desiredElem, sameTypeExprs...)
 		if err != nil {
 			return nil, nil, pgerror.Wrapf(err, pgcode.DatatypeMismatch, "tuples %s are not the same type", Exprs(exprs))
 		}
@@ -2937,7 +2948,12 @@ func (stripFuncsVisitor) VisitPost(expr Expr) Expr { return expr }
 // Note: even the input is a slice of overloadImpl, they're essentially a slice
 // of QualifiedOverload. Also, the input should not be empty.
 func getMostSignificantOverload(
-	overloads []overloadImpl, searchPath SearchPath, expr *FuncExpr, getFuncSig func() string,
+	qualifiedOverloads []QualifiedOverload,
+	overloads []overloadImpl,
+	filter []uint8,
+	searchPath SearchPath,
+	expr *FuncExpr,
+	getFuncSig func() string,
 ) (QualifiedOverload, error) {
 	ambiguousError := func() error {
 		return pgerror.Newf(
@@ -2946,31 +2962,34 @@ func getMostSignificantOverload(
 			getFuncSig(),
 			// Use "overloads" for the errors string since we want to print out
 			// candidates from all schemas.
-			formatCandidates(expr.Func.String(), overloads),
+			formatCandidates(expr.Func.String(), overloads, filter),
 		)
 	}
-	checkAmbiguity := func(oImpls []overloadImpl) (QualifiedOverload, error) {
-		if len(oImpls) > 1 {
+	checkAmbiguity := func(oImpls []uint8) (QualifiedOverload, error) {
+		if len(oImpls) != 1 {
 			// Throw ambiguity error if there are more than one candidate overloads from
 			// same schema.
 			return QualifiedOverload{}, ambiguousError()
 		}
-		return oImpls[0].(QualifiedOverload), nil
+		return qualifiedOverloads[oImpls[0]], nil
 	}
 
 	if searchPath == nil || searchPath == EmptySearchPath {
-		return checkAmbiguity(overloads)
+		return checkAmbiguity(filter)
 	}
 
 	udfFound := false
 	uniqueSchema := true
-	for i, o := range overloads {
-		if o.(QualifiedOverload).IsUDF {
+	seenSchema := ""
+	for _, idx := range filter {
+		o := qualifiedOverloads[idx]
+		if o.IsUDF {
 			udfFound = true
 		}
-		if i > 0 && o.(QualifiedOverload).Schema != overloads[i-1].(QualifiedOverload).Schema {
+		if seenSchema != "" && o.Schema != seenSchema {
 			uniqueSchema = false
 		}
+		seenSchema = o.Schema
 	}
 
 	if !udfFound || uniqueSchema {
@@ -2985,20 +3004,20 @@ func getMostSignificantOverload(
 		// explicit schema or schemas on the search path. So if overloads are from
 		// the same schema, overloads are either from an explicit schema or from a
 		// schema on search path.
-		return checkAmbiguity(overloads)
+		return checkAmbiguity(filter)
 	}
 
 	found := false
 	var ret QualifiedOverload
 	for i, n := 0, searchPath.NumElements(); i < n; i++ {
 		schema := searchPath.GetSchema(i)
-		for i := range overloads {
-			if overloads[i].(QualifiedOverload).Schema == schema {
+		for _, idx := range filter {
+			if r := qualifiedOverloads[idx]; r.Schema == schema {
 				if found {
 					return QualifiedOverload{}, ambiguousError()
 				}
 				found = true
-				ret = overloads[i].(QualifiedOverload)
+				ret = r
 			}
 		}
 		if found {

--- a/pkg/sql/sem/tree/type_check_internal_test.go
+++ b/pkg/sql/sem/tree/type_check_internal_test.go
@@ -199,7 +199,7 @@ func attemptTypeCheckSameTypedExprs(t *testing.T, idx int, test sameTypedExprsTe
 					idx, test.expectedType, buildExprs(exprs), typ)
 			}
 			if !reflect.DeepEqual(semaCtx.Placeholders.Types, test.expectedPTypes) {
-				t.Errorf("%d: expected placeholder types %v after TypeCheckSameTypedExprs for %v, found %v", idx, test.expectedPTypes, buildExprs(exprs), semaCtx.Placeholders.Types)
+				t.Errorf("%d: expected placeholder types %v after typeCheckSameTypedExprs for %v, found %v", idx, test.expectedPTypes, buildExprs(exprs), semaCtx.Placeholders.Types)
 			}
 		}
 	})
@@ -345,7 +345,9 @@ func TestTypeCheckSameTypedExprsError(t *testing.T) {
 				desired = d.desired
 			}
 			forEachPerm(d.exprs, 0, func(exprs []copyableExpr) {
-				if _, _, err := tree.TypeCheckSameTypedExprs(ctx, &semaCtx, desired, buildExprs(exprs)...); !testutils.IsError(err, d.expectedErr) {
+				if _, _, err := tree.TypeCheckSameTypedExprs(
+					ctx, &semaCtx, desired, buildExprs(exprs)...,
+				); !testutils.IsError(err, d.expectedErr) {
 					t.Errorf("%d: expected %s, but found %v", i, d.expectedErr, err)
 				}
 			})

--- a/pkg/sql/sem/tree/typing.go
+++ b/pkg/sql/sem/tree/typing.go
@@ -37,9 +37,7 @@ func FindBinaryOverload(
 	// right children. No more than one match should ever be found. The
 	// TestTypingBinaryAssumptions test ensures this will be the case even if
 	// new operators or overloads are added.
-	for _, binOverloads := range BinOps[bin] {
-		o := binOverloads.(*BinOp)
-
+	for _, o := range *BinOps[bin] {
 		if leftType.Family() == types.UnknownFamily {
 			if rightType.Equivalent(o.RightType) {
 				return o, true

--- a/pkg/sql/sem/tree/typing.go
+++ b/pkg/sql/sem/tree/typing.go
@@ -13,6 +13,7 @@ package tree
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treebin"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 )
 
 // InferBinaryType infers the return type of a binary expression, given the type
@@ -31,26 +32,25 @@ func InferBinaryType(bin treebin.BinaryOperatorSymbol, leftType, rightType *type
 // If an overload is not found, FindBinaryOverload returns false.
 func FindBinaryOverload(
 	bin treebin.BinaryOperatorSymbol, leftType, rightType *types.T,
-) (_ *BinOp, ok bool) {
+) (ret *BinOp, ok bool) {
 
 	// Find the binary op that matches the type of the expression's left and
 	// right children. No more than one match should ever be found. The
 	// TestTypingBinaryAssumptions test ensures this will be the case even if
 	// new operators or overloads are added.
-	for _, o := range *BinOps[bin] {
+	_ = BinOps[bin].ForEachBinOp(func(o *BinOp) error {
 		if leftType.Family() == types.UnknownFamily {
-			if rightType.Equivalent(o.RightType) {
-				return o, true
-			}
+			ok = rightType.Equivalent(o.RightType)
 		} else if rightType.Family() == types.UnknownFamily {
-			if leftType.Equivalent(o.LeftType) {
-				return o, true
-			}
+			ok = leftType.Equivalent(o.LeftType)
 		} else {
-			if leftType.Equivalent(o.LeftType) && rightType.Equivalent(o.RightType) {
-				return o, true
-			}
+			ok = leftType.Equivalent(o.LeftType) && rightType.Equivalent(o.RightType)
 		}
-	}
-	return nil, false
+		if !ok {
+			return nil
+		}
+		ret = o
+		return iterutil.StopIteration()
+	})
+	return ret, ok
 }

--- a/pkg/sql/sem/tree/typing_test.go
+++ b/pkg/sql/sem/tree/typing_test.go
@@ -8,12 +8,11 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package tree_test
+package tree
 
 import (
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
@@ -27,16 +26,15 @@ import (
 func TestTypingBinaryAssumptions(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	for name, overloads := range tree.BinOps {
-		for i, op := range *overloads {
+	for name, overloads := range BinOps {
+		for i, op := range overloads.overloads {
 
 			// Check for basic ambiguity where two different binary op overloads
 			// both allow equivalent operand types.
-			for i2, op2 := range *overloads {
+			for i2, op2 := range overloads.overloads {
 				if i == i2 {
 					continue
 				}
-
 				if op.LeftType.Equivalent(op2.LeftType) && op.RightType.Equivalent(op2.RightType) {
 					format := "found equivalent operand type ambiguity for %s:\n%+v\n%+v"
 					t.Errorf(format, name, op, op2)
@@ -46,7 +44,7 @@ func TestTypingBinaryAssumptions(t *testing.T) {
 			// Handle ops that allow null operands. Check for ambiguity where
 			// the return type cannot be inferred from the non-null operand.
 			if op.CalledOnNullInput {
-				for i2, op2 := range *overloads {
+				for i2, op2 := range overloads.overloads {
 					if i == i2 {
 						continue
 					}

--- a/pkg/sql/sem/tree/typing_test.go
+++ b/pkg/sql/sem/tree/typing_test.go
@@ -28,17 +28,15 @@ func TestTypingBinaryAssumptions(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	for name, overloads := range tree.BinOps {
-		for i, overload := range overloads {
-			op := overload.(*tree.BinOp)
+		for i, op := range *overloads {
 
 			// Check for basic ambiguity where two different binary op overloads
 			// both allow equivalent operand types.
-			for i2, overload2 := range overloads {
+			for i2, op2 := range *overloads {
 				if i == i2 {
 					continue
 				}
 
-				op2 := overload2.(*tree.BinOp)
 				if op.LeftType.Equivalent(op2.LeftType) && op.RightType.Equivalent(op2.RightType) {
 					format := "found equivalent operand type ambiguity for %s:\n%+v\n%+v"
 					t.Errorf(format, name, op, op2)
@@ -48,12 +46,11 @@ func TestTypingBinaryAssumptions(t *testing.T) {
 			// Handle ops that allow null operands. Check for ambiguity where
 			// the return type cannot be inferred from the non-null operand.
 			if op.CalledOnNullInput {
-				for i2, overload2 := range overloads {
+				for i2, op2 := range *overloads {
 					if i == i2 {
 						continue
 					}
 
-					op2 := overload2.(*tree.BinOp)
 					if !op2.CalledOnNullInput {
 						continue
 					}

--- a/pkg/sql/telemetry.go
+++ b/pkg/sql/telemetry.go
@@ -30,36 +30,39 @@ func init() {
 			panic(errors.AssertionFailedf("missing name for operator %q", op.String()))
 		}
 		opName := tree.UnaryOpName[op]
-		for _, o := range *overloads {
+		_ = overloads.ForEachUnaryOp(func(o *tree.UnaryOp) error {
 			c := sqltelemetry.UnaryOpCounter(opName, o.Typ.String())
 			o.OnTypeCheck = func() {
 				telemetry.Inc(c)
 			}
-		}
+			return nil
+		})
 	}
 
 	for op, overloads := range tree.BinOps {
 		opName := treebin.BinaryOpName(op)
-		for _, o := range *overloads {
+		_ = overloads.ForEachBinOp(func(o *tree.BinOp) error {
 			lname := o.LeftType.String()
 			rname := o.RightType.String()
 			c := sqltelemetry.BinOpCounter(opName, lname, rname)
 			o.OnTypeCheck = func() {
 				telemetry.Inc(c)
 			}
-		}
+			return nil
+		})
 	}
 
 	for op, overloads := range tree.CmpOps {
 		opName := treecmp.ComparisonOpName(op)
-		for _, o := range *overloads {
+		_ = overloads.ForEachCmpOp(func(o *tree.CmpOp) error {
 			lname := o.LeftType.String()
 			rname := o.RightType.String()
 			c := sqltelemetry.CmpOpCounter(opName, lname, rname)
 			o.OnTypeCheck = func() {
 				telemetry.Inc(c)
 			}
-		}
+			return nil
+		})
 	}
 
 	tree.OnTypeCheckIfErr = func() {

--- a/pkg/sql/telemetry.go
+++ b/pkg/sql/telemetry.go
@@ -30,8 +30,7 @@ func init() {
 			panic(errors.AssertionFailedf("missing name for operator %q", op.String()))
 		}
 		opName := tree.UnaryOpName[op]
-		for _, impl := range overloads {
-			o := impl.(*tree.UnaryOp)
+		for _, o := range *overloads {
 			c := sqltelemetry.UnaryOpCounter(opName, o.Typ.String())
 			o.OnTypeCheck = func() {
 				telemetry.Inc(c)
@@ -41,8 +40,7 @@ func init() {
 
 	for op, overloads := range tree.BinOps {
 		opName := treebin.BinaryOpName(op)
-		for _, impl := range overloads {
-			o := impl.(*tree.BinOp)
+		for _, o := range *overloads {
 			lname := o.LeftType.String()
 			rname := o.RightType.String()
 			c := sqltelemetry.BinOpCounter(opName, lname, rname)
@@ -54,8 +52,7 @@ func init() {
 
 	for op, overloads := range tree.CmpOps {
 		opName := treecmp.ComparisonOpName(op)
-		for _, impl := range overloads {
-			o := impl.(*tree.CmpOp)
+		for _, o := range *overloads {
 			lname := o.LeftType.String()
 			rname := o.RightType.String()
 			c := sqltelemetry.CmpOpCounter(opName, lname, rname)


### PR DESCRIPTION
This PR does some refactoring to optimize function type checking. It uses a
sync.Pool over the type checking state to avoid allocations. Additionally,
it paves a path to avoid unexported symbols from making their way out of the
package. There are some minor warts as of this commit, namely we now make the
exported maps of operators into pointers to avoid the underlying slices from
escaping. A follow-up PR will change the code to unexport the weird slice
pointer types and replace them with structs with an unexported slice field.

This is a new perf win all around AFAICT.

```
name                                                       old time/op    new time/op    delta
FuncExprTypeCheck/builtin_called_on_null_input-16             805ns ± 3%     604ns ± 4%   -24.94%  (p=0.000 n=10+10)
FuncExprTypeCheck/builtin_not_called_on_null_input-16         768ns ± 3%     572ns ± 2%   -25.48%  (p=0.000 n=10+9)
FuncExprTypeCheck/builtin_aggregate-16                       1.63µs ± 1%    0.92µs ± 4%   -43.52%  (p=0.000 n=9+9)
FuncExprTypeCheck/builtin_aggregate_not_called_on_null-16     902ns ± 1%     672ns ± 5%   -25.48%  (p=0.000 n=9+10)
FuncExprTypeCheck/udf_same_name_as_builtin-16                1.17µs ± 1%    0.75µs ± 1%   -35.83%  (p=0.000 n=9+9)
FuncExprTypeCheck/udf_across_different_schemas-16            1.95µs ± 2%    1.51µs ± 5%   -22.83%  (p=0.000 n=10+10)
FuncExprTypeCheck/unary_operator-16                           268ns ± 2%     263ns ± 3%    -1.93%  (p=0.003 n=10+9)
FuncExprTypeCheck/binary_operator-16                         1.01µs ± 1%    0.96µs ± 2%    -4.99%  (p=0.000 n=10+9)
FuncExprTypeCheck/comparison_operator-16                     1.66µs ± 1%    1.63µs ± 1%    -1.91%  (p=0.000 n=10+9)
FuncExprTypeCheck/tuple_comparison_operator-16               4.88µs ± 2%    4.85µs ± 1%    -0.68%  (p=0.041 n=10+8)
FuncExprTypeCheck/tuple_in_operator-16                        780ns ± 2%     783ns ± 2%      ~     (p=0.481 n=10+10)

name                                                       old alloc/op   new alloc/op   delta
FuncExprTypeCheck/builtin_called_on_null_input-16              117B ± 7%       0B ±433%   -99.68%  (p=0.000 n=10+8)
FuncExprTypeCheck/builtin_not_called_on_null_input-16          114B ± 1%       2B ±248%   -97.98%  (p=0.000 n=8+10)
FuncExprTypeCheck/builtin_aggregate-16                         442B ± 0%       1B ±100%   -99.87%  (p=0.000 n=9+9)
FuncExprTypeCheck/builtin_aggregate_not_called_on_null-16      130B ± 0%        0B       -100.00%  (p=0.000 n=8+8)
FuncExprTypeCheck/udf_same_name_as_builtin-16                  260B ± 0%        0B       -100.00%  (p=0.000 n=9+10)
FuncExprTypeCheck/udf_across_different_schemas-16              661B ± 0%      401B ± 0%   -39.38%  (p=0.000 n=8+9)
FuncExprTypeCheck/unary_operator-16                           0.00B          0.00B           ~     (all equal)
FuncExprTypeCheck/binary_operator-16                          88.4B ± 1%      0.0B       -100.00%  (p=0.000 n=9+9)
FuncExprTypeCheck/comparison_operator-16                       129B ± 0%       1B ±129%   -99.32%  (p=0.000 n=9+8)
FuncExprTypeCheck/tuple_comparison_operator-16                 820B ± 0%      435B ± 0%   -46.94%  (p=0.000 n=9+9)
FuncExprTypeCheck/tuple_in_operator-16                         344B ± 0%      344B ± 0%      ~     (all equal)

name                                                       old allocs/op  new allocs/op  delta
FuncExprTypeCheck/builtin_called_on_null_input-16              6.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
FuncExprTypeCheck/builtin_not_called_on_null_input-16          6.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
FuncExprTypeCheck/builtin_aggregate-16                         14.0 ± 0%       0.0       -100.00%  (p=0.000 n=10+10)
FuncExprTypeCheck/builtin_aggregate_not_called_on_null-16      7.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
FuncExprTypeCheck/udf_same_name_as_builtin-16                  10.0 ± 0%       0.0       -100.00%  (p=0.000 n=10+10)
FuncExprTypeCheck/udf_across_different_schemas-16              15.0 ± 0%       5.0 ± 0%   -66.67%  (p=0.000 n=10+10)
FuncExprTypeCheck/unary_operator-16                            0.00           0.00           ~     (all equal)
FuncExprTypeCheck/binary_operator-16                           3.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
FuncExprTypeCheck/comparison_operator-16                       3.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
FuncExprTypeCheck/tuple_comparison_operator-16                 13.0 ± 0%       4.0 ± 0%   -69.23%  (p=0.000 n=10+10)
FuncExprTypeCheck/tuple_in_operator-16                         4.00 ± 0%      4.00 ± 0%      ~     (all equal)
```

Epic: None

Release note: None