### PR TITLE
cluster-ui: add explain plan tab for statement insights

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/insightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/insightsApi.ts
@@ -591,6 +591,7 @@ type ExecutionInsightsResponseRow = {
   causes: string[];
   problem: string;
   index_recommendations: string[];
+  plan_gist: string;
 };
 
 export type StatementInsights = StatementInsightEvent[];
@@ -630,6 +631,7 @@ function getStatementInsightsFromClusterExecutionInsightsResponse(
       problem: row.problem,
       indexRecommendations: row.index_recommendations,
       insights: null,
+      planGist: row.plan_gist,
     };
   });
 }
@@ -669,6 +671,7 @@ const statementInsightsQuery: InsightQuery<
       index_recommendations,
       problem,
       causes,
+      plan_gist,
       row_number()                          OVER (
         PARTITION BY txn_fingerprint_id
         ORDER BY end_time DESC

--- a/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
@@ -89,6 +89,7 @@ export type StatementInsightEvent = {
   application: string;
   insights: Insight[];
   indexRecommendations: string[];
+  planGist: string;
 };
 
 export type Insight = {

--- a/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
@@ -332,7 +332,7 @@ export function populateStatementInsightsFromProblemAndCauses(
   statements: StatementInsightEvent[],
 ): StatementInsightEvent[] {
   if (!statements || statements?.length === 0) {
-    return;
+    return [];
   }
   const stmts: StatementInsightEvent[] = [];
   statements.forEach(statement => {

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/insightsDetails.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/insightsDetails.module.scss
@@ -1,0 +1,3 @@
+.section {
+  padding: 12px 24px 12px 0px;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
-import React, { useContext } from "react";
+import React, { useContext, useMemo } from "react";
 import Helmet from "react-helmet";
 import { RouteComponentProps } from "react-router-dom";
 import { ArrowLeft } from "@cockroachlabs/icons";
@@ -43,6 +43,81 @@ import { CockroachCloudContext } from "../../contexts";
 const tableCx = classNames.bind(insightTableStyles);
 const summaryCardStylesCx = classNames.bind(summaryCardStyles);
 
+const insightsTableData = (
+  insightDetails: StatementInsightEvent | null,
+): InsightRecommendation[] => {
+  if (!insightDetails) return [];
+
+  const recs: InsightRecommendation[] = [];
+  let rec: InsightRecommendation;
+  const execDetails: executionDetails = {
+    statement: insightDetails.query,
+    fingerprintID: insightDetails.statementFingerprintID,
+    retries: insightDetails.retries,
+  };
+  insightDetails.insights.forEach(insight => {
+    switch (insight.name) {
+      case InsightNameEnum.highContention:
+        rec = {
+          type: "HighContention",
+          execution: execDetails,
+          details: {
+            duration: insightDetails.elapsedTimeMillis,
+            description: insight.description,
+          },
+        };
+        break;
+      case InsightNameEnum.failedExecution:
+        rec = {
+          type: "FailedExecution",
+        };
+        break;
+      case InsightNameEnum.highRetryCount:
+        rec = {
+          type: "HighRetryCount",
+          execution: execDetails,
+          details: {
+            description: insight.description,
+          },
+        };
+        break;
+      case InsightNameEnum.planRegression:
+        rec = {
+          type: "PlanRegression",
+          execution: execDetails,
+          details: {
+            description: insight.description,
+          },
+        };
+        break;
+      case InsightNameEnum.suboptimalPlan:
+        rec = {
+          type: "SuboptimalPlan",
+          database: insightDetails.databaseName,
+          execution: {
+            ...execDetails,
+            indexRecommendations: insightDetails.indexRecommendations,
+          },
+          details: {
+            description: insight.description,
+          },
+        };
+        break;
+      default:
+        rec = {
+          type: "Unknown",
+          details: {
+            duration: insightDetails.elapsedTimeMillis,
+            description: insight.description,
+          },
+        };
+        break;
+    }
+    recs.push(rec);
+  });
+  return recs;
+};
+
 export interface StatementInsightDetailsStateProps {
   insightEventDetails: StatementInsightEvent;
   insightError: Error | null;
@@ -51,203 +126,131 @@ export interface StatementInsightDetailsStateProps {
 export type StatementInsightDetailsProps = StatementInsightDetailsStateProps &
   RouteComponentProps<unknown>;
 
-export class StatementInsightDetails extends React.Component<StatementInsightDetailsProps> {
-  constructor(props: StatementInsightDetailsProps) {
-    super(props);
-  }
+export const StatementInsightDetails: React.FC<
+  StatementInsightDetailsProps
+> = ({ history, insightEventDetails, insightError, match }) => {
+  const isCockroachCloud = useContext(CockroachCloudContext);
 
-  prevPage = (): void => this.props.history.goBack();
+  const prevPage = (): void => history.goBack();
 
-  renderContent = (): React.ReactElement => {
-    const insightDetailsArr = populateStatementInsightsFromProblemAndCauses([
-      this.props.insightEventDetails,
-    ]);
-    const insightDetails = insightDetailsArr[0];
-    const isCockroachCloud = useContext(CockroachCloudContext);
-    const insightsColumns = makeInsightsColumns(isCockroachCloud);
-    function insightsTableData(): InsightRecommendation[] {
-      const recs: InsightRecommendation[] = [];
-      let rec: InsightRecommendation;
-      const execDetails: executionDetails = {
-        statement: insightDetails.query,
-        fingerprintID: insightDetails.statementFingerprintID,
-        retries: insightDetails.retries,
-      };
-      insightDetails.insights.forEach(insight => {
-        switch (insight.name) {
-          case InsightNameEnum.highContention:
-            rec = {
-              type: "HighContention",
-              execution: execDetails,
-              details: {
-                duration: insightDetails.elapsedTimeMillis,
-                description: insight.description,
-              },
-            };
-            break;
-          case InsightNameEnum.failedExecution:
-            rec = {
-              type: "FailedExecution",
-            };
-            break;
-          case InsightNameEnum.highRetryCount:
-            rec = {
-              type: "HighRetryCount",
-              execution: execDetails,
-              details: {
-                description: insight.description,
-              },
-            };
-            break;
-          case InsightNameEnum.planRegression:
-            rec = {
-              type: "PlanRegression",
-              execution: execDetails,
-              details: {
-                description: insight.description,
-              },
-            };
-            break;
-          case InsightNameEnum.suboptimalPlan:
-            rec = {
-              type: "SuboptimalPlan",
-              database: insightDetails.databaseName,
-              execution: {
-                ...execDetails,
-                indexRecommendations: insightDetails.indexRecommendations,
-              },
-              details: {
-                description: insight.description,
-              },
-            };
-            break;
-          default:
-            rec = {
-              type: "Unknown",
-              details: {
-                duration: insightDetails.elapsedTimeMillis,
-                description: insight.description,
-              },
-            };
-            break;
-        }
-        recs.push(rec);
-      });
-      return recs;
-    }
-    const tableData = insightsTableData();
-    return (
-      <>
-        <section className={tableCx("section")}>
-          <Row gutter={24}>
-            <Col className="gutter-row" span={24}>
-              <SqlBox size={SqlBoxSize.custom} value={insightDetails.query} />
-            </Col>
-          </Row>
-          <Row gutter={24}>
-            <Col className="gutter-row" span={12}>
-              <SummaryCard>
-                <SummaryCardItem
-                  label="Start Time"
-                  value={insightDetails.startTime.format(DATE_FORMAT_24_UTC)}
-                />
-                <SummaryCardItem
-                  label="End Time"
-                  value={insightDetails.endTime.format(DATE_FORMAT_24_UTC)}
-                />
-                <SummaryCardItem
-                  label="Elapsed Time"
-                  value={Duration(insightDetails.elapsedTimeMillis * 1e6)}
-                />
-                <SummaryCardItem
-                  label="Rows Read"
-                  value={insightDetails.rowsRead}
-                />
-                <SummaryCardItem
-                  label="Rows Written"
-                  value={insightDetails.rowsWritten}
-                />
-                <SummaryCardItem
-                  label="Transaction Priority"
-                  value={capitalize(insightDetails.priority)}
-                />
-                <SummaryCardItem
-                  label="Full Scan"
-                  value={capitalize(String(insightDetails.isFullScan))}
-                />
-              </SummaryCard>
-            </Col>
-            <Col className="gutter-row" span={12}>
-              <SummaryCard>
-                <SummaryCardItem
-                  label="Transaction Retries"
-                  value={insightDetails.retries}
-                />
-                {insightDetails.lastRetryReason && (
-                  <SummaryCardItem
-                    label="Last Retry Reason"
-                    value={insightDetails.lastRetryReason.toString()}
-                  />
-                )}
-                <p className={summaryCardStylesCx("summary--card__divider")} />
-                <SummaryCardItem
-                  label="Session ID"
-                  value={String(insightDetails.sessionID)}
-                />
-                <SummaryCardItem
-                  label="Transaction Fingerprint ID"
-                  value={String(insightDetails.transactionFingerprintID)}
-                />
-                <SummaryCardItem
-                  label="Transaction Execution ID"
-                  value={String(insightDetails.transactionID)}
-                />
-                <SummaryCardItem
-                  label="Statement Fingerprint ID"
-                  value={String(insightDetails.statementFingerprintID)}
-                />
-              </SummaryCard>
-            </Col>
-          </Row>
-          <Row gutter={24} className={tableCx("margin-bottom")}>
-            <InsightsSortedTable columns={insightsColumns} data={tableData} />
-          </Row>
-        </section>
-      </>
-    );
-  };
+  const insightsColumns = useMemo(
+    () => makeInsightsColumns(isCockroachCloud),
+    [isCockroachCloud],
+  );
 
-  render(): React.ReactElement {
-    return (
+  const insightDetailsArr = useMemo(
+    () => populateStatementInsightsFromProblemAndCauses([insightEventDetails]),
+    [insightEventDetails],
+  );
+  const insightDetails = insightDetailsArr.length ? insightDetailsArr[0] : null;
+  const tableData = insightsTableData(insightDetails);
+
+  return (
+    <div>
+      <Helmet title={"Details | Insight"} />
       <div>
-        <Helmet title={"Details | Insight"} />
-        <div>
-          <Button
-            onClick={this.prevPage}
-            type="unstyled-link"
-            size="small"
-            icon={<ArrowLeft fontSize={"10px"} />}
-            iconPosition="left"
-            className={commonStyles("small-margin")}
-          >
-            Insights
-          </Button>
-          <h3
-            className={commonStyles("base-heading", "no-margin-bottom")}
-          >{`Statement Execution ID: ${String(
-            getMatchParamByName(this.props.match, "id"),
-          )}`}</h3>
-        </div>
-        <section>
-          <Loading
-            loading={this.props.insightEventDetails == null}
-            page={"Transaction Insight details"}
-            error={this.props.insightError}
-            render={this.renderContent}
-            renderError={() => InsightsError()}
-          />
-        </section>
+        <Button
+          onClick={prevPage}
+          type="unstyled-link"
+          size="small"
+          icon={<ArrowLeft fontSize={"10px"} />}
+          iconPosition="left"
+          className={commonStyles("small-margin")}
+        >
+          Insights
+        </Button>
+        <h3
+          className={commonStyles("base-heading", "no-margin-bottom")}
+        >{`Statement Execution ID: ${String(
+          getMatchParamByName(match, "id"),
+        )}`}</h3>
       </div>
-    );
-  }
-}
+      <section>
+        <Loading
+          loading={insightEventDetails == null}
+          page={"Transaction Insight details"}
+          error={insightError}
+          renderError={() => InsightsError()}
+        >
+          <section className={tableCx("section")}>
+            <Row gutter={24}>
+              <Col className="gutter-row" span={24}>
+                <SqlBox size={SqlBoxSize.custom} value={insightDetails.query} />
+              </Col>
+            </Row>
+            <Row gutter={24}>
+              <Col className="gutter-row" span={12}>
+                <SummaryCard>
+                  <SummaryCardItem
+                    label="Start Time"
+                    value={insightDetails.startTime.format(DATE_FORMAT_24_UTC)}
+                  />
+                  <SummaryCardItem
+                    label="End Time"
+                    value={insightDetails.endTime.format(DATE_FORMAT_24_UTC)}
+                  />
+                  <SummaryCardItem
+                    label="Elapsed Time"
+                    value={Duration(insightDetails.elapsedTimeMillis * 1e6)}
+                  />
+                  <SummaryCardItem
+                    label="Rows Read"
+                    value={insightDetails.rowsRead}
+                  />
+                  <SummaryCardItem
+                    label="Rows Written"
+                    value={insightDetails.rowsWritten}
+                  />
+                  <SummaryCardItem
+                    label="Transaction Priority"
+                    value={capitalize(insightDetails.priority)}
+                  />
+                  <SummaryCardItem
+                    label="Full Scan"
+                    value={capitalize(String(insightDetails.isFullScan))}
+                  />
+                </SummaryCard>
+              </Col>
+              <Col className="gutter-row" span={12}>
+                <SummaryCard>
+                  <SummaryCardItem
+                    label="Transaction Retries"
+                    value={insightDetails.retries}
+                  />
+                  {insightDetails.lastRetryReason && (
+                    <SummaryCardItem
+                      label="Last Retry Reason"
+                      value={insightDetails.lastRetryReason.toString()}
+                    />
+                  )}
+                  <p
+                    className={summaryCardStylesCx("summary--card__divider")}
+                  />
+                  <SummaryCardItem
+                    label="Session ID"
+                    value={String(insightDetails.sessionID)}
+                  />
+                  <SummaryCardItem
+                    label="Transaction Fingerprint ID"
+                    value={String(insightDetails.transactionFingerprintID)}
+                  />
+                  <SummaryCardItem
+                    label="Transaction Execution ID"
+                    value={String(insightDetails.transactionID)}
+                  />
+                  <SummaryCardItem
+                    label="Statement Fingerprint ID"
+                    value={String(insightDetails.statementFingerprintID)}
+                  />
+                </SummaryCard>
+              </Col>
+            </Row>
+            <Row gutter={24} className={tableCx("margin-bottom")}>
+              <InsightsSortedTable columns={insightsColumns} data={tableData} />
+            </Row>
+          </section>
+        </Loading>
+      </section>
+    </div>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
@@ -7,120 +7,39 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
-import React, { useContext, useMemo } from "react";
+import React, { useState } from "react";
 import Helmet from "react-helmet";
 import { RouteComponentProps } from "react-router-dom";
 import { ArrowLeft } from "@cockroachlabs/icons";
-import { Col, Row } from "antd";
+import { Row, Col, Tabs } from "antd";
+import "antd/lib/tabs/style";
 import "antd/lib/col/style";
 import "antd/lib/row/style";
 import { Button } from "src/button";
 import { Loading } from "src/loading";
 import { SqlBox, SqlBoxSize } from "src/sql";
-import { SummaryCard, SummaryCardItem } from "src/summaryCard";
-import { capitalize, Duration } from "src/util";
-import { DATE_FORMAT_24_UTC } from "src/util/format";
 import { getMatchParamByName } from "src/util/query";
-import {
-  InsightsSortedTable,
-  makeInsightsColumns,
-} from "src/insightsTable/insightsTable";
-import { populateStatementInsightsFromProblemAndCauses } from "../utils";
-import {
-  InsightNameEnum,
-  StatementInsightEvent,
-  executionDetails,
-  InsightRecommendation,
-} from "../types";
+import { StatementInsightEvent } from "../types";
 import { InsightsError } from "../insightsErrorComponent";
-
 import classNames from "classnames/bind";
+
 import { commonStyles } from "src/common";
-import insightTableStyles from "src/insightsTable/insightsTable.module.scss";
-import summaryCardStyles from "src/summaryCard/summaryCard.module.scss";
-import { CockroachCloudContext } from "../../contexts";
+import { getExplainPlanFromGist } from "src/api/decodePlanGistApi";
+import { StatementInsightDetailsOverviewTab } from "./statementInsightDetailsOverviewTab";
 
-const tableCx = classNames.bind(insightTableStyles);
-const summaryCardStylesCx = classNames.bind(summaryCardStyles);
+// Styles
+import insightsDetailsStyles from "src/insights/workloadInsightDetails/insightsDetails.module.scss";
 
-const insightsTableData = (
-  insightDetails: StatementInsightEvent | null,
-): InsightRecommendation[] => {
-  if (!insightDetails) return [];
+const cx = classNames.bind(insightsDetailsStyles);
 
-  const recs: InsightRecommendation[] = [];
-  let rec: InsightRecommendation;
-  const execDetails: executionDetails = {
-    statement: insightDetails.query,
-    fingerprintID: insightDetails.statementFingerprintID,
-    retries: insightDetails.retries,
-  };
-  insightDetails.insights.forEach(insight => {
-    switch (insight.name) {
-      case InsightNameEnum.highContention:
-        rec = {
-          type: "HighContention",
-          execution: execDetails,
-          details: {
-            duration: insightDetails.elapsedTimeMillis,
-            description: insight.description,
-          },
-        };
-        break;
-      case InsightNameEnum.failedExecution:
-        rec = {
-          type: "FailedExecution",
-        };
-        break;
-      case InsightNameEnum.highRetryCount:
-        rec = {
-          type: "HighRetryCount",
-          execution: execDetails,
-          details: {
-            description: insight.description,
-          },
-        };
-        break;
-      case InsightNameEnum.planRegression:
-        rec = {
-          type: "PlanRegression",
-          execution: execDetails,
-          details: {
-            description: insight.description,
-          },
-        };
-        break;
-      case InsightNameEnum.suboptimalPlan:
-        rec = {
-          type: "SuboptimalPlan",
-          database: insightDetails.databaseName,
-          execution: {
-            ...execDetails,
-            indexRecommendations: insightDetails.indexRecommendations,
-          },
-          details: {
-            description: insight.description,
-          },
-        };
-        break;
-      default:
-        rec = {
-          type: "Unknown",
-          details: {
-            duration: insightDetails.elapsedTimeMillis,
-            description: insight.description,
-          },
-        };
-        break;
-    }
-    recs.push(rec);
-  });
-  return recs;
-};
-
+enum TabKeysEnum {
+  OVERVIEW = "overview",
+  EXPLAIN = "explain",
+}
 export interface StatementInsightDetailsStateProps {
   insightEventDetails: StatementInsightEvent;
   insightError: Error | null;
+  isTenant?: boolean;
 }
 
 export type StatementInsightDetailsProps = StatementInsightDetailsStateProps &
@@ -128,129 +47,89 @@ export type StatementInsightDetailsProps = StatementInsightDetailsStateProps &
 
 export const StatementInsightDetails: React.FC<
   StatementInsightDetailsProps
-> = ({ history, insightEventDetails, insightError, match }) => {
-  const isCockroachCloud = useContext(CockroachCloudContext);
+> = ({ history, insightEventDetails, insightError, match, isTenant }) => {
+  const [explain, setExplain] = useState<string>(null);
 
   const prevPage = (): void => history.goBack();
 
-  const insightsColumns = useMemo(
-    () => makeInsightsColumns(isCockroachCloud),
-    [isCockroachCloud],
-  );
+  const onTabClick = (key: TabKeysEnum) => {
+    if (
+      !isTenant &&
+      key === TabKeysEnum.EXPLAIN &&
+      insightEventDetails?.planGist &&
+      !explain
+    ) {
+      // Get the explain plan.
+      getExplainPlanFromGist({ planGist: insightEventDetails.planGist }).then(
+        res => {
+          setExplain(res.explainPlan || res.error);
+        },
+      );
+    }
+  };
 
-  const insightDetailsArr = useMemo(
-    () => populateStatementInsightsFromProblemAndCauses([insightEventDetails]),
-    [insightEventDetails],
-  );
-  const insightDetails = insightDetailsArr.length ? insightDetailsArr[0] : null;
-  const tableData = insightsTableData(insightDetails);
+  const executionID = getMatchParamByName(match, "id");
 
   return (
     <div>
       <Helmet title={"Details | Insight"} />
+      <Button
+        onClick={prevPage}
+        type="unstyled-link"
+        size="small"
+        icon={<ArrowLeft fontSize={"10px"} />}
+        iconPosition="left"
+        className={commonStyles("small-margin")}
+      >
+        Insights
+      </Button>
+      <h3 className={commonStyles("base-heading", "no-margin-bottom")}>
+        Statement Execution ID: {executionID}
+      </h3>
       <div>
-        <Button
-          onClick={prevPage}
-          type="unstyled-link"
-          size="small"
-          icon={<ArrowLeft fontSize={"10px"} />}
-          iconPosition="left"
-          className={commonStyles("small-margin")}
-        >
-          Insights
-        </Button>
-        <h3
-          className={commonStyles("base-heading", "no-margin-bottom")}
-        >{`Statement Execution ID: ${String(
-          getMatchParamByName(match, "id"),
-        )}`}</h3>
-      </div>
-      <section>
         <Loading
           loading={insightEventDetails == null}
           page={"Transaction Insight details"}
           error={insightError}
           renderError={() => InsightsError()}
         >
-          <section className={tableCx("section")}>
-            <Row gutter={24}>
-              <Col className="gutter-row" span={24}>
-                <SqlBox size={SqlBoxSize.custom} value={insightDetails.query} />
+          <section className={cx("section")}>
+            <Row>
+              <Col span={24}>
+                <SqlBox
+                  size={SqlBoxSize.custom}
+                  value={insightEventDetails?.query}
+                />
               </Col>
-            </Row>
-            <Row gutter={24}>
-              <Col className="gutter-row" span={12}>
-                <SummaryCard>
-                  <SummaryCardItem
-                    label="Start Time"
-                    value={insightDetails.startTime.format(DATE_FORMAT_24_UTC)}
-                  />
-                  <SummaryCardItem
-                    label="End Time"
-                    value={insightDetails.endTime.format(DATE_FORMAT_24_UTC)}
-                  />
-                  <SummaryCardItem
-                    label="Elapsed Time"
-                    value={Duration(insightDetails.elapsedTimeMillis * 1e6)}
-                  />
-                  <SummaryCardItem
-                    label="Rows Read"
-                    value={insightDetails.rowsRead}
-                  />
-                  <SummaryCardItem
-                    label="Rows Written"
-                    value={insightDetails.rowsWritten}
-                  />
-                  <SummaryCardItem
-                    label="Transaction Priority"
-                    value={capitalize(insightDetails.priority)}
-                  />
-                  <SummaryCardItem
-                    label="Full Scan"
-                    value={capitalize(String(insightDetails.isFullScan))}
-                  />
-                </SummaryCard>
-              </Col>
-              <Col className="gutter-row" span={12}>
-                <SummaryCard>
-                  <SummaryCardItem
-                    label="Transaction Retries"
-                    value={insightDetails.retries}
-                  />
-                  {insightDetails.lastRetryReason && (
-                    <SummaryCardItem
-                      label="Last Retry Reason"
-                      value={insightDetails.lastRetryReason.toString()}
-                    />
-                  )}
-                  <p
-                    className={summaryCardStylesCx("summary--card__divider")}
-                  />
-                  <SummaryCardItem
-                    label="Session ID"
-                    value={String(insightDetails.sessionID)}
-                  />
-                  <SummaryCardItem
-                    label="Transaction Fingerprint ID"
-                    value={String(insightDetails.transactionFingerprintID)}
-                  />
-                  <SummaryCardItem
-                    label="Transaction Execution ID"
-                    value={String(insightDetails.transactionID)}
-                  />
-                  <SummaryCardItem
-                    label="Statement Fingerprint ID"
-                    value={String(insightDetails.statementFingerprintID)}
-                  />
-                </SummaryCard>
-              </Col>
-            </Row>
-            <Row gutter={24} className={tableCx("margin-bottom")}>
-              <InsightsSortedTable columns={insightsColumns} data={tableData} />
             </Row>
           </section>
+          <Tabs
+            className={commonStyles("cockroach--tabs")}
+            defaultActiveKey={TabKeysEnum.OVERVIEW}
+            onTabClick={onTabClick}
+          >
+            <Tabs.TabPane tab="Overview" key={TabKeysEnum.OVERVIEW}>
+              <StatementInsightDetailsOverviewTab
+                insightEventDetails={insightEventDetails}
+              />
+            </Tabs.TabPane>
+            {!isTenant && (
+              <Tabs.TabPane tab="Explain Plan" key={TabKeysEnum.EXPLAIN}>
+                <section className={cx("section")}>
+                  <Row gutter={24}>
+                    <Col span={24}>
+                      <SqlBox
+                        value={explain || "Not available."}
+                        size={SqlBoxSize.custom}
+                      />
+                    </Col>
+                  </Row>
+                </section>
+              </Tabs.TabPane>
+            )}
+          </Tabs>
         </Loading>
-      </section>
+      </div>
     </div>
   );
 };

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsConnected.tsx
@@ -18,6 +18,7 @@ import {
   selectStatementInsightDetails,
   selectStatementInsightsError,
 } from "src/store/insights/statementInsights";
+import { selectIsTenant } from "src/store/uiConfig";
 
 const mapStateToProps = (
   state: AppState,
@@ -28,6 +29,7 @@ const mapStateToProps = (
   return {
     insightEventDetails: insightStatements,
     insightError: insightError,
+    isTenant: selectIsTenant(state),
   };
 };
 

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
@@ -1,0 +1,210 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+import React, { useContext, useMemo } from "react";
+import { Col, Row } from "antd";
+import {
+  InsightsSortedTable,
+  makeInsightsColumns,
+} from "src/insightsTable/insightsTable";
+import { SummaryCard, SummaryCardItem } from "src/summaryCard";
+import { capitalize, Duration } from "src/util";
+import { DATE_FORMAT_24_UTC } from "src/util/format";
+import {
+  executionDetails,
+  InsightNameEnum,
+  InsightRecommendation,
+  StatementInsightEvent,
+} from "../types";
+import { populateStatementInsightsFromProblemAndCauses } from "../utils";
+import classNames from "classnames/bind";
+import { CockroachCloudContext } from "../../contexts";
+
+// Styles
+import insightsDetailsStyles from "src/insights/workloadInsightDetails/insightsDetails.module.scss";
+import summaryCardStyles from "src/summaryCard/summaryCard.module.scss";
+import insightTableStyles from "src/insightsTable/insightsTable.module.scss";
+import "antd/lib/col/style";
+import "antd/lib/row/style";
+
+const cx = classNames.bind(insightsDetailsStyles);
+const tableCx = classNames.bind(insightTableStyles);
+const summaryCardStylesCx = classNames.bind(summaryCardStyles);
+
+const insightsTableData = (
+  insightDetails: StatementInsightEvent | null,
+): InsightRecommendation[] => {
+  if (!insightDetails) return [];
+
+  const recs: InsightRecommendation[] = [];
+  let rec: InsightRecommendation;
+  const execDetails: executionDetails = {
+    statement: insightDetails.query,
+    fingerprintID: insightDetails.statementFingerprintID,
+    retries: insightDetails.retries,
+  };
+  insightDetails.insights.forEach(insight => {
+    switch (insight.name) {
+      case InsightNameEnum.highContention:
+        rec = {
+          type: "HighContention",
+          execution: execDetails,
+          details: {
+            duration: insightDetails.elapsedTimeMillis,
+            description: insight.description,
+          },
+        };
+        break;
+      case InsightNameEnum.failedExecution:
+        rec = {
+          type: "FailedExecution",
+        };
+        break;
+      case InsightNameEnum.highRetryCount:
+        rec = {
+          type: "HighRetryCount",
+          execution: execDetails,
+          details: {
+            description: insight.description,
+          },
+        };
+        break;
+      case InsightNameEnum.planRegression:
+        rec = {
+          type: "PlanRegression",
+          execution: execDetails,
+          details: {
+            description: insight.description,
+          },
+        };
+        break;
+      case InsightNameEnum.suboptimalPlan:
+        rec = {
+          type: "SuboptimalPlan",
+          database: insightDetails.databaseName,
+          execution: {
+            ...execDetails,
+            indexRecommendations: insightDetails.indexRecommendations,
+          },
+          details: {
+            description: insight.description,
+          },
+        };
+        break;
+      default:
+        rec = {
+          type: "Unknown",
+          details: {
+            duration: insightDetails.elapsedTimeMillis,
+            description: insight.description,
+          },
+        };
+        break;
+    }
+    recs.push(rec);
+  });
+  return recs;
+};
+
+export interface StatementInsightDetailsOverviewTabProps {
+  insightEventDetails: StatementInsightEvent;
+}
+
+export const StatementInsightDetailsOverviewTab: React.FC<
+  StatementInsightDetailsOverviewTabProps
+> = ({ insightEventDetails }) => {
+  const isCockroachCloud = useContext(CockroachCloudContext);
+
+  const insightsColumns = useMemo(
+    () => makeInsightsColumns(isCockroachCloud),
+    [isCockroachCloud],
+  );
+
+  const insightDetailsArr = useMemo(
+    () => populateStatementInsightsFromProblemAndCauses([insightEventDetails]),
+    [insightEventDetails],
+  );
+  const insightDetails = insightDetailsArr.length ? insightDetailsArr[0] : null;
+  const tableData = insightsTableData(insightDetails);
+
+  return (
+    <section className={cx("section")}>
+      <Row gutter={24}>
+        <Col span={12}>
+          <SummaryCard>
+            <SummaryCardItem
+              label="Start Time"
+              value={insightDetails.startTime.format(DATE_FORMAT_24_UTC)}
+            />
+            <SummaryCardItem
+              label="End Time"
+              value={insightDetails.endTime.format(DATE_FORMAT_24_UTC)}
+            />
+            <SummaryCardItem
+              label="Elapsed Time"
+              value={Duration(insightDetails.elapsedTimeMillis * 1e6)}
+            />
+            <SummaryCardItem
+              label="Rows Read"
+              value={insightDetails.rowsRead}
+            />
+            <SummaryCardItem
+              label="Rows Written"
+              value={insightDetails.rowsWritten}
+            />
+            <SummaryCardItem
+              label="Transaction Priority"
+              value={capitalize(insightDetails.priority)}
+            />
+            <SummaryCardItem
+              label="Full Scan"
+              value={capitalize(String(insightDetails.isFullScan))}
+            />
+          </SummaryCard>
+        </Col>
+        <Col className="gutter-row" span={12}>
+          <SummaryCard>
+            <SummaryCardItem
+              label="Transaction Retries"
+              value={insightDetails.retries}
+            />
+            {insightDetails.lastRetryReason && (
+              <SummaryCardItem
+                label="Last Retry Reason"
+                value={insightDetails.lastRetryReason.toString()}
+              />
+            )}
+            <p className={summaryCardStylesCx("summary--card__divider")} />
+            <SummaryCardItem
+              label="Session ID"
+              value={String(insightDetails.sessionID)}
+            />
+            <SummaryCardItem
+              label="Transaction Fingerprint ID"
+              value={String(insightDetails.transactionFingerprintID)}
+            />
+            <SummaryCardItem
+              label="Transaction Execution ID"
+              value={String(insightDetails.transactionID)}
+            />
+            <SummaryCardItem
+              label="Statement Fingerprint ID"
+              value={String(insightDetails.statementFingerprintID)}
+            />
+          </SummaryCard>
+        </Col>
+      </Row>
+      <Row gutter={24} className={tableCx("margin-bottom")}>
+        <Col>
+          <InsightsSortedTable columns={insightsColumns} data={tableData} />
+        </Col>
+      </Row>
+    </section>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsights.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsights.fixture.ts
@@ -40,6 +40,7 @@ export const statementInsightsPropsFixture: StatementInsightsViewProps = {
       rowsRead: 100,
       insights: null,
       indexRecommendations: ["make this index"],
+      planGist: "abc",
     },
     {
       statementID: "f72f37ea-b3a0-451f-80b8-dfb27d0bc2a9",
@@ -65,6 +66,7 @@ export const statementInsightsPropsFixture: StatementInsightsViewProps = {
       rowsRead: 100,
       insights: null,
       indexRecommendations: ["make that index"],
+      planGist: "abc",
     },
     {
       statementID: "f72f37ea-b3a0-451f-80b8-dfb27d0bc2a9",
@@ -91,6 +93,7 @@ export const statementInsightsPropsFixture: StatementInsightsViewProps = {
       rowsRead: 100,
       insights: null,
       indexRecommendations: ["make these indices"],
+      planGist: "abc",
     },
   ],
   statementsError: null,

--- a/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.module.scss
@@ -31,11 +31,6 @@
   margin-bottom: 30px;
 }
 
-.section {
-  flex: 0 0 auto;
-  padding: 12px 24px 12px 0px;
-}
-
 .inline {
   display: inline-flex;
 }


### PR DESCRIPTION
## Commit 1

This commit refactors the statement insight details page
component from a class component to a functional component.

Release note: None

## Commit 2

cluster-ui: add explain plan tab for statement insights

Closes https://github.com/cockroachdb/cockroach/issues/88093

This commit adds a new tab to the statement insight details
page. The page is now separated into two tabs:
1. Overview - what was already  on the page (insights details)
2. Explain Plan - the explain plan for the stmt being viewed

Release note (ui change): new tab view added to the stmt insight
details page:
1. Overview - what was already  on the page (insights details)
2. Explain Plan - the explain plan for the stmt being viewed

<img width="1729" alt="image" src="https://user-images.githubusercontent.com/20136951/196738717-fbb51349-a3a8-4dc0-8d39-f66449b31394.png">
