### PR TITLE
sql/schemachanger: inject DML statements into end to end tests

### DIFF
--- a/pkg/sql/schemachanger/BUILD.bazel
+++ b/pkg/sql/schemachanger/BUILD.bazel
@@ -73,6 +73,7 @@ sctest_gen(
     test_data = glob(["testdata/end_to_end/**"]),
     tests = [
         "EndToEndSideEffects",
+        "ExecuteWithDMLInjection",
         "GenerateSchemaChangeCorpus",
         "Pause",
         "Rollback",

--- a/pkg/sql/schemachanger/sctest_generated_test.go
+++ b/pkg/sql/schemachanger/sctest_generated_test.go
@@ -25,6 +25,11 @@ func TestEndToEndSideEffects_add_column(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	sctest.EndToEndSideEffects(t, "pkg/sql/schemachanger/testdata/end_to_end/add_column", sctest.SingleNodeCluster)
 }
+func TestExecuteWithDMLInjection_add_column(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.ExecuteWithDMLInjection(t, "pkg/sql/schemachanger/testdata/end_to_end/add_column", sctest.SingleNodeCluster)
+}
 func TestGenerateSchemaChangeCorpus_add_column(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -44,6 +49,11 @@ func TestEndToEndSideEffects_add_column_default_seq(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.EndToEndSideEffects(t, "pkg/sql/schemachanger/testdata/end_to_end/add_column_default_seq", sctest.SingleNodeCluster)
+}
+func TestExecuteWithDMLInjection_add_column_default_seq(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.ExecuteWithDMLInjection(t, "pkg/sql/schemachanger/testdata/end_to_end/add_column_default_seq", sctest.SingleNodeCluster)
 }
 func TestGenerateSchemaChangeCorpus_add_column_default_seq(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -65,6 +75,11 @@ func TestEndToEndSideEffects_add_column_default_unique(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	sctest.EndToEndSideEffects(t, "pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique", sctest.SingleNodeCluster)
 }
+func TestExecuteWithDMLInjection_add_column_default_unique(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.ExecuteWithDMLInjection(t, "pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique", sctest.SingleNodeCluster)
+}
 func TestGenerateSchemaChangeCorpus_add_column_default_unique(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -84,6 +99,11 @@ func TestEndToEndSideEffects_add_column_no_default(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.EndToEndSideEffects(t, "pkg/sql/schemachanger/testdata/end_to_end/add_column_no_default", sctest.SingleNodeCluster)
+}
+func TestExecuteWithDMLInjection_add_column_no_default(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.ExecuteWithDMLInjection(t, "pkg/sql/schemachanger/testdata/end_to_end/add_column_no_default", sctest.SingleNodeCluster)
 }
 func TestGenerateSchemaChangeCorpus_add_column_no_default(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -105,6 +125,11 @@ func TestEndToEndSideEffects_alter_table_add_primary_key_drop_rowid(t *testing.T
 	defer log.Scope(t).Close(t)
 	sctest.EndToEndSideEffects(t, "pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid", sctest.SingleNodeCluster)
 }
+func TestExecuteWithDMLInjection_alter_table_add_primary_key_drop_rowid(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.ExecuteWithDMLInjection(t, "pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid", sctest.SingleNodeCluster)
+}
 func TestGenerateSchemaChangeCorpus_alter_table_add_primary_key_drop_rowid(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -124,6 +149,11 @@ func TestEndToEndSideEffects_alter_table_alter_primary_key_drop_rowid(t *testing
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.EndToEndSideEffects(t, "pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid", sctest.SingleNodeCluster)
+}
+func TestExecuteWithDMLInjection_alter_table_alter_primary_key_drop_rowid(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.ExecuteWithDMLInjection(t, "pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid", sctest.SingleNodeCluster)
 }
 func TestGenerateSchemaChangeCorpus_alter_table_alter_primary_key_drop_rowid(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -145,6 +175,11 @@ func TestEndToEndSideEffects_alter_table_alter_primary_key_vanilla(t *testing.T)
 	defer log.Scope(t).Close(t)
 	sctest.EndToEndSideEffects(t, "pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla", sctest.SingleNodeCluster)
 }
+func TestExecuteWithDMLInjection_alter_table_alter_primary_key_vanilla(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.ExecuteWithDMLInjection(t, "pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla", sctest.SingleNodeCluster)
+}
 func TestGenerateSchemaChangeCorpus_alter_table_alter_primary_key_vanilla(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -164,6 +199,11 @@ func TestEndToEndSideEffects_create_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.EndToEndSideEffects(t, "pkg/sql/schemachanger/testdata/end_to_end/create_index", sctest.SingleNodeCluster)
+}
+func TestExecuteWithDMLInjection_create_index(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.ExecuteWithDMLInjection(t, "pkg/sql/schemachanger/testdata/end_to_end/create_index", sctest.SingleNodeCluster)
 }
 func TestGenerateSchemaChangeCorpus_create_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -185,6 +225,11 @@ func TestEndToEndSideEffects_drop_column_basic(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	sctest.EndToEndSideEffects(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_column_basic", sctest.SingleNodeCluster)
 }
+func TestExecuteWithDMLInjection_drop_column_basic(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.ExecuteWithDMLInjection(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_column_basic", sctest.SingleNodeCluster)
+}
 func TestGenerateSchemaChangeCorpus_drop_column_basic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -204,6 +249,11 @@ func TestEndToEndSideEffects_drop_column_computed_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.EndToEndSideEffects(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_column_computed_index", sctest.SingleNodeCluster)
+}
+func TestExecuteWithDMLInjection_drop_column_computed_index(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.ExecuteWithDMLInjection(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_column_computed_index", sctest.SingleNodeCluster)
 }
 func TestGenerateSchemaChangeCorpus_drop_column_computed_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -225,6 +275,11 @@ func TestEndToEndSideEffects_drop_column_create_index_separate_statements(t *tes
 	defer log.Scope(t).Close(t)
 	sctest.EndToEndSideEffects(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements", sctest.SingleNodeCluster)
 }
+func TestExecuteWithDMLInjection_drop_column_create_index_separate_statements(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.ExecuteWithDMLInjection(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements", sctest.SingleNodeCluster)
+}
 func TestGenerateSchemaChangeCorpus_drop_column_create_index_separate_statements(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -244,6 +299,11 @@ func TestEndToEndSideEffects_drop_column_unique_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.EndToEndSideEffects(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_column_unique_index", sctest.SingleNodeCluster)
+}
+func TestExecuteWithDMLInjection_drop_column_unique_index(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.ExecuteWithDMLInjection(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_column_unique_index", sctest.SingleNodeCluster)
 }
 func TestGenerateSchemaChangeCorpus_drop_column_unique_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -265,6 +325,11 @@ func TestEndToEndSideEffects_drop_column_with_index(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	sctest.EndToEndSideEffects(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_index", sctest.SingleNodeCluster)
 }
+func TestExecuteWithDMLInjection_drop_column_with_index(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.ExecuteWithDMLInjection(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_index", sctest.SingleNodeCluster)
+}
 func TestGenerateSchemaChangeCorpus_drop_column_with_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -284,6 +349,11 @@ func TestEndToEndSideEffects_drop_index_hash_sharded_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.EndToEndSideEffects(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_index_hash_sharded_index", sctest.SingleNodeCluster)
+}
+func TestExecuteWithDMLInjection_drop_index_hash_sharded_index(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.ExecuteWithDMLInjection(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_index_hash_sharded_index", sctest.SingleNodeCluster)
 }
 func TestGenerateSchemaChangeCorpus_drop_index_hash_sharded_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -305,6 +375,11 @@ func TestEndToEndSideEffects_drop_index_partial_expression_index(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	sctest.EndToEndSideEffects(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_index_partial_expression_index", sctest.SingleNodeCluster)
 }
+func TestExecuteWithDMLInjection_drop_index_partial_expression_index(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.ExecuteWithDMLInjection(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_index_partial_expression_index", sctest.SingleNodeCluster)
+}
 func TestGenerateSchemaChangeCorpus_drop_index_partial_expression_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -324,6 +399,11 @@ func TestEndToEndSideEffects_drop_index_vanilla_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.EndToEndSideEffects(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_index_vanilla_index", sctest.SingleNodeCluster)
+}
+func TestExecuteWithDMLInjection_drop_index_vanilla_index(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.ExecuteWithDMLInjection(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_index_vanilla_index", sctest.SingleNodeCluster)
 }
 func TestGenerateSchemaChangeCorpus_drop_index_vanilla_index(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -345,6 +425,11 @@ func TestEndToEndSideEffects_drop_multiple_columns_separate_statements(t *testin
 	defer log.Scope(t).Close(t)
 	sctest.EndToEndSideEffects(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_multiple_columns_separate_statements", sctest.SingleNodeCluster)
 }
+func TestExecuteWithDMLInjection_drop_multiple_columns_separate_statements(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.ExecuteWithDMLInjection(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_multiple_columns_separate_statements", sctest.SingleNodeCluster)
+}
 func TestGenerateSchemaChangeCorpus_drop_multiple_columns_separate_statements(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -365,6 +450,11 @@ func TestEndToEndSideEffects_drop_schema(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	sctest.EndToEndSideEffects(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_schema", sctest.SingleNodeCluster)
 }
+func TestExecuteWithDMLInjection_drop_schema(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.ExecuteWithDMLInjection(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_schema", sctest.SingleNodeCluster)
+}
 func TestGenerateSchemaChangeCorpus_drop_schema(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -384,6 +474,11 @@ func TestEndToEndSideEffects_drop_table(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	sctest.EndToEndSideEffects(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_table", sctest.SingleNodeCluster)
+}
+func TestExecuteWithDMLInjection_drop_table(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.ExecuteWithDMLInjection(t, "pkg/sql/schemachanger/testdata/end_to_end/drop_table", sctest.SingleNodeCluster)
 }
 func TestGenerateSchemaChangeCorpus_drop_table(t *testing.T) {
 	defer leaktest.AfterTest(t)()

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column
@@ -9,6 +9,30 @@ CREATE SEQUENCE db.public.sq1;
 +object {104 105 tbl} -> 106
 +object {104 105 sq1} -> 107
 
+stage-exec phase=PostCommitPhase stage=:
+INSERT INTO db.public.tbl VALUES($stageKey);
+INSERT INTO db.public.tbl VALUES($stageKey + 1);
+----
+
+# Each insert will be injected twice per stage, so we should always,
+# see a count of 2.
+stage-query phase=PostCommitPhase stage=:
+SELECT count(*)=$successfulStageCount*2 FROM db.public.tbl;
+----
+true
+
+
+stage-exec phase=PostCommitNonRevertiblePhase stage=:
+INSERT INTO db.public.tbl VALUES($stageKey);
+INSERT INTO db.public.tbl VALUES($stageKey + 1);
+----
+
+# Each insert will be injected twice per stage, so we should always,
+# see a count of 2.
+stage-query phase=PostCommitNonRevertiblePhase stage=:
+SELECT count(*)=$successfulStageCount*2 FROM db.public.tbl;
+----
+true
 
 test
 ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAULT 42

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_seq
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_seq
@@ -9,6 +9,41 @@ CREATE SEQUENCE db.public.sq1;
 +object {104 105 tbl} -> 106
 +object {104 105 sq1} -> 107
 
+stage-exec phase=PostCommitPhase stage=1:2 schemaChangeExecError=(.*unimplemented: cannot evaluate scalar expressions containing sequence operations in this context.*)
+INSERT INTO db.public.tbl VALUES($stageKey);
+INSERT INTO db.public.tbl VALUES($stageKey + 1);
+----
+
+# Each insert will be injected twice per stage, so we should always,
+# see a count of 2.
+stage-query phase=PostCommitPhase stage=1:2
+SELECT count(*) FROM db.public.tbl;
+----
+2
+
+stage-exec phase=PostCommitPhase stage=3:
+INSERT INTO db.public.tbl VALUES($stageKey);
+INSERT INTO db.public.tbl VALUES($stageKey + 1);
+----
+
+# Each insert will be injected twice per stage, so we should always,
+# see a count of 2.
+stage-query phase=PostCommitPhase stage=3:
+SELECT count(*)=$successfulStageCount*2 FROM db.public.tbl;
+----
+true
+
+stage-exec phase=PostCommitNonRevertiblePhase stage=:
+INSERT INTO db.public.tbl VALUES($stageKey);
+INSERT INTO db.public.tbl VALUES($stageKey + 1);
+----
+
+
+stage-query phase=PostCommitNonRevertiblePhase stage=:
+SELECT count(*)=$successfulStageCount*2 FROM db.public.tbl;
+----
+true
+
 test
 ALTER TABLE db.public.tbl ADD COLUMN l INT NOT NULL DEFAULT nextval('db.public.sq1')
 ----

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique
@@ -7,8 +7,82 @@ CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
 +schema {104 0 public} -> 105
 +object {104 105 tbl} -> 106
 
+stage-exec phase=PostCommitPhase stage=1:2 schemaChangeExecError=(.*duplicate key value violates unique constraint.*)
+INSERT INTO db.public.tbl VALUES($stageKey);
+INSERT INTO db.public.tbl VALUES($stageKey + 1);
+----
+
+# Execute deletes to make sure these function correctly.
+stage-exec phase=PostCommitPhase stage=3
+INSERT INTO db.public.tbl VALUES($stageKey);
+INSERT INTO db.public.tbl VALUES($stageKey + 1);
+INSERT INTO db.public.tbl VALUES($stageKey + 2);
+DELETE FROM db.public.tbl WHERE i=$stageKey OR i=$stageKey+1
+----
+
+# Execute a harmless update that will change an existing value.
+stage-exec phase=PostCommitPhase stage=4
+UPDATE db.public.tbl SET i=$stageKey;
+----
+
+
+stage-exec phase=PostCommitPhase stage=5:14 schemaChangeExecError=(.*duplicate key value violates unique constraint.*)
+INSERT INTO db.public.tbl VALUES($stageKey);
+INSERT INTO db.public.tbl VALUES($stageKey + 1);
+----
+
+
+# Each insert will be injected twice per stage, so we should always,
+# see a count of 2.
+stage-query phase=PostCommitPhase stage=1:2
+SELECT count(*) FROM db.public.tbl;
+----
+2
+
+stage-query phase=PostCommitPhase stage=3:4
+SELECT count(*) FROM db.public.tbl;
+----
+1
+
+stage-query phase=PostCommitPhase stage=5:14
+SELECT count(*) FROM db.public.tbl;
+----
+2
+
+stage-exec phase=PostCommitPhase stage=15:
+INSERT INTO db.public.tbl VALUES($stageKey);
+INSERT INTO db.public.tbl VALUES($stageKey + 1);
+----
+duplicate key value violates unique constraint "tbl_j_key".*
+
+# Later on the unique constraint is enforced, so we expect the second
+# insert to fail.
+stage-query phase=PostCommitPhase stage=15:
+SELECT count(*) FROM db.public.tbl;
+----
+1
+
+stage-exec phase=PostCommitNonRevertiblePhase stage=1
+INSERT INTO db.public.tbl VALUES($stageKey);
+INSERT INTO db.public.tbl VALUES($stageKey + 1);
+----
+duplicate key value violates unique constraint "tbl_j_key".*
+
+stage-exec phase=PostCommitNonRevertiblePhase stage=2:
+INSERT INTO db.public.tbl VALUES($stageKey);
+----
+duplicate key value violates unique constraint "tbl_j_key".*
+
+# We will only succeed in inserting a single row, all other rows will be duplicates.
+stage-query phase=PostCommitNonRevertiblePhase stage=:
+SELECT count(*) FROM db.public.tbl;
+----
+1
+
+# Add a column with a default value such that only a single value will be allowed,
+# we will intentionally use an expression to make things more complex.
 test
-ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE DEFAULT CAST(date_part('year', now()) AS INT);
 ----
 begin transaction #1
 # begin StatementPhase
@@ -16,7 +90,7 @@ checking for feature: ALTER TABLE
 increment telemetry for sql.schema.alter_table
 increment telemetry for sql.schema.alter_table.add_column
 increment telemetry for sql.schema.qualifcation.default_expr
-increment telemetry for sql.schema.new_column_type.uuid
+increment telemetry for sql.schema.new_column_type.int8
 ## StatementPhase stage 1 of 1 with 11 MutationType ops
 upsert descriptor #106
   ...
@@ -33,14 +107,15 @@ upsert descriptor #106
      modificationTime: {}
   +  mutations:
   +  - column:
-  +      defaultExpr: gen_random_uuid()
+  +      defaultExpr: CAST(date_part('year':::STRING, now():::TIMESTAMPTZ) AS INT8)
   +      id: 2
   +      name: j
   +      nullable: true
   +      pgAttributeNum: 2
   +      type:
-  +        family: UuidFamily
-  +        oid: 2950
+  +        family: IntFamily
+  +        oid: 20
+  +        width: 64
   +    direction: ADD
   +    mutationId: 1
   +    state: DELETE_ONLY
@@ -112,7 +187,7 @@ upsert descriptor #106
      unexposedParentSchemaId: 105
   -  version: "1"
   +  version: "2"
-write *eventpb.AlterTable to event log: ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+write *eventpb.AlterTable to event log: ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8)
 # end StatementPhase
 # begin PreCommitPhase
 ## PreCommitPhase stage 1 of 1 with 2 MutationType ops
@@ -127,9 +202,10 @@ upsert descriptor #106
   +    jobId: "1"
   +    relevantStatements:
   +    - statement:
-  +        redactedStatement: ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN ‹j› UUID UNIQUE
-  +          DEFAULT gen_random_uuid()
-  +        statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+  +        redactedStatement: ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE
+  +          DEFAULT CAST(date_part(‹'year'›, now()) AS INT8)
+  +        statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+  +          now()) AS INT8)
   +        statementTag: ALTER TABLE
   +    revertible: true
   +    targetRanks: <redacted>
@@ -141,7 +217,7 @@ upsert descriptor #106
      unexposedParentSchemaId: 105
   -  version: "1"
   +  version: "2"
-create job #1 (non-cancelable: false): "ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()"
+create job #1 (non-cancelable: false): "ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year', now()) AS INT8)"
   descriptor IDs: [106]
 # end PreCommitPhase
 commit transaction #1
@@ -467,18 +543,19 @@ upsert descriptor #106
   ...
          oid: 20
          width: 64
-  +  - defaultExpr: gen_random_uuid()
+  +  - defaultExpr: CAST(date_part('year':::STRING, now():::TIMESTAMPTZ) AS INT8)
   +    id: 2
   +    name: j
   +    nullable: true
   +    pgAttributeNum: 2
   +    type:
-  +      family: UuidFamily
-  +      oid: 2950
+  +      family: IntFamily
+  +      oid: 20
+  +      width: 64
      createAsOfTime:
        wallTime: "1640995200000000000"
   ...
-           statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+             now()) AS INT8)
            statementTag: ALTER TABLE
   -    revertible: true
        targetRanks: <redacted>
@@ -511,14 +588,15 @@ upsert descriptor #106
      modificationTime: {}
      mutations:
   -  - column:
-  -      defaultExpr: gen_random_uuid()
+  -      defaultExpr: CAST(date_part('year':::STRING, now():::TIMESTAMPTZ) AS INT8)
   -      id: 2
   -      name: j
   -      nullable: true
   -      pgAttributeNum: 2
   -      type:
-  -        family: UuidFamily
-  -        oid: 2950
+  -        family: IntFamily
+  -        oid: 20
+  -        width: 64
   -    direction: ADD
   -    mutationId: 1
   -    state: WRITE_ONLY
@@ -597,9 +675,10 @@ upsert descriptor #106
   -    jobId: "1"
   -    relevantStatements:
   -    - statement:
-  -        redactedStatement: ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN ‹j› UUID UNIQUE
-  -          DEFAULT gen_random_uuid()
-  -        statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+  -        redactedStatement: ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE
+  -          DEFAULT CAST(date_part(‹'year'›, now()) AS INT8)
+  -        statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+  -          now()) AS INT8)
   -        statementTag: ALTER TABLE
   -    targetRanks: <redacted>
   -    targets: <redacted>
@@ -692,7 +771,7 @@ upsert descriptor #106
   -  version: "12"
   +  version: "13"
 write *eventpb.FinishSchemaChange to event log
-create job #2 (non-cancelable: true): "GC for ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()"
+create job #2 (non-cancelable: true): "GC for ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year', now()) AS INT8)"
   descriptor IDs: [106]
 update progress of schema change job #1: "all stages completed"
 set schema change job #1 to non-cancellable

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_no_default
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_no_default
@@ -7,6 +7,30 @@ CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
 +schema {104 0 public} -> 105
 +object {104 105 tbl} -> 106
 
+stage-exec phase=PostCommitPhase stage=:
+INSERT INTO db.public.tbl VALUES($stageKey);
+INSERT INTO db.public.tbl VALUES($stageKey + 1);
+----
+
+# Each insert will be injected twice per stage, so we should always,
+# see a count of 2.
+stage-query phase=PostCommitPhase stage=:
+SELECT count(*)=$successfulStageCount*2 FROM db.public.tbl;
+----
+true
+
+
+stage-exec phase=PostCommitNonRevertiblePhase stage=:
+INSERT INTO db.public.tbl VALUES($stageKey);
+INSERT INTO db.public.tbl VALUES($stageKey + 1);
+----
+
+# Each insert will be injected twice per stage, so we should always,
+# see a count of 2.
+stage-query phase=PostCommitNonRevertiblePhase stage=:
+SELECT count(*)=$successfulStageCount*2 FROM db.public.tbl;
+----
+true
 
 test
 ALTER TABLE db.public.tbl ADD COLUMN j INT

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid
@@ -4,6 +4,31 @@ CREATE TABLE t (a INT NOT NULL)
 ...
 +object {100 101 t} -> 104
 
+stage-exec phase=PostCommitPhase stage=1:
+INSERT INTO t VALUES($stageKey);
+INSERT INTO t VALUES($stageKey + 1);
+----
+
+# Each insert will be injected twice per stage, so we should always,
+# see a count of 2.
+stage-query phase=PostCommitPhase stage=:
+SELECT count(*)=$successfulStageCount*2 FROM t;
+----
+true
+
+
+stage-exec phase=PostCommitNonRevertiblePhase stage=:
+INSERT INTO t VALUES($stageKey);
+INSERT INTO t VALUES($stageKey + 1);
+----
+
+# Each insert will be injected twice per stage, so we should always,
+# see a count of 2.
+stage-query phase=PostCommitNonRevertiblePhase stage=:
+SELECT count(*)=$successfulStageCount*2 FROM t;
+----
+true
+
 test
 alter table t add primary key (a);
 ----

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid
@@ -4,6 +4,33 @@ CREATE TABLE t (a INT NOT NULL)
 ...
 +object {100 101 t} -> 104
 
+stage-exec phase=PostCommitPhase stage=:
+INSERT INTO t VALUES($stageKey);
+INSERT INTO t VALUES($stageKey + 1);
+----
+pq: INSERT has more expressions than target columns, 2 expressions for 1 targets
+
+# Each insert will be injected twice per stage, so we should always,
+# see a count of 2.
+stage-query phase=PostCommitPhase stage=:
+SELECT count(*)=$successfulStageCount*2 FROM t;
+----
+true
+
+
+stage-exec phase=PostCommitNonRevertiblePhase stage=:
+INSERT INTO t VALUES($stageKey);
+INSERT INTO t VALUES($stageKey + 1);
+----
+pq: INSERT has more expressions than target columns, 2 expressions for 1 targets
+
+# Each insert will be injected twice per stage, so we should always,
+# see a count of 2.
+stage-query phase=PostCommitNonRevertiblePhase stage=:
+SELECT count(*)=$successfulStageCount*2 FROM t;
+----
+true
+
 test
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a)
 ----

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla
@@ -4,6 +4,29 @@ CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL)
 ...
 +object {100 101 t} -> 104
 
+stage-exec phase=PostCommitPhase stage=:
+INSERT INTO t VALUES($stageKey, $stageKey);
+INSERT INTO t VALUES($stageKey + 1, $stageKey + 1);
+----
+
+# Each insert will be injected twice per stage, so we should always,
+# see a count of 2.
+stage-query phase=PostCommitPhase stage=:
+SELECT count(*)=$successfulStageCount*2 FROM t;
+----
+true
+
+stage-exec phase=PostCommitNonRevertiblePhase stage=:
+INSERT INTO t VALUES($stageKey, $stageKey);
+INSERT INTO t VALUES($stageKey + 1, $stageKey + 1);
+----
+
+# Each insert will be injected twice per stage, so we should always,
+# see a count of 2.
+stage-query phase=PostCommitNonRevertiblePhase stage=:
+SELECT count(*)=$successfulStageCount*2 FROM t;
+----
+true
 
 test
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j)

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_index
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_index
@@ -7,6 +7,40 @@ CREATE TABLE t (k INT PRIMARY KEY, v e NOT NULL);
 +object {100 101 _e} -> 105
 +object {100 101 t} -> 106
 
+
+stage-exec phase=PostCommitPhase stage=:
+INSERT INTO t VALUES($stageKey, 'a');
+INSERT INTO t VALUES($stageKey + 1, 'b');
+INSERT INTO t VALUES($stageKey + 2, 'c');
+DELETE FROM t WHERE v = 'a' and k=$stageKey;
+INSERT INTO t VALUES($stageKey, 'a');
+UPDATE t SET v='a' WHERE k > 0;
+----
+
+# Each insert will be injected thrice per stage, so we should always,
+# see a count of 2.
+stage-query phase=PostCommitPhase stage=:
+SELECT count(*)=$successfulStageCount*3 FROM t where v='a';
+----
+true
+
+
+stage-exec phase=PostCommitNonRevertiblePhase stage=:
+INSERT INTO t VALUES($stageKey, 'a');
+INSERT INTO t VALUES($stageKey + 1, 'b');
+INSERT INTO t VALUES($stageKey + 2, 'c');
+DELETE FROM t WHERE v = 'a' and k=$stageKey;
+INSERT INTO t VALUES($stageKey, 'a');
+UPDATE t SET v='a' WHERE k > 0;
+----
+
+# Each insert will be injected twice per stage, so we should always,
+# see a count of 2.
+stage-query phase=PostCommitNonRevertiblePhase stage=:
+SELECT count(*)=$successfulStageCount*3 FROM t where v='a';
+----
+true
+
 test
 CREATE INDEX idx1 ON t (v) WHERE (v = 'a');
 ----

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_basic
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_basic
@@ -4,6 +4,31 @@ CREATE TABLE t (i INT PRIMARY KEY, j INT)
 ...
 +object {100 101 t} -> 104
 
+stage-exec phase=PostCommitPhase stage=:
+INSERT INTO t VALUES($stageKey);
+INSERT INTO t VALUES($stageKey + 1);
+----
+
+# Each insert will be injected twice per stage, so we should always,
+# see a count of 2.
+stage-query phase=PostCommitPhase stage=:
+SELECT count(*)=$successfulStageCount*2 FROM t;
+----
+true
+
+
+stage-exec phase=PostCommitNonRevertiblePhase stage=:
+INSERT INTO t VALUES($stageKey);
+INSERT INTO t VALUES($stageKey + 1);
+----
+
+# Each insert will be injected twice per stage, so we should always,
+# see a count of 2.
+stage-query phase=PostCommitNonRevertiblePhase stage=:
+SELECT count(*)=$successfulStageCount*2 FROM t;
+----
+true
+
 test
 ALTER TABLE t DROP COLUMN j
 ----

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_computed_index
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_computed_index
@@ -4,6 +4,31 @@ create table t (i INT PRIMARY KEY, j INT, INDEX((j+1)));
 ...
 +object {100 101 t} -> 104
 
+stage-exec phase=PostCommitPhase stage=:
+INSERT INTO t VALUES($stageKey);
+INSERT INTO t VALUES($stageKey + 1);
+----
+
+# Each insert will be injected twice per stage, so we should always,
+# see a count of 2.
+stage-query phase=PostCommitPhase stage=:
+SELECT count(*)=$successfulStageCount*2 FROM t;
+----
+true
+
+
+stage-exec phase=PostCommitNonRevertiblePhase stage=:
+INSERT INTO t VALUES($stageKey);
+INSERT INTO t VALUES($stageKey + 1);
+----
+
+# Each insert will be injected twice per stage, so we should always,
+# see a count of 2.
+stage-query phase=PostCommitNonRevertiblePhase stage=:
+SELECT count(*)=$successfulStageCount*2 FROM t;
+----
+true
+
 test
 ALTER TABLE t DROP COLUMN j CASCADE;
 ----

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements
@@ -4,6 +4,31 @@ CREATE TABLE t (i INT PRIMARY KEY, j INT, k INT DEFAULT 32 ON UPDATE 42, INDEX((
 ...
 +object {100 101 t} -> 104
 
+stage-exec phase=PostCommitPhase stage=:
+INSERT INTO t (i, k) VALUES($stageKey, $stageKey);
+INSERT INTO t (i, k) VALUES($stageKey + 1, $stageKey + 1)
+----
+
+# Each insert will be injected twice per stage, so we should always,
+# see a count of 2.
+stage-query phase=PostCommitPhase stage=:
+SELECT count(*)=$successfulStageCount*2 FROM t;
+----
+true
+
+
+stage-exec phase=PostCommitNonRevertiblePhase stage=:
+INSERT INTO t (i, k) VALUES($stageKey, $stageKey);
+INSERT INTO t (i, k) VALUES($stageKey + 1, $stageKey + 1)
+----
+
+# Each insert will be injected twice per stage, so we should always,
+# see a count of 2.
+stage-query phase=PostCommitNonRevertiblePhase stage=:
+SELECT count(*)=$successfulStageCount*2 FROM t;
+----
+true
+
 test
 ALTER TABLE t DROP COLUMN j CASCADE;
 CREATE UNIQUE INDEX idx ON t(k);

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_index
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_with_index
@@ -4,6 +4,32 @@ CREATE TABLE t (i INT PRIMARY KEY, j INT, INDEX (j))
 ...
 +object {100 101 t} -> 104
 
+
+stage-exec phase=PostCommitPhase stage=:
+INSERT INTO t (i) VALUES($stageKey);
+INSERT INTO t (i) VALUES($stageKey + 1);
+----
+
+# Each insert will be injected twice per stage, so we should always,
+# see a count of 2.
+stage-query phase=PostCommitPhase stage=:
+SELECT count(*)=$successfulStageCount*2 FROM t;
+----
+true
+
+
+stage-exec phase=PostCommitNonRevertiblePhase stage=:
+INSERT INTO t (i) VALUES($stageKey);
+INSERT INTO t (i) VALUES($stageKey + 1);
+----
+
+# Each insert will be injected twice per stage, so we should always,
+# see a count of 2.
+stage-query phase=PostCommitNonRevertiblePhase stage=:
+SELECT count(*)=$successfulStageCount*2 FROM t;
+----
+true
+
 test
 ALTER TABLE t DROP COLUMN j
 ----

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_index_hash_sharded_index
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_index_hash_sharded_index
@@ -5,6 +5,18 @@ CREATE INDEX idx ON t(j) USING HASH
 ...
 +object {100 101 t} -> 104
 
+stage-exec phase=PostCommitNonRevertiblePhase stage=:
+INSERT INTO t (i, j) VALUES($stageKey, $stageKey);
+INSERT INTO t (i, j) VALUES($stageKey + 1, $stageKey +1);
+----
+
+# Each insert will be injected twice per stage, so we should always,
+# see a count of 2.
+stage-query phase=PostCommitNonRevertiblePhase stage=:
+SELECT count(*)=$successfulStageCount*2 FROM t;
+----
+true
+
 test
 DROP INDEX idx CASCADE
 ----

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_index_partial_expression_index
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_index_partial_expression_index
@@ -5,6 +5,10 @@ CREATE INDEX idx ON t(lower(j)) WHERE i > 0
 ...
 +object {100 101 t} -> 104
 
+stage-exec phase=PostCommitNonRevertiblePhase stage=:
+INSERT INTO t (i, j) VALUES($stageKey, 'TESt1');
+----
+
 test
 DROP INDEX idx CASCADE
 ----

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_index_vanilla_index
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_index_vanilla_index
@@ -5,6 +5,23 @@ CREATE INDEX idx ON t(j)
 ...
 +object {100 101 t} -> 104
 
+stage-exec phase=PostCommitNonRevertiblePhase stage=:
+INSERT INTO t (i, j) VALUES($stageKey, $stageKey);
+INSERT INTO t (i, j) VALUES($stageKey + 1, $stageKey + 1);
+----
+
+stage-exec phase=PostCommitNonRevertiblePhase stage=:
+DELETE FROM t WHERE j=$stageKey+1;
+INSERT INTO t (i, j) VALUES($stageKey + 1, $stageKey + 1);
+----
+
+# Each insert will be injected twice per stage, so we should always,
+# see a count of 2.
+stage-query phase=PostCommitNonRevertiblePhase stage=:
+SELECT count(*)=$successfulStageCount*2 FROM t;
+----
+true
+
 test
 DROP INDEX idx CASCADE
 ----

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_multiple_columns_separate_statements
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_multiple_columns_separate_statements
@@ -4,6 +4,45 @@ CREATE TABLE t (i INT PRIMARY KEY, j INT, k INT DEFAULT 32 ON UPDATE 42, INDEX((
 ...
 +object {100 101 t} -> 104
 
+
+stage-exec phase=PostCommitPhase stage=:
+INSERT INTO t (i, j, k) VALUES($stageKey, $stageKey, $stageKey);
+----
+pq: column "j" does not exist
+
+stage-exec phase=PostCommitPhase stage=:
+INSERT INTO t (i) VALUES($stageKey);
+----
+
+stage-exec phase=PostCommitPhase stage=:
+SELECT j+1, k FROM t
+----
+pq: column "j" does not exist
+
+stage-exec phase=PostCommitPhase stage=:
+SELECT count(i) FROM t
+----
+$successfulStageCount
+
+stage-exec phase=PostCommitNonRevertiblePhase stage=:
+INSERT INTO t (i, j, k) VALUES($stageKey, $stageKey, $stageKey);
+----
+pq: column "j" does not exist
+
+stage-exec phase=PostCommitNonRevertiblePhase stage=:
+INSERT INTO t (i) VALUES($stageKey);
+----
+
+stage-exec phase=PostCommitNonRevertiblePhase stage=:
+SELECT j+1, k FROM t
+----
+pq: column "j" does not exist
+
+stage-exec phase=PostCommitNonRevertiblePhase stage=:
+SELECT count(i) FROM t
+----
+$successfulStageCount
+
 test
 ALTER TABLE t DROP COLUMN j CASCADE;
 ALTER TABLE t DROP COLUMN k CASCADE;

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_schema
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_schema
@@ -100,14 +100,3 @@ set schema change job #1 to non-cancellable
 updated schema change job #1 descriptor IDs to []
 commit transaction #3
 # end PostCommitPhase
-
-setup
-CREATE SCHEMA db.sc;
-CREATE TABLE db.sc.t (k INT, v STRING);
-CREATE TYPE db.sc.e AS ENUM('a', 'b', 'c');
-----
-...
-+schema {104 0 sc} -> 107
-+object {104 107 t} -> 108
-+object {104 107 e} -> 109
-+object {104 107 _e} -> 110

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_unique
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_unique
@@ -3,9 +3,9 @@ CREATE DATABASE db;
 CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
 
 /* test */
-EXPLAIN (ddl) ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_random_uuid() UNIQUE;
+EXPLAIN (ddl) ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE DEFAULT CAST(date_part('year', now()) AS INT);
 ----
-Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid(); 
+Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8); 
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 8 elements transitioning toward PUBLIC

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_10_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_10_of_15
@@ -3,10 +3,10 @@ CREATE DATABASE db;
 CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
 
 /* test */
-ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE DEFAULT CAST(date_part('year', now()) AS INT);
 EXPLAIN (ddl) rollback at post-commit stage 10 of 15;
 ----
-Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid(); 
+Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
       │    ├── 2 elements transitioning toward PUBLIC

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_11_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_11_of_15
@@ -3,10 +3,10 @@ CREATE DATABASE db;
 CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
 
 /* test */
-ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE DEFAULT CAST(date_part('year', now()) AS INT);
 EXPLAIN (ddl) rollback at post-commit stage 11 of 15;
 ----
-Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid(); 
+Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
       │    ├── 2 elements transitioning toward PUBLIC

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_12_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_12_of_15
@@ -3,10 +3,10 @@ CREATE DATABASE db;
 CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
 
 /* test */
-ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE DEFAULT CAST(date_part('year', now()) AS INT);
 EXPLAIN (ddl) rollback at post-commit stage 12 of 15;
 ----
-Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid(); 
+Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
       │    ├── 2 elements transitioning toward PUBLIC

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_13_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_13_of_15
@@ -3,10 +3,10 @@ CREATE DATABASE db;
 CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
 
 /* test */
-ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE DEFAULT CAST(date_part('year', now()) AS INT);
 EXPLAIN (ddl) rollback at post-commit stage 13 of 15;
 ----
-Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid(); 
+Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
       │    ├── 2 elements transitioning toward PUBLIC

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_14_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_14_of_15
@@ -3,10 +3,10 @@ CREATE DATABASE db;
 CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
 
 /* test */
-ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE DEFAULT CAST(date_part('year', now()) AS INT);
 EXPLAIN (ddl) rollback at post-commit stage 14 of 15;
 ----
-Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid(); 
+Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
       │    ├── 2 elements transitioning toward PUBLIC

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_15_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_15_of_15
@@ -3,10 +3,10 @@ CREATE DATABASE db;
 CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
 
 /* test */
-ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE DEFAULT CAST(date_part('year', now()) AS INT);
 EXPLAIN (ddl) rollback at post-commit stage 15 of 15;
 ----
-Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid(); 
+Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
       │    ├── 2 elements transitioning toward PUBLIC

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_1_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_1_of_15
@@ -3,10 +3,10 @@ CREATE DATABASE db;
 CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
 
 /* test */
-ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE DEFAULT CAST(date_part('year', now()) AS INT);
 EXPLAIN (ddl) rollback at post-commit stage 1 of 15;
 ----
-Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid(); 
+Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8); 
  └── PostCommitNonRevertiblePhase
       └── Stage 1 of 1 in PostCommitNonRevertiblePhase
            ├── 11 elements transitioning toward ABSENT

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_2_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_2_of_15
@@ -3,10 +3,10 @@ CREATE DATABASE db;
 CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
 
 /* test */
-ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE DEFAULT CAST(date_part('year', now()) AS INT);
 EXPLAIN (ddl) rollback at post-commit stage 2 of 15;
 ----
-Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid(); 
+Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
       │    ├── 8 elements transitioning toward ABSENT

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_3_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_3_of_15
@@ -3,10 +3,10 @@ CREATE DATABASE db;
 CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
 
 /* test */
-ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE DEFAULT CAST(date_part('year', now()) AS INT);
 EXPLAIN (ddl) rollback at post-commit stage 3 of 15;
 ----
-Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid(); 
+Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
       │    ├── 8 elements transitioning toward ABSENT

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_4_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_4_of_15
@@ -3,10 +3,10 @@ CREATE DATABASE db;
 CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
 
 /* test */
-ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE DEFAULT CAST(date_part('year', now()) AS INT);
 EXPLAIN (ddl) rollback at post-commit stage 4 of 15;
 ----
-Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid(); 
+Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
       │    ├── 8 elements transitioning toward ABSENT

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_5_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_5_of_15
@@ -3,10 +3,10 @@ CREATE DATABASE db;
 CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
 
 /* test */
-ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE DEFAULT CAST(date_part('year', now()) AS INT);
 EXPLAIN (ddl) rollback at post-commit stage 5 of 15;
 ----
-Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid(); 
+Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
       │    ├── 8 elements transitioning toward ABSENT

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_6_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_6_of_15
@@ -3,10 +3,10 @@ CREATE DATABASE db;
 CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
 
 /* test */
-ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE DEFAULT CAST(date_part('year', now()) AS INT);
 EXPLAIN (ddl) rollback at post-commit stage 6 of 15;
 ----
-Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid(); 
+Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
       │    ├── 8 elements transitioning toward ABSENT

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_7_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_7_of_15
@@ -3,10 +3,10 @@ CREATE DATABASE db;
 CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
 
 /* test */
-ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE DEFAULT CAST(date_part('year', now()) AS INT);
 EXPLAIN (ddl) rollback at post-commit stage 7 of 15;
 ----
-Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid(); 
+Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
       │    ├── 8 elements transitioning toward ABSENT

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_8_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_8_of_15
@@ -3,10 +3,10 @@ CREATE DATABASE db;
 CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
 
 /* test */
-ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE DEFAULT CAST(date_part('year', now()) AS INT);
 EXPLAIN (ddl) rollback at post-commit stage 8 of 15;
 ----
-Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid(); 
+Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
       │    ├── 8 elements transitioning toward ABSENT

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_9_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_unique.rollback_9_of_15
@@ -3,10 +3,10 @@ CREATE DATABASE db;
 CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
 
 /* test */
-ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE DEFAULT CAST(date_part('year', now()) AS INT);
 EXPLAIN (ddl) rollback at post-commit stage 9 of 15;
 ----
-Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid(); 
+Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
       │    ├── 2 elements transitioning toward PUBLIC

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique
@@ -3,9 +3,9 @@ CREATE DATABASE db;
 CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
 
 /* test */
-EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_random_uuid() UNIQUE;
+EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE DEFAULT CAST(date_part('year', now()) AS INT);
 ----
-• Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid(); 
+• Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8); 
 │
 ├── • StatementPhase
 │   │
@@ -112,7 +112,8 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_r
 │           │     EventBase:
 │           │       Authorization:
 │           │         UserName: root
-│           │       Statement: ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+│           │       Statement: ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+│           │         now()) AS INT8)
 │           │       StatementTag: ALTER TABLE
 │           │       TargetMetadata:
 │           │         SourceElementID: 1
@@ -131,14 +132,15 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_r
 │           │       TableID: 106
 │           │       TypeT:
 │           │         Type:
-│           │           family: UuidFamily
-│           │           oid: 2950
+│           │           family: IntFamily
+│           │           oid: 20
+│           │           width: 64
 │           │
 │           ├── • AddColumnDefaultExpression
 │           │     Default:
 │           │       ColumnID: 2
 │           │       Expression:
-│           │         Expr: gen_random_uuid()
+│           │         Expr: CAST(date_part('year':::STRING, now():::TIMESTAMPTZ) AS INT8)
 │           │       TableID: 106
 │           │
 │           ├── • MakeAbsentIndexBackfilling
@@ -198,9 +200,10 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_r
 │                 JobID: 1
 │                 RunningStatus: PostCommitPhase stage 1 of 15 with 2 MutationType ops pending
 │                 Statements:
-│                 - statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
-│                   redactedstatement: ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT
-│                     gen_random_uuid()
+│                 - statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+│                     now()) AS INT8)
+│                   redactedstatement: ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT
+│                     CAST(date_part(‹'year'›, now()) AS INT8)
 │                   statementtag: ALTER TABLE
 │
 ├── • PostCommitPhase
@@ -511,7 +514,8 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_r
 │   │       │     EventBase:
 │   │       │       Authorization:
 │   │       │         UserName: root
-│   │       │       Statement: ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+│   │       │       Statement: ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+│   │       │         now()) AS INT8)
 │   │       │       StatementTag: ALTER TABLE
 │   │       │       TargetMetadata:
 │   │       │         SourceElementID: 1
@@ -835,7 +839,8 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_r
     │       │     EventBase:
     │       │       Authorization:
     │       │         UserName: root
-    │       │       Statement: ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+    │       │       Statement: ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+    │       │         now()) AS INT8)
     │       │       StatementTag: ALTER TABLE
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
@@ -943,7 +948,8 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_r
             │     EventBase:
             │       Authorization:
             │         UserName: root
-            │       Statement: ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+            │         now()) AS INT8)
             │       StatementTag: ALTER TABLE
             │       TargetMetadata:
             │         SourceElementID: 1
@@ -954,7 +960,8 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_r
             ├── • CreateGCJobForIndex
             │     IndexID: 1
             │     StatementForDropJob:
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • MakeIndexAbsent
@@ -964,7 +971,8 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_r
             ├── • CreateGCJobForIndex
             │     IndexID: 3
             │     StatementForDropJob:
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • MakeIndexAbsent
@@ -974,7 +982,8 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_r
             ├── • CreateGCJobForIndex
             │     IndexID: 5
             │     StatementForDropJob:
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • RemoveJobStateFromDescriptor

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_10_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_10_of_15
@@ -3,10 +3,10 @@ CREATE DATABASE db;
 CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
 
 /* test */
-ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE DEFAULT CAST(date_part('year', now()) AS INT);
 EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
 ----
-• Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid(); 
+• Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8); 
 │
 └── • PostCommitNonRevertiblePhase
     │
@@ -189,7 +189,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │       │     EventBase:
     │       │       Authorization:
     │       │         UserName: root
-    │       │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+    │       │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+    │       │         now()) AS INT8)
     │       │       StatementTag: ALTER TABLE
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
@@ -209,7 +210,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │       │     EventBase:
     │       │       Authorization:
     │       │         UserName: root
-    │       │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+    │       │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+    │       │         now()) AS INT8)
     │       │       StatementTag: ALTER TABLE
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
@@ -404,7 +406,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
             │     EventBase:
             │       Authorization:
             │         UserName: root
-            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+            │         now()) AS INT8)
             │       StatementTag: ALTER TABLE
             │       TargetMetadata:
             │         SourceElementID: 1
@@ -416,28 +419,32 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 5
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent
@@ -445,7 +452,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
             │     EventBase:
             │       Authorization:
             │         UserName: root
-            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+            │         now()) AS INT8)
             │       StatementTag: ALTER TABLE
             │       TargetMetadata:
             │         SourceElementID: 1

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_11_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_11_of_15
@@ -3,10 +3,10 @@ CREATE DATABASE db;
 CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
 
 /* test */
-ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE DEFAULT CAST(date_part('year', now()) AS INT);
 EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
 ----
-• Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid(); 
+• Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8); 
 │
 └── • PostCommitNonRevertiblePhase
     │
@@ -189,7 +189,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │       │     EventBase:
     │       │       Authorization:
     │       │         UserName: root
-    │       │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+    │       │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+    │       │         now()) AS INT8)
     │       │       StatementTag: ALTER TABLE
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
@@ -209,7 +210,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │       │     EventBase:
     │       │       Authorization:
     │       │         UserName: root
