### PR TITLE
ci: add arm64 scripts for tests

### DIFF
--- a/build/teamcity/cockroach/ci/tests-aws-linux-arm64-bigvm/unit_tests.sh
+++ b/build/teamcity/cockroach/ci/tests-aws-linux-arm64-bigvm/unit_tests.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source build/teamcity/cockroach/ci/tests/unit_tests.sh

--- a/build/teamcity/cockroach/ci/tests-aws-linux-arm64/acceptance.sh
+++ b/build/teamcity/cockroach/ci/tests-aws-linux-arm64/acceptance.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source build/teamcity/cockroach/ci/tests/acceptance.sh

--- a/build/teamcity/cockroach/ci/tests-aws-linux-arm64/bench.sh
+++ b/build/teamcity/cockroach/ci/tests-aws-linux-arm64/bench.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source build/teamcity/cockroach/ci/tests/bench.sh

--- a/build/teamcity/cockroach/ci/tests-aws-linux-arm64/local_roachtest.sh
+++ b/build/teamcity/cockroach/ci/tests-aws-linux-arm64/local_roachtest.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source build/teamcity/cockroach/ci/tests/local_roachtest.sh

--- a/build/teamcity/cockroach/ci/tests-aws-linux-arm64/maybe_stress.sh
+++ b/build/teamcity/cockroach/ci/tests-aws-linux-arm64/maybe_stress.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source build/teamcity/cockroach/ci/tests/maybe_stress.sh

--- a/build/teamcity/cockroach/ci/tests-aws-linux-arm64/maybe_stressrace.sh
+++ b/build/teamcity/cockroach/ci/tests-aws-linux-arm64/maybe_stressrace.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source build/teamcity/cockroach/ci/tests/maybe_stressrace.sh

--- a/build/teamcity/cockroach/ci/tests-aws-linux-arm64/testrace.sh
+++ b/build/teamcity/cockroach/ci/tests-aws-linux-arm64/testrace.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source build/teamcity/cockroach/ci/tests/testrace.sh

--- a/build/teamcity/cockroach/ci/tests-aws-linux-arm64/ui_test.sh
+++ b/build/teamcity/cockroach/ci/tests-aws-linux-arm64/ui_test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source build/teamcity/cockroach/ci/tests/ui_test.sh

--- a/build/teamcity/cockroach/ci/tests-gcp-linux-x86_64-bigvm/unit_tests.sh
+++ b/build/teamcity/cockroach/ci/tests-gcp-linux-x86_64-bigvm/unit_tests.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source build/teamcity/cockroach/ci/tests/unit_tests.sh

--- a/build/teamcity/cockroach/ci/tests-gcp-linux-x86_64-bigvm/unused_lint.sh
+++ b/build/teamcity/cockroach/ci/tests-gcp-linux-x86_64-bigvm/unused_lint.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source build/teamcity/cockroach/ci/tests/unused_test.sh


### PR DESCRIPTION
Note that some non-impl scripts do contain some pre-processing steps so I kept all existing scripts unchanged and pointed arm64 scripts to them. This ensures we don't repeat ourselves.

Release note: None
Epic: CRDB-1463