### PR TITLE
pkg/ui: Make tracez v2 page node-aware

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/tracezApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/tracezApi.ts
@@ -10,68 +10,74 @@
 
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { fetchData } from "src/api";
-import TakeTracingSnapshotRequest = cockroach.server.serverpb.TakeTracingSnapshotRequest;
 
-export type ListTracingSnapshotsRequestMessage =
+export type ListTracingSnapshotsRequest =
   cockroach.server.serverpb.ListTracingSnapshotsRequest;
-export type ListTracingSnapshotsResponseMessage =
+export type ListTracingSnapshotsResponse =
   cockroach.server.serverpb.ListTracingSnapshotsResponse;
 
-export type TakeTracingSnapshotRequestMessage = TakeTracingSnapshotRequest;
-export type TakeTracingSnapshotResponseMessage =
+export const TakeTracingSnapshotRequest =
+  cockroach.server.serverpb.TakeTracingSnapshotRequest;
+export type TakeTracingSnapshotResponse =
   cockroach.server.serverpb.TakeTracingSnapshotResponse;
 
-export type GetTracingSnapshotRequestMessage =
+export type GetTracingSnapshotRequest =
   cockroach.server.serverpb.GetTracingSnapshotRequest;
-export type GetTracingSnapshotResponseMessage =
+export type GetTracingSnapshotResponse =
   cockroach.server.serverpb.GetTracingSnapshotResponse;
 
 export type Span = cockroach.server.serverpb.ITracingSpan;
 export type Snapshot = cockroach.server.serverpb.ITracingSnapshot;
 
-export type GetTraceRequestMessage = cockroach.server.serverpb.GetTraceRequest;
-export type GetTraceResponseMessage =
-  cockroach.server.serverpb.GetTraceResponse;
+export type GetTraceRequest = cockroach.server.serverpb.GetTraceRequest;
+export type GetTraceResponse = cockroach.server.serverpb.GetTraceResponse;
 
 const API_PREFIX = "_admin/v1";
 
