### PR TITLE
sqlinstance: don't pretend to release the instance ID on shutdown

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1242,6 +1242,12 @@ func (s *SQLServer) setInstanceID(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	// TODO(andrei): Release the instance ID on server shutdown. It is not trivial
+	// to determine where/when exactly to do that, though. Doing it after stopper
+	// quiescing doesn't work. Doing it too soon, for example as part of draining,
+	// is potentially dangerous because the server will continue to use the
+	// instance ID for a while.
+
 	err = s.sqlIDContainer.SetSQLInstanceID(ctx, instanceID)
 	if err != nil {
 		return err

--- a/pkg/sql/sqlinstance/instanceprovider/instanceprovider.go
+++ b/pkg/sql/sqlinstance/instanceprovider/instanceprovider.go
@@ -141,9 +141,5 @@ func (p *provider) Instance(
 // shutdownSQLInstance releases the instance ID and stops the stopper.
 func (p *provider) shutdownSQLInstance(ctx context.Context) {
 	p.stopped.Set(true)
-	err := p.storage.ReleaseInstanceID(ctx, p.instanceID)
-	if err != nil {
-		log.Ops.Warningf(ctx, "could not release instance id %d", p.instanceID)
-	}
 	p.stopper.Stop(ctx)
 }

--- a/pkg/sql/sqlinstance/instancestorage/instancestorage.go
+++ b/pkg/sql/sqlinstance/instancestorage/instancestorage.go
@@ -227,9 +227,11 @@ func (s *Storage) getAllInstanceRows(
 	return instances, nil
 }
 
-// ReleaseInstanceID releases an instance ID prior to shutdown of a SQL pod
-// The instance ID can be reused by another SQL pod of the same tenant.
+// ReleaseInstanceID deletes an instance ID record. The instance ID becomes
+// available to be reused by another SQL pod of the same tenant.
 func (s *Storage) ReleaseInstanceID(ctx context.Context, id base.SQLInstanceID) error {
+	// TODO(andrei): Ensure that we do not delete an instance ID that we no longer
+	// own, instead of deleting blindly.
 	key := makeInstanceKey(s.codec, s.tableID, id)
 	ctx = multitenant.WithTenantCostControlExemption(ctx)
 	if _, err := s.db.Del(ctx, key); err != nil {


### PR DESCRIPTION
Before this patch, the code looked like tenant SQL servers release their instance IDs on shutdown, but in fact they didn't. Instead of releasing on server shutdown, releasing the instance ID was done in a callback that was running under very specific circumstances - i.e. when the session heartbeat loop found the session record to have been deleted. Additionally, that callback also ran unreliably - it short-circuited if the session is not expired according to the local clock.

This patch does away with releasing the instance ID, on two arguments:
1. The instance ID was rarely and inconsistently released to begin with, as explained above.
2. The instance ID release code is buggy - it blindly deletes the instance ID, even if another server had stolen it. In fact, given when we were releasing, I think we were particularly likely to release IDs that had been stolen. This is very dangerous. Better to never do it than run this risk.

I've considered properly releasing the instance ID on shutdown, but I had trouble working out exactly when and where this can be done: you can't do it after stopper quiescing, and you don't want to do it too soon before that while the instance ID is still used by the server. I think properly releasing the ID will have to be coupled with a way of rejecting further uses of the ID. In the meantime I've left a TODO.

Fixes #90576

Release note: None