### PR TITLE
changefeedccl: update row.Fetcher for key_only envelope and UDTs

### DIFF
--- a/pkg/ccl/changefeedccl/cdceval/constraint.go
+++ b/pkg/ccl/changefeedccl/cdceval/constraint.go
@@ -36,6 +36,7 @@ func ConstrainPrimaryIndexSpanByFilter(
 	descr catalog.TableDescriptor,
 	target jobspb.ChangefeedTargetSpecification,
 	includeVirtual bool,
+	keyOnly bool,
 ) (_ []roachpb.Span, updatedSelect string, _ error) {
 	if selectClause == "" {
 		return nil, "", errors.AssertionFailedf("unexpected empty filter")
@@ -46,7 +47,7 @@ func ConstrainPrimaryIndexSpanByFilter(
 			"could not parse changefeed expression")
 	}
 
-	ed, err := newEventDescriptorForTarget(descr, target, schemaTS(execCtx), includeVirtual)
+	ed, err := newEventDescriptorForTarget(descr, target, schemaTS(execCtx), includeVirtual, keyOnly)
 	if err != nil {
 		return nil, "", err
 	}

--- a/pkg/ccl/changefeedccl/cdceval/expr_eval_test.go
+++ b/pkg/ccl/changefeedccl/cdceval/expr_eval_test.go
@@ -417,7 +417,7 @@ CREATE TABLE foo (
 
 			serverCfg := s.DistSQLServer().(*distsql.ServerImpl).ServerConfig
 			ctx := context.Background()
-			decoder, err := cdcevent.NewEventDecoder(ctx, &serverCfg, targets, false)
+			decoder, err := cdcevent.NewEventDecoder(ctx, &serverCfg, targets, false, false)
 			require.NoError(t, err)
 
 			for _, action := range tc.setupActions {
@@ -639,7 +639,7 @@ func decodeRowErr(
 	} else {
 		kv.Value = v.Value
 	}
-	return decoder.DecodeKV(context.Background(), kv, v.Timestamp())
+	return decoder.DecodeKV(context.Background(), kv, v.Timestamp(), false)
 }
 
 func decodeRow(

--- a/pkg/ccl/changefeedccl/cdceval/validation.go
+++ b/pkg/ccl/changefeedccl/cdceval/validation.go
@@ -42,6 +42,7 @@ func NormalizeAndValidateSelectForTarget(
 	target jobspb.ChangefeedTargetSpecification,
 	sc *tree.SelectClause,
 	includeVirtual bool,
+	keyOnly bool,
 	splitColFams bool,
 ) (n NormalizedSelectClause, _ jobspb.ChangefeedTargetSpecification, _ error) {
 	execCtx.SemaCtx()
@@ -93,7 +94,7 @@ func NormalizeAndValidateSelectForTarget(
 		return n, target, err
 	}
 
-	ed, err := newEventDescriptorForTarget(desc, target, schemaTS(execCtx), includeVirtual)
+	ed, err := newEventDescriptorForTarget(desc, target, schemaTS(execCtx), includeVirtual, keyOnly)
 	if err != nil {
 		return n, target, err
 	}
@@ -187,12 +188,13 @@ func newEventDescriptorForTarget(
 	target jobspb.ChangefeedTargetSpecification,
 	schemaTS hlc.Timestamp,
 	includeVirtual bool,
+	keyOnly bool,
 ) (*cdcevent.EventDescriptor, error) {
 	family, err := getTargetFamilyDescriptor(desc, target)
 	if err != nil {
 		return nil, err
 	}
-	return cdcevent.NewEventDescriptor(desc, family, includeVirtual, schemaTS)
+	return cdcevent.NewEventDescriptor(desc, family, includeVirtual, keyOnly, schemaTS)
 }
 
 func getTargetFamilyDescriptor(

--- a/pkg/ccl/changefeedccl/cdceval/validation_test.go
+++ b/pkg/ccl/changefeedccl/cdceval/validation_test.go
@@ -243,7 +243,7 @@ func TestNormalizeAndValidate(t *testing.T) {
 				StatementTimeName: tc.desc.GetName(),
 			}
 
-			_, _, err = NormalizeAndValidateSelectForTarget(ctx, execCtx, tc.desc, target, sc, false, tc.splitColFams)
+			_, _, err = NormalizeAndValidateSelectForTarget(ctx, execCtx, tc.desc, target, sc, false, false, tc.splitColFams)
 			if tc.expectErr != "" {
 				require.Regexp(t, tc.expectErr, err)
 				return
@@ -347,7 +347,7 @@ func TestSelectClauseRequiresPrev(t *testing.T) {
 				TableID:           tc.desc.GetID(),
 				StatementTimeName: tc.desc.GetName(),
 			}
-			normalized, _, err := NormalizeAndValidateSelectForTarget(ctx, execCtx, tc.desc, target, sc, false, false)
+			normalized, _, err := NormalizeAndValidateSelectForTarget(ctx, execCtx, tc.desc, target, sc, false, false, false)
 			require.NoError(t, err)
 			actual, err := SelectClauseRequiresPrev(context.Background(), *execCtx.SemaCtx(), normalized)
 			require.NoError(t, err)

--- a/pkg/ccl/changefeedccl/cdcevent/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/cdcevent/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
         "event_test.go",
         "main_test.go",
         "projection_test.go",
+        "rowfetcher_test.go",
     ],
     args = ["-test.timeout=295s"],
     embed = [":cdcevent"],
@@ -64,6 +65,7 @@ go_test(
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/lease",
         "//pkg/sql/distsql",
         "//pkg/sql/rowenc",
         "//pkg/sql/sem/eval",
@@ -76,6 +78,7 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/randutil",
+        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/ccl/changefeedccl/cdcevent/event.go
+++ b/pkg/ccl/changefeedccl/cdcevent/event.go
@@ -49,7 +49,7 @@ type Metadata struct {
 // Decoder is an interface for decoding KVs into cdc event row.
 type Decoder interface {
 	// DecodeKV decodes specified key value to Row.
-	DecodeKV(ctx context.Context, kv roachpb.KeyValue, schemaTS hlc.Timestamp) (Row, error)
+	DecodeKV(ctx context.Context, kv roachpb.KeyValue, schemaTS hlc.Timestamp, keyOnly bool) (Row, error)
 }
 
 // Row holds a row corresponding to an event.
@@ -209,6 +209,7 @@ func NewEventDescriptor(
 	desc catalog.TableDescriptor,
 	family *descpb.ColumnFamilyDescriptor,
 	includeVirtualColumns bool,
+	keyOnly bool,
 	schemaTS hlc.Timestamp,
 ) (*EventDescriptor, error) {
 	sd := EventDescriptor{
@@ -270,20 +271,28 @@ func NewEventDescriptor(
 		isInFamily := inFamily.Contains(col.GetID())
 		virtual := col.IsVirtual() && includeVirtualColumns
 		pKeyOrd, isPKey := primaryKeyOrdinal.Get(col.GetID())
-		if isInFamily || isPKey {
-			colIdx := addColumn(col, ord)
-			if isInFamily {
-				sd.valueCols = append(sd.valueCols, colIdx)
-			}
-
+		if keyOnly {
 			if isPKey {
+				colIdx := addColumn(col, ord)
+				sd.valueCols = append(sd.valueCols, colIdx)
 				sd.keyCols[pKeyOrd] = colIdx
+				ord++
 			}
-			ord++
-		} else if virtual {
-			colIdx := addColumn(col, virtualColOrd)
-			sd.valueCols = append(sd.valueCols, colIdx)
-			ord++
+		} else {
+			if isInFamily || isPKey {
+				colIdx := addColumn(col, ord)
+				ord++
+				if isInFamily {
+					sd.valueCols = append(sd.valueCols, colIdx)
+				}
+				if isPKey {
+					sd.keyCols[pKeyOrd] = colIdx
+				}
+			} else if virtual {
+				colIdx := addColumn(col, virtualColOrd)
+				sd.valueCols = append(sd.valueCols, colIdx)
+				ord++
+			}
 		}
 	}
 
@@ -366,6 +375,7 @@ func getEventDescriptorCached(
 	desc catalog.TableDescriptor,
 	family *descpb.ColumnFamilyDescriptor,
 	includeVirtual bool,
+	keyOnly bool,
 	schemaTS hlc.Timestamp,
 	cache *cache.UnorderedCache,
 ) (*EventDescriptor, error) {
@@ -378,7 +388,7 @@ func getEventDescriptorCached(
 		}
 	}
 
-	ed, err := NewEventDescriptor(desc, family, includeVirtual, schemaTS)
+	ed, err := NewEventDescriptor(desc, family, includeVirtual, keyOnly, schemaTS)
 	if err != nil {
 		return nil, err
 	}
@@ -392,6 +402,7 @@ func NewEventDecoder(
 	cfg *execinfra.ServerConfig,
 	targets changefeedbase.Targets,
 	includeVirtual bool,
+	keyOnly bool,
 ) (Decoder, error) {
 	rfCache, err := newRowFetcherCache(
 		ctx,
@@ -411,7 +422,7 @@ func NewEventDecoder(
 		family *descpb.ColumnFamilyDescriptor,
 		schemaTS hlc.Timestamp,
 	) (*EventDescriptor, error) {
-		return getEventDescriptorCached(desc, family, includeVirtual, schemaTS, eventDescriptorCache)
+		return getEventDescriptorCached(desc, family, includeVirtual, keyOnly, schemaTS, eventDescriptorCache)
 	}
 
 	return &eventDecoder{
@@ -422,9 +433,9 @@ func NewEventDecoder(
 
 // DecodeKV decodes key value at specified schema timestamp.
 func (d *eventDecoder) DecodeKV(
-	ctx context.Context, kv roachpb.KeyValue, schemaTS hlc.Timestamp,
+	ctx context.Context, kv roachpb.KeyValue, schemaTS hlc.Timestamp, keyOnly bool,
 ) (Row, error) {
-	if err := d.initForKey(ctx, kv.Key, schemaTS); err != nil {
+	if err := d.initForKey(ctx, kv.Key, schemaTS, keyOnly); err != nil {
 		return Row{}, err
 	}
 
@@ -455,14 +466,14 @@ func (d *eventDecoder) DecodeKV(
 // initForKey initializes decoder state to prepare it to decode
 // key/value at specified timestamp.
 func (d *eventDecoder) initForKey(
-	ctx context.Context, key roachpb.Key, schemaTS hlc.Timestamp,
+	ctx context.Context, key roachpb.Key, schemaTS hlc.Timestamp, keyOnly bool,
 ) error {
 	desc, familyID, err := d.rfCache.tableDescForKey(ctx, key, schemaTS)
 	if err != nil {
 		return err
 	}
 
-	fetcher, family, err := d.rfCache.RowFetcherForColumnFamily(desc, familyID)
+	fetcher, family, err := d.rfCache.RowFetcherForColumnFamily(desc, familyID, keyOnly)
 	if err != nil {
 		return err
 	}
@@ -533,7 +544,7 @@ func TestingMakeEventRow(
 		panic(err) // primary column family always exists.
 	}
 	const includeVirtual = false
-	ed, err := NewEventDescriptor(desc, family, includeVirtual, hlc.Timestamp{})
+	ed, err := NewEventDescriptor(desc, family, includeVirtual, false, hlc.Timestamp{})
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/ccl/changefeedccl/cdcevent/rowfetcher_cache.go
+++ b/pkg/ccl/changefeedccl/cdcevent/rowfetcher_cache.go
@@ -176,7 +176,7 @@ var ErrUnwatchedFamily = errors.New("watched table but unwatched family")
 // RowFetcherForColumnFamily returns row.Fetcher for the specified column family.
 // Returns ErrUnwatchedFamily error if family is not watched.
 func (c *rowFetcherCache) RowFetcherForColumnFamily(
-	tableDesc catalog.TableDescriptor, family descpb.FamilyID,
+	tableDesc catalog.TableDescriptor, family descpb.FamilyID, keyOnly bool,
 ) (*row.Fetcher, *descpb.ColumnFamilyDescriptor, error) {
 	idVer := CacheKey{ID: tableDesc.GetID(), Version: tableDesc.GetVersion(), FamilyID: family}
 	if v, ok := c.fetchers.Get(idVer); ok {
@@ -217,7 +217,12 @@ func (c *rowFetcherCache) RowFetcherForColumnFamily(
 
 	var spec descpb.IndexFetchSpec
 
-	relevantColumns, err := getRelevantColumnsForFamily(tableDesc, familyDesc)
+	var relevantColumns descpb.ColumnIDs
+	if keyOnly {
+		relevantColumns = tableDesc.GetPrimaryIndex().CollectKeyColumnIDs().Ordered()
+	} else {
+		relevantColumns, err = getRelevantColumnsForFamily(tableDesc, familyDesc)
+	}
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/ccl/changefeedccl/cdcevent/rowfetcher_cache.go
+++ b/pkg/ccl/changefeedccl/cdcevent/rowfetcher_cache.go
@@ -189,8 +189,9 @@ func (c *rowFetcherCache) RowFetcherForColumnFamily(
 		// UserDefinedTypeColsHaveSameVersion if we have a hit because we are
 		// guaranteed that the tables have the same version. Additionally, these
 		// fetchers are always initialized with a single tabledesc.Immutable.
-		// TODO (zinger): Only check types used in the relevant family.
-		if catalog.UserDefinedTypeColsHaveSameVersion(tableDesc, f.tableDesc) {
+		if safe, err := catalog.UserDefinedTypeColsInFamilyHaveSameVersion(tableDesc, f.tableDesc, family); err != nil {
+			return nil, nil, err
+		} else if safe {
 			return &f.fetcher, &f.familyDesc, nil
 		}
 	}

--- a/pkg/ccl/changefeedccl/cdcevent/rowfetcher_test.go
+++ b/pkg/ccl/changefeedccl/cdcevent/rowfetcher_test.go
@@ -1,0 +1,107 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package cdcevent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
+	"github.com/cockroachdb/cockroach/pkg/sql/distsql"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRowFetcherCache(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.Background())
+	serverCfg := s.DistSQLServer().(*distsql.ServerImpl).ServerConfig
+	sqlDB := sqlutils.MakeSQLRunner(db)
+
+	sqlDB.Exec(t, `CREATE TYPE status AS ENUM ('open', 'closed', 'inactive')`)
+	sqlDB.Exec(t, `CREATE TYPE priority AS ENUM ('high', 'low')`)
+	sqlDB.Exec(t, `
+		CREATE TABLE foo (
+			a INT PRIMARY KEY, 
+			b status, 
+			c priority,
+			FAMILY only_b (b),
+			FAMILY only_c (c)
+   )`)
+
+	ctx := context.Background()
+
+	tableDesc := cdctest.GetHydratedTableDescriptor(t, s.ExecutorConfig(), "foo")
+	refreshDesc := func() {
+		prevVersion := tableDesc.GetVersion()
+		tableDesc = cdctest.GetHydratedTableDescriptor(t, s.ExecutorConfig(), "foo")
+		// Sanity check that the tableDesc version does not change (which does not happen
+		// after altering UDTs).
+		assert.Equal(t, prevVersion, tableDesc.GetVersion())
+	}
+
+	targetType := jobspb.ChangefeedTargetSpecification_COLUMN_FAMILY
+	family := "only_c"
+	targets := changefeedbase.Targets{}
+	targets.Add(changefeedbase.Target{
+		Type:       targetType,
+		TableID:    tableDesc.GetID(),
+		FamilyName: family,
+	})
+	cFamilyID := descpb.FamilyID(1)
+
+	rfCache, err := newRowFetcherCache(ctx, serverCfg.Codec,
+		serverCfg.LeaseManager.(*lease.Manager),
+		serverCfg.CollectionFactory,
+		serverCfg.DB,
+		targets)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure a cache hit using the same table descriptor, family, and targets.
+	rf, _, err := rfCache.RowFetcherForColumnFamily(tableDesc, cFamilyID, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rf2, _, err := rfCache.RowFetcherForColumnFamily(tableDesc, cFamilyID, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.True(t, rf == rf2)
+
+	// Changing a type in another column family does not cause a cache eviction.
+	sqlDB.Exec(t, `ALTER TYPE status ADD VALUE 'pending'`)
+	refreshDesc()
+	rf3, _, err := rfCache.RowFetcherForColumnFamily(tableDesc, cFamilyID, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.True(t, rf == rf3)
+
+	// Changing a type in the same column family does cause a cache eviction.
+	sqlDB.Exec(t, `ALTER TYPE priority ADD VALUE 'medium'`)
+	refreshDesc()
+	rf4, _, err := rfCache.RowFetcherForColumnFamily(tableDesc, cFamilyID, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.True(t, rf != rf4)
+}

--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -199,8 +199,10 @@ func fetchSpansForTables(
 	}
 	target := details.TargetSpecifications[0]
 	includeVirtual := details.Opts[changefeedbase.OptVirtualColumns] == string(changefeedbase.OptVirtualColumnsNull)
+	keyOnly := details.Opts[changefeedbase.OptEnvelope] == string(changefeedbase.OptEnvelopeKeyOnly)
+
 	return cdceval.ConstrainPrimaryIndexSpanByFilter(
-		ctx, execCtx, details.Select, tableDescs[0], target, includeVirtual)
+		ctx, execCtx, details.Select, tableDescs[0], target, includeVirtual, keyOnly)
 }
 
 var replanChangefeedThreshold = settings.RegisterFloatSetting(

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -414,7 +414,7 @@ func createChangefeedJobRecord(
 	if changefeedStmt.Select != nil {
 		// Serialize changefeed expression.
 		normalized, _, err := validateAndNormalizeChangefeedExpression(
-			ctx, p, changefeedStmt.Select, targetDescs, targets, opts.IncludeVirtual(), opts.IsSet(changefeedbase.OptSplitColumnFamilies),
+			ctx, p, changefeedStmt.Select, targetDescs, targets, opts.IncludeVirtual(), opts.KeyOnly(), opts.IsSet(changefeedbase.OptSplitColumnFamilies),
 		)
 		if err != nil {
 			return nil, err
@@ -877,6 +877,7 @@ func validateAndNormalizeChangefeedExpression(
 	descriptors map[tree.TablePattern]catalog.Descriptor,
 	targets []jobspb.ChangefeedTargetSpecification,
 	includeVirtual bool,
+	keyOnly bool,
 	splitColFams bool,
 ) (n cdceval.NormalizedSelectClause, target jobspb.ChangefeedTargetSpecification, _ error) {
 	if len(descriptors) != 1 || len(targets) != 1 {
@@ -887,7 +888,7 @@ func validateAndNormalizeChangefeedExpression(
 		tableDescr = d.(catalog.TableDescriptor)
 	}
 	return cdceval.NormalizeAndValidateSelectForTarget(
-		ctx, execCtx, tableDescr, targets[0], sc, includeVirtual, splitColFams)
+		ctx, execCtx, tableDescr, targets[0], sc, includeVirtual, keyOnly, splitColFams)
 }
 
 type changefeedResumer struct {

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -6682,7 +6682,7 @@ func normalizeCDCExpression(t *testing.T, execCfgI interface{}, exprStr string) 
 
 	execCtx := p.(sql.JobExecContext)
 	_, _, err = cdceval.NormalizeAndValidateSelectForTarget(
-		context.Background(), execCtx, desc, target, sc, false, false,
+		context.Background(), execCtx, desc, target, sc, false, false, false,
 	)
 	require.NoError(t, err)
 	log.Infof(context.Background(), "PostNorm: %s", tree.StmtDebugString(sc))

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -831,6 +831,11 @@ func (s StatementOptions) IncludeVirtual() bool {
 	return s.m[OptVirtualColumns] == string(OptVirtualColumnsNull)
 }
 
+// KeyOnly returns true if we are using the 'key_only' envelope.
+func (s StatementOptions) KeyOnly() bool {
+	return s.m[OptEnvelope] == string(OptEnvelopeKeyOnly)
+}
+
 // GetMinCheckpointFrequency returns the minimum frequency with which checkpoints should be
 // recorded. Returns nil if not set, and an error if invalid.
 func (s StatementOptions) GetMinCheckpointFrequency() (*time.Duration, error) {

--- a/pkg/sql/catalog/table_elements.go
+++ b/pkg/sql/catalog/table_elements.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 )
@@ -760,6 +761,34 @@ func UserDefinedTypeColsHaveSameVersion(desc TableDescriptor, otherDesc TableDes
 		}
 	}
 	return true
+}
+
+// UserDefinedTypeColsInFamilyHaveSameVersion returns whether one table descriptor's
+// columns with user defined type metadata have the same versions of metadata
+// as in the other descriptor, for all columns in the same family.
+// Note that this function is only valid on two
+// descriptors representing the same table at the same version.
+func UserDefinedTypeColsInFamilyHaveSameVersion(
+	desc TableDescriptor, otherDesc TableDescriptor, familyID descpb.FamilyID,
+) (bool, error) {
+	family, err := desc.FindFamilyByID(familyID)
+	if err != nil {
+		return false, err
+	}
+
+	familyCols := util.FastIntSet{}
+	for _, colID := range family.ColumnIDs {
+		familyCols.Add(int(colID))
+	}
+
+	otherCols := otherDesc.UserDefinedTypeColumns()
+	for i, thisCol := range desc.UserDefinedTypeColumns() {
+		this, other := thisCol.GetType(), otherCols[i].GetType()
+		if familyCols.Contains(int(thisCol.GetID())) && this.TypeMeta.Version != other.TypeMeta.Version {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 // ColumnIDToOrdinalMap returns a map from Column ID to the ordinal


### PR DESCRIPTION
### cdcevent: fetch only key columns when using key_only envelope
Previously, when using the key_only envelope, the row.Fetcher would fetch more
columns than just the key columns. These columns would be ignored during
encoding. This change makes is so that non-key columns are omitted at the
row.Fetcher level.

Release note: None

### cdcevent: do not invalidate cache for fam if UDT in different fam changes

Previously, we would evict an entry from the rowFetcherCache if any UDT was
updated. This PR makes it so that we only evict the entry if a UDT in a target
column family changes.

Release note: None

Fixes: https://github.com/cockroachdb/cockroach/issues/80976
Epic: none