### PR TITLE
backupccl: update progress more frequently

### DIFF
--- a/pkg/jobs/progress.go
+++ b/pkg/jobs/progress.go
@@ -143,7 +143,7 @@ func (p *ProgressUpdateBatcher) Add(ctx context.Context, delta float32) error {
 	p.completed += delta
 	completed := p.completed
 	shouldReport := p.completed-p.reported > progressFractionThreshold
-	shouldReport = shouldReport && p.lastReported.Add(progressTimeThreshold).Before(timeutil.Now())
+	shouldReport = shouldReport || (p.completed > p.reported && p.lastReported.Add(progressTimeThreshold).Before(timeutil.Now()))
 
 	if shouldReport {
 		p.reported = p.completed


### PR DESCRIPTION
A code comment in the ChunkProgressLogger implementation says:

> To avoid hammering the system.jobs table, when a response comes
> back, we issue a progress update only if a) it's been a duration of
> progressTimeThreshold since the last update, or b) the difference between the
> last logged fractionCompleted and the current fractionCompleted is more than
> progressFractionThreshold.

But as implemented, it would only update the progress if both of those conditions were true. For very large or very slow backups, this meant that progress updates could be _very_ far about, which is a bit disconcerting.

Here, I've changed the condition to match the comment, so now, if progress has been made, we should see an update every 15 seconds.

Epic: None
Release note (bug fix): Fix bug that could result in infrequent progress updates for very large backup or restore jobs.