### PR TITLE
workload/schemachanger: correctly filter out unknown schema change errors

### DIFF
--- a/pkg/sql/sqlerrors/BUILD.bazel
+++ b/pkg/sql/sqlerrors/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
-        "//pkg/util/log",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/sql/sqlerrors/errors.go
+++ b/pkg/sql/sqlerrors/errors.go
@@ -12,16 +12,12 @@
 package sqlerrors
 
 import (
-	"context"
-	"runtime/debug"
-
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
 
@@ -109,7 +105,6 @@ func NewInvalidSchemaDefinitionError(err error) error {
 // NewUndefinedSchemaError creates an error for an undefined schema.
 // TODO (lucy): Have this take a database name.
 func NewUndefinedSchemaError(name string) error {
-	log.Errorf(context.Background(), "MISSING SCHEMA: %s", debug.Stack())
 	return pgerror.Newf(pgcode.InvalidSchemaName, "unknown schema %q", name)
 }
 

--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -1116,7 +1116,9 @@ SELECT count(*) FROM %s
 }
 
 var (
-	regexpUnknownSchemaErr = regexp.MustCompile(`unknown schema \[\d+\]`)
+	// regexpUnknownSchemaErr matches unknown schema errors with
+	// a descriptor ID, which will have the form: unknown schema "[123]"
+	regexpUnknownSchemaErr = regexp.MustCompile(`unknown schema "\[\d+]"`)
 )
 
 // checkAndAdjustForUnknownSchemaErrors in certain contexts we will attempt to
@@ -1129,7 +1131,7 @@ func (og *operationGenerator) checkAndAdjustForUnknownSchemaErrors(err error) er
 		if regexpUnknownSchemaErr.MatchString(pgErr.Message) {
 			og.opGenLog.WriteString(fmt.Sprintf("Rolling back due to unknown schema error %v",
 				err))
-			// Force a rollback and log inside the oepration generator.
+			// Force a rollback and log inside the operation generator.
 			return errors.Mark(err, errRunInTxnRbkSentinel)
 		}
 	}


### PR DESCRIPTION
When code was added to handle unknown schema errors inside the schemachanger workload, the
regex used had a flaw that did not correctly quote the errors allowing no retries to occur. This meant
we never address the original errors but just avoided them due to low probability.

This PR also cleans up some debug code accidentally added in an older PR.


