### PR TITLE
cli/cert,sql: make it easier to use identity maps

### DIFF
--- a/pkg/cli/cert_test.go
+++ b/pkg/cli/cert_test.go
@@ -18,6 +18,7 @@ func Example_cert() {
 	c.RunWithCAArgs([]string{"cert", "create-client", "Ομηρος"})
 	c.RunWithCAArgs([]string{"cert", "create-client", "0foo"})
 	c.RunWithCAArgs([]string{"cert", "create-client", ",foo"})
+	c.RunWithCAArgs([]string{"cert", "create-client", "--disable-username-validation", ",foo"})
 
 	// Output:
 	// cert create-client foo
@@ -26,4 +27,7 @@ func Example_cert() {
 	// cert create-client ,foo
 	// ERROR: failed to generate client certificate and key: username is invalid
 	// HINT: Usernames are case insensitive, must start with a letter, digit or underscore, may contain letters, digits, dashes, periods, or underscores, and must not exceed 63 characters.
+	// cert create-client --disable-username-validation ,foo
+	// warning: the specified identity ",foo" is not a valid SQL username.
+	// Before it can be used to log in, an identity map rule will need to be set on the server.
 }

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -791,6 +791,13 @@ system tenant.`,
 		Description: `Also write the key in pkcs8 format to <certs-dir>/client.<username>.key.pk8.`,
 	}
 
+	DisableUsernameValidation = FlagInfo{
+		Name: "disable-username-validation",
+		Description: `Do not validate that the provided identity has a valid structure for
+a SQL identifier. If passed, and the identity is not a valid SQL identifier, the generated
+certificate can only be used if an identity map has been configured server-side.`,
+	}
+
 	Password = FlagInfo{
 		Name:        "password",
 		Description: `Prompt for the new user's password.`,

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -271,6 +271,10 @@ var certCtx struct {
 	// scoped to. By creating a tenant-scoped certicate, the usage of that certificate
 	// is restricted to a specific tenant.
 	tenantScope []roachpb.TenantID
+
+	// disableUsernameValidation removes the username syntax check on
+	// the input.
+	disableUsernameValidation bool
 }
 
 func setCertContextDefaults() {
@@ -282,6 +286,7 @@ func setCertContextDefaults() {
 	certCtx.allowCAKeyReuse = false
 	certCtx.overwriteFiles = false
 	certCtx.generatePKCS8Key = false
+	certCtx.disableUsernameValidation = false
 	certCtx.certPrincipalMap = nil
 	certCtx.tenantScope = []roachpb.TenantID{roachpb.SystemTenantID}
 }

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -599,9 +599,10 @@ func init() {
 			cliflagcfg.DurationFlag(f, &certCtx.certificateLifetime, cliflags.CertificateLifetime)
 		}
 
-		// PKCS8 key format is only available for the client cert command.
 		if cmd == createClientCertCmd {
+			// PKCS8 key format is only available for the client cert command.
 			cliflagcfg.BoolFlag(f, &certCtx.generatePKCS8Key, cliflags.GeneratePKCS8Key)
+			cliflagcfg.BoolFlag(f, &certCtx.disableUsernameValidation, cliflags.DisableUsernameValidation)
 		}
 	}
 

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -843,8 +843,9 @@ func (s *Server) newSessionData(args SessionArgs) *sessiondata.SessionData {
 			RemoteAddr: args.RemoteAddr,
 		},
 		LocalOnlySessionData: sessiondatapb.LocalOnlySessionData{
-			ResultsBufferSize: args.ConnResultsBufferSize,
-			IsSuperuser:       args.IsSuperuser,
+			ResultsBufferSize:   args.ConnResultsBufferSize,
+			IsSuperuser:         args.IsSuperuser,
+			SystemIdentityProto: args.SystemIdentity.EncodeProto(),
 		},
 	}
 	if len(args.CustomOptionSessionDefaults) > 0 {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1988,6 +1988,7 @@ type SessionDefaults map[string]string
 type SessionArgs struct {
 	User                        username.SQLUsername
 	IsSuperuser                 bool
+	SystemIdentity              username.SQLUsername
 	SessionDefaults             SessionDefaults
 	CustomOptionSessionDefaults SessionDefaults
 	// RemoteAddr is the client's address. This is nil iff this is an internal

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4790,6 +4790,7 @@ statement_timeout                                     0
 stub_catalog_tables                                   on
 synchronize_seqscans                                  on
 synchronous_commit                                    on
+system_identity                                       root
 testing_optimizer_cost_perturbation                   0
 testing_optimizer_disable_rule_probability            0
 testing_optimizer_random_seed                         0

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4263,6 +4263,7 @@ statement_timeout                                     0                   NULL  
 stub_catalog_tables                                   on                  NULL      NULL        NULL        string
 synchronize_seqscans                                  on                  NULL      NULL        NULL        string
 synchronous_commit                                    on                  NULL      NULL        NULL        string
+system_identity                                       root                NULL      NULL        NULL        string
 testing_optimizer_cost_perturbation                   0                   NULL      NULL        NULL        string
 testing_optimizer_disable_rule_probability            0                   NULL      NULL        NULL        string
 testing_optimizer_random_seed                         0                   NULL      NULL        NULL        string
@@ -4399,6 +4400,7 @@ statement_timeout                                     0                   NULL  
 stub_catalog_tables                                   on                  NULL  user     NULL      on                  on
 synchronize_seqscans                                  on                  NULL  user     NULL      on                  on
 synchronous_commit                                    on                  NULL  user     NULL      on                  on
+system_identity                                       root                NULL  user     NULL      root                root
 testing_optimizer_cost_perturbation                   0                   NULL  user     NULL      0                   0
 testing_optimizer_disable_rule_probability            0                   NULL  user     NULL      0                   0
 testing_optimizer_random_seed                         0                   NULL  user     NULL      0                   0
@@ -4534,6 +4536,7 @@ statement_timeout                                     NULL    NULL     NULL     
 stub_catalog_tables                                   NULL    NULL     NULL     NULL        NULL
 synchronize_seqscans                                  NULL    NULL     NULL     NULL        NULL
 synchronous_commit                                    NULL    NULL     NULL     NULL        NULL
+system_identity                                       NULL    NULL     NULL     NULL        NULL
 testing_optimizer_cost_perturbation                   NULL    NULL     NULL     NULL        NULL
 testing_optimizer_disable_rule_probability            NULL    NULL     NULL     NULL        NULL
 testing_optimizer_random_seed                         NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -130,6 +130,7 @@ statement_timeout                                     0
 stub_catalog_tables                                   on
 synchronize_seqscans                                  on
 synchronous_commit                                    on
+system_identity                                       root
 testing_optimizer_cost_perturbation                   0
 testing_optimizer_disable_rule_probability            0
 testing_optimizer_random_seed                         0

--- a/pkg/sql/pgwire/auth.go
+++ b/pkg/sql/pgwire/auth.go
@@ -126,6 +126,7 @@ func (c *conn) handleAuthentication(
 	} else {
 		systemIdentity = c.sessionArgs.User
 	}
+	c.sessionArgs.SystemIdentity = systemIdentity
 
 	// Delegate to the AuthMethod's MapRole to choose the actual
 	// database user that a successful authentication will result in.

--- a/pkg/sql/pgwire/testdata/auth/identity_map
+++ b/pkg/sql/pgwire/testdata/auth/identity_map
@@ -107,9 +107,9 @@ subtest end
 # system identity and get a remapping.
 subtest password_remapped_user_ok
 
-connect user=will_be_carl database=mydb password=oggod
+connect user=will_be_carl database=mydb password=oggod show_system_identity
 ----
-ok mydb
+ok mydb will_be_carl
 
 authlog 7
 .*client_connection_end
@@ -149,9 +149,9 @@ subtest end
 # database username.
 subtest cert_with_principal_not_in_users
 
-connect user=testuser2 database=mydb force_certs
+connect user=testuser2 database=mydb force_certs show_system_identity
 ----
-ok mydb
+ok mydb testuser2
 
 authlog 6
 .*client_connection_end

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -299,6 +299,10 @@ message LocalOnlySessionData {
   // run before the transaction is canceled. If set to 0, there is no timeout.
   int64 transaction_timeout = 81 [(gogoproto.casttype) = "time.Duration"];
 
+  // SystemIdentityProto is the original name of the client presented to pgwire
+  // before it was mapped to a SQL identifier.
+  string system_identity_proto = 82 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/security/username.SQLUsernameProto"];
+
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //
   // be propagated to the remote nodes. If so, that parameter should live  //

--- a/pkg/sql/sessiondatapb/session_data.go
+++ b/pkg/sql/sessiondatapb/session_data.go
@@ -88,3 +88,9 @@ func VectorizeExecModeFromString(val string) (VectorizeExecMode, bool) {
 func (s *SessionData) User() username.SQLUsername {
 	return s.UserProto.Decode()
 }
+
+// SystemIdentity retrieves the session's system identity.
+// (Identity presented by the client prior to identity mapping.)
+func (s *LocalOnlySessionData) SystemIdentity() username.SQLUsername {
+	return s.SystemIdentityProto.Decode()
+}

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -984,6 +984,17 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
+	`system_identity`: {
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return evalCtx.SessionData().SystemIdentity().Normalized(), nil
+		},
+		GetFromSessionData: func(sd *sessiondata.SessionData) string {
+			return sd.SystemIdentity().Normalized()
+		},
+		GlobalDefault: func(_ *settings.Values) string { return "" },
+	},
+
+	// CockroachDB extension.
 	`large_full_scan_rows`: {
 		GetStringVal: makeFloatGetStringValFn(`large_full_scan_rows`),
 		Set: func(_ context.Context, m sessionDataMutator, s string) error {


### PR DESCRIPTION
This PR contains two changes:

- to facilitate testing, it introduces a new flag `--disable-username-validation` to `cockroach cert create-client`.
- to facilitate introspection, it introduces a new SQL session variable `system_identity` which contains the username presented by the SQL client prior to identity mapping.

Fixes #90436.

Relating to the issue linked above:
- I have tested manually that crdb already supports HBA rule filtering using domain names (for example `host all foo@bar all` and `host all foo@baz all` will match foo@bar and foo@baz separately.
- I have test manually that the system identity is already propagated to the authentication logs.
