### PR TITLE
sql/ttl: rename num_active_ranges metrics

### DIFF
--- a/pkg/sql/ttl/ttljob/ttljob_metrics.go
+++ b/pkg/sql/ttl/ttljob/ttljob_metrics.go
@@ -33,14 +33,14 @@ import (
 
 // RowLevelTTLAggMetrics are the row-level TTL job agg metrics.
 type RowLevelTTLAggMetrics struct {
-	RangeTotalDuration *aggmetric.AggHistogram
-	SelectDuration     *aggmetric.AggHistogram
-	DeleteDuration     *aggmetric.AggHistogram
-	RowSelections      *aggmetric.AggCounter
-	RowDeletions       *aggmetric.AggCounter
-	NumActiveRanges    *aggmetric.AggGauge
-	TotalRows          *aggmetric.AggGauge
-	TotalExpiredRows   *aggmetric.AggGauge
+	SpanTotalDuration *aggmetric.AggHistogram
+	SelectDuration    *aggmetric.AggHistogram
+	DeleteDuration    *aggmetric.AggHistogram
+	RowSelections     *aggmetric.AggCounter
+	RowDeletions      *aggmetric.AggCounter
+	NumActiveSpans    *aggmetric.AggGauge
+	TotalRows         *aggmetric.AggGauge
+	TotalExpiredRows  *aggmetric.AggGauge
 
 	defaultRowLevelMetrics rowLevelTTLMetrics
 	mu                     struct {
@@ -52,14 +52,14 @@ type RowLevelTTLAggMetrics struct {
 var _ metric.Struct = (*RowLevelTTLAggMetrics)(nil)
 
 type rowLevelTTLMetrics struct {
-	RangeTotalDuration *aggmetric.Histogram
-	SelectDuration     *aggmetric.Histogram
-	DeleteDuration     *aggmetric.Histogram
-	RowSelections      *aggmetric.Counter
-	RowDeletions       *aggmetric.Counter
-	NumActiveRanges    *aggmetric.Gauge
-	TotalRows          *aggmetric.Gauge
-	TotalExpiredRows   *aggmetric.Gauge
+	SpanTotalDuration *aggmetric.Histogram
+	SelectDuration    *aggmetric.Histogram
+	DeleteDuration    *aggmetric.Histogram
+	RowSelections     *aggmetric.Counter
+	RowDeletions      *aggmetric.Counter
+	NumActiveSpans    *aggmetric.Gauge
+	TotalRows         *aggmetric.Gauge
+	TotalExpiredRows  *aggmetric.Gauge
 }
 
 // MetricStruct implements the metric.Struct interface.
@@ -67,14 +67,14 @@ func (m *RowLevelTTLAggMetrics) MetricStruct() {}
 
 func (m *RowLevelTTLAggMetrics) metricsWithChildren(children ...string) rowLevelTTLMetrics {
 	return rowLevelTTLMetrics{
-		RangeTotalDuration: m.RangeTotalDuration.AddChild(children...),
-		SelectDuration:     m.SelectDuration.AddChild(children...),
-		DeleteDuration:     m.DeleteDuration.AddChild(children...),
-		RowSelections:      m.RowSelections.AddChild(children...),
-		RowDeletions:       m.RowDeletions.AddChild(children...),
-		NumActiveRanges:    m.NumActiveRanges.AddChild(children...),
-		TotalRows:          m.TotalRows.AddChild(children...),
-		TotalExpiredRows:   m.TotalExpiredRows.AddChild(children...),
+		SpanTotalDuration: m.SpanTotalDuration.AddChild(children...),
+		SelectDuration:    m.SelectDuration.AddChild(children...),
+		DeleteDuration:    m.DeleteDuration.AddChild(children...),
+		RowSelections:     m.RowSelections.AddChild(children...),
+		RowDeletions:      m.RowDeletions.AddChild(children...),
+		NumActiveSpans:    m.NumActiveSpans.AddChild(children...),
+		TotalRows:         m.TotalRows.AddChild(children...),
+		TotalExpiredRows:  m.TotalExpiredRows.AddChild(children...),
 	}
 }
 
@@ -98,10 +98,10 @@ func (m *RowLevelTTLAggMetrics) loadMetrics(labelMetrics bool, relation string) 
 func makeRowLevelTTLAggMetrics(histogramWindowInterval time.Duration) metric.Struct {
 	b := aggmetric.MakeBuilder("relation")
 	ret := &RowLevelTTLAggMetrics{
-		RangeTotalDuration: b.Histogram(
+		SpanTotalDuration: b.Histogram(
 			metric.Metadata{
-				Name:        "jobs.row_level_ttl.range_total_duration",
-				Help:        "Duration for processing a range during row level TTL.",
+				Name:        "jobs.row_level_ttl.span_total_duration",
+				Help:        "Duration for processing a span during row level TTL.",
 				Measurement: "nanoseconds",
 				Unit:        metric.Unit_NANOSECONDS,
 				MetricType:  io_prometheus_client.MetricType_HISTOGRAM,
@@ -149,11 +149,11 @@ func makeRowLevelTTLAggMetrics(histogramWindowInterval time.Duration) metric.Str
 				MetricType:  io_prometheus_client.MetricType_COUNTER,
 			},
 		),
-		NumActiveRanges: b.Gauge(
+		NumActiveSpans: b.Gauge(
 			metric.Metadata{
-				Name:        "jobs.row_level_ttl.num_active_ranges",
-				Help:        "Number of active workers attempting to delete for row level TTL.",
-				Measurement: "num_active_workers",
+				Name:        "jobs.row_level_ttl.num_active_spans",
+				Help:        "Number of active spans the TTL job is deleting from.",
+				Measurement: "num_active_spans",
 				Unit:        metric.Unit_COUNT,
 			},
 		),

--- a/pkg/sql/ttl/ttljob/ttljob_processor.go
+++ b/pkg/sql/ttl/ttljob/ttljob_processor.go
@@ -184,7 +184,7 @@ func (t *ttlProcessor) work(ctx context.Context) error {
 					)
 					// add before returning err in case of partial success
 					atomic.AddInt64(&processorRowCount, spanRowCount)
-					metrics.RangeTotalDuration.RecordValue(int64(timeutil.Since(start)))
+					metrics.SpanTotalDuration.RecordValue(int64(timeutil.Since(start)))
 					if err != nil {
 						// Continue until channel is fully read.
 						// Otherwise, the keys input will be blocked.
@@ -262,8 +262,8 @@ func (t *ttlProcessor) runTTLOnSpan(
 	relationName string,
 	deleteRateLimiter *quotapool.RateLimiter,
 ) (spanRowCount int64, err error) {
-	metrics.NumActiveRanges.Inc(1)
-	defer metrics.NumActiveRanges.Dec(1)
+	metrics.NumActiveSpans.Inc(1)
+	defer metrics.NumActiveSpans.Dec(1)
 
 	// TODO(#82140): investigate improving row deletion performance with secondary indexes
 

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -2827,9 +2827,9 @@ var charts = []sectionDescription{
 		Organization: [][]string{{SQLLayer, "SQL", "Row Level TTL"}},
 		Charts: []chartDescription{
 			{
-				Title: "Active Range Deletes",
+				Title: "Active Span Deletes",
 				Metrics: []string{
-					"jobs.row_level_ttl.num_active_ranges",
+					"jobs.row_level_ttl.num_active_spans",
 				},
 				AxisLabel: "Num Running",
 			},
@@ -2852,7 +2852,7 @@ var charts = []sectionDescription{
 			{
 				Title: "Net Processing Latency",
 				Metrics: []string{
-					"jobs.row_level_ttl.range_total_duration",
+					"jobs.row_level_ttl.span_total_duration",
 				},
 				AxisLabel: "Latency (nanoseconds)",
 			},

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/ttl.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/ttl.tsx
@@ -74,15 +74,14 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
     <LineGraph
-      title="Ranges in Progress"
+      title="Spans in Progress"
       sources={nodeSources}
-      tooltip={`Number of active ranges being processed by TTL.`}
+      tooltip={`Number of active spans being processed by TTL.`}
     >
-      <Axis label="range count" units={AxisUnits.Count}>
+      <Axis label="span count" units={AxisUnits.Count}>
         <Metric
-          name="cr.node.jobs.row_level_ttl.num_active_ranges"
-          title="number of ranges being processed"
-          nonNegativeRate
+          name="cr.node.jobs.row_level_ttl.num_active_spans"
+          title="number of spans being processed"
         />
       </Axis>
     </LineGraph>,


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/90094

Release note (ops change): These TTL metrics have been renamed: 
jobs.row_level_ttl.range_total_duration -> jobs.row_level_ttl.span_total_duration
jobs.row_level_ttl.num_active_ranges -> jobs.row_level_ttl.num_active_spans