-    │       │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+    │       │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+    │       │         now()) AS INT8)
     │       │       StatementTag: ALTER TABLE
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
@@ -404,7 +406,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
             │     EventBase:
             │       Authorization:
             │         UserName: root
-            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+            │         now()) AS INT8)
             │       StatementTag: ALTER TABLE
             │       TargetMetadata:
             │         SourceElementID: 1
@@ -416,28 +419,32 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 5
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent
@@ -445,7 +452,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
             │     EventBase:
             │       Authorization:
             │         UserName: root
-            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+            │         now()) AS INT8)
             │       StatementTag: ALTER TABLE
             │       TargetMetadata:
             │         SourceElementID: 1

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_12_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_12_of_15
@@ -3,10 +3,10 @@ CREATE DATABASE db;
 CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
 
 /* test */
-ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE DEFAULT CAST(date_part('year', now()) AS INT);
 EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
 ----
-• Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid(); 
+• Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8); 
 │
 └── • PostCommitNonRevertiblePhase
     │
@@ -193,7 +193,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │       │     EventBase:
     │       │       Authorization:
     │       │         UserName: root
-    │       │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+    │       │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+    │       │         now()) AS INT8)
     │       │       StatementTag: ALTER TABLE
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
@@ -212,7 +213,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │       │     EventBase:
     │       │       Authorization:
     │       │         UserName: root
