### PR TITLE
builtins: fix pg_function_is_visible to work with UDFs

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -3440,6 +3440,8 @@ table. Returns an error if validation fails.</p>
 </span></td><td>Stable</td></tr>
 <tr><td><a name="pg_column_size"></a><code>pg_column_size(anyelement...) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Return size in bytes of the column provided as an argument</p>
 </span></td><td>Immutable</td></tr>
+<tr><td><a name="pg_function_is_visible"></a><code>pg_function_is_visible(oid: oid) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether the function with the given OID belongs to one of the schemas on the search path.</p>
+</span></td><td>Stable</td></tr>
 <tr><td><a name="pg_get_function_identity_arguments"></a><code>pg_get_function_identity_arguments(func_oid: oid) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the argument list (without defaults) necessary to identify a function, in the form it would need to appear in within ALTER FUNCTION, for instance.</p>
 </span></td><td>Stable</td></tr>
 <tr><td><a name="pg_get_function_result"></a><code>pg_get_function_result(func_oid: oid) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the types of the result of the specified function.</p>

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -68,13 +68,6 @@ func (so *DummySequenceOperators) SchemaExists(
 	return false, errors.WithStack(errSequenceOperators)
 }
 
-// IsTypeVisible is part of the eval.DatabaseCatalog interface.
-func (so *DummySequenceOperators) IsTypeVisible(
-	ctx context.Context, curDB string, searchPath sessiondata.SearchPath, typeID oid.Oid,
-) (bool, bool, error) {
-	return false, false, errors.WithStack(errEvalPlanner)
-}
-
 // HasAnyPrivilege is part of the eval.DatabaseCatalog interface.
 func (so *DummySequenceOperators) HasAnyPrivilege(
 	ctx context.Context,
@@ -363,13 +356,6 @@ func (ep *DummyEvalPlanner) ValidateAllMultiRegionZoneConfigsInCurrentDatabase(
 // SchemaExists is part of the eval.DatabaseCatalog interface.
 func (ep *DummyEvalPlanner) SchemaExists(ctx context.Context, dbName, scName string) (bool, error) {
 	return false, errors.WithStack(errEvalPlanner)
-}
-
-// IsTypeVisible is part of the eval.DatabaseCatalog interface.
-func (ep *DummyEvalPlanner) IsTypeVisible(
-	ctx context.Context, curDB string, searchPath sessiondata.SearchPath, typeID oid.Oid,
-) (bool, bool, error) {
-	return false, false, errors.WithStack(errEvalPlanner)
 }
 
 // HasAnyPrivilege is part of the eval.DatabaseCatalog interface.

--- a/pkg/sql/importer/import_table_creation.go
+++ b/pkg/sql/importer/import_table_creation.go
@@ -303,13 +303,6 @@ func (so *importSequenceOperators) SchemaExists(
 	return false, errSequenceOperators
 }
 
-// IsTypeVisible is part of the eval.DatabaseCatalog interface.
-func (so *importSequenceOperators) IsTypeVisible(
-	ctx context.Context, curDB string, searchPath sessiondata.SearchPath, typeID oid.Oid,
-) (bool, bool, error) {
-	return false, false, errors.WithStack(errSequenceOperators)
-}
-
 // HasAnyPrivilege is part of the eval.DatabaseCatalog interface.
 func (so *importSequenceOperators) HasAnyPrivilege(
 	ctx context.Context,

--- a/pkg/sql/logictest/testdata/logic_test/pg_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pg_builtins
@@ -79,19 +79,25 @@ NULL
 statement ok
 CREATE TABLE is_visible(a int primary key);
 CREATE TYPE visible_type AS ENUM('a');
+CREATE FUNCTION visible_function() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
 CREATE SCHEMA other;
 CREATE TABLE other.not_visible(a int primary key);
 CREATE TYPE other.not_visible_type AS ENUM('b');
+CREATE FUNCTION other.function_not_visible() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
 CREATE DATABASE db2;
 SET DATABASE = db2;
 CREATE TABLE table_in_db2(a int primary key);
 CREATE TYPE type_in_db2 AS ENUM('c');
+CREATE FUNCTION function_in_db2() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
 
 let $table_in_db2_id
 SELECT c.oid FROM pg_class c WHERE c.relname = 'table_in_db2';
 
 let $type_in_db2_id
 SELECT t.oid FROM pg_type t WHERE t.typname = 'type_in_db2';
+
+let $function_in_db2_id
+SELECT p.oid FROM pg_proc p WHERE p.proname = 'function_in_db2';
 
 statement ok
 SET DATABASE = test;
@@ -150,6 +156,39 @@ SELECT pg_type_is_visible(NULL)
 ----
 NULL
 
+query TB rowsort
+SELECT p.proname, pg_function_is_visible(p.oid)
+FROM pg_proc p
+WHERE p.proname IN ('visible_function', 'function_not_visible')
+----
+function_not_visible  false
+visible_function      true
+
+# Looking up a function in a different database should return NULL.
+query B
+SELECT pg_function_is_visible($function_in_db2_id)
+----
+NULL
+
+# Looking up a non-existent OID should return NULL.
+query B
+SELECT pg_function_is_visible(1010101010)
+----
+NULL
+
+query B
+SELECT pg_function_is_visible(NULL)
+----
+NULL
+
+# Looking up builtins should work.
+query BBB
+SELECT
+  pg_function_is_visible('pg_function_is_visible'::regproc),
+  pg_function_is_visible('uuid_generate_v4'::regproc),
+  pg_function_is_visible('crdb_internal.force_panic'::regproc)
+----
+true  true  true
 
 query TT
 SELECT pg_get_partkeydef(1), pg_get_partkeydef(NULL)
@@ -174,11 +213,11 @@ WHERE c.relname IN ('is_updatable', 'is_updatable_view', 'pg_class')
 ORDER BY c.oid, a.attnum
 ----
 relname            attname              oid         attnum  pg_relation_is_updatable  pg_column_is_updatable
-is_updatable       a                    120         1       28                        true
-is_updatable       b                    120         2       28                        true
-is_updatable       c                    120         3       28                        false
-is_updatable_view  a                    121         1       0                         false
-is_updatable_view  b                    121         2       0                         false
+is_updatable       a                    123         1       28                        true
+is_updatable       b                    123         2       28                        true
+is_updatable       c                    123         3       28                        false
+is_updatable_view  a                    124         1       0                         false
+is_updatable_view  b                    124         2       0                         false
 pg_class           oid                  4294967123  1       0                         false
 pg_class           relname              4294967123  2       0                         false
 pg_class           relnamespace         4294967123  3       0                         false

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -34,12 +34,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
-	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/errors"
-	"github.com/lib/pq/oid"
 )
 
 var _ resolver.SchemaResolver = &planner{}
@@ -136,48 +133,6 @@ func (p *planner) GetSchemasForDB(
 func (p *planner) SchemaExists(ctx context.Context, dbName, scName string) (found bool, err error) {
 	found, _, err = p.LookupSchema(ctx, dbName, scName)
 	return found, err
-}
-
-// IsTypeVisible is part of the eval.DatabaseCatalog interface.
-func (p *planner) IsTypeVisible(
-	ctx context.Context, curDB string, searchPath sessiondata.SearchPath, typeID oid.Oid,
-) (isVisible bool, exists bool, err error) {
-	// Check builtin types first. They are always globally visible.
-	if _, ok := types.OidToType[typeID]; ok {
-		return true, true, nil
-	}
-
-	if !types.IsOIDUserDefinedType(typeID) {
-		return false, false, nil //nolint:returnerrcheck
-	}
-
-	id, err := typedesc.UserDefinedTypeOIDToID(typeID)
-	if err != nil {
-		return false, false, err
-	}
-	typName, _, err := p.GetTypeDescriptor(ctx, id)
-	if err != nil {
-		// If a "not found" error happened here, we return "not exists" rather than
-		// the error.
-		if errors.Is(err, catalog.ErrDescriptorNotFound) ||
-			errors.Is(err, catalog.ErrDescriptorDropped) ||
-			pgerror.GetPGCode(err) == pgcode.UndefinedObject {
-			return false, false, nil //nolint:returnerrcheck
-		}
-		return false, false, err
-	}
-	if typName.CatalogName.String() != curDB {
-		// If the type is in a different database, then it's considered to be
-		// "not existing" instead of just "not visible"; this matches PostgreSQL.
-		return false, false, nil
-	}
-	iter := searchPath.Iter()
-	for scName, ok := iter.Next(); ok; scName, ok = iter.Next() {
-		if typName.SchemaName.String() == scName {
-			return true, true, nil
-		}
-	}
-	return false, true, nil
 }
 
 // HasAnyPrivilege is part of the eval.DatabaseCatalog interface.

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -1203,13 +1203,8 @@ SELECT description
 					return tree.DNull, nil
 				}
 				foundSchemaName := string(tree.MustBeDString(row[0]))
-				iter := evalCtx.SessionData().SearchPath.Iter()
-				for scName, ok := iter.Next(); ok; scName, ok = iter.Next() {
-					if foundSchemaName == scName {
-						return tree.DBoolTrue, nil
-					}
-				}
-				return tree.DBoolFalse, nil
+				isVisible := evalCtx.SessionData().SearchPath.Contains(foundSchemaName, true /* includeImplicit */)
+				return tree.MakeDBool(tree.DBool(isVisible)), nil
 			},
 			Info:       "Returns whether the function with the given OID belongs to one of the schemas on the search path.",
 			Volatility: volatility.Stable,
@@ -1237,13 +1232,8 @@ SELECT description
 					return tree.DNull, nil
 				}
 				foundSchemaName := string(tree.MustBeDString(row[0]))
