### PR TITLE
storage: clone `pointSynthesizingIter` seek keys

### DIFF
--- a/pkg/storage/point_synthesizing_iter.go
+++ b/pkg/storage/point_synthesizing_iter.go
@@ -122,6 +122,9 @@ type PointSynthesizingIter struct {
 	// It is reset to false on every call to updateRangeKeys(), and accumulates
 	// changes during intermediate positioning operations.
 	rangeKeyChanged bool
+
+	// seekKeyBuf is used to clone seek keys.
+	seekKeyBuf roachpb.Key
 }
 
 var _ MVCCIterator = (*PointSynthesizingIter)(nil)
@@ -137,6 +140,7 @@ func NewPointSynthesizingIter(parent MVCCIterator) *PointSynthesizingIter {
 		rangeKeysBuf:   iter.rangeKeysBuf,
 		rangeKeysPos:   iter.rangeKeysPos,
 		rangeKeysStart: iter.rangeKeysStart,
+		seekKeyBuf:     iter.seekKeyBuf,
 	}
 	return iter
 }
@@ -147,7 +151,12 @@ func NewPointSynthesizingIterAtParent(parent MVCCIterator) *PointSynthesizingIte
 	iter := NewPointSynthesizingIter(parent)
 	iter.rangeKeyChanged = true // force range key detection
 	if ok, err := iter.updateIter(); ok && err == nil {
-		iter.updateSeekGEPosition(parent.UnsafeKey())
+		// updateSeekGEPosition may step parent and then compare against seekKey, so
+		// we need to clone it.
+		seekKey := parent.UnsafeKey()
+		iter.seekKeyBuf = append(iter.seekKeyBuf[:0], seekKey.Key...)
+		seekKey.Key = iter.seekKeyBuf
+		iter.updateSeekGEPosition(seekKey)
 	}
 	return iter
 }
@@ -168,6 +177,7 @@ func (i *PointSynthesizingIter) release() {
 		rangeKeysBuf:   i.rangeKeysBuf[:0],
 		rangeKeysPos:   i.rangeKeysPos[:0],
 		rangeKeysStart: i.rangeKeysStart[:0],
+		seekKeyBuf:     i.seekKeyBuf[:0],
 	}
 	pointSynthesizingIterPool.Put(i)
 }
@@ -350,6 +360,12 @@ func (i *PointSynthesizingIter) clearRangeKeys() {
 
 // SeekGE implements MVCCIterator.
 func (i *PointSynthesizingIter) SeekGE(seekKey MVCCKey) {
+	// The seek key may originate from UnsafeKey (see pebbleMVCCScanner), in which
+	// case it would be invalidated when we seek the parent iter below, so we have
+	// to clone it. We could be clever and try to detect if the backing array is
+	// the same as i.iterKey, but let's be obviously correct instead.
+	i.seekKeyBuf = append(i.seekKeyBuf[:0], seekKey.Key...)
+	seekKey.Key = i.seekKeyBuf
 	i.reverse = false
 	i.iter.SeekGE(seekKey)
 	if ok, _ := i.updateIter(); !ok {
@@ -361,6 +377,8 @@ func (i *PointSynthesizingIter) SeekGE(seekKey MVCCKey) {
 
 // SeekIntentGE implements MVCCIterator.
 func (i *PointSynthesizingIter) SeekIntentGE(seekKey roachpb.Key, txnUUID uuid.UUID) {
+	i.seekKeyBuf = append(i.seekKeyBuf[:0], seekKey...)
+	seekKey = i.seekKeyBuf
 	i.reverse = false
 	i.iter.SeekIntentGE(seekKey, txnUUID)
 	if ok, _ := i.updateIter(); !ok {
@@ -482,6 +500,8 @@ func (i *PointSynthesizingIter) NextKey() {
 
 // SeekLT implements MVCCIterator.
 func (i *PointSynthesizingIter) SeekLT(seekKey MVCCKey) {
+	i.seekKeyBuf = append(i.seekKeyBuf[:0], seekKey.Key...)
+	seekKey.Key = i.seekKeyBuf
 	i.reverse = true
 	i.iter.SeekLT(seekKey)
 	if ok, _ := i.updateIter(); !ok {


### PR DESCRIPTION
The seek keys passed to `pointSynthesizingIter` seek methods may have originated from `UnsafeKey()`. Repositioning the parent iterator may therefore invalidate the seek key, but the code keeps using it afterwards.

This patch clones the seek key in a reusable buffer. The overhead of this should be negligible, considering the overall cost of a seek. `MVCCGet` benchmarks don't show a significant difference:

```
name                                                                  old time/op    new time/op    delta
MVCCGet_Pebble/batch=false/versions=1/valueSize=8/numRangeKeys=0-24     5.11µs ± 1%    5.13µs ± 1%    ~     (p=0.143 n=10+10)
MVCCGet_Pebble/batch=false/versions=1/valueSize=8/numRangeKeys=1-24     9.32µs ± 1%    9.41µs ± 1%  +0.96%  (p=0.001 n=10+10)
MVCCGet_Pebble/batch=false/versions=10/valueSize=8/numRangeKeys=0-24    19.1µs ± 2%    19.2µs ± 3%    ~     (p=0.075 n=10+10)
MVCCGet_Pebble/batch=false/versions=10/valueSize=8/numRangeKeys=1-24    25.7µs ± 2%    25.7µs ± 2%    ~     (p=0.853 n=10+10)
MVCCGet_Pebble/batch=true/versions=1/valueSize=8/numRangeKeys=0-24      3.10µs ± 2%    3.09µs ± 1%    ~     (p=0.985 n=10+10)
MVCCGet_Pebble/batch=true/versions=1/valueSize=8/numRangeKeys=1-24      5.05µs ± 0%    5.02µs ± 0%  -0.46%  (p=0.000 n=10+10)
MVCCGet_Pebble/batch=true/versions=10/valueSize=8/numRangeKeys=0-24     16.5µs ± 3%    16.4µs ± 2%    ~     (p=0.579 n=10+10)
MVCCGet_Pebble/batch=true/versions=10/valueSize=8/numRangeKeys=1-24     20.6µs ± 2%    20.7µs ± 1%  +0.60%  (p=0.022 n=9+10)
```

Touches #90642.
Epic: CRDB-2624.

Release note: None