### PR TITLE
sql: add implicit_txn column to insights execution

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -6417,7 +6417,8 @@ CREATE TABLE crdb_internal.%s (
 	last_retry_reason          STRING,
 	exec_node_ids              INT[] NOT NULL,
 	contention                 INTERVAL,
-	index_recommendations      STRING[] NOT NULL
+	index_recommendations      STRING[] NOT NULL,
+	implicit_txn               BOOL NOT NULL
 )`
 
 var crdbInternalClusterExecutionInsightsTable = virtualSchemaTable{
@@ -6531,6 +6532,7 @@ func populateExecutionInsights(
 			execNodeIDs,
 			contentionTime,
 			indexRecommendations,
+			tree.MakeDBool(tree.DBool(insight.Transaction.ImplicitTxn)),
 		))
 	}
 	return

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -271,7 +271,8 @@ CREATE TABLE crdb_internal.cluster_execution_insights (
    last_retry_reason STRING NULL,
    exec_node_ids INT8[] NOT NULL,
    contention INTERVAL NULL,
-   index_recommendations STRING[] NOT NULL
+   index_recommendations STRING[] NOT NULL,
+   implicit_txn BOOL NOT NULL
 )  CREATE TABLE crdb_internal.cluster_execution_insights (
    session_id STRING NOT NULL,
    txn_id UUID NOT NULL,
@@ -296,7 +297,8 @@ CREATE TABLE crdb_internal.cluster_execution_insights (
    last_retry_reason STRING NULL,
    exec_node_ids INT8[] NOT NULL,
    contention INTERVAL NULL,
-   index_recommendations STRING[] NOT NULL
+   index_recommendations STRING[] NOT NULL,
+   implicit_txn BOOL NOT NULL
 )  {}  {}
 CREATE TABLE crdb_internal.cluster_inflight_traces (
    trace_id INT8 NOT NULL,
@@ -993,7 +995,8 @@ CREATE TABLE crdb_internal.node_execution_insights (
    last_retry_reason STRING NULL,
    exec_node_ids INT8[] NOT NULL,
    contention INTERVAL NULL,
-   index_recommendations STRING[] NOT NULL
+   index_recommendations STRING[] NOT NULL,
+   implicit_txn BOOL NOT NULL
 )  CREATE TABLE crdb_internal.node_execution_insights (
    session_id STRING NOT NULL,
    txn_id UUID NOT NULL,
@@ -1018,7 +1021,8 @@ CREATE TABLE crdb_internal.node_execution_insights (
    last_retry_reason STRING NULL,
    exec_node_ids INT8[] NOT NULL,
    contention INTERVAL NULL,
-   index_recommendations STRING[] NOT NULL
+   index_recommendations STRING[] NOT NULL,
+   implicit_txn BOOL NOT NULL
 )  {}  {}
 CREATE TABLE crdb_internal.node_inflight_trace_spans (
    trace_id INT8 NOT NULL,

--- a/pkg/sql/sqlstats/insights/insights.proto
+++ b/pkg/sql/sqlstats/insights/insights.proto
@@ -68,6 +68,7 @@ message Transaction {
     (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/roachpb.TransactionFingerprintID",
     (gogoproto.nullable) = false];
   string user_priority = 3;
+  bool implicit_txn = 4;
 }
 
 message Statement {
@@ -99,7 +100,6 @@ message Statement {
   repeated int64 nodes = 17;
   google.protobuf.Duration contention = 18 [(gogoproto.stdduration) = true];
   repeated string index_recommendations = 19;
-
 }
 
 message Insight {

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
@@ -315,7 +315,8 @@ func (s *Container) RecordTransaction(
 	s.insights.ObserveTransaction(value.SessionID, &insights.Transaction{
 		ID:            value.TransactionID,
 		FingerprintID: key,
-		UserPriority:  value.Priority.String()})
+		UserPriority:  value.Priority.String(),
+		ImplicitTxn:   value.ImplicitTxn})
 
 	return nil
 }


### PR DESCRIPTION
This commit adds a new column `implicit_txn` (boolean) to:
- `crdb_internal.cluster_execution_insights`
- `crdb_internal.node_execution_insights`

Part Of #87750

Release note (sql change): Adds a new column `implicit_txn` (boolean) to `crdb_internal.cluster_execution_insights` and `crdb_internal.node_execution_insights`