### PR TITLE
opt: fix wrong results due to sorting 1st join of paired join

### DIFF
--- a/pkg/sql/opt/ordering/inverted_join.go
+++ b/pkg/sql/opt/ordering/inverted_join.go
@@ -33,7 +33,7 @@ func invertedJoinBuildChildReqOrdering(
 	// We may need to remove ordering columns that are not output by the input
 	// expression.
 	child := parent.Child(0).(memo.RelExpr)
-	res := projectOrderingToInput(child, required)
+	res := ProjectOrderingToInput(child, required)
 	// It is in principle possible that the inverted join has an ON condition that
 	// forces an equality on two columns in the input. In this case we need to
 	// trim the column groups to keep the ordering valid w.r.t the child FDs
@@ -41,7 +41,7 @@ func invertedJoinBuildChildReqOrdering(
 	//
 	// This case indicates that we didn't do a good job pushing down equalities
 	// (see #36219), but it should be handled correctly here nevertheless.
-	return trimColumnGroups(&res, &child.Relational().FuncDeps)
+	return TrimColumnGroups(&res, &child.Relational().FuncDeps)
 }
 
 func invertedJoinBuildProvided(expr memo.RelExpr, required *props.OrderingChoice) opt.Ordering {

--- a/pkg/sql/opt/ordering/lookup_join.go
+++ b/pkg/sql/opt/ordering/lookup_join.go
@@ -41,7 +41,7 @@ func lookupJoinCanProvideOrdering(expr memo.RelExpr, required *props.OrderingCho
 		// expression. This results in an equivalent ordering, but with fewer
 		// options in the OrderingChoice.
 		child := lookupJoin.Input
-		res := projectOrderingToInput(child, required)
+		res := ProjectOrderingToInput(child, required)
 		// It is in principle possible that the lookup join has an ON condition that
 		// forces an equality on two columns in the input. In this case we need to
 		// trim the column groups to keep the ordering valid w.r.t the child FDs
@@ -49,7 +49,7 @@ func lookupJoinCanProvideOrdering(expr memo.RelExpr, required *props.OrderingCho
 		//
 		// This case indicates that we didn't do a good job pushing down equalities
 		// (see #36219), but it should be handled correctly here nevertheless.
-		res = trimColumnGroups(&res, &child.Relational().FuncDeps)
+		res = TrimColumnGroups(&res, &child.Relational().FuncDeps)
 		return CanProvide(child, &res)
 	}
 	if !canProjectUsingOnlyInputCols {
@@ -106,7 +106,7 @@ func lookupOrIndexJoinBuildChildReqOrdering(
 
 	// We may need to remove ordering columns that are not output by the input
 	// expression.
-	res := projectOrderingToInput(child, required)
+	res := ProjectOrderingToInput(child, required)
 	// It is in principle possible that the lookup join has an ON condition that
 	// forces an equality on two columns in the input. In this case we need to
 	// trim the column groups to keep the ordering valid w.r.t the child FDs
@@ -114,7 +114,7 @@ func lookupOrIndexJoinBuildChildReqOrdering(
 	//
 	// This case indicates that we didn't do a good job pushing down equalities
 	// (see #36219), but it should be handled correctly here nevertheless.
-	res = trimColumnGroups(&res, &child.Relational().FuncDeps)
+	res = TrimColumnGroups(&res, &child.Relational().FuncDeps)
 
 	// The propagation of FDs might not be perfect; in that case we need to
 	// simplify the required ordering, or risk passing through unnecessary columns

--- a/pkg/sql/opt/ordering/lookup_join.go
+++ b/pkg/sql/opt/ordering/lookup_join.go
@@ -31,7 +31,8 @@ func lookupJoinCanProvideOrdering(expr memo.RelExpr, required *props.OrderingCho
 	inputCols := lookupJoin.Input.Relational().OutputCols
 	canProjectUsingOnlyInputCols := required.CanProjectCols(inputCols)
 
-	if canProjectUsingOnlyInputCols && lookupJoin.IsSecondJoinInPairedJoiner {
+	if canProjectUsingOnlyInputCols &&
+		(lookupJoin.IsFirstJoinInPairedJoiner || lookupJoin.IsSecondJoinInPairedJoiner) {
 		// Can only pass through ordering if the ordering can be provided by the
 		// child, since we don't want a sort to be interposed between the child
 		// and this join.

--- a/pkg/sql/opt/ordering/project.go
+++ b/pkg/sql/opt/ordering/project.go
@@ -53,16 +53,16 @@ func projectBuildChildReqOrdering(
 
 	// We may need to remove ordering columns that are not output by the input
 	// expression.
-	result := projectOrderingToInput(proj.Input, &simplified)
+	result := ProjectOrderingToInput(proj.Input, &simplified)
 
 	return result
 }
 
-// projectOrderingToInput projects out columns from an ordering (if necessary);
+// ProjectOrderingToInput projects out columns from an ordering (if necessary);
 // can only be used if the ordering can be expressed in terms of the input
 // columns. If projection is not necessary, returns a shallow copy of the
 // ordering.
-func projectOrderingToInput(
+func ProjectOrderingToInput(
 	input memo.RelExpr, ordering *props.OrderingChoice,
 ) props.OrderingChoice {
 	childOutCols := input.Relational().OutputCols

--- a/pkg/sql/opt/ordering/select.go
+++ b/pkg/sql/opt/ordering/select.go
@@ -36,13 +36,13 @@ func selectBuildChildReqOrdering(
 	// Use interesting orderings from the child to "guide" the required ordering
 	// that gets passed down and make it more likely that the child will be able
 	// to provide the ordering. This step is needed before the call to
-	// trimColumnGroups, since that function will arbitrarily remove columns from
+	// TrimColumnGroups, since that function will arbitrarily remove columns from
 	// each group to ensure all columns in the group are equivalent according to
 	// the child FDs.
 	//
 	// For example, suppose the required ordering is +(1|2),+3, and the child has
 	// an interesting ordering of +1,+2,+3. +1,+2,+3 implies +(1|2),+3, so the
-	// child can provide the ordering. However, trimColumnGroups will convert
+	// child can provide the ordering. However, TrimColumnGroups will convert
 	// +(1|2),+3 to +1,+3, which the child cannot provide. We should instead pass
 	// down +1,+2,+3 as the required ordering to avoid an unnecessary sort.
 	//
@@ -61,16 +61,16 @@ func selectBuildChildReqOrdering(
 			break
 		}
 	}
-	return trimColumnGroups(required, &child.Relational().FuncDeps)
+	return TrimColumnGroups(required, &child.Relational().FuncDeps)
 }
 
-// trimColumnGroups removes columns from ColumnOrderingChoice groups as
+// TrimColumnGroups removes columns from ColumnOrderingChoice groups as
 // necessary, so that all columns in each group are equivalent according to
 // the given FDs. It is used when the parent expression can have column
 // equivalences that the input expression does not (for example a Select with an
 // equality condition); the columns in a group must be equivalent at the level
 // of the operator where the ordering is required.
-func trimColumnGroups(required *props.OrderingChoice, fds *props.FuncDepSet) props.OrderingChoice {
+func TrimColumnGroups(required *props.OrderingChoice, fds *props.FuncDepSet) props.OrderingChoice {
 	res := *required
 	copied := false
 	for i := range res.Columns {

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -12924,3 +12924,117 @@ explain
            │         └── filters
            │              └── t85353.a:1 < 10 [outer=(1), constraints=(/1: (/NULL - /9]; tight)]
            └── filters (true)
+
+# Regression test for #89603
+exec-ddl
+CREATE TABLE table11 (
+      col1_1 FLOAT8 NOT NULL,
+      col1_2 TIMESTAMP NOT NULL,
+      col1_3 BYTES NOT NULL,
+      col1_4 NAME NOT NULL,
+      col1_5 OID NULL,
+      col1_6 JSONB NULL,
+      col1_7 REGPROCEDURE NULL,
+      INDEX table1_col1_3_col1_1_expr_idx (col1_3 ASC, col1_1 DESC)
+  )
+----
+
+# The sort must be done as the last step instead of in between the first and
+# second joins of the paired join.
+opt set=testing_optimizer_random_seed=4057832385546395198 set=testing_optimizer_cost_perturbation=1.0
+SELECT
+        tab_17534.col1_3 AS col_52140,
+        0:::OID AS col_52141,
+        tab_17533.col1_7 AS col_52142,
+        '\x58':::BYTES AS col_52143,
+        0:::OID AS col_52144
+FROM
+        table11@[0] AS tab_17533
+        RIGHT JOIN table11@[0] AS tab_17534
+                JOIN table11@[0] AS tab_17535 ON
+                                (tab_17534.crdb_internal_mvcc_timestamp) = (tab_17535.crdb_internal_mvcc_timestamp)
+                                AND (tab_17534.col1_4) = (tab_17535.col1_4)
+                JOIN table11@[0] AS tab_17536 ON
+                                (tab_17535.col1_1) = (tab_17536.col1_1)
+                                AND (tab_17535.col1_3) = (tab_17536.col1_3)
+                                AND (tab_17534.col1_6) = (tab_17536.col1_6)
+                JOIN table11@[0] AS tab_17537
+                        JOIN table11@[0] AS tab_17538 ON
+                                        (tab_17537.crdb_internal_mvcc_timestamp) = (tab_17538.crdb_internal_mvcc_timestamp) ON
+                                (tab_17536.col1_2) = (tab_17538.col1_2) AND (tab_17535.col1_4) = (tab_17537.col1_4) ON
+                        (tab_17533.col1_3) = (tab_17537.col1_3) AND (tab_17533.col1_6) = (tab_17536.col1_6)
+ORDER BY
+        tab_17535.col1_4, tab_17535.col1_3 DESC
+----
+project
+ ├── columns: col_52140:13!null col_52141:61!null col_52142:7 col_52143:62!null col_52144:61!null  [hidden: tab_17535.col1_3:23!null tab_17535.col1_4:24!null]
+ ├── immutable
+ ├── fd: ()-->(61,62)
+ ├── ordering: +24,-23 opt(61,62) [actual: +24,-23]
+ ├── sort
+ │    ├── columns: tab_17533.col1_3:3 tab_17533.col1_6:6 tab_17533.col1_7:7 tab_17534.col1_3:13!null tab_17534.col1_4:14!null tab_17534.col1_6:16!null tab_17534.crdb_internal_mvcc_timestamp:19!null tab_17535.col1_1:21!null tab_17535.col1_3:23!null tab_17535.col1_4:24!null tab_17535.crdb_internal_mvcc_timestamp:29!null tab_17536.col1_1:31!null tab_17536.col1_2:32!null tab_17536.col1_3:33!null tab_17536.col1_6:36!null tab_17537.col1_3:43!null tab_17537.col1_4:44!null tab_17537.crdb_internal_mvcc_timestamp:49!null tab_17538.col1_2:52!null tab_17538.crdb_internal_mvcc_timestamp:59!null
+ │    ├── immutable
+ │    ├── fd: (19)==(29), (29)==(19), (14)==(24,44), (24)==(14,44), (21)==(31), (31)==(21), (23)==(33), (33)==(23), (16)==(36), (36)==(16), (49)==(59), (59)==(49), (32)==(52), (52)==(32), (44)==(14,24)
+ │    ├── ordering: +(14|24|44),-(23|33) [actual: +14,-23]
+ │    └── left-join (lookup table11 [as=tab_17533])
+ │         ├── columns: tab_17533.col1_3:3 tab_17533.col1_6:6 tab_17533.col1_7:7 tab_17534.col1_3:13!null tab_17534.col1_4:14!null tab_17534.col1_6:16!null tab_17534.crdb_internal_mvcc_timestamp:19!null tab_17535.col1_1:21!null tab_17535.col1_3:23!null tab_17535.col1_4:24!null tab_17535.crdb_internal_mvcc_timestamp:29!null tab_17536.col1_1:31!null tab_17536.col1_2:32!null tab_17536.col1_3:33!null tab_17536.col1_6:36!null tab_17537.col1_3:43!null tab_17537.col1_4:44!null tab_17537.crdb_internal_mvcc_timestamp:49!null tab_17538.col1_2:52!null tab_17538.crdb_internal_mvcc_timestamp:59!null
+ │         ├── key columns: [70] = [8]
+ │         ├── lookup columns are key
+ │         ├── second join in paired joiner
+ │         ├── immutable
+ │         ├── fd: (19)==(29), (29)==(19), (14)==(24,44), (24)==(14,44), (21)==(31), (31)==(21), (23)==(33), (33)==(23), (16)==(36), (36)==(16), (49)==(59), (59)==(49), (32)==(52), (52)==(32), (44)==(14,24)
+ │         ├── left-join (lookup table11@table1_col1_3_col1_1_expr_idx [as=tab_17533])
+ │         │    ├── columns: tab_17534.col1_3:13!null tab_17534.col1_4:14!null tab_17534.col1_6:16!null tab_17534.crdb_internal_mvcc_timestamp:19!null tab_17535.col1_1:21!null tab_17535.col1_3:23!null tab_17535.col1_4:24!null tab_17535.crdb_internal_mvcc_timestamp:29!null tab_17536.col1_1:31!null tab_17536.col1_2:32!null tab_17536.col1_3:33!null tab_17536.col1_6:36!null tab_17537.col1_3:43!null tab_17537.col1_4:44!null tab_17537.crdb_internal_mvcc_timestamp:49!null tab_17538.col1_2:52!null tab_17538.crdb_internal_mvcc_timestamp:59!null tab_17533.col1_1:63 tab_17533.col1_3:65 tab_17533.rowid:70 continuation:73
+ │         │    ├── key columns: [43] = [65]
+ │         │    ├── first join in paired joiner; continuation column: continuation:73
+ │         │    ├── immutable
+ │         │    ├── fd: (19)==(29), (29)==(19), (14)==(24,44), (24)==(14,44), (21)==(31), (31)==(21), (23)==(33), (33)==(23), (16)==(36), (36)==(16), (49)==(59), (59)==(49), (32)==(52), (52)==(32), (44)==(14,24), (70)-->(63,65,73)
+ │         │    ├── inner-join (hash)
+ │         │    │    ├── columns: tab_17534.col1_3:13!null tab_17534.col1_4:14!null tab_17534.col1_6:16!null tab_17534.crdb_internal_mvcc_timestamp:19!null tab_17535.col1_1:21!null tab_17535.col1_3:23!null tab_17535.col1_4:24!null tab_17535.crdb_internal_mvcc_timestamp:29!null tab_17536.col1_1:31!null tab_17536.col1_2:32!null tab_17536.col1_3:33!null tab_17536.col1_6:36!null tab_17537.col1_3:43!null tab_17537.col1_4:44!null tab_17537.crdb_internal_mvcc_timestamp:49!null tab_17538.col1_2:52!null tab_17538.crdb_internal_mvcc_timestamp:59!null
+ │         │    │    ├── immutable
+ │         │    │    ├── fd: (19)==(29), (29)==(19), (14)==(24,44), (24)==(14,44), (21)==(31), (31)==(21), (23)==(33), (33)==(23), (16)==(36), (36)==(16), (49)==(59), (59)==(49), (32)==(52), (52)==(32), (44)==(14,24)
+ │         │    │    ├── inner-join (hash)
+ │         │    │    │    ├── columns: tab_17534.col1_3:13!null tab_17534.col1_4:14!null tab_17534.col1_6:16!null tab_17534.crdb_internal_mvcc_timestamp:19!null tab_17535.col1_1:21!null tab_17535.col1_3:23!null tab_17535.col1_4:24!null tab_17535.crdb_internal_mvcc_timestamp:29!null tab_17536.col1_1:31!null tab_17536.col1_2:32!null tab_17536.col1_3:33!null tab_17536.col1_6:36!null tab_17537.col1_3:43!null tab_17537.col1_4:44!null tab_17537.crdb_internal_mvcc_timestamp:49
+ │         │    │    │    ├── multiplicity: left-rows(zero-or-more), right-rows(one-or-more)
+ │         │    │    │    ├── immutable
+ │         │    │    │    ├── fd: (24)==(14,44), (44)==(14,24), (21)==(31), (31)==(21), (23)==(33), (33)==(23), (19)==(29), (29)==(19), (14)==(24,44), (16)==(36), (36)==(16)
+ │         │    │    │    ├── scan table11 [as=tab_17537]
+ │         │    │    │    │    └── columns: tab_17537.col1_3:43!null tab_17537.col1_4:44!null tab_17537.crdb_internal_mvcc_timestamp:49
+ │         │    │    │    ├── inner-join (lookup table11 [as=tab_17536])
+ │         │    │    │    │    ├── columns: tab_17534.col1_3:13!null tab_17534.col1_4:14!null tab_17534.col1_6:16!null tab_17534.crdb_internal_mvcc_timestamp:19!null tab_17535.col1_1:21!null tab_17535.col1_3:23!null tab_17535.col1_4:24!null tab_17535.crdb_internal_mvcc_timestamp:29!null tab_17536.col1_1:31!null tab_17536.col1_2:32!null tab_17536.col1_3:33!null tab_17536.col1_6:36!null
+ │         │    │    │    │    ├── key columns: [38] = [38]
+ │         │    │    │    │    ├── lookup columns are key
+ │         │    │    │    │    ├── immutable
+ │         │    │    │    │    ├── fd: (19)==(29), (29)==(19), (14)==(24), (24)==(14), (21)==(31), (31)==(21), (23)==(33), (33)==(23), (16)==(36), (36)==(16)
+ │         │    │    │    │    ├── inner-join (lookup table11@table1_col1_3_col1_1_expr_idx [as=tab_17536])
+ │         │    │    │    │    │    ├── columns: tab_17534.col1_3:13!null tab_17534.col1_4:14!null tab_17534.col1_6:16 tab_17534.crdb_internal_mvcc_timestamp:19!null tab_17535.col1_1:21!null tab_17535.col1_3:23!null tab_17535.col1_4:24!null tab_17535.crdb_internal_mvcc_timestamp:29!null tab_17536.col1_1:31!null tab_17536.col1_3:33!null tab_17536.rowid:38!null
+ │         │    │    │    │    │    ├── key columns: [23 21] = [33 31]
+ │         │    │    │    │    │    ├── immutable
+ │         │    │    │    │    │    ├── fd: (19)==(29), (29)==(19), (14)==(24), (24)==(14), (38)-->(31,33), (23)==(33), (33)==(23), (21)==(31), (31)==(21)
+ │         │    │    │    │    │    ├── inner-join (hash)
+ │         │    │    │    │    │    │    ├── columns: tab_17534.col1_3:13!null tab_17534.col1_4:14!null tab_17534.col1_6:16 tab_17534.crdb_internal_mvcc_timestamp:19!null tab_17535.col1_1:21!null tab_17535.col1_3:23!null tab_17535.col1_4:24!null tab_17535.crdb_internal_mvcc_timestamp:29!null
+ │         │    │    │    │    │    │    ├── immutable
+ │         │    │    │    │    │    │    ├── fd: (19)==(29), (29)==(19), (14)==(24), (24)==(14)
+ │         │    │    │    │    │    │    ├── scan table11 [as=tab_17535]
+ │         │    │    │    │    │    │    │    └── columns: tab_17535.col1_1:21!null tab_17535.col1_3:23!null tab_17535.col1_4:24!null tab_17535.crdb_internal_mvcc_timestamp:29
+ │         │    │    │    │    │    │    ├── scan table11 [as=tab_17534]
+ │         │    │    │    │    │    │    │    └── columns: tab_17534.col1_3:13!null tab_17534.col1_4:14!null tab_17534.col1_6:16 tab_17534.crdb_internal_mvcc_timestamp:19
+ │         │    │    │    │    │    │    └── filters
+ │         │    │    │    │    │    │         ├── tab_17534.crdb_internal_mvcc_timestamp:19 = tab_17535.crdb_internal_mvcc_timestamp:29 [outer=(19,29), immutable, constraints=(/19: (/NULL - ]; /29: (/NULL - ]), fd=(19)==(29), (29)==(19)]
+ │         │    │    │    │    │    │         └── tab_17534.col1_4:14 = tab_17535.col1_4:24 [outer=(14,24), constraints=(/14: (/NULL - ]; /24: (/NULL - ]), fd=(14)==(24), (24)==(14)]
+ │         │    │    │    │    │    └── filters (true)
+ │         │    │    │    │    └── filters
+ │         │    │    │    │         └── tab_17534.col1_6:16 = tab_17536.col1_6:36 [outer=(16,36), immutable, constraints=(/16: (/NULL - ]; /36: (/NULL - ]), fd=(16)==(36), (36)==(16)]
+ │         │    │    │    └── filters
+ │         │    │    │         └── tab_17535.col1_4:24 = tab_17537.col1_4:44 [outer=(24,44), constraints=(/24: (/NULL - ]; /44: (/NULL - ]), fd=(24)==(44), (44)==(24)]
+ │         │    │    ├── scan table11 [as=tab_17538]
+ │         │    │    │    └── columns: tab_17538.col1_2:52!null tab_17538.crdb_internal_mvcc_timestamp:59
+ │         │    │    └── filters
+ │         │    │         ├── tab_17537.crdb_internal_mvcc_timestamp:49 = tab_17538.crdb_internal_mvcc_timestamp:59 [outer=(49,59), immutable, constraints=(/49: (/NULL - ]; /59: (/NULL - ]), fd=(49)==(59), (59)==(49)]
+ │         │    │         └── tab_17536.col1_2:32 = tab_17538.col1_2:52 [outer=(32,52), constraints=(/32: (/NULL - ]; /52: (/NULL - ]), fd=(32)==(52), (52)==(32)]
+ │         │    └── filters (true)
+ │         └── filters
+ │              └── tab_17533.col1_6:6 = tab_17536.col1_6:36 [outer=(6,36), immutable, constraints=(/6: (/NULL - ]; /36: (/NULL - ]), fd=(6)==(36), (36)==(6)]
+ └── projections
+      ├── 0 [as=col_52141:61]
+      └── '\x58' [as=col_52143:62]


### PR DESCRIPTION
Fixes #89603

This fixes an issue where an illegal paired join plan is created by the
optimizer where the first join in the pair is sorted. This breaks the
assumption required in paired joiner logic that the first join in the
pair is never sorted or distributed for proper interpretation of the
continuation column:
```
// ContinuationCol is the column ID of the continuation column when
// IsFirstJoinInPairedJoiner is true. The continuation column is a
// boolean column that indicates whether an output row is a
// continuation of a group corresponding to a single left input row.
ContinuationCol opt.ColumnID
```

Function `lookupJoinCanProvideOrdering` allows the required ordering to
be passed to the child of the first join in a paired join if only the
input columns are projected (no lookup columns). This is not sufficient
because only when the first join can further pass the required ordering
on to its input can a sort be avoided.

The solution is to modify `lookupJoinCanProvideOrdering` to indicate the
second join in a paired join can provide an ordering if both the first
join and the first join's child can provide the ordering.

Release note (bug fix): This patch fixes possible, but rare, incorrect
results from paired lookup joins where the first join in the pair is
sorted.

xform: assertion for unenforcible props

This commit adds an assertion that a sort on the first join of a paired 
join is never enforced.

Fixes #89603

Release note: None 
