### PR TITLE
storage: don't synthesize below existing points in `pointSynthesizingIter`

### DIFF
--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_iter_point_synthesis
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_iter_point_synthesis
@@ -77,10 +77,7 @@ iter_scan
 iter_seek_ge: "a"/4.000000000,0=/<empty>
 iter_scan: "a"/4.000000000,0=/<empty>
 iter_scan: "a"/2.000000000,0=/BYTES/a2
-iter_scan: "a"/1.000000000,0=/<empty>
 iter_scan: "b"/4.000000000,0=/<empty>
-iter_scan: "b"/3.000000000,0=/<empty>
-iter_scan: "b"/1.000000000,0=/<empty>
 iter_scan: "c"/5.000000000,0=/<empty>
 iter_scan: "c"/3.000000000,0=/<empty>
 iter_scan: "c"/1.000000000,0=/<empty>
@@ -89,7 +86,6 @@ iter_scan: "d"/7.000000000,0=/BYTES/d7
 iter_scan: "d"/5.000000000,0=/<empty>
 iter_scan: "d"/4.000000000,0=/BYTES/d4
 iter_scan: "d"/2.000000000,0=/BYTES/d2
-iter_scan: "d"/1.000000000,0=/<empty>
 iter_scan: "e"/5.000000000,0=/<empty>
 iter_scan: "e"/3.000000000,0=/BYTES/e3
 iter_scan: "f"/6.000000000,0=/BYTES/f6
@@ -102,7 +98,6 @@ iter_scan: "g"/4.000000000,0=/BYTES/g4
 iter_scan: "g"/3.000000000,0=/<empty>
 iter_scan: "g"/2.000000000,0=/BYTES/g2
 iter_scan: "h"/3.000000000,0=/BYTES/h3
-iter_scan: "h"/1.000000000,0=/<empty>
 iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: "j"/7.000000000,0=/BYTES/j7
 iter_scan: "k"/5.000000000,0=/BYTES/k5
@@ -123,7 +118,6 @@ iter_scan: "l"/5.000000000,0=/<empty>
 iter_scan: "k"/5.000000000,0=/BYTES/k5
 iter_scan: "j"/7.000000000,0=/BYTES/j7
 iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
-iter_scan: "h"/1.000000000,0=/<empty>
 iter_scan: "h"/3.000000000,0=/BYTES/h3
 iter_scan: "g"/2.000000000,0=/BYTES/g2
 iter_scan: "g"/3.000000000,0=/<empty>
@@ -136,7 +130,6 @@ iter_scan: "f"/5.000000000,0=/<empty>
 iter_scan: "f"/6.000000000,0=/BYTES/f6
 iter_scan: "e"/3.000000000,0=/BYTES/e3
 iter_scan: "e"/5.000000000,0=/<empty>
-iter_scan: "d"/1.000000000,0=/<empty>
 iter_scan: "d"/2.000000000,0=/BYTES/d2
 iter_scan: "d"/4.000000000,0=/BYTES/d4
 iter_scan: "d"/5.000000000,0=/<empty>
@@ -145,10 +138,7 @@ iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000
 iter_scan: "c"/1.000000000,0=/<empty>
 iter_scan: "c"/3.000000000,0=/<empty>
 iter_scan: "c"/5.000000000,0=/<empty>
-iter_scan: "b"/1.000000000,0=/<empty>
-iter_scan: "b"/3.000000000,0=/<empty>
 iter_scan: "b"/4.000000000,0=/<empty>
-iter_scan: "a"/1.000000000,0=/<empty>
 iter_scan: "a"/2.000000000,0=/BYTES/a2
 iter_scan: "a"/4.000000000,0=/<empty>
 iter_scan: .
@@ -276,15 +266,15 @@ iter_seek_lt: "l"/5.000000000,0=/<empty>
 iter_seek_lt: "l"/5.000000000,0=/<empty>
 iter_seek_lt: "k"/5.000000000,0=/BYTES/k5
 iter_seek_lt: "j"/7.000000000,0=/BYTES/j7
