### PR TITLE
release-22.2: workload/schemachanger: watchdog thread can hang on timeout

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -3559,7 +3559,7 @@ func (og *operationGenerator) typeFromTypeName(
 		return nil, errors.Wrapf(err, "typeFromTypeName: %s", typeName)
 	}
 	typ, err := tree.ResolveType(
-		context.Background(),
+		ctx,
 		stmt.AST.(*tree.Select).Select.(*tree.SelectClause).Exprs[0].Expr.(*tree.CastExpr).Type,
 		&txTypeResolver{tx: tx},
 	)

--- a/pkg/workload/schemachange/watch_dog.go
+++ b/pkg/workload/schemachange/watch_dog.go
@@ -96,7 +96,9 @@ func (w *schemaChangeWatchDog) watchLoop(ctx context.Context) {
 			// Give the connections a small amount of time to clean up, if they fail
 			// to do so, we will dump stacks.
 			select {
-			case <-w.cmdChannel:
+			case responseChannel := <-w.cmdChannel:
+				// Only command is to stop.
+				close(responseChannel)
 				return
 			case <-time.After(time.Second * 4):
 				panic("dumping stacks, we failed to terminate threads on time.")


### PR DESCRIPTION
Fixes: #90824

Previously, the watchdog did not close the reply channel on clean up which could lead to a hang on the connection thread. Additionally, there was another bug where operationGenerator.typeFromTypeName did not use a proper context.

Release note: None
Release justification: low risk and fixes hangs inside workload

Note: This is targeting release-22.2, since the PR on master with the same bug hasn't been merged (it will be fixed directly in there).