### PR TITLE
opt: improve WithScan properties for recursive CTEs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/with
+++ b/pkg/sql/logictest/testdata/logic_test/with
@@ -1141,3 +1141,100 @@ SELECT i, j FROM u@u_j_idx
 query TTTTTTTT
 EXPERIMENTAL SCRUB TABLE u WITH OPTIONS INDEX ALL
 ----
+
+# Example pulled from a blog post.
+# https://malisper.me/the-missing-postgres-scan-the-loose-index-scan
+statement ok
+CREATE TABLE ints (n BIGINT, INDEX (n));
+
+statement ok
+INSERT INTO ints
+VALUES (1), (1), (1), (2), (4), (4), (4), (4), (5), (5),
+  (6), (7), (7), (7), (8), (9), (9), (9), (9), (9);
+
+query I
+WITH RECURSIVE temp (i) AS (
+  (SELECT n FROM ints ORDER BY n ASC LIMIT 1)
+UNION ALL (
+  SELECT n FROM temp,
+    LATERAL (
+      SELECT n
+      FROM ints
+      WHERE n > i
+      ORDER BY n ASC
+      LIMIT 1
+    ) sub
+  )
+)
+SELECT count(*) FROM temp;
+----
+8
+
+query I rowsort
+WITH RECURSIVE temp (i) AS (
+  (SELECT n FROM ints ORDER BY n ASC LIMIT 1)
+UNION ALL (
+  SELECT n FROM temp,
+    LATERAL (
+      SELECT n
+      FROM ints
+      WHERE n > i
+      ORDER BY n ASC
+      LIMIT 1
+    ) sub
+  )
+)
+SELECT * FROM temp;
+----
+1
+2
+4
+5
+6
+7
+8
+9
+
+# Added limit to the recursive branch.
+query I
+WITH RECURSIVE temp (i) AS (
+  (SELECT n FROM ints ORDER BY n ASC LIMIT 1)
+UNION ALL (
+  SELECT n FROM temp,
+    LATERAL (
+      SELECT n
+      FROM ints
+      WHERE n > i
+      ORDER BY n ASC
+      LIMIT 1
+    ) sub LIMIT 1
+  )
+)
+SELECT count(*) FROM temp;
+----
+8
+
+query I rowsort
+WITH RECURSIVE temp (i) AS (
+  (SELECT n FROM ints ORDER BY n ASC LIMIT 1)
+UNION ALL (
+  SELECT n FROM temp,
+    LATERAL (
+      SELECT n
+      FROM ints
+      WHERE n > i
+      ORDER BY n ASC
+      LIMIT 1
+    ) sub LIMIT 1
+  )
+)
+SELECT * FROM temp;
+----
+1
+2
+4
+5
+6
+7
+8
+9

--- a/pkg/sql/opt/norm/general_funcs.go
+++ b/pkg/sql/opt/norm/general_funcs.go
@@ -477,6 +477,12 @@ func (c *CustomFuncs) CanHaveZeroRows(input memo.RelExpr) bool {
 	return input.Relational().Cardinality.CanBeZero()
 }
 
+// HasBoundedCardinality returns true if the input expression returns a bounded
+// number of rows.
+func (c *CustomFuncs) HasBoundedCardinality(input memo.RelExpr) bool {
+	return !input.Relational().Cardinality.IsUnbounded()
+}
+
 // ----------------------------------------------------------------------
 //
 // Key functions

--- a/pkg/sql/opt/norm/general_funcs.go
+++ b/pkg/sql/opt/norm/general_funcs.go
@@ -483,6 +483,17 @@ func (c *CustomFuncs) HasBoundedCardinality(input memo.RelExpr) bool {
 	return !input.Relational().Cardinality.IsUnbounded()
 }
 
+// GetLimitFromCardinality returns a ConstExpr equal to the upper bound on the
+// input expression's cardinality. It panics if the expression is unbounded.
+func (c *CustomFuncs) GetLimitFromCardinality(input memo.RelExpr) opt.ScalarExpr {
+	if input.Relational().Cardinality.IsUnbounded() {
+		panic(errors.AssertionFailedf("called GetLimitFromCardinality on unbounded expression"))
+	}
+	return c.f.ConstructConstVal(
+		tree.NewDInt(tree.DInt(input.Relational().Cardinality.Max)), types.Int,
+	)
+}
+
 // ----------------------------------------------------------------------
 //
 // Key functions

--- a/pkg/sql/opt/norm/rules/with.opt
+++ b/pkg/sql/opt/norm/rules/with.opt
@@ -12,3 +12,21 @@
 )
 =>
 (InlineWith $binding $input $withPrivate)
+
+# ApplyLimitToRecursiveCTEScan updates the properties of the recursive with
+# scans in the input of a recursive CTE to reflect a limit that applies to
+# all iterations.
+[ApplyLimitToRecursiveCTEScan, Normalize]
+(RecursiveCTE
+    $binding:* & ^(HasBoundedCardinality $binding)
+    $initial:* & (HasBoundedCardinality $initial)
+    $recursive:* & (HasBoundedCardinality $recursive)
+    $private:*
+)
+=>
+(ApplyLimitToRecursiveCTEScan
+    $binding
+    $initial
+    $recursive
+    $private
+)

--- a/pkg/sql/opt/norm/rules/with.opt
+++ b/pkg/sql/opt/norm/rules/with.opt
@@ -30,3 +30,37 @@
     $recursive
     $private
 )
+
+# TryAddLimitToRecursiveBranch attempts to infer a limit that applies to the
+# (unbounded) recursive branch of the CTE. This is accomplished by taking the
+# upper bound of the initial branch, and checking whether applying that limit
+# to the recursive WithScans would allow the same bound to be inferred for the
+# recursive branch. This is useful because it can allow
+# ApplyLimitToRecursiveCTEScan to fire. See the CanAddRecursiveLimit comment
+# for details on when it is possible to make this transformation.
+#
+# The added limit doesn't need an ordering because it will never actually limit
+# the number of rows returned.
+[TryAddLimitToRecursiveBranch, Normalize]
+(RecursiveCTE
+    $binding:* & ^(HasBoundedCardinality $binding)
+    $initial:* & (HasBoundedCardinality $initial)
+    $recursive:* & ^(HasBoundedCardinality $recursive)
+    $private:* &
+        (CanAddRecursiveLimit
+            $recursive
+            (GetRecursiveWithID $private)
+            (MakeEmptyColSet)
+        )
+)
+=>
+(RecursiveCTE
+    $binding
+    $initial
+    (Limit
+        $recursive
+        (GetLimitFromCardinality $initial)
+        (EmptyOrdering)
+    )
+    $private
+)

--- a/pkg/sql/opt/norm/testdata/rules/with
+++ b/pkg/sql/opt/norm/testdata/rules/with
@@ -1,3 +1,11 @@
+exec-ddl
+CREATE TABLE ints (n BIGINT, INDEX (n));
+----
+
+# --------------------------------------------------
+# InlineWith
+# --------------------------------------------------
+
 build format=show-all
 WITH foo AS (SELECT 1) (SELECT * FROM foo) UNION ALL (SELECT * FROM foo)
 ----
@@ -1052,3 +1060,453 @@ union-all
       │         └── j:12 = 2 [outer=(12), constraints=(/12: [/2 - /2]; tight), fd=()-->(12)]
       └── projections
            └── 1 [as="?column?":18]
