### PR TITLE
changefeed,kvcoord: populate AC headers for backfill work

### DIFF
--- a/pkg/ccl/changefeedccl/kvfeed/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/kvfeed/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/sql/covering",
         "//pkg/storage/enginepb",
+        "//pkg/util/admission/admissionpb",
         "//pkg/util/ctxgroup",
         "//pkg/util/hlc",
         "//pkg/util/limit",

--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -61,6 +61,7 @@ go_library(
         "//pkg/sql/pgwire/pgerror",
         "//pkg/storage/enginepb",
         "//pkg/util",
+        "//pkg/util/admission/admissionpb",
         "//pkg/util/buildutil",
         "//pkg/util/contextutil",
         "//pkg/util/ctxgroup",


### PR DESCRIPTION
This is an opportunistic change and something to backport to v22.2. In v22.2 we introduced a disabled-by-default elastic CPU limiter (#86638) to dynamically grant CPU time for background work like backups -- something hope to enable-by-default in CC and under observation for select 22.2 clusters. Recently we found another use for this limiter -- rangefeed catchup scans (#89709). It's unclear yet whether we want that integration to make it back to v22.2 but this commit leaves that option open by populating the right AC headers we'd need for the integration. Populating these AC headers is safe -- the Rangefeed RPC is not hooked into AC yet, so these headers are not looked at. For the initial scan requests we're only setting a lower priority bit, something 22.1 nodes already know to handle (they do so for all batch requests).

Release note: None
Release justification: Low-risk change that opens the door to a future backport in a non-.0 release to address cases where rangefeed catchup scans affect foreground latencies.