### PR TITLE
bazci: fix call into `find`

### DIFF
--- a/pkg/cmd/bazci/bazci.go
+++ b/pkg/cmd/bazci/bazci.go
@@ -485,8 +485,8 @@ func createTarball(goTestJSONOutputFilePath string) error {
 // EMERGENCY_BALLAST filename.
 func removeEmergencyBallasts() {
 	findCmdArgs := []string{
-		"-name",
 		artifactsDir,
+		"-name",
 		"EMERGENCY_BALLAST",
 		"-delete",
 	}


### PR DESCRIPTION
Otherwise we get error messages like this:

```
find: paths must precede expression: `EMERGENCY_BALLAST'
```

Release note: None
Epic: None