### PR TITLE
server,sqlliveness: rework shutting down SQL pods on sqlliveness problems

### DIFF
--- a/pkg/cli/mt_start_sql.go
+++ b/pkg/cli/mt_start_sql.go
@@ -171,11 +171,7 @@ func runStartSQL(cmd *cobra.Command, args []string) error {
 	// logging to files, periodic memory output, heap and goroutine dumps.
 	// Then use them here.
 
-	var serverStatusMu serverStatus
-	serverStatusMu.started = true
-
-	return waitForShutdown(
-		func() serverShutdownInterface { return tenantServer },
-		stopper, tenantServer.ShutdownRequested(), signalCh,
-		&serverStatusMu)
+	serverStatus := &serverStatus{}
+	serverStatus.setStarted(tenantServer)
+	return waitForShutdown(stopper, tenantServer.ShutdownRequested(), signalCh, serverStatus)
 }

--- a/pkg/cli/mt_start_sql.go
+++ b/pkg/cli/mt_start_sql.go
@@ -172,6 +172,6 @@ func runStartSQL(cmd *cobra.Command, args []string) error {
 	// Then use them here.
 
 	serverStatus := &serverStatus{}
-	serverStatus.setStarted(tenantServer)
+	serverStatus.setStarted(tenantServer, stopper)
 	return waitForShutdown(stopper, tenantServer.ShutdownRequested(), signalCh, serverStatus)
 }

--- a/pkg/cli/mt_start_sql.go
+++ b/pkg/cli/mt_start_sql.go
@@ -171,13 +171,11 @@ func runStartSQL(cmd *cobra.Command, args []string) error {
 	// logging to files, periodic memory output, heap and goroutine dumps.
 	// Then use them here.
 
-	serverStartupErrC := make(chan error, 1)
 	var serverStatusMu serverStatus
 	serverStatusMu.started = true
 
 	return waitForShutdown(
 		func() serverShutdownInterface { return tenantServer },
-		stopper,
-		serverStartupErrC, signalCh,
+		stopper, tenantServer.ShutdownRequested(), signalCh,
 		&serverStatusMu)
 }

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -633,7 +633,7 @@ If problems persist, please see %s.`
 				return errors.Wrap(err, "cockroach server exited with error")
 			}
 			// Server started, notify the shutdown monitor running concurrently.
-			if shutdownInProgress := serverStatusMu.setStarted(s); shutdownInProgress {
+			if shutdownInProgress := serverStatusMu.setStarted(s, stopper); shutdownInProgress {
 				// A shutdown was requested already, e.g. by sending SIGTERM to the process:
 				// maybeWaitForShutdown (which runs concurrently with this goroutine) has
 				// called serverStatusMu.startShutdown() already.
@@ -718,30 +718,39 @@ func newServerStartupError(cause error) error {
 // We need this intermediate coordination because it isn't safe to try
 // to drain a server that doesn't exist or is in the middle of
 // starting up, or to start a server after shutdown has begun.
-//
-// TODO(knz): clarify the transfer of ownership for the stopper.Stop
-// call further, as per suggestion in https://github.com/cockroachdb/cockroach/issues/90233.
 type serverStatus struct {
 	syncutil.Mutex
 	// s is a reference to the server, to be used by the shutdown process. This
 	// starts as nil, and is set by setStarted(). Once set, a graceful shutdown
 	// should use a soft drain.
 	s serverShutdownInterface
+	// stopper is the server's stopper. This is set in setStarted(), together with
+	// `s`. The stopper is handed out to callers of startShutdown(), who will
+	// Stop() it.
+	stopper *stop.Stopper
 	// shutdownRequested indicates that shutdown has started
 	// already. After draining has become true, server startup should
 	// stop.
 	shutdownRequested bool
 }
 
-// setStarted marks the server as started. It returns whether shutdown
-// has been requested already. In that case, we know that the shutdown
-// goroutine did not use the stopper, so the server startup can do
-// that.
-func (s *serverStatus) setStarted(server serverShutdownInterface) bool {
+// setStarted marks the server as started. The serverStatus receives a reference
+// to the server and to the server's stopper. These references will be handed to
+// the shutdown process, which calls startShutdown(). In particular, the
+// shutdown process will take resposibility for calling stopper.Stop().
+//
+// setStarted returns whether shutdown has been requested already. If it has,
+// then the serverStatus does not take ownership of the stopper; the caller is
+// responsible for calling stopper.Stop().
+func (s *serverStatus) setStarted(server serverShutdownInterface, stopper *stop.Stopper) bool {
 	s.Lock()
 	defer s.Unlock()
+	if s.shutdownRequested {
+		return true
+	}
 	s.s = server
-	return s.shutdownRequested
+	s.stopper = stopper
+	return false
 }
 
 // shutdownInProgress returns whether a shutdown has been requested
@@ -754,12 +763,13 @@ func (s *serverStatus) shutdownInProgress() bool {
 
 // startShutdown registers the shutdown request and returns whether the server
 // was started already. If the server started, a reference to the server is also
-// returned.
-func (s *serverStatus) startShutdown() (bool, serverShutdownInterface) {
+// returned, and a reference to the stopper that the caller needs to eventually
+// Stop().
+func (s *serverStatus) startShutdown() (bool, serverShutdownInterface, *stop.Stopper) {
 	s.Lock()
 	defer s.Unlock()
 	s.shutdownRequested = true
-	return s.s != nil, s.s
+	return s.s != nil, s.s, s.stopper
 }
 
 // serverShutdownInterface is the subset of the APIs on a server
@@ -796,7 +806,7 @@ func waitForShutdown(
 		returnErr = err
 		// There's no point in draining if the server didn't even fully start.
 		drain := !errors.HasType(err, &serverStartupError{})
-		startShutdownAsync(stopper, serverStatusMu, stopWithoutDrain, drain)
+		startShutdownAsync(serverStatusMu, stopWithoutDrain, drain)
 		// We do not return here, on purpose, because we want the common
 		// shutdown logic below to apply for this case as well.
 
@@ -838,7 +848,7 @@ func waitForShutdown(
 			}
 		}
 
-		startShutdownAsync(stopper, serverStatusMu, stopWithoutDrain, true /* shouldDrain */)
+		startShutdownAsync(serverStatusMu, stopWithoutDrain, true /* shouldDrain */)
 	// Don't return: we're shutting down gracefully.
 
 	case <-log.FatalChan():
@@ -940,10 +950,7 @@ func waitForShutdown(
 // some time after server startup has completed, and we are thus
 // interested in being graceful to application load.
 func startShutdownAsync(
-	stopper *stop.Stopper,
-	serverStatusMu *serverStatus,
-	stopWithoutDrain chan<- struct{},
-	shouldDrain bool,
+	serverStatusMu *serverStatus, stopWithoutDrain chan<- struct{}, shouldDrain bool,
 ) {
 	// StartAlwaysFlush both flushes and ensures that subsequent log
 	// writes are flushed too.
@@ -956,7 +963,7 @@ func startShutdownAsync(
 		// server has started already, and the graceful shutdown should
 		// call the Drain method. We cannot call Drain if the server has
 		// not started yet.
-		canUseDrain, s := serverStatusMu.startShutdown()
+		canUseDrain, s, stopper := serverStatusMu.startShutdown()
 
 		if !canUseDrain {
 			// The server has not started yet. We can't use the Drain() call.

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -578,7 +578,7 @@ If problems persist, please see %s.`
 	// if we get stuck on something during initialization (#10138).
 	var serverStatusMu serverStatus
 	var s *server.Server
