### PR TITLE
release-22.2.0: sql: bump workmem size to avoid sqllite flakes on index/1000 tests

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1476,8 +1476,13 @@ func (t *logicTest) newCluster(
 	var randomWorkmem int
 	if t.rng.Float64() < 0.5 && !serverArgs.DisableWorkmemRandomization {
 		// Randomize sql.distsql.temp_storage.workmem cluster setting in
-		// [10KiB, 100KiB) range.
-		randomWorkmem = 10<<10 + t.rng.Intn(90<<10)
+		// [10KiB, 100KiB) range for normal tests and even bigger for sqlite
+		// tests.
+		if *Bigtest {
+			randomWorkmem = 100<<10 + t.rng.Intn(90<<10)
+		} else {
+			randomWorkmem = 10<<10 + t.rng.Intn(90<<10)
+		}
 	}
 
 	// Set cluster settings.


### PR DESCRIPTION
Backport 1/1 commits from #90095.

/cc @cockroachdb/release

---

Below ~70k these tests would flake like so:

```
pq: streamer budget: memory budget exceeded: 38112 bytes requested, 57344 currently allocated, 76801 bytes in budget
```

Fixes: #89635

Release note: None

Release justification: Testing only change
