### PR TITLE
clisqlshell: make the input to `\set` more flexible

### DIFF
--- a/pkg/cli/clisqlshell/sql_test.go
+++ b/pkg/cli/clisqlshell/sql_test.go
@@ -175,10 +175,10 @@ func Example_sql_config() {
 	// invalid syntax: \set unknownoption. Try \? for help.
 	// ERROR: -e: invalid syntax
 	// sql --set display_format=invalidvalue -e select 123 as "123"
-	// \set display_format invalidvalue: invalid table display format: invalidvalue (possible values: tsv, csv, table, records, sql, html, raw)
+	// \set display_format=invalidvalue: invalid table display format: invalidvalue (possible values: tsv, csv, table, records, sql, html, raw)
 	// ERROR: -e: invalid table display format: invalidvalue (possible values: tsv, csv, table, records, sql, html, raw)
 	// sql -e \set display_format=invalidvalue -e select 123 as "123"
-	// \set display_format invalidvalue: invalid table display format: invalidvalue (possible values: tsv, csv, table, records, sql, html, raw)
+	// \set display_format=invalidvalue: invalid table display format: invalidvalue (possible values: tsv, csv, table, records, sql, html, raw)
 	// ERROR: -e: invalid table display format: invalidvalue (possible values: tsv, csv, table, records, sql, html, raw)
 }
 


### PR DESCRIPTION
Fixes #88270.

Prior to this change, `\set a = b` would report an error; also `\set a =b` did not work, and it was not possible to add spaces to the prompt with e.g. `\set prompt1 "a b"`.

Release note (cli change): The input syntax of `\set` is now more flexible: it is now more accepting of space characters in various positions of the syntax, and it supports quoted values, e.g. via `\set prompt1 "a b c"`.