### PR TITLE
kvserver: cleanup replica checksum computation func

### DIFF
--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -555,7 +555,7 @@ func WatchForDisappearingReplicas(t testing.TB, store *Store) {
 func ChecksumRange(
 	ctx context.Context, desc roachpb.RangeDescriptor, snap storage.Reader,
 ) ([]byte, error) {
-	lim := quotapool.NewRateLimiter("test", 1<<30, 1<<30)
+	lim := quotapool.NewRateLimiter("test", quotapool.Inf(), 0)
 	res, err := replicaSHA512(ctx, desc, snap, roachpb.ChecksumMode_CHECK_FULL, lim)
 	if err != nil {
 		return nil, err

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -550,15 +550,3 @@ func WatchForDisappearingReplicas(t testing.TB, store *Store) {
 		}
 	}
 }
-
-// ChecksumRange returns a checksum over the KV data of the given range.
-func ChecksumRange(
-	ctx context.Context, desc roachpb.RangeDescriptor, snap storage.Reader,
-) ([]byte, error) {
-	lim := quotapool.NewRateLimiter("test", quotapool.Inf(), 0)
-	res, err := replicaSHA512(ctx, desc, snap, roachpb.ChecksumMode_CHECK_FULL, lim)
-	if err != nil {
-		return nil, err
-	}
-	return res.SHA512[:], nil
-}

--- a/pkg/kv/kvserver/replica_consistency_test.go
+++ b/pkg/kv/kvserver/replica_consistency_test.go
@@ -164,7 +164,6 @@ func TestReplicaChecksumSHA512(t *testing.T) {
 
 	ctx := context.Background()
 	sb := &strings.Builder{}
-	lim := quotapool.NewRateLimiter("rate", quotapool.Inf(), 0)
 	eng := storage.NewDefaultInMemForTesting()
 	defer eng.Close()
 
@@ -175,9 +174,10 @@ func TestReplicaChecksumSHA512(t *testing.T) {
 	}
 
 	// Hash the empty state.
-	rh, err := replicaSHA512(ctx, desc, eng, roachpb.ChecksumMode_CHECK_FULL, lim)
+	unlim := quotapool.NewRateLimiter("test", quotapool.Inf(), 0)
+	rd, err := CalcReplicaDigest(ctx, desc, eng, roachpb.ChecksumMode_CHECK_FULL, unlim)
 	require.NoError(t, err)
-	fmt.Fprintf(sb, "checksum0: %x\n", rh.SHA512[:])
+	fmt.Fprintf(sb, "checksum0: %x\n", rd.SHA512)
 
 	// We incrementally add writes, and check the checksums after each write to
 	// make sure they differ such that each write affects the checksum.
@@ -213,17 +213,16 @@ func TestReplicaChecksumSHA512(t *testing.T) {
 			require.NoError(t, storage.MVCCPut(ctx, eng, nil, key, ts, localTS, value, nil))
 		}
 
-		rh, err = replicaSHA512(ctx, desc, eng, roachpb.ChecksumMode_CHECK_FULL, lim)
+		rd, err = CalcReplicaDigest(ctx, desc, eng, roachpb.ChecksumMode_CHECK_FULL, unlim)
 		require.NoError(t, err)
-		fmt.Fprintf(sb, "checksum%d: %x\n", i+1, rh.SHA512[:])
+		fmt.Fprintf(sb, "checksum%d: %x\n", i+1, rd.SHA512)
 	}
 
 	// Run another check to obtain stats for the final state.
-	rh, err = replicaSHA512(ctx, desc, eng, roachpb.ChecksumMode_CHECK_FULL, lim)
+	rd, err = CalcReplicaDigest(ctx, desc, eng, roachpb.ChecksumMode_CHECK_FULL, unlim)
 	require.NoError(t, err)
-
 	jsonpb := protoutil.JSONPb{Indent: "  "}
-	json, err := jsonpb.Marshal(&rh.RecomputedMS)
+	json, err := jsonpb.Marshal(&rd.RecomputedMS)
 	require.NoError(t, err)
 	fmt.Fprintf(sb, "stats: %s\n", string(json))
 

--- a/pkg/kv/kvserver/replica_consistency_test.go
+++ b/pkg/kv/kvserver/replica_consistency_test.go
@@ -164,7 +164,7 @@ func TestReplicaChecksumSHA512(t *testing.T) {
 
 	ctx := context.Background()
 	sb := &strings.Builder{}
-	lim := quotapool.NewRateLimiter("rate", 1e9, 0)
+	lim := quotapool.NewRateLimiter("rate", quotapool.Inf(), 0)
 	eng := storage.NewDefaultInMemForTesting()
 	defer eng.Close()
 

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -10431,9 +10431,8 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 		// Regression test for #31870.
 		snap := tc.engine.NewSnapshot()
 		defer snap.Close()
-		res, err := replicaSHA512(ctx, *tc.repl.Desc(), tc.engine,
-			roachpb.ChecksumMode_CHECK_FULL,
-			quotapool.NewRateLimiter("ConsistencyQueue", quotapool.Inf(), 0))
+		res, err := CalcReplicaDigest(ctx, *tc.repl.Desc(), tc.engine, roachpb.ChecksumMode_CHECK_FULL,
+			quotapool.NewRateLimiter("test", quotapool.Inf(), 0))
 		if err != nil {
 			return hlc.Timestamp{}, err
 		}
@@ -10998,17 +10997,13 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			ts, err := test.setupFn()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			ba, expTS := test.batchFn(ts)
 			actualTS, err := send(ba)
 			if !testutils.IsError(err, test.expErr) {
 				t.Fatalf("expected error %q; got \"%v\"", test.expErr, err)
 			}
-			if actualTS != expTS {
-				t.Fatalf("expected ts=%s; got %s", expTS, actualTS)
-			}
+			require.Equal(t, expTS, actualTS)
 		})
 	}
 }

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -10433,7 +10433,7 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 		defer snap.Close()
 		res, err := replicaSHA512(ctx, *tc.repl.Desc(), tc.engine,
 			roachpb.ChecksumMode_CHECK_FULL,
-			quotapool.NewRateLimiter("ConsistencyQueue", quotapool.Limit(math.MaxFloat64), math.MaxInt64))
+			quotapool.NewRateLimiter("ConsistencyQueue", quotapool.Inf(), 0))
 		if err != nil {
 			return hlc.Timestamp{}, err
 		}

--- a/pkg/util/quotapool/int_rate.go
+++ b/pkg/util/quotapool/int_rate.go
@@ -22,6 +22,11 @@ import (
 // Limit defines a rate in terms of quota per second.
 type Limit float64
 
+// Inf returns the infinite rate limit, which allows any rate and bursts.
+func Inf() Limit {
+	return Limit(math.Inf(1))
+}
+
 // RateLimiter implements a token-bucket style rate limiter.
 // It has the added feature that quota acquired from the pool can be returned
 // in the case that they end up not getting used.
@@ -34,6 +39,8 @@ type RateLimiter struct {
 // token bucket which has a maximum capacity of burst. If a request attempts to
 // acquire more than burst, it will block until the bucket is full and then
 // put the token bucket in debt.
+//
+// If rate == Inf() then any bursts are allowed, and acquisition does not block.
 func NewRateLimiter(name string, rate Limit, burst int64, options ...Option) *RateLimiter {
 	rl := &RateLimiter{}
 	tb := &TokenBucket{}


### PR DESCRIPTION
This commit makes the replica checksum helper more convenient for tests, and simplifies the tests using it.

Follows up on https://github.com/cockroachdb/cockroach/pull/89813#discussion_r997404648

Epic: None
Release note: None