### PR TITLE
backupccl: lift is-admin check into SHOW BACKUP prep

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/show-backup-union
+++ b/pkg/ccl/backupccl/testdata/backup-restore/show-backup-union
@@ -1,0 +1,19 @@
+new-server name=s1
+----
+
+exec-sql
+CREATE USER bigboss
+----
+
+exec-sql
+GRANT admin TO bigboss
+----
+
+exec-sql
+BACKUP INTO 'nodelocal://0/test/'
+----
+
+# Just verify that concurrent privilege checks don't panic.
+exec-sql
+SELECT * FROM [SHOW BACKUPS IN 'nodelocal://0/test'] UNION SELECT * FROM [SHOW BACKUPS IN 'nodelocal://0/test']
+----

--- a/pkg/cloud/cloudprivilege/privileges.go
+++ b/pkg/cloud/cloudprivilege/privileges.go
@@ -33,7 +33,14 @@ func CheckDestinationPrivileges(ctx context.Context, p sql.PlanHookState, to []s
 	if isAdmin {
 		return nil
 	}
+	return CheckNonAdminDestinationPrivileges(ctx, p, to)
+}
 
+// CheckNonAdminDestinationPrivileges iterates over the External Storage URIs
+// and ensures the non-admin user has adequate privileges to use each of them.
+func CheckNonAdminDestinationPrivileges(
+	ctx context.Context, p sql.PlanHookState, to []string,
+) error {
 	// Check destination specific privileges.
 	for _, uri := range to {
 		conf, err := cloud.ExternalStorageConfFromURI(uri, p.User())


### PR DESCRIPTION
The planner's UserHasAdminRole method is not thread-safe and cannot run in the plan hook closure itself. This commit hoists it out of the closure definition, which for plan hook nodes is the equivalent of the startExec method.

Fixes #88385.

Release note: None