### PR TITLE
sql: add user-defined composite types

### DIFF
--- a/docs/generated/sql/bnf/create_type.bnf
+++ b/docs/generated/sql/bnf/create_type.bnf
@@ -1,3 +1,5 @@
 create_type_stmt ::=
 	'CREATE' 'TYPE' type_name 'AS' 'ENUM' '(' opt_enum_val_list ')'
 	| 'CREATE' 'TYPE' 'IF' 'NOT' 'EXISTS' type_name 'AS' 'ENUM' '(' opt_enum_val_list ')'
+	| 'CREATE' 'TYPE' type_name 'AS' '(' opt_composite_type_list ')'
+	| 'CREATE' 'TYPE' 'IF' 'NOT' 'EXISTS' type_name 'AS' '(' opt_composite_type_list ')'

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1719,6 +1719,8 @@ create_table_as_stmt ::=
 create_type_stmt ::=
 	'CREATE' 'TYPE' type_name 'AS' 'ENUM' '(' opt_enum_val_list ')'
 	| 'CREATE' 'TYPE' 'IF' 'NOT' 'EXISTS' type_name 'AS' 'ENUM' '(' opt_enum_val_list ')'
+	| 'CREATE' 'TYPE' type_name 'AS' '(' opt_composite_type_list ')'
+	| 'CREATE' 'TYPE' 'IF' 'NOT' 'EXISTS' type_name 'AS' '(' opt_composite_type_list ')'
 
 create_view_stmt ::=
 	'CREATE' opt_temp 'VIEW' view_name opt_column_list 'AS' select_stmt
@@ -2436,6 +2438,10 @@ opt_enum_val_list ::=
 	enum_val_list
 	| 
 
+opt_composite_type_list ::=
+	composite_type_list
+	| 
+
 opt_temp ::=
 	'TEMPORARY'
 	| 'TEMP'
@@ -3046,6 +3052,9 @@ create_as_table_defs ::=
 
 enum_val_list ::=
 	( 'SCONST' ) ( ( ',' 'SCONST' ) )*
+
+composite_type_list ::=
+	( name simple_typename ) ( ( ',' name simple_typename ) )*
 
 func_param_with_default_list ::=
 	( func_param_with_default ) ( ( ',' func_param_with_default ) )*

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -2258,7 +2258,7 @@ func restoreCreateDefaultPrimaryRegionEnums(
 		return nil, nil, err
 	}
 	regionEnum.ArrayTypeID = regionEnumArrayID
-	regionArrayEnum, err := sql.CreateEnumArrayTypeDesc(
+	regionArrayEnum, err := sql.CreateUserDefinedArrayTypeDesc(
 		p.RunParams(ctx),
 		regionEnum,
 		db,

--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -427,6 +427,13 @@ func TestTenantLogic_column_families(
 	runLogicTest(t, "column_families")
 }
 
+func TestTenantLogic_composite_types(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "composite_types")
+}
+
 func TestTenantLogic_computed(
 	t *testing.T,
 ) {

--- a/pkg/sql/catalog/colinfo/col_type_info.go
+++ b/pkg/sql/catalog/colinfo/col_type_info.go
@@ -106,7 +106,15 @@ func ValidateColumnDefType(t *types.T) error {
 		types.INetFamily, types.IntervalFamily, types.JsonFamily, types.OidFamily, types.TimeFamily,
 		types.TimestampFamily, types.TimestampTZFamily, types.UuidFamily, types.TimeTZFamily,
 		types.GeographyFamily, types.GeometryFamily, types.EnumFamily, types.Box2DFamily:
-		// These types are OK.
+	// These types are OK.
+
+	case types.TupleFamily:
+		if !t.UserDefined() {
+			return pgerror.New(pgcode.InvalidTableDefinition, "cannot use anonymous record type as table column")
+		}
+		if t.TypeMeta.ImplicitRecordType {
+			return unimplemented.NewWithIssue(70099, "cannot use table record type as table column")
+		}
 
 	default:
 		return pgerror.Newf(pgcode.InvalidTableDefinition,

--- a/pkg/sql/catalog/descpb/structured.proto
+++ b/pkg/sql/catalog/descpb/structured.proto
@@ -1367,6 +1367,8 @@ message TypeDescriptor {
     // kind of TypeDescriptor is *never* persisted to disk! If you are here,
     // thinking about using or persisting this value, you should *not* do that!
     TABLE_IMPLICIT_RECORD_TYPE = 3;
+    // Represents a user-defined composite type.
+    COMPOSITE = 4;
     // Add more entries as we support more user defined types.
   }
   optional Kind kind = 5 [(gogoproto.nullable) = false];
@@ -1440,7 +1442,30 @@ message TypeDescriptor {
   // descriptor being changed as part of a declarative schema change.
   optional cockroach.sql.schemachanger.scpb.DescriptorState declarative_schema_changer_state = 17;
 
-  // Next field is 18.
+  // Composite describes a composite type, which is just a stored, labeled tuple
+  // type, like a struct in Go.
+  message Composite {
+    option (gogoproto.equal) = true;
+
+    // CompositeElement describes one element of a composite type.
+    message CompositeElement {
+      option (gogoproto.equal) = true;
+
+      // ElementType is the type of this composite element.
+      optional sql.sem.types.T element_type = 1;
+      // ElementLabel is the label of this composite element.
+      optional string element_label = 2 [(gogoproto.nullable) = false];
+    }
+
+    // Elements is a slice of the fields within this composite type, including
+    // the type and the label.
+    repeated CompositeElement elements = 1 [(gogoproto.nullable) = false];
+  }
+
+  // Composite is the list of fields if this is a composite type.
+  optional Composite composite = 18;
+
+  // Next field is 19.
 }
 
 // SchemaDescriptor represents a physical schema and is stored in a structured

--- a/pkg/sql/catalog/tabledesc/validate_test.go
+++ b/pkg/sql/catalog/tabledesc/validate_test.go
@@ -258,6 +258,7 @@ var validationMap = []struct {
 			"OfflineReason":                 {status: thisFieldReferencesNoObjects},
 			"RegionConfig":                  {status: iSolemnlySwearThisFieldIsValidated},
 			"DeclarativeSchemaChangerState": {status: thisFieldReferencesNoObjects},
+			"Composite":                     {status: iSolemnlySwearThisFieldIsValidated},
 		},
 	},
 	{
@@ -2833,6 +2834,29 @@ func TestValidateCrossTableReferences(t *testing.T) {
 				ParentID:                1,
 				UnexposedParentSchemaID: keys.PublicSchemaID,
 				DependsOn:               []descpb.ID{100},
+			},
+		},
+		// Composite types.
+		{ // 17
+			err: `referenced type ID 500: referenced descriptor not found`,
+			desc: descpb.TableDescriptor{
+				Name:                    "foo",
+				ID:                      51,
+				ParentID:                1,
+				UnexposedParentSchemaID: keys.PublicSchemaID,
+				PrimaryIndex: descpb.IndexDescriptor{
+					ID:             1,
+					Name:           "bar",
+					KeyColumnIDs:   []descpb.ColumnID{1},
+					KeyColumnNames: []string{"a"},
+				},
+				Columns: []descpb.ColumnDescriptor{
+					{
+						Name: "a",
+						ID:   1,
+						Type: types.MakeCompositeType(catid.TypeIDToOID(500), catid.TypeIDToOID(100500), nil, nil),
+					},
+				},
 			},
 		},
 	}

--- a/pkg/sql/catalog/typedesc/table_implicit_record_type.go
+++ b/pkg/sql/catalog/typedesc/table_implicit_record_type.go
@@ -81,7 +81,8 @@ func CreateImplicitRecordTypeFromTableDesc(
 		Name: &types.UserDefinedTypeName{
 			Name: descriptor.GetName(),
 		},
-		Version: uint32(descriptor.GetVersion()),
+		Version:            uint32(descriptor.GetVersion()),
+		ImplicitRecordType: true,
 	}
 
 	// Note: Implicit types for virtual tables are hardcoded to have USAGE

--- a/pkg/sql/catalog/typedesc/type_desc.go
+++ b/pkg/sql/catalog/typedesc/type_desc.go
@@ -567,6 +567,10 @@ func (desc *immutable) ValidateSelf(vea catalog.ValidationErrorAccumulator) {
 		if desc.GetArrayTypeID() != descpb.InvalidID {
 			vea.Report(errors.AssertionFailedf("ALIAS type desc has array type ID %d", desc.GetArrayTypeID()))
 		}
+	case descpb.TypeDescriptor_COMPOSITE:
+		if desc.Composite == nil {
+			vea.Report(errors.AssertionFailedf("COMPOSITE type desc has nil composite type"))
+		}
 	case descpb.TypeDescriptor_TABLE_IMPLICIT_RECORD_TYPE:
 		vea.Report(errors.AssertionFailedf("invalid type descriptor: kind %s should never be serialized or validated", desc.Kind.String()))
 	default:
@@ -679,6 +683,20 @@ func (desc *immutable) ValidateForwardReferences(
 			vea.Report(errors.AssertionFailedf("aliased type %q (%d) is dropped", typ.GetName(), typ.GetID()))
 		}
 	}
+
+	if desc.GetKind() == descpb.TypeDescriptor_COMPOSITE {
+		for _, e := range desc.Composite.Elements {
+			t := e.ElementType
+			if t.UserDefined() {
+				// User-defined type references within user-defined types are currently
+				// not supported, but this should be validated elsewhere.
+				// See issue https://github.com/cockroachdb/cockroach/issues/91779.
+				vea.Report(errors.AssertionFailedf("invalid reference to user-defined type %q from composite type %q",
+					t.String(), desc.GetName(),
+				))
+			}
+		}
+	}
 }
 
 // ValidateBackReferences implements the catalog.Descriptor interface.
@@ -708,7 +726,7 @@ func (desc *immutable) ValidateBackReferences(
 			continue
 		}
 		switch depDesc.DescriptorType() {
-		case catalog.Table, catalog.Function:
+		case catalog.Table, catalog.Function, catalog.Type:
 			if depDesc.Dropped() {
 				vea.Report(errors.AssertionFailedf(
 					"referencing %s %d was dropped without dependency unlinking", depDesc.DescriptorType(), id))
@@ -826,6 +844,20 @@ func (desc *immutable) MakeTypesT(
 			return nil, err
 		}
 		return desc.Alias, nil
+	case descpb.TypeDescriptor_COMPOSITE:
+		contents := make([]*types.T, len(desc.Composite.Elements))
+		labels := make([]string, len(desc.Composite.Elements))
+		for i, e := range desc.Composite.Elements {
+			contents[i] = e.ElementType
+			labels[i] = e.ElementLabel
+		}
+		typ := types.MakeCompositeType(catid.TypeIDToOID(desc.GetID()), catid.TypeIDToOID(desc.ArrayTypeID),
+			contents, labels)
+		// Hydrate the composite type and return it.
+		if err := desc.HydrateTypeInfoWithName(ctx, typ, name, res); err != nil {
+			return nil, err
+		}
+		return typ, nil
 	default:
 		return nil, errors.AssertionFailedf("unknown type kind %s", t.String())
 	}
@@ -947,6 +979,12 @@ func (desc *immutable) HydrateTypeInfoWithName(
 				}
 			default:
 				return errors.AssertionFailedf("unhandled alias type family %s", typ.Family())
+			}
+		}
+	case descpb.TypeDescriptor_COMPOSITE:
+		for _, e := range desc.Composite.Elements {
+			if err := EnsureTypeIsHydrated(ctx, e.ElementType, res); err != nil {
+				return err
 			}
 		}
 	default:
