### PR TITLE
scstage: fixed a planner bug when building stages

### DIFF
--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_alter_primary_key
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_alter_primary_key
@@ -573,6 +573,9 @@ PostCommitNonRevertiblePhase stage 4 of 4 with 6 MutationType ops
     [[ColumnDefaultExpression:{DescID: 104, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
     [[PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
   ops:
+    *scop.RemoveColumnDefaultExpression
+      ColumnID: 3
+      TableID: 104
     *scop.CreateGCJobForIndex
       IndexID: 3
       StatementForDropJob:
@@ -589,9 +592,6 @@ PostCommitNonRevertiblePhase stage 4 of 4 with 6 MutationType ops
           SourceElementID: 1
           SubWorkID: 1
       IndexID: 3
-      TableID: 104
-    *scop.RemoveColumnDefaultExpression
-      ColumnID: 3
       TableID: 104
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 3

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_drop_column
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_drop_column
@@ -470,6 +470,14 @@ PostCommitNonRevertiblePhase stage 3 of 3 with 9 MutationType ops
     [[ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
     [[PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 2}, ABSENT], DELETE_ONLY] -> ABSENT
   ops:
+    *scop.RemoveDroppedColumnType
+      ColumnID: 2
+      TableID: 107
+    *scop.UpdateTableBackReferencesInTypes
+      BackReferencedTableID: 107
+      TypeIDs:
+      - 104
+      - 105
     *scop.CreateGCJobForIndex
       IndexID: 1
       StatementForDropJob:
@@ -487,14 +495,6 @@ PostCommitNonRevertiblePhase stage 3 of 3 with 9 MutationType ops
           SubWorkID: 1
       IndexID: 1
       TableID: 107
-    *scop.RemoveDroppedColumnType
-      ColumnID: 2
-      TableID: 107
-    *scop.UpdateTableBackReferencesInTypes
-      BackReferencedTableID: 107
-      TypeIDs:
-      - 104
-      - 105
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 2
       EventBase:
@@ -1423,6 +1423,14 @@ PostCommitNonRevertiblePhase stage 3 of 3 with 10 MutationType ops
     [[ColumnDefaultExpression:{DescID: 107, ColumnID: 3, ReferencedSequenceIDs: [106]}, ABSENT], PUBLIC] -> ABSENT
     [[PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 2}, ABSENT], DELETE_ONLY] -> ABSENT
   ops:
+    *scop.RemoveColumnDefaultExpression
+      ColumnID: 3
+      TableID: 107
+    *scop.UpdateBackReferencesInSequences
+      BackReferencedColumnID: 3
+      BackReferencedTableID: 107
+      SequenceIDs:
+      - 106
     *scop.CreateGCJobForIndex
       IndexID: 1
       StatementForDropJob:
@@ -1440,14 +1448,6 @@ PostCommitNonRevertiblePhase stage 3 of 3 with 10 MutationType ops
           SubWorkID: 1
       IndexID: 1
       TableID: 107
-    *scop.RemoveColumnDefaultExpression
-      ColumnID: 3
-      TableID: 107
-    *scop.UpdateBackReferencesInSequences
-      BackReferencedColumnID: 3
-      BackReferencedTableID: 107
-      SequenceIDs:
-      - 106
     *scop.MakeDeleteOnlyColumnAbsent
       ColumnID: 3
       EventBase:

--- a/pkg/sql/schemachanger/testdata/explain/add_column.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column.rollback_1_of_7
@@ -23,11 +23,11 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
            └── 9 Mutation operations
                 ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
+                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
-                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/add_column.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column.rollback_5_of_7
@@ -34,11 +34,11 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
            │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 8 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
-                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/add_column.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column.rollback_6_of_7
@@ -34,11 +34,11 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
            │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 8 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
-                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/add_column.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column.rollback_7_of_7
@@ -34,11 +34,11 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
            │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 8 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
-                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_1_of_7
@@ -23,12 +23,12 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
            └── 11 Mutation operations
                 ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
+                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
+                ├── UpdateBackReferencesInSequences {"BackReferencedColumnID":2,"BackReferencedTableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
-                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
-                ├── UpdateBackReferencesInSequences {"BackReferencedColumnID":2,"BackReferencedTableID":106}
                 ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":107}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_5_of_7
@@ -35,12 +35,12 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
            │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 10 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
+                ├── UpdateBackReferencesInSequences {"BackReferencedColumnID":2,"BackReferencedTableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
-                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
-                ├── UpdateBackReferencesInSequences {"BackReferencedColumnID":2,"BackReferencedTableID":106}
                 ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":107}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_6_of_7
@@ -35,12 +35,12 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
            │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 10 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
+                ├── UpdateBackReferencesInSequences {"BackReferencedColumnID":2,"BackReferencedTableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
-                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
-                ├── UpdateBackReferencesInSequences {"BackReferencedColumnID":2,"BackReferencedTableID":106}
                 ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":107}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_7_of_7
@@ -35,12 +35,12 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
            │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 10 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
+                ├── UpdateBackReferencesInSequences {"BackReferencedColumnID":2,"BackReferencedTableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
-                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
-                ├── UpdateBackReferencesInSequences {"BackReferencedColumnID":2,"BackReferencedTableID":106}
                 ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":107}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_10_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_10_of_15
@@ -62,9 +62,9 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
            │    └── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
            └── 6 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
-                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_11_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_11_of_15
@@ -62,9 +62,9 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
            │    └── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
            └── 6 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
-                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_12_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_12_of_15
@@ -62,9 +62,9 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
            │    └── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
            └── 6 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
-                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_13_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_13_of_15
@@ -64,9 +64,9 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
            │    └── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
            └── 6 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
-                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_14_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_14_of_15
@@ -64,9 +64,9 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
            │    └── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
            └── 6 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
-                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_15_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_15_of_15
@@ -64,9 +64,9 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
            │    └── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
            └── 6 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
-                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_1_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_1_of_15
@@ -22,11 +22,11 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
            └── 9 Mutation operations
                 ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
+                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
-                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_5_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_5_of_15
@@ -33,11 +33,11 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
            │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 8 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
-                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_6_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_6_of_15
@@ -33,11 +33,11 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
            │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 8 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
-                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_7_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_7_of_15
@@ -33,11 +33,11 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
            │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 8 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
-                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_8_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_8_of_15
@@ -33,11 +33,11 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
            │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 8 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
-                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_9_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_9_of_15
@@ -60,9 +60,9 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
            │    └── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
            └── 6 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
-                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":106}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_add_primary_key_drop_rowid
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_add_primary_key_drop_rowid
@@ -203,9 +203,9 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
            │    ├── PUBLIC                → ABSENT           ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
            │    └── PUBLIC                → ABSENT           ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
            └── 6 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
-                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":104}
                 ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid
@@ -324,9 +324,9 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
            │    ├── PUBLIC                → ABSENT           ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 3}
            │    └── PUBLIC                → ABSENT           ColumnDefaultExpression:{DescID: 104, ColumnID: 3}
            └── 6 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":3,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
-                ├── RemoveColumnDefaultExpression {"ColumnID":3,"TableID":104}
                 ├── MakeDeleteOnlyColumnAbsent {"ColumnID":3,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_10_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_10_of_15
@@ -58,6 +58,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":11,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":12,"TableID":104}
       │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":12,"TableID":104}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":104}
@@ -70,7 +71,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── LogEvent {"TargetStatus":1}
       │         ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
-      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":11,"TableID":104}
       │         ├── LogEvent {"TargetStatus":1}
       │         ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_11_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_11_of_15
@@ -58,6 +58,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":11,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":12,"TableID":104}
       │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":12,"TableID":104}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":104}
@@ -70,7 +71,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── LogEvent {"TargetStatus":1}
       │         ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
-      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":11,"TableID":104}
       │         ├── LogEvent {"TargetStatus":1}
       │         ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_12_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_12_of_15
@@ -58,6 +58,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":11,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":12,"TableID":104}
       │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":12,"TableID":104}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":104}
@@ -70,7 +71,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── LogEvent {"TargetStatus":1}
       │         ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
-      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":11,"TableID":104}
       │         ├── LogEvent {"TargetStatus":1}
       │         ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_9_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_9_of_15
@@ -56,6 +56,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":5,"TableID":104}
       │         ├── SetIndexName {"IndexID":5,"Name":"crdb_internal_in...","TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":11,"TableID":104}
       │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":12,"TableID":104}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
@@ -71,12 +72,11 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
-      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":11,"TableID":104}
-      │         ├── CreateGCJobForIndex {"IndexID":12,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
       │         ├── LogEvent {"TargetStatus":1}
       │         ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":12,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_computed_index
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_computed_index
@@ -125,8 +125,8 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":104}
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":3,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 3 of 3 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.statement_1_of_2
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.statement_1_of_2
@@ -132,8 +132,8 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":104}
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 3 of 3 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_unique_index
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_unique_index
@@ -129,9 +129,9 @@ Schema change plan for ALTER TABLE ‹t›.‹public›.‹test› DROP COLUMN �
            │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
            │    └── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
            └── 6 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":3,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":1,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":1,"TableID":106}
-                ├── RemoveColumnDefaultExpression {"ColumnID":3,"TableID":106}
                 ├── MakeDeleteOnlyColumnAbsent {"ColumnID":3,"TableID":106}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.statement_1_of_2
+++ b/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.statement_1_of_2
@@ -132,8 +132,8 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":104}
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 3 of 3 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.statement_2_of_2
+++ b/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.statement_2_of_2
@@ -114,8 +114,8 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
       │         ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":104}
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 3 of 3 in PostCommitNonRevertiblePhase
@@ -128,10 +128,10 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
            │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
            │    └── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
            └── 8 Mutation operations
-                ├── CreateGCJobForIndex {"IndexID":1,"TableID":104}
-                ├── MakeIndexAbsent {"IndexID":1,"TableID":104}
                 ├── RemoveColumnDefaultExpression {"ColumnID":3,"TableID":104}
                 ├── RemoveColumnOnUpdateExpression {"ColumnID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":1,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":1,"TableID":104}
                 ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":104}
                 ├── MakeDeleteOnlyColumnAbsent {"ColumnID":3,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_1_of_7
@@ -110,6 +110,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │     Name: crdb_internal_column_2_name_placeholder
             │     TableID: 106
             │
+            ├── • RemoveColumnDefaultExpression
+            │     ColumnID: 2
+            │     TableID: 106
+            │
             ├── • CreateGCJobForIndex
             │     IndexID: 2
             │     StatementForDropJob:
@@ -140,10 +144,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │
             ├── • MakeIndexAbsent
             │     IndexID: 3
-            │     TableID: 106
-            │
-            ├── • RemoveColumnDefaultExpression
-            │     ColumnID: 2
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_5_of_7
@@ -169,6 +169,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
         │
         └── • 8 Mutation operations
             │
+            ├── • RemoveColumnDefaultExpression
+            │     ColumnID: 2
+            │     TableID: 106
+            │
             ├── • CreateGCJobForIndex
             │     IndexID: 2
             │     StatementForDropJob:
@@ -199,10 +203,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             │
             ├── • MakeIndexAbsent
             │     IndexID: 3
-            │     TableID: 106
-            │
-            ├── • RemoveColumnDefaultExpression
-            │     ColumnID: 2
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_6_of_7
@@ -169,6 +169,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
         │
         └── • 8 Mutation operations
             │
+            ├── • RemoveColumnDefaultExpression
+            │     ColumnID: 2
+            │     TableID: 106
+            │
             ├── • CreateGCJobForIndex
             │     IndexID: 2
             │     StatementForDropJob:
@@ -199,10 +203,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             │
             ├── • MakeIndexAbsent
             │     IndexID: 3
-            │     TableID: 106
-            │
-            ├── • RemoveColumnDefaultExpression
-            │     ColumnID: 2
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_7_of_7
@@ -169,6 +169,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
         │
         └── • 8 Mutation operations
             │
+            ├── • RemoveColumnDefaultExpression
+            │     ColumnID: 2
+            │     TableID: 106
+            │
             ├── • CreateGCJobForIndex
             │     IndexID: 2
             │     StatementForDropJob:
@@ -199,10 +203,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             │
             ├── • MakeIndexAbsent
             │     IndexID: 3
-            │     TableID: 106
-            │
-            ├── • RemoveColumnDefaultExpression
-            │     ColumnID: 2
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_1_of_7
@@ -110,6 +110,16 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │     Name: crdb_internal_column_2_name_placeholder
             │     TableID: 106
             │
+            ├── • RemoveColumnDefaultExpression
+            │     ColumnID: 2
+            │     TableID: 106
+            │
+            ├── • UpdateBackReferencesInSequences
+            │     BackReferencedColumnID: 2
+            │     BackReferencedTableID: 106
+            │     SequenceIDs:
+            │     - 107
+            │
             ├── • CreateGCJobForIndex
             │     IndexID: 2
             │     StatementForDropJob:
@@ -141,16 +151,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             ├── • MakeIndexAbsent
             │     IndexID: 3
             │     TableID: 106
-            │
-            ├── • RemoveColumnDefaultExpression
-            │     ColumnID: 2
-            │     TableID: 106
-            │
-            ├── • UpdateBackReferencesInSequences
-            │     BackReferencedColumnID: 2
-            │     BackReferencedTableID: 106
-            │     SequenceIDs:
-            │     - 107
             │
             ├── • MakeDeleteOnlyColumnAbsent
             │     ColumnID: 2

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_5_of_7
@@ -172,6 +172,16 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
         │
         └── • 10 Mutation operations
             │
+            ├── • RemoveColumnDefaultExpression
+            │     ColumnID: 2
+            │     TableID: 106
+            │
+            ├── • UpdateBackReferencesInSequences
+            │     BackReferencedColumnID: 2
+            │     BackReferencedTableID: 106
+            │     SequenceIDs:
+            │     - 107
+            │
             ├── • CreateGCJobForIndex
             │     IndexID: 2
             │     StatementForDropJob:
@@ -203,16 +213,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             ├── • MakeIndexAbsent
             │     IndexID: 3
             │     TableID: 106
-            │
-            ├── • RemoveColumnDefaultExpression
-            │     ColumnID: 2
-            │     TableID: 106
-            │
-            ├── • UpdateBackReferencesInSequences
-            │     BackReferencedColumnID: 2
-            │     BackReferencedTableID: 106
-            │     SequenceIDs:
-            │     - 107
             │
             ├── • MakeDeleteOnlyColumnAbsent
             │     ColumnID: 2

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_6_of_7
@@ -172,6 +172,16 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
         │
         └── • 10 Mutation operations
             │
+            ├── • RemoveColumnDefaultExpression
+            │     ColumnID: 2
+            │     TableID: 106
+            │
+            ├── • UpdateBackReferencesInSequences
+            │     BackReferencedColumnID: 2
+            │     BackReferencedTableID: 106
+            │     SequenceIDs:
+            │     - 107
+            │
             ├── • CreateGCJobForIndex
             │     IndexID: 2
             │     StatementForDropJob:
@@ -203,16 +213,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             ├── • MakeIndexAbsent
             │     IndexID: 3
             │     TableID: 106
-            │
-            ├── • RemoveColumnDefaultExpression
-            │     ColumnID: 2
-            │     TableID: 106
-            │
-            ├── • UpdateBackReferencesInSequences
-            │     BackReferencedColumnID: 2
-            │     BackReferencedTableID: 106
-            │     SequenceIDs:
-            │     - 107
             │
             ├── • MakeDeleteOnlyColumnAbsent
             │     ColumnID: 2

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_7_of_7
@@ -172,6 +172,16 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
         │
         └── • 10 Mutation operations
             │
+            ├── • RemoveColumnDefaultExpression
+            │     ColumnID: 2
+            │     TableID: 106
+            │
+            ├── • UpdateBackReferencesInSequences
+            │     BackReferencedColumnID: 2
+            │     BackReferencedTableID: 106
+            │     SequenceIDs:
+            │     - 107
+            │
             ├── • CreateGCJobForIndex
             │     IndexID: 2
             │     StatementForDropJob:
@@ -203,16 +213,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             ├── • MakeIndexAbsent
             │     IndexID: 3
             │     TableID: 106
-            │
-            ├── • RemoveColumnDefaultExpression
-            │     ColumnID: 2
-            │     TableID: 106
-            │
-            ├── • UpdateBackReferencesInSequences
-            │     BackReferencedColumnID: 2
-            │     BackReferencedTableID: 106
-            │     SequenceIDs:
-            │     - 107
             │
             ├── • MakeDeleteOnlyColumnAbsent
             │     ColumnID: 2

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_10_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_10_of_15
@@ -378,6 +378,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
         │
         └── • 6 Mutation operations
             │
+            ├── • RemoveColumnDefaultExpression
+            │     ColumnID: 2
+            │     TableID: 106
+            │
             ├── • CreateGCJobForIndex
             │     IndexID: 2
             │     StatementForDropJob:
@@ -396,10 +400,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
             │         SourceElementID: 1
             │         SubWorkID: 1
             │     IndexID: 2
-            │     TableID: 106
-            │
-            ├── • RemoveColumnDefaultExpression
-            │     ColumnID: 2
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_11_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_11_of_15
@@ -378,6 +378,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
         │
         └── • 6 Mutation operations
             │
+            ├── • RemoveColumnDefaultExpression
+            │     ColumnID: 2
+            │     TableID: 106
+            │
             ├── • CreateGCJobForIndex
             │     IndexID: 2
             │     StatementForDropJob:
@@ -396,10 +400,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
             │         SourceElementID: 1
             │         SubWorkID: 1
             │     IndexID: 2
-            │     TableID: 106
-            │
-            ├── • RemoveColumnDefaultExpression
-            │     ColumnID: 2
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_12_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_12_of_15
@@ -378,6 +378,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
         │
         └── • 6 Mutation operations
             │
+            ├── • RemoveColumnDefaultExpression
+            │     ColumnID: 2
+            │     TableID: 106
+            │
             ├── • CreateGCJobForIndex
             │     IndexID: 2
             │     StatementForDropJob:
@@ -396,10 +400,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
             │         SourceElementID: 1
             │         SubWorkID: 1
             │     IndexID: 2
-            │     TableID: 106
-            │
-            ├── • RemoveColumnDefaultExpression
-            │     ColumnID: 2
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_13_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_13_of_15
@@ -388,6 +388,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
         │
         └── • 6 Mutation operations
             │
+            ├── • RemoveColumnDefaultExpression
+            │     ColumnID: 2
+            │     TableID: 106
+            │
             ├── • CreateGCJobForIndex
             │     IndexID: 2
             │     StatementForDropJob:
@@ -406,10 +410,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
             │         SourceElementID: 1
             │         SubWorkID: 1
             │     IndexID: 2
-            │     TableID: 106
-            │
-            ├── • RemoveColumnDefaultExpression
-            │     ColumnID: 2
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_14_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_14_of_15
@@ -388,6 +388,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
         │
         └── • 6 Mutation operations
             │
+            ├── • RemoveColumnDefaultExpression
+            │     ColumnID: 2
+            │     TableID: 106
+            │
             ├── • CreateGCJobForIndex
             │     IndexID: 2
             │     StatementForDropJob:
@@ -406,10 +410,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
             │         SourceElementID: 1
             │         SubWorkID: 1
             │     IndexID: 2
-            │     TableID: 106
-            │
-            ├── • RemoveColumnDefaultExpression
-            │     ColumnID: 2
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_15_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_15_of_15
@@ -388,6 +388,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
         │
         └── • 6 Mutation operations
             │
+            ├── • RemoveColumnDefaultExpression
+            │     ColumnID: 2
+            │     TableID: 106
+            │
             ├── • CreateGCJobForIndex
             │     IndexID: 2
             │     StatementForDropJob:
@@ -406,10 +410,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
             │         SourceElementID: 1
             │         SubWorkID: 1
             │     IndexID: 2
-            │     TableID: 106
-            │
-            ├── • RemoveColumnDefaultExpression
-            │     ColumnID: 2
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_1_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_1_of_15
@@ -118,6 +118,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 15;
             │     Name: crdb_internal_column_2_name_placeholder
             │     TableID: 106
             │
+            ├── • RemoveColumnDefaultExpression
+            │     ColumnID: 2
+            │     TableID: 106
+            │
             ├── • CreateGCJobForIndex
             │     IndexID: 2
             │     StatementForDropJob:
@@ -148,10 +152,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 15;
             │
             ├── • MakeIndexAbsent
             │     IndexID: 3
-            │     TableID: 106
-            │
-            ├── • RemoveColumnDefaultExpression
-            │     ColumnID: 2
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_5_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_5_of_15
@@ -177,6 +177,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 15;
         │
         └── • 8 Mutation operations
             │
+            ├── • RemoveColumnDefaultExpression
+            │     ColumnID: 2
+            │     TableID: 106
+            │
             ├── • CreateGCJobForIndex
             │     IndexID: 2
             │     StatementForDropJob:
@@ -207,10 +211,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 15;
             │
             ├── • MakeIndexAbsent
             │     IndexID: 3
-            │     TableID: 106
-            │
-            ├── • RemoveColumnDefaultExpression
-            │     ColumnID: 2
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_6_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_6_of_15
@@ -177,6 +177,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 15;
         │
         └── • 8 Mutation operations
             │
+            ├── • RemoveColumnDefaultExpression
+            │     ColumnID: 2
+            │     TableID: 106
+            │
             ├── • CreateGCJobForIndex
             │     IndexID: 2
             │     StatementForDropJob:
@@ -207,10 +211,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 15;
             │
             ├── • MakeIndexAbsent
             │     IndexID: 3
-            │     TableID: 106
-            │
-            ├── • RemoveColumnDefaultExpression
-            │     ColumnID: 2
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_7_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_7_of_15
@@ -177,6 +177,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 15;
         │
         └── • 8 Mutation operations
             │
+            ├── • RemoveColumnDefaultExpression
+            │     ColumnID: 2
+            │     TableID: 106
+            │
             ├── • CreateGCJobForIndex
             │     IndexID: 2
             │     StatementForDropJob:
@@ -207,10 +211,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 15;
             │
             ├── • MakeIndexAbsent
             │     IndexID: 3
-            │     TableID: 106
-            │
-            ├── • RemoveColumnDefaultExpression
-            │     ColumnID: 2
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_8_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_8_of_15
@@ -177,6 +177,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 8 of 15;
         │
         └── • 8 Mutation operations
             │
+            ├── • RemoveColumnDefaultExpression
+            │     ColumnID: 2
+            │     TableID: 106
+            │
             ├── • CreateGCJobForIndex
             │     IndexID: 2
             │     StatementForDropJob:
@@ -207,10 +211,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 8 of 15;
             │
             ├── • MakeIndexAbsent
             │     IndexID: 3
-            │     TableID: 106
-            │
-            ├── • RemoveColumnDefaultExpression
-            │     ColumnID: 2
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_9_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_9_of_15
@@ -368,6 +368,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
         │
         └── • 6 Mutation operations
             │
+            ├── • RemoveColumnDefaultExpression
+            │     ColumnID: 2
+            │     TableID: 106
+            │
             ├── • CreateGCJobForIndex
             │     IndexID: 2
             │     StatementForDropJob:
@@ -386,10 +390,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
             │         SourceElementID: 1
             │         SubWorkID: 1
             │     IndexID: 2
-            │     TableID: 106
-            │
-            ├── • RemoveColumnDefaultExpression
-            │     ColumnID: 2
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid
@@ -968,6 +968,10 @@ EXPLAIN (ddl, verbose) alter table t add primary key (a);
         │
         └── • 6 Mutation operations
             │
+            ├── • RemoveColumnDefaultExpression
+            │     ColumnID: 2
+            │     TableID: 104
+            │
             ├── • CreateGCJobForIndex
             │     IndexID: 2
             │     StatementForDropJob:
@@ -985,10 +989,6 @@ EXPLAIN (ddl, verbose) alter table t add primary key (a);
             │         SourceElementID: 1
             │         SubWorkID: 1
             │     IndexID: 2
-            │     TableID: 104
-            │
-            ├── • RemoveColumnDefaultExpression
-            │     ColumnID: 2
             │     TableID: 104
             │
             ├── • MakeDeleteOnlyColumnAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid
@@ -1832,6 +1832,10 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
         │
         └── • 6 Mutation operations
             │
+            ├── • RemoveColumnDefaultExpression
+            │     ColumnID: 3
+            │     TableID: 104
+            │
             ├── • CreateGCJobForIndex
             │     IndexID: 5
             │     StatementForDropJob:
@@ -1850,10 +1854,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
             │         SourceElementID: 1
             │         SubWorkID: 1
             │     IndexID: 5
-            │     TableID: 104
-            │
-            ├── • RemoveColumnDefaultExpression
-            │     ColumnID: 3
             │     TableID: 104
             │
             ├── • MakeDeleteOnlyColumnAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_10_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_10_of_15
@@ -360,6 +360,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │       │     IndexID: 10
     │       │     TableID: 104
     │       │
+    │       ├── • RemoveDroppedIndexPartialPredicate
+    │       │     IndexID: 11
+    │       │     TableID: 104
+    │       │
     │       ├── • MakeWriteOnlyIndexDeleteOnly
     │       │     IndexID: 12
     │       │     TableID: 104
@@ -452,10 +456,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │       │
     │       ├── • MakeIndexAbsent
     │       │     IndexID: 9
-    │       │     TableID: 104
-    │       │
-    │       ├── • RemoveDroppedIndexPartialPredicate
-    │       │     IndexID: 11
     │       │     TableID: 104
     │       │
     │       ├── • LogEvent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_11_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_11_of_15
@@ -360,6 +360,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │       │     IndexID: 10
     │       │     TableID: 104
     │       │
+    │       ├── • RemoveDroppedIndexPartialPredicate
+    │       │     IndexID: 11
+    │       │     TableID: 104
+    │       │
     │       ├── • MakeWriteOnlyIndexDeleteOnly
     │       │     IndexID: 12
     │       │     TableID: 104
@@ -452,10 +456,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │       │
     │       ├── • MakeIndexAbsent
     │       │     IndexID: 9
-    │       │     TableID: 104
-    │       │
-    │       ├── • RemoveDroppedIndexPartialPredicate
-    │       │     IndexID: 11
     │       │     TableID: 104
     │       │
     │       ├── • LogEvent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_12_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_12_of_15
@@ -360,6 +360,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │       │     IndexID: 10
     │       │     TableID: 104
     │       │
+    │       ├── • RemoveDroppedIndexPartialPredicate
+    │       │     IndexID: 11
+    │       │     TableID: 104
+    │       │
     │       ├── • MakeWriteOnlyIndexDeleteOnly
     │       │     IndexID: 12
     │       │     TableID: 104
@@ -452,10 +456,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │       │
     │       ├── • MakeIndexAbsent
     │       │     IndexID: 9
-    │       │     TableID: 104
-    │       │
-    │       ├── • RemoveDroppedIndexPartialPredicate
-    │       │     IndexID: 11
     │       │     TableID: 104
     │       │
     │       ├── • LogEvent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_9_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_9_of_15
@@ -374,6 +374,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
     │       │     TableID: 104
     │       │
     │       ├── • RemoveDroppedIndexPartialPredicate
+    │       │     IndexID: 11
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveDroppedIndexPartialPredicate
     │       │     IndexID: 12
     │       │     TableID: 104
     │       │
@@ -487,22 +491,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
     │       │     IndexID: 10
     │       │     TableID: 104
     │       │
-    │       ├── • RemoveDroppedIndexPartialPredicate
-    │       │     IndexID: 11
-    │       │     TableID: 104
-    │       │
-    │       ├── • CreateGCJobForIndex
-    │       │     IndexID: 12
-    │       │     StatementForDropJob:
-    │       │       Rollback: true
-    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
-    │       │         KEY USING COLUMNS (a)
-    │       │     TableID: 104
-    │       │
-    │       ├── • MakeIndexAbsent
-    │       │     IndexID: 12
-    │       │     TableID: 104
-    │       │
     │       ├── • LogEvent
     │       │     Element:
     │       │       SecondaryIndex:
@@ -532,6 +520,18 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
     │       │
     │       ├── • MakeIndexAbsent
     │       │     IndexID: 11
+    │       │     TableID: 104
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 12
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 12
     │       │     TableID: 104
     │       │
     │       ├── • SetJobStateOnDescriptor

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index
@@ -611,10 +611,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
     │       │     IndexID: 4
     │       │     TableID: 104
     │       │
-    │       ├── • MakeWriteOnlyIndexDeleteOnly
-    │       │     IndexID: 1
-    │       │     TableID: 104
-    │       │
     │       ├── • MakeDeleteOnlyColumnAbsent
     │       │     ColumnID: 3
     │       │     EventBase:
@@ -625,6 +621,10 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
     │       │         SubWorkID: 1
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 1
     │       │     TableID: 104
     │       │
     │       ├── • SetJobStateOnDescriptor

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.statement_1_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.statement_1_of_2
@@ -674,10 +674,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
     │       │     IndexID: 4
     │       │     TableID: 104
     │       │
-    │       ├── • MakeWriteOnlyIndexDeleteOnly
-    │       │     IndexID: 1
-    │       │     TableID: 104
-    │       │
     │       ├── • MakeDeleteOnlyColumnAbsent
     │       │     ColumnID: 4
     │       │     EventBase:
@@ -688,6 +684,10 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
     │       │         SubWorkID: 1
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 1
     │       │     TableID: 104
     │       │
     │       ├── • SetJobStateOnDescriptor

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index
@@ -624,6 +624,10 @@ EXPLAIN (ddl, verbose) ALTER TABLE t.test DROP pi;
         │
         └── • 6 Mutation operations
             │
+            ├── • RemoveColumnDefaultExpression
+            │     ColumnID: 3
+            │     TableID: 106
+            │
             ├── • CreateGCJobForIndex
             │     IndexID: 1
             │     StatementForDropJob:
@@ -640,10 +644,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE t.test DROP pi;
             │         SourceElementID: 1
             │         SubWorkID: 1
             │     IndexID: 1
-            │     TableID: 106
-            │
-            ├── • RemoveColumnDefaultExpression
-            │     ColumnID: 3
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.statement_1_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.statement_1_of_2
@@ -674,10 +674,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
     │       │     IndexID: 4
     │       │     TableID: 104
     │       │
-    │       ├── • MakeWriteOnlyIndexDeleteOnly
-    │       │     IndexID: 1
-    │       │     TableID: 104
-    │       │
     │       ├── • MakeDeleteOnlyColumnAbsent
     │       │     ColumnID: 4
     │       │     EventBase:
@@ -688,6 +684,10 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
     │       │         SubWorkID: 1
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 1
     │       │     TableID: 104
     │       │
     │       ├── • SetJobStateOnDescriptor

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.statement_2_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.statement_2_of_2
@@ -563,10 +563,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN k CASCADE;
     │       │     IndexID: 4
     │       │     TableID: 104
     │       │
-    │       ├── • MakeWriteOnlyIndexDeleteOnly
-    │       │     IndexID: 1
-    │       │     TableID: 104
-    │       │
     │       ├── • MakeDeleteOnlyColumnAbsent
     │       │     ColumnID: 4
     │       │     EventBase:
@@ -577,6 +573,10 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN k CASCADE;
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
     │       │         SubWorkID: 1
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 1
     │       │     TableID: 104
     │       │
     │       ├── • SetJobStateOnDescriptor
@@ -697,6 +697,14 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN k CASCADE;
         │
         └── • 8 Mutation operations
             │
+            ├── • RemoveColumnDefaultExpression
+            │     ColumnID: 3
+            │     TableID: 104
+            │
+            ├── • RemoveColumnOnUpdateExpression
+            │     ColumnID: 3
+            │     TableID: 104
+            │
             ├── • CreateGCJobForIndex
             │     IndexID: 1
             │     StatementForDropJob:
@@ -713,14 +721,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN k CASCADE;
             │         SourceElementID: 1
             │         SubWorkID: 1
             │     IndexID: 1
-            │     TableID: 104
-            │
-            ├── • RemoveColumnDefaultExpression
-            │     ColumnID: 3
-            │     TableID: 104
-            │
-            ├── • RemoveColumnOnUpdateExpression
-            │     ColumnID: 3
             │     TableID: 104
             │
             ├── • MakeDeleteOnlyColumnAbsent


### PR DESCRIPTION
We discovered and fixed a bug when building stages from a graph in the declarative schema changer. It's a one-line change. The issue is in a place where we need `SameStagePrecedence`; we previously only used `SameStagePrecedence` but we forgot that `Precedence` can also be used for this purpose.

There is no real test changes. If you look closer at them, it's just some text are being moved up/down a few lines. The plan (or stages built) out of the planner is not changed.

Epic: None
Release note: None