### PR TITLE
release-21.2: changefeedccl: default catchup_scan_iterator_optimization to true

### DIFF
--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -59,7 +59,7 @@ var RangeFeedRefreshInterval = settings.RegisterDurationSetting(
 var RangefeedTBIEnabled = settings.RegisterBoolSetting(
 	"kv.rangefeed.catchup_scan_iterator_optimization.enabled",
 	"if true, rangefeeds will use time-bound iterators for catchup-scans when possible",
-	util.ConstantWithMetamorphicTestBool("kv.rangefeed.catchup_scan_iterator_optimization.enabled", false),
+	util.ConstantWithMetamorphicTestBool("kv.rangefeed.catchup_scan_iterator_optimization.enabled", true),
 )
 
 // RangefeedSeparatedIntentScanEnabled controls whether to use the


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/79727

Changefeed catchup scans can be disruptive to upgrades / foreground
traffic, consuming a lot of IOPS. We're confident enough in
catchup_scan_iterator_optimization and it has enough value that it's
worth defaulting it to true in 21.2.

Release note (performance improvement):
kv.rangefeed.catchup_scan_iterator_optimization now defaults to true,
reducing IOP impact of changefeeds.
Release justification: High value feature that we're now confident is safe to default as true

