### PR TITLE
roachtest: configure ignore and block lists for 23.1 in roachtests

### DIFF
--- a/pkg/cmd/roachtest/tests/activerecord_blocklist.go
+++ b/pkg/cmd/roachtest/tests/activerecord_blocklist.go
@@ -16,6 +16,7 @@ var activeRecordBlocklists = blocklistsForVersion{
 	{"v21.2", "activeRecordBlockList21_2", activeRecordBlockList21_2, "activeRecordIgnoreList21_2", activeRecordIgnoreList21_2},
 	{"v22.1", "activeRecordBlockList22_1", activeRecordBlockList22_1, "activeRecordIgnoreList22_1", activeRecordIgnoreList22_1},
 	{"v22.2", "activeRecordBlockList22_2", activeRecordBlockList22_2, "activeRecordIgnoreList22_2", activeRecordIgnoreList22_2},
+	{"v23.1", "activeRecordBlockList23_1", activeRecordBlockList23_1, "activeRecordIgnoreList23_1", activeRecordIgnoreList23_1},
 }
 
 // These are lists of known activerecord test errors and failures.
@@ -29,6 +30,8 @@ var activeRecordBlocklists = blocklistsForVersion{
 // Please keep these lists alphabetized for easy diffing.
 // After a failed run, an updated version of this blocklist should be available
 // in the test log.
+var activeRecordBlockList23_1 = blocklist{}
+
 var activeRecordBlockList22_2 = blocklist{}
 
 var activeRecordBlockList22_1 = blocklist{}
@@ -38,6 +41,8 @@ var activeRecordBlockList21_2 = blocklist{}
 var activeRecordBlockList21_1 = blocklist{}
 
 var activeRecordBlockList20_2 = blocklist{}
+
+var activeRecordIgnoreList23_1 = activeRecordIgnoreList22_2
 
 var activeRecordIgnoreList22_2 = activeRecordIgnoreList22_1
 

--- a/pkg/cmd/roachtest/tests/gopg_blocklist.go
+++ b/pkg/cmd/roachtest/tests/gopg_blocklist.go
@@ -16,6 +16,7 @@ var gopgBlocklists = blocklistsForVersion{
 	{"v21.2", "gopgBlockList21_2", gopgBlockList21_2, "gopgIgnoreList21_2", gopgIgnoreList21_2},
 	{"v22.1", "gopgBlockList22_1", gopgBlockList22_1, "gopgIgnoreList22_1", gopgIgnoreList22_1},
 	{"v22.2", "gopgBlockList22_2", gopgBlockList22_2, "gopgIgnoreList22_2", gopgIgnoreList22_2},
+	{"v23.1", "gopgBlockList23_1", gopgBlockList23_1, "gopgIgnoreList23_1", gopgIgnoreList23_1},
 }
 
 // These are lists of known gopg test errors and failures.
@@ -26,6 +27,8 @@ var gopgBlocklists = blocklistsForVersion{
 // Please keep these lists alphabetized for easy diffing.
 // After a failed run, an updated version of this blocklist should be available
 // in the test log.
+
+var gopgBlockList23_1 = gopgBlockList22_2
 
 var gopgBlockList22_2 = gopgBlockList22_1
 
@@ -80,6 +83,8 @@ var gopgBlockList20_2 = blocklist{
 	"v10.TestReadColumnValue":                                         "26925",
 	"v10.TestUnixSocket":                                              "31113",
 }
+
+var gopgIgnoreList23_1 = gopgIgnoreList22_2
 
 var gopgIgnoreList22_2 = gopgIgnoreList22_1
 

--- a/pkg/cmd/roachtest/tests/hibernate_blocklist.go
+++ b/pkg/cmd/roachtest/tests/hibernate_blocklist.go
@@ -16,6 +16,7 @@ var hibernateBlocklists = blocklistsForVersion{
 	{"v21.2", "hibernateBlockList21_2", hibernateBlockList21_2, "hibernateIgnoreList21_2", hibernateIgnoreList21_2},
 	{"v22.1", "hibernateBlockList22_1", hibernateBlockList22_1, "hibernateIgnoreList22_1", hibernateIgnoreList22_1},
 	{"v22.2", "hibernateBlockList22_2", hibernateBlockList22_2, "hibernateIgnoreList22_2", hibernateIgnoreList22_2},
+	{"v23.1", "hibernateBlockList23_1", hibernateBlockList23_1, "hibernateIgnoreList23_1", hibernateIgnoreList23_1},
 }
 
 var hibernateSpatialBlocklists = blocklistsForVersion{
@@ -23,11 +24,14 @@ var hibernateSpatialBlocklists = blocklistsForVersion{
 	{"v21.2", "hibernateSpatialBlockList21_2", hibernateSpatialBlockList21_2, "", nil},
 	{"v22.1", "hibernateSpatialBlockList22_1", hibernateSpatialBlockList22_1, "", nil},
 	{"v22.2", "hibernateSpatialBlockList22_2", hibernateSpatialBlockList22_2, "", nil},
+	{"v23.1", "hibernateSpatialBlockList23_1", hibernateSpatialBlockList23_1, "", nil},
 }
 
 // Please keep these lists alphabetized for easy diffing.
 // After a failed run, an updated version of this blocklist should be available
 // in the test log.
+var hibernateSpatialBlockList23_1 = blocklist{}
+
 var hibernateSpatialBlockList22_2 = blocklist{}
 
 var hibernateSpatialBlockList22_1 = blocklist{}
@@ -35,6 +39,8 @@ var hibernateSpatialBlockList22_1 = blocklist{}
 var hibernateSpatialBlockList21_2 = blocklist{}
 
 var hibernateSpatialBlockList21_1 = blocklist{}
+
+var hibernateBlockList23_1 = hibernateBlockList22_2
 
 var hibernateBlockList22_2 = hibernateBlockList22_1
 
@@ -237,6 +243,8 @@ var hibernateBlockList20_2 = blocklist{
 	"org.hibernate.test.naturalid.inheritance.cache.InheritedNaturalIdNoCacheTest.testLoadExtendedByNormal":                                                                                      "unknown",
 	"org.hibernate.test.where.annotations.EagerManyToOneFetchModeSelectWhereTest.testAssociatedWhereClause":                                                                                      "unknown",
 }
+
+var hibernateIgnoreList23_1 = hibernateIgnoreList22_2
 
 var hibernateIgnoreList22_2 = hibernateIgnoreList22_1
 

--- a/pkg/cmd/roachtest/tests/jasyncsql_blocklist.go
+++ b/pkg/cmd/roachtest/tests/jasyncsql_blocklist.go
@@ -13,7 +13,10 @@ package tests
 var jasyncsqlBlocklists = blocklistsForVersion{
 	{"v22.1", "jasyncsqlBlocklist22_1", jasyncBlocklist22_1, "jasyncsqlIgnoreList22_1", jasyncsqlIgnoreList22_1},
 	{"v22.2", "jasyncsqlBlocklist22_2", jasyncBlocklist22_2, "jasyncsqlIgnoreList22_2", jasyncsqlIgnoreList22_2},
+	{"v23.1", "jasyncsqlBlocklist23_1", jasyncBlocklist23_1, "jasyncsqlIgnoreList23_1", jasyncsqlIgnoreList23_1},
 }
+
+var jasyncBlocklist23_1 = jasyncBlocklist22_2
 
 var jasyncBlocklist22_2 = jasyncBlocklist22_1
 
@@ -74,6 +77,8 @@ var jasyncBlocklist22_1 = blocklist{
 	"com.github.aysnc.sql.db.integration.pool.SuspendingPoolSpec.transactions should commit simple inserts , prepared statements":                                   "unknown",
 	"com.github.aysnc.sql.db.integration.pool.SuspendingPoolSpec.transactions with pool should commit simple inserts , prepared statements":                         "unknown",
 }
+
+var jasyncsqlIgnoreList23_1 = jasyncsqlIgnoreList22_2
 
 var jasyncsqlIgnoreList22_2 = jasyncsqlIgnoreList22_1
 

--- a/pkg/cmd/roachtest/tests/libpq_blocklist.go
+++ b/pkg/cmd/roachtest/tests/libpq_blocklist.go
@@ -16,7 +16,10 @@ var libPQBlocklists = blocklistsForVersion{
 	{"v21.2", "libPQBlocklist21_2", libPQBlocklist21_2, "libPQIgnorelist21_2", libPQIgnorelist21_2},
 	{"v22.1", "libPQBlocklist22_1", libPQBlocklist22_1, "libPQIgnorelist22_1", libPQIgnorelist22_1},
 	{"v22.2", "libPQBlocklist22_2", libPQBlocklist22_2, "libPQIgnorelist22_2", libPQIgnorelist22_2},
+	{"v23.1", "libPQBlocklist23_1", libPQBlocklist23_1, "libPQIgnorelist23_1", libPQIgnorelist23_1},
 }
+
+var libPQBlocklist23_1 = libPQBlocklist22_2
 
 var libPQBlocklist22_2 = libPQBlocklist22_1
 
@@ -125,6 +128,8 @@ var libPQBlocklist20_2 = blocklist{
 	"pq.TestRuntimeParameters":                       "12137",
 	"pq.TestStringWithNul":                           "26366",
 }
+
+var libPQIgnorelist23_1 = libPQIgnorelist22_2
 
 var libPQIgnorelist22_2 = libPQIgnorelist22_1
 

--- a/pkg/cmd/roachtest/tests/liquibase_blocklist.go
+++ b/pkg/cmd/roachtest/tests/liquibase_blocklist.go
@@ -16,7 +16,10 @@ var liquibaseBlocklists = blocklistsForVersion{
 	{"v21.2", "liquibaseBlocklist21_2", liquibaseBlocklist21_2, "liquibaseIgnorelist21_2", liquibaseIgnorelist21_2},
 	{"v22.1", "liquibaseBlocklist22_1", liquibaseBlocklist22_1, "liquibaseIgnorelist21_2", liquibaseIgnorelist22_1},
 	{"v22.2", "liquibaseBlocklist22_2", liquibaseBlocklist22_2, "liquibaseIgnorelist21_2", liquibaseIgnorelist22_2},
+	{"v23.1", "liquibaseBlocklist23_1", liquibaseBlocklist23_1, "liquibaseIgnorelist23_1", liquibaseIgnorelist23_1},
 }
+
+var liquibaseBlocklist23_1 = liquibaseBlocklist22_2
 
 var liquibaseBlocklist22_2 = liquibaseBlocklist22_1
 
@@ -33,6 +36,8 @@ var liquibaseBlocklist21_2 = blocklist{
 var liquibaseBlocklist21_1 = liquibaseBlocklist20_2
 
 var liquibaseBlocklist20_2 = blocklist{}
+
+var liquibaseIgnorelist23_1 = liquibaseIgnorelist22_2
 
 var liquibaseIgnorelist22_2 = liquibaseIgnorelist22_1
 

--- a/pkg/cmd/roachtest/tests/pgx_blocklist.go
+++ b/pkg/cmd/roachtest/tests/pgx_blocklist.go
@@ -16,11 +16,14 @@ var pgxBlocklists = blocklistsForVersion{
 	{"v21.2", "pgxBlocklist21_2", pgxBlocklist21_2, "pgxIgnorelist21_2", pgxIgnorelist21_2},
 	{"v22.1", "pgxBlocklist22_1", pgxBlocklist22_1, "pgxIgnorelist22_1", pgxIgnorelist22_1},
 	{"v22.2", "pgxBlocklist22_2", pgxBlocklist22_2, "pgxIgnorelist22_2", pgxIgnorelist22_2},
+	{"v23.1", "pgxBlocklist23_1", pgxBlocklist23_1, "pgxIgnorelist23_1", pgxIgnorelist23_1},
 }
 
 // Please keep these lists alphabetized for easy diffing.
 // After a failed run, an updated version of this blocklist should be available
 // in the test log.
+var pgxBlocklist23_1 = blocklist{}
+
 var pgxBlocklist22_2 = blocklist{}
 
 var pgxBlocklist22_1 = blocklist{}
@@ -30,6 +33,8 @@ var pgxBlocklist21_2 = blocklist{}
 var pgxBlocklist21_1 = blocklist{}
 
 var pgxBlocklist20_2 = blocklist{}
+
+var pgxIgnorelist23_1 = pgxIgnorelist22_2
 
 var pgxIgnorelist22_2 = pgxIgnorelist22_1
 

--- a/pkg/cmd/roachtest/tests/psycopg_blocklist.go
+++ b/pkg/cmd/roachtest/tests/psycopg_blocklist.go
@@ -16,6 +16,7 @@ var psycopgBlocklists = blocklistsForVersion{
 	{"v21.2", "psycopgBlockList21_2", psycopgBlockList21_2, "psycopgIgnoreList21_2", psycopgIgnoreList21_2},
 	{"v22.1", "psycopgBlockList22_1", psycopgBlockList22_1, "psycopgIgnoreList22_1", psycopgIgnoreList22_1},
 	{"v22.2", "psycopgBlockList22_2", psycopgBlockList22_2, "psycopgIgnoreList22_2", psycopgIgnoreList22_2},
+	{"v23.1", "psycopgBlockList23_1", psycopgBlockList23_1, "psycopgIgnoreList23_1", psycopgIgnoreList23_1},
 }
 
 // These are lists of known psycopg test errors and failures.
@@ -29,6 +30,8 @@ var psycopgBlocklists = blocklistsForVersion{
 // Please keep these lists alphabetized for easy diffing.
 // After a failed run, an updated version of this blocklist should be available
 // in the test log.
+var psycopgBlockList23_1 = blocklist{}
+
 var psycopgBlockList22_2 = blocklist{}
 
 var psycopgBlockList22_1 = blocklist{}
@@ -49,6 +52,8 @@ var psycopgBlockList21_1 = blocklist{
 var psycopgBlockList20_2 = blocklist{
 	"tests.test_async_keyword.CancelTests.test_async_cancel": "41335",
 }
+
+var psycopgIgnoreList23_1 = psycopgIgnoreList22_2
 
 var psycopgIgnoreList22_2 = psycopgIgnoreList22_1
 


### PR DESCRIPTION
Configure ignore and block lists for 23.1 in roachtests.

Release note: None
Epic: RE-253