### PR TITLE
release-22.2.0: Add arm64 support to docker image creating tasks

### DIFF
--- a/build/release/teamcity-support.sh
+++ b/build/release/teamcity-support.sh
@@ -4,6 +4,18 @@
 root="$(dirname $(dirname $(cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )))"
 source "$root/build/teamcity-common-support.sh"
 
+declare -a platform_names=( "amd64::amd64" "aarch64::arm64" )
+declare -a tarball_archs=( "${platform_names[@]%%::*}" ) 
+declare -a docker_archs=( "${platform_names[@]##*::}" )
+
+function tarball_arch_from_platform_name() {
+  echo "${1%%::*}"
+}
+
+function docker_arch_from_platform_name() {
+  echo "${1##*::}"
+}
+
 remove_files_on_exit() {
   rm -rf ~/.docker
   common_support_remove_files_on_exit

--- a/build/teamcity/cockroach/ci/builds/build_docker_image.sh
+++ b/build/teamcity/cockroach/ci/builds/build_docker_image.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euxo pipefail
+
+# The first and only parameter is the name of the architecture the image is being built for.
+# This should be the format Docker expects for the platform flag minus linux/ - i.e., either
+# amd64 or arm64. Old TC configs will run this file directly and not supply a platform, so
+# default to amd64.
+build_arch=${1:-amd64}
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
 source "$dir/teamcity-support.sh"  # For $root
@@ -11,7 +17,7 @@ chmod o+rwx "${artifacts}"
 
 tc_start_block "Copy cockroach binary and dependency files to build/deploy"
 
-# Get the cockroach binary from Build (Linux x86_64)
+# Get the cockroach binary from Build (Linux ${arch})
 # Artifacts rules:
 # bazel-bin/pkg/cmd/cockroach/cockroach_/cockroach=>upstream_artifacts
 # bazel-bin/c-deps/libgeos/lib/libgeos.so=>upstream_artifacts
@@ -33,11 +39,19 @@ docker_image_tar_name="cockroach-docker-image.tar"
 
 docker_tag="cockroachdb/cockroach-ci"
 
+# We have to always pull here because this runner may have been used to build
+# a different architecture's docker image. If that's the case, the cache will
+# return the cached version of the UBI base image (which will be for the wrong
+# architecture), then build will use it and fail because it's for the wrong
+# architecture. The cache is really stupid, in other words.
+
 docker build \
   --no-cache \
+  --platform=linux/${build_arch} \
   --tag="$docker_tag" \
   --memory 30g \
   --memory-swap -1 \
+  --pull \
   build/deploy
 
 docker save "$docker_tag" | gzip > "${artifacts}/${docker_image_tar_name}".gz

--- a/build/teamcity/cockroach/ci/builds/build_docker_image_arm64.sh
+++ b/build/teamcity/cockroach/ci/builds/build_docker_image_arm64.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+source "$(dirname "${0}")/build_docker_image.sh" arm64

--- a/build/teamcity/cockroach/ci/builds/build_docker_image_x86_64.sh
+++ b/build/teamcity/cockroach/ci/builds/build_docker_image_x86_64.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+source "$(dirname "${0}")/build_docker_image.sh" amd64


### PR DESCRIPTION
Backport 1/1 commits from #89548.

/cc @cockroachdb/release

---

This changes the x86_64 image in nightly and final build steps to be prefixed
with "amd64-", and adds an arm64 image which is prefixed with "arm64-".
The unprefixed image, which was previously the x86_64 image, is now a
multi-architecture image which points to the two prefixed images.

This change also splits build_docker_image into build_docker_image_arm64
and build_docker_image_x86_64. The Build and Test Docker TeamCity builds
have been split accordingly, into arm64 and x86_64 variants for each.
These builds do not build/test the combined image, only the individual
platforms' images.

Part of https://github.com/cockroachdb/cockroach/issues/60778

Release note (general change): Cockroach Docker images are now multi
architecture manifests supporting the x86_64 (amd64) and arm64
architectures.


Release justification: Linux Arm64 platform is going to be supported in 22.2