### PR TITLE
ui: add apply recommendations to table details

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetails.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetails.selectors.ts
@@ -25,6 +25,7 @@ import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { IndexDetailsPageData } from "./indexDetailsPage";
 import { selectIsTenant } from "../store/uiConfig";
 import { BreadcrumbItem } from "../breadcrumbs";
+import { RecommendationType as RecType } from "./indexDetailsPage";
 const { RecommendationType } = cockroach.sql.IndexRecommendation;
 
 export const selectIndexDetails = createSelector(
@@ -48,8 +49,13 @@ export const selectIndexDetails = createSelector(
         indexRec => indexRec.index_id === details.statistics.key.index_id,
       ) || [];
     const indexRecommendations = filteredIndexRecommendations.map(indexRec => {
+      let type: RecType = "Unknown";
+      switch (RecommendationType[indexRec.type].toString()) {
+        case "DROP_UNUSED":
+          type = "DROP_UNUSED";
+      }
       return {
-        type: RecommendationType[indexRec.type].toString(),
+        type: type,
         reason: indexRec.reason,
       };
     });

--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
@@ -70,8 +70,10 @@ interface IndexDetails {
   indexRecommendations: IndexRecommendation[];
 }
 
+export type RecommendationType = "DROP_UNUSED" | "Unknown";
+
 interface IndexRecommendation {
-  type: string;
+  type: RecommendationType;
   reason: string;
 }
 
@@ -141,20 +143,14 @@ export class IndexDetailsPage extends React.Component<
         </tr>
       );
     }
-    return indexRecommendations.map(recommendation => {
+    return indexRecommendations.map((recommendation, key) => {
       let recommendationType: string;
       switch (recommendation.type) {
         case "DROP_UNUSED":
           recommendationType = "Drop unused index";
       }
-      // TODO(thomas): using recommendation.type as the key seems not good.
-      //  - if it is possible for an index to have multiple recommendations of the same type
-      //  this could cause issues.
       return (
-        <tr
-          key={recommendationType}
-          className={cx("index-recommendations-rows")}
-        >
+        <tr key={key} className={cx("index-recommendations-rows")}>
           <td
             className={cx(
               "index-recommendations-rows__header",

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.ts
@@ -11,7 +11,11 @@
 import { RouteComponentProps } from "react-router";
 import { createSelector } from "reselect";
 import _ from "lodash";
-import { DatabaseTablePageData, util } from "@cockroachlabs/cluster-ui";
+import {
+  DatabaseTablePageData,
+  util,
+  RecommendationType as RecType,
+} from "@cockroachlabs/cluster-ui";
 
 import { cockroach } from "src/js/protos";
 import {
@@ -95,8 +99,13 @@ export const mapStateToProps = createSelector(
           ) || [];
         const indexRecommendations = filteredIndexRecommendations.map(
           indexRec => {
+            let type: RecType = "Unknown";
+            switch (RecommendationType[indexRec.type].toString()) {
+              case "DROP_UNUSED":
+                type = "DROP_UNUSED";
+            }
             return {
-              type: RecommendationType[indexRec.type].toString(),
+              type: type,
               reason: indexRec.reason,
             };
           },

--- a/pkg/ui/workspaces/db-console/src/views/databases/indexDetailsPage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/indexDetailsPage/redux.ts
@@ -9,7 +9,11 @@
 // licenses/APL.txt.
 
 import { createSelector } from "reselect";
-import { IndexDetailsPageData, util } from "@cockroachlabs/cluster-ui";
+import {
+  IndexDetailsPageData,
+  util,
+  RecommendationType as RecType,
+} from "@cockroachlabs/cluster-ui";
 import { AdminUIState } from "src/redux/state";
 import { RouteComponentProps } from "react-router";
 import { getMatchParamByName } from "src/util/query";
@@ -47,8 +51,14 @@ export const mapStateToProps = createSelector(
         indexRec => indexRec.index_id === details.statistics.key.index_id,
       ) || [];
     const indexRecommendations = filteredIndexRecommendations.map(indexRec => {
+      let type: RecType = "Unknown";
+      switch (RecommendationType[indexRec.type].toString()) {
+        case "DROP_UNUSED":
+          type = "DROP_UNUSED";
+      }
+
       return {
-        type: RecommendationType[indexRec.type].toString(),
+        type: type,
         reason: indexRec.reason,
       };
     });


### PR DESCRIPTION
On Table details page, we have a table with index
recommendations, which right now is focused on drop unused indexes. This commit adds the button the apply the recommendations, when there is one.

Fixes #86949
<img width="1235" alt="Screen Shot 2022-10-17 at 12 49 05 PM" src="https://user-images.githubusercontent.com/1017486/196237146-72814f16-05c4-4bba-a716-f6ba875c7b65.png">

<img width="1281" alt="Screen Shot 2022-10-17 at 12 49 11 PM" src="https://user-images.githubusercontent.com/1017486/196237156-777470de-3fd8-41ea-951f-d053bf6337a1.png">



Release note (ui change): Add apply button on Table Details page (db console only), when there is a recommendation to drop an unused index.