### PR TITLE
ui: add scroll to filter

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.module.scss
@@ -40,6 +40,8 @@ $dropdown-hover-color: darken($colors--background, 2.5%);
 
   .dropdown-content-wrapper {
     padding: 18px 20px 22px 16px;
+    overflow-y: scroll;
+    max-height: 580px;
 
     .filter-label {
       height: 16px;


### PR DESCRIPTION
Previously, when a filter was displaying all the options or when a lot filters where selected, increasing the dropdown area height, the user couldn't reach the 'Apply'.

Because we want to keep the top of the dropdown area always aligned the the filter button (the one that open/close the filter), increasing the table area won't help.
This commits adds a scroll to the filter.

Fixes #90358

Note to Reviewers: on the videos I added several of the same filter to show a extreme case of this bug where it would have a large height.

Before
https://www.loom.com/share/63b660fd1a72433fa02ea4a1a9e9f999

After
https://www.loom.com/share/bbf5572972b3431b997b1681458cb633

Release note (bug fix): Now when the height of the filter is big, it has a scroll so it can reach the 'Apply'