### PR TITLE
bazci: fix incorrect error return

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -281,7 +281,6 @@ ALL_TESTS = [
     "//pkg/sql/catalog/catprivilege:catprivilege_test",
     "//pkg/sql/catalog/colinfo:colinfo_test",
     "//pkg/sql/catalog/dbdesc:dbdesc_test",
-    "//pkg/sql/catalog/descpb:catalog_disallowed_imports_test",
     "//pkg/sql/catalog/descpb:descpb_test",
     "//pkg/sql/catalog/descs:descs_test",
     "//pkg/sql/catalog/funcdesc:funcdesc_test",

--- a/pkg/cmd/bazci/bazci.go
+++ b/pkg/cmd/bazci/bazci.go
@@ -317,9 +317,9 @@ func bazciImpl(cmd *cobra.Command, args []string) (retErr error) {
 	bazelCmd := exec.Command("bazel", args...)
 	bazelCmd.Stdout = os.Stdout
 	bazelCmd.Stderr = os.Stderr
-	err := bazelCmd.Run()
-	if err != nil {
-		fmt.Printf("got error %+v from bazel run\n", err)
+	retErr = bazelCmd.Run()
+	if retErr != nil {
+		fmt.Printf("got error %+v from bazel run\n", retErr)
 	}
 	server.Wait()
 	return

--- a/pkg/sql/catalog/descpb/BUILD.bazel
+++ b/pkg/sql/catalog/descpb/BUILD.bazel
@@ -3,7 +3,6 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 load("//build:STRINGER.bzl", "stringer")
-load("//pkg/testutils/buildutil:buildutil.bzl", "disallowed_imports_test")
 
 go_library(
     name = "descpb",
@@ -24,6 +23,7 @@ go_library(
     deps = [
         "//pkg/keys",
         "//pkg/sql/catalog/catpb",
+        "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/protoreflect",
@@ -93,11 +93,6 @@ stringer(
     name = "gen-formatversion-stringer",
     src = "structured.go",
     typ = "FormatVersion",
-)
-
-disallowed_imports_test(
-    "catalog",
-    disallowed_list = ["//pkg/sql/parser"],
 )
 
 get_x_data(name = "get_x_data")

--- a/pkg/sql/catalog/descpb/column.go
+++ b/pkg/sql/catalog/descpb/column.go
@@ -11,11 +11,26 @@
 package descpb
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
+	"github.com/cockroachdb/errors"
 )
+
+// HasNullDefault checks that the column descriptor has a default of NULL.
+func (desc *ColumnDescriptor) HasNullDefault() bool {
+	if !desc.HasDefault() {
+		return false
+	}
+	defaultExpr, err := parser.ParseExpr(*desc.DefaultExpr)
+	if err != nil {
+		panic(errors.NewAssertionErrorWithWrappedErrf(err,
+			"failed to parse default expression %s", *desc.DefaultExpr))
+	}
+	return defaultExpr == tree.DNull
+}
 
 // HasDefault returns true if the column has a default value.
 func (desc *ColumnDescriptor) HasDefault() bool {

--- a/pkg/sql/catalog/table_elements.go
+++ b/pkg/sql/catalog/table_elements.go
@@ -292,10 +292,6 @@ type Column interface {
 	// HasDefault returns true iff the column has a default expression set.
 	HasDefault() bool
 
-	// HasNullDefault returns true if the column has a default expression and
-	// that expression is NULL.
-	HasNullDefault() bool
-
 	// GetDefaultExpr returns the column default expression if it exists,
 	// empty string otherwise.
 	GetDefaultExpr() string
@@ -812,7 +808,7 @@ func ColumnNeedsBackfill(col Column) bool {
 	//  - computed columns
 	//  - non-nullable columns (note: if a non-nullable column doesn't have a
 	//    default value, the backfill will fail unless the table is empty).
-	if col.HasNullDefault() {
+	if col.ColumnDesc().HasNullDefault() {
 		return false
 	}
 	return col.HasDefault() || !col.IsNullable() || col.IsComputed()

--- a/pkg/sql/catalog/tabledesc/column.go
+++ b/pkg/sql/catalog/tabledesc/column.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
-	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -102,19 +101,6 @@ func (w column) IsNullable() bool {
 // HasDefault returns true iff the column has a default expression set.
 func (w column) HasDefault() bool {
 	return w.desc.HasDefault()
-}
-
-// HasNullDefault checks that the column descriptor has a default of NULL.
-func (w column) HasNullDefault() bool {
-	if !w.HasDefault() {
-		return false
-	}
-	// We ignore the error because what are we going to do with it? It means
-	// that the default expressions is not parsable. Somebody with a context
-	// who needs to use it will be in a better place to log it. If it is not
-	// parsable, it is not NULL.
-	defaultExpr, _ := parser.ParseExpr(w.GetDefaultExpr())
-	return defaultExpr == tree.DNull
 }
 
 // GetDefaultExpr returns the column default expression if it exists,


### PR DESCRIPTION
In a recent change, the way `bazci` returns bazel errors was changed and they were not being returned (assigned) properly which made TeamCity unit tests build check succeed even if some test targets fail to build (normally in this case bazel exits without running remaining tests with an error and TeamCity build check fails but now TeamCity build check falsely succeeds). This happened on all branches that rebased as far as the offending commit.

This PR fixes `bazci's` error and reverts a commit that falsely succeeded due to the issue. `master` should be green when this PR is merged.

Release branches are not affected because the offending PR wasn’t backported to any release branch.

Release note: None
Epic: none