### PR TITLE
release-22.2: execbuilder: enforce_home_region should only apply to DML

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
@@ -63,7 +63,6 @@ CREATE TABLE messages_rbr (
     account_id INT NOT NULL,
     message_id   UUID DEFAULT gen_random_uuid(),
     message    STRING NOT NULL,
-    crdb_region crdb_internal_region NOT NULL,
     PRIMARY KEY (account_id),
     INDEX msg_idx(message)
 )
@@ -175,6 +174,83 @@ CREATE TABLE json_arr2_rbt (
 
 statement ok
 SET enforce_home_region = true
+
+### Regression tests for issue #89875
+
+# Non-DML statements should not error out due to enforce_home_region.
+query T
+SELECT table_name FROM [SHOW CREATE messages_global]
+----
+messages_global
+
+# Non-DML SHOW RANGES statement on RBR table should succeed.
+query I
+SELECT DISTINCT range_id FROM [SHOW RANGES FROM TABLE messages_rbr]
+----
+52
+
+# Update does not fail when accessing all rows in messages_rbr because lookup
+# join does not error out the lookup table in phase 1.
+statement ok
+UPDATE messages_rbt SET account_id = -account_id WHERE account_id NOT IN (SELECT account_id FROM messages_rbr)
+
+# Update should fail accessing all rows in messages_rbr.
+statement error pq: Query has no home region\. Try adding a filter on messages_rbr\.crdb_region and/or on key column \(messages_rbr\.account_id\)\.
+UPDATE messages_rbt SET account_id = -account_id WHERE message_id NOT IN (SELECT message_id FROM messages_rbr)
+
+# Update should fail accessing all rows in messages_rbr.
+statement error pq: Query has no home region\. Try adding a filter on messages_rbr\.crdb_region and/or on key column \(messages_rbr\.account_id\)\.
+UPDATE messages_rbr SET account_id = -account_id WHERE account_id NOT IN (SELECT account_id FROM messages_rbt)
+
+# Delete does not fail when accessing all rows in messages_rbr because lookup
+# join does not error out the lookup table in phase 1.
+statement ok
+DELETE FROM messages_rbt WHERE account_id NOT IN (SELECT account_id FROM messages_rbr)
+
+# Delete should fail accessing all rows in messages_rbr.
+# join does not error out the lookup table in phase 1.
+statement error pq: Query has no home region\. Try adding a filter on messages_rbr\.crdb_region and/or on key column \(messages_rbr\.account_id\)\.
+DELETE FROM messages_rbt WHERE message_id NOT IN (SELECT message_id FROM messages_rbr)
+
+# Delete of potentially all rows in messages_rbr should fail.
+statement error pq: Query has no home region\. Try adding a filter on messages_rbr\.crdb_region and/or on key column \(messages_rbr\.account_id\)\.
+DELETE FROM messages_rbr WHERE account_id NOT IN (SELECT account_id FROM messages_rbt)
+
+# Delete accessing all regions should fail.
+statement error pq: Query has no home region\. Try adding a filter on messages_rbr\.crdb_region and/or on key column \(messages_rbr\.account_id\)\.
+DELETE FROM messages_rbr WHERE message = 'Hello World!'
+
+# Insert should fail accessing all rows in messages_rbr.
+statement error pq: Query has no home region\. Try adding a filter on messages_rbr\.crdb_region and/or on key column \(messages_rbr\.account_id\)\.
+INSERT INTO messages_rbt SELECT * FROM messages_rbr
+
+# Insert into an RBR table should succeed. New rows are placed in the gateway region.
+statement ok
+INSERT INTO messages_rbr SELECT * FROM messages_rbt
+
+# Upsert into an RBR table should succeed.
+statement ok
+UPSERT INTO messages_rbr SELECT * FROM messages_rbt
+
+# Upsert should fail accessing all rows in messages_rbr.
+statement error pq: Query has no home region\. Try adding a LIMIT clause\.
+UPSERT INTO messages_rbt SELECT * FROM messages_rbr
+
+# Upsert into an RBR table uses locality-optimized lookup join and should
+# succeed.
+statement ok
+UPSERT INTO messages_rbr SELECT * FROM messages_rbt
+
+# UNION ALL where one branch scans all rows of an RBR table should fail.
+statement error pq: Query has no home region\. Try adding a LIMIT clause\.
+SELECT * FROM messages_rbr UNION ALL SELECT * FROM messages_rbt
+
+# UNION ALL where one branch scans 1 row of an RBR table should succeed.
+query TTT
+SELECT * FROM (SELECT * FROM messages_rbr LIMIT 1) UNION ALL SELECT * FROM messages_rbt
+----
+
+### End regression tests for issue #89875
 
 # A join relation with no home region as the left input of lookup join should
 # not be allowed.
@@ -302,7 +378,7 @@ SELECT * FROM messages_rbr rbr INNER LOOKUP JOIN messages_global g2 ON rbr.accou
   INNER LOOKUP JOIN messages_global g3 ON g2.account_id = g3.account_id
 
 # Locality optimized lookup join is allowed.
-query TTTTTTT retry
+query TTTTTT retry
 SELECT * FROM messages_rbr rbr, messages_rbt rbt WHERE rbr.account_id = rbt.account_id LIMIT 1
 ----
 
@@ -337,7 +413,7 @@ SELECT message from messages_rbt@messages_rbt_pkey
 ----
 
 # A local join between an RBR and RBT table should be allowed.
-query TTTTTTT retry
+query TTTTTT retry
 SELECT * FROM  messages_rbt rbt INNER LOOKUP JOIN messages_rbr rbr ON rbr.account_id = rbt.account_id
 AND rbr.crdb_region = 'ap-southeast-2'
 ----
@@ -346,17 +422,18 @@ query T retry
 EXPLAIN(OPT) SELECT * FROM  messages_rbt rbt INNER LOOKUP JOIN messages_rbr rbr ON rbr.account_id = rbt.account_id
 AND rbr.crdb_region = 'ap-southeast-2'
 ----
-inner-join (lookup messages_rbr [as=rbr])
- ├── flags: force lookup join (into right side)
- ├── lookup columns are key
- ├── project
- │    ├── scan messages_rbt [as=rbt]
- │    └── projections
- │         └── 'ap-southeast-2'
- └── filters (true)
+project
+ └── inner-join (lookup messages_rbr [as=rbr])
+      ├── flags: force lookup join (into right side)
+      ├── lookup columns are key
+      ├── project
+      │    ├── scan messages_rbt [as=rbt]
+      │    └── projections
+      │         └── 'ap-southeast-2'
+      └── filters (true)
 
 # A local join between an RBR and RBT table should be allowed.
-query TTTTTTT retry
+query TTTTTT retry
 SELECT * FROM messages_rbr rbr INNER LOOKUP JOIN messages_rbt rbt ON rbr.account_id = rbt.account_id
 AND rbr.crdb_region = 'ap-southeast-2'
 ----
@@ -365,12 +442,13 @@ query T retry
 EXPLAIN(OPT) SELECT * FROM messages_rbr rbr INNER LOOKUP JOIN messages_rbt rbt ON rbr.account_id = rbt.account_id
 AND rbr.crdb_region = 'ap-southeast-2'
 ----
-inner-join (lookup messages_rbt [as=rbt])
- ├── flags: force lookup join (into right side)
- ├── lookup columns are key
- ├── scan messages_rbr [as=rbr]
- │    └── constraint: /4/1: [/'ap-southeast-2' - /'ap-southeast-2']
- └── filters (true)
+project
+ └── inner-join (lookup messages_rbt [as=rbt])
+      ├── flags: force lookup join (into right side)
+      ├── lookup columns are key
+      ├── scan messages_rbr [as=rbr]
+      │    └── constraint: /4/1: [/'ap-southeast-2' - /'ap-southeast-2']
+      └── filters (true)
 
 # A lookup join between with a global table as either input should be allowed.
 query TTTTTT retry
@@ -420,7 +498,7 @@ SELECT * FROM messages_rbr_alt rbr INNER LOOKUP JOIN messages_global g2 ON rbr.a
 
 # A lookup join relation with a left input join relation which uses locality
 # optimized scan in one of the tables of the lookup join should be allowed.
-query TTTTTTTTTT retry
+query TTTTTTTTT retry
 SELECT * FROM (SELECT * FROM messages_rbr LIMIT 1) rbr INNER LOOKUP JOIN
   messages_global g2 ON rbr.account_id = g2.account_id
   INNER LOOKUP JOIN messages_global g3 ON g2.account_id = g3.account_id

--- a/pkg/sql/constraint.go
+++ b/pkg/sql/constraint.go
@@ -155,7 +155,7 @@ func (p *planner) ConstrainPrimaryIndexSpanByExpr(
 		remainingFilter = tree.DBoolTrue
 	} else {
 		eb := execbuilder.New(newExecFactory(p), &p.optPlanningCtx.optimizer,
-			nf.Memo(), &oc, &remaining, evalCtx, false)
+			nf.Memo(), &oc, &remaining, evalCtx, false, p.IsANSIDML())
 		eb.SetBuiltinFuncWrapper(semaCtx.FunctionResolver)
 		expr, err := eb.BuildScalar()
 		if err != nil {

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -452,6 +452,11 @@ func (ep *DummyEvalPlanner) GetMultiregionConfig(databaseID descpb.ID) (interfac
 	return nil /* regionConfig */, false
 }
 
+// IsANSIDML is part of the eval.Planner interface.
+func (ep *DummyEvalPlanner) IsANSIDML() bool {
+	return false
+}
+
 // DummyPrivilegedAccessor implements the tree.PrivilegedAccessor interface by returning errors.
 type DummyPrivilegedAccessor struct{}
 

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -712,6 +712,7 @@ func (h *harness) runSimple(tb testing.TB, query benchQuery, phase Phase) {
 		root,
 		&h.evalCtx,
 		true, /* allowAutoCommit */
+		stmt.IsANSIDML(),
 	)
 	if _, err = eb.Build(); err != nil {
 		tb.Fatalf("%v", err)
@@ -764,7 +765,8 @@ func (h *harness) runPrepared(tb testing.TB, phase Phase) {
 		nil, /* catalog */
 		root,
 		&h.evalCtx,
-		true, /* allowAutoCommit */
+		true,  /* allowAutoCommit */
+		false, /* isANSIDML */
 	)
 	if _, err := eb.Build(); err != nil {
 		tb.Fatalf("%v", err)

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -179,6 +179,11 @@ type Builder struct {
 	// doScanExprCollection, when true, causes buildScan to add any ScanExprs it
 	// processes to the builtScans slice.
 	doScanExprCollection bool
+
+	// IsANSIDML is true if the AST the execbuilder is working on is one of the
+	// 4 DML statements, SELECT, UPDATE, INSERT, DELETE, or an EXPLAIN of one of
+	// these statements.
+	IsANSIDML bool
 }
 
 // New constructs an instance of the execution node builder using the
@@ -199,6 +204,7 @@ func New(
 	e opt.Expr,
 	evalCtx *eval.Context,
 	allowAutoCommit bool,
+	isANSIDML bool,
 ) *Builder {
 	b := &Builder{
 		factory:                factory,
@@ -209,6 +215,7 @@ func New(
 		evalCtx:                evalCtx,
 		allowAutoCommit:        allowAutoCommit,
 		initialAllowAutoCommit: allowAutoCommit,
+		IsANSIDML:              isANSIDML,
 	}
 	if evalCtx != nil {
 		sd := evalCtx.SessionData()

--- a/pkg/sql/opt/exec/execbuilder/cascades.go
+++ b/pkg/sql/opt/exec/execbuilder/cascades.go
@@ -293,7 +293,8 @@ func (cb *cascadeBuilder) planCascade(
 	}
 
 	// 5. Execbuild the optimized expression.
-	eb := New(execFactory, &o, factory.Memo(), cb.b.catalog, optimizedExpr, evalCtx, allowAutoCommit)
+	eb := New(execFactory, &o, factory.Memo(), cb.b.catalog, optimizedExpr, evalCtx, allowAutoCommit,
+		evalCtx.Planner.IsANSIDML())
 	if bufferRef != nil {
 		// Set up the With binding.
 		eb.addBuiltWithExpr(cascadeInputWithID, bufferColMap, bufferRef)

--- a/pkg/sql/opt/exec/execbuilder/format.go
+++ b/pkg/sql/opt/exec/execbuilder/format.go
@@ -48,6 +48,7 @@ func fmtInterceptor(f *memo.ExprFmtCtx, scalar opt.ScalarExpr) string {
 		scalar,
 		nil,   /* evalCtx */
 		false, /* allowAutoCommit */
+		false, /* isANSIDML */
 	)
 	expr, err := bld.BuildScalar()
 	if err != nil {

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -721,7 +721,7 @@ func (b *Builder) buildUDF(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Typ
 		// TODO(mgartner): Add support for WITH expressions inside UDF bodies.
 		// TODO(mgartner): Add support for subqueries inside UDF bodies.
 		ef := ref.(exec.Factory)
-		eb := New(ef, &o, f.Memo(), b.catalog, newRightSide, b.evalCtx, false /* allowAutoCommit */)
+		eb := New(ef, &o, f.Memo(), b.catalog, newRightSide, b.evalCtx, false /* allowAutoCommit */, b.IsANSIDML)
 		eb.disableTelemetry = true
 		plan, err := eb.Build()
 		if err != nil {

--- a/pkg/sql/opt/exec/execbuilder/statement.go
+++ b/pkg/sql/opt/exec/execbuilder/statement.go
@@ -152,6 +152,7 @@ func (b *Builder) buildExplain(explainExpr *memo.ExplainExpr) (execPlan, error) 
 
 			explainBld := New(
 				ef, b.optimizer, b.mem, b.catalog, explainExpr.Input, b.evalCtx, b.initialAllowAutoCommit,
+				b.IsANSIDML,
 			)
 			explainBld.disableTelemetry = true
 			plan, err := explainBld.Build()

--- a/pkg/sql/opt/idxconstraint/index_constraints_test.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints_test.go
@@ -138,6 +138,7 @@ func TestIndexConstraints(t *testing.T) {
 					execBld := execbuilder.New(
 						nil /* execFactory */, nil /* optimizer */, f.Memo(), nil, /* catalog */
 						&remainingFilter, &evalCtx, false, /* allowAutoCommit */
+						false, /* isANSIDML */
 					)
 					expr, err := execBld.BuildScalar()
 					if err != nil {

--- a/pkg/sql/opt/lookupjoin/constraint_builder_test.go
+++ b/pkg/sql/opt/lookupjoin/constraint_builder_test.go
@@ -320,6 +320,7 @@ func formatScalar(e opt.Expr, f *norm.Factory, evalCtx *eval.Context) string {
 	execBld := execbuilder.New(
 		nil /* execFactory */, nil /* optimizer */, f.Memo(), nil, /* catalog */
 		e, evalCtx, false, /* allowAutoCommit */
+		false, /* isANSIDML */
 	)
 	expr, err := execBld.BuildScalar()
 	if err != nil {

--- a/pkg/sql/opt/metadata_test.go
+++ b/pkg/sql/opt/metadata_test.go
@@ -455,3 +455,8 @@ func (f *fakeGetMultiregionConfigPlanner) GetMultiregionConfig(
 	f.getMultiregionConfigCalled++
 	return nil, false
 }
+
+// IsANSIDML is part of the eval.Planner interface.
+func (f *fakeGetMultiregionConfigPlanner) IsANSIDML() bool {
+	return false
+}

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -541,7 +541,7 @@ func (b *Builder) buildScan(
 
 	// Scanning tables in databases that don't use the SURVIVE ZONE FAILURE option
 	// is disallowed when EnforceHomeRegion is true.
-	if b.evalCtx.SessionData().EnforceHomeRegion {
+	if b.evalCtx.SessionData().EnforceHomeRegion && parser.IsANSIDML(b.stmt) {
 		errorOnInvalidMultiregionDB(b.evalCtx, tabMeta)
 	}
 

--- a/pkg/sql/opt/partialidx/implicator_test.go
+++ b/pkg/sql/opt/partialidx/implicator_test.go
@@ -115,6 +115,7 @@ func TestImplicator(t *testing.T) {
 				execBld := execbuilder.New(
 					nil /* factory */, nil /* optimizer */, f.Memo(), nil, /* catalog */
 					&remainingFilters, &evalCtx, false, /* allowAutoCommit */
+					false, /* isANSIDML */
 				)
 				expr, err := execBld.BuildScalar()
 				if err != nil {

--- a/pkg/sql/opt/props/physical/distribution.go
+++ b/pkg/sql/opt/props/physical/distribution.go
@@ -184,7 +184,7 @@ func (d *Distribution) FromIndexScan(
 			// If the above methods failed to find a distribution, then the
 			// distribution is all regions in the database.
 			regionsNames, ok := tabMeta.GetRegionsInDatabase(evalCtx.Planner)
-			if !ok && evalCtx.SessionData().EnforceHomeRegion {
+			if !ok && evalCtx.SessionData().EnforceHomeRegion && evalCtx.Planner.IsANSIDML() {
 				err := pgerror.New(pgcode.QueryHasNoHomeRegion,
 					"Query has no home region. Try accessing only tables defined in multi-region databases.")
 				panic(err)

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -2287,6 +2287,8 @@ func (ot *OptTester) ExecBuild(f exec.Factory, mem *memo.Memo, expr opt.Expr) (e
 		db := kv.NewDB(log.MakeTestingAmbientCtxWithNewTracer(), factory, clock, stopper)
 		ot.evalCtx.Txn = kv.NewTxn(context.Background(), db, 1)
 	}
-	bld := execbuilder.New(f, ot.makeOptimizer(), mem, ot.catalog, expr, &ot.evalCtx, true)
+	bld := execbuilder.New(f, ot.makeOptimizer(), mem, ot.catalog, expr, &ot.evalCtx, true,
+		false, /* isANSIDML */
+	)
 	return bld.Build()
 }

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -671,7 +671,7 @@ func (c *coster) computeDistributeCost(
 		// If the distribution will be elided, the cost is zero.
 		return memo.Cost(0)
 	}
-	if c.evalCtx != nil && c.evalCtx.SessionData().EnforceHomeRegion {
+	if c.evalCtx != nil && c.evalCtx.SessionData().EnforceHomeRegion && c.evalCtx.Planner.IsANSIDML() {
 		return LargeDistributeCost
 	}
 
@@ -940,7 +940,7 @@ func (c *coster) computeLookupJoinCost(
 		join.Flags,
 		join.LocalityOptimized,
 	)
-	if c.evalCtx != nil && c.evalCtx.SessionData().EnforceHomeRegion {
+	if c.evalCtx != nil && c.evalCtx.SessionData().EnforceHomeRegion && c.evalCtx.Planner.IsANSIDML() {
 		provided := distribution.BuildLookupJoinLookupTableDistribution(c.evalCtx, join)
 		if provided.Any() || len(provided.Regions) != 1 {
 			cost += LargeDistributeCost
@@ -1106,7 +1106,7 @@ func (c *coster) computeInvertedJoinCost(
 
 	cost += memo.Cost(rowsProcessed) * perRowCost
 
-	if c.evalCtx != nil && c.evalCtx.SessionData().EnforceHomeRegion {
+	if c.evalCtx != nil && c.evalCtx.SessionData().EnforceHomeRegion && c.evalCtx.Planner.IsANSIDML() {
 		provided := distribution.BuildInvertedJoinLookupTableDistribution(c.evalCtx, join)
 		if provided.Any() || len(provided.Regions) != 1 {
 			cost += LargeDistributeCost

--- a/pkg/sql/parser/parse.go
+++ b/pkg/sql/parser/parse.go
@@ -63,6 +63,24 @@ type Statement struct {
 	NumAnnotations tree.AnnotationIdx
 }
 
+// IsANSIDML returns true if the AST is one of the 4 DML statements,
+// SELECT, UPDATE, INSERT, DELETE, or an EXPLAIN of one of these statements.
+func (stmt Statement) IsANSIDML() bool {
+	return IsANSIDML(stmt.AST)
+}
+
+// IsANSIDML returns true if the AST is one of the 4 DML statements,
+// SELECT, UPDATE, INSERT, DELETE, or an EXPLAIN of one of these statements.
+func IsANSIDML(stmt tree.Statement) bool {
+	switch t := stmt.(type) {
+	case *tree.Select, *tree.ParenSelect, *tree.Delete, *tree.Insert, *tree.Update:
+		return true
+	case *tree.Explain:
+		return IsANSIDML(t.Statement)
+	}
+	return false
+}
+
 // Statements is a list of parsed statements.
 type Statements []Statement
 

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -619,7 +619,7 @@ func (opc *optPlanningCtx) runExecBuilder(
 		f = gf
 	}
 	if !planTop.instrumentation.ShouldBuildExplainPlan() {
-		bld := execbuilder.New(f, &opc.optimizer, mem, &opc.catalog, mem.RootExpr(), evalCtx, allowAutoCommit)
+		bld := execbuilder.New(f, &opc.optimizer, mem, &opc.catalog, mem.RootExpr(), evalCtx, allowAutoCommit, stmt.IsANSIDML())
 		plan, err := bld.Build()
 		if err != nil {
 			return err
@@ -641,6 +641,7 @@ func (opc *optPlanningCtx) runExecBuilder(
 		explainFactory := explain.NewFactory(f)
 		bld := execbuilder.New(
 			explainFactory, &opc.optimizer, mem, &opc.catalog, mem.RootExpr(), evalCtx, allowAutoCommit,
+			stmt.IsANSIDML(),
 		)
 		plan, err := bld.Build()
 		if err != nil {

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -2311,3 +2311,8 @@ func (p *planner) GetMultiregionConfig(databaseID descpb.ID) (interface{}, bool)
 	}
 	return &regionConfig, true
 }
+
+// IsANSIDML is part of the eval.Planner interface.
+func (p *planner) IsANSIDML() bool {
+	return p.stmt.IsANSIDML()
+}

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -358,6 +358,11 @@ type Planner interface {
 	// second return value is false if the database doesn't exist or is not
 	// multiregion.
 	GetMultiregionConfig(databaseID descpb.ID) (interface{}, bool)
+
+	// IsANSIDML returns true if the statement being planned is one of the 4 DML
+	// statements, SELECT, UPDATE, INSERT, DELETE, or an EXPLAIN of one of these
+	// statements.
+	IsANSIDML() bool
 }
 
 // InternalRows is an iterator interface that's exposed by the internal

--- a/pkg/sql/sem/eval/eval_test.go
+++ b/pkg/sql/sem/eval/eval_test.go
@@ -106,6 +106,7 @@ func optBuildScalar(evalCtx *eval.Context, e tree.Expr) (tree.TypedExpr, error) 
 	bld := execbuilder.New(
 		nil /* factory */, &o, o.Memo(), nil /* catalog */, o.Memo().RootExpr(),
 		evalCtx, false, /* allowAutoCommit */
+		false, /* isANSIDML */
 	)
 	expr, err := bld.BuildScalar()
 	if err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #90007.

/cc @cockroachdb/release

---

Fixes #89875
Fixes #88789

This fixes a problem where the enforce_home_region session flag might
cause non-DML statements to error out, such as SHOW CREATE, if those
statements utilize scans or joins of multiregion tables.

This also fixes issues with proper erroring out of mutation DML like
UPDATE AND DELETE. For example, the following previously did not error:
```
CREATE TABLE messages_rbr (
    account_id INT NOT NULL,
    message_id   UUID DEFAULT gen_random_uuid(),
    message    STRING NOT NULL,
    PRIMARY KEY (account_id),
    INDEX msg_idx(message)
)
LOCALITY REGIONAL BY ROW;

SET enforce_home_region = true;

DELETE FROM messages_rbr WHERE message = 'Hello World!'
ERROR: Query has no home region. Try adding a filter on messages_rbr.crdb_region and/or on key column (messages_rbr.account_id).
SQLSTATE: XCHR2
```

Release note (bug fix): This patch fixes an issue with the
enforce_home_region session setting which may cause SHOW CREATE TABLE or
other non-DML statements to error out if the optimizer plan for the
statement involves accessing a multiregion table.

Release justification: Low risk bug fix for preview feature