-    │       │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+    │       │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+    │       │         now()) AS INT8)
     │       │       StatementTag: ALTER TABLE
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
@@ -404,7 +406,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
             │     EventBase:
             │       Authorization:
             │         UserName: root
-            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+            │         now()) AS INT8)
             │       StatementTag: ALTER TABLE
             │       TargetMetadata:
             │         SourceElementID: 1
@@ -416,28 +419,32 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 5
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent
@@ -445,7 +452,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
             │     EventBase:
             │       Authorization:
             │         UserName: root
-            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+            │         now()) AS INT8)
             │       StatementTag: ALTER TABLE
             │       TargetMetadata:
             │         SourceElementID: 1

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_13_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_13_of_15
@@ -3,10 +3,10 @@ CREATE DATABASE db;
 CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
 
 /* test */
-ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE DEFAULT CAST(date_part('year', now()) AS INT);
 EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
 ----
-• Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid(); 
+• Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8); 
 │
 └── • PostCommitNonRevertiblePhase
     │
@@ -180,7 +180,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
     │       │     EventBase:
     │       │       Authorization:
     │       │         UserName: root
-    │       │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+    │       │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+    │       │         now()) AS INT8)
     │       │       StatementTag: ALTER TABLE
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
@@ -267,7 +268,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
     │       │     EventBase:
     │       │       Authorization:
     │       │         UserName: root
