### PR TITLE
acceptance: pin python version to 3.10

### DIFF
--- a/pkg/acceptance/compose/gss/python/Dockerfile
+++ b/pkg/acceptance/compose/gss/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.10
 ENV PYTHONUNBUFFERED 1
 
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \


### PR DESCRIPTION
Previously, our acceptance tests used `python:3` as the base for its docker images. This lead to test failures when the upstream pushed a new version of Python.

This change pins the Python version to 3.10, what assumes the tests will fetch the latest patch version.

Release note: None
Epic: None