@@ -1091,7 +1129,8 @@ func (desc *immutable) GetIDClosure() (map[descpb.ID]struct{}, error) {
 	ret := make(map[descpb.ID]struct{})
 	// Collect the descriptor's own ID.
 	ret[desc.ID] = struct{}{}
-	if desc.Kind == descpb.TypeDescriptor_ALIAS {
+	switch desc.Kind {
+	case descpb.TypeDescriptor_ALIAS:
 		// If this descriptor is an alias for another type, then get collect the
 		// closure for alias.
 		children, err := GetTypeDescriptorClosure(desc.Alias)
@@ -1101,7 +1140,17 @@ func (desc *immutable) GetIDClosure() (map[descpb.ID]struct{}, error) {
 		for id := range children {
 			ret[id] = struct{}{}
 		}
-	} else {
+	case descpb.TypeDescriptor_COMPOSITE:
+		for _, e := range desc.Composite.Elements {
+			children, err := GetTypeDescriptorClosure(e.ElementType)
+			if err != nil {
+				return nil, err
+			}
+			for id := range children {
+				ret[id] = struct{}{}
+			}
+		}
+	default:
 		// Otherwise, take the array type ID.
 		ret[desc.ArrayTypeID] = struct{}{}
 	}

--- a/pkg/sql/catalog/typedesc/type_desc_test.go
+++ b/pkg/sql/catalog/typedesc/type_desc_test.go
@@ -63,6 +63,17 @@ func TestTypeDescIsCompatibleWith(t *testing.T) {
 			a: descpb.TypeDescriptor{
 				Name: "a",
 				Kind: descpb.TypeDescriptor_ENUM,
+			},
+			b: descpb.TypeDescriptor{
+				Name: "b",
+				Kind: descpb.TypeDescriptor_COMPOSITE,
+			},
+			err: `"b" of type "COMPOSITE" is not compatible with type "ENUM"`,
+		},
+		{
+			a: descpb.TypeDescriptor{
+				Name: "a",
+				Kind: descpb.TypeDescriptor_ENUM,
 				EnumMembers: []descpb.TypeDescriptor_EnumMember{
 					{
 						LogicalRepresentation:  "us-east-1",
@@ -785,6 +796,41 @@ func TestValidateTypeDesc(t *testing.T) {
 				},
 				ArrayTypeID: typeID,
 				Privileges:  defaultPrivileges,
+			},
+		},
+		{
+			`COMPOSITE type desc has nil composite type`,
+			descpb.TypeDescriptor{
+				Name:           "t",
+				ID:             typeDescID,
+				ParentID:       dbID,
+				ParentSchemaID: keys.PublicSchemaID,
+				Kind:           descpb.TypeDescriptor_COMPOSITE,
+				Privileges:     defaultPrivileges,
+			},
+		},
+		{
+			`referenced database ID 500: referenced descriptor not found`,
+			descpb.TypeDescriptor{
+				Name:           "t",
+				ID:             typeDescID,
+				ParentID:       500,
+				ParentSchemaID: keys.PublicSchemaID,
+				Kind:           descpb.TypeDescriptor_COMPOSITE,
+				Privileges:     defaultPrivileges,
+				Composite:      &descpb.TypeDescriptor_Composite{},
+			},
+		},
+		{
+			`referenced schema ID 500: referenced descriptor not found`,
+			descpb.TypeDescriptor{
+				Name:           "t",
+				ID:             typeDescID,
+				ParentID:       dbID,
+				ParentSchemaID: 500,
+				Kind:           descpb.TypeDescriptor_COMPOSITE,
+				Privileges:     defaultPrivileges,
+				Composite:      &descpb.TypeDescriptor_Composite{},
 			},
 		},
 	}

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -52,6 +52,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/nstree"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/clusterunique"
 	"github.com/cockroachdb/cockroach/pkg/sql/idxusage"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -2595,8 +2596,10 @@ CREATE TABLE crdb_internal.builtin_functions (
 }
 
 func writeCreateTypeDescRow(
+	ctx context.Context,
 	db catalog.DatabaseDescriptor,
 	sc catalog.SchemaDescriptor,
+	resolver tree.TypeReferenceResolver,
 	typeDesc catalog.TypeDescriptor,
 	addRow func(...tree.Datum) error,
 ) (written bool, err error) {
@@ -2633,6 +2636,36 @@ func writeCreateTypeDescRow(
 		// Multi-region enums are created implicitly, so we don't have create
 		// statements for them.
 		return false, nil
+	case descpb.TypeDescriptor_COMPOSITE:
+		name, err := tree.NewUnresolvedObjectName(2, [3]string{typeDesc.GetName(), sc.GetName()}, 0)
+		if err != nil {
+			return false, err
+		}
+		composite := typeDesc.TypeDesc().Composite
+		typeList := make([]tree.CompositeTypeElem, len(composite.Elements))
+		for i := range composite.Elements {
+			if err := typedesc.EnsureTypeIsHydrated(
+				ctx, composite.Elements[i].ElementType, resolver.(catalog.TypeDescriptorResolver),
+			); err != nil {
+				return false, err
+			}
+			typeList[i].Type = composite.Elements[i].ElementType
+			typeList[i].Label = tree.Name(composite.Elements[i].ElementLabel)
+		}
+		node := &tree.CreateType{
+			Variety:           tree.Composite,
+			TypeName:          name,
+			CompositeTypeList: typeList,
+		}
+		return true, addRow(
+			tree.NewDInt(tree.DInt(db.GetID())),       // database_id
+			tree.NewDString(db.GetName()),             // database_name
+			tree.NewDString(sc.GetName()),             // schema_name
+			tree.NewDInt(tree.DInt(typeDesc.GetID())), // descriptor_id
+			tree.NewDString(typeDesc.GetName()),       // descriptor_name
+			tree.NewDString(tree.AsString(node)),      // create_statement
+			tree.DNull,                                // enum_members
+		)
 	case descpb.TypeDescriptor_ALIAS:
 		// Alias types are created implicitly, so we don't have create
 		// statements for them.
@@ -2658,7 +2691,7 @@ CREATE TABLE crdb_internal.create_type_statements (
 `,
 	populate: func(ctx context.Context, p *planner, db catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return forEachTypeDesc(ctx, p, db, func(db catalog.DatabaseDescriptor, sc catalog.SchemaDescriptor, typeDesc catalog.TypeDescriptor) error {
-			_, err := writeCreateTypeDescRow(db, sc, typeDesc, addRow)
+			_, err := writeCreateTypeDescRow(ctx, db, sc, p.semaCtx.TypeResolver, typeDesc, addRow)
 			return err
 		})
 	},
@@ -2676,7 +2709,7 @@ CREATE TABLE crdb_internal.create_type_statements (
 				if err != nil || typDesc == nil {
 					return false, err
 				}
-				return writeCreateTypeDescRow(db, scName, typDesc, addRow)
+				return writeCreateTypeDescRow(ctx, db, scName, p.semaCtx.TypeResolver, typDesc, addRow)
 			},
 		},
 	},

--- a/pkg/sql/logictest/testdata/logic_test/composite_types
+++ b/pkg/sql/logictest/testdata/logic_test/composite_types
@@ -1,0 +1,238 @@
+statement ok
+CREATE TYPE t AS (a INT, b INT)
+
+statement ok
+DROP TYPE t
+
+statement ok
+CREATE TYPE t AS (a INT, b INT)
+
+statement error pq: relation "t" does not exist
+SELECT * FROM t
+
+statement error pq: type "test.public.t" already exists
+CREATE TABLE t (x INT)
+
+statement error pq: type "test.public.t" already exists
+CREATE TYPE t AS (a INT)
+
+statement ok
+CREATE TABLE torename (x INT)
+
+statement error pq: type "test.public.t" already exists
+ALTER TABLE torename RENAME TO t
+
+query TII
+SELECT (1, 2)::t, ((1, 2)::t).a, ((1, 2)::t).b
+----
+(1,2)  1  2
+
+statement error could not identify column \"foo\"
+SELECT ((1, 2)::t).foo
+
+statement ok
+CREATE TABLE tab (a t)
+
+statement ok
+INSERT INTO tab VALUES (NULL), ((1, 2))
+
+statement ok
+INSERT INTO tab VALUES ((1, NULL))
+
+# TODO(jordan): this should work fine, but is blocked behind a type-system issue:
+# see #93349.
+statement error VALUES types tuple{int, unknown} and tuple{int, int} cannot be matched
+INSERT INTO tab VALUES ((1, 2)), ((1, NULL))
+
+query TII rowsort
+SELECT a, (a).a, (a).b FROM tab
+----
+NULL   NULL  NULL
+(1,2)  1     2
+(1,)   1     NULL
+
+statement error cannot drop type \"t\" because other objects .* still depend on it
+DROP TYPE t
+
+# Test arrays of composite types.
+statement ok
+CREATE TABLE atyp(a t[])
+
+query TT
+SHOW CREATE TABLE atyp
+----
+atyp  CREATE TABLE public.atyp (
+        a T[] NULL,
+        rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+        CONSTRAINT atyp_pkey PRIMARY KEY (rowid ASC)
+      )
+
+statement ok
+INSERT INTO atyp VALUES(ARRAY[(1, 2), (3, 4), NULL, (5, NULL)])
+
+query T
+SELECT * FROM atyp
+----
+{"(1,2)","(3,4)",NULL,"(5,)"}
+
+statement ok
+DROP TABLE atyp
+
+# Nested types not supported. #91779
+statement error composite types that reference user-defined types not yet supported
+CREATE TYPE t2 AS (t1 t, t2 t)
+
+# Uncomment the below when #91779 is resolved.
+
+#statement ok
+#CREATE TABLE tab2 (a t2)
+#
+#query TTT
+#SELECT ((1, 2), (3, 4))::t2, (((1, 2), (3, 4))::t2).t1, (((1, 2), (3, 4))::t2).t2
+#----
+#("(1,2)","(3,4)")  (1,2)  (3,4)
+#
+#query II
+#SELECT ((((1, 2), (3, 4))::t2).t1).a, ((((1, 2), (3, 4))::t2).t1).b
+#----
+#1  2
+#
+## TODO(jordan): this syntax works in Postgres.
+#query error syntax error
+#SELECT (((1, 2), (3, 4))::t2).t1.a
+#
+#statement ok
+#INSERT INTO tab2 VALUES(((1, 2), (3, 4)))
+#
+#query TTII
+#SELECT a, (a).t1, ((a).t1).a, ((a).t1).b FROM tab2
+#----
+#("(1,2)","(3,4)")  (1,2)  1  2
+#
+## Can't drop type t because tab, tab2, and t2 depend on it
+#statement error cannot drop type \"t\" because other objects .* still depend on it
+#DROP TYPE t
+#
+## Can't drop type t2 because tab2 depends on it
+#statement error cannot drop type \"t2\" because other objects .* still depend on it
+#DROP TYPE t2
+#
+#statement ok
+#DROP TABLE tab2
+
+statement ok
+DROP TABLE tab
+
+query TTTT
+SELECT database_name, schema_name, descriptor_name, create_statement FROM crdb_internal.create_type_statements
+----
+test  public  t   CREATE TYPE public.t AS (a INT8, b INT8)
+
+## Can't drop type t because t2 depends on it
+#statement error cannot drop type \"t\" because other objects .* still depend on it
+#DROP TYPE t
+#
+#statement ok
+#DROP TYPE t2
+
+statement ok
+DROP TYPE t
+
+# An empty type is valid.
+statement ok
+CREATE TYPE t AS ()
+
+statement ok
+DROP TYPE t
+
+# Composite types which reference other types of UDTs are not yet supported.
+statement ok
+CREATE TYPE e AS ENUM ('a', 'b', 'c')
+
+# We'll use tab to check the implicit table alias type.
+statement ok
+CREATE TABLE tab (a INT, b INT)
+
+statement error composite types that reference user-defined types not yet supported
+CREATE TYPE t AS (e e)
+
+# This should fail - we shouldn't persist implicit table types.
+statement error composite types that reference user-defined types not yet supported
+CREATE TYPE t AS (a tab)
+
+statement error composite types that reference user-defined types not yet supported
+CREATE TYPE t AS (a pg_catalog.pg_class)
+
+# Test that if an composite type value is being used by a default expression or
+# computed column, we disallow dropping it.
+subtest drop_used_composite_type_values
+
+statement ok
+CREATE TYPE t AS (a INT, b TEXT)
+
+statement ok
+CREATE TABLE a (a INT DEFAULT (((1, 'hi')::t).a))
+
+statement error cannot drop type \"t\" because other objects .* still depend on it
+DROP TYPE t
+
+# Re-enable when #91972 is resolved.
+#statement ok
+#ALTER TABLE a ALTER COLUMN a SET DEFAULT 3
+#
+#statement ok
+#DROP TYPE t;
+#CREATE TYPE t AS (a INT, b TEXT);
+
+statement ok
+DROP TABLE a;
+CREATE TABLE a (a INT ON UPDATE (((1, 'hi')::t).a))
+
+statement error cannot drop type \"t\" because other objects .* still depend on it
+DROP TYPE t
+
+# Re-enable when #91972 is resolved.
+#statement ok
+#ALTER TABLE a ALTER COLUMN a SET ON UPDATE 3
+#
+#statement ok
+#DROP TYPE t;
+#CREATE TYPE t AS (a INT, b TEXT);
+
+statement ok
+DROP TABLE a;
+CREATE TABLE a (a INT AS (((1, 'hi')::t).a) STORED)
+
+statement error cannot drop type \"t\" because other objects .* still depend on it
+DROP TYPE t
+
+# Re-enable when #91972 is resolved.
+#statement ok
+#ALTER TABLE a ALTER COLUMN a DROP STORED
+#
+#statement ok
+#DROP TYPE t;
+#CREATE TYPE t AS (a INT, b TEXT);
+
+statement ok
+DROP TABLE a;
+CREATE TABLE a (a INT, INDEX (a) WHERE a > (((1, 'hi')::t).a))
+
+statement error cannot drop type \"t\" because other objects .* still depend on it
+DROP TYPE t
+
+statement ok
+DROP TABLE a;
+DROP TYPE t;
+CREATE TYPE t AS (a INT, b TEXT);
+CREATE TABLE a (a INT CHECK (a > (((1, 'hi')::t).a)))
+
+statement error cannot drop type \"t\" because other objects .* still depend on it
+DROP TYPE t
+
+statement ok
+ALTER TABLE a DROP CONSTRAINT check_a
+
+statement ok
+DROP TYPE t;
+DROP TABLE a

--- a/pkg/sql/logictest/testdata/logic_test/create_as
+++ b/pkg/sql/logictest/testdata/logic_test/create_as
@@ -99,7 +99,7 @@ CREATE TABLE foo (x, y, z) AS SELECT catalog_name, schema_name, sql_path FROM in
 statement error pq: relation "test.public.foo" already exists
 CREATE TABLE foo (x, y, z) AS SELECT catalog_name, schema_name, sql_path FROM information_schema.schemata
 
-statement error pq: value type tuple cannot be used for table columns
+statement error pq: cannot use anonymous record type as table column
 CREATE TABLE foo2 (x) AS (VALUES(ROW()))
 
 statement error pq: nested array unsupported as column type: int\[\]\[\]

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -409,16 +409,21 @@ statement ok
 CREATE TYPE constraint_db.mytype AS ENUM ('foo', 'bar', 'baz')
 
 statement ok
+CREATE TYPE constraint_db.compositetype AS (a INT, b INT)
+
+statement ok
 CREATE TABLE constraint_db.t6 (
   a INT,
   b INT,
   c STRING,
   m constraint_db.mytype,
+  n constraint_db.compositetype,
   INDEX ((a + b))
 );
 CREATE INDEX ON constraint_db.t6 (lower(c), (a + b));
 CREATE UNIQUE INDEX ON constraint_db.t6 (lower(c));
-CREATE INDEX ON constraint_db.t6 ((m = 'foo')) WHERE m = 'foo'
+CREATE INDEX ON constraint_db.t6 ((m = 'foo')) WHERE m = 'foo';
+CREATE INDEX ON constraint_db.t6 (((n).a = 3)) WHERE ((n).b) = 5
 
 ## pg_catalog.pg_namespace
 
@@ -581,14 +586,15 @@ oid         relname            relnamespace  reltype  reloftype  relowner    rel
 3214807592  t4_pkey            109           0        0          1546506610  2631952481  0            0
 117         t5                 109           100117   0          1546506610  2631952481  0            0
 1869730585  t5_pkey            109           0        0          1546506610  2631952481  0            0
-120         t6                 109           100120   0          1546506610  2631952481  0            0
-2129466852  t6_pkey            109           0        0          1546506610  2631952481  0            0
-2129466855  t6_expr_idx        109           0        0          1546506610  2631952481  0            0
-2129466854  t6_expr_expr1_idx  109           0        0          1546506610  2631952481  0            0
-2129466848  t6_expr_key        109           0        0          1546506610  2631952481  0            0
-2129466850  t6_expr_idx1       109           0        0          1546506610  2631952481  0            0
-121         mv1                109           100121   0          1546506610  0           0            0
-784389845   mv1_pkey           109           0        0          1546506610  2631952481  0            0
+122         t6                 109           100122   0          1546506610  2631952481  0            0
+524653574   t6_pkey            109           0        0          1546506610  2631952481  0            0
+524653573   t6_expr_idx        109           0        0          1546506610  2631952481  0            0
+524653572   t6_expr_expr1_idx  109           0        0          1546506610  2631952481  0            0
+524653570   t6_expr_key        109           0        0          1546506610  2631952481  0            0
+524653568   t6_expr_idx1       109           0        0          1546506610  2631952481  0            0
+524653582   t6_expr_idx2       109           0        0          1546506610  2631952481  0            0
+123         mv1                109           100123   0          1546506610  0           0            0
+3474543863  mv1_pkey           109           0        0          1546506610  2631952481  0            0
 
 query TIRIOBBT colnames
 SELECT relname, relpages, reltuples, relallvisible, reltoastrelid, relhasindex, relisshared, relpersistence
@@ -620,6 +626,7 @@ t6_expr_idx        NULL      NULL       0              0              false     
 t6_expr_expr1_idx  NULL      NULL       0              0              false        false        p
 t6_expr_key        NULL      NULL       0              0              false        false        p
 t6_expr_idx1       NULL      NULL       0              0              false        false        p
+t6_expr_idx2       NULL      NULL       0              0              false        false        p
 mv1                NULL      NULL       0              0              true         false        p
 mv1_pkey           NULL      NULL       0              0              false        false        p
 
@@ -647,12 +654,13 @@ t4                 false      r        4         0          false       true
 t4_pkey            false      i        1         0          false       false
 t5                 false      r        4         0          false       true
 t5_pkey            false      i        1         0          false       false
-t6                 false      r        5         0          false       true
+t6                 false      r        6         0          false       true
 t6_pkey            false      i        1         0          false       false
 t6_expr_idx        false      i        1         0          false       false
 t6_expr_expr1_idx  false      i        2         0          false       false
 t6_expr_key        false      i        1         0          false       false
 t6_expr_idx1       false      i        1         0          false       false
+t6_expr_idx2       false      i        1         0          false       false
 mv1                false      m        2         0          false       true
 mv1_pkey           false      i        1         0          false       false
 
@@ -686,6 +694,7 @@ t6_expr_idx        false        false           false           0             NU
 t6_expr_expr1_idx  false        false           false           0             NULL    NULL
 t6_expr_key        false        false           false           0             NULL    NULL
 t6_expr_idx1       false        false           false           0             NULL    NULL
+t6_expr_idx2       false        false           false           0             NULL    NULL
 mv1                false        false           false           0             NULL    NULL
 mv1_pkey           false        false           false           0             NULL    NULL
 
@@ -746,20 +755,22 @@ attrelid    relname            attname                   atttypid  attstattarget
 117         t5                 c                         25        0              -1      3       0         -1
 117         t5                 rowid                     20        0              8       4       0         -1
 1869730585  t5_pkey            rowid                     20        0              8       1       0         -1
-120         t6                 a                         20        0              8       1       0         -1
-120         t6                 b                         20        0              8       2       0         -1
-120         t6                 c                         25        0              -1      3       0         -1
-120         t6                 m                         100118    0              -1      4       0         -1
-120         t6                 rowid                     20        0              8       6       0         -1
-2129466852  t6_pkey            rowid                     20        0              8       1       0         -1
-2129466855  t6_expr_idx        crdb_internal_idx_expr    20        0              8       1       0         -1
-2129466854  t6_expr_expr1_idx  crdb_internal_idx_expr_1  25        0              -1      1       0         -1
-2129466854  t6_expr_expr1_idx  crdb_internal_idx_expr    20        0              8       2       0         -1
-2129466848  t6_expr_key        crdb_internal_idx_expr_1  25        0              -1      1       0         -1
-2129466850  t6_expr_idx1       crdb_internal_idx_expr_2  16        0              1       1       0         -1
-121         mv1                ?column?                  20        0              8       1       0         -1
-121         mv1                rowid                     20        0              8       2       0         -1
-784389845   mv1_pkey           rowid                     20        0              8       1       0         -1
+122         t6                 a                         20        0              8       1       0         -1
+122         t6                 b                         20        0              8       2       0         -1
+122         t6                 c                         25        0              -1      3       0         -1
+122         t6                 m                         100118    0              -1      4       0         -1
+122         t6                 n                         100120    0              16      5       0         -1
+122         t6                 rowid                     20        0              8       7       0         -1
+524653574   t6_pkey            rowid                     20        0              8       1       0         -1
+524653573   t6_expr_idx        crdb_internal_idx_expr    20        0              8       1       0         -1
+524653572   t6_expr_expr1_idx  crdb_internal_idx_expr_1  25        0              -1      1       0         -1
+524653572   t6_expr_expr1_idx  crdb_internal_idx_expr    20        0              8       2       0         -1
+524653570   t6_expr_key        crdb_internal_idx_expr_1  25        0              -1      1       0         -1
+524653568   t6_expr_idx1       crdb_internal_idx_expr_2  16        0              1       1       0         -1
+524653582   t6_expr_idx2       crdb_internal_idx_expr_3  16        0              1       1       0         -1
+123         mv1                ?column?                  20        0              8       1       0         -1
+123         mv1                rowid                     20        0              8       2       0         -1
+3474543863  mv1_pkey           rowid                     20        0              8       1       0         -1
 
 query TTIBTTBBTT colnames,rowsort
 SELECT c.relname, attname, atttypmod, attbyval, attstorage, attalign, attnotnull, atthasdef, attidentity, attgenerated
@@ -820,6 +831,7 @@ t6                 a                         -1         NULL      NULL        NU
 t6                 b                         -1         NULL      NULL        NULL      false       false      ·            ·
 t6                 c                         -1         NULL      NULL        NULL      false       false      ·            ·
 t6                 m                         -1         NULL      NULL        NULL      false       false      ·            ·
+t6                 n                         -1         NULL      NULL        NULL      false       false      ·            ·
 t6                 rowid                     -1         NULL      NULL        NULL      true        true       ·            ·
 t6_pkey            rowid                     -1         NULL      NULL        NULL      true        true       ·            ·
 t6_expr_idx        crdb_internal_idx_expr    -1         NULL      NULL        NULL      false       false      ·            v
@@ -827,6 +839,7 @@ t6_expr_expr1_idx  crdb_internal_idx_expr_1  -1         NULL      NULL        NU
 t6_expr_expr1_idx  crdb_internal_idx_expr    -1         NULL      NULL        NULL      false       false      ·            v
 t6_expr_key        crdb_internal_idx_expr_1  -1         NULL      NULL        NULL      false       false      ·            v
 t6_expr_idx1       crdb_internal_idx_expr_2  -1         NULL      NULL        NULL      false       false      ·            v
+t6_expr_idx2       crdb_internal_idx_expr_3  -1         NULL      NULL        NULL      false       false      ·            v
 mv1                ?column?                  -1         NULL      NULL        NULL      false       false      ·            ·
 mv1                rowid                     -1         NULL      NULL        NULL      true        true       ·            ·
 mv1_pkey           rowid                     -1         NULL      NULL        NULL      true        true       ·            ·
@@ -890,6 +903,7 @@ t6                 a                         false         true        0        
 t6                 b                         false         true        0            NULL    NULL        NULL
 t6                 c                         false         true        0            NULL    NULL        NULL
 t6                 m                         false         true        0            NULL    NULL        NULL
+t6                 n                         false         true        0            NULL    NULL        NULL
 t6                 rowid                     false         true        0            NULL    NULL        NULL
 t6_pkey            rowid                     false         true        0            NULL    NULL        NULL
 t6_expr_idx        crdb_internal_idx_expr    false         true        0            NULL    NULL        NULL
@@ -897,6 +911,7 @@ t6_expr_expr1_idx  crdb_internal_idx_expr_1  false         true        0        
 t6_expr_expr1_idx  crdb_internal_idx_expr    false         true        0            NULL    NULL        NULL
 t6_expr_key        crdb_internal_idx_expr_1  false         true        0            NULL    NULL        NULL
 t6_expr_idx1       crdb_internal_idx_expr_2  false         true        0            NULL    NULL        NULL
+t6_expr_idx2       crdb_internal_idx_expr_3  false         true        0            NULL    NULL        NULL
 mv1                ?column?                  false         true        0            NULL    NULL        NULL
 mv1                rowid                     false         true        0            NULL    NULL        NULL
 mv1_pkey           rowid                     false         true        0            NULL    NULL        NULL
@@ -997,8 +1012,8 @@ oid         relname  adrelid  adnum  adbin                                 adsrc
 1221463946  t3       114      4      unique_rowid()                        unique_rowid()                        unique_rowid()
 1740936492  t4       116      4      unique_rowid()                        unique_rowid()                        unique_rowid()
 3086013501  t5       117      4      unique_rowid()                        unique_rowid()                        unique_rowid()
-655595746   t6       120      6      unique_rowid()                        unique_rowid()                        unique_rowid()
-2000672759  mv1      121      2      unique_rowid()                        unique_rowid()                        unique_rowid()
+3345749761  t6       122      7      unique_rowid()                        unique_rowid()                        unique_rowid()
+395859477   mv1      123      2      unique_rowid()                        unique_rowid()                        unique_rowid()
 
 ## pg_catalog.pg_indexes
 
@@ -1019,12 +1034,13 @@ crdb_oid    schemaname  tablename  indexname          tablespace
 2695335053  public      t3         t3_a_b_idx         NULL
 3214807592  public      t4         t4_pkey            NULL
 1869730585  public      t5         t5_pkey            NULL
-2129466852  public      t6         t6_pkey            NULL
-2129466855  public      t6         t6_expr_idx        NULL
-2129466854  public      t6         t6_expr_expr1_idx  NULL
-2129466848  public      t6         t6_expr_key        NULL
-2129466850  public      t6         t6_expr_idx1       NULL
-784389845   public      mv1        mv1_pkey           NULL
+524653574   public      t6         t6_pkey            NULL
+524653573   public      t6         t6_expr_idx        NULL
+524653572   public      t6         t6_expr_expr1_idx  NULL
+524653570   public      t6         t6_expr_key        NULL
+524653568   public      t6         t6_expr_idx1       NULL
+524653582   public      t6         t6_expr_idx2       NULL
+3474543863  public      mv1        mv1_pkey           NULL
 
 query OTTT colnames
 SELECT crdb_oid, tablename, indexname, indexdef
@@ -1043,12 +1059,13 @@ crdb_oid    tablename  indexname          indexdef
 2695335053  t3         t3_a_b_idx         CREATE INDEX t3_a_b_idx ON constraint_db.public.t3 USING btree (a ASC, b DESC) STORING (c)
 3214807592  t4         t4_pkey            CREATE UNIQUE INDEX t4_pkey ON constraint_db.public.t4 USING btree (rowid ASC)
 1869730585  t5         t5_pkey            CREATE UNIQUE INDEX t5_pkey ON constraint_db.public.t5 USING btree (rowid ASC)
-2129466852  t6         t6_pkey            CREATE UNIQUE INDEX t6_pkey ON constraint_db.public.t6 USING btree (rowid ASC)
-2129466855  t6         t6_expr_idx        CREATE INDEX t6_expr_idx ON constraint_db.public.t6 USING btree ((a + b) ASC)
-2129466854  t6         t6_expr_expr1_idx  CREATE INDEX t6_expr_expr1_idx ON constraint_db.public.t6 USING btree (lower(c) ASC, (a + b) ASC)
-2129466848  t6         t6_expr_key        CREATE UNIQUE INDEX t6_expr_key ON constraint_db.public.t6 USING btree (lower(c) ASC)
-2129466850  t6         t6_expr_idx1       CREATE INDEX t6_expr_idx1 ON constraint_db.public.t6 USING btree ((m = 'foo'::constraint_db.public.mytype) ASC) WHERE (m = 'foo'::constraint_db.public.mytype)
-784389845   mv1        mv1_pkey           CREATE UNIQUE INDEX mv1_pkey ON constraint_db.public.mv1 USING btree (rowid ASC)
+524653574   t6         t6_pkey            CREATE UNIQUE INDEX t6_pkey ON constraint_db.public.t6 USING btree (rowid ASC)
+524653573   t6         t6_expr_idx        CREATE INDEX t6_expr_idx ON constraint_db.public.t6 USING btree ((a + b) ASC)
+524653572   t6         t6_expr_expr1_idx  CREATE INDEX t6_expr_expr1_idx ON constraint_db.public.t6 USING btree (lower(c) ASC, (a + b) ASC)
+524653570   t6         t6_expr_key        CREATE UNIQUE INDEX t6_expr_key ON constraint_db.public.t6 USING btree (lower(c) ASC)
+524653568   t6         t6_expr_idx1       CREATE INDEX t6_expr_idx1 ON constraint_db.public.t6 USING btree ((m = 'foo'::constraint_db.public.mytype) ASC) WHERE (m = 'foo'::constraint_db.public.mytype)
+524653582   t6         t6_expr_idx2       CREATE INDEX t6_expr_idx2 ON constraint_db.public.t6 USING btree (((n).a = 3) ASC) WHERE ((n).b = 5)
+3474543863  mv1        mv1_pkey           CREATE UNIQUE INDEX mv1_pkey ON constraint_db.public.mv1 USING btree (rowid ASC)
 
 ## pg_catalog.pg_index
 
@@ -1060,7 +1077,7 @@ WHERE indnkeyatts = 2
 indexrelid  indrelid  indnatts  indisunique  indisprimary  indisexclusion
 3687884464  110       2         true         false         false
 2695335053  114       3         false        false         false
-2129466854  120       2         false        false         false
+524653572   122       2         false        false         false
 
 query OBBBBB colnames
 SELECT indexrelid, indimmediate, indisclustered, indisvalid, indcheckxmin, indisready
@@ -1070,7 +1087,7 @@ WHERE indnkeyatts = 2
 indexrelid  indimmediate  indisclustered  indisvalid  indcheckxmin  indisready
 3687884464  true          false           true        false         false
 2695335053  false         false           true        false         false
-2129466854  false         false           true        false         false
+524653572   false         false           true        false         false
 
 query OOBBTTTTTT colnames
 SELECT indexrelid, indrelid, indislive, indisreplident, indkey, indcollation, indclass, indoption, indexprs, indpred
@@ -1080,7 +1097,7 @@ WHERE indnkeyatts = 2
 indexrelid  indrelid  indislive  indisreplident  indkey  indcollation  indclass  indoption  indexprs            indpred
 3687884464  110       true       false           3 4     0 0           0 0       2 2        NULL                NULL
 2695335053  114       true       false           1 2 3   0 0           0 0       2 1        NULL                NULL
-2129466854  120       true       false           0 0     3403232968 0  0 0       2 2        (lower(c)) (a + b)  NULL
+524653572   122       true       false           0 0     3403232968 0  0 0       2 2        (lower(c)) (a + b)  NULL
 
 # Index expression elements should have an indkey of 0 and be included in
 # indexprs.
@@ -1097,8 +1114,9 @@ relname            indkey  indexprs                                  indpred
 t6_expr_expr1_idx  0 0     (lower(c)) (a + b)                        NULL
 t6_expr_idx        0       (a + b)                                   NULL
 t6_expr_idx1       0       (m = 'foo'::constraint_db.public.mytype)  m = 'foo'::constraint_db.public.mytype
+t6_expr_idx2       0       ((n).a = 3)                               (n).b = 5
 t6_expr_key        0       (lower(c))                                NULL
-t6_pkey            6       NULL                                      NULL
+t6_pkey            7       NULL                                      NULL
 
 statement ok
 SET DATABASE = system
@@ -1363,9 +1381,9 @@ uwi_b_partial  u        false          false        true          116       0   
 t5_pkey        p        false          false        true          117       0         1869730585
 fk_b_c         f        false          false        true          117       0         0
 t5_a_fkey      f        false          false        true          117       0         0
-t6_pkey        p        false          false        true          120       0         2129466852
-t6_expr_key    u        false          false        true          120       0         2129466848
-mv1_pkey       p        false          false        true          121       0         784389845
+t6_pkey        p        false          false        true          122       0         524653574
+t6_expr_key    u        false          false        true          122       0         524653570
+mv1_pkey       p        false          false        true          123       0         3474543863
 
 query T
 SELECT conname
@@ -1438,8 +1456,8 @@ uwi_b_partial  true        0            true          NULL
 t5_pkey        true        0            true          {4}
 fk_b_c         true        0            true          {2,3}
 t5_a_fkey      true        0            true          {1}
-t6_pkey        true        0            true          {6}
-t6_expr_key    true        0            true          {7}
+t6_pkey        true        0            true          {7}
+t6_expr_key    true        0            true          {8}
 mv1_pkey       true        0            true          {2}
 
 query TTTTTTTTT colnames
@@ -1582,8 +1600,8 @@ SELECT * FROM pg_rewrite WHERE ev_class IN (
 ) ORDER BY oid
 ----
 oid         rulename  ev_class  ev_type  ev_enabled  is_instead  ev_qual  ev_action
-554906963   _RETURN   129       1        NULL        true        NULL     NULL
-1899983969  _RETURN   130       1        NULL        true        NULL     NULL
+2159720243  _RETURN   131       1        NULL        true        NULL     NULL
+3504797253  _RETURN   132       1        NULL        true        NULL     NULL
 
 ## pg_catalog.pg_enum
 statement ok
@@ -1597,10 +1615,10 @@ oid         enumtypid  enumsortorder  enumlabel
 3341603527  100118     0              foo
 3341603335  100118     1              bar
 3341603399  100118     2              baz
-2452389720  100131     0              v1
-2452389784  100131     1              v2
-2553055434  100133     0              v3
-2553055242  100133     1              v4
+2553055434  100133     0              v1
+2553055242  100133     1              v2
+2519500068  100135     0              v3
+2519500260  100135     1              v4
 
 ## pg_catalog.pg_type
 
@@ -1703,15 +1721,17 @@ oid     typname                typnamespace  typowner    typlen  typbyval  typty
 100117  t5                     109           1546506610  -1      false     c
 100118  mytype                 109           1546506610  -1      false     e
 100119  _mytype                109           1546506610  -1      false     b
-100120  t6                     109           1546506610  -1      false     c
-100121  mv1                    109           1546506610  -1      false     c
-100128  source_table           109           1546506610  -1      false     c
-100129  depend_view            109           1546506610  -1      false     c
-100130  view_dependingon_view  109           1546506610  -1      false     c
-100131  newtype1               109           1546506610  -1      false     e
-100132  _newtype1              109           1546506610  -1      false     b
-100133  newtype2               109           1546506610  -1      false     e
-100134  _newtype2              109           1546506610  -1      false     b
+100120  compositetype          109           1546506610  16      true      c
+100121  _compositetype         109           1546506610  -1      false     b
+100122  t6                     109           1546506610  -1      false     c
+100123  mv1                    109           1546506610  -1      false     c
+100130  source_table           109           1546506610  -1      false     c
+100131  depend_view            109           1546506610  -1      false     c
+100132  view_dependingon_view  109           1546506610  -1      false     c
+100133  newtype1               109           1546506610  -1      false     e
+100134  _newtype1              109           1546506610  -1      false     b
+100135  newtype2               109           1546506610  -1      false     e
+100136  _newtype2              109           1546506610  -1      false     b
 
 query OTTBBTOOO colnames
 SELECT oid, typname, typcategory, typispreferred, typisdefined, typdelim, typrelid, typelem, typarray
@@ -1812,15 +1832,17 @@ oid     typname                typcategory  typispreferred  typisdefined  typdel
 100117  t5                     C            false           true          ,         117       0        0
 100118  mytype                 E            false           true          ,         0         0        100119
 100119  _mytype                A            false           true          ,         0         100118   0
-100120  t6                     C            false           true          ,         120       0        0
-100121  mv1                    C            false           true          ,         121       0        0
-100128  source_table           C            false           true          ,         128       0        0
-100129  depend_view            C            false           true          ,         129       0        0
-100130  view_dependingon_view  C            false           true          ,         130       0        0
-100131  newtype1               E            false           true          ,         0         0        100132
-100132  _newtype1              A            false           true          ,         0         100131   0
-100133  newtype2               E            false           true          ,         0         0        100134
-100134  _newtype2              A            false           true          ,         0         100133   0
+100120  compositetype          C            false           true          ,         0         0        100121
+100121  _compositetype         A            false           true          ,         0         100120   0
+100122  t6                     C            false           true          ,         122       0        0
+100123  mv1                    C            false           true          ,         123       0        0
+100130  source_table           C            false           true          ,         130       0        0
+100131  depend_view            C            false           true          ,         131       0        0
+100132  view_dependingon_view  C            false           true          ,         132       0        0
+100133  newtype1               E            false           true          ,         0         0        100134
+100134  _newtype1              A            false           true          ,         0         100133   0
+100135  newtype2               E            false           true          ,         0         0        100136
+100136  _newtype2              A            false           true          ,         0         100135   0
 
 query OTOOOOOOO colnames
 SELECT oid, typname, typinput, typoutput, typreceive, typsend, typmodin, typmodout, typanalyze
@@ -1921,15 +1943,17 @@ oid     typname                typinput        typoutput        typreceive      
 100117  t5                     record_in       record_out       record_recv       record_send       0         0          0
 100118  mytype                 enum_in         enum_out         enum_recv         enum_send         0         0          0
 100119  _mytype                array_in        array_out        array_recv        array_send        0         0          0
-100120  t6                     record_in       record_out       record_recv       record_send       0         0          0
-100121  mv1                    record_in       record_out       record_recv       record_send       0         0          0
-100128  source_table           record_in       record_out       record_recv       record_send       0         0          0
-100129  depend_view            record_in       record_out       record_recv       record_send       0         0          0
-100130  view_dependingon_view  record_in       record_out       record_recv       record_send       0         0          0
-100131  newtype1               enum_in         enum_out         enum_recv         enum_send         0         0          0
-100132  _newtype1              array_in        array_out        array_recv        array_send        0         0          0
-100133  newtype2               enum_in         enum_out         enum_recv         enum_send         0         0          0
-100134  _newtype2              array_in        array_out        array_recv        array_send        0         0          0
+100120  compositetype          record_in       record_out       record_recv       record_send       0         0          0
+100121  _compositetype         array_in        array_out        array_recv        array_send        0         0          0
+100122  t6                     record_in       record_out       record_recv       record_send       0         0          0
+100123  mv1                    record_in       record_out       record_recv       record_send       0         0          0
+100130  source_table           record_in       record_out       record_recv       record_send       0         0          0
+100131  depend_view            record_in       record_out       record_recv       record_send       0         0          0
+100132  view_dependingon_view  record_in       record_out       record_recv       record_send       0         0          0
+100133  newtype1               enum_in         enum_out         enum_recv         enum_send         0         0          0
+100134  _newtype1              array_in        array_out        array_recv        array_send        0         0          0
+100135  newtype2               enum_in         enum_out         enum_recv         enum_send         0         0          0
+100136  _newtype2              array_in        array_out        array_recv        array_send        0         0          0
 
 query OTTTBOI colnames
 SELECT oid, typname, typalign, typstorage, typnotnull, typbasetype, typtypmod
@@ -2030,15 +2054,17 @@ oid     typname                typalign  typstorage  typnotnull  typbasetype  ty
 100117  t5                     NULL      NULL        false       0            -1
 100118  mytype                 NULL      NULL        false       0            -1
 100119  _mytype                NULL      NULL        false       0            -1
-100120  t6                     NULL      NULL        false       0            -1
-100121  mv1                    NULL      NULL        false       0            -1
-100128  source_table           NULL      NULL        false       0            -1
-100129  depend_view            NULL      NULL        false       0            -1
-100130  view_dependingon_view  NULL      NULL        false       0            -1
-100131  newtype1               NULL      NULL        false       0            -1
-100132  _newtype1              NULL      NULL        false       0            -1
-100133  newtype2               NULL      NULL        false       0            -1
-100134  _newtype2              NULL      NULL        false       0            -1
+100120  compositetype          NULL      NULL        false       0            -1
+100121  _compositetype         NULL      NULL        false       0            -1
+100122  t6                     NULL      NULL        false       0            -1
+100123  mv1                    NULL      NULL        false       0            -1
+100130  source_table           NULL      NULL        false       0            -1
+100131  depend_view            NULL      NULL        false       0            -1
+100132  view_dependingon_view  NULL      NULL        false       0            -1
+100133  newtype1               NULL      NULL        false       0            -1
+100134  _newtype1              NULL      NULL        false       0            -1
+100135  newtype2               NULL      NULL        false       0            -1
+100136  _newtype2              NULL      NULL        false       0            -1
 
 query OTIOTTT colnames
 SELECT oid, typname, typndims, typcollation, typdefaultbin, typdefault, typacl
@@ -2139,15 +2165,17 @@ oid     typname                typndims  typcollation  typdefaultbin  typdefault
 100117  t5                     0         0             NULL           NULL        NULL
 100118  mytype                 0         0             NULL           NULL        NULL
 100119  _mytype                0         0             NULL           NULL        NULL
-100120  t6                     0         0             NULL           NULL        NULL
-100121  mv1                    0         0             NULL           NULL        NULL
-100128  source_table           0         0             NULL           NULL        NULL
-100129  depend_view            0         0             NULL           NULL        NULL
-100130  view_dependingon_view  0         0             NULL           NULL        NULL
-100131  newtype1               0         0             NULL           NULL        NULL
-100132  _newtype1              0         0             NULL           NULL        NULL
-100133  newtype2               0         0             NULL           NULL        NULL
-100134  _newtype2              0         0             NULL           NULL        NULL
+100120  compositetype          0         0             NULL           NULL        NULL
+100121  _compositetype         0         0             NULL           NULL        NULL
+100122  t6                     0         0             NULL           NULL        NULL
+100123  mv1                    0         0             NULL           NULL        NULL
+100130  source_table           0         0             NULL           NULL        NULL
+100131  depend_view            0         0             NULL           NULL        NULL
+100132  view_dependingon_view  0         0             NULL           NULL        NULL
+100133  newtype1               0         0             NULL           NULL        NULL
+100134  _newtype1              0         0             NULL           NULL        NULL
+100135  newtype2               0         0             NULL           NULL        NULL
+100136  _newtype2              0         0             NULL           NULL        NULL
 
 user testuser
 
@@ -2176,7 +2204,7 @@ FROM pg_catalog.pg_type
 WHERE typname = 'newtype1'
 ----
 oid     typname   typnamespace  typowner    typlen  typbyval  typtype
-100131  newtype1  109           1546506610  -1      false     e
+100133  newtype1  109           1546506610  -1      false     e
 
 query OTOOIBT colnames
 SELECT oid, typname, typnamespace, typowner, typlen, typbyval, typtype
@@ -2198,7 +2226,7 @@ FROM pg_catalog.pg_type
 WHERE typname = 'source_table'
 ----
 oid     typname       typnamespace  typowner    typlen  typbyval  typtype
-100128  source_table  109           1546506610  -1      false     c
+100130  source_table  109           1546506610  -1      false     c
 
 let $sourceid
 SELECT oid
@@ -2212,7 +2240,7 @@ FROM pg_catalog.pg_type
 WHERE oid = $sourceid
 ----
 oid     typname       typnamespace  typowner    typlen  typbyval  typtype
-100128  source_table  109           1546506610  -1      false     c
+100130  source_table  109           1546506610  -1      false     c
 
 let $vtableSourceId
 SELECT oid
@@ -3172,8 +3200,8 @@ query OOIIIIIB colnames
 SELECT * FROM pg_catalog.pg_sequence
 ----
 seqrelid  seqtypid  seqstart  seqincrement  seqmax               seqmin  seqcache  seqcycle
-137       20        1         1             9223372036854775807  1       1         false
-138       20        6         2             10                   5       1         false
+139       20        1         1             9223372036854775807  1       1         false
+140       20        6         2             10                   5       1         false
 
 statement ok
 DROP DATABASE seq
@@ -3226,8 +3254,8 @@ WHERE n.nspname = 'public'
 1221463946  t3   unique_rowid()
 1740936492  t4   unique_rowid()
 3086013501  t5   unique_rowid()
-655595746   t6   unique_rowid()
-2000672759  mv1  unique_rowid()
+3345749761  t6   unique_rowid()
+395859477   mv1  unique_rowid()
 
 # Verify that a set database shows tables from that database for a non-root
 # user, when that user has permissions.
@@ -3764,13 +3792,13 @@ CREATE TABLE jt (a INT PRIMARY KEY); INSERT INTO jt VALUES(1); INSERT INTO jt VA
 query ITT
 SELECT a, oid, relname FROM jt INNER LOOKUP JOIN pg_class ON a::oid=oid
 ----
-168  168  jt
+170  170  jt
 
 query ITT
 SELECT a, oid, relname FROM jt LEFT OUTER LOOKUP JOIN pg_class ON a::oid=oid
 ----
 1    NULL  NULL
-168  168   jt
+170  170   jt
 
 subtest regression_49207
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/record
+++ b/pkg/sql/logictest/testdata/logic_test/record
@@ -59,7 +59,7 @@ t      d  e  d  e
 (1,2)  1  2  1  2
 
 # You can't use a table type as a column type.
-statement error value type tuple\{int AS d, string AS e\} cannot be used for table columns
+statement error cannot use table record type as table column
 CREATE TABLE fail (a implicit_col)
 
 # REGTYPE works, and returns the type ID.
@@ -146,7 +146,7 @@ CREATE TABLE fail (b INT, INDEX((b + (((1,'a')::b).a))))
 statement error cannot modify table record type
 CREATE INDEX ON a((a + (((1,'a')::b).a)))
 
-statement error value type tuple{int AS a, e AS e} cannot be used for table columns
+statement error cannot use table record type as table column
 CREATE VIEW v AS SELECT (1,'a')::b
 
 statement error cannot modify table record type "b"

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -394,6 +394,13 @@ func TestLogic_collatedstring_uniqueindex2(
 	runLogicTest(t, "collatedstring_uniqueindex2")
 }
 
+func TestLogic_composite_types(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "composite_types")
+}
+
 func TestLogic_computed(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -394,6 +394,13 @@ func TestLogic_collatedstring_uniqueindex2(
 	runLogicTest(t, "collatedstring_uniqueindex2")
 }
 
+func TestLogic_composite_types(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "composite_types")
+}
+
 func TestLogic_computed(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -394,6 +394,13 @@ func TestLogic_collatedstring_uniqueindex2(
 	runLogicTest(t, "collatedstring_uniqueindex2")
 }
 
+func TestLogic_composite_types(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "composite_types")
+}
+
 func TestLogic_computed(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -394,6 +394,13 @@ func TestLogic_collatedstring_uniqueindex2(
 	runLogicTest(t, "collatedstring_uniqueindex2")
 }
 
+func TestLogic_composite_types(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "composite_types")
+}
+
 func TestLogic_computed(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -394,6 +394,13 @@ func TestLogic_collatedstring_uniqueindex2(
 	runLogicTest(t, "collatedstring_uniqueindex2")
 }
 
+func TestLogic_composite_types(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "composite_types")
+}
+
 func TestLogic_computed(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -408,6 +408,13 @@ func TestLogic_column_families(
 	runLogicTest(t, "column_families")
 }
 
+func TestLogic_composite_types(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "composite_types")
+}
+
 func TestLogic_computed(
 	t *testing.T,
 ) {

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -495,7 +495,6 @@ func TestUnimplementedSyntax(t *testing.T) {
 
 		{`CREATE RECURSIVE VIEW a AS SELECT b`, 0, `create recursive view`, ``},
 
-		{`CREATE TYPE a AS (b)`, 27792, ``, ``},
 		{`CREATE TYPE a AS RANGE b`, 27791, ``, ``},
 		{`CREATE TYPE a (b)`, 27793, `base`, ``},
 		{`CREATE TYPE a`, 27793, `shell`, ``},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -305,6 +305,9 @@ func (u *sqlSymUnion) nameList() tree.NameList {
 func (u *sqlSymUnion) enumValueList() tree.EnumValueList {
     return u.val.(tree.EnumValueList)
 }
+func (u *sqlSymUnion) compositeTypeList() []tree.CompositeTypeElem {
+    return u.val.([]tree.CompositeTypeElem)
+}
 func (u *sqlSymUnion) unresolvedName() *tree.UnresolvedName {
     return u.val.(*tree.UnresolvedName)
 }
@@ -1464,6 +1467,7 @@ func (u *sqlSymUnion) functionObjs() tree.FuncObjs {
 
 %type <str> explain_option_name
 %type <[]string> explain_option_list opt_enum_val_list enum_val_list
+%type <[]tree.CompositeTypeElem> composite_type_list opt_composite_type_list
 
 %type <tree.ResolvableTypeReference> typename simple_typename cast_target
 %type <*types.T> const_typename
@@ -9674,7 +9678,23 @@ create_type_stmt:
   }
 | CREATE TYPE error // SHOW HELP: CREATE TYPE
   // Record/Composite types.
-| CREATE TYPE type_name AS '(' error      { return unimplementedWithIssue(sqllex, 27792) }
+| CREATE TYPE type_name AS '(' opt_composite_type_list ')'
+  {
+    $$.val = &tree.CreateType{
+      TypeName: $3.unresolvedObjectName(),
+      Variety: tree.Composite,
+      CompositeTypeList: $6.compositeTypeList(),
+    }
+  }
+| CREATE TYPE IF NOT EXISTS type_name AS '(' opt_composite_type_list ')'
+  {
+    $$.val = &tree.CreateType{
+      TypeName: $6.unresolvedObjectName(),
+      Variety: tree.Composite,
+      IfNotExists: true,
+      CompositeTypeList: $9.compositeTypeList(),
+    }
+  }
   // Range types.
 | CREATE TYPE type_name AS RANGE error    { return unimplementedWithIssue(sqllex, 27791) }
   // Base (primitive) types.
@@ -9702,6 +9722,36 @@ enum_val_list:
 | enum_val_list ',' SCONST
   {
     $$.val = append($1.enumValueList(), tree.EnumValue($3))
+  }
+
+opt_composite_type_list:
+  composite_type_list
+  {
+    $$.val = $1.compositeTypeList()
+  }
+| /* EMPTY */
+  {
+    $$.val = []tree.CompositeTypeElem{}
+  }
+
+composite_type_list:
+  name simple_typename
+  {
+    $$.val = []tree.CompositeTypeElem{
+        tree.CompositeTypeElem{
+            Label: tree.Name($1),
+            Type: $2.typeReference(),
+        },
+    }
+  }
+| composite_type_list ',' name simple_typename
+  {
+    $$.val = append($1.compositeTypeList(),
+        tree.CompositeTypeElem{
+            Label: tree.Name($3),
+            Type: $4.typeReference(),
+        },
+    )
   }
 
 // %Help: CREATE INDEX - create a new index

--- a/pkg/sql/parser/testdata/create_type
+++ b/pkg/sql/parser/testdata/create_type
@@ -45,3 +45,27 @@ CREATE TYPE a.b.c AS ENUM ('a', 'b', 'c')
 CREATE TYPE a.b.c AS ENUM ('a', 'b', 'c') -- fully parenthesized
 CREATE TYPE a.b.c AS ENUM ('a', 'b', 'c') -- literals removed
 CREATE TYPE _._._ AS ENUM (_, _, _) -- identifiers removed
+
+parse
+CREATE TYPE foo AS (a INT)
+----
+CREATE TYPE foo AS (a INT8) -- normalized!
+CREATE TYPE foo AS (a INT8) -- fully parenthesized
+CREATE TYPE foo AS (a INT8) -- literals removed
+CREATE TYPE _ AS (_ INT8) -- identifiers removed
+
+parse
+CREATE TYPE foo AS (a INT, b x)
+----
+CREATE TYPE foo AS (a INT8, b x) -- normalized!
+CREATE TYPE foo AS (a INT8, b x) -- fully parenthesized
+CREATE TYPE foo AS (a INT8, b x) -- literals removed
+CREATE TYPE _ AS (_ INT8, _ x) -- identifiers removed
+
+parse
+CREATE TYPE foo AS ()
+----
+CREATE TYPE foo AS ()
+CREATE TYPE foo AS () -- fully parenthesized
+CREATE TYPE foo AS () -- literals removed
+CREATE TYPE _ AS () -- identifiers removed

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -3003,14 +3003,18 @@ func addPGTypeRow(
 			builtinPrefix = "array_"
 			typElem = tree.NewDOid(typ.ArrayContents().Oid())
 		}
+	case types.EnumFamily:
+		builtinPrefix = "enum_"
+		typType = typTypeEnum
+		typArray = tree.NewDOid(types.CalcArrayOid(typ))
+	case types.TupleFamily:
+		builtinPrefix = "record_"
+		typType = typTypeComposite
+		typArray = tree.NewDOid(types.CalcArrayOid(typ))
 	case types.VoidFamily:
 		// void does not have an array type.
 	default:
 		typArray = tree.NewDOid(types.CalcArrayOid(typ))
-	}
-	if typ.Family() == types.EnumFamily {
-		builtinPrefix = "enum_"
-		typType = typTypeEnum
 	}
 	if cat == typCategoryPseudo {
 		typType = typTypePseudo
@@ -4216,6 +4220,9 @@ func typCategory(typ *types.T) tree.Datum {
 	// Special case ARRAY of ANY.
 	if typ.Family() == types.ArrayFamily && typ.ArrayContents().Family() == types.AnyFamily {
 		return typCategoryPseudo
+	}
+	if typ.UserDefined() && typ.Family() == types.TupleFamily {
+		return typCategoryComposite
 	}
 	return datumToTypeCategory[typ.Family()]
 }

--- a/pkg/sql/schemachanger/scbuild/builder_state.go
+++ b/pkg/sql/schemachanger/scbuild/builder_state.go
@@ -697,6 +697,8 @@ func (b *builderState) ResolveEnumType(
 		// Implicit record types are not directly modifiable.
 		panic(pgerror.Newf(pgcode.DependentObjectsStillExist,
 			"cannot modify table record type %q", typ.GetName()))
+	case descpb.TypeDescriptor_COMPOSITE:
+		panic(scerrors.NotImplementedErrorf(name, "composite types not supported in new schema changer"))
 	default:
 		panic(errors.AssertionFailedf("unknown type kind %s", typ.GetKind()))
 	}

--- a/pkg/sql/schemachanger/scdecomp/decomp.go
+++ b/pkg/sql/schemachanger/scdecomp/decomp.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
@@ -189,6 +190,9 @@ func (w *walkCtx) walkType(typ catalog.TypeDescriptor) {
 				LogicalRepresentation:  typ.GetMemberLogicalRepresentation(ord),
 			})
 		}
+	case descpb.TypeDescriptor_COMPOSITE:
+		name := tree.Name(typ.GetName())
+		panic(scerrors.NotImplementedErrorf(&name, "composite types not supported in new schema changer"))
 	default:
 		panic(errors.AssertionFailedf("unsupported type kind %q", typ.GetKind()))
 	}

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -340,12 +340,21 @@ func (l *EnumValueList) Format(ctx *FmtCtx) {
 	}
 }
 
+// CompositeTypeElem is a single element in a composite type definition.
+type CompositeTypeElem struct {
+	Label Name
+	Type  ResolvableTypeReference
+}
+
 // CreateType represents a CREATE TYPE statement.
 type CreateType struct {
 	TypeName *UnresolvedObjectName
 	Variety  CreateTypeVariety
 	// EnumLabels is set when this represents a CREATE TYPE ... AS ENUM statement.
 	EnumLabels EnumValueList
+	// CompositeTypeList is set when this repesnets a CREATE TYPE ... AS ( )
+	// statement.
+	CompositeTypeList []CompositeTypeElem
 	// IfNotExists is true if IF NOT EXISTS was requested.
 	IfNotExists bool
 }
@@ -364,6 +373,17 @@ func (node *CreateType) Format(ctx *FmtCtx) {
 	case Enum:
 		ctx.WriteString("AS ENUM (")
 		ctx.FormatNode(&node.EnumLabels)
+		ctx.WriteString(")")
+	case Composite:
+		ctx.WriteString("AS (")
+		for i, elem := range node.CompositeTypeList {
+			if i != 0 {
+				ctx.WriteString(", ")
+			}
+			ctx.FormatNode(&elem.Label)
+			ctx.WriteString(" ")
+			ctx.WriteString(elem.Type.SQLString())
+		}
 		ctx.WriteString(")")
 	}
 }

--- a/pkg/sql/types/oid.go
+++ b/pkg/sql/types/oid.go
@@ -225,10 +225,13 @@ func CalcArrayOid(elemTyp *T) oid.Oid {
 
 	case TupleFamily:
 		if elemTyp.UserDefined() {
-			// We're currently not creating array types for implicitly-defined
-			// per-table record types. So, we cheat a little, and return, as the OID
-			// for an array of these things, the OID for a generic array of records.
-			return oid.T__record
+			if elemTyp.TypeMeta.ImplicitRecordType {
+				// We're currently not creating array types for implicitly-defined
+				// per-table record types. So, we cheat a little, and return, as the OID
+				// for an array of these things, the OID for a generic array of records.
+				return oid.T__record
+			}
+			return elemTyp.UserDefinedArrayOID()
 		}
 	}
 


### PR DESCRIPTION
Closes #27792

This commit adds user-defined composite types, which are created with
the `CREATE TYPE t AS (field1 type1, field2 type2, ...)` syntax.

See documentation here:
https://www.postgresql.org/docs/current/rowtypes.html

It permits this kind of thing:

```
CREATE TYPE t AS (a INT, b INT);
CREATE TABLE a (a t);
INSERT INTO a VALUES((1, 2))
SELECT (a).b FROM a
```

Release note (sql change): add user-defined composite column types