### PR TITLE
sqlinstance: simplify instance provider code

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -446,7 +446,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 			}
 			info, err := cfg.sqlInstanceProvider.GetInstance(cfg.rpcContext.MasterCtx, base.SQLInstanceID(nodeID))
 			if err != nil {
-				return nil, errors.Errorf("unable to look up descriptor for nsql%d", nodeID)
+				return nil, errors.Wrapf(err, "unable to look up descriptor for nsql%d", nodeID)
 			}
 			return &util.UnresolvedAddr{AddressField: info.InstanceAddr}, nil
 		}

--- a/pkg/sql/sqlinstance/instanceprovider/BUILD.bazel
+++ b/pkg/sql/sqlinstance/instanceprovider/BUILD.bazel
@@ -23,7 +23,6 @@ go_library(
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "@com_github_cockroachdb_errors//:errors",
-        "@com_github_cockroachdb_logtags//:logtags",
     ],
 )
 

--- a/pkg/sql/sqlinstance/instanceprovider/instanceprovider_test.go
+++ b/pkg/sql/sqlinstance/instanceprovider/instanceprovider_test.go
@@ -65,7 +65,7 @@ func TestInstanceProvider(t *testing.T) {
 		defer stopper.Stop(ctx)
 		instanceProvider := instanceprovider.NewTestInstanceProvider(stopper, slInstance, addr)
 		slInstance.Start(ctx)
-		instanceProvider.InitAndWaitForTest(ctx)
+		instanceProvider.InitForTest(ctx)
 		instanceID, sessionID, err := instanceProvider.Instance(ctx)
 		require.NoError(t, err)
 		require.Equal(t, expectedInstanceID, instanceID)
@@ -89,22 +89,10 @@ func TestInstanceProvider(t *testing.T) {
 
 		// Verify that the SQL instance is shutdown on session expiry.
 		testutils.SucceedsSoon(t, func() error {
-			if _, _, err = instanceProvider.Instance(ctx); !errors.Is(err, stop.ErrUnavailable) {
+			if _, _, err = instanceProvider.Instance(ctx); !errors.Is(err, instanceprovider.ErrProviderShutDown) {
 				return errors.Errorf("sql instance is not shutdown on session expiry")
 			}
 			return nil
 		})
-	})
-
-	t.Run("test-shutdown-before-init", func(t *testing.T) {
-		stopper, slInstance, _, _ := setup(t)
-		defer stopper.Stop(ctx)
-		instanceProvider := instanceprovider.NewTestInstanceProvider(stopper, slInstance, "addr")
-		slInstance.Start(ctx)
-		instanceProvider.ShutdownSQLInstanceForTest(ctx)
-		instanceProvider.InitAndWaitForTest(ctx)
-		_, _, err := instanceProvider.Instance(ctx)
-		require.Error(t, err)
-		require.Equal(t, "instance never initialized", err.Error())
 	})
 }

--- a/pkg/sql/sqlinstance/instanceprovider/test_helpers.go
+++ b/pkg/sql/sqlinstance/instanceprovider/test_helpers.go
@@ -23,7 +23,7 @@ import (
 // and InitAndWaitForTest methods for testing purposes.
 type TestInstanceProvider interface {
 	sqlinstance.Provider
-	InitAndWaitForTest(context.Context)
+	InitForTest(context.Context)
 	ShutdownSQLInstanceForTest(context.Context)
 }
 
@@ -38,15 +38,14 @@ func NewTestInstanceProvider(
 		stopper:      stopper,
 		session:      session,
 		instanceAddr: addr,
-		initialized:  make(chan struct{}),
+		started:      true,
 	}
-	p.mu.started = true
 	return p
 }
 
 // InitAndWaitForTest explicitly calls initAndWait for testing purposes.
-func (p *provider) InitAndWaitForTest(ctx context.Context) {
-	_ = p.initAndWait(ctx)
+func (p *provider) InitForTest(ctx context.Context) {
+	_ = p.init(ctx)
 }
 
 // ShutdownSQLInstanceForTest explicitly calls shutdownSQLInstance for testing purposes.

--- a/pkg/sql/sqlinstance/instancestorage/instancereader.go
+++ b/pkg/sql/sqlinstance/instancestorage/instancereader.go
@@ -89,7 +89,8 @@ func NewReader(
 	return NewTestingReader(storage, slReader, f, codec, keys.SQLInstancesTableID, clock, stopper)
 }
 
-// Start initializes the rangefeed for the Reader.
+// Start initializes the rangefeed for the Reader. The rangefeed will run until
+// the stopper stops.
 func (r *Reader) Start(ctx context.Context) error {
 	rf := r.maybeStartRangeFeed(ctx)
 	select {


### PR DESCRIPTION
Before this patch, the instance provider was seemingly protecting
against different methods being called concurrently with or before
Start(). This protection was not necessary, as Start() is run to
completion before the provider is used by anyone else. Also, part of the
protection was broken: a bunch of unrelated code chunks were guarded by
a sync.Once and at least one instance (the error handling after
p.Reader.Start()) was running clearly after a the Once was used by
p.initAndWait() - and so it was erroneously never running. Also, the
code was bizarre - initializing was executed in an async task, but the
caller was immediately waiting for it.

This patch removes all such protection, assuming that Start() runs
before anything else.

Release note: None
Epic: None