### PR TITLE
build: stop local cluster, if any, before running acceptance roachtests

### DIFF
--- a/build/teamcity/cockroach/ci/tests/local_roachtest_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/local_roachtest_impl.sh
@@ -10,9 +10,17 @@ fi
 
 bazel build --config=$CROSSLINUX_CONFIG --config=ci //pkg/cmd/cockroach-short \
       //pkg/cmd/roachtest \
+      //pkg/cmd/roachprod \
       //pkg/cmd/workload
 
 BAZEL_BIN=$(bazel info bazel-bin --config=$CROSSLINUX_CONFIG --config=ci)
+
+# if there are any local clusters on this host, stop them before we
+# attempt to run acceptance tests. While this is generally not the
+# case, if a previous `roachtest` run was abruptly killed, the local
+# cluster would remain active and cause every test below to fail.
+$BAZEL_BIN/pkg/cmd/roachprod/roachprod_/roachprod destroy --all-local
+
 $BAZEL_BIN/pkg/cmd/roachtest/roachtest_/roachtest run acceptance kv/splits cdc/bank \
   --local \
   --parallelism=1 \


### PR DESCRIPTION
This stops the `local` cluster, if any, before attempting to run acceptance roachtests in CI. If a previous `roachtest` run on the same host was abruptly killed, the local cluster would remain active and cause every test to fail.

Fixes #88757.

Epic: None.

Release note: None.