-iter_seek_lt: "h"/1.000000000,0=/<empty>
-iter_seek_lt: "h"/1.000000000,0=/<empty>
+iter_seek_lt: "h"/3.000000000,0=/BYTES/h3
+iter_seek_lt: "h"/3.000000000,0=/BYTES/h3
 iter_seek_lt: "g"/2.000000000,0=/BYTES/g2
 iter_seek_lt: "f"/2.000000000,0=/BYTES/f2
 iter_seek_lt: "e"/3.000000000,0=/BYTES/e3
-iter_seek_lt: "d"/1.000000000,0=/<empty>
+iter_seek_lt: "d"/2.000000000,0=/BYTES/d2
 iter_seek_lt: "c"/1.000000000,0=/<empty>
-iter_seek_lt: "b"/1.000000000,0=/<empty>
-iter_seek_lt: "a"/1.000000000,0=/<empty>
+iter_seek_lt: "b"/4.000000000,0=/<empty>
+iter_seek_lt: "a"/2.000000000,0=/BYTES/a2
 iter_seek_lt: .
 
 run ok
@@ -368,7 +358,7 @@ iter_seek_ge: "a"/4.000000000,0=/<empty>
 iter_seek_ge: "a"/4.000000000,0=/<empty>
 iter_seek_ge: "a"/2.000000000,0=/BYTES/a2
 iter_seek_ge: "a"/2.000000000,0=/BYTES/a2
-iter_seek_ge: "a"/1.000000000,0=/<empty>
+iter_seek_ge: "b"/4.000000000,0=/<empty>
 
 run ok
 iter_new types=pointsAndRanges pointSynthesis
@@ -380,9 +370,9 @@ iter_seek_ge k=b ts=1
 ----
 iter_seek_ge: "b"/4.000000000,0=/<empty>
 iter_seek_ge: "b"/4.000000000,0=/<empty>
-iter_seek_ge: "b"/3.000000000,0=/<empty>
-iter_seek_ge: "b"/1.000000000,0=/<empty>
-iter_seek_ge: "b"/1.000000000,0=/<empty>
+iter_seek_ge: "c"/5.000000000,0=/<empty>
+iter_seek_ge: "c"/5.000000000,0=/<empty>
+iter_seek_ge: "c"/5.000000000,0=/<empty>
 
 run ok
 iter_new types=pointsAndRanges pointSynthesis
@@ -420,7 +410,7 @@ iter_seek_ge: "d"/5.000000000,0=/<empty>
 iter_seek_ge: "d"/4.000000000,0=/BYTES/d4
 iter_seek_ge: "d"/2.000000000,0=/BYTES/d2
 iter_seek_ge: "d"/2.000000000,0=/BYTES/d2
-iter_seek_ge: "d"/1.000000000,0=/<empty>
+iter_seek_ge: "e"/5.000000000,0=/<empty>
 
 run ok
 iter_new types=pointsAndRanges pointSynthesis
@@ -481,8 +471,8 @@ iter_seek_ge k=h ts=1
 ----
 iter_seek_ge: "h"/3.000000000,0=/BYTES/h3
 iter_seek_ge: "h"/3.000000000,0=/BYTES/h3
-iter_seek_ge: "h"/1.000000000,0=/<empty>
-iter_seek_ge: "h"/1.000000000,0=/<empty>
+iter_seek_ge: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_ge: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 
 run ok
 iter_new types=pointsAndRanges pointSynthesis
@@ -654,11 +644,11 @@ iter_seek_lt k=b ts=3
 iter_seek_lt k=b ts=4
 iter_seek_lt k=b ts=5
 ----
-iter_seek_lt: "b"/3.000000000,0=/<empty>
-iter_seek_lt: "b"/3.000000000,0=/<empty>
 iter_seek_lt: "b"/4.000000000,0=/<empty>
