### PR TITLE
release-22.1: azure: make number of concurrent upload buffers configurable

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -11,6 +11,7 @@ bulkio.backup.read_timeout	duration	5m0s	amount of time after which a read attem
 bulkio.backup.read_with_priority_after	duration	1m0s	amount of time since the read-as-of time above which a BACKUP should use priority when retrying reads
 bulkio.stream_ingestion.minimum_flush_interval	duration	5s	the minimum timestamp between flushes; flushes may still occur if internal buffers fill up
 changefeed.node_throttle_config	string		specifies node level throttling configuration for all changefeeeds
+cloudstorage.azure.concurrent_upload_buffers	integer	1	controls the number of concurrent buffers that will be used by the Azure client when uploading chunks.Each buffer can buffer up to cloudstorage.write_chunk.size of memory during an upload
 cloudstorage.http.custom_ca	string		custom root CA (appended to system's default CAs) for verifying certificates when interacting with HTTPS storage
 cloudstorage.timeout	duration	10m0s	the timeout for import/export storage operations
 cluster.organization	string		organization name

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -16,6 +16,7 @@
 <tr><td><code>bulkio.backup.read_with_priority_after</code></td><td>duration</td><td><code>1m0s</code></td><td>amount of time since the read-as-of time above which a BACKUP should use priority when retrying reads</td></tr>
 <tr><td><code>bulkio.stream_ingestion.minimum_flush_interval</code></td><td>duration</td><td><code>5s</code></td><td>the minimum timestamp between flushes; flushes may still occur if internal buffers fill up</td></tr>
 <tr><td><code>changefeed.node_throttle_config</code></td><td>string</td><td><code></code></td><td>specifies node level throttling configuration for all changefeeeds</td></tr>
+<tr><td><code>cloudstorage.azure.concurrent_upload_buffers</code></td><td>integer</td><td><code>1</code></td><td>controls the number of concurrent buffers that will be used by the Azure client when uploading chunks.Each buffer can buffer up to cloudstorage.write_chunk.size of memory during an upload</td></tr>
 <tr><td><code>cloudstorage.http.custom_ca</code></td><td>string</td><td><code></code></td><td>custom root CA (appended to system's default CAs) for verifying certificates when interacting with HTTPS storage</td></tr>
 <tr><td><code>cloudstorage.timeout</code></td><td>duration</td><td><code>10m0s</code></td><td>the timeout for import/export storage operations</td></tr>
 <tr><td><code>cluster.organization</code></td><td>string</td><td><code></code></td><td>organization name</td></tr>

--- a/pkg/cloud/azure/BUILD.bazel
+++ b/pkg/cloud/azure/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/cloud",
         "//pkg/roachpb",
         "//pkg/server/telemetry",
+        "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/util/contextutil",
         "//pkg/util/ioctx",

--- a/pkg/cloud/azure/azure_storage.go
+++ b/pkg/cloud/azure/azure_storage.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/ioctx"
@@ -31,6 +32,14 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/gogo/protobuf/types"
 )
+
+var maxConcurrentUploadBuffers = settings.RegisterIntSetting(
+	settings.TenantWritable,
+	"cloudstorage.azure.concurrent_upload_buffers",
+	"controls the number of concurrent buffers that will be used by the Azure client when uploading chunks."+
+		"Each buffer can buffer up to cloudstorage.write_chunk.size of memory during an upload",
+	1,
+).WithPublic()
 
 const (
 	// AzureAccountNameParam is the query parameter for account_name in an azure URI.
@@ -140,6 +149,7 @@ func (s *azureStorage) Writer(ctx context.Context, basename string) (io.WriteClo
 		_, err := azblob.UploadStreamToBlockBlob(
 			ctx, r, blob, azblob.UploadStreamToBlockBlobOptions{
 				BufferSize: int(cloud.WriteChunkSize.Get(&s.settings.SV)),
+				MaxBuffers: int(maxConcurrentUploadBuffers.Get(&s.settings.SV)),
 			},
 		)
 		return err


### PR DESCRIPTION
This change makes the number of concurrent buffers used by the Azure SDK Writer configurable. When uploading a file the writes are divided into 8MiB chunks that are then streamed to Azure. The SDK exposes the number of buffers that can be concurrently filled and uploaded and we were previously using the default value of 1. This change introduces a cluster setting `cloudstorage.azure.concurrent_upload_buffers` that defaults to 1 but can be increased to speed up the upload of files during a backup.

Note, increasing the number of concurrent buffers implies an increase in the amount of data held in memory.

Informs: #90297

Release note (sql change): new cluster setting
`cloudstorage.azure.concurrent_upload_buffers` to configure the number of concurrent buffers used when uploading files to Azure

Release justification: adds a configurable setting to fix a regression in Azure backups.