### PR TITLE
roachtest: don't monitor client node in network/authentication

### DIFF
--- a/pkg/cmd/roachtest/tests/network.go
+++ b/pkg/cmd/roachtest/tests/network.go
@@ -153,7 +153,7 @@ SELECT $1::INT = ALL (
 	// in case an error occurs.
 	woopsCh := make(chan struct{}, len(serverNodes)-1)
 
-	m := c.NewMonitor(ctx)
+	m := c.NewMonitor(ctx, serverNodes)
 
 	var numConns uint32
 


### PR DESCRIPTION
Fixes #90117.

This commit switches the `network/authentication/nodes=4` test to only monitor nodes that have cockroach processes running. This avoids flakes when the monitor does not find a process on node 4.

I don't understand why this doesn't reliably fail without this change, but we shouldn't be seeing `unexpected node event: 4` failures in this test. We've seen so in (at least) #90117 and #83307.

Release note: None.