-iter_seek_lt: "a"/1.000000000,0=/<empty>
-iter_seek_lt: "a"/1.000000000,0=/<empty>
+iter_seek_lt: "b"/4.000000000,0=/<empty>
+iter_seek_lt: "b"/4.000000000,0=/<empty>
+iter_seek_lt: "a"/2.000000000,0=/BYTES/a2
+iter_seek_lt: "a"/2.000000000,0=/BYTES/a2
 
 run ok
 iter_new types=pointsAndRanges pointSynthesis
@@ -673,8 +663,8 @@ iter_seek_lt: "c"/3.000000000,0=/<empty>
 iter_seek_lt: "c"/3.000000000,0=/<empty>
 iter_seek_lt: "c"/5.000000000,0=/<empty>
 iter_seek_lt: "c"/5.000000000,0=/<empty>
-iter_seek_lt: "b"/1.000000000,0=/<empty>
-iter_seek_lt: "b"/1.000000000,0=/<empty>
+iter_seek_lt: "b"/4.000000000,0=/<empty>
+iter_seek_lt: "b"/4.000000000,0=/<empty>
 
 run ok
 iter_new types=pointsAndRanges pointSynthesis
@@ -709,8 +699,8 @@ iter_seek_lt: "e"/3.000000000,0=/BYTES/e3
 iter_seek_lt: "e"/3.000000000,0=/BYTES/e3
 iter_seek_lt: "e"/5.000000000,0=/<empty>
 iter_seek_lt: "e"/5.000000000,0=/<empty>
-iter_seek_lt: "d"/1.000000000,0=/<empty>
-iter_seek_lt: "d"/1.000000000,0=/<empty>
+iter_seek_lt: "d"/2.000000000,0=/BYTES/d2
+iter_seek_lt: "d"/2.000000000,0=/BYTES/d2
 
 run ok
 iter_new types=pointsAndRanges pointSynthesis
@@ -763,8 +753,8 @@ iter_new types=pointsAndRanges pointSynthesis
 iter_seek_lt k=i ts=1
 iter_seek_lt k=i ts=2
 ----
-iter_seek_lt: "h"/1.000000000,0=/<empty>
-iter_seek_lt: "h"/1.000000000,0=/<empty>
+iter_seek_lt: "h"/3.000000000,0=/BYTES/h3
+iter_seek_lt: "h"/3.000000000,0=/BYTES/h3
 
 run ok
 iter_new types=pointsAndRanges pointSynthesis
@@ -851,10 +841,7 @@ iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000
 iter_scan: "c"/1.000000000,0=/<empty>
 iter_scan: "c"/3.000000000,0=/<empty>
 iter_scan: "c"/5.000000000,0=/<empty>
-iter_scan: "b"/1.000000000,0=/<empty>
-iter_scan: "b"/3.000000000,0=/<empty>
 iter_scan: "b"/4.000000000,0=/<empty>
-iter_scan: "a"/1.000000000,0=/<empty>
 iter_scan: "a"/2.000000000,0=/BYTES/a2
 iter_scan: "a"/4.000000000,0=/<empty>
 iter_scan: .
@@ -871,10 +858,7 @@ iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000
 iter_scan: "c"/1.000000000,0=/<empty>
 iter_scan: "c"/3.000000000,0=/<empty>
 iter_scan: "c"/5.000000000,0=/<empty>
-iter_scan: "b"/1.000000000,0=/<empty>
-iter_scan: "b"/3.000000000,0=/<empty>
 iter_scan: "b"/4.000000000,0=/<empty>
-iter_scan: "a"/1.000000000,0=/<empty>
 iter_scan: "a"/2.000000000,0=/BYTES/a2
 iter_scan: "a"/4.000000000,0=/<empty>
 iter_scan: .
@@ -891,7 +875,6 @@ iter_scan: "g"/4.000000000,0=/BYTES/g4
 iter_scan: "g"/3.000000000,0=/<empty>
 iter_scan: "g"/2.000000000,0=/BYTES/g2
 iter_scan: "h"/3.000000000,0=/BYTES/h3
