### PR TITLE
licenses: Update BSL for master/23.1

### DIFF
--- a/licenses/BSL.txt
+++ b/licenses/BSL.txt
@@ -3,8 +3,8 @@ Business Source License 1.1
 Parameters
 
 Licensor:             Cockroach Labs, Inc.
-Licensed Work:        CockroachDB 22.2
-                      The Licensed Work is (c) 2022 Cockroach Labs, Inc.
+Licensed Work:        CockroachDB 23.1
+                      The Licensed Work is (c) 2023 Cockroach Labs, Inc.
 Additional Use Grant: You may make use of the Licensed Work, provided that
                       you may not use the Licensed Work for a Database
                       Service.
@@ -15,7 +15,7 @@ Additional Use Grant: You may make use of the Licensed Work, provided that
                       Licensed Work by creating tables whose schemas are
                       controlled by such third parties.
 
-Change Date:          2025-10-01
+Change Date:          2026-04-01
 
 Change License:       Apache License, Version 2.0
 


### PR DESCRIPTION
This commit updates the BSL license for 23.1

Release note: None
Epic: RE-241