### PR TITLE
[dnm] use clusterversion.Refer to tie arbitrary code to cluster versions

### DIFF
--- a/pkg/clusterversion/refer.go
+++ b/pkg/clusterversion/refer.go
@@ -1,0 +1,26 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+//
+
+package clusterversion
+
+// Refer allows tying one or more objects (or even a code comment, etc)
+// to a cluster version, with the intention that when the cluster version
+// falls under the min supported version and is in the process of being
+// removed, associated clean-up can happen.
+//
+// This is helpful when there is otherwise no reason to tie the code whose
+// cleanup is desired to the version. For example, when a proto field becomes
+// deprecated, there may be a version gate in the code somewhere, but it may not
+// refer directly to the proto field; and yet one may desire removing that the
+// proto field exactly when the version disappears.
+func Refer(v Key, subj ...interface{}) {
+	_ = 0 // no-op
+}

--- a/pkg/kv/kvserver/kvserverpb/log.go
+++ b/pkg/kv/kvserver/kvserverpb/log.go
@@ -10,6 +10,15 @@
 
 package kvserverpb
 
+import "github.com/cockroachdb/cockroach/pkg/clusterversion"
+
+func init() {
+	// In the real world, when the field below was deprecated, we'd have
+	// introduced something like clusterversion.NoReferenceToUsingAppliedStateKey
+	// and would refer to that instead, but this is only a demonstration.
+	clusterversion.Refer(clusterversion.Start22_2, ReplicaState{}.DeprecatedUsingAppliedStateKey)
+}
+
 // RangeLogEventReason specifies the reason why a range-log event happened.
 type RangeLogEventReason string
 

--- a/pkg/kv/kvserver/kvserverpb/state.proto
+++ b/pkg/kv/kvserver/kvserverpb/state.proto
@@ -90,9 +90,8 @@ message ReplicaState {
   // (#72222). Once that's done, we should be able to stop sending the replica
   // state as part of the snapshot in the subsequent release.
   //
-  // TODO(irfansharif): Remove this field in the release after the one where we
-  // stop consulting the protobuf copy of the replica state when applying a
-  // snapshot.
+  // This field can be removed together with
+  // clusterversion.NoReferenceToUsingAppliedStateKey.
   bool deprecated_using_applied_state_key = 11;
   // Version tells us which migrations can be assumed to have run against this
   // particular replica. When we introduce backwards incompatible changes to the


### PR DESCRIPTION
Release note: None