-				iter := evalCtx.SessionData().SearchPath.Iter()
-				for scName, ok := iter.Next(); ok; scName, ok = iter.Next() {
-					if foundSchemaName == scName {
-						return tree.DBoolTrue, nil
-					}
-				}
-				return tree.DBoolFalse, nil
+				isVisible := evalCtx.SessionData().SearchPath.Contains(foundSchemaName, true /* includeImplicit */)
+				return tree.MakeDBool(tree.DBool(isVisible)), nil
 			},
 			Info:       "Returns whether the table with the given OID belongs to one of the schemas on the search path.",
 			Volatility: volatility.Stable,
@@ -1275,13 +1265,8 @@ SELECT description
 					return tree.DNull, nil
 				}
 				foundSchemaName := string(tree.MustBeDString(row[0]))
-				iter := evalCtx.SessionData().SearchPath.Iter()
-				for scName, ok := iter.Next(); ok; scName, ok = iter.Next() {
-					if foundSchemaName == scName {
-						return tree.DBoolTrue, nil
-					}
-				}
-				return tree.DBoolFalse, nil
+				isVisible := evalCtx.SessionData().SearchPath.Contains(foundSchemaName, true /* includeImplicit */)
+				return tree.MakeDBool(tree.DBool(isVisible)), nil
 			},
 			Info:       "Returns whether the type with the given OID belongs to one of the schemas on the search path.",
 			Volatility: volatility.Stable,

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -1252,9 +1252,9 @@ SELECT description
 
 	// pg_type_is_visible returns true if the input oid corresponds to a type
 	// that is part of the databases on the search path, or NULL if no such type
