### PR TITLE
release-22.2: ui: fix size of charts on stmt details

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/summaryCard/index.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/summaryCard/index.tsx
@@ -19,6 +19,7 @@ import "antd/lib/tooltip/style";
 interface ISummaryCardProps {
   children: React.ReactNode;
   className?: string;
+  id?: string;
 }
 
 const cx = classnames.bind(styles);
@@ -28,7 +29,12 @@ const booleanSettingCx = classnames.bind(booleanSettingStyles);
 export const SummaryCard: React.FC<ISummaryCardProps> = ({
   children,
   className = "",
-}) => <div className={`${cx("summary--card")} ${className}`}>{children}</div>;
+  id,
+}) => (
+  <div className={`${cx("summary--card")} ${className}`} id={id}>
+    {children}
+  </div>
+);
 
 interface ISummaryCardItemProps {
   label: React.ReactNode;


### PR DESCRIPTION
Backport 1/1 commits from #90014.

/cc @cockroachdb/release

---

Previously, the charts on statement details were
overlapping and not changing width with window
resize. This commit fixes the size, aligning with
summary card used on the page.

Fixes #85270

Before
<img width="1544" alt="Screen Shot 2022-10-14 at 5 39 58 PM" src="https://user-images.githubusercontent.com/1017486/195950839-7135fe7c-6791-4e8d-a4ae-c8ed50586591.png">


After
https://www.loom.com/share/eb2e188f7acc401f9f1b88451dcbdbae

Release note (bug fix): Charts on Statement Details page are no longer overlapping.

---

Release justification: bug fix
