### PR TITLE
roachtest: fix costfuzz and unoptimized-query-oracle setups

### DIFF
--- a/pkg/cmd/roachtest/tests/costfuzz.go
+++ b/pkg/cmd/roachtest/tests/costfuzz.go
@@ -27,6 +27,7 @@ import (
 
 func registerCostFuzz(r registry.Registry) {
 	for _, setupName := range []string{sqlsmith.RandTableSetupName, sqlsmith.SeedMultiRegionSetupName} {
+		setupName := setupName
 		var clusterSpec spec.ClusterSpec
 		switch setupName {
 		case sqlsmith.SeedMultiRegionSetupName:

--- a/pkg/cmd/roachtest/tests/query_comparison_util.go
+++ b/pkg/cmd/roachtest/tests/query_comparison_util.go
@@ -138,6 +138,7 @@ func runOneRoundQueryComparison(
 
 	rnd, seed := randutil.NewTestRand()
 	t.L().Printf("seed: %d", seed)
+	t.L().Printf("setupName: %s", qct.setupName)
 
 	setup := sqlsmith.Setups[qct.setupName](rnd)
 

--- a/pkg/cmd/roachtest/tests/unoptimized_query_oracle.go
+++ b/pkg/cmd/roachtest/tests/unoptimized_query_oracle.go
@@ -42,6 +42,7 @@ func registerUnoptimizedQueryOracle(r registry.Registry) {
 	for i := range disableRuleSpecs {
 		disableRuleSpec := &disableRuleSpecs[i]
 		for _, setupName := range []string{sqlsmith.RandTableSetupName, sqlsmith.SeedMultiRegionSetupName} {
+			setupName := setupName
 			var clusterSpec spec.ClusterSpec
 			switch setupName {
 			case sqlsmith.SeedMultiRegionSetupName:

--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -243,7 +243,7 @@ FROM
 			key := tree.MakeSchemaQualifiedTypeName(scName, name)
 			udtMapping[key] = typ
 		default:
-			return nil, errors.New("unsupported SQLSmith type kind")
+			return nil, errors.Newf("unsupported SQLSmith type kind: %s", string(membersRaw))
 		}
 	}
 	var udts []*types.T


### PR DESCRIPTION
This commit fixes a bug that was recently introduced when registering the costfuzz and unoptimized-query-oracle tests. This bug was due to the well-known range loop variable issue described here: https://github.com/golang/go/issues/20733.

This commit also adds some additional logging and debug information to help with future issues with these test cases.

Fixes #90010

Release note: None