### PR TITLE
roachprod: add InitTarget to Start and Init

### DIFF
--- a/pkg/cmd/roachprod/flags.go
+++ b/pkg/cmd/roachprod/flags.go
@@ -187,6 +187,8 @@ func initFlags() {
 		"encrypt", startOpts.EncryptedStores, "start nodes with encryption at rest turned on")
 	startCmd.Flags().BoolVar(&startOpts.SkipInit,
 		"skip-init", startOpts.SkipInit, "skip initializing the cluster")
+	startCmd.Flags().IntVar(&startOpts.InitTarget,
+		"init-target", startOpts.InitTarget, "node on which to run initialization")
 	startCmd.Flags().IntVar(&startOpts.StoreCount,
 		"store-count", startOpts.StoreCount, "number of stores to start each node with")
 	startCmd.Flags().BoolVar(&startOpts.ScheduleBackups,
@@ -250,6 +252,9 @@ Default is "RECURRING '*/15 * * * *' FULL BACKUP '@hourly' WITH SCHEDULE OPTIONS
 
 	grafanaDumpCmd.Flags().StringVar(&grafanaDumpDir, "dump-dir", "",
 		"the absolute path to dump prometheus data to (use the contained 'prometheus-docker-run.sh' to visualize")
+
+	initCmd.Flags().IntVar(&startOpts.InitTarget,
+		"init-target", startOpts.InitTarget, "node on which to run initialization")
 
 	for _, cmd := range []*cobra.Command{createCmd, destroyCmd, extendCmd, logsCmd} {
 		cmd.Flags().StringVarP(&username, "username", "u", os.Getenv("ROACHPROD_USER"),

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -485,7 +485,7 @@ default cluster settings. It's intended to be used in conjunction with
 `,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.Init(context.Background(), roachprodLibraryLogger, args[0])
+		return roachprod.Init(context.Background(), roachprodLibraryLogger, args[0], startOpts)
 	}),
 }
 

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -2290,16 +2290,12 @@ func (c *SyncedCluster) ParallelE(
 // Init initializes the cluster. It does it through node 1 (as per TargetNodes)
 // to maintain parity with auto-init behavior of `roachprod start` (when
 // --skip-init) is not specified.
-func (c *SyncedCluster) Init(ctx context.Context, l *logger.Logger) error {
-	// We reserve a few special operations for the first node, so we
-	// strive to maintain the same here for interoperability.
-	const firstNodeIdx = 1
-
-	if err := c.initializeCluster(ctx, l, firstNodeIdx); err != nil {
+func (c *SyncedCluster) Init(ctx context.Context, l *logger.Logger, node Node) error {
+	if err := c.initializeCluster(ctx, l, node); err != nil {
 		return errors.WithDetail(err, "install.Init() failed: unable to initialize cluster.")
 	}
 
-	if err := c.setClusterSettings(ctx, l, firstNodeIdx); err != nil {
+	if err := c.setClusterSettings(ctx, l, node); err != nil {
 		return errors.WithDetail(err, "install.Init() failed: unable to set cluster settings.")
 	}
 

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -643,6 +643,7 @@ func DefaultStartOpts() install.StartOpts {
 		TenantID:           2,
 		ScheduleBackups:    false,
 		ScheduleBackupArgs: "",
+		InitTarget:         1,
 	}
 }
 
@@ -710,7 +711,7 @@ func Stop(ctx context.Context, l *logger.Logger, clusterName string, opts StopOp
 }
 
 // Init initializes the cluster.
-func Init(ctx context.Context, l *logger.Logger, clusterName string) error {
+func Init(ctx context.Context, l *logger.Logger, clusterName string, opts install.StartOpts) error {
 	if err := LoadClusters(); err != nil {
 		return err
 	}
@@ -718,7 +719,7 @@ func Init(ctx context.Context, l *logger.Logger, clusterName string) error {
 	if err != nil {
 		return err
 	}
-	return c.Init(ctx, l)
+	return c.Init(ctx, l, opts.GetInitTarget())
 }
 
 // Wipe wipes the nodes in a cluster.


### PR DESCRIPTION
This is a small change that makes it easier to use a single roachprod created cluster to initialise multiple CRDB clusters. The intended use is for cluster to cluster performance roachtests.

In a roachtest, you might use this as follows:

    srcCluster := c.Range(1, 3)
    dstCluster := c.Range(4, 6)

    srcStartOps := option.DefaultStartOpts()
    srcStartOps.RoachprodOpts.InitTarget = 1
    srcClusterSetting := install.MakeClusterSettings(install.SecureOption(true))
    c.Start(ctx, t.L(), srcStartOps, srcClusterSetting, srcCluster)

    dstStartOps := option.DefaultStartOpts()
    dstStartOps.RoachprodOpts.InitTarget = 4
    dstClusterSetting := install.MakeClusterSettings(install.SecureOption(true))
    c.Start(ctx, t.L(), dstStartOps, dstClusterSetting, dstCluster)

You can also use this feature using the roachprod command line with the `--init-target` option.

Epic: CRDB-18751

Release note: None