### PR TITLE
sql: add virtual index on status to crdb_internal.jobs table

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -802,7 +802,8 @@ CREATE TABLE crdb_internal.jobs (
    next_run TIMESTAMP NULL,
    num_runs INT8 NULL,
    execution_errors STRING[] NULL,
-   execution_events JSONB NULL
+   execution_events JSONB NULL,
+   INDEX jobs_status_idx (status ASC) STORING (job_id, job_type, description, statement, user_name, descriptor_ids, running_status, created, started, finished, modified, fraction_completed, high_water_timestamp, error, coordinator_id, trace_id, last_run, next_run, num_runs, execution_errors, execution_events)
 )  CREATE TABLE crdb_internal.jobs (
    job_id INT8 NULL,
    job_type STRING NULL,
@@ -825,7 +826,8 @@ CREATE TABLE crdb_internal.jobs (
    next_run TIMESTAMP NULL,
    num_runs INT8 NULL,
    execution_errors STRING[] NULL,
-   execution_events JSONB NULL
+   execution_events JSONB NULL,
+   INDEX jobs_status_idx (status ASC) STORING (job_id, job_type, description, statement, user_name, descriptor_ids, running_status, created, started, finished, modified, fraction_completed, high_water_timestamp, error, coordinator_id, trace_id, last_run, next_run, num_runs, execution_errors, execution_events)
 )  {}  {}
 CREATE TABLE crdb_internal.kv_node_liveness (
    node_id INT8 NOT NULL,

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual
@@ -261,3 +261,16 @@ vectorized: true
 • virtual table
   table: tables@tables_parent_id_idx (partial index)
   spans: [/1 - /1]
+
+# Validate that the virtual index on 'status' works.
+# Vectorized execution may be on or off during tests, so exclude it from the output.
+query T
+SELECT info FROM [EXPLAIN SELECT count(*) FROM crdb_internal.jobs WHERE status = 'paused'] WHERE info NOT LIKE 'vectorized%'
+----
+    distribution: local
+    ·
+    • group (scalar)
+    │
+    └── • virtual table
+          table: jobs@jobs_status_idx
+          spans: [/'paused' - /'paused']


### PR DESCRIPTION
Previously, performing a query on the crdb_internal.jobs table would require the entire virtual table to be generated, even if there was a filter being used. This change makes it so that only relevant rows are generated when filtering on `status`, which reduces the amount of rows which need to be processed.

Informs: https://github.com/cockroachdb/cockroach/issues/85467

Release note: None
Epic: None