### PR TITLE
metrics: add tsdb persistence to AggHistogram

### DIFF
--- a/pkg/util/metric/aggmetric/histogram.go
+++ b/pkg/util/metric/aggmetric/histogram.go
@@ -31,6 +31,7 @@ type AggHistogram struct {
 var _ metric.Iterable = (*AggHistogram)(nil)
 var _ metric.PrometheusIterable = (*AggHistogram)(nil)
 var _ metric.PrometheusExportable = (*AggHistogram)(nil)
+var _ metric.WindowedHistogram = (*AggHistogram)(nil)
 
 // NewHistogram constructs a new AggHistogram.
 func NewHistogram(
@@ -64,6 +65,21 @@ func (a *AggHistogram) GetMetadata() metric.Metadata { return a.h.GetMetadata() 
 
 // Inspect is part of the metric.Iterable interface.
 func (a *AggHistogram) Inspect(f func(interface{})) { f(a) }
+
+// TotalCountWindowed is part of the metric.WindowedHistogram interface
+func (a *AggHistogram) TotalCountWindowed() int64 {
+	return a.h.TotalCountWindowed()
+}
+
+// TotalSumWindowed is part of the metric.WindowedHistogram interface
+func (a *AggHistogram) TotalSumWindowed() float64 {
+	return a.h.TotalSumWindowed()
+}
+
+// ValueAtQuantileWindowed is part of the metric.WindowedHistogram interface
+func (a *AggHistogram) ValueAtQuantileWindowed(q float64) float64 {
+	return a.h.ValueAtQuantileWindowed(q)
+}
 
 // GetType is part of the metric.PrometheusExportable interface.
 func (a *AggHistogram) GetType() *io_prometheus_client.MetricType {


### PR DESCRIPTION
Previously, `AggHistogram` instances would not persist their quantiles to tsdb due to a missing interface implementation of `metrics.WindowedHistogram`. This PR adds a trivial implementation that delegates to the aggregate histogram instance within the struct.

This is relatively safe to do even though an `AggHistogram` could contain many children because we are only exporting a single set of aggregate quantiles per-`AggHistogram`. The children are only iterated over via the `PrometheusIterable` interface which is used by the prometheus exporter, but not by the metrics recorder.

Release note (bug fix, ops change): Previously, certain aggregate histograms would appear in `_status/vars` but not be available for graphing in the DB Console. These are now made available. They include changefeed-related histograms, and row-level-TTL histograms.

Epic: None