-iter_scan: "h"/1.000000000,0=/<empty>
 iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: "j"/7.000000000,0=/BYTES/j7
 iter_scan: "k"/5.000000000,0=/BYTES/k5
@@ -909,7 +892,6 @@ iter_seek_lt: "g"/3.000000000,0=/<empty>
 iter_scan: "g"/3.000000000,0=/<empty>
 iter_scan: "g"/2.000000000,0=/BYTES/g2
 iter_scan: "h"/3.000000000,0=/BYTES/h3
-iter_scan: "h"/1.000000000,0=/<empty>
 iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: "j"/7.000000000,0=/BYTES/j7
 iter_scan: "k"/5.000000000,0=/BYTES/k5
@@ -944,7 +926,7 @@ iter_next
 iter_seek_lt: "e"/5.000000000,0=/<empty>
 iter_next: "e"/3.000000000,0=/BYTES/e3
 iter_prev: "e"/5.000000000,0=/<empty>
-iter_prev: "d"/1.000000000,0=/<empty>
+iter_prev: "d"/2.000000000,0=/BYTES/d2
 iter_next: "e"/5.000000000,0=/<empty>
 
 run ok
@@ -962,7 +944,7 @@ iter_next
 ----
 iter_seek_ge: "e"/3.000000000,0=/BYTES/e3
 iter_prev: "e"/5.000000000,0=/<empty>
-iter_prev: "d"/1.000000000,0=/<empty>
+iter_prev: "d"/2.000000000,0=/BYTES/d2
 iter_next_key: "e"/5.000000000,0=/<empty>
 iter_next: "e"/3.000000000,0=/BYTES/e3
 iter_next_key: "f"/6.000000000,0=/BYTES/f6

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_scans
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_scans
@@ -120,7 +120,6 @@ scan: "a" -> /<empty> @3.000000000,0
 scan: "b" -> /<empty> @2.000000000,0
 scan: "c" -> /<empty> @4.000000000,0
 scan: "d" -> /<empty> @4.000000000,0
-scan: "e" -> /<empty> @4.000000000,0
 scan: "f" -> /<empty> @4.000000000,0
 scan: "h" -> /<empty> @4.000000000,0
 scan: "j" -> /<empty> @4.000000000,0
@@ -132,7 +131,6 @@ scan: "a" -> /<empty> @3.000000000,0
 scan: "b" -> /<empty> @2.000000000,0
 scan: "c" -> /<empty> @4.000000000,0
 scan: "d" -> /<empty> @4.000000000,0
-scan: "e" -> /<empty> @4.000000000,0
 scan: "f" -> /BYTES/f5 @5.000000000,0
 scan: "h" -> /<empty> @4.000000000,0
 scan: "j" -> /<empty> @4.000000000,0
@@ -145,7 +143,6 @@ scan: "a" -> /<empty> @3.000000000,0
 scan: "b" -> /<empty> @2.000000000,0
 scan: "c" -> /<empty> @4.000000000,0
 scan: "d" -> /<empty> @4.000000000,0
-scan: "e" -> /<empty> @4.000000000,0
 scan: "f" -> /BYTES/f5 @5.000000000,0
 scan: "h" -> /<empty> @4.000000000,0
 scan: "j" -> /<empty> @4.000000000,0
@@ -170,7 +167,7 @@ scan: "b" -> /<empty> @2.000000000,0
 scan: "c" -> /<empty> @4.000000000,0
 scan: "d" -> /<empty> @4.000000000,0
 scan: intent "e" {id=00000000 key="e" pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0}
-scan: "e" -> /<empty> @4.000000000,0
+scan: "e"-"f" -> <no data>
 scan: "f" -> /BYTES/f5 @5.000000000,0
 scan: "g" -> /<empty> @4.000000000,0
 scan: "h" -> /<empty> @4.000000000,0
