### PR TITLE
release-22.1: jobs,sql/importer: retry circuit breaker open errors

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -126,6 +126,7 @@ ALL_TESTS = [
     "//pkg/internal/rsg:rsg_test",
     "//pkg/internal/sqlsmith:sqlsmith_test",
     "//pkg/internal/team:team_test",
+    "//pkg/jobs/joberror:joberror_test",
     "//pkg/jobs/jobsprotectedts:jobsprotectedts_test",
     "//pkg/jobs:jobs_test",
     "//pkg/keys:keys_test",

--- a/pkg/jobs/joberror/BUILD.bazel
+++ b/pkg/jobs/joberror/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "joberror",
@@ -11,6 +11,20 @@ go_library(
         "//pkg/util/circuit",
         "//pkg/util/grpcutil",
         "//pkg/util/sysutil",
+        "@com_github_cockroachdb_circuitbreaker//:circuitbreaker",
         "@com_github_cockroachdb_errors//:errors",
+    ],
+)
+
+go_test(
+    name = "joberror_test",
+    srcs = ["errors_test.go"],
+    embed = [":joberror"],
+    deps = [
+        "//pkg/util/circuit",
+        "@com_github_cockroachdb_circuitbreaker//:circuitbreaker",
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/jobs/joberror/errors.go
+++ b/pkg/jobs/joberror/errors.go
@@ -13,6 +13,7 @@ package joberror
 import (
 	"strings"
 
+	circuitbreaker "github.com/cockroachdb/circuitbreaker"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
 	"github.com/cockroachdb/cockroach/pkg/util/circuit"
@@ -41,8 +42,11 @@ func IsDistSQLRetryableError(err error) bool {
 }
 
 // isBreakerOpenError returns true if err is a circuit.ErrBreakerOpen.
+//
+// NB: Two packages have ErrBreakerOpen error types.  The cicruitbreaker package
+// is used by the nodedialer. The circuit package is used by kvserver.
 func isBreakerOpenError(err error) bool {
-	return errors.Is(err, circuit.ErrBreakerOpen)
+	return errors.Is(err, circuit.ErrBreakerOpen) || errors.Is(err, circuitbreaker.ErrBreakerOpen)
 }
 
 // IsPermanentBulkJobError returns true if the error results in a permanent

--- a/pkg/jobs/joberror/errors_test.go
+++ b/pkg/jobs/joberror/errors_test.go
@@ -1,0 +1,45 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package joberror
+
+import (
+	"fmt"
+	"testing"
+
+	circuitbreaker "github.com/cockroachdb/circuitbreaker"
+	"github.com/cockroachdb/cockroach/pkg/util/circuit"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrBreakerOpenIsRetriable(t *testing.T) {
+	br := circuit.NewBreaker(circuit.Options{
+		Name: redact.Sprint("Breaker"),
+		AsyncProbe: func(_ func(error), done func()) {
+			done() // never untrip
+		},
+		EventHandler: &circuit.EventLogger{Log: func(redact.StringBuilder) {}},
+	})
+	br.Report(errors.New("test error"))
+	utilBreakderErr := br.Signal().Err()
+	// NB: This matches the error that dial produces.
+	dialErr := errors.Wrapf(circuitbreaker.ErrBreakerOpen, "unable to dial n%d", 9)
+
+	for _, e := range []error{
+		utilBreakderErr,
+		dialErr,
+	} {
+		t.Run(fmt.Sprintf("%s", e), func(t *testing.T) {
+			require.False(t, IsPermanentBulkJobError(e))
+		})
+	}
+}

--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -170,6 +170,7 @@ go_test(
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/roachpb",
+        "//pkg/rpc",
         "//pkg/security",
         "//pkg/security/securitytest",
         "//pkg/server",

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -57,15 +57,18 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+type importTestingKnobs struct {
+	afterImport            func(summary roachpb.RowCount) error
+	beforeRunDSP           func() error
+	alwaysFlushJobProgress bool
+}
+
 type importResumer struct {
 	job      *jobs.Job
 	settings *cluster.Settings
 	res      roachpb.RowCount
 
-	testingKnobs struct {
-		afterImport            func(summary roachpb.RowCount) error
-		alwaysFlushJobProgress bool
-	}
+	testingKnobs importTestingKnobs
 }
 
 func (r *importResumer) TestingSetAfterImportKnob(fn func(summary roachpb.RowCount) error) {
@@ -278,7 +281,7 @@ func (r *importResumer) Resume(ctx context.Context, execCtx interface{}) error {
 	procsPerNode := int(processorsPerNode.Get(&p.ExecCfg().Settings.SV))
 
 	res, err := ingestWithRetry(ctx, p, r.job, tables, typeDescs, files, format, details.Walltime,
-		r.testingKnobs.alwaysFlushJobProgress, procsPerNode)
+		r.testingKnobs, procsPerNode)
 	if err != nil {
 		return err
 	}
@@ -1237,7 +1240,7 @@ func ingestWithRetry(
 	from []string,
 	format roachpb.IOFileFormat,
 	walltime int64,
-	alwaysFlushProgress bool,
+	testingKnobs importTestingKnobs,
 	procsPerNode int,
 ) (roachpb.BulkOpSummary, error) {
 	resumerSpan := tracing.SpanFromContext(ctx)
@@ -1264,7 +1267,7 @@ func ingestWithRetry(
 			RetryError:    tracing.RedactAndTruncateError(err),
 		})
 		res, err = distImport(ctx, execCtx, job, tables, typeDescs, from, format, walltime,
-			alwaysFlushProgress, procsPerNode)
+			testingKnobs, procsPerNode)
 		if err == nil {
 			break
 		}


### PR DESCRIPTION
Backport 1/1 commits from #89354.

/cc @cockroachdb/release

---

We would like to retry circuit breaker open errors. In fact, jobs.IsPermanentBulkJobError already looks like it would return false for breaker open errors.

But, there are actually two circuit breaker packages we use:

    github.com/cockroachdb/circuitbreaker
    github.com/cockroachdb/cockroach/pkg/util/circuit

Both define ErrBreakerOpen. IsPermanentBulkJobError would only catch errors from one of these packages. Now, we test for both.

As a result, ErrBreakerOpen errors emerging from the nodedialer will now be retried.

Fixes #89159
Fixes #85111
Fixes #81353
Fixes #91332

I may be being a bit optimistic that this will fully fixe those failures. Success of the job still requires that the retry of the job is successful.

Release note (bug fix): Fix bug that resulted in some retriable errors not being retried during IMPORT.

Release justification: Low-risk bug fix.