+
+# --------------------------------------------------
+# ApplyLimitToRecursiveCTEScan
+# --------------------------------------------------
+
+# Simple iterative case. Note that the limit is not explicit on the anchor
+# branch, but its cardinality is bounded anyway.
+norm expect=ApplyLimitToRecursiveCTEScan
+WITH RECURSIVE cte (i) AS (
+  (SELECT 1)
+  UNION ALL
+  (SELECT i+1 FROM cte WHERE i <= 10 LIMIT 1)
+)
+SELECT i FROM cte;
+----
+project
+ ├── columns: i:5
+ ├── cardinality: [1 - ]
+ ├── immutable
+ ├── recursive-c-t-e
+ │    ├── columns: i:2
+ │    ├── working table binding: &2
+ │    ├── initial columns: "?column?":1
+ │    ├── recursive columns: "?column?":4
+ │    ├── cardinality: [1 - ]
+ │    ├── immutable
+ │    ├── fake-rel
+ │    │    ├── columns: i:2
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    └── fd: ()-->(2)
+ │    ├── values
+ │    │    ├── columns: "?column?":1!null
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1)
+ │    │    └── (1,)
+ │    └── project
+ │         ├── columns: "?column?":4!null
+ │         ├── cardinality: [0 - 1]
+ │         ├── immutable
+ │         ├── key: ()
+ │         ├── fd: ()-->(4)
+ │         ├── select
+ │         │    ├── columns: i:3!null
+ │         │    ├── cardinality: [0 - 1]
+ │         │    ├── key: ()
+ │         │    ├── fd: ()-->(3)
+ │         │    ├── with-scan &2 (cte)
+ │         │    │    ├── columns: i:3
+ │         │    │    ├── mapping:
+ │         │    │    │    └──  i:2 => i:3
+ │         │    │    ├── cardinality: [1 - 1]
+ │         │    │    ├── key: ()
+ │         │    │    └── fd: ()-->(3)
+ │         │    └── filters
+ │         │         └── i:3 <= 10 [outer=(3), constraints=(/3: (/NULL - /10]; tight)]
+ │         └── projections
+ │              └── i:3 + 1 [as="?column?":4, outer=(3), immutable]
+ └── projections
+      └── i:2 [as=i:5, outer=(2)]
+
+# Case with different (but bounded) cardinalities for the anchor and
+# recursive branches. The max cardinality of the two is used for the
+# recursive scan.
+norm expect=ApplyLimitToRecursiveCTEScan
+WITH RECURSIVE cte (i) AS (
+  (SELECT 1)
+  UNION ALL
+  (SELECT i+1 FROM cte WHERE i <= 10 LIMIT 5)
+)
+SELECT i FROM cte;
+----
+project
+ ├── columns: i:5
+ ├── cardinality: [1 - ]
+ ├── immutable
+ ├── recursive-c-t-e
+ │    ├── columns: i:2
+ │    ├── working table binding: &2
+ │    ├── initial columns: "?column?":1
+ │    ├── recursive columns: "?column?":4
+ │    ├── cardinality: [1 - ]
+ │    ├── immutable
+ │    ├── fake-rel
+ │    │    ├── columns: i:2
+ │    │    └── cardinality: [1 - 5]
+ │    ├── values
+ │    │    ├── columns: "?column?":1!null
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1)
+ │    │    └── (1,)
+ │    └── project
+ │         ├── columns: "?column?":4!null
+ │         ├── cardinality: [0 - 5]
+ │         ├── immutable
+ │         ├── select
+ │         │    ├── columns: i:3!null
+ │         │    ├── cardinality: [0 - 5]
+ │         │    ├── with-scan &2 (cte)
+ │         │    │    ├── columns: i:3
+ │         │    │    ├── mapping:
+ │         │    │    │    └──  i:2 => i:3
+ │         │    │    └── cardinality: [1 - 5]
+ │         │    └── filters
+ │         │         └── i:3 <= 10 [outer=(3), constraints=(/3: (/NULL - /10]; tight)]
+ │         └── projections
+ │              └── i:3 + 1 [as="?column?":4, outer=(3), immutable]
+ └── projections
+      └── i:2 [as=i:5, outer=(2)]
+
+# Example from postgres blog with limit added to the recursive branch.
+# https://malisper.me/the-missing-postgres-scan-the-loose-index-scan
+norm expect=ApplyLimitToRecursiveCTEScan
+WITH RECURSIVE temp (i) AS (
+  (SELECT n FROM ints ORDER BY n ASC LIMIT 1)
+UNION ALL (
+  SELECT n FROM temp,
+    LATERAL (
+      SELECT n
+      FROM ints
+      WHERE n > i
+      ORDER BY n ASC
+      LIMIT 1
+    ) sub LIMIT 1
+  )
+)
+SELECT count(*) FROM temp;
+----
+scalar-group-by
+ ├── columns: count:13!null
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(13)
+ ├── recursive-c-t-e
+ │    ├── columns: i:5
+ │    ├── working table binding: &2
+ │    ├── initial columns: n:1
+ │    ├── recursive columns: n:7
+ │    ├── fake-rel
+ │    │    ├── columns: i:5
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    └── fd: ()-->(5)
+ │    ├── limit
+ │    │    ├── columns: n:1
+ │    │    ├── internal-ordering: +1
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1)
+ │    │    ├── sort
+ │    │    │    ├── columns: n:1
+ │    │    │    ├── ordering: +1
+ │    │    │    ├── limit hint: 1.00
+ │    │    │    └── scan ints
+ │    │    │         └── columns: n:1
+ │    │    └── 1
+ │    └── project
+ │         ├── columns: n:7!null
+ │         ├── cardinality: [0 - 1]
+ │         ├── key: ()
+ │         ├── fd: ()-->(7)
+ │         └── limit
+ │              ├── columns: i:6!null n:7!null rownum:11!null
+ │              ├── internal-ordering: +7 opt(6,11)
+ │              ├── cardinality: [0 - 1]
+ │              ├── key: ()
+ │              ├── fd: ()-->(6,7,11)
+ │              ├── sort
+ │              │    ├── columns: i:6!null n:7!null rownum:11!null
+ │              │    ├── fd: ()-->(6,11)
+ │              │    ├── ordering: +7 opt(6,11) [actual: +7]
+ │              │    ├── limit hint: 1.00
+ │              │    └── inner-join (cross)
+ │              │         ├── columns: i:6!null n:7!null rownum:11!null
+ │              │         ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+ │              │         ├── fd: ()-->(6,11)
+ │              │         ├── ordinality
+ │              │         │    ├── columns: i:6 rownum:11!null
+ │              │         │    ├── cardinality: [1 - 1]
+ │              │         │    ├── key: ()
+ │              │         │    ├── fd: ()-->(6,11)
+ │              │         │    └── with-scan &2 (temp)
+ │              │         │         ├── columns: i:6
+ │              │         │         ├── mapping:
+ │              │         │         │    └──  i:5 => i:6
+ │              │         │         ├── cardinality: [1 - 1]
+ │              │         │         ├── key: ()
+ │              │         │         └── fd: ()-->(6)
+ │              │         ├── scan ints
+ │              │         │    └── columns: n:7
+ │              │         └── filters
+ │              │              └── n:7 > i:6 [outer=(6,7), constraints=(/6: (/NULL - ]; /7: (/NULL - ])]
+ │              └── 1
+ └── aggregations
+      └── count-rows [as=count_rows:13]
+
+# No-op because the optimizer cannot prove that the recursive branch has a
+# limit without performing induction from the fact that the anchor branch
+# has one row.
+norm expect-not=ApplyLimitToRecursiveCTEScan
+WITH RECURSIVE cte (i) AS (
+  (SELECT 1)
+  UNION ALL
+  (SELECT i+1 FROM cte WHERE i <= 10)
+)
+SELECT i FROM cte;
+----
+project
+ ├── columns: i:5
+ ├── cardinality: [1 - ]
+ ├── immutable
+ ├── recursive-c-t-e
+ │    ├── columns: i:2
+ │    ├── working table binding: &1
+ │    ├── initial columns: "?column?":1
+ │    ├── recursive columns: "?column?":4
+ │    ├── cardinality: [1 - ]
+ │    ├── immutable
+ │    ├── fake-rel
+ │    │    ├── columns: i:2
+ │    │    └── cardinality: [1 - ]
+ │    ├── values
+ │    │    ├── columns: "?column?":1!null
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1)
+ │    │    └── (1,)
+ │    └── project
+ │         ├── columns: "?column?":4!null
+ │         ├── immutable
+ │         ├── select
+ │         │    ├── columns: i:3!null
+ │         │    ├── with-scan &1 (cte)
+ │         │    │    ├── columns: i:3
+ │         │    │    ├── mapping:
+ │         │    │    │    └──  i:2 => i:3
+ │         │    │    └── cardinality: [1 - ]
+ │         │    └── filters
+ │         │         └── i:3 <= 10 [outer=(3), constraints=(/3: (/NULL - /10]; tight)]
+ │         └── projections
+ │              └── i:3 + 1 [as="?column?":4, outer=(3), immutable]
+ └── projections
+      └── i:2 [as=i:5, outer=(2)]
+
+# No-op for the same reason as above.
+norm expect-not=ApplyLimitToRecursiveCTEScan
+WITH RECURSIVE temp (i) AS (
+  (SELECT n FROM ints ORDER BY n ASC LIMIT 1)
+UNION ALL (
+  SELECT n FROM temp,
+    LATERAL (
+      SELECT n
+      FROM ints
+      WHERE n > i
+      ORDER BY n ASC
+      LIMIT 1
+    ) sub
+  )
+)
+SELECT count(*) FROM temp;
+----
+scalar-group-by
+ ├── columns: count:13!null
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(13)
+ ├── recursive-c-t-e
+ │    ├── columns: i:5
+ │    ├── working table binding: &1
+ │    ├── initial columns: n:1
+ │    ├── recursive columns: n:7
+ │    ├── fake-rel
+ │    │    ├── columns: i:5
+ │    │    └── cardinality: [1 - ]
+ │    ├── limit
+ │    │    ├── columns: n:1
+ │    │    ├── internal-ordering: +1
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1)
+ │    │    ├── sort
+ │    │    │    ├── columns: n:1
+ │    │    │    ├── ordering: +1
+ │    │    │    ├── limit hint: 1.00
+ │    │    │    └── scan ints
+ │    │    │         └── columns: n:1
+ │    │    └── 1
+ │    └── project
+ │         ├── columns: n:7!null
+ │         └── distinct-on
+ │              ├── columns: n:7!null rownum:11!null
+ │              ├── grouping columns: rownum:11!null
+ │              ├── internal-ordering: +7
+ │              ├── key: (11)
+ │              ├── fd: (11)-->(7)
+ │              ├── sort
+ │              │    ├── columns: i:6!null n:7!null rownum:11!null
+ │              │    ├── fd: (11)-->(6)
+ │              │    ├── ordering: +7
+ │              │    └── inner-join (cross)
+ │              │         ├── columns: i:6!null n:7!null rownum:11!null
+ │              │         ├── fd: (11)-->(6)
+ │              │         ├── ordinality
+ │              │         │    ├── columns: i:6 rownum:11!null
+ │              │         │    ├── cardinality: [1 - ]
+ │              │         │    ├── key: (11)
+ │              │         │    ├── fd: (11)-->(6)
+ │              │         │    └── with-scan &1 (temp)
+ │              │         │         ├── columns: i:6
+ │              │         │         ├── mapping:
+ │              │         │         │    └──  i:5 => i:6
+ │              │         │         └── cardinality: [1 - ]
+ │              │         ├── scan ints
+ │              │         │    └── columns: n:7
+ │              │         └── filters
+ │              │              └── n:7 > i:6 [outer=(6,7), constraints=(/6: (/NULL - ]; /7: (/NULL - ])]
+ │              └── aggregations
+ │                   └── first-agg [as=n:7, outer=(7)]
+ │                        └── n:7
+ └── aggregations
+      └── count-rows [as=count_rows:13]
+
+# No-op because the anchor branch is unbounded.
+norm expect-not=ApplyLimitToRecursiveCTEScan
+WITH RECURSIVE cte (i) AS (
+  (SELECT n FROM ints)
+  UNION ALL
+  (SELECT i+1 FROM cte WHERE i <= 10)
+)
+SELECT i FROM cte;
+----
+project
+ ├── columns: i:8
+ ├── immutable
+ ├── recursive-c-t-e
+ │    ├── columns: i:5
+ │    ├── working table binding: &1
+ │    ├── initial columns: n:1
+ │    ├── recursive columns: "?column?":7
+ │    ├── immutable
+ │    ├── fake-rel
+ │    │    ├── columns: i:5
+ │    │    └── cardinality: [1 - ]
+ │    ├── scan ints
+ │    │    └── columns: n:1
+ │    └── project
+ │         ├── columns: "?column?":7!null
+ │         ├── immutable
+ │         ├── select
+ │         │    ├── columns: i:6!null
+ │         │    ├── with-scan &1 (cte)
+ │         │    │    ├── columns: i:6
+ │         │    │    ├── mapping:
+ │         │    │    │    └──  i:5 => i:6
+ │         │    │    └── cardinality: [1 - ]
+ │         │    └── filters
+ │         │         └── i:6 <= 10 [outer=(6), constraints=(/6: (/NULL - /10]; tight)]
+ │         └── projections
+ │              └── i:6 + 1 [as="?column?":7, outer=(6), immutable]
+ └── projections
+      └── i:5 [as=i:8, outer=(5)]
+
+# No-op because the recursive branch is unbounded.
+norm expect-not=ApplyLimitToRecursiveCTEScan
+WITH RECURSIVE cte (i) AS (
+  (SELECT 1)
+  UNION ALL
+  (SELECT n FROM cte INNER JOIN ints ON n > i)
+)
+SELECT i FROM cte;
+----
+project
+ ├── columns: i:8
+ ├── cardinality: [1 - ]
+ ├── recursive-c-t-e
+ │    ├── columns: i:2
+ │    ├── working table binding: &1
+ │    ├── initial columns: "?column?":1
+ │    ├── recursive columns: n:4
+ │    ├── cardinality: [1 - ]
+ │    ├── fake-rel
+ │    │    ├── columns: i:2
+ │    │    └── cardinality: [1 - ]
+ │    ├── values
+ │    │    ├── columns: "?column?":1!null
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1)
+ │    │    └── (1,)
+ │    └── project
+ │         ├── columns: n:4!null
+ │         └── inner-join (cross)
+ │              ├── columns: i:3!null n:4!null
+ │              ├── with-scan &1 (cte)
+ │              │    ├── columns: i:3
+ │              │    ├── mapping:
+ │              │    │    └──  i:2 => i:3
+ │              │    └── cardinality: [1 - ]
+ │              ├── scan ints
+ │              │    └── columns: n:4
+ │              └── filters
+ │                   └── n:4 > i:3 [outer=(3,4), constraints=(/3: (/NULL - ]; /4: (/NULL - ])]
+ └── projections
+      └── i:2 [as=i:8, outer=(2)]
+
+# Case with Union instead of UnionAll.
+norm
+WITH RECURSIVE cte (i) AS (
+  (VALUES (0), (1), (2))
+  UNION
+  (SELECT (i + 1) % 4 FROM cte)
+)
+SELECT * FROM cte
+----
+project
+ ├── columns: i:5
+ ├── cardinality: [3 - ]
+ ├── immutable
+ ├── recursive-c-t-e
+ │    ├── columns: i:2
+ │    ├── deduplicate
+ │    ├── working table binding: &1
+ │    ├── initial columns: column1:1
+ │    ├── recursive columns: "?column?":4
+ │    ├── cardinality: [3 - ]
+ │    ├── immutable
+ │    ├── fake-rel
+ │    │    ├── columns: i:2
+ │    │    └── cardinality: [1 - ]
+ │    ├── values
+ │    │    ├── columns: column1:1!null
+ │    │    ├── cardinality: [3 - 3]
+ │    │    ├── (0,)
+ │    │    ├── (1,)
+ │    │    └── (2,)
+ │    └── project
+ │         ├── columns: "?column?":4
+ │         ├── cardinality: [1 - ]
+ │         ├── immutable
+ │         ├── with-scan &1 (cte)
+ │         │    ├── columns: i:3
+ │         │    ├── mapping:
+ │         │    │    └──  i:2 => i:3
+ │         │    └── cardinality: [1 - ]
+ │         └── projections
+ │              └── (i:3 + 1) % 4 [as="?column?":4, outer=(3), immutable]
+ └── projections
+      └── i:2 [as=i:5, outer=(2)]

--- a/pkg/sql/opt/norm/testdata/rules/with
+++ b/pkg/sql/opt/norm/testdata/rules/with
@@ -2,6 +2,10 @@ exec-ddl
 CREATE TABLE ints (n BIGINT, INDEX (n));
 ----
 
+exec-ddl
+CREATE TABLE xy (x INT PRIMARY KEY, y INT);
+----
+
 # --------------------------------------------------
 # InlineWith
 # --------------------------------------------------
@@ -783,7 +787,7 @@ union-all
 norm expect-not=InlineWith
 WITH RECURSIVE t(n) AS MATERIALIZED (VALUES (1) UNION ALL SELECT n+1 FROM t WHERE n < 100 ) SELECT sum(n) FROM t;
 ----
-with &2 (t)
+with &3 (t)
  ├── columns: sum:6
  ├── materialized
  ├── cardinality: [1 - 1]
@@ -792,14 +796,16 @@ with &2 (t)
  ├── fd: ()-->(6)
  ├── recursive-c-t-e
  │    ├── columns: n:2
- │    ├── working table binding: &1
+ │    ├── working table binding: &2
  │    ├── initial columns: column1:1
  │    ├── recursive columns: "?column?":4
  │    ├── cardinality: [1 - ]
  │    ├── immutable
  │    ├── fake-rel
  │    │    ├── columns: n:2
- │    │    └── cardinality: [1 - ]
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    └── fd: ()-->(2)
  │    ├── values
  │    │    ├── columns: column1:1!null
  │    │    ├── cardinality: [1 - 1]
@@ -808,14 +814,22 @@ with &2 (t)
  │    │    └── (1,)
  │    └── project
  │         ├── columns: "?column?":4!null
+ │         ├── cardinality: [0 - 1]
  │         ├── immutable
+ │         ├── key: ()
+ │         ├── fd: ()-->(4)
  │         ├── select
  │         │    ├── columns: n:3!null