-    │       │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+    │       │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+    │       │         now()) AS INT8)
     │       │       StatementTag: ALTER TABLE
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
@@ -414,7 +416,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
             │     EventBase:
             │       Authorization:
             │         UserName: root
-            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+            │         now()) AS INT8)
             │       StatementTag: ALTER TABLE
             │       TargetMetadata:
             │         SourceElementID: 1
@@ -426,28 +429,32 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 5
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent
@@ -455,7 +462,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
             │     EventBase:
             │       Authorization:
             │         UserName: root
-            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+            │         now()) AS INT8)
             │       StatementTag: ALTER TABLE
             │       TargetMetadata:
             │         SourceElementID: 1

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_14_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_14_of_15
@@ -3,10 +3,10 @@ CREATE DATABASE db;
 CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
 
 /* test */
-ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE DEFAULT CAST(date_part('year', now()) AS INT);
 EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
 ----
-• Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid(); 
+• Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8); 
 │
 └── • PostCommitNonRevertiblePhase
     │
@@ -180,7 +180,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
     │       │     EventBase:
     │       │       Authorization:
     │       │         UserName: root
-    │       │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+    │       │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+    │       │         now()) AS INT8)
     │       │       StatementTag: ALTER TABLE
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
@@ -267,7 +268,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
     │       │     EventBase:
     │       │       Authorization:
     │       │         UserName: root
