### PR TITLE
cluster-ui: fetch databases using sql-over-http endpoint

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/databasesApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/databasesApi.ts
@@ -1,0 +1,65 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import {
+  executeInternalSql,
+  SqlExecutionRequest,
+  sqlResultsAreEmpty,
+} from "./sqlApi";
+import { withTimeout } from "./util";
+import moment from "moment";
+
+export type DatabasesColumns = {
+  database_name: string;
+  owner: string;
+  primary_region: string;
+  secondary_region: string;
+  regions: string[];
+  survival_goal: string;
+};
+
+export type DatabasesListResponse = { databases: string[] };
+
+export const databasesRequest: SqlExecutionRequest = {
+  statements: [
+    {
+      sql: `SHOW DATABASES`,
+    },
+  ],
+  execute: true,
+};
+
+// getDatabasesList fetches databases names from the database. Callers of
+// getDatabasesList from cluster-ui will need to pass a timeout argument for
+// promise timeout handling (callers from db-console already have promise
+// timeout handling as part of the cacheDataReducer).
+export function getDatabasesList(
+  timeout?: moment.Duration,
+): Promise<DatabasesListResponse> {
+  return withTimeout(
+    executeInternalSql<DatabasesColumns>(databasesRequest),
+    timeout,
+  ).then(result => {
+    // If request succeeded but query failed, throw error (caught by saga/cacheDataReducer).
+    if (result.error) {
+      throw result.error;
+    }
+
+    if (sqlResultsAreEmpty(result)) {
+      return { databases: [] };
+    }
+
+    const dbNames: string[] = result.execution.txn_results[0].rows.map(
+      row => row.database_name,
+    );
+
+    return { databases: dbNames };
+  });
+}

--- a/pkg/ui/workspaces/cluster-ui/src/api/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/index.ts
@@ -20,3 +20,4 @@ export * from "./schemaInsightsApi";
 export * from "./schedulesApi";
 export * from "./sqlApi";
 export * from "./tracezApi";
+export * from "./databasesApi";

--- a/pkg/ui/workspaces/cluster-ui/src/api/util.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/util.ts
@@ -1,0 +1,42 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import moment from "moment";
+
+export const PROMISE_TIMEOUT = moment.duration(30, "s"); // seconds
+
+// withTimeout wraps a promise in a timeout (cribbed from db-console).
+export function withTimeout<T>(
+  promise: Promise<T>,
+  timeout?: moment.Duration,
+): Promise<T> {
+  if (timeout) {
+    return new Promise<T>((resolve, reject) => {
+      setTimeout(
+        () => reject(new TimeoutError(timeout)),
+        timeout.asMilliseconds(),
+      );
+      promise.then(resolve, reject);
+    });
+  } else {
+    return promise;
+  }
+}
+
+export class TimeoutError extends Error {
+  timeout: moment.Duration;
+  constructor(timeout: moment.Duration) {
+    const message = `Promise timed out after ${timeout.asMilliseconds()} ms`;
+    super(message);
+
+    this.name = this.constructor.name;
+    this.timeout = timeout;
+  }
+}

--- a/pkg/ui/workspaces/db-console/src/app.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.spec.tsx
@@ -9,6 +9,7 @@
 // licenses/APL.txt.
 
 import { stubComponentInModule } from "./test-utils/mockComponent";
