### PR TITLE
opgen: added a bool field in struct opgen.transition

### DIFF
--- a/pkg/sql/schemachanger/scplan/internal/opgen/op_gen.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/op_gen.go
@@ -147,7 +147,14 @@ func (r *registry) buildGraph(
 // InitialStatus returns the status at the source of an op-edge path.
 func InitialStatus(e scpb.Element, target scpb.Status) scpb.Status {
 	if t, found := findTarget(e, target); found {
-		return t.transitions[0].from
+		for _, tstn := range t.transitions {
+			if tstn.isEquiv {
+				continue
+			}
+			return tstn.from
+		}
+		// All transitions results from `equiv(xxx)` specs. Return `to` of the last transition.
+		return target
 	}
 	return scpb.Status_UNKNOWN
 }


### PR DESCRIPTION
This PR adds a bool field in struct opgen.transition that indicates whether it results from a `equiv(xx)` transition spec in the opgen file. It will be useful for a test where we need to find the inital status on a adding/dropping path. Without such a change, it can be problematic if we have a `equiv(xx)` spec as the first transition. E.g.
```
  ToAbsent(
    PUBLIC,
    equiv(VALIDATED),
    to(WRITE_ONLY),
    to(ABSENT),
  )
```
Without this change, the inital status will confusingly be `VALIDATED`, and the next status will be `PUBLIC`.
With this change, the initial status will be `PUBLIC`, and the next status will be `WRITE_ONLY`.

We also added some comments when we make transitions from the specs.

Epic: None
Release note: None