-    │       │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+    │       │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+    │       │         now()) AS INT8)
     │       │       StatementTag: ALTER TABLE
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
@@ -414,7 +416,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
             │     EventBase:
             │       Authorization:
             │         UserName: root
-            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+            │         now()) AS INT8)
             │       StatementTag: ALTER TABLE
             │       TargetMetadata:
             │         SourceElementID: 1
@@ -426,28 +429,32 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 5
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent
@@ -455,7 +462,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
             │     EventBase:
             │       Authorization:
             │         UserName: root
-            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+            │         now()) AS INT8)
             │       StatementTag: ALTER TABLE
             │       TargetMetadata:
             │         SourceElementID: 1

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_15_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_15_of_15
@@ -3,10 +3,10 @@ CREATE DATABASE db;
 CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
 
 /* test */
-ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE DEFAULT CAST(date_part('year', now()) AS INT);
 EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
 ----
-• Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid(); 
+• Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8); 
 │
 └── • PostCommitNonRevertiblePhase
     │
@@ -184,7 +184,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
     │       │     EventBase:
     │       │       Authorization:
     │       │         UserName: root
-    │       │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+    │       │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+    │       │         now()) AS INT8)
     │       │       StatementTag: ALTER TABLE
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
@@ -267,7 +268,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
     │       │     EventBase:
     │       │       Authorization:
     │       │         UserName: root
