### PR TITLE
[do-not-merge] build: add pebble metamorphic crossversion nightly

### DIFF
--- a/build/teamcity/cockroach/nightlies/pebble_nightly_build_test_binary.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_build_test_binary.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# This script is run by pebble_nightly_metamorphic_crossversion.sh to build test
+# binaries of the pebble metamorphic package at different branches. This script
+# takes two argments:
+#   - The pebble branch to build, eg "crl-release-22.1" or "master"
+#   - A destination directory into which the binary will be copied with the
+#     filename <SHA>.test.
+# This script prints the pebble SHA that was built.
+
+set -euo pipefail
+
+PEBBLE_BRANCH="$1"
+DEST="$2"
+
+BAZEL_BIN=$(bazel info bazel-bin --config ci)
+
+bazel run @go_sdk//:bin/go get "github.com/cockroachdb/pebble@$PEBBLE_BRANCH"
+NEW_DEPS_BZL_CONTENT=$(bazel run //pkg/cmd/mirror)
+echo "$NEW_DEPS_BZL_CONTENT" > DEPS.bzl
+
+# Use the Pebble SHA from the version in the modified go.mod file.
+# Note that we need to pluck the Git SHA from the go.sum-style version, i.e.
+# v0.0.0-20220214174839-6af77d5598c9SUM => 6af77d5598c9
+PEBBLE_SHA=$(grep 'github\.com/cockroachdb/pebble' go.mod | cut -d'-' -f3)
+
+bazel build --define gotags=bazel,invariants \
+      @com_github_cockroachdb_pebble//internal/metamorphic:metamorphic_test
+
+cp $BAZEL_BIN/external/com_github_cockroachdb_pebble/internal/metamorphic/metamorphic_test_/metamorphic_test \
+    "$DEST/$PEBBLE_SHA.test"
+chmod a+w "$DEST/$PEBBLE_SHA.test"
+echo "$PEBBLE_SHA"

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_crossversion.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_crossversion.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# This script is run by the Pebble Nightly Crossversion Metamorphic - TeamCity
+# build configuration.
+
+set -euo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+mkdir -p bin
+chmod o+rwx bin
+mkdir -p $root/artifacts
+
+VERSIONS=""
+LAST_SHA=""
+for branch in "$@"
+do
+    tc_start_block "Compile Pebble $branch metamorphic test binary"
+    SHA=$("$dir/teamcity/cockroach/nightlies/pebble_nightly_build_test_binary.sh" "$branch" "bin" | tail -n1)
+    VERSIONS="$VERSIONS -version $branch,$SHA,/test-bin/$SHA.test"
+    LAST_SHA="$SHA"
+    echo "$PWD/bin/$SHA.test"
+    stat "$PWD/bin/$SHA.test"
+    tc_end_block "Compile Pebble $branch metamorphic test binary"
+done
+
+ls -l "$PWD/bin/"
+
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e BUILD_VCS_NUMBER=$LAST_SHA -e GITHUB_API_TOKEN -e GITHUB_REPO -e TC_BUILDTYPE_ID -e TC_BUILD_BRANCH -e TC_BUILD_ID -e TC_SERVER_URL --mount type=bind,source=$PWD/bin,target=/test-bin" \
+                               run_bazel \
+                               build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_crossversion_impl.sh \
+                               "$VERSIONS"

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_crossversion_impl.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_crossversion_impl.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
+
+set -euxo pipefail
+
+ARTIFACTS_DIR=$PWD/artifacts/meta
+mkdir -p "${ARTIFACTS_DIR}"
+chmod o+rwx "${ARTIFACTS_DIR}"
+chmod -R o+rwx "/test-bin"
+ls -l "/test-bin"
+GO_TEST_JSON_OUTPUT_FILE=$PWD/artifacts/test.json.txt
+
+echo "TC_SERVER_URL is $TC_SERVER_URL"
+
+bazel build //pkg/cmd/bazci --config=ci
+
+BAZEL_BIN=$(bazel info bazel-bin --config ci)
+
+# The script accepts the arguments accepted by TestMetaCrossVersion. It should
+# look like:
+#
+#   --version release-21.2,f390aeb3d,f390aeb3d.test --version release-22.1,c5e43d21,c5e43d21.test
+#
+# We need to pass these same arguments to the test invocation. To do that,
+# prefix each argument with `--test_arg `, so that we can instruct bazel
+# to set the arguments appropriately.
+test_args=$(echo $@ | python3 -c "import sys; print(' '.join(['--test_arg=' +word.strip() for word in sys.stdin.read().split(' ')]))")
+test_args="--test_arg=-test.v $test_args"
+
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --process_test_failures -- \
+                                      test @com_github_cockroachdb_pebble//internal/metamorphic/crossversion:crossversion_test \
+                                      --test_timeout=25200 '--test_filter=TestMetaCrossVersion$' \
+                                      --define gotags=bazel,invariants \
+                                      "--test_env=GO_TEST_JSON_OUTPUT_FILE=$GO_TEST_JSON_OUTPUT_FILE" \
+                                      --run_under "@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts 'GO_TEST_JSON_OUTPUT_FILE=cat,XML_OUTPUT_FILE=$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci merge-test-xmls' -maxtime 6h -maxfails 1 -stderr -p 1" \
+                                      $test_args \
+                                      --test_output streamed


### PR DESCRIPTION
Add scripts for a new nightly that runs Pebble metamorphic tests across SHAs from multiple release branches, passing data directories from one release to the next. This nightly improves our test coverage of upgrade paths and compatibility with databases constructed by previous versions.

The entrypoint script interprets each argument as a Pebble branch name. For each provided branch, it retrieves the Pebble SHA and builds the metamorphic package's test binary at that SHA.

The built metamorphic test binaries are passed through flags to the crossversion test.

Close #82544 (CRDB-20465).

Epic: CRDB-20465
Release note: none
Release justification: Non-production code changes