### PR TITLE
server: start purging web_sessions in secondary tenants

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -938,11 +938,6 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		kvMemoryMonitor:        kvMemoryMonitor,
 	}
 
-	// Begin an async task to periodically purge old sessions in the system.web_sessions table.
-	if err = startPurgeOldSessions(ctx, sAuth); err != nil {
-		return nil, err
-	}
-
 	return lateBoundServer, err
 }
 
@@ -1591,6 +1586,11 @@ func (s *Server) PreStart(ctx context.Context) error {
 	// count it as a KV operation since it grooms cluster-wide data, not
 	// something associated to SQL tenants.
 	s.startSystemLogsGC(ctx)
+
+	// Begin an async task to periodically purge old sessions in the system.web_sessions table.
+	if err = startPurgeOldSessions(ctx, s.authentication); err != nil {
+		return err
+	}
 
 	// Connect the HTTP endpoints. This also wraps the privileged HTTP
 	// endpoints served by gwMux by the HTTP cookie authentication

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -285,6 +285,11 @@ func startTenantInternal(
 
 	httpServer.handleHealth(gwMux)
 
+	// Begin an async task to periodically purge old sessions in the system.web_sessions table.
+	if err := startPurgeOldSessions(ctx, authServer); err != nil {
+		return nil, nil, nil, "", "", err
+	}
+
 	// TODO(knz): Add support for the APIv2 tree here.
 	if err := httpServer.setupRoutes(ctx,
 		authServer,      /* authnServer */


### PR DESCRIPTION
Fixes #90522.

The next PR #90384 will ensure this code lands in the right place.
