### PR TITLE
sql: avoid constructing an error in a common auth check

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -5239,14 +5239,17 @@ func makeClusterDatabasePrivilegesFromDescriptor(
 			for _, priv := range u.Privileges {
 				// We use this function to check for the grant option so that the
 				// object owner also gets is_grantable=true.
-				grantOptionErr := p.CheckGrantOptionsForUser(
-					ctx, db.GetPrivileges(), db, []privilege.Kind{priv.Kind}, u.User, true, /* isGrant */
+				isGrantable, err := p.CheckGrantOptionsForUser(
+					ctx, db.GetPrivileges(), db, []privilege.Kind{priv.Kind}, u.User,
 				)
+				if err != nil {
+					return err
+				}
 				if err := addRow(
 					dbNameStr,                           // database_name
 					userNameStr,                         // grantee
 					tree.NewDString(priv.Kind.String()), // privilege_type
-					yesOrNoDatum(grantOptionErr == nil), // is_grantable
+					yesOrNoDatum(isGrantable),
 				); err != nil {
 					return err
 				}

--- a/pkg/sql/grant_revoke.go
+++ b/pkg/sql/grant_revoke.go
@@ -272,7 +272,7 @@ func (n *changeDescriptorBackedPrivilegesNode) startExec(params runParams) error
 				}
 			}
 
-			err := p.CheckGrantOptionsForUser(ctx, descriptor.GetPrivileges(), descriptor, n.desiredprivs, p.User(), n.isGrant)
+			err := p.MustCheckGrantOptionsForUser(ctx, descriptor.GetPrivileges(), descriptor, n.desiredprivs, p.User(), n.isGrant)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/grant_revoke_system.go
+++ b/pkg/sql/grant_revoke_system.go
@@ -66,7 +66,7 @@ func (n *changeNonDescriptorBackedPrivilegesNode) startExec(params runParams) er
 			return err
 		}
 
-		err = params.p.CheckGrantOptionsForUser(params.ctx, syntheticPrivDesc, systemPrivilegeObject, n.desiredprivs, params.p.User(), n.isGrant)
+		err = params.p.MustCheckGrantOptionsForUser(params.ctx, syntheticPrivDesc, systemPrivilegeObject, n.desiredprivs, params.p.User(), n.isGrant)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -1043,16 +1043,19 @@ var informationSchemaTypePrivilegesTable = virtualSchemaTable{
 						for _, priv := range u.Privileges {
 							// We use this function to check for the grant option so that the
 							// object owner also gets is_grantable=true.
-							grantOptionErr := p.CheckGrantOptionsForUser(
-								ctx, typeDesc.GetPrivileges(), typeDesc, []privilege.Kind{priv.Kind}, u.User, true, /* isGrant */
+							isGrantable, err := p.CheckGrantOptionsForUser(
+								ctx, typeDesc.GetPrivileges(), typeDesc, []privilege.Kind{priv.Kind}, u.User,
 							)
+							if err != nil {
+								return err
+							}
 							if err := addRow(
 								userNameStr,                         // grantee
 								dbNameStr,                           // type_catalog
 								scNameStr,                           // type_schema
 								typeNameStr,                         // type_name
 								tree.NewDString(priv.Kind.String()), // privilege_type
-								yesOrNoDatum(grantOptionErr == nil), // is_grantable
+								yesOrNoDatum(isGrantable),           // is_grantable
 							); err != nil {
 								return err
 							}
@@ -1083,15 +1086,18 @@ var informationSchemaSchemataTablePrivileges = virtualSchemaTable{
 						for _, priv := range u.Privileges {
 							// We use this function to check for the grant option so that the
 							// object owner also gets is_grantable=true.
-							grantOptionErr := p.CheckGrantOptionsForUser(
-								ctx, sc.GetPrivileges(), sc, []privilege.Kind{priv.Kind}, u.User, true, /* isGrant */
+							isGrantable, err := p.CheckGrantOptionsForUser(
+								ctx, sc.GetPrivileges(), sc, []privilege.Kind{priv.Kind}, u.User,
 							)
+							if err != nil {
+								return err
+							}
 							if err := addRow(
 								userNameStr,                         // grantee
 								dbNameStr,                           // table_catalog
 								scNameStr,                           // table_schema
 								tree.NewDString(priv.Kind.String()), // privilege_type
-								yesOrNoDatum(grantOptionErr == nil), // is_grantable
+								yesOrNoDatum(isGrantable),           // is_grantable
 							); err != nil {
 								return err
 							}
@@ -1395,9 +1401,12 @@ func populateTablePrivileges(
 					if err != nil {
 						return err
 					}
-					grantOptionErr := p.CheckGrantOptionsForUser(
-						ctx, privs, table, []privilege.Kind{priv.Kind}, u.User, true, /* isGrant */
+					isGrantable, err := p.CheckGrantOptionsForUser(
+						ctx, privs, table, []privilege.Kind{priv.Kind}, u.User,
 					)
+					if err != nil {
+						return err
+					}
 					if err := addRow(
 						tree.DNull,                          // grantor
 						granteeNameStr,                      // grantee
@@ -1405,7 +1414,7 @@ func populateTablePrivileges(
 						scNameStr,                           // table_schema
 						tbNameStr,                           // table_name
 						tree.NewDString(priv.Kind.String()), // privilege_type
-						yesOrNoDatum(grantOptionErr == nil), // is_grantable
+						yesOrNoDatum(isGrantable),           // is_grantable
 						yesOrNoDatum(priv.Kind == privilege.SELECT), // with_hierarchy
 					); err != nil {
 						return err

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -265,11 +265,14 @@ func (p *planner) HasAnyPrivilege(
 		}
 
 		if priv.GrantOption {
-			if err := p.CheckGrantOptionsForUser(ctx, desc.GetPrivileges(), desc, []privilege.Kind{priv.Kind}, user, true /* isGrant */); err != nil {
-				if pgerror.GetPGCode(err) == pgcode.WarningPrivilegeNotGranted {
-					continue
-				}
+			isGrantable, err := p.CheckGrantOptionsForUser(
+				ctx, desc.GetPrivileges(), desc, []privilege.Kind{priv.Kind}, user,
+			)
+			if err != nil {
 				return eval.HasNoPrivilege, err
+			}
+			if !isGrantable {
+				continue
 			}
 		}
 		return eval.HasPrivilege, nil


### PR DESCRIPTION
These errors were often being constructed for almost every single row in the execution of SHOW GRANTS. They are very expensive to construct.

Epic: CRDB-20865

Release note: None