### PR TITLE
sql: remove unnecessary rowsorts from distsql_stats logic tests

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -291,7 +291,7 @@ import (
 //            duration. If the test succeeds at any time during that period, it
 //            is considered successful. Otherwise, it is a failure. See
 //            testutils.SucceedsSoon for more information. If run with the
-//            -rewrite flag, inserts a 500ms sleep before executing the query
+//            -rewrite flag, inserts a 2s sleep before executing the query
 //            once.
 //      - async: runs the query asynchronously, marking it as a pending
 //            query using the label parameter as a unique name, to be completed
@@ -2722,9 +2722,9 @@ func (t *logicTest) processSubtest(
 							t.purgeZoneConfig()
 							// The presence of the retry flag indicates that we expect this
 							// query may need some time to succeed. If we are rewriting, wait
-							// 500ms before executing the query.
+							// 2s before executing the query.
 							// TODO(rytaft): We may want to make this sleep time configurable.
-							time.Sleep(time.Millisecond * 500)
+							time.Sleep(time.Second * 2)
 						}
 						if err := t.execQuery(query); err != nil {
 							t.Error(err)

--- a/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
@@ -22,14 +22,14 @@ INSERT INTO data SELECT a, b, c::FLOAT, NULL FROM
 # available for each set of column names. This is important in order to
 # tolerate the rare case of multiple auto stats jobs running between two retry
 # iterations.
-query TTIII colnames,rowsort,retry
+query TTIII colnames,retry
 SELECT DISTINCT ON (column_names) statistics_name, column_names, row_count, distinct_count, null_count
-FROM [SHOW STATISTICS FOR TABLE data] ORDER BY column_names, created
+FROM [SHOW STATISTICS FOR TABLE data] ORDER BY column_names, created DESC
 ----
 statistics_name  column_names  row_count  distinct_count  null_count
-__auto__         {a,b,c}       1000       1000            0
-__auto__         {a,b}         1000       100             0
 __auto__         {a}           1000       10              0
+__auto__         {a,b}         1000       100             0
+__auto__         {a,b,c}       1000       1000            0
 __auto__         {b}           1000       10              0
 __auto__         {c}           1000       10              0
 __auto__         {d}           1000       1               1000
@@ -43,14 +43,14 @@ statement ok
 UPDATE data SET d = 10 WHERE (a = 1 OR a = 2 OR a = 3) AND b > 1
 
 # There should be no change to stats.
-query TTIII colnames,rowsort
+query TTIII colnames
 SELECT DISTINCT ON (column_names) statistics_name, column_names, row_count, distinct_count, null_count
 FROM [SHOW STATISTICS FOR TABLE data] ORDER BY column_names ASC, created DESC
 ----
 statistics_name  column_names  row_count  distinct_count  null_count
-__auto__         {a,b,c}       1000       1000            0
-__auto__         {a,b}         1000       100             0
 __auto__         {a}           1000       10              0
+__auto__         {a,b}         1000       100             0
+__auto__         {a,b,c}       1000       1000            0
 __auto__         {b}           1000       10              0
 __auto__         {c}           1000       10              0
 __auto__         {d}           1000       1               1000
@@ -76,14 +76,14 @@ UPDATE data SET d = 12 WHERE d = 10
 # with each one affecting at most 88 rows. Since 88 < 205, the refresh is not
 # guaranteed, making this test flaky.
 skipif config 3node-tenant-default-configs
-query TTIII colnames,rowsort,retry
+query TTIII colnames,retry
 SELECT DISTINCT ON (column_names) statistics_name, column_names, row_count, distinct_count, null_count
 FROM [SHOW STATISTICS FOR TABLE data] ORDER BY column_names ASC, created DESC
 ----
 statistics_name  column_names  row_count  distinct_count  null_count
-__auto__         {a,b,c}       1000       1000            0
-__auto__         {a,b}         1000       100             0
 __auto__         {a}           1000       10              0
+__auto__         {a,b}         1000       100             0
+__auto__         {a,b,c}       1000       1000            0
 __auto__         {b}           1000       10              0
 __auto__         {c}           1000       10              0
 __auto__         {d}           1000       2               730
@@ -95,14 +95,14 @@ generate_series(1, 11) AS a(a),
 generate_series(1, 10) AS b(b),
 generate_series(1, 5) AS c(c)
 
-query TTIII colnames,rowsort,retry
+query TTIII colnames,retry
 SELECT DISTINCT ON (column_names) statistics_name, column_names, row_count, distinct_count, null_count
 FROM [SHOW STATISTICS FOR TABLE data] ORDER BY column_names ASC, created DESC
 ----
 statistics_name  column_names  row_count  distinct_count  null_count
-__auto__         {a,b,c}       1050       1050            0
-__auto__         {a,b}         1050       110             0
 __auto__         {a}           1050       11              0
+__auto__         {a,b}         1050       110             0
+__auto__         {a,b,c}       1050       1050            0
 __auto__         {b}           1050       10              0
 __auto__         {c}           1050       10              0
 __auto__         {d}           1050       3               365
@@ -111,14 +111,14 @@ __auto__         {d}           1050       3               365
 statement ok
 DELETE FROM data WHERE c > 5
 
-query TTIII colnames,rowsort,retry
+query TTIII colnames,retry
 SELECT DISTINCT ON (column_names) statistics_name, column_names, row_count, distinct_count, null_count
 FROM [SHOW STATISTICS FOR TABLE data] ORDER BY column_names ASC, created DESC
 ----
 statistics_name  column_names  row_count  distinct_count  null_count
-__auto__         {a,b,c}       550        550             0
-__auto__         {a,b}         550        110             0
 __auto__         {a}           550        11              0
+__auto__         {a,b}         550        110             0
+__auto__         {a,b,c}       550        550             0
 __auto__         {b}           550        10              0
 __auto__         {c}           550        5               0
 __auto__         {d}           550        1               0
@@ -129,7 +129,7 @@ CREATE TABLE copy AS SELECT * FROM data
 
 # Distinct count for rowid can be flaky, so don't show it. The estimate is
 # almost always 550, but occasionally it is 549...
-query TTII colnames,rowsort,retry
+query TTII colnames,retry
 SELECT DISTINCT ON (column_names) statistics_name, column_names, row_count, null_count
 FROM [SHOW STATISTICS FOR TABLE copy] ORDER BY column_names ASC, created DESC
 ----
@@ -143,7 +143,7 @@ __auto__         {rowid}       550        0
 statement ok
 CREATE TABLE test_create (x INT PRIMARY KEY, y CHAR)
 
-query TTIII colnames,rowsort,retry
+query TTIII colnames,retry
 SELECT DISTINCT ON (column_names) statistics_name, column_names, row_count, distinct_count, null_count
 FROM [SHOW STATISTICS FOR TABLE test_create] ORDER BY column_names ASC, created DESC
 ----
@@ -155,7 +155,7 @@ __auto__         {y}           0          0               0
 statement ok
 DELETE FROM copy WHERE true
 
-query TTII colnames,rowsort,retry
+query TTII colnames,retry
 SELECT DISTINCT ON (column_names) statistics_name, column_names, row_count, null_count
 FROM [SHOW STATISTICS FOR TABLE copy] ORDER BY column_names ASC, created DESC
 ----
@@ -186,7 +186,7 @@ statement ok
 INSERT INTO my_schema.my_table SELECT k, NULL FROM
    generate_series(1, 10) AS k(k)
 
-query TTIII colnames,rowsort,retry
+query TTIII colnames,retry
 SELECT DISTINCT ON (column_names) statistics_name, column_names, row_count, distinct_count, null_count
 FROM [SHOW STATISTICS FOR TABLE my_schema.my_table] ORDER BY column_names ASC, created DESC
 ----

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -879,7 +879,7 @@ INSERT INTO et VALUES ('hello', 'hello'), ('howdy', 'howdy'), ('hi', 'hi');
 statement ok
 CREATE STATISTICS s FROM et
 
-query TTIIB colnames,rowsort
+query TTIIB colnames
 SELECT
   statistics_name,
   column_names,
@@ -979,7 +979,7 @@ INSERT INTO prim VALUES (1, 1, 1), (2, 2, 2), (3, 3, 3);
 statement ok
 CREATE STATISTICS s FROM prim
 
-query TTIIB colnames,rowsort
+query TTIIB colnames
 SELECT
   statistics_name,
   column_names,
@@ -1019,7 +1019,7 @@ INSERT INTO sec VALUES (1, 1, 1), (2, 2, 2), (3, 3, 3);
 statement ok
 CREATE STATISTICS s FROM sec
 
-query TTIIB colnames,rowsort
+query TTIIB colnames
 SELECT
   statistics_name,
   column_names,
@@ -1068,7 +1068,7 @@ INSERT INTO partial VALUES (1, 1, 1, 1, '{"a": "b"}'), (2, 2, 2, 10, '{"c": "d"}
 statement ok
 CREATE STATISTICS s FROM partial
 
-query TTIIB colnames,rowsort
+query TTIIB colnames
 SELECT
   statistics_name,
   column_names,
@@ -1121,7 +1121,7 @@ INSERT INTO virt VALUES (1), (2), (3)
 statement ok
 CREATE STATISTICS s FROM virt
 
-query TTIIB colnames,rowsort
+query TTIIB colnames
 SELECT
   statistics_name,
   column_names,
@@ -1158,7 +1158,7 @@ INSERT INTO expression VALUES (1, 1, '{"a": "b"}'), (2, 10, '{"c": "d"}'), (3, 1
 statement ok
 CREATE STATISTICS s FROM expression
 
-query TTIIB colnames,rowsort
+query TTIIB colnames
 SELECT
   statistics_name,
   column_names,
@@ -1187,7 +1187,7 @@ INSERT INTO noind VALUES (1, 1, 1), (2, 2, 2), (3, 3, 3);
 statement ok
 CREATE STATISTICS s FROM noind
 
-query TTIIB colnames,rowsort
+query TTIIB colnames
 SELECT
   statistics_name,
   column_names,
@@ -1885,7 +1885,7 @@ CREATE STATISTICS u_b_a ON b, a FROM u;
 statement ok
 CREATE STATISTICS u_c_d_b ON c, d, b FROM u;
 
-query TT colnames,rowsort
+query TT colnames
 SELECT statistics_name, column_names
 FROM [SHOW STATISTICS FOR TABLE u]
 ORDER BY column_names, statistics_name


### PR DESCRIPTION
**sql: remove unnecessary rowsorts from distsql_stats logic tests**

In distsql_stats and distsql_automatic_stats logic tests we frequently
use queries like the following:

```sql
SELECT ...
FROM [SHOW STATISTICS FOR TABLE foo]
ORDER BY column_names, created DESC
```

These queries have guaranteed order, and do not need the rowsort option.

Epic: CRDB-20535

Release note: None

**sql: bump testlogic --rewrite delay for queries with retry to 2 sec**

This prevents some spurious rewrites in the distsql_automatic_stats
logic test.

Epic: CRDB-20535

Release note: None