### PR TITLE
backupccl: add metrics for file SST sink

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "create_scheduled_backup.go",
         "file_sst_sink.go",
         "key_rewriter.go",
+        "metrics.go",
         "restoration_data.go",
         "restore_data_processor.go",
         "restore_job.go",

--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -551,7 +551,8 @@ func runBackupProcessor(
 			return err
 		}
 
-		sink, err := makeFileSSTSink(ctx, sinkConf, storage, memAcc)
+		metrics := flowCtx.Cfg.JobRegistry.MetricsStruct().Backup.(*Metrics)
+		sink, err := makeFileSSTSink(ctx, sinkConf, storage, memAcc, metrics)
 		if err != nil {
 			return err
 		}

--- a/pkg/ccl/backupccl/metrics.go
+++ b/pkg/ccl/backupccl/metrics.go
@@ -1,0 +1,59 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package backupccl
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+)
+
+var (
+	metaFileSSTSinkFlushedBytes = metric.Metadata{
+		Name:        "backup.file_sst_sink.flushed.bytes",
+		Help:        "Bytes flushed by the file SST sink",
+		Measurement: "Bytes",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaFileSSTSinkFlushedFiles = metric.Metadata{
+		Name:        "backup.file_sst_sink.flushed.files",
+		Help:        "Files flushed by the file SST sink",
+		Measurement: "Flushes",
+		Unit:        metric.Unit_COUNT,
+	}
+)
+
+// Metrics are for monitoring of backup jobs.
+type Metrics struct {
+	// FileSSTSinkFlushedBytes tracks the number of bytes that have been flushed
+	// across file SST sinks that are responsible for writing SSTs to
+	// ExternalStorage during backup.
+	FileSSTSinkFlushedBytes *metric.Counter
+	// FileSSTSinkFlushedFiles tracks the number of SST files that have been
+	// flushed across file SST sinks that are responsible for writing SSTs to
+	// ExternalStorage during backup.
+	FileSSTSinkFlushedFiles *metric.Counter
+}
+
+// MetricStruct implements the metric.Struct interface.
+func (*Metrics) MetricStruct() {}
+
+// MakeMetrics makes the metrics for stream ingestion job monitoring.
+func MakeMetrics() metric.Struct {
+	m := &Metrics{
+		FileSSTSinkFlushedBytes: metric.NewCounter(metaFileSSTSinkFlushedBytes),
+		FileSSTSinkFlushedFiles: metric.NewCounter(metaFileSSTSinkFlushedFiles),
+	}
+	return m
+}
+
+func init() {
+	jobs.MakeBackupMetricsHook = MakeMetrics
+}

--- a/pkg/jobs/metrics.go
+++ b/pkg/jobs/metrics.go
@@ -30,6 +30,7 @@ type Metrics struct {
 	RowLevelTTL  metric.Struct
 	Changefeed   metric.Struct
 	StreamIngest metric.Struct
+	Backup       metric.Struct
 
 	// AdoptIterations counts the number of adopt loops executed by Registry.
 	AdoptIterations *metric.Counter
@@ -201,6 +202,9 @@ func (m *Metrics) init(histogramWindowInterval time.Duration) {
 	if MakeStreamIngestMetricsHook != nil {
 		m.StreamIngest = MakeStreamIngestMetricsHook(histogramWindowInterval)
 	}
+	if MakeBackupMetricsHook != nil {
+		m.Backup = MakeBackupMetricsHook()
+	}
 	m.AdoptIterations = metric.NewCounter(metaAdoptIterations)
 	m.ClaimedJobs = metric.NewCounter(metaClaimedJobs)
 	m.ResumedJobs = metric.NewCounter(metaResumedClaimedJobs)
@@ -234,6 +238,9 @@ var MakeStreamIngestMetricsHook func(duration time.Duration) metric.Struct
 
 // MakeRowLevelTTLMetricsHook allows for registration of row-level TTL metrics.
 var MakeRowLevelTTLMetricsHook func(time.Duration) metric.Struct
+
+// MakeBackupMetricsHook allows for registration of backup metrics.
+var MakeBackupMetricsHook func() metric.Struct
 
 // JobTelemetryMetrics is a telemetry metrics for individual job types.
 type JobTelemetryMetrics struct {


### PR DESCRIPTION
This change adds two new metrics to track the bytes and files flushed by file SST sinks during a backup.

`backup.file_sst_sink.flushed.bytes`
`backup.file_sst_sink.flushed.files`

Release note: None