### PR TITLE
sqlsmith: make push of filter into join an essential rule

### DIFF
--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -1046,6 +1046,14 @@ func (o *Optimizer) disableRulesRandom(probability float64) {
 		int(opt.PruneScanCols),
 		// Needed to ensure that the input of a RangeExpr is always an AndExpr.
 		int(opt.SimplifyRange),
+		// Map and push filter into join rules are needed now that SQLSmith tests
+		// populate tables with many rows and can perform many joins. Otherwise the
+		// intermediate result set data size can grow too large, especially for
+		// geospatial and JSON data types.
+		int(opt.MapFilterIntoJoinLeft),
+		int(opt.MapFilterIntoJoinRight),
+		int(opt.PushFilterIntoJoinLeft),
+		int(opt.PushFilterIntoJoinRight),
 	)
 
 	var disabledRules RuleSet


### PR DESCRIPTION
Fixes #89986

Now that SQLSmith based tests populate tables with more rows than previously, and perform more joins, the intermediate result set size can grow too large when filters are not pushed into joins, causing tests to time out, especially when joins involve JSON or geospatial data types.

The solution is to make the following normalization rules essential so they cannot be randomly disabled:
```
MapFilterIntoJoinLeft
MapFilterIntoJoinRight
PushFilterIntoJoinLeft
PushFilterIntoJoinRight
```

Release note: None