### PR TITLE
clusterversion: allow forcing release binary to dev version

### DIFF
--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -502,12 +502,14 @@ var rawVersionsSingleton = keyedVersions{
 	// *************************************************
 }
 
-const (
-	// developmentBranch should be toggled to false on a release branch once the
-	// set of versions becomes append-only and associated upgrade implementations
-	// are frozen. It is always true on the main development branch.
-	developmentBranch = true
+// developmentBranch must true on the main development branch but should be set
+// to false on a release branch once the set of versions becomes append-only and
+// associated upgrade implementations are frozen. It can be forced to true via
+// an env var even on a release branch, to allow running a release binary in a
+// dev cluster.
+var developmentBranch = true || envutil.EnvOrDefaultBool("COCKROACH_FORCE_DEV_VERSION", false)
 
+const (
 	// finalVersion should be set on a release branch to the minted final cluster
 	// version key, e.g. to V22_2 on the release-22.2 branch once it is minted.
 	// Setting it has the effect of ensuring no versions are subsequently added.


### PR DESCRIPTION
Previously it was impossible to start a release binary that supported up to say, 23.1, in a cluster where the cluster version was in the 'development' range (+1m). While this was somewhat intentional -- to mark a dev cluster as dev forever -- we still want the option to try to run release binaries in that cluster.

The new environment variable COCKROACH_FORCE_DEV_VERSION will cause a binary to identify itself as development and offset its version even if it is a release binary.

Epic: none.

Release note (ops change): Release version binaries can now be instructed via the enviroment variable COCKROACH_FORCE_DEV_VERSION to override their cluster version support to match that of develeopment builds, which can allow a release binary to be started in a cluster that is run or has previously run a development build.