### PR TITLE
sql: amortize and prevent some allocations

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -2969,6 +2969,7 @@ func (b *Builder) buildWindow(w *memo.WindowExpr) (execPlan, error) {
 	argIdxs := make([][]exec.NodeColumnOrdinal, len(w.Windows))
 	filterIdxs := make([]int, len(w.Windows))
 	exprs := make([]*tree.FuncExpr, len(w.Windows))
+	windowVals := make([]tree.WindowDef, len(w.Windows))
 
 	for i := range w.Windows {
 		item := &w.Windows[i]
@@ -3010,16 +3011,17 @@ func (b *Builder) buildWindow(w *memo.WindowExpr) (execPlan, error) {
 			filterIdxs[i] = -1
 		}
 
+		windowVals[i] = tree.WindowDef{
+			Partitions: partitionExprs,
+			OrderBy:    orderingExprs,
+			Frame:      frame,
+		}
 		exprs[i] = tree.NewTypedFuncExpr(
 			b.wrapFunction(name),
 			0,
 			args,
 			builtFilter,
-			&tree.WindowDef{
-				Partitions: partitionExprs,
-				OrderBy:    orderingExprs,
-				Frame:      frame,
-			},
+			&windowVals[i],
 			overload.FixedReturnType(),
 			props,
 			overload,

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -316,6 +316,7 @@ func (b *Builder) buildCase(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Ty
 	}
 
 	// Extract the list of WHEN ... THEN ... clauses.
+	whensVals := make([]tree.When, len(cas.Whens))
 	whens := make([]*tree.When, len(cas.Whens))
 	for i, expr := range cas.Whens {
 		whenExpr := expr.(*memo.WhenExpr)
@@ -327,7 +328,8 @@ func (b *Builder) buildCase(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Ty
 		if err != nil {
 			return nil, err
 		}
-		whens[i] = &tree.When{Cond: cond, Val: val}
+		whensVals[i] = tree.When{Cond: cond, Val: val}
+		whens[i] = &whensVals[i]
 	}
 
 	elseExpr, err := b.buildScalar(ctx, cas.OrElse)


### PR DESCRIPTION
A few small allocation reductions.

```
name                    old time/op    new time/op    delta
Parse/simple-32           9.90µs ± 1%    7.11µs ± 1%  -28.17%  (p=0.000 n=10+10)
Parse/string-32           14.5µs ± 1%     9.9µs ± 2%  -31.59%  (p=0.000 n=9+9)
Parse/tpcc-delivery-32    19.2µs ± 1%    13.3µs ± 2%  -30.53%  (p=0.000 n=10+9)
Parse/account-32          25.4µs ± 3%    19.8µs ± 2%  -22.36%  (p=0.000 n=10+10)

name                    old alloc/op   new alloc/op   delta
Parse/simple-32           2.56kB ± 0%    3.28kB ± 0%  +28.12%  (p=0.000 n=10+10)
Parse/string-32           3.60kB ± 0%    3.55kB ± 0%   -1.33%  (p=0.000 n=10+10)
Parse/tpcc-delivery-32    5.49kB ± 0%    5.44kB ± 0%   -0.87%  (p=0.000 n=10+10)
Parse/account-32          9.42kB ± 0%    9.94kB ± 0%   +5.61%  (p=0.000 n=10+10)

name                    old allocs/op  new allocs/op  delta
Parse/simple-32             21.0 ± 0%      21.0 ± 0%     ~     (all equal)
Parse/string-32             26.0 ± 0%      25.0 ± 0%   -3.85%  (p=0.000 n=10+10)
Parse/tpcc-delivery-32      35.0 ± 0%      34.0 ± 0%   -2.86%  (p=0.000 n=10+10)
Parse/account-32            77.0 ± 0%      73.0 ± 0%   -5.19%  (p=0.000 n=10+10)
```

```
name                                           old time/op    new time/op    delta
FlowSetup/vectorize=true/distribute=true-32       125µs ± 1%     123µs ± 1%  -1.43%  (p=0.001 n=10+10)
FlowSetup/vectorize=true/distribute=false-32      121µs ± 1%     120µs ± 1%  -1.32%  (p=0.000 n=9+9)
FlowSetup/vectorize=false/distribute=true-32      121µs ± 1%     119µs ± 1%  -1.35%  (p=0.000 n=10+9)
FlowSetup/vectorize=false/distribute=false-32     119µs ± 7%     116µs ± 2%  -2.51%  (p=0.022 n=10+9)

name                                           old alloc/op   new alloc/op   delta
FlowSetup/vectorize=true/distribute=true-32      21.7kB ± 5%    21.7kB ± 5%    ~     (p=0.930 n=10+10)
FlowSetup/vectorize=true/distribute=false-32     20.7kB ± 5%    20.6kB ± 5%    ~     (p=0.739 n=10+10)
FlowSetup/vectorize=false/distribute=true-32     26.6kB ± 0%    26.5kB ± 1%    ~     (p=0.505 n=8+8)
FlowSetup/vectorize=false/distribute=false-32    25.4kB ± 0%    25.4kB ± 0%    ~     (p=0.744 n=8+8)

name                                           old allocs/op  new allocs/op  delta
FlowSetup/vectorize=true/distribute=true-32         245 ± 2%       245 ± 4%    ~     (p=1.000 n=9+9)
FlowSetup/vectorize=true/distribute=false-32        236 ± 5%       233 ± 0%    ~     (p=0.176 n=10+8)
FlowSetup/vectorize=false/distribute=true-32        241 ± 0%       241 ± 0%    ~     (p=0.471 n=9+9)
FlowSetup/vectorize=false/distribute=false-32       232 ± 1%       232 ± 1%    ~     (p=1.000 n=8+8)
```

Epic: CRDB-20535