### PR TITLE
ui: add refresh hook to stmt insight details

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import Helmet from "react-helmet";
 import { RouteComponentProps } from "react-router-dom";
 import { ArrowLeft } from "@cockroachlabs/icons";
@@ -45,6 +45,7 @@ export interface StatementInsightDetailsStateProps {
 
 export interface StatementInsightDetailsDispatchProps {
   setTimeScale: (ts: TimeScale) => void;
+  refreshStatementInsights: () => void;
 }
 
 export type StatementInsightDetailsProps = StatementInsightDetailsStateProps &
@@ -60,6 +61,7 @@ export const StatementInsightDetails: React.FC<
   match,
   isTenant,
   setTimeScale,
+  refreshStatementInsights,
 }) => {
   const [explain, setExplain] = useState<string>(null);
 
@@ -82,6 +84,12 @@ export const StatementInsightDetails: React.FC<
   };
 
   const executionID = getMatchParamByName(match, "id");
+
+  useEffect(() => {
+    if (insightEventDetails == null) {
+      refreshStatementInsights();
+    }
+  }, [insightEventDetails, refreshStatementInsights]);
 
   return (
     <div>

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsConnected.tsx
@@ -17,6 +17,7 @@ import {
 } from "./statementInsightDetails";
 import { AppState } from "src/store";
 import {
+  actions as statementInsights,
   selectStatementInsightDetails,
   selectStatementInsightsError,
 } from "src/store/insights/statementInsights";
@@ -40,6 +41,7 @@ const mapStateToProps = (
 const mapDispatchToProps = (
   dispatch: Dispatch,
 ): StatementInsightDetailsDispatchProps => ({
+  refreshStatementInsights: statementInsights.refresh,
   setTimeScale: (ts: TimeScale) => {
     dispatch(
       sqlStatsActions.updateTimeScale({

--- a/pkg/ui/workspaces/db-console/src/views/insights/statementInsightDetailsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/insights/statementInsightDetailsPage.tsx
@@ -15,6 +15,7 @@ import {
 import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { AdminUIState } from "src/redux/state";
+import { refreshStatementInsights } from "src/redux/apiReducers";
 import { selectStatementInsightDetails } from "src/views/insights/insightsSelectors";
 import { setGlobalTimeScaleAction } from "src/redux/statements";
 
@@ -32,6 +33,7 @@ const mapStateToProps = (
 
 const mapDispatchToProps: StatementInsightDetailsDispatchProps = {
   setTimeScale: setGlobalTimeScaleAction,
+  refreshStatementInsights: refreshStatementInsights,
 };
 
 const StatementInsightDetailsPage = withRouter(


### PR DESCRIPTION
This commit adds a useEffect hook to the statement insight details page that refreshes the statement insights store when it's empty.

On DB Console: https://www.loom.com/share/cf014b1f5daa42f5b94d4d458afbfbb8

On CC Console (built on https://github.com/cockroachlabs/managed-service/pull/10097): https://www.loom.com/share/ee28f186bf2f49ce807cd6ac0f579ef0

Fixes #90385.

Release note: None