### PR TITLE
release-22.2: changefeedccl: job-level retry when error message is about draining

### DIFF
--- a/pkg/ccl/changefeedccl/changefeedbase/errors.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/errors.go
@@ -124,7 +124,9 @@ func IsRetryableError(err error) bool {
 	// that we can't recover the structure and we have to rely on this
 	// unfortunate string comparison.
 	errStr := err.Error()
-	if strings.Contains(errStr, retryableErrorString) || strings.Contains(errStr, kvcoord.SendErrorString) {
+	if strings.Contains(errStr, retryableErrorString) ||
+		strings.Contains(errStr, kvcoord.SendErrorString) ||
+		strings.Contains(errStr, "draining") {
 		return true
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #89913.

/cc @cockroachdb/release

---

See #https://github.com/cockroachlabs/support/issues/1839. The flow retryable error marker doesn't survive every path by which it can bubble up, so just look for the single word "draining" as false positives are much better than false negatives.

Fixes #89663

Release note (enterprise change): Fixed a bug that could cause changefeeds to fail during a rolling restart.

Release justification: Fixes a bug that could cause changefeeds to fail during a rolling restart (including if this version is being upgraded to).