### PR TITLE
release-22.2.0: changefeedccl: job-level retry when error message is about draining

### DIFF
--- a/pkg/ccl/changefeedccl/changefeedbase/errors.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/errors.go
@@ -112,10 +112,9 @@ func IsRetryableError(err error) bool {
 	// by avoiding string comparisons.
 
 	errStr := err.Error()
-	if strings.Contains(errStr, retryableErrorString) {
-		// If a RetryableError occurs on a remote node, DistSQL serializes it such
-		// that we can't recover the structure and we have to rely on this
-		// unfortunate string comparison.
+	if strings.Contains(errStr, retryableErrorString) ||
+		strings.Contains(errStr, "failed to send RPC") ||
+		strings.Contains(errStr, "draining") {
 		return true
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #89913.

/cc @cockroachdb/release

---

See #https://github.com/cockroachlabs/support/issues/1839. The flow retryable error marker doesn't survive every path by which it can bubble up, so just look for the single word "draining" as false positives are much better than false negatives.

Fixes #89663

Release note (enterprise change): Fixed a bug that could cause changefeeds to fail during a rolling restart.

Release justification: Fixes a bug that could cause changefeeds to fail during a rolling restart (including if this version is being upgraded to).