### PR TITLE
ccl/jwtauthccl: allow inferring of key algorithm

### DIFF
--- a/pkg/ccl/jwtauthccl/authentication_jwt.go
+++ b/pkg/ccl/jwtauthccl/authentication_jwt.go
@@ -130,7 +130,7 @@ func (authenticator *jwtAuthenticator) ValidateJWTLogin(
 
 	telemetry.Inc(beginAuthUseCounter)
 
-	parsedToken, err := jwt.Parse(tokenBytes, jwt.WithKeySet(authenticator.mu.conf.jwks), jwt.WithValidate(true))
+	parsedToken, err := jwt.Parse(tokenBytes, jwt.WithKeySet(authenticator.mu.conf.jwks), jwt.WithValidate(true), jwt.InferAlgorithmFromKey(true))
 	if err != nil {
 		return errors.Newf("JWT authentication: invalid token")
 	}


### PR DESCRIPTION
Previously, if a user failed to provide the algorithm claim
within the JWKS, CRDB would not accept any JWTs that used
that key. This change makes CRDB accept algorithms from
specified by a JWT so long as they are compatible with the
key type (for example RSA and RSA256). This case only
applies when the JWKS does not explicitly specify an
algorithm.

This came up because Azure's listed JWKS does not specify
algorithms.

Fixes CC-8211.

Release note (bug fix): During JWT based auth, infer the
algorithm type if it is not specified by the JWKS. This
enbables support for a wider range of JWKSes.

Release justification: low danger, usability fix.