- │         │    ├── with-scan &1 (t)
+ │         │    ├── cardinality: [0 - 1]
+ │         │    ├── key: ()
+ │         │    ├── fd: ()-->(3)
+ │         │    ├── with-scan &2 (t)
  │         │    │    ├── columns: n:3
  │         │    │    ├── mapping:
  │         │    │    │    └──  n:2 => n:3
- │         │    │    └── cardinality: [1 - ]
+ │         │    │    ├── cardinality: [1 - 1]
+ │         │    │    ├── key: ()
+ │         │    │    └── fd: ()-->(3)
  │         │    └── filters
  │         │         └── n:3 < 100 [outer=(3), constraints=(/3: (/NULL - /99]; tight)]
  │         └── projections
@@ -825,7 +839,7 @@ with &2 (t)
       ├── cardinality: [1 - 1]
       ├── key: ()
       ├── fd: ()-->(6)
-      ├── with-scan &2 (t)
+      ├── with-scan &3 (t)
       │    ├── columns: n:5
       │    ├── mapping:
       │    │    └──  n:2 => n:5
@@ -850,14 +864,16 @@ scalar-group-by
  │    ├── immutable
  │    ├── recursive-c-t-e
  │    │    ├── columns: n:2
- │    │    ├── working table binding: &1
+ │    │    ├── working table binding: &2
  │    │    ├── initial columns: column1:1
  │    │    ├── recursive columns: "?column?":4
  │    │    ├── cardinality: [1 - ]
  │    │    ├── immutable
  │    │    ├── fake-rel
  │    │    │    ├── columns: n:2
- │    │    │    └── cardinality: [1 - ]
+ │    │    │    ├── cardinality: [1 - 1]
+ │    │    │    ├── key: ()
+ │    │    │    └── fd: ()-->(2)
  │    │    ├── values
  │    │    │    ├── columns: column1:1!null
  │    │    │    ├── cardinality: [1 - 1]
@@ -866,14 +882,22 @@ scalar-group-by
  │    │    │    └── (1,)
  │    │    └── project
  │    │         ├── columns: "?column?":4!null
+ │    │         ├── cardinality: [0 - 1]
  │    │         ├── immutable
+ │    │         ├── key: ()
+ │    │         ├── fd: ()-->(4)
  │    │         ├── select
  │    │         │    ├── columns: n:3!null
- │    │         │    ├── with-scan &1 (t)
+ │    │         │    ├── cardinality: [0 - 1]
+ │    │         │    ├── key: ()
+ │    │         │    ├── fd: ()-->(3)
+ │    │         │    ├── with-scan &2 (t)
  │    │         │    │    ├── columns: n:3
  │    │         │    │    ├── mapping:
  │    │         │    │    │    └──  n:2 => n:3
- │    │         │    │    └── cardinality: [1 - ]
+ │    │         │    │    ├── cardinality: [1 - 1]
+ │    │         │    │    ├── key: ()
+ │    │         │    │    └── fd: ()-->(3)
  │    │         │    └── filters
  │    │         │         └── n:3 < 100 [outer=(3), constraints=(/3: (/NULL - /99]; tight)]
  │    │         └── projections
@@ -1067,7 +1091,7 @@ union-all
 
 # Simple iterative case. Note that the limit is not explicit on the anchor
 # branch, but its cardinality is bounded anyway.
