### PR TITLE
ui: link insights to fingerprint details

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
@@ -70,6 +70,7 @@ export type StatementInsightEvent = {
   transactionID: string;
   statementFingerprintID: string;
   transactionFingerprintID: string;
+  implicitTxn: boolean;
   startTime: Moment;
   elapsedTimeMillis: number;
   sessionID: string;

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
@@ -26,6 +26,7 @@ import classNames from "classnames/bind";
 import { commonStyles } from "src/common";
 import { getExplainPlanFromGist } from "src/api/decodePlanGistApi";
 import { StatementInsightDetailsOverviewTab } from "./statementInsightDetailsOverviewTab";
+import { TimeScale } from "../../timeScaleDropdown";
 
 // Styles
 import insightsDetailsStyles from "src/insights/workloadInsightDetails/insightsDetails.module.scss";
@@ -42,12 +43,24 @@ export interface StatementInsightDetailsStateProps {
   isTenant?: boolean;
 }
 
+export interface StatementInsightDetailsDispatchProps {
+  setTimeScale: (ts: TimeScale) => void;
+}
+
 export type StatementInsightDetailsProps = StatementInsightDetailsStateProps &
+  StatementInsightDetailsDispatchProps &
   RouteComponentProps<unknown>;
 
 export const StatementInsightDetails: React.FC<
   StatementInsightDetailsProps
-> = ({ history, insightEventDetails, insightError, match, isTenant }) => {
+> = ({
+  history,
+  insightEventDetails,
+  insightError,
+  match,
+  isTenant,
+  setTimeScale,
+}) => {
   const [explain, setExplain] = useState<string>(null);
 
   const prevPage = (): void => history.goBack();
@@ -111,6 +124,7 @@ export const StatementInsightDetails: React.FC<
             <Tabs.TabPane tab="Overview" key={TabKeysEnum.OVERVIEW}>
               <StatementInsightDetailsOverviewTab
                 insightEventDetails={insightEventDetails}
+                setTimeScale={setTimeScale}
               />
             </Tabs.TabPane>
             {!isTenant && (

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsConnected.tsx
@@ -8,9 +8,11 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 import { connect } from "react-redux";
+import { Dispatch } from "redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import {
   StatementInsightDetails,
+  StatementInsightDetailsDispatchProps,
   StatementInsightDetailsStateProps,
 } from "./statementInsightDetails";
 import { AppState } from "src/store";
@@ -19,6 +21,8 @@ import {
   selectStatementInsightsError,
 } from "src/store/insights/statementInsights";
 import { selectIsTenant } from "src/store/uiConfig";
+import { TimeScale } from "../../timeScaleDropdown";
+import { actions as sqlStatsActions } from "../../store/sqlStats";
 
 const mapStateToProps = (
   state: AppState,
@@ -33,8 +37,25 @@ const mapStateToProps = (
   };
 };
 
+const mapDispatchToProps = (
+  dispatch: Dispatch,
+): StatementInsightDetailsDispatchProps => ({
+  setTimeScale: (ts: TimeScale) => {
+    dispatch(
+      sqlStatsActions.updateTimeScale({
+        ts: ts,
+      }),
+    );
+  },
+});
+
 export const StatementInsightDetailsConnected = withRouter(
-  connect<StatementInsightDetailsStateProps, RouteComponentProps>(
+  connect<
+    StatementInsightDetailsStateProps,
+    StatementInsightDetailsDispatchProps,
+    RouteComponentProps
+  >(
     mapStateToProps,
+    mapDispatchToProps,
   )(StatementInsightDetails),
 );

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
@@ -32,6 +32,11 @@ import summaryCardStyles from "src/summaryCard/summaryCard.module.scss";
 import insightTableStyles from "src/insightsTable/insightsTable.module.scss";
 import "antd/lib/col/style";
 import "antd/lib/row/style";
+import {
+  StatementDetailsLink,
+  TransactionDetailsLink,
+} from "../workloadInsights/util";
+import { TimeScale } from "../../timeScaleDropdown";
 
 const cx = classNames.bind(insightsDetailsStyles);
 const tableCx = classNames.bind(insightTableStyles);
@@ -114,11 +119,12 @@ const insightsTableData = (
 
 export interface StatementInsightDetailsOverviewTabProps {
   insightEventDetails: StatementInsightEvent;
+  setTimeScale: (ts: TimeScale) => void;
 }
 
 export const StatementInsightDetailsOverviewTab: React.FC<
   StatementInsightDetailsOverviewTabProps
-> = ({ insightEventDetails }) => {
+> = ({ insightEventDetails, setTimeScale }) => {
   const isCockroachCloud = useContext(CockroachCloudContext);
 
   const insightsColumns = useMemo(
@@ -187,7 +193,11 @@ export const StatementInsightDetailsOverviewTab: React.FC<
             />
             <SummaryCardItem
               label="Transaction Fingerprint ID"
-              value={String(insightDetails.transactionFingerprintID)}
+              value={TransactionDetailsLink(
+                insightDetails.transactionFingerprintID,
+                insightDetails.startTime,
+                setTimeScale,
+              )}
             />
             <SummaryCardItem
               label="Transaction Execution ID"
@@ -195,7 +205,7 @@ export const StatementInsightDetailsOverviewTab: React.FC<
             />
             <SummaryCardItem
               label="Statement Fingerprint ID"
-              value={String(insightDetails.statementFingerprintID)}
+              value={StatementDetailsLink(insightDetails, setTimeScale)}
             />
           </SummaryCard>
         </Col>

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
@@ -43,6 +43,8 @@ import { commonStyles } from "src/common";
 import insightTableStyles from "src/insightsTable/insightsTable.module.scss";
 import { CockroachCloudContext } from "../../contexts";
 import { InsightsError } from "../insightsErrorComponent";
+import { TransactionDetailsLink } from "../workloadInsights/util";
+import { TimeScale } from "../../timeScaleDropdown";
 
 const tableCx = classNames.bind(insightTableStyles);
 
@@ -55,6 +57,7 @@ export interface TransactionInsightDetailsDispatchProps {
   refreshTransactionInsightDetails: (
     req: TransactionInsightEventDetailsRequest,
   ) => void;
+  setTimeScale: (ts: TimeScale) => void;
 }
 
 export type TransactionInsightDetailsProps =
@@ -152,7 +155,11 @@ export class TransactionInsightDetails extends React.Component<TransactionInsigh
               <SummaryCard>
                 <SummaryCardItem
                   label="Transaction Fingerprint ID"
-                  value={String(insightDetails.fingerprintID)}
+                  value={TransactionDetailsLink(
+                    insightDetails.fingerprintID,
+                    insightDetails.startTime,
+                    this.props.setTimeScale,
+                  )}
                 />
               </SummaryCard>
             </Col>

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsConnected.tsx
@@ -20,6 +20,9 @@ import {
   selectTransactionInsightDetailsError,
   actions,
 } from "src/store/insightDetails/transactionInsightDetails";
+import { TimeScale } from "../../timeScaleDropdown";
+import { actions as sqlStatsActions } from "../../store/sqlStats";
+import { Dispatch } from "redux";
 
 const mapStateToProps = (
   state: AppState,
@@ -33,9 +36,18 @@ const mapStateToProps = (
   };
 };
 
-const mapDispatchToProps = {
+const mapDispatchToProps = (
+  dispatch: Dispatch,
+): TransactionInsightDetailsDispatchProps => ({
   refreshTransactionInsightDetails: actions.refresh,
-};
+  setTimeScale: (ts: TimeScale) => {
+    dispatch(
+      sqlStatsActions.updateTimeScale({
+        ts: ts,
+      }),
+    );
+  },
+});
 
 export const TransactionInsightDetailsConnected = withRouter(
   connect<

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsights.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsights.fixture.ts
@@ -20,6 +20,7 @@ export const statementInsightsPropsFixture: StatementInsightsViewProps = {
       statementFingerprintID: "abc",
       transactionFingerprintID: "defg",
       transactionID: "f72f37ea-b3a0-451f-80b8-dfb27d0bc2a5",
+      implicitTxn: true,
       query:
         "SELECT IFNULL(a, b) FROM (SELECT (SELECT code FROM promo_codes WHERE code > $1 ORDER BY code LIMIT _) AS a, (SELECT code FROM promo_codes ORDER BY code LIMIT _) AS b)",
       startTime: moment.utc("2022.08.10"),
@@ -47,6 +48,7 @@ export const statementInsightsPropsFixture: StatementInsightsViewProps = {
       statementFingerprintID: "938x3",
       transactionFingerprintID: "1971x3",
       transactionID: "e72f37ea-b3a0-451f-80b8-dfb27d0bc2a5",
+      implicitTxn: true,
       query: "INSERT INTO vehicles VALUES ($1, $2, __more1_10__)",
       startTime: moment.utc("2022.08.10"),
       endTime: moment.utc("2022.08.10 00:00:00.25"),
@@ -73,6 +75,7 @@ export const statementInsightsPropsFixture: StatementInsightsViewProps = {
       statementFingerprintID: "hisas",
       transactionFingerprintID: "3anc",
       transactionID: "f72f37ea-b3a0-451f-80b8-dfb27d0bc2a0",
+      implicitTxn: true,
       query:
         "UPSERT INTO vehicle_location_histories VALUES ($1, $2, now(), $3, $4)",
       startTime: moment.utc("2022.08.10"),
@@ -107,4 +110,5 @@ export const statementInsightsPropsFixture: StatementInsightsViewProps = {
   refreshStatementInsights: () => {},
   onSortChange: () => {},
   onFiltersChange: () => {},
+  setTimeScale: () => {},
 };

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsTable.tsx
@@ -17,12 +17,17 @@ import {
 } from "src/sortedtable";
 import { Count, DATE_FORMAT, Duration, limitText } from "src/util";
 import { InsightExecEnum, StatementInsightEvent } from "src/insights";
-import { InsightCell, insightsTableTitles } from "../util";
+import {
+  InsightCell,
+  insightsTableTitles,
+  StatementDetailsLink,
+} from "../util";
 import { StatementInsights } from "../../../api";
 import { Tooltip } from "@cockroachlabs/ui-components";
 import { Link } from "react-router-dom";
 import classNames from "classnames/bind";
 import styles from "../util/workloadInsights.module.scss";
+import { TimeScale } from "../../../timeScaleDropdown";
 
 const cx = classNames.bind(styles);
 
@@ -35,7 +40,9 @@ interface StatementInsightsTable {
   visibleColumns: ColumnDescriptor<StatementInsightEvent>[];
 }
 
-export function makeStatementInsightsColumns(): ColumnDescriptor<StatementInsightEvent>[] {
+export function makeStatementInsightsColumns(
+  setTimeScale: (ts: TimeScale) => void,
+): ColumnDescriptor<StatementInsightEvent>[] {
   const execType = InsightExecEnum.STATEMENT;
   return [
     {
@@ -52,7 +59,8 @@ export function makeStatementInsightsColumns(): ColumnDescriptor<StatementInsigh
     {
       name: "statementFingerprintID",
       title: insightsTableTitles.fingerprintID(execType),
-      cell: (item: StatementInsightEvent) => item.statementFingerprintID,
+      cell: (item: StatementInsightEvent) =>
+        StatementDetailsLink(item, setTimeScale),
       sort: (item: StatementInsightEvent) => item.statementFingerprintID,
       showByDefault: true,
     },

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
@@ -21,7 +21,6 @@ import { PageConfig, PageConfigItem } from "src/pageConfig/pageConfig";
 import { Search } from "src/search/search";
 import {
   calculateActiveFilters,
-  defaultFilters,
   Filter,
   getFullFiltersAsStringRecord,
 } from "src/queryFilter/filter";
@@ -48,6 +47,7 @@ import styles from "src/statementsPage/statementsPage.module.scss";
 import sortableTableStyles from "src/sortedtable/sortedtable.module.scss";
 import ColumnsSelector from "../../../columnsSelector/columnsSelector";
 import { SelectOption } from "../../../multiSelectCheckbox/multiSelectCheckbox";
+import { TimeScale } from "../../../timeScaleDropdown";
 
 const cx = classNames.bind(styles);
 const sortableTableCx = classNames.bind(sortableTableStyles);
@@ -66,6 +66,7 @@ export type StatementInsightsViewDispatchProps = {
   onSortChange: (ss: SortSetting) => void;
   refreshStatementInsights: () => void;
   onColumnsChange: (selectedColumns: string[]) => void;
+  setTimeScale: (ts: TimeScale) => void;
 };
 
 export type StatementInsightsViewProps = StatementInsightsViewStateProps &
@@ -101,6 +102,7 @@ export const StatementInsightsView: React.FC<StatementInsightsViewProps> = (
     onFiltersChange,
     onSortChange,
     onColumnsChange,
+    setTimeScale,
     selectedColumnNames,
     dropDownSelect,
   } = props;
@@ -194,7 +196,7 @@ export const StatementInsightsView: React.FC<StatementInsightsViewProps> = (
     resetPagination();
   };
 
-  const defaultColumns = makeStatementInsightsColumns();
+  const defaultColumns = makeStatementInsightsColumns(setTimeScale);
 
   const visibleColumns = defaultColumns.filter(x =>
     isSelected(x, selectedColumnNames),

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsights.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsights.fixture.ts
@@ -66,4 +66,5 @@ export const transactionInsightsPropsFixture: TransactionInsightsViewProps = {
   refreshTransactionInsights: () => {},
   onSortChange: () => {},
   onFiltersChange: () => {},
+  setTimeScale: () => {},
 };

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsTable.tsx
@@ -17,8 +17,14 @@ import {
 } from "src/sortedtable";
 import { DATE_FORMAT, Duration } from "src/util";
 import { InsightExecEnum, TransactionInsightEvent } from "src/insights";
-import { InsightCell, insightsTableTitles, QueriesCell } from "../util";
+import {
+  InsightCell,
+  insightsTableTitles,
+  QueriesCell,
+  TransactionDetailsLink,
+} from "../util";
 import { Link } from "react-router-dom";
+import { TimeScale } from "../../../timeScaleDropdown";
 
 interface TransactionInsightsTable {
   data: TransactionInsightEvent[];
@@ -26,9 +32,12 @@ interface TransactionInsightsTable {
   onChangeSortSetting: (ss: SortSetting) => void;
   pagination: ISortedTablePagination;
   renderNoResult?: React.ReactNode;
+  setTimeScale: (ts: TimeScale) => void;
 }
 
-export function makeTransactionInsightsColumns(): ColumnDescriptor<TransactionInsightEvent>[] {
+export function makeTransactionInsightsColumns(
+  setTimeScale: (ts: TimeScale) => void,
+): ColumnDescriptor<TransactionInsightEvent>[] {
   const execType = InsightExecEnum.TRANSACTION;
   return [
     {
@@ -44,7 +53,12 @@ export function makeTransactionInsightsColumns(): ColumnDescriptor<TransactionIn
     {
       name: "fingerprintID",
       title: insightsTableTitles.fingerprintID(execType),
-      cell: (item: TransactionInsightEvent) => String(item.fingerprintID),
+      cell: (item: TransactionInsightEvent) =>
+        TransactionDetailsLink(
+          item.fingerprintID,
+          item.startTime,
+          setTimeScale,
+        ),
       sort: (item: TransactionInsightEvent) => item.fingerprintID,
     },
     {
@@ -90,7 +104,7 @@ export function makeTransactionInsightsColumns(): ColumnDescriptor<TransactionIn
 export const TransactionInsightsTable: React.FC<
   TransactionInsightsTable
 > = props => {
-  const columns = makeTransactionInsightsColumns();
+  const columns = makeTransactionInsightsColumns(props.setTimeScale);
   return (
     <SortedTable columns={columns} className="statements-table" {...props} />
   );

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsView.tsx
@@ -20,7 +20,6 @@ import { PageConfig, PageConfigItem } from "src/pageConfig/pageConfig";
 import { Search } from "src/search/search";
 import {
   calculateActiveFilters,
-  defaultFilters,
   Filter,
   getFullFiltersAsStringRecord,
 } from "src/queryFilter/filter";
@@ -43,6 +42,7 @@ import { InsightsError } from "../../insightsErrorComponent";
 
 import styles from "src/statementsPage/statementsPage.module.scss";
 import sortableTableStyles from "src/sortedtable/sortedtable.module.scss";
+import { TimeScale } from "../../../timeScaleDropdown";
 
 const cx = classNames.bind(styles);
 const sortableTableCx = classNames.bind(sortableTableStyles);
@@ -59,6 +59,7 @@ export type TransactionInsightsViewDispatchProps = {
   onFiltersChange: (filters: WorkloadInsightEventFilters) => void;
   onSortChange: (ss: SortSetting) => void;
   refreshTransactionInsights: () => void;
+  setTimeScale: (ts: TimeScale) => void;
 };
 
 export type TransactionInsightsViewProps = TransactionInsightsViewStateProps &
@@ -78,6 +79,7 @@ export const TransactionInsightsView: React.FC<TransactionInsightsViewProps> = (
     refreshTransactionInsights,
     onFiltersChange,
     onSortChange,
+    setTimeScale,
     dropDownSelect,
   } = props;
 
@@ -232,6 +234,7 @@ export const TransactionInsightsView: React.FC<TransactionInsightsViewProps> = (
                 data={filteredTransactions}
                 sortSetting={sortSetting}
                 onChangeSortSetting={onChangeSortSetting}
+                setTimeScale={setTimeScale}
                 renderNoResult={
                   <EmptyInsightsTablePlaceholder
                     isEmptySearchResults={

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/detailsLinks.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/detailsLinks.tsx
@@ -1,0 +1,66 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { StatementInsightEvent } from "../../types";
+import React from "react";
+import { HexStringToInt64String } from "../../../util";
+import { Link } from "react-router-dom";
+import { StatementLinkTarget } from "../../../statementsTable";
+import moment from "moment/moment";
+import { TimeScale } from "../../../timeScaleDropdown";
+import { Moment } from "moment";
+
+export function TransactionDetailsLink(
+  transactionFingerprintID: string,
+  startTime: Moment,
+  setTimeScale: (tw: TimeScale) => void,
+): React.ReactElement {
+  const txnID = HexStringToInt64String(transactionFingerprintID);
+  const path = `/transaction/${txnID}`;
+  const timeScale: TimeScale = {
+    windowSize: moment.duration(65, "minutes"),
+    fixedWindowEnd: startTime.add(1, "hour"),
+    sampleSize: moment.duration(1, "hour"),
+    key: "Custom",
+  };
+  return (
+    <Link to={path} onClick={() => setTimeScale(timeScale)}>
+      <div>{String(transactionFingerprintID)}</div>
+    </Link>
+  );
+}
+
+export function StatementDetailsLink(
+  insightDetails: StatementInsightEvent,
+  setTimeScale: (tw: TimeScale) => void,
+): React.ReactElement {
+  const linkProps = {
+    statementFingerprintID: HexStringToInt64String(
+      insightDetails.statementFingerprintID,
+    ),
+    appNames: [insightDetails.application],
+    implicitTxn: insightDetails.implicitTxn,
+  };
+  const timeScale: TimeScale = {
+    windowSize: moment.duration(insightDetails.elapsedTimeMillis),
+    fixedWindowEnd: insightDetails.endTime,
+    sampleSize: moment.duration(1, "hour"),
+    key: "Custom",
+  };
+
+  return (
+    <Link
+      to={StatementLinkTarget(linkProps)}
+      onClick={() => setTimeScale(timeScale)}
+    >
+      <div>{String(insightDetails.statementFingerprintID)}</div>
+    </Link>
+  );
+}

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/index.ts
@@ -13,3 +13,4 @@ export * from "./queriesCell";
 export * from "./emptyInsightsTablePlaceholder";
 export * from "./insightsColumns";
 export * from "./dropDownSelect";
+export * from "./detailsLinks";

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/workloadInsightsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/workloadInsightsPageConnected.tsx
@@ -39,7 +39,14 @@ import {
   selectFilters,
   selectSortSetting,
 } from "src/store/insights/transactionInsights";
-import { bindActionCreators } from "redux";
+import { bindActionCreators, Dispatch } from "redux";
+import { TimeScale } from "../../timeScaleDropdown";
+import { actions as sqlStatsActions } from "../../store/sqlStats";
+import {
+  StatementInsightDetails,
+  StatementInsightDetailsDispatchProps,
+  StatementInsightDetailsStateProps,
+} from "../workloadInsightDetails";
 
 const transactionMapStateToProps = (
   state: AppState,
@@ -62,7 +69,9 @@ const statementMapStateToProps = (
   selectedColumnNames: selectColumns(state),
 });
 
-const TransactionDispatchProps = {
+const TransactionDispatchProps = (
+  dispatch: Dispatch,
+): TransactionInsightsViewDispatchProps => ({
   onFiltersChange: (filters: WorkloadInsightEventFilters) =>
     localStorageActions.update({
       key: "filters/InsightsPage",
@@ -73,10 +82,19 @@ const TransactionDispatchProps = {
       key: "sortSetting/InsightsPage",
       value: ss,
     }),
+  setTimeScale: (ts: TimeScale) => {
+    dispatch(
+      sqlStatsActions.updateTimeScale({
+        ts: ts,
+      }),
+    );
+  },
   refreshTransactionInsights: transactionInsights.refresh,
-};
+});
 
-const StatementDispatchProps: StatementInsightsViewDispatchProps = {
+const StatementDispatchProps = (
+  dispatch: Dispatch,
+): StatementInsightsViewDispatchProps => ({
   onFiltersChange: (filters: WorkloadInsightEventFilters) =>
     localStorageActions.update({
       key: "filters/InsightsPage",
@@ -92,8 +110,15 @@ const StatementDispatchProps: StatementInsightsViewDispatchProps = {
       key: "showColumns/StatementInsightsPage",
       value: value.join(","),
     }),
+  setTimeScale: (ts: TimeScale) => {
+    dispatch(
+      sqlStatsActions.updateTimeScale({
+        ts: ts,
+      }),
+    );
+  },
   refreshStatementInsights: statementInsights.refresh,
-};
+});
 
 type StateProps = {
   transactionInsightsViewStateProps: TransactionInsightsViewStateProps;
@@ -120,14 +145,8 @@ export const WorkloadInsightsPageConnected = withRouter(
       statementInsightsViewStateProps: statementMapStateToProps(state, props),
     }),
     dispatch => ({
-      transactionInsightsViewDispatchProps: bindActionCreators(
-        TransactionDispatchProps,
-        dispatch,
-      ),
-      statementInsightsViewDispatchProps: bindActionCreators(
-        StatementDispatchProps,
-        dispatch,
-      ),
+      transactionInsightsViewDispatchProps: TransactionDispatchProps(dispatch),
+      statementInsightsViewDispatchProps: StatementDispatchProps(dispatch),
     }),
     (stateProps, dispatchProps) => ({
       transactionInsightsViewProps: {

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -73,7 +73,7 @@ import {
   timeScale1hMinOptions,
   TimeScaleDropdown,
   timeScaleToString,
-  toDateRange,
+  toRoundedDateRange,
 } from "../timeScaleDropdown";
 
 import { commonStyles } from "../common";
@@ -153,7 +153,7 @@ export type StatementsPageProps = StatementsPageDispatchProps &
 function statementsRequestFromProps(
   props: StatementsPageProps,
 ): cockroach.server.serverpb.StatementsRequest {
-  const [start, end] = toDateRange(props.timeScale);
+  const [start, end] = toRoundedDateRange(props.timeScale);
   return new cockroach.server.serverpb.StatementsRequest({
     combined: true,
     start: Long.fromNumber(start.unix()),

--- a/pkg/ui/workspaces/cluster-ui/src/store/sqlStats/sqlStats.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sqlStats/sqlStats.sagas.ts
@@ -23,7 +23,7 @@ import {
   UpdateTimeScalePayload,
 } from "./sqlStats.reducer";
 import { actions as sqlDetailsStatsActions } from "../statementDetails/statementDetails.reducer";
-import { toDateRange } from "../../timeScaleDropdown";
+import { toRoundedDateRange } from "../../timeScaleDropdown";
 
 export function* refreshSQLStatsSaga(action: PayloadAction<StatementsRequest>) {
   yield put(sqlStatsActions.request(action.payload));
@@ -50,7 +50,7 @@ export function* updateSQLStatsTimeScaleSaga(
       value: ts,
     }),
   );
-  const [start, end] = toDateRange(ts);
+  const [start, end] = toRoundedDateRange(ts);
   const req = new cockroach.server.serverpb.StatementsRequest({
     combined: true,
     start: Long.fromNumber(start.unix()),

--- a/pkg/ui/workspaces/cluster-ui/src/summaryCard/summaryCard.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/summaryCard/summaryCard.module.scss
@@ -85,6 +85,13 @@
         letter-spacing: 0.1px;
         margin-bottom: 0;
       }
+      a {
+        color: $colors--link;
+        &:hover {
+          color: $colors--link;
+          text-decoration: underline;
+        }
+      }
     }
   }
 }

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -67,7 +67,7 @@ import {
   timeScale1hMinOptions,
   TimeScaleDropdown,
   timeScaleToString,
-  toDateRange,
+  toRoundedDateRange,
 } from "../timeScaleDropdown";
 import timeScaleStyles from "../timeScaleDropdown/timeScale.module.scss";
 
@@ -113,7 +113,7 @@ interface TState {
 function statementsRequestFromProps(
   props: TransactionDetailsProps,
 ): protos.cockroach.server.serverpb.StatementsRequest {
-  const [start, end] = toDateRange(props.timeScale);
+  const [start, end] = toRoundedDateRange(props.timeScale);
   return new protos.cockroach.server.serverpb.StatementsRequest({
     combined: true,
     start: Long.fromNumber(start.unix()),

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -63,10 +63,10 @@ import { commonStyles } from "../common";
 import {
   TimeScaleDropdown,
   TimeScale,
-  toDateRange,
   timeScaleToString,
   timeScale1hMinOptions,
   getValidOption,
+  toRoundedDateRange,
 } from "../timeScaleDropdown";
 import { InlineAlert } from "@cockroachlabs/ui-components";
 import { TransactionViewType } from "./transactionsPageTypes";
@@ -118,7 +118,7 @@ export type TransactionsPageProps = TransactionsPageStateProps &
 function statementsRequestFromProps(
   props: TransactionsPageProps,
 ): protos.cockroach.server.serverpb.StatementsRequest {
-  const [start, end] = toDateRange(props.timeScale);
+  const [start, end] = toRoundedDateRange(props.timeScale);
   return new protos.cockroach.server.serverpb.StatementsRequest({
     combined: true,
     start: Long.fromNumber(start.unix()),

--- a/pkg/ui/workspaces/db-console/src/redux/statements/statementsSagas.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/statements/statementsSagas.ts
@@ -41,7 +41,7 @@ import {
   createStatementDiagnosticsAlertLocalSetting,
   cancelStatementDiagnosticsAlertLocalSetting,
 } from "src/redux/alerts";
-import { TimeScale, toDateRange } from "@cockroachlabs/cluster-ui";
+import { TimeScale, toRoundedDateRange } from "@cockroachlabs/cluster-ui";
 import Long from "long";
 import { setTimeScale } from "src/redux/timeScale";
 
@@ -157,7 +157,7 @@ export function* setCombinedStatementsTimeScaleSaga(
   const ts = action.payload;
 
   yield put(setTimeScale(ts));
-  const [start, end] = toDateRange(ts);
+  const [start, end] = toRoundedDateRange(ts);
   const req = new CombinedStatementsRequest({
     combined: true,
     start: Long.fromNumber(start.unix()),

--- a/pkg/ui/workspaces/db-console/src/views/insights/statementInsightDetailsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/insights/statementInsightDetailsPage.tsx
@@ -10,11 +10,13 @@
 import {
   StatementInsightDetails,
   StatementInsightDetailsStateProps,
+  StatementInsightDetailsDispatchProps,
 } from "@cockroachlabs/cluster-ui";
 import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { AdminUIState } from "src/redux/state";
 import { selectStatementInsightDetails } from "src/views/insights/insightsSelectors";
+import { setGlobalTimeScaleAction } from "src/redux/statements";
 
 const mapStateToProps = (
   state: AdminUIState,
@@ -28,9 +30,18 @@ const mapStateToProps = (
   };
 };
 
+const mapDispatchToProps: StatementInsightDetailsDispatchProps = {
+  setTimeScale: setGlobalTimeScaleAction,
+};
+
 const StatementInsightDetailsPage = withRouter(
-  connect<StatementInsightDetailsStateProps, RouteComponentProps>(
+  connect<
+    StatementInsightDetailsStateProps,
+    StatementInsightDetailsDispatchProps,
+    RouteComponentProps
+  >(
     mapStateToProps,
+    mapDispatchToProps,
   )(StatementInsightDetails),
 );
 

--- a/pkg/ui/workspaces/db-console/src/views/insights/transactionInsightDetailsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/insights/transactionInsightDetailsPage.tsx
@@ -18,6 +18,7 @@ import { RouteComponentProps, withRouter } from "react-router-dom";
 import { refreshTransactionInsightDetails } from "src/redux/apiReducers";
 import { AdminUIState } from "src/redux/state";
 import { selectTransactionInsightDetails } from "src/views/insights/insightsSelectors";
+import { setGlobalTimeScaleAction } from "src/redux/statements";
 
 const mapStateToProps = (
   state: AdminUIState,
@@ -33,8 +34,9 @@ const mapStateToProps = (
   };
 };
 
-const mapDispatchToProps = {
+const mapDispatchToProps: TransactionInsightDetailsDispatchProps = {
   refreshTransactionInsightDetails: refreshTransactionInsightDetails,
+  setTimeScale: setGlobalTimeScaleAction,
 };
 
 const TransactionInsightDetailsPage = withRouter(

--- a/pkg/ui/workspaces/db-console/src/views/insights/workloadInsightsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/insights/workloadInsightsPage.tsx
@@ -33,6 +33,7 @@ import {
 } from "src/views/insights/insightsSelectors";
 import { bindActionCreators } from "redux";
 import { LocalSetting } from "src/redux/localsettings";
+import { setGlobalTimeScaleAction } from "src/redux/statements";
 
 export const insightStatementColumnsLocalSetting = new LocalSetting<
   AdminUIState,
@@ -69,6 +70,7 @@ const TransactionDispatchProps = {
   onFiltersChange: (filters: WorkloadInsightEventFilters) =>
     filtersLocalSetting.set(filters),
   onSortChange: (ss: SortSetting) => sortSettingLocalSetting.set(ss),
+  setTimeScale: setGlobalTimeScaleAction,
   refreshTransactionInsights: refreshTransactionInsights,
 };
 
@@ -79,6 +81,7 @@ const StatementDispatchProps: StatementInsightsViewDispatchProps = {
   refreshStatementInsights: refreshStatementInsights,
   onColumnsChange: (value: string[]) =>
     insightStatementColumnsLocalSetting.set(value.join(",")),
+  setTimeScale: setGlobalTimeScaleAction,
 };
 
 type StateProps = {


### PR DESCRIPTION
Now from the Insights page, clicking on the statement or fingerprint ids, it will bring you to their respective details page.

This commit also filter out transaction insights that didn't have their value set yet (meaning they're still 0).

Finally, this commit fixes the start/end values being passed to the combined statement endpoint, to the correct rounded values, aligning what we say on the UI.

Fixes #87750

https://www.loom.com/share/d9d6de0c78af4496b538a905732c745b
Note to reviewers: the bug displayed on the video will be addressed on #90397

Release note (ui change): The fingerprint id values for statement and transactions on the insights pages are links that open the respective details page on the time period of the execution of that statement/transaction.

Release note (bug fix): Sendind the proper start/end values to the endpoint used on SQL Activity page, now returning the full hour as described on the UI.