### PR TITLE
execbuilder: fix enforce_home_region erroring of input table to LOJ

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
@@ -192,10 +192,10 @@ statement error pq: Query has no home region\. Try adding a filter on p\.crdb_re
 SELECT * FROM parent p, child c WHERE p_id = c_p_id AND
 p.crdb_region = c.crdb_region LIMIT 1
 
-# Locality optimized lookup join should not error out in phase 1.
-query TTT retry
+# Locality optimized join is not allowed if the input is a full scan of an RBR
+# table.
+statement error pq: Query has no home region. Try adding a filter on c\.crdb_region and/or on key column \(c\.c_id\)\.
 SELECT * FROM parent p, child c WHERE p_id = c_p_id LIMIT 1
-----
 
 # Locality optimized lookup join should not error out in phase 1.
 query TT retry
@@ -443,6 +443,11 @@ inner-join (lookup messages_global [as=g3])
 
 statement ok
 ALTER TABLE messages_rbt SET LOCALITY REGIONAL BY TABLE IN "us-east-1";
+
+# Regression test for issue #88788
+# A full scan on an RBT table should error out lookup join.
+statement error pq: Query has no home region\. The home region \('us-east-1'\) of table 'messages_rbt' does not match the home region \('ap-southeast-2'\) of lookup table 'messages_rbr'\.
+SELECT * FROM messages_rbr rbr, messages_rbt rbt WHERE rbr.account_id = rbt.account_id LIMIT 1
 
 # Select from REGIONAL BY TABLE should indicate the gateway region to use.
 statement error pq: Query is not running in its home region. Try running the query from region 'us-east-1'.

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -2056,10 +2056,6 @@ func (b *Builder) filterSuggestionError(
 }
 
 func (b *Builder) handleRemoteLookupJoinError(join *memo.LookupJoinExpr) (err error) {
-	if join.LocalityOptimized {
-		// Locality optimized joins are considered local in phase 1.
-		return nil
-	}
 	lookupTableMeta := join.Memo().Metadata().TableMeta(join.Table)
 	lookupTable := lookupTableMeta.Table
 
@@ -2085,9 +2081,10 @@ func (b *Builder) handleRemoteLookupJoinError(join *memo.LookupJoinExpr) (err er
 	}
 
 	homeRegion := ""
-	if lookupTable.IsGlobalTable() {
+	if lookupTable.IsGlobalTable() || join.LocalityOptimized {
 		// HomeRegion() does not automatically fill in the home region of a global
 		// table as the gateway region, so let's manually set it here.
+		// Locality optimized joins are considered local in phase 1.
 		homeRegion = gatewayRegion
 	} else {
 		homeRegion, _ = lookupTable.HomeRegion()


### PR DESCRIPTION
Fixes #88788

This fixes erroring out of locality-optimized join when the input table's home region does not match the gateway region and session flag `enforce_home_region` is true.

Release note (bug fix): This patch fixes detection and erroring out of queries using locality-optimized join when session setting enforce_home_region is true and the input table to the join has no home region or its home region does not match the gateway region.