### PR TITLE
roachtest: avoid using sudo to install python packages

### DIFF
--- a/pkg/cmd/roachtest/tests/asyncpg.go
+++ b/pkg/cmd/roachtest/tests/asyncpg.go
@@ -23,6 +23,7 @@ import (
 )
 
 const asyncpgRunTestCmd = `
+source venv/bin/activate && 
 cd /mnt/data1/asyncpg && 
 PGPORT=26257 PGHOST=localhost PGUSER=root PGDATABASE=defaultdb python3 setup.py test > asyncpg.stdout
 `
@@ -84,7 +85,13 @@ func registerAsyncpg(r registry.Registry) {
 			c,
 			node,
 			"install python and pip",
-			`sudo apt-get -qq install python3.7 python3-pip libpq-dev python-dev`,
+			`sudo apt-get -qq install python3.7 python3-pip libpq-dev python-dev python3-virtualenv`,
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repeatRunE(
+			ctx, t, c, node, "create virtualenv", `virtualenv venv`,
 		); err != nil {
 			t.Fatal(err)
 		}
@@ -95,14 +102,12 @@ func registerAsyncpg(r registry.Registry) {
 			c,
 			node,
 			"install asyncpg's dependencies",
-			"cd /mnt/data1/asyncpg && sudo pip3 install django && pip3 install -e ."); err != nil {
+			"source venv/bin/activate && cd /mnt/data1/asyncpg && pip3 install -e ."); err != nil {
 			t.Fatal(err)
 		}
 
-		blocklistName, expectedFailureList, ignoredlistName, ignoredlist := asyncpgBlocklists.getLists(version)
-		if expectedFailureList == nil {
-			t.Fatalf("No asyncpg blocklist defined for cockroach version %s", version)
-		}
+		blocklistName, expectedFailureList := "asyncpgBlocklist", asyncpgBlocklist
+		ignoredlistName, ignoredlist := "asyncpgIgnoreList", asyncpgIgnoreList
 		if ignoredlist == nil {
 			t.Fatalf("No asyncpg ignorelist defined for cockroach version %s", version)
 		}

--- a/pkg/cmd/roachtest/tests/asyncpg_blocklist.go
+++ b/pkg/cmd/roachtest/tests/asyncpg_blocklist.go
@@ -10,12 +10,6 @@
 
 package tests
 
-var asyncpgBlocklists = blocklistsForVersion{
-	{"v21.2", "asyncpgBlocklist21_2", asyncpgBlocklist21_2, "asyncpgIgnoreList21_2", asyncpgIgnoreList21_2},
-	{"v22.1", "asyncpgBlocklist22_1", asyncpgBlocklist22_1, "asyncpgIgnoreList22_1", asyncpgIgnoreList22_1},
-	{"v22.2", "asyncpgBlocklist22_2", asyncpgBlocklist22_2, "asyncpgIgnoreList22_2", asyncpgIgnoreList22_2},
-}
-
 // These are lists of known asyncpg test errors and failures.
 // When the asyncpg test suite is run, the results are compared to this list.
 // Any failed test that is on this list is reported as FAIL - expected.
@@ -24,9 +18,7 @@ var asyncpgBlocklists = blocklistsForVersion{
 // Please keep these lists alphabetized for easy diffing.
 // After a failed run, an updated version of this blocklist should be available
 // in the test log.
-var asyncpgBlocklist22_2 = asyncpgBlocklist22_1
-
-var asyncpgBlocklist22_1 = blocklist{
+var asyncpgBlocklist = blocklist{
 	"test_cache_invalidation.TestCacheInvalidation.test_prepare_cache_invalidation_in_pool":               "experimental support - https://github.com/cockroachdb/cockroach/issues/49329",
 	"test_cache_invalidation.TestCacheInvalidation.test_prepare_cache_invalidation_in_transaction":        "experimental support - https://github.com/cockroachdb/cockroach/issues/49329",
 	"test_cache_invalidation.TestCacheInvalidation.test_prepare_cache_invalidation_silent":                "experimental support - https://github.com/cockroachdb/cockroach/issues/49329",
@@ -109,101 +101,5 @@ var asyncpgBlocklist22_1 = blocklist{
 	"test_utils.TestUtils.test_mogrify_multiple":                                                          "query decorrelation - https://github.com/cockroachdb/cockroach/issues/80169",
 	"test_utils.TestUtils.test_mogrify_simple":                                                            "query decorrelation - https://github.com/cockroachdb/cockroach/issues/80169",
 }
-var asyncpgBlocklist21_2 = blocklist{
-	"test_cache_invalidation.TestCacheInvalidation.test_prepare_cache_invalidation_in_pool":               "unknown",
-	"test_cache_invalidation.TestCacheInvalidation.test_prepare_cache_invalidation_in_transaction":        "unknown",
-	"test_cache_invalidation.TestCacheInvalidation.test_prepare_cache_invalidation_silent":                "unknown",
-	"test_cache_invalidation.TestCacheInvalidation.test_prepared_type_cache_invalidation":                 "unknown",
-	"test_cache_invalidation.TestCacheInvalidation.test_type_cache_invalidation_in_cancelled_transaction": "unknown",
-	"test_cache_invalidation.TestCacheInvalidation.test_type_cache_invalidation_in_pool":                  "unknown",
-	"test_cache_invalidation.TestCacheInvalidation.test_type_cache_invalidation_in_transaction":           "unknown",
-	"test_cache_invalidation.TestCacheInvalidation.test_type_cache_invalidation_on_change_attr":           "unknown",
-	"test_cache_invalidation.TestCacheInvalidation.test_type_cache_invalidation_on_drop_type_attr":        "unknown",
-	"test_cancellation.TestCancellation.test_cancellation_03":                                             "unknown",
-	"test_codecs.TestCodecs.test_array_with_custom_json_text_codec":                                       "unknown",
-	"test_codecs.TestCodecs.test_composites_in_arrays":                                                    "unknown",
-	"test_codecs.TestCodecs.test_enum":                                                                    "unknown",
-	"test_codecs.TestCodecs.test_enum_and_range":                                                          "unknown",
-	"test_codecs.TestCodecs.test_enum_function_return":                                                    "unknown",
-	"test_codecs.TestCodecs.test_enum_in_array":                                                           "unknown",
-	"test_codecs.TestCodecs.test_enum_in_composite":                                                       "unknown",
-	"test_codecs.TestCodecs.test_invalid_input":                                                           "unknown",
-	"test_codecs.TestCodecs.test_relacl_array_type":                                                       "unknown",
-	"test_codecs.TestCodecs.test_timetz_encoding":                                                         "unknown",
-	"test_codecs.TestCodecs.test_unhandled_type_fallback":                                                 "unknown",
-	"test_codecs.TestCodecs.test_unknown_type_text_fallback":                                              "unknown",
-	"test_codecs.TestCodecs.test_void":                                                                    "unknown",
-	"test_connect.TestSettings.test_get_settings_01":                                                      "unknown",
-	"test_copy.TestCopyFrom.test_copy_from_query_basics":                                                  "unknown",
-	"test_copy.TestCopyFrom.test_copy_from_query_cancellation_explicit":                                   "unknown",
-	"test_copy.TestCopyFrom.test_copy_from_query_cancellation_on_sink_error":                              "unknown",
-	"test_copy.TestCopyFrom.test_copy_from_query_cancellation_while_waiting_for_data":                     "unknown",
-	"test_copy.TestCopyFrom.test_copy_from_query_timeout_1":                                               "unknown",
-	"test_copy.TestCopyFrom.test_copy_from_query_timeout_2":                                               "unknown",
-	"test_copy.TestCopyFrom.test_copy_from_query_to_path":                                                 "unknown",
-	"test_copy.TestCopyFrom.test_copy_from_query_to_path_like":                                            "unknown",
-	"test_copy.TestCopyFrom.test_copy_from_query_to_sink":                                                 "unknown",
-	"test_copy.TestCopyFrom.test_copy_from_query_with_args":                                               "unknown",
-	"test_copy.TestCopyFrom.test_copy_from_table_basics":                                                  "unknown",
-	"test_copy.TestCopyFrom.test_copy_from_table_large_rows":                                              "unknown",
-	"test_copy.TestCopyTo.test_copy_records_to_table_1":                                                   "unknown",
-	"test_copy.TestCopyTo.test_copy_records_to_table_async":                                               "unknown",
-	"test_copy.TestCopyTo.test_copy_to_table_basics":                                                      "unknown",
-	"test_cursor.TestCursor.test_cursor_02":                                                               "unknown",
-	"test_cursor.TestCursor.test_cursor_04":                                                               "unknown",
-	"test_cursor.TestIterableCursor.test_cursor_iterable_02":                                              "unknown",
-	"test_exceptions.TestExceptions.test_exceptions_str":                                                  "unknown",
-	"test_exceptions.TestExceptions.test_exceptions_unpacking":                                            "unknown",
-	"test_execute.TestExecuteMany.test_executemany_client_failure_after_writes":                           "unknown",
-	"test_execute.TestExecuteMany.test_executemany_client_failure_in_transaction":                         "unknown",
-	"test_execute.TestExecuteMany.test_executemany_client_server_failure_conflict":                        "unknown",
-	"test_execute.TestExecuteMany.test_executemany_prepare":                                               "unknown",
-	"test_execute.TestExecuteMany.test_executemany_server_failure":                                        "unknown",
-	"test_execute.TestExecuteMany.test_executemany_server_failure_after_writes":                           "unknown",
-	"test_execute.TestExecuteMany.test_executemany_server_failure_during_writes":                          "unknown",
-	"test_execute.TestExecuteMany.test_executemany_timeout":                                               "unknown",
-	"test_execute.TestExecuteMany.test_executemany_timeout_flow_control":                                  "unknown",
-	"test_execute.TestExecuteScript.test_execute_script_3":                                                "unknown",
-	"test_execute.TestExecuteScript.test_execute_script_check_transactionality":                           "unknown",
-	"test_execute.TestExecuteScript.test_execute_script_interrupted_close":                                "unknown",
-	"test_introspection.TestIntrospection.test_introspection_no_stmt_cache_01":                            "unknown",
-	"test_introspection.TestIntrospection.test_introspection_no_stmt_cache_02":                            "unknown",
-	"test_introspection.TestIntrospection.test_introspection_no_stmt_cache_03":                            "unknown",
-	"test_introspection.TestIntrospection.test_introspection_on_large_db":                                 "unknown",
-	"test_introspection.TestIntrospection.test_introspection_retries_after_cache_bust":                    "unknown",
-	"test_introspection.TestIntrospection.test_introspection_sticks_for_ps":                               "unknown",
-	"test_listeners.TestListeners.test_listen_01":                                                         "unknown",
-	"test_listeners.TestListeners.test_listen_02":                                                         "unknown",
-	"test_listeners.TestListeners.test_listen_notletters":                                                 "unknown",
-	"test_listeners.TestLogListeners.test_log_listener_01":                                                "unknown",
-	"test_listeners.TestLogListeners.test_log_listener_02":                                                "unknown",
-	"test_listeners.TestLogListeners.test_log_listener_03":                                                "unknown",
-	"test_pool.TestPool.test_pool_handles_query_cancel_in_release":                                        "unknown",
-	"test_pool.TestPool.test_pool_handles_task_cancel_in_release":                                         "unknown",
-	"test_pool.TestPool.test_pool_init_race":                                                              "unknown",
-	"test_pool.TestPool.test_pool_init_run_until_complete":                                                "unknown",
-	"test_pool.TestPool.test_pool_remote_close":                                                           "unknown",
-	"test_prepare.TestPrepare.test_prepare_06_interrupted_close":                                          "unknown",
-	"test_prepare.TestPrepare.test_prepare_08_big_result":                                                 "unknown",
-	"test_prepare.TestPrepare.test_prepare_09_raise_error":                                                "unknown",
-	"test_prepare.TestPrepare.test_prepare_14_explain":                                                    "unknown",
-	"test_prepare.TestPrepare.test_prepare_16_command_result":                                             "unknown",
-	"test_prepare.TestPrepare.test_prepare_19_concurrent_calls":                                           "unknown",
-	"test_prepare.TestPrepare.test_prepare_22_empty":                                                      "unknown",
-	"test_prepare.TestPrepare.test_prepare_28_max_args":                                                   "unknown",
-	"test_prepare.TestPrepare.test_prepare_31_pgbouncer_note":                                             "unknown",
-	"test_prepare.TestPrepare.test_prepare_statement_invalid":                                             "unknown",
-	"test_record.TestRecord.test_record_subclass_01":                                                      "unknown",
-	"test_record.TestRecord.test_record_subclass_02":                                                      "unknown",
-	"test_record.TestRecord.test_record_subclass_03":                                                      "unknown",
-	"test_record.TestRecord.test_record_subclass_04":                                                      "unknown",
-	"test_timeout.TestConnectionCommandTimeout.test_command_timeout_01":                                   "unknown",
-	"test_timeout.TestTimeout.test_timeout_04":                                                            "unknown",
-	"test_timeout.TestTimeout.test_timeout_06":                                                            "unknown",
-	"test_utils.TestUtils.test_mogrify_multiple":                                                          "unknown",
-	"test_utils.TestUtils.test_mogrify_simple":                                                            "unknown",
-}
 
-var asyncpgIgnoreList22_2 = asyncpgIgnoreList22_1
-var asyncpgIgnoreList22_1 = asyncpgIgnoreList21_2
-var asyncpgIgnoreList21_2 = blocklist{}
+var asyncpgIgnoreList = blocklist{}

--- a/pkg/cmd/roachtest/tests/blocklist_test.go
+++ b/pkg/cmd/roachtest/tests/blocklist_test.go
@@ -37,7 +37,7 @@ func TestBlocklists(t *testing.T) {
 		"pgjdbc":       pgjdbcBlockList,
 		"psycopg":      psycopgBlockList20_2,
 		"django":       djangoBlocklist,
-		"sqlAlchemy":   sqlAlchemyBlocklist20_2,
+		"sqlAlchemy":   sqlAlchemyBlocklist,
 		"libpq":        libPQBlocklist20_2,
 		"gopg":         gopgBlockList20_2,
 		"pgx":          pgxBlocklist20_2,

--- a/pkg/cmd/roachtest/tests/django.go
+++ b/pkg/cmd/roachtest/tests/django.go
@@ -93,9 +93,7 @@ func registerDjango(r registry.Registry) {
 		}
 
 		if err := repeatRunE(
-			ctx, t, c, node, "create virtualenv",
-			`virtualenv venv &&
-				source venv/bin/activate`,
+			ctx, t, c, node, "create virtualenv", `virtualenv venv`,
 		); err != nil {
 			t.Fatal(err)
 		}
@@ -106,7 +104,7 @@ func registerDjango(r registry.Registry) {
 			c,
 			node,
 			"install pytest",
-			`pip3 install pytest pytest-xdist psycopg2`,
+			`source venv/bin/activate && pip3 install pytest pytest-xdist psycopg2`,
 		); err != nil {
 			t.Fatal(err)
 		}
@@ -127,7 +125,7 @@ func registerDjango(r registry.Registry) {
 			node,
 			"install django-cockroachdb",
 			fmt.Sprintf(
-				`pip3 install django-cockroachdb==%s`,
+				`source venv/bin/activate && pip3 install django-cockroachdb==%s`,
 				djangoCockroachDBSupportedTag,
 			),
 		); err != nil {
@@ -157,6 +155,7 @@ func registerDjango(r registry.Registry) {
 
 		if err := repeatRunE(
 			ctx, t, c, node, "install django's dependencies", `
+				source venv/bin/activate &&
 				cd /mnt/data1/django/tests &&
 				pip3 install -e .. &&
 				pip3 install -r requirements/py3.txt &&
@@ -232,7 +231,7 @@ func registerDjango(r registry.Registry) {
 
 // Test results are only in stderr, so stdout is redirected and printed later.
 const djangoRunTestCmd = `
-cd /mnt/data1/django/tests &&
+source venv/bin/activate && cd /mnt/data1/django/tests &&
 python3 runtests.py %[1]s --settings cockroach_settings -v 2 > %[1]s.stdout
 `
 

--- a/pkg/cmd/roachtest/tests/sqlalchemy_blocklist.go
+++ b/pkg/cmd/roachtest/tests/sqlalchemy_blocklist.go
@@ -10,30 +10,6 @@
 
 package tests
 
-var sqlAlchemyBlocklists = blocklistsForVersion{
-	{"v20.2", "sqlAlchemyBlocklist20_2", sqlAlchemyBlocklist20_2, "sqlAlchemyIgnoreList20_2", sqlAlchemyIgnoreList20_2},
-	{"v21.1", "sqlAlchemyBlocklist21_1", sqlAlchemyBlocklist21_1, "sqlAlchemyIgnoreList21_1", sqlAlchemyIgnoreList21_1},
-	{"v21.2", "sqlAlchemyBlocklist21_2", sqlAlchemyBlocklist21_2, "sqlAlchemyIgnoreList21_2", sqlAlchemyIgnoreList21_2},
-	{"v22.1", "sqlAlchemyBlocklist22_1", sqlAlchemyBlocklist22_1, "sqlAlchemyIgnoreList22_1", sqlAlchemyIgnoreList22_1},
-	{"v22.2", "sqlAlchemyBlocklist22_2", sqlAlchemyBlocklist22_2, "sqlAlchemyIgnoreList22_2", sqlAlchemyIgnoreList22_2},
-}
+var sqlAlchemyBlocklist = blocklist{}
 
-var sqlAlchemyBlocklist22_2 = blocklist{}
-
-var sqlAlchemyBlocklist22_1 = blocklist{}
-
-var sqlAlchemyBlocklist21_2 = blocklist{}
-
-var sqlAlchemyBlocklist21_1 = blocklist{}
-
-var sqlAlchemyBlocklist20_2 = blocklist{}
-
-var sqlAlchemyIgnoreList22_2 = sqlAlchemyIgnoreList22_1
-
-var sqlAlchemyIgnoreList22_1 = sqlAlchemyIgnoreList21_2
-
-var sqlAlchemyIgnoreList21_2 = sqlAlchemyIgnoreList21_1
-
-var sqlAlchemyIgnoreList21_1 = sqlAlchemyIgnoreList20_2
-
-var sqlAlchemyIgnoreList20_2 = blocklist{}
+var sqlAlchemyIgnoreList = blocklist{}


### PR DESCRIPTION
see also https://github.com/cockroachdb/cockroach/issues/88675

sudo can make it confusing which veresion of a package is being installed and used. This fixes the usage of virtualenvs, and avoid sudo.

This also removes per-version blocklists for python tools' tests.

Release note: None