### PR TITLE
release-22.2: server, sql, ui: add plan gist to active queries, add explain plan to active stms and insights

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -2139,6 +2139,7 @@ ActiveQuery represents a query in flight on some Session.
 | sql_summary | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | A summarized version of the sql query. | [reserved](#support-status) |
 | is_full_scan | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  | True if the query contains a full table or index scan. Note that this field is only valid if the query is in the EXECUTING phase. | [reserved](#support-status) |
 | elapsed_time | [google.protobuf.Duration](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Duration) |  | Time elapsed since this query started execution. | [reserved](#support-status) |
+| plan_gist | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The compressed plan that can be converted back into the statement's logical plan. Empty if the statement is in the PREPARING state. | [reserved](#support-status) |
 
 
 
@@ -2281,6 +2282,7 @@ ActiveQuery represents a query in flight on some Session.
 | sql_summary | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | A summarized version of the sql query. | [reserved](#support-status) |
 | is_full_scan | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  | True if the query contains a full table or index scan. Note that this field is only valid if the query is in the EXECUTING phase. | [reserved](#support-status) |
 | elapsed_time | [google.protobuf.Duration](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Duration) |  | Time elapsed since this query started execution. | [reserved](#support-status) |
+| plan_gist | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The compressed plan that can be converted back into the statement's logical plan. Empty if the statement is in the PREPARING state. | [reserved](#support-status) |
 
 
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
@@ -215,15 +215,15 @@ SELECT * FROM crdb_internal.session_variables WHERE variable = ''
 ----
 variable  value  hidden
 
-query TTITTTTTTBTB colnames
+query TTITTTTTTBTBT colnames
 SELECT * FROM crdb_internal.node_queries WHERE node_id < 0
 ----
-query_id  txn_id  node_id  session_id user_name  start  query  client_address  application_name  distributed  phase  full_scan
+query_id  txn_id  node_id  session_id  user_name  start  query  client_address  application_name  distributed  phase  full_scan  plan_gist
 
-query TTITTTTTTBTB colnames
+query TTITTTTTTBTBT colnames
 SELECT * FROM crdb_internal.cluster_queries WHERE node_id < 0
 ----
-query_id  txn_id  node_id  session_id user_name  start  query  client_address  application_name  distributed  phase  full_scan
+query_id  txn_id  node_id  session_id  user_name  start  query  client_address  application_name  distributed  phase  full_scan  plan_gist
 
 query TITTTTIIIT colnames
 SELECT  * FROM crdb_internal.node_transactions WHERE node_id < 0

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -912,6 +912,10 @@ message ActiveQuery {
   // Time elapsed since this query started execution.
   google.protobuf.Duration elapsed_time = 11
   [ (gogoproto.nullable) = false, (gogoproto.stdduration) = true ];
+
+  // The compressed plan that can be converted back into the statement's logical plan.
+  // Empty if the statement is in the PREPARING state.
+  string plan_gist = 12;
 }
 
 // Request object for ListSessions and ListLocalSessions.

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3195,6 +3195,7 @@ func (ex *connExecutor) serialize() serverpb.Session {
 			Phase:          (serverpb.ActiveQuery_Phase)(query.phase),
 			Progress:       float32(progress),
 			IsFullScan:     query.isFullScan,
+			PlanGist:       query.planGist,
 		})
 	}
 	lastActiveQuery := ""

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1129,6 +1129,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 		if !ok {
 			return nil, errors.AssertionFailedf("query %d not in registry", stmt.QueryID)
 		}
+		queryMeta.planGist = planner.instrumentation.planGist.String()
 		queryMeta.phase = executing
 		// TODO(yuzefovich): introduce ternary PlanDistribution into queryMeta.
 		queryMeta.isDistributed = distributePlan.WillDistribute()

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1962,6 +1962,10 @@ type queryMeta struct {
 	hidden bool
 
 	progressAtomic uint64
+
+	// The compressed plan for this query. This can converted  back into the
+	// logical plan. This field will only be populated in the EXECUTING phase.
+	planGist string
 }
 
 // cancel cancels the query associated with this queryMeta, by closing the

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -347,15 +347,15 @@ SELECT * FROM crdb_internal.session_variables WHERE variable = ''
 ----
 variable  value  hidden
 
-query TTITTTTTTBTB colnames
+query TTITTTTTTBTBT colnames
 SELECT * FROM crdb_internal.node_queries WHERE node_id < 0
 ----
-query_id  txn_id  node_id  session_id user_name  start  query  client_address  application_name  distributed  phase  full_scan
+query_id  txn_id  node_id  session_id  user_name  start  query  client_address  application_name  distributed  phase  full_scan  plan_gist
 
-query TTITTTTTTBTB colnames
+query TTITTTTTTBTBT colnames
 SELECT * FROM crdb_internal.cluster_queries WHERE node_id < 0
 ----
-query_id  txn_id  node_id  session_id user_name  start  query  client_address  application_name  distributed  phase  full_scan
+query_id  txn_id  node_id  session_id  user_name  start  query  client_address  application_name  distributed  phase  full_scan  plan_gist
 
 query TITTTTIIIT colnames
 SELECT  * FROM crdb_internal.node_transactions WHERE node_id < 0

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -366,7 +366,8 @@ CREATE TABLE crdb_internal.cluster_queries (
    application_name STRING NULL,
    distributed BOOL NULL,
    phase STRING NULL,
-   full_scan BOOL NULL
+   full_scan BOOL NULL,
+   plan_gist STRING NULL
 )  CREATE TABLE crdb_internal.cluster_queries (
    query_id STRING NULL,
    txn_id UUID NULL,
@@ -379,7 +380,8 @@ CREATE TABLE crdb_internal.cluster_queries (
    application_name STRING NULL,
    distributed BOOL NULL,
    phase STRING NULL,
-   full_scan BOOL NULL
+   full_scan BOOL NULL,
+   plan_gist STRING NULL
 )  {}  {}
 CREATE TABLE crdb_internal.cluster_sessions (
    node_id INT8 NOT NULL,
@@ -1058,7 +1060,8 @@ CREATE TABLE crdb_internal.node_queries (
    application_name STRING NULL,
    distributed BOOL NULL,
    phase STRING NULL,
-   full_scan BOOL NULL
+   full_scan BOOL NULL,
+   plan_gist STRING NULL
 )  CREATE TABLE crdb_internal.node_queries (
    query_id STRING NULL,
    txn_id UUID NULL,
@@ -1071,7 +1074,8 @@ CREATE TABLE crdb_internal.node_queries (
    application_name STRING NULL,
    distributed BOOL NULL,
    phase STRING NULL,
-   full_scan BOOL NULL
+   full_scan BOOL NULL,
+   plan_gist STRING NULL
 )  {}  {}
 CREATE TABLE crdb_internal.node_runtime_info (
    node_id INT8 NOT NULL,

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementUtils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementUtils.ts
@@ -121,6 +121,7 @@ export function getActiveExecutionsFromSessions(
           user: session.username,
           clientAddress: session.client_address,
           isFullScan: query.is_full_scan || false, // Or here is for conversion in case the field is null.
+          planGist: query.plan_gist,
         };
 
         statements.push(activeStmt);

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/types.ts
@@ -41,6 +41,7 @@ export type ActiveStatement = ActiveExecution &
     user: string;
     clientAddress: string;
     isFullScan: boolean;
+    planGist?: string;
   };
 
 export type ActiveTransaction = ActiveExecution & {

--- a/pkg/ui/workspaces/cluster-ui/src/api/decodePlanGistApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/decodePlanGistApi.ts
@@ -1,0 +1,68 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { SqlExecutionRequest, executeInternalSql } from "./sqlApi";
+
+export type DecodePlanGistResponse = {
+  explainPlan?: string;
+  error?: string;
+};
+
+export type DecodePlanGistRequest = {
+  planGist: string;
+};
+
+type DecodePlanGistColumns = {
+  plan_row: string;
+};
+
+/**
+ * getExplainPlanFromGist decodes the provided planGist into the logical
+ * plan string.
+ * @param req the request providing the planGist
+ */
+export function getExplainPlanFromGist(
+  req: DecodePlanGistRequest,
+): Promise<DecodePlanGistResponse> {
+  const request: SqlExecutionRequest = {
+    statements: [
+      {
+        sql: `SELECT crdb_internal.decode_plan_gist('${req.planGist}') as plan_row`,
+      },
+    ],
+    execute: true,
+    timeout: "10s",
+  };
+
+  return executeInternalSql<DecodePlanGistColumns>(request).then(result => {
+    if (
+      result.execution.txn_results.length === 0 ||
+      !result.execution.txn_results[0].rows
+    ) {
+      return {
+        error: result.execution.txn_results
+          ? result.execution.txn_results[0].error?.message
+          : null,
+      };
+    }
+
+    if (result.execution.txn_results[0].error) {
+      return {
+        error: result.execution.txn_results[0].error.message,
+      };
+    }
+
+    const explainPlan = result.execution.txn_results[0].rows
+      .map(col => col.plan_row)
+      .join("\n");
+
+    return { explainPlan };
+  });
+}

--- a/pkg/ui/workspaces/cluster-ui/src/api/insightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/insightsApi.ts
@@ -589,6 +589,7 @@ type ExecutionInsightsResponseRow = {
   causes: string[];
   problem: string;
   index_recommendations: string[];
+  plan_gist: string;
 };
 
 export type StatementInsights = StatementInsightEvent[];
@@ -628,6 +629,7 @@ function getStatementInsightsFromClusterExecutionInsightsResponse(
       problem: row.problem,
       indexRecommendations: row.index_recommendations,
       insights: null,
+      planGist: row.plan_gist,
     };
   });
 }
@@ -667,6 +669,7 @@ const statementInsightsQuery: InsightQuery<
       index_recommendations,
       problem,
       causes,
+      plan_gist,
       row_number()                          OVER (
         PARTITION BY txn_fingerprint_id
         ORDER BY end_time DESC

--- a/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
@@ -89,6 +89,7 @@ export type StatementInsightEvent = {
   application: string;
   insights: Insight[];
   indexRecommendations: string[];
+  planGist: string;
 };
 
 export type Insight = {

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/insightsDetails.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/insightsDetails.module.scss
@@ -1,0 +1,3 @@
+.section {
+  padding: 12px 24px 12px 0px;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
@@ -7,120 +7,39 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
-import React, { useContext, useMemo } from "react";
+import React, { useState } from "react";
 import Helmet from "react-helmet";
 import { RouteComponentProps } from "react-router-dom";
 import { ArrowLeft } from "@cockroachlabs/icons";
-import { Col, Row } from "antd";
+import { Row, Col, Tabs } from "antd";
+import "antd/lib/tabs/style";
 import "antd/lib/col/style";
 import "antd/lib/row/style";
 import { Button } from "src/button";
 import { Loading } from "src/loading";
 import { SqlBox, SqlBoxSize } from "src/sql";
-import { SummaryCard, SummaryCardItem } from "src/summaryCard";
-import { capitalize, Duration } from "src/util";
-import { DATE_FORMAT_24_UTC } from "src/util/format";
 import { getMatchParamByName } from "src/util/query";
-import {
-  InsightsSortedTable,
-  makeInsightsColumns,
-} from "src/insightsTable/insightsTable";
-import { populateStatementInsightsFromProblemAndCauses } from "../utils";
-import {
-  InsightNameEnum,
-  StatementInsightEvent,
-  executionDetails,
-  InsightRecommendation,
-} from "../types";
+import { StatementInsightEvent } from "../types";
 import { InsightsError } from "../insightsErrorComponent";
-
 import classNames from "classnames/bind";
+
 import { commonStyles } from "src/common";
-import insightTableStyles from "src/insightsTable/insightsTable.module.scss";
-import summaryCardStyles from "src/summaryCard/summaryCard.module.scss";
-import { CockroachCloudContext } from "../../contexts";
+import { getExplainPlanFromGist } from "src/api/decodePlanGistApi";
+import { StatementInsightDetailsOverviewTab } from "./statementInsightDetailsOverviewTab";
 
-const tableCx = classNames.bind(insightTableStyles);
-const summaryCardStylesCx = classNames.bind(summaryCardStyles);
+// Styles
+import insightsDetailsStyles from "src/insights/workloadInsightDetails/insightsDetails.module.scss";
 
-const insightsTableData = (
-  insightDetails: StatementInsightEvent | null,
-): InsightRecommendation[] => {
-  if (!insightDetails) return [];
+const cx = classNames.bind(insightsDetailsStyles);
 
-  const recs: InsightRecommendation[] = [];
-  let rec: InsightRecommendation;
-  const execDetails: executionDetails = {
-    statement: insightDetails.query,
-    fingerprintID: insightDetails.statementFingerprintID,
-    retries: insightDetails.retries,
-  };
-  insightDetails.insights.forEach(insight => {
-    switch (insight.name) {
-      case InsightNameEnum.highContention:
-        rec = {
-          type: "HighContention",
-          execution: execDetails,
-          details: {
-            duration: insightDetails.elapsedTimeMillis,
-            description: insight.description,
-          },
-        };
-        break;
-      case InsightNameEnum.failedExecution:
-        rec = {
-          type: "FailedExecution",
-        };
-        break;
-      case InsightNameEnum.highRetryCount:
-        rec = {
-          type: "HighRetryCount",
-          execution: execDetails,
-          details: {
-            description: insight.description,
-          },
-        };
-        break;
-      case InsightNameEnum.planRegression:
-        rec = {
-          type: "PlanRegression",
-          execution: execDetails,
-          details: {
-            description: insight.description,
-          },
-        };
-        break;
-      case InsightNameEnum.suboptimalPlan:
-        rec = {
-          type: "SuboptimalPlan",
-          database: insightDetails.databaseName,
-          execution: {
-            ...execDetails,
-            indexRecommendations: insightDetails.indexRecommendations,
-          },
-          details: {
-            description: insight.description,
-          },
-        };
-        break;
-      default:
-        rec = {
-          type: "Unknown",
-          details: {
-            duration: insightDetails.elapsedTimeMillis,
-            description: insight.description,
-          },
-        };
-        break;
-    }
-    recs.push(rec);
-  });
-  return recs;
-};
-
+enum TabKeysEnum {
+  OVERVIEW = "overview",
+  EXPLAIN = "explain",
+}
 export interface StatementInsightDetailsStateProps {
   insightEventDetails: StatementInsightEvent;
   insightError: Error | null;
+  isTenant?: boolean;
 }
 
 export type StatementInsightDetailsProps = StatementInsightDetailsStateProps &
@@ -128,130 +47,89 @@ export type StatementInsightDetailsProps = StatementInsightDetailsStateProps &
 
 export const StatementInsightDetails: React.FC<
   StatementInsightDetailsProps
-> = ({ history, insightEventDetails, insightError, match }) => {
-  const isCockroachCloud = useContext(CockroachCloudContext);
+> = ({ history, insightEventDetails, insightError, match, isTenant }) => {
+  const [explain, setExplain] = useState<string>(null);
 
   const prevPage = (): void => history.goBack();
 
-  const insightsColumns = useMemo(
-    () => makeInsightsColumns(isCockroachCloud),
-    [isCockroachCloud],
-  );
+  const onTabClick = (key: TabKeysEnum) => {
+    if (
+      !isTenant &&
+      key === TabKeysEnum.EXPLAIN &&
+      insightEventDetails?.planGist &&
+      !explain
+    ) {
+      // Get the explain plan.
+      getExplainPlanFromGist({ planGist: insightEventDetails.planGist }).then(
+        res => {
+          setExplain(res.explainPlan || res.error);
+        },
+      );
+    }
+  };
 
-  const insightDetailsArr = useMemo(() => {
-    const eventDetails = [insightEventDetails];
-    populateStatementInsightsFromProblemAndCauses(eventDetails);
-    return eventDetails;
-  }, [insightEventDetails]);
-  const insightDetails = insightDetailsArr.length ? insightDetailsArr[0] : null;
-  const tableData = insightsTableData(insightDetails);
+  const executionID = getMatchParamByName(match, "id");
 
   return (
     <div>
       <Helmet title={"Details | Insight"} />
+      <Button
+        onClick={prevPage}
+        type="unstyled-link"
+        size="small"
+        icon={<ArrowLeft fontSize={"10px"} />}
+        iconPosition="left"
+        className={commonStyles("small-margin")}
+      >
+        Insights
+      </Button>
+      <h3 className={commonStyles("base-heading", "no-margin-bottom")}>
+        Statement Execution ID: {executionID}
+      </h3>
       <div>
-        <Button
-          onClick={prevPage}
-          type="unstyled-link"
-          size="small"
-          icon={<ArrowLeft fontSize={"10px"} />}
-          iconPosition="left"
-          className={commonStyles("small-margin")}
-        >
-          Insights
-        </Button>
-        <h3
-          className={commonStyles("base-heading", "no-margin-bottom")}
-        >{`Statement Execution ID: ${String(
-          getMatchParamByName(match, "id"),
-        )}`}</h3>
-      </div>
-      <section>
         <Loading
           loading={insightEventDetails == null}
           page={"Transaction Insight details"}
           error={insightError}
           renderError={() => InsightsError()}
         >
-          <section className={tableCx("section")}>
-            <Row gutter={24}>
-              <Col className="gutter-row" span={24}>
-                <SqlBox size={SqlBoxSize.custom} value={insightDetails.query} />
+          <section className={cx("section")}>
+            <Row>
+              <Col span={24}>
+                <SqlBox
+                  size={SqlBoxSize.custom}
+                  value={insightEventDetails?.query}
+                />
               </Col>
-            </Row>
-            <Row gutter={24}>
-              <Col className="gutter-row" span={12}>
-                <SummaryCard>
-                  <SummaryCardItem
-                    label="Start Time"
-                    value={insightDetails.startTime.format(DATE_FORMAT_24_UTC)}
-                  />
-                  <SummaryCardItem
-                    label="End Time"
-                    value={insightDetails.endTime.format(DATE_FORMAT_24_UTC)}
-                  />
-                  <SummaryCardItem
-                    label="Elapsed Time"
-                    value={Duration(insightDetails.elapsedTimeMillis * 1e6)}
-                  />
-                  <SummaryCardItem
-                    label="Rows Read"
-                    value={insightDetails.rowsRead}
-                  />
-                  <SummaryCardItem
-                    label="Rows Written"
-                    value={insightDetails.rowsWritten}
-                  />
-                  <SummaryCardItem
-                    label="Transaction Priority"
-                    value={capitalize(insightDetails.priority)}
-                  />
-                  <SummaryCardItem
-                    label="Full Scan"
-                    value={capitalize(String(insightDetails.isFullScan))}
-                  />
-                </SummaryCard>
-              </Col>
-              <Col className="gutter-row" span={12}>
-                <SummaryCard>
-                  <SummaryCardItem
-                    label="Transaction Retries"
-                    value={insightDetails.retries}
-                  />
-                  {insightDetails.lastRetryReason && (
-                    <SummaryCardItem
-                      label="Last Retry Reason"
-                      value={insightDetails.lastRetryReason.toString()}
-                    />
-                  )}
-                  <p
-                    className={summaryCardStylesCx("summary--card__divider")}
-                  />
-                  <SummaryCardItem
-                    label="Session ID"
-                    value={String(insightDetails.sessionID)}
-                  />
-                  <SummaryCardItem
-                    label="Transaction Fingerprint ID"
-                    value={String(insightDetails.transactionFingerprintID)}
-                  />
-                  <SummaryCardItem
-                    label="Transaction Execution ID"
-                    value={String(insightDetails.transactionID)}
-                  />
-                  <SummaryCardItem
-                    label="Statement Fingerprint ID"
-                    value={String(insightDetails.statementFingerprintID)}
-                  />
-                </SummaryCard>
-              </Col>
-            </Row>
-            <Row gutter={24} className={tableCx("margin-bottom")}>
-              <InsightsSortedTable columns={insightsColumns} data={tableData} />
             </Row>
           </section>
+          <Tabs
+            className={commonStyles("cockroach--tabs")}
+            defaultActiveKey={TabKeysEnum.OVERVIEW}
+            onTabClick={onTabClick}
+          >
+            <Tabs.TabPane tab="Overview" key={TabKeysEnum.OVERVIEW}>
+              <StatementInsightDetailsOverviewTab
+                insightEventDetails={insightEventDetails}
+              />
+            </Tabs.TabPane>
+            {!isTenant && (
+              <Tabs.TabPane tab="Explain Plan" key={TabKeysEnum.EXPLAIN}>
+                <section className={cx("section")}>
+                  <Row gutter={24}>
+                    <Col span={24}>
+                      <SqlBox
+                        value={explain || "Not available."}
+                        size={SqlBoxSize.custom}
+                      />
+                    </Col>
+                  </Row>
+                </section>
+              </Tabs.TabPane>
+            )}
+          </Tabs>
         </Loading>
-      </section>
+      </div>
     </div>
   );
 };

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
-import React, { useContext } from "react";
+import React, { useContext, useMemo } from "react";
 import Helmet from "react-helmet";
 import { RouteComponentProps } from "react-router-dom";
 import { ArrowLeft } from "@cockroachlabs/icons";
@@ -43,6 +43,81 @@ import { CockroachCloudContext } from "../../contexts";
 const tableCx = classNames.bind(insightTableStyles);
 const summaryCardStylesCx = classNames.bind(summaryCardStyles);
 
+const insightsTableData = (
+  insightDetails: StatementInsightEvent | null,
+): InsightRecommendation[] => {
+  if (!insightDetails) return [];
+
+  const recs: InsightRecommendation[] = [];
+  let rec: InsightRecommendation;
+  const execDetails: executionDetails = {
+    statement: insightDetails.query,
+    fingerprintID: insightDetails.statementFingerprintID,
+    retries: insightDetails.retries,
+  };
+  insightDetails.insights.forEach(insight => {
+    switch (insight.name) {
+      case InsightNameEnum.highContention:
+        rec = {
+          type: "HighContention",
+          execution: execDetails,
+          details: {
+            duration: insightDetails.elapsedTimeMillis,
+            description: insight.description,
+          },
+        };
+        break;
+      case InsightNameEnum.failedExecution:
+        rec = {
+          type: "FailedExecution",
+        };
+        break;
+      case InsightNameEnum.highRetryCount:
+        rec = {
+          type: "HighRetryCount",
+          execution: execDetails,
+          details: {
+            description: insight.description,
+          },
+        };
+        break;
+      case InsightNameEnum.planRegression:
+        rec = {
+          type: "PlanRegression",
+          execution: execDetails,
+          details: {
+            description: insight.description,
+          },
+        };
+        break;
+      case InsightNameEnum.suboptimalPlan:
+        rec = {
+          type: "SuboptimalPlan",
+          database: insightDetails.databaseName,
+          execution: {
+            ...execDetails,
+            indexRecommendations: insightDetails.indexRecommendations,
+          },
+          details: {
+            description: insight.description,
+          },
+        };
+        break;
+      default:
+        rec = {
+          type: "Unknown",
+          details: {
+            duration: insightDetails.elapsedTimeMillis,
+            description: insight.description,
+          },
+        };
+        break;
+    }
+    recs.push(rec);
+  });
+  return recs;
+};
+
 export interface StatementInsightDetailsStateProps {
   insightEventDetails: StatementInsightEvent;
   insightError: Error | null;
@@ -51,202 +126,132 @@ export interface StatementInsightDetailsStateProps {
 export type StatementInsightDetailsProps = StatementInsightDetailsStateProps &
   RouteComponentProps<unknown>;
 
-export class StatementInsightDetails extends React.Component<StatementInsightDetailsProps> {
-  constructor(props: StatementInsightDetailsProps) {
-    super(props);
-  }
-  prevPage = (): void => this.props.history.goBack();
+export const StatementInsightDetails: React.FC<
+  StatementInsightDetailsProps
+> = ({ history, insightEventDetails, insightError, match }) => {
+  const isCockroachCloud = useContext(CockroachCloudContext);
 
-  renderContent = (): React.ReactElement => {
-    const insightDetailsArr = [this.props.insightEventDetails];
-    populateStatementInsightsFromProblemAndCauses(insightDetailsArr);
-    const insightDetails = insightDetailsArr[0];
-    const isCockroachCloud = useContext(CockroachCloudContext);
-    const insightsColumns = makeInsightsColumns(isCockroachCloud);
-    function insightsTableData(): InsightRecommendation[] {
-      const recs: InsightRecommendation[] = [];
-      let rec: InsightRecommendation;
-      const execDetails: executionDetails = {
-        statement: insightDetails.query,
-        fingerprintID: insightDetails.statementFingerprintID,
-        retries: insightDetails.retries,
-      };
+  const prevPage = (): void => history.goBack();
 
-      insightDetails.insights.forEach(insight => {
-        switch (insight.name) {
-          case InsightNameEnum.highContention:
-            rec = {
-              type: "HighContention",
-              execution: execDetails,
-              details: {
-                duration: insightDetails.elapsedTimeMillis,
-                description: insight.description,
-              },
-            };
-            break;
-          case InsightNameEnum.failedExecution:
-            rec = {
-              type: "FailedExecution",
-            };
-            break;
-          case InsightNameEnum.highRetryCount:
-            rec = {
-              type: "HighRetryCount",
-              execution: execDetails,
-              details: {
-                description: insight.description,
-              },
-            };
-            break;
-          case InsightNameEnum.planRegression:
-            rec = {
-              type: "PlanRegression",
-              execution: execDetails,
-              details: {
-                description: insight.description,
-              },
-            };
-            break;
-          case InsightNameEnum.suboptimalPlan:
-            rec = {
-              type: "SuboptimalPlan",
-              database: insightDetails.databaseName,
-              execution: {
-                ...execDetails,
-                indexRecommendations: insightDetails.indexRecommendations,
-              },
-              details: {
-                description: insight.description,
-              },
-            };
-            break;
-          default:
-            rec = {
-              type: "Unknown",
-              details: {
-                duration: insightDetails.elapsedTimeMillis,
-                description: insight.description,
-              },
-            };
-            break;
-        }
-        recs.push(rec);
-      });
-      return recs;
-    }
-    const tableData = insightsTableData();
-    return (
-      <>
-        <section className={tableCx("section")}>
-          <Row gutter={24}>
-            <Col className="gutter-row" span={24}>
-              <SqlBox size={SqlBoxSize.custom} value={insightDetails.query} />
-            </Col>
-          </Row>
-          <Row gutter={24}>
-            <Col className="gutter-row" span={12}>
-              <SummaryCard>
-                <SummaryCardItem
-                  label="Start Time"
-                  value={insightDetails.startTime.format(DATE_FORMAT_24_UTC)}
-                />
-                <SummaryCardItem
-                  label="End Time"
-                  value={insightDetails.endTime.format(DATE_FORMAT_24_UTC)}
-                />
-                <SummaryCardItem
-                  label="Elapsed Time"
-                  value={Duration(insightDetails.elapsedTimeMillis * 1e6)}
-                />
-                <SummaryCardItem
-                  label="Rows Read"
-                  value={insightDetails.rowsRead}
-                />
-                <SummaryCardItem
-                  label="Rows Written"
-                  value={insightDetails.rowsWritten}
-                />
-                <SummaryCardItem
-                  label="Transaction Priority"
-                  value={capitalize(insightDetails.priority)}
-                />
-                <SummaryCardItem
-                  label="Full Scan"
-                  value={capitalize(String(insightDetails.isFullScan))}
-                />
-              </SummaryCard>
-            </Col>
-            <Col className="gutter-row" span={12}>
-              <SummaryCard>
-                <SummaryCardItem
-                  label="Transaction Retries"
-                  value={insightDetails.retries}
-                />
-                {insightDetails.lastRetryReason && (
-                  <SummaryCardItem
-                    label="Last Retry Reason"
-                    value={insightDetails.lastRetryReason.toString()}
-                  />
-                )}
-                <p className={summaryCardStylesCx("summary--card__divider")} />
-                <SummaryCardItem
-                  label="Session ID"
-                  value={String(insightDetails.sessionID)}
-                />
-                <SummaryCardItem
-                  label="Transaction Fingerprint ID"
-                  value={String(insightDetails.transactionFingerprintID)}
-                />
-                <SummaryCardItem
-                  label="Transaction Execution ID"
-                  value={String(insightDetails.transactionID)}
-                />
-                <SummaryCardItem
-                  label="Statement Fingerprint ID"
-                  value={String(insightDetails.statementFingerprintID)}
-                />
-              </SummaryCard>
-            </Col>
-          </Row>
-          <Row gutter={24} className={tableCx("margin-bottom")}>
-            <InsightsSortedTable columns={insightsColumns} data={tableData} />
-          </Row>
-        </section>
-      </>
-    );
-  };
+  const insightsColumns = useMemo(
+    () => makeInsightsColumns(isCockroachCloud),
+    [isCockroachCloud],
+  );
 
-  render(): React.ReactElement {
-    return (
+  const insightDetailsArr = useMemo(() => {
+    const eventDetails = [insightEventDetails];
+    populateStatementInsightsFromProblemAndCauses(eventDetails);
+    return eventDetails;
+  }, [insightEventDetails]);
+  const insightDetails = insightDetailsArr.length ? insightDetailsArr[0] : null;
+  const tableData = insightsTableData(insightDetails);
+
+  return (
+    <div>
+      <Helmet title={"Details | Insight"} />
       <div>
-        <Helmet title={"Details | Insight"} />
-        <div>
-          <Button
-            onClick={this.prevPage}
-            type="unstyled-link"
-            size="small"
-            icon={<ArrowLeft fontSize={"10px"} />}
-            iconPosition="left"
-            className={commonStyles("small-margin")}
-          >
-            Insights
-          </Button>
-          <h3
-            className={commonStyles("base-heading", "no-margin-bottom")}
-          >{`Statement Execution ID: ${String(
-            getMatchParamByName(this.props.match, "id"),
-          )}`}</h3>
-        </div>
-        <section>
-          <Loading
-            loading={this.props.insightEventDetails == null}
-            page={"Transaction Insight details"}
-            error={this.props.insightError}
-            render={this.renderContent}
-            renderError={() => InsightsError()}
-          />
-        </section>
+        <Button
+          onClick={prevPage}
+          type="unstyled-link"
+          size="small"
+          icon={<ArrowLeft fontSize={"10px"} />}
+          iconPosition="left"
+          className={commonStyles("small-margin")}
+        >
+          Insights
+        </Button>
+        <h3
+          className={commonStyles("base-heading", "no-margin-bottom")}
+        >{`Statement Execution ID: ${String(
+          getMatchParamByName(match, "id"),
+        )}`}</h3>
       </div>
-    );
-  }
-}
+      <section>
+        <Loading
+          loading={insightEventDetails == null}
+          page={"Transaction Insight details"}
+          error={insightError}
+          renderError={() => InsightsError()}
+        >
+          <section className={tableCx("section")}>
+            <Row gutter={24}>
+              <Col className="gutter-row" span={24}>
+                <SqlBox size={SqlBoxSize.custom} value={insightDetails.query} />
+              </Col>
+            </Row>
+            <Row gutter={24}>
+              <Col className="gutter-row" span={12}>
+                <SummaryCard>
+                  <SummaryCardItem
+                    label="Start Time"
+                    value={insightDetails.startTime.format(DATE_FORMAT_24_UTC)}
+                  />
+                  <SummaryCardItem
+                    label="End Time"
+                    value={insightDetails.endTime.format(DATE_FORMAT_24_UTC)}
+                  />
+                  <SummaryCardItem
+                    label="Elapsed Time"
+                    value={Duration(insightDetails.elapsedTimeMillis * 1e6)}
+                  />
+                  <SummaryCardItem
+                    label="Rows Read"
+                    value={insightDetails.rowsRead}
+                  />
+                  <SummaryCardItem
+                    label="Rows Written"
+                    value={insightDetails.rowsWritten}
+                  />
+                  <SummaryCardItem
+                    label="Transaction Priority"
+                    value={capitalize(insightDetails.priority)}
+                  />
+                  <SummaryCardItem
+                    label="Full Scan"
+                    value={capitalize(String(insightDetails.isFullScan))}
+                  />
+                </SummaryCard>
+              </Col>
+              <Col className="gutter-row" span={12}>
+                <SummaryCard>
+                  <SummaryCardItem
+                    label="Transaction Retries"
+                    value={insightDetails.retries}
+                  />
+                  {insightDetails.lastRetryReason && (
+                    <SummaryCardItem
+                      label="Last Retry Reason"
+                      value={insightDetails.lastRetryReason.toString()}
+                    />
+                  )}
+                  <p
+                    className={summaryCardStylesCx("summary--card__divider")}
+                  />
+                  <SummaryCardItem
+                    label="Session ID"
+                    value={String(insightDetails.sessionID)}
+                  />
+                  <SummaryCardItem
+                    label="Transaction Fingerprint ID"
+                    value={String(insightDetails.transactionFingerprintID)}
+                  />
+                  <SummaryCardItem
+                    label="Transaction Execution ID"
+                    value={String(insightDetails.transactionID)}
+                  />
+                  <SummaryCardItem
+                    label="Statement Fingerprint ID"
+                    value={String(insightDetails.statementFingerprintID)}
+                  />
+                </SummaryCard>
+              </Col>
+            </Row>
+            <Row gutter={24} className={tableCx("margin-bottom")}>
+              <InsightsSortedTable columns={insightsColumns} data={tableData} />
+            </Row>
+          </section>
+        </Loading>
+      </section>
+    </div>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
@@ -1,0 +1,211 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+import React, { useContext, useMemo } from "react";
+import { Col, Row } from "antd";
+import {
+  InsightsSortedTable,
+  makeInsightsColumns,
+} from "src/insightsTable/insightsTable";
+import { SummaryCard, SummaryCardItem } from "src/summaryCard";
+import { capitalize, Duration } from "src/util";
+import { DATE_FORMAT_24_UTC } from "src/util/format";
+import {
+  executionDetails,
+  InsightNameEnum,
+  InsightRecommendation,
+  StatementInsightEvent,
+} from "../types";
+import { populateStatementInsightsFromProblemAndCauses } from "../utils";
+import classNames from "classnames/bind";
+import { CockroachCloudContext } from "../../contexts";
+
+// Styles
+import insightsDetailsStyles from "src/insights/workloadInsightDetails/insightsDetails.module.scss";
+import summaryCardStyles from "src/summaryCard/summaryCard.module.scss";
+import insightTableStyles from "src/insightsTable/insightsTable.module.scss";
+import "antd/lib/col/style";
+import "antd/lib/row/style";
+
+const cx = classNames.bind(insightsDetailsStyles);
+const tableCx = classNames.bind(insightTableStyles);
+const summaryCardStylesCx = classNames.bind(summaryCardStyles);
+
+const insightsTableData = (
+  insightDetails: StatementInsightEvent | null,
+): InsightRecommendation[] => {
+  if (!insightDetails) return [];
+
+  const recs: InsightRecommendation[] = [];
+  let rec: InsightRecommendation;
+  const execDetails: executionDetails = {
+    statement: insightDetails.query,
+    fingerprintID: insightDetails.statementFingerprintID,
+    retries: insightDetails.retries,
+  };
+  insightDetails.insights.forEach(insight => {
+    switch (insight.name) {
+      case InsightNameEnum.highContention:
+        rec = {
+          type: "HighContention",
+          execution: execDetails,
+          details: {
+            duration: insightDetails.elapsedTimeMillis,
+            description: insight.description,
+          },
+        };
+        break;
+      case InsightNameEnum.failedExecution:
+        rec = {
+          type: "FailedExecution",
+        };
+        break;
+      case InsightNameEnum.highRetryCount:
+        rec = {
+          type: "HighRetryCount",
+          execution: execDetails,
+          details: {
+            description: insight.description,
+          },
+        };
+        break;
+      case InsightNameEnum.planRegression:
+        rec = {
+          type: "PlanRegression",
+          execution: execDetails,
+          details: {
+            description: insight.description,
+          },
+        };
+        break;
+      case InsightNameEnum.suboptimalPlan:
+        rec = {
+          type: "SuboptimalPlan",
+          database: insightDetails.databaseName,
+          execution: {
+            ...execDetails,
+            indexRecommendations: insightDetails.indexRecommendations,
+          },
+          details: {
+            description: insight.description,
+          },
+        };
+        break;
+      default:
+        rec = {
+          type: "Unknown",
+          details: {
+            duration: insightDetails.elapsedTimeMillis,
+            description: insight.description,
+          },
+        };
+        break;
+    }
+    recs.push(rec);
+  });
+  return recs;
+};
+
+export interface StatementInsightDetailsOverviewTabProps {
+  insightEventDetails: StatementInsightEvent;
+}
+
+export const StatementInsightDetailsOverviewTab: React.FC<
+  StatementInsightDetailsOverviewTabProps
+> = ({ insightEventDetails }) => {
+  const isCockroachCloud = useContext(CockroachCloudContext);
+
+  const insightsColumns = useMemo(
+    () => makeInsightsColumns(isCockroachCloud),
+    [isCockroachCloud],
+  );
+
+  const insightDetailsArr = useMemo(() => {
+    const eventDetails = [insightEventDetails];
+    populateStatementInsightsFromProblemAndCauses(eventDetails);
+    return eventDetails;
+  }, [insightEventDetails]);
+  const insightDetails = insightDetailsArr.length ? insightDetailsArr[0] : null;
+  const tableData = insightsTableData(insightDetails);
+
+  return (
+    <section className={cx("section")}>
+      <Row gutter={24}>
+        <Col span={12}>
+          <SummaryCard>
+            <SummaryCardItem
+              label="Start Time"
+              value={insightDetails.startTime.format(DATE_FORMAT_24_UTC)}
+            />
+            <SummaryCardItem
+              label="End Time"
+              value={insightDetails.endTime.format(DATE_FORMAT_24_UTC)}
+            />
+            <SummaryCardItem
+              label="Elapsed Time"
+              value={Duration(insightDetails.elapsedTimeMillis * 1e6)}
+            />
+            <SummaryCardItem
+              label="Rows Read"
+              value={insightDetails.rowsRead}
+            />
+            <SummaryCardItem
+              label="Rows Written"
+              value={insightDetails.rowsWritten}
+            />
+            <SummaryCardItem
+              label="Transaction Priority"
+              value={capitalize(insightDetails.priority)}
+            />
+            <SummaryCardItem
+              label="Full Scan"
+              value={capitalize(String(insightDetails.isFullScan))}
+            />
+          </SummaryCard>
+        </Col>
+        <Col className="gutter-row" span={12}>
+          <SummaryCard>
+            <SummaryCardItem
+              label="Transaction Retries"
+              value={insightDetails.retries}
+            />
+            {insightDetails.lastRetryReason && (
+              <SummaryCardItem
+                label="Last Retry Reason"
+                value={insightDetails.lastRetryReason.toString()}
+              />
+            )}
+            <p className={summaryCardStylesCx("summary--card__divider")} />
+            <SummaryCardItem
+              label="Session ID"
+              value={String(insightDetails.sessionID)}
+            />
+            <SummaryCardItem
+              label="Transaction Fingerprint ID"
+              value={String(insightDetails.transactionFingerprintID)}
+            />
+            <SummaryCardItem
+              label="Transaction Execution ID"
+              value={String(insightDetails.transactionID)}
+            />
+            <SummaryCardItem
+              label="Statement Fingerprint ID"
+              value={String(insightDetails.statementFingerprintID)}
+            />
+          </SummaryCard>
+        </Col>
+      </Row>
+      <Row gutter={24} className={tableCx("margin-bottom")}>
+        <Col>
+          <InsightsSortedTable columns={insightsColumns} data={tableData} />
+        </Col>
+      </Row>
+    </section>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsights.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsights.fixture.ts
@@ -40,6 +40,7 @@ export const statementInsightsPropsFixture: StatementInsightsViewProps = {
       rowsRead: 100,
       insights: null,
       indexRecommendations: ["make this index"],
+      planGist: "abc",
     },
     {
       statementID: "f72f37ea-b3a0-451f-80b8-dfb27d0bc2a9",
@@ -65,6 +66,7 @@ export const statementInsightsPropsFixture: StatementInsightsViewProps = {
       rowsRead: 100,
       insights: null,
       indexRecommendations: ["make that index"],
+      planGist: "abc",
     },
     {
       statementID: "f72f37ea-b3a0-451f-80b8-dfb27d0bc2a9",
@@ -91,6 +93,7 @@ export const statementInsightsPropsFixture: StatementInsightsViewProps = {
       rowsRead: 100,
       insights: null,
       indexRecommendations: ["make these indices"],
+      planGist: "abc",
     },
   ],
   statementsError: null,

--- a/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.module.scss
@@ -31,11 +31,6 @@
   margin-bottom: 30px;
 }
 
-.section {
-  flex: 0 0 auto;
-  padding: 12px 24px 12px 0px;
-}
-
 .inline {
   display: inline-flex;
 }

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/activeStatementDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/activeStatementDetailsConnected.tsx
@@ -22,6 +22,7 @@ import {
   selectActiveStatement,
   selectContentionDetailsForStatement,
 } from "src/selectors/activeExecutions.selectors";
+import { selectIsTenant } from "src/store/uiConfig";
 
 // For tenant cases, we don't show information about node, regions and
 // diagnostics.
@@ -33,6 +34,7 @@ const mapStateToProps = (
     contentionDetails: selectContentionDetailsForStatement(state, props),
     statement: selectActiveStatement(state, props),
     match: props.match,
+    isTenant: selectIsTenant(state),
   };
 };
 

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/activeStatementDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/activeStatementDetailsOverviewTab.tsx
@@ -1,0 +1,132 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import classNames from "classnames/bind";
+import { Link } from "react-router-dom";
+import { Col, Row } from "antd";
+import { SummaryCard, SummaryCardItem } from "src/summaryCard";
+import {
+  ActiveStatement,
+  ExecutionContentionDetails,
+} from "src/activeExecutions";
+import { WaitTimeInsightsPanel } from "src/detailsPanels/waitTimeInsightsPanel";
+import { StatusIcon } from "src/activeExecutions/statusIcon";
+import { DATE_FORMAT_24_UTC, Duration } from "src/util";
+
+import "antd/lib/col/style";
+import "antd/lib/row/style";
+import summaryCardStyles from "src/summaryCard/summaryCard.module.scss";
+
+const summaryCardStylesCx = classNames.bind(summaryCardStyles);
+
+import styles from "./statementDetails.module.scss";
+const cx = classNames.bind(styles);
+
+type Props = {
+  statement?: ActiveStatement;
+  contentionDetails?: ExecutionContentionDetails;
+};
+
+export const ActiveStatementDetailsOverviewTab = ({
+  statement,
+  contentionDetails,
+}: Props): React.ReactElement => {
+  if (!statement) return null;
+
+  return (
+    <>
+      <section className={cx("section", "section--container")}>
+        <Row gutter={24}>
+          <Col className="gutter-row" span={12}>
+            <SummaryCard className={cx("summary-card")}>
+              <Row>
+                <Col>
+                  <SummaryCardItem
+                    label="Start Time (UTC)"
+                    value={statement.start.format(DATE_FORMAT_24_UTC)}
+                  />
+                  <SummaryCardItem
+                    label="Elapsed Time"
+                    value={Duration(
+                      statement.elapsedTime.asMilliseconds() * 1e6,
+                    )}
+                  />
+                  <SummaryCardItem
+                    label="Status"
+                    value={
+                      <>
+                        <StatusIcon status={statement.status} />
+                        {statement.status}
+                      </>
+                    }
+                  />
+                  <SummaryCardItem
+                    label="Full Scan"
+                    value={statement.isFullScan.toString()}
+                  />
+                </Col>
+              </Row>
+            </SummaryCard>
+          </Col>
+          <Col className="gutter-row" span={12}>
+            <SummaryCard className={cx("summary-card")}>
+              <SummaryCardItem
+                label="Application Name"
+                value={statement.application}
+              />
+              <SummaryCardItem label="User Name" value={statement.user} />
+              <SummaryCardItem
+                label="Client Address"
+                value={statement.clientAddress}
+              />
+              <p className={summaryCardStylesCx("summary--card__divider")} />
+              <SummaryCardItem
+                label="Session ID"
+                value={
+                  <Link
+                    className={cx("text-link")}
+                    to={`/session/${statement.sessionID}`}
+                  >
+                    {statement.sessionID}
+                  </Link>
+                }
+              />
+              <SummaryCardItem
+                label="Transaction Execution ID"
+                value={
+                  <Link
+                    className={cx("text-link")}
+                    to={`/execution/transaction/${statement.transactionID}`}
+                  >
+                    {statement.transactionID}
+                  </Link>
+                }
+              />
+            </SummaryCard>
+          </Col>
+        </Row>
+      </section>
+      {contentionDetails && (
+        <WaitTimeInsightsPanel
+          execType="statement"
+          executionID={statement.statementID}
+          schemaName={contentionDetails.waitInsights?.schemaName}
+          tableName={contentionDetails.waitInsights?.tableName}
+          indexName={contentionDetails.waitInsights?.indexName}
+          databaseName={contentionDetails.waitInsights?.databaseName}
+          waitTime={contentionDetails.waitInsights?.waitTime}
+          waitingExecutions={contentionDetails.waitingExecutions}
+          blockingExecutions={contentionDetails.blockingExecutions}
+        />
+      )}
+    </>
+  );
+};


### PR DESCRIPTION
Backport:
  * 1/1 commits from "server, sql: add plan gist to active queries" (#88770)
  * 1/1 commits from "ui/cluster-ui: show active statement explain plan" (#89021)
  * 2/2 commits from "cluster-ui: add explain plan tab for statement insights" (#90250)

Please see individual PRs for details.

Release justification: low-risk, high benefit change to existing functionality

/cc @cockroachdb/release