### PR TITLE
release-22.1: release: S3 redirects should use abs path

### DIFF
--- a/pkg/cmd/publish-provisional-artifacts/main_test.go
+++ b/pkg/cmd/publish-provisional-artifacts/main_test.go
@@ -322,17 +322,17 @@ func TestBless(t *testing.T) {
 			expectedGets: nil,
 			expectedPuts: []string{
 				"s3://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz/no-cache " +
-					"REDIRECT cockroach-v0.0.1.linux-amd64.tgz",
+					"REDIRECT /cockroach-v0.0.1.linux-amd64.tgz",
 				"s3://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz.sha256sum/no-cache " +
-					"REDIRECT cockroach-v0.0.1.linux-amd64.tgz.sha256sum",
+					"REDIRECT /cockroach-v0.0.1.linux-amd64.tgz.sha256sum",
 				"s3://binaries.cockroachdb.com/cockroach-latest.darwin-10.9-amd64.tgz/no-cache " +
-					"REDIRECT cockroach-v0.0.1.darwin-10.9-amd64.tgz",
+					"REDIRECT /cockroach-v0.0.1.darwin-10.9-amd64.tgz",
 				"s3://binaries.cockroachdb.com/cockroach-latest.darwin-10.9-amd64.tgz.sha256sum/no-cache " +
-					"REDIRECT cockroach-v0.0.1.darwin-10.9-amd64.tgz.sha256sum",
+					"REDIRECT /cockroach-v0.0.1.darwin-10.9-amd64.tgz.sha256sum",
 				"s3://binaries.cockroachdb.com/cockroach-latest.windows-6.2-amd64.zip/no-cache " +
-					"REDIRECT cockroach-v0.0.1.windows-6.2-amd64.zip",
+					"REDIRECT /cockroach-v0.0.1.windows-6.2-amd64.zip",
 				"s3://binaries.cockroachdb.com/cockroach-latest.windows-6.2-amd64.zip.sha256sum/no-cache " +
-					"REDIRECT cockroach-v0.0.1.windows-6.2-amd64.zip.sha256sum",
+					"REDIRECT /cockroach-v0.0.1.windows-6.2-amd64.zip.sha256sum",
 			},
 		},
 	}

--- a/pkg/release/upload.go
+++ b/pkg/release/upload.go
@@ -254,7 +254,7 @@ type LatestOpts struct {
 // MarkLatestReleaseWithSuffix adds redirects to release files using "latest" instead of the version
 func MarkLatestReleaseWithSuffix(svc ObjectPutGetter, o LatestOpts, suffix string) {
 	keys := makeArchiveKeys(o.Platform, o.VersionStr, "cockroach")
-	versionedKey := keys.archive + suffix
+	versionedKey := "/" + keys.archive + suffix
 	oLatest := o
 	oLatest.VersionStr = latestStr
 	latestKeys := makeArchiveKeys(oLatest.Platform, oLatest.VersionStr, "cockroach")


### PR DESCRIPTION
Backport 1/1 commits from #90804.

/cc @cockroachdb/release

---

Previously, S3 "latest" redirects used relative path, while the AWS API expects the redirects to start with "/", "http://", or "https://".

This patch adds a slash to the key name for all redirect calls. The GCS implementation already strips the leading slash and should handle it properly.

Release note: None
Epic: None

Release justification: non-production, infrastructure-only change.