### PR TITLE
sql: skip dropped descriptors in REASSIGN OWNED BY

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/reassign_owned_by
+++ b/pkg/sql/logictest/testdata/logic_test/reassign_owned_by
@@ -331,3 +331,27 @@ user testuser2
 
 statement ok
 DROP TABLE t1;
+
+# In issue #90238 we noticed that reassign owned by does not skip
+# over dropped descriptor as it scans the entire descriptors table
+# to determine which ones to update ownership on. This can lead be
+# problematic scenarios since it will attempt to modify ownership
+# on descriptors that may have had their parents cleaned up.
+subtest reassign_owned_by_with_dropped_descriptors
+user root
+statement ok
+CREATE DATABASE db1;
+ALTER DATABASE db1 OWNER TO testuser;
+CREATE SCHEMA db1.sc1;
+ALTER SCHEMA db1.sc1 OWNER TO testuser;
+CREATE TABLE db1.sc1.table(n int);
+ALTER TABLE db1.sc1.table OWNER TO testuser;
+
+statement ok
+DROP SCHEMA db1.sc1 CASCADE;
+
+statement ok
+use db1;
+REASSIGN OWNED BY testuser TO testuser2;
+
+

--- a/pkg/sql/reassign_owned_by.go
+++ b/pkg/sql/reassign_owned_by.go
@@ -205,6 +205,9 @@ func (n *reassignOwnedByNode) reassignDatabaseOwner(
 	if err != nil {
 		return err
 	}
+	if mutableDbDesc.Dropped() {
+		return nil
+	}
 	owner, err := decodeusername.FromRoleSpec(
 		params.p.SessionData(), username.PurposeValidation, n.n.NewRole,
 	)
@@ -230,6 +233,9 @@ func (n *reassignOwnedByNode) reassignSchemaOwner(
 	mutableSchemaDesc, err := params.p.Descriptors().GetMutableDescriptorByID(params.ctx, params.p.txn, schemaDesc.GetID())
 	if err != nil {
 		return err
+	}
+	if mutableSchemaDesc.Dropped() {
+		return nil
 	}
 	owner, err := decodeusername.FromRoleSpec(
 		params.p.SessionData(), username.PurposeValidation, n.n.NewRole,
@@ -257,7 +263,9 @@ func (n *reassignOwnedByNode) reassignTableOwner(
 	if err != nil {
 		return err
 	}
-
+	if mutableTbDesc.Dropped() {
+		return nil
+	}
 	tableName, err := params.p.getQualifiedTableName(params.ctx, tbDesc)
 	if err != nil {
 		return err
@@ -287,6 +295,9 @@ func (n *reassignOwnedByNode) reassignTypeOwner(
 	mutableTypDesc, err := params.p.Descriptors().GetMutableDescriptorByID(params.ctx, params.p.txn, typDesc.GetID())
 	if err != nil {
 		return err
+	}
+	if mutableTypDesc.Dropped() {
+		return nil
 	}
 	arrayDesc, err := params.p.Descriptors().GetMutableTypeVersionByID(
 		params.ctx, params.p.txn, typDesc.GetArrayTypeID())
@@ -335,6 +346,9 @@ func (n *reassignOwnedByNode) reassignFunctionOwner(
 	)
 	if err != nil {
 		return err
+	}
+	if mutableDesc.Dropped() {
+		return nil
 	}
 	newOwner, err := decodeusername.FromRoleSpec(
 		params.p.SessionData(), username.PurposeValidation, n.n.NewRole,

--- a/pkg/sql/schema_resolver.go
+++ b/pkg/sql/schema_resolver.go
@@ -188,6 +188,7 @@ func (sr *schemaResolver) getQualifiedTableName(
 	schemaID := desc.GetParentSchemaID()
 	scDesc, err := sr.descCollection.GetImmutableSchemaByID(ctx, sr.txn, schemaID,
 		tree.SchemaLookupFlags{
+			Required:       true,
 			IncludeOffline: true,
 			IncludeDropped: true,
 			AvoidLeased:    true,


### PR DESCRIPTION
This PR will make the following changes

1. REASSIGN OWNED BY incorrectly worked on all descriptors previously, which meant this operation would attempt to modify authorization on descriptors that were dropped as well. This could be problematic in some cases since this operation needs the parent objects to be around for tables to be successful.
2. getQualifiedTableName did not properly return an error if the parent schema object was missing.