### PR TITLE
backupccl: add cloud backup restore tests to nightly test suite

### DIFF
--- a/build/teamcity/cockroach/nightlies/cloud_unit_tests_impl.sh
+++ b/build/teamcity/cockroach/nightlies/cloud_unit_tests_impl.sh
@@ -22,29 +22,37 @@ export AWS_SHARED_CREDENTIALS_FILE="$PWD/.aws/credentials"
 export AWS_CONFIG_FILE="$PWD/.aws/config"
 log_into_aws
 
+bazel_test_env=(--test_env=GO_TEST_WRAP_TESTV=1 \
+  --test_env=GO_TEST_WRAP=1 \
+  --test_env=GOOGLE_CREDENTIALS_JSON="$GOOGLE_EPHEMERAL_CREDENTIALS" \
+  --test_env=GOOGLE_APPLICATION_CREDENTIALS="$GOOGLE_APPLICATION_CREDENTIALS" \
+  --test_env=GOOGLE_BUCKET="nightly-cloud-unit-tests" \
+  --test_env=GOOGLE_LIMITED_BUCKET="$GOOGLE_LIMITED_BUCKET" \
+  --test_env=GOOGLE_KMS_KEY_NAME="$GOOGLE_KMS_KEY_NAME" \
+  --test_env=GOOGLE_LIMITED_KEY_ID="$GOOGLE_LIMITED_KEY_ID" \
+  --test_env=ASSUME_SERVICE_ACCOUNT_CHAIN="$ASSUME_SERVICE_ACCOUNT_CHAIN" \
+  --test_env=ASSUME_SERVICE_ACCOUNT="$ASSUME_SERVICE_ACCOUNT" \
+  --test_env=AWS_S3_BUCKET="$AWS_S3_BUCKET" \
+  --test_env=AWS_ASSUME_ROLE="$AWS_ASSUME_ROLE" \
+  --test_env=AWS_ROLE_ARN_CHAIN="$AWS_ROLE_ARN_CHAIN" \
+  --test_env=AWS_KMS_KEY_ARN="$AWS_KMS_KEY_ARN" \
+  --test_env=AWS_KMS_REGION="$AWS_KMS_REGION" \
+  --test_env=AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
+  --test_env=AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
+  --test_env=AWS_DEFAULT_REGION="$AWS_DEFAULT_REGION" \
+  --test_env=AWS_SHARED_CREDENTIALS_FILE="$AWS_SHARED_CREDENTIALS_FILE" \
+  --test_env=AWS_CONFIG_FILE="$AWS_CONFIG_FILE")
 exit_status=0
+
 $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --process_test_failures -- test --config=ci \
     //pkg/cloud/gcp:gcp_test //pkg/cloud/amazon:amazon_test //pkg/ccl/cloudccl/gcp:gcp_test //pkg/ccl/cloudccl/amazon:amazon_test \
-    --test_env=GO_TEST_WRAP_TESTV=1 \
-    --test_env=GO_TEST_WRAP=1 \
-    --test_env=GOOGLE_CREDENTIALS_JSON="$GOOGLE_EPHEMERAL_CREDENTIALS" \
-    --test_env=GOOGLE_APPLICATION_CREDENTIALS="$GOOGLE_APPLICATION_CREDENTIALS" \
-    --test_env=GOOGLE_BUCKET="nightly-cloud-unit-tests" \
-    --test_env=GOOGLE_LIMITED_BUCKET="$GOOGLE_LIMITED_BUCKET" \
-    --test_env=GOOGLE_KMS_KEY_NAME="$GOOGLE_KMS_KEY_NAME" \
-    --test_env=GOOGLE_LIMITED_KEY_ID="$GOOGLE_LIMITED_KEY_ID" \
-    --test_env=ASSUME_SERVICE_ACCOUNT_CHAIN="$ASSUME_SERVICE_ACCOUNT_CHAIN" \
-    --test_env=ASSUME_SERVICE_ACCOUNT="$ASSUME_SERVICE_ACCOUNT" \
-    --test_env=AWS_S3_BUCKET="$AWS_S3_BUCKET" \
-    --test_env=AWS_ASSUME_ROLE="$AWS_ASSUME_ROLE" \
-    --test_env=AWS_ROLE_ARN_CHAIN="$AWS_ROLE_ARN_CHAIN" \
-    --test_env=AWS_KMS_KEY_ARN="$AWS_KMS_KEY_ARN" \
-    --test_env=AWS_KMS_REGION="$AWS_KMS_REGION" \
-    --test_env=AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
-    --test_env=AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
-    --test_env=AWS_DEFAULT_REGION="$AWS_DEFAULT_REGION" \
-    --test_env=AWS_SHARED_CREDENTIALS_FILE="$AWS_SHARED_CREDENTIALS_FILE" \
-    --test_env=AWS_CONFIG_FILE="$AWS_CONFIG_FILE" \
+    "${bazel_test_env[@]}" \
+    --test_timeout=900 \
+    || exit_status=$?
+
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --process_test_failures -- test --config=ci \
+    //pkg/ccl/backupccl:backupccl_test --test_filter='^TestCloudBackupRestore' \
+    "${bazel_test_env[@]}" \
     --test_timeout=900 \
     || exit_status=$?
 

--- a/pkg/ccl/backupccl/backup_cloud_test.go
+++ b/pkg/ccl/backupccl/backup_cloud_test.go
@@ -122,9 +122,9 @@ func setupS3URI(
 func TestCloudBackupRestoreGoogleCloudStorage(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	bucket := os.Getenv("GS_BUCKET")
+	bucket := os.Getenv("GOOGLE_BUCKET")
 	if bucket == "" {
-		skip.IgnoreLint(t, "GS_BUCKET env var must be set")
+		skip.IgnoreLint(t, "GOOGLE_BUCKET env var must be set")
 	}
 
 	// TODO(dan): Actually invalidate the descriptor cache and delete this line.


### PR DESCRIPTION
Previously, the unit tests in ccl/backupccl/backup_cloud_test.go were not run apart of CI as they did not have access to actual external storage containers and proper credentials. This patch adds these tests to a nightly test suite build on team city agents with access to actual cloud resources.

Epic: None

Release note: None