### PR TITLE
sql: update user OID col in some pg_catalog tables to match system.users

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -5432,7 +5432,7 @@ CREATE TABLE crdb_internal.default_privileges (
 				}
 
 				addRowsForSchema := func(defaultPrivilegeDescriptor catalog.DefaultPrivilegeDescriptor, schema tree.Datum) error {
-					if err := forEachRole(ctx, p, func(userName username.SQLUsername, isRole bool, options roleOptions, settings tree.Datum) error {
+					if err := forEachRole(ctx, p, func(userName username.SQLUsername, isRole bool, options roleOptions, settings tree.Datum, _ *tree.DOid) error {
 						role := catpb.DefaultPrivilegesRole{
 							Role: userName,
 						}


### PR DESCRIPTION
The user OID column in the following pg_catalog tables have been updated
to match the user ID found in system.users:
* pg_authid
* pg_namespace
* pg_roles
* pg_shadow
* pg_user

Part of #90561

Release note (sql change): The OID col of the following pg_catalog
tables have been updated to match the user ID in system.users:
pg_authid, pg_namespace, pg_roles, pg_shadow, and pg_user.