### PR TITLE
coldata: grow the underlying byte slice more rapidly

### DIFF
--- a/pkg/col/coldata/bytes.go
+++ b/pkg/col/coldata/bytes.go
@@ -146,6 +146,20 @@ func (e *element) setNonInlined(v []byte, b *Bytes) {
 			},
 			inlined: false,
 		}
+		// Use a custom append to grow the buffer faster than go does by default.
+		if rem := cap(b.buffer) - len(b.buffer); rem < len(v) {
+			increment := cap(b.buffer)                  // at least double the buffer
+			if need := len(v) - rem; increment < need { // grow enough to fit v
+				increment = need
+			}
+			const initialBufferSize = 256 // don't go smaller than this
+			if increment < initialBufferSize {
+				increment = initialBufferSize
+			}
+			realloc := make([]byte, len(b.buffer), cap(b.buffer)+increment)
+			copy(realloc, b.buffer)
+			b.buffer = realloc
+		}
 		b.buffer = append(b.buffer, v...)
 	}
 }

--- a/pkg/sql/colexec/colexecdisk/external_sort_test.go
+++ b/pkg/sql/colexec/colexecdisk/external_sort_test.go
@@ -163,7 +163,7 @@ func TestExternalSortMemoryAccounting(t *testing.T) {
 	}
 	// We cannot guarantee a fixed value, so we use an allowed range.
 	expMin := memoryLimit
-	expMax := int64(float64(memoryLimit) * 1.8)
+	expMax := int64(float64(memoryLimit) * 2.2)
 	require.GreaterOrEqualf(t, totalMaxMemUsage, expMin, "minimum memory bound not satisfied: "+
 		"actual %d, expected min %d", totalMaxMemUsage, expMin)
 	require.GreaterOrEqualf(t, expMax, totalMaxMemUsage, "maximum memory bound not satisfied: "+


### PR DESCRIPTION
It was growing too slowly accounting for a huge chunk of CPU time and allocations in YCSB/E. This seems to be worth almost 10% on YCSB/E (3273.1 vs 3554.4).

Epic: None

Release note: None