### PR TITLE
release-22.2: batcheval: remove requirement to set ReturnSST

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_export.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export.go
@@ -124,10 +124,6 @@ func evalExport(
 		return result.Result{}, nil
 	}
 
-	if !args.ReturnSST {
-		return result.Result{}, errors.New("ReturnSST is required")
-	}
-
 	if args.Encryption != nil {
 		return result.Result{}, errors.New("returned SSTs cannot be encrypted")
 	}


### PR DESCRIPTION
Since 21.2 we have been unconditionally setting ReturnSST to true for all ExportRequests. In https://github.com/cockroachdb/cockroach/pull/90740 we removed the ReturnSST parameter and so 23.1 nodes will no longer set this field. In a mixed-version cluster where a 23.1 node sends an ExportRequest to a 22.2 node, this will cause the ExportRequest to unnecessarily fail. This diff removes the requirement that ReturnSST must be set allowing us to delete the param in 23.1.

Fixes: #90754

Release note (bug fix): Remove redundant assertion that ExportRequests should have ReturnSST.

Release justification: low risk bug fix that allows us to remove a redundant parameter from ExportRequest in a future release