### PR TITLE
kvserver: bump check priority of recently modified ranges

### DIFF
--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -105,8 +105,9 @@ func ConsistencyQueueShouldQueue(
 	interval time.Duration,
 ) (bool, float64) {
 	return consistencyQueueShouldQueueImpl(ctx, now, consistencyShouldQueueData{
-		desc, getQueueLastProcessed, isNodeAvailable,
-		disableLastProcessedCheck, interval})
+		desc: desc, lastUpdateNanos: 0, getQueueLastProcessed: getQueueLastProcessed,
+		isNodeAvailable: isNodeAvailable, disableLastProcessedCheck: disableLastProcessedCheck,
+		interval: interval})
 }
 
 // LogReplicaChangeTest adds a fake replica change event to the log for the

--- a/pkg/kv/kvserver/queue.go
+++ b/pkg/kv/kvserver/queue.go
@@ -276,7 +276,7 @@ type queueImpl interface {
 	// (vs. it being a no-op or an error).
 	process(context.Context, *Replica, spanconfig.StoreReader) (processed bool, err error)
 
-	// processScheduled is called after async task was created to run process.
+	// postProcessScheduled is called after async task was created to run process.
 	// This function is called by the process loop synchronously. This method is
 	// called regardless of process being called or not since replica validity
 	// checks are done asynchronously.


### PR DESCRIPTION
Introduce a limited bump in consistency check priority for replicas that have been recently modified.

In large clusters, there is a chance that some ranges are rarely touched, and, correspondingly, have fewer chances of having a newly introduced inconsistency. Also, it seems important to check consistency timely for the hottest ranges.

Previously, ranges were added to the consistency queue with a priority proportional to the last time they were in the queue. This ensures that every range is eventually processed, even if the speed of processing is low enough that some replicas are skipped.

This commit adds a limited increase in priority based on the LastUpdateNanos metric in MVCC stats. The guarantee that every replica will eventually be processed is preserved, however the min-max spread of when this happens is slightly increased.

Fixes #87255

Release note: None