-export function listTracingSnapshots(): Promise<ListTracingSnapshotsResponseMessage> {
+export function listTracingSnapshots(
+  nodeID: string,
+): Promise<ListTracingSnapshotsResponse> {
+  // Note that the server is clever enough to ignore proxy requests to node "local."
   return fetchData(
     cockroach.server.serverpb.ListTracingSnapshotsResponse,
-    `${API_PREFIX}/trace_snapshots`,
+    `${API_PREFIX}/trace_snapshots?remote_node_id=${nodeID}`,
     null,
     null,
   );
 }
 
-export function takeTracingSnapshot(): Promise<TakeTracingSnapshotResponseMessage> {
+export function takeTracingSnapshot(
+  nodeID: string,
+): Promise<TakeTracingSnapshotResponse> {
   const req = new TakeTracingSnapshotRequest();
   return fetchData(
     cockroach.server.serverpb.TakeTracingSnapshotResponse,
-    `${API_PREFIX}/trace_snapshots`,
+    `${API_PREFIX}/trace_snapshots?remote_node_id=${nodeID}`,
+    cockroach.server.serverpb.TakeTracingSnapshotRequest,
     req as any,
-    null,
   );
 }
 
-export function getTracingSnapshot(
-  snapshotID: number,
-): Promise<GetTracingSnapshotResponseMessage> {
+export function getTracingSnapshot(req: {
+  nodeID: string;
+  snapshotID: number;
+}): Promise<GetTracingSnapshotResponse> {
   return fetchData(
     cockroach.server.serverpb.GetTracingSnapshotResponse,
-    `${API_PREFIX}/trace_snapshots/${snapshotID}`,
+    `${API_PREFIX}/trace_snapshots/${req.snapshotID}?remote_node_id=${req.nodeID}`,
     null,
     null,
   );
 }
 
-export function getTraceForSnapshot(
-  req: GetTraceRequestMessage,
-): Promise<GetTraceResponseMessage> {
+export function getTraceForSnapshot(req: {
+  nodeID: string;
+  req: GetTraceRequest;
+}): Promise<GetTraceResponse> {
   return fetchData(
     cockroach.server.serverpb.GetTraceResponse,
-    `${API_PREFIX}/traces`,
-    req as any,
-    null,
+    `${API_PREFIX}/traces?remote_node_id=${req.nodeID}`,
+    cockroach.server.serverpb.GetTraceRequest,
+    req.req as any,
   );
 }

--- a/pkg/ui/workspaces/cluster-ui/src/tracez/snapshot/snapshotPage.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/tracez/snapshot/snapshotPage.spec.tsx
@@ -16,11 +16,13 @@ import * as H from "history";
 
 import { SortSetting } from "../../sortedtable";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import { TakeTracingSnapshotResponse } from "src/api/tracezApi";
 import GetTracingSnapshotResponse = cockroach.server.serverpb.GetTracingSnapshotResponse;
 
 const getMockSnapshotPageProps = (): SnapshotPageProps => {
   const history = H.createHashHistory();
   return {
+    snapshotsValid: false,
     location: history.location,
     history,
     match: {
@@ -29,8 +31,12 @@ const getMockSnapshotPageProps = (): SnapshotPageProps => {
       isExact: false,
       params: {},
     },
-    refreshSnapshot: (id: number): void => {},
-    refreshSnapshots: (): void => {},
+    refreshSnapshot: (_req: { nodeID: string; snapshotID: number }): void => {},
+    refreshSnapshots: (_nodeID: string): void => {},
+    refreshNodes: (): void => {},
+    takeSnapshot(_nodeID: string): Promise<TakeTracingSnapshotResponse> {
+      return Promise.resolve(undefined);
+    },
     setSort: (value: SortSetting): void => {},
     snapshotError: undefined,
     snapshotLoading: false,
@@ -45,6 +51,7 @@ const getMockSnapshotPageProps = (): SnapshotPageProps => {
 describe("Snapshot", () => {
   it("renders expected snapshot table columns", () => {
     const props = getMockSnapshotPageProps();
+    props.match.params.snapshotID = "1";
     props.snapshot = GetTracingSnapshotResponse.fromObject({
       snapshot: {
         spans: [{ span_id: 1 }],

--- a/pkg/ui/workspaces/db-console/src/app.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.spec.tsx
@@ -498,9 +498,9 @@ describe("Routing to", () => {
     });
   });
 
-  describe("'/debug/tracez_v2/snapshot/:id' path", () => {
-    test("routes to <ScheduleDetails> component", () => {
-      navigateToPath("/debug/tracez_v2/snapshot/12345");
+  describe("'/debug/tracez_v2/node/:nodeID/snapshot/:snapshotID' path", () => {
+    test("routes to <SnapshotPage> component", () => {
+      navigateToPath("/debug/tracez_v2/node/1/snapshot/12345");
       screen.getByTestId("snapshotPage");
     });
   });

--- a/pkg/ui/workspaces/db-console/src/app.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.tsx
@@ -330,7 +330,12 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
                   />
                   <Route
                     exact
-                    path="/debug/tracez_v2/snapshot/:snapshotID"
+                    path="/debug/tracez_v2/node/:nodeID"
+                    component={SnapshotPage}
+                  />
+                  <Route
+                    exact
+                    path="/debug/tracez_v2/node/:nodeID/snapshot/:snapshotID"
                     component={SnapshotPage}
                   />
                   <Route exact path="/debug/redux" component={ReduxDebug} />

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -466,15 +466,18 @@ const scheduleReducerObj = new KeyedCachedDataReducer(
 );
 export const refreshSchedule = scheduleReducerObj.refresh;
 
-const snapshotsReducerObj = new CachedDataReducer(
+const snapshotsReducerObj = new KeyedCachedDataReducer(
   clusterUiApi.listTracingSnapshots,
   "snapshots",
+  (nodeID: string): string => nodeID,
   moment.duration(1, "s"),
 );
 export const refreshSnapshots = snapshotsReducerObj.refresh;
 
-export const snapshotKey = (snapshotID: number): string =>
-  snapshotID.toString();
+export const snapshotKey = (req: {
+  nodeID: string;
+  snapshotID: number;
+}): string => req.nodeID + "/" + req.snapshotID.toString();
 
 const snapshotReducerObj = new KeyedCachedDataReducer(
   clusterUiApi.getTracingSnapshot,
@@ -525,8 +528,8 @@ export interface APIReducersState {
   schemaInsights: CachedDataReducerState<clusterUiApi.InsightRecommendation[]>;
   schedules: KeyedCachedDataReducerState<clusterUiApi.Schedules>;
   schedule: KeyedCachedDataReducerState<clusterUiApi.Schedule>;
-  snapshots: CachedDataReducerState<clusterUiApi.ListTracingSnapshotsResponseMessage>;
-  snapshot: KeyedCachedDataReducerState<clusterUiApi.GetTracingSnapshotResponseMessage>;
+  snapshots: KeyedCachedDataReducerState<clusterUiApi.ListTracingSnapshotsResponse>;
+  snapshot: KeyedCachedDataReducerState<clusterUiApi.GetTracingSnapshotResponse>;
 }
 
 export const apiReducersReducer = combineReducers<APIReducersState>({

--- a/pkg/ui/workspaces/db-console/src/views/tracez_v2/snapshotPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/tracez_v2/snapshotPage.tsx
@@ -13,9 +13,15 @@ import {
   SnapshotPageStateProps,
   SortSetting,
 } from "@cockroachlabs/cluster-ui";
+import { api as clusterUiApi } from "@cockroachlabs/cluster-ui";
 import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
-import { refreshSnapshot, refreshSnapshots } from "src/redux/apiReducers";
+import {
+  refreshNodes,
+  refreshSnapshot,
+  refreshSnapshots,
+  snapshotKey,
+} from "src/redux/apiReducers";
 import { LocalSetting } from "src/redux/localsettings";
 import { AdminUIState } from "src/redux/state";
 import { getMatchParamByName } from "src/util/query";
@@ -30,26 +36,42 @@ const mapStateToProps = (
   state: AdminUIState,
   props: RouteComponentProps,
 ): SnapshotPageStateProps => {
-  const snapshotsState = state.cachedData.snapshots;
+  const nodeID = getMatchParamByName(props.match, "nodeID");
+  const snapshotsState = state.cachedData.snapshots[nodeID];
 
   const snapshotID = getMatchParamByName(props.match, "snapshotID");
-  const snapshotState = state.cachedData.snapshot[snapshotID];
+  const snapshotState =
+    state.cachedData.snapshot[
+      snapshotKey({
+        nodeID: nodeID,
+        snapshotID: parseInt(snapshotID),
+      })
+    ];
+
+  const nodesState = state.cachedData.nodes;
 
   return {
     sort: sortSetting.selector(state),
 
+    // Pass down valid to gate redirect.
     snapshots: snapshotsState ? snapshotsState.data : null,
     snapshotsLoading: snapshotsState ? snapshotsState.inFlight : false,
     snapshotsError: snapshotsState ? snapshotsState.lastError : null,
+    snapshotsValid: snapshotsState?.valid,
 
     snapshot: snapshotState ? snapshotState.data : null,
     snapshotLoading: snapshotState ? snapshotState.inFlight : false,
     snapshotError: snapshotState ? snapshotState.lastError : null,
+
+    nodes: nodesState ? nodesState.data : null,
+
+    takeSnapshot: clusterUiApi.takeTracingSnapshot,
   };
 };
 
 const mapDispatchToProps = {
   setSort: sortSetting.set,
+  refreshNodes,
   refreshSnapshots,
   refreshSnapshot,
 };


### PR DESCRIPTION
Release note: None

Demo video below. Note that it starts on the v1 trace page, and I navigate to the new one by typing in the address bar.

https://user-images.githubusercontent.com/261508/196736069-952dadde-dcb7-4060-8563-e98727b48a48.mov

Part of https://github.com/cockroachdb/cockroach/issues/83679
