### PR TITLE
azure: make number of concurrent upload buffers configurable

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -16,6 +16,7 @@ changefeed.event_consumer_workers	integer	0	the number of workers to use when pr
 changefeed.fast_gzip.enabled	boolean	true	use fast gzip implementation
 changefeed.node_throttle_config	string		specifies node level throttling configuration for all changefeeeds
 changefeed.schema_feed.read_with_priority_after	duration	1m0s	retry with high priority if we were not able to read descriptors for too long; 0 disables
+cloudstorage.azure.concurrent_upload_buffers	integer	1	controls the number of concurrent buffers that will be used by the Azure client when uploading chunks.Each buffer can buffer up to cloudstorage.write_chunk.size of memory during an upload
 cloudstorage.http.custom_ca	string		custom root CA (appended to system's default CAs) for verifying certificates when interacting with HTTPS storage
 cloudstorage.timeout	duration	10m0s	the timeout for import/export storage operations
 cluster.organization	string		organization name

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -22,6 +22,7 @@
 <tr><td><code>changefeed.fast_gzip.enabled</code></td><td>boolean</td><td><code>true</code></td><td>use fast gzip implementation</td></tr>
 <tr><td><code>changefeed.node_throttle_config</code></td><td>string</td><td><code></code></td><td>specifies node level throttling configuration for all changefeeeds</td></tr>
 <tr><td><code>changefeed.schema_feed.read_with_priority_after</code></td><td>duration</td><td><code>1m0s</code></td><td>retry with high priority if we were not able to read descriptors for too long; 0 disables</td></tr>
+<tr><td><code>cloudstorage.azure.concurrent_upload_buffers</code></td><td>integer</td><td><code>1</code></td><td>controls the number of concurrent buffers that will be used by the Azure client when uploading chunks.Each buffer can buffer up to cloudstorage.write_chunk.size of memory during an upload</td></tr>
 <tr><td><code>cloudstorage.http.custom_ca</code></td><td>string</td><td><code></code></td><td>custom root CA (appended to system's default CAs) for verifying certificates when interacting with HTTPS storage</td></tr>
 <tr><td><code>cloudstorage.timeout</code></td><td>duration</td><td><code>10m0s</code></td><td>the timeout for import/export storage operations</td></tr>
 <tr><td><code>cluster.organization</code></td><td>string</td><td><code></code></td><td>organization name</td></tr>

--- a/pkg/cloud/azure/BUILD.bazel
+++ b/pkg/cloud/azure/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/cloud/externalconn/utils",
         "//pkg/security/username",
         "//pkg/server/telemetry",
+        "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/util/contextutil",
         "//pkg/util/ioctx",


### PR DESCRIPTION
This change makes the number of concurrent buffers used by the Azure SDK Writer configurable. When uploading a file the writes are divided into 8MiB chunks that are then streamed to Azure. The SDK exposes the number of buffers that can be concurrently filled and uploaded and we were previously using the default value of 1. This change introduces a cluster setting `cloudstorage.azure.concurrent_upload_buffers` that defaults to 1 but can be increased to speed up the upload of files during a backup.

Note, increasing the number of concurrent buffers implies an increase in the amount of data held in memory.

Informs: #90297

Release note (sql change): new cluster setting
`cloudstorage.azure.concurrent_upload_buffers` to configure the number of concurrent buffers used when uploading files to Azure