### PR TITLE
opt,logictest: allow rounding of floats in tests results

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -894,9 +894,9 @@ type logicQuery struct {
 	// messages.
 	rawOpts string
 
-	// roundFloatsInStrings can be set to use a regular expression to find floats
-	// that may be embedded in strings and replace them with rounded versions.
-	roundFloatsInStrings bool
+	// roundFloatsInStringsSigFigs specifies the number of significant figures
+	// to round floats embedded in strings to where zero means do not round.
+	roundFloatsInStringsSigFigs int
 }
 
 var allowedKVOpTypes = []string{
@@ -2551,13 +2551,19 @@ func (t *logicTest) processSubtest(
 						case "noticetrace":
 							query.noticetrace = true
 
-						case "round-in-strings":
-							query.roundFloatsInStrings = true
-
 						case "async":
 							query.expectAsync = true
 
 						default:
+							if strings.HasPrefix(opt, "round-in-strings") {
+								significantFigures, err := floatcmp.ParseRoundInStringsDirective(opt)
+								if err != nil {
+									return err
+								}
+								query.roundFloatsInStringsSigFigs = significantFigures
+								break
+							}
+
 							if strings.HasPrefix(opt, "nodeidx=") {
 								idx, err := strconv.ParseInt(strings.SplitN(opt, "=", 2)[1], 10, 64)
 								if err != nil {
@@ -3312,8 +3318,8 @@ func (t *logicTest) finishExecQuery(query logicQuery, rows *gosql.Rows, err erro
 							val = "·"
 						}
 						s := fmt.Sprint(val)
-						if query.roundFloatsInStrings {
-							s = roundFloatsInString(s)
+						if query.roundFloatsInStringsSigFigs > 0 {
+							s = floatcmp.RoundFloatsInString(s, query.roundFloatsInStringsSigFigs)
 						}
 						actualResultsRaw = append(actualResultsRaw, s)
 					} else {
@@ -4121,14 +4127,4 @@ func (t *logicTest) printCompletion(path string, config logictestbase.TestCluste
 	}
 	t.outf("--- done: %s with config %s: %d tests, %d failures%s", path, config.Name,
 		t.progress, t.failures, unsupportedMsg)
-}
-
-func roundFloatsInString(s string) string {
-	return string(regexp.MustCompile(`(\d+\.\d+)`).ReplaceAllFunc([]byte(s), func(x []byte) []byte {
-		f, err := strconv.ParseFloat(string(x), 64)
-		if err != nil {
-			return []byte(err.Error())
-		}
-		return []byte(fmt.Sprintf("%.6g", f))
-	}))
 }

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -1081,7 +1081,7 @@ ALTER TABLE t47742 INJECT STATISTICS '[
 ]'
 ----
 
-opt
+opt round-in-strings=5
 SELECT a, b::string FROM t47742 WHERE b = true
 ----
 project
@@ -1091,7 +1091,7 @@ project
  ├── fd: ()-->(6)
  ├── index-join t47742
  │    ├── columns: a:1(int) t47742.b:2(bool!null)
- │    ├── stats: [rows=3063.5, distinct(2)=1.00247, null(2)=0]
+ │    ├── stats: [rows=3063.5, distinct(2)=1.0025, null(2)=0]
  │    │   histogram(2)=  0    0    0.0024693 3063.5
  │    │                <--- false ----------- true
  │    ├── fd: ()-->(2)

--- a/pkg/sql/opt/testutils/opttester/BUILD.bazel
+++ b/pkg/sql/opt/testutils/opttester/BUILD.bazel
@@ -47,6 +47,7 @@ go_library(
         "//pkg/sql/sem/volatility",
         "//pkg/sql/stats",
         "//pkg/testutils",
+        "//pkg/testutils/floatcmp",
         "//pkg/testutils/sqlutils",
         "//pkg/util",
         "//pkg/util/hlc",

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -62,6 +62,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/volatility"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/floatcmp"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -251,6 +252,10 @@ type Flags struct {
 	// SkipRace indicates that a test should be skipped if the race detector is
 	// enabled.
 	SkipRace bool
+
+	// RoundFloatsInStringsSigFigs specifies the number of significant figures
+	// to round floats embedded in strings to where zero means do not round.
+	RoundFloatsInStringsSigFigs int
 }
 
 // New constructs a new instance of the OptTester for the given SQL statement.
@@ -619,6 +624,9 @@ func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 			d.Fatalf(tb, "%+v", err)
 		}
 		ot.postProcess(tb, d, e)
+		if ot.Flags.RoundFloatsInStringsSigFigs > 0 {
+			return floatcmp.RoundFloatsInString(ot.FormatExpr(e), ot.Flags.RoundFloatsInStringsSigFigs)
+		}
 		return ot.FormatExpr(e)
 
 	case "assign-placeholders-build", "assign-placeholders-norm", "assign-placeholders-opt":
@@ -885,6 +893,15 @@ func ruleNamesToRuleSet(args []string) (RuleSet, error) {
 // See OptTester.RunCommand for supported flags.
 func (f *Flags) Set(arg datadriven.CmdArg) error {
 	switch arg.Key {
+	case "round-in-strings":
+		if len(arg.Vals) != 1 {
+			return fmt.Errorf("round-in-strings requires a single argument")
+		}
+		sigFigs, err := strconv.Atoi(arg.Vals[0])
+		if err != nil {
+			return err
+		}
+		f.RoundFloatsInStringsSigFigs = sigFigs
 	case "set":
 		for _, val := range arg.Vals {
 			s := strings.Split(val, "=")


### PR DESCRIPTION
This code change updates `round-in-strings` for logictests to
allow specifiying the number of significant figures to round
floats in test results to.

It also adds `round-in-strings` to `opt`.

Release note: None
Epic: none