### PR TITLE
cdctest: simplify FingerprintValidator

### DIFF
--- a/pkg/ccl/changefeedccl/cdctest/validator.go
+++ b/pkg/ccl/changefeedccl/cdctest/validator.go
@@ -319,13 +319,6 @@ type validatorRow struct {
 	updated    hlc.Timestamp
 }
 
-// eventKey returns a key that encodes the key and timestamp of a row
-// received from a changefeed. Can be used to keep track of which
-// updates have been seen before in a validator.
-func (row validatorRow) eventKey() string {
-	return fmt.Sprintf("%s|%s", row.key, row.updated.AsOfSystemTime())
-}
-
 // FingerprintValidator verifies that recreating a table from its changefeed
 // will fingerprint the same at all "interesting" points in time.
 type FingerprintValidator struct {
@@ -349,12 +342,6 @@ type FingerprintValidator struct {
 	fprintOrigColumns int
 	fprintTestColumns int
 	buffer            []validatorRow
-
-	// previouslySeen keeps track of previous events to validate
-	// changefeed semantics. The map will store at most
-	// `maxPreviousEntries` events
-	previouslySeen     map[string]struct{}
-	maxPreviousEntries int
 
 	failures []string
 }
@@ -436,17 +423,6 @@ func (v *FingerprintValidator) DBFunc(
 	return v
 }
 
-// ValidateDuplicatedEvents enables the validation of duplicated
-// messages in the fingerprint validator. Whenever a row is received
-// with a timestamp lower than the last `resolved` timestamp seen, we
-// verify that the event has been seen before (if it hasn't, that
-// would be a violation of the changefeed guarantees)
-func (v *FingerprintValidator) ValidateDuplicatedEvents(maxEntries int) *FingerprintValidator {
-	v.previouslySeen = make(map[string]struct{})
-	v.maxPreviousEntries = maxEntries
-	return v
-}
-
 // NoteRow implements the Validator interface.
 func (v *FingerprintValidator) NoteRow(
 	ignoredPartition string, key, value string, updated hlc.Timestamp,
@@ -456,9 +432,6 @@ func (v *FingerprintValidator) NoteRow(
 	}
 
 	row := validatorRow{key: key, value: value, updated: updated}
-	if err := v.maybeValidateDuplicatedEvent(row); err != nil {
-		return err
-	}
 
 	// if this row's timestamp is earlier than the last resolved
 	// timestamp we processed, we can skip it as it is a duplicate
@@ -467,7 +440,7 @@ func (v *FingerprintValidator) NoteRow(
 	}
 
 	v.buffer = append(v.buffer, row)
-	return v.maybeAddSeenEvent(row)
+	return nil
 }
 
 // applyRowUpdate applies the update represented by `row` to the scratch table.
@@ -627,47 +600,6 @@ func (v *FingerprintValidator) NoteResolved(partition string, resolved hlc.Times
 		lastFingerprintedAt != resolved {
 		return v.fingerprint(resolved)
 	}
-	return nil
-}
-
-// maybeAddSeenEvent is a no-op if the caller did not call
-// ValidateDuplicatedEvents. Otherwise, we keep a reference to the row
-// key and MVCC timestamp for later validation
-func (v *FingerprintValidator) maybeAddSeenEvent(row validatorRow) error {
-	if v.previouslySeen == nil {
-		return nil
-	}
-
-	if len(v.previouslySeen) >= v.maxPreviousEntries {
-		return fmt.Errorf("trying to add more than %d previous events", v.maxPreviousEntries)
-	}
-
-	v.previouslySeen[row.eventKey()] = struct{}{}
-	return nil
-}
-
-// maybeValidateDuplicatedEvent is a no-op if the caller did not call
-// ValidateDuplicatedEvents. Otherwise, it returns an error if the
-// row's timestamp is earlier than the validator's `resolved`
-// timestamp *and* it has not been seen before; that would be a
-// violation of the changefeed's guarantees.
-func (v *FingerprintValidator) maybeValidateDuplicatedEvent(row validatorRow) error {
-	if v.previouslySeen == nil {
-		return nil
-	}
-
-	// row's timestamp is after the last resolved timestamp; no problem
-	if v.resolved.LessEq(row.updated) {
-		return nil
-	}
-
-	// row's timestamp is earlier than resolved timestamp *and* it
-	// hasn't been seen before; that shouldn't happen
-	if _, seen := v.previouslySeen[row.eventKey()]; !seen {
-		return fmt.Errorf("unexpected out-of-order event at timestamp %s prior to resolved timestamp %s",
-			row.updated.AsOfSystemTime(), v.resolved.AsOfSystemTime())
-	}
-
 	return nil
 }
 

--- a/pkg/cmd/roachtest/tests/mixed_version_cdc.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_cdc.go
@@ -38,13 +38,6 @@ const (
 	// resolvedInterval is the value passed to the `resolved` option
 	// when creating the changefeed
 	resolvedInterval = "10s"
-
-	// maxPreviousEntries is the maximum number of previously seen
-	// events the FingerprintValidator will keep in memory when
-	// validating changefeed semantics. The current value corresponds to
-	// less than 20MB of memory, and should be sufficient for about 50k
-	// bank workload transactions
-	maxPreviousEntries = 100_000
 )
 
 var (
@@ -228,7 +221,7 @@ func (cmvt *cdcMixedVersionTester) setupVerifier(node int) versionStep {
 			if err != nil {
 				t.Fatal(err)
 			}
-			fprintV.DBFunc(cmvt.cdcDBConn(getConn)).ValidateDuplicatedEvents(maxPreviousEntries)
+			fprintV.DBFunc(cmvt.cdcDBConn(getConn))
 			validators := cdctest.Validators{
 				cdctest.NewOrderValidator(tableName),
 				fprintV,


### PR DESCRIPTION
In recent work related to writing `cdc/mixed-versions` and debugging its failure (#87251), we introduced new functionality in the `FingerprintValidator` related to validating the ordering of messages received, particularly with respect to `resolved` events. However, that logic is duplicated as it is already implemented in the `OrderValidator`, which the roachtest already used. This removes timestamp validation logic from `FingerprintValidator`; the ordering validator should be used if the test intends to perform that validation.

Epic: None.

Release note: None.