### PR TITLE
ui: never use "fancy" webpackbar reporter

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/webpack.config.js
+++ b/pkg/ui/workspaces/cluster-ui/webpack.config.js
@@ -160,7 +160,7 @@ module.exports = (env, argv) => {
       new WebpackBar({
         name: "cluster-ui",
         color: "cyan",
-        reporters: [ env.WEBPACK_WATCH ? "basic" : "fancy" ],
+        reporters: [ "basic" ],
         profile: true,
       }),
       new MomentLocalesPlugin(),

--- a/pkg/ui/workspaces/db-console/webpack.config.js
+++ b/pkg/ui/workspaces/db-console/webpack.config.js
@@ -45,7 +45,7 @@ module.exports = (env, argv) => {
     new WebpackBar({
       name: "db-console",
       color: "orange",
-      reporters: [ (env.WEBPACK_WATCH || env.WEBPACK_SERVE) ? "basic" : "fancy" ],
+      reporters: [ "basic" ],
       profile: true,
     }),
   ];


### PR DESCRIPTION
Previously, devs relied on the webpackbar package to provide multiple
concurrent progress bars when building the UI in "watch" mode. Since
Bazel's adoption however, most CLI output is buffered during builds
until a taret finishes. In the case of the webpack bundling targets for
cluster-ui and db-console, webpackbar would previously emit a massive
number of carriage-return (without line feed) characters so it could
print its own progress bars. Since these were only visible those targets
completed, they were only noise. Always use the "simple" webpackbar
reporter, to avoid cluttering CI build logs.

fixes https://github.com/cockroachdb/cockroach/issues/90724

Release note: None