### PR TITLE
backfill: retain dropping columns when validating inverted index

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1668,7 +1668,7 @@ func countExpectedRowsForInvertedIndex(
 		// Make the mutations public in an in-memory copy of the descriptor and
 		// add it to the Collection's synthetic descriptors, so that we can use
 		// SQL below to perform the validation.
-		fakeDesc, err := tableDesc.MakeFirstMutationPublic(catalog.IgnoreConstraints)
+		fakeDesc, err := tableDesc.MakeFirstMutationPublic(catalog.IgnoreConstraints, catalog.RetainDroppingColumns)
 		if err != nil {
 			return 0, err
 		}

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -1822,3 +1822,13 @@ CREATE TABLE t_85877 (i INT NOT NULL, j INT NOT NULL, k INT NOT NULL, PRIMARY KE
 
 statement ok
 ALTER TABLE t_85877 ALTER PRIMARY KEY USING COLUMNS (j, k)
+
+# The following subtest tests validating an inverted index while
+# a column is being dropped.
+subtest regression_90306
+
+statement ok
+CREATE TABLE t_90306 (j INT[], k INT NOT NULL, INVERTED INDEX (j));
+
+statement ok
+ALTER TABLE t_90306 ALTER PRIMARY KEY USING COLUMNS (k);


### PR DESCRIPTION
Previously, when validating a forward index, we made the first mutation(s) public with two filters: ignore constraints and retain dropping columns. But we forgot to include the retain-dropping-columns policy when validating *inverted* index. This will only manifest itself in rare cases involving dropping column and validating inverted indexes. An example to trigger this rare case is:
```
create table t (j int[], k int not null, inverted index (j));

alter table t alter primary key using columns (k);
```

Fixes #90306
Release note: None