### PR TITLE
gc: add delete range parameters to gc request

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_gc.go
+++ b/pkg/kv/kvserver/batcheval/cmd_gc.go
@@ -54,6 +54,18 @@ func declareKeysGC(
 			Key: keys.MVCCRangeKeyGCKey(rs.GetRangeID()),
 		})
 	}
+	// For clear subrange operations we only need to obtain locks if we are
+	// removing multiple keys and not when we remove multiple versions.
+	// Versions case is not different from points deletions as we never remove
+	// data above gc threshold.
+	// Multiple keys versions is similar to ClearRangeKey case below where we
+	// must prevent writers adding any keys in the middle of this range.
+	if rk := gcr.ClearSubRangeKey; rk != nil {
+		if rk.EndKey != nil {
+			latchSpans.AddMVCC(spanset.SpanReadWrite, roachpb.Span{Key: rk.StartKey, EndKey: rk.EndKey},
+				hlc.MaxTimestamp)
+		}
+	}
 	// For ClearRangeKey request we still obtain a wide write lock as we don't
 	// expect any operations running on the range.
 	if rk := gcr.ClearRangeKey; rk != nil {
@@ -180,6 +192,23 @@ func GC(
 		if err := storage.MVCCGarbageCollect(
 			ctx, readWriter, cArgs.Stats, gcKeys, h.Timestamp,
 		); err != nil {
+			return result.Result{}, err
+		}
+	}
+
+	// Garbage collect specified keys defined by clear range subranges i.e. parts
+	// of the whole range containing no more data.
+	if rk := args.ClearSubRangeKey; rk != nil {
+		// To avoid unnecessary write locks if we only remove part of history for
+		// the single key we pass it as range without end bound. Then we can create
+		// a safe range that only spans from particular timestamp up to the next
+		// key.
+		endKey := rk.EndKey
+		if endKey == nil {
+			endKey = rk.StartKey.Next()
+		}
+		if err := storage.MVCCGarbageCollectPointsWithClearRange(ctx, readWriter, cArgs.Stats,
+			rk.StartKey, endKey, rk.StartKeyTimestamp, cArgs.EvalCtx.GetGCThreshold()); err != nil {
 			return result.Result{}, err
 		}
 	}

--- a/pkg/kv/kvserver/gc/data_distribution_test.go
+++ b/pkg/kv/kvserver/gc/data_distribution_test.go
@@ -388,11 +388,11 @@ type uniformDistSpec struct {
 	deleteFrac                       float64
 	// keysPerValue parameters determine number of versions for a key. This number
 	// includes tombstones and intents which may be present on top of the history.
-	keysPerValueMin, keysPerValueMax int
+	versionsPerKeyMin, versionsPerKeyMax int
 	// Fractions define how likely is that a key will belong to one of categories.
 	// If we only had a single version for each key, then that would be fraction
 	// of total number of objects, but if we have many versions, this value would
-	// roughly be total objects/avg(keysPerValueMin, keysPerValueMax) * frac.
+	// roughly be total objects/avg(versionsPerKeyMin, versionsPerKeyMax) * frac.
 	intentFrac, oldIntentFrac float64
 	rangeKeyFrac              float64
 }
@@ -414,7 +414,7 @@ func (ds uniformDistSpec) dist(maxRows int, rng *rand.Rand) dataDistribution {
 		uniformTableStringKeyDistribution(ds.desc().StartKey.AsRawKey(), ds.keySuffixMin,
 			ds.keySuffixMax, rng),
 		uniformValueStringDistribution(ds.valueLenMin, ds.valueLenMax, ds.deleteFrac, rng),
-		uniformValuesPerKey(ds.keysPerValueMin, ds.keysPerValueMax, rng),
+		uniformVersionsPerKey(ds.versionsPerKeyMin, ds.versionsPerKeyMax, rng),
 		ds.intentFrac,
 		ds.oldIntentFrac,
 		ds.rangeKeyFrac,
@@ -436,12 +436,12 @@ func (ds uniformDistSpec) String() string {
 		"ts=[%d,%d],"+
 			"keySuffix=[%d,%d],"+
 			"valueLen=[%d,%d],"+
-			"keysPerValue=[%d,%d],"+
+			"versionsPerKey=[%d,%d],"+
 			"deleteFrac=%f,intentFrac=%f,oldIntentFrac=%f,rangeFrac=%f",
 		ds.tsSecFrom, ds.tsSecTo,
 		ds.keySuffixMin, ds.keySuffixMax,
 		ds.valueLenMin, ds.valueLenMax,
-		ds.keysPerValueMin, ds.keysPerValueMax,
+		ds.versionsPerKeyMin, ds.versionsPerKeyMax,
 		ds.deleteFrac, ds.intentFrac, ds.oldIntentFrac, ds.rangeKeyFrac)
 }
 
@@ -497,7 +497,7 @@ func uniformValueStringDistribution(
 	}
 }
 
