### PR TITLE
scbuildstmt: fallback for `ADD COLUMN NOT NULL UNIQUE`

### DIFF
--- a/pkg/sql/schemachanger/scbuild/testdata/unimplemented_alter_table
+++ b/pkg/sql/schemachanger/scbuild/testdata/unimplemented_alter_table
@@ -57,6 +57,10 @@ ALTER TABLE defaultdb.foo ADD COLUMN p INT, DROP COLUMN o
 ----
 
 unimplemented
+ALTER TABLE defaultdb.foo ADD COLUMN p INT NOT NULL UNIQUE
+----
+
+unimplemented
 ALTER TABLE defaultdb.foo DROP CONSTRAINT foobar
 ----
 


### PR DESCRIPTION
An issue (#90174) was recently discovered when we have concurrent `add column not null unique` and inserts. This PR fall backs to the old schema changer for `add column unique` and `add column not null unique`.

Informs #90174
Release note: None