### PR TITLE
release-22.1: backupccl: use the backup codec when inspecting spans in the backupManifest

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1264,21 +1264,10 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 	defer func() {
 		mem.Shrink(ctx, memSize)
 	}()
-	// backupCodec is the codec that was used to encode the keys in the backup. It
-	// is the tenant in which the backup was taken.
-	backupCodec := keys.SystemSQLCodec
-	backupTenantID := roachpb.SystemTenantID
 
-	if len(sqlDescs) != 0 {
-		if len(latestBackupManifest.Spans) != 0 && !latestBackupManifest.HasTenants() {
-			// If there are no tenant targets, then the entire keyspace covered by
-			// Spans must lie in 1 tenant.
-			_, backupTenantID, err = keys.DecodeTenantPrefix(latestBackupManifest.Spans[0].Key)
-			if err != nil {
-				return err
-			}
-			backupCodec = keys.MakeSQLCodec(backupTenantID)
-		}
+	backupCodec, backupTenantID, err := makeBackupCodec(latestBackupManifest)
+	if err != nil {
+		return err
 	}
 
 	lastBackupIndex, err := getBackupIndexAtTime(backupManifests, details.EndTime)


### PR DESCRIPTION
Backport 1/1 commits from #90477.

/cc @cockroachdb/release

---


Informs #90475, #90474

Previously, during restore planning, the restoring cluster's codec was accidentally used to reason about spans in the backup manifest. When a backup was restored by a different tenant, two bugs described in #90475, #90474 could manifest. This patch fixes these bugs.

Release note: None

Release justification: bug fix