### PR TITLE
roachprod: log Get failures in roachtests

### DIFF
--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -2021,7 +2021,7 @@ func (c *SyncedCluster) Get(l *logger.Logger, nodes Nodes, src, dest string) err
 		}
 	}
 
-	if config.Quiet && l.File == nil {
+	if config.Quiet && l.File != nil {
 		l.Printf("\n")
 		linesMu.Lock()
 		for i := range lines {


### PR DESCRIPTION
`roachprod.Get` and `roachprod.Put` behaved differently when it comes to logging of errors: the former would not log errors found while running `scp` if there was a file backing the logger, while the latter would.

However, there is no reason for this difference, and it was probably an oversight introduced in an old, really large PR (#74223). This commit makes behavior consistent in both calls and should allow us to see `Get` errors in logs, especially important in `roachtest` failures.

Epic: None.

Release note: None.