### PR TITLE
ui: fix size of charts on stmt details

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import React, { ReactNode } from "react";
+import React, { ReactNode, useEffect } from "react";
 import { Col, Row, Tabs } from "antd";
 import "antd/lib/col/style";
 import "antd/lib/row/style";
@@ -47,7 +47,6 @@ import summaryCardStyles from "src/summaryCard/summaryCard.module.scss";
 import timeScaleStyles from "src/timeScaleDropdown/timeScale.module.scss";
 import styles from "./statementDetails.module.scss";
 import { commonStyles } from "src/common";
-import { NodeSummaryStats } from "../nodes";
 import { UIConfigState } from "../store";
 import { StatementDetailsRequest } from "src/api/statementsApi";
 import {
@@ -81,16 +80,12 @@ type IStatementDiagnosticsReport =
 
 const { TabPane } = Tabs;
 
-export interface Fraction {
-  numerator: number;
-  denominator: number;
-}
-
 export type StatementDetailsProps = StatementDetailsOwnProps &
   RouteComponentProps<{ implicitTxn: string; statement: string }>;
 
 export interface StatementDetailsState {
   currentTab?: string;
+  cardWidth: number;
 
   /**
    * The latest non-null query text associated with the statement fingerprint in the URL.
@@ -106,17 +101,6 @@ export interface StatementDetailsState {
    */
   formattedQuery: string;
 }
-
-export type NodesSummary = {
-  nodeStatuses: cockroach.server.status.statuspb.INodeStatus[];
-  nodeIDs: string[];
-  nodeStatusByID: Dictionary<cockroach.server.status.statuspb.INodeStatus>;
-  nodeSums: NodeSummaryStats;
-  nodeDisplayNameByID: Dictionary<string>;
-  livenessStatusByNodeID: Dictionary<cockroach.kv.kvserver.liveness.livenesspb.NodeLivenessStatus>;
-  livenessByNodeID: Dictionary<cockroach.kv.kvserver.liveness.livenesspb.ILiveness>;
-  storeIDsByNodeID: Dictionary<string[]>;
-};
 
 export interface StatementDetailsDispatchProps {
   refreshStatementDetails: (req: StatementDetailsRequest) => void;
@@ -223,6 +207,7 @@ export class StatementDetails extends React.Component<
     const searchParams = new URLSearchParams(props.history.location.search);
     this.state = {
       currentTab: searchParams.get("tab") || "overview",
+      cardWidth: 700,
       query: this.props.statementDetails?.statement?.metadata?.query,
       formattedQuery:
         this.props.statementDetails?.statement?.metadata?.formatted_query,
@@ -263,7 +248,21 @@ export class StatementDetails extends React.Component<
     this.props.refreshStatementDetails(req);
   };
 
+  handleResize = (): void => {
+    // Use the same size as the summary card and remove a space for margin (22).
+    const cardWidth = document.getElementById("first-card")
+      ? document.getElementById("first-card")?.offsetWidth - 22
+      : 700;
+    if (cardWidth !== this.state.cardWidth) {
+      this.setState({
+        cardWidth: cardWidth,
+      });
+    }
+  };
+
   componentDidMount(): void {
+    window.addEventListener("resize", this.handleResize);
+    this.handleResize();
     this.refreshStatementDetails(
       this.props.timeScale,
       this.props.statementFingerprintID,
@@ -508,6 +507,7 @@ export class StatementDetails extends React.Component<
     if (!hasData) {
       return this.renderNoDataWithTimeScaleAndSqlBoxTabContent(hasTimeout);
     }
+    const { cardWidth } = this.state;
     const { nodeRegions, isTenant } = this.props;
     const { stats } = this.props.statementDetails.statement;
     const {
@@ -562,7 +562,7 @@ export class StatementDetails extends React.Component<
     const executionAndPlanningOps: Partial<Options> = {
       axes: [{}, { label: "Time Spent" }],
       series: [{}, { label: "Execution" }, { label: "Planning" }],
-      width: 735,
+      width: cardWidth,
     };
 
     const rowsProcessedTimeseries: AlignedData =
@@ -570,7 +570,7 @@ export class StatementDetails extends React.Component<
     const rowsProcessedOps: Partial<Options> = {
       axes: [{}, { label: "Rows" }],
       series: [{}, { label: "Rows Read" }, { label: "Rows Written" }],
-      width: 735,
+      width: cardWidth,
     };
 
     const execRetriesTimeseries: AlignedData =
@@ -579,7 +579,7 @@ export class StatementDetails extends React.Component<
       axes: [{}, { label: "Retries" }],
       series: [{}, { label: "Retries" }],
       legend: { show: false },
-      width: 735,
+      width: cardWidth,
     };
 
     const execCountTimeseries: AlignedData =
@@ -588,7 +588,7 @@ export class StatementDetails extends React.Component<
       axes: [{}, { label: "Execution Counts" }],
       series: [{}, { label: "Execution Counts" }],
       legend: { show: false },
-      width: 735,
+      width: cardWidth,
     };
 
     const contentionTimeseries: AlignedData =
@@ -597,7 +597,7 @@ export class StatementDetails extends React.Component<
       axes: [{}, { label: "Contention" }],
       series: [{}, { label: "Contention" }],
       legend: { show: false },
-      width: 735,
+      width: cardWidth,
     };
 
     return (
@@ -626,7 +626,7 @@ export class StatementDetails extends React.Component<
           </Row>
           <Row gutter={24}>
             <Col className="gutter-row" span={12}>
-              <SummaryCard className={cx("summary-card")}>
+              <SummaryCard id="first-card" className={cx("summary-card")}>
                 {!isTenant && (
                   <>
                     <SummaryCardItem

--- a/pkg/ui/workspaces/cluster-ui/src/summaryCard/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/summaryCard/index.tsx
@@ -19,6 +19,7 @@ import "antd/lib/tooltip/style";
 interface ISummaryCardProps {
   children: React.ReactNode;
   className?: string;
+  id?: string;
 }
 
 const cx = classnames.bind(styles);
@@ -28,7 +29,12 @@ const booleanSettingCx = classnames.bind(booleanSettingStyles);
 export const SummaryCard: React.FC<ISummaryCardProps> = ({
   children,
   className = "",
-}) => <div className={`${cx("summary--card")} ${className}`}>{children}</div>;
+  id,
+}) => (
+  <div className={`${cx("summary--card")} ${className}`} id={id}>
+    {children}
+  </div>
+);
 
 interface ISummaryCardItemProps {
   label: React.ReactNode;


### PR DESCRIPTION
Previously, the charts on statement details were
overlapping and not changing width with window
resize. This commit fixes the size, aligning with
summary card used on the page.

Fixes #85270

Before
<img width="1544" alt="Screen Shot 2022-10-14 at 5 39 58 PM" src="https://user-images.githubusercontent.com/1017486/195950839-7135fe7c-6791-4e8d-a4ae-c8ed50586591.png">


After
https://www.loom.com/share/eb2e188f7acc401f9f1b88451dcbdbae

Release note (bug fix): Charts on Statement Details page are no longer overlapping.