### PR TITLE
backupccl: use the backup codec when inspecting spans in the backupManifest

### DIFF
--- a/pkg/ccl/backupccl/backupinfo/manifest_handling.go
+++ b/pkg/ccl/backupccl/backupinfo/manifest_handling.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/cloud/cloudpb"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -1398,4 +1399,19 @@ func getBackupManifests(
 	}
 
 	return manifests, memMu.total, nil
+}
+
+// MakeBackupCodec returns the codec that was used to encode the keys in the backup.
+func MakeBackupCodec(manifest backuppb.BackupManifest) (keys.SQLCodec, error) {
+	backupCodec := keys.SystemSQLCodec
+	if len(manifest.Spans) != 0 && !manifest.HasTenants() {
+		// If there are no tenant targets, then the entire keyspace covered by
+		// Spans must lie in 1 tenant.
+		_, backupTenantID, err := keys.DecodeTenantPrefix(manifest.Spans[0].Key)
+		if err != nil {
+			return backupCodec, err
+		}
+		backupCodec = keys.MakeSQLCodec(backupTenantID)
+	}
+	return backupCodec, nil
 }

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1519,6 +1519,11 @@ func doRestorePlan(
 		}
 	}
 
+	backupCodec, err := backupinfo.MakeBackupCodec(mainBackupManifests[0])
+	if err != nil {
+		return err
+	}
+
 	// wasOffline tracks which tables were in an offline or adding state at some
 	// point in the incremental chain, meaning their spans would be seeing
 	// non-transactional bulk-writes. If that backup exported those spans, then it
@@ -1540,7 +1545,7 @@ func doRestorePlan(
 			if err := catalog.ForEachNonDropIndex(
 				tabledesc.NewBuilder(table).BuildImmutable().(catalog.TableDescriptor),
 				func(index catalog.Index) error {
-					if index.Adding() && spans.ContainsKey(p.ExecCfg().Codec.IndexPrefix(uint32(table.ID), uint32(index.GetID()))) {
+					if index.Adding() && spans.ContainsKey(backupCodec.IndexPrefix(uint32(table.ID), uint32(index.GetID()))) {
 						k := tableAndIndex{tableID: table.ID, indexID: index.GetID()}
 						if _, ok := wasOffline[k]; !ok {
 							wasOffline[k] = m.EndTime
@@ -1562,8 +1567,7 @@ func doRestorePlan(
 				"use SHOW BACKUP to find correct targets")
 	}
 
-	if err := checkMissingIntroducedSpans(sqlDescs, mainBackupManifests, endTime,
-		p.ExecCfg().Codec); err != nil {
+	if err := checkMissingIntroducedSpans(sqlDescs, mainBackupManifests, endTime, backupCodec); err != nil {
 		return err
 	}
 


### PR DESCRIPTION

Informs #90475, #90474

Release note (bug fix): previously, during restore planning, the restoring cluster's codec was accidentally used to reason about spans in the backup manifest. When a backup was restored by a different tenant, two bugs described in #90475, #90474 could manifest. This patch fixes these bugs.