-    │       │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+    │       │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+    │       │         now()) AS INT8)
     │       │       StatementTag: ALTER TABLE
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
@@ -414,7 +416,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
             │     EventBase:
             │       Authorization:
             │         UserName: root
-            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+            │         now()) AS INT8)
             │       StatementTag: ALTER TABLE
             │       TargetMetadata:
             │         SourceElementID: 1
@@ -426,28 +429,32 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 5
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent
@@ -455,7 +462,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
             │     EventBase:
             │       Authorization:
             │         UserName: root
-            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+            │         now()) AS INT8)
             │       StatementTag: ALTER TABLE
             │       TargetMetadata:
             │         SourceElementID: 1

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_1_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_1_of_15
@@ -3,10 +3,10 @@ CREATE DATABASE db;
 CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
 
 /* test */
-ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE DEFAULT CAST(date_part('year', now()) AS INT);
 EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 15;
 ----
-• Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid(); 
+• Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8); 
 │
 └── • PostCommitNonRevertiblePhase
     │
@@ -132,7 +132,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 15;
             │     EventBase:
             │       Authorization:
             │         UserName: root
-            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+            │         now()) AS INT8)
             │       StatementTag: ALTER TABLE
             │       TargetMetadata:
             │         SourceElementID: 1
@@ -144,7 +145,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • MakeIndexAbsent
@@ -156,7 +158,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 15;
             │     EventBase:
             │       Authorization:
             │         UserName: root
