### PR TITLE
roachtest: Index overload automation of TPC-E

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -76,6 +76,7 @@ var (
 	// failure), roachtest can be invoked with --metamorphic-encryption-probability=0
 	encryptionProbability     float64
 	instanceType              string
+	minCPUPlatform            string
 	localSSDArg               bool
 	workload                  string
 	deprecatedRoachprodBinary string
@@ -570,6 +571,9 @@ func MachineTypeToCPUs(s string) int {
 		// GCE machine types.
 		var v int
 		if _, err := fmt.Sscanf(s, "n1-standard-%d", &v); err == nil {
+			return v
+		}
+		if _, err := fmt.Sscanf(s, "n2-standard-%d", &v); err == nil {
 			return v
 		}
 		if _, err := fmt.Sscanf(s, "n1-highcpu-%d", &v); err == nil {

--- a/pkg/cmd/roachtest/cluster_test.go
+++ b/pkg/cmd/roachtest/cluster_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestClusterNodes(t *testing.T) {
-	c := &clusterImpl{spec: spec.MakeClusterSpec(spec.GCE, "", 10)}
+	c := &clusterImpl{spec: spec.MakeClusterSpec(spec.GCE, "", "", 10)}
 	opts := func(opts ...option.Option) []option.Option {
 		return opts
 	}

--- a/pkg/cmd/roachtest/github_test.go
+++ b/pkg/cmd/roachtest/github_test.go
@@ -76,7 +76,7 @@ func TestShouldPost(t *testing.T) {
 		{false, 1, "token", "master", true, ""},
 	}
 
-	reg := makeTestRegistry(spec.GCE, "", "", false)
+	reg := makeTestRegistry(spec.GCE, "", "", "", false)
 	for _, c := range testCases {
 		t.Setenv("GITHUB_API_TOKEN", c.envGithubAPIToken)
 		t.Setenv("TC_BUILD_BRANCH", c.envTcBuildBranch)
@@ -144,7 +144,7 @@ func TestCreatePostRequest(t *testing.T) {
 		{true, false, true, false, otherErr, false, nil},
 	}
 
-	reg := makeTestRegistry(spec.GCE, "", "", false)
+	reg := makeTestRegistry(spec.GCE, "", "", "", false)
 	for _, c := range testCases {
 		clusterSpec := reg.MakeClusterSpec(1)
 

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -189,7 +189,7 @@ Examples:
    roachtest list tag:weekly
 `,
 		RunE: func(_ *cobra.Command, args []string) error {
-			r := makeTestRegistry(cloud, instanceType, zonesF, localSSDArg)
+			r := makeTestRegistry(cloud, instanceType, minCPUPlatform, zonesF, localSSDArg)
 			if !listBench {
 				tests.RegisterTests(&r)
 			} else {
@@ -320,6 +320,8 @@ runner itself.
 		cmd.Flags().StringVar(
 			&instanceType, "instance-type", instanceType,
 			"the instance type to use (see https://aws.amazon.com/ec2/instance-types/, https://cloud.google.com/compute/docs/machine-types or https://docs.microsoft.com/en-us/azure/virtual-machines/windows/sizes)")
+		cmd.Flags().StringVar(
+			&minCPUPlatform, "min-cpu-platform", minCPUPlatform, "")
 		cmd.Flags().IntVar(
 			&cpuQuota, "cpu-quota", 300,
 			"The number of cloud CPUs roachtest is allowed to use at any one time.")
@@ -388,7 +390,7 @@ func runTests(register func(registry.Registry), cfg cliCfg) error {
 	if cfg.count <= 0 {
 		return fmt.Errorf("--count (%d) must by greater than 0", cfg.count)
 	}
-	r := makeTestRegistry(cloud, instanceType, zonesF, localSSDArg)
+	r := makeTestRegistry(cloud, instanceType, minCPUPlatform, zonesF, localSSDArg)
 	register(&r)
 	cr := newClusterRegistry()
 	stopper := stop.NewStopper()

--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -39,9 +39,10 @@ const (
 // ClusterSpec represents a test's description of what its cluster needs to
 // look like. It becomes part of a clusterConfig when the cluster is created.
 type ClusterSpec struct {
-	Cloud        string
-	InstanceType string // auto-chosen if left empty
-	NodeCount    int
+	Cloud          string
+	InstanceType   string // auto-chosen if left empty
+	MinCPUPlatform string
+	NodeCount      int
 	// CPUs is the number of CPUs per node.
 	CPUs                 int
 	HighMem              bool
@@ -65,8 +66,10 @@ type ClusterSpec struct {
 }
 
 // MakeClusterSpec makes a ClusterSpec.
-func MakeClusterSpec(cloud string, instanceType string, nodeCount int, opts ...Option) ClusterSpec {
-	spec := ClusterSpec{Cloud: cloud, InstanceType: instanceType, NodeCount: nodeCount}
+func MakeClusterSpec(
+	cloud string, instanceType string, minCPUPlatform string, nodeCount int, opts ...Option,
+) ClusterSpec {
+	spec := ClusterSpec{Cloud: cloud, InstanceType: instanceType, MinCPUPlatform: minCPUPlatform, NodeCount: nodeCount}
 	defaultOpts := []Option{CPU(4), nodeLifetimeOption(12 * time.Hour), ReuseAny()}
 	for _, o := range append(defaultOpts, opts...) {
 		o.apply(&spec)
@@ -122,6 +125,7 @@ func getAWSOpts(machineType string, zones []string, volumeSize int, localSSD boo
 
 func getGCEOpts(
 	machineType string,
+	minCPUPlatform string,
 	zones []string,
 	volumeSize, localSSDCount int,
 	localSSD bool,
@@ -130,6 +134,7 @@ func getGCEOpts(
 ) vm.ProviderOpts {
 	opts := gce.DefaultProviderOpts()
 	opts.MachineType = machineType
+	opts.MinCPUPlatform = minCPUPlatform
 	if volumeSize != 0 {
 		opts.PDVolumeSize = volumeSize
 	}
@@ -193,6 +198,7 @@ func (s *ClusterSpec) RoachprodOpts(
 
 	createVMOpts.GeoDistributed = s.Geo
 	machineType := s.InstanceType
+	minCPUPlatform := s.MinCPUPlatform
 	ssdCount := s.SSDs
 	if s.CPUs != 0 {
 		// Default to the user-supplied machine type, if any.
@@ -252,7 +258,7 @@ func (s *ClusterSpec) RoachprodOpts(
 	case AWS:
 		providerOpts = getAWSOpts(machineType, zones, s.VolumeSize, createVMOpts.SSDOpts.UseLocalSSD)
 	case GCE:
-		providerOpts = getGCEOpts(machineType, zones, s.VolumeSize, ssdCount,
+		providerOpts = getGCEOpts(machineType, minCPUPlatform, zones, s.VolumeSize, ssdCount,
 			createVMOpts.SSDOpts.UseLocalSSD, s.RAID0, s.TerminateOnMigration)
 	case Azure:
 		providerOpts = getAzureOpts(machineType, zones)

--- a/pkg/cmd/roachtest/test_registry.go
+++ b/pkg/cmd/roachtest/test_registry.go
@@ -34,26 +34,27 @@ func ownerToAlias(o registry.Owner) team.Alias {
 }
 
 type testRegistryImpl struct {
-	m            map[string]*registry.TestSpec
-	cloud        string
-	instanceType string // optional
-	zones        string
-	preferSSD    bool
-
-	promRegistry *prometheus.Registry
+	m              map[string]*registry.TestSpec
+	cloud          string
+	instanceType   string // optional
+	minCPUPlatform string // optional
+	zones          string
+	preferSSD      bool
+	promRegistry   *prometheus.Registry
 }
 
 // makeTestRegistry constructs a testRegistryImpl and configures it with opts.
 func makeTestRegistry(
-	cloud string, instanceType string, zones string, preferSSD bool,
+	cloud string, instanceType string, minCPUPlatform string, zones string, preferSSD bool,
 ) testRegistryImpl {
 	return testRegistryImpl{
-		cloud:        cloud,
-		instanceType: instanceType,
-		zones:        zones,
-		preferSSD:    preferSSD,
-		m:            make(map[string]*registry.TestSpec),
-		promRegistry: prometheus.NewRegistry(),
+		cloud:          cloud,
+		instanceType:   instanceType,
+		zones:          zones,
+		preferSSD:      preferSSD,
+		m:              make(map[string]*registry.TestSpec),
+		promRegistry:   prometheus.NewRegistry(),
+		minCPUPlatform: minCPUPlatform,
 	}
 }
 
@@ -83,7 +84,7 @@ func (r *testRegistryImpl) MakeClusterSpec(nodeCount int, opts ...spec.Option) s
 		finalOpts = append(finalOpts, spec.Zones(r.zones))
 	}
 	finalOpts = append(finalOpts, opts...)
-	return spec.MakeClusterSpec(r.cloud, r.instanceType, nodeCount, finalOpts...)
+	return spec.MakeClusterSpec(r.cloud, r.instanceType, r.minCPUPlatform, nodeCount, finalOpts...)
 }
 
 const testNameRE = "^[a-zA-Z0-9-_=/,]+$"

--- a/pkg/cmd/roachtest/test_registry_test.go
+++ b/pkg/cmd/roachtest/test_registry_test.go
@@ -22,7 +22,8 @@ import (
 
 func TestMakeTestRegistry(t *testing.T) {
 	testutils.RunTrueAndFalse(t, "preferSSD", func(t *testing.T, preferSSD bool) {
-		r := makeTestRegistry(spec.AWS, "foo", "zone123", preferSSD)
+		r := makeTestRegistry(spec.AWS, "foo", "", "zone123", preferSSD)
+		require.NoError(t, err)
 		require.Equal(t, preferSSD, r.preferSSD)
 		require.Equal(t, "zone123", r.zones)
 		require.Equal(t, "foo", r.instanceType)

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -44,7 +44,7 @@ const defaultParallelism = 10
 
 func mkReg(t *testing.T) testRegistryImpl {
 	t.Helper()
-	return makeTestRegistry(spec.GCE, "", "", false /* preferSSD */)
+	return makeTestRegistry(spec.GCE, "", "", "", false)
 }
 
 func TestMatchOrSkip(t *testing.T) {
@@ -343,7 +343,7 @@ func TestRunnerTestTimeout(t *testing.T) {
 		Name:    `timeout`,
 		Owner:   OwnerUnitTest,
 		Timeout: 10 * time.Millisecond,
-		Cluster: spec.MakeClusterSpec(spec.GCE, "", 0),
+		Cluster: spec.MakeClusterSpec(spec.GCE, "", "", 0),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			<-ctx.Done()
 		},
@@ -378,7 +378,7 @@ func TestRegistryPrepareSpec(t *testing.T) {
 				Name:    "a",
 				Owner:   OwnerUnitTest,
 				Run:     dummyRun,
-				Cluster: spec.MakeClusterSpec(spec.GCE, "", 0),
+				Cluster: spec.MakeClusterSpec(spec.GCE, "", "", 0),
 			},
 			"",
 			[]string{"a"},
@@ -388,7 +388,7 @@ func TestRegistryPrepareSpec(t *testing.T) {
 				Name:    "illegal *[]",
 				Owner:   OwnerUnitTest,
 				Run:     dummyRun,
-				Cluster: spec.MakeClusterSpec(spec.GCE, "", 0),
+				Cluster: spec.MakeClusterSpec(spec.GCE, "", "", 0),
 			},
 			`illegal \*\[\]: Name must match this regexp: `,
 			nil,
@@ -396,8 +396,12 @@ func TestRegistryPrepareSpec(t *testing.T) {
 	}
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
-			r := makeTestRegistry(spec.GCE, "", "", false /* preferSSD */)
+			r := makeTestRegistry(spec.GCE, "", "", "", false)
 			err := r.prepareSpec(&c.spec)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = r.prepareSpec(&c.spec)
 			if !testutils.IsError(err, c.expectedErr) {
 				t.Fatalf("expected %q, but found %q", c.expectedErr, err.Error())
 			}
@@ -423,7 +427,7 @@ func runExitCodeTest(t *testing.T, injectedError error) error {
 	r.Add(registry.TestSpec{
 		Name:    "boom",
 		Owner:   OwnerUnitTest,
-		Cluster: spec.MakeClusterSpec(spec.GCE, "", 0),
+		Cluster: spec.MakeClusterSpec(spec.GCE, "", "", 0),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if injectedError != nil {
 				t.Fatal(injectedError)

--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "admission_control_elastic_backup.go",
         "admission_control_elastic_cdc.go",
         "admission_control_index_overload.go",
+        "admission_control_index_overload_tpce.go",
         "admission_control_multi_store_overload.go",
         "admission_control_multitenant_fairness.go",
         "admission_control_snapshot_overload.go",

--- a/pkg/cmd/roachtest/tests/admission_control.go
+++ b/pkg/cmd/roachtest/tests/admission_control.go
@@ -36,4 +36,5 @@ func registerAdmission(r registry.Registry) {
 	registerTPCCOverload(r)
 	registerTPCCSevereOverload(r)
 	registerIndexOverload(r)
+	registerIndexOverloadTPCE(r)
 }

--- a/pkg/cmd/roachtest/tests/admission_control_index_overload_tpce.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_overload_tpce.go
@@ -1,0 +1,106 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/errors"
+)
+
+// For a faster test use this instead
+const customers = 25000
+const threads = 400
+
+func registerIndexOverloadTPCE(r registry.Registry) {
+	runTPCE := func(ctx context.Context, t test.Test, c cluster.Cluster) {
+		nodes := c.Spec().NodeCount
+		roachNodes := c.Range(1, nodes-1)
+		workloadNode := c.Node(nodes)
+		racks := nodes - 1
+
+		t.Status("installing cockroach")
+		c.Put(ctx, t.Cockroach(), "./cockroach", roachNodes)
+
+		startOpts := option.DefaultStartOptsNoBackups()
+		settings := install.MakeClusterSettings(install.NumRacksOption(racks))
+		c.Start(ctx, t.L(), startOpts, settings, roachNodes)
+
+		t.Status("installing docker")
+		require.NoError(t, c.Install(ctx, t.L(), workloadNode, "docker"))
+
+		importC := make(chan struct{})
+		m := c.NewMonitor(ctx, roachNodes)
+		m.Go(func(ctx context.Context) error {
+			const dockerRun = `sudo docker run cockroachdb/tpc-e:latest`
+
+			roachNodeIPs, err := c.InternalIP(ctx, t.L(), roachNodes)
+			require.NoError(t, err)
+
+			roachNodeIPFlags := make([]string, len(roachNodeIPs))
+			for i, ip := range roachNodeIPs {
+				roachNodeIPFlags[i] = fmt.Sprintf("--hosts=%s", ip)
+			}
+
+			c.Run(ctx, workloadNode, fmt.Sprintf("%s --customers=%d --racks=%d --init %s",
+				dockerRun, customers, racks, roachNodeIPFlags[0]))
+			close(importC)
+
+			t.Status("running workload (~1 hours)")
+			result, err := c.RunWithDetailsSingleNode(ctx, t.L(), workloadNode,
+				fmt.Sprintf("%s --customers=%d --racks=%d --duration=1h --threads=%d %s",
+					dockerRun, customers, racks, threads, strings.Join(roachNodeIPFlags, " ")))
+			require.NoError(t, err)
+
+			t.L().Printf("workload output:\n%s\n", result.Stdout)
+			if strings.Contains(result.Stdout, "Reported tpsE :    --   (not between 80% and 100%)") {
+				return errors.New("invalid tpsE fraction")
+			}
+			return nil
+		})
+		m.Go(func(ctx context.Context) error {
+			// Wait for the import to complete.
+			t.Status("waiting for import to complete (~90m)")
+			<-importC
+
+			t.Status("waiting 10m before creating the index")
+			<-time.After(10 * time.Minute)
+
+			t.Status("creating index (~30min) - this will cause IO overload")
+			db := c.Conn(ctx, t.L(), 1)
+			_, err := db.ExecContext(ctx, "create index on tpce.trade (t_qty, t_bid_price, t_ca_id, t_id) storing (t_s_symb, t_exec_name)")
+			require.NoError(t, err)
+
+			t.Status("index creation complete")
+			return db.Close()
+		})
+		m.Wait()
+	}
+
+	// This test takes about 2 hours to run on 10 N2 machines.
+	r.Add(registry.TestSpec{
+		Name:    "admission-control/index-overload-tpce",
+		Owner:   registry.OwnerAdmissionControl,
+		Cluster: spec.MakeClusterSpec(spec.GCE, "n2-standard-8", "Intel Ice Lake", 10, spec.CPU(8), spec.SSD(1)),
+		Skip:    "Waiting for snapshotting of GCE images",
+		Run:     runTPCE,
+	})
+}

--- a/pkg/cmd/roachtest/tests/tpcc_test.go
+++ b/pkg/cmd/roachtest/tests/tpcc_test.go
@@ -26,16 +26,16 @@ func TestTPCCSupportedWarehouses(t *testing.T) {
 		buildVersion *version.Version
 		expected     int
 	}{
-		{"gce", spec.MakeClusterSpec(spec.GCE, "", 4, spec.CPU(16)), version.MustParse(`v2.1.0`), 1300},
-		{"gce", spec.MakeClusterSpec(spec.GCE, "", 4, spec.CPU(16)), version.MustParse(`v19.1.0-rc.1`), 1250},
-		{"gce", spec.MakeClusterSpec(spec.GCE, "", 4, spec.CPU(16)), version.MustParse(`v19.1.0`), 1250},
+		{"gce", spec.MakeClusterSpec(spec.GCE, "", "", 4, spec.CPU(16)), version.MustParse(`v2.1.0`), 1300},
+		{"gce", spec.MakeClusterSpec(spec.GCE, "", "", 4, spec.CPU(16)), version.MustParse(`v19.1.0-rc.1`), 1250},
+		{"gce", spec.MakeClusterSpec(spec.GCE, "", "", 4, spec.CPU(16)), version.MustParse(`v19.1.0`), 1250},
 
-		{"aws", spec.MakeClusterSpec(spec.GCE, "", 4, spec.CPU(16)), version.MustParse(`v19.1.0-rc.1`), 2100},
-		{"aws", spec.MakeClusterSpec(spec.GCE, "", 4, spec.CPU(16)), version.MustParse(`v19.1.0`), 2100},
+		{"aws", spec.MakeClusterSpec(spec.GCE, "", "", 4, spec.CPU(16)), version.MustParse(`v19.1.0-rc.1`), 2100},
+		{"aws", spec.MakeClusterSpec(spec.GCE, "", "", 4, spec.CPU(16)), version.MustParse(`v19.1.0`), 2100},
 
-		{"nope", spec.MakeClusterSpec(spec.GCE, "", 4, spec.CPU(16)), version.MustParse(`v2.1.0`), expectPanic},
-		{"gce", spec.MakeClusterSpec(spec.GCE, "", 5, spec.CPU(160)), version.MustParse(`v2.1.0`), expectPanic},
-		{"gce", spec.MakeClusterSpec(spec.GCE, "", 4, spec.CPU(16)), version.MustParse(`v1.0.0`), expectPanic},
+		{"nope", spec.MakeClusterSpec(spec.GCE, "", "", 4, spec.CPU(16)), version.MustParse(`v2.1.0`), expectPanic},
+		{"gce", spec.MakeClusterSpec(spec.GCE, "", "", 5, spec.CPU(160)), version.MustParse(`v2.1.0`), expectPanic},
+		{"gce", spec.MakeClusterSpec(spec.GCE, "", "", 4, spec.CPU(16)), version.MustParse(`v1.0.0`), expectPanic},
 	}
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {


### PR DESCRIPTION
This patch adds the ability to run tests against n2 standard from within roachprod / roachtest.

Release note: None
Epic: None