### PR TITLE
sql: add a cluster setting to allow users to change their own password

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -93,6 +93,7 @@ server.web_session.purge.max_deletions_per_cycle	integer	1000	the maximum number
 server.web_session.purge.period	duration	1h0m0s	the time until old sessions are deleted
 server.web_session.purge.ttl	duration	1h0m0s	if nonzero, entries in system.web_sessions older than this duration are periodically purged
 server.web_session_timeout	duration	168h0m0s	the duration that a newly created web session will be valid
+sql.auth.change_own_password.enabled	boolean	false	controls whether a user is allowed to change their own password, even if they have no other privileges
 sql.auth.resolve_membership_single_scan.enabled	boolean	true	determines whether to populate the role membership cache with a single scan
 sql.closed_session_cache.capacity	integer	1000	the maximum number of sessions in the cache
 sql.closed_session_cache.time_to_live	integer	3600	the maximum time to live, in seconds

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -112,6 +112,7 @@
 <tr><td><code>server.web_session.purge.period</code></td><td>duration</td><td><code>1h0m0s</code></td><td>the time until old sessions are deleted</td></tr>
 <tr><td><code>server.web_session.purge.ttl</code></td><td>duration</td><td><code>1h0m0s</code></td><td>if nonzero, entries in system.web_sessions older than this duration are periodically purged</td></tr>
 <tr><td><code>server.web_session_timeout</code></td><td>duration</td><td><code>168h0m0s</code></td><td>the duration that a newly created web session will be valid</td></tr>
+<tr><td><code>sql.auth.change_own_password.enabled</code></td><td>boolean</td><td><code>false</code></td><td>controls whether a user is allowed to change their own password, even if they have no other privileges</td></tr>
 <tr><td><code>sql.auth.resolve_membership_single_scan.enabled</code></td><td>boolean</td><td><code>true</code></td><td>determines whether to populate the role membership cache with a single scan</td></tr>
 <tr><td><code>sql.closed_session_cache.capacity</code></td><td>integer</td><td><code>1000</code></td><td>the maximum number of sessions in the cache</td></tr>
 <tr><td><code>sql.closed_session_cache.time_to_live</code></td><td>integer</td><td><code>3600</code></td><td>the maximum time to live, in seconds</td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -1332,6 +1332,9 @@ ALTER ROLE testuser CREATELOGIN
 user testuser
 
 statement ok
+ALTER USER testuser PASSWORD NULL
+
+statement ok
 CREATE USER testuser3 WITH PASSWORD 'abc'
 
 statement ok
@@ -1381,6 +1384,12 @@ user root
 statement ok
 ALTER USER testuser NOCREATELOGIN
 
+# Verify default setting for sql.auth.change_own_password.enabled.
+query B
+SHOW CLUSTER SETTING sql.auth.change_own_password.enabled
+----
+false
+
 user testuser
 
 statement error user testuser does not have CREATELOGIN privilege
@@ -1391,6 +1400,13 @@ CREATE ROLE testuser6
 
 statement error user testuser does not have CREATELOGIN privilege
 CREATE USER testuser5 WITH PASSWORD 'abc'
+
+# Verify that testuser cannot change its own password.
+statement error user testuser does not have CREATELOGIN privilege
+ALTER USER testuser PASSWORD 'xyz'
+
+statement error user testuser does not have CREATELOGIN privilege
+ALTER USER CURRENT_USER PASSWORD '123'
 
 statement error user testuser does not have CREATELOGIN privilege
 ALTER USER testuser2 WITH PASSWORD 'abc'
@@ -1426,6 +1442,51 @@ statement error user testuser does not have CREATELOGIN privilege
 CREATE ROLE otherrole4 LOGIN
 
 user root
+
+subtest change_own_password
+
+statement ok
+SET CLUSTER SETTING sql.auth.change_own_password.enabled = true
+
+user testuser
+
+# Verify that testuser can change its own password now.
+statement ok
+ALTER USER testuser PASSWORD 'xyz'
+
+statement ok
+ALTER USER CURRENT_USER PASSWORD '123'
+
+# Verify that testuser cannot *remove* its own password.
+statement error user testuser does not have CREATELOGIN privilege
+ALTER USER testuser PASSWORD NULL
+
+# testuser still cannot change another user's password.
+statement error user testuser does not have CREATELOGIN privilege
+ALTER USER testuser2 WITH PASSWORD 'abc'
+
+# Verify that testuser cannot modify other role options of itself.
+statement error user testuser does not have CREATELOGIN privilege
+ALTER USER testuser PASSWORD 'abc' VALID UNTIL '4044-10-31'
+
+user root
+
+statement ok
+SET ROLE testuser
+
+# Changing users with SET ROLE should allow self-password change.
+statement ok
+ALTER USER testuser PASSWORD 'cat'
+
+# Changing users with SET ROLE should still mean that changing other users
+# is disallowed.
+statement error user testuser does not have CREATELOGIN privilege
+ALTER USER testuser2 WITH PASSWORD 'abc'
+
+statement ok
+RESET ROLE
+
+subtest end
 
 # Verify that root is allowed to edit some other role that has ADMIN.
 statement ok


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/54660

This will help with a CRDB Dedicated use case, to allow Console users to reset their own password.

Release note (sql change): Added the
sql.auth.change_own_password.enabled cluster setting. It defaults to false. When set to true, any user is allowed to change their own password to a non-null value. Changing other role options still has the same privilege requirements as before (either CREATEROLE or CREATELOGIN, depending on the option).