### PR TITLE
ui: correct tooltip message for circuit breaker events chart

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/graphTooltips.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/graphTooltips.tsx
@@ -161,8 +161,8 @@ export const CircuitBreakerTrippedReplicasTooltip: React.FC = () => (
 
 export const CircuitBreakerTrippedEventsTooltip: React.FC = () => (
   <div>
-    The number of circuit breaker events occurred per second across all nodes
-    since the process started.
+    The number of circuit breaker events occurred per aggregated interval of
+    time across all nodes since the process started.
   </div>
 );
 


### PR DESCRIPTION
This patch corrects the message on circuit breaker events chart to highlight that the chart displays the total number of events per aggregated interval of time instead of "per second".

Release note: None

Epic: none