### PR TITLE
backupccl: re-enable data driven tests to run within a tenant

### DIFF
--- a/pkg/ccl/backupccl/datadriven_test.go
+++ b/pkg/ccl/backupccl/datadriven_test.go
@@ -142,7 +142,7 @@ func (d *datadrivenTestState) addServer(t *testing.T, cfg serverCfg) error {
 	var cleanup func()
 	params := base.TestClusterArgs{}
 	params.ServerArgs.ExternalIODirConfig = cfg.ioConf
-	params.ServerArgs.DisableDefaultTestTenant = true
+	params.ServerArgs.DisableDefaultTestTenant = cfg.disableTenant
 	params.ServerArgs.Knobs = base.TestingKnobs{
 		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 	}

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-grants
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-grants
@@ -3,9 +3,13 @@
 # the restoring descriptors reference may not be the same users as they
 # referenced in the backed up cluster.
 
+# TODO(DisasterRecovery): this test currently hangs when run within a tenant
+# (see https://github.com/cockroachdb/cockroach/issues/90444), and should be refactored
+# to run smoothly in a tenant.
+
 # We allow implicit access to non-admin users so that we can test
 # with nodelocal.
-new-server name=s1 allow-implicit-access
+new-server name=s1 allow-implicit-access disable-tenant
 ----
 
 # TODO(ssd): We reset the closed timestamp configurables to avoid schema
@@ -159,7 +163,7 @@ BACKUP INTO 'nodelocal://0/test/'
 # above.
 subtest cluster-restore
 
-new-server name=s2 share-io-dir=s1 allow-implicit-access
+new-server name=s2 share-io-dir=s1 allow-implicit-access disable-tenant
 ----
 
 exec-sql


### PR DESCRIPTION
TestDataDriven unit tests were recently enabled to run within tenants(#88271). This was quickly disabled as it caused TestDataDriven/restore-grants to flake (tracked in #90444). This patch re-enables TestDataDriven unit tests to run within a tenant, except for TestDataDriven/restore-grants. Further investigation is needed to understand why restore-grants hangs when run within a tenant.

Informs #90444

Release note: None