### PR TITLE
ui: simplify insights sagas, fix contention query filter

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/insightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/insightsApi.ts
@@ -30,8 +30,7 @@ import moment from "moment";
 // Transaction insight events.
 
 // There are three transaction contention event insight queries:
-// 1. A query that selects transaction contention events from crdb_internal.transaction_contention_events
-// and joins on transaction ids from crdb_internal.cluster_execution_insights.
+// 1. A query that selects transaction contention events from crdb_internal.transaction_contention_events.
 // 2. A query that selects statement fingerprint IDS from crdb_internal.transaction_statistics, filtering on the
 // fingerprint IDs recorded in the contention events.
 // 3. A query that selects statement queries from crdb_internal.statement_statistics, filtering on the fingerprint IDs
@@ -75,12 +74,10 @@ const txnContentionQuery = `SELECT *
                                                waiting_txn_fingerprint_id,
                                                max(collection_ts)       AS collection_ts,
                                                sum(contention_duration) AS total_contention_duration
-                                        FROM crdb_internal.transaction_contention_events tce
-                                        WHERE waiting_txn_fingerprint_id != '\x0000000000000000'
-                                        GROUP BY waiting_txn_id, waiting_txn_fingerprint_id),
-                                       (SELECT txn_id FROM crdb_internal.cluster_execution_insights)
-                                  WHERE total_contention_duration > threshold
-                                     OR waiting_txn_id = txn_id)
+                                        FROM crdb_internal.transaction_contention_events
+                                        WHERE encode(waiting_txn_fingerprint_id, 'hex') != '0000000000000000'
+                                        GROUP BY waiting_txn_id, waiting_txn_fingerprint_id)
+                                  WHERE total_contention_duration > threshold)
                             WHERE rank = 1`;
 
 type TransactionContentionResponseColumns = {

--- a/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/schemaInsightsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/schemaInsightsPageConnected.tsx
@@ -28,6 +28,7 @@ import {
 import { SchemaInsightEventFilters } from "../types";
 import { SortSetting } from "src/sortedtable";
 import { actions as localStorageActions } from "../../store/localStorage";
+import { Dispatch } from "redux";
 
 const mapStateToProps = (
   state: AppState,
@@ -41,19 +42,29 @@ const mapStateToProps = (
   sortSetting: selectSortSetting(state),
 });
 
-const mapDispatchToProps = {
-  onFiltersChange: (filters: SchemaInsightEventFilters) =>
-    localStorageActions.update({
-      key: "filters/SchemaInsightsPage",
-      value: filters,
-    }),
-  onSortChange: (ss: SortSetting) =>
-    localStorageActions.update({
-      key: "sortSetting/SchemaInsightsPage",
-      value: ss,
-    }),
-  refreshSchemaInsights: actions.refresh,
-};
+const mapDispatchToProps = (
+  dispatch: Dispatch,
+): SchemaInsightsViewDispatchProps => ({
+  onFiltersChange: (filters: SchemaInsightEventFilters) => {
+    dispatch(
+      localStorageActions.update({
+        key: "filters/SchemaInsightsPage",
+        value: filters,
+      }),
+    );
+  },
+  onSortChange: (ss: SortSetting) => {
+    dispatch(
+      localStorageActions.update({
+        key: "sortSetting/SchemaInsightsPage",
+        value: ss,
+      }),
+    );
+  },
+  refreshSchemaInsights: () => {
+    dispatch(actions.refresh());
+  },
+});
 
 export const SchemaInsightsPageConnected = withRouter(
   connect<

--- a/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/schemaInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/schemaInsightsView.tsx
@@ -83,9 +83,9 @@ export const SchemaInsightsView: React.FC<SchemaInsightsViewProps> = ({
   );
 
   useEffect(() => {
-    // Refresh every 5mins.
+    // Refresh every 1 minute.
     refreshSchemaInsights();
-    const interval = setInterval(refreshSchemaInsights, 60 * 1000 * 5);
+    const interval = setInterval(refreshSchemaInsights, 60 * 1000);
     return () => {
       clearInterval(interval);
     };

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsConnected.tsx
@@ -41,7 +41,9 @@ const mapStateToProps = (
 const mapDispatchToProps = (
   dispatch: Dispatch,
 ): StatementInsightDetailsDispatchProps => ({
-  refreshStatementInsights: statementInsights.refresh,
+  refreshStatementInsights: () => {
+    dispatch(statementInsights.refresh());
+  },
   setTimeScale: (ts: TimeScale) => {
     dispatch(
       sqlStatsActions.updateTimeScale({

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
@@ -80,10 +80,6 @@ export class TransactionInsightDetails extends React.Component<TransactionInsigh
     this.refresh();
   }
 
-  componentDidUpdate(): void {
-    this.refresh();
-  }
-
   prevPage = (): void => this.props.history.goBack();
 
   renderContent = (): React.ReactElement => {

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsConnected.tsx
@@ -23,6 +23,7 @@ import {
 import { TimeScale } from "../../timeScaleDropdown";
 import { actions as sqlStatsActions } from "../../store/sqlStats";
 import { Dispatch } from "redux";
+import { TransactionInsightEventDetailsRequest } from "src/api";
 
 const mapStateToProps = (
   state: AppState,
@@ -39,7 +40,11 @@ const mapStateToProps = (
 const mapDispatchToProps = (
   dispatch: Dispatch,
 ): TransactionInsightDetailsDispatchProps => ({
-  refreshTransactionInsightDetails: actions.refresh,
+  refreshTransactionInsightDetails: (
+    req: TransactionInsightEventDetailsRequest,
+  ) => {
+    dispatch(actions.refresh(req));
+  },
   setTimeScale: (ts: TimeScale) => {
     dispatch(
       sqlStatsActions.updateTimeScale({

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
@@ -12,7 +12,6 @@ import React, { useEffect, useState } from "react";
 import classNames from "classnames/bind";
 import { useHistory } from "react-router-dom";
 import {
-  ColumnDescriptor,
   ISortedTablePagination,
   SortSetting,
 } from "src/sortedtable/sortedtable";
@@ -29,6 +28,7 @@ import { Pagination } from "src/pagination";
 import { queryByName, syncHistory } from "src/util/query";
 import { getTableSortFromURL } from "src/sortedtable/getTableSortFromURL";
 import { TableStatistics } from "src/tableStatistics";
+import { isSelectedColumn } from "src/columnsSelector/utils";
 
 import { StatementInsights } from "src/api/insightsApi";
 import {
@@ -37,7 +37,6 @@ import {
   makeStatementInsightsColumns,
   WorkloadInsightEventFilters,
   populateStatementInsightsFromProblemAndCauses,
-  StatementInsightEvent,
 } from "src/insights";
 import { EmptyInsightsTablePlaceholder } from "../util";
 import { StatementInsightsTable } from "./statementInsightsTable";
@@ -74,21 +73,6 @@ export type StatementInsightsViewProps = StatementInsightsViewStateProps &
 
 const INSIGHT_STMT_SEARCH_PARAM = "q";
 const INTERNAL_APP_NAME_PREFIX = "$ internal";
-
-function isSelected(
-  column: ColumnDescriptor<StatementInsightEvent>,
-  selectedColumns: string[],
-): boolean {
-  if (column.alwaysShow) {
-    return true;
-  }
-
-  if (selectedColumns === null || selectedColumns === undefined) {
-    return column.showByDefault;
-  }
-
-  return selectedColumns.includes(column.name);
-}
 
 export const StatementInsightsView: React.FC<StatementInsightsViewProps> = (
   props: StatementInsightsViewProps,
@@ -199,7 +183,7 @@ export const StatementInsightsView: React.FC<StatementInsightsViewProps> = (
   const defaultColumns = makeStatementInsightsColumns(setTimeScale);
 
   const visibleColumns = defaultColumns.filter(x =>
-    isSelected(x, selectedColumnNames),
+    isSelectedColumn(selectedColumnNames, x),
   );
 
   const clearFilters = () =>
@@ -227,7 +211,7 @@ export const StatementInsightsView: React.FC<StatementInsightsViewProps> = (
       (c): SelectOption => ({
         label: (c.title as React.ReactElement).props.children,
         value: c.name,
-        isSelected: isSelected(c, selectedColumnNames),
+        isSelected: isSelectedColumn(selectedColumnNames, c),
       }),
     );
 

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsView.tsx
@@ -93,9 +93,9 @@ export const TransactionInsightsView: React.FC<TransactionInsightsViewProps> = (
   );
 
   useEffect(() => {
-    // Refresh every 10 seconds.
+    // Refresh every 20 seconds.
     refreshTransactionInsights();
-    const interval = setInterval(refreshTransactionInsights, 10 * 1000);
+    const interval = setInterval(refreshTransactionInsights, 20 * 1000);
     return () => {
       clearInterval(interval);
     };

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/workloadInsightsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/workloadInsightsPageConnected.tsx
@@ -73,15 +73,19 @@ const TransactionDispatchProps = (
   dispatch: Dispatch,
 ): TransactionInsightsViewDispatchProps => ({
   onFiltersChange: (filters: WorkloadInsightEventFilters) =>
-    localStorageActions.update({
-      key: "filters/InsightsPage",
-      value: filters,
-    }),
+    dispatch(
+      localStorageActions.update({
+        key: "filters/InsightsPage",
+        value: filters,
+      }),
+    ),
   onSortChange: (ss: SortSetting) =>
-    localStorageActions.update({
-      key: "sortSetting/InsightsPage",
-      value: ss,
-    }),
+    dispatch(
+      localStorageActions.update({
+        key: "sortSetting/InsightsPage",
+        value: ss,
+      }),
+    ),
   setTimeScale: (ts: TimeScale) => {
     dispatch(
       sqlStatsActions.updateTimeScale({
@@ -89,27 +93,39 @@ const TransactionDispatchProps = (
       }),
     );
   },
-  refreshTransactionInsights: transactionInsights.refresh,
+  refreshTransactionInsights: () => {
+    dispatch(transactionInsights.refresh());
+  },
 });
 
 const StatementDispatchProps = (
   dispatch: Dispatch,
 ): StatementInsightsViewDispatchProps => ({
   onFiltersChange: (filters: WorkloadInsightEventFilters) =>
-    localStorageActions.update({
-      key: "filters/InsightsPage",
-      value: filters,
-    }),
+    dispatch(
+      localStorageActions.update({
+        key: "filters/InsightsPage",
+        value: filters,
+      }),
+    ),
   onSortChange: (ss: SortSetting) =>
-    localStorageActions.update({
-      key: "sortSetting/InsightsPage",
-      value: ss,
-    }),
+    dispatch(
+      localStorageActions.update({
+        key: "sortSetting/InsightsPage",
+        value: ss,
+      }),
+    ),
+  // We use `null` when the value was never set and it will show all columns.
+  // If the user modifies the selection and no columns are selected,
+  // the function will save the value as a blank space, otherwise
+  // it gets saved as `null`.
   onColumnsChange: (value: string[]) =>
-    localStorageActions.update({
-      key: "showColumns/StatementInsightsPage",
-      value: value.join(","),
-    }),
+    dispatch(
+      localStorageActions.update({
+        key: "showColumns/StatementInsightsPage",
+        value: value.length === 0 ? " " : value.join(","),
+      }),
+    ),
   setTimeScale: (ts: TimeScale) => {
     dispatch(
       sqlStatsActions.updateTimeScale({
@@ -117,7 +133,9 @@ const StatementDispatchProps = (
       }),
     );
   },
-  refreshStatementInsights: statementInsights.refresh,
+  refreshStatementInsights: () => {
+    dispatch(statementInsights.refresh());
+  },
 });
 
 type StateProps = {

--- a/pkg/ui/workspaces/cluster-ui/src/store/insightDetails/transactionInsightDetails/transactionInsightDetails.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insightDetails/transactionInsightDetails/transactionInsightDetails.sagas.ts
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { all, call, delay, put, takeLatest } from "redux-saga/effects";
+import { all, call, put, takeLatest } from "redux-saga/effects";
 
 import { actions } from "./transactionInsightDetails.reducer";
 import {
@@ -37,14 +37,9 @@ export function* requestTransactionInsightDetailsSaga(
   }
 }
 
-export function* receivedTransactionInsightDetailsSaga() {
-  yield put(actions.invalidated());
-}
-
 export function* transactionInsightDetailsSaga() {
   yield all([
     takeLatest(actions.refresh, refreshTransactionInsightDetailsSaga),
     takeLatest(actions.request, requestTransactionInsightDetailsSaga),
-    takeLatest(actions.received, receivedTransactionInsightDetailsSaga),
   ]);
 }

--- a/pkg/ui/workspaces/cluster-ui/src/store/insights/statementInsights/statementInsights.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insights/statementInsights/statementInsights.sagas.ts
@@ -8,12 +8,10 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { all, call, delay, put, takeLatest } from "redux-saga/effects";
+import { all, call, put, takeLatest } from "redux-saga/effects";
 
 import { actions } from "./statementInsights.reducer";
 import { getStatementInsightsApi } from "src/api/insightsApi";
-import { throttleWithReset } from "../../utils";
-import { rootActions } from "../../reducers";
 
 export function* refreshStatementInsightsSaga() {
   yield put(actions.request());
@@ -28,26 +26,9 @@ export function* requestStatementInsightsSaga(): any {
   }
 }
 
-export function* receivedStatementInsightsSaga(delayMs: number) {
-  yield delay(delayMs);
-  yield put(actions.invalidated());
-}
-
-export function* statementInsightsSaga(
-  cacheInvalidationPeriod: number = 10 * 1000,
-) {
+export function* statementInsightsSaga() {
   yield all([
-    throttleWithReset(
-      cacheInvalidationPeriod,
-      actions.refresh,
-      [actions.invalidated, rootActions.resetState],
-      refreshStatementInsightsSaga,
-    ),
+    takeLatest(actions.refresh, refreshStatementInsightsSaga),
     takeLatest(actions.request, requestStatementInsightsSaga),
-    takeLatest(
-      actions.received,
-      receivedStatementInsightsSaga,
-      cacheInvalidationPeriod,
-    ),
   ]);
 }

--- a/pkg/ui/workspaces/cluster-ui/src/store/insights/transactionInsights/transactionInsights.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insights/transactionInsights/transactionInsights.reducer.ts
@@ -47,7 +47,6 @@ const transactionInsightsSlice = createSlice({
     invalidated: state => {
       state.valid = false;
     },
-    // Define actions that don't change state.
     refresh: noopReducer,
     request: noopReducer,
   },

--- a/pkg/ui/workspaces/cluster-ui/src/store/insights/transactionInsights/transactionInsights.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insights/transactionInsights/transactionInsights.sagas.ts
@@ -8,12 +8,10 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { all, call, delay, put, takeLatest } from "redux-saga/effects";
+import { all, call, put, takeEvery } from "redux-saga/effects";
 
 import { actions } from "./transactionInsights.reducer";
 import { getTransactionInsightEventState } from "src/api/insightsApi";
-import { throttleWithReset } from "src/store/utils";
-import { rootActions } from "src/store/reducers";
 
 export function* refreshTransactionInsightsSaga() {
   yield put(actions.request());
@@ -28,26 +26,9 @@ export function* requestTransactionInsightsSaga(): any {
   }
 }
 
-export function* receivedTransactionInsightsSaga(delayMs: number) {
-  yield delay(delayMs);
-  yield put(actions.invalidated());
-}
-
-export function* transactionInsightsSaga(
-  cacheInvalidationPeriod: number = 10 * 1000,
-) {
+export function* transactionInsightsSaga() {
   yield all([
-    throttleWithReset(
-      cacheInvalidationPeriod,
-      actions.refresh,
-      [actions.invalidated, rootActions.resetState],
-      refreshTransactionInsightsSaga,
-    ),
-    takeLatest(actions.request, requestTransactionInsightsSaga),
-    takeLatest(
-      actions.received,
-      receivedTransactionInsightsSaga,
-      cacheInvalidationPeriod,
-    ),
+    takeEvery(actions.refresh, refreshTransactionInsightsSaga),
+    takeEvery(actions.request, requestTransactionInsightsSaga),
   ]);
 }

--- a/pkg/ui/workspaces/cluster-ui/src/store/schemaInsights/schemaInsights.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/schemaInsights/schemaInsights.sagas.ts
@@ -11,8 +11,6 @@
 import { all, call, put, takeLatest } from "redux-saga/effects";
 
 import { actions } from "./schemaInsights.reducer";
-import { CACHE_INVALIDATION_PERIOD, throttleWithReset } from "../utils";
-import { rootActions } from "../reducers";
 import { getSchemaInsights } from "../../api";
 
 export function* refreshSchemaInsightsSaga() {
@@ -28,16 +26,9 @@ export function* requestSchemaInsightsSaga(): any {
   }
 }
 
-export function* schemaInsightsSaga(
-  cacheInvalidationPeriod: number = CACHE_INVALIDATION_PERIOD,
-) {
+export function* schemaInsightsSaga() {
   yield all([
-    throttleWithReset(
-      cacheInvalidationPeriod,
-      actions.refresh,
-      [actions.invalidated, rootActions.resetState],
-      refreshSchemaInsightsSaga,
-    ),
+    takeLatest(actions.refresh, refreshSchemaInsightsSaga),
     takeLatest(actions.request, requestSchemaInsightsSaga),
   ]);
 }

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -399,8 +399,8 @@ export const refreshLiveWorkload = (): ThunkAction<any, any, any, Action> => {
 const transactionInsightsReducerObj = new CachedDataReducer(
   clusterUiApi.getTransactionInsightEventState,
   "transactionInsights",
-  moment.duration(10, "s"),
-  moment.duration(30, "s"),
+  null,
+  moment.duration(5, "m"),
 );
 export const refreshTransactionInsights = transactionInsightsReducerObj.refresh;
 
@@ -408,7 +408,7 @@ const statementInsightsReducerObj = new CachedDataReducer(
   clusterUiApi.getStatementInsightsApi,
   "statementInsights",
   null,
-  moment.duration(30, "s"), // Timeout
+  moment.duration(5, "m"),
 );
 export const refreshStatementInsights = statementInsightsReducerObj.refresh;
 
@@ -420,6 +420,8 @@ const transactionInsightDetailsReducerObj = new KeyedCachedDataReducer(
   clusterUiApi.getTransactionInsightEventDetailsState,
   "transactionInsightDetails",
   transactionInsightRequestKey,
+  null,
+  moment.duration(5, "m"),
 );
 export const refreshTransactionInsightDetails =
   transactionInsightDetailsReducerObj.refresh;
@@ -428,7 +430,7 @@ const schemaInsightsReducerObj = new CachedDataReducer(
   clusterUiApi.getSchemaInsights,
   "schemaInsights",
   null,
-  moment.duration(30, "s"),
+  moment.duration(5, "m"),
 );
 export const refreshSchemaInsights = schemaInsightsReducerObj.refresh;
 


### PR DESCRIPTION
This PR simplifies the insights sagas by moving the insights store refresh interval to the components and removing the root-level reset saga. The commit also updates the SQL query for the transaction contention events to not JOIN with the internal insights table, and to filter out all unresolved txn fingerprint IDs.

Fixes #90142.

Release note: None

Loom: https://www.loom.com/share/f12685c712124560b326f211b44a06d1