### PR TITLE
release-22.2: backupccl: upgrade restoreTPCCIncLatest/nodes=10 backup fixture

### DIFF
--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -409,7 +409,7 @@ func (rd *restoreDataProcessor) processRestoreSpanEntry(
 		// i.e. allow all shadowing without AddSSTable having to check for overlapping
 		// keys. This is because RESTORE is expected to ingest into an empty keyspace.
 		// If a restore job is resumed, the un-checkpointed spans that are re-ingested
-		// will perfectly shadow (equal key, value and ts) the already ingested keys.
+		// will shadow (equal key, value; different ts) the already ingested keys.
 		//
 		// NB: disallowShadowingBelow used to be unconditionally set to logical=1.
 		// This permissive value would allow shadowing in case the RESTORE has to


### PR DESCRIPTION
Backport 1/1 commits from #90669.

/cc @cockroachdb/release

---

restoreTPCCIncLatest/nodes=10 has been consistently failing because the backup fixture is more than one major version behind the cluster running the restore. This patch updates the backup fixture used by this roachtest.

Fixes #88090

Release note: None

Release justification: test only change, fixes a failing roachtest
