### PR TITLE
storage: add MVCCKey.CloneInto

### DIFF
--- a/pkg/storage/mvcc_key.go
+++ b/pkg/storage/mvcc_key.go
@@ -77,6 +77,13 @@ func (k MVCCKey) Clone() MVCCKey {
 	return k
 }
 
+// CloneInto copies the key into the provided destination MVCCKey, reusing and
+// overwriting its key slice.
+func (k MVCCKey) CloneInto(dst *MVCCKey) {
+	dst.Key = append(dst.Key[:0], k.Key...)
+	dst.Timestamp = k.Timestamp
+}
+
 // Compare returns -1 if this key is less than the given key, 0 if they're
 // equal, or 1 if this is greater. Comparison is by key,timestamp, where larger
 // timestamps sort before smaller ones except empty ones which sort first (like

--- a/pkg/storage/sst.go
+++ b/pkg/storage/sst.go
@@ -384,7 +384,7 @@ func CheckSSTConflicts(
 		extRangeKeysChanged := extHasRange && !extPrevRangeKeys.Bounds.Equal(extRangeKeys.Bounds)
 		extKeyChanged := !extPrevKey.Equal(extIter.UnsafeKey())
 		if extKeyChanged {
-			extPrevKey = extIter.Key()
+			extIter.UnsafeKey().CloneInto(&extPrevKey)
 		}
 		// Case where SST and engine both have range keys at the current iterator
 		// points. The SST range keys must be newer than engine range keys.
@@ -845,7 +845,7 @@ func CheckSSTConflicts(
 				sstIter.SeekGE(sstPrevKey)
 				sstOK, sstErr = sstIter.Valid()
 			} else {
-				extPrevKey := extIter.Key()
+				extIter.UnsafeKey().CloneInto(&extPrevKey)
 				if extHasPoint {
 					extIter.NextKey()
 				} else {


### PR DESCRIPTION
Add a MVCCKey.CloneInto method that may be used in place of MVCCIterator.Key() using MVCCIterator.UnsafeKey().CloneInto(&k) when the lifetime of the key copy is known. Use CloneInto to remove extra allocations in CheckSSTConflicts.

```
name                                                                          old time/op    new time/op    delta
CheckSSTConflicts/keys=1000/sstKeys=10/overlap=false/prefixSeek=false-24         120µs ± 3%     120µs ± 2%     ~     (p=0.690 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=10/overlap=false/prefixSeek=true-24         3.34µs ± 3%    3.26µs ± 2%     ~     (p=0.151 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=10/overlap=true/prefixSeek=false-24          151µs ± 2%     147µs ± 1%   -2.30%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=10/overlap=true/prefixSeek=true-24           135µs ± 3%     134µs ± 1%     ~     (p=0.690 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=100/overlap=false/prefixSeek=false-24        125µs ± 2%     125µs ± 3%     ~     (p=1.000 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=100/overlap=false/prefixSeek=true-24        3.31µs ± 3%    3.28µs ± 4%     ~     (p=0.690 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=100/overlap=true/prefixSeek=false-24         437µs ± 2%     417µs ± 3%   -4.50%  (p=0.016 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=100/overlap=true/prefixSeek=true-24          200µs ± 0%     199µs ± 3%     ~     (p=0.730 n=4+5)
CheckSSTConflicts/keys=1000/sstKeys=1000/overlap=false/prefixSeek=false-24       131µs ± 4%     129µs ± 3%     ~     (p=0.841 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=1000/overlap=false/prefixSeek=true-24       3.35µs ± 5%    3.30µs ± 4%     ~     (p=0.548 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=1000/overlap=true/prefixSeek=false-24        887µs ± 3%     843µs ± 2%   -4.95%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=1000/overlap=true/prefixSeek=true-24         820µs ± 2%     805µs ± 3%     ~     (p=0.310 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=10000/overlap=false/prefixSeek=false-24      133µs ± 2%     132µs ± 2%     ~     (p=0.421 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=10000/overlap=false/prefixSeek=true-24      3.25µs ± 3%    3.35µs ± 1%   +3.18%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=10000/overlap=true/prefixSeek=false-24      2.14ms ± 3%    2.09ms ± 3%     ~     (p=0.151 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=10000/overlap=true/prefixSeek=true-24       6.89ms ± 3%    6.82ms ± 2%     ~     (p=0.310 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=10/overlap=false/prefixSeek=false-24        117µs ± 1%     119µs ± 2%   +1.80%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=10/overlap=false/prefixSeek=true-24        3.30µs ± 4%    3.27µs ± 3%     ~     (p=0.548 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=10/overlap=true/prefixSeek=false-24         150µs ± 4%     149µs ± 2%     ~     (p=1.000 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=10/overlap=true/prefixSeek=true-24          129µs ± 2%     132µs ± 3%     ~     (p=0.151 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=100/overlap=false/prefixSeek=false-24       124µs ± 3%     122µs ± 1%     ~     (p=0.548 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=100/overlap=false/prefixSeek=true-24       3.25µs ± 3%    3.28µs ± 4%     ~     (p=0.690 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=100/overlap=true/prefixSeek=false-24        451µs ± 4%     454µs ± 3%     ~     (p=0.690 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=100/overlap=true/prefixSeek=true-24         196µs ± 2%     198µs ± 4%     ~     (p=0.548 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=1000/overlap=false/prefixSeek=false-24      128µs ± 4%     128µs ± 4%     ~     (p=1.000 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=1000/overlap=false/prefixSeek=true-24      3.29µs ± 2%    3.25µs ± 4%     ~     (p=0.548 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=1000/overlap=true/prefixSeek=false-24      3.18ms ± 5%    3.12ms ± 3%     ~     (p=0.222 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=1000/overlap=true/prefixSeek=true-24        829µs ± 5%     830µs ± 4%     ~     (p=1.000 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=10000/overlap=false/prefixSeek=false-24     131µs ± 3%     131µs ± 4%     ~     (p=0.421 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=10000/overlap=false/prefixSeek=true-24     3.36µs ± 2%    3.26µs ± 3%   -2.84%  (p=0.048 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=10000/overlap=true/prefixSeek=false-24     7.54ms ± 2%    6.97ms ± 2%   -7.58%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=10000/overlap=true/prefixSeek=true-24      6.92ms ± 3%    6.81ms ± 2%     ~     (p=0.310 n=5+5)

name                                                                          old alloc/op   new alloc/op   delta
CheckSSTConflicts/keys=1000/sstKeys=10/overlap=false/prefixSeek=false-24        31.6kB ± 0%    31.6kB ± 0%     ~     (p=0.151 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=10/overlap=false/prefixSeek=true-24           160B ± 0%      160B ± 0%     ~     (p=0.444 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=10/overlap=true/prefixSeek=false-24         31.6kB ± 0%    31.6kB ± 0%   -0.14%  (p=0.016 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=10/overlap=true/prefixSeek=true-24          31.7kB ± 0%    31.7kB ± 0%     ~     (p=1.000 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=100/overlap=false/prefixSeek=false-24       31.6kB ± 0%    31.6kB ± 0%     ~     (p=0.278 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=100/overlap=false/prefixSeek=true-24          161B ± 0%      160B ± 0%     ~     (p=0.095 n=5+4)
CheckSSTConflicts/keys=1000/sstKeys=100/overlap=true/prefixSeek=false-24        32.3kB ± 0%    31.6kB ± 0%   -2.29%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=100/overlap=true/prefixSeek=true-24         31.7kB ± 0%    31.7kB ± 0%     ~     (p=0.841 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=1000/overlap=false/prefixSeek=false-24      31.6kB ± 0%    31.6kB ± 0%     ~     (p=0.095 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=1000/overlap=false/prefixSeek=true-24         161B ± 0%      161B ± 0%     ~     (p=0.333 n=4+5)
CheckSSTConflicts/keys=1000/sstKeys=1000/overlap=true/prefixSeek=false-24       39.3kB ± 0%    31.6kB ± 0%  -19.70%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=1000/overlap=true/prefixSeek=true-24        31.7kB ± 0%    31.7kB ± 0%     ~     (p=0.841 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=10000/overlap=false/prefixSeek=false-24     31.6kB ± 0%    31.5kB ± 0%     ~     (p=0.278 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=10000/overlap=false/prefixSeek=true-24        160B ± 0%      160B ± 0%     ~     (p=0.444 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=10000/overlap=true/prefixSeek=false-24      39.4kB ± 0%    31.7kB ± 0%  -19.56%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=10000/overlap=true/prefixSeek=true-24       32.2kB ± 0%    32.2kB ± 1%     ~     (p=1.000 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=10/overlap=false/prefixSeek=false-24       31.5kB ± 0%    31.5kB ± 0%   +0.03%  (p=0.032 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=10/overlap=false/prefixSeek=true-24          160B ± 0%      160B ± 0%     ~     (all equal)
CheckSSTConflicts/keys=10000/sstKeys=10/overlap=true/prefixSeek=false-24        31.5kB ± 0%    31.5kB ± 0%   -0.16%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=10/overlap=true/prefixSeek=true-24         31.6kB ± 0%    31.6kB ± 0%     ~     (p=0.722 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=100/overlap=false/prefixSeek=false-24      31.5kB ± 0%    31.5kB ± 0%     ~     (p=0.413 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=100/overlap=false/prefixSeek=true-24         160B ± 0%      160B ± 0%     ~     (all equal)
CheckSSTConflicts/keys=10000/sstKeys=100/overlap=true/prefixSeek=false-24       32.2kB ± 0%    31.5kB ± 0%   -2.35%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=100/overlap=true/prefixSeek=true-24        31.6kB ± 0%    31.6kB ± 0%     ~     (p=0.889 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=1000/overlap=false/prefixSeek=false-24     31.5kB ± 0%    31.5kB ± 0%     ~     (p=0.984 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=1000/overlap=false/prefixSeek=true-24        160B ± 0%      160B ± 0%     ~     (all equal)
CheckSSTConflicts/keys=10000/sstKeys=1000/overlap=true/prefixSeek=false-24      39.6kB ± 0%    31.7kB ± 0%  -20.11%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=1000/overlap=true/prefixSeek=true-24       31.6kB ± 0%    31.6kB ± 0%     ~     (p=0.222 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=10000/overlap=false/prefixSeek=false-24    31.5kB ± 0%    31.5kB ± 0%     ~     (p=0.222 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=10000/overlap=false/prefixSeek=true-24       160B ± 0%      160B ± 0%     ~     (all equal)
CheckSSTConflicts/keys=10000/sstKeys=10000/overlap=true/prefixSeek=false-24      107kB ± 0%      32kB ± 0%  -70.33%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=10000/overlap=true/prefixSeek=true-24      32.0kB ± 1%    32.0kB ± 0%     ~     (p=0.690 n=5+5)

name                                                                          old allocs/op  new allocs/op  delta
CheckSSTConflicts/keys=1000/sstKeys=10/overlap=false/prefixSeek=false-24          88.0 ± 0%      88.0 ± 0%     ~     (all equal)
CheckSSTConflicts/keys=1000/sstKeys=10/overlap=false/prefixSeek=true-24           4.00 ± 0%      4.00 ± 0%     ~     (all equal)
CheckSSTConflicts/keys=1000/sstKeys=10/overlap=true/prefixSeek=false-24           97.0 ± 0%      89.0 ± 0%   -8.25%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=10/overlap=true/prefixSeek=true-24            90.0 ± 0%      90.0 ± 0%     ~     (all equal)
CheckSSTConflicts/keys=1000/sstKeys=100/overlap=false/prefixSeek=false-24         88.0 ± 0%      88.0 ± 0%     ~     (all equal)
CheckSSTConflicts/keys=1000/sstKeys=100/overlap=false/prefixSeek=true-24          4.00 ± 0%      4.00 ± 0%     ~     (all equal)
CheckSSTConflicts/keys=1000/sstKeys=100/overlap=true/prefixSeek=false-24           187 ± 0%        89 ± 0%  -52.41%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=100/overlap=true/prefixSeek=true-24           90.0 ± 0%      90.0 ± 0%     ~     (all equal)
CheckSSTConflicts/keys=1000/sstKeys=1000/overlap=false/prefixSeek=false-24        88.0 ± 0%      88.0 ± 0%     ~     (all equal)
CheckSSTConflicts/keys=1000/sstKeys=1000/overlap=false/prefixSeek=true-24         4.00 ± 0%      4.00 ± 0%     ~     (all equal)
CheckSSTConflicts/keys=1000/sstKeys=1000/overlap=true/prefixSeek=false-24        1.09k ± 0%     0.09k ± 0%  -91.81%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=1000/sstKeys=1000/overlap=true/prefixSeek=true-24          90.0 ± 0%      90.0 ± 0%     ~     (all equal)
CheckSSTConflicts/keys=1000/sstKeys=10000/overlap=false/prefixSeek=false-24       88.0 ± 0%      88.0 ± 0%     ~     (all equal)
CheckSSTConflicts/keys=1000/sstKeys=10000/overlap=false/prefixSeek=true-24        4.00 ± 0%      4.00 ± 0%     ~     (all equal)
CheckSSTConflicts/keys=1000/sstKeys=10000/overlap=true/prefixSeek=false-24       1.09k ± 0%     0.09k ± 0%     ~     (p=0.079 n=4+5)
CheckSSTConflicts/keys=1000/sstKeys=10000/overlap=true/prefixSeek=true-24         91.0 ± 0%      91.0 ± 0%     ~     (all equal)
CheckSSTConflicts/keys=10000/sstKeys=10/overlap=false/prefixSeek=false-24         87.0 ± 0%      87.6 ± 1%     ~     (p=0.167 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=10/overlap=false/prefixSeek=true-24          4.00 ± 0%      4.00 ± 0%     ~     (all equal)
CheckSSTConflicts/keys=10000/sstKeys=10/overlap=true/prefixSeek=false-24          96.0 ± 0%      88.0 ± 0%   -8.33%  (p=0.000 n=5+4)
CheckSSTConflicts/keys=10000/sstKeys=10/overlap=true/prefixSeek=true-24           89.0 ± 0%      89.4 ± 1%     ~     (p=0.556 n=4+5)
CheckSSTConflicts/keys=10000/sstKeys=100/overlap=false/prefixSeek=false-24        87.0 ± 0%      87.0 ± 0%     ~     (all equal)
CheckSSTConflicts/keys=10000/sstKeys=100/overlap=false/prefixSeek=true-24         4.00 ± 0%      4.00 ± 0%     ~     (all equal)
CheckSSTConflicts/keys=10000/sstKeys=100/overlap=true/prefixSeek=false-24          186 ± 0%        88 ± 1%  -52.58%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=100/overlap=true/prefixSeek=true-24          89.6 ± 1%      89.6 ± 1%     ~     (p=1.000 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=1000/overlap=false/prefixSeek=false-24       87.0 ± 0%      87.0 ± 0%     ~     (all equal)
CheckSSTConflicts/keys=10000/sstKeys=1000/overlap=false/prefixSeek=true-24        4.00 ± 0%      4.00 ± 0%     ~     (all equal)
CheckSSTConflicts/keys=10000/sstKeys=1000/overlap=true/prefixSeek=false-24       1.09k ± 0%     0.09k ± 0%  -91.81%  (p=0.008 n=5+5)
CheckSSTConflicts/keys=10000/sstKeys=1000/overlap=true/prefixSeek=true-24         89.0 ± 0%      89.6 ± 1%     ~     (p=0.238 n=4+5)
CheckSSTConflicts/keys=10000/sstKeys=10000/overlap=false/prefixSeek=false-24      87.4 ± 1%      87.0 ± 0%     ~     (p=0.333 n=5+4)
CheckSSTConflicts/keys=10000/sstKeys=10000/overlap=false/prefixSeek=true-24       4.00 ± 0%      4.00 ± 0%     ~     (all equal)
CheckSSTConflicts/keys=10000/sstKeys=10000/overlap=true/prefixSeek=false-24      9.52k ± 0%     0.09k ± 0%  -99.05%  (p=0.000 n=5+4)
CheckSSTConflicts/keys=10000/sstKeys=10000/overlap=true/prefixSeek=true-24        90.8 ± 1%      91.0 ± 0%     ~     (p=0.556 n=5+4
```

Fix #90482.
Epic: None
Release note: None