### PR TITLE
server: write pebble log messages to storage channel

### DIFF
--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -853,7 +853,11 @@ func NewPebble(ctx context.Context, cfg PebbleConfig) (p *Pebble, err error) {
 	logCtx = logtags.AddTag(logCtx, "s", storeIDContainer)
 	logCtx = logtags.AddTag(logCtx, "pebble", nil)
 
-	if cfg.Opts.Logger == nil {
+	// If no logger was passed, the previous call to `EnsureDefaults` on
+	// `cfg.Opts` will set the logger to pebble's `DefaultLogger`. In
+	// crdb, we want pebble-related logs to go to the storage channel,
+	// so we update the logger here accordingly.
+	if cfg.Opts.Logger == nil || cfg.Opts.Logger == pebble.DefaultLogger {
 		cfg.Opts.Logger = pebbleLogger{
 			ctx:   logCtx,
 			depth: 1,


### PR DESCRIPTION
Previously, when setting up the server, the pebble engine would be initialized with Pebble's default logger. The reason for this is that the pebble initialization code calls `EnsureDefaults` on the configuration options _before_ checking if the `options.Logger` is nil/unset. At that point, it will never be unset, as `EnsureDefaults` will set the logger to `pebble.DefaultLogger` if it was not previously set.

This change overwrites the pebble logger if its found to be the `DefaultLogger`. We never want to use pebble's `DefaultLogger` in CRDB as that would mean pebble would use the standard library `log` package, making every message emitted by Pebble to be treated as `INFO` level messages, regardless of severity (including `log.Fatal` calls).

Related to #83079.

Fixes #72683.
Fixes #90483.

Release note: None.