### PR TITLE
changefeedccl: add high-level recovers in cdceval

### DIFF
--- a/pkg/ccl/changefeedccl/cdceval/functions.go
+++ b/pkg/ccl/changefeedccl/cdceval/functions.go
@@ -181,3 +181,10 @@ func makeStringSet(vals ...string) map[string]struct{} {
 	}
 	return m
 }
+
+// TestingEnableVolatileFunction allows functions with the given name (lowercase)
+// to be used in expressions if their volatility level would disallow them by default.
+// Used for testing.
+func TestingEnableVolatileFunction(fnName string) {
+	supportedVolatileBuiltinFunctions[fnName] = struct{}{}
+}

--- a/pkg/ccl/changefeedccl/cdceval/validation.go
+++ b/pkg/ccl/changefeedccl/cdceval/validation.go
@@ -43,7 +43,12 @@ func NormalizeAndValidateSelectForTarget(
 	sc *tree.SelectClause,
 	includeVirtual bool,
 	splitColFams bool,
-) (n NormalizedSelectClause, _ jobspb.ChangefeedTargetSpecification, _ error) {
+) (n NormalizedSelectClause, _ jobspb.ChangefeedTargetSpecification, retErr error) {
+	defer func() {
+		if pan := recover(); pan != nil {
+			retErr = errors.Newf("low-level error while normalizing expression, probably syntax is unsupported in CREATE CHANGEFEED: %s", pan)
+		}
+	}()
 	execCtx.SemaCtx()
 	execCfg := execCtx.ExecCfg()
 	if !execCfg.Settings.Version.IsActive(ctx, clusterversion.EnablePredicateProjectionChangefeed) {

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -4522,6 +4522,55 @@ func TestChangefeedDescription(t *testing.T) {
 
 }
 
+func TestChangefeedPanicRecovery(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	// Panics can mess with the test setup so run these each in their own test.
+
+	prep := func(t *testing.T, sqlDB *sqlutils.SQLRunner) {
+		cdceval.TestingEnableVolatileFunction(`crdb_internal.force_panic`)
+		sqlDB.Exec(t, `CREATE TABLE foo(id int primary key, s string)`)
+		sqlDB.Exec(t, `INSERT INTO foo(id, s) VALUES (0, 'hello'), (1, null)`)
+	}
+
+	cdcTest(t, func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		prep(t, sqlDB)
+		// Check that disallowed expressions have a good error message.
+		// Also regression test for https://github.com/cockroachdb/cockroach/issues/90416
+		sqlDB.ExpectErr(t, "syntax is unsupported in CREATE CHANGEFEED",
+			`CREATE CHANGEFEED WITH schema_change_policy='stop' AS SELECT 1 FROM foo WHERE EXISTS (SELECT true)`)
+	})
+
+	// Check that all panics while evaluating the WHERE clause in an expression are recovered from.
+	cdcTest(t, func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		prep(t, sqlDB)
+		foo := feed(t, f,
+			`CREATE CHANGEFEED WITH schema_change_policy='stop' AS SELECT 1 FROM foo WHERE crdb_internal.force_panic('wat') IS NULL`)
+		defer closeFeed(t, foo)
+		var err error
+		for err == nil {
+			_, err = foo.Next()
+		}
+		require.Error(t, err, "error while evaluating WHERE clause")
+	})
+
+	// Check that all panics while evaluating the SELECT clause in an expression are recovered from.
+	cdcTest(t, func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		prep(t, sqlDB)
+		foo := feed(t, f,
+			`CREATE CHANGEFEED WITH schema_change_policy='stop' AS SELECT crdb_internal.force_panic('wat') FROM foo`)
+		defer closeFeed(t, foo)
+		var err error
+		for err == nil {
+			_, err = foo.Next()
+		}
+		require.Error(t, err, "error while evaluating SELECT clause")
+	})
+}
+
 func TestChangefeedPauseUnpause(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)


### PR DESCRIPTION
SQL is complicated. If we hit a panic while parsing or evaluating SQL, we need to fail the changefeed, not crash the node.

Informs #90416.

Release note (sql change): Fixed a bug that could cause crashes when parsing malformed changefeed expressions.