### PR TITLE
multiregionccl: add a datadriven test for secondary region failover

### DIFF
--- a/pkg/ccl/multiregionccl/datadriven_test.go
+++ b/pkg/ccl/multiregionccl/datadriven_test.go
@@ -194,6 +194,12 @@ SET CLUSTER SETTING kv.closed_timestamp.propagation_slack = '0.5s'
 			case "cleanup-cluster":
 				ds.cleanup(ctx)
 
+			case "stop-server":
+				mustHaveArgOrFatal(t, d, serverIdx)
+				var idx int
+				d.ScanArgs(t, serverIdx, &idx)
+				ds.tc.StopServer(idx)
+
 			case "exec-sql":
 				mustHaveArgOrFatal(t, d, serverIdx)
 				var err error
@@ -301,7 +307,7 @@ SET CLUSTER SETTING kv.closed_timestamp.propagation_slack = '0.5s'
 				// There's a lot going on here and things can fail at various steps, for
 				// completely legitimate reasons, which is why this thing needs to be
 				// wrapped in a succeeds soon.
-				if err := testutils.SucceedsSoonError(func() error {
+				if err := testutils.SucceedsWithinError(func() error {
 					desc, err := ds.tc.LookupRange(lookupKey)
 					if err != nil {
 						return err
@@ -404,7 +410,7 @@ SET CLUSTER SETTING kv.closed_timestamp.propagation_slack = '0.5s'
 					}
 
 					return nil
-				}); err != nil {
+				}, 2*time.Minute); err != nil {
 					return err.Error()
 				}
 

--- a/pkg/ccl/multiregionccl/testdata/secondary_region
+++ b/pkg/ccl/multiregionccl/testdata/secondary_region
@@ -1,0 +1,67 @@
+new-cluster localities=us-east-1,us-east-1,us-west-1,us-west-1,us-central-1,us-central-1,us-central-1,eu-west-1,eu-west-1,eu-west-1
+----
+
+exec-sql idx=2
+SET CLUSTER SETTING server.time_until_store_dead = '25s';
+----
+
+exec-sql idx=2
+CREATE DATABASE db PRIMARY REGION "us-west-1" REGIONS "us-central-1", "eu-west-1" SECONDARY REGION "us-east-1";
+----
+
+exec-sql idx=2
+ALTER DATABASE db SURVIVE REGION FAILURE;
+----
+
+exec-sql idx=2
+CREATE TABLE db.rbt(k INT PRIMARY KEY, v INT) LOCALITY REGIONAL BY TABLE IN "us-west-1";
+----
+
+exec-sql idx=2
+INSERT INTO db.rbt VALUES (1, 1), (2,2)
+----
+
+# Two of nodes 4, 5, 6, 7, 8, and 9 will have replicas, but it's not deterministic.
+wait-for-zone-config-changes idx=2 db-name=db table-name=rbt num-voters=5 num-non-voters=1 leaseholder=2 voters=0,1,3
+----
+
+# Execute query in us-west-1.
+trace-sql idx=2
+SELECT * FROM db.rbt WHERE k = 1
+----
+served locally: true
+served via follower read: false
+
+# Execute query in us-east-1.
+refresh-range-descriptor-cache idx=0 table-name=rbt
+SELECT * FROM db.rbt WHERE k = 1
+----
+LAG_BY_CLUSTER_SETTING
+
+trace-sql idx=0
+SELECT * FROM db.rbt WHERE k = 1
+----
+served locally: false
+
+# Stop all the nodes in us-west-1.
+stop-server idx=2
+----
+
+stop-server idx=3
+----
+
+# Four of nodes 4, 5, 6, 7, 8, and 9 will have replicas, but it's not deterministic.
+wait-for-zone-config-changes idx=0 db-name=db table-name=rbt num-voters=5 num-non-voters=1 leaseholder=0 voters=1
+----
+
+refresh-range-descriptor-cache idx=0 table-name=rbt
+SELECT * FROM db.rbt WHERE k = 2
+----
+LAG_BY_CLUSTER_SETTING
+
+# Reads from us-east-1 now should be local since the data should have failed over.
+trace-sql idx=0
+SELECT * FROM db.rbt WHERE k = 1
+----
+served locally: true
+served via follower read: false


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/90169

This test shows that the lease holder and voters fail over to the secondary region when the primary region is taken offline.

Release note: None