### PR TITLE
clisqlshell: fix the behavior of ctrl+c under `--no-line-editor`

### DIFF
--- a/pkg/cli/clisqlshell/sql.go
+++ b/pkg/cli/clisqlshell/sql.go
@@ -2358,6 +2358,7 @@ func (c *cliState) maybeHandleInterrupt() func() {
 					// by re-throwing the signal after stopping the signal capture.
 					signal.Reset(os.Interrupt)
 					_ = sysutil.InterruptSelf()
+					return
 				}
 
 				fmt.Fprintf(c.iCtx.stderr, "\nattempting to cancel query...\n")


### PR DESCRIPTION
Fixes #90653.

Prior to this commit, there was a race condition in the cancellation goroutine, between re-sending the signal and control flowing out of the conditional into a call to a (nil) cancelFn.

This commit fixes that.

(No release note because the feature has not been released yet.)

Release note: None