### PR TITLE
rowcontainer: fix an edge case when spilling to disk

### DIFF
--- a/pkg/sql/rowcontainer/row_container.go
+++ b/pkg/sql/rowcontainer/row_container.go
@@ -592,6 +592,8 @@ func (f *DiskBackedRowContainer) SpillToDisk(ctx context.Context) error {
 		return errors.New("already using disk")
 	}
 	drc := MakeDiskRowContainer(f.diskMonitor, f.mrc.types, f.mrc.ordering, f.engine)
+	f.src = &drc
+	f.drc = &drc
 	if f.deDuplicate {
 		drc.DoDeDuplicate()
 		// After spilling to disk we don't need this map to de-duplicate. The
@@ -616,9 +618,6 @@ func (f *DiskBackedRowContainer) SpillToDisk(ctx context.Context) error {
 		}
 	}
 	f.mrc.Clear(ctx)
-
-	f.src = &drc
-	f.drc = &drc
 	f.spilled = true
 	return nil
 }


### PR DESCRIPTION
This commit fixes a long-standing problem that could occur when temp
disk storage is set to a very low value. In particular, previously,
while spilling to disk, we could create a disk-backed container, add
some rows to it from the in-memory container (which would consume some
of the disk space from the accounting system), but then if we hit the
temp storage limit, we would lose the reference to the disk container.
As a result, we wouldn't close it meaning we wouldn't release the disk
account. This was the case since we stored the reference to the disk
container only _after_ moving all rows into it.

There is no fundamental reason why we delayed that in the case of the
regular disk-backed container so we now just update the references right
away. In case of the hash disk container there is some more tricky going
when spilling to disk, so we just explicitly close the newly-created
disk container in the defer if the reference is about to be lost.

The impact of the bug is pretty minor since in production settings the
temp disk storage has a limit of 32GiB vastly exceeding reasonable memory
limits (i.e. the maximum number of rows that could be buffered in the
in-memory container before having to spill).

Fixes: #90822.
Fixes: #90823.

Release note: None