### PR TITLE
roachtest: allow running skipped tests

### DIFF
--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -85,6 +85,7 @@ func main() {
 	var literalArtifacts string
 	var httpPort int
 	var debugEnabled bool
+	var runSkipped bool
 	var skipInit bool
 	var clusterID string
 	var count = 1
@@ -187,7 +188,7 @@ Examples:
 			matchedTests := r.List(context.Background(), args)
 			for _, test := range matchedTests {
 				var skip string
-				if test.Skip != "" {
+				if test.Skip != "" && !runSkipped {
 					skip = " (skipped: " + test.Skip + ")"
 				}
 				fmt.Printf("%s [%s]%s\n", test.Name, test.Owner, skip)
@@ -222,6 +223,7 @@ runner itself.
 				count:                  count,
 				cpuQuota:               cpuQuota,
 				debugEnabled:           debugEnabled,
+				runSkipped:             runSkipped,
 				skipInit:               skipInit,
 				httpPort:               httpPort,
 				parallelism:            parallelism,
@@ -262,6 +264,7 @@ runner itself.
 				count:                  count,
 				cpuQuota:               cpuQuota,
 				debugEnabled:           debugEnabled,
+				runSkipped:             runSkipped,
 				skipInit:               skipInit,
 				httpPort:               httpPort,
 				parallelism:            parallelism,
@@ -287,6 +290,8 @@ runner itself.
 			&count, "count", 1, "the number of times to run each test")
 		cmd.Flags().BoolVarP(
 			&debugEnabled, "debug", "d", debugEnabled, "don't wipe and destroy cluster if test fails")
+		cmd.Flags().BoolVar(
+			&runSkipped, "run-skipped", runSkipped, "run skipped tests")
 		cmd.Flags().BoolVar(
 			&skipInit, "skip-init", false, "skip initialization step (imports, table creation, etc.) for tests that support it, useful when re-using clusters with --wipe=false")
 		cmd.Flags().IntVarP(
@@ -356,6 +361,7 @@ type cliCfg struct {
 	count                  int
 	cpuQuota               int
 	debugEnabled           bool
+	runSkipped             bool
 	skipInit               bool
 	httpPort               int
 	parallelism            int
@@ -380,7 +386,7 @@ func runTests(register func(registry.Registry), cfg cliCfg) error {
 	defer stopper.Stop(context.Background())
 	runner := newTestRunner(cr, stopper, r.buildVersion)
 
-	filter := registry.NewTestFilter(cfg.args)
+	filter := registry.NewTestFilter(cfg.args, cfg.runSkipped)
 	clusterType := roachprodCluster
 	if local {
 		clusterType = localCluster
@@ -540,11 +546,11 @@ func testRunnerLogger(
 func testsToRun(
 	ctx context.Context, r testRegistryImpl, filter *registry.TestFilter,
 ) []registry.TestSpec {
-	tests := r.GetTests(ctx, filter)
+	tests, tagMismatch := r.GetTests(ctx, filter)
 
 	var notSkipped []registry.TestSpec
 	for _, s := range tests {
-		if s.Skip == "" {
+		if s.Skip == "" || filter.RunSkipped {
 			notSkipped = append(notSkipped, s)
 		} else {
 			if teamCity {
@@ -553,6 +559,13 @@ func testsToRun(
 			}
 			fmt.Fprintf(os.Stdout, "--- SKIP: %s (%s)\n\t%s\n", s.Name, "0.00s", s.Skip)
 		}
+	}
+	for _, s := range tagMismatch {
+		if teamCity {
+			fmt.Fprintf(os.Stdout, "##teamcity[testIgnored name='%s' message='tag mismatch']\n",
+				s.Name)
+		}
+		fmt.Fprintf(os.Stdout, "--- SKIP: %s (%s)\n\ttag mismatch\n", s.Name, "0.00s")
 	}
 	return notSkipped
 }

--- a/pkg/cmd/roachtest/registry/filter.go
+++ b/pkg/cmd/roachtest/registry/filter.go
@@ -21,14 +21,15 @@ type TestFilter struct {
 	Name *regexp.Regexp
 	Tag  *regexp.Regexp
 	// RawTag is the string representation of the regexps in tag.
-	RawTag []string
+	RawTag     []string
+	RunSkipped bool
 }
 
 // NewTestFilter initializes a new filter. The strings are interpreted
 // as regular expressions. As a special case, a `tag:` prefix implies
 // that the remainder of the string filters tests by tag, and not by
 // name.
-func NewTestFilter(filter []string) *TestFilter {
+func NewTestFilter(filter []string, runSkipped bool) *TestFilter {
 	var name []string
 	var tag []string
 	var rawTag []string
@@ -61,8 +62,9 @@ func NewTestFilter(filter []string) *TestFilter {
 	}
 
 	return &TestFilter{
-		Name:   makeRE(name),
-		Tag:    makeRE(tag),
-		RawTag: rawTag,
+		Name:       makeRE(name),
+		Tag:        makeRE(tag),
+		RawTag:     rawTag,
+		RunSkipped: runSkipped,
 	}
 }

--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -12,7 +12,6 @@ package registry
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
@@ -84,26 +83,36 @@ type TestSpec struct {
 	Run func(ctx context.Context, t test.Test, c cluster.Cluster)
 }
 
-// MatchOrSkip returns true if the filter matches the test. If the filter does
+// MatchType is the type of match a file has to a TestFilter.
+type MatchType int
+
+const (
+	// Matched means that the file passes the filter and the tags.
+	Matched MatchType = iota
+	// FailedFilter means that the file fails the filter.
+	FailedFilter
+	// FailedTags means that the file passed the filter but failed the tags
+	// match.
+	FailedTags
+)
+
+// Match returns Matched if the filter matches the test. If the filter does
 // not match the test because the tag filter does not match, the test is
-// matched, but marked as skipped.
-//
-// TODO(tbg): it's gross that this sets t.Skip, let the caller do this.
-func (t *TestSpec) MatchOrSkip(filter *TestFilter) bool {
+// marked as FailedTags.
+func (t *TestSpec) Match(filter *TestFilter) MatchType {
 	if !filter.Name.MatchString(t.Name) {
-		return false
+		return FailedFilter
 	}
 	if len(t.Tags) == 0 {
 		if !filter.Tag.MatchString("default") {
-			t.Skip = fmt.Sprintf("%s does not match [default]", filter.RawTag)
+			return FailedTags
 		}
-		return true
+		return Matched
 	}
 	for _, t := range t.Tags {
 		if filter.Tag.MatchString(t) {
-			return true
+			return Matched
 		}
 	}
-	t.Skip = fmt.Sprintf("%s does not match %s", filter.RawTag, t.Tags)
-	return true
+	return FailedTags
 }

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -779,9 +779,6 @@ func (r *testRunner) runTest(
 	l *logger.Logger,
 	github *githubIssues,
 ) error {
-	if t.Spec().(*registry.TestSpec).Skip != "" {
-		return fmt.Errorf("can't run skipped test: %s: %s", t.Name(), t.Spec().(*registry.TestSpec).Skip)
-	}
 
 	runID := t.Name()
 	if runCount > 1 {


### PR DESCRIPTION
This commit adds the flag --run-skipped which allows running tests that are marked with `Skip`. Typically `Skip` is used for either tests that are flakey or otherwise fail. Prior to this commit a developer would be required to manually edit the test to comment out the Skip line to run a test which is inefficient.

Release note: None
Epic: None