### PR TITLE
release: generate archives once, fix checksum format

### DIFF
--- a/pkg/cmd/publish-provisional-artifacts/main.go
+++ b/pkg/cmd/publish-provisional-artifacts/main.go
@@ -195,23 +195,32 @@ func run(providers []release.ObjectPutGetter, flags runFlags, execFn release.Exe
 				}
 			} else {
 				for _, provider := range providers {
+					crdbFiles := append(
+						[]release.ArchiveFile{release.MakeCRDBBinaryArchiveFile(o.AbsolutePath, "cockroach")},
+						release.MakeCRDBLibraryArchiveFiles(o.PkgDir, o.Platform)...,
+					)
+					crdbBody, err := release.CreateArchive(o.Platform, o.VersionStr, "cockroach", crdbFiles)
+					if err != nil {
+						log.Fatalf("cannot create crdb release archive %s", err)
+					}
+
+					sqlFiles := []release.ArchiveFile{release.MakeCRDBBinaryArchiveFile(o.CockroachSQLAbsolutePath, "cockroach-sql")}
+					sqlBody, err := release.CreateArchive(o.Platform, o.VersionStr, "cockroach-sql", sqlFiles)
+					if err != nil {
+						log.Fatalf("cannot create sql release archive %s", err)
+					}
 					release.PutRelease(provider, release.PutReleaseOptions{
 						NoCache:       false,
 						Platform:      o.Platform,
 						VersionStr:    o.VersionStr,
 						ArchivePrefix: "cockroach",
-						Files: append(
-							[]release.ArchiveFile{release.MakeCRDBBinaryArchiveFile(o.AbsolutePath, "cockroach")},
-							release.MakeCRDBLibraryArchiveFiles(o.PkgDir, o.Platform)...,
-						),
-					})
+					}, crdbBody)
 					release.PutRelease(provider, release.PutReleaseOptions{
 						NoCache:       false,
 						Platform:      o.Platform,
 						VersionStr:    o.VersionStr,
 						ArchivePrefix: "cockroach-sql",
-						Files:         []release.ArchiveFile{release.MakeCRDBBinaryArchiveFile(o.CockroachSQLAbsolutePath, "cockroach-sql")},
-					})
+					}, sqlBody)
 				}
 			}
 		}


### PR DESCRIPTION
Previously, the release archives were generated multiple times and we ended up uploading different binary content to different cloud providers. Also, the checksum format was missing an extra space, what prevents non coreutils checksum tools from working properly.

This change makes the releae process to generate archives only once and fixes the checksum format.

Fixes: #89915
Fixes: #89917

Release note: None