### PR TITLE
backupccl: disable tenants in datadriven test

### DIFF
--- a/pkg/ccl/backupccl/datadriven_test.go
+++ b/pkg/ccl/backupccl/datadriven_test.go
@@ -142,7 +142,7 @@ func (d *datadrivenTestState) addServer(t *testing.T, cfg serverCfg) error {
 	var cleanup func()
 	params := base.TestClusterArgs{}
 	params.ServerArgs.ExternalIODirConfig = cfg.ioConf
-	params.ServerArgs.DisableDefaultTestTenant = cfg.disableTenant
+	params.ServerArgs.DisableDefaultTestTenant = true
 	params.ServerArgs.Knobs = base.TestingKnobs{
 		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 	}


### PR DESCRIPTION
In #88271 we enabled most DD tests to run as tenants but we saw an uptick in timeouts on CI. This change disables these tests from being run as tenants while we dig into the timeouts.

Release note: None

Epic: none