### PR TITLE
kv: fix interaction between lock reservations and SKIP LOCKED

### DIFF
--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -767,12 +767,15 @@ type lockTableGuard interface {
 	// that conflict.
 	CheckOptimisticNoConflicts(*spanset.SpanSet) (ok bool)
 
-	// IsKeyLockedByConflictingTxn returns whether the provided key is locked by a
-	// conflicting transaction in the lockTableGuard's snapshot of the lock table,
-	// given the caller's own desired locking strength. If so, the lock holder is
-	// returned. A transaction's own lock does not appear to be locked to itself.
-	// The method is used by requests in conjunction with the SkipLocked wait
-	// policy to determine which keys they should skip over during evaluation.
+	// IsKeyLockedByConflictingTxn returns whether the specified key is locked or
+	// reserved (see lockTable "reservations") by a conflicting transaction in the
+	// lockTableGuard's snapshot of the lock table, given the caller's own desired
+	// locking strength. If so, true is returned. If the key is locked, the lock
+	// holder is also returned. Otherwise, if the key is reserved, nil is also
+	// returned. A transaction's own lock or reservation does not appear to be
+	// locked to itself (false is returned). The method is used by requests in
+	// conjunction with the SkipLocked wait policy to determine which keys they
+	// should skip over during evaluation.
 	IsKeyLockedByConflictingTxn(roachpb.Key, lock.Strength) (bool, *enginepb.TxnMeta)
 }
 

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -749,12 +749,15 @@ func (g *Guard) CheckOptimisticNoLatchConflicts() (ok bool) {
 	return g.lm.CheckOptimisticNoConflicts(g.lg, g.Req.LatchSpans)
 }
 
