### PR TITLE
sql/catalog: break descpb->parser dep

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -281,6 +281,7 @@ ALL_TESTS = [
     "//pkg/sql/catalog/catprivilege:catprivilege_test",
     "//pkg/sql/catalog/colinfo:colinfo_test",
     "//pkg/sql/catalog/dbdesc:dbdesc_test",
+    "//pkg/sql/catalog/descpb:catalog_disallowed_imports_test",
     "//pkg/sql/catalog/descpb:descpb_test",
     "//pkg/sql/catalog/descs:descs_test",
     "//pkg/sql/catalog/funcdesc:funcdesc_test",

--- a/pkg/sql/catalog/dbdesc/database_desc.go
+++ b/pkg/sql/catalog/dbdesc/database_desc.go
@@ -290,6 +290,9 @@ func (desc *immutable) ValidateForwardReferences(
 	vea catalog.ValidationErrorAccumulator, vdg catalog.ValidationDescGetter,
 ) {
 	// Check multi-region enum type.
+	if !desc.IsMultiRegion() {
+		return
+	}
 	if enumID, err := desc.MultiRegionEnumID(); err == nil {
 		report := func(err error) {
 			vea.Report(errors.Wrap(err, "multi-region enum"))

--- a/pkg/sql/catalog/descpb/BUILD.bazel
+++ b/pkg/sql/catalog/descpb/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 load("//build:STRINGER.bzl", "stringer")
+load("//pkg/testutils/buildutil:buildutil.bzl", "disallowed_imports_test")
 
 go_library(
     name = "descpb",
@@ -23,7 +24,6 @@ go_library(
     deps = [
         "//pkg/keys",
         "//pkg/sql/catalog/catpb",
-        "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/protoreflect",
@@ -93,6 +93,11 @@ stringer(
     name = "gen-formatversion-stringer",
     src = "structured.go",
     typ = "FormatVersion",
+)
+
+disallowed_imports_test(
+    "catalog",
+    disallowed_list = ["//pkg/sql/parser"],
 )
 
 get_x_data(name = "get_x_data")

--- a/pkg/sql/catalog/descpb/column.go
+++ b/pkg/sql/catalog/descpb/column.go
@@ -11,26 +11,11 @@
 package descpb
 
 import (
-	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
-	"github.com/cockroachdb/errors"
 )
-
-// HasNullDefault checks that the column descriptor has a default of NULL.
-func (desc *ColumnDescriptor) HasNullDefault() bool {
-	if !desc.HasDefault() {
-		return false
-	}
-	defaultExpr, err := parser.ParseExpr(*desc.DefaultExpr)
-	if err != nil {
-		panic(errors.NewAssertionErrorWithWrappedErrf(err,
-			"failed to parse default expression %s", *desc.DefaultExpr))
-	}
-	return defaultExpr == tree.DNull
-}
 
 // HasDefault returns true if the column has a default value.
 func (desc *ColumnDescriptor) HasDefault() bool {

--- a/pkg/sql/catalog/table_elements.go
+++ b/pkg/sql/catalog/table_elements.go
@@ -292,6 +292,10 @@ type Column interface {
 	// HasDefault returns true iff the column has a default expression set.
 	HasDefault() bool
 
+	// HasNullDefault returns true if the column has a default expression and
+	// that expression is NULL.
+	HasNullDefault() bool
+
 	// GetDefaultExpr returns the column default expression if it exists,
 	// empty string otherwise.
 	GetDefaultExpr() string
@@ -808,7 +812,7 @@ func ColumnNeedsBackfill(col Column) bool {
 	//  - computed columns
 	//  - non-nullable columns (note: if a non-nullable column doesn't have a
 	//    default value, the backfill will fail unless the table is empty).
-	if col.ColumnDesc().HasNullDefault() {
+	if col.HasNullDefault() {
 		return false
 	}
 	return col.HasDefault() || !col.IsNullable() || col.IsComputed()

--- a/pkg/sql/catalog/tabledesc/column.go
+++ b/pkg/sql/catalog/tabledesc/column.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -101,6 +102,19 @@ func (w column) IsNullable() bool {
 // HasDefault returns true iff the column has a default expression set.
 func (w column) HasDefault() bool {
 	return w.desc.HasDefault()
+}
+
+// HasNullDefault checks that the column descriptor has a default of NULL.
+func (w column) HasNullDefault() bool {
+	if !w.HasDefault() {
+		return false
+	}
+	// We ignore the error because what are we going to do with it? It means
+	// that the default expressions is not parsable. Somebody with a context
+	// who needs to use it will be in a better place to log it. If it is not
+	// parsable, it is not NULL.
+	defaultExpr, _ := parser.ParseExpr(w.GetDefaultExpr())
+	return defaultExpr == tree.DNull
 }
 
 // GetDefaultExpr returns the column default expression if it exists,


### PR DESCRIPTION
There was no need for this. Saw it as I was looking at something else.

Release note: None