### PR TITLE
server: use GRANT statement for test server auth user role grant

### DIFF
--- a/pkg/server/testserver_http.go
+++ b/pkg/server/testserver_http.go
@@ -150,12 +150,10 @@ func (ts *httpTestServer) createAuthUser(userName username.SQLUsername, isAdmin 
 		return err
 	}
 	if isAdmin {
-		// We can't use the GRANT statement here because we don't want
-		// to rely on CCL code.
 		if _, err := ts.t.sqlServer.internalExecutor.ExecEx(context.TODO(),
 			"grant-admin", nil,
 			sessiondata.InternalExecutorOverride{User: username.RootUserName()},
-			"INSERT INTO system.role_members (role, member, \"isAdmin\") VALUES ('admin', $1, true)", userName.Normalized(),
+			fmt.Sprintf("GRANT admin TO %s WITH ADMIN OPTION", userName.Normalized()),
 		); err != nil {
 			return err
 		}


### PR DESCRIPTION
Previously, the admin role is granted to the auth user by manually inserting a row into system.role_members. This change replaces the row insertion with a GRANT statement to abstract away the interaction with system tables.

Part of #87079

Release note: None