### PR TITLE
ci: prevent using arm64 image in docker build

### DIFF
--- a/build/release/teamcity-publish-redhat-release.sh
+++ b/build/release/teamcity-publish-redhat-release.sh
@@ -56,6 +56,7 @@ sed \
 cat build/deploy-redhat/Dockerfile
 
 docker build --no-cache \
+  --pull \
   --label release=$rhel_release \
   --tag=${rhel_repository}:${build_name} \
   build/deploy-redhat

--- a/build/teamcity/internal/release/process/make-and-publish-build-artifacts.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-artifacts.sh
@@ -76,7 +76,8 @@ curl -f -s -S -o- "https://${bucket}.s3.amazonaws.com/cockroach-${build_name}.li
 cp cockroach lib/libgeos.so lib/libgeos_c.so build/deploy
 cp -r licenses build/deploy/
 
-docker build --no-cache --tag="${gcr_repository}:${build_name}" build/deploy
+docker rmi registry.access.redhat.com/ubi8/ubi-minimal || true
+docker build --pull --platform linux/amd64 --no-cache --tag="${gcr_repository}:${build_name}" build/deploy
 docker push "${gcr_repository}:${build_name}"
 tc_end_block "Make and push docker image"
 

--- a/build/teamcity/internal/release/process/publish-cockroach-release.sh
+++ b/build/teamcity/internal/release/process/publish-cockroach-release.sh
@@ -105,7 +105,12 @@ curl -f -s -S -o- "https://${s3_download_hostname}/cockroach-${build_name}.linux
 cp cockroach lib/libgeos.so lib/libgeos_c.so build/deploy
 cp -r licenses build/deploy/
 
+# Try to remove the base image before building. This should prevent platform mismatch.
+docker rmi registry.access.redhat.com/ubi8/ubi-minimal || true
+# Explicitly use amd64 as a platform to prevent using a worng image
 docker build \
+  --pull \
+  --platform linux/amd64 \
   --label version=$version \
   --no-cache \
   --tag=${dockerhub_repository}:{"$build_name",latest,latest-"${release_branch}"} \


### PR DESCRIPTION
Previously, if the agent had a docker image used by `docker build`, but the base image is for a different platform, this would lead to the situation, where the target image uses arm64, but the cockroach binaries inside are amd64.

This patch adds a few guards to prevent the issue:

* Remove the base image
* Use `--pull` to always pull the latest image
* Explicitly specify the target platform

Release note: None