### PR TITLE
bazel: set correct flags for `printf` analyzer

### DIFF
--- a/build/bazelutil/nogo_config.json
+++ b/build/bazelutil/nogo_config.json
@@ -118,6 +118,9 @@
         }
     },
     "printf": {
+        "analyzer_flags": {
+            "funcs": "ErrEvent,ErrEventf,Error,Errorf,ErrorfDepth,Event,Eventf,Fatal,Fatalf,FatalfDepth,Info,Infof,InfofDepth,AssertionFailedf,AssertionFailedWithDepthf,NewAssertionErrorWithWrappedErrf,DangerousStatementf,pgerror.New,pgerror.NewWithDepthf,pgerror.Newf,SetDetailf,SetHintf,Unimplemented,Unimplementedf,UnimplementedWithDepthf,UnimplementedWithIssueDetailf,UnimplementedWithIssuef,VEvent,VEventf,Warning,Warningf,WarningfDepth,Wrapf,WrapWithDepthf,redact.Fprint,redact.Fprintf,redact.Sprint,redact.Sprintf"
+        },
         "only_files": {
             "cockroach/pkg/.*$": "first-party code"
         }

--- a/pkg/testutils/docker/single_node_docker_test.go
+++ b/pkg/testutils/docker/single_node_docker_test.go
@@ -568,7 +568,7 @@ func cleanQueryResult(queryRes string) (string, error) {
 	r := regexp.MustCompile(`([\s\S]+)\n{3}Time:.+`)
 	res := r.FindStringSubmatch(formatted)
 	if len(res) < 2 {
-		return "", errors.Wrapf(errors.Newf("%s", queryRes), "cannot parse the query result: %#v")
+		return "", errors.Errorf("cannot parse the query result: %s", queryRes)
 	}
 	return res[1], nil
 


### PR DESCRIPTION
Closes #80006.

Release note: None
Epic: CRDB-8349