### PR TITLE
roachtest: add test to exercise multiple upgrades in a single test

### DIFF
--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -24,7 +24,6 @@ func registerAcceptance(r registry.Registry) {
 		name              string
 		fn                func(ctx context.Context, t test.Test, c cluster.Cluster)
 		skip              string
-		minVersion        string
 		numNodes          int
 		timeout           time.Duration
 		encryptionSupport registry.EncryptionSupport
@@ -43,7 +42,6 @@ func registerAcceptance(r registry.Registry) {
 			{name: "reset-quorum", fn: runResetQuorum, numNodes: 8},
 			{
 				name: "many-splits", fn: runManySplits,
-				minVersion:        "v19.2.0", // SQL syntax unsupported on 19.1.x
 				encryptionSupport: registry.EncryptionMetamorphic,
 			},
 			{name: "cli/node-status", fn: runCLINodeStatus},
@@ -72,8 +70,7 @@ func registerAcceptance(r registry.Registry) {
 				// the cockroach binary built from the branch on which the test is
 				// running. If that branch corresponds to an older release, then upgrading
 				// to head after 19.2 fails.
-				minVersion: "v19.2.0",
-				timeout:    30 * time.Minute,
+				timeout: 30 * time.Minute,
 			},
 		},
 	}

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -52,6 +52,16 @@ const (
 	usingExistingData // skips import
 )
 
