### PR TITLE
persistedsqlstats: skip logical_plan_sampling_for_explicit_txn

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/datadriven_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/datadriven_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -151,6 +152,11 @@ func TestSQLStatsDataDriven(t *testing.T) {
 				dbName,
 			)
 			return fmt.Sprintf("%t, %t", previouslySampled, savePlanForStats)
+		case "skip":
+			var issue int
+			d.ScanArgs(t, "issue-num", &issue)
+			skip.WithIssue(t, issue)
+			return ""
 		}
 
 		return ""

--- a/pkg/sql/sqlstats/persistedsqlstats/testdata/logical_plan_sampling_for_explicit_txn
+++ b/pkg/sql/sqlstats/persistedsqlstats/testdata/logical_plan_sampling_for_explicit_txn
@@ -1,3 +1,6 @@
+skip issue-num=89861
+----
+
 # This test checks the expected behavior of logical plan sampling.
 # Given a tuple of (db_name, implicitTxn, fingerprint string), the logical plan
 # is only sampled if and only if no logical plan has been sampled for the given


### PR DESCRIPTION
Skipping the test since its flaky.

Informs: #89861

Release note: None