-	// exists. CockroachDB doesn't support the notion of type visibility, so we
-	// always return true for any type oid that we support, and NULL for those
-	// that we don't.
+	// exists. CockroachDB doesn't support the notion of type visibility for
+	// builtin types, so we  always return true for those. For user-defined types,
+	// we consult pg_type.
 	// https://www.postgresql.org/docs/9.6/static/functions-info.html
 	"pg_type_is_visible": makeBuiltin(defProps(),
 		tree.Overload{
@@ -1262,16 +1262,26 @@ SELECT description
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				oidArg := tree.MustBeDOid(args[0])
-				isVisible, exists, err := evalCtx.Planner.IsTypeVisible(
-					ctx, evalCtx.SessionData().Database, evalCtx.SessionData().SearchPath, oidArg.Oid,
+				row, err := evalCtx.Planner.QueryRowEx(
+					ctx, "pg_type_is_visible",
+					sessiondata.NoSessionDataOverride,
+					"SELECT n.nspname from pg_type t JOIN pg_namespace n ON t.typnamespace = n.oid WHERE t.oid=$1 LIMIT 1",
+					oidArg.Oid,
 				)
 				if err != nil {
 					return nil, err
 				}
-				if !exists {
+				if row == nil {
 					return tree.DNull, nil
 				}
-				return tree.MakeDBool(tree.DBool(isVisible)), nil
+				foundSchemaName := string(tree.MustBeDString(row[0]))
+				iter := evalCtx.SessionData().SearchPath.Iter()
+				for scName, ok := iter.Next(); ok; scName, ok = iter.Next() {
+					if foundSchemaName == scName {
+						return tree.DBoolTrue, nil
+					}
+				}
+				return tree.DBoolFalse, nil
 			},
 			Info:       "Returns whether the type with the given OID belongs to one of the schemas on the search path.",
 			Volatility: volatility.Stable,

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -1183,28 +1183,35 @@ SELECT description
 
 	// pg_function_is_visible returns true if the input oid corresponds to a
 	// builtin function that is part of the databases on the search path.
-	// CockroachDB doesn't have a concept of namespaced functions, so this is
-	// always true if the builtin exists at all, and NULL otherwise.
 	// https://www.postgresql.org/docs/9.6/static/functions-info.html
 	"pg_function_is_visible": makeBuiltin(defProps(),
 		tree.Overload{
 			Types:      tree.ParamTypes{{Name: "oid", Typ: types.Oid}},
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				oid := tree.MustBeDOid(args[0])
-				t, err := evalCtx.Planner.QueryRowEx(
+				oidArg := tree.MustBeDOid(args[0])
+				row, err := evalCtx.Planner.QueryRowEx(
 					ctx, "pg_function_is_visible",
 					sessiondata.NoSessionDataOverride,
-					"SELECT * from pg_proc WHERE oid=$1 LIMIT 1", oid.Oid)
+					"SELECT n.nspname from pg_proc p JOIN pg_namespace n ON p.pronamespace = n.oid WHERE p.oid=$1 LIMIT 1",
+					oidArg.Oid,
+				)
 				if err != nil {
 					return nil, err
 				}
-				if t != nil {
-					return tree.DBoolTrue, nil
+				if row == nil {
+					return tree.DNull, nil
 				}
-				return tree.DNull, nil
+				foundSchemaName := string(tree.MustBeDString(row[0]))
+				iter := evalCtx.SessionData().SearchPath.Iter()
+				for scName, ok := iter.Next(); ok; scName, ok = iter.Next() {
+					if foundSchemaName == scName {
+						return tree.DBoolTrue, nil
+					}
+				}
+				return tree.DBoolFalse, nil
 			},
-			Info:       notUsableInfo,
+			Info:       "Returns whether the function with the given OID belongs to one of the schemas on the search path.",
 			Volatility: volatility.Stable,
 		},
 	),

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -65,12 +65,6 @@ type DatabaseCatalog interface {
 	// whether it exists.
 	SchemaExists(ctx context.Context, dbName, scName string) (found bool, err error)
 
-	// IsTypeVisible checks if the type with the given ID belongs to a schema
-	// on the given sessiondata.SearchPath.
-	IsTypeVisible(
-		ctx context.Context, curDB string, searchPath sessiondata.SearchPath, typeID oid.Oid,
-	) (isVisible bool, exists bool, err error)
-
 	// HasAnyPrivilege returns whether the current user has privilege to access
 	// the given object.
 	HasAnyPrivilege(ctx context.Context, specifier HasPrivilegeSpecifier, user username.SQLUsername, privs []privilege.Privilege) (HasAnyPrivilegeResult, error)

--- a/pkg/sql/sessiondata/search_path.go
+++ b/pkg/sql/sessiondata/search_path.go
@@ -167,9 +167,15 @@ func (s SearchPath) GetPathArray() []string {
 }
 
 // Contains returns true iff the SearchPath contains the given string.
-func (s SearchPath) Contains(target string) bool {
-	for _, candidate := range s.GetPathArray() {
-		if candidate == target {
+func (s SearchPath) Contains(target string, includeImplicit bool) bool {
+	var iter SearchPathIter
+	if includeImplicit {
+		iter = s.Iter()
+	} else {
+		iter = s.IterWithoutImplicitPGSchemas()
+	}
+	for candidate, ok := iter.Next(); ok; candidate, ok = iter.Next() {
+		if target == candidate {
 			return true
 		}
 	}

--- a/pkg/sql/show_create_clauses.go
+++ b/pkg/sql/show_create_clauses.go
@@ -447,7 +447,7 @@ func showForeignKeyConstraint(
 		if err != nil {
 			return err
 		}
-		fkTableName.ExplicitSchema = !searchPath.Contains(fkTableName.SchemaName.String())
+		fkTableName.ExplicitSchema = !searchPath.Contains(fkTableName.SchemaName.String(), false /* includeImplicit */)
 		refNames, err = fkTable.NamesForColumnIDs(fk.ReferencedColumnIDs)
 		if err != nil {
 			return err


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/89546

### builtins: fix pg_function_is_visible to work with UDFs

Release note (bug fix): The pg_function_is_visible function now
correctly reports visibility based on the functions that are visible on
the current search_path.

### builtins: use pg_type to implement pg_type_is_visible

This saves us from having to maintain the old code, which I personally
found to be a bit hard to work with. Using the internal executor like
this should be faster than it used to be, since there is an index on
pg_type(oid) that will avoid any lookups for builtin types.

### sessiondata: consolidate logic for searching the search_path 