+stubComponentInModule("src/views/databases/databasesPage", "DatabasesPage");
 stubComponentInModule(
   "src/views/databases/databaseDetailsPage",
   "DatabaseDetailsPage",
@@ -61,7 +62,6 @@ const LOADING_CLUSTER_STATUS = /Loading cluster status.*/;
 const NODE_LOG_HEADER = /Logs Node.*/;
 const EVENTS_HEADER = "Events";
 const JOBS_HEADER = "Jobs";
-const DATABASES_HEADER = "Databases";
 const SQL_ACTIVITY_HEADER = "SQL Activity";
 const STATEMENTS_DETAILS_HEADER = "Statement Fingerprint";
 const TRANSACTION_DETAILS_HEADER = "Transaction Details";
@@ -269,7 +269,7 @@ describe("Routing to", () => {
   describe("'/databases' path", () => {
     test("routes to <DatabasesPage> component", () => {
       navigateToPath("/databases");
-      screen.getByText(DATABASES_HEADER, { selector: "h3" });
+      screen.getByTestId("DatabasesPage");
     });
   });
 

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -92,7 +92,7 @@ export const locationsReducerObj = new CachedDataReducer(
 export const refreshLocations = locationsReducerObj.refresh;
 
 const databasesReducerObj = new CachedDataReducer(
-  api.getDatabaseList,
+  clusterUiApi.getDatabasesList,
   "databases",
 );
 export const refreshDatabases = databasesReducerObj.refresh;
@@ -484,7 +484,7 @@ export interface APIReducersState {
   raft: CachedDataReducerState<api.RaftDebugResponseMessage>;
   version: CachedDataReducerState<VersionList>;
   locations: CachedDataReducerState<api.LocationsResponseMessage>;
-  databases: CachedDataReducerState<api.DatabasesResponseMessage>;
+  databases: CachedDataReducerState<clusterUiApi.DatabasesListResponse>;
   databaseDetails: KeyedCachedDataReducerState<api.DatabaseDetailsResponseMessage>;
   tableDetails: KeyedCachedDataReducerState<api.TableDetailsResponseMessage>;
   tableStats: KeyedCachedDataReducerState<api.TableStatsResponseMessage>;

--- a/pkg/ui/workspaces/db-console/src/util/api.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.ts
@@ -21,11 +21,6 @@ import { propsToQueryString } from "src/util/query";
 import { cockroach } from "src/js/protos";
 import TakeTracingSnapshotRequest = cockroach.server.serverpb.TakeTracingSnapshotRequest;
 
-export type DatabasesRequestMessage =
-  protos.cockroach.server.serverpb.DatabasesRequest;
-export type DatabasesResponseMessage =
-  protos.cockroach.server.serverpb.DatabasesResponse;
-
 export type DatabaseDetailsRequestMessage =
   protos.cockroach.server.serverpb.DatabaseDetailsRequest;
 export type DatabaseDetailsResponseMessage =
@@ -395,19 +390,6 @@ export type APIRequestFn<TReq, TResponse> = (
 
 const serverpb = protos.cockroach.server.serverpb;
 const tspb = protos.cockroach.ts.tspb;
-
-// getDatabaseList gets a list of all database names
-export function getDatabaseList(
-  _req: DatabasesRequestMessage,
-  timeout?: moment.Duration,
-): Promise<DatabasesResponseMessage> {
-  return timeoutFetch(
-    serverpb.DatabasesResponse,
-    `${API_PREFIX}/databases`,
-    null,
-    timeout,
-  );
-}
 
 // getDatabaseDetails gets details for a specific database
 export function getDatabaseDetails(

--- a/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.spec.ts
@@ -112,9 +112,7 @@ describe("Databases Page", function () {
   });
 
   it("makes a row for each database", async function () {
-    fakeApi.stubDatabases({
-      databases: ["system", "test"],
-    });
+    fakeApi.stubDatabases(["system", "test"]);
     fakeApi.stubClusterSettings({
       key_values: {
         "sql.stats.automatic_collection.enabled": { value: "true" },
@@ -158,9 +156,7 @@ describe("Databases Page", function () {
   });
 
   it("fills in database details", async function () {
-    fakeApi.stubDatabases({
-      databases: ["system", "test"],
-    });
+    fakeApi.stubDatabases(["system", "test"]);
 
     fakeApi.stubDatabaseDetails("system", {
       table_names: ["foo", "bar"],
@@ -212,9 +208,7 @@ describe("Databases Page", function () {
   describe("fallback cases", function () {
     describe("missing tables", function () {
       it("exposes them so the component can refresh them", async function () {
-        fakeApi.stubDatabases({
-          databases: ["system"],
-        });
+        fakeApi.stubDatabases(["system"]);
 
         fakeApi.stubDatabaseDetails("system", {
           table_names: ["foo", "bar"],
@@ -242,9 +236,7 @@ describe("Databases Page", function () {
       });
 
       it("merges available individual stats into the totals", async function () {
-        fakeApi.stubDatabases({
-          databases: ["system"],
-        });
+        fakeApi.stubDatabases(["system"]);
 
         fakeApi.stubDatabaseDetails("system", {
           table_names: ["foo", "bar"],
@@ -280,9 +272,7 @@ describe("Databases Page", function () {
 
     describe("missing stats", function () {
       it("builds a list of missing tables", async function () {
-        fakeApi.stubDatabases({
-          databases: ["system"],
-        });
+        fakeApi.stubDatabases(["system"]);
 
         fakeApi.stubDatabaseDetails("system", {
           table_names: ["foo", "bar"],
@@ -308,9 +298,7 @@ describe("Databases Page", function () {
       });
 
       it("merges individual stats into the totals", async function () {
-        fakeApi.stubDatabases({
-          databases: ["system"],
-        });
+        fakeApi.stubDatabases(["system"]);
 
         fakeApi.stubDatabaseDetails("system", {
           table_names: ["foo", "bar"],


### PR DESCRIPTION
Part of: https://github.com/cockroachdb/cockroach/issues/89429

Addresses: #90257 (blocked from resolving by #80789)

This commit introduces a function to cluster-ui that fetches database names using the sql-over-http endpoint. This removes the need to use the admin server's `/databases` endpoint.

Loom (DB-Console): https://www.loom.com/share/e9f773b93b0c46528c39abd4767ced23

-----
Initially considered creating the cluster-ui connected component within this PR as well, but decided to save it for a followup PR.

Release note: None