### PR TITLE
ci: improve unused lint error messages

### DIFF
--- a/build/teamcity/cockroach/ci/tests/unused_test.sh
+++ b/build/teamcity/cockroach/ci/tests/unused_test.sh
@@ -8,7 +8,7 @@ source "$dir/teamcity-support.sh"  # For $root
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
 tc_start_block "Run unused test"
-echo "##teamcity[testStarted name='UnusedLint']"
+echo "##teamcity[testStarted name='UnusedLint' captureStandardOutput='true']"
 exit_status=0
 run_bazel build/teamcity/cockroach/ci/tests/unused_test_impl.sh || exit_status=$?
 if [ "$exit_status" -ne 0 ]; then


### PR DESCRIPTION
By setting `captureStandardOutput='true'` we make sure that error
messages from the build are displayed to the user.

Closes #85542.

Epic CRDB-15060

Release note: None