-norm expect=ApplyLimitToRecursiveCTEScan
+norm expect=ApplyLimitToRecursiveCTEScan expect-not=TryAddLimitToRecursiveBranch
 WITH RECURSIVE cte (i) AS (
   (SELECT 1)
   UNION ALL
@@ -1125,7 +1149,7 @@ project
 # Case with different (but bounded) cardinalities for the anchor and
 # recursive branches. The max cardinality of the two is used for the
 # recursive scan.
-norm expect=ApplyLimitToRecursiveCTEScan
+norm expect=ApplyLimitToRecursiveCTEScan expect-not=TryAddLimitToRecursiveBranch
 WITH RECURSIVE cte (i) AS (
   (SELECT 1)
   UNION ALL
@@ -1174,7 +1198,7 @@ project
 
 # Example from postgres blog with limit added to the recursive branch.
 # https://malisper.me/the-missing-postgres-scan-the-loose-index-scan
-norm expect=ApplyLimitToRecursiveCTEScan
+norm expect=ApplyLimitToRecursiveCTEScan expect-not=TryAddLimitToRecursiveBranch
 WITH RECURSIVE temp (i) AS (
   (SELECT n FROM ints ORDER BY n ASC LIMIT 1)
 UNION ALL (
@@ -1260,8 +1284,8 @@ scalar-group-by
 
 # No-op because the optimizer cannot prove that the recursive branch has a
 # limit without performing induction from the fact that the anchor branch
-# has one row.
-norm expect-not=ApplyLimitToRecursiveCTEScan
+# has one row. TryAddLimitToRecursiveBranch is disabled to exercise the case.
+norm expect-not=ApplyLimitToRecursiveCTEScan disable=TryAddLimitToRecursiveBranch
 WITH RECURSIVE cte (i) AS (
   (SELECT 1)
   UNION ALL
@@ -1307,7 +1331,7 @@ project
       └── i:2 [as=i:5, outer=(2)]
 
 # No-op for the same reason as above.
-norm expect-not=ApplyLimitToRecursiveCTEScan
+norm expect-not=ApplyLimitToRecursiveCTEScan disable=TryAddLimitToRecursiveBranch
 WITH RECURSIVE temp (i) AS (
   (SELECT n FROM ints ORDER BY n ASC LIMIT 1)
 UNION ALL (
@@ -1385,7 +1409,7 @@ scalar-group-by
       └── count-rows [as=count_rows:13]
 
 # No-op because the anchor branch is unbounded.
-norm expect-not=ApplyLimitToRecursiveCTEScan
+norm expect-not=ApplyLimitToRecursiveCTEScan expect-not=TryAddLimitToRecursiveBranch
 WITH RECURSIVE cte (i) AS (
   (SELECT n FROM ints)
   UNION ALL
@@ -1425,7 +1449,7 @@ project
       └── i:5 [as=i:8, outer=(5)]
 
 # No-op because the recursive branch is unbounded.
-norm expect-not=ApplyLimitToRecursiveCTEScan
+norm expect-not=ApplyLimitToRecursiveCTEScan expect-not=TryAddLimitToRecursiveBranch
 WITH RECURSIVE cte (i) AS (
   (SELECT 1)
   UNION ALL
@@ -1483,14 +1507,14 @@ project
  ├── recursive-c-t-e
  │    ├── columns: i:2
  │    ├── deduplicate
- │    ├── working table binding: &1
+ │    ├── working table binding: &2
  │    ├── initial columns: column1:1
  │    ├── recursive columns: "?column?":4
  │    ├── cardinality: [3 - ]
  │    ├── immutable
  │    ├── fake-rel
  │    │    ├── columns: i:2
- │    │    └── cardinality: [1 - ]
+ │    │    └── cardinality: [1 - 3]
  │    ├── values
  │    │    ├── columns: column1:1!null
  │    │    ├── cardinality: [3 - 3]
@@ -1499,14 +1523,1382 @@ project
  │    │    └── (2,)
  │    └── project
  │         ├── columns: "?column?":4
- │         ├── cardinality: [1 - ]
+ │         ├── cardinality: [1 - 3]
  │         ├── immutable
- │         ├── with-scan &1 (cte)
+ │         ├── with-scan &2 (cte)
  │         │    ├── columns: i:3
  │         │    ├── mapping:
  │         │    │    └──  i:2 => i:3
- │         │    └── cardinality: [1 - ]
+ │         │    └── cardinality: [1 - 3]
  │         └── projections
  │              └── (i:3 + 1) % 4 [as="?column?":4, outer=(3), immutable]
+ └── projections
+      └── i:2 [as=i:5, outer=(2)]
+
+# --------------------------------------------------
+# TryAddLimitToRecursiveBranch
+# --------------------------------------------------
+
+# Example from postgres blog (no changes made).
+# https://malisper.me/the-missing-postgres-scan-the-loose-index-scan
+norm expect=TryAddLimitToRecursiveBranch
+WITH RECURSIVE temp (i) AS (
+  (SELECT n FROM ints ORDER BY n ASC LIMIT 1)
+UNION ALL (
+  SELECT n FROM temp,
+    LATERAL (
+      SELECT n
+      FROM ints
+      WHERE n > i
+      ORDER BY n ASC
+      LIMIT 1
+    ) sub
+  )
+)
+SELECT count(*) FROM temp;
+----
+scalar-group-by
+ ├── columns: count:13!null
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(13)
+ ├── recursive-c-t-e
+ │    ├── columns: i:5
+ │    ├── working table binding: &2
+ │    ├── initial columns: n:1
+ │    ├── recursive columns: n:7
+ │    ├── fake-rel
+ │    │    ├── columns: i:5
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    └── fd: ()-->(5)
+ │    ├── limit
+ │    │    ├── columns: n:1
+ │    │    ├── internal-ordering: +1
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1)
+ │    │    ├── sort
+ │    │    │    ├── columns: n:1
+ │    │    │    ├── ordering: +1
+ │    │    │    ├── limit hint: 1.00
+ │    │    │    └── scan ints
+ │    │    │         └── columns: n:1
+ │    │    └── 1
+ │    └── project
+ │         ├── columns: n:7!null
+ │         ├── cardinality: [0 - 1]
+ │         ├── key: ()
+ │         ├── fd: ()-->(7)
+ │         └── limit
+ │              ├── columns: i:6!null n:7!null rownum:11!null
+ │              ├── internal-ordering: +7 opt(6,11)
+ │              ├── cardinality: [0 - 1]
+ │              ├── key: ()
+ │              ├── fd: ()-->(6,7,11)
+ │              ├── sort
+ │              │    ├── columns: i:6!null n:7!null rownum:11!null
+ │              │    ├── fd: ()-->(6,11)
+ │              │    ├── ordering: +7 opt(6,11) [actual: +7]
+ │              │    ├── limit hint: 1.00
+ │              │    └── inner-join (cross)
+ │              │         ├── columns: i:6!null n:7!null rownum:11!null
+ │              │         ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+ │              │         ├── fd: ()-->(6,11)
+ │              │         ├── ordinality
+ │              │         │    ├── columns: i:6 rownum:11!null
+ │              │         │    ├── cardinality: [1 - 1]
+ │              │         │    ├── key: ()
+ │              │         │    ├── fd: ()-->(6,11)
+ │              │         │    └── with-scan &2 (temp)
+ │              │         │         ├── columns: i:6
+ │              │         │         ├── mapping:
+ │              │         │         │    └──  i:5 => i:6
+ │              │         │         ├── cardinality: [1 - 1]
+ │              │         │         ├── key: ()
+ │              │         │         └── fd: ()-->(6)
+ │              │         ├── scan ints
+ │              │         │    └── columns: n:7
+ │              │         └── filters
+ │              │              └── n:7 > i:6 [outer=(6,7), constraints=(/6: (/NULL - ]; /7: (/NULL - ])]
+ │              └── 1
+ └── aggregations
+      └── count-rows [as=count_rows:13]
+
+# Simple case with a Project and Select.
+norm expect=TryAddLimitToRecursiveBranch
+WITH RECURSIVE cte (i) AS (
+  (SELECT 1)
+  UNION ALL
+  (SELECT i+1 FROM cte WHERE i <= 10)
+)
+SELECT i FROM cte;
+----
+project
+ ├── columns: i:5
+ ├── cardinality: [1 - ]
+ ├── immutable
+ ├── recursive-c-t-e
+ │    ├── columns: i:2
+ │    ├── working table binding: &2
+ │    ├── initial columns: "?column?":1
+ │    ├── recursive columns: "?column?":4
+ │    ├── cardinality: [1 - ]
+ │    ├── immutable
+ │    ├── fake-rel
+ │    │    ├── columns: i:2
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    └── fd: ()-->(2)
+ │    ├── values
+ │    │    ├── columns: "?column?":1!null
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1)
+ │    │    └── (1,)
+ │    └── project
+ │         ├── columns: "?column?":4!null
+ │         ├── cardinality: [0 - 1]
+ │         ├── immutable
+ │         ├── key: ()
+ │         ├── fd: ()-->(4)
+ │         ├── select
+ │         │    ├── columns: i:3!null
+ │         │    ├── cardinality: [0 - 1]
+ │         │    ├── key: ()
+ │         │    ├── fd: ()-->(3)
+ │         │    ├── with-scan &2 (cte)
+ │         │    │    ├── columns: i:3
+ │         │    │    ├── mapping:
+ │         │    │    │    └──  i:2 => i:3
+ │         │    │    ├── cardinality: [1 - 1]
+ │         │    │    ├── key: ()
+ │         │    │    └── fd: ()-->(3)
+ │         │    └── filters
+ │         │         └── i:3 <= 10 [outer=(3), constraints=(/3: (/NULL - /10]; tight)]
+ │         └── projections
+ │              └── i:3 + 1 [as="?column?":4, outer=(3), immutable]
+ └── projections
+      └── i:2 [as=i:5, outer=(2)]
+
+# Case with an ordinality operator.
+norm expect=TryAddLimitToRecursiveBranch
+WITH RECURSIVE cte (i, j) AS (
+  (SELECT 1, 2)
+  UNION ALL
+  (SELECT i+1, ordinality FROM (SELECT i FROM cte WHERE i <= 10) WITH ORDINALITY)
+)
+SELECT i, j FROM cte;
+----
+project
+ ├── columns: i:9 j:10
+ ├── cardinality: [1 - ]
+ ├── immutable
+ ├── recursive-c-t-e
+ │    ├── columns: i:3 j:4
+ │    ├── working table binding: &2
+ │    ├── initial columns: "?column?":1 "?column?":2
+ │    ├── recursive columns: "?column?":8 ordinality:7
+ │    ├── cardinality: [1 - ]
+ │    ├── immutable
+ │    ├── fake-rel
+ │    │    ├── columns: i:3 j:4
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    └── fd: ()-->(3,4)
+ │    ├── values
+ │    │    ├── columns: "?column?":1!null "?column?":2!null
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1,2)
+ │    │    └── (1, 2)
+ │    └── project
+ │         ├── columns: "?column?":8!null ordinality:7!null
+ │         ├── cardinality: [0 - 1]
+ │         ├── immutable
+ │         ├── key: ()
+ │         ├── fd: ()-->(7,8)
+ │         ├── ordinality
+ │         │    ├── columns: i:5!null ordinality:7!null
+ │         │    ├── cardinality: [0 - 1]
+ │         │    ├── key: ()
+ │         │    ├── fd: ()-->(5,7)
+ │         │    └── select
+ │         │         ├── columns: i:5!null
+ │         │         ├── cardinality: [0 - 1]
+ │         │         ├── key: ()
+ │         │         ├── fd: ()-->(5)
+ │         │         ├── with-scan &2 (cte)
+ │         │         │    ├── columns: i:5
+ │         │         │    ├── mapping:
+ │         │         │    │    └──  i:3 => i:5
+ │         │         │    ├── cardinality: [1 - 1]
+ │         │         │    ├── key: ()
+ │         │         │    └── fd: ()-->(5)
+ │         │         └── filters
+ │         │              └── i:5 <= 10 [outer=(5), constraints=(/5: (/NULL - /10]; tight)]
+ │         └── projections
+ │              └── i:5 + 1 [as="?column?":8, outer=(5), immutable]
+ └── projections
+      ├── i:3 [as=i:9, outer=(3)]
+      └── j:4 [as=j:10, outer=(4)]
+
+# Case with a window function.
+norm expect=TryAddLimitToRecursiveBranch
+WITH RECURSIVE cte (i, j) AS (
+  (SELECT 1, 2)
+  UNION ALL
+  (SELECT i+1, sum(i) OVER (ORDER BY j) FROM cte WHERE i <= 10)
+)
+SELECT i, j FROM cte;
+----
+project
+ ├── columns: i:10 j:11
+ ├── cardinality: [1 - ]
+ ├── immutable
+ ├── recursive-c-t-e
+ │    ├── columns: i:3 j:4
+ │    ├── working table binding: &2
+ │    ├── initial columns: "?column?":1 "?column?":9
+ │    ├── recursive columns: "?column?":8 sum:7
+ │    ├── cardinality: [1 - ]
+ │    ├── immutable
+ │    ├── fake-rel
+ │    │    ├── columns: i:3 j:4
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    └── fd: ()-->(3,4)
+ │    ├── values
+ │    │    ├── columns: "?column?":1!null "?column?":9!null
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1,9)
+ │    │    └── (1, 2)
+ │    └── project
+ │         ├── columns: "?column?":8!null sum:7
+ │         ├── cardinality: [0 - 1]
+ │         ├── immutable
+ │         ├── key: ()
+ │         ├── fd: ()-->(7,8)
+ │         ├── window partition=()
+ │         │    ├── columns: i:5!null sum:7
+ │         │    ├── cardinality: [0 - 1]
+ │         │    ├── key: ()
+ │         │    ├── fd: ()-->(5)
+ │         │    ├── select
+ │         │    │    ├── columns: i:5!null
+ │         │    │    ├── cardinality: [0 - 1]
+ │         │    │    ├── key: ()
+ │         │    │    ├── fd: ()-->(5)
+ │         │    │    ├── with-scan &2 (cte)
+ │         │    │    │    ├── columns: i:5
+ │         │    │    │    ├── mapping:
+ │         │    │    │    │    └──  i:3 => i:5
+ │         │    │    │    ├── cardinality: [1 - 1]
+ │         │    │    │    ├── key: ()
+ │         │    │    │    └── fd: ()-->(5)
+ │         │    │    └── filters
+ │         │    │         └── i:5 <= 10 [outer=(5), constraints=(/5: (/NULL - /10]; tight)]
+ │         │    └── windows
+ │         │         └── sum [as=sum:7, outer=(5)]
+ │         │              └── i:5
+ │         └── projections
+ │              └── i:5 + 1 [as="?column?":8, outer=(5), immutable]
+ └── projections
+      ├── i:3 [as=i:10, outer=(3)]
+      └── j:4 [as=j:11, outer=(4)]
+
+# Case with DistinctOn.
+norm expect=TryAddLimitToRecursiveBranch
+WITH RECURSIVE cte (i) AS (
+  (SELECT 1)
+  UNION ALL
+  (SELECT DISTINCT i+1 FROM cte WHERE i <= 10)
+)
+SELECT i FROM cte;
+----
+project
+ ├── columns: i:5
+ ├── cardinality: [1 - ]
+ ├── immutable
+ ├── recursive-c-t-e
+ │    ├── columns: i:2
+ │    ├── working table binding: &2
+ │    ├── initial columns: "?column?":1
+ │    ├── recursive columns: "?column?":4
+ │    ├── cardinality: [1 - ]
+ │    ├── immutable
+ │    ├── fake-rel
+ │    │    ├── columns: i:2
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    └── fd: ()-->(2)
+ │    ├── values
+ │    │    ├── columns: "?column?":1!null
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1)
+ │    │    └── (1,)
+ │    └── project
+ │         ├── columns: "?column?":4!null
+ │         ├── cardinality: [0 - 1]
+ │         ├── immutable
+ │         ├── key: ()
+ │         ├── fd: ()-->(4)
+ │         ├── select
+ │         │    ├── columns: i:3!null
+ │         │    ├── cardinality: [0 - 1]
+ │         │    ├── key: ()
+ │         │    ├── fd: ()-->(3)
+ │         │    ├── with-scan &2 (cte)
+ │         │    │    ├── columns: i:3
+ │         │    │    ├── mapping:
+ │         │    │    │    └──  i:2 => i:3
+ │         │    │    ├── cardinality: [1 - 1]
+ │         │    │    ├── key: ()
+ │         │    │    └── fd: ()-->(3)
+ │         │    └── filters
+ │         │         └── i:3 <= 10 [outer=(3), constraints=(/3: (/NULL - /10]; tight)]
+ │         └── projections
+ │              └── i:3 + 1 [as="?column?":4, outer=(3), immutable]
+ └── projections
+      └── i:2 [as=i:5, outer=(2)]
+
+# Case with GroupBy.
+norm expect=TryAddLimitToRecursiveBranch
+WITH RECURSIVE cte (i, j) AS (
+  (SELECT 1, 2)
+  UNION ALL
+  (SELECT i+1, sum(j) FROM cte WHERE i <= 10 GROUP BY i)
+)
+SELECT i, j FROM cte;
+----
+project
+ ├── columns: i:10 j:11
+ ├── cardinality: [1 - ]
+ ├── immutable
+ ├── recursive-c-t-e
+ │    ├── columns: i:3 j:4
+ │    ├── working table binding: &2
+ │    ├── initial columns: "?column?":1 "?column?":9
+ │    ├── recursive columns: "?column?":8 sum:7
+ │    ├── cardinality: [1 - ]
+ │    ├── immutable
+ │    ├── fake-rel
+ │    │    ├── columns: i:3 j:4
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    └── fd: ()-->(3,4)
+ │    ├── values
+ │    │    ├── columns: "?column?":1!null "?column?":9!null
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1,9)
+ │    │    └── (1, 2)
+ │    └── project
+ │         ├── columns: "?column?":8!null sum:7
+ │         ├── cardinality: [0 - 1]
+ │         ├── immutable
+ │         ├── key: ()
+ │         ├── fd: ()-->(7,8)
+ │         ├── group-by (streaming)
+ │         │    ├── columns: i:5!null sum:7
+ │         │    ├── cardinality: [0 - 1]
+ │         │    ├── key: ()
+ │         │    ├── fd: ()-->(5,7)
+ │         │    ├── select
+ │         │    │    ├── columns: i:5!null j:6
+ │         │    │    ├── cardinality: [0 - 1]
+ │         │    │    ├── key: ()
+ │         │    │    ├── fd: ()-->(5,6)
+ │         │    │    ├── with-scan &2 (cte)
+ │         │    │    │    ├── columns: i:5 j:6
+ │         │    │    │    ├── mapping:
+ │         │    │    │    │    ├──  i:3 => i:5
+ │         │    │    │    │    └──  j:4 => j:6
+ │         │    │    │    ├── cardinality: [1 - 1]
+ │         │    │    │    ├── key: ()
+ │         │    │    │    └── fd: ()-->(5,6)
+ │         │    │    └── filters
+ │         │    │         └── i:5 <= 10 [outer=(5), constraints=(/5: (/NULL - /10]; tight)]
+ │         │    └── aggregations
+ │         │         ├── sum [as=sum:7, outer=(6)]
+ │         │         │    └── j:6
+ │         │         └── const-agg [as=i:5, outer=(5)]
+ │         │              └── i:5
+ │         └── projections
+ │              └── i:5 + 1 [as="?column?":8, outer=(5), immutable]
+ └── projections
+      ├── i:3 [as=i:10, outer=(3)]
+      └── j:4 [as=j:11, outer=(4)]
+
+# Case with InnerJoin.
+norm expect=TryAddLimitToRecursiveBranch
+WITH RECURSIVE cte (i, j) AS (
+  (SELECT 1, 2)
+  UNION ALL
+  (SELECT i+1, y FROM cte INNER JOIN xy ON j = x WHERE i <= 10)
+)
+SELECT i, j FROM cte;
+----
+project
+ ├── columns: i:12 j:13
+ ├── cardinality: [1 - ]
+ ├── immutable
+ ├── recursive-c-t-e
+ │    ├── columns: i:3 j:4
+ │    ├── working table binding: &2
+ │    ├── initial columns: "?column?":1 "?column?":2
+ │    ├── recursive columns: "?column?":11 y:8
+ │    ├── cardinality: [1 - ]
+ │    ├── immutable
+ │    ├── fake-rel
+ │    │    ├── columns: i:3 j:4
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    └── fd: ()-->(3,4)
+ │    ├── values
+ │    │    ├── columns: "?column?":1!null "?column?":2!null
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1,2)
+ │    │    └── (1, 2)
+ │    └── project
+ │         ├── columns: "?column?":11!null y:8
+ │         ├── cardinality: [0 - 1]
+ │         ├── immutable
+ │         ├── key: ()
+ │         ├── fd: ()-->(8,11)
+ │         ├── inner-join (hash)
+ │         │    ├── columns: i:5!null j:6!null x:7!null y:8
+ │         │    ├── cardinality: [0 - 1]
+ │         │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+ │         │    ├── key: ()
+ │         │    ├── fd: ()-->(5-8), (7)==(6), (6)==(7)
+ │         │    ├── select
+ │         │    │    ├── columns: i:5!null j:6
+ │         │    │    ├── cardinality: [0 - 1]
+ │         │    │    ├── key: ()
+ │         │    │    ├── fd: ()-->(5,6)
+ │         │    │    ├── with-scan &2 (cte)
+ │         │    │    │    ├── columns: i:5 j:6
+ │         │    │    │    ├── mapping:
+ │         │    │    │    │    ├──  i:3 => i:5
+ │         │    │    │    │    └──  j:4 => j:6
+ │         │    │    │    ├── cardinality: [1 - 1]
+ │         │    │    │    ├── key: ()
+ │         │    │    │    └── fd: ()-->(5,6)
+ │         │    │    └── filters
+ │         │    │         └── i:5 <= 10 [outer=(5), constraints=(/5: (/NULL - /10]; tight)]
+ │         │    ├── scan xy
+ │         │    │    ├── columns: x:7!null y:8
+ │         │    │    ├── key: (7)
+ │         │    │    └── fd: (7)-->(8)
+ │         │    └── filters
+ │         │         └── j:6 = x:7 [outer=(6,7), constraints=(/6: (/NULL - ]; /7: (/NULL - ]), fd=(6)==(7), (7)==(6)]
+ │         └── projections
+ │              └── i:5 + 1 [as="?column?":11, outer=(5), immutable]
+ └── projections
+      ├── i:3 [as=i:12, outer=(3)]
+      └── j:4 [as=j:13, outer=(4)]
+
+# Case with LeftJoin.
+norm expect=TryAddLimitToRecursiveBranch
+WITH RECURSIVE cte (i, j) AS (
+  (SELECT 1, 2)
+  UNION ALL
+  (SELECT i+1, y FROM cte LEFT JOIN xy ON j = x WHERE i <= 10)
+)
+SELECT i, j FROM cte;
+----
+project
+ ├── columns: i:12 j:13
+ ├── cardinality: [1 - ]
+ ├── immutable
+ ├── recursive-c-t-e
+ │    ├── columns: i:3 j:4
+ │    ├── working table binding: &2
+ │    ├── initial columns: "?column?":1 "?column?":2
+ │    ├── recursive columns: "?column?":11 y:8
+ │    ├── cardinality: [1 - ]
+ │    ├── immutable
+ │    ├── fake-rel
+ │    │    ├── columns: i:3 j:4
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    └── fd: ()-->(3,4)
+ │    ├── values
+ │    │    ├── columns: "?column?":1!null "?column?":2!null
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1,2)
+ │    │    └── (1, 2)
+ │    └── project
+ │         ├── columns: "?column?":11!null y:8
+ │         ├── cardinality: [0 - 1]
+ │         ├── immutable
+ │         ├── key: ()
+ │         ├── fd: ()-->(8,11)
+ │         ├── left-join (hash)
+ │         │    ├── columns: i:5!null j:6 x:7 y:8
+ │         │    ├── cardinality: [0 - 1]
+ │         │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+ │         │    ├── key: ()
+ │         │    ├── fd: ()-->(5-8)
+ │         │    ├── select
+ │         │    │    ├── columns: i:5!null j:6
+ │         │    │    ├── cardinality: [0 - 1]
+ │         │    │    ├── key: ()
+ │         │    │    ├── fd: ()-->(5,6)
+ │         │    │    ├── with-scan &2 (cte)
+ │         │    │    │    ├── columns: i:5 j:6
+ │         │    │    │    ├── mapping:
+ │         │    │    │    │    ├──  i:3 => i:5
+ │         │    │    │    │    └──  j:4 => j:6
+ │         │    │    │    ├── cardinality: [1 - 1]
+ │         │    │    │    ├── key: ()
+ │         │    │    │    └── fd: ()-->(5,6)
+ │         │    │    └── filters
+ │         │    │         └── i:5 <= 10 [outer=(5), constraints=(/5: (/NULL - /10]; tight)]
+ │         │    ├── scan xy
+ │         │    │    ├── columns: x:7!null y:8
+ │         │    │    ├── key: (7)
+ │         │    │    └── fd: (7)-->(8)
+ │         │    └── filters
+ │         │         └── j:6 = x:7 [outer=(6,7), constraints=(/6: (/NULL - ]; /7: (/NULL - ]), fd=(6)==(7), (7)==(6)]
+ │         └── projections
+ │              └── i:5 + 1 [as="?column?":11, outer=(5), immutable]
+ └── projections
+      ├── i:3 [as=i:12, outer=(3)]
+      └── j:4 [as=j:13, outer=(4)]
+
+# Case with SemiJoin.
+norm expect=TryAddLimitToRecursiveBranch
+WITH RECURSIVE cte (i) AS (
+  (SELECT 1)
+  UNION ALL
+  (SELECT i+1 FROM cte WHERE i <= 10 AND EXISTS (SELECT * FROM xy WHERE i = x))
+)
+SELECT i FROM cte;
+----
+project
+ ├── columns: i:9
+ ├── cardinality: [1 - ]
+ ├── immutable
+ ├── recursive-c-t-e
+ │    ├── columns: i:2
+ │    ├── working table binding: &2
+ │    ├── initial columns: "?column?":1
+ │    ├── recursive columns: "?column?":8
+ │    ├── cardinality: [1 - ]
+ │    ├── immutable
+ │    ├── fake-rel
+ │    │    ├── columns: i:2
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    └── fd: ()-->(2)
+ │    ├── values
+ │    │    ├── columns: "?column?":1!null
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1)
+ │    │    └── (1,)
+ │    └── project
+ │         ├── columns: "?column?":8!null
+ │         ├── cardinality: [0 - 1]
+ │         ├── immutable
+ │         ├── key: ()
+ │         ├── fd: ()-->(8)
+ │         ├── semi-join (hash)
+ │         │    ├── columns: i:3!null
+ │         │    ├── cardinality: [0 - 1]
+ │         │    ├── key: ()
+ │         │    ├── fd: ()-->(3)
+ │         │    ├── select
+ │         │    │    ├── columns: i:3!null
+ │         │    │    ├── cardinality: [0 - 1]
+ │         │    │    ├── key: ()
+ │         │    │    ├── fd: ()-->(3)
+ │         │    │    ├── with-scan &2 (cte)
+ │         │    │    │    ├── columns: i:3
+ │         │    │    │    ├── mapping:
+ │         │    │    │    │    └──  i:2 => i:3
+ │         │    │    │    ├── cardinality: [1 - 1]
+ │         │    │    │    ├── key: ()
+ │         │    │    │    └── fd: ()-->(3)
+ │         │    │    └── filters
+ │         │    │         └── i:3 <= 10 [outer=(3), constraints=(/3: (/NULL - /10]; tight)]
+ │         │    ├── select
+ │         │    │    ├── columns: x:4!null
+ │         │    │    ├── key: (4)
+ │         │    │    ├── scan xy
+ │         │    │    │    ├── columns: x:4!null
+ │         │    │    │    └── key: (4)
+ │         │    │    └── filters
+ │         │    │         └── x:4 <= 10 [outer=(4), constraints=(/4: (/NULL - /10]; tight)]
+ │         │    └── filters
+ │         │         └── i:3 = x:4 [outer=(3,4), constraints=(/3: (/NULL - ]; /4: (/NULL - ]), fd=(3)==(4), (4)==(3)]
+ │         └── projections
+ │              └── i:3 + 1 [as="?column?":8, outer=(3), immutable]
+ └── projections
+      └── i:2 [as=i:9, outer=(2)]
+
+# Case with AntiJoin.
+norm expect=TryAddLimitToRecursiveBranch
+WITH RECURSIVE cte (i) AS (
+  (SELECT 1)
+  UNION ALL
+  (SELECT i+1 FROM cte WHERE i <= 10 AND NOT EXISTS (SELECT * FROM xy WHERE i = x))
+)
+SELECT i FROM cte;
+----
+project
+ ├── columns: i:9
+ ├── cardinality: [1 - ]
+ ├── immutable
+ ├── recursive-c-t-e
+ │    ├── columns: i:2
+ │    ├── working table binding: &2
+ │    ├── initial columns: "?column?":1
+ │    ├── recursive columns: "?column?":8
+ │    ├── cardinality: [1 - ]
+ │    ├── immutable
+ │    ├── fake-rel
+ │    │    ├── columns: i:2
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    └── fd: ()-->(2)
+ │    ├── values
+ │    │    ├── columns: "?column?":1!null
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1)
+ │    │    └── (1,)
+ │    └── project
+ │         ├── columns: "?column?":8!null
+ │         ├── cardinality: [0 - 1]
+ │         ├── immutable
+ │         ├── key: ()
+ │         ├── fd: ()-->(8)
+ │         ├── anti-join (hash)
+ │         │    ├── columns: i:3!null
+ │         │    ├── cardinality: [0 - 1]
+ │         │    ├── key: ()
+ │         │    ├── fd: ()-->(3)
+ │         │    ├── select
+ │         │    │    ├── columns: i:3!null
+ │         │    │    ├── cardinality: [0 - 1]
+ │         │    │    ├── key: ()
+ │         │    │    ├── fd: ()-->(3)
+ │         │    │    ├── with-scan &2 (cte)
+ │         │    │    │    ├── columns: i:3
+ │         │    │    │    ├── mapping:
+ │         │    │    │    │    └──  i:2 => i:3
+ │         │    │    │    ├── cardinality: [1 - 1]
+ │         │    │    │    ├── key: ()
+ │         │    │    │    └── fd: ()-->(3)
+ │         │    │    └── filters
+ │         │    │         └── i:3 <= 10 [outer=(3), constraints=(/3: (/NULL - /10]; tight)]
+ │         │    ├── select
+ │         │    │    ├── columns: x:4!null
+ │         │    │    ├── key: (4)
+ │         │    │    ├── scan xy
+ │         │    │    │    ├── columns: x:4!null
+ │         │    │    │    └── key: (4)
+ │         │    │    └── filters
+ │         │    │         └── x:4 <= 10 [outer=(4), constraints=(/4: (/NULL - /10]; tight)]
+ │         │    └── filters
+ │         │         └── i:3 = x:4 [outer=(3,4), constraints=(/3: (/NULL - ]; /4: (/NULL - ]), fd=(3)==(4), (4)==(3)]
+ │         └── projections
+ │              └── i:3 + 1 [as="?column?":8, outer=(3), immutable]
+ └── projections
+      └── i:2 [as=i:9, outer=(2)]
+
+# Case with child CTE.
+norm expect=TryAddLimitToRecursiveBranch disable=InlineWith
+WITH RECURSIVE cte (i) AS (
+  (SELECT 1)
+  UNION ALL
+  (
+    SELECT i+1 FROM (
+      WITH nested (x) AS (SELECT x FROM xy)
+      SELECT i FROM cte INNER JOIN nested ON i = x
+    )
+    WHERE i <= 10
+  )
+)
+SELECT i FROM cte;
+----
+with &2 (nested)
+ ├── columns: i:10
+ ├── cardinality: [1 - ]
+ ├── immutable
+ ├── scan xy
+ │    ├── columns: xy.x:3!null
+ │    └── key: (3)
+ └── with &4 (cte)
+      ├── columns: i:10
+      ├── cardinality: [1 - ]
+      ├── immutable
+      ├── recursive-c-t-e
+      │    ├── columns: i:2
+      │    ├── working table binding: &3
+      │    ├── initial columns: "?column?":1
+      │    ├── recursive columns: "?column?":9
+      │    ├── cardinality: [1 - ]
+      │    ├── immutable
+      │    ├── fake-rel
+      │    │    ├── columns: i:2
+      │    │    ├── cardinality: [1 - 1]
+      │    │    ├── key: ()
+      │    │    └── fd: ()-->(2)
+      │    ├── values
+      │    │    ├── columns: "?column?":1!null
+      │    │    ├── cardinality: [1 - 1]
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(1)
+      │    │    └── (1,)
+      │    └── project
+      │         ├── columns: "?column?":9!null
+      │         ├── cardinality: [0 - 1]
+      │         ├── immutable
+      │         ├── key: ()
+      │         ├── fd: ()-->(9)
+      │         ├── inner-join (hash)
+      │         │    ├── columns: i:7!null x:8!null
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+      │         │    ├── key: ()
+      │         │    ├── fd: ()-->(7,8), (8)==(7), (7)==(8)
+      │         │    ├── select
+      │         │    │    ├── columns: i:7!null
+      │         │    │    ├── cardinality: [0 - 1]
+      │         │    │    ├── key: ()
+      │         │    │    ├── fd: ()-->(7)
+      │         │    │    ├── with-scan &3 (cte)
+      │         │    │    │    ├── columns: i:7
+      │         │    │    │    ├── mapping:
+      │         │    │    │    │    └──  i:2 => i:7
+      │         │    │    │    ├── cardinality: [1 - 1]
+      │         │    │    │    ├── key: ()
+      │         │    │    │    └── fd: ()-->(7)
+      │         │    │    └── filters
+      │         │    │         └── i:7 <= 10 [outer=(7), constraints=(/7: (/NULL - /10]; tight)]
+      │         │    ├── select
+      │         │    │    ├── columns: x:8!null
+      │         │    │    ├── key: (8)
+      │         │    │    ├── with-scan &2 (nested)
+      │         │    │    │    ├── columns: x:8!null
+      │         │    │    │    ├── mapping:
+      │         │    │    │    │    └──  xy.x:3 => x:8
+      │         │    │    │    └── key: (8)
+      │         │    │    └── filters
+      │         │    │         └── x:8 <= 10 [outer=(8), constraints=(/8: (/NULL - /10]; tight)]
+      │         │    └── filters
+      │         │         └── i:7 = x:8 [outer=(7,8), constraints=(/7: (/NULL - ]; /8: (/NULL - ]), fd=(7)==(8), (8)==(7)]
+      │         └── projections
+      │              └── i:7 + 1 [as="?column?":9, outer=(7), immutable]
+      └── with-scan &4 (cte)
+           ├── columns: i:10
+           ├── mapping:
+           │    └──  i:2 => i:10
+           └── cardinality: [1 - ]
+
+# Case with parent CTE.
+norm expect=TryAddLimitToRecursiveBranch disable=InlineWith
+WITH parent (x) AS (SELECT x FROM xy)
+SELECT * FROM (
+  WITH RECURSIVE cte (i) AS (
+    (SELECT 1)
+    UNION ALL
+    (
+      SELECT i+1 FROM cte
+      INNER JOIN parent ON i = x
+      WHERE i <= 10
+    )
+  )
+  SELECT i FROM cte
+)
+----
+with &1 (parent)
+ ├── columns: i:10
+ ├── cardinality: [1 - ]
+ ├── immutable
+ ├── scan xy
+ │    ├── columns: xy.x:1!null
+ │    └── key: (1)
+ └── with &4 (cte)
+      ├── columns: i:10
+      ├── cardinality: [1 - ]
+      ├── immutable
+      ├── recursive-c-t-e
+      │    ├── columns: i:6
+      │    ├── working table binding: &3
+      │    ├── initial columns: "?column?":5
+      │    ├── recursive columns: "?column?":9
+      │    ├── cardinality: [1 - ]
+      │    ├── immutable
+      │    ├── fake-rel
+      │    │    ├── columns: i:6
+      │    │    ├── cardinality: [1 - 1]
+      │    │    ├── key: ()
+      │    │    └── fd: ()-->(6)
+      │    ├── values
+      │    │    ├── columns: "?column?":5!null
+      │    │    ├── cardinality: [1 - 1]
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(5)
+      │    │    └── (1,)
+      │    └── project
+      │         ├── columns: "?column?":9!null
+      │         ├── cardinality: [0 - 1]
+      │         ├── immutable
+      │         ├── key: ()
+      │         ├── fd: ()-->(9)
+      │         ├── inner-join (hash)
+      │         │    ├── columns: i:7!null x:8!null
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+      │         │    ├── key: ()
+      │         │    ├── fd: ()-->(7,8), (8)==(7), (7)==(8)
+      │         │    ├── select
+      │         │    │    ├── columns: i:7!null
+      │         │    │    ├── cardinality: [0 - 1]
+      │         │    │    ├── key: ()
+      │         │    │    ├── fd: ()-->(7)
+      │         │    │    ├── with-scan &3 (cte)
+      │         │    │    │    ├── columns: i:7
+      │         │    │    │    ├── mapping:
+      │         │    │    │    │    └──  i:6 => i:7
+      │         │    │    │    ├── cardinality: [1 - 1]
+      │         │    │    │    ├── key: ()
+      │         │    │    │    └── fd: ()-->(7)
+      │         │    │    └── filters
+      │         │    │         └── i:7 <= 10 [outer=(7), constraints=(/7: (/NULL - /10]; tight)]
+      │         │    ├── select
+      │         │    │    ├── columns: x:8!null
+      │         │    │    ├── key: (8)
+      │         │    │    ├── with-scan &1 (parent)
+      │         │    │    │    ├── columns: x:8!null
+      │         │    │    │    ├── mapping:
+      │         │    │    │    │    └──  xy.x:1 => x:8
+      │         │    │    │    └── key: (8)
+      │         │    │    └── filters
+      │         │    │         └── x:8 <= 10 [outer=(8), constraints=(/8: (/NULL - /10]; tight)]
+      │         │    └── filters
+      │         │         └── i:7 = x:8 [outer=(7,8), constraints=(/7: (/NULL - ]; /8: (/NULL - ]), fd=(7)==(8), (8)==(7)]
+      │         └── projections
+      │              └── i:7 + 1 [as="?column?":9, outer=(7), immutable]
+      └── with-scan &4 (cte)
+           ├── columns: i:10
+           ├── mapping:
+           │    └──  i:6 => i:10
+           └── cardinality: [1 - ]
+
+# Case where the DistinctOn de-duplicates the output of the join.
+norm expect=TryAddLimitToRecursiveBranch
+WITH RECURSIVE cte (i, j) AS (
+  (SELECT 1, 2)
+  UNION ALL
+  (SELECT DISTINCT ON (i) i+1, x FROM cte INNER JOIN xy ON j = y WHERE i <= 10)
+)
+SELECT i, j FROM cte;
+----
+project
+ ├── columns: i:12 j:13
+ ├── cardinality: [1 - ]
+ ├── immutable
+ ├── recursive-c-t-e
+ │    ├── columns: i:3 j:4
+ │    ├── working table binding: &2
+ │    ├── initial columns: "?column?":1 "?column?":2
+ │    ├── recursive columns: "?column?":11 x:7
+ │    ├── cardinality: [1 - ]
+ │    ├── immutable
+ │    ├── fake-rel
+ │    │    ├── columns: i:3 j:4
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    └── fd: ()-->(3,4)
+ │    ├── values
+ │    │    ├── columns: "?column?":1!null "?column?":2!null
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1,2)
+ │    │    └── (1, 2)
+ │    └── project
+ │         ├── columns: "?column?":11!null x:7!null
+ │         ├── cardinality: [0 - 1]
+ │         ├── immutable
+ │         ├── key: ()
+ │         ├── fd: ()-->(7,11)
+ │         ├── limit
+ │         │    ├── columns: i:5!null j:6!null x:7!null y:8!null
+ │         │    ├── cardinality: [0 - 1]
+ │         │    ├── key: ()
+ │         │    ├── fd: ()-->(5-8), (8)==(6), (6)==(8)
+ │         │    ├── inner-join (hash)
+ │         │    │    ├── columns: i:5!null j:6!null x:7!null y:8!null
+ │         │    │    ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+ │         │    │    ├── key: (7)
+ │         │    │    ├── fd: ()-->(5,6,8), (6)==(8), (8)==(6)
+ │         │    │    ├── limit hint: 1.00
+ │         │    │    ├── select
+ │         │    │    │    ├── columns: i:5!null j:6
+ │         │    │    │    ├── cardinality: [0 - 1]
+ │         │    │    │    ├── key: ()
+ │         │    │    │    ├── fd: ()-->(5,6)
+ │         │    │    │    ├── with-scan &2 (cte)
+ │         │    │    │    │    ├── columns: i:5 j:6
+ │         │    │    │    │    ├── mapping:
+ │         │    │    │    │    │    ├──  i:3 => i:5
+ │         │    │    │    │    │    └──  j:4 => j:6
+ │         │    │    │    │    ├── cardinality: [1 - 1]
+ │         │    │    │    │    ├── key: ()
+ │         │    │    │    │    └── fd: ()-->(5,6)
+ │         │    │    │    └── filters
+ │         │    │    │         └── i:5 <= 10 [outer=(5), constraints=(/5: (/NULL - /10]; tight)]
+ │         │    │    ├── scan xy
+ │         │    │    │    ├── columns: x:7!null y:8
+ │         │    │    │    ├── key: (7)
+ │         │    │    │    └── fd: (7)-->(8)
+ │         │    │    └── filters
+ │         │    │         └── j:6 = y:8 [outer=(6,8), constraints=(/6: (/NULL - ]; /8: (/NULL - ]), fd=(6)==(8), (8)==(6)]
+ │         │    └── 1
+ │         └── projections
+ │              └── i:5 + 1 [as="?column?":11, outer=(5), immutable]
+ └── projections
+      ├── i:3 [as=i:12, outer=(3)]
+      └── j:4 [as=j:13, outer=(4)]
+
+# Case where the GroupBy de-duplicates the output of the join.
+norm expect=TryAddLimitToRecursiveBranch
+WITH RECURSIVE cte (i, j) AS (
+  (SELECT 1, 2)
+  UNION ALL
+  (SELECT i+1, sum(x) FROM cte INNER JOIN xy ON j = y WHERE i <= 10 GROUP BY i)
+)
+SELECT i, j FROM cte;
+----
+project
+ ├── columns: i:14 j:15
+ ├── cardinality: [1 - ]
+ ├── immutable
+ ├── recursive-c-t-e
+ │    ├── columns: i:3 j:4
+ │    ├── working table binding: &2
+ │    ├── initial columns: "?column?":1 "?column?":13
+ │    ├── recursive columns: "?column?":12 sum:11
+ │    ├── cardinality: [1 - ]
+ │    ├── immutable
+ │    ├── fake-rel
+ │    │    ├── columns: i:3 j:4
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    └── fd: ()-->(3,4)
+ │    ├── values
+ │    │    ├── columns: "?column?":1!null "?column?":13!null
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1,13)
+ │    │    └── (1, 2)
+ │    └── project
+ │         ├── columns: "?column?":12!null sum:11!null
+ │         ├── cardinality: [0 - 1]
+ │         ├── immutable
+ │         ├── key: ()
+ │         ├── fd: ()-->(11,12)
+ │         ├── group-by (streaming)
+ │         │    ├── columns: i:5!null sum:11!null
+ │         │    ├── cardinality: [0 - 1]
+ │         │    ├── key: ()
+ │         │    ├── fd: ()-->(5,11)
+ │         │    ├── inner-join (hash)
+ │         │    │    ├── columns: i:5!null j:6!null x:7!null y:8!null
+ │         │    │    ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+ │         │    │    ├── key: (7)
+ │         │    │    ├── fd: ()-->(5,6,8), (6)==(8), (8)==(6)
+ │         │    │    ├── select
+ │         │    │    │    ├── columns: i:5!null j:6
+ │         │    │    │    ├── cardinality: [0 - 1]
+ │         │    │    │    ├── key: ()
+ │         │    │    │    ├── fd: ()-->(5,6)
+ │         │    │    │    ├── with-scan &2 (cte)
+ │         │    │    │    │    ├── columns: i:5 j:6
+ │         │    │    │    │    ├── mapping:
+ │         │    │    │    │    │    ├──  i:3 => i:5
+ │         │    │    │    │    │    └──  j:4 => j:6
+ │         │    │    │    │    ├── cardinality: [1 - 1]
+ │         │    │    │    │    ├── key: ()
+ │         │    │    │    │    └── fd: ()-->(5,6)
+ │         │    │    │    └── filters
+ │         │    │    │         └── i:5 <= 10 [outer=(5), constraints=(/5: (/NULL - /10]; tight)]
+ │         │    │    ├── scan xy
+ │         │    │    │    ├── columns: x:7!null y:8
+ │         │    │    │    ├── key: (7)
+ │         │    │    │    └── fd: (7)-->(8)
+ │         │    │    └── filters
+ │         │    │         └── j:6 = y:8 [outer=(6,8), constraints=(/6: (/NULL - ]; /8: (/NULL - ]), fd=(6)==(8), (8)==(6)]
+ │         │    └── aggregations
+ │         │         ├── sum [as=sum:11, outer=(7)]
+ │         │         │    └── x:7
+ │         │         └── const-agg [as=i:5, outer=(5)]
+ │         │              └── i:5
+ │         └── projections
+ │              └── i:5 + 1 [as="?column?":12, outer=(5), immutable]
+ └── projections
+      ├── i:3 [as=i:14, outer=(3)]
+      └── j:4 [as=j:15, outer=(4)]
+
+# No-op because the recursive branch already has a limit.
+norm expect-not=TryAddLimitToRecursiveBranch
+WITH RECURSIVE cte (i) AS (
+  (SELECT 1)
+  UNION ALL
+  (SELECT i+1 FROM cte WHERE i <= 10 LIMIT 1)
+)
+SELECT i FROM cte;
+----
+project
+ ├── columns: i:5
+ ├── cardinality: [1 - ]
+ ├── immutable
+ ├── recursive-c-t-e
+ │    ├── columns: i:2
+ │    ├── working table binding: &2
+ │    ├── initial columns: "?column?":1
+ │    ├── recursive columns: "?column?":4
+ │    ├── cardinality: [1 - ]
+ │    ├── immutable
+ │    ├── fake-rel
+ │    │    ├── columns: i:2
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    └── fd: ()-->(2)
+ │    ├── values
+ │    │    ├── columns: "?column?":1!null
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1)
+ │    │    └── (1,)
+ │    └── project
+ │         ├── columns: "?column?":4!null
+ │         ├── cardinality: [0 - 1]
+ │         ├── immutable
+ │         ├── key: ()
+ │         ├── fd: ()-->(4)
+ │         ├── select
+ │         │    ├── columns: i:3!null
+ │         │    ├── cardinality: [0 - 1]
+ │         │    ├── key: ()
+ │         │    ├── fd: ()-->(3)
+ │         │    ├── with-scan &2 (cte)
+ │         │    │    ├── columns: i:3
+ │         │    │    ├── mapping:
+ │         │    │    │    └──  i:2 => i:3
+ │         │    │    ├── cardinality: [1 - 1]
+ │         │    │    ├── key: ()
+ │         │    │    └── fd: ()-->(3)
+ │         │    └── filters
+ │         │         └── i:3 <= 10 [outer=(3), constraints=(/3: (/NULL - /10]; tight)]
+ │         └── projections
+ │              └── i:3 + 1 [as="?column?":4, outer=(3), immutable]
+ └── projections
+      └── i:2 [as=i:5, outer=(2)]
+
+# No-op case where the join can duplicate rows.
+norm expect-not=TryAddLimitToRecursiveBranch
+WITH RECURSIVE cte (i, j) AS (
+  (SELECT 1, 2)
+  UNION ALL
+  (SELECT i+1, y FROM cte INNER JOIN xy ON j = y WHERE i <= 10)
+)
+SELECT i, j FROM cte;
+----
+project
+ ├── columns: i:12 j:13
+ ├── cardinality: [1 - ]
+ ├── immutable
+ ├── recursive-c-t-e
+ │    ├── columns: i:3 j:4
+ │    ├── working table binding: &1
+ │    ├── initial columns: "?column?":1 "?column?":2
+ │    ├── recursive columns: "?column?":11 y:8
+ │    ├── cardinality: [1 - ]
+ │    ├── immutable
+ │    ├── fake-rel
+ │    │    ├── columns: i:3 j:4
+ │    │    └── cardinality: [1 - ]
+ │    ├── values
+ │    │    ├── columns: "?column?":1!null "?column?":2!null
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1,2)
+ │    │    └── (1, 2)
+ │    └── project
+ │         ├── columns: "?column?":11!null y:8!null
+ │         ├── immutable
+ │         ├── inner-join (hash)
+ │         │    ├── columns: i:5!null j:6!null y:8!null
+ │         │    ├── fd: (6)==(8), (8)==(6)
+ │         │    ├── select
+ │         │    │    ├── columns: i:5!null j:6
+ │         │    │    ├── with-scan &1 (cte)
+ │         │    │    │    ├── columns: i:5 j:6
+ │         │    │    │    ├── mapping:
+ │         │    │    │    │    ├──  i:3 => i:5
+ │         │    │    │    │    └──  j:4 => j:6
+ │         │    │    │    └── cardinality: [1 - ]
+ │         │    │    └── filters
+ │         │    │         └── i:5 <= 10 [outer=(5), constraints=(/5: (/NULL - /10]; tight)]
+ │         │    ├── scan xy
+ │         │    │    └── columns: y:8
+ │         │    └── filters
+ │         │         └── j:6 = y:8 [outer=(6,8), constraints=(/6: (/NULL - ]; /8: (/NULL - ]), fd=(6)==(8), (8)==(6)]
+ │         └── projections
+ │              └── i:5 + 1 [as="?column?":11, outer=(5), immutable]
+ └── projections
+      ├── i:3 [as=i:12, outer=(3)]
+      └── j:4 [as=j:13, outer=(4)]
+
+# No-op case where the join can duplicate rows and the DistinctOn does not
+# de-duplicate the output of the join.
+norm expect-not=TryAddLimitToRecursiveBranch
+WITH RECURSIVE cte (i, j) AS (
+  (SELECT 1, 2)
+  UNION ALL
+  (SELECT DISTINCT ON (y) i+1, x FROM cte INNER JOIN xy ON j = y WHERE i <= 10)
+)
+SELECT i, j FROM cte;
+----
+project
+ ├── columns: i:12 j:13
+ ├── cardinality: [1 - ]
+ ├── immutable
+ ├── recursive-c-t-e
+ │    ├── columns: i:3 j:4
+ │    ├── working table binding: &1
+ │    ├── initial columns: "?column?":1 "?column?":2
+ │    ├── recursive columns: "?column?":11 x:7
+ │    ├── cardinality: [1 - ]
+ │    ├── immutable
+ │    ├── fake-rel
+ │    │    ├── columns: i:3 j:4
+ │    │    └── cardinality: [1 - ]
+ │    ├── values
+ │    │    ├── columns: "?column?":1!null "?column?":2!null
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1,2)
+ │    │    └── (1, 2)
+ │    └── project
+ │         ├── columns: x:7!null "?column?":11!null
+ │         ├── immutable
+ │         ├── key: (7)
+ │         ├── fd: (7)-->(11)
+ │         └── distinct-on
+ │              ├── columns: x:7!null y:8!null "?column?":11!null
+ │              ├── grouping columns: y:8!null
+ │              ├── immutable
+ │              ├── key: (8)
+ │              ├── fd: (7)-->(8), (8)-->(7,11)
+ │              ├── project
+ │              │    ├── columns: "?column?":11!null x:7!null y:8!null
+ │              │    ├── immutable
+ │              │    ├── fd: (7)-->(8)
+ │              │    ├── inner-join (hash)
+ │              │    │    ├── columns: i:5!null j:6!null x:7!null y:8!null
+ │              │    │    ├── fd: (7)-->(8), (6)==(8), (8)==(6)
+ │              │    │    ├── select
+ │              │    │    │    ├── columns: i:5!null j:6
+ │              │    │    │    ├── with-scan &1 (cte)
+ │              │    │    │    │    ├── columns: i:5 j:6
+ │              │    │    │    │    ├── mapping:
+ │              │    │    │    │    │    ├──  i:3 => i:5
+ │              │    │    │    │    │    └──  j:4 => j:6
+ │              │    │    │    │    └── cardinality: [1 - ]
+ │              │    │    │    └── filters
+ │              │    │    │         └── i:5 <= 10 [outer=(5), constraints=(/5: (/NULL - /10]; tight)]
+ │              │    │    ├── scan xy
+ │              │    │    │    ├── columns: x:7!null y:8
+ │              │    │    │    ├── key: (7)
+ │              │    │    │    └── fd: (7)-->(8)
+ │              │    │    └── filters
+ │              │    │         └── j:6 = y:8 [outer=(6,8), constraints=(/6: (/NULL - ]; /8: (/NULL - ]), fd=(6)==(8), (8)==(6)]
+ │              │    └── projections
+ │              │         └── i:5 + 1 [as="?column?":11, outer=(5), immutable]
+ │              └── aggregations
+ │                   ├── first-agg [as="?column?":11, outer=(11)]
+ │                   │    └── "?column?":11
+ │                   └── first-agg [as=x:7, outer=(7)]
+ │                        └── x:7
+ └── projections
+      ├── i:3 [as=i:12, outer=(3)]
+      └── j:4 [as=j:13, outer=(4)]
+
+# No-op case with the recursive scan in the right input of a LeftJoin.
+norm expect-not=TryAddLimitToRecursiveBranch
+WITH RECURSIVE cte (i, j) AS (
+  (SELECT 1, 2)
+  UNION ALL
+  (SELECT i+1, y FROM xy LEFT JOIN cte ON j = x AND i <= 10)
+)
+SELECT i, j FROM cte;
+----
+project
+ ├── columns: i:12 j:13
+ ├── cardinality: [1 - ]
+ ├── immutable
+ ├── recursive-c-t-e
+ │    ├── columns: i:3 j:4
+ │    ├── working table binding: &1
+ │    ├── initial columns: "?column?":1 "?column?":2
+ │    ├── recursive columns: "?column?":11 y:6
+ │    ├── cardinality: [1 - ]
+ │    ├── immutable
+ │    ├── fake-rel
+ │    │    ├── columns: i:3 j:4
+ │    │    └── cardinality: [1 - ]
+ │    ├── values
+ │    │    ├── columns: "?column?":1!null "?column?":2!null
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1,2)
+ │    │    └── (1, 2)
+ │    └── project
+ │         ├── columns: "?column?":11 y:6
+ │         ├── immutable
+ │         ├── left-join (hash)
+ │         │    ├── columns: x:5!null y:6 i:9 j:10
+ │         │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
+ │         │    ├── fd: (5)-->(6)
+ │         │    ├── scan xy
+ │         │    │    ├── columns: x:5!null y:6
+ │         │    │    ├── key: (5)
+ │         │    │    └── fd: (5)-->(6)
+ │         │    ├── select
+ │         │    │    ├── columns: i:9!null j:10
+ │         │    │    ├── with-scan &1 (cte)
+ │         │    │    │    ├── columns: i:9 j:10
+ │         │    │    │    ├── mapping:
+ │         │    │    │    │    ├──  i:3 => i:9
+ │         │    │    │    │    └──  j:4 => j:10
+ │         │    │    │    └── cardinality: [1 - ]
+ │         │    │    └── filters
+ │         │    │         └── i:9 <= 10 [outer=(9), constraints=(/9: (/NULL - /10]; tight)]
+ │         │    └── filters
+ │         │         └── j:10 = x:5 [outer=(5,10), constraints=(/5: (/NULL - ]; /10: (/NULL - ]), fd=(5)==(10), (10)==(5)]
+ │         └── projections
+ │              └── i:9 + 1 [as="?column?":11, outer=(9), immutable]
+ └── projections
+      ├── i:3 [as=i:12, outer=(3)]
+      └── j:4 [as=j:13, outer=(4)]
+
+# No-op case with a FullJoin.
+norm expect-not=TryAddLimitToRecursiveBranch
+WITH RECURSIVE cte (i, j) AS (
+  (SELECT 1, 2)
+  UNION ALL
+  (SELECT i+1, y FROM cte FULL JOIN xy ON j = x AND i <= 10)
+)
+SELECT i, j FROM cte;
+----
+project
+ ├── columns: i:12 j:13
+ ├── cardinality: [1 - ]
+ ├── immutable
+ ├── recursive-c-t-e
+ │    ├── columns: i:3 j:4
+ │    ├── working table binding: &1
+ │    ├── initial columns: "?column?":1 "?column?":2
+ │    ├── recursive columns: "?column?":11 y:8
+ │    ├── cardinality: [1 - ]
+ │    ├── immutable
+ │    ├── fake-rel
+ │    │    ├── columns: i:3 j:4
+ │    │    └── cardinality: [1 - ]
+ │    ├── values
+ │    │    ├── columns: "?column?":1!null "?column?":2!null
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1,2)
+ │    │    └── (1, 2)
+ │    └── project
+ │         ├── columns: "?column?":11 y:8
+ │         ├── cardinality: [1 - ]
+ │         ├── immutable
+ │         ├── full-join (hash)
+ │         │    ├── columns: i:5 j:6 x:7 y:8
+ │         │    ├── cardinality: [1 - ]
+ │         │    ├── multiplicity: left-rows(exactly-one), right-rows(one-or-more)
+ │         │    ├── fd: (7)-->(8)
+ │         │    ├── with-scan &1 (cte)
+ │         │    │    ├── columns: i:5 j:6
+ │         │    │    ├── mapping:
+ │         │    │    │    ├──  i:3 => i:5
+ │         │    │    │    └──  j:4 => j:6
+ │         │    │    └── cardinality: [1 - ]
+ │         │    ├── scan xy
+ │         │    │    ├── columns: x:7!null y:8
+ │         │    │    ├── key: (7)
+ │         │    │    └── fd: (7)-->(8)
+ │         │    └── filters
+ │         │         ├── j:6 = x:7 [outer=(6,7), constraints=(/6: (/NULL - ]; /7: (/NULL - ]), fd=(6)==(7), (7)==(6)]
+ │         │         └── i:5 <= 10 [outer=(5), constraints=(/5: (/NULL - /10]; tight)]
+ │         └── projections
+ │              └── i:5 + 1 [as="?column?":11, outer=(5), immutable]
+ └── projections
+      ├── i:3 [as=i:12, outer=(3)]
+      └── j:4 [as=j:13, outer=(4)]
+
+# Case with a limit. No-op because the limit causes the recursive branch to
+# have an upper bound. Note that we could get a better upper bound by
+# matching TryAddLimitToRecursiveBranch if the anchor limit is smaller than
+# the recursive branch limit, but it doesn't seem useful enough to justify
+# the added complexity.
+norm expect-not=TryAddLimitToRecursiveBranch
+WITH RECURSIVE cte (i) AS (
+  (SELECT 1)
+  UNION ALL
+  (SELECT i+1 FROM cte WHERE i <= 10 ORDER BY i LIMIT 5)
+)
+SELECT i FROM cte;
+----
+project
+ ├── columns: i:5
+ ├── cardinality: [1 - ]
+ ├── immutable
+ ├── recursive-c-t-e
+ │    ├── columns: i:2
+ │    ├── working table binding: &2
+ │    ├── initial columns: "?column?":1
+ │    ├── recursive columns: "?column?":4
+ │    ├── cardinality: [1 - ]
+ │    ├── immutable
+ │    ├── fake-rel
+ │    │    ├── columns: i:2
+ │    │    └── cardinality: [1 - 5]
+ │    ├── values
+ │    │    ├── columns: "?column?":1!null
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1)
+ │    │    └── (1,)
+ │    └── project
+ │         ├── columns: "?column?":4!null
+ │         ├── cardinality: [0 - 5]
+ │         ├── immutable
+ │         ├── select
+ │         │    ├── columns: i:3!null
+ │         │    ├── cardinality: [0 - 5]
+ │         │    ├── with-scan &2 (cte)
+ │         │    │    ├── columns: i:3
+ │         │    │    ├── mapping:
+ │         │    │    │    └──  i:2 => i:3
+ │         │    │    └── cardinality: [1 - 5]
+ │         │    └── filters
+ │         │         └── i:3 <= 10 [outer=(3), constraints=(/3: (/NULL - /10]; tight)]
+ │         └── projections
+ │              └── i:3 + 1 [as="?column?":4, outer=(3), immutable]
  └── projections
       └── i:2 [as=i:5, outer=(2)]

