### PR TITLE
colexecwindow: fix up some of the gcassert assertions

### DIFF
--- a/pkg/sql/colexec/colexecwindow/min_max_queue.go
+++ b/pkg/sql/colexec/colexecwindow/min_max_queue.go
@@ -59,9 +59,6 @@ func (q *minMaxQueue) isEmpty() bool {
 // get returns the element at position pos in the minMaxQueue (zero-based).
 // gcassert:inline
 func (q *minMaxQueue) get(pos int) uint32 {
-	if q.empty || pos < 0 || pos >= q.len() {
-		colexecerror.InternalError(errors.AssertionFailedf("index out of bounds: %d", pos))
-	}
 	return q.buffer[(pos+q.head)%cap(q.buffer)]
 }
 
@@ -77,9 +74,6 @@ func (q *minMaxQueue) getFirst() uint32 {
 // getLast returns the element at the end of the minMaxQueue.
 // gcassert:inline
 func (q *minMaxQueue) getLast() uint32 {
-	if q.empty {
-		colexecerror.InternalError(errors.AssertionFailedf("getting last from empty minMaxQueue"))
-	}
 	return q.buffer[(cap(q.buffer)+q.tail-1)%cap(q.buffer)]
 }
 
@@ -87,7 +81,6 @@ func (q *minMaxQueue) getLast() uint32 {
 // underlying slice if necessary, subject to the max length limit. If the
 // minMaxQueue has already reached the maximum length, addLast returns true,
 // otherwise false.
-// gcassert:inline
 func (q *minMaxQueue) addLast(element uint32) (reachedLimit bool) {
 	if q.maybeGrow() {
 		return true
@@ -99,7 +92,6 @@ func (q *minMaxQueue) addLast(element uint32) (reachedLimit bool) {
 }
 
 // removeLast removes a single element from the end of the minMaxQueue.
-// gcassert:inline
 func (q *minMaxQueue) removeLast() {
 	if q.empty {
 		colexecerror.InternalError(errors.AssertionFailedf("removing last from empty ring buffer"))
@@ -113,7 +105,6 @@ func (q *minMaxQueue) removeLast() {
 
 // removeAllBefore removes from the minMaxQueue all values in the range
 // [0, val).
-// gcassert:inline
 func (q *minMaxQueue) removeAllBefore(val uint32) {
 	if q.empty {
 		return

--- a/pkg/sql/colexec/colexecwindow/min_max_removable_agg.eg.go
+++ b/pkg/sql/colexec/colexecwindow/min_max_removable_agg.eg.go
@@ -196,8 +196,8 @@ func (a *minBoolAggregator) processBatch(batch coldata.Batch, startIdx, endIdx i
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Bool()
-	_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
 			toAdd, toRemove := a.framer.slidingWindowIntervals()
@@ -520,8 +520,8 @@ func (a *minDecimalAggregator) processBatch(batch coldata.Batch, startIdx, endId
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Decimal()
-	_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
 			toAdd, toRemove := a.framer.slidingWindowIntervals()
@@ -675,8 +675,8 @@ func (a *minInt16Aggregator) processBatch(batch coldata.Batch, startIdx, endIdx 
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Int16()
-	_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
 			toAdd, toRemove := a.framer.slidingWindowIntervals()
@@ -852,8 +852,8 @@ func (a *minInt32Aggregator) processBatch(batch coldata.Batch, startIdx, endIdx 
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Int32()
-	_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
 			toAdd, toRemove := a.framer.slidingWindowIntervals()
@@ -1029,8 +1029,8 @@ func (a *minInt64Aggregator) processBatch(batch coldata.Batch, startIdx, endIdx 
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Int64()
-	_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
 			toAdd, toRemove := a.framer.slidingWindowIntervals()
@@ -1206,8 +1206,8 @@ func (a *minFloat64Aggregator) processBatch(batch coldata.Batch, startIdx, endId
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Float64()
-	_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
 			toAdd, toRemove := a.framer.slidingWindowIntervals()
@@ -1399,8 +1399,8 @@ func (a *minTimestampAggregator) processBatch(batch coldata.Batch, startIdx, end
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Timestamp()
-	_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
 			toAdd, toRemove := a.framer.slidingWindowIntervals()
@@ -1568,8 +1568,8 @@ func (a *minIntervalAggregator) processBatch(batch coldata.Batch, startIdx, endI
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Interval()
-	_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
 			toAdd, toRemove := a.framer.slidingWindowIntervals()
@@ -1921,8 +1921,8 @@ func (a *minDatumAggregator) processBatch(batch coldata.Batch, startIdx, endIdx 
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Datum()
-	_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
 			toAdd, toRemove := a.framer.slidingWindowIntervals()
@@ -2163,8 +2163,8 @@ func (a *maxBoolAggregator) processBatch(batch coldata.Batch, startIdx, endIdx i
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Bool()
-	_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
 			toAdd, toRemove := a.framer.slidingWindowIntervals()
@@ -2487,8 +2487,8 @@ func (a *maxDecimalAggregator) processBatch(batch coldata.Batch, startIdx, endId
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Decimal()
-	_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
 			toAdd, toRemove := a.framer.slidingWindowIntervals()
@@ -2642,8 +2642,8 @@ func (a *maxInt16Aggregator) processBatch(batch coldata.Batch, startIdx, endIdx 
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Int16()
-	_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
 			toAdd, toRemove := a.framer.slidingWindowIntervals()
@@ -2819,8 +2819,8 @@ func (a *maxInt32Aggregator) processBatch(batch coldata.Batch, startIdx, endIdx 
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Int32()
-	_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
 			toAdd, toRemove := a.framer.slidingWindowIntervals()
@@ -2996,8 +2996,8 @@ func (a *maxInt64Aggregator) processBatch(batch coldata.Batch, startIdx, endIdx 
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Int64()
-	_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
 			toAdd, toRemove := a.framer.slidingWindowIntervals()
@@ -3173,8 +3173,8 @@ func (a *maxFloat64Aggregator) processBatch(batch coldata.Batch, startIdx, endId
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Float64()
-	_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
 			toAdd, toRemove := a.framer.slidingWindowIntervals()
@@ -3366,8 +3366,8 @@ func (a *maxTimestampAggregator) processBatch(batch coldata.Batch, startIdx, end
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Timestamp()
-	_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
 			toAdd, toRemove := a.framer.slidingWindowIntervals()
@@ -3535,8 +3535,8 @@ func (a *maxIntervalAggregator) processBatch(batch coldata.Batch, startIdx, endI
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Interval()
-	_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
 			toAdd, toRemove := a.framer.slidingWindowIntervals()
@@ -3888,8 +3888,8 @@ func (a *maxDatumAggregator) processBatch(batch coldata.Batch, startIdx, endIdx 
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.Datum()
-	_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
 			toAdd, toRemove := a.framer.slidingWindowIntervals()

--- a/pkg/sql/colexec/colexecwindow/min_max_removable_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/min_max_removable_agg_tmpl.go
@@ -173,10 +173,10 @@ func (a *_AGG_TYPEAggregator) processBatch(batch coldata.Batch, startIdx, endIdx
 	outVec := batch.ColVec(a.outputColIdx)
 	outNulls := outVec.Nulls()
 	outCol := outVec.TemplateType()
-	// {{if not .IsBytesLike}}
-	_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
-	// {{end}}
 	a.allocator.PerformOperation([]coldata.Vec{outVec}, func() {
+		// {{if not .IsBytesLike}}
+		_, _ = outCol.Get(startIdx), outCol.Get(endIdx-1)
+		// {{end}}
 		for i := startIdx; i < endIdx; i++ {
 			a.framer.next(a.Ctx)
 			toAdd, toRemove := a.framer.slidingWindowIntervals()


### PR DESCRIPTION
This commit removes some of the `gcassert` assertions that are actually
not true - here we use `// gcassert` as opposed to `//gcassert`, and
since we used the old gcassert version, they weren't actually enforced.

Additionally, this commit adjusts the code a bit in order to make the
assertions valid in some cases. One interesting change was to move the
slice accesses into `PerformOperation` which made BCEs to occur.

Epic: None

Release note: None