-	shutdownErrC := make(chan error, 1)
+	shutdownReqC := make(chan server.ShutdownRequest, 1)
 	go func() {
 		// Ensure that the log files see the startup messages immediately.
 		defer log.Flush()
@@ -598,13 +598,7 @@ If problems persist, please see %s.`
 		// defined above.
 		defer startupSpan.Finish()
 
-		// Any error beyond this point should be reported through the
-		// shutdownErrC defined above. However, in Go the code pattern "if err
-		// != nil { return err }" is more common. Expecting contributors
-		// to remember to write "if err != nil { shutdownErrC <- err }" beyond
-		// this point is optimistic. To avoid any mistake, we capture all
-		// the error returns in a closure, and do the shutdownErrC reporting,
-		// if needed, when that function returns.
+		// Any error beyond this point is reported through shutdownReqC.
 		if err := func() error {
 			// Instantiate the server.
 			var err error
@@ -674,41 +668,22 @@ If problems persist, please see %s.`
 			return reportServerInfo(ctx, tBegin, &serverCfg, s.ClusterSettings(),
 				true /* isHostNode */, initialStart, uuid.UUID{} /* tenantClusterID */)
 		}(); err != nil {
-			shutdownErrC <- newServerStartupError(err)
+			shutdownReqC <- server.MakeShutdownRequest(
+				server.ShutdownReasonServerStartupError, errors.Wrapf(err, "server startup failed"))
 		} else {
 			// Start a goroutine that watches for shutdown requests and notifies
 			// errChan.
 			go func() {
 				select {
-				case err := <-s.ShutdownRequested():
-					shutdownErrC <- err
+				case req := <-s.ShutdownRequested():
+					shutdownReqC <- req
 				case <-stopper.ShouldQuiesce():
 				}
 			}()
 		}
 	}()
 
-	return waitForShutdown(stopper, shutdownErrC, signalCh, &serverStatusMu)
-}
-
-// serverStartupError wraps errors encoutered during server startup.
-type serverStartupError struct {
-	cause error
-}
-
-var _ errors.Wrapper = &serverStartupError{}
-
-func (e *serverStartupError) Error() string {
-	return fmt.Sprintf("error during server startup: %s", e.Unwrap())
-}
-
-// Unwrap implements the errors.Wrapper interface.
-func (e *serverStartupError) Unwrap() error {
-	return e.cause
-}
-
-func newServerStartupError(cause error) error {
-	return &serverStartupError{cause: cause}
+	return waitForShutdown(stopper, shutdownReqC, signalCh, &serverStatusMu)
 }
 
 // serverStatus coordinates the async goroutine that starts the server