--- a/pkg/sql/opt/norm/with_funcs.go
+++ b/pkg/sql/opt/norm/with_funcs.go
@@ -13,6 +13,7 @@ package norm
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/errors"
 )
 
@@ -126,4 +127,73 @@ func (c *CustomFuncs) InlineWithScan(private *memo.WithScanPrivate) memo.RelExpr
 		ID:   c.f.Metadata().NextUniqueID(),
 	})
 	return c.f.ConstructProject(newValuesExpr, projections, opt.ColSet{})
+}
+
+// ApplyLimitToRecursiveCTEScan re-optimizes the recursive branch of a recursive
+// CTE with a limit applied to the binding. This is possible when both the
+// initial and recursive branches have a limit.
+func (c *CustomFuncs) ApplyLimitToRecursiveCTEScan(
+	binding, initial, recursive memo.RelExpr, private *memo.RecursiveCTEPrivate,
+) memo.RelExpr {
+	// The cardinality of each iteration is at least the minimum of the min
+	// cardinality guaranteed by both branches, and at most the maximum of the max
+	// cardinality guaranteed by both branches.
+	newCard := initial.Relational().Cardinality.Union(recursive.Relational().Cardinality)
+	if private.Deduplicate {
+		// Rows may be filtered by the de-duplication process, so we can only
+		// guarantee that each WithScan will return at least one row.
+		newCard = newCard.AsLowAs(1)
+	}
+
+	// Use the initial branch's row count estimate for WithScan estimate.
+	newRowCount := initial.Relational().Statistics().RowCount
+	newBinding := c.f.ConstructFakeRel(&memo.FakeRelPrivate{
+		Props: MakeBindingPropsForRecursiveCTE(newCard, binding.Relational().OutputCols, newRowCount),
+	})
+
+	// Re-optimize the recursive branch with the new properties.
+	withID := private.WithID
+	newWithID := c.f.Memo().NextWithID()
+	c.f.Metadata().AddWithBinding(newWithID, newBinding)
+
+	var replace ReplaceFunc
+	replace = func(e opt.Expr) opt.Expr {
+		if withScan, ok := e.(*memo.WithScanExpr); ok && withScan.With == withID {
+			// Reconstruct the with scan using the new binding.
+			newPrivate := withScan.WithScanPrivate
+			newPrivate.With = newWithID
+			newPrivate.ID = c.f.Metadata().NextUniqueID()
+			return c.f.ConstructWithScan(&newPrivate)
+		}
+		return c.f.Replace(e, replace)
+	}
+	newRecursive := replace(recursive).(memo.RelExpr)
+	newPrivate := *private
+	newPrivate.WithID = newWithID
+	return c.f.ConstructRecursiveCTE(newBinding, initial, newRecursive, &newPrivate)
+}
+
+// MakeBindingPropsForRecursiveCTE makes a Relational struct that applies to all
+// iterations of a recursive CTE. The caller must verify that the supplied
+// cardinality applies to all iterations.
+func MakeBindingPropsForRecursiveCTE(
+	card props.Cardinality, outCols opt.ColSet, rowCount float64,
+) *props.Relational {
+	// The working table will always have at least one row, because any iteration
+	// that returns zero rows will end the loop.
+	card = card.AtLeast(props.OneCardinality)
+	bindingProps := &props.Relational{}
+	bindingProps.OutputCols = outCols
+	bindingProps.Cardinality = card
+	bindingProps.Statistics().RowCount = rowCount
+	// Row count must be greater than 0 or the stats code will throw an error.
+	// Set it to 1 to match the cardinality.
+	if bindingProps.Statistics().RowCount < 1 {
+		bindingProps.Statistics().RowCount = 1
+	}
+	// We can infer a zero-column key in the case when there are zero or one rows.
+	if bindingProps.Cardinality.IsZeroOrOne() {
+		bindingProps.FuncDeps.AddStrictKey(opt.ColSet{}, outCols)
+	}
+	return bindingProps
 }