-func uniformValuesPerKey(valuesPerKeyMin, valuesPerKeyMax int, rng *rand.Rand) func() int {
+func uniformVersionsPerKey(valuesPerKeyMin, valuesPerKeyMax int, rng *rand.Rand) func() int {
 	if valuesPerKeyMin > valuesPerKeyMax {
 		panic(fmt.Errorf("min (%d) > max (%d)", valuesPerKeyMin, valuesPerKeyMax))
 	}

--- a/pkg/kv/kvserver/gc/gc.go
+++ b/pkg/kv/kvserver/gc/gc.go
@@ -19,6 +19,8 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -46,6 +48,20 @@ const (
 	// Raft command for each GCRequest does not significantly exceed
 	// this threshold.
 	KeyVersionChunkBytes = base.ChunkRaftCommandThresholdBytes
+	// minRangeDeleteVersions is min number of versions we will try to delete
+	// using range deletion. Thinking behind this constant is that if we have
+	// less than this count, using pebble range tombstone is more expensive
+	// than using multiple point deletions.
+	defaultMinRangeDeleteVersions = 10000
+	// defaultMaxPendingKeysSize is a max amount of memory used to store pending
+	// keys while trying to decide if clear range operation is feasible. If we
+	// don't have enough keys when this value is reached, points GC operation
+	// will be flushed to free memory even if we still can potentially issue
+	// clear range in the future.
+	defaultMaxPendingKeysSize = 1 << 20
+	// hlcTimestampSize is the size of hlc timestamp used for mem usage
+	// calculations.
+	hlcTimestampSize = 16
 )
 
 // IntentAgeThreshold is the threshold after which an extant intent
@@ -113,6 +129,15 @@ var MaxIntentKeyBytesPerCleanupBatch = settings.RegisterIntSetting(
 	"kv.gc.intent_cleanup_batch_byte_size",
 	"if non zero, gc will split found intents into batches of this size when trying to resolve them",
 	1e6,
+	settings.NonNegativeInt,
+)
+
+// MinKeyNumberForClearRange system setting restricting stuff
+// TODO(oleg): write a description
+var MinKeyNumberForClearRange = settings.RegisterIntSetting(settings.SystemOnly,
+	"kv.gc.clear_range_min_keys",
+	"if non zero, gc will issue clear range requests if number of consecutive garbage keys exceeds this threshold",
+	defaultMinRangeDeleteVersions,
 	settings.NonNegativeInt,
 )
 
@@ -266,6 +291,21 @@ type RunOptions struct {
 	// considered abandoned and fit for removal, as measured by the maximum of
 	// its last heartbeat and read timestamp.
 	TxnCleanupThreshold time.Duration
+	// ClearRangeMinKeys is minimum count of keys to delete with a DeleteRangeKeys type request.
+	// If there's less than this number of keys to delete, GC would fall back to point deletions.
+	// 0 means default value of defaultMinRangeDeleteVersions is used.
+	ClearRangeMinKeys int64
+	// MaxKeyVersionChunkBytes is the max size of keys for all versions of objects a single gc
+	// batch would contain. This includes not only keys within the request, but also all versions
+	// covered below request keys. This is important because of the resulting raft command size
+	// generated in response to GC request.
+	MaxKeyVersionChunkBytes int64
+	// MaxPendingKeysSize maximum amount of bytes of pending GC batches kept in
+	// memory while searching for eligible clear range span. If span of minimum
+	// configured length is not found before this limit is reached, gc will resort
+	// to issuing point delete requests for the oldest batch to free up memory
+	// before resuming further iteration.
+	MaxPendingKeysSize int64
 }
 
 // CleanupIntentsFunc synchronously resolves the supplied intents
@@ -311,7 +351,9 @@ func Run(
 		Threshold: newThreshold,
 	}
 
-	fastPath, err := processReplicatedKeyRange(ctx, desc, snap, now, newThreshold, options.IntentAgeThreshold, gcer,
+	fastPath, err := processReplicatedKeyRange(ctx, desc, snap, now, newThreshold, options.IntentAgeThreshold,
+		populateBatcherOptions(options),
+		gcer,
 		intentBatcherOptions{
 			maxIntentsPerIntentCleanupBatch:        options.MaxIntentsPerIntentCleanupBatch,
 			maxIntentKeyBytesPerIntentCleanupBatch: options.MaxIntentKeyBytesPerIntentCleanupBatch,
@@ -329,7 +371,8 @@ func Run(
 	// From now on, all keys processed are range-local and inline (zero timestamp).
 
 	// Process local range key entries (txn records, queue last processed times).
-	if err := processLocalKeyRange(ctx, snap, desc, txnExp, &info, cleanupTxnIntentsAsyncFn, gcer); err != nil {
+	if err := processLocalKeyRange(ctx, snap, desc, txnExp, &info, cleanupTxnIntentsAsyncFn,
+		gcer); err != nil {
 		if errors.Is(err, ctx.Err()) {
 			return Info{}, err
 		}
@@ -350,6 +393,24 @@ func Run(
 	return info, nil
 }
 
+func populateBatcherOptions(options RunOptions) gcKeyBatcherThresholds {
+	batcherOptions := gcKeyBatcherThresholds{
+		clearRangeMinKeys:         int(options.ClearRangeMinKeys),
+		batchGCKeysBytesThreshold: options.MaxKeyVersionChunkBytes,
+		maxPendingKeysSize:        int(options.MaxPendingKeysSize),
+	}
+	if batcherOptions.clearRangeMinKeys > 0 {
+		batcherOptions.clearRangeEnabled = true
+	}
+	if batcherOptions.batchGCKeysBytesThreshold == 0 {
+		batcherOptions.batchGCKeysBytesThreshold = KeyVersionChunkBytes
+	}
+	if batcherOptions.maxPendingKeysSize == 0 {
+		batcherOptions.maxPendingKeysSize = defaultMaxPendingKeysSize
+	}
+	return batcherOptions
+}
+
 // processReplicatedKeyRange identifies garbage and sends GC requests to
 // remove it.
 //
@@ -363,7 +424,8 @@ func processReplicatedKeyRange(
 	now hlc.Timestamp,
 	threshold hlc.Timestamp,
 	intentAgeThreshold time.Duration,
-	gcer GCer,
+	batcherThresholds gcKeyBatcherThresholds,
+	gcer PureGCer,
 	options intentBatcherOptions,
 	cleanupIntentsFn CleanupIntentsFunc,
 	info *Info,
@@ -391,140 +453,476 @@ func processReplicatedKeyRange(
 		}
 	}
 
-	var alloc bufalloc.ByteAllocator
 	// Compute intent expiration (intent age at which we attempt to resolve).
 	intentExp := now.Add(-intentAgeThreshold.Nanoseconds(), 0)
 
-	intentBatcher := newIntentBatcher(cleanupIntentsFn, options, info)
+	return excludeUserKeySpan, rditer.IterateMVCCReplicaKeySpans(desc, snap, rditer.IterateOptions{
+		CombineRangesAndPoints: true,
+		Reverse:                true,
+		ExcludeUserKeySpan:     excludeUserKeySpan,
+	}, func(iterator storage.MVCCIterator, span roachpb.Span, keyType storage.IterKeyType) error {
+		intentBatcher := newIntentBatcher(cleanupIntentsFn, options, info)
 
-	// handleIntent will deserialize transaction info and if intent is older than
-	// threshold enqueue it to batcher, otherwise ignore it.
-	handleIntent := func(keyValue *mvccKeyValue) error {
-		meta := &enginepb.MVCCMetadata{}
-		if err := protoutil.Unmarshal(keyValue.metaValue, meta); err != nil {
-			log.Errorf(ctx, "unable to unmarshal MVCC metadata for key %q: %+v", keyValue.key, err)
+		// handleIntent will deserialize transaction info and if intent is older than
+		// threshold enqueue it to batcher, otherwise ignore it.
+		handleIntent := func(keyValue *mvccKeyValue) error {
+			meta := &enginepb.MVCCMetadata{}
+			if err := protoutil.Unmarshal(keyValue.metaValue, meta); err != nil {
+				log.Errorf(ctx, "unable to unmarshal MVCC metadata for key %q: %+v", keyValue.key, err)
+				return nil
+			}
+			if meta.Txn != nil {
+				// Keep track of intent to resolve if older than the intent
+				// expiration threshold.
+				if meta.Timestamp.ToTimestamp().Less(intentExp) {
+					info.IntentsConsidered++
+					if err := intentBatcher.addAndMaybeFlushIntents(ctx, keyValue.key.Key, meta); err != nil {
+						if errors.Is(err, ctx.Err()) {
+							return err
+						}
+						log.Warningf(ctx, "failed to cleanup intents batch: %v", err)
+					}
+				}
+			}
 			return nil
 		}
-		if meta.Txn != nil {
-			// Keep track of intent to resolve if older than the intent
-			// expiration threshold.
-			if meta.Timestamp.ToTimestamp().Less(intentExp) {
-				info.IntentsConsidered++
-				if err := intentBatcher.addAndMaybeFlushIntents(ctx, keyValue.key.Key, meta); err != nil {
-					if errors.Is(err, ctx.Err()) {
-						return err
-					}
-					log.Warningf(ctx, "failed to cleanup intents batch: %v", err)
+
+		// Iterate all versions of all keys from oldest to newest. If a version is an
+		// intent it will have the highest timestamp of any versions and will be
+		// followed by a metadata entry.
+		// The loop determines if next object is garbage, non-garbage or intent and
+		// notifies batcher with its detail. Batcher is responsible for accumulating
+		// pending key data and sending sending keys to GCer as needed.
+		// It could also request the main loop to rewind to a previous point to
+		// retry (this is needed when attempt to collect a clear range batch fails
+		// in the middle of key versions).
+		it := makeGCIterator(iterator, threshold)
+
+		b := gcKeyBatcher{
+			gcKeyBatcherThresholds: batcherThresholds,
+			gcer:                   gcer,
+			pointsBatches:          make([]pointsBatch, 1),
+			clearRangeEndKey:       desc.EndKey.AsRawKey(),
+			prevWasNewest:          true,
+		}
+
+		for ; ; it.step() {
+			var upd gcBatchCounters
+			var err error
+
+			s, ok := it.state()
+			if !ok {
+				if it.err != nil {
+					return it.err
+				}
+				break
+			}
+
+			switch {
+			case s.curIsNotValue():
+				// Skip over non mvcc data.
+				upd, err = b.foundNonGCableData(ctx, s.cur, true /* isNewestPoint */)
+			case s.curIsIntent():
+				upd, err = b.foundNonGCableData(ctx, s.cur, true /* isNewestPoint */)
+				if err != nil {
+					return err
+				}
+				if err = handleIntent(s.next); err != nil {
+					return err
+				}
+				// For intents, we force step over the intent metadata after provisional
+				// value is found.
+				it.step()
+			default:
+				if isGarbage(threshold, s.cur, s.next, s.curIsNewest(), s.firstRangeTombstoneTsAtOrBelowGC) {
+					upd, err = b.foundGarbage(ctx, s.cur, s.curLastKeyVersion())
+				} else {
+					upd, err = b.foundNonGCableData(ctx, s.cur, s.curLastKeyVersion())
 				}
 			}
+			if err != nil {
+				return err
+			}
+			upd.updateGcInfo(info)
+			// TODO(oleg): remove all printf statements from gc.go
+			//fmt.Printf("%s: %s\n", s.cur.key.String(), b.String())
+		}
+
+		upd, err := b.flushLastBatch(ctx)
+		if err != nil {
+			return err
+		}
+		upd.updateGcInfo(info)
+
+		// We need to send out last intent cleanup batch.
+		if err := intentBatcher.maybeFlushPendingIntents(ctx); err != nil {
+			if errors.Is(err, ctx.Err()) {
+				return err
+			}
+			log.Warningf(ctx, "failed to cleanup intents batch: %v", err)
 		}
 		return nil
+	})
+}
+
+// gcBatchCounters contain statistics about garbage that is collected for the
+// range of keys.
+type gcBatchCounters struct {
+	keyBytes, valBytes int64
+	// keysAffected includes key when it is first encountered, but would not be
+	// included if key versions were split between batches.
+	keysAffected int
+	// memUsed is amount of bytes batch takes in memory (sum of all keys and
+	// timestamps excluding any supporting structures).
+	memUsed int
+	// versionsAffected is a number of key versions covered by batch. This is
+	// used for clear range accounting.
+	versionsAffected int
+}
+
+func (c gcBatchCounters) updateGcInfo(info *Info) {
+	info.AffectedVersionsKeyBytes += c.keyBytes
+	info.AffectedVersionsValBytes += c.valBytes
+	info.NumKeysAffected += c.keysAffected
+}
+
+func (c *gcBatchCounters) add(o gcBatchCounters) {
+	c.keyBytes += o.keyBytes
+	c.valBytes += o.valBytes
+	c.keysAffected += o.keysAffected
+	c.versionsAffected += o.versionsAffected
+	c.memUsed += o.memUsed
+}
+
+func (c *gcBatchCounters) sub(o gcBatchCounters) {
+	c.keyBytes -= o.keyBytes
+	c.valBytes -= o.valBytes
+	c.keysAffected -= o.keysAffected
+	c.versionsAffected -= o.versionsAffected
+	c.memUsed -= o.memUsed
+}
+
+func (c gcBatchCounters) String() string {
+	return fmt.Sprintf("Counters{keyBytes=%d, valBytes=%d, keys=%d, versions=%d, memUsed=%d}",
+		c.keyBytes, c.valBytes, c.keysAffected, c.versionsAffected, c.memUsed)
+}
+
+// gcKeyBatcherThresholds collection configuration options.
+type gcKeyBatcherThresholds struct {
+	batchGCKeysBytesThreshold int64
+	clearRangeMinKeys         int
+	clearRangeEnabled         bool
+	maxPendingKeysSize        int
+}
+
+type pointsBatch struct {
+	gcBatchCounters
+	batchGCKeys []roachpb.GCRequest_GCKey
+	alloc       bufalloc.ByteAllocator
+}
+
+func (b pointsBatch) String() string {
+	return fmt.Sprintf("PointsBatch{keyCount=%d, counters=%s}",
+		len(b.batchGCKeys), b.gcBatchCounters.String())
+}
+
+// gcKeyBatcher is responsible for collecting MVCCKeys and feeding them to GCer
+// for removal.
+// It is receiving notifications if next key is garbage or not and makes decision
+// how to batch the data and weather to use point deletion requests or clear
+// range requests.
+// Internally it would start collecting point data into the batch until it
+// reaches configured batchGCKeysBytesThreshold (which limits size of the raft
+// entry that this request will create later). At this point it will decide
+// if it should switch into ClearRange mode. If decision is made to proceed with
+// clear range, current state is saved into checkpoint.
+// If later non garbage data is found, batcher looks on number of keys covered
+// by already checked range and will either:
+//   - send clear range batch up to the previous key
+//   - restore state from checkpoint and send point key batch then rewind to the
+//     version after the last sent key
+type gcKeyBatcher struct {
+	gcKeyBatcherThresholds
+
+	prevWasNewest bool
+	// Points batches are accumulated until we cross clear range threshold.
+	// There's always at least one points batch initialized.
+	pointsBatches []pointsBatch
+	// totalMemUsed sum of memUsed of all points batches cached to avoid
+	// recomputing on every check.
+	totalMemUsed int
+
+	// Tracking of clear range requests.
+	clearRangeEndKey          roachpb.Key
+	clearRangeStartKey        storage.MVCCKey
+	clearRangeCounters        gcBatchCounters
+	partialPointBatchCounters gcBatchCounters
+
+	gcer PureGCer
+}
+
+func (b *gcKeyBatcher) String() string {
+	pbs := make([]string, len(b.pointsBatches))
+	for i, pb := range b.pointsBatches {
+		pbs[i] = pb.String()
+	}
+	return fmt.Sprintf("gcKeyBatcher{batches=[%s], clearRangeCnt=%s, partialBatchCnt=%s, totalMem=%d}",
+		strings.Join(pbs, ", "),
+		b.clearRangeCounters.String(),
+		b.partialPointBatchCounters.String(),
+		b.totalMemUsed)
+}
+
+func (b *gcKeyBatcher) foundNonGCableData(
+	ctx context.Context, cur *mvccKeyValue, isNewestPoint bool,
+) (counterUpdate gcBatchCounters, err error) {
+	b.prevWasNewest = isNewestPoint
+	if !b.clearRangeEnabled {
+		return counterUpdate, nil
 	}
 
-	// Iterate all versions of all keys from oldest to newest. If a version is an
-	// intent it will have the highest timestamp of any versions and will be
-	// followed by a metadata entry. The loop will determine whether a given key
-	// has garbage and, if so, will determine the timestamp of the latest version
-	// which is garbage to be added to the current batch. If the current version
-	// pushes the size of keys to be removed above the limit, the current key will
-	// be added with that version and the batch will be sent. When the newest
-	// version for a key has been reached, if haveGarbageForThisKey, we'll add the
-	// current key to the batch with the gcTimestampForThisKey.
-	var (
-		batchGCKeys           []roachpb.GCRequest_GCKey
-		batchGCKeysBytes      int64
-		haveGarbageForThisKey bool
-		gcTimestampForThisKey hlc.Timestamp
-		sentBatchForThisKey   bool
-	)
-	it := makeGCIterator(desc, snap, threshold, excludeUserKeySpan)
-	defer it.close()
-	for ; ; it.step() {
-		s, ok := it.state()
-		if !ok {
-			if it.err != nil {
-				return false, it.err
-			}
-			break
-		}
-		if s.curIsNotValue() { // Step over metadata or other system keys
-			continue
-		}
-		if s.curIsIntent() {
-			if err := handleIntent(s.next); err != nil {
-				return false, err
-			}
-			continue
-		}
-		// No more values in buffer or next value has different key.
-		isNewestPoint := s.curIsNewest()
-		if garbage, err :=
-			isGarbage(threshold, s.cur, s.next, isNewestPoint, s.firstRangeTombstoneTsAtOrBelowGC); garbage && err == nil {
-			keyBytes := int64(s.cur.key.EncodedSize())
-			batchGCKeysBytes += keyBytes
-			haveGarbageForThisKey = true
-			gcTimestampForThisKey = s.cur.key.Timestamp
-			info.AffectedVersionsKeyBytes += keyBytes
-			info.AffectedVersionsValBytes += int64(s.cur.mvccValueLen)
-		} else if err != nil {
-			return false, err
-		}
-		// We bump how many keys were processed when we reach newest key and looking
-		// if key has garbage or if garbage for this key was included in previous
-		// batch.
-		if affected := isNewestPoint && (sentBatchForThisKey || haveGarbageForThisKey); affected {
-			info.NumKeysAffected++
-			// If we reached newest timestamp for the key then we should reset sent
-			// batch to ensure subsequent keys are not included in affected keys if
-			// they don't have garbage.
-			sentBatchForThisKey = false
-		}
-		shouldSendBatch := batchGCKeysBytes >= KeyVersionChunkBytes
-		if shouldSendBatch || isNewestPoint && haveGarbageForThisKey {
-			alloc, s.cur.key.Key = alloc.Copy(s.cur.key.Key, 0)
-			batchGCKeys = append(batchGCKeys, roachpb.GCRequest_GCKey{
-				Key:       s.cur.key.Key,
-				Timestamp: gcTimestampForThisKey,
-			})
-			haveGarbageForThisKey = false
-			gcTimestampForThisKey = hlc.Timestamp{}
+	// Check if there are any complete clear range or point batches collected
+	// and flush them as we reached end of current consecutive key span.
+	counterUpdate, err = b.maybeFlushPendingBatches(ctx)
+	if err != nil {
+		return gcBatchCounters{}, err
+	}
+	b.clearRangeCounters = gcBatchCounters{}
 
-			// Mark that we sent a batch for this key so we know that we had garbage
-			// even if it turns out that there's no more garbage for this key.
-			// We want to count a key as affected once even if we paginate the
-			// deletion of its versions.
-			sentBatchForThisKey = shouldSendBatch && !isNewestPoint
-		}
-		// If limit was reached, delegate to GC'r to remove collected batch.
-		if shouldSendBatch {
-			if err := gcer.GC(ctx, batchGCKeys, nil, nil, nil); err != nil {
-				if errors.Is(err, ctx.Err()) {
-					return false, err
+	if isNewestPoint {
+		b.clearRangeEndKey = append(b.clearRangeEndKey[:0], cur.key.Key...)
+	}
+	return counterUpdate, nil
+}
+
+func (b *gcKeyBatcher) foundGarbage(
+	ctx context.Context, cur *mvccKeyValue, isNewestPoint bool,
+) (counterUpdate gcBatchCounters, err error) {
+	// If we are restarting clear range collection, then last points batch might
+	// be reverted to partial at the time of flush. We will save its
+	// pre-clear-range state and use for GC stats update.
+	if b.clearRangeEnabled && b.prevWasNewest && b.clearRangeCounters.versionsAffected == 0 {
+		b.partialPointBatchCounters = b.pointsBatches[len(b.pointsBatches)-1].gcBatchCounters
+	}
+
+	var key roachpb.Key
+	var keySize = int64(cur.key.EncodedSize())
+	// If still collecting points, add to points first.
+	if !b.clearRangeEnabled || b.clearRangeCounters.versionsAffected < b.clearRangeMinKeys {
+		// First check if current batch is full and add a new points batch.
+		i := len(b.pointsBatches) - 1
+		newBatchStarted := false
+		if b.pointsBatches[i].gcBatchCounters.keyBytes >= b.batchGCKeysBytesThreshold {
+			// If clear range is disabled, flush batches immediately as they are
+			// formed.
+			if !b.clearRangeEnabled {
+				if counterUpdate, err = b.flushPointsBatch(ctx, &b.pointsBatches[i]); err != nil {
+					return gcBatchCounters{}, err
 				}
-				// Even though we are batching the GC process, it's
-				// safe to continue because we bumped the GC
-				// thresholds. We may leave some inconsistent history
-				// behind, but nobody can read it.
-				log.Warningf(ctx, "failed to GC a batch of keys: %v", err)
+			} else {
+				b.pointsBatches = append(b.pointsBatches, pointsBatch{})
+				i++
 			}
-			batchGCKeys = nil
-			batchGCKeysBytes = 0
-			alloc = bufalloc.ByteAllocator{}
+			newBatchStarted = true
+		}
+		if b.prevWasNewest {
+			b.pointsBatches[i].gcBatchCounters.keysAffected++
+		}
+		// Whenever new key is started or new batch is started with the same key in
+		// it, record key value using batches' allocator.
+		if b.prevWasNewest || newBatchStarted {
+			b.pointsBatches[i].alloc, key = b.pointsBatches[i].alloc.Copy(cur.key.Key, 0)
+			b.pointsBatches[i].batchGCKeys = append(b.pointsBatches[i].batchGCKeys,
+				roachpb.GCRequest_GCKey{Key: key, Timestamp: cur.key.Timestamp})
+			keyMemUsed := len(key) + hlcTimestampSize
+			b.pointsBatches[i].memUsed += keyMemUsed
+			b.totalMemUsed += keyMemUsed
+		} else {
+			// For already registered key just bump the timestamp to the newer one.
+			b.pointsBatches[i].batchGCKeys[len(b.pointsBatches[i].batchGCKeys)-1].Timestamp = cur.key.Timestamp
+		}
+		b.pointsBatches[i].gcBatchCounters.keyBytes += keySize
+		b.pointsBatches[i].gcBatchCounters.valBytes += int64(cur.mvccValueLen)
+		b.pointsBatches[i].gcBatchCounters.versionsAffected++
+
+		// Check if we exceeded in memory bytes limit allowed for points collection.
+		if i > 0 && b.totalMemUsed >= b.maxPendingKeysSize {
+			//fmt.Printf("flushing overflow points batch\n")
+			// We accumulated more keys in memory than allowed by thresholds, we need
+			// to flush oldest batch to protect node from exhausting memory.
+			lastKey, update, err := b.flushOldestPointBatches(ctx, 1)
+			if err != nil {
+				return gcBatchCounters{}, err
+			}
+			counterUpdate.add(update)
+			// If oldest batch intersected with currently tracked clear range request
+			// then bump clear range end key to the one that follows lowest key of the
+			// cleared batch. We know that all keys for current key with lower
+			// timestamps are eligible for collection and end range is exclusive.
+			// The check is needed because clearRangeEndKey cloud be bumped already
+			// to current key by non gc data on the previous key, but only now we
+			// exceeded the size threshold and trying to remove oldest batch.
+			if b.clearRangeEndKey.Compare(lastKey) > 0 {
+				// If flushed batch was split by start of the range, then we must remove
+				// preceding part from clear range total to avoid.
+				b.clearRangeCounters.sub(update)
+				b.clearRangeCounters.add(b.partialPointBatchCounters)
+				b.clearRangeEndKey = lastKey[:len(lastKey):len(lastKey)].Next()
+			}
+			b.partialPointBatchCounters = gcBatchCounters{}
 		}
 	}
-	// We need to send out last intent cleanup batch.
-	if err := intentBatcher.maybeFlushPendingIntents(ctx); err != nil {
+
+	if b.clearRangeEnabled {
+		if b.prevWasNewest {
+			if key == nil {
+				// We reuse the start key slice to avoid reallocating it on every new
+				// non-garbage key.
+				key = append(b.clearRangeStartKey.Key[:0], cur.key.Key...)
+			}
+			b.clearRangeStartKey = storage.MVCCKey{Key: key}
+			b.clearRangeCounters.keysAffected++
+		}
+		b.clearRangeStartKey.Timestamp = cur.key.Timestamp
+		b.clearRangeCounters.keyBytes += keySize
+		b.clearRangeCounters.valBytes += int64(cur.mvccValueLen)
+		b.clearRangeCounters.versionsAffected++
+	}
+
+	b.prevWasNewest = isNewestPoint
+	return counterUpdate, nil
+}
+
+// maybeFlushPendingBatches flushes accumulated GC requests. If clear range is
+// used and current data is eligible for deletion then pending points batch and
+// clear range request are flushed.
+// If there's not enough point keys to justify clear range, then point point
+// batches may be flushed:
+//   - if there's a single batch and it didn't reach desired size, nothing is
+//     flushed
+//   - if there's more than single points batch accumulated, then all batches
+//     except for last are flushed
+func (b *gcKeyBatcher) maybeFlushPendingBatches(
+	ctx context.Context,
+) (counterUpdate gcBatchCounters, err error) {
+	// Find where in first points batch is start key and flush "prefix".
+	if b.clearRangeEnabled && b.clearRangeCounters.versionsAffected >= b.clearRangeMinKeys {
+		//fmt.Printf("flushing range batch on live data\n")
+		// Optionally flush parts of the first batch if it doesn't match
+		// end of the range.
+		batchLen := len(b.pointsBatches[0].batchGCKeys)
+		// Find a key that is equal or less than end of clear range key.
+		// Batch is sorted in the reverse order, timestamps are not relevant since
+		// we can't have the same key more than once within single points batch.
+		lastIdx := sort.Search(batchLen, func(i int) bool {
+			return b.pointsBatches[0].batchGCKeys[i].Key.Compare(b.clearRangeEndKey) < 0
+		})
+		// If lastIdx == 0 we can have a clear range request which goes back to
+		// previous key completely covering this range. If this is true then we don't
+		// need to handle this batch.
+		if lastIdx > 0 {
+			b.pointsBatches[0].batchGCKeys = b.pointsBatches[0].batchGCKeys[:lastIdx]
+			b.pointsBatches[0].gcBatchCounters = b.partialPointBatchCounters
+			upd, err := b.flushPointsBatch(ctx, &b.pointsBatches[0])
+			if err != nil {
+				return gcBatchCounters{}, err
+			}
+			counterUpdate.add(upd)
+		}
+		b.pointsBatches = make([]pointsBatch, 1)
+
+		// Flush clear range.
+		// To reduce locking contention between keys, if we have a range that only
+		// covers multiple versions of a single key we could avoid latching range
+		// and fall back to poing GC behaviour where gc threshold guards against
+		// key interference. We do it by resetting end key and thus signalling
+		// gc request handler to skip locking and use StartKey.Next() as the end
+		// of the range.
+		endRange := b.clearRangeEndKey
+		if b.clearRangeCounters.keysAffected == 1 {
+			endRange = nil
+		}
+		if err := b.gcer.GC(ctx, nil, nil, nil, &roachpb.GCRequest_GCClearSubRangeKey{
+			StartKey:          b.clearRangeStartKey.Key,
+			StartKeyTimestamp: b.clearRangeStartKey.Timestamp,
+			EndKey:            endRange,
+		}); err != nil {
+			if errors.Is(err, ctx.Err()) {
+				return gcBatchCounters{}, err
+			}
+			// Even though we are batching the GC process, it's
+			// safe to continue because we bumped the GC
+			// thresholds. We may leave some inconsistent history
+			// behind, but nobody can read it.
+			log.Warningf(ctx, "failed to GC keys with clear range: %v", err)
+		}
+		counterUpdate.add(b.clearRangeCounters)
+		b.totalMemUsed = 0
+	} else if flushTo := len(b.pointsBatches) - 1; flushTo > 0 {
+		//fmt.Printf("flushing points batch on live data\n")
+		_, update, err := b.flushOldestPointBatches(ctx, flushTo)
+		if err != nil {
+			return gcBatchCounters{}, err
+		}
+		counterUpdate.add(update)
+	}
+	return counterUpdate, nil
+}
+
+// flushOldestPointBatches flushes oldest points batch and returns its counters.
+// unsafeLastKey must not be retained as it will prevent batch allocator to be
+// released.
+func (b *gcKeyBatcher) flushOldestPointBatches(
+	ctx context.Context, count int,
+) (unsafeLastKey roachpb.Key, counterUpdate gcBatchCounters, err error) {
+	var i int
+	for i = 0; i < count; i++ {
+		var upd gcBatchCounters
+		unsafeLastKey = b.pointsBatches[i].batchGCKeys[len(b.pointsBatches[i].batchGCKeys)-1].Key
+		if upd, err = b.flushPointsBatch(ctx, &b.pointsBatches[i]); err != nil {
+			return nil, gcBatchCounters{}, err
+		}
+		counterUpdate.add(upd)
+	}
+	remaining := len(b.pointsBatches) - i
+	copy(b.pointsBatches[0:remaining], b.pointsBatches[i:])
+	// Zero out remaining batches to free app allocators.
+	for i = remaining; i < len(b.pointsBatches); i++ {
+		b.pointsBatches[i] = pointsBatch{}
+	}
+	b.pointsBatches = b.pointsBatches[:remaining]
+	return unsafeLastKey, counterUpdate, nil
+}
+
+// flushPointsBatch flushes points batch and zeroes out its content.
+// TODO(oleg): check if we could get rid of zeroing out?
+func (b *gcKeyBatcher) flushPointsBatch(
+	ctx context.Context, batch *pointsBatch,
+) (counters gcBatchCounters, err error) {
+	if err := b.gcer.GC(ctx, batch.batchGCKeys, nil, nil, nil); err != nil {
 		if errors.Is(err, ctx.Err()) {
-			return false, err
+			return counters, err
 		}
-		log.Warningf(ctx, "failed to cleanup intents batch: %v", err)
+		// Even though we are batching the GC process, it's
+		// safe to continue because we bumped the GC
+		// thresholds. We may leave some inconsistent history
+		// behind, but nobody can read it.
+		log.Warningf(ctx, "failed to GC a batch of keys: %v", err)
 	}
-	if len(batchGCKeys) > 0 {
-		if err := gcer.GC(ctx, batchGCKeys, nil, nil, nil); err != nil {
-			return false, err
-		}
+	counters = batch.gcBatchCounters
+	b.totalMemUsed -= counters.memUsed
+	*batch = pointsBatch{}
+	return counters, nil
+}
+
+func (b *gcKeyBatcher) flushLastBatch(
+	ctx context.Context,
+) (counterUpdate gcBatchCounters, err error) {
+	if len(b.pointsBatches[0].batchGCKeys) == 0 {
+		return gcBatchCounters{}, nil
 	}
-	return excludeUserKeySpan, nil
+	b.pointsBatches = append(b.pointsBatches, pointsBatch{})
+	return b.maybeFlushPendingBatches(ctx)
 }
 
 type intentBatcher struct {
@@ -669,10 +1067,10 @@ func isGarbage(
 	cur, next *mvccKeyValue,
 	isNewestPoint bool,
 	firstRangeTombstoneTsAtOrBelowGC hlc.Timestamp,
-) (bool, error) {
+) bool {
 	// If the value is not at or below the threshold then it's not garbage.
 	if belowThreshold := cur.key.Timestamp.LessEq(threshold); !belowThreshold {
-		return false, nil
+		return false
 	}
 	if cur.key.Timestamp.Less(firstRangeTombstoneTsAtOrBelowGC) {
 		if util.RaceEnabled {
@@ -681,11 +1079,11 @@ func isGarbage(
 					firstRangeTombstoneTsAtOrBelowGC.String(), threshold.String()))
 			}
 		}
-		return true, nil
+		return true
 	}
 	isDelete := cur.mvccValueIsTombstone
 	if isNewestPoint && !isDelete {
-		return false, nil
+		return false
 	}
 	// INVARIANT: !isNewestPoint || isDelete
 	// Therefore !isDelete => !isNewestPoint, which can be restated as
@@ -697,7 +1095,7 @@ func isGarbage(
 	if !isDelete && next == nil {
 		panic("huh")
 	}
-	return isDelete || next.key.Timestamp.LessEq(threshold), nil
+	return isDelete || next.key.Timestamp.LessEq(threshold)
 }
 
 // processLocalKeyRange scans the local range key entries, consisting of

--- a/pkg/kv/kvserver/gc/gc.go
+++ b/pkg/kv/kvserver/gc/gc.go
@@ -268,6 +268,9 @@ type Info struct {
 	// ClearRangeKeyFailures reports 1 if GC identified a possibility to collect
 	// with ClearRange operation, but request failed.
 	ClearRangeKeyFailures int
+	// ClearConsecutiveKeysOperations is a number of clear range requests used to
+	// remove consecutive keys.
+	ClearConsecutiveKeysOperations int
 }
 
 // RunOptions contains collection of limits that GC run applies when performing operations
@@ -507,7 +510,7 @@ func processReplicatedKeyRange(
 		}
 
 		for ; ; it.step() {
-			var upd gcBatchCounters
+			var upd gcInfoUpdate
 			var err error
 
 			s, ok := it.state()
@@ -580,10 +583,18 @@ type gcBatchCounters struct {
 	versionsAffected int
 }
 
-func (c gcBatchCounters) updateGcInfo(info *Info) {
-	info.AffectedVersionsKeyBytes += c.keyBytes
-	info.AffectedVersionsValBytes += c.valBytes
-	info.NumKeysAffected += c.keysAffected
+// gcInfoUpdate accumulates changes to gcInfo when processing a single key
+// version.
+type gcInfoUpdate struct {
+	gcBatchCounters
+	clearRangeOps int
+}
+
+func (u gcInfoUpdate) updateGcInfo(info *Info) {
+	info.AffectedVersionsKeyBytes += u.keyBytes
+	info.AffectedVersionsValBytes += u.valBytes
+	info.NumKeysAffected += u.keysAffected
+	info.ClearConsecutiveKeysOperations += u.clearRangeOps
 }
 
 func (c *gcBatchCounters) add(o gcBatchCounters) {
@@ -675,7 +686,7 @@ func (b *gcKeyBatcher) String() string {
 
 func (b *gcKeyBatcher) foundNonGCableData(
 	ctx context.Context, cur *mvccKeyValue, isNewestPoint bool,
-) (counterUpdate gcBatchCounters, err error) {
+) (counterUpdate gcInfoUpdate, err error) {
 	b.prevWasNewest = isNewestPoint
 	if !b.clearRangeEnabled {
 		return counterUpdate, nil
@@ -685,7 +696,7 @@ func (b *gcKeyBatcher) foundNonGCableData(
 	// and flush them as we reached end of current consecutive key span.
 	counterUpdate, err = b.maybeFlushPendingBatches(ctx)
 	if err != nil {
-		return gcBatchCounters{}, err
+		return gcInfoUpdate{}, err
 	}
 	b.clearRangeCounters = gcBatchCounters{}
 
@@ -697,7 +708,7 @@ func (b *gcKeyBatcher) foundNonGCableData(
 
 func (b *gcKeyBatcher) foundGarbage(
 	ctx context.Context, cur *mvccKeyValue, isNewestPoint bool,
-) (counterUpdate gcBatchCounters, err error) {
+) (counterUpdate gcInfoUpdate, err error) {
 	// If we are restarting clear range collection, then last points batch might
 	// be reverted to partial at the time of flush. We will save its
 	// pre-clear-range state and use for GC stats update.
@@ -716,9 +727,11 @@ func (b *gcKeyBatcher) foundGarbage(
 			// If clear range is disabled, flush batches immediately as they are
 			// formed.
 			if !b.clearRangeEnabled {
-				if counterUpdate, err = b.flushPointsBatch(ctx, &b.pointsBatches[i]); err != nil {
-					return gcBatchCounters{}, err
+				upd, err := b.flushPointsBatch(ctx, &b.pointsBatches[i])
+				if err != nil {
+					return gcInfoUpdate{}, err
 				}
+				counterUpdate.add(upd)
 			} else {
 				b.pointsBatches = append(b.pointsBatches, pointsBatch{})
 				i++
@@ -752,7 +765,7 @@ func (b *gcKeyBatcher) foundGarbage(
 			// to flush oldest batch to protect node from exhausting memory.
 			lastKey, update, err := b.flushOldestPointBatches(ctx, 1)
 			if err != nil {
-				return gcBatchCounters{}, err
+				return gcInfoUpdate{}, err
 			}
 			counterUpdate.add(update)
 			// If oldest batch intersected with currently tracked clear range request
@@ -804,7 +817,7 @@ func (b *gcKeyBatcher) foundGarbage(
 //     except for last are flushed
 func (b *gcKeyBatcher) maybeFlushPendingBatches(
 	ctx context.Context,
-) (counterUpdate gcBatchCounters, err error) {
+) (counterUpdate gcInfoUpdate, err error) {
 	// Find where in first points batch is start key and flush "prefix".
 	if b.clearRangeEnabled && b.clearRangeCounters.versionsAffected >= b.clearRangeMinKeys {
 		//fmt.Printf("flushing range batch on live data\n")
@@ -825,7 +838,7 @@ func (b *gcKeyBatcher) maybeFlushPendingBatches(
 			b.pointsBatches[0].gcBatchCounters = b.partialPointBatchCounters
 			upd, err := b.flushPointsBatch(ctx, &b.pointsBatches[0])
 			if err != nil {
-				return gcBatchCounters{}, err
+				return gcInfoUpdate{}, err
 			}
 			counterUpdate.add(upd)
 		}
@@ -848,7 +861,7 @@ func (b *gcKeyBatcher) maybeFlushPendingBatches(
 			EndKey:            endRange,
 		}); err != nil {
 			if errors.Is(err, ctx.Err()) {
-				return gcBatchCounters{}, err
+				return gcInfoUpdate{}, err
 			}
 			// Even though we are batching the GC process, it's
 			// safe to continue because we bumped the GC
@@ -857,12 +870,13 @@ func (b *gcKeyBatcher) maybeFlushPendingBatches(
 			log.Warningf(ctx, "failed to GC keys with clear range: %v", err)
 		}
 		counterUpdate.add(b.clearRangeCounters)
+		counterUpdate.clearRangeOps++
 		b.totalMemUsed = 0
 	} else if flushTo := len(b.pointsBatches) - 1; flushTo > 0 {
 		//fmt.Printf("flushing points batch on live data\n")
 		_, update, err := b.flushOldestPointBatches(ctx, flushTo)
 		if err != nil {
-			return gcBatchCounters{}, err
+			return gcInfoUpdate{}, err
 		}
 		counterUpdate.add(update)
 	}
@@ -915,11 +929,9 @@ func (b *gcKeyBatcher) flushPointsBatch(
 	return counters, nil
 }
 
-func (b *gcKeyBatcher) flushLastBatch(
-	ctx context.Context,
-) (counterUpdate gcBatchCounters, err error) {
+func (b *gcKeyBatcher) flushLastBatch(ctx context.Context) (counterUpdate gcInfoUpdate, err error) {
 	if len(b.pointsBatches[0].batchGCKeys) == 0 {
-		return gcBatchCounters{}, nil
+		return gcInfoUpdate{}, nil
 	}
 	b.pointsBatches = append(b.pointsBatches, pointsBatch{})
 	return b.maybeFlushPendingBatches(ctx)

--- a/pkg/kv/kvserver/gc/gc_iterator_test.go
+++ b/pkg/kv/kvserver/gc/gc_iterator_test.go
@@ -163,8 +163,14 @@ func TestGCIterator(t *testing.T) {
 			ds.setupTest(t, eng, desc)
 			snap := eng.NewSnapshot()
 			defer snap.Close()
-			it := makeGCIterator(&desc, snap, tc.gcThreshold, false)
-			defer it.close()
+			mvccIt := snap.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
+				LowerBound: desc.StartKey.AsRawKey(),
+				UpperBound: desc.EndKey.AsRawKey(),
+				KeyTypes:   storage.IterKeyTypePointsAndRanges,
+			})
+			mvccIt.SeekLT(storage.MVCCKey{Key: desc.EndKey.AsRawKey()})
+			defer mvccIt.Close()
+			it := makeGCIterator(mvccIt, tc.gcThreshold)
 			expectations := tc.expectations
 			for i, ex := range expectations {
 				s, ok := it.state()

--- a/pkg/kv/kvserver/gc/gc_old_test.go
+++ b/pkg/kv/kvserver/gc/gc_old_test.go
@@ -150,7 +150,7 @@ func runGCOld(
 						if batchGCKeysBytes >= KeyVersionChunkBytes {
 							batchGCKeys = append(batchGCKeys, roachpb.GCRequest_GCKey{Key: expBaseKey, Timestamp: keys[i].Timestamp})
 
-							err := gcer.GC(ctx, batchGCKeys, nil, nil)
+							err := gcer.GC(ctx, batchGCKeys, nil, nil, nil)
 
 							batchGCKeys = nil
 							batchGCKeysBytes = 0
@@ -209,7 +209,7 @@ func runGCOld(
 	// Handle last collected set of keys/vals.
 	processKeysAndValues()
 	if len(batchGCKeys) > 0 {
-		if err := gcer.GC(ctx, batchGCKeys, nil, nil); err != nil {
+		if err := gcer.GC(ctx, batchGCKeys, nil, nil, nil); err != nil {
 			return Info{}, err
 		}
 	}

--- a/pkg/kv/kvserver/gc/gc_random_test.go
+++ b/pkg/kv/kvserver/gc/gc_random_test.go
@@ -46,47 +46,47 @@ var (
 		tsSecFrom: 1, tsSecTo: 100,
 		keySuffixMin: 2, keySuffixMax: 6,
 		valueLenMin: 1, valueLenMax: 1,
-		deleteFrac:      0,
-		keysPerValueMin: 1, keysPerValueMax: 2,
+		deleteFrac:        0,
+		versionsPerKeyMin: 1, versionsPerKeyMax: 2,
 		intentFrac: .1,
 	}
 	someVersionsMidSizeRows = uniformDistSpec{
 		tsSecFrom: 1, tsSecTo: 100,
 		keySuffixMin: 8, keySuffixMax: 8,
 		valueLenMin: 8, valueLenMax: 16,
-		deleteFrac:      .1,
-		keysPerValueMin: 1, keysPerValueMax: 100,
+		deleteFrac:        .1,
+		versionsPerKeyMin: 1, versionsPerKeyMax: 100,
 		intentFrac: .1,
 	}
 	lotsOfVersionsMidSizeRows = uniformDistSpec{
 		tsSecFrom: 1, tsSecTo: 100,
-		keySuffixMin: 8, keySuffixMax: 8,
+		keySuffixMin: 7, keySuffixMax: 9,
 		valueLenMin: 8, valueLenMax: 16,
-		deleteFrac:      .1,
-		keysPerValueMin: 1000, keysPerValueMax: 1000000,
+		deleteFrac:        .1,
+		versionsPerKeyMin: 1000, versionsPerKeyMax: 1000000,
 		intentFrac: .1,
 	}
 	// This spec is identical to someVersionsMidSizeRows except for number of
 	// intents.
 	someVersionsMidSizeRowsLotsOfIntents = uniformDistSpec{
 		tsSecFrom: 1, tsSecTo: 100,
-		keySuffixMin: 8, keySuffixMax: 8,
+		keySuffixMin: 7, keySuffixMax: 9,
 		valueLenMin: 8, valueLenMax: 16,
-		deleteFrac:      .1,
-		keysPerValueMin: 1, keysPerValueMax: 100,
+		deleteFrac:        .1,
+		versionsPerKeyMin: 1, versionsPerKeyMax: 100,
 		intentFrac: 1,
 	}
 	someVersionsWithSomeRangeKeys = uniformDistSpec{
 		tsSecFrom: 1, tsSecTo: 100,
 		tsSecMinIntent: 70, tsSecOldIntentTo: 85,
-		keySuffixMin: 8, keySuffixMax: 8,
+		keySuffixMin: 7, keySuffixMax: 9,
 		valueLenMin: 8, valueLenMax: 16,
-		deleteFrac:      .1,
-		keysPerValueMin: 1,
-		keysPerValueMax: 100,
-		intentFrac:      .1,
-		oldIntentFrac:   .1,
-		rangeKeyFrac:    .1,
+		deleteFrac:        .1,
+		versionsPerKeyMin: 1,
+		versionsPerKeyMax: 100,
+		intentFrac:        .1,
+		oldIntentFrac:     .1,
+		rangeKeyFrac:      .1,
 	}
 
 	// smallEngineBlocks configures Pebble with a block size of 1 byte, to provoke
@@ -278,6 +278,7 @@ func TestNewVsInvariants(t *testing.T) {
 		t.Run(fmt.Sprintf("%v@%v,ttl=%vsec", tc.ds, tc.now, tc.ttlSec), func(t *testing.T) {
 			rng, seed := randutil.NewTestRand()
 			t.Logf("Using subtest seed: %d", seed)
+			//rng := randutil.NewTestRandWithSeed(4249930301727204042)
 
 			desc := tc.ds.desc()
 			eng := storage.NewDefaultInMemForTesting(storage.If(smallEngineBlocks, storage.BlockSize(1)))
@@ -297,6 +298,7 @@ func TestNewVsInvariants(t *testing.T) {
 				gcThreshold, RunOptions{
 					IntentAgeThreshold:  intentAgeThreshold,
 					TxnCleanupThreshold: txnCleanupThreshold,
+					ClearRangeMinKeys:   100,
 				}, ttl,
 				&gcer,
 				gcer.resolveIntents,
@@ -316,12 +318,23 @@ func TestNewVsInvariants(t *testing.T) {
 				_, err := storage.MVCCResolveWriteIntent(ctx, eng, &stats, l)
 				require.NoError(t, err, "failed to resolve intent")
 			}
+			for _, cr := range gcer.clearSubRangeKeys() {
+				require.NoError(t,
+					storage.MVCCGarbageCollectPointsWithClearRange(ctx, eng, &stats, cr.StartKey, cr.EndKey,
+						cr.StartKeyTimestamp, gcThreshold))
+			}
 			for _, batch := range gcer.rangeKeyBatches() {
 				rangeKeys := makeCollectableGCRangesFromGCRequests(desc.StartKey.AsRawKey(),
 					desc.EndKey.AsRawKey(), batch)
 				require.NoError(t,
 					storage.MVCCGarbageCollectRangeKeys(ctx, eng, &stats, rangeKeys))
 			}
+			if len(gcer.gcClearRangeKeys) > 0 {
+				panic("Clear range happened")
+			}
+
+			fmt.Printf("GCER requests\nPoint keys: %d\nSubranges: %d\nRange keys: %d\n",
+				len(gcer.gcKeys), len(gcer.gcClearSubRangeKeys), len(gcer.gcRangeKeyBatches))
 
 			assertLiveData(t, eng, beforeGC, *desc, tc.now, gcThreshold, intentThreshold, ttl,
 				gcInfoNew)
@@ -738,7 +751,8 @@ func mergeRanges(fragments [][]storage.MVCCRangeKeyValue) []storage.MVCCRangeKey
 }
 
 type fakeGCer struct {
-	gcKeys map[string]roachpb.GCRequest_GCKey
+	gcKeys          map[string]roachpb.GCRequest_GCKey
+	gcPointsBatches [][]roachpb.GCRequest_GCKey
 	// fake GCer stores range key batches as it since we need to be able to
 	// feed them into MVCCGarbageCollectRangeKeys and ranges argument should be
 	// non-overlapping.
@@ -774,12 +788,22 @@ func (f *fakeGCer) GC(
 	for _, k := range keys {
 		f.gcKeys[k.Key.String()] = k
 	}
-	f.gcRangeKeyBatches = append(f.gcRangeKeyBatches, rangeKeys)
+	if keys != nil {
+		f.gcPointsBatches = append(f.gcPointsBatches, keys)
+	}
+	if rangeKeys != nil {
+		f.gcRangeKeyBatches = append(f.gcRangeKeyBatches, rangeKeys)
+	}
 	if clearRangeKey != nil {
 		f.gcClearRangeKeys = append(f.gcClearRangeKeys, *clearRangeKey)
 	}
 	if clearSubRangeKey != nil {
-		f.gcClearSubRangeKeys = append(f.gcClearSubRangeKeys, *clearSubRangeKey)
+		// Cloning keys because GC can reuse key slices for range keys.
+		f.gcClearSubRangeKeys = append(f.gcClearSubRangeKeys, roachpb.GCRequest_GCClearSubRangeKey{
+			StartKey:          clearSubRangeKey.StartKey.Clone(),
+			StartKeyTimestamp: clearSubRangeKey.StartKeyTimestamp,
+			EndKey:            clearSubRangeKey.EndKey.Clone(),
+		})
 	}
 	return nil
 }
@@ -829,6 +853,14 @@ func (f *fakeGCer) rangeKeys() []roachpb.GCRequest_GCRangeKey {
 	return reqs
 }
 
+func (f *fakeGCer) clearRangeKeys() []roachpb.GCRequest_GCClearRangeKey {
+	return f.gcClearRangeKeys
+}
+
+func (f *fakeGCer) clearSubRangeKeys() []roachpb.GCRequest_GCClearSubRangeKey {
+	return f.gcClearSubRangeKeys
+}
+
 func intentLess(a, b *roachpb.Intent) bool {
 	cmp := a.Key.Compare(b.Key)
 	switch {
@@ -853,25 +885,36 @@ func makeCollectableGCRangesFromGCRequests(
 ) []storage.CollectableGCRangeKey {
 	collectableKeys := make([]storage.CollectableGCRangeKey, len(rangeKeys))
 	for i, rk := range rangeKeys {
-		leftPeekBound := rk.StartKey.Prevish(roachpb.PrevishKeyLength)
-		if len(rangeStart) > 0 && leftPeekBound.Compare(rangeStart) <= 0 {
-			leftPeekBound = rangeStart
-		}
-		rightPeekBound := rk.EndKey.Next()
-		if len(rangeEnd) > 0 && rightPeekBound.Compare(rangeEnd) >= 0 {
-			rightPeekBound = rangeEnd
-		}
+		peekBounds := expandRangeSpan(roachpb.Span{
+			Key:    rk.StartKey,
+			EndKey: rk.EndKey,
+		}, roachpb.Span{
+			Key:    rangeStart,
+			EndKey: rangeEnd,
+		})
 		collectableKeys[i] = storage.CollectableGCRangeKey{
 			MVCCRangeKey: storage.MVCCRangeKey{
 				StartKey:  rk.StartKey,
 				EndKey:    rk.EndKey,
 				Timestamp: rk.Timestamp,
 			},
-			LatchSpan: roachpb.Span{
-				Key:    leftPeekBound,
-				EndKey: rightPeekBound,
-			},
+			LatchSpan: peekBounds,
 		}
 	}
 	return collectableKeys
+}
+
+func expandRangeSpan(rangeKey, limits roachpb.Span) roachpb.Span {
+	leftPeekBound := rangeKey.Key.Prevish(roachpb.PrevishKeyLength)
+	if len(limits.Key) > 0 && leftPeekBound.Compare(limits.Key) <= 0 {
+		leftPeekBound = limits.Key
+	}
+	rightPeekBound := rangeKey.EndKey.Next()
+	if len(limits.EndKey) > 0 && rightPeekBound.Compare(limits.EndKey) >= 0 {
+		rightPeekBound = limits.EndKey
+	}
+	return roachpb.Span{
+		Key:    leftPeekBound,
+		EndKey: rightPeekBound,
+	}
 }

--- a/pkg/kv/kvserver/gc/gc_random_test.go
+++ b/pkg/kv/kvserver/gc/gc_random_test.go
@@ -742,12 +742,13 @@ type fakeGCer struct {
 	// fake GCer stores range key batches as it since we need to be able to
 	// feed them into MVCCGarbageCollectRangeKeys and ranges argument should be
 	// non-overlapping.
-	gcRangeKeyBatches [][]roachpb.GCRequest_GCRangeKey
-	gcClearRangeKeys  []roachpb.GCRequest_GCClearRangeKey
-	threshold         Threshold
-	intents           []roachpb.Intent
-	batches           [][]roachpb.Intent
-	txnIntents        []txnIntents
+	gcRangeKeyBatches   [][]roachpb.GCRequest_GCRangeKey
+	gcClearRangeKeys    []roachpb.GCRequest_GCClearRangeKey
+	gcClearSubRangeKeys []roachpb.GCRequest_GCClearSubRangeKey
+	threshold           Threshold
+	intents             []roachpb.Intent
+	batches             [][]roachpb.Intent
+	txnIntents          []txnIntents
 }
 
 func makeFakeGCer() fakeGCer {
@@ -768,6 +769,7 @@ func (f *fakeGCer) GC(
 	keys []roachpb.GCRequest_GCKey,
 	rangeKeys []roachpb.GCRequest_GCRangeKey,
 	clearRangeKey *roachpb.GCRequest_GCClearRangeKey,
+	clearSubRangeKey *roachpb.GCRequest_GCClearSubRangeKey,
 ) error {
 	for _, k := range keys {
 		f.gcKeys[k.Key.String()] = k
@@ -775,6 +777,9 @@ func (f *fakeGCer) GC(
 	f.gcRangeKeyBatches = append(f.gcRangeKeyBatches, rangeKeys)
 	if clearRangeKey != nil {
 		f.gcClearRangeKeys = append(f.gcClearRangeKeys, *clearRangeKey)
+	}
+	if clearSubRangeKey != nil {
+		f.gcClearSubRangeKeys = append(f.gcClearSubRangeKeys, *clearSubRangeKey)
 	}
 	return nil
 }

--- a/pkg/kv/kvserver/gc/gc_test.go
+++ b/pkg/kv/kvserver/gc/gc_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -147,15 +149,15 @@ func TestIntentAgeThresholdSetting(t *testing.T) {
 	nowTs := hlc.Timestamp{
 		WallTime: now.Nanoseconds(),
 	}
-	fakeGCer := makeFakeGCer()
+	gcer := makeFakeGCer()
 
 	// Test GC desired behavior.
 	info, err := Run(ctx, &desc, snap, nowTs, nowTs,
 		RunOptions{
 			IntentAgeThreshold:  intentLongThreshold,
 			TxnCleanupThreshold: txnCleanupThreshold,
-		}, gcTTL, &fakeGCer, fakeGCer.resolveIntents,
-		fakeGCer.resolveIntentsAsync)
+		}, gcTTL, &gcer, gcer.resolveIntents,
+		gcer.resolveIntentsAsync)
 	require.NoError(t, err, "GC Run shouldn't fail")
 	assert.Zero(t, info.IntentsConsidered,
 		"Expected no intents considered by GC with default threshold")
@@ -164,8 +166,8 @@ func TestIntentAgeThresholdSetting(t *testing.T) {
 		RunOptions{
 			IntentAgeThreshold:  intentShortThreshold,
 			TxnCleanupThreshold: txnCleanupThreshold,
-		}, gcTTL, &fakeGCer, fakeGCer.resolveIntents,
-		fakeGCer.resolveIntentsAsync)
+		}, gcTTL, &gcer, gcer.resolveIntents,
+		gcer.resolveIntentsAsync)
 	require.NoError(t, err, "GC Run shouldn't fail")
 	assert.Equal(t, 1, info.IntentsConsidered,
 		"Expected 1 intents considered by GC with short threshold")
@@ -224,7 +226,7 @@ func TestIntentCleanupBatching(t *testing.T) {
 	baseGCer.normalize()
 
 	var batchSize int64 = 7
-	fakeGCer := makeFakeGCer()
+	gcer := makeFakeGCer()
 	info, err := Run(ctx, &desc, snap, nowTs, nowTs,
 		RunOptions{
 			IntentAgeThreshold:              intentAgeThreshold,
@@ -232,18 +234,18 @@ func TestIntentCleanupBatching(t *testing.T) {
 			TxnCleanupThreshold:             txnCleanupThreshold,
 		},
 		gcTTL,
-		&fakeGCer, fakeGCer.resolveIntents, fakeGCer.resolveIntentsAsync)
+		&gcer, gcer.resolveIntents, gcer.resolveIntentsAsync)
 	require.NoError(t, err, "GC Run shouldn't fail")
 	maxIntents := 0
-	for _, batch := range fakeGCer.batches {
+	for _, batch := range gcer.batches {
 		if intents := len(batch); intents > maxIntents {
 			maxIntents = intents
 		}
 	}
 	require.Equal(t, int64(maxIntents), batchSize, "Batch size")
 	require.Equal(t, 15, info.ResolveTotal)
-	fakeGCer.normalize()
-	require.EqualValues(t, baseGCer, fakeGCer, "GC result with batching")
+	gcer.normalize()
+	require.EqualValues(t, baseGCer, gcer, "GC result with batching")
 }
 
 type testResolver [][]roachpb.Intent
@@ -699,6 +701,14 @@ var avoidMergingDifferentTs = `
  1 |
 `
 
+type testRunData struct {
+	data                 string
+	deleteRangeThreshold int64
+	keyBytesThreshold    int64
+	disableClearRange    bool
+	maxPendingKeySize    int64
+}
+
 func TestGC(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	for _, d := range []struct {
@@ -724,12 +734,392 @@ func TestGC(t *testing.T) {
 		{name: "avoid_merging_different_ts", data: avoidMergingDifferentTs},
 	} {
 		t.Run(d.name, func(t *testing.T) {
-			runTest(t, d.data)
+			testutils.RunTrueAndFalse(t, "clearRange", func(t *testing.T, clearRange bool) {
+				runTest(t, testRunData{
+					data:                 d.data,
+					deleteRangeThreshold: 2,
+					disableClearRange:    !clearRange,
+				}, nil)
+			})
 		})
 	}
 }
 
-func runTest(t *testing.T, data string) {
+type ClearRangeKey roachpb.GCRequest_GCClearSubRangeKey
+
+// Format implements the fmt.Formatter interface.
+func (k ClearRangeKey) Format(f fmt.State, _ rune) {
+	fmt.Fprintf(f, "ClearRangeKey{%s@%s - %s}", k.StartKey, k.StartKeyTimestamp, k.EndKey)
+}
+
+type ClearRangeKeys []roachpb.GCRequest_GCClearSubRangeKey
+
+func (k ClearRangeKeys) toTestData() (spans []ClearRangeKey) {
+	if len(k) == 0 {
+		return nil
+	}
+	spans = make([]ClearRangeKey, len(k))
+	for i, c := range k {
+		spans[i] = ClearRangeKey{
+			StartKey:          c.StartKey,
+			StartKeyTimestamp: c.StartKeyTimestamp,
+			EndKey:            c.EndKey,
+		}
+	}
+	return spans
+}
+
+type clearPointsKey roachpb.GCRequest_GCKey
+
+// Format implements the fmt.Formatter interface.
+func (k clearPointsKey) Format(f fmt.State, c rune) {
+	storage.MVCCKey{
+		Key:       k.Key,
+		Timestamp: k.Timestamp,
+	}.Format(f, c)
+}
+
+type gcPointsBatches [][]roachpb.GCRequest_GCKey
+
+func (b gcPointsBatches) toTestData() (keys [][]clearPointsKey) {
+	if len(b) == 0 {
+		return nil
+	}
+	keys = make([][]clearPointsKey, len(b))
+	for i, b := range b {
+		keys[i] = make([]clearPointsKey, len(b))
+		for j, k := range b {
+			keys[i][j] = clearPointsKey{
+				Key:       k.Key,
+				Timestamp: k.Timestamp,
+			}
+		}
+	}
+	return keys
+}
+
+// For testing clear range we perform normal checks, but also explicitly verify
+// generated clear range spans as normal point key deletions would do the same
+// job but less efficiently.
+type clearRangeTestData struct {
+	name        string
+	data        testRunData
+	clearSpans  []ClearRangeKey
+	clearPoints [][]clearPointsKey
+}
+
+func TestGCUseClearRange(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	first := keys.SystemSQLCodec.TablePrefix(42)
+	// mkKey creates a key in a table from a string value. If key ends with a +
+	// then Next() key is returned.
+	mkKey := func(key string) roachpb.Key {
+		if l := len(key); l > 1 && key[l-1] == '+' {
+			return append(first[:len(first):len(first)], key[:l-1]...).Next()
+		}
+		return append(first[:len(first):len(first)], key...)
+	}
+	last := first.PrefixEnd()
+
+	mkPointKey := func(start string, ts int64) clearPointsKey {
+		return clearPointsKey{
+			Key:       mkKey(start),
+			Timestamp: hlc.Timestamp{WallTime: ts * time.Second.Nanoseconds()},
+		}
+	}
+	mkKeyPair := func(start string, startTs int64, end string) ClearRangeKey {
+		return ClearRangeKey{
+			StartKey:          mkKey(start),
+			StartKeyTimestamp: hlc.Timestamp{WallTime: startTs * time.Second.Nanoseconds()},
+			EndKey:            mkKey(end),
+		}
+	}
+	mkKeyPairToLast := func(start string, startTs int64) ClearRangeKey {
+		return ClearRangeKey{
+			StartKey:          mkKey(start),
+			StartKeyTimestamp: hlc.Timestamp{WallTime: startTs * time.Second.Nanoseconds()},
+			EndKey:            last,
+		}
+	}
+	mkRawKeyPair := func(start, end roachpb.Key) ClearRangeKey {
+		return ClearRangeKey{
+			StartKey: start,
+			EndKey:   end,
+		}
+	}
+	_, _, _ = mkKeyPair, mkKeyPairToLast, mkRawKeyPair
+	clearRangeTestDefaults := func(d testRunData) testRunData {
+		if d.deleteRangeThreshold == 0 {
+			d.deleteRangeThreshold = 1
+		}
+		if d.keyBytesThreshold == 0 {
+			d.keyBytesThreshold = 1
+		}
+		return d
+	}
+
+	for _, d := range []clearRangeTestData{
+		// TODO(oleg): test full range optimization test
+		{
+			name: "clear multiple keys fully",
+			data: testRunData{
+				data: `
+   | a  bb ccc  d e
+---+---------------
+ 6 |
+>5 |
+ 4 |    .  .    E
+ 3 | A     cc
+ 2 |    bb ddd
+ 1 |
+`,
+			},
+			clearSpans: []ClearRangeKey{
+				mkKeyPair("bb", 4, "d"),
+			},
+		},
+		{
+			name: "clear multiple keys from version",
+			data: testRunData{
+				data: `
+   | a  bb ccc  d e
+---+---------------
+ 6 |
+>5 |
+ 4 |    C  .    F
+ 3 | A     ee
+ 2 |    dd
+ 1 |
+`,
+			},
+			clearSpans: []ClearRangeKey{
+				mkKeyPair("bb", 2, "d"),
+			},
+		},
+		{
+			name: "clear multiple keys till end range",
+			data: testRunData{
+				data: `
+   | a  bb ccc  d e
+---+---------------
+ 6 |
+>5 |            .
+ 4 |    C  .    f
+ 3 | A     ee
+ 2 |    dd
+ 1 |
+`,
+			},
+			clearSpans: []ClearRangeKey{
+				mkKeyPairToLast("bb", 2),
+			},
+		},
+		{
+			name: "clear multiple keys from start range",
+			data: testRunData{
+				data: `
+   | a  bb ccc  d e
+---+---------------
+ 9 | 
+ 8 |
+ 7 |
+ 6 |
+>5 |            
+ 4 | .  .  .    F
+ 3 | a     ee
+ 2 |    dd
+ 1 |
+`,
+			},
+			clearSpans: []ClearRangeKey{
+				mkKeyPair("a", 4, "d"),
+			},
+		},
+		{
+			name: "clear when points and clear batch overlap",
+			data: testRunData{
+				data: `
+   | a  bb ccc  d e
+---+---------------
+ 7 |
+ 6 |            W
+>5 |       .     
+ 4 |    .  e    .
+ 3 | A     rr   x
+ 2 |    dd vvv  y
+ 1 |       uuu  z
+`,
+				deleteRangeThreshold: 7,
+				// Single letter key size is 15 bytes.
+				keyBytesThreshold: 15*4 + 17*2,
+			},
+			clearSpans: []ClearRangeKey{
+				mkKeyPair("bb", 4, "d"),
+			},
+			clearPoints: [][]clearPointsKey{
+				{mkPointKey("d", 4)},
+			},
+		},
+		{
+			name: "multiple points batches before clear",
+			data: testRunData{
+				data: `
+   | a  bb ccc  d e
+---+---------------
+ 9 | 
+ 8 |
+ 7 |
+ 6 |            C
+>5 |       .    . .
+ 4 |    .  f    
+ 3 | A     rr   x x
+ 2 |    dd vvv  y y
+ 1 | b  e  uu   z z
+`,
+				deleteRangeThreshold: 9,
+				// Single letter key size is 15 bytes.
+				keyBytesThreshold: 15 * 4,
+			},
+			clearSpans: []ClearRangeKey{
+				mkKeyPair("a", 1, "d"),
+			},
+			clearPoints: [][]clearPointsKey{
+				{mkPointKey("e", 5)},
+				{mkPointKey("d", 5)},
+			},
+		},
+		{
+			name: "clear range restart on live data",
+			data: testRunData{
+				data: `
+   | a  bb ccc  d e
+---+---------------
+ 8 |
+ 7 |       E
+ 6 |           
+>5 |    .  .      
+ 4 |    c  f    . .
+ 3 | A          h i
+ 2 | b  dd ggg
+ 1 |      
+`,
+			},
+			clearSpans: []ClearRangeKey{
+				mkKeyPairToLast("ccc", 5),
+				mkKeyPair("a", 2, "ccc"),
+			},
+		},
+		{
+			name: "clear range restart on intent",
+			data: testRunData{
+				data: `
+   | a  bb ccc  d e
+---+---------------
+ 8 |
+ 7 |       !E
+ 6 |           
+>5 |    .  .      
+ 4 |    c  f    . .
+ 3 | A          h i
+ 2 | b  dd ggg
+ 1 |      
+`,
+			},
+			clearSpans: []ClearRangeKey{
+				mkKeyPairToLast("ccc", 5),
+				mkKeyPair("a", 2, "ccc"),
+			},
+		},
+		{
+			name: "memory limit overrides clear range",
+			data: testRunData{
+				data: `
+   | a  bbbbbbbbbb c dddddddddd
+---+-------------------------------
+ 8 |
+ 7 |
+ 6 |              
+>5 |    .          .      
+ 4 |    c          f .
+ 3 | A               y
+ 2 | b  dd         g z
+ 1 |
+`,
+				deleteRangeThreshold: 6,
+				keyBytesThreshold:    30,
+				maxPendingKeySize:    90,
+			},
+		},
+		{
+			// Long key is used to trigger memory overflow flush
+			name: "memory limit overrides oldest batch only",
+			data: testRunData{
+				data: `
+   | a  b c d eeeeeeeeee f g
+---+-------------------------------
+ 6 |              
+>5 |    . .   .          . .
+ 4 |    c f . x          y z
+ 3 | A  d g u
+ 2 | b  e h v
+ 1 |    f i w
+`,
+				deleteRangeThreshold: 7,
+				keyBytesThreshold:    1, // Force each batch to have a single key.
+				maxPendingKeySize:    127,
+			},
+			clearSpans: []ClearRangeKey{
+				mkKeyPair("a", 2, "eeeeeeeeee+"),
+			},
+		},
+		{
+			// Partial batch is a points batch, where there is a non garbage key in
+			// the middle doesn't allow it to be collected by clear range fully.
+			name: "memory limit overrides partial batch",
+			data: testRunData{
+				data: `
+   | a  b c d eeeeeeeeee 
+---+---------------------
+ 6 |          X
+>5 |    . .   .
+ 4 |    c f . x
+ 3 | A  d g u
+ 2 | b  e h v
+ 1 |    f i w
+`,
+				deleteRangeThreshold: 7,
+				keyBytesThreshold:    55,
+				maxPendingKeySize:    80,
+			},
+			clearSpans: []ClearRangeKey{
+				mkKeyPair("a", 2, "d+"),
+			},
+			clearPoints: [][]clearPointsKey{
+				// First batch is large and has live data in the middle so
+				// breaks in two. It is then removed because of its size and
+				// end key for clear range is advanced.
+				{mkPointKey("eeeeeeeeee", 5), mkPointKey("d", 1)},
+				{mkPointKey("d", 4)},
+			},
+		},
+		// TODO(oleg): add test with range tombstones
+	} {
+		t.Run(d.name, func(t *testing.T) {
+			runTest(t, clearRangeTestDefaults(d.data), func(t *testing.T, gcer *fakeGCer) {
+				require.EqualValues(t, d.clearSpans, ClearRangeKeys(gcer.gcClearSubRangeKeys).toTestData(),
+					"clear range requests")
+				if d.clearPoints != nil {
+					require.EqualValues(t, d.clearPoints, gcPointsBatches(gcer.gcPointsBatches).toTestData())
+				}
+			})
+		})
+	}
+}
+
+type gcVerifier func(t *testing.T, gcer *fakeGCer)
+
+func runTest(t *testing.T, data testRunData, verify gcVerifier) {
 	ctx := context.Background()
 	tablePrefix := keys.SystemSQLCodec.TablePrefix(42)
 	desc := roachpb.RangeDescriptor{
@@ -740,24 +1130,50 @@ func runTest(t *testing.T, data string) {
 	eng := storage.NewDefaultInMemForTesting()
 	defer eng.Close()
 
-	dataItems, gcTS, now := readTableData(t, desc.StartKey.AsRawKey(), data)
+	dataItems, gcTS, now := readTableData(t, desc.StartKey.AsRawKey(), data.data)
 	ds := dataItems.fullDistribution()
 	stats := ds.setupTest(t, eng, desc)
 	snap := eng.NewSnapshot()
 	defer snap.Close()
 
+	if data.disableClearRange {
+		data.deleteRangeThreshold = 0
+	}
+	if data.maxPendingKeySize == 0 {
+		data.maxPendingKeySize = math.MaxInt64
+	}
+
 	gcer := makeFakeGCer()
 	_, err := Run(ctx, &desc, snap, now, gcTS,
 		RunOptions{
-			IntentAgeThreshold:  time.Nanosecond * time.Duration(now.WallTime),
-			TxnCleanupThreshold: txnCleanupThreshold,
+			IntentAgeThreshold:      time.Nanosecond * time.Duration(now.WallTime),
+			TxnCleanupThreshold:     txnCleanupThreshold,
+			MaxKeyVersionChunkBytes: data.keyBytesThreshold,
+			ClearRangeMinKeys:       data.deleteRangeThreshold,
+			MaxPendingKeysSize:      data.maxPendingKeySize,
 		}, time.Second,
 		&gcer,
 		gcer.resolveIntents, gcer.resolveIntentsAsync)
+
+	if verify != nil {
+		verify(t, &gcer)
+	}
+
 	require.NoError(t, err)
 	require.Empty(t, gcer.intents, "expecting no intents")
 	require.NoError(t,
 		storage.MVCCGarbageCollect(ctx, eng, &stats, gcer.pointKeys(), gcTS))
+
+	for _, r := range gcer.clearRangeKeys() {
+		require.NoError(t,
+			storage.MVCCGarbageCollectWholeRange(ctx, eng, &stats, r.StartKey, r.EndKey, gcTS, stats))
+	}
+
+	for _, r := range gcer.clearSubRangeKeys() {
+		require.NoError(t,
+			storage.MVCCGarbageCollectPointsWithClearRange(ctx, eng, &stats, r.StartKey, r.EndKey,
+				r.StartKeyTimestamp, gcTS))
+	}
 
 	for _, batch := range gcer.rangeKeyBatches() {
 		rangeKeys := makeCollectableGCRangesFromGCRequests(desc.StartKey.AsRawKey(),
@@ -823,7 +1239,12 @@ func requireEqualReaders(
 			break
 		}
 
-		require.Equal(t, okExp, okAct, "iterators have different number of elements")
+		if okExp && !okAct {
+			t.Errorf("expected data not found in actual: %s", itExp.UnsafeKey().String())
+		}
+		if !okExp && okAct {
+			t.Errorf("unexpected data found in actual: %s", itActual.UnsafeKey().String())
+		}
 		require.True(t, itExp.UnsafeKey().Equal(itActual.UnsafeKey()),
 			"expected key not equal to actual (expected %s, found %s)", itExp.UnsafeKey(),
 			itActual.UnsafeKey())
@@ -1458,4 +1879,517 @@ func TestRangeKeyBatching(t *testing.T) {
 			require.EqualValues(t, data.expect, gcer.rangeKeys())
 		})
 	}
+}
+
+type GR roachpb.GCRequest_GCKey
+
+func (g GR) Format(f fmt.State, r rune) {
+	g.Key.Format(f, r)
+	fmt.Fprintf(f, "@%d", g.Timestamp.WallTime/1e9)
+}
+
+type GCR roachpb.GCRequest_GCClearSubRangeKey
+
+func (g GCR) Format(f fmt.State, r rune) {
+	g.StartKey.Format(f, r)
+	fmt.Fprintf(f, "@%d-", g.StartKeyTimestamp.WallTime/1e9)
+	g.EndKey.Format(f, r)
+}
+
+// Union of GC args
+type gcReq struct {
+	gcKeys []GR
+	// Note that we just reuse the type, but semantic is different
+	gcClearRangeKey GCR
+}
+
+func (o gcReq) Format(f fmt.State, r rune) {
+	if len(o.gcKeys) > 0 {
+		fmt.Fprintf(f, "%s", o.gcKeys)
+	} else {
+		o.gcClearRangeKey.Format(f, r)
+	}
+}
+
+type capturingGCer struct {
+	t   *testing.T
+	ops []gcReq
+}
+
+func (c *capturingGCer) GC(
+	_ context.Context,
+	k []roachpb.GCRequest_GCKey,
+	_ []roachpb.GCRequest_GCRangeKey,
+	_ *roachpb.GCRequest_GCClearRangeKey,
+	crk *roachpb.GCRequest_GCClearSubRangeKey,
+) error {
+	if len(k) > 0 {
+		kk := make([]GR, len(k))
+		for i, k := range k {
+			kk[i] = GR{Key: k.Key.Clone(), Timestamp: k.Timestamp}
+		}
+		c.ops = append(c.ops, gcReq{gcKeys: kk})
+		return nil
+	}
+	if crk != nil {
+		c.ops = append(c.ops, gcReq{gcClearRangeKey: GCR{
+			StartKey:          crk.StartKey.Clone(),
+			StartKeyTimestamp: crk.StartKeyTimestamp,
+			EndKey:            crk.EndKey.Clone(),
+		}})
+		return nil
+	}
+	c.t.Fatal("unexpected or empty GC request")
+	return nil
+}
+
+type gcData struct {
+	kv      mvccKeyValue
+	garbage bool
+}
+
+func TestGcKeyBatcher(t *testing.T) {
+	ctx := context.Background()
+
+	// Size is a GC size including 1 extra byte and MVCCVersionTimestampSize
+	keyOfSize := func(seq int, size int) roachpb.Key {
+		t.Helper()
+		var k roachpb.Key
+		k = append(k, keys.SystemSQLCodec.IndexPrefix(42, 1)...)
+		kt := encoding.EncodeStringAscending(k, fmt.Sprintf("%06d", seq))
+		baseKeySize := storage.MVCCKey{Key: kt, Timestamp: hlc.Timestamp{WallTime: 1}}.EncodedSize()
+		if padding := size - baseKeySize; padding < 0 {
+			t.Fatalf("invalid test data: test key size is too small. must be >= %d", baseKeySize)
+		} else if padding > 0 {
+			k = encoding.EncodeStringAscending(k, fmt.Sprintf("%06d-%s", seq, strings.Repeat("a", padding-1)))
+		} else {
+			k = kt
+		}
+		require.Equal(t, size,
+			storage.MVCCKey{Key: k, Timestamp: hlc.Timestamp{WallTime: 1}}.EncodedSize(),
+			"test infra bug: generated key size mismatched requested")
+		return k
+	}
+
+	hist := func(key roachpb.Key, versions, garbage int) []gcData {
+		require.LessOrEqual(t, garbage, versions, "invalid test data: can not have more garbage than versions")
+		var res []gcData
+		for i := 0; i < versions; i++ {
+			res = append(res, gcData{
+				kv: mvccKeyValue{
+					key: storage.MVCCKey{
+						Key: key,
+						Timestamp: hlc.Timestamp{
+							WallTime: int64(i+1) * time.Second.Nanoseconds(),
+						},
+					},
+					mvccValueLen: 10,
+				},
+				garbage: i < garbage,
+			})
+		}
+		return res
+	}
+
+	point := func(key roachpb.Key, ts int) GR {
+		return GR{
+			Key:       key,
+			Timestamp: hlc.Timestamp{WallTime: int64(ts) * time.Second.Nanoseconds()},
+		}
+	}
+
+	points := func(keys ...GR) gcReq {
+		return gcReq{gcKeys: keys}
+	}
+
+	clearRange := func(key roachpb.Key, ts int, endKey roachpb.Key) gcReq {
+		return gcReq{
+			gcClearRangeKey: GCR{
+				StartKey:          key,
+				StartKeyTimestamp: hlc.Timestamp{WallTime: int64(ts) * time.Second.Nanoseconds()},
+				EndKey:            endKey,
+			},
+		}
+	}
+
+	const minKeySize = 24
+
+	for _, d := range []struct {
+		name     string
+		data     []gcData
+		reqs     []gcReq
+		batchMax int64
+		memMax   int
+		rangeMin int
+	}{
+		{
+			// Test verifies that min key limit is not reached with 4 versions of the
+			// first key, but reached on the second and third. We have two consecutive
+			// keys specifically to avoid single key range optimizations.
+			name: "minimum range limit",
+			data: keySeq(
+				hist(keyOfSize(4, minKeySize), 6, 5),
+				hist(keyOfSize(3, minKeySize), 1, 1),
+				hist(keyOfSize(2, minKeySize), 10, 9),
+				hist(keyOfSize(1, minKeySize), 2, 1),
+			),
+			reqs: []gcReq{
+				points(point(keyOfSize(4, minKeySize), 5)),
+				clearRange(keyOfSize(2, minKeySize), 9, keyOfSize(4, minKeySize)),
+				points(point(keyOfSize(1, minKeySize), 1)),
+			},
+			rangeMin: 6,
+			batchMax: minKeySize * 5,
+		},
+		{
+			// Test verifies that a batch could be split correctly by the start of
+			// range key. We have two consecutive keys specifically to avoid single
+			// key range optimizations.
+			name: "clear range mid batch",
+			data: keySeq(
+				hist(keyOfSize(4, minKeySize), 5, 2),
+				hist(keyOfSize(3, minKeySize), 1, 1),
+				hist(keyOfSize(2, minKeySize), 10, 9),
+				hist(keyOfSize(1, minKeySize), 2, 1),
+			),
+			reqs: []gcReq{
+				points(point(keyOfSize(4, minKeySize), 2)),
+				clearRange(keyOfSize(2, minKeySize), 9, keyOfSize(4, minKeySize)),
+				points(point(keyOfSize(1, minKeySize), 1)),
+			},
+			rangeMin: 6,
+			batchMax: minKeySize * 4,
+		},
+		{
+			// Test verifies that a batch could be split correctly by the start of
+			// range key. Batch spans multiple keys with non gc data.
+			name: "clear range mid batch 2",
+			data: keySeq(
+				hist(keyOfSize(5, minKeySize), 2, 1),
+				hist(keyOfSize(4, minKeySize), 3, 2),
+				hist(keyOfSize(3, minKeySize), 1, 1),
+				hist(keyOfSize(2, minKeySize), 10, 8),
+				hist(keyOfSize(1, minKeySize), 2, 1),
+			),
+			reqs: []gcReq{
+				points(
+					point(keyOfSize(5, minKeySize), 1),
+					point(keyOfSize(4, minKeySize), 2),
+				),
+				clearRange(keyOfSize(2, minKeySize), 8, keyOfSize(4, minKeySize)),
+				points(point(keyOfSize(1, minKeySize), 1)),
+			},
+			rangeMin: 6,
+			batchMax: minKeySize * 4,
+		},
+		{
+			name: "clear range at batch boundary",
+			data: keySeq(
+				hist(keyOfSize(4, minKeySize), 3, 2),
+				hist(keyOfSize(3, minKeySize), 1, 1),
+				hist(keyOfSize(2, minKeySize), 10, 9),
+				hist(keyOfSize(1, minKeySize), 2, 1),
+			),
+			reqs: []gcReq{
+				points(point(keyOfSize(4, minKeySize), 2)),
+				clearRange(keyOfSize(2, minKeySize), 9, keyOfSize(4, minKeySize)),
+				points(point(keyOfSize(1, minKeySize), 1)),
+			},
+			rangeMin: 6,
+			batchMax: minKeySize * 2,
+		},
+		{
+			// Test verifies that point batch history is not lost when non-garbage
+			// data is found. Batch spans multiple versions of a key.
+			name: "clear multiple points batches",
+			data: keySeq(
+				hist(keyOfSize(3, minKeySize), 10, 8),
+				hist(keyOfSize(2, minKeySize), 10, 10),
+				hist(keyOfSize(1, minKeySize), 2, 1),
+			),
+			reqs: []gcReq{
+				points(point(keyOfSize(3, minKeySize), 5)),
+				points(point(keyOfSize(3, minKeySize), 8)),
+				clearRange(keyOfSize(1, minKeySize), 1, keyOfSize(3, minKeySize)),
+			},
+			rangeMin: 10,
+			batchMax: minKeySize*4 + 1,
+		},
+		{
+			// Test verifies that point batch history is not lost when non-garbage
+			// data is found. Batch spans multiple keys.
+			name: "clear multiple points batches 2",
+			data: keySeq(
+				hist(keyOfSize(6, 24), 2, 2),
+				hist(keyOfSize(5, 24), 2, 2),
+				hist(keyOfSize(4, 24), 2, 2),
+				hist(keyOfSize(3, 24), 2, 1),
+				hist(keyOfSize(2, 24), 10, 10),
+				hist(keyOfSize(1, 24), 2, 1),
+			),
+			reqs: []gcReq{
+				points(
+					point(keyOfSize(6, 24), 2),
+					point(keyOfSize(5, 24), 2),
+					point(keyOfSize(4, 24), 1),
+				),
+				points(
+					point(keyOfSize(4, 24), 2),
+					point(keyOfSize(3, 24), 1),
+				),
+				clearRange(keyOfSize(1, 24), 1, keyOfSize(3, 24)),
+			},
+			rangeMin: 10,
+			batchMax: 100,
+		},
+		{
+			// Test clear range reaches start of the range.
+			name: "clear range to first key",
+			data: keySeq(
+				hist(keyOfSize(3, 24), 2, 1),
+				hist(keyOfSize(2, 24), 10, 10),
+				hist(keyOfSize(1, 24), 2, 2),
+			),
+			reqs: []gcReq{
+				points(point(keyOfSize(3, 24), 1)),
+				clearRange(keyOfSize(1, 24), 2, keyOfSize(3, 24)),
+			},
+			rangeMin: 10,
+			batchMax: 100,
+		},
+		{
+			// Test clear range reaches start of the range.
+			name: "clear points to first key",
+			data: keySeq(
+				hist(keyOfSize(3, 24), 2, 1),
+				hist(keyOfSize(2, 24), 8, 8),
+				hist(keyOfSize(1, 24), 3, 3),
+			),
+			reqs: []gcReq{
+				points(
+					point(keyOfSize(3, 24), 1),
+					point(keyOfSize(2, 24), 3),
+				),
+				points(
+					point(keyOfSize(2, 24), 7),
+				),
+				points(
+					point(keyOfSize(2, 24), 8),
+					point(keyOfSize(1, 24), 3),
+				),
+			},
+			rangeMin: 100,
+			batchMax: 96,
+		},
+		{
+			// Test clear range ends at the end of the range.
+			name: "clear range to last key",
+			data: keySeq(
+				hist(keyOfSize(3, 24), 2, 2),
+				hist(keyOfSize(2, 24), 10, 10),
+				hist(keyOfSize(1, 24), 2, 1),
+			),
+			reqs: []gcReq{
+				clearRange(keyOfSize(1, 24), 1, keys.MaxKey),
+			},
+			rangeMin: 10,
+		},
+		{
+			// Test memory limit is reached before min range limit.
+			// For memory limits we need multiple keys (not versions) since we only
+			// keep latest version of the key per batch.
+			name: "prevent clear range when reaching memory limit",
+			data: keySeq(
+				hist(keyOfSize(6, 24), 2, 2),
+				hist(keyOfSize(5, 24), 2, 2),
+				hist(keyOfSize(4, 24), 2, 2),
+				hist(keyOfSize(3, 24), 2, 2),
+				hist(keyOfSize(2, 24), 2, 2),
+				hist(keyOfSize(1, 24), 2, 2),
+			),
+			reqs: []gcReq{
+				points(
+					point(keyOfSize(6, 24), 2),
+					point(keyOfSize(5, 24), 2),
+				),
+				points(
+					point(keyOfSize(4, 24), 2),
+					point(keyOfSize(3, 24), 2),
+				),
+				points(
+					point(keyOfSize(2, 24), 2),
+					point(keyOfSize(1, 24), 2),
+				),
+			},
+			rangeMin: 6,
+			batchMax: 96,
+			memMax:   1,
+		},
+		{
+			// Test memory limit is reached before min range limit.
+			// For memory limits we need multiple keys (not versions) since we only
+			// keep latest version of the key per batch.
+			name: "delay clear range when reaching memory limit",
+			data: keySeq(
+				hist(keyOfSize(6, 100), 2, 2),
+				hist(keyOfSize(5, 24), 2, 2),
+				hist(keyOfSize(4, 24), 2, 2),
+				hist(keyOfSize(3, 24), 2, 2),
+				hist(keyOfSize(2, 24), 2, 2),
+				hist(keyOfSize(1, 24), 2, 2),
+			),
+			reqs: []gcReq{
+				points(
+					point(keyOfSize(6, 100), 1),
+				),
+				points(
+					point(keyOfSize(6, 100), 2),
+				),
+				// Next() is iffy, but we don't have a better option when we flush the
+				// batch as we don't always know if there are more versions of the same
+				// key or not that should be covered by clear range.
+				clearRange(keyOfSize(1, 24), 2, keyOfSize(6, 100).Next()),
+			},
+			rangeMin: 5,
+			batchMax: 100,
+			// When calculating mem size we don't use encoded length, but raw key and
+			// timestamp length which adds 3 extra bytes.
+			memMax: 100,
+		},
+		{
+			// Test memory limit is reached before min range limit. Range starts in
+			// the middle of the points batch. Is it even possible?
+			name: "delay clear range to mid batch",
+			data: keySeq(
+				hist(keyOfSize(6, 100), 2, 1),
+				hist(keyOfSize(5, 24), 2, 2),
+				hist(keyOfSize(4, 24), 2, 2),
+				hist(keyOfSize(3, 24), 2, 2),
+				hist(keyOfSize(2, 24), 2, 2),
+				hist(keyOfSize(1, 24), 2, 2),
+			),
+			reqs: []gcReq{
+				points(
+					point(keyOfSize(6, 100), 1),
+					point(keyOfSize(5, 24), 1),
+				),
+				clearRange(keyOfSize(1, 24), 2, keyOfSize(5, 24).Next()),
+			},
+			rangeMin: 6,
+			batchMax: 101,
+			// When calculating mem size we don't use encoded length, but raw key and
+			// timestamp length which adds 3 extra bytes.
+			memMax: 120,
+		},
+		{
+			// Verify that when we delete multiple versions of the same key, then we
+			// don't send the end range key to signal that we can avoid locking.
+			name: "clear range optimize single key deletions for several versions",
+			data: keySeq(
+				hist(keyOfSize(3, 24), 2, 1),
+				hist(keyOfSize(2, 24), 10, 10),
+				hist(keyOfSize(1, 24), 2, 0),
+			),
+			reqs: []gcReq{
+				points(point(keyOfSize(3, 24), 1)),
+				clearRange(keyOfSize(2, 24), 10, nil),
+			},
+			rangeMin: 6,
+		},
+		{
+			// Verify that when we delete multiple versions of the same key, then we
+			// don't send the end range key to signal that we can avoid locking.
+			name: "clear range optimize single key deletions for all versions",
+			data: keySeq(
+				hist(keyOfSize(3, 24), 2, 1),
+				hist(keyOfSize(2, 24), 10, 9),
+				hist(keyOfSize(1, 24), 2, 0),
+			),
+			reqs: []gcReq{
+				points(point(keyOfSize(3, 24), 1)),
+				clearRange(keyOfSize(2, 24), 9, nil),
+			},
+			rangeMin: 6,
+		},
+	} {
+		t.Run(d.name, func(t *testing.T) {
+			g := capturingGCer{}
+			enabled := true
+			if d.rangeMin == 0 {
+				enabled = false
+			}
+			memMax := d.memMax
+			if memMax == 0 {
+				memMax = math.MaxInt
+			}
+			batchMax := d.batchMax
+			if batchMax == 0 {
+				batchMax = math.MaxInt64
+			}
+			b := gcKeyBatcher{
+				gcKeyBatcherThresholds: gcKeyBatcherThresholds{
+					batchGCKeysBytesThreshold: batchMax,
+					clearRangeMinKeys:         d.rangeMin,
+					clearRangeEnabled:         enabled,
+					maxPendingKeysSize:        memMax,
+				},
+				gcer:             &g,
+				pointsBatches:    make([]pointsBatch, 1),
+				clearRangeEndKey: keys.MaxKey,
+				prevWasNewest:    true,
+			}
+
+			assertBatcher := func(cnt gcBatchCounters) {
+				// Assert used memory invariants.
+				totalMem := 0
+				for _, b := range b.pointsBatches {
+					batchMem := 0
+					for _, k := range b.batchGCKeys {
+						batchMem += len(k.Key) + hlcTimestampSize
+					}
+					require.Equal(t, batchMem, b.memUsed, "batch memory usage")
+					totalMem += batchMem
+				}
+				require.Equal(t, totalMem, b.totalMemUsed, "batcher memory usage")
+			}
+
+			process := func(k gcData, newest bool) {
+				var (
+					upd gcBatchCounters
+					err error
+				)
+				if k.garbage {
+					upd, err = b.foundGarbage(ctx, &k.kv, newest)
+				} else {
+					upd, err = b.foundNonGCableData(ctx, &k.kv, newest)
+				}
+				require.NoError(t, err, "failed to update batcher")
+				assertBatcher(upd)
+			}
+
+			// Run simulated GC
+			var prev gcData
+			for _, k := range d.data {
+				if prev.kv.key.Key != nil {
+					newest := prev.kv.key.Key.Compare(k.kv.key.Key) != 0
+					process(prev, newest)
+				}
+				prev = k
+			}
+			process(prev, true)
+			upd, err := b.flushLastBatch(ctx)
+			require.NoError(t, err, "failed last batch")
+			assertBatcher(upd)
+
+			// Assert batch history
+			require.EqualValues(t, d.reqs, g.ops, "Produced batches")
+		})
+	}
+}
+
+func keySeq(keyHistory ...[]gcData) (res []gcData) {
+	for _, h := range keyHistory {
+		res = append(res, h...)
+	}
+	return res
 }

--- a/pkg/kv/kvserver/gc/gc_test.go
+++ b/pkg/kv/kvserver/gc/gc_test.go
@@ -60,6 +60,7 @@ func (c *collectingGCer) GC(
 	keys []roachpb.GCRequest_GCKey,
 	_ []roachpb.GCRequest_GCRangeKey,
 	_ *roachpb.GCRequest_GCClearRangeKey,
+	_ *roachpb.GCRequest_GCClearSubRangeKey,
 ) error {
 	c.keys = append(c.keys, keys)
 	return nil

--- a/pkg/kv/kvserver/gc/gc_test.go
+++ b/pkg/kv/kvserver/gc/gc_test.go
@@ -2339,7 +2339,7 @@ func TestGcKeyBatcher(t *testing.T) {
 				prevWasNewest:    true,
 			}
 
-			assertBatcher := func(cnt gcBatchCounters) {
+			assertBatcher := func(cnt gcInfoUpdate) {
 				// Assert used memory invariants.
 				totalMem := 0
 				for _, b := range b.pointsBatches {
@@ -2355,7 +2355,7 @@ func TestGcKeyBatcher(t *testing.T) {
 
 			process := func(k gcData, newest bool) {
 				var (
-					upd gcBatchCounters
+					upd gcInfoUpdate
 					err error
 				)
 				if k.garbage {

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -1316,6 +1316,12 @@ sub-level and file counts.`,
 		Measurement: "Range Keys",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaGCClearConsecutiveKeys = metric.Metadata{
+		Name:        "queue.gc.info.numclearconsecutivekeys",
+		Help:        "Number of clear range requests to remove consecutive keys issued by GC",
+		Measurement: "Requests",
+		Unit:        metric.Unit_COUNT,
+	}
 	metaGCIntentsConsidered = metric.Metadata{
 		Name:        "queue.gc.info.intentsconsidered",
 		Help:        "Number of 'old' intents",
@@ -1889,6 +1895,7 @@ type StoreMetrics struct {
 	// GCInfo cumulative totals.
 	GCNumKeysAffected            *metric.Counter
 	GCNumRangeKeysAffected       *metric.Counter
+	GCClearConsecutiveKeys       *metric.Counter
 	GCIntentsConsidered          *metric.Counter
 	GCIntentTxns                 *metric.Counter
 	GCTransactionSpanScanned     *metric.Counter
@@ -2426,6 +2433,7 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		// GCInfo cumulative totals.
 		GCNumKeysAffected:            metric.NewCounter(metaGCNumKeysAffected),
 		GCNumRangeKeysAffected:       metric.NewCounter(metaGCNumRangeKeysAffected),
+		GCClearConsecutiveKeys:       metric.NewCounter(metaGCClearConsecutiveKeys),
 		GCIntentsConsidered:          metric.NewCounter(metaGCIntentsConsidered),
 		GCIntentTxns:                 metric.NewCounter(metaGCIntentTxns),
 		GCTransactionSpanScanned:     metric.NewCounter(metaGCTransactionSpanScanned),

--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -681,6 +681,7 @@ func (mgcq *mvccGCQueue) process(
 	maxIntentsPerCleanupBatch := gc.MaxIntentsPerCleanupBatch.Get(&repl.store.ClusterSettings().SV)
 	maxIntentKeyBytesPerCleanupBatch := gc.MaxIntentKeyBytesPerCleanupBatch.Get(&repl.store.ClusterSettings().SV)
 	txnCleanupThreshold := gc.TxnCleanupThreshold.Get(&repl.store.ClusterSettings().SV)
+	minKeyNumberForClearRange := gc.MinKeyNumberForClearRange.Get(&repl.store.ClusterSettings().SV)
 
 	info, err := gc.Run(ctx, desc, snap, gcTimestamp, newThreshold,
 		gc.RunOptions{
@@ -690,6 +691,7 @@ func (mgcq *mvccGCQueue) process(
 			TxnCleanupThreshold:                    txnCleanupThreshold,
 			MaxTxnsPerIntentCleanupBatch:           intentresolver.MaxTxnsPerIntentCleanupBatch,
 			IntentCleanupBatchTimeout:              mvccGCQueueIntentBatchTimeout,
+			ClearRangeMinKeys:                      minKeyNumberForClearRange,
 		},
 		conf.TTL(),
 		&replicaGCer{

--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -785,6 +785,7 @@ func updateStoreMetricsWithGCInfo(metrics *StoreMetrics, info gc.Info) {
 	metrics.GCResolveTotal.Inc(int64(info.ResolveTotal))
 	metrics.GCUsedClearRange.Inc(int64(info.ClearRangeKeyOperations))
 	metrics.GCFailedClearRange.Inc(int64(info.ClearRangeKeyFailures))
+	metrics.GCClearConsecutiveKeys.Inc(int64(info.ClearConsecutiveKeysOperations))
 }
 
 func (mgcq *mvccGCQueue) postProcessScheduled(

--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -595,14 +595,16 @@ func (r *replicaGCer) GC(
 	keys []roachpb.GCRequest_GCKey,
 	rangeKeys []roachpb.GCRequest_GCRangeKey,
 	clearRangeKey *roachpb.GCRequest_GCClearRangeKey,
+	clearSubRangeKey *roachpb.GCRequest_GCClearSubRangeKey,
 ) error {
-	if len(keys) == 0 && len(rangeKeys) == 0 && clearRangeKey == nil {
+	if len(keys) == 0 && len(rangeKeys) == 0 && clearRangeKey == nil && clearSubRangeKey == nil {
 		return nil
 	}
 	req := r.template()
 	req.Keys = keys
 	req.RangeKeys = rangeKeys
 	req.ClearRangeKey = clearRangeKey
+	req.ClearSubRangeKey = clearSubRangeKey
 	return r.send(ctx, req)
 }
 

--- a/pkg/kv/kvserver/rditer/replica_data_iter.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter.go
@@ -434,6 +434,7 @@ func IterateReplicaKeySpans(
 type IterateOptions struct {
 	CombineRangesAndPoints bool
 	Reverse                bool
+	ExcludeUserKeySpan     bool
 }
 
 // IterateMVCCReplicaKeySpans iterates over replica's key spans in the similar
@@ -449,6 +450,9 @@ func IterateMVCCReplicaKeySpans(
 		panic("reader must provide consistent iterators")
 	}
 	spans := MakeReplicatedKeySpansExceptLockTable(desc)
+	if options.ExcludeUserKeySpan {
+		spans = MakeReplicatedKeySpansExcludingUserAndLockTable(desc)
+	}
 	if options.Reverse {
 		spanMax := len(spans) - 1
 		for i := 0; i < len(spans)/2; i++ {

--- a/pkg/kv/kvserver/rditer/replica_data_iter.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter.go
@@ -406,16 +406,79 @@ func IterateReplicaKeySpans(
 	keyTypes := []storage.IterKeyType{storage.IterKeyTypePointsOnly, storage.IterKeyTypeRangesOnly}
 	for _, span := range spans {
 		for _, keyType := range keyTypes {
-			iter := reader.NewEngineIterator(storage.IterOptions{
-				KeyTypes:   keyType,
-				LowerBound: span.Key,
-				UpperBound: span.EndKey,
-			})
-			ok, err := iter.SeekEngineKeyGE(storage.EngineKey{Key: span.Key})
-			if err == nil && ok {
-				err = visitor(iter, span, keyType)
+			err := func() error {
+				iter := reader.NewEngineIterator(storage.IterOptions{
+					KeyTypes:   keyType,
+					LowerBound: span.Key,
+					UpperBound: span.EndKey,
+				})
+				defer iter.Close()
+				ok, err := iter.SeekEngineKeyGE(storage.EngineKey{Key: span.Key})
+				if err == nil && ok {
+					err = visitor(iter, span, keyType)
+				}
+				return err
+			}()
+			if err != nil {
+				return iterutil.Map(err)
 			}
-			iter.Close()
+		}
+	}
+	return nil
+}
+
+// IterateOptions instructs how points and ranges should be presented to visitor
+// and if iterators should be visited in forward or reverse order.
+// Reverse iterator are also positioned at the end of the range prior to being
+// passed to visitor.
+type IterateOptions struct {
+	CombineRangesAndPoints bool
+	Reverse                bool
+}
+
+// IterateMVCCReplicaKeySpans iterates over replica's key spans in the similar
+// way to IterateReplicaKeySpans, but uses MVCCIterator and gives additional
+// options to create reverse iterators and to combine keys are ranges.
+func IterateMVCCReplicaKeySpans(
+	desc *roachpb.RangeDescriptor,
+	reader storage.Reader,
+	options IterateOptions,
+	visitor func(storage.MVCCIterator, roachpb.Span, storage.IterKeyType) error,
+) error {
+	if !reader.ConsistentIterators() {
+		panic("reader must provide consistent iterators")
+	}
+	spans := MakeReplicatedKeySpansExceptLockTable(desc)
+	if options.Reverse {
+		spanMax := len(spans) - 1
+		for i := 0; i < len(spans)/2; i++ {
+			spans[spanMax-i], spans[i] = spans[i], spans[spanMax-i]
+		}
+	}
+	keyTypes := []storage.IterKeyType{storage.IterKeyTypePointsOnly, storage.IterKeyTypeRangesOnly}
+	if options.CombineRangesAndPoints {
+		keyTypes = []storage.IterKeyType{storage.IterKeyTypePointsAndRanges}
+	}
+	for _, span := range spans {
+		for _, keyType := range keyTypes {
+			err := func() error {
+				iter := reader.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{
+					LowerBound: span.Key,
+					UpperBound: span.EndKey,
+					KeyTypes:   keyType,
+				})
+				defer iter.Close()
+				if options.Reverse {
+					iter.SeekLT(storage.MakeMVCCMetadataKey(span.EndKey))
+				} else {
+					iter.SeekGE(storage.MakeMVCCMetadataKey(span.Key))
+				}
+				ok, err := iter.Valid()
+				if err == nil && ok {
+					err = visitor(iter, span, keyType)
+				}
+				return err
+			}()
 			if err != nil {
 				return iterutil.Map(err)
 			}

--- a/pkg/kv/kvserver/rditer/replica_data_iter_test.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter_test.go
@@ -148,52 +148,53 @@ func verifyRDReplicatedOnlyMVCCIter(
 			}, hlc.Timestamp{WallTime: 42})
 			readWriter = spanset.NewReadWriterAt(readWriter, &spans, hlc.Timestamp{WallTime: 42})
 		}
-		iter := NewReplicaMVCCDataIterator(desc, readWriter, ReplicaDataIteratorOptions{
-			Reverse:  reverse,
-			IterKind: storage.MVCCKeyAndIntentsIterKind,
-			KeyTypes: storage.IterKeyTypePointsAndRanges,
-		})
-		defer iter.Close()
-		next := iter.Next
-		if reverse {
-			next = iter.Prev
-		}
 		var rangeStart roachpb.Key
 		actualKeys := []storage.MVCCKey{}
 		actualRanges := []storage.MVCCRangeKey{}
-		for {
-			ok, err := iter.Valid()
-			require.NoError(t, err)
-			if !ok {
-				break
-			}
-			p, r := iter.HasPointAndRange()
-			if p {
-				if !reverse {
-					actualKeys = append(actualKeys, iter.Key())
-				} else {
-					actualKeys = append([]storage.MVCCKey{iter.Key()}, actualKeys...)
+		err := IterateMVCCReplicaKeySpans(desc, readWriter, IterateOptions{
+			CombineRangesAndPoints: false,
+			Reverse:                reverse,
+		}, func(iter storage.MVCCIterator, span roachpb.Span, keyType storage.IterKeyType) error {
+			for {
+				ok, err := iter.Valid()
+				require.NoError(t, err)
+				if !ok {
+					break
 				}
-			}
-			if r {
-				rangeKeys := iter.RangeKeys().Clone()
-				if !rangeKeys.Bounds.Key.Equal(rangeStart) {
-					rangeStart = rangeKeys.Bounds.Key.Clone()
+				p, r := iter.HasPointAndRange()
+				if p {
 					if !reverse {
-						for _, v := range rangeKeys.Versions {
-							actualRanges = append(actualRanges, rangeKeys.AsRangeKey(v))
-						}
+						actualKeys = append(actualKeys, iter.Key())
 					} else {
-						for i := rangeKeys.Len() - 1; i >= 0; i-- {
-							actualRanges = append([]storage.MVCCRangeKey{
-								rangeKeys.AsRangeKey(rangeKeys.Versions[i])},
-								actualRanges...)
+						actualKeys = append([]storage.MVCCKey{iter.Key()}, actualKeys...)
+					}
+				}
+				if r {
+					rangeKeys := iter.RangeKeys().Clone()
+					if !rangeKeys.Bounds.Key.Equal(rangeStart) {
+						rangeStart = rangeKeys.Bounds.Key.Clone()
+						if !reverse {
+							for _, v := range rangeKeys.Versions {
+								actualRanges = append(actualRanges, rangeKeys.AsRangeKey(v))
+							}
+						} else {
+							for i := rangeKeys.Len() - 1; i >= 0; i-- {
+								actualRanges = append([]storage.MVCCRangeKey{
+									rangeKeys.AsRangeKey(rangeKeys.Versions[i]),
+								}, actualRanges...)
+							}
 						}
 					}
 				}
+				if reverse {
+					iter.Prev()
+				} else {
+					iter.Next()
+				}
 			}
-			next()
-		}
+			return nil
+		})
+		require.NoError(t, err, "visitor failed")
 		require.Equal(t, expectedKeys, actualKeys)
 		require.Equal(t, expectedRangeKeys, actualRanges)
 	}
@@ -521,5 +522,99 @@ func benchReplicaEngineDataIterator(b *testing.B, numRanges, numKeysPerRange, va
 				require.NoError(b, err)
 			}
 		}
+	}
+}
+
+func TestIterateMVCCReplicaKeySpans(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Set up a new engine and write a single range key across the entire span.
+	eng := storage.NewDefaultInMemForTesting()
+	defer eng.Close()
+
+	require.NoError(t, eng.PutEngineRangeKey(keys.MinKey.Next(), keys.MaxKey, []byte{1}, []byte{}))
+	require.NoError(t,
+		eng.PutMVCC(storage.MVCCKey{Key: roachpb.Key("a"), Timestamp: hlc.Timestamp{WallTime: 1}},
+			storage.MVCCValue{}))
+	require.NoError(t,
+		eng.PutMVCC(storage.MVCCKey{Key: roachpb.Key("b"), Timestamp: hlc.Timestamp{WallTime: 1}},
+			storage.MVCCValue{}))
+	require.NoError(t,
+		eng.PutMVCC(storage.MVCCKey{Key: roachpb.Key("c"), Timestamp: hlc.Timestamp{WallTime: 1}},
+			storage.MVCCValue{}))
+
+	// Use a snapshot for the iteration, because we need consistent
+	// iterators.
+	snapshot := eng.NewSnapshot()
+	defer snapshot.Close()
+
+	// Iterate over three range descriptors, both replicated and unreplicated.
+	descs := []roachpb.RangeDescriptor{
+		{
+			RangeID:  1,
+			StartKey: roachpb.RKey("a"),
+			EndKey:   roachpb.RKey("b"),
+		},
+		{
+			RangeID:  2,
+			StartKey: roachpb.RKey("b"),
+			EndKey:   roachpb.RKey("c"),
+		},
+		{
+			RangeID:  3,
+			StartKey: roachpb.RKey("c"),
+			EndKey:   roachpb.RKey("d"),
+		},
+	}
+	for _, desc := range descs {
+		t.Run(desc.KeySpan().String(), func(t *testing.T) {
+			testutils.RunTrueAndFalse(t, "reverse", func(t *testing.T, reverse bool) {
+				expectedSpans := MakeReplicatedKeySpansExceptLockTable(&desc)
+				if reverse {
+					for i, j := 0, len(expectedSpans)-1; i < j; i, j = i+1, j-1 {
+						expectedSpans[i], expectedSpans[j] = expectedSpans[j], expectedSpans[i]
+					}
+				}
+
+				var actualSpans []roachpb.Span
+				require.NoError(t, IterateMVCCReplicaKeySpans(&desc, snapshot, IterateOptions{CombineRangesAndPoints: true, Reverse: reverse},
+					func(iter storage.MVCCIterator, span roachpb.Span, keyType storage.IterKeyType) error {
+						// We should never see any point keys.
+						require.Equal(t, storage.IterKeyTypePointsAndRanges, keyType)
+
+						// The iterator should already be positioned on the range key, which should
+						// span the entire key span and be the only range key.
+						bounds := iter.RangeBounds()
+						require.Equal(t, span, bounds)
+						actualSpans = append(actualSpans, bounds.Clone())
+
+						fmt.Printf("Iterating span: %s\n", span.String())
+
+						// Only user key spans are interesting.
+						if len(span.Key) == 1 {
+							p, r := iter.HasPointAndRange()
+							require.True(t, r, "must have range")
+							// When using forward iterator, we first land on range tombstone
+							// because point has a timestamp and its key is next.
+							// When using backward iterator, we land on point and range at the
+							// same time.
+							require.Equal(t, reverse, p, "has point")
+							if !reverse {
+								iter.Next()
+							} else {
+								iter.Prev()
+							}
+							ok, err := iter.Valid()
+							require.NoError(t, err)
+							require.True(t, ok)
+							p, r = iter.HasPointAndRange()
+							require.True(t, r, "must have range")
+							require.Equal(t, !reverse, p, "has point")
+						}
+						return nil
+					}))
+				require.Equal(t, expectedSpans, actualSpans)
+			})
+		})
 	}
 }

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -1010,6 +1010,18 @@ message GCRequest {
   // the request will fail.
   GCClearRangeKey clear_range_key = 7;
 
+  // GCClearSubRangeKey contains a range of GCd point keys to clear. Start
+  // of ranges starts at a key with a timestamp includive and ends with a
+  // key without timestamp exclusive. Resulting operations will delete data
+  // in range [start_key@ts, end_key).
+  // This operation doesn't remove range tombstones covered.
+  message GCClearSubRangeKey {
+    bytes start_key = 1 [(gogoproto.casttype) = "Key"];
+    util.hlc.Timestamp start_key_timestamp = 2 [(gogoproto.nullable) = false];
+    bytes end_key = 3 [(gogoproto.casttype) = "Key"];
+  }
+  GCClearSubRangeKey clear_sub_range_key = 8;
+  
   reserved 5;
 }
 

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -5305,6 +5305,143 @@ func CanGCEntireRange(
 	return coveredByRangeTombstones, nil
 }
 
+var emptyMetaToken enginepb.MVCCMetadata
+
+// MVCCGarbageCollectPointsWithClearRange removes garbage collected data falling under
+// ranges covered by rks. This function performs a check to ensure that no
+// non-deleted data (most recent or history with timestamp greater that
+// threshold) is being deleted.
+func MVCCGarbageCollectPointsWithClearRange(
+	ctx context.Context,
+	rw ReadWriter,
+	ms *enginepb.MVCCStats,
+	start, end roachpb.Key,
+	startTimestamp hlc.Timestamp,
+	gcThreshold hlc.Timestamp,
+) error {
+	var countKeys int64
+	var removedEntries int64
+	defer func(begin time.Time) {
+		// TODO(oleg): this could be misleading if GC fails, but this function still
+		// reports how many keys were GC'd. The approach is identical to what point
+		// key GC does for consistency, but both places could be improved.
+		log.Eventf(ctx,
+			"done with GC evaluation for clear range at %.2f keys/sec. Deleted %d entries",
+			countKeys, float64(countKeys)*1e9/float64(timeutil.Since(begin)), removedEntries)
+	}(timeutil.Now())
+
+	iter := rw.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
+		LowerBound: start,
+		UpperBound: end,
+		KeyTypes:   IterKeyTypePointsAndRanges,
+	})
+	defer iter.Close()
+
+	iter.SeekGE(MVCCKey{Key: start})
+
+	var (
+		prevPointKey    MVCCKey
+		rangeTombstones MVCCRangeKeyStack
+	)
+
+	for ; ; iter.Next() {
+		if ok, err := iter.Valid(); err != nil {
+			return err
+		} else if !ok {
+			break
+		}
+
+		hasPoint, hasRange := iter.HasPointAndRange()
+		if hasRange {
+			if iter.RangeKeyChanged() {
+				rangeTombstones = iter.RangeKeys().Clone()
+			}
+		} else {
+			rangeTombstones = MVCCRangeKeyStack{}
+		}
+
+		if hasPoint {
+			countKeys++
+			unsafeKey := iter.UnsafeKey()
+			newKey := !prevPointKey.Key.Equal(unsafeKey.Key)
+			if newKey {
+				prevPointKey.Key = unsafeKey.Key.Clone()
+				prevPointKey.Timestamp = hlc.Timestamp{}
+			}
+
+			// Skip keys that fall outside of range.
+			if unsafeKey.Compare(MVCCKey{Key: end}) >= 0 {
+				break
+			}
+			if unsafeKey.Compare(MVCCKey{Key: start, Timestamp: startTimestamp}) < 0 {
+				prevPointKey.Timestamp = unsafeKey.Timestamp
+				continue
+			}
+
+			if unsafeKey.Timestamp.IsEmpty() {
+				return errors.Errorf("attempt to clear range with data %s", unsafeKey.String())
+			}
+			if gcThreshold.Less(unsafeKey.Timestamp) {
+				return errors.Errorf("attempt to clear range with data %s", unsafeKey.String())
+			}
+
+			// Unmarshal value to check if we are dealing with tombstone.
+			unsafeValRaw := iter.UnsafeValue()
+			unsafeVal, unsafeValOK, err := tryDecodeSimpleMVCCValue(unsafeValRaw)
+			if !unsafeValOK && err == nil {
+				unsafeVal, err = decodeExtendedMVCCValue(unsafeValRaw)
+			}
+			if err != nil {
+				return err
+			}
+
+			// Find timestamp covering current key.
+			coveredBy := prevPointKey.Timestamp
+			if rangeKeyCover, ok := rangeTombstones.FirstAtOrAbove(unsafeKey.Timestamp); ok {
+				// If there's a range between current value and value above
+				// use that timestamp.
+				if coveredBy.IsEmpty() || rangeKeyCover.Timestamp.Less(coveredBy) {
+					coveredBy = rangeKeyCover.Timestamp
+				}
+			}
+			isCovered := !coveredBy.IsEmpty() && coveredBy.LessEq(gcThreshold)
+
+			isTombstone := unsafeVal.IsTombstone()
+			validTill := coveredBy
+			if isTombstone {
+				validTill = unsafeKey.Timestamp
+			}
+
+			if !isCovered && !isTombstone {
+				return errors.Errorf("attempt to clear range with data %s", unsafeKey.String())
+			}
+
+			// Prevent deletion of values on gcThreshold.
+			if !isTombstone && unsafeKey.Timestamp.Equal(gcThreshold) {
+				return errors.Errorf("attempt to clear range with data %s", unsafeKey.String())
+			}
+
+			if ms != nil {
+				if newKey {
+					ms.Add(updateStatsOnGC(unsafeKey.Key, int64(EncodedMVCCKeyPrefixLength(unsafeKey.Key)), 0,
+						&emptyMetaToken, validTill.WallTime))
+				}
+				ms.Add(updateStatsOnGC(unsafeKey.Key, MVCCVersionTimestampSize, int64(len(unsafeValRaw)), nil,
+					validTill.WallTime))
+			}
+			prevPointKey.Timestamp = unsafeKey.Timestamp
+			removedEntries++
+		}
+	}
+
+	// If timestamp is not empty we delete subset of versions (this may be first
+	// key of requested range or full extent).
+	if err := rw.ClearMVCCVersions(MVCCKey{Key: start, Timestamp: startTimestamp}, MVCCKey{Key: end}); err != nil {
+		return err
+	}
+	return nil
+}
+
 // MVCCFindSplitKey finds a key from the given span such that the left side of
 // the split is roughly targetSize bytes. It only considers MVCC point keys, not
 // range keys. The returned key will never be chosen from the key ranges listed

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -119,6 +119,7 @@ var (
 // clear_time_range k=<key> end=<key> ts=<int>[,<int>] targetTs=<int>[,<int>] [clearRangeThreshold=<int>] [maxBatchSize=<int>] [maxBatchByteSize=<int>]
 //
 // gc_clear_range k=<key> end=<key> startTs=<int>[,<int>] ts=<int>[,<int>]
+// gc_points_clear_range k=<key> end=<key> startTs=<int>[,<int>] ts=<int>[,<int>]
 // replace_point_tombstones_with_range_tombstones k=<key> [end=<key>]
 //
 // sst_put            [ts=<int>[,<int>]] [localTs=<int>[,<int>]] k=<key> [v=<string>]
@@ -689,25 +690,26 @@ var commands = map[string]cmd{
 	"check_intent":         {typReadOnly, cmdCheckIntent},
 	"add_lock":             {typLocksUpdate, cmdAddLock},
 
-	"clear":            {typDataUpdate, cmdClear},
-	"clear_range":      {typDataUpdate, cmdClearRange},
-	"clear_rangekey":   {typDataUpdate, cmdClearRangeKey},
-	"clear_time_range": {typDataUpdate, cmdClearTimeRange},
-	"cput":             {typDataUpdate, cmdCPut},
-	"del":              {typDataUpdate, cmdDelete},
-	"del_range":        {typDataUpdate, cmdDeleteRange},
-	"del_range_ts":     {typDataUpdate, cmdDeleteRangeTombstone},
-	"del_range_pred":   {typDataUpdate, cmdDeleteRangePredicate},
-	"export":           {typReadOnly, cmdExport},
-	"get":              {typReadOnly, cmdGet},
-	"gc_clear_range":   {typDataUpdate, cmdGCClearRange},
-	"increment":        {typDataUpdate, cmdIncrement},
-	"initput":          {typDataUpdate, cmdInitPut},
-	"merge":            {typDataUpdate, cmdMerge},
-	"put":              {typDataUpdate, cmdPut},
-	"put_rangekey":     {typDataUpdate, cmdPutRangeKey},
-	"scan":             {typReadOnly, cmdScan},
-	"is_span_empty":    {typReadOnly, cmdIsSpanEmpty},
+	"clear":                 {typDataUpdate, cmdClear},
+	"clear_range":           {typDataUpdate, cmdClearRange},
+	"clear_rangekey":        {typDataUpdate, cmdClearRangeKey},
+	"clear_time_range":      {typDataUpdate, cmdClearTimeRange},
+	"cput":                  {typDataUpdate, cmdCPut},
+	"del":                   {typDataUpdate, cmdDelete},
+	"del_range":             {typDataUpdate, cmdDeleteRange},
+	"del_range_ts":          {typDataUpdate, cmdDeleteRangeTombstone},
+	"del_range_pred":        {typDataUpdate, cmdDeleteRangePredicate},
+	"export":                {typReadOnly, cmdExport},
+	"get":                   {typReadOnly, cmdGet},
+	"gc_clear_range":        {typDataUpdate, cmdGCClearRange},
+	"gc_points_clear_range": {typDataUpdate, cmdGCPointsClearRange},
+	"increment":             {typDataUpdate, cmdIncrement},
+	"initput":               {typDataUpdate, cmdInitPut},
+	"merge":                 {typDataUpdate, cmdMerge},
+	"put":                   {typDataUpdate, cmdPut},
+	"put_rangekey":          {typDataUpdate, cmdPutRangeKey},
+	"scan":                  {typReadOnly, cmdScan},
+	"is_span_empty":         {typReadOnly, cmdIsSpanEmpty},
 
 	"iter_new":                    {typReadOnly, cmdIterNew},
 	"iter_new_incremental":        {typReadOnly, cmdIterNewIncremental}, // MVCCIncrementalIterator
@@ -1014,6 +1016,15 @@ func cmdGCClearRange(e *evalCtx) error {
 		cms, err := storage.ComputeStats(rw, key, endKey, 100e9)
 		require.NoError(e.t, err, "failed to compute range stats")
 		return storage.MVCCGarbageCollectWholeRange(e.ctx, rw, e.ms, key, endKey, gcTs, cms)
+	})
+}
+
+func cmdGCPointsClearRange(e *evalCtx) error {
+	key, endKey := e.getKeyRange()
+	gcTs := e.getTs(nil)
+	startTs := e.getTsWithName("startTs")
+	return e.withWriter("gc_clear_range", func(rw storage.ReadWriter) error {
+		return storage.MVCCGarbageCollectPointsWithClearRange(e.ctx, rw, e.ms, key, endKey, startTs, gcTs)
 	})
 }
 

--- a/pkg/storage/testdata/mvcc_histories/gc_clear_full_range
+++ b/pkg/storage/testdata/mvcc_histories/gc_clear_full_range
@@ -1,0 +1,98 @@
+run ok
+put k=A v=B ts=10
+----
+>> at end:
+data: "A"/10.000000000,0 -> /BYTES/B
+
+# Check that we can't invoke gc_clear_range if we have live data.
+run error
+gc_clear_range k=A end=Z ts=30
+----
+>> at end:
+data: "A"/10.000000000,0 -> /BYTES/B
+error: (*withstack.withStack:) range contains live data, can't use GC clear range
+
+run ok
+del k=A ts=30
+----
+del: "A": found key true
+>> at end:
+data: "A"/30.000000000,0 -> /<empty>
+data: "A"/10.000000000,0 -> /BYTES/B
+
+# Check that we can't invoke gc_clear_range if we are not covered by range tombstones.
+run error
+gc_clear_range k=A end=Z ts=30
+----
+>> at end:
+data: "A"/30.000000000,0 -> /<empty>
+data: "A"/10.000000000,0 -> /BYTES/B
+error: (*withstack.withStack:) found key not covered by range tombstone "A"/30.000000000,0
+
+run ok stats
+del_range_ts k=A endKey=Z ts=50
+----
+>> del_range_ts k=A endKey=Z ts=50
+stats: range_key_count=+1 range_key_bytes=+14 range_val_count=+1 gc_bytes_age=+700
+>> at end:
+rangekey: A{-\x00}/[50.000000000,0=/<empty>]
+data: "A"/30.000000000,0 -> /<empty>
+data: "A"/10.000000000,0 -> /BYTES/B
+stats: key_count=1 key_bytes=26 val_count=2 val_bytes=6 range_key_count=1 range_key_bytes=14 range_val_count=1 gc_bytes_age=2940
+
+# Check that we can't delete if range tombstone covering all range is above gc threshold.
+run error
+gc_clear_range k=A end=Z ts=40
+----
+>> at end:
+rangekey: A{-\x00}/[50.000000000,0=/<empty>]
+data: "A"/30.000000000,0 -> /<empty>
+data: "A"/10.000000000,0 -> /BYTES/B
+error: (*withstack.withStack:) range tombstones above gc threshold. GC=40.000000000,0, range=50.000000000,0
+
+# Check that we can delete if range tombstone covers all range.
+run stats ok
+gc_clear_range k=A end=Z ts=60
+----
+>> gc_clear_range k=A end=Z ts=60
+stats: key_count=-1 key_bytes=-26 val_count=-2 val_bytes=-6 range_key_count=-1 range_key_bytes=-14 range_val_count=-1 gc_bytes_age=-2940
+>> at end:
+<no data>
+stats: 
+
+# Check that is we have range tombstone coverage that covers subset but there's no other data we can still clear.
+run ok
+put k=A v=B ts=10
+del_range_ts k=A endKey=D ts=20
+----
+>> at end:
+rangekey: A{-\x00}/[20.000000000,0=/<empty>]
+data: "A"/10.000000000,0 -> /BYTES/B
+
+run stats ok
+gc_clear_range k=A end=Z ts=60
+----
+>> gc_clear_range k=A end=Z ts=60
+stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-6 range_key_count=-1 range_key_bytes=-14 range_val_count=-1 gc_bytes_age=-2720
+>> at end:
+<no data>
+stats: 
+
+# Check that gc clear range can't be performed over intents
+run ok
+with t=A
+  txn_begin ts=10
+  put k=B v=O
+----
+>> at end:
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
+meta: "B"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} ts=10.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "B"/10.000000000,0 -> /BYTES/O
+
+run error
+gc_clear_range k=A end=Z ts=40
+----
+>> at end:
+meta: "B"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} ts=10.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "B"/10.000000000,0 -> /BYTES/O
+error: (*withstack.withStack:) range contains live data, can't use GC clear range

--- a/pkg/storage/testdata/mvcc_histories/gc_clear_range
+++ b/pkg/storage/testdata/mvcc_histories/gc_clear_range
@@ -1,98 +1,263 @@
+# 1.Clear empty range
+run ok stats
+gc_points_clear_range k=a ts=3 end=z
+----
+>> gc_points_clear_range k=a ts=3 end=z
+stats: no change
+>> at end:
+<no data>
+stats: 
+
+# 2.Clear range starting from a version under value
 run ok
-put k=A v=B ts=10
+put k=a v=11 ts=2,0
+put k=a v=12 ts=5,0
 ----
 >> at end:
-data: "A"/10.000000000,0 -> /BYTES/B
-
-# Check that we can't invoke gc_clear_range if we have live data.
-run error
-gc_clear_range k=A end=Z ts=30
-----
->> at end:
-data: "A"/10.000000000,0 -> /BYTES/B
-error: (*withstack.withStack:) range contains live data, can't use GC clear range
-
-run ok
-del k=A ts=30
-----
-del: "A": found key true
->> at end:
-data: "A"/30.000000000,0 -> /<empty>
-data: "A"/10.000000000,0 -> /BYTES/B
-
-# Check that we can't invoke gc_clear_range if we are not covered by range tombstones.
-run error
-gc_clear_range k=A end=Z ts=30
-----
->> at end:
-data: "A"/30.000000000,0 -> /<empty>
-data: "A"/10.000000000,0 -> /BYTES/B
-error: (*withstack.withStack:) found key not covered by range tombstone "A"/30.000000000,0
+data: "a"/5.000000000,0 -> /BYTES/12
+data: "a"/2.000000000,0 -> /BYTES/11
 
 run ok stats
-del_range_ts k=A endKey=Z ts=50
+gc_points_clear_range k=a startTs=2 end=z ts=5
 ----
->> del_range_ts k=A endKey=Z ts=50
-stats: range_key_count=+1 range_key_bytes=+14 range_val_count=+1 gc_bytes_age=+700
+>> gc_points_clear_range k=a startTs=2 end=z ts=5
+stats: key_bytes=-12 val_count=-1 val_bytes=-7 gc_bytes_age=-1805
 >> at end:
-rangekey: A{-\x00}/[50.000000000,0=/<empty>]
-data: "A"/30.000000000,0 -> /<empty>
-data: "A"/10.000000000,0 -> /BYTES/B
-stats: key_count=1 key_bytes=26 val_count=2 val_bytes=6 range_key_count=1 range_key_bytes=14 range_val_count=1 gc_bytes_age=2940
+data: "a"/5.000000000,0 -> /BYTES/12
+stats: key_count=1 key_bytes=14 val_count=1 val_bytes=7 live_count=1 live_bytes=21
 
-# Check that we can't delete if range tombstone covering all range is above gc threshold.
-run error
-gc_clear_range k=A end=Z ts=40
+run ok
+clear_range k=a end=z
 ----
 >> at end:
-rangekey: A{-\x00}/[50.000000000,0=/<empty>]
-data: "A"/30.000000000,0 -> /<empty>
-data: "A"/10.000000000,0 -> /BYTES/B
-error: (*withstack.withStack:) range tombstones above gc threshold. GC=40.000000000,0, range=50.000000000,0
+<no data>
 
-# Check that we can delete if range tombstone covers all range.
-run stats ok
-gc_clear_range k=A end=Z ts=60
+# 3. Clear range from version under tombstone
+run ok
+put k=a v=11 ts=2,0
+del k=a ts=5,0
 ----
->> gc_clear_range k=A end=Z ts=60
-stats: key_count=-1 key_bytes=-26 val_count=-2 val_bytes=-6 range_key_count=-1 range_key_bytes=-14 range_val_count=-1 gc_bytes_age=-2940
+del: "a": found key true
+>> at end:
+data: "a"/5.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/11
+
+run ok stats
+gc_points_clear_range k=a startTs=5 end=z ts=5
+----
+>> gc_points_clear_range k=a startTs=5 end=z ts=5
+stats: key_count=-1 key_bytes=-26 val_count=-2 val_bytes=-7 gc_bytes_age=-3135
 >> at end:
 <no data>
 stats: 
 
-# Check that is we have range tombstone coverage that covers subset but there's no other data we can still clear.
+# 4. Clear range from version under range tombstone
 run ok
-put k=A v=B ts=10
-del_range_ts k=A endKey=D ts=20
+put k=a v=11 ts=2,0
+del_range_ts k=a end=b ts=5,0
 ----
 >> at end:
-rangekey: A{-\x00}/[20.000000000,0=/<empty>]
-data: "A"/10.000000000,0 -> /BYTES/B
+rangekey: {a-b}/[5.000000000,0=/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/11
 
-run stats ok
-gc_clear_range k=A end=Z ts=60
+run ok stats
+gc_points_clear_range k=a startTs=2 end=z ts=5
 ----
->> gc_clear_range k=A end=Z ts=60
-stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-6 range_key_count=-1 range_key_bytes=-14 range_val_count=-1 gc_bytes_age=-2720
+>> gc_points_clear_range k=a startTs=2 end=z ts=5
+stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-7 gc_bytes_age=-1995
+>> at end:
+rangekey: {a-b}/[5.000000000,0=/<empty>]
+stats: range_key_count=1 range_key_bytes=13 range_val_count=1 gc_bytes_age=1235
+
+run ok
+clear_range k=a end=z
+----
+>> at end:
+<no data>
+
+# 5. Clear range up to another value
+run ok
+put k=a v=11 ts=2,0
+put k=a v=12 ts=5,0
+put k=c v=13 ts=5,0
+----
+>> at end:
+data: "a"/5.000000000,0 -> /BYTES/12
+data: "a"/2.000000000,0 -> /BYTES/11
+data: "c"/5.000000000,0 -> /BYTES/13
+
+run ok stats
+gc_points_clear_range k=a startTs=2 end=c ts=5
+----
+>> gc_points_clear_range k=a startTs=2 end=c ts=5
+stats: key_bytes=-12 val_count=-1 val_bytes=-7 gc_bytes_age=-1805
+>> at end:
+data: "a"/5.000000000,0 -> /BYTES/12
+data: "c"/5.000000000,0 -> /BYTES/13
+stats: key_count=2 key_bytes=28 val_count=2 val_bytes=14 live_count=2 live_bytes=42
+
+run ok
+clear_range k=a end=z
+----
+>> at end:
+<no data>
+
+# 6. Clear range up to another intent
+run ok
+put k=a v=11 ts=2,0
+put k=a v=12 ts=5,0
+with t=A k=c
+  txn_begin ts=4,0
+  put v=1
+----
+>> at end:
+txn: "A" meta={id=00000000 key="c" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=4.000000000,0 wto=false gul=0,0
+data: "a"/5.000000000,0 -> /BYTES/12
+data: "a"/2.000000000,0 -> /BYTES/11
+meta: "c"/0,0 -> txn={id=00000000 key="c" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "c"/4.000000000,0 -> /BYTES/1
+
+run ok stats
+gc_points_clear_range k=a startTs=2 end=c ts=5
+----
+>> gc_points_clear_range k=a startTs=2 end=c ts=5
+stats: key_bytes=-12 val_count=-1 val_bytes=-7 gc_bytes_age=-1805
+>> at end:
+data: "a"/5.000000000,0 -> /BYTES/12
+meta: "c"/0,0 -> txn={id=00000000 key="c" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "c"/4.000000000,0 -> /BYTES/1
+stats: key_count=2 key_bytes=28 val_count=2 val_bytes=64 live_count=2 live_bytes=92 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=96
+
+run ok
+clear_range k=a end=z
+----
+>> at end:
+<no data>
+
+# 7. Clear from before first key
+run ok
+put k=b v=11 ts=2,0
+del k=b ts=5,0
+----
+del: "b": found key true
+>> at end:
+data: "b"/5.000000000,0 -> /<empty>
+data: "b"/2.000000000,0 -> /BYTES/11
+
+run ok stats
+gc_points_clear_range k=a end=z ts=5
+----
+>> gc_points_clear_range k=a end=z ts=5
+stats: key_count=-1 key_bytes=-26 val_count=-2 val_bytes=-7 gc_bytes_age=-3135
 >> at end:
 <no data>
 stats: 
 
-# Check that gc clear range can't be performed over intents
 run ok
-with t=A
-  txn_begin ts=10
-  put k=B v=O
+clear_range k=a end=z
 ----
 >> at end:
-txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
-meta: "B"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} ts=10.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "B"/10.000000000,0 -> /BYTES/O
+<no data>
 
-run error
-gc_clear_range k=A end=Z ts=40
+# 8. Clear value under range tombstone
+run ok
+put k=b v=123 ts=2,0
+del_range_ts k=a end=c ts=5,0
 ----
 >> at end:
-meta: "B"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} ts=10.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "B"/10.000000000,0 -> /BYTES/O
-error: (*withstack.withStack:) range contains live data, can't use GC clear range
+rangekey: {a-c}/[5.000000000,0=/<empty>]
+data: "b"/2.000000000,0 -> /BYTES/123
+
+run ok stats
+gc_points_clear_range k=a end=z ts=5
+----
+>> gc_points_clear_range k=a end=z ts=5
+stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-8 gc_bytes_age=-2090
+>> at end:
+rangekey: {a-c}/[5.000000000,0=/<empty>]
+stats: range_key_count=1 range_key_bytes=13 range_val_count=1 gc_bytes_age=1235
+
+run ok
+clear_range k=a end=z
+----
+>> at end:
+<no data>
+
+# 8. Clear value under point tombstone
+run ok
+put k=b v=123 ts=2,0
+del k=b ts=5,0
+----
+del: "b": found key true
+>> at end:
+data: "b"/5.000000000,0 -> /<empty>
+data: "b"/2.000000000,0 -> /BYTES/123
+
+run ok stats
+gc_points_clear_range k=a end=z ts=5
+----
+>> gc_points_clear_range k=a end=z ts=5
+stats: key_count=-1 key_bytes=-26 val_count=-2 val_bytes=-8 gc_bytes_age=-3230
+>> at end:
+<no data>
+stats: 
+
+run ok
+clear_range k=a end=z
+----
+>> at end:
+<no data>
+
+# 9. Clear value under point and range tombstone (checking that garbage age is correctly calculated)
+run ok
+put k=b v=123 ts=2,0
+del k=b ts=4,0
+del_range_ts k=a end=c ts=5,0
+----
+del: "b": found key true
+>> at end:
+rangekey: {a-c}/[5.000000000,0=/<empty>]
+data: "b"/4.000000000,0 -> /<empty>
+data: "b"/2.000000000,0 -> /BYTES/123
+
+run ok stats
+gc_points_clear_range k=a end=z ts=5
+----
+>> gc_points_clear_range k=a end=z ts=5
+stats: key_count=-1 key_bytes=-26 val_count=-2 val_bytes=-8 gc_bytes_age=-3264
+>> at end:
+rangekey: {a-c}/[5.000000000,0=/<empty>]
+stats: range_key_count=1 range_key_bytes=13 range_val_count=1 gc_bytes_age=1235
+
+run ok
+clear_range k=a end=z
+----
+>> at end:
+<no data>
+
+# 10. Clear value under range and point tombstone (checking that garbage age is correctly calculated)
+run ok
+put k=b v=123 ts=2,0
+del_range_ts k=a end=c ts=4,0
+del k=b ts=5,0
+----
+del: "b": found key false
+>> at end:
+rangekey: {a-c}/[4.000000000,0=/<empty>]
+data: "b"/5.000000000,0 -> /<empty>
+data: "b"/2.000000000,0 -> /BYTES/123
+
+run ok stats
+gc_points_clear_range k=a end=z ts=5
+----
+>> gc_points_clear_range k=a end=z ts=5
+stats: key_count=-1 key_bytes=-26 val_count=-2 val_bytes=-8 gc_bytes_age=-3250
+>> at end:
+rangekey: {a-c}/[4.000000000,0=/<empty>]
+stats: range_key_count=1 range_key_bytes=13 range_val_count=1 gc_bytes_age=1248
+
+run ok
+clear_range k=a end=z
+----
+>> at end:
+<no data>

--- a/pkg/storage/testdata/mvcc_histories/gc_clear_range_errors
+++ b/pkg/storage/testdata/mvcc_histories/gc_clear_range_errors
@@ -1,0 +1,94 @@
+# 1. Fail to clear non deleted key
+run ok
+put k=a v=12 ts=2,0
+----
+>> at end:
+data: "a"/2.000000000,0 -> /BYTES/12
+
+run error
+gc_points_clear_range k=a startTs=2 end=z ts=5
+----
+>> at end:
+data: "a"/2.000000000,0 -> /BYTES/12
+error: (*withstack.withStack:) attempt to clear range with data "a"/2.000000000,0
+
+run ok
+clear_range k=a end=z
+----
+>> at end:
+<no data>
+
+# 2. Fail to clear intent
+run ok
+with t=A k=a
+  txn_begin ts=4,0
+  put v=1
+----
+>> at end:
+txn: "A" meta={id=00000000 key="a" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=4.000000000,0 wto=false gul=0,0
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/4.000000000,0 -> /BYTES/1
+
+run error
+gc_points_clear_range k=a end=z ts=5
+----
+>> at end:
+meta: "a"/0,0 -> txn={id=00000000 key="a" pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/4.000000000,0 -> /BYTES/1
+error: (*withstack.withStack:) attempt to clear range with data "a"
+
+run ok
+clear_range k=a end=z
+----
+>> at end:
+<no data>
+
+# 3. Fail to delete key above gc threshold
+run ok
+put k=a v=11 ts=2,0
+del k=a ts=5,0
+----
+del: "a": found key true
+>> at end:
+data: "a"/5.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/11
+
+run error
+gc_points_clear_range k=a startTs=2 end=z ts=4
+----
+>> at end:
+data: "a"/5.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/11
+error: (*withstack.withStack:) attempt to clear range with data "a"/2.000000000,0
+
+run ok
+clear_range k=a end=z
+----
+>> at end:
+<no data>
+
+# 4. Fail to delete key above range tombstone (checking if range tombstones are not breaking timestamp check logic)
+run ok
+put k=a v=11 ts=2,0
+del_range_ts k=a end=b ts=3,0
+put k=a v=12 ts=5,0
+----
+>> at end:
+rangekey: {a-b}/[3.000000000,0=/<empty>]
+data: "a"/5.000000000,0 -> /BYTES/12
+data: "a"/2.000000000,0 -> /BYTES/11
+
+run error
+gc_points_clear_range k=a startTs=5 end=z ts=5
+----
+>> at end:
+rangekey: {a-b}/[3.000000000,0=/<empty>]
+data: "a"/5.000000000,0 -> /BYTES/12
+data: "a"/2.000000000,0 -> /BYTES/11
+error: (*withstack.withStack:) attempt to clear range with data "a"/5.000000000,0
+
+run ok
+clear_range k=a end=z
+----
+>> at end:
+<no data>

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -924,6 +924,7 @@ var charts = []sectionDescription{
 				Metrics: []string{
 					"queue.gc.info.clearrangesuccess",
 					"queue.gc.info.clearrangefailed",
+					"queue.gc.info.numclearconsecutivekeys",
 				},
 			},
 			{


### PR DESCRIPTION
This commit adds clear_sub_range_key parameters to GC request.
clear_sub_range_keys is used by GC queue to remove chunks of
consecutive keys where no new data was written above the GC
threshold and storage can optimize deletions with range
tombstones.
To support new types of keys, GCer interface is also updated
to pass provided keys down to request.

Release note: None