### PR TITLE
release-22.1: server: limit concurrency of table stats requests

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -699,7 +699,9 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	lateBoundServer := &Server{}
 	// TODO(tbg): give adminServer only what it needs (and avoid circular deps).
 	adminAuthzCheck := &adminPrivilegeChecker{ie: internalExecutor}
-	sAdmin := newAdminServer(lateBoundServer, adminAuthzCheck, internalExecutor)
+	sAdmin := newAdminServer(
+		lateBoundServer, cfg.Settings, adminAuthzCheck, internalExecutor,
+	)
 
 	// These callbacks help us avoid a dependency on gossip in httpServer.
 	parseNodeIDFn := func(s string) (roachpb.NodeID, bool, error) {
@@ -948,11 +950,11 @@ func (s *Server) Start(ctx context.Context) error {
 // underinitialized services. This is avoided with some additional
 // complexity that can be summarized as follows:
 //
-// - before blocking trying to connect to the Gossip network, we already open
-//   the admin UI (so that its diagnostics are available)
-// - we also allow our Gossip and our connection health Ping service
-// - everything else returns Unavailable errors (which are retryable)
-// - once the node has started, unlock all RPCs.
+//   - before blocking trying to connect to the Gossip network, we already open
+//     the admin UI (so that its diagnostics are available)
+//   - we also allow our Gossip and our connection health Ping service
+//   - everything else returns Unavailable errors (which are retryable)
+//   - once the node has started, unlock all RPCs.
 //
 // The passed context can be used to trace the server startup. The context
 // should represent the general startup operation.


### PR DESCRIPTION
Backport 1/1 commits from #90210.

/cc @cockroachdb/release

---

These requests can be very expensive, especially if there are lots of ranges. Furthermore, the number of requests to be sent tends to scale with the number of tables, just like the range count. This unbounded concurrency was a recipe for trouble.

Informs #90196.

Release justification: fixes a problematic performance issue after UI action

Release note (ui change): Requests to fetch table and database statistics now have limited concurrency. This may make loading the database page slower, but in return should result in making those pages less disruptive.
