### PR TITLE
sql/catalog/resolver: skip offline tables when resolving indexes

### DIFF
--- a/pkg/sql/catalog/resolver/resolver.go
+++ b/pkg/sql/catalog/resolver/resolver.go
@@ -791,6 +791,9 @@ func findTableContainingIndex(
 	}
 
 	lflags := tree.ObjectLookupFlags{
+		CommonLookupFlags: tree.CommonLookupFlags{
+			IncludeOffline: true,
+		},
 		DesiredObjectKind:    tree.TableObject,
 		DesiredTableDescKind: tree.ResolveAnyTableKind,
 	}
@@ -799,7 +802,7 @@ func findTableContainingIndex(
 		if err != nil {
 			return false, nil, nil, err
 		}
-		if candidateTbl == nil || !(candidateTbl.IsTable() || candidateTbl.MaterializedView()) {
+		if candidateTbl == nil || !(candidateTbl.IsTable() || candidateTbl.MaterializedView()) || candidateTbl.Offline() {
 			continue
 		}
 


### PR DESCRIPTION
Fixes #89708

Previously, we have `IncludeOffline=false` in the lookup flag used to resolve table when looping through all tables to find an index. This is problematic because it errored out if a table has been taken offline. This pr sets the flag to `true` and skip offline table explicitly.

Epic: None

Release note: None