### PR TITLE
encoding: make DecodeFloatDescending return same NaN as ascending

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/float
+++ b/pkg/sql/logictest/testdata/logic_test/float
@@ -188,3 +188,24 @@ SELECT ((col2::FLOAT8 // 1.0:::FLOAT8::FLOAT8)::FLOAT8) FROM t87605@[0] ORDER BY
 ----
 1.234567e+06
 1.2345678901234e+13
+
+# Regression test for issue #89961.
+
+statement ok
+CREATE TABLE t89961 (a float PRIMARY KEY, INDEX (a DESC))
+
+statement ok
+INSERT INTO t89961 VALUES ('NaN')
+
+# We use st_makepointm because it is sensitive to different NaN encodings. The
+# following two queries should have the same result.
+
+query T
+SELECT st_makepointm(a, 1.234567890123456e+07, -0.6571774097533073)::string FROM t89961@t89961_pkey
+----
+0101000040010000000000F87FDCE9D6DC298C67412DEF51EB9807E5BF
+
+query T
+SELECT st_makepointm(a, 1.234567890123456e+07, -0.6571774097533073)::string FROM t89961@t89961_a_idx;
+----
+0101000040010000000000F87FDCE9D6DC298C67412DEF51EB9807E5BF

--- a/pkg/util/encoding/float.go
+++ b/pkg/util/encoding/float.go
@@ -93,12 +93,10 @@ func DecodeFloatAscending(buf []byte) ([]byte, float64, error) {
 // DecodeFloatDescending decodes floats encoded with EncodeFloatDescending.
 func DecodeFloatDescending(buf []byte) ([]byte, float64, error) {
 	b, r, err := DecodeFloatAscending(buf)
-	if r != 0 {
-		// All values except for 0 and NaN were negated in
-		// EncodeFloatDescending, so we have to negate them back. Note that we
-		// don't need to check whether r is NaN since negating NaN gives back
-		// NaN too. Negative zero uses composite indexes to decode itself
-		// correctly.
+	if r != 0 && !math.IsNaN(r) {
+		// All values except for 0 and NaN were negated in EncodeFloatDescending, so
+		// we have to negate them back. Negative zero uses composite indexes to
+		// decode itself correctly.
 		r = -r
 	}
 	return b, r, err


### PR DESCRIPTION
There are multiple representations of NaN in floating point. We were returning a different representation for descending indexes. There are some functions, such as `st_makepointm` that are sensitive to the difference, and this complicates testing. So let's always return the same bitwise representation for NaN.

Fixes: #89961

Release note: None