### PR TITLE
workflow: Added a github workflow to publish Cluster UI

### DIFF
--- a/.github/workflows/cluster-ui-release-next.yml
+++ b/.github/workflows/cluster-ui-release-next.yml
@@ -1,0 +1,45 @@
+name: Publish Cluster UI Pre-release
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'pkg/ui/workspaces/cluster-ui/**/*.tsx?'
+      - 'pkg/ui/workspaces/cluster-ui/yarn.lock'
+
+jobs:
+  publish_cluster_ui:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: pkg/ui/workspaces/cluster-ui
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+
+    - name: Bazel Cache
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/bazel
+        key: ${{ runner.os }}-bazel-cache
+
+    - name: Setup NodeJS
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16
+        cache: 'yarn'
+        cache-dependency-path: pkg/ui/workspaces/cluster-ui/yarn.lock
+      env:
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: Build Cluster UI
+      run: |
+        yarn install --frozen-lockfile
+        bazel build //pkg/ui/workspaces/cluster-ui:cluster-ui
+
+    - name: Publish prerelease version
+      run: |
+        echo "yarn version --prerelease --preid prerelease"
+        echo "yarn publish --access public --tag next"

--- a/.github/workflows/cluster-ui-release.yml
+++ b/.github/workflows/cluster-ui-release.yml
@@ -1,0 +1,50 @@
+name: Publish Cluster UI Release
+on:
+  push:
+    branches:
+      - 'release-*'
+    paths:
+      - 'pkg/ui/workspaces/cluster-ui/**/*.tsx?'
+      - 'pkg/ui/workspaces/cluster-ui/yarn.lock'
+
+jobs:
+  publish_cluster_ui:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: pkg/ui/workspaces/cluster-ui
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+
+    - name: Bazel Cache
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/bazel
+        key: ${{ runner.os }}-bazel-cache
+
+    - name: Setup NodeJS
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16
+        cache: 'yarn'
+        cache-dependency-path: pkg/ui/workspaces/cluster-ui/yarn.lock
+      env:
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: Get Branch name
+      shell: bash
+      run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+      id: branch-name
+
+    - name: Build Cluster UI
+      run: |
+        yarn install --frozen-lockfile
+        bazel build //pkg/ui/workspaces/cluster-ui:cluster-ui
+
+    - name: Publish prerelease version
+      run: |
+        echo "yarn version --patch"
+        echo "yarn publish --access public --tag ${{ steps.branch_name.outputs.branch }}"

--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "22.2.0-prerelease-5",
+  "version": "22.2.0-prerelease.5",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds two workflows to publish Cluster UI to npm. The workflows are intended to publish when there are changes to Cluster UI (`pkg/ui/workspaces/cluster-ui`) on a base branch (`master` or `release-*`). Since versions published from `master` differ slightly from versions published from release branches, I thought this called for two separate workflows.

**Publishing from master**

The `master` branch represents the *next* version of CockroachDB that's in development. As such, versions of Cluster UI published from this branch are [prerelease versions](https://semver.org/#spec-item-9) of the next major version of CRDB (example: `22.2.0-prerelease-5`). These versions have the [distribution tag](https://docs.npmjs.com/adding-dist-tags-to-packages) `next` to represent that they are not associated with a stable version of the DB. 

**Publishing from a release branch**

Release branches represent specific released versions of CockroachDB and versions of Cluster UI published from these branches are intended for use with a specific version of the database. Cluster UI thus shares the first two parts of the version with the version of CRDB it was published from (Cluster UI version `21.1.3` is for CRDB `v21.1`, Cluster UI version 22.1.9 is for CRDB `v22.1`, etc). When an update is published from one of these branches, the patch version is incremented, and the version is version is assigned a distribution tag the same as the branch it was published from (ex. `release-21.1`, `release-22.0`, etc).

**Testing Workflows**

The workflows in the pull-request currently build Cluster UI, but instead of publishing will echo the expected publish commands. This is so that as changes to Cluster UI are merged, the CRUX team can ensure the correct publishing flows will occur as a result.