### PR TITLE
sql: support indexes in regclass cast and pg_table_is_visible

### DIFF
--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -73,8 +73,8 @@ exp,benchmark
 4,ORMQueries/information_schema._pg_index_position
 3,ORMQueries/pg_attribute
 3,ORMQueries/pg_class
-9,ORMQueries/pg_is_other_temp_schema
-17,ORMQueries/pg_is_other_temp_schema_multiple_times
+7,ORMQueries/pg_is_other_temp_schema
+7,ORMQueries/pg_is_other_temp_schema_multiple_times
 4,ORMQueries/pg_my_temp_schema
 4,ORMQueries/pg_my_temp_schema_multiple_times
 4,ORMQueries/pg_namespace

--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -53,9 +53,9 @@ exp,benchmark
 11,GrantRole/grant_1_role
 15,GrantRole/grant_2_roles
 3,ORMQueries/activerecord_type_introspection_query
-3,ORMQueries/django_table_introspection_1_table
-3,ORMQueries/django_table_introspection_4_tables
-3,ORMQueries/django_table_introspection_8_tables
+6,ORMQueries/django_table_introspection_1_table
+6,ORMQueries/django_table_introspection_4_tables
+6,ORMQueries/django_table_introspection_8_tables
 2,ORMQueries/has_column_privilege_using_attnum
 2,ORMQueries/has_column_privilege_using_column_name
 1,ORMQueries/has_schema_privilege_1

