### PR TITLE
sql: add contention_events to cluster_execution_insights

### DIFF
--- a/pkg/sql/colexecop/BUILD.bazel
+++ b/pkg/sql/colexecop/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/col/coldata",
+        "//pkg/roachpb",
         "//pkg/sql/colexecerror",
         "//pkg/sql/colmem",
         "//pkg/sql/execinfra/execopnode",

--- a/pkg/sql/colexecop/operator.go
+++ b/pkg/sql/colexecop/operator.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra/execopnode"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -73,9 +74,9 @@ type KVReader interface {
 	// GetBatchRequestsIssued returns the number of BatchRequests issued to KV
 	// by this operator. It must be safe for concurrent use.
 	GetBatchRequestsIssued() int64
-	// GetCumulativeContentionTime returns the amount of time KV reads spent
+	// GetContentionInfo returns the amount of time KV reads spent
 	// contending. It must be safe for concurrent use.
-	GetCumulativeContentionTime() time.Duration
+	GetContentionInfo() (time.Duration, []roachpb.ContentionEvent)
 	// GetScanStats returns statistics about the scan that happened during the
 	// KV reads. It must be safe for concurrent use.
 	GetScanStats() execstats.ScanStats

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -165,8 +165,8 @@ func (s *ColBatchScan) GetBatchRequestsIssued() int64 {
 	return s.cf.getBatchRequestsIssued()
 }
 
