### PR TITLE
batcheval: delete redundant `ReturnSST` parameter

### DIFF
--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -350,7 +350,6 @@ func runBackupProcessor(
 							EnableTimeBoundIteratorOptimization: true, // NB: Must set for 22.1 compatibility.
 							MVCCFilter:                          spec.MVCCFilter,
 							TargetFileSize:                      batcheval.ExportRequestTargetFileSize.Get(&clusterSettings.SV),
-							ReturnSST:                           true,
 							SplitMidKey:                         splitMidKey,
 						}
 

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -2166,7 +2166,6 @@ func fetchDescVersionModificationTime(
 		RequestHeader: header,
 		MVCCFilter:    roachpb.MVCCFilter_All,
 		StartTime:     hlc.Timestamp{},
-		ReturnSST:     true,
 	}
 	clock := hlc.NewClockWithSystemTimeSource(time.Minute /* maxOffset */)
 	hh := roachpb.Header{Timestamp: clock.Now()}

--- a/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
@@ -607,7 +607,6 @@ func fetchDescriptorsWithPriorityOverride(
 		RequestHeader: roachpb.RequestHeaderFromSpan(span),
 		StartTime:     startTS,
 		MVCCFilter:    roachpb.MVCCFilter_All,
-		ReturnSST:     true,
 	}
 
 	fetchDescriptors := func(ctx context.Context) (roachpb.Response, error) {

--- a/pkg/kv/bulk/sst_batcher_test.go
+++ b/pkg/kv/bulk/sst_batcher_test.go
@@ -64,7 +64,6 @@ func TestDuplicateHandling(t *testing.T) {
 			},
 			MVCCFilter: roachpb.MVCCFilter_All,
 			StartTime:  hlc.Timestamp{},
-			ReturnSST:  true,
 		}
 		header := roachpb.Header{Timestamp: s.Clock().Now()}
 		resp, err := kv.SendWrappedWith(ctx,

--- a/pkg/kv/kvclient/revision_reader.go
+++ b/pkg/kv/kvclient/revision_reader.go
@@ -39,7 +39,6 @@ func GetAllRevisions(
 		RequestHeader: roachpb.RequestHeader{Key: startKey, EndKey: endKey},
 		StartTime:     startTime,
 		MVCCFilter:    roachpb.MVCCFilter_All,
-		ReturnSST:     true,
 	}
 	resp, pErr := kv.SendWrappedWith(ctx, db.NonTransactionalSender(), header, req)
 	if pErr != nil {

--- a/pkg/kv/kvserver/batcheval/cmd_export.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export.go
@@ -124,10 +124,6 @@ func evalExport(
 		return result.Result{}, nil
 	}
 
-	if !args.ReturnSST {
-		return result.Result{}, errors.New("ReturnSST is required")
-	}
-
 	if args.Encryption != nil {
 		return result.Result{}, errors.New("returned SSTs cannot be encrypted")
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_export_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export_test.go
@@ -57,7 +57,6 @@ func TestExportCmd(t *testing.T) {
 			RequestHeader:  roachpb.RequestHeader{Key: bootstrap.TestingUserTableDataMin(), EndKey: keys.MaxKey},
 			StartTime:      start,
 			MVCCFilter:     mvccFilter,
-			ReturnSST:      true,
 			TargetFileSize: batcheval.ExportRequestTargetFileSize.Get(&tc.Server(0).ClusterSettings().SV),
 		}
 		var h roachpb.Header

--- a/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
+++ b/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
@@ -531,7 +531,7 @@ func TestReplicaCircuitBreaker_ExemptRequests(t *testing.T) {
 	tc.TripBreaker(n1)
 
 	exemptRequests := []func() roachpb.Request{
-		func() roachpb.Request { return &roachpb.ExportRequest{ReturnSST: true} },
+		func() roachpb.Request { return &roachpb.ExportRequest{} },
 		func() roachpb.Request {
 			sstFile := &storage.MemFile{}
 			sst := storage.MakeIngestionSSTWriter(context.Background(), cluster.MakeTestingClusterSettings(), sstFile)

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -1521,9 +1521,6 @@ message ExportRequest {
 	// ingesting the SSTs via `AddSSTable`.
   bool split_mid_key = 13;
 
-  // Return the exported SST data in the response.
-  bool return_sst = 5 [(gogoproto.customname) = "ReturnSST"];
-
   // This parameter has no effect on 22.2, as TBI is always enabled. For
   // compatibility with 22.1 nodes, callers must continue to set this as
   // appropriate until 22.2.
@@ -1541,13 +1538,7 @@ message ExportRequest {
   // then there is no limit.
   int64 target_file_size = 10;
 
-  // ReturnSSTBelowSize is the threshold which (if non-zero) causes files which
-  // are below that size threshold to be returned, as if ReturnSST were set,
-  // instead of being written to the assigned storage location.
-  // Note: returned SSTs are never encrypted.
-  int64 return_sst_below_size = 11;
-
-  reserved 2, 8;
+  reserved 2, 5, 8, 11;
 }
 
 // BulkOpSummary summarizes the data processed by an operation, counting the

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -258,7 +258,6 @@ func getDescriptorsFromStoreForInterval(
 		RequestHeader: requestHeader,
 		StartTime:     lowerBound.Prev(),
 		MVCCFilter:    roachpb.MVCCFilter_All,
-		ReturnSST:     true,
 	}
 
 	// Export request returns descriptors in decreasing modification time.


### PR DESCRIPTION
In older versions of cockroach (21.1 and before) there was an option to instruct ExportRequest to either return the generated SST to the caller, or to directly write it to ExternalStorage during command evaluation. Since
https://github.com/cockroachdb/cockroach/pull/68468/commits/d54200d1097a6f5b8117050c753005dd352806ef we have unconditionally asked ExportRequest to return SSTs to the caller and have deleted all ExternalStorage interactions during command evaluation. So there is no point keeping this parameter around on the request itself.

Release note: None