### PR TITLE
rpc: fix regression in BenchmarkKV/Scan/Native

### DIFF
--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -1337,7 +1337,7 @@ func (a rangeFeedServerAdapter) Send(e *roachpb.RangeFeedEvent) error {
 
 // IsLocal returns true if the given InternalClient is local.
 func IsLocal(iface RestrictedInternalClient) bool {
-	_, ok := iface.(*internalClientAdapter)
+	_, ok := iface.(internalClientAdapter)
 	return ok // internalClientAdapter is used for local connections.
 }
 


### PR DESCRIPTION
We perform extra validation of BatchResponses obtained from remote nodes. I think we unintentionally broke this behavior in 3ebf6ee6e212eb0d8cce489f3b8e5a17ffbe1611 when we made the change this patch reverts. As a result, after that commit, we'd end up running validation for local RPCs as well. We tracked down the regression in the `BenchmarkKV/Scan/Native` microbenchmark to this change.

Benchmark results of this commitpatch against master:

```
name                          old time/op    new time/op    delta
KV/Scan/Native/rows=1-10        17.2µs ± 1%    17.1µs ± 2%     ~     (p=0.165 n=10+10)
KV/Scan/Native/rows=10-10       19.5µs ± 2%    18.7µs ± 2%   -4.08%  (p=0.000 n=10+10)
KV/Scan/Native/rows=100-10      36.4µs ±20%    29.9µs ± 2%  -17.81%  (p=0.000 n=9+10)
KV/Scan/Native/rows=1000-10      173µs ± 9%     136µs ± 1%  -21.40%  (p=0.000 n=8+8)
KV/Scan/Native/rows=10000-10    1.45ms ± 1%    1.12ms ± 1%  -22.66%  (p=0.000 n=10+9)
```

Closes #89545

Release note: None