### PR TITLE
sql/catalog: break descpb->parser dep

### DIFF
--- a/pkg/sql/catalog/descs/descriptor.go
+++ b/pkg/sql/catalog/descs/descriptor.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemadesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
@@ -132,6 +131,13 @@ func getDescriptorsByID(
 		log.VEventf(ctx, 2, "looking up descriptors for ids %v", idsForLog)
 	}
 	var vls validationLevelMap
+	switch len(ids) {
+	case 1:
+		var arr [1]catalog.ValidationLevel
+		vls = arr[:]
+	default:
+		vls = make(validationLevelMap, len(ids))
+	}
 	{
 		// Look up the descriptors in all layers except the storage layer on a
 		// best-effort basis.
@@ -164,7 +170,7 @@ func getDescriptorsByID(
 					continue
 				}
 				descs[i] = desc
-				vls.set(i, vl)
+				vls[i] = vl
 			}
 		}
 	}
@@ -183,13 +189,13 @@ func getDescriptorsByID(
 		for i, id := range ids {
 			if descs[i] == nil {
 				descs[i] = tc.stored.GetCachedByID(id)
-				vls.set(i, tc.stored.GetValidationLevelByID(id))
+				vls[i] = tc.stored.GetValidationLevelByID(id)
 			}
 		}
 	}
 
 	// At this point, all descriptors are in the slice, finalize and hydrate them.
-	if err := tc.finalizeDescriptors(ctx, txn, flags, descs, &vls); err != nil {
+	if err := tc.finalizeDescriptors(ctx, txn, flags, descs, vls); err != nil {
 		return err
 	}
 	if err := tc.hydrateDescriptors(ctx, txn, flags, descs); err != nil {
@@ -527,7 +533,7 @@ func (tc *Collection) finalizeDescriptors(
 	txn *kv.Txn,
 	flags tree.CommonLookupFlags,
 	descs []catalog.Descriptor,
-	validationLevels *validationLevelMap,
+	validationLevels validationLevelMap,
 ) error {
 	// Add the descriptors to the uncommitted layer if we want them to be mutable.
 	if flags.RequireMutable {
@@ -546,7 +552,7 @@ func (tc *Collection) finalizeDescriptors(
 	}
 	var toValidate []catalog.Descriptor
 	for i := range descs {
-		if validationLevels.get(i) < requiredLevel {
+		if validationLevels[i] < requiredLevel {
 			toValidate = append(toValidate, descs[i])
 		}
 	}
@@ -575,14 +581,4 @@ func isTemporarySchema(name string) bool {
 // validationLevelMap is used to map indexes in a slice to their required
 // validation level. This avoids any heap allocations as compared to a
 // slice containing the correspondence between an index to a validation level.
-type validationLevelMap struct {
-	m util.FastIntMap
-}
-
-func (vlm *validationLevelMap) get(idx int) catalog.ValidationLevel {
-	return catalog.ValidationLevel(vlm.m.GetDefault(idx))
-}
-
-func (vlm *validationLevelMap) set(idx int, l catalog.ValidationLevel) {
-	vlm.m.Set(idx, int(l))
-}
+type validationLevelMap []catalog.ValidationLevel


### PR DESCRIPTION
There was no need for this. Saw it as I was looking at something else. The problem was that I thought the validation levels were small. They aren't because they are bit sets. 

Release note: None