### PR TITLE
workload/ycsb: allocate a conn to each worker

### DIFF
--- a/pkg/workload/ycsb/BUILD.bazel
+++ b/pkg/workload/ycsb/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_jackc_pgconn//:pgconn",
         "@com_github_jackc_pgx_v4//:pgx",
+        "@com_github_jackc_pgx_v4//pgxpool",
         "@com_github_spf13_pflag//:pflag",
         "@org_golang_x_exp//rand",
     ],


### PR DESCRIPTION
In #89980, we adopted pgx in the ycsb workload. This patch moved everything over to use a MultiConnPool and set the max number of connections per URL to be equal to concurrency/number of urls. This is problematic because the pool structure would round-robin over those URLs. If ever one gateway is slower, the effective concurrency of the workload will be reduced because some workers will block waiting for connections.

This patch goes back to assigning a connection explicitly to each worker.

Hopefully this will resolve the observed decrease in throughput observed in roachperf.

Epic: None

Release note: None