--- a/pkg/sql/faketreeeval/BUILD.bazel
+++ b/pkg/sql/faketreeeval/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
         "//pkg/security/username",
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/descpb",
-        "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/pgwire/pgnotice",

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
@@ -52,11 +51,6 @@ var errSequenceOperators = unimplemented.NewWithIssue(42508,
 func (so *DummySequenceOperators) GetSerialSequenceNameFromColumn(
 	ctx context.Context, tn *tree.TableName, columnName tree.Name,
 ) (*tree.TableName, error) {
-	return nil, errors.WithStack(errSequenceOperators)
-}
-
-// ParseQualifiedTableName is part of the eval.DatabaseCatalog interface.
-func (so *DummySequenceOperators) ParseQualifiedTableName(sql string) (*tree.TableName, error) {
 	return nil, errors.WithStack(errSequenceOperators)
 }
 
@@ -371,11 +365,6 @@ func (ep *DummyEvalPlanner) ValidateAllMultiRegionZoneConfigsInCurrentDatabase(
 	_ context.Context,
 ) error {
 	return errors.WithStack(errEvalPlanner)
-}
-
-// ParseQualifiedTableName is part of the eval.DatabaseCatalog interface.
-func (ep *DummyEvalPlanner) ParseQualifiedTableName(sql string) (*tree.TableName, error) {
-	return parser.ParseQualifiedTableName(sql)
 }
 
 // SchemaExists is part of the eval.DatabaseCatalog interface.

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -68,13 +68,6 @@ func (so *DummySequenceOperators) SchemaExists(
 	return false, errors.WithStack(errSequenceOperators)
 }
 
-// IsTableVisible is part of the eval.DatabaseCatalog interface.
-func (so *DummySequenceOperators) IsTableVisible(
-	ctx context.Context, curDB string, searchPath sessiondata.SearchPath, tableID oid.Oid,
-) (bool, bool, error) {
-	return false, false, errors.WithStack(errSequenceOperators)
-}
-
 // IsTypeVisible is part of the eval.DatabaseCatalog interface.
 func (so *DummySequenceOperators) IsTypeVisible(
 	ctx context.Context, curDB string, searchPath sessiondata.SearchPath, typeID oid.Oid,
@@ -370,13 +363,6 @@ func (ep *DummyEvalPlanner) ValidateAllMultiRegionZoneConfigsInCurrentDatabase(
 // SchemaExists is part of the eval.DatabaseCatalog interface.
 func (ep *DummyEvalPlanner) SchemaExists(ctx context.Context, dbName, scName string) (bool, error) {
 	return false, errors.WithStack(errEvalPlanner)
-}
-
-// IsTableVisible is part of the eval.DatabaseCatalog interface.
-func (ep *DummyEvalPlanner) IsTableVisible(
-	ctx context.Context, curDB string, searchPath sessiondata.SearchPath, tableID oid.Oid,
-) (bool, bool, error) {
-	return false, false, errors.WithStack(errEvalPlanner)
 }
 
 // IsTypeVisible is part of the eval.DatabaseCatalog interface.

--- a/pkg/sql/importer/import_table_creation.go
+++ b/pkg/sql/importer/import_table_creation.go
@@ -303,13 +303,6 @@ func (so *importSequenceOperators) SchemaExists(
 	return false, errSequenceOperators
 }
 
-// IsTableVisible is part of the eval.DatabaseCatalog interface.
-func (so *importSequenceOperators) IsTableVisible(
-	ctx context.Context, curDB string, searchPath sessiondata.SearchPath, tableID oid.Oid,
-) (bool, bool, error) {
-	return false, false, errors.WithStack(errSequenceOperators)
-}
-
 // IsTypeVisible is part of the eval.DatabaseCatalog interface.
 func (so *importSequenceOperators) IsTypeVisible(
 	ctx context.Context, curDB string, searchPath sessiondata.SearchPath, typeID oid.Oid,

--- a/pkg/sql/importer/import_table_creation.go
+++ b/pkg/sql/importer/import_table_creation.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemadesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/faketreeeval"
-	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -288,16 +287,6 @@ func (so *importSequenceOperators) GetSerialSequenceNameFromColumn(
 	ctx context.Context, tn *tree.TableName, columnName tree.Name,
 ) (*tree.TableName, error) {
 	return nil, errors.WithStack(errSequenceOperators)
-}
-
-// ParseQualifiedTableName implements the eval.DatabaseCatalog interface.
-func (so *importSequenceOperators) ParseQualifiedTableName(sql string) (*tree.TableName, error) {
-	name, err := parser.ParseTableName(sql)
-	if err != nil {
-		return nil, err
-	}
-	tn := name.ToTableName()
-	return &tn, nil
 }
 
 // ResolveTableName implements the eval.DatabaseCatalog interface.

--- a/pkg/sql/logictest/testdata/logic_test/pg_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pg_builtins
@@ -99,10 +99,12 @@ SET DATABASE = test;
 query TB rowsort
 SELECT c.relname, pg_table_is_visible(c.oid)
 FROM pg_class c
-WHERE c.relname IN ('is_visible', 'not_visible')
+WHERE c.relname IN ('is_visible', 'not_visible', 'is_visible_pkey', 'not_visible_pkey')
 ----
-is_visible   true
-not_visible  false
+is_visible        true
+is_visible_pkey   true
+not_visible       false
+not_visible_pkey  false
 
 # Looking up a table in a different database should return NULL.
 query B

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -312,7 +312,8 @@ pg_catalog.pg_namespace  CREATE TABLE pg_catalog.pg_namespace (
                            oid OID NULL,
                            nspname NAME NOT NULL,
                            nspowner OID NULL,
-                           nspacl STRING[] NULL
+                           nspacl STRING[] NULL,
+                           INDEX pg_namespace_oid_idx (oid ASC) STORING (nspname, nspowner, nspacl)
                          )
 
 query TTBTTTB colnames
@@ -2593,7 +2594,7 @@ objoid      classoid    objsubid  description
 4294967098  4294967123  0         pg_largeobject_metadata was created for compatibility and is currently unimplemented
 4294967096  4294967123  0         locks held by active processes (empty - feature does not exist)
 4294967095  4294967123  0         available materialized views (empty - feature does not exist)
-4294967094  4294967123  0         available namespaces (incomplete; namespaces and databases are congruent in CockroachDB)
+4294967094  4294967123  0         available namespaces
 4294967093  4294967123  0         opclass (empty - Operator classes not supported yet)
 4294967092  4294967123  0         operators (incomplete)
 4294967091  4294967123  0         pg_opfamily was created for compatibility and is currently unimplemented

--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -579,3 +579,114 @@ SELECT 1:::OID >= -2147483649:::INT8
 
 query error OID out of range: -2147483649
 SELECT -2147483649:::INT8 >= 1:::OID
+
+# Test that we can cast index names to a regclass, and vice-versa.
+
+statement ok
+CREATE TABLE table_with_indexes (a INT PRIMARY key, b INT)
+
+query TT
+SELECT relname, oid::regclass::string from pg_class where oid='table_with_indexes_pkey'::regclass
+----
+table_with_indexes_pkey  table_with_indexes_pkey
+
+statement ok
+CREATE INDEX my_b_index ON table_with_indexes(b)
+
+query TT
+SELECT relname, oid::regclass::string from pg_class where oid='my_b_index'::regclass
+----
+my_b_index  my_b_index
+
+# Test that we can cast table and index names from different schemas.
+
+statement ok
+CREATE SCHEMA other_schema
+
+statement ok
+CREATE TABLE other_schema.table_with_indexes (a INT PRIMARY key, b INT)
+
+statement ok
+CREATE INDEX my_b_index ON other_schema.table_with_indexes(b)
+
+query TTT
+SELECT c.relname, c.oid::regclass::string, n.nspname from pg_class c
+JOIN pg_namespace n ON c.relnamespace = n.oid
+WHERE c.oid='other_schema.table_with_indexes'::regclass
+----
+table_with_indexes  table_with_indexes  other_schema
+
+query TTT
+SELECT c.relname, c.oid::regclass::string, n.nspname from pg_class c
+JOIN pg_namespace n ON c.relnamespace = n.oid
+WHERE c.oid='other_schema.table_with_indexes_pkey'::regclass
+----
+table_with_indexes_pkey  table_with_indexes_pkey  other_schema
+
+query TTT
+SELECT c.relname, c.oid::regclass::string, n.nspname from pg_class c
+JOIN pg_namespace n ON c.relnamespace = n.oid
+WHERE c.oid='other_schema.my_b_index'::regclass
+----
+my_b_index  my_b_index  other_schema
+
+# Changing the search_path should influence what gets resolved while casting.
+
+statement ok
+SET search_path = other_schema, public
+
+query TTT
+SELECT c.relname, c.oid::regclass::string, n.nspname from pg_class c
+JOIN pg_namespace n ON c.relnamespace = n.oid
+WHERE c.oid='table_with_indexes'::regclass
+----
+table_with_indexes  table_with_indexes  other_schema
+
+query TTT
+SELECT c.relname, c.oid::regclass::string, n.nspname from pg_class c
+JOIN pg_namespace n ON c.relnamespace = n.oid
+WHERE c.oid='table_with_indexes_pkey'::regclass
+----
+table_with_indexes_pkey  table_with_indexes_pkey  other_schema
+
+query TTT
+SELECT c.relname, c.oid::regclass::string, n.nspname from pg_class c
+JOIN pg_namespace n ON c.relnamespace = n.oid
+WHERE c.oid='my_b_index'::regclass
+----
+my_b_index  my_b_index  other_schema
+
+statement ok
+SET search_path = public, other_schema
+
+query TTT
+SELECT c.relname, c.oid::regclass::string, n.nspname from pg_class c
+JOIN pg_namespace n ON c.relnamespace = n.oid
+WHERE c.oid='table_with_indexes'::regclass
+----
+table_with_indexes  table_with_indexes  public
+
+query TTT
+SELECT c.relname, c.oid::regclass::string, n.nspname from pg_class c
+JOIN pg_namespace n ON c.relnamespace = n.oid
+WHERE c.oid='table_with_indexes_pkey'::regclass
+----
+table_with_indexes_pkey  table_with_indexes_pkey  public
+
+query TTT
+SELECT c.relname, c.oid::regclass::string, n.nspname from pg_class c
+JOIN pg_namespace n ON c.relnamespace = n.oid
+WHERE c.oid='my_b_index'::regclass
+----
+my_b_index  my_b_index  public
+
+statement ok
+RESET search_path
+
+# Check that we can cast table names from pg_catalog also.
+query TTT
+SELECT c.relname, c.oid::regclass::string, n.nspname from pg_class c
+JOIN pg_namespace n ON c.relnamespace = n.oid
+WHERE c.oid='pg_type'::regclass
+----
+pg_type  pg_type  pg_catalog

--- a/pkg/sql/logictest/testdata/logic_test/temp_table
+++ b/pkg/sql/logictest/testdata/logic_test/temp_table
@@ -19,6 +19,15 @@ SELECT table_name, type FROM [SHOW TABLES]
 ----
 tbl  table
 
+# Verify that temp schema is visible in pg_namespace index.
+let $tempSchemaOID
+SELECT oid FROM pg_namespace where nspname LIKE 'pg_temp%'
+
+query B
+SELECT nspname LIKE 'pg_temp%' FROM pg_namespace where oid = $tempSchemaOID
+----
+true
+
 statement ok
 DROP TABLE tbl
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual
@@ -130,19 +130,15 @@ ORDER BY
 distribution: local
 vectorized: true
 ·
-• sort
-│ order: +conname
+• render
 │
-└── • render
+└── • virtual table lookup join
+    │ table: pg_namespace@pg_namespace_oid_idx
+    │ equality: (connamespace) = (oid)
+    │ pred: nspname = 'public'
     │
-    └── • hash join
-        │ equality: (oid) = (connamespace)
-        │
-        ├── • filter
-        │   │ filter: nspname = 'public'
-        │   │
-        │   └── • virtual table
-        │         table: pg_namespace@primary
+    └── • sort
+        │ order: +conname
         │
         └── • virtual table lookup join
             │ table: pg_attribute@pg_attribute_attrelid_idx

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -589,15 +589,6 @@ func (p *planner) GetTypeFromValidSQLSyntax(sql string) (*types.T, error) {
 	return tree.ResolveType(context.TODO(), ref, p.semaCtx.GetTypeResolver())
 }
 
-// ParseQualifiedTableName implements the eval.DatabaseCatalog interface.
-// This exists to get around a circular dependency between sql/sem/tree and
-// sql/parser. sql/parser depends on tree to make objects, so tree cannot import
-// ParseQualifiedTableName even though some builtins need that function.
-// TODO(jordan): remove this once builtins can be moved outside of sql/sem/tree.
-func (p *planner) ParseQualifiedTableName(sql string) (*tree.TableName, error) {
-	return parser.ParseQualifiedTableName(sql)
-}
-
 // ResolveTableName implements the eval.DatabaseCatalog interface.
 func (p *planner) ResolveTableName(ctx context.Context, tn *tree.TableName) (tree.ID, error) {
 	flags := tree.ObjectLookupFlagsWithRequiredTableKind(tree.ResolveAnyTableKind)

--- a/pkg/sql/sem/eval/BUILD.bazel
+++ b/pkg/sql/sem/eval/BUILD.bazel
@@ -67,6 +67,7 @@ go_library(
         "//pkg/sql/sem/tree/treewindow",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sessiondatapb",
+        "//pkg/sql/sqlerrors",
         "//pkg/sql/sqlliveness",
         "//pkg/sql/sqltelemetry",
         "//pkg/sql/types",

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -65,12 +65,6 @@ type DatabaseCatalog interface {
 	// whether it exists.
 	SchemaExists(ctx context.Context, dbName, scName string) (found bool, err error)
 
-	// IsTableVisible checks if the table with the given ID belongs to a schema
-	// on the given sessiondata.SearchPath.
-	IsTableVisible(
-		ctx context.Context, curDB string, searchPath sessiondata.SearchPath, tableID oid.Oid,
-	) (isVisible bool, exists bool, err error)
-
 	// IsTypeVisible checks if the type with the given ID belongs to a schema
 	// on the given sessiondata.SearchPath.
 	IsTypeVisible(

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -54,11 +54,6 @@ const (
 // and is to be used from Context.
 type DatabaseCatalog interface {
 
-	// ParseQualifiedTableName parses a SQL string of the form
-	// `[ database_name . ] [ schema_name . ] table_name`.
-	// NB: this is deprecated! Use parser.ParseQualifiedTableName when possible.
-	ParseQualifiedTableName(sql string) (*tree.TableName, error)
-
 	// ResolveTableName expands the given table name and
 	// makes it point to a valid object.
 	// If the database name is not given, it uses the search path to find it, and

--- a/pkg/sql/vtable/pg_catalog.go
+++ b/pkg/sql/vtable/pg_catalog.go
@@ -508,7 +508,8 @@ CREATE TABLE pg_catalog.pg_namespace (
 	oid OID,
 	nspname NAME NOT NULL,
 	nspowner OID,
-	nspacl STRING[]
+	nspacl STRING[],
+	INDEX (oid)
 )`
 
 // PGCatalogOpclass describes the schema of the pg_catalog.pg_opclass table.


### PR DESCRIPTION
Epic: CRDB-23454
fixes https://github.com/cockroachdb/cockroach/issues/88097

### sql: remove deprecated function from DatabaseCatalog

The ParseQualifiedTableName function was deprecated and unused.

### sql: support casts from index name to regclass

Release note (sql change): Casts from index name to regclass are now
supported. Previously, only table names could be cast to regclass.

### sql: add index on pg_namespace(oid)

This will allow us to efficiently join to this table.

### sql: fix pg_table_is_visible to handle indexes

This uses the internal executor now to do the introspection using
pg_class where everything can be looked up all at once.

There's an increase in number of round trips, but it's a constant
factor.

Release note (bug fix): Fixed the pg_table_is_visible builtin function
so it correctly reports visibility of indexes based on the current
search_path.