### PR TITLE
Bump actions to version 3

### DIFF
--- a/.github/workflows/bincheck.yml
+++ b/.github/workflows/bincheck.yml
@@ -9,18 +9,18 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: sudo apt-get update && sudo apt-get install -y qemu-system-x86
     - run: cd build/release/bincheck && ./test-linux ${{ github.ref_name }} ${{ github.sha }}
 
   darwin:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: cd build/release/bincheck && ./test-macos ${{ github.ref_name }} ${{ github.sha }}
 
   windows:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: cd build/release/bincheck && bash test-windows ${{ github.ref_name }} ${{ github.sha }}

--- a/.github/workflows/pr-epic-issue-ref-lint.yml
+++ b/.github/workflows/pr-epic-issue-ref-lint.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Bazel cache
         id: bazel-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cache/bazel


### PR DESCRIPTION
This PR updates the used actions to the latest main version.
No changes in behavior expected.

Epic: none
Release note: none