-// GetCumulativeContentionTime is part of the colexecop.KVReader interface.
-func (s *ColBatchScan) GetCumulativeContentionTime() time.Duration {
+// GetContentionInfo is part of the colexecop.KVReader interface.
+func (s *ColBatchScan) GetContentionInfo() (time.Duration, []roachpb.ContentionEvent) {
 	return execstats.GetCumulativeContentionTime(s.Ctx, nil /* recording */)
 }
 

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -399,8 +399,8 @@ func (s *ColIndexJoin) GetBatchRequestsIssued() int64 {
 	return s.cf.getBatchRequestsIssued()
 }
 
-// GetCumulativeContentionTime is part of the colexecop.KVReader interface.
-func (s *ColIndexJoin) GetCumulativeContentionTime() time.Duration {
+// GetContentionInfo is part of the colexecop.KVReader interface.
+func (s *ColIndexJoin) GetContentionInfo() (time.Duration, []roachpb.ContentionEvent) {
 	return execstats.GetCumulativeContentionTime(s.Ctx, nil /* recording */)
 }
 

--- a/pkg/sql/colflow/stats.go
+++ b/pkg/sql/colflow/stats.go
@@ -224,7 +224,9 @@ func (vsc *vectorizedStatsCollectorImpl) GetStats() *execinfrapb.ComponentStats 
 		s.KV.TuplesRead.Set(uint64(vsc.kvReader.GetRowsRead()))
 		s.KV.BytesRead.Set(uint64(vsc.kvReader.GetBytesRead()))
 		s.KV.BatchRequestsIssued.Set(uint64(vsc.kvReader.GetBatchRequestsIssued()))
-		s.KV.ContentionTime.Set(vsc.kvReader.GetCumulativeContentionTime())
+		totalContentionTime, events := vsc.kvReader.GetContentionInfo()
+		s.KV.ContentionTime.Set(totalContentionTime)
+		s.KV.ContentionEvents = events
 		scanStats := vsc.kvReader.GetScanStats()
 		execstats.PopulateKVMVCCStats(&s.KV, &scanStats)
 	} else {

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -6446,6 +6446,7 @@ CREATE TABLE crdb_internal.%s (
 	last_retry_reason          STRING,
 	exec_node_ids              INT[] NOT NULL,
 	contention                 INTERVAL,
+	contention_events          JSONB,
 	index_recommendations      STRING[] NOT NULL,
 	implicit_txn               BOOL NOT NULL
 )`
@@ -6486,33 +6487,32 @@ func populateExecutionInsights(
 
 	response, err := p.extendedEvalCtx.SQLStatusServer.ListExecutionInsights(ctx, request)
 	if err != nil {
-		return
+		return err
 	}
 	for _, insight := range response.Insights {
 		causes := tree.NewDArray(types.String)
 		for _, cause := range insight.Causes {
-			if errProblem := causes.Append(tree.NewDString(cause.String())); err != nil {
-				err = errors.CombineErrors(err, errProblem)
+			if err = causes.Append(tree.NewDString(cause.String())); err != nil {
+				return err
 			}
 		}
 
-		startTimestamp, errTimestamp := tree.MakeDTimestamp(insight.Statement.StartTime, time.Nanosecond)
-		if errTimestamp != nil {
-			err = errors.CombineErrors(err, errTimestamp)
-			return
+		var startTimestamp *tree.DTimestamp
+		startTimestamp, err = tree.MakeDTimestamp(insight.Statement.StartTime, time.Nanosecond)
+		if err != nil {
+			return err
 		}
 
-		endTimestamp, errTimestamp := tree.MakeDTimestamp(insight.Statement.EndTime, time.Nanosecond)
-		if errTimestamp != nil {
-			err = errors.CombineErrors(err, errTimestamp)
-			return
+		var endTimestamp *tree.DTimestamp
+		endTimestamp, err = tree.MakeDTimestamp(insight.Statement.EndTime, time.Nanosecond)
+		if err != nil {
+			return err
 		}
 
 		execNodeIDs := tree.NewDArray(types.Int)
 		for _, nodeID := range insight.Statement.Nodes {
-			if errNodeID := execNodeIDs.Append(tree.NewDInt(tree.DInt(nodeID))); errNodeID != nil {
-				err = errors.CombineErrors(err, errNodeID)
-				return
+			if err = execNodeIDs.Append(tree.NewDInt(tree.DInt(nodeID))); err != nil {
+				return err
 			}
 		}
 
@@ -6529,9 +6529,20 @@ func populateExecutionInsights(
 			)
 		}
 
+		contentionEvents := tree.DNull
+		if len(insight.Statement.ContentionEvents) > 0 {
+			var contentionEventsJSON json.JSON
+			contentionEventsJSON, err = sqlstatsutil.BuildContentionEventsJSON(insight.Statement.ContentionEvents)
+			if err != nil {
+				return err
+			}
+
+			contentionEvents = tree.NewDJSON(contentionEventsJSON)
+		}
+
 		indexRecommendations := tree.NewDArray(types.String)
 		for _, recommendation := range insight.Statement.IndexRecommendations {
-			if err := indexRecommendations.Append(tree.NewDString(recommendation)); err != nil {
+			if err = indexRecommendations.Append(tree.NewDString(recommendation)); err != nil {
 				return err
 			}
 		}
@@ -6560,9 +6571,14 @@ func populateExecutionInsights(
 			autoRetryReason,
 			execNodeIDs,
 			contentionTime,
+			contentionEvents,
 			indexRecommendations,
 			tree.MakeDBool(tree.DBool(insight.Transaction.ImplicitTxn)),
 		))
+
+		if err != nil {
+			return err
+		}
 	}
 	return
 }

--- a/pkg/sql/execinfrapb/component_stats.proto
+++ b/pkg/sql/execinfrapb/component_stats.proto
@@ -15,6 +15,7 @@ option go_package = "execinfrapb";
 import "gogoproto/gogo.proto";
 
 import "util/optional/optional.proto";
+import "roachpb/api.proto";
 
 // ComponentID identifies a component in a flow. There are multiple types of
 // components (e.g. processors, streams); each component of a certain type has
@@ -126,7 +127,7 @@ message KVStats {
   // Cumulated time spent waiting for a KV request. This includes disk IO time
   // and potentially network time (if any of the keys are not local).
   optional util.optional.Duration kv_time = 3 [(gogoproto.customname) = "KVTime",
-                                               (gogoproto.nullable) = false];
+    (gogoproto.nullable) = false];
 
   // ContentionTime is the cumulative time a KV request spent contending with
   // other transactions. This time accounts for a portion of KVTime above.
@@ -136,6 +137,9 @@ message KVStats {
   optional util.optional.Uint num_internal_steps = 6 [(gogoproto.nullable) = false];
   optional util.optional.Uint num_interface_seeks = 7 [(gogoproto.nullable) = false];
   optional util.optional.Uint num_internal_seeks = 8 [(gogoproto.nullable) = false];
+
+  // contention_events hit at the statement level.
+  repeated cockroach.roachpb.ContentionEvent contention_events = 10 [(gogoproto.nullable) = false];
 }
 
 // ExecStats contains statistics about the execution of a component.

--- a/pkg/sql/execstats/BUILD.bazel
+++ b/pkg/sql/execstats/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
     embed = [":execstats"],
     deps = [
         "//pkg/base",
+        "//pkg/roachpb",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/security/username",

--- a/pkg/sql/execstats/traceanalyzer_test.go
+++ b/pkg/sql/execstats/traceanalyzer_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
@@ -240,6 +241,7 @@ func TestTraceAnalyzerProcessStats(t *testing.T) {
 }
 
 func TestQueryLevelStatsAccumulate(t *testing.T) {
+	aEvent := roachpb.ContentionEvent{Duration: 7 * time.Second}
 	a := execstats.QueryLevelStats{
 		NetworkBytesSent:      1,
 		MaxMemUsage:           2,
@@ -249,8 +251,10 @@ func TestQueryLevelStatsAccumulate(t *testing.T) {
 		KVTime:                5 * time.Second,
 		NetworkMessages:       6,
 		ContentionTime:        7 * time.Second,
+		ContentionEvents:      []roachpb.ContentionEvent{aEvent},
 		MaxDiskUsage:          8,
 	}
+	bEvent := roachpb.ContentionEvent{Duration: 14 * time.Second}
 	b := execstats.QueryLevelStats{
 		NetworkBytesSent:      8,
 		MaxMemUsage:           9,
@@ -260,6 +264,7 @@ func TestQueryLevelStatsAccumulate(t *testing.T) {
 		KVTime:                12 * time.Second,
 		NetworkMessages:       13,
 		ContentionTime:        14 * time.Second,
+		ContentionEvents:      []roachpb.ContentionEvent{bEvent},
 		MaxDiskUsage:          15,
 	}
 	expected := execstats.QueryLevelStats{
@@ -271,6 +276,7 @@ func TestQueryLevelStatsAccumulate(t *testing.T) {
 		KVTime:                17 * time.Second,
 		NetworkMessages:       19,
 		ContentionTime:        21 * time.Second,
+		ContentionEvents:      []roachpb.ContentionEvent{aEvent, bEvent},
 		MaxDiskUsage:          15,
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -273,6 +273,7 @@ CREATE TABLE crdb_internal.cluster_execution_insights (
    last_retry_reason STRING NULL,
    exec_node_ids INT8[] NOT NULL,
    contention INTERVAL NULL,
+   contention_events JSONB NULL,
    index_recommendations STRING[] NOT NULL,
    implicit_txn BOOL NOT NULL
 )  CREATE TABLE crdb_internal.cluster_execution_insights (
@@ -299,6 +300,7 @@ CREATE TABLE crdb_internal.cluster_execution_insights (
    last_retry_reason STRING NULL,
    exec_node_ids INT8[] NOT NULL,
    contention INTERVAL NULL,
+   contention_events JSONB NULL,
    index_recommendations STRING[] NOT NULL,
    implicit_txn BOOL NOT NULL
 )  {}  {}
@@ -997,6 +999,7 @@ CREATE TABLE crdb_internal.node_execution_insights (
    last_retry_reason STRING NULL,
    exec_node_ids INT8[] NOT NULL,
    contention INTERVAL NULL,
+   contention_events JSONB NULL,
    index_recommendations STRING[] NOT NULL,
    implicit_txn BOOL NOT NULL
 )  CREATE TABLE crdb_internal.node_execution_insights (
@@ -1023,6 +1026,7 @@ CREATE TABLE crdb_internal.node_execution_insights (
    last_retry_reason STRING NULL,
    exec_node_ids INT8[] NOT NULL,
    contention INTERVAL NULL,
+   contention_events JSONB NULL,
    index_recommendations STRING[] NOT NULL,
    implicit_txn BOOL NOT NULL
 )  {}  {}

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -763,13 +763,15 @@ func (ij *invertedJoiner) execStatsForTrace() *execinfrapb.ComponentStats {
 		return nil
 	}
 	ij.scanStats = execstats.GetScanStats(ij.Ctx, ij.ExecStatsTrace)
+	contentionTime, contentionEvents := execstats.GetCumulativeContentionTime(ij.Ctx, ij.ExecStatsTrace)
 	ret := execinfrapb.ComponentStats{
 		Inputs: []execinfrapb.InputStats{is},
 		KV: execinfrapb.KVStats{
 			BytesRead:           optional.MakeUint(uint64(ij.fetcher.GetBytesRead())),
 			TuplesRead:          fis.NumTuples,
 			KVTime:              fis.WaitTime,
-			ContentionTime:      optional.MakeTimeValue(execstats.GetCumulativeContentionTime(ij.Ctx, ij.ExecStatsTrace)),
+			ContentionTime:      optional.MakeTimeValue(contentionTime),
+			ContentionEvents:    contentionEvents,
 			BatchRequestsIssued: optional.MakeUint(uint64(ij.fetcher.GetBatchRequestsIssued())),
 		},
 		Exec: execinfrapb.ExecStats{

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -1171,13 +1171,15 @@ func (jr *joinReader) execStatsForTrace() *execinfrapb.ComponentStats {
 	}
 
 	jr.scanStats = execstats.GetScanStats(jr.Ctx, jr.ExecStatsTrace)
+	contentionTime, contentionEvents := execstats.GetCumulativeContentionTime(jr.Ctx, jr.ExecStatsTrace)
 	ret := &execinfrapb.ComponentStats{
 		Inputs: []execinfrapb.InputStats{is},
 		KV: execinfrapb.KVStats{
 			BytesRead:           optional.MakeUint(uint64(jr.fetcher.GetBytesRead())),
 			TuplesRead:          fis.NumTuples,
 			KVTime:              fis.WaitTime,
-			ContentionTime:      optional.MakeTimeValue(execstats.GetCumulativeContentionTime(jr.Ctx, jr.ExecStatsTrace)),
+			ContentionTime:      optional.MakeTimeValue(contentionTime),
+			ContentionEvents:    contentionEvents,
 			BatchRequestsIssued: optional.MakeUint(uint64(jr.fetcher.GetBatchRequestsIssued())),
 		},
 		Output: jr.OutputHelper.Stats(),

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -309,12 +309,14 @@ func (tr *tableReader) execStatsForTrace() *execinfrapb.ComponentStats {
 		return nil
 	}
 	tr.scanStats = execstats.GetScanStats(tr.Ctx, tr.ExecStatsTrace)
+	contentionTime, contentionEvents := execstats.GetCumulativeContentionTime(tr.Ctx, tr.ExecStatsTrace)
 	ret := &execinfrapb.ComponentStats{
 		KV: execinfrapb.KVStats{
 			BytesRead:           optional.MakeUint(uint64(tr.fetcher.GetBytesRead())),
 			TuplesRead:          is.NumTuples,
 			KVTime:              is.WaitTime,
-			ContentionTime:      optional.MakeTimeValue(execstats.GetCumulativeContentionTime(tr.Ctx, tr.ExecStatsTrace)),
+			ContentionTime:      optional.MakeTimeValue(contentionTime),
+			ContentionEvents:    contentionEvents,
 			BatchRequestsIssued: optional.MakeUint(uint64(tr.fetcher.GetBatchRequestsIssued())),
 		},
 		Output: tr.OutputHelper.Stats(),

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -848,9 +848,11 @@ func (z *zigzagJoiner) ConsumerClosed() {
 func (z *zigzagJoiner) execStatsForTrace() *execinfrapb.ComponentStats {
 	z.scanStats = execstats.GetScanStats(z.Ctx, z.ExecStatsTrace)
 
+	contentionTime, contentionEvents := execstats.GetCumulativeContentionTime(z.Ctx, z.ExecStatsTrace)
 	kvStats := execinfrapb.KVStats{
 		BytesRead:           optional.MakeUint(uint64(z.getBytesRead())),
-		ContentionTime:      optional.MakeTimeValue(execstats.GetCumulativeContentionTime(z.Ctx, z.ExecStatsTrace)),
+		ContentionTime:      optional.MakeTimeValue(contentionTime),
+		ContentionEvents:    contentionEvents,
 		BatchRequestsIssued: optional.MakeUint(uint64(z.getBatchRequestsIssued())),
 	}
 	execstats.PopulateKVMVCCStats(&kvStats, &z.scanStats)

--- a/pkg/sql/sqlstats/insights/BUILD.bazel
+++ b/pkg/sql/sqlstats/insights/BUILD.bazel
@@ -66,6 +66,7 @@ proto_library(
     strip_import_prefix = "/pkg",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/roachpb:roachpb_proto",
         "@com_github_gogo_protobuf//gogoproto:gogo_proto",
         "@com_google_protobuf//:duration_proto",
         "@com_google_protobuf//:timestamp_proto",
@@ -79,6 +80,7 @@ go_proto_library(
     proto = ":insights_proto",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/roachpb",
         "//pkg/util/uuid",  # keep
         "@com_github_gogo_protobuf//gogoproto",
     ],

--- a/pkg/sql/sqlstats/insights/insights.proto
+++ b/pkg/sql/sqlstats/insights/insights.proto
@@ -12,6 +12,7 @@ syntax = "proto3";
 package cockroach.sql.insights;
 option go_package = "insights";
 
+import "roachpb/api.proto";
 import "gogoproto/gogo.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/duration.proto";
@@ -100,6 +101,8 @@ message Statement {
   repeated int64 nodes = 17;
   google.protobuf.Duration contention = 18 [(gogoproto.stdduration) = true];
   repeated string index_recommendations = 19;
+  // contention_events hit at the statement level.
+  repeated cockroach.roachpb.ContentionEvent contention_events = 20 [(gogoproto.nullable) = false];
 }
 
 message Insight {

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/BUILD.bazel
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/keys",
         "//pkg/roachpb",
         "//pkg/sql/sem/tree",
         "//pkg/util/encoding",

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding.go
@@ -286,6 +286,25 @@ func BuildStmtDetailsMetadataJSON(
 	return (*aggregatedMetadata)(metadata).jsonFields().encodeJSON()
 }
 
+// BuildContentionEventsJSON returns a json.JSON object for contention events
+// roachpb.ContentionEvent.
+// JSON Schema for contention events
+//
+//	{
+//	  "$schema": "https://json-schema.org/draft/2020-12/schema",
+//	  "title": "system.statement_statistics.contention_events",
+//	  "type": "object",
+//	  [{
+//	    "blockingTxnID": { "type": "string" },
+//	    "durationMs":    { "type": "number" },
+//	    "indexID":       { "type": "number" },
+//	    "tableID":       { "type": "number" }
+//	  }]
+//	}
+func BuildContentionEventsJSON(events []roachpb.ContentionEvent) (json.JSON, error) {
+	return (*contentionEvents)(&events).encodeJSON()
+}
+
 // EncodeUint64ToBytes returns the []byte representation of an uint64 value.
 func EncodeUint64ToBytes(id uint64) []byte {
 	result := make([]byte, 0, 8)

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
@@ -177,8 +177,10 @@ func (s *Container) RecordStatement(
 	}
 
 	var contention *time.Duration
+	var contentionEvents []roachpb.ContentionEvent
 	if value.ExecStats != nil {
 		contention = &value.ExecStats.ContentionTime
+		contentionEvents = value.ExecStats.ContentionEvents
 	}
 
 	s.insights.ObserveStatement(value.SessionID, &insights.Statement{
@@ -200,6 +202,7 @@ func (s *Container) RecordStatement(
 		RowsWritten:          value.RowsWritten,
 		Nodes:                value.Nodes,
 		Contention:           contention,
+		ContentionEvents:     contentionEvents,
 		IndexRecommendations: value.IndexRecommendations,
 	})
 


### PR DESCRIPTION
The original contention column will remain
to make query operations faster. The events
are being put into a json column because it's
possible there could be multiple blocking events
for a single statement. The json column avoids the complexity of adding another table and keeping it
in sync with the insights table.

The table can be joined with index_columns and tables to get the database name, table name, and index name that contention occurred on. This does not contain the blocking statement information, and the blocking fingerprint id.

closes: #88561

Release note (sql change): Adds contention_events
to cluster_execution_insights. This is used
to see which transaction is blocking the specific
statement.