### PR TITLE
ui: address an old TODO

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planView/planView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planView/planView.tsx
@@ -43,16 +43,7 @@ export interface FlatPlanNode {
 }
 
 function warnForAttribute(attr: IAttr): boolean {
-  // TODO(yuzefovich): 'spans ALL' is pre-20.1 attribute (and it might show up
-  // during an upgrade), so we should remove the check for it after 20.2
-  // release.
-  if (
-    attr.key === "spans" &&
-    (attr.value === "FULL SCAN" || attr.value === "ALL")
-  ) {
-    return true;
-  }
-  return false;
+  return attr.key === "spans" && attr.value === "FULL SCAN";
 }
 
 // planNodeAttrsToString converts an array of FlatPlanNodeAttribute[] into a string.


### PR DESCRIPTION
This commit addresses an old TODO to simplify the check for when we warn about full scans.

Epic: None

Release note: None