### PR TITLE
clusterversion: use clusterversion.Refer to tie arbitrary code to cluster versions

### DIFF
--- a/pkg/cli/clisqlclient/refer.go
+++ b/pkg/cli/clisqlclient/refer.go
@@ -1,0 +1,18 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package clisqlclient
+
+import "github.com/cockroachdb/cockroach/pkg/clusterversion"
+
+func init() {
+	// TODO(irfansharif): Remove this in 23.1.
+	clusterversion.Refer(clusterversion.V22_2, isAtLeast22dot2ClusterVersion)
+}

--- a/pkg/clusterversion/refer.go
+++ b/pkg/clusterversion/refer.go
@@ -1,0 +1,51 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+//
+
+package clusterversion
+
+// Refer allows tying one or more objects (or even a code comment, etc)
+// to a cluster version, to denote that these objects that be cleaned-up
+// once min supported version moves above the referred-to version.
+//
+// This is helpful when there is otherwise no way to tie the code whose
+// cleanup is desired to a particular version. For example, when a proto
+// field becomes deprecated, there may be a version gate in the code
+// somewhere, but it may not refer directly to the proto field; yet one
+// may desire removing that the proto field exactly when the version
+// disappears.
+//
+// Usage:
+// - version:
+//    - should be a base version const, i.e. V22_1, V22_2, etc.
+//    - is the maximum version where we still need the field, i.e.
+//      when we delete `version`, we can delete `obj`.
+// - obj:
+//    - is the object(s) that should remain in the code as long as
+//    `version` exists.
+//
+// Example:
+//
+// (1) In your code you have:
+//
+//    // We need to keep it for 22.1, but can remove it once we're on 22.2+ binaries
+//    const NeededFor22_1 = "blah"
+//
+// (2) Use Refer to map object to the last required version, i.e.:
+//
+//    func init() {
+//      // 22.1 is the maximum version where we still need the field,
+//      // i.e. when we delete 22.1, we can delete the field.
+//      clusterversion.Refer(clusterversion.V22_1, NeededFor22_1)
+//    }
+//
+func Refer(version Key, obj ...interface{}) {
+	_ = 0 // no-op
+}

--- a/pkg/jobs/jobspb/refer.go
+++ b/pkg/jobs/jobspb/refer.go
@@ -1,0 +1,27 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+//
+
+package jobspb
+
+import "github.com/cockroachdb/cockroach/pkg/clusterversion"
+
+func init() {
+	// Waiting for the index/table to expire before issuing ClearRange
+	// requests over the table span.
+	//
+	// TODO(ajwerner): Remove this in 23.1.
+	clusterversion.Refer(clusterversion.V22_2, SchemaChangeGCProgress_WAITING_FOR_CLEAR)
+	// The GC TTL has expired. This element is marked for imminent deletion
+	// or is being cleared.
+	//
+	// TODO(ajwerner): Remove this in 23.1.
+	clusterversion.Refer(clusterversion.V22_2, SchemaChangeGCProgress_CLEARING)
+}

--- a/pkg/keys/refer.go
+++ b/pkg/keys/refer.go
@@ -1,0 +1,20 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package keys
+
+import "github.com/cockroachdb/cockroach/pkg/clusterversion"
+
+func init() {
+	// PublicSchemaID refers to old references where Public schemas are
+	// descriptorless.
+	// TODO(richardjcai): This should be fully removed in 22.2.
+	clusterversion.Refer(clusterversion.V22_1, PublicSchemaID)
+}


### PR DESCRIPTION
This PR pulls in the `clusterversion.Refer` example from https://github.com/cockroachdb/cockroach/pull/90428, as well as creates a few in-code examples of its usage.

Release Note: None