### PR TITLE
bazci: stream test results

### DIFF
--- a/build/patches/go_googleapis.patch
+++ b/build/patches/go_googleapis.patch
@@ -14,3 +14,21 @@ diff -urN a/google/cloud/kms/v1/BUILD.bazel b/google/cloud/kms/v1/BUILD.bazel
 +        "@org_golang_google_genproto//protobuf/field_mask:go_default_library",
 +    ],
  )
+diff -urN a/google/devtools/build/v1/BUILD.bazel a/google/devtools/build/v1/BUILD.bazel
+--- a/google/devtools/build/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/google/devtools/build/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -25,5 +25,13 @@
+     importpath = "google.golang.org/genproto/googleapis/devtools/build/v1",
+     proto = ":build_proto",
+     visibility = ["//visibility:public"],
+-    deps = ["//google/api:annotations_go_proto"],
++    deps = [
++        "@com_github_golang_protobuf//ptypes/any:go_default_library",
++        "@com_github_golang_protobuf//ptypes/duration:go_default_library",
++        "@com_github_golang_protobuf//ptypes/empty:go_default_library",
++        "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
++        "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
++        "@org_golang_google_genproto//googleapis/api/annotations:go_default_library",
++        "@org_golang_google_genproto//protobuf/field_mask:go_default_library",
++    ],
+ )

--- a/pkg/cmd/bazci/BUILD.bazel
+++ b/pkg/cmd/bazci/BUILD.bazel
@@ -16,8 +16,11 @@ go_library(
         "//pkg/cmd/bazci/testfilter",
         "@com_github_alessio_shellescape//:shellescape",
         "@com_github_cockroachdb_errors//:errors",
-        "@com_github_gogo_protobuf//proto",
+        "@com_github_gogo_protobuf//types",
         "@com_github_spf13_cobra//:cobra",
+        "@go_googleapis//google/devtools/build/v1:build_go_proto",
+        "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_protobuf//types/known/emptypb",
     ],
 )
 

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -889,6 +889,7 @@ func TestLint(t *testing.T) {
 			":!ccl/sqlproxyccl/tenantdirsvr/test_directory_svr.go",
 			":!ccl/sqlproxyccl/tenantdirsvr/test_simple_directory_svr.go",
 			":!ccl/sqlproxyccl/tenantdirsvr/test_static_directory_svr.go",
+			":!cmd/bazci/*.go",
 		)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Have `bazci` start a [build event service](https://bazel.build/remote/bep)
to monitor the build, rather than parsing the `bep` log at the end of
the build. This gives us better behavior in CI, as test results can
"stream" instead of requiring us to wait until all tests have completed
to report.

Release note: None
Epic CRDB-15060