### PR TITLE
release-22.2: kvserver: reduce log verbosity in lease score

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
@@ -2206,7 +2206,9 @@ func loadBasedLeaseRebalanceScore(
 	underfullScore := underfullLeaseThreshold - remoteStore.Capacity.LeaseCount
 	totalScore := overfullScore + underfullScore
 
-	log.KvDistribution.Infof(ctx,
+	log.KvDistribution.VEventf(
+		ctx,
+		2,
 		"node: %d, sourceWeight: %.2f, remoteWeight: %.2f, remoteLatency: %v, "+
 			"rebalanceThreshold: %.2f, meanLeases: %.2f, sourceLeaseCount: %d, overfullThreshold: %d, "+
 			"remoteLeaseCount: %d, underfullThreshold: %d, totalScore: %d",


### PR DESCRIPTION
Backport 1/1 commits from #89996.

/cc @cockroachdb/release

---

This patch reduces the logging verbosity in the allocator, in order to
avoid flooding distribution logs. Specifically, the lease transfer score
fn is called for every existing replica of a range. This in turn is
called for every range that is processed in the replicate queue, from
maybeTransferLease. As it logged as `VInfo`, it made up the majority of
logging. This patch changes the log verbosity to `VEvent` 2.

resolves: #89898

Release note: None
Release justification: No logic change, reduce logging.
