### PR TITLE
cli,server: move runInitialSQL to the server package

### DIFF
--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -39,7 +39,6 @@ go_library(
         "haproxy.go",
         "import.go",
         "init.go",
-        "initial_sql.go",
         "log_flags.go",
         "mt.go",
         "mt_cert.go",

--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -256,7 +256,7 @@ func runDemoInternal(
 
 	initGEOS(ctx)
 
-	if err := c.Start(ctx, runInitialSQL); err != nil {
+	if err := c.Start(ctx); err != nil {
 		return clierrorplus.CheckAndMaybeShout(err)
 	}
 	sqlCtx.ShellCtx.DemoCluster = c

--- a/pkg/cli/democluster/BUILD.bazel
+++ b/pkg/cli/democluster/BUILD.bazel
@@ -68,7 +68,6 @@ go_test(
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
-        "//pkg/sql",
         "//pkg/testutils/skip",
         "//pkg/util/leaktest",
         "//pkg/util/log",

--- a/pkg/cli/democluster/api.go
+++ b/pkg/cli/democluster/api.go
@@ -16,7 +16,6 @@ import (
 
 	democlusterapi "github.com/cockroachdb/cockroach/pkg/cli/democluster/api"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
-	"github.com/cockroachdb/cockroach/pkg/server"
 )
 
 // DemoCluster represents a demo cluster.
@@ -28,7 +27,6 @@ type DemoCluster interface {
 	// before the initialization completes.
 	Start(
 		ctx context.Context,
-		runInitialSQL func(ctx context.Context, s *server.Server, startSingleNode bool, adminUser, adminPassword string) error,
 	) error
 
 	// GetConnURL retrieves the connection URL to the first node.

--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -180,10 +180,7 @@ func NewDemoCluster(
 	return c, nil
 }
 
-func (c *transientCluster) Start(
-	ctx context.Context,
-	runInitialSQL func(ctx context.Context, s *server.Server, startSingleNode bool, adminUser, adminPassword string) error,
-) (err error) {
+func (c *transientCluster) Start(ctx context.Context) (err error) {
 	ctx = logtags.AddTag(ctx, "start-demo-cluster", nil)
 
 	// Initialize the connection database.
@@ -464,7 +461,7 @@ func (c *transientCluster) Start(
 		server := c.firstServer.Server
 		ctx = server.AnnotateCtx(ctx)
 
-		if err := runInitialSQL(ctx, server, c.demoCtx.NumNodes < 3, demoUsername, demoPassword); err != nil {
+		if err := server.RunInitialSQL(ctx, c.demoCtx.NumNodes < 3, demoUsername, demoPassword); err != nil {
 			return err
 		}
 		if c.demoCtx.Insecure {

--- a/pkg/cli/democluster/demo_cluster_test.go
+++ b/pkg/cli/democluster/demo_cluster_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
-	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -178,17 +177,7 @@ func TestTransientClusterSimulateLatencies(t *testing.T) {
 	// terminates above.
 	ctx, _ = c.stopper.WithCancelOnQuiesce(ctx)
 
-	require.NoError(t, c.Start(ctx, func(ctx context.Context, s *server.Server, _ bool, adminUser, adminPassword string) error {
-		return s.RunLocalSQL(ctx,
-			func(ctx context.Context, ie *sql.InternalExecutor) error {
-				_, err := ie.Exec(
-					ctx, "admin-user", nil,
-					fmt.Sprintf("CREATE USER %s WITH PASSWORD $1", adminUser),
-					adminPassword,
-				)
-				return err
-			})
-	}))
+	require.NoError(t, c.Start(ctx))
 
 	for _, tc := range []struct {
 		desc    string
@@ -296,14 +285,7 @@ func TestTransientClusterMultitenant(t *testing.T) {
 	// terminates above.
 	ctx, _ = c.stopper.WithCancelOnQuiesce(ctx)
 
-	require.NoError(t, c.Start(ctx, func(ctx context.Context, s *server.Server, _ bool, adminUser, adminPassword string) error {
-		return s.RunLocalSQL(ctx,
-			func(ctx context.Context, ie *sql.InternalExecutor) error {
-				_, err := ie.Exec(ctx, "admin-user", nil, fmt.Sprintf("CREATE USER %s WITH PASSWORD '%s'", adminUser,
-					adminPassword))
-				return err
-			})
-	}))
+	require.NoError(t, c.Start(ctx))
 
 	for i := 0; i < demoCtx.NumNodes; i++ {
 		url, err := c.getNetworkURLForServer(ctx, i,

--- a/pkg/cli/mt_start_sql.go
+++ b/pkg/cli/mt_start_sql.go
@@ -94,5 +94,5 @@ func runStartSQL(cmd *cobra.Command, args []string) error {
 		return s, nil
 	}
 
-	return runStartInternal(cmd, serverType, initConfig, newServerFn, nil /* maybeRunInitialSQL */)
+	return runStartInternal(cmd, serverType, initConfig, newServerFn, false /* startSingleNode */)
 }

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -344,6 +344,13 @@ type serverStartupInterface interface {
 	// that depend on certain strings displayed from this when orchestrating
 	// KV-only nodes.
 	InitialStart() bool
+
+	// RunInitialSQL runs the SQL initialization for brand new clusters,
+	// if the cluster is being started for the first time.
+	// The arguments are:
+	// - startSingleNode is used by 'demo' and 'start-single-node'.
+	// - adminUser/adminPassword is used for 'demo'.
+	RunInitialSQL(ctx context.Context, startSingleNode bool, adminUser, adminPassword string) error
 }
 
 var errCannotUseJoin = errors.New("cannot use --join with 'cockroach start-single-node' -- use 'cockroach start' instead")
@@ -381,8 +388,14 @@ func runStartJoin(cmd *cobra.Command, args []string) error {
 // of other active nodes used to join this node to the cockroach
 // cluster, if this is its first time connecting.
 //
-// If the argument startSingleNode is set the replication factor
-// will be set to 1 all zone configs (see initial_sql.go).
+// The argument startSingleNode is morally equivalent to `cmd ==
+// startSingleNodeCmd`, and triggers special initialization specific
+// to one-node clusters. See server/initial_sql.go for details.
+//
+// We need a separate argument instead of solely relying on cmd
+// because we cannot refer to startSingleNodeCmd under
+// runStartInternal: there would be a cyclic dependency between
+// runStart, runStartSingleNode and runStartSingleNodeCmd.
 func runStart(cmd *cobra.Command, args []string, startSingleNode bool) error {
 	const serverType redact.SafeString = "node"
 
@@ -399,15 +412,7 @@ func runStart(cmd *cobra.Command, args []string, startSingleNode bool) error {
 		return s, nil
 	}
 
-	maybeRunInitialSQL := func(ctx context.Context, s serverStartupInterface) error {
-		// Run SQL for new clusters.
-		//
-		// The adminUser/adminPassword fields are for the benefit of 'cockroach demo'
-		// only and not used here.
-		return runInitialSQL(ctx, s.(*server.Server), startSingleNode, "" /* adminUser */, "" /* adminPassword */)
-	}
-
-	return runStartInternal(cmd, serverType, serverCfg.InitNode, newServerFn, maybeRunInitialSQL)
+	return runStartInternal(cmd, serverType, serverCfg.InitNode, newServerFn, startSingleNode)
 }
 
 // runStartInternal contains the code common to start a regular server
@@ -417,7 +422,7 @@ func runStartInternal(
 	serverType redact.SafeString,
 	initConfigFn func(context.Context) error,
 	newServerFn newServerFn,
-	maybeRunInitialSQL func(context.Context, serverStartupInterface) error,
+	startSingleNode bool,
 ) error {
 	tBegin := timeutil.Now()
 
@@ -594,7 +599,7 @@ If problems persist, please see %s.`
 	// if we get stuck on something during initialization (#10138).
 
 	srvStatus, serverShutdownReqC := createAndStartServerAsync(ctx,
-		tBegin, &serverCfg, stopper, startupSpan, newServerFn, maybeRunInitialSQL, serverType)
+		tBegin, &serverCfg, stopper, startupSpan, newServerFn, startSingleNode, serverType)
 
 	return waitForShutdown(
 		// NB: we delay the access to s, as it is assigned
@@ -619,8 +624,6 @@ If problems persist, please see %s.`
 //   - startupSpan: the tracing span for the context that was started earlier
 //     during startup. It needs to be finalized when the async goroutine completes.
 //   - newServerFn: a constructor function for the server object.
-//   - maybeRunInitialSQL: a callback that will be called after the server has
-//     initialized, but before it starts accepting clients.
 //   - serverType: a title used for the type of server. This is used
 //     when reporting the startup messages on the terminal & logs.
 func createAndStartServerAsync(
@@ -630,7 +633,7 @@ func createAndStartServerAsync(
 	stopper *stop.Stopper,
 	startupSpan *tracing.Span,
 	newServerFn newServerFn,
-	maybeRunInitialSQL func(context.Context, serverStartupInterface) error,
+	startSingleNode bool,
 	serverType redact.SafeString,
 ) (srvStatus *serverStatus, serverShutdownReqC <-chan server.ShutdownRequest) {
 	var serverStatusMu serverStatus
@@ -708,12 +711,10 @@ func createAndStartServerAsync(
 			if !cluster.TelemetryOptOut() {
 				s.StartDiagnostics(ctx)
 			}
-			initialStart := s.InitialStart()
 
-			if maybeRunInitialSQL != nil {
-				if err := maybeRunInitialSQL(ctx, s); err != nil {
-					return err
-				}
+			// Run one-off cluster initialization.
+			if err := s.RunInitialSQL(ctx, startSingleNode, "" /* adminUser */, "" /* adminPassword */); err != nil {
+				return err
 			}
 
 			// Now let SQL clients in.
@@ -724,7 +725,7 @@ func createAndStartServerAsync(
 			// Now inform the user that the server is running and tell the
 			// user about its run-time derived parameters.
 			return reportServerInfo(ctx, tBegin, serverCfg, s.ClusterSettings(),
-				serverType, initialStart, s.LogicalClusterID())
+				serverType, s.InitialStart(), s.LogicalClusterID())
 		}(); err != nil {
 			shutdownReqC <- server.MakeShutdownRequest(
 				server.ShutdownReasonServerStartupError, errors.Wrapf(err, "server startup failed"))

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "index_usage_stats.go",
         "init.go",
         "init_handshake.go",
+        "initial_sql.go",
         "listen_and_update_addrs.go",
         "load_endpoint.go",
         "loopback.go",

--- a/pkg/server/initial_sql.go
+++ b/pkg/server/initial_sql.go
@@ -8,29 +8,27 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package cli
+package server
 
 import (
 	"context"
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
-	"github.com/cockroachdb/cockroach/pkg/server"
-	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
 
-// runInitialSQL concerns itself with running "initial SQL" code when
+// RunInitialSQL concerns itself with running "initial SQL" code when
 // a cluster is started for the first time.
 //
 // The "startSingleNode" argument is true for `start-single-node`,
 // and `cockroach demo` with 2 nodes or fewer.
 // If adminUser is non-empty, an admin user with that name is
 // created upon initialization. Its password is then also returned.
-func runInitialSQL(
-	ctx context.Context, s *server.Server, startSingleNode bool, adminUser, adminPassword string,
+func (s *Server) RunInitialSQL(
+	ctx context.Context, startSingleNode bool, adminUser, adminPassword string,
 ) error {
 	newCluster := s.InitialStart() && s.NodeID() == kvserver.FirstNodeID
 	if !newCluster {
@@ -42,7 +40,7 @@ func runInitialSQL(
 		// For start-single-node, set the default replication factor to
 		// 1 so as to avoid warning messages and unnecessary rebalance
 		// churn.
-		if err := cliDisableReplication(ctx, s); err != nil {
+		if err := s.disableReplication(ctx); err != nil {
 			log.Ops.Errorf(ctx, "could not disable replication: %v", err)
 			return err
 		}
@@ -51,7 +49,7 @@ func runInitialSQL(
 	}
 
 	if adminUser != "" && !s.Insecure() {
-		if err := createAdminUser(ctx, s, adminUser, adminPassword); err != nil {
+		if err := s.createAdminUser(ctx, adminUser, adminPassword); err != nil {
 			return err
 		}
 	}
@@ -59,51 +57,53 @@ func runInitialSQL(
 	return nil
 }
 
-// createAdminUser creates an admin user with the given name.
-func createAdminUser(ctx context.Context, s *server.Server, adminUser, adminPassword string) error {
-	return s.RunLocalSQL(ctx,
-		func(ctx context.Context, ie *sql.InternalExecutor) error {
-			_, err := ie.Exec(
-				ctx, "admin-user", nil,
-				fmt.Sprintf("CREATE USER %s WITH PASSWORD $1", adminUser),
-				adminPassword,
-			)
-			if err != nil {
-				return err
-			}
-			// TODO(knz): Demote the admin user to an operator privilege with fewer options.
-			_, err = ie.Exec(ctx, "admin-user", nil, fmt.Sprintf("GRANT admin TO %s", tree.Name(adminUser)))
-			return err
-		})
+// RunInitialSQL implements cli.serverStartupInterface.
+func (s *SQLServerWrapper) RunInitialSQL(context.Context, bool, string, string) error {
+	return nil
 }
 
-// cliDisableReplication changes the replication factor on
+// createAdminUser creates an admin user with the given name.
+func (s *Server) createAdminUser(ctx context.Context, adminUser, adminPassword string) error {
+	ie := s.sqlServer.internalExecutor
+	_, err := ie.Exec(
+		ctx, "admin-user", nil,
+		fmt.Sprintf("CREATE USER %s WITH PASSWORD $1", adminUser),
+		adminPassword,
+	)
+	if err != nil {
+		return err
+	}
+	// TODO(knz): Demote the admin user to an operator privilege with fewer options.
+	_, err = ie.Exec(ctx, "admin-user", nil, fmt.Sprintf("GRANT admin TO %s", tree.Name(adminUser)))
+	return err
+}
+
+// disableReplication changes the replication factor on
 // all defined zones to become 1. This is used by start-single-node
 // and demo to define single-node clusters, so as to avoid
 // churn in the log files.
 //
 // The change is effected using the internal SQL interface of the
 // given server object.
-func cliDisableReplication(ctx context.Context, s *server.Server) error {
-	return s.RunLocalSQL(ctx,
-		func(ctx context.Context, ie *sql.InternalExecutor) (retErr error) {
-			it, err := ie.QueryIterator(ctx, "get-zones", nil,
-				"SELECT target FROM crdb_internal.zones")
-			if err != nil {
-				return err
-			}
-			// We have to make sure to close the iterator since we might return
-			// from the for loop early (before Next() returns false).
-			defer func() { retErr = errors.CombineErrors(retErr, it.Close()) }()
+func (s *Server) disableReplication(ctx context.Context) (retErr error) {
+	ie := s.sqlServer.internalExecutor
 
-			var ok bool
-			for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
-				zone := string(*it.Cur()[0].(*tree.DString))
-				if _, err := ie.Exec(ctx, "set-zone", nil,
-					fmt.Sprintf("ALTER %s CONFIGURE ZONE USING num_replicas = 1", zone)); err != nil {
-					return err
-				}
-			}
+	it, err := ie.QueryIterator(ctx, "get-zones", nil,
+		"SELECT target FROM crdb_internal.zones")
+	if err != nil {
+		return err
+	}
+	// We have to make sure to close the iterator since we might return
+	// from the for loop early (before Next() returns false).
+	defer func() { retErr = errors.CombineErrors(retErr, it.Close()) }()
+
+	var ok bool
+	for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
+		zone := string(*it.Cur()[0].(*tree.DString))
+		if _, err := ie.Exec(ctx, "set-zone", nil,
+			fmt.Sprintf("ALTER %s CONFIGURE ZONE USING num_replicas = 1", zone)); err != nil {
 			return err
-		})
+		}
+	}
+	return err
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1814,22 +1814,6 @@ func init() {
 	tracing.RegisterTagRemapping("n", "node")
 }
 
-// RunLocalSQL calls fn on a SQL internal executor on this server.
-// This is meant for use for SQL initialization during bootstrapping.
-//
-// The internal SQL interface should be used instead of a regular SQL
-// network connection for SQL initializations when setting up a new
-// server, because it is possible for the server to listen on a
-// network interface that is not reachable from loopback. It is also
-// possible for the TLS certificates to be invalid when used locally
-// (e.g. if the hostname in the cert is an advertised address that's
-// only reachable externally).
-func (s *Server) RunLocalSQL(
-	ctx context.Context, fn func(ctx context.Context, sqlExec *sql.InternalExecutor) error,
-) error {
-	return fn(ctx, s.sqlServer.internalExecutor)
-}
-
 // Insecure returns true iff the server has security disabled.
 func (s *Server) Insecure() bool {
 	return s.cfg.Insecure


### PR DESCRIPTION
Requested/suggested by @andreimatei in https://github.com/cockroachdb/cockroach/pull/90176#pullrequestreview-1158948904.

This also enables us to get rid of the ill-advised `RunLocalSQL`
method on `Server`.




