### PR TITLE
server: fix tracing benchmark

### DIFF
--- a/pkg/server/bench_test.go
+++ b/pkg/server/bench_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -58,10 +57,8 @@ func BenchmarkSetupSpanForIncomingRPC(b *testing.B) {
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_, sp := setupSpanForIncomingRPC(
-					ctx, roachpb.SystemTenantID, ba, tr, cluster.MakeTestingClusterSettings(),
-				)
-				sp.finish(nil /* br */)
+				_, sp := setupSpanForIncomingRPC(ctx, roachpb.SystemTenantID, ba, tr)
+				sp.finish(nil /* br */, dontRedactEvenIfTenantRequest)
 			}
 		})
 	}

--- a/pkg/server/node_tenant_test.go
+++ b/pkg/server/node_tenant_test.go
@@ -25,11 +25,11 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
-// TestMaybeRedactRecording verifies that redactRecording strips
-// sensitive details for recordings consumed by tenants.
+// Check that redactRecording strips sensitive details from recordings.
 //
-// See kvccl.TestTenantTracesAreRedacted for an end-to-end test of this.
-func TestRedactRecordingForTenant(t *testing.T) {
+// See kvccl.TestTenantTracesAreRedacted for an end-to-end test of tenant trace
+// redaction.
+func TestRedactRecording(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	const (


### PR DESCRIPTION
A tracing benchmark had been inadvertently polluted by creating test cluster settings in the benchmark loop. This patch fixes it, and cleans up the code under test so that it no longer awkwardly stashes the cluster settings.

Fixes #89202

With this fix, the benchmark shows an expected degradation since 22.1 caused by one new alloc, which is worth it. It's interesting that these results are with the 22.1 benchmark built with go1.19. With 22.1 built with 1.17 and master built with 1.19, the new numbers are significantly better than 22.1.

```
name                                  old time/op    new time/op    delta
SetupSpanForIncomingRPC/traceInfo-32     304ns ± 1%     382ns ± 2%   +25.41%  (p=0.008 n=5+5)
SetupSpanForIncomingRPC/grpcMeta-32     1.21µs ± 3%    1.18µs ± 2%    -2.87%  (p=0.024 n=5+5)
SetupSpanForIncomingRPC/no_parent-32     311ns ± 4%     384ns ± 5%   +23.49%  (p=0.008 n=5+5)

name                                  old alloc/op   new alloc/op   delta
SetupSpanForIncomingRPC/traceInfo-32     48.0B ± 0%     80.0B ± 0%   +66.67%  (p=0.008 n=5+5)
SetupSpanForIncomingRPC/grpcMeta-32       592B ± 0%      624B ± 0%    +5.41%  (p=0.008 n=5+5)
SetupSpanForIncomingRPC/no_parent-32     48.0B ± 0%     80.0B ± 0%   +66.67%  (p=0.008 n=5+5)

name                                  old allocs/op  new allocs/op  delta
SetupSpanForIncomingRPC/traceInfo-32      1.00 ± 0%      2.00 ± 0%  +100.00%  (p=0.008 n=5+5)
SetupSpanForIncomingRPC/grpcMeta-32       7.00 ± 0%      8.00 ± 0%   +14.29%  (p=0.008 n=5+5)
SetupSpanForIncomingRPC/no_parent-32      1.00 ± 0%      2.00 ± 0%  +100.00%  (p=0.008 n=5+5)
```

Release note: None
Epic: None