--- a/pkg/sql/opt/norm/with_funcs.go
+++ b/pkg/sql/opt/norm/with_funcs.go
@@ -197,3 +197,88 @@ func MakeBindingPropsForRecursiveCTE(
 	}
 	return bindingProps
 }
+
+// CanAddRecursiveLimit traverses the given expression tree and checks whether a
+// limit that applies to all WithScanExprs with the given ID also applies to the
+// given expression. This is the case when the expression does not duplicate
+// input rows or add new ones. For example, a limit on the input of a DistinctOn
+// always applies to the DistinctOn, but the same is not true for a
+// ScalarGroupBy because it returns one row when the input returns zero rows.
+// This check is used to infer cardinality for recursive CTE expressions.
+//
+// dedupCols describes the set of columns which are de-duplicated by an ancestor
+// of the given expression. This is useful for handling cases where a join
+// duplicates input rows (thus invalidating a limit on input rows) and a later
+// operator de-duplicates (making the limit valid once more).
+func (c *CustomFuncs) CanAddRecursiveLimit(
+	expr memo.RelExpr, withID opt.WithID, dedupCols opt.ColSet,
+) bool {
+	switch t := expr.(type) {
+	case *memo.WithScanExpr:
+		return t.With == withID
+	case *memo.ProjectExpr, *memo.SelectExpr, *memo.LimitExpr,
+		*memo.OrdinalityExpr, *memo.WindowExpr:
+		// The operators never add rows to the input, although they can remove them.
+		// Therefore, a limit that applies to the input also applies to the output
+		// of these operators. In the case of a LimitExpr, we assume the limit is
+		// larger than the candidate limit since if this wasn't the case, the limit
+		// should have been propagated to the expression with which
+		// CanAddRecursiveLimit was originally called.
+		return c.CanAddRecursiveLimit(t.Child(0).(memo.RelExpr), withID, dedupCols)
+	case *memo.DistinctOnExpr, *memo.GroupByExpr:
+		// DistinctOn and GroupBy expressions de-duplicate the grouping columns.
+		private := t.Private().(*memo.GroupingPrivate)
+		dedupCols = private.GroupingCols
+		return c.CanAddRecursiveLimit(t.Child(0).(memo.RelExpr), withID, dedupCols)
+	case *memo.InnerJoinExpr:
+		left, right := t.Child(0).(memo.RelExpr), t.Child(1).(memo.RelExpr)
+		if c.JoinDoesNotDuplicateLeftRows(t) ||
+			(!dedupCols.Empty() && dedupCols.SubsetOf(left.Relational().OutputCols)) {
+			// Either this join will not de-duplicate left rows, or any duplication
+			// will be reversed by an ancestor DistinctOn or GroupBy. It is sufficient
+			// to check whether the de-duplicated columns is a subset of the left
+			// output columns because grouping on a strict subset of columns always
+			// implies grouping on the containing set. In other words, grouping on a
+			// subset is equivalent to first grouping on the containing set, then
+			// grouping on the subset.
+			if c.CanAddRecursiveLimit(left, withID, dedupCols) {
+				return true
+			}
+		}
+		if c.JoinDoesNotDuplicateRightRows(t) ||
+			(!dedupCols.Empty() && dedupCols.SubsetOf(right.Relational().OutputCols)) {
+			// This join will not duplicate right rows, so a limit applying to the
+			// right input applies to the output of the join.
+			if c.CanAddRecursiveLimit(right, withID, dedupCols) {
+				return true
+			}
+		}
+	case *memo.LeftJoinExpr:
+		// We can't propagate a limit through the right side of a LeftJoin because
+		// the join will add unmatched left rows, meaning the cardinality will
+		// always be at least that of the left input even if the right input has a
+		// limit. FullJoins can't be considered at all here for the same reasons.
+		left := t.Child(0).(memo.RelExpr)
+		if c.JoinDoesNotDuplicateLeftRows(t) ||
+			(!dedupCols.Empty() && dedupCols.SubsetOf(left.Relational().OutputCols)) {
+			// This join will not duplicate left rows, so a limit applying to the left
+			// input applies to the output of the join.
+			if c.CanAddRecursiveLimit(left, withID, dedupCols) {
+				return true
+			}
+		}
+	case *memo.SemiJoinExpr, *memo.AntiJoinExpr:
+		// SemiJoins and AntiJoins never duplicate left rows (and don't output right
+		// rows).
+		return c.CanAddRecursiveLimit(t.Child(0).(memo.RelExpr), withID, dedupCols)
+	case *memo.WithExpr:
+		return c.CanAddRecursiveLimit(t.Main, withID, dedupCols)
+	}
+	return false
+}
+
+// GetRecursiveWithID returns the WithID associated with the recursive CTE
+// corresponding to the given private.
+func (c *CustomFuncs) GetRecursiveWithID(private *memo.RecursiveCTEPrivate) opt.WithID {
+	return private.WithID
+}

