### PR TITLE
kvserver: improve help text for `admission.io.overload`

### DIFF
--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -1057,15 +1057,10 @@ The messages are dropped to help these replicas to recover from I/O overload.`,
 	}
 
 	metaIOOverload = metric.Metadata{
-		Name: "admission.io.overload",
-		Help: `1-normalized float to pause replication to raft group followers if its value exceeds a given threshold.
-
-This threshold is the admission.kv.pause_replication_io_threshold cluster setting
-(pause replication feature is disabled if this setting is 0, feature is disabled by default);
-see pkg/kv/kvserver/replica_raft_overload.go for more details. Composed of LSM L0
-sub-level and file counts.`,
+		Name:        "admission.io.overload",
+		Help:        `1-normalized float indicating whether IO admission control considers the store as overloaded with respect to compaction out of L0 (considers sub-level and file counts).`,
 		Measurement: "Threshold",
-		Unit:        metric.Unit_COUNT,
+		Unit:        metric.Unit_PERCENT,
 	}
 
 	// Replica queue metrics.

--- a/pkg/kv/kvserver/replica_raft_overload.go
+++ b/pkg/kv/kvserver/replica_raft_overload.go
@@ -24,6 +24,8 @@ import (
 	"go.etcd.io/etcd/raft/v3/tracker"
 )
 
+// pauseReplicationIOThreshold is the admission.io.overload threshold at which
+// we pause replication to non-essential followers.
 var pauseReplicationIOThreshold = settings.RegisterFloatSetting(
 	settings.SystemOnly,
 	"admission.kv.pause_replication_io_threshold",


### PR DESCRIPTION
Since this is text that's available in any running binary (`SHOW ALL CLUSTER SETTINGS`), we shouldn't expect readers to have the source code checked out, which makes our referencing of specific file names less than useful. See https://github.com/cockroachdb/cockroach/pull/87656#pullrequestreview-1117364353.

Release note: None
Release justification: No behavioural change, only changing user-visible help text.