-            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+            │         now()) AS INT8)
             │       StatementTag: ALTER TABLE
             │       TargetMetadata:
             │         SourceElementID: 1

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_2_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_2_of_15
@@ -3,10 +3,10 @@ CREATE DATABASE db;
 CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
 
 /* test */
-ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE DEFAULT CAST(date_part('year', now()) AS INT);
 EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 15;
 ----
-• Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid(); 
+• Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8); 
 │
 └── • PostCommitNonRevertiblePhase
     │
@@ -96,7 +96,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 15;
     │       │     EventBase:
     │       │       Authorization:
     │       │         UserName: root
-    │       │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+    │       │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+    │       │         now()) AS INT8)
     │       │       StatementTag: ALTER TABLE
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
@@ -202,7 +203,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • MakeIndexAbsent
@@ -213,7 +215,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 15;
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent
@@ -221,7 +224,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 15;
             │     EventBase:
             │       Authorization:
             │         UserName: root
-            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+            │         now()) AS INT8)
             │       StatementTag: ALTER TABLE
             │       TargetMetadata:
             │         SourceElementID: 1

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_3_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_3_of_15
@@ -3,10 +3,10 @@ CREATE DATABASE db;
 CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
 
 /* test */
-ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE DEFAULT CAST(date_part('year', now()) AS INT);
 EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 15;
 ----
-• Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid(); 
+• Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8); 
 │
 └── • PostCommitNonRevertiblePhase
     │
