### PR TITLE
metrics: expose pebble fsync latency

### DIFF
--- a/monitoring/rules/aggregation.rules.yml
+++ b/monitoring/rules/aggregation.rules.yml
@@ -95,3 +95,15 @@ groups:
     expr: histogram_quantile(0.95, raft_process_commandcommit_latency_bucket:rate1m)
   - record: raft_process_commandcommit_latency:rate1m:quantile_99
     expr: histogram_quantile(0.99, raft_process_commandcommit_latency_bucket:rate1m)
+  - record: storage_wal_fsync_latency_bucket:rate1m
+    expr: rate(storage_wal_fsync_latency_bucket{job="cockroachdb"}[1m])
+  - record: storage_wal_fsync_latency:rate1m:quantile_50
+    expr: histogram_quantile(0.5, storage_wal_fsync_latency_bucket:rate1m)
+  - record: storage_wal_fsync_latency:rate1m:quantile_75
+    expr: histogram_quantile(0.75, storage_wal_fsync_latency_bucket:rate1m)
+  - record: storage_wal_fsync_latency:rate1m:quantile_90
+    expr: histogram_quantile(0.9, storage_wal_fsync_latency_bucket:rate1m)
+  - record: storage_wal_fsync_latency:rate1m:quantile_95
+    expr: histogram_quantile(0.95, storage_wal_fsync_latency_bucket:rate1m)
+  - record: storage_wal_fsync_latency:rate1m:quantile_99
+    expr: histogram_quantile(0.99, storage_wal_fsync_latency_bucket:rate1m)

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -203,6 +203,7 @@ go_library(
         "@com_github_gogo_protobuf//proto",
         "@com_github_google_btree//:btree",
         "@com_github_kr_pretty//:pretty",
+        "@com_github_prometheus_client_model//go",
         "@io_etcd_go_etcd_raft_v3//:raft",
         "@io_etcd_go_etcd_raft_v3//raftpb",
         "@io_etcd_go_etcd_raft_v3//tracker",

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -743,7 +743,7 @@ func (n *Node) startComputePeriodicMetrics(stopper *stop.Stopper, interval time.
 	_ = stopper.RunAsyncTask(ctx, "compute-metrics", func(ctx context.Context) {
 		// Compute periodic stats at the same frequency as metrics are sampled.
 		ticker := time.NewTicker(interval)
-		previousMetrics := make(map[*kvserver.Store]*storage.Metrics)
+		previousMetrics := make(map[*kvserver.Store]*storage.MetricsForInterval)
 		defer ticker.Stop()
 		for tick := 0; ; tick++ {
 			select {
@@ -761,16 +761,21 @@ func (n *Node) startComputePeriodicMetrics(stopper *stop.Stopper, interval time.
 // computeMetricsPeriodically instructs each store to compute the value of
 // complicated metrics.
 func (n *Node) computeMetricsPeriodically(
-	ctx context.Context, storeToMetrics map[*kvserver.Store]*storage.Metrics, tick int,
+	ctx context.Context, storeToMetrics map[*kvserver.Store]*storage.MetricsForInterval, tick int,
 ) error {
 	return n.stores.VisitStores(func(store *kvserver.Store) error {
 		if newMetrics, err := store.ComputeMetricsPeriodically(ctx, storeToMetrics[store], tick); err != nil {
 			log.Warningf(ctx, "%s: unable to compute metrics: %s", store, err)
 		} else {
 			if storeToMetrics[store] == nil {
-				storeToMetrics[store] = &newMetrics
+				storeToMetrics[store] = &storage.MetricsForInterval{
+					FlushWriteThroughput: newMetrics.LogWriter.WriteThroughput,
+				}
 			} else {
-				*storeToMetrics[store] = newMetrics
+				storeToMetrics[store].FlushWriteThroughput = newMetrics.Flush.WriteThroughput
+			}
+			if err := newMetrics.LogWriter.FsyncLatency.Write(&storeToMetrics[store].WALFsyncLatency); err != nil {
+				return err
 			}
 		}
 		return nil

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -491,7 +491,7 @@ func TestNodeStatusWritten(t *testing.T) {
 	// were multiple replicas, more care would need to be taken in the initial
 	// syncFeed().
 	forceWriteStatus := func() {
-		if err := ts.node.computeMetricsPeriodically(ctx, map[*kvserver.Store]*storage.Metrics{}, 0); err != nil {
+		if err := ts.node.computeMetricsPeriodically(ctx, map[*kvserver.Store]*storage.MetricsForInterval{}, 0); err != nil {
 			t.Fatalf("error publishing store statuses: %s", err)
 		}
 

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -345,7 +345,7 @@ func startServer(t *testing.T) *TestServer {
 	// Make sure the node status is available. This is done by forcing stores to
 	// publish their status, synchronizing to the event feed with a canary
 	// event, and then forcing the server to write summaries immediately.
-	if err := ts.node.computeMetricsPeriodically(context.Background(), map[*kvserver.Store]*storage.Metrics{}, 0); err != nil {
+	if err := ts.node.computeMetricsPeriodically(context.Background(), map[*kvserver.Store]*storage.MetricsForInterval{}, 0); err != nil {
 		t.Fatalf("error publishing store statuses: %s", err)
 	}
 

--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -93,6 +93,7 @@ go_library(
         "@com_github_dustin_go_humanize//:go-humanize",
         "@com_github_elastic_gosigar//:gosigar",
         "@com_github_gogo_protobuf//proto",
+        "@com_github_prometheus_client_model//go",
         "@io_etcd_go_etcd_raft_v3//raftpb",
     ],
 )

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
+	prometheusgo "github.com/prometheus/client_model/go"
 )
 
 // DefaultStorageEngine represents the default storage engine to use.
@@ -992,6 +993,13 @@ type Metrics struct {
 	// DiskStallCount counts the number of times Pebble observes slow writes
 	// on disk lasting longer than MaxSyncDuration (`storage.max_sync_duration`).
 	DiskStallCount int64
+}
+
+// MetricsForInterval is a set of pebble.Metrics that need to be saved in order to
+// compute metrics according to an interval.
+type MetricsForInterval struct {
+	WALFsyncLatency      prometheusgo.Metric
+	FlushWriteThroughput pebble.ThroughputMetric
 }
 
 // NumSSTables returns the total number of SSTables in the LSM, aggregated

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -3076,6 +3076,10 @@ var charts = []sectionDescription{
 				Title:   "Flush Utilization",
 				Metrics: []string{"storage.flush.utilization"},
 			},
+			{
+				Title:   "WAL Fsync Latency",
+				Metrics: []string{"storage.wal.fsync.latency"},
+			},
 		},
 	},
 	{

--- a/pkg/util/metric/metric_test.go
+++ b/pkg/util/metric/metric_test.go
@@ -21,6 +21,7 @@ import (
 
 	_ "github.com/cockroachdb/cockroach/pkg/util/log" // for flags
 	"github.com/kr/pretty"
+	"github.com/prometheus/client_golang/prometheus"
 	prometheusgo "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 )
@@ -138,6 +139,72 @@ func TestHistogram(t *testing.T) {
 		}
 		expSum += float64(m)
 	}
+
+	act := *h.ToPrometheusMetric().Histogram
+	exp := prometheusgo.Histogram{
+		SampleCount: u(len(measurements)),
+		SampleSum:   &expSum,
+		Bucket: []*prometheusgo.Bucket{
+			{CumulativeCount: u(1), UpperBound: f(1)},
+			{CumulativeCount: u(3), UpperBound: f(5)},
+			{CumulativeCount: u(4), UpperBound: f(10)},
+			{CumulativeCount: u(6), UpperBound: f(25)},
+			{CumulativeCount: u(9), UpperBound: f(100)},
+			// NB: 200 is greater than the largest defined bucket so prometheus
+			// puts it in an implicit bucket with +Inf as the upper bound.
+		},
+	}
+
+	if !reflect.DeepEqual(act, exp) {
+		t.Fatalf("expected differs from actual: %s", pretty.Diff(exp, act))
+	}
+
+	require.Equal(t, 0.0, h.ValueAtQuantileWindowed(0))
+	require.Equal(t, 1.0, h.ValueAtQuantileWindowed(10))
+	require.Equal(t, 17.5, h.ValueAtQuantileWindowed(50))
+	require.Equal(t, 75.0, h.ValueAtQuantileWindowed(80))
+	require.Equal(t, 100.0, h.ValueAtQuantileWindowed(99.99))
+}
+
+func TestManualWindowHistogram(t *testing.T) {
+	u := func(v int) *uint64 {
+		n := uint64(v)
+		return &n
+	}
+
+	f := func(v int) *float64 {
+		n := float64(v)
+		return &n
+	}
+
+	buckets := []float64{
+		1.0,
+		5.0,
+		10.0,
+		25.0,
+		100.0,
+	}
+
+	h := NewManualWindowHistogram(
+		Metadata{},
+		buckets,
+	)
+
+	// should return 0 if no observations are made
+	require.Equal(t, 0.0, h.ValueAtQuantileWindowed(0))
+
+	histogram := prometheus.NewHistogram(prometheus.HistogramOpts{Buckets: buckets})
+	pMetric := &prometheusgo.Metric{}
+	// 200 is intentionally set us the first value to verify that the function
+	// does not return NaN or Inf.
+	measurements := []float64{200, 0, 4, 5, 10, 20, 25, 30, 40, 90}
+	var expSum float64
+	for _, m := range measurements {
+		histogram.Observe(m)
+		expSum += m
+	}
+	require.NoError(t, histogram.Write(pMetric))
+	h.Update(histogram, pMetric.Histogram)
 
 	act := *h.ToPrometheusMetric().Histogram
 	exp := prometheusgo.Histogram{


### PR DESCRIPTION
Given that pebble produces fsync latency as a prometheus histogram,
create a new histogram `ManualWindowHistogram` that implements windowing
to ensure that the data can be exported in Cockroach DB. This histogram
does not collect values over time and expose them, instead, it allows
for the cumulative and windowed metrics to be replaced. This means that
the client is responsible for managing the replacement of the data to
ensure that it is exported properly.

Additionally, introduce a new struct `MetricsForInterval` to store the
previous metrics. In order to perform subtraction between histograms
they need to be converted to `prometheusgo.Metric`s which means that
they cannot be stored on the `pebble.Metrics`. Hence this means that
either these metrics need to be added to `storage.Metrics` which is
confusing since that means there are now two metrics that represent the
same data in different formats:

```go
storage.pebble.Metrics.FsyncLatency prometheus.Histogram
storage.FsyncLatency prometheusgo.Metric
```
Or a new struct is created that will contain the metrics needed to
compute the metrics over an interval. The new struct was chosen since it
was easier to understand.


Release note: None
Depends on: #89459 https://github.com/cockroachdb/pebble/pull/2014
Epic: CRDB-17515