+// rampDuration returns the default durations passed to the `ramp`
+// option when running a tpcc workload in these tests.
+func rampDuration(isLocal bool) time.Duration {
+	if isLocal {
+		return 30 * time.Second
+	}
+
+	return 5 * time.Minute
+}
+
 type tpccOptions struct {
 	Warehouses         int
 	ExtraRunArgs       string
@@ -234,16 +244,15 @@ func runTPCC(ctx context.Context, t test.Test, c cluster.Cluster, opts tpccOptio
 		ep = &cep
 	}
 
-	rampDuration := 5 * time.Minute
 	if c.IsLocal() {
 		opts.Warehouses = 1
 		if opts.Duration > time.Minute {
 			opts.Duration = time.Minute
 		}
-		rampDuration = 30 * time.Second
 	}
 	crdbNodes, workloadNode := setupTPCC(ctx, t, c, opts)
 	m := c.NewMonitor(ctx, crdbNodes)
+	rampDur := rampDuration(c.IsLocal())
 	for i := range workloadInstances {
 		// Make a copy of i for the goroutine.
 		i := i
@@ -255,13 +264,13 @@ func runTPCC(ctx context.Context, t test.Test, c cluster.Cluster, opts tpccOptio
 				statsPrefix = fmt.Sprintf("workload_%d.", i)
 			}
 			t.WorkerStatus(fmt.Sprintf("running tpcc worker=%d warehouses=%d ramp=%s duration=%s on %s (<%s)",
-				i, opts.Warehouses, rampDuration, opts.Duration, pgURLs[i], time.Minute))
+				i, opts.Warehouses, rampDur, opts.Duration, pgURLs[i], time.Minute))
 			cmd := fmt.Sprintf(
 				"./cockroach workload run tpcc --warehouses=%d --histograms="+t.PerfArtifactsDir()+"/%sstats.json "+
 					opts.ExtraRunArgs+" --ramp=%s --duration=%s --prometheus-port=%d --pprofport=%d %s %s",
 				opts.Warehouses,
 				statsPrefix,
-				rampDuration,
+				rampDur,
 				opts.Duration,
 				workloadInstances[i].prometheusPort,
 				workloadPProfStartPort+i,
@@ -346,6 +355,138 @@ func maxSupportedTPCCWarehouses(
 	return warehouses
 }
 
+// runTPCCMixedHeadroom runs a mixed-version test that imports a large
+// `bank` dataset, and runs one or multiple database upgrades while a
+// TPCC workload is running. The number of database upgrades is
+// controlled by the `versionsToUpgrade` parameter.
+func runTPCCMixedHeadroom(
+	ctx context.Context, t test.Test, c cluster.Cluster, cloud string, versionsToUpgrade int,
+) {
+	if runtime.GOARCH == "arm64" {
+		t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/89268")
+	}
+	crdbNodes := c.Range(1, c.Spec().NodeCount-1)
+	workloadNode := c.Node(c.Spec().NodeCount)
+
+	maxWarehouses := maxSupportedTPCCWarehouses(*t.BuildVersion(), cloud, c.Spec())
+	headroomWarehouses := int(float64(maxWarehouses) * 0.7)
+	if c.IsLocal() {
+		headroomWarehouses = 10
+	}
+
+	// We'll need this below.
+	tpccBackgroundStepper := func(duration time.Duration) backgroundStepper {
+		return backgroundStepper{
+			nodes: crdbNodes,
+			run: func(ctx context.Context, u *versionUpgradeTest) error {
+				t.L().Printf("running background TPCC workload for %s", duration)
+				runTPCC(ctx, t, c, tpccOptions{
+					Warehouses: headroomWarehouses,
+					Duration:   duration,
+					SetupType:  usingExistingData,
+					Start: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+						// Noop - we don't let tpcc upload or start binaries in this test.
+					},
+				})
+				return nil
+			}}
+	}
+
+	randomCRDBNode := func() int { return crdbNodes.RandNode()[0] }
+	const mainBinary = ""
+
+	// NB: this results in ~100GB of (actual) disk usage per node once things
+	// have settled down, and ~7.5k ranges. The import takes ~40 minutes.
+	// The full 6.5m import ran into out of disk errors (on 250gb machines),
+	// hence division by two.
+	bankRows := 65104166 / 2
+	if c.IsLocal() {
+		bankRows = 1000
+	}
+
+	history, err := PredecessorHistory(*t.BuildVersion(), versionsToUpgrade)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sep := " -> "
+	t.L().Printf("testing upgrade: %s%scurrent", strings.Join(history, sep), sep)
+	history = append(history, mainBinary)
+
+	waitForWorkloadToRampUp := sleepStep(rampDuration(c.IsLocal()))
+	logStep := func(format string, args ...interface{}) versionStep {
+		return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
+			t.L().Printf(format, args...)
+		}
+	}
+
+	oldestVersion := history[0]
+	setupSteps := []versionStep{
+		logStep("starting from fixture at version %s", oldestVersion),
+		uploadAndStartFromCheckpointFixture(crdbNodes, oldestVersion),
+		waitForUpgradeStep(crdbNodes),               // let oldest version settle (gossip etc)
+		uploadVersionStep(workloadNode, mainBinary), // for tpccBackgroundStepper's workload
+
+		// Load TPCC dataset, don't run TPCC yet. We do this while in the
+		// version we are starting with to load some data and hopefully
+		// create some state that will need work by long-running
+		// migrations.
+		importTPCCStep(oldestVersion, headroomWarehouses, crdbNodes),
+		// Add a lot of cold data to this cluster. This further stresses the version
+		// upgrade machinery, in which a) all ranges are touched and b) work proportional
+		// to the amount data may be carried out.
+		importLargeBankStep(oldestVersion, bankRows, crdbNodes),
+	}
+
+	// upgradeToVersionSteps returns the list of steps to be performed
+	// when upgrading to the given version.
+	upgradeToVersionSteps := func(crdbVersion string) []versionStep {
+		duration := 10 * time.Minute
+		versionString := crdbVersion
+		if crdbVersion == mainBinary {
+			duration = 100 * time.Minute
+			versionString = "current"
+		}
+		tpccWorkload := tpccBackgroundStepper(duration)
+
+		return []versionStep{
+			logStep("upgrading to version %q", versionString),
+			preventAutoUpgradeStep(randomCRDBNode()),
+			// Upload and restart cluster into the new
+			// binary (stays at previous cluster version).
+			binaryUpgradeStep(crdbNodes, crdbVersion),
+			// Now start running TPCC in the background.
+			tpccWorkload.launch,
+			// Wait for the workload to ramp up before attemping to
+			// upgrade the cluster version. If we start the migrations
+			// immediately after launching the tpcc workload above, they
+			// could finish "too quickly", before the workload had a
+			// chance to pick up the pace (starting all the workers, range
+			// merge/splits, compactions, etc). By waiting here, we
+			// increase the concurrency exposed to the upgrade migrations,
+			// and increase the chances of exposing bugs (such as #83079).
+			waitForWorkloadToRampUp,
+			// While tpcc is running in the background, bump the cluster
+			// version manually. We do this over allowing automatic upgrades
+			// to get a better idea of what errors come back here, if any.
+			// This will block until the long-running migrations have run.
+			allowAutoUpgradeStep(randomCRDBNode()),
+			setClusterSettingVersionStep,
+			// Wait until TPCC background run terminates
+			// and fail if it reports an error.
+			tpccWorkload.wait,
+		}
+	}
+
+	// Test steps consist of the setup steps + the upgrade steps for
+	// each upgrade being carried out here.
+	testSteps := append([]versionStep{}, setupSteps...)
+	for _, nextVersion := range history[1:] {
+		testSteps = append(testSteps, upgradeToVersionSteps(nextVersion)...)
+	}
+
+	newVersionUpgradeTest(c, testSteps...).run(ctx, t)
+}
+
 func registerTPCC(r registry.Registry) {
 	cloud := r.MakeClusterSpec(1).Cloud
 	headroomSpec := r.MakeClusterSpec(4, spec.CPU(16), spec.RandomlyUseZfs())
@@ -385,81 +526,18 @@ func registerTPCC(r registry.Registry) {
 		Cluster:           mixedHeadroomSpec,
 		EncryptionSupport: registry.EncryptionMetamorphic,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			if runtime.GOARCH == "arm64" {
-				t.Skip("Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/89268")
-			}
-			crdbNodes := c.Range(1, 4)
-			workloadNode := c.Node(5)
-
-			maxWarehouses := maxSupportedTPCCWarehouses(*t.BuildVersion(), cloud, t.Spec().(*registry.TestSpec).Cluster)
-			headroomWarehouses := int(float64(maxWarehouses) * 0.7)
-			if c.IsLocal() {
-				headroomWarehouses = 10
-			}
-
-			// We'll need this below.
-			tpccBackgroundStepper := backgroundStepper{
-				nodes: crdbNodes,
-				run: func(ctx context.Context, u *versionUpgradeTest) error {
-					const duration = 120 * time.Minute
-					t.L().Printf("running background TPCC workload")
-					runTPCC(ctx, t, c, tpccOptions{
-						Warehouses: headroomWarehouses,
-						Duration:   duration,
-						SetupType:  usingExistingData,
-						Start: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-							// Noop - we don't let tpcc upload or start binaries in this test.
-						},
-					})
-					return nil
-				}}
-			const (
-				mainBinary = ""
-				n1         = 1
-			)
-
-			// NB: this results in ~100GB of (actual) disk usage per node once things
-			// have settled down, and ~7.5k ranges. The import takes ~40 minutes.
-			// The full 6.5m import ran into out of disk errors (on 250gb machines),
-			// hence division by two.
-			bankRows := 65104166 / 2
-			if c.IsLocal() {
-				bankRows = 1000
-			}
-
-			oldV, err := PredecessorVersion(*t.BuildVersion())
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			newVersionUpgradeTest(c,
-				uploadAndStartFromCheckpointFixture(crdbNodes, oldV),
-				waitForUpgradeStep(crdbNodes), // let predecessor version settle (gossip etc)
-				preventAutoUpgradeStep(n1),
-				// Load TPCC dataset, don't run TPCC yet. We do this while in the old
-				// version to load some data and hopefully create some state that will
-				// need work by long-running migrations.
-				importTPCCStep(oldV, headroomWarehouses, crdbNodes),
-				// Add a lot of cold data to this cluster. This further stresses the version
-				// upgrade machinery, in which a) all ranges are touched and b) work proportional
-				// to the amount data may be carried out.
-				importLargeBankStep(oldV, bankRows, crdbNodes),
-				// Upload and restart cluster into the new
-				// binary (stays at old cluster version).
-				binaryUpgradeStep(crdbNodes, mainBinary),
-				uploadVersionStep(workloadNode, mainBinary), // for tpccBackgroundStepper's workload
-				// Now start running TPCC in the background.
-				tpccBackgroundStepper.launch,
-				// While tpcc is running in the background, bump the cluster
-				// version manually. We do this over allowing automatic upgrades
-				// to get a better idea of what errors come back here, if any.
-				// This will block until the long-running migrations have run.
-				allowAutoUpgradeStep(n1),
-				setClusterSettingVersionStep,
-				// Wait until TPCC background run terminates
-				// and fail if it reports an error.
-				tpccBackgroundStepper.wait,
-			).run(ctx, t)
+			runTPCCMixedHeadroom(ctx, t, c, cloud, 1)
+		},
+	})
+	r.Add(registry.TestSpec{
+		// run the same mixed-headroom test, but going back two versions
+		Name:              "tpcc/mixed-headroom/multiple-upgrades/" + mixedHeadroomSpec.String(),
+		Owner:             registry.OwnerTestEng,
+		Tags:              []string{`default`},
+		Cluster:           mixedHeadroomSpec,
+		EncryptionSupport: registry.EncryptionMetamorphic,
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			runTPCCMixedHeadroom(ctx, t, c, cloud, 2)
 		},
 	})
 	r.Add(registry.TestSpec{

--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -196,7 +196,7 @@ func (u *versionUpgradeTest) run(ctx context.Context, t test.Test) {
 
 	for i, step := range u.steps {
 		if step != nil {
-			t.Status(fmt.Sprintf("versionUpgrateTest: starting step %d", i+1))
+			t.Status(fmt.Sprintf("versionUpgradeTest: starting step %d", i+1))
 			step(ctx, t, u)
 		}
 	}


### PR DESCRIPTION
All of our existing mixed-version roachtests only test that a node
running the previous version can be upgraded to the current one. In
order to expand the coverage of upgrade-related paths, this commit
introduces a new roachtest (`tpcc/mixed-headroom/multiple-upgrades`)
that starts off 2 releases prior to the current one, and upgrades a
cluster all the way to the current cockroach version.

The test is a variation of the existing `tpcc/mixed-headroom` test,
and uses the same structure: a large bank dataset is imported, and the
upgrade happens while a `tpcc` workload is running.

Note that currently failures that happen during the upgrade from two
releases prior to the previous release will still fail the test and
create a GitHub issue for the Test Eng team to investigate. In the
future, we may consider only creating issues if the upgrade is related
to the "final" upgrade in the test, when the cluster is being upgraded
to the current version. Upgrades to older releases should already be
covered by roachtests in release branches, and such failures would
mostly just add noise.

Epic: CRDB-19321
Jira issue: [CRDB-20907](https://cockroachlabs.atlassian.net/browse/CRDB-20907)
Release note: None