### PR TITLE
roachpb: remove stale `timestamp.proto` import

### DIFF
--- a/pkg/roachpb/internal_raft.proto
+++ b/pkg/roachpb/internal_raft.proto
@@ -12,7 +12,6 @@ syntax = "proto2";
 package cockroach.roachpb;
 option go_package = "roachpb";
 
-import "util/hlc/timestamp.proto";
 import "gogoproto/gogo.proto";
 
 // RaftTruncatedState contains metadata about the truncated portion of the raft log.


### PR DESCRIPTION
Fixes build warnings of the form:

```
roachpb/internal_raft.proto: warning: Import util/hlc/timestamp.proto but not used.
```

Likely fallout from #89502.

Epic: None

Release note: None