### PR TITLE
Revert fmtsafe.go output

### DIFF
--- a/pkg/testutils/lint/passes/fmtsafe/fmtsafe.go
+++ b/pkg/testutils/lint/passes/fmtsafe/fmtsafe.go
@@ -245,8 +245,7 @@ func checkCallExpr(pass *analysis.Pass, enclosingFnName string, call *ast.CallEx
 		return
 	}
 
-	pass.Reportf(call.Lparen, escNl("%s() [calling %s]: %s argument is not a constant expression"+Tip),
-		enclosingFnName, fnName, argType)
+	pass.Reportf(call.Lparen, escNl("%s(): %s argument is not a constant expression"+Tip), enclosingFnName, argType)
 }
 
 // Tip is exported for use in tests.


### PR DESCRIPTION
TestLint/TestRoachVet is a unit test which runs roachvet and greps various messages from its output - the reverted message being one of them.

Release note: none.
Epic: none