### PR TITLE
release-22.2: roachtest: add test to exercise multiple upgrades in a single test

### DIFF
--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -196,7 +196,7 @@ func (u *versionUpgradeTest) run(ctx context.Context, t test.Test) {
 
 	for i, step := range u.steps {
 		if step != nil {
-			t.Status(fmt.Sprintf("versionUpgrateTest: starting step %d", i+1))
+			t.Status(fmt.Sprintf("versionUpgradeTest: starting step %d", i+1))
 			step(ctx, t, u)
 		}
 	}


### PR DESCRIPTION
Backport 1/2 commits from #90654.

/cc @cockroachdb/release

---

All of our existing mixed-version roachtests only test that a node
running the previous version can be upgraded to the current one. In
order to expand the coverage of upgrade-related paths, this commit
introduces a new roachtest (`tpcc/mixed-headroom/multiple-upgrades`)
that starts off 2 releases prior to the current one, and upgrades a
cluster all the way to the current cockroach version.

The test is a variation of the existing `tpcc/mixed-headroom` test,
and uses the same structure: a large bank dataset is imported, and the
upgrade happens while a `tpcc` workload is running.

Note that currently failures that happen during the upgrade from two
releases prior to the previous release will still fail the test and
create a GitHub issue for the Test Eng team to investigate. In the
future, we may consider only creating issues if the upgrade is related
to the "final" upgrade in the test, when the cluster is being upgraded
to the current version. Upgrades to older releases should already be
covered by roachtests in release branches, and such failures would
mostly just add noise.

Epic: CRDB-19321
Jira issue: [CRDB-20907](https://cockroachlabs.atlassian.net/browse/CRDB-20907)
Release note: None
Release justification: adds a new test, improving mixed-version coverage.