### PR TITLE
logictest: check for nil SystemConfig before purging zone config cache

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -2269,7 +2269,9 @@ func (t *logicTest) purgeZoneConfig() {
 	for i := 0; i < t.cluster.NumServers(); i++ {
 		sysconfigProvider := t.cluster.Server(i).SystemConfigProvider()
 		sysconfig := sysconfigProvider.GetSystemConfig()
-		sysconfig.PurgeZoneConfigCache()
+		if sysconfig != nil {
+			sysconfig.PurgeZoneConfigCache()
+		}
 	}
 }
 

--- a/pkg/testutils/serverutils/test_cluster_shim.go
+++ b/pkg/testutils/serverutils/test_cluster_shim.go
@@ -264,7 +264,9 @@ func StartNewTestCluster(
 	for i := 0; i < cluster.NumServers(); i++ {
 		sysconfigProvider := cluster.Server(i).SystemConfigProvider()
 		sysconfig := sysconfigProvider.GetSystemConfig()
-		sysconfig.PurgeZoneConfigCache()
+		if sysconfig != nil {
+			sysconfig.PurgeZoneConfigCache()
+		}
 	}
 	return cluster
 }


### PR DESCRIPTION
Fixes #88398

This fixes a panic which can occur duing cluster startup in a logic test or during retry of a test case in a logic test when an attempt is made to purge the zone config cache and no SystemConfig is available.

Release note: None