### PR TITLE
release-22.1: kvserver: honor lease preferences in store balance

### DIFF
--- a/pkg/kv/kvserver/allocator_test.go
+++ b/pkg/kv/kvserver/allocator_test.go
@@ -1702,6 +1702,10 @@ func (r *mockRepl) StoreID() roachpb.StoreID {
 	return r.storeID
 }
 
+func (r *mockRepl) Desc() *roachpb.RangeDescriptor {
+	return &roachpb.RangeDescriptor{}
+}
+
 func (r *mockRepl) GetRangeID() roachpb.RangeID {
 	return roachpb.RangeID(0)
 }

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -3375,7 +3375,7 @@ func (r *Replica) adminScatter(
 	if args.RandomizeLeases && r.OwnsValidLease(ctx, r.store.Clock().NowAsClockTimestamp()) {
 		desc := r.Desc()
 		potentialLeaseTargets := r.store.allocator.ValidLeaseTargets(
-			ctx, r.SpanConfig(), desc.Replicas().VoterDescriptors(), r, false, /* excludeLeaseRepl */
+			ctx, r.SpanConfig(), desc.Replicas().VoterDescriptors(), r, transferLeaseOptions{},
 		)
 		if len(potentialLeaseTargets) > 0 {
 			newLeaseholderIdx := rand.Intn(len(potentialLeaseTargets))

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -1497,6 +1497,9 @@ type transferLeaseOptions struct {
 	// to disregard the existing lease counts on candidates.
 	checkCandidateFullness bool
 	dryRun                 bool
+	// allowUninitializedCandidates allows a lease transfer target to include
+	// replicas which are not in the existing replica set.
+	allowUninitializedCandidates bool
 }
 
 // leaseTransferOutcome represents the result of shedLease().

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -705,35 +705,68 @@ func (sr *StoreRebalancer) chooseRangeToRebalance(
 			continue
 		}
 
-		storeDescMap := storeListToMap(allStoresList)
-
 		// Pick the voter with the least QPS to be leaseholder;
 		// RelocateRange transfers the lease to the first provided target.
 		//
-		// TODO(aayush): Does this logic need to exist? This logic does not take
-		// lease preferences into account. So it is already broken in a way.
+		// If a lease preference exists among the incoming voting set, then we
+		// consider only those stores as lease transfer targets. Otherwise, if
+		// there are no preferred leaseholders, either due to no lease
+		// preference being set or no preferred stores in the incoming voting
+		// set, we consider every incoming voter as a transfer candidate.
+		// NB: This implies that lease preferences will be ignored if no voting
+		// replicas exist that satisfy the lease preference. We could also
+		// ignore this rebalance opportunity in this case, however we do not as
+		// it is more likely than not that this would only occur under
+		// misconfiguration.
+		validTargets := sr.rq.allocator.ValidLeaseTargets(
+			ctx,
+			rebalanceCtx.conf,
+			targetVoterRepls,
+			rebalanceCtx.replWithStats.repl,
+			transferLeaseOptions{
+				allowUninitializedCandidates: true,
+			},
+		)
+
+		// When there are no valid targets, due to all existing voting replicas
+		// requiring a snapshot as well as the incoming, new voting replicas
+		// being on dead stores, ignore this rebalance option. The lease for
+		// this range post-rebalance would have no suitable location.
+		if len(validTargets) == 0 {
+			log.VEventf(
+				ctx,
+				3,
+				"could not find rebalance opportunities for r%d, no replica found to hold lease",
+				replWithStats.repl.RangeID,
+			)
+			continue
+		}
+
+		storeDescMap := storeListToMap(allStoresList)
 		newLeaseIdx := 0
 		newLeaseQPS := math.MaxFloat64
-		var raftStatus *raft.Status
-		for i := 0; i < len(targetVoterRepls); i++ {
-			// Ensure we don't transfer the lease to an existing replica that is behind
-			// in processing its raft log.
-			if replica, ok := rangeDesc.GetReplicaDescriptor(targetVoterRepls[i].StoreID); ok {
-				if raftStatus == nil {
-					raftStatus = sr.getRaftStatusFn(replWithStats.repl)
-				}
-				if replicaIsBehind(raftStatus, replica.ReplicaID) {
-					continue
-				}
-			}
-
-			storeDesc, ok := storeDescMap[targetVoterRepls[i].StoreID]
+		// Find the voter in the resulting voting set, which is a valid lease
+		// target and on a store with the least QPS to become the leaseholder.
+		// NB: The reason we do not call allocator.TransferLeaseTarget is
+		// because it requires that all the candidates are existing, rather
+		// than possibly new, incoming voters that are yet to be initialized.
+		for i := range validTargets {
+			storeDesc, ok := storeDescMap[validTargets[i].StoreID]
 			if ok && storeDesc.Capacity.QueriesPerSecond < newLeaseQPS {
 				newLeaseIdx = i
 				newLeaseQPS = storeDesc.Capacity.QueriesPerSecond
 			}
 		}
-		targetVoterRepls[0], targetVoterRepls[newLeaseIdx] = targetVoterRepls[newLeaseIdx], targetVoterRepls[0]
+
+		// Swap the target leaseholder with the first target voter, to transfer
+		// the lease to this voter target when rebalancing the range.
+		for i := range targetVoterRepls {
+			if targetVoterRepls[i].StoreID == validTargets[newLeaseIdx].StoreID {
+				targetVoterRepls[0], targetVoterRepls[i] = targetVoterRepls[i], targetVoterRepls[0]
+				break
+			}
+		}
+
 		return replWithStats,
 			roachpb.MakeReplicaSet(targetVoterRepls).ReplicationTargets(),
 			roachpb.MakeReplicaSet(targetNonVoterRepls).ReplicationTargets()

--- a/pkg/kv/kvserver/store_rebalancer_test.go
+++ b/pkg/kv/kvserver/store_rebalancer_test.go
@@ -318,18 +318,7 @@ func TestChooseLeaseToTransfer(t *testing.T) {
 	// order to pass replicaIsBehind checks, fake out the function for getting
 	// raft status with one that always returns all replicas as up to date.
 	sr.getRaftStatusFn = func(r *Replica) *raft.Status {
-		status := &raft.Status{
-			Progress: make(map[uint64]tracker.Progress),
-		}
-		status.Lead = uint64(r.ReplicaID())
-		status.Commit = 1
-		for _, replica := range r.Desc().InternalReplicas {
-			status.Progress[uint64(replica.ReplicaID)] = tracker.Progress{
-				Match: 1,
-				State: tracker.StateReplicate,
-			}
-		}
-		return status
+		return TestingRaftStatusFn(r)
 	}
 
 	testCases := []struct {
@@ -594,18 +583,7 @@ func TestChooseRangeToRebalanceRandom(t *testing.T) {
 			// order to pass replicaIsBehind checks, fake out the function for getting
 			// raft status with one that always returns all replicas as up to date.
 			sr.getRaftStatusFn = func(r *Replica) *raft.Status {
-				status := &raft.Status{
-					Progress: make(map[uint64]tracker.Progress),
-				}
-				status.Lead = uint64(r.ReplicaID())
-				status.Commit = 1
-				for _, replica := range r.Desc().InternalReplicas {
-					status.Progress[uint64(replica.ReplicaID)] = tracker.Progress{
-						Match: 1,
-						State: tracker.StateReplicate,
-					}
-				}
-				return status
+				return TestingRaftStatusFn(r)
 			}
 			a.storePool.isStoreReadyForRoutineReplicaTransfer = func(_ context.Context, this roachpb.StoreID) bool {
 				for _, deadStore := range deadStores {
@@ -692,41 +670,53 @@ func TestChooseRangeToRebalanceAcrossHeterogeneousZones(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 
-	constraint := func(region string, numReplicas int32) roachpb.ConstraintsConjunction {
+	constraint := func(region string) roachpb.Constraint {
+		return roachpb.Constraint{
+			Type:  roachpb.Constraint_REQUIRED,
+			Key:   "region",
+			Value: region,
+		}
+	}
+	conjunctionConstraint := func(region string, numReplicas int32) roachpb.ConstraintsConjunction {
 		return roachpb.ConstraintsConjunction{
 			NumReplicas: numReplicas,
-			Constraints: []roachpb.Constraint{
-				{
-					Type:  roachpb.Constraint_REQUIRED,
-					Key:   "region",
-					Value: region,
-				},
-			},
+			Constraints: []roachpb.Constraint{constraint(region)},
 		}
 	}
 
 	oneReplicaPerRegion := []roachpb.ConstraintsConjunction{
-		constraint("a", 1),
-		constraint("b", 1),
-		constraint("c", 1),
+		conjunctionConstraint("a", 1),
+		conjunctionConstraint("b", 1),
+		conjunctionConstraint("c", 1),
 	}
 	twoReplicasInHotRegion := []roachpb.ConstraintsConjunction{
-		constraint("a", 2),
+		conjunctionConstraint("a", 2),
 	}
 	allReplicasInHotRegion := []roachpb.ConstraintsConjunction{
-		constraint("a", 3),
+		conjunctionConstraint("a", 3),
 	}
 	twoReplicasInSecondHottestRegion := []roachpb.ConstraintsConjunction{
-		constraint("b", 2),
+		conjunctionConstraint("b", 2),
 	}
 	oneReplicaInColdestRegion := []roachpb.ConstraintsConjunction{
-		constraint("c", 1),
+		conjunctionConstraint("c", 1),
+	}
+	leasePreferredHotRegion := []roachpb.LeasePreference{
+		{Constraints: []roachpb.Constraint{
+			constraint("a"),
+		}},
+	}
+	leasePreferredSecondHotRegion := []roachpb.LeasePreference{
+		{Constraints: []roachpb.Constraint{
+			constraint("b"),
+		}},
 	}
 
 	testCases := []struct {
 		name                          string
 		voters, nonVoters             []roachpb.StoreID
 		voterConstraints, constraints []roachpb.ConstraintsConjunction
+		leasePreferences              []roachpb.LeasePreference
 
 		// the first listed voter target is expected to be the leaseholder.
 		expRebalancedVoters, expRebalancedNonVoters []roachpb.StoreID
@@ -748,6 +738,17 @@ func TestChooseRangeToRebalanceAcrossHeterogeneousZones(t *testing.T) {
 			constraints:         oneReplicaPerRegion,
 			expRebalancedVoters: []roachpb.StoreID{9, 6, 3},
 		},
+		// A replica is in a heavily loaded region, on a relatively heavily
+		// loaded store. We expect it to be moved to a less busy store
+		// within the same region. The new replica in the heavy region must also
+		// get the lease due to preferences.
+		{
+			name:                "rebalance one replica within heavy region, prefer lease in heavy region",
+			voters:              []roachpb.StoreID{1, 6, 9},
+			constraints:         oneReplicaPerRegion,
+			leasePreferences:    leasePreferredHotRegion,
+			expRebalancedVoters: []roachpb.StoreID{3, 6, 9},
+		},
 		// Two replicas are in the hot region, both on relatively heavily loaded
 		// nodes. We expect one of those replicas to be moved to a less busy store
 		// within the same region.
@@ -755,7 +756,26 @@ func TestChooseRangeToRebalanceAcrossHeterogeneousZones(t *testing.T) {
 			name:                "rebalance two replicas out of three within heavy region",
 			voters:              []roachpb.StoreID{1, 2, 9},
 			constraints:         twoReplicasInHotRegion,
+			leasePreferences:    leasePreferredHotRegion,
+			expRebalancedVoters: []roachpb.StoreID{3, 2, 9},
+		},
+		// Two replicas are in the hot region, both on relatively heavily
+		// loaded nodes. We expect one of those replicas to be moved to a
+		// less busy store within the same region. The lease has a
+		// preference for this region, so the moved replica, in the same
+		// region should get the lease.
+		{
+			name:                "rebalance two replicas out of three within heavy region, prefer lease in heavy region",
+			voters:              []roachpb.StoreID{1, 2, 9},
+			constraints:         twoReplicasInHotRegion,
 			expRebalancedVoters: []roachpb.StoreID{9, 2, 3},
+		},
+		{
+			name:        "rebalance two replicas out of five within heavy region",
+			voters:      []roachpb.StoreID{1, 2, 6, 8, 9},
+			constraints: twoReplicasInHotRegion,
+			// NB: Because of the diversity heuristic we won't rebalance to node 7.
+			expRebalancedVoters: []roachpb.StoreID{9, 3, 6, 8, 2},
 		},
 		{
 			name:        "rebalance two replicas out of five within heavy region",
@@ -769,7 +789,7 @@ func TestChooseRangeToRebalanceAcrossHeterogeneousZones(t *testing.T) {
 		// the same region.
 		{
 			// Within the hottest region, expect rebalance from the hottest node (n1)
-			// to the coolest node (n3). Within the lease hot region, we don't expect
+			// to the coolest node (n3). Within the least hot region, we don't expect
 			// a rebalance from n8 to n9 because the qps difference between the two
 			// stores is too small.
 			name:                "QPS balance without constraints",
@@ -813,6 +833,32 @@ func TestChooseRangeToRebalanceAcrossHeterogeneousZones(t *testing.T) {
 			expRebalancedVoters: []roachpb.StoreID{9, 5, 6, 8, 3},
 		},
 		{
+			name:   "primary region with second highest QPS, region survival, one voter on sub-optimal node, prefer lease hottest region",
+			voters: []roachpb.StoreID{3, 4, 5, 8, 9},
+			// Pin two voters to the second hottest region (region B) and have overall
+			// constraints require at least one replica per each region.
+			voterConstraints: twoReplicasInSecondHottestRegion,
+			constraints:      oneReplicaPerRegion,
+			leasePreferences: leasePreferredHotRegion,
+			// NB: Expect the voter on node 4 (hottest node in region B) to
+			// move to node 6 (least hot region in region B). Expect the
+			// lease to stay in the hot region (node 3).
+			expRebalancedVoters: []roachpb.StoreID{3, 5, 6, 8, 9},
+		},
+		{
+			name:   "primary region with second highest QPS, region survival, one voter on sub-optimal node, prefer lease second hottest region",
+			voters: []roachpb.StoreID{3, 4, 5, 8, 9},
+			// Pin two voters to the second hottest region (region B) and have overall
+			// constraints require at least one replica per each region.
+			voterConstraints: twoReplicasInSecondHottestRegion,
+			constraints:      oneReplicaPerRegion,
+			leasePreferences: leasePreferredSecondHotRegion,
+			// NB: Expect the voter on node 4 (hottest node in region B) to move to
+			// node 6 (least hot region in region B). Expect lease to transfer
+			// to least hot store, in the second hottest region (node 6).
+			expRebalancedVoters: []roachpb.StoreID{6, 5, 3, 8, 9},
+		},
+		{
 			name:   "primary region with highest QPS, region survival, two voters on sub-optimal nodes",
 			voters: []roachpb.StoreID{1, 2, 3, 4, 9},
 			// Pin two voters to the hottest region (region A) and have overall
@@ -833,11 +879,25 @@ func TestChooseRangeToRebalanceAcrossHeterogeneousZones(t *testing.T) {
 			// NB: Expect replica from node 7 to move to node 9.
 			expRebalancedVoters: []roachpb.StoreID{9, 5, 6},
 		},
+		{
+			name:   "two voters second hottest, one voter coldest, prefer lease in hottest",
+			voters: []roachpb.StoreID{4, 5, 8},
+			// Pin two voters to the second hottest and one voter to the
+			// coldest region.
+			constraints:      append(oneReplicaInColdestRegion, twoReplicasInSecondHottestRegion...),
+			leasePreferences: leasePreferredHotRegion,
+			// NB: Despite the lease preference in the hottest region, it is
+			// impossible to place replicas there due to constraints. We
+			// ignore lease the preference and select the least hot store
+			// to hold the lease (node 8) .
+			expRebalancedVoters: []roachpb.StoreID{8, 5, 6},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Boilerplate for test setup.
-			stopper, g, _, a, _ := createTestAllocator(ctx, 10, false /* deterministic */)
+			testingKnobs := AllocatorTestingKnobs{RaftStatusFn: TestingRaftStatusFn}
+			stopper, g, _, a, _ := createTestAllocatorWithKnobs(ctx, 10, false /* deterministic */, &testingKnobs)
 			defer stopper.Stop(context.Background())
 			gossiputil.NewStoreGossiper(g).GossipStores(multiRegionStores, t)
 			storeList, _, _ := a.storePool.getStoreList(storeFilterThrottled)
@@ -860,24 +920,14 @@ func TestChooseRangeToRebalanceAcrossHeterogeneousZones(t *testing.T) {
 			// order to pass replicaIsBehind checks, fake out the function for getting
 			// raft status with one that always returns all replicas as up to date.
 			sr.getRaftStatusFn = func(r *Replica) *raft.Status {
-				status := &raft.Status{
-					Progress: make(map[uint64]tracker.Progress),
-				}
-				status.Lead = uint64(r.ReplicaID())
-				status.Commit = 1
-				for _, replica := range r.Desc().InternalReplicas {
-					status.Progress[uint64(replica.ReplicaID)] = tracker.Progress{
-						Match: 1,
-						State: tracker.StateReplicate,
-					}
-				}
-				return status
+				return TestingRaftStatusFn(r)
 			}
 
 			s.cfg.DefaultSpanConfig.NumVoters = int32(len(tc.voters))
 			s.cfg.DefaultSpanConfig.NumReplicas = int32(len(tc.voters) + len(tc.nonVoters))
 			s.cfg.DefaultSpanConfig.Constraints = tc.constraints
 			s.cfg.DefaultSpanConfig.VoterConstraints = tc.voterConstraints
+			s.cfg.DefaultSpanConfig.LeasePreferences = tc.leasePreferences
 			const testingQPS = float64(60)
 			loadRanges(
 				rr, s, []testRange{
@@ -1102,18 +1152,7 @@ func TestChooseRangeToRebalanceOffHotNodes(t *testing.T) {
 			// order to pass replicaIsBehind checks, fake out the function for getting
 			// raft status with one that always returns all replicas as up to date.
 			sr.getRaftStatusFn = func(r *Replica) *raft.Status {
-				status := &raft.Status{
-					Progress: make(map[uint64]tracker.Progress),
-				}
-				status.Lead = uint64(r.ReplicaID())
-				status.Commit = 1
-				for _, replica := range r.Desc().InternalReplicas {
-					status.Progress[uint64(replica.ReplicaID)] = tracker.Progress{
-						Match: 1,
-						State: tracker.StateReplicate,
-					}
-				}
-				return status
+				return TestingRaftStatusFn(r)
 			}
 
 			s.cfg.DefaultSpanConfig.NumReplicas = int32(len(tc.voters))
@@ -1233,4 +1272,33 @@ func TestNoLeaseTransferToBehindReplicas(t *testing.T) {
 		t.Errorf("got targets %v for range with RaftStatus %v; want %v",
 			targets, sr.getRaftStatusFn(repl), expectTargets)
 	}
+}
+
+// TestingRaftStatusFn returns a raft status where all replicas are up to date and
+// the replica on the store with ID StoreID is the leader. It may be used for
+// testing.
+func TestingRaftStatusFn(
+	r interface {
+		Desc() *roachpb.RangeDescriptor
+		StoreID() roachpb.StoreID
+	},
+) *raft.Status {
+	status := &raft.Status{
+		Progress: make(map[uint64]tracker.Progress),
+	}
+	replDesc, ok := r.Desc().GetReplicaDescriptor(r.StoreID())
+	if !ok {
+		return status
+	}
+
+	status.Lead = uint64(replDesc.ReplicaID)
+	status.RaftState = raft.StateLeader
+	status.Commit = 1
+	for _, replica := range r.Desc().InternalReplicas {
+		status.Progress[uint64(replica.ReplicaID)] = tracker.Progress{
+			Match: 1,
+			State: tracker.StateReplicate,
+		}
+	}
+	return status
 }

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"go.etcd.io/etcd/raft/v3"
 )
 
 // StoreTestingKnobs is a part of the context used to control parts of
@@ -422,6 +423,10 @@ type AllocatorTestingKnobs struct {
 	// targets produced by the Allocator to include replicas that may be waiting
 	// for snapshots.
 	AllowLeaseTransfersToReplicasNeedingSnapshots bool
+	RaftStatusFn                                  func(r interface {
+		Desc() *roachpb.RangeDescriptor
+		StoreID() roachpb.StoreID
+	}) *raft.Status
 }
 
 // PinnedLeasesKnob is a testing know for controlling what store can acquire a


### PR DESCRIPTION
Manual reconstruction of #84863, mostly due to merge conflicts from \#79991 which will not make it to 22.1. Previously, lease preferences were not considered when selecting a voter to become the leaseholder after replica rebalancing. Instead, the voter on the store with the least QPS was selected. This patch introduces a check to try and satisfy the lease preference from the rebalanced voting set of replicas, if possible. Among voters satisfying the preference, the one on a store with the least QPS is selected to be the leaseholder.

When not possible, where none of the voting replicas satisfy the lease preference, the store rebalancer will pick the miminum QPS store, as before.

Release note (bug fix, performance improvement): Previously it was possible for leases to temporarily move outside of explicitly configured regions. This often happened during load based-rebalancing, something CRDB continually does across the cluster. Because of this it was also possible to observe a continual rate of lease thrashing as leases moved out of configured zones, triggered rebalancing, induce other leases to move out of configured zone, while the original set moved back, and so on. This is now fixed.

Release justification: Bug fix.