@@ -781,46 +756,30 @@ type serverShutdownInterface interface {
 
 // waitForShutdown blocks until interrupted by a shutdown signal, which can come
 // in several forms:
-// - a call to stopper.Stop(). This is done, by example, by the DrainServer.
-// - a shutdown request coming from an internal module being signaled on shutdownC.
-// - receiving a Unix signal on signalCh.
+//   - a shutdown request coming from an internal module being signaled on
+//     shutdownC. This can be some internal error or a drain RPC.
+//   - receiving a Unix signal on signalCh.
+//   - a log.Fatal() call.
 //
 // Depending on what interruption is received, the server might be drained
 // before shutting down.
 func waitForShutdown(
 	stopper *stop.Stopper,
-	shutdownC <-chan error,
+	shutdownC <-chan server.ShutdownRequest,
 	signalCh chan os.Signal,
 	serverStatusMu *serverStatus,
 ) (returnErr error) {
-	// We'll want to log any shutdown activity against a separate span.
-	// We cannot use s.AnnotateCtx here because the server might not have
-	// been assigned yet (the goroutine above runs asynchronously).
 	shutdownCtx, shutdownSpan := serverCfg.AmbientCtx.AnnotateCtxWithSpan(context.Background(), "server shutdown")
 	defer shutdownSpan.Finish()
 
 	stopWithoutDrain := make(chan struct{}) // closed if interrupted very early
 
 	select {
-	case err := <-shutdownC:
-		returnErr = err
+	case shutdownRequest := <-shutdownC:
+		returnErr = shutdownRequest.ShutdownCause()
 		// There's no point in draining if the server didn't even fully start.
-		drain := !errors.HasType(err, &serverStartupError{})
+		drain := shutdownRequest.Reason != server.ShutdownReasonServerStartupError
 		startShutdownAsync(serverStatusMu, stopWithoutDrain, drain)
-		// We do not return here, on purpose, because we want the common
-		// shutdown logic below to apply for this case as well.
-
-	case <-stopper.ShouldQuiesce():
-		// Receiving a signal on ShouldQuiesce means that a shutdown was requested
-		// via the Drain RPC. The RPC handler called stopper.Stop(), so there's no
-		// need (and it's also too late) for us to call startShutdownAsync().
-
-		// StartAlwaysFlush both flushes and ensures that subsequent log
-		// writes are flushed too.
-		log.StartAlwaysFlush()
-		// We fall through to the common logic below so that an operator
-		// looking at a server running in the foreground on their terminal
-		// can see what is going on.
 
 	case sig := <-signalCh:
 		// We start flushing log writes from here, because if a

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -928,7 +928,7 @@ func startShutdownAsync(
 	getS func() serverShutdownInterface,
 	stopper *stop.Stopper,
 	serverStatusMu *serverStatus,
-	stopWithoutDrain chan struct{},
+	stopWithoutDrain chan<- struct{},
 	shouldDrain bool,
 ) {
 	// StartAlwaysFlush both flushes and ensures that subsequent log

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -207,6 +207,7 @@ go_library(
         "//pkg/sql/sqlinstance",
         "//pkg/sql/sqlinstance/instanceprovider",
         "//pkg/sql/sqlliveness",
+        "//pkg/sql/sqlliveness/slinstance",
         "//pkg/sql/sqlliveness/slprovider",
         "//pkg/sql/sqlstats",
         "//pkg/sql/sqlstats/insights",

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -60,6 +60,7 @@ go_library(
         "status.go",
         "status_local_file_retrieval.go",
         "sticky_engine.go",
+        "stop_trigger.go",
         "tcp_keepalive_manager.go",
         "tenant.go",
         "tenant_admin.go",

--- a/pkg/server/drain.go
+++ b/pkg/server/drain.go
@@ -96,7 +96,9 @@ func (s *adminServer) Drain(req *serverpb.DrainRequest, stream serverpb.Admin_Dr
 }
 
 type drainServer struct {
-	stopper      *stop.Stopper
+	stopper *stop.Stopper
+	// stopTrigger is used to request that the server is shut down.
+	stopTrigger  *stopTrigger
 	grpc         *grpcServer
 	sqlServer    *SQLServer
 	drainSleepFn func(time.Duration)
@@ -109,7 +111,11 @@ type drainServer struct {
 
 // newDrainServer constructs a drainServer suitable for any kind of server.
 func newDrainServer(
-	cfg BaseConfig, stopper *stop.Stopper, grpc *grpcServer, sqlServer *SQLServer,
+	cfg BaseConfig,
+	stopper *stop.Stopper,
+	stopTrigger *stopTrigger,
+	grpc *grpcServer,
+	sqlServer *SQLServer,
 ) *drainServer {
 	var drainSleepFn = time.Sleep
 	if cfg.TestingKnobs.Server != nil {
@@ -119,6 +125,7 @@ func newDrainServer(
 	}
 	return &drainServer{
 		stopper:      stopper,
+		stopTrigger:  stopTrigger,
 		grpc:         grpc,
 		sqlServer:    sqlServer,
 		drainSleepFn: drainSleepFn,
@@ -175,7 +182,7 @@ func (s *drainServer) maybeShutdownAfterDrain(
 		// away (and who knows whether gRPC-goroutines are tied up in some
 		// stopper task somewhere).
 		s.grpc.Stop()
-		s.stopper.Stop(ctx)
+		s.stopTrigger.signalStop(ctx, MakeShutdownRequest(ShutdownReasonDrainRPC, nil /* err */))
 	}()
 
 	select {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -168,6 +168,9 @@ type Server struct {
 }
 
 // NewServer creates a Server from a server.Config.
+//
+// The caller is responsible for listening on the server's ShutdownRequested()
+// channel and calling stopper.Stop().
 func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	if err := cfg.ValidateAddrs(context.Background()); err != nil {
 		return nil, err
@@ -1780,6 +1783,12 @@ func (s *Server) AcceptClients(ctx context.Context) error {
 // RPC.
 func (s *Server) Stop() {
 	s.stopper.Stop(context.Background())
+}
+
+// ShutdownRequested returns a channel that is signaled when a subsystem wants
+// the server to be shut down.
+func (s *Server) ShutdownRequested() <-chan error {
+	return s.sqlServer.ShutdownRequested()
 }
 
 // TempDir returns the filepath of the temporary directory used for temp storage.

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -93,6 +93,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlinstance"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlinstance/instanceprovider"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/slinstance"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/slprovider"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
@@ -135,6 +136,7 @@ import (
 type SQLServer struct {
 	ambientCtx              log.AmbientContext
 	stopper                 *stop.Stopper
+	stopTrigger             *stopTrigger
 	sqlIDContainer          *base.SQLIDContainer
 	pgServer                *pgwire.Server
 	distSQLServer           *distsql.ServerImpl
@@ -235,6 +237,47 @@ type sqlServerOptionalKVArgs struct {
 // are only available if the SQL server runs as part of a standalone SQL node.
 type sqlServerOptionalTenantArgs struct {
 	tenantConnect kvtenant.Connector
+}
+
+// stopTrigger is used by modules to signal the desire to stop the server. When
+// signaled, the stopTrigger notifies listeners on a channel.
+type stopTrigger struct {
+	mu struct {
+		syncutil.Mutex
+		shutdownErr error
+	}
+	c chan error
+}
+
+func newStopTrigger() *stopTrigger {
+	return &stopTrigger{
+		// The channel is buffered so that there's no requirement that anyone ever
+		// calls C() and reads from this channel.
+		c: make(chan error, 1),
+	}
+}
+
+// signalStop is used to signal that the server should shut down. The shutdown
+// is asynchronous.
+func (s *stopTrigger) signalStop(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.mu.shutdownErr != nil {
+		// Someone else already triggered the shutdown.
+		return
+	}
+	s.mu.shutdownErr = err
+	// Writing to s.c is done under the lock, so there can ever only be one value
+	// written and the writer does not block.
+	s.c <- err
+}
+
+// C returns the channel that is signaled by signaledStop().
+//
+// Generally, there should be only one caller to C(); shutdown requests are
+// delivered once, not broadcast.
+func (s *stopTrigger) C() <-chan error {
+	return s.c
 }
 
 type sqlServerArgs struct {
@@ -404,6 +447,21 @@ func newRootSQLMemoryMonitor(opts monitorAndMetricsOptions) monitorAndMetrics {
 	}
 }
 
+// stopperSessionEventListener implements slinstance.SessionEventListener and
+// turns a session deletion event into a request to stop the server.
+type stopperSessionEventListener struct {
+	trigger *stopTrigger
+}
+
+var _ slinstance.SessionEventListener = &stopperSessionEventListener{}
+
+func (s *stopperSessionEventListener) OnSessionDeleted() {
+	s.trigger.signalStop(errors.New("sql liveness session deleted"))
+}
+
+// newSQLServer constructs a new SQLServer. The caller is responsible for
+// listening to the server's ShutdownRequested() channel and stopping
+// cfg.stopper when signaled.
 func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	// NB: ValidateAddrs also fills in defaults.
 	if err := cfg.Config.ValidateAddrs(ctx); err != nil {
@@ -428,15 +486,29 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	tracingService := service.New(cfg.Tracer)
 	tracingservicepb.RegisterTracingServer(cfg.grpcServer, tracingService)
 
-	sqllivenessKnobs, _ := cfg.TestingKnobs.SQLLivenessKnobs.(*sqlliveness.TestingKnobs)
-	cfg.sqlLivenessProvider = slprovider.New(
-		cfg.AmbientCtx,
-		cfg.stopper, cfg.clock, cfg.db, codec, cfg.Settings, sqllivenessKnobs,
-	)
+	stopTrigger := newStopTrigger()
+
 	// If the node id is already populated, we only need to create a placeholder
 	// instance provider without initializing the instance, since this is not a
 	// SQL pod server.
 	_, isNotSQLPod := cfg.nodeIDContainer.OptionalNodeID()
+
+	sqllivenessKnobs, _ := cfg.TestingKnobs.SQLLivenessKnobs.(*sqlliveness.TestingKnobs)
+	var sessionEventsConsumer slinstance.SessionEventListener
+	if !isNotSQLPod {
+		// For SQL pods, we want the process to shutdown when the session liveness
+		// record is found to be deleted. This is because, if the session is
+		// deleted, the instance ID used by this server may have been stolen by
+		// another server, or it may be stolen in the future. This server shouldn't
+		// use the instance ID anymore, and there's no mechanism for allocating a
+		// new one after startup.
+		sessionEventsConsumer = &stopperSessionEventListener{trigger: stopTrigger}
+	}
+	cfg.sqlLivenessProvider = slprovider.New(
+		cfg.AmbientCtx,
+		cfg.stopper, cfg.clock, cfg.db, codec, cfg.Settings, sqllivenessKnobs, sessionEventsConsumer,
+	)
+
 	if isNotSQLPod {
 		cfg.sqlInstanceProvider = sqlinstance.NewFakeSQLProvider()
 	} else {
@@ -1160,6 +1232,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	return &SQLServer{
 		ambientCtx:                        cfg.BaseConfig.AmbientCtx,
 		stopper:                           cfg.stopper,
+		stopTrigger:                       stopTrigger,
 		sqlIDContainer:                    cfg.nodeIDContainer,
 		pgServer:                          pgServer,
 		distSQLServer:                     distSQLServer,
@@ -1614,4 +1687,10 @@ func prepareUnixSocket(
 // for this server.
 func (s *SQLServer) LogicalClusterID() uuid.UUID {
 	return s.execCfg.NodeInfo.LogicalClusterID()
+}
+
+// ShutdownRequested returns a channel that is signaled when a subsystem wants
+// the server to be shut down.
+func (s *SQLServer) ShutdownRequested() <-chan error {
+	return s.stopTrigger.C()
 }

--- a/pkg/server/stop_trigger.go
+++ b/pkg/server/stop_trigger.go
@@ -1,0 +1,111 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package server
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/errors"
+)
+
+// stopTrigger is used by modules to signal the desire to stop the server. When
+// signaled, the stopTrigger notifies listeners on a channel.
+type stopTrigger struct {
+	mu struct {
+		syncutil.Mutex
+		shutdownRequest ShutdownRequest
+	}
+	c chan ShutdownRequest
+}
+
+func newStopTrigger() *stopTrigger {
+	return &stopTrigger{
+		// The channel is buffered so that there's no requirement that anyone ever
+		// calls C() and reads from this channel.
+		c: make(chan ShutdownRequest, 1),
+	}
+}
+
+// signalStop is used to signal that the server should shut down. The shutdown
+// is asynchronous.
+func (s *stopTrigger) signalStop(ctx context.Context, r ShutdownRequest) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.mu.shutdownRequest.Empty() {
+		// Someone else already triggered the shutdown.
+		log.Infof(ctx, "received a second shutdown request: %s", r)
+		return
+	}
+	s.mu.shutdownRequest = r
+	// Writing to s.c is done under the lock, so there can ever only be one value
+	// written and the writer does not block.
+	s.c <- r
+}
+
+// ShutdownRequest is used to signal a request to shutdown the server through
+// stopTrigger. It carries the reason for the shutdown.
+type ShutdownRequest struct {
+	// Reason identifies the cause of the shutdown.
+	Reason ShutdownReason
+	// Err is populated for reason ServerStartupError and FatalError.
+	Err error
+}
+
+// MakeShutdownRequest constructs a ShutdownRequest.
+func MakeShutdownRequest(reason ShutdownReason, err error) ShutdownRequest {
+	if reason == ShutdownReasonDrainRPC && err != nil {
+		panic("unexpected err for ShutdownReasonDrainRPC")
+	}
+	return ShutdownRequest{
+		Reason: reason,
+		Err:    err,
+	}
+}
+
+// ShutdownReason identifies the reason for a ShutdownRequest.
+type ShutdownReason int
+
+const (
+	// ShutdownReasonDrainRPC represents a drain RPC with the shutdown flag set.
+	ShutdownReasonDrainRPC ShutdownReason = iota
+	// ShutdownReasonServerStartupError means that the server startup process
+	// failed.
+	ShutdownReasonServerStartupError
+	// ShutdownReasonFatalError identifies an error that requires the server be
+	// terminated. Compared to a panic or log.Fatal(), the termination can be more
+	// graceful, though.
+	ShutdownReasonFatalError
+)
+
+// ShutdownCause returns the reason for the shutdown request, as an error.
+func (r ShutdownRequest) ShutdownCause() error {
+	switch r.Reason {
+	case ShutdownReasonDrainRPC:
+		return errors.Newf("shutdown requested by drain RPC")
+	default:
+		return r.Err
+	}
+}
+
+// C returns the channel that is signaled by signaledStop().
+//
+// Generally, there should be only one caller to C(); shutdown requests are
+// delivered once, not broadcast.
+func (s *stopTrigger) C() <-chan ShutdownRequest {
+	return s.c
+}
+
+// Empty returns true if the receiver is the zero value.
+func (r ShutdownRequest) Empty() bool {
+	return r == (ShutdownRequest{})
+}

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -271,7 +271,7 @@ func NewTenantServer(
 	)
 
 	// Create a drain server.
-	drainServer := newDrainServer(baseCfg, args.stopper, args.grpc, sqlServer)
+	drainServer := newDrainServer(baseCfg, args.stopper, args.stopTrigger, args.grpc, sqlServer)
 	// Connect the admin server to the drain service.
 	//
 	// TODO(knz): This would not be necessary if we could use the
@@ -696,7 +696,7 @@ func (s *SQLServerWrapper) StartDiagnostics(ctx context.Context) {
 
 // ShutdownRequested returns a channel that is signaled when a subsystem wants
 // the server to be shut down.
-func (s *SQLServerWrapper) ShutdownRequested() <-chan error {
+func (s *SQLServerWrapper) ShutdownRequested() <-chan ShutdownRequest {
 	return s.sqlServer.ShutdownRequested()
 }
 
@@ -892,6 +892,7 @@ func makeTenantSQLServerArgs(
 		SQLConfig:                &sqlCfg,
 		BaseConfig:               &baseCfg,
 		stopper:                  stopper,
+		stopTrigger:              newStopTrigger(),
 		clock:                    clock,
 		runtime:                  runtime,
 		rpcContext:               rpcContext,

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -131,7 +131,11 @@ func (s *SQLServerWrapper) Drain(
 	return s.drainServer.runDrain(ctx, verbose)
 }
 
-// NewTenantServer creates a tenant-specific, SQL-only server against a KV backend.
+// NewTenantServer creates a tenant-specific, SQL-only server against a KV
+// backend.
+//
+// The caller is responsible for listening to the server's ShutdownRequested()
+// channel and stopping cfg.stopper when signaled.
 func NewTenantServer(
 	ctx context.Context, stopper *stop.Stopper, baseCfg BaseConfig, sqlCfg SQLConfig,
 ) (*SQLServerWrapper, error) {
@@ -688,6 +692,12 @@ func (s *SQLServerWrapper) LogicalClusterID() uuid.UUID {
 // Used in cli/mt_start_sql.go.
 func (s *SQLServerWrapper) StartDiagnostics(ctx context.Context) {
 	s.sqlServer.StartDiagnostics(ctx)
+}
+
+// ShutdownRequested returns a channel that is signaled when a subsystem wants
+// the server to be shut down.
+func (s *SQLServerWrapper) ShutdownRequested() <-chan error {
+	return s.sqlServer.ShutdownRequested()
 }
 
 func makeTenantSQLServerArgs(

--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -1815,9 +1815,6 @@ type fakeSession struct{ exp hlc.Timestamp }
 func (f fakeSession) ID() sqlliveness.SessionID { return "foo" }
 func (f fakeSession) Expiration() hlc.Timestamp { return f.exp }
 func (f fakeSession) Start() hlc.Timestamp      { panic("unimplemented") }
-func (f fakeSession) RegisterCallbackForSessionExpiry(func(ctx context.Context)) {
-	panic("unimplemented")
-}
 
 var _ sqlliveness.Session = (*fakeSession)(nil)
 

--- a/pkg/sql/sqlinstance/instanceprovider/BUILD.bazel
+++ b/pkg/sql/sqlinstance/instanceprovider/BUILD.bazel
@@ -38,13 +38,11 @@ go_test(
         "//pkg/sql/sqlliveness",
         "//pkg/sql/sqlliveness/slinstance",
         "//pkg/sql/sqlliveness/slstorage",
-        "//pkg/testutils",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/stop",
         "//pkg/util/timeutil",
-        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/sqlinstance/instanceprovider/instanceprovider_test.go
+++ b/pkg/sql/sqlinstance/instanceprovider/instanceprovider_test.go
@@ -22,13 +22,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/slinstance"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/slstorage"
-	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -40,7 +38,7 @@ func TestInstanceProvider(t *testing.T) {
 
 	ctx := context.Background()
 	setup := func(t *testing.T) (
-		*stop.Stopper, *slinstance.Instance, *slstorage.FakeStorage, *hlc.Clock,
+		*stop.Stopper, *slinstance.Instance, *slstorage.FakeStorage, *channelSessionEventListener, *hlc.Clock,
 	) {
 		timeSource := timeutil.NewTestTimeSource()
 		clock := hlc.NewClock(timeSource, base.DefaultMaxClockOffset)
@@ -54,14 +52,15 @@ func TestInstanceProvider(t *testing.T) {
 
 		stopper := stop.NewStopper()
 		fakeStorage := slstorage.NewFakeStorage()
-		slInstance := slinstance.NewSQLInstance(stopper, clock, fakeStorage, settings, nil)
-		return stopper, slInstance, fakeStorage, clock
+		events := &channelSessionEventListener{c: make(chan struct{})}
+		slInstance := slinstance.NewSQLInstance(stopper, clock, fakeStorage, settings, nil /* testKnobs */, events)
+		return stopper, slInstance, fakeStorage, events, clock
 	}
 
 	t.Run("test-init-shutdown", func(t *testing.T) {
 		const addr = "addr"
 		const expectedInstanceID = base.SQLInstanceID(1)
-		stopper, slInstance, storage, clock := setup(t)
+		stopper, slInstance, storage, events, clock := setup(t)
 		defer stopper.Stop(ctx)
 		instanceProvider := instanceprovider.NewTestInstanceProvider(stopper, slInstance, func() string { return addr })
 		slInstance.Start(ctx)
@@ -87,12 +86,21 @@ func TestInstanceProvider(t *testing.T) {
 		// Delete the session to shutdown the instance.
 		require.NoError(t, storage.Delete(ctx, sessionID))
 
-		// Verify that the SQL instance is shutdown on session expiry.
-		testutils.SucceedsSoon(t, func() error {
-			if _, _, err = instanceProvider.Instance(ctx); !errors.Is(err, instanceprovider.ErrProviderShutDown) {
-				return errors.Errorf("sql instance is not shutdown on session expiry")
-			}
-			return nil
-		})
+		select {
+		case <-events.c:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("session deletion event not signaled")
+		}
 	})
+}
+
+type channelSessionEventListener struct {
+	c chan struct{}
+}
+
+var _ slinstance.SessionEventListener = &channelSessionEventListener{}
+
+// OnSessionDeleted implements the slinstance.SessionEventListener interface.
+func (d *channelSessionEventListener) OnSessionDeleted() {
+	close(d.c)
 }

--- a/pkg/sql/sqlinstance/instanceprovider/instanceprovider_test.go
+++ b/pkg/sql/sqlinstance/instanceprovider/instanceprovider_test.go
@@ -101,6 +101,6 @@ type channelSessionEventListener struct {
 var _ slinstance.SessionEventListener = &channelSessionEventListener{}
 
 // OnSessionDeleted implements the slinstance.SessionEventListener interface.
-func (d *channelSessionEventListener) OnSessionDeleted() {
+func (d *channelSessionEventListener) OnSessionDeleted(context.Context) {
 	close(d.c)
 }

--- a/pkg/sql/sqlinstance/instanceprovider/test_helpers.go
+++ b/pkg/sql/sqlinstance/instanceprovider/test_helpers.go
@@ -24,7 +24,6 @@ import (
 type TestInstanceProvider interface {
 	sqlinstance.Provider
 	InitForTest(context.Context)
-	ShutdownSQLInstanceForTest(context.Context)
 }
 
 // NewTestInstanceProvider initializes a instanceprovider.provider
@@ -43,12 +42,7 @@ func NewTestInstanceProvider(
 	return p
 }
 
-// InitAndWaitForTest explicitly calls initAndWait for testing purposes.
+// InitForTest explicitly calls initAndWait for testing purposes.
 func (p *provider) InitForTest(ctx context.Context) {
 	_ = p.init(ctx)
-}
-
-// ShutdownSQLInstanceForTest explicitly calls shutdownSQLInstance for testing purposes.
-func (p *provider) ShutdownSQLInstanceForTest(ctx context.Context) {
-	p.shutdownSQLInstance(ctx)
 }

--- a/pkg/sql/sqlliveness/slinstance/slinstance.go
+++ b/pkg/sql/sqlliveness/slinstance/slinstance.go
@@ -67,9 +67,6 @@ type session struct {
 	mu struct {
 		syncutil.RWMutex
 		exp hlc.Timestamp
-		// sessionExpiryCallbacks are invoked when the session expires. They're
-		// invoked under the session's lock, so keep them small.
-		sessionExpiryCallbacks []func(ctx context.Context)
 	}
 }
 
@@ -88,27 +85,18 @@ func (s *session) Start() hlc.Timestamp {
 	return s.start
 }
 
-// RegisterCallbackForSessionExpiry adds the given function to the list
-// of functions called after a session expires. The functions are
-// executed in a goroutine.
-func (s *session) RegisterCallbackForSessionExpiry(sExp func(context.Context)) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.mu.sessionExpiryCallbacks = append(s.mu.sessionExpiryCallbacks, sExp)
-}
-
-func (s *session) invokeSessionExpiryCallbacks(ctx context.Context) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	for _, callback := range s.mu.sessionExpiryCallbacks {
-		callback(ctx)
-	}
-}
-
 func (s *session) setExpiration(exp hlc.Timestamp) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.mu.exp = exp
+}
+
+// SessionEventListener is an interface used by the Instance to notify
+// listeners of some state changes.
+type SessionEventListener interface {
+	// OnSessionDeleted is called when the session liveness record is found to be
+	// missing.
+	OnSessionDeleted()
 }
 
 // Instance implements the sqlliveness.Instance interface by storing the
@@ -117,15 +105,17 @@ func (s *session) setExpiration(exp hlc.Timestamp) {
 // to replace a session that has expired and deleted from the table.
 // TODO(rima): Rename Instance to avoid confusion with sqlinstance.SQLInstance.
 type Instance struct {
-	clock     *hlc.Clock
-	settings  *cluster.Settings
-	stopper   *stop.Stopper
-	storage   Writer
-	ttl       func() time.Duration
-	hb        func() time.Duration
-	testKnobs sqlliveness.TestingKnobs
-	startErr  error
-	mu        struct {
+	clock    *hlc.Clock
+	settings *cluster.Settings
+	stopper  *stop.Stopper
+	// sessionEvents gets notified of some session state changes.
+	sessionEvents SessionEventListener
+	storage       Writer
+	ttl           func() time.Duration
+	hb            func() time.Duration
+	testKnobs     sqlliveness.TestingKnobs
+	startErr      error
+	mu            struct {
 		started bool
 		syncutil.Mutex
 		blockCh chan struct{}
@@ -154,9 +144,7 @@ func (l *Instance) clearSession(ctx context.Context) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	if expiration := l.mu.s.Expiration(); expiration.Less(l.clock.Now()) {
-		// If the session has expired, invoke the session expiry callbacks
-		// associated with the session.
-		l.mu.s.invokeSessionExpiryCallbacks(ctx)
+		l.sessionEvents.OnSessionDeleted()
 	}
 	l.mu.s = nil
 	l.mu.blockCh = make(chan struct{})
@@ -206,6 +194,10 @@ func (l *Instance) createSession(ctx context.Context) (*session, error) {
 	return s, nil
 }
 
+// extendSession adds the ttl to the session's expiration.
+//
+// Returns false if the session record is not found, meaning that someone
+// deleted it.
 func (l *Instance) extendSession(ctx context.Context, s *session) (bool, error) {
 	exp := l.clock.Now().Add(l.ttl().Nanoseconds(), 0)
 
@@ -266,6 +258,7 @@ func (l *Instance) heartbeatLoop(ctx context.Context) {
 						// the session failed.
 						close(l.mu.blockCh)
 					}()
+					l.sessionEvents.OnSessionDeleted()
 					return
 				}
 				l.setSession(newSession)
@@ -293,18 +286,26 @@ func (l *Instance) heartbeatLoop(ctx context.Context) {
 
 // NewSQLInstance returns a new Instance struct and starts its heartbeating
 // loop.
+//
+// sessionEvents, if not nil, gets notified of some session state transitions.
 func NewSQLInstance(
 	stopper *stop.Stopper,
 	clock *hlc.Clock,
 	storage Writer,
 	settings *cluster.Settings,
 	testKnobs *sqlliveness.TestingKnobs,
+	sessionEvents SessionEventListener,
 ) *Instance {
+	if sessionEvents == nil {
+		sessionEvents = &dummySessionEventListener{}
+	}
+
 	l := &Instance{
-		clock:    clock,
-		settings: settings,
-		storage:  storage,
-		stopper:  stopper,
+		clock:         clock,
+		settings:      settings,
+		storage:       storage,
+		stopper:       stopper,
+		sessionEvents: sessionEvents,
 		ttl: func() time.Duration {
 			return DefaultTTL.Get(&settings.SV)
 		},
@@ -371,3 +372,10 @@ func (l *Instance) Session(ctx context.Context) (sqlliveness.Session, error) {
 		}
 	}
 }
+
+type dummySessionEventListener struct{}
+
+var _ SessionEventListener = &dummySessionEventListener{}
+
+// OnSessionDeleted implements the slinstance.SessionEventListener interface.
+func (d *dummySessionEventListener) OnSessionDeleted() {}

--- a/pkg/sql/sqlliveness/slinstance/slinstance_test.go
+++ b/pkg/sql/sqlliveness/slinstance/slinstance_test.go
@@ -44,11 +44,11 @@ func TestSQLInstance(t *testing.T) {
 	slinstance.DefaultHeartBeat.Override(ctx, &settings.SV, 10*time.Millisecond)
 
 	fakeStorage := slstorage.NewFakeStorage()
-	sqlInstance := slinstance.NewSQLInstance(stopper, clock, fakeStorage, settings, nil)
+	sqlInstance := slinstance.NewSQLInstance(stopper, clock, fakeStorage, settings, nil, nil)
 	sqlInstance.Start(ctx)
 
 	// Add one more instance to introduce concurrent access to storage.
-	dummy := slinstance.NewSQLInstance(stopper, clock, fakeStorage, settings, nil)
+	dummy := slinstance.NewSQLInstance(stopper, clock, fakeStorage, settings, nil, nil)
 	dummy.Start(ctx)
 
 	s1, err := sqlInstance.Session(ctx)

--- a/pkg/sql/sqlliveness/slprovider/slprovider.go
+++ b/pkg/sql/sqlliveness/slprovider/slprovider.go
@@ -28,6 +28,8 @@ import (
 )
 
 // New constructs a new Provider.
+//
+// sessionEvents, if not nil, gets notified of some session state transitions.
 func New(
 	ambientCtx log.AmbientContext,
 	stopper *stop.Stopper,
@@ -36,9 +38,10 @@ func New(
 	codec keys.SQLCodec,
 	settings *cluster.Settings,
 	testingKnobs *sqlliveness.TestingKnobs,
+	sessionEvents slinstance.SessionEventListener,
 ) sqlliveness.Provider {
 	storage := slstorage.NewStorage(ambientCtx, stopper, clock, db, codec, settings)
-	instance := slinstance.NewSQLInstance(stopper, clock, storage, settings, testingKnobs)
+	instance := slinstance.NewSQLInstance(stopper, clock, storage, settings, testingKnobs, sessionEvents)
 	return &provider{
 		Storage:  storage,
 		Instance: instance,

--- a/pkg/sql/sqlliveness/sqlliveness.go
+++ b/pkg/sql/sqlliveness/sqlliveness.go
@@ -88,9 +88,6 @@ type Session interface {
 	// this time will be assured that any resources claimed under this session
 	// are known to be valid.
 	Expiration() hlc.Timestamp
-
-	// RegisterCallbackForSessionExpiry registers a callback to be executed when the session expires.
-	RegisterCallbackForSessionExpiry(func(ctx context.Context))
 }
 
 // Reader abstracts over the state of session records.

--- a/pkg/sql/sqlliveness/sqllivenesstestutils/alwaysalivesession.go
+++ b/pkg/sql/sqlliveness/sqllivenesstestutils/alwaysalivesession.go
@@ -11,8 +11,6 @@
 package sqllivenesstestutils
 
 import (
-	"context"
-
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
@@ -35,6 +33,3 @@ func (f alwaysAliveSession) Expiration() hlc.Timestamp { return hlc.MaxTimestamp
 
 // Start implements the sqlliveness.Session interface.
 func (f alwaysAliveSession) Start() hlc.Timestamp { return hlc.MinTimestamp }
-
-// RegisterCallbackForSessionExpiry implements the sqlliveness.Session interface.
-func (f alwaysAliveSession) RegisterCallbackForSessionExpiry(func(context.Context)) {}


### PR DESCRIPTION
This patch changes how stopping the stopper and, in turn, terminating
the process happens for tenant SQL pods when the sqlliveness session is
expired. Before this patch, the liveness code was calling the
Stopper.Stop() directly. This patch replaces that with bubbling up an
event up to the cli layer, which is where the logic around terminating
the process lives. That guy has  more complex shutdown logic - it has
the opportunity to perform draining if it wants (or at least it will
in https://github.com/cockroachdb/cockroach/pull/90143), and it also prints
a message with the cause of the exit.

An alternative considered was to extend the Stopper.Stop() interface
somehow with a termination message, and continue to use the stopper as
the mechanism used by arbitrary modules to signal the desire to
terminate the server. I've decided against it, though, in favor of
introducing another mechanism for signaling requests to terminate up to
the cli layer, on the argument that the stopper is passed around so
widely and used in a lot of non-production libraries, such that it's
hard to trace and tell what production modules call Stop() on it and
under which circumstances. Also, stopper.Stop() cannot be deadlocks if
called from inside a stopper task (and our code generally runs inside
stopper tasks), so we'd also need to add a new async stop interface to
the stopper.
Thus, the goal of this patch is to keep the number of callers to
Stopper.Stop() small - right now there are two of them: one in the cli,
and one in the drainServer. In a followup patch, I might remove the
drainServer call, and then we'd be left with exactly one caller to
Stopper.Stop().

Fixes https://github.com/cockroachdb/cockroach/issues/85540

Release note: None
Epic: None