### PR TITLE
ci: let testrace use `simplestamp` config

### DIFF
--- a/build/teamcity/cockroach/ci/tests/testrace_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/testrace_impl.sh
@@ -30,7 +30,7 @@ do
                 echo "Skipping test $test"
                 continue
             fi
-            $(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci -- test --config=ci --config=race "$test" \
+            $(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci -- test --config=ci --config=race --config=simplestamp "$test" \
                                 --test_env=COCKROACH_LOGIC_TESTS_SKIP=true \
                                 --test_env=GOMAXPROCS=8 \
                                 --test_arg=-test.timeout="${go_timeout}s"


### PR DESCRIPTION
Release note: None
Epic: none