@@ -277,7 +274,6 @@ scan k=a end=z ts=4 tombstones reverse
 scan: "j" -> /<empty> @4.000000000,0
 scan: "h" -> /<empty> @4.000000000,0
 scan: "f" -> /<empty> @4.000000000,0
-scan: "e" -> /<empty> @4.000000000,0
 scan: "d" -> /<empty> @4.000000000,0
 scan: "c" -> /<empty> @4.000000000,0
 scan: "b" -> /<empty> @2.000000000,0
@@ -289,7 +285,6 @@ scan k=a end=z ts=5 tombstones reverse
 scan: "j" -> /<empty> @4.000000000,0
 scan: "h" -> /<empty> @4.000000000,0
 scan: "f" -> /BYTES/f5 @5.000000000,0
-scan: "e" -> /<empty> @4.000000000,0
 scan: "d" -> /<empty> @4.000000000,0
 scan: "c" -> /<empty> @4.000000000,0
 scan: "b" -> /<empty> @2.000000000,0
@@ -302,7 +297,6 @@ scan: intent "e" {id=00000000 key="e" pri=0.00000000 epo=0 ts=6.000000000,0 min=
 scan: "j" -> /<empty> @4.000000000,0
 scan: "h" -> /<empty> @4.000000000,0
 scan: "f" -> /BYTES/f5 @5.000000000,0
-scan: "e" -> /<empty> @4.000000000,0
 scan: "d" -> /<empty> @4.000000000,0
 scan: "c" -> /<empty> @4.000000000,0
 scan: "b" -> /<empty> @2.000000000,0
@@ -328,7 +322,7 @@ scan: "b" -> /<empty> @2.000000000,0
 scan: "c" -> /<empty> @4.000000000,0
 scan: "d" -> /<empty> @4.000000000,0
 scan: intent "e" {id=00000000 key="e" pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0}
-scan: "e" -> /<empty> @4.000000000,0
+scan: "e"-"f" -> <no data>
 scan: "f" -> /BYTES/f5 @5.000000000,0
 scan: "g" -> /<empty> @4.000000000,0
 scan: "h" -> /<empty> @4.000000000,0
@@ -376,7 +370,6 @@ scan k=a end=h+ ts=4 tombstones reverse
 ----
 scan: "h" -> /<empty> @4.000000000,0
 scan: "f" -> /<empty> @4.000000000,0
-scan: "e" -> /<empty> @4.000000000,0
 scan: "d" -> /<empty> @4.000000000,0
 scan: "c" -> /<empty> @4.000000000,0
 scan: "b" -> /<empty> @2.000000000,0

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_scans_complex
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_scans_complex
@@ -166,28 +166,21 @@ scan: "k" -> /BYTES/k5 @5.000000000,0
 run ok
 scan k=a end=z ts=1 tombstones inconsistent
 ----
-scan: "a" -> /<empty> @1.000000000,0
-scan: "b" -> /<empty> @1.000000000,0
 scan: "c" -> /<empty> @1.000000000,0
-scan: "d" -> /<empty> @1.000000000,0
-scan: "h" -> /<empty> @1.000000000,0
 
 run ok
 scan k=a end=z ts=2 tombstones inconsistent
 ----
 scan: "a" -> /BYTES/a2 @2.000000000,0
-scan: "b" -> /<empty> @1.000000000,0
 scan: "c" -> /<empty> @1.000000000,0
 scan: "d" -> /BYTES/d2 @2.000000000,0
 scan: "f" -> /BYTES/f2 @2.000000000,0
 scan: "g" -> /BYTES/g2 @2.000000000,0
-scan: "h" -> /<empty> @1.000000000,0
 
 run ok
 scan k=a end=z ts=3 tombstones inconsistent
 ----
 scan: "a" -> /BYTES/a2 @2.000000000,0
-scan: "b" -> /<empty> @3.000000000,0
 scan: "c" -> /<empty> @3.000000000,0
 scan: "d" -> /BYTES/d2 @2.000000000,0
 scan: "e" -> /BYTES/e3 @3.000000000,0
@@ -305,21 +298,15 @@ scan: "f" -> /BYTES/f6 @6.000000000,0
 run ok
 scan k=a end=z ts=1 reverse tombstones inconsistent
 ----
-scan: "h" -> /<empty> @1.000000000,0
-scan: "d" -> /<empty> @1.000000000,0
 scan: "c" -> /<empty> @1.000000000,0
-scan: "b" -> /<empty> @1.000000000,0
-scan: "a" -> /<empty> @1.000000000,0
 
 run ok
 scan k=a end=z ts=2 reverse tombstones inconsistent
 ----
-scan: "h" -> /<empty> @1.000000000,0
 scan: "g" -> /BYTES/g2 @2.000000000,0
 scan: "f" -> /BYTES/f2 @2.000000000,0
 scan: "d" -> /BYTES/d2 @2.000000000,0
 scan: "c" -> /<empty> @1.000000000,0
-scan: "b" -> /<empty> @1.000000000,0
 scan: "a" -> /BYTES/a2 @2.000000000,0
 
 run ok
@@ -332,7 +319,6 @@ scan: "f" -> /<empty> @3.000000000,0
 scan: "e" -> /BYTES/e3 @3.000000000,0
 scan: "d" -> /BYTES/d2 @2.000000000,0
 scan: "c" -> /<empty> @3.000000000,0
-scan: "b" -> /<empty> @3.000000000,0
 scan: "a" -> /BYTES/a2 @2.000000000,0
 
 run ok

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_scans_reverse_skip_regression
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_scans_reverse_skip_regression
@@ -1,0 +1,41 @@
+# Regression test for https://github.com/cockroachdb/cockroach/issues/90642.
+#
+#  REAL DATASET          SYNTHETIC DATASET
+#  2    a2 [b2]          2   a2 [b2]
+#  1    [---)            1   x
+#       a   b                a   b
+#
+# Recall that pebbleMVCCScanner only enables pointSynthesizingIter when it
+# encounters a range key. In the case above, during a reverse scan, the [a-b)@1
+# range key will first become visible to pebbleMVCCScanner when it lands on a@2,
+# so it enabled point synthesis positioned at the a@2 point key. Notice how the
+# iterator has now skipped over the synthetic point tombstone a@1.
+#
+# This is particularly problematic when combined with pebbleMVCCScanner peeking,
+# which assumes that following a iterPeekPrev() call, an iterNext() call can
+# step the parent iterator forward once to get back to the original position.
+# With the above bug, that is no longer true, as it instead lands on the 
+# synthetic point tombstone which was skipped during reverse iteration. During
+# intent processing for b@2, such an iterNext() call is expected to land on the
+# intent's provisional value at b@2, but it instead lands on the intent itself
+# at b@0. This in turn caused a value checksum or decoding failure, where it was
+# expecting the current key to be b@2, but the actual key was b@0.
+run ok
+del_range_ts k=a end=b ts=1
+put k=a ts=2 v=a2
+with t=A
+  txn_begin k=b ts=2
+  put k=b v=b2
+----
+>> at end:
+txn: "A" meta={id=00000000 key="b" pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/a2
+meta: "b"/0,0 -> txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} ts=2.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "b"/2.000000000,0 -> /BYTES/b2
+
+run ok
+scan t=A k=a end=z reverse
+----
+scan: "b" -> /BYTES/b2 @2.000000000,0
+scan: "a" -> /BYTES/a2 @2.000000000,0


### PR DESCRIPTION
Early proof of concept -- it fixes the problem, but needs some polish.

---

`pointSynthesizingIter` will synthesize point tombstones for all MVCC range tombstones at their start key and above (but not below) existing point keys. The start key condition took precedence here, such that points would be synthesized below an existing point key when colocated with a range tombstone start key. This patch changes the precedence, such that points will not be synthesized below an existing point key even if it's colocated with the range tombstone start key.

Resolves #90642.

Release note: None