### PR TITLE
release-22.1: sql,server: increase severity of upgraded-related logging

### DIFF
--- a/pkg/migration/migrationmanager/manager.go
+++ b/pkg/migration/migrationmanager/manager.go
@@ -101,10 +101,16 @@ func (m *Manager) Migrate(
 	user security.SQLUsername,
 	from, to clusterversion.ClusterVersion,
 	updateSystemVersionSetting sql.UpdateVersionSystemSettingHook,
-) error {
+) (returnErr error) {
 	// TODO(irfansharif): Should we inject every ctx here with specific labels
 	// for each migration, so they log distinctly?
 	ctx = logtags.AddTag(ctx, "migration-mgr", nil)
+	defer func() {
+		if returnErr != nil {
+			log.Warningf(ctx, "error encountered during version upgrade: %v", returnErr)
+		}
+	}()
+
 	if from == to {
 		// Nothing to do here.
 		log.Infof(ctx, "no need to migrate, cluster already at newest version")

--- a/pkg/server/auto_upgrade.go
+++ b/pkg/server/auto_upgrade.go
@@ -53,7 +53,7 @@ func (s *Server) startAttemptUpgrade(ctx context.Context) {
 			// Check if we should upgrade cluster version, keep checking upgrade
 			// status, or stop attempting upgrade.
 			if quit, err := s.upgradeStatus(ctx); err != nil {
-				log.Infof(ctx, "failed attempt to upgrade cluster version, error: %s", err)
+				log.Errorf(ctx, "failed attempt to upgrade cluster version, error: %v", err)
 				continue
 			} else if quit {
 				log.Info(ctx, "no need to upgrade, cluster already at the newest version")
@@ -76,7 +76,7 @@ func (s *Server) startAttemptUpgrade(ctx context.Context) {
 					sessiondata.InternalExecutorOverride{User: security.RootUserName()},
 					"SET CLUSTER SETTING version = crdb_internal.node_executable_version();",
 				); err != nil {
-					log.Infof(ctx, "error when finalizing cluster version upgrade: %s", err)
+					log.Errorf(ctx, "error when finalizing cluster version upgrade: %v", err)
 				} else {
 					log.Info(ctx, "successfully upgraded cluster version")
 					return
@@ -85,7 +85,7 @@ func (s *Server) startAttemptUpgrade(ctx context.Context) {
 		}
 	}); err != nil {
 		cancel()
-		log.Infof(ctx, "failed attempt to upgrade cluster version, error: %s", err)
+		log.Errorf(ctx, "failed attempt to upgrade cluster version, error: %v", err)
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1554,9 +1554,15 @@ func (s *Server) PreStart(ctx context.Context) error {
 	s.ctSender.Run(ctx, state.nodeID)
 
 	// Attempt to upgrade cluster version now that the sql server has been
-	// started. At this point we know that all startupmigrations have successfully
-	// been run so it is safe to upgrade to the binary's current version.
-	s.startAttemptUpgrade(ctx)
+	// started. At this point we know that all startupmigrations and permanent
+	// upgrades have successfully been run so it is safe to upgrade to the
+	// binary's current version.
+	//
+	// NB: We run this under the startup ctx (not workersCtx) so as to ensure
+	// all the upgrade steps are traced, for use during troubleshooting.
+	if err := s.startAttemptUpgrade(ctx); err != nil {
+		return errors.Wrap(err, "cannot start upgrade task")
+	}
 
 	if err := s.node.tenantSettingsWatcher.Start(ctx, s.sqlServer.execCfg.SystemTableIDResolver); err != nil {
 		return errors.Wrap(err, "failed to initialize the tenant settings watcher")


### PR DESCRIPTION
Backport 1/1 commits from #90165.
Backport 1/1 commits from #91049. 

/cc @cockroachdb/release

---

Informs #90148.

This increases the severity from INFO in the following cases:

- in the case when `SET CLUSTER SETTING version` is issued from a SQL client (WARNING in case of failure).
- in the case when the server spontaneously decides to upgrade in the background (ERROR in case of failure).

Release note: None

---
Release justification: increases troubleshootability