### PR TITLE
server: fix a log message

### DIFF
--- a/pkg/server/stop_trigger.go
+++ b/pkg/server/stop_trigger.go
@@ -43,7 +43,7 @@ func (s *stopTrigger) signalStop(ctx context.Context, r ShutdownRequest) {
 	defer s.mu.Unlock()
 	if !s.mu.shutdownRequest.Empty() {
 		// Someone else already triggered the shutdown.
-		log.Infof(ctx, "received a second shutdown request: %s", r)
+		log.Infof(ctx, "received a second shutdown request: %s", r.ShutdownCause())
 		return
 	}
 	s.mu.shutdownRequest = r


### PR DESCRIPTION
It was trying to %s a non-Stringer. This was caught by `TestRoachVet` under make, but not by the dev builds for some reason; I'm raising this linting mismatch elsewhere.

Release note: None
Epic: None