### PR TITLE
ui: fix undefined table stats

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/tableStatistics/tableStatistics.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/tableStatistics/tableStatistics.tsx
@@ -36,7 +36,7 @@ interface TableStatistics {
 // This component has also a clear filter option.
 export const TableStatistics: React.FC<TableStatistics> = ({
   pagination,
-  totalCount,
+  totalCount = 0,
   search,
   arrayItemName,
   onClearFilters,


### PR DESCRIPTION
Previously, if no value was being passed as totalCount, the table stats were showing an "undefined value". This commit as a default value as 0 for the total.

Fixes https://github.com/cockroachdb/cockroach/issues/89869

Before
<img width="411" alt="Screen Shot 2022-10-11 at 8 43 04 PM" src="https://user-images.githubusercontent.com/1017486/195453624-52ad8c79-95ee-4dda-a703-b7492b7e2fe3.png">

After
<img width="281" alt="Screen Shot 2022-10-12 at 5 21 52 PM" src="https://user-images.githubusercontent.com/1017486/195453705-e4fff03c-770f-4f32-8b87-3d26b9b072ff.png">


Release note (bug fix): show correct value on table stats on UI, when there is no values to show.