### PR TITLE
dbdesc: don't validate multi-region enum if not mr database

### DIFF
--- a/pkg/sql/catalog/dbdesc/database_desc.go
+++ b/pkg/sql/catalog/dbdesc/database_desc.go
@@ -290,6 +290,9 @@ func (desc *immutable) ValidateForwardReferences(
 	vea catalog.ValidationErrorAccumulator, vdg catalog.ValidationDescGetter,
 ) {
 	// Check multi-region enum type.
+	if !desc.IsMultiRegion() {
+		return
+	}
 	if enumID, err := desc.MultiRegionEnumID(); err == nil {
 		report := func(err error) {
 			vea.Report(errors.Wrap(err, "multi-region enum"))


### PR DESCRIPTION
I saw building the error as 2.8% of CPU time in a profile.

Epic: CRDB-20865
    
Release note: None

