### PR TITLE
sql: fix a non-deterministic DELETE ... USING logic test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/delete
+++ b/pkg/sql/logictest/testdata/logic_test/delete
@@ -451,12 +451,12 @@ DELETE FROM u_a AS foo USING u_b AS bar WHERE bar.a > foo.c ORDER BY bar.a DESC 
 
 # Test aliased table names, ORDER BY and LIMIT where ORDER BY references the target
 # table.
-query ITIIT
-DELETE FROM u_a AS foo USING u_b AS bar WHERE bar.a > foo.c ORDER BY foo.a DESC LIMIT 3 RETURNING *;
+query ITI
+DELETE FROM u_a AS foo USING u_b AS bar WHERE bar.a > foo.c ORDER BY foo.a DESC LIMIT 3 RETURNING foo.*;
 ----
-7  d  35  40  d
-6  d  30  40  d
-5  d  25  40  d
+7  d  35
+6  d  30
+5  d  25
 
 query ITI rowsort
 SELECT * FROM u_a;


### PR DESCRIPTION
Previously, a logic test testing ORDER BY and LIMIT in DELETE ... USING statements would sometimes return a different row from the USING table when run through stress tests, due to the ORDER BY ... LIMIT clause allowing the USING to join on either of two rows. This fix changes the output columns of the RETURNING to ensure it only returns columns from the target table and ensures deterministic output.

Release note: None

Epic: CRDB-5498