--- a/pkg/sql/opt/optbuilder/with.go
+++ b/pkg/sql/opt/optbuilder/with.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -286,22 +287,14 @@ func (b *Builder) buildCTE(
 	// The properties of the binding are tricky: the recursive expression is
 	// invoked repeatedly and these must hold each time. We can't use the initial
 	// expression's properties directly, as those only hold the first time the
-	// recursive query is executed. We can't really say too much about what the
-	// working table contains, except that it has at least one row (the recursive
-	// query is never invoked with an empty working table).
-	bindingProps := &props.Relational{}
-	bindingProps.OutputCols = outScope.colSet()
-	bindingProps.Cardinality = props.AnyCardinality.AtLeast(props.OneCardinality)
-	// We don't really know the input row count, except for the first time we run
-	// the recursive query. We don't have anything better though.
-	bindingProps.Statistics().RowCount = initialScope.expr.Relational().Statistics().RowCount
-	// Row count must be greater than 0 or the stats code will throw an error.
-	// Set it to 1 to match the cardinality.
-	if bindingProps.Statistics().RowCount < 1 {
-		bindingProps.Statistics().RowCount = 1
-	}
+	// recursive query is executed. We don't really know the input row count,
+	// except for the first time we run the recursive query. We don't have
+	// anything better though.
+	initialRowCount := initialScope.expr.Relational().Statistics().RowCount
 	cteSrc.expr = b.factory.ConstructFakeRel(&memo.FakeRelPrivate{
-		Props: bindingProps,
+		Props: norm.MakeBindingPropsForRecursiveCTE(
+			props.AnyCardinality, outScope.colSet(), initialRowCount,
+		),
 	})
 	b.factory.Metadata().AddWithBinding(withID, cteSrc.expr)
 

--- a/pkg/sql/opt/props/cardinality.go
+++ b/pkg/sql/opt/props/cardinality.go
@@ -135,6 +135,15 @@ func (c Cardinality) Skip(rows uint32) Cardinality {
 	return Cardinality{Min: min, Max: max}
 }
 
+// Union returns a cardinality that covers both of the given cardinality ranges.
+// Example: [0-1].Union([5-10]) = [0-10]
+func (c Cardinality) Union(other Cardinality) Cardinality {
+	return Cardinality{
+		Min: minVal(c.Min, other.Min),
+		Max: maxVal(c.Max, other.Max),
+	}
+}
+
 func (c Cardinality) String() string {
 	if c.Max == math.MaxUint32 {
 		return fmt.Sprintf("[%d - ]", c.Min)


### PR DESCRIPTION
**opt: update recursive cte scan with limit that applies to both branches**

This commit adds an optimization rule `ApplyLimitToRecursiveCTEScan` that
matches recursive CTE expressions that have bounded cardinality in both the
anchor and recursive branches, then updates the properties of the recursive
scan to reflect this limit. This can allow other rules to fire in the
recursive branch.

**opt: infer a limit that applies to the recursive branch of a recursive cte**

It is common to see cases where we are unable to infer that the recursive
branch of a recursive CTE returns a limited number of rows because the
properties of the recursive branch depend on the properties of the
recursive `WithScan`. This commit adds a new rule called
`TryAddLimitToRecursiveBranch` that matches cases where the anchor branch
has bounded cardinality but not the recursive branch. It then traverses
the recursive branch until it finds a matching `WithScan`, and checks
whether applying the limit from the anchor branch to the `WithScan` would
cause the recursive branch to have the same upper cardinality bound. If
this is the case, `TryAddLimitToRecursiveBranch` re-optimizes the
recursive branch with a limit added on top of it. Doing so can allow
other rules to fire - for example, `ApplyLimitToRecursiveCTEScan`.

Informs https://github.com/cockroachdb/cockroach/issues/89954

Release note (performance improvement): The optimizer can now better
calculate the properties of recursive CTE expressions in the presence
of a `LIMIT`.