### PR TITLE
sql: remove unused planner field

### DIFF
--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -215,9 +215,6 @@ type planner struct {
 	// query.
 	cancelChecker cancelchecker.CancelChecker
 
-	// isPreparing is true if this planner is currently preparing.
-	isPreparing bool
-
 	// curPlan collects the properties of the current plan being prepared. This state
 	// is undefined at the beginning of the planning of each new statement, and cannot
 	// be reused for an old prepared statement after a new statement has been prepared.
@@ -1043,7 +1040,6 @@ func (p *planner) resetPlanner(
 	p.semaCtx.IntervalStyle = sd.GetIntervalStyle()
 
 	p.autoCommit = false
-	p.isPreparing = false
 
 	p.schemaResolver.txn = txn
 	p.schemaResolver.sessionDataStack = p.EvalContext().SessionDataStack


### PR DESCRIPTION
Unused fields are confusing.

Epic: None

Release note: None