### PR TITLE
sql: add log.Scope to test that was missing it

### DIFF
--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -1119,6 +1119,7 @@ func TestShowLastQueryStatisticsUnknown(t *testing.T) {
 //     min(sqlliveness.Session expiry, lease descriptor expiration).
 func TestTransactionDeadline(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	var mu struct {


### PR DESCRIPTION
Release note: None
Epic: None