@@ -96,7 +96,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 15;
     │       │     EventBase:
     │       │       Authorization:
     │       │         UserName: root
-    │       │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+    │       │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+    │       │         now()) AS INT8)
     │       │       StatementTag: ALTER TABLE
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
@@ -202,7 +203,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • MakeIndexAbsent
@@ -213,7 +215,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 15;
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent
@@ -221,7 +224,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 15;
             │     EventBase:
             │       Authorization:
             │         UserName: root
-            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+            │         now()) AS INT8)
             │       StatementTag: ALTER TABLE
             │       TargetMetadata:
             │         SourceElementID: 1

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_4_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_4_of_15
@@ -3,10 +3,10 @@ CREATE DATABASE db;
 CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
 
 /* test */
-ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE DEFAULT CAST(date_part('year', now()) AS INT);
 EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 15;
 ----
-• Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid(); 
+• Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8); 
 │
 └── • PostCommitNonRevertiblePhase
     │
@@ -96,7 +96,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 15;
     │       │     EventBase:
     │       │       Authorization:
     │       │         UserName: root
-    │       │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+    │       │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+    │       │         now()) AS INT8)
     │       │       StatementTag: ALTER TABLE
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
@@ -202,7 +203,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • MakeIndexAbsent
@@ -213,7 +215,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 15;
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent
@@ -221,7 +224,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 15;
             │     EventBase:
             │       Authorization:
             │         UserName: root
-            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+            │         now()) AS INT8)
             │       StatementTag: ALTER TABLE
             │       TargetMetadata:
             │         SourceElementID: 1

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_5_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_5_of_15
@@ -3,10 +3,10 @@ CREATE DATABASE db;
 CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
 
 /* test */
-ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE DEFAULT CAST(date_part('year', now()) AS INT);
 EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 15;
 ----
-• Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid(); 
+• Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8); 
 │
 └── • PostCommitNonRevertiblePhase
     │
@@ -200,7 +200,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 15;
             │     EventBase:
             │       Authorization:
             │         UserName: root
-            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+            │         now()) AS INT8)
             │       StatementTag: ALTER TABLE
             │       TargetMetadata:
             │         SourceElementID: 1
@@ -212,7 +213,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • MakeIndexAbsent
@@ -223,7 +225,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 15;
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent
@@ -231,7 +234,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 15;
             │     EventBase:
             │       Authorization:
             │         UserName: root
-            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+            │         now()) AS INT8)
             │       StatementTag: ALTER TABLE
             │       TargetMetadata:
             │         SourceElementID: 1

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_6_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_6_of_15
@@ -3,10 +3,10 @@ CREATE DATABASE db;
 CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
 
 /* test */
-ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE DEFAULT CAST(date_part('year', now()) AS INT);
 EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 15;
 ----
-• Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid(); 
+• Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8); 
 │
 └── • PostCommitNonRevertiblePhase
     │
@@ -200,7 +200,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 15;
             │     EventBase:
             │       Authorization:
             │         UserName: root
-            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+            │         now()) AS INT8)
             │       StatementTag: ALTER TABLE
             │       TargetMetadata:
             │         SourceElementID: 1
@@ -212,7 +213,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • MakeIndexAbsent
@@ -223,7 +225,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 15;
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent
@@ -231,7 +234,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 15;
             │     EventBase:
             │       Authorization:
             │         UserName: root
-            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+            │         now()) AS INT8)
             │       StatementTag: ALTER TABLE
             │       TargetMetadata:
             │         SourceElementID: 1

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_7_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_7_of_15
@@ -3,10 +3,10 @@ CREATE DATABASE db;
 CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
 
 /* test */
-ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE DEFAULT CAST(date_part('year', now()) AS INT);
 EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 15;
 ----
-• Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid(); 
+• Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8); 
 │
 └── • PostCommitNonRevertiblePhase
     │
@@ -200,7 +200,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 15;
             │     EventBase:
             │       Authorization:
             │         UserName: root
-            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+            │         now()) AS INT8)
             │       StatementTag: ALTER TABLE
             │       TargetMetadata:
             │         SourceElementID: 1
@@ -212,7 +213,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • MakeIndexAbsent
@@ -223,7 +225,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 15;
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent
@@ -231,7 +234,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 15;
             │     EventBase:
             │       Authorization:
             │         UserName: root
-            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+            │         now()) AS INT8)
             │       StatementTag: ALTER TABLE
             │       TargetMetadata:
             │         SourceElementID: 1

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_8_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_8_of_15
@@ -3,10 +3,10 @@ CREATE DATABASE db;
 CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
 
 /* test */
-ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE DEFAULT CAST(date_part('year', now()) AS INT);
 EXPLAIN (ddl, verbose) rollback at post-commit stage 8 of 15;
 ----
-• Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid(); 
+• Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8); 
 │
 └── • PostCommitNonRevertiblePhase
     │
@@ -200,7 +200,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 8 of 15;
             │     EventBase:
             │       Authorization:
             │         UserName: root
-            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+            │         now()) AS INT8)
             │       StatementTag: ALTER TABLE
             │       TargetMetadata:
             │         SourceElementID: 1
@@ -212,7 +213,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 8 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • MakeIndexAbsent
@@ -223,7 +225,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 8 of 15;
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent
@@ -231,7 +234,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 8 of 15;
             │     EventBase:
             │       Authorization:
             │         UserName: root
-            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+            │         now()) AS INT8)
             │       StatementTag: ALTER TABLE
             │       TargetMetadata:
             │         SourceElementID: 1

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_9_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_unique.rollback_9_of_15
@@ -3,10 +3,10 @@ CREATE DATABASE db;
 CREATE TABLE db.public.tbl (i INT PRIMARY KEY);
 
 /* test */
-ALTER TABLE db.public.tbl ADD COLUMN j UUID DEFAULT gen_random_uuid() UNIQUE;
+ALTER TABLE db.public.tbl ADD COLUMN j INT UNIQUE DEFAULT CAST(date_part('year', now()) AS INT);
 EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
 ----
-• Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid(); 
+• Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8); 
 │
 └── • PostCommitNonRevertiblePhase
     │
@@ -195,7 +195,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
     │       │     EventBase:
     │       │       Authorization:
     │       │         UserName: root
-    │       │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+    │       │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+    │       │         now()) AS INT8)
     │       │       StatementTag: ALTER TABLE
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
@@ -215,7 +216,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
     │       │     EventBase:
     │       │       Authorization:
     │       │         UserName: root
-    │       │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+    │       │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+    │       │         now()) AS INT8)
     │       │       StatementTag: ALTER TABLE
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
@@ -379,7 +381,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
             │     EventBase:
             │       Authorization:
             │         UserName: root
-            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+            │         now()) AS INT8)
             │       StatementTag: ALTER TABLE
             │       TargetMetadata:
             │         SourceElementID: 1
@@ -391,21 +394,24 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
             │     IndexID: 2
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 3
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • CreateGCJobForIndex
             │     IndexID: 4
             │     StatementForDropJob:
             │       Rollback: true
-            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year',
+            │         now()) AS INT8)
             │     TableID: 106
             │
             ├── • MakeDeleteOnlyColumnAbsent
@@ -413,7 +419,8 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
             │     EventBase:
             │       Authorization:
             │         UserName: root
-            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› UUID UNIQUE DEFAULT gen_random_uuid()
+            │       Statement: ALTER TABLE ‹db›.public.‹tbl› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›,
+            │         now()) AS INT8)
             │       StatementTag: ALTER TABLE
             │       TargetMetadata:
             │         SourceElementID: 1


### PR DESCRIPTION
Fixes: #83304

Previously, the declarative schema changer tests only ran DDL
statements for the schema change and had no mechanism for
determining correct behaviour if queries were run concurrently
at each phase. To address this, this patch adds a new framework
to these tests which allows us to inject DML (inserts / selects)
at various stages of a declarative schema change. This gives us
a more powerful framework for validating behaviour.

Release note: None

The first commit here can be ignored, and its a separate PR to make sure this runs stable. A PR is already open for it.