### PR TITLE
build: let teamcity know if current branch supports arm64 testing

### DIFF
--- a/build/teamcity/cockroach/ci/tests/.run_on_arm
+++ b/build/teamcity/cockroach/ci/tests/.run_on_arm
@@ -1,0 +1,1 @@
+This file exists to let teamcity know that it can run tests on ARM64 in the current branch.


### PR DESCRIPTION
This change adds a new file `.run_on_arm` to let teamcity know that if this file exists on a given branch then it can run CI checks on arm64. This will ensure we do not attempt to run the checks on old release branches that do not support testing on arm64.

Release note: None
Epic: CRDB-1463