### PR TITLE
sql: add a subtest directive for `DELETE FROM ... USING`

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/delete
+++ b/pkg/sql/logictest/testdata/logic_test/delete
@@ -337,6 +337,8 @@ SELECT * FROM a AS OF SYSTEM TIME $ts
 
 # Test that USING works.
 
+subtest delete_using
+
 statement ok
 CREATE TABLE u_a (
     a INT NOT NULL PRIMARY KEY,


### PR DESCRIPTION
This PR adds a subtest directive for `DELETE FROM ... USING` logictests. Previously, if a `DELETE FROM ... USING` test would fail, it could  be mistriaged because it was labeled with an incorrect directive. This fix ensures that tests testing the `DELETE FROM ... USING` functionality have the `delete_using` directive.

Epic: CRDB-5498

Release note: None