### PR TITLE
roachtest/tpchvec: disable auto stats collection

### DIFF
--- a/pkg/cmd/roachtest/tests/tpchvec.go
+++ b/pkg/cmd/roachtest/tests/tpchvec.go
@@ -544,6 +544,13 @@ func runTPCHVec(
 	t.Status("waiting for full replication")
 	err := WaitFor3XReplication(ctx, t, conn)
 	require.NoError(t, err)
+
+	_, err = conn.Exec("SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false;")
+	require.NoError(t, err)
+	defer func() {
+		_, err := conn.Exec("RESET CLUSTER SETTING sql.stats.automatic_collection.enabled;")
+		require.NoError(t, err)
+	}()
 	createStatsFromTables(t, conn, tpchTables)
 
 	testRun(ctx, t, c, conn, testCase)


### PR DESCRIPTION
At the beginning of the tpchvec tests we load the TPC-H dataset and analyze all tables. Then we proceed to run each query a few times, both with and without some settings. During these tests we should disable automatic stats collection so that it doesn't interfere with results.

Fixes: #89895

Release note: None