### PR TITLE
release-22.2: randgen: do not generate partitions with NULL values

### DIFF
--- a/pkg/sql/randgen/schema.go
+++ b/pkg/sql/randgen/schema.go
@@ -584,7 +584,8 @@ func randIndexTableDefFromCols(
 				t.Exprs = make([]tree.Expr, prefixLen)
 				for k := 0; k < prefixLen; k++ {
 					colType := tree.MustBeStaticallyKnownType(cols[k].Type)
-					t.Exprs[k] = RandDatum(rng, colType, cols[k].Nullable.Nullability != tree.NotNull)
+					// TODO(#82774): Allow null values once #82774 is addressed.
+					t.Exprs[k] = RandDatum(rng, colType, false /* nullOk */)
 					// Variable expressions are not supported in partitions, and NaN and
 					// infinity are considered variable expressions, so if one is
 					// generated then regenerate the value.


### PR DESCRIPTION
Backport 1/1 commits from #89938.

/cc @cockroachdb/release

---

This commit prevents randomized tests from re-discovering #82774, a bug in the optimizer that causes incorrect results when partitions contain `NULL` values.

Informs #82774

Release note: None

---

Release justification: Test-only change.