### PR TITLE
sql,server: increase severity of upgraded-related logging

### DIFF
--- a/pkg/server/auto_upgrade.go
+++ b/pkg/server/auto_upgrade.go
@@ -53,7 +53,7 @@ func (s *Server) startAttemptUpgrade(ctx context.Context) {
 			// Check if we should upgrade cluster version, keep checking upgrade
 			// status, or stop attempting upgrade.
 			if quit, err := s.upgradeStatus(ctx); err != nil {
-				log.Infof(ctx, "failed attempt to upgrade cluster version, error: %s", err)
+				log.Errorf(ctx, "failed attempt to upgrade cluster version, error: %v", err)
 				continue
 			} else if quit {
 				log.Info(ctx, "no need to upgrade, cluster already at the newest version")
@@ -76,7 +76,7 @@ func (s *Server) startAttemptUpgrade(ctx context.Context) {
 					sessiondata.InternalExecutorOverride{User: username.RootUserName()},
 					"SET CLUSTER SETTING version = crdb_internal.node_executable_version();",
 				); err != nil {
-					log.Infof(ctx, "error when finalizing cluster version upgrade: %s", err)
+					log.Errorf(ctx, "error when finalizing cluster version upgrade: %v", err)
 				} else {
 					log.Info(ctx, "successfully upgraded cluster version")
 					return
@@ -85,7 +85,7 @@ func (s *Server) startAttemptUpgrade(ctx context.Context) {
 		}
 	}); err != nil {
 		cancel()
-		log.Infof(ctx, "failed attempt to upgrade cluster version, error: %s", err)
+		log.Errorf(ctx, "failed attempt to upgrade cluster version, error: %v", err)
 	}
 }
 

--- a/pkg/upgrade/upgrademanager/manager.go
+++ b/pkg/upgrade/upgrademanager/manager.go
@@ -105,10 +105,16 @@ func (m *Manager) Migrate(
 	user username.SQLUsername,
 	from, to clusterversion.ClusterVersion,
 	updateSystemVersionSetting sql.UpdateVersionSystemSettingHook,
-) error {
+) (returnErr error) {
 	// TODO(irfansharif): Should we inject every ctx here with specific labels
 	// for each upgrade, so they log distinctly?
 	ctx = logtags.AddTag(ctx, "migration-mgr", nil)
+	defer func() {
+		if returnErr != nil {
+			log.Warningf(ctx, "error encountered during version upgrade: %v", returnErr)
+		}
+	}()
+
 	if from == to {
 		// Nothing to do here.
 		log.Infof(ctx, "no need to migrate, cluster already at newest version")


### PR DESCRIPTION
Informs #90148.

This increases the severity from INFO in the following cases:

- in the case when `SET CLUSTER SETTING version` is issued from a SQL client (WARNING in case of failure).
- in the case when the server spontaneously decides to upgrade in the background (ERROR in case of failure).

Release note: None