### PR TITLE
release-22.1: ttl: replace range iterator and boundary checks with DistSQL SpanPartitions

### DIFF
--- a/pkg/sql/ttl/ttljob/BUILD.bazel
+++ b/pkg/sql/ttl/ttljob/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
         "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/kv",
-        "//pkg/kv/kvclient/kvcoord",
         "//pkg/roachpb",
         "//pkg/security",
         "//pkg/server/telemetry",


### PR DESCRIPTION
fixes https://github.com/cockroachlabs/support/issues/1867

Backport using spans from the DistSQL planner and key decoding from 22.2
to determine table boundaries and PK values for the TTL job.

Release note (bug fix): Fix `invalid uvarint length of 9` error during TTL job.
This bug potentially affects keys with secondary tenant prefixes which includes
the serverless environment.

Release justification: Fix TTL key decoding.