-// IsKeyLockedByConflictingTxn returns whether the provided key is locked by a
-// conflicting transaction in the Guard's snapshot of the lock table, given the
-// caller's own desired locking strength. If so, the lock holder is returned. A
-// transaction's own lock does not appear to be locked to itself. The method is
-// used by requests in conjunction with the SkipLocked wait policy to determine
-// which keys they should skip over during evaluation.
+// IsKeyLockedByConflictingTxn returns whether the specified key is locked or
+// reserved (see lockTable "reservations") by a conflicting transaction in the
+// Guard's snapshot of the lock table, given the caller's own desired locking
+// strength. If so, true is returned. If the key is locked, the lock holder is
+// also returned. Otherwise, if the key is reserved, nil is also returned. A
+// transaction's own lock or reservation does not appear to be locked to itself
+// (false is returned). The method is used by requests in conjunction with the
+// SkipLocked wait policy to determine which keys they should skip over during
+// evaluation.
 func (g *Guard) IsKeyLockedByConflictingTxn(
 	key roachpb.Key, strength lock.Strength,
 ) (bool, *enginepb.TxnMeta) {

--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -364,7 +364,11 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 				d.ScanArgs(t, "key", &key)
 				strength := scanLockStrength(t, d)
 				if ok, txn := g.IsKeyLockedByConflictingTxn(roachpb.Key(key), strength); ok {
-					return fmt.Sprintf("locked: true, holder: %s", txn.ID)
+					holder := "<nil>"
+					if txn != nil {
+						holder = txn.ID.String()
+					}
+					return fmt.Sprintf("locked: true, holder: %s", holder)
 				}
 				return "locked: false"
 

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -499,7 +499,11 @@ func TestLockTableBasic(t *testing.T) {
 				d.ScanArgs(t, "k", &key)
 				strength := scanLockStrength(t, d)
 				if ok, txn := g.IsKeyLockedByConflictingTxn(roachpb.Key(key), strength); ok {
-					return fmt.Sprintf("locked: true, holder: %s", txn.ID)
+					holder := "<nil>"
+					if txn != nil {
+						holder = txn.ID.String()
+					}
+					return fmt.Sprintf("locked: true, holder: %s", holder)
 				}
 				return "locked: false"
 

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_skip
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_skip
@@ -4,9 +4,16 @@ new-txn name=txn1 ts=10,1 epoch=0
 new-txn name=txn2 ts=11,1 epoch=0
 ----
 
+new-txn name=txn3 ts=12,1 epoch=0
+----
+
+new-txn name=txn4 ts=13,1 epoch=0
+----
+
 # -------------------------------------------------------------
 # Prep: Txn 1 acquire locks at key k and key k2
 #       Txn 2 acquire locks at key k3
+#       Txn 4 acquires reservation at key k4
 # -------------------------------------------------------------
 
 new-request name=req1 txn=txn1 ts=10,0
@@ -52,15 +59,61 @@ finish req=req2
 ----
 [-] finish req2: finishing request
 
+new-request name=req3 txn=txn3 ts=12,0
+  put key=k4 value=v
+----
+
+sequence req=req3
+----
+[3] sequence req3: sequencing request
+[3] sequence req3: acquiring latches
+[3] sequence req3: scanning lock table for conflicting locks
+[3] sequence req3: sequencing complete, returned guard
+
+on-lock-acquired req=req3 key=k4
+----
+[-] acquire lock: txn 00000003 @ k4
+
+finish req=req3
+----
+[-] finish req3: finishing request
+
+new-request name=req4 txn=txn4 ts=13,0
+  put key=k4 value=v
+----
+
+sequence req=req4
+----
+[4] sequence req4: sequencing request
+[4] sequence req4: acquiring latches
+[4] sequence req4: scanning lock table for conflicting locks
+[4] sequence req4: waiting in lock wait-queues
+[4] sequence req4: lock wait-queue event: wait for (distinguished) txn 00000003 holding lock @ key "k4" (queuedWriters: 1, queuedReaders: 0)
+[4] sequence req4: pushing after 0s for: liveness detection = true, deadlock detection = true, timeout enforcement = false, priority enforcement = false
+[4] sequence req4: pushing txn 00000003 to abort
+[4] sequence req4: blocked on select in concurrency_test.(*cluster).PushTransaction
+
+on-txn-updated txn=txn3 status=aborted
+----
+[-] update txn: aborting txn3
+[4] sequence req4: resolving intent "k4" for txn 00000003 with ABORTED status
+[4] sequence req4: lock wait-queue event: done waiting
+[4] sequence req4: conflicted with 00000003-0000-0000-0000-000000000000 on "k4" for 0.000s
+[4] sequence req4: acquiring latches
+[4] sequence req4: scanning lock table for conflicting locks
+[4] sequence req4: sequencing complete, returned guard
+
 debug-lock-table
 ----
-global: num=3
+global: num=4
  lock: "k"
   holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
  lock: "k2"
   holder: txn: 00000001-0000-0000-0000-000000000000, ts: 10.000000000,0, info: unrepl epoch: 0, seqs: [0]
  lock: "k3"
   holder: txn: 00000002-0000-0000-0000-000000000000, ts: 11.000000000,0, info: unrepl epoch: 0, seqs: [0]
+ lock: "k4"
+  res: req: 4, txn: 00000004-0000-0000-0000-000000000000, ts: 13.000000000,0, seq: 0
 local: num=0
 
 # -------------------------------------------------------------
@@ -70,15 +123,15 @@ local: num=0
 # -------------------------------------------------------------
 
 new-request name=reqSkipLocked txn=txn2 ts=9,0 wait-policy=skip-locked
-  scan key=k endkey=k5
+  scan key=k endkey=k6
 ----
 
 sequence req=reqSkipLocked
 ----
-[3] sequence reqSkipLocked: sequencing request
-[3] sequence reqSkipLocked: acquiring latches
-[3] sequence reqSkipLocked: scanning lock table for conflicting locks
-[3] sequence reqSkipLocked: sequencing complete, returned guard
+[5] sequence reqSkipLocked: sequencing request
+[5] sequence reqSkipLocked: acquiring latches
+[5] sequence reqSkipLocked: scanning lock table for conflicting locks
+[5] sequence reqSkipLocked: sequencing complete, returned guard
 
 is-key-locked-by-conflicting-txn req=reqSkipLocked key=k strength=none
 ----
@@ -96,6 +149,10 @@ is-key-locked-by-conflicting-txn req=reqSkipLocked key=k4 strength=none
 ----
 locked: false
 
+is-key-locked-by-conflicting-txn req=reqSkipLocked key=k5 strength=none
+----
+locked: false
+
 is-key-locked-by-conflicting-txn req=reqSkipLocked key=k strength=exclusive
 ----
 locked: true, holder: 00000001-0000-0000-0000-000000000000
@@ -110,11 +167,19 @@ locked: false
 
 is-key-locked-by-conflicting-txn req=reqSkipLocked key=k4 strength=exclusive
 ----
+locked: true, holder: <nil>
+
+is-key-locked-by-conflicting-txn req=reqSkipLocked key=k5 strength=exclusive
+----
 locked: false
 
 finish req=reqSkipLocked
 ----
 [-] finish reqSkipLocked: finishing request
+
+finish req=req4
+----
+[-] finish req4: finishing request
 
 reset
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/skip_locked
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/skip_locked
@@ -13,6 +13,7 @@ new-txn txn=txn2 ts=9,1 epoch=0
 #  c: locked by txn2
 #  d: locked by txn1
 #  e: unlocked
+#  f: reservation by txn1
 
 new-request r=req1 txn=txn1 ts=10,1 spans=w@b,d
 ----
@@ -50,7 +51,7 @@ global: num=2
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
-new-request r=req2 txn=txn2 ts=9,1 spans=w@c
+new-request r=req2 txn=txn2 ts=9,1 spans=w@c+w@f
 ----
 
 scan r=req2
@@ -72,81 +73,183 @@ global: num=3
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
-dequeue r=req2
+acquire r=req2 k=f durability=u
 ----
-global: num=3
+global: num=4
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000002, ts: 9.000000000,1, info: unrepl epoch: 0, seqs: [0]
  lock: "d"
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "f"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 9.000000000,1, info: unrepl epoch: 0, seqs: [0]
 local: num=0
 
-# ---------------------------------------------------------------------------------
-# req3 will scan the lock table with a Skip wait policy. It will not need to wait.
-# Once it begins evaluating, it will probe into the lock table to determine which
-# keys to skip.
-# ---------------------------------------------------------------------------------
+dequeue r=req2
+----
+global: num=4
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 9.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "d"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "f"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 9.000000000,1, info: unrepl epoch: 0, seqs: [0]
+local: num=0
 
-new-request r=req3 txn=txn2 ts=9,1 spans=r@a,f skip-locked
+new-request r=req3 txn=txn1 ts=10,1 spans=w@f
 ----
 
 scan r=req3
 ----
-start-waiting: false
+start-waiting: true
 
 should-wait r=req3
 ----
-false
+true
 
-is-key-locked-by-conflicting-txn r=req3 k=a strength=none
+release txn=txn2 span=f
 ----
-locked: false
-
-is-key-locked-by-conflicting-txn r=req3 k=b strength=none
-----
-locked: false
-
-is-key-locked-by-conflicting-txn r=req3 k=c strength=none
-----
-locked: false
-
-is-key-locked-by-conflicting-txn r=req3 k=d strength=none
-----
-locked: false
-
-is-key-locked-by-conflicting-txn r=req3 k=e strength=none
-----
-locked: false
-
-is-key-locked-by-conflicting-txn r=req3 k=a strength=exclusive
-----
-locked: false
-
-is-key-locked-by-conflicting-txn r=req3 k=b strength=exclusive
-----
-locked: true, holder: 00000000-0000-0000-0000-000000000001
-
-is-key-locked-by-conflicting-txn r=req3 k=c strength=exclusive
-----
-locked: false
-
-is-key-locked-by-conflicting-txn r=req3 k=d strength=exclusive
-----
-locked: true, holder: 00000000-0000-0000-0000-000000000001
-
-is-key-locked-by-conflicting-txn r=req3 k=e strength=exclusive
-----
-locked: false
-
-dequeue r=req3
-----
-global: num=3
+global: num=4
  lock: "b"
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
  lock: "c"
   holder: txn: 00000000-0000-0000-0000-000000000002, ts: 9.000000000,1, info: unrepl epoch: 0, seqs: [0]
  lock: "d"
   holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "f"
+  res: req: 3, txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, seq: 0
+local: num=0
+
+# ---------------------------------------------------------------------------------
+# req4 will scan the lock table with a Skip wait policy. It will not need to wait.
+# Once it begins evaluating, it will probe into the lock table to determine which
+# keys to skip.
+# ---------------------------------------------------------------------------------
+
+new-request r=req4 txn=txn2 ts=9,1 spans=r@a,g skip-locked
+----
+
+scan r=req4
+----
+start-waiting: false
+
+should-wait r=req4
+----
+false
+
+is-key-locked-by-conflicting-txn r=req4 k=a strength=none
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req4 k=b strength=none
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req4 k=c strength=none
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req4 k=d strength=none
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req4 k=e strength=none
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req4 k=f strength=none
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req4 k=a strength=exclusive
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req4 k=b strength=exclusive
+----
+locked: true, holder: 00000000-0000-0000-0000-000000000001
+
+is-key-locked-by-conflicting-txn r=req4 k=c strength=exclusive
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req4 k=d strength=exclusive
+----
+locked: true, holder: 00000000-0000-0000-0000-000000000001
+
+is-key-locked-by-conflicting-txn r=req4 k=e strength=exclusive
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req4 k=f strength=exclusive
+----
+locked: true, holder: <nil>
+
+dequeue r=req4
+----
+global: num=4
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 9.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "d"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "f"
+  res: req: 3, txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, seq: 0
+local: num=0
+
+# ---------------------------------------------------------------------------------
+# req5 is the same as req4, except is has a timestamp equal to txn1's to
+# exercise the strength=none cases again.
+# ---------------------------------------------------------------------------------
+
+new-request r=req5 txn=txn2 ts=10,1 spans=r@a,g skip-locked
+----
+
+scan r=req5
+----
+start-waiting: false
+
+should-wait r=req5
+----
+false
+
+is-key-locked-by-conflicting-txn r=req5 k=a strength=none
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req5 k=b strength=none
+----
+locked: true, holder: 00000000-0000-0000-0000-000000000001
+
+is-key-locked-by-conflicting-txn r=req5 k=c strength=none
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req5 k=d strength=none
+----
+locked: true, holder: 00000000-0000-0000-0000-000000000001
+
+is-key-locked-by-conflicting-txn r=req5 k=e strength=none
+----
+locked: false
+
+is-key-locked-by-conflicting-txn r=req5 k=f strength=none
+----
+locked: false
+
+dequeue r=req5
+----
+global: num=4
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000002, ts: 9.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "d"
+  holder: txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, info: unrepl epoch: 0, seqs: [0]
+ lock: "f"
+  res: req: 3, txn: 00000000-0000-0000-0000-000000000001, ts: 10.000000000,1, seq: 0
 local: num=0

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -864,12 +864,14 @@ func MVCCBlindPutProto(
 // table (i.e. unreplicated locks) and locks only stored in the persistent lock
 // table keyspace (i.e. replicated locks that have yet to be "discovered").
 type LockTableView interface {
-	// IsKeyLockedByConflictingTxn returns whether the specified key is locked by
-	// a conflicting transaction, given the caller's own desired locking strength.
-	// If so, the lock holder is returned. A transaction's own lock does not
-	// appear to be locked to itself (false is returned). The method is used by
-	// requests in conjunction with the SkipLocked wait policy to determine which
-	// keys they should skip over during evaluation.
+	// IsKeyLockedByConflictingTxn returns whether the specified key is locked or
+	// reserved (see lockTable "reservations") by a conflicting transaction, given
+	// the caller's own desired locking strength. If so, true is returned. If the
+	// key is locked, the lock holder is also returned. Otherwise, if the key is
+	// reserved, nil is also returned. A transaction's own lock or reservation
+	// does not appear to be locked to itself (false is returned). The method is
+	// used by requests in conjunction with the SkipLocked wait policy to
+	// determine which keys they should skip over during evaluation.
 	IsKeyLockedByConflictingTxn(roachpb.Key, lock.Strength) (bool, *enginepb.TxnMeta)
 }
 
@@ -3617,6 +3619,9 @@ func buildScanIntents(data []byte) ([]roachpb.Intent, error) {
 		}
 		if err := protoutil.Unmarshal(reader.Value(), &meta); err != nil {
 			return nil, err
+		}
+		if meta.Txn == nil {
+			return nil, errors.AssertionFailedf("unexpected nil MVCCMetadata.Txn: %v", meta)
 		}
 		intents = append(intents, roachpb.MakeIntent(meta.Txn, key.Key))
 	}


### PR DESCRIPTION
Fixes #88980.

This commit adjusts lockTableGuardImpl.IsKeyLockedByConflictingTxn to return `(true, nil)` in cases when it observes a conflicting lock reservation. This informs the MVCC scanner that it should skip the corresponding key, but also that it should not try to resolve a lock on this key (which is used to prevent locks from leaking indefinitely). The MVCC scanner is then adjusted to handle this nil return value correctly, which avoids a nil pointer crash in `buildScanIntents`.

Release notes (bug fix): A nil pointer crash that could be hit when interleaving SELECT FOR UPDATE SKIP LOCKED statements has been resolved.