### PR TITLE
coldata: remove Bytes.AppendVal

### DIFF
--- a/pkg/col/coldata/bytes.go
+++ b/pkg/col/coldata/bytes.go
@@ -413,17 +413,6 @@ func (b *Bytes) appendSliceWithSel(src *Bytes, destIdx int, sel []int) {
 	}
 }
 
-// AppendVal appends the given []byte value to the end of the receiver. A nil
-// value will be "converted" into an empty byte slice.
-// TODO(yuzefovich): remove this method.
-func (b *Bytes) AppendVal(v []byte) {
-	if b.isWindow {
-		panic("AppendVal is called on a window into Bytes")
-	}
-	b.elements = append(b.elements, element{})
-	b.elements[len(b.elements)-1].set(v, b)
-}
-
 // Len returns how many []byte values the receiver contains.
 //
 //gcassert:inline

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_base.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_base.go
@@ -560,7 +560,9 @@ func (b *argWidthOverloadBase) AppendSlice(
 // AppendVal is a function that should only be used in templates.
 func (b *argWidthOverloadBase) AppendVal(target, v string) string {
 	switch b.CanonicalTypeFamily {
-	case types.BytesFamily, types.JsonFamily, typeconv.DatumVecCanonicalTypeFamily:
+	case types.BytesFamily, types.JsonFamily:
+		colexecerror.InternalError(errors.AssertionFailedf("AppendVal should not be called on Bytes vector"))
+	case typeconv.DatumVecCanonicalTypeFamily:
 		return fmt.Sprintf("%s.AppendVal(%s)", target, v)
 	case types.DecimalFamily:
 		return fmt.Sprintf(`%[1]s = append(%[1]s, apd.Decimal{})


### PR DESCRIPTION
This method is now used only in tests, so it can easily be removed.

Epic: None

Release note: None