### PR TITLE
sql, ccl: Fix Invalid Secondary Region Zone Configs

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/secondary_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/secondary_region
@@ -153,7 +153,7 @@ PARTITION "us-east-1" OF TABLE db.public.rbr  ALTER PARTITION "us-east-1" OF TAB
                                               num_voters = 3,
                                               constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
                                               voter_constraints = '[+region=us-east-1]',
-                                              lease_preferences = '[[+region=us-east-1, +region=ca-central-1]]'
+                                              lease_preferences = '[[+region=us-east-1], [+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "ap-southeast-2" OF TABLE db.rbr
@@ -166,7 +166,7 @@ PARTITION "ap-southeast-2" OF TABLE db.public.rbr  ALTER PARTITION "ap-southeast
                                                    num_voters = 3,
                                                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
                                                    voter_constraints = '[+region=ap-southeast-2]',
-                                                   lease_preferences = '[[+region=ap-southeast-2, +region=ca-central-1]]'
+                                                   lease_preferences = '[[+region=ap-southeast-2], [+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "ca-central-1" OF TABLE db.rbr
@@ -200,7 +200,7 @@ DATABASE db  ALTER DATABASE db CONFIGURE ZONE USING
              num_replicas = 5,
              num_voters = 5,
              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-             voter_constraints = e'{\'+region=ap-southeast-2,+region=ca-central-1\': 2}',
+             voter_constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2}',
              lease_preferences = '[[+region=ap-southeast-2, +region=ca-central-1]]'
 
 # Verify that the zone configuration on the table is expected.
@@ -214,7 +214,7 @@ TABLE db.public.rbt_in_primary  ALTER TABLE db.public.rbt_in_primary CONFIGURE Z
                                 num_replicas = 5,
                                 num_voters = 5,
                                 constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                voter_constraints = e'{\'+region=ap-southeast-2,+region=ca-central-1\': 2}',
+                                voter_constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2}',
                                 lease_preferences = '[[+region=ap-southeast-2, +region=ca-central-1]]'
 
 query TT
@@ -227,7 +227,7 @@ TABLE db.public.rbt_in_us_east  ALTER TABLE db.public.rbt_in_us_east CONFIGURE Z
                                 num_replicas = 5,
                                 num_voters = 5,
                                 constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                voter_constraints = e'{\'+region=us-east-1,+region=ca-central-1\': 2}',
+                                voter_constraints = '{+region=ca-central-1: 2, +region=us-east-1: 2}',
                                 lease_preferences = '[[+region=us-east-1, +region=ca-central-1]]'
 
 query TT
@@ -254,8 +254,8 @@ PARTITION "us-east-1" OF TABLE db.public.rbr  ALTER PARTITION "us-east-1" OF TAB
                                               num_replicas = 5,
                                               num_voters = 5,
                                               constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                              voter_constraints = e'{\'+region=us-east-1,+region=ca-central-1\': 2}',
-                                              lease_preferences = '[[+region=us-east-1, +region=ca-central-1]]'
+                                              voter_constraints = '{+region=ca-central-1: 2, +region=us-east-1: 2}',
+                                              lease_preferences = '[[+region=us-east-1], [+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "ap-southeast-2" OF TABLE db.rbr
@@ -267,8 +267,8 @@ PARTITION "ap-southeast-2" OF TABLE db.public.rbr  ALTER PARTITION "ap-southeast
                                                    num_replicas = 5,
                                                    num_voters = 5,
                                                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                                   voter_constraints = e'{\'+region=ap-southeast-2,+region=ca-central-1\': 2}',
-                                                   lease_preferences = '[[+region=ap-southeast-2, +region=ca-central-1]]'
+                                                   voter_constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2}',
+                                                   lease_preferences = '[[+region=ap-southeast-2], [+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "ca-central-1" OF TABLE db.rbr
@@ -295,7 +295,7 @@ DATABASE db  ALTER DATABASE db CONFIGURE ZONE USING
              num_replicas = 5,
              num_voters = 5,
              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-             voter_constraints = e'{\'+region=ap-southeast-2,+region=ca-central-1\': 2}',
+             voter_constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2}',
              lease_preferences = '[[+region=ap-southeast-2, +region=ca-central-1]]'
 
 # Verify that the zone configuration on the table is expected.
@@ -314,7 +314,7 @@ TABLE db.public.rbt_in_us_east  ALTER TABLE db.public.rbt_in_us_east CONFIGURE Z
                                 num_replicas = 5,
                                 num_voters = 5,
                                 constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                voter_constraints = e'{\'+region=us-east-1,+region=ca-central-1\': 2}',
+                                voter_constraints = '{+region=ca-central-1: 2, +region=us-east-1: 2}',
                                 lease_preferences = '[[+region=us-east-1, +region=ca-central-1]]'
 
 query TT
@@ -341,8 +341,8 @@ PARTITION "us-east-1" OF TABLE db.public.rbr  ALTER PARTITION "us-east-1" OF TAB
                                               num_replicas = 5,
                                               num_voters = 5,
                                               constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                              voter_constraints = e'{\'+region=us-east-1,+region=ca-central-1\': 2}',
-                                              lease_preferences = '[[+region=us-east-1, +region=ca-central-1]]'
+                                              voter_constraints = '{+region=ca-central-1: 2, +region=us-east-1: 2}',
+                                              lease_preferences = '[[+region=us-east-1], [+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "ap-southeast-2" OF TABLE db.rbr
@@ -354,8 +354,8 @@ PARTITION "ap-southeast-2" OF TABLE db.public.rbr  ALTER PARTITION "ap-southeast
                                                    num_replicas = 5,
                                                    num_voters = 5,
                                                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                                   voter_constraints = e'{\'+region=ap-southeast-2,+region=ca-central-1\': 2}',
-                                                   lease_preferences = '[[+region=ap-southeast-2, +region=ca-central-1]]'
+                                                   voter_constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2}',
+                                                   lease_preferences = '[[+region=ap-southeast-2], [+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "ca-central-1" OF TABLE db.rbr


### PR DESCRIPTION
fixes #88559

This commit corrects the secondary region zone
configs.

Release note (bug fix): The zone configs generated for a database with a secondary region were invalid. The voter_constraints and the lease preferences called for voters and leaseholders to exist in both the
primary and secondary region which is impossible.