### PR TITLE
ui: handle errors on db endpoints

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
@@ -51,6 +51,8 @@ import { performanceTuningRecipes } from "src/util/docs";
 import { CockroachCloudContext } from "../contexts";
 import IdxRecAction from "../insights/indexActionBtn";
 import { RecommendationType } from "../indexDetailsPage";
+import LoadingError from "../sqlActivity/errorComponent";
+import { Loading } from "../loading";
 
 const cx = classNames.bind(styles);
 const booleanSettingCx = classnames.bind(booleanSettingStyles);
@@ -111,6 +113,7 @@ export interface DatabaseTablePageData {
 export interface DatabaseTablePageDataDetails {
   loading: boolean;
   loaded: boolean;
+  lastError: Error;
   createStatement: string;
   replicaCount: number;
   indexNames: string[];
@@ -124,6 +127,7 @@ export interface DatabaseTablePageDataDetails {
 export interface DatabaseTablePageIndexStats {
   loading: boolean;
   loaded: boolean;
+  lastError: Error;
   stats: IndexStat[];
   lastReset: Moment;
 }
@@ -149,6 +153,7 @@ interface Grant {
 export interface DatabaseTablePageDataStats {
   loading: boolean;
   loaded: boolean;
+  lastError: Error;
   sizeInBytes: number;
   rangeCount: number;
   nodesByRegionString?: string;
@@ -245,14 +250,23 @@ export class DatabaseTablePage extends React.Component<
     if (this.props.refreshNodes != null) {
       this.props.refreshNodes();
     }
-    if (!this.props.details.loaded && !this.props.details.loading) {
+
+    if (
+      !this.props.details.loaded &&
+      !this.props.details.loading &&
+      this.props.details.lastError === undefined
+    ) {
       return this.props.refreshTableDetails(
         this.props.databaseName,
         this.props.name,
       );
     }
 
-    if (!this.props.stats.loaded && !this.props.stats.loading) {
+    if (
+      !this.props.stats.loaded &&
+      !this.props.stats.loading &&
+      this.props.stats.lastError === undefined
+    ) {
       return this.props.refreshTableStats(
         this.props.databaseName,
         this.props.name,
@@ -517,139 +531,188 @@ export class DatabaseTablePage extends React.Component<
               key={indexTabKey}
               className={cx("tab-pane")}
             >
-              <Row gutter={18}>
-                <Col className="gutter-row" span={18}>
-                  <SqlBox value={this.props.details.createStatement} />
-                </Col>
-              </Row>
+              <Loading
+                loading={this.props.details.loading && this.props.stats.loading}
+                page={"table_details"}
+                error={
+                  this.props.details.lastError || this.props.stats.lastError
+                }
+                render={() => (
+                  <>
+                    <Row gutter={18}>
+                      <Col className="gutter-row" span={18}>
+                        <SqlBox value={this.props.details.createStatement} />
+                      </Col>
+                    </Row>
 
-              <Row gutter={18}>
-                <Col className="gutter-row" span={8}>
-                  <SummaryCard className={cx("summary-card")}>
-                    <SummaryCardItem
-                      label="Size"
-                      value={format.Bytes(this.props.stats.sizeInBytes)}
-                    />
-                    <SummaryCardItem
-                      label="Replicas"
-                      value={this.props.details.replicaCount}
-                    />
-                    <SummaryCardItem
-                      label="Ranges"
-                      value={this.props.stats.rangeCount}
-                    />
-                    <SummaryCardItem
-                      label="% of Live Data"
-                      value={this.formatMVCCInfo(this.props.details)}
-                    />
-                    {this.props.details.statsLastUpdated && (
-                      <SummaryCardItem
-                        label="Table Stats Last Updated"
-                        value={this.props.details.statsLastUpdated.format(
-                          DATE_FORMAT_24_UTC,
-                        )}
-                      />
-                    )}
-                    {this.props.automaticStatsCollectionEnabled != null && (
-                      <SummaryCardItemBoolSetting
-                        label="Auto Stats Collection"
-                        value={this.props.automaticStatsCollectionEnabled}
-                        toolTipText={
-                          <span>
-                            {" "}
-                            Automatic statistics can help improve query
-                            performance. Learn how to{" "}
-                            <Anchor
-                              href={tableStatsClusterSetting}
-                              target="_blank"
-                              className={booleanSettingCx(
-                                "crl-hover-text__link-text",
+                    <Row gutter={18}>
+                      <Col className="gutter-row" span={8}>
+                        <SummaryCard className={cx("summary-card")}>
+                          <SummaryCardItem
+                            label="Size"
+                            value={format.Bytes(this.props.stats.sizeInBytes)}
+                          />
+                          <SummaryCardItem
+                            label="Replicas"
+                            value={this.props.details.replicaCount}
+                          />
+                          <SummaryCardItem
+                            label="Ranges"
+                            value={this.props.stats.rangeCount}
+                          />
+                          <SummaryCardItem
+                            label="% of Live Data"
+                            value={this.formatMVCCInfo(this.props.details)}
+                          />
+                          {this.props.details.statsLastUpdated && (
+                            <SummaryCardItem
+                              label="Table Stats Last Updated"
+                              value={this.props.details.statsLastUpdated.format(
+                                DATE_FORMAT_24_UTC,
                               )}
-                            >
-                              manage statistics collection
-                            </Anchor>
-                            .
-                          </span>
-                        }
-                      />
-                    )}
-                  </SummaryCard>
-                </Col>
-
-                <Col className="gutter-row" span={10}>
-                  <SummaryCard className={cx("summary-card")}>
-                    {this.props.showNodeRegionsSection && (
-                      <SummaryCardItem
-                        label="Regions/Nodes"
-                        value={this.props.stats.nodesByRegionString}
-                      />
-                    )}
-                    <SummaryCardItem
-                      label="Database"
-                      value={this.props.databaseName}
-                    />
-                    <SummaryCardItem
-                      label="Indexes"
-                      value={this.props.details.indexNames.join(", ")}
-                      className={cx("database-table-page__indexes--value")}
-                    />
-                  </SummaryCard>
-                </Col>
-              </Row>
-              <Row gutter={18}>
-                <SummaryCard
-                  className={cx("summary-card", "index-stats__summary-card")}
-                >
-                  <div className={cx("index-stats__header")}>
-                    <Heading type="h5">Index Stats</Heading>
-                    <div className={cx("index-stats__reset-info")}>
-                      <Tooltip
-                        placement="bottom"
-                        title="Index stats accumulate from the time the index was created or had its stats reset. Clicking ‘Reset all index stats’ will reset index stats for the entire cluster. Last reset is the timestamp at which the last reset started."
-                      >
-                        <div
-                          className={cx("index-stats__last-reset", "underline")}
-                        >
-                          {this.getLastResetString()}
-                        </div>
-                      </Tooltip>
-                      <div>
-                        <a
-                          className={cx(
-                            "action",
-                            "separator",
-                            "index-stats__reset-btn",
+                            />
                           )}
-                          onClick={() =>
-                            this.props.resetIndexUsageStats(
-                              this.props.databaseName,
-                              this.props.name,
-                            )
-                          }
-                        >
-                          Reset all index stats
-                        </a>
-                      </div>
-                    </div>
-                  </div>
-                  <IndexUsageStatsTable
-                    className="index-stats-table"
-                    data={this.props.indexStats.stats}
-                    columns={this.indexStatsColumns}
-                    sortSetting={this.state.indexSortSetting}
-                    onChangeSortSetting={this.changeIndexSortSetting.bind(this)}
-                    loading={this.props.indexStats.loading}
-                  />
-                </SummaryCard>
-              </Row>
+                          {this.props.automaticStatsCollectionEnabled !=
+                            null && (
+                            <SummaryCardItemBoolSetting
+                              label="Auto Stats Collection"
+                              value={this.props.automaticStatsCollectionEnabled}
+                              toolTipText={
+                                <span>
+                                  {" "}
+                                  Automatic statistics can help improve query
+                                  performance. Learn how to{" "}
+                                  <Anchor
+                                    href={tableStatsClusterSetting}
+                                    target="_blank"
+                                    className={booleanSettingCx(
+                                      "crl-hover-text__link-text",
+                                    )}
+                                  >
+                                    manage statistics collection
+                                  </Anchor>
+                                  .
+                                </span>
+                              }
+                            />
+                          )}
+                        </SummaryCard>
+                      </Col>
+
+                      <Col className="gutter-row" span={10}>
+                        <SummaryCard className={cx("summary-card")}>
+                          {this.props.showNodeRegionsSection && (
+                            <SummaryCardItem
+                              label="Regions/Nodes"
+                              value={this.props.stats.nodesByRegionString}
+                            />
+                          )}
+                          <SummaryCardItem
+                            label="Database"
+                            value={this.props.databaseName}
+                          />
+                          <SummaryCardItem
+                            label="Indexes"
+                            value={this.props.details.indexNames.join(", ")}
+                            className={cx(
+                              "database-table-page__indexes--value",
+                            )}
+                          />
+                        </SummaryCard>
+                      </Col>
+                    </Row>
+                    <Row gutter={18}>
+                      <SummaryCard
+                        className={cx(
+                          "summary-card",
+                          "index-stats__summary-card",
+                        )}
+                      >
+                        <div className={cx("index-stats__header")}>
+                          <Heading type="h5">Index Stats</Heading>
+                          <div className={cx("index-stats__reset-info")}>
+                            <Tooltip
+                              placement="bottom"
+                              title="Index stats accumulate from the time the index was created or had its stats reset. Clicking ‘Reset all index stats’ will reset index stats for the entire cluster. Last reset is the timestamp at which the last reset started."
+                            >
+                              <div
+                                className={cx(
+                                  "index-stats__last-reset",
+                                  "underline",
+                                )}
+                              >
+                                {this.getLastResetString()}
+                              </div>
+                            </Tooltip>
+                            <div>
+                              <a
+                                className={cx(
+                                  "action",
+                                  "separator",
+                                  "index-stats__reset-btn",
+                                )}
+                                onClick={() =>
+                                  this.props.resetIndexUsageStats(
+                                    this.props.databaseName,
+                                    this.props.name,
+                                  )
+                                }
+                              >
+                                Reset all index stats
+                              </a>
+                            </div>
+                          </div>
+                        </div>
+                        <IndexUsageStatsTable
+                          className="index-stats-table"
+                          data={this.props.indexStats.stats}
+                          columns={this.indexStatsColumns}
+                          sortSetting={this.state.indexSortSetting}
+                          onChangeSortSetting={this.changeIndexSortSetting.bind(
+                            this,
+                          )}
+                          loading={this.props.indexStats.loading}
+                        />
+                      </SummaryCard>
+                    </Row>
+                  </>
+                )}
+                renderError={() =>
+                  LoadingError({
+                    statsType: "databases",
+                    timeout:
+                      this.props.details.lastError?.name
+                        ?.toLowerCase()
+                        .includes("timeout") ||
+                      this.props.stats.lastError?.name
+                        ?.toLowerCase()
+                        .includes("timeout"),
+                  })
+                }
+              />
             </TabPane>
             <TabPane tab="Grants" key={grantsTabKey} className={cx("tab-pane")}>
-              <DatabaseTableGrantsTable
-                data={this.props.details.grants}
-                columns={this.grantsColumns}
-                sortSetting={this.state.grantSortSetting}
-                onChangeSortSetting={this.changeGrantSortSetting.bind(this)}
+              <Loading
                 loading={this.props.details.loading}
+                page={"table_details_grants"}
+                error={this.props.details.lastError}
+                render={() => (
+                  <DatabaseTableGrantsTable
+                    data={this.props.details.grants}
+                    columns={this.grantsColumns}
+                    sortSetting={this.state.grantSortSetting}
+                    onChangeSortSetting={this.changeGrantSortSetting.bind(this)}
+                    loading={this.props.details.loading}
+                  />
+                )}
+                renderError={() =>
+                  LoadingError({
+                    statsType: "databases",
+                    timeout: this.props.details.lastError?.name
+                      ?.toLowerCase()
+                      .includes("timeout"),
+                  })
+                }
               />
             </TabPane>
           </Tabs>

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
@@ -23,7 +23,7 @@ import {
 } from "./sessionsTable";
 
 import { SummaryCard, SummaryCardItem } from "../summaryCard";
-import SQLActivityError from "../sqlActivity/errorComponent";
+import LoadingError from "../sqlActivity/errorComponent";
 
 import { DurationToMomentDuration, TimestampToMoment } from "src/util/convert";
 import { Bytes, DATE_FORMAT } from "src/util/format";
@@ -214,7 +214,7 @@ export class SessionDetails extends React.Component<SessionDetailsProps> {
             error={this.props.sessionError}
             render={this.renderContent}
             renderError={() =>
-              SQLActivityError({
+              LoadingError({
                 statsType: "sessions",
               })
             }

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
@@ -23,7 +23,7 @@ import classNames from "classnames/bind";
 import { sessionsTable } from "src/util/docs";
 
 import emptyTableResultsIcon from "../assets/emptyState/empty-table-results.svg";
-import SQLActivityError from "../sqlActivity/errorComponent";
+import LoadingError from "../sqlActivity/errorComponent";
 import { Pagination } from "src/pagination";
 import {
   SortSetting,
@@ -464,7 +464,7 @@ export class SessionsPage extends React.Component<
           error={this.props.sessionsError}
           render={this.renderSessions}
           renderError={() =>
-            SQLActivityError({
+            LoadingError({
               statsType: "sessions",
             })
           }

--- a/pkg/ui/workspaces/cluster-ui/src/sqlActivity/errorComponent.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sqlActivity/errorComponent.tsx
@@ -19,7 +19,7 @@ interface SQLActivityErrorProps {
   timeout?: boolean;
 }
 
-const SQLActivityError: React.FC<SQLActivityErrorProps> = props => {
+const LoadingError: React.FC<SQLActivityErrorProps> = props => {
   const error = props.timeout ? "a timeout" : "an unexpected error";
   return (
     <div className={cx("row")}>
@@ -37,4 +37,4 @@ const SQLActivityError: React.FC<SQLActivityErrorProps> = props => {
   );
 };
 
-export default SQLActivityError;
+export default LoadingError;

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -57,7 +57,7 @@ import {
   timeScaleToString,
   toRoundedDateRange,
 } from "../timeScaleDropdown";
-import SQLActivityError from "../sqlActivity/errorComponent";
+import LoadingError from "../sqlActivity/errorComponent";
 import {
   ActivateDiagnosticsModalRef,
   ActivateStatementDiagnosticsModal,
@@ -395,7 +395,7 @@ export class StatementDetails extends React.Component<
             error={error}
             render={this.renderTabs}
             renderError={() =>
-              SQLActivityError({
+              LoadingError({
                 statsType: "statements",
               })
             }
@@ -483,7 +483,7 @@ export class StatementDetails extends React.Component<
         {hasTimeout && (
           <InlineAlert
             intent="danger"
-            title={SQLActivityError({
+            title={LoadingError({
               statsType: "statements",
               timeout: true,
             })}

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/activeStatementsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/activeStatementsView.tsx
@@ -20,7 +20,7 @@ import { PageConfig, PageConfigItem } from "src/pageConfig/pageConfig";
 import { Search } from "src/search/search";
 import { ActiveStatement, ActiveStatementFilters } from "src/activeExecutions";
 import { Filter } from "src/queryFilter";
-import SQLActivityError from "src/sqlActivity/errorComponent";
+import LoadingError from "src/sqlActivity/errorComponent";
 import {
   ACTIVE_STATEMENT_SEARCH_PARAM,
   getAppsFromActiveExecutions,
@@ -191,7 +191,7 @@ export const ActiveStatementsView: React.FC<ActiveStatementsViewProps> = ({
           page="active statements"
           error={sessionsError}
           renderError={() =>
-            SQLActivityError({
+            LoadingError({
               statsType: "statements",
             })
           }

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -66,7 +66,7 @@ import { UIConfigState } from "../store";
 import { StatementsRequest } from "src/api/statementsApi";
 import Long from "long";
 import ClearStats from "../sqlActivity/clearStats";
-import SQLActivityError from "../sqlActivity/errorComponent";
+import LoadingError from "../sqlActivity/errorComponent";
 import {
   getValidOption,
   TimeScale,
@@ -744,7 +744,7 @@ export class StatementsPage extends React.Component<
             error={this.props.statementsError}
             render={() => this.renderStatements(regions)}
             renderError={() =>
-              SQLActivityError({
+              LoadingError({
                 statsType: "statements",
                 timeout: this.props.statementsError?.name
                   ?.toLowerCase()

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -44,7 +44,7 @@ import {
   unset,
 } from "src/util";
 import { UIConfigState } from "../store";
-import SQLActivityError from "../sqlActivity/errorComponent";
+import LoadingError from "../sqlActivity/errorComponent";
 
 import summaryCardStyles from "../summaryCard/summaryCard.module.scss";
 import transactionDetailsStyles from "./transactionDetails.modules.scss";
@@ -484,7 +484,7 @@ export class TransactionDetails extends React.Component<
             );
           }}
           renderError={() =>
-            SQLActivityError({
+            LoadingError({
               statsType: "transactions",
             })
           }

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/activeTransactionsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/activeTransactionsView.tsx
@@ -23,7 +23,7 @@ import {
   ActiveStatementFilters,
   ActiveTransactionFilters,
 } from "src/activeExecutions";
-import SQLActivityError from "src/sqlActivity/errorComponent";
+import LoadingError from "src/sqlActivity/errorComponent";
 import {
   calculateActiveFilters,
   Filter,
@@ -192,7 +192,7 @@ export const ActiveTransactionsView: React.FC<ActiveTransactionsViewProps> = ({
           page="active transactions"
           error={sessionsError}
           renderError={() =>
-            SQLActivityError({
+            LoadingError({
               statsType: "transactions",
             })
           }

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -58,7 +58,7 @@ import {
   StatisticTableColumnKeys,
 } from "../statsTableUtil/statsTableUtil";
 import ClearStats from "../sqlActivity/clearStats";
-import SQLActivityError from "../sqlActivity/errorComponent";
+import LoadingError from "../sqlActivity/errorComponent";
 import { commonStyles } from "../common";
 import {
   TimeScaleDropdown,
@@ -578,7 +578,7 @@ export class TransactionsPage extends React.Component<
               );
             }}
             renderError={() =>
-              SQLActivityError({
+              LoadingError({
                 statsType: "transactions",
                 timeout: this.props?.error?.name
                   ?.toLowerCase()

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -94,6 +94,8 @@ export const refreshLocations = locationsReducerObj.refresh;
 const databasesReducerObj = new CachedDataReducer(
   api.getDatabaseList,
   "databases",
+  null,
+  moment.duration(10, "m"),
 );
 export const refreshDatabases = databasesReducerObj.refresh;
 
@@ -105,6 +107,8 @@ const databaseDetailsReducerObj = new KeyedCachedDataReducer(
   api.getDatabaseDetails,
   "databaseDetails",
   databaseRequestToID,
+  null,
+  moment.duration(10, "m"),
 );
 
 const hotRangesRequestToID = (req: api.HotRangesRequestMessage) =>
@@ -137,6 +141,8 @@ const tableDetailsReducerObj = new KeyedCachedDataReducer(
   api.getTableDetails,
   "tableDetails",
   tableRequestToID,
+  null,
+  moment.duration(10, "m"),
 );
 export const refreshTableDetails = tableDetailsReducerObj.refresh;
 
@@ -144,6 +150,8 @@ const tableStatsReducerObj = new KeyedCachedDataReducer(
   api.getTableStats,
   "tableStats",
   tableRequestToID,
+  null,
+  moment.duration(10, "m"),
 );
 export const refreshTableStats = tableStatsReducerObj.refresh;
 

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.spec.ts
@@ -125,6 +125,7 @@ describe("Database Details Page", function () {
     driver.assertProperties({
       loading: false,
       loaded: false,
+      lastError: undefined,
       name: "things",
       showNodeRegionsColumn: false,
       viewMode: ViewMode.Tables,
@@ -144,6 +145,7 @@ describe("Database Details Page", function () {
     driver.assertProperties({
       loading: false,
       loaded: true,
+      lastError: null,
       name: "things",
       showNodeRegionsColumn: false,
       viewMode: ViewMode.Tables,
@@ -155,6 +157,7 @@ describe("Database Details Page", function () {
           details: {
             loading: false,
             loaded: false,
+            lastError: undefined,
             columnCount: 0,
             indexCount: 0,
             userCount: 0,
@@ -169,6 +172,7 @@ describe("Database Details Page", function () {
           stats: {
             loading: false,
             loaded: false,
+            lastError: undefined,
             replicationSizeInBytes: 0,
             rangeCount: 0,
             nodesByRegionString: "",
@@ -179,6 +183,7 @@ describe("Database Details Page", function () {
           details: {
             loading: false,
             loaded: false,
+            lastError: undefined,
             columnCount: 0,
             indexCount: 0,
             userCount: 0,
@@ -193,6 +198,7 @@ describe("Database Details Page", function () {
           stats: {
             loading: false,
             loaded: false,
+            lastError: undefined,
             replicationSizeInBytes: 0,
             rangeCount: 0,
             nodesByRegionString: "",
@@ -326,6 +332,7 @@ describe("Database Details Page", function () {
     driver.assertTableDetails("foo", {
       loading: false,
       loaded: true,
+      lastError: null,
       columnCount: 5,
       indexCount: 3,
       userCount: 2,
@@ -343,6 +350,7 @@ describe("Database Details Page", function () {
     driver.assertTableDetails("bar", {
       loading: false,
       loaded: true,
+      lastError: null,
       columnCount: 4,
       indexCount: 1,
       userCount: 3,
@@ -442,6 +450,7 @@ describe("Database Details Page", function () {
     driver.assertTableStats("foo", {
       loading: false,
       loaded: true,
+      lastError: null,
       replicationSizeInBytes: 44040192,
       rangeCount: 4200,
       nodesByRegionString: "",
@@ -450,6 +459,7 @@ describe("Database Details Page", function () {
     driver.assertTableStats("bar", {
       loading: false,
       loaded: true,
+      lastError: null,
       replicationSizeInBytes: 8675309,
       rangeCount: 1023,
       nodesByRegionString: "",

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.ts
@@ -115,6 +115,7 @@ export const mapStateToProps = createSelector(
     return {
       loading: !!databaseDetails[database]?.inFlight,
       loaded: !!databaseDetails[database]?.valid,
+      lastError: databaseDetails[database]?.lastError,
       name: database,
       showNodeRegionsColumn,
       viewMode,
@@ -139,6 +140,7 @@ export const mapStateToProps = createSelector(
           details: {
             loading: !!details?.inFlight,
             loaded: !!details?.valid,
+            lastError: details?.lastError,
             columnCount: details?.data?.columns?.length || 0,
             indexCount: numIndexes,
             userCount: roles.length,
@@ -158,6 +160,7 @@ export const mapStateToProps = createSelector(
           stats: {
             loading: !!stats?.inFlight,
             loaded: !!stats?.valid,
+            lastError: stats?.lastError,
             replicationSizeInBytes: FixLong(
               stats?.data?.approximate_disk_bytes || 0,
             ).toNumber(),

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.spec.ts
@@ -169,6 +169,7 @@ describe("Database Table Page", function () {
         details: {
           loading: false,
           loaded: false,
+          lastError: undefined,
           createStatement: "",
           replicaCount: 0,
           indexNames: [],
@@ -182,6 +183,7 @@ describe("Database Table Page", function () {
         stats: {
           loading: false,
           loaded: false,
+          lastError: undefined,
           sizeInBytes: 0,
           rangeCount: 0,
           nodesByRegionString: "",
@@ -189,6 +191,7 @@ describe("Database Table Page", function () {
         indexStats: {
           loading: false,
           loaded: false,
+          lastError: undefined,
           stats: [],
           lastReset: null,
         },
@@ -223,6 +226,7 @@ describe("Database Table Page", function () {
     driver.assertTableDetails({
       loading: false,
       loaded: true,
+      lastError: null,
       createStatement: "CREATE TABLE foo",
       replicaCount: 5,
       indexNames: ["primary", "another_index"],
@@ -251,6 +255,7 @@ describe("Database Table Page", function () {
     driver.assertTableStats({
       loading: false,
       loaded: true,
+      lastError: null,
       sizeInBytes: 44040192,
       rangeCount: 4200,
       nodesByRegionString: "",
@@ -306,6 +311,7 @@ describe("Database Table Page", function () {
     driver.assertIndexStats({
       loading: false,
       loaded: true,
+      lastError: null,
       stats: [
         {
           indexName: "jobs_status_created_idx",

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.ts
@@ -133,6 +133,7 @@ export const mapStateToProps = createSelector(
       details: {
         loading: !!details?.inFlight,
         loaded: !!details?.valid,
+        lastError: details?.lastError,
         createStatement: details?.data?.create_table_statement || "",
         replicaCount: details?.data?.zone_config?.num_replicas || 0,
         indexNames: _.uniq(_.map(details?.data?.indexes, index => index.name)),
@@ -149,6 +150,7 @@ export const mapStateToProps = createSelector(
       stats: {
         loading: !!stats?.inFlight,
         loaded: !!stats?.valid,
+        lastError: stats?.lastError,
         sizeInBytes: FixLong(
           stats?.data?.approximate_disk_bytes || 0,
         ).toNumber(),
@@ -158,6 +160,7 @@ export const mapStateToProps = createSelector(
       indexStats: {
         loading: !!indexStats?.inFlight,
         loaded: !!indexStats?.valid,
+        lastError: indexStats?.lastError,
         stats: indexStatsData,
         lastReset: lastReset,
       },

--- a/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.spec.ts
@@ -104,6 +104,7 @@ describe("Databases Page", function () {
     driver.assertProperties({
       loading: false,
       loaded: false,
+      lastError: undefined,
       databases: [],
       sortSetting: { ascending: true, columnTitle: "name" },
       automaticStatsCollectionEnabled: true,
@@ -127,10 +128,12 @@ describe("Databases Page", function () {
     driver.assertProperties({
       loading: false,
       loaded: true,
+      lastError: null,
       databases: [
         {
           loading: false,
           loaded: false,
+          lastError: undefined,
           name: "system",
           sizeInBytes: 0,
           tableCount: 0,
@@ -142,6 +145,7 @@ describe("Databases Page", function () {
         {
           loading: false,
           loaded: false,
+          lastError: undefined,
           name: "test",
           sizeInBytes: 0,
           tableCount: 0,
@@ -187,6 +191,7 @@ describe("Databases Page", function () {
     driver.assertDatabaseProperties("system", {
       loading: false,
       loaded: true,
+      lastError: null,
       name: "system",
       sizeInBytes: 7168,
       tableCount: 2,
@@ -199,6 +204,7 @@ describe("Databases Page", function () {
     driver.assertDatabaseProperties("test", {
       loading: false,
       loaded: true,
+      lastError: null,
       name: "test",
       sizeInBytes: 1234,
       tableCount: 1,
@@ -231,6 +237,7 @@ describe("Databases Page", function () {
         driver.assertDatabaseProperties("system", {
           loading: false,
           loaded: true,
+          lastError: null,
           name: "system",
           sizeInBytes: 7168,
           tableCount: 2,
@@ -267,6 +274,7 @@ describe("Databases Page", function () {
         driver.assertDatabaseProperties("system", {
           loading: false,
           loaded: true,
+          lastError: null,
           name: "system",
           sizeInBytes: 8192,
           tableCount: 2,
@@ -294,6 +302,7 @@ describe("Databases Page", function () {
         driver.assertDatabaseProperties("system", {
           loading: false,
           loaded: true,
+          lastError: null,
           name: "system",
           sizeInBytes: 0,
           tableCount: 2,
@@ -333,6 +342,7 @@ describe("Databases Page", function () {
         driver.assertDatabaseProperties("system", {
           loading: false,
           loaded: true,
+          lastError: null,
           name: "system",
           sizeInBytes: 7168,
           tableCount: 2,
@@ -347,6 +357,7 @@ describe("Databases Page", function () {
         driver.assertDatabaseProperties("system", {
           loading: false,
           loaded: true,
+          lastError: null,
           name: "system",
           sizeInBytes: 8192,
           tableCount: 2,

--- a/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.ts
@@ -46,6 +46,11 @@ const selectLoaded = createSelector(
   databases => databases.valid,
 );
 
+const selectLastError = createSelector(
+  (state: AdminUIState) => state.cachedData.databases,
+  databases => databases.lastError,
+);
+
 const sortSettingLocalSetting = new LocalSetting(
   "sortSetting/DatabasesPage",
   (state: AdminUIState) => state.localSettings,
@@ -106,6 +111,7 @@ const selectDatabases = createSelector(
       return {
         loading: !!details?.inFlight,
         loaded: !!details?.valid,
+        lastError: details?.lastError,
         name: database,
         sizeInBytes: sizeInBytes,
         tableCount: details?.data?.table_names?.length || 0,
@@ -125,6 +131,7 @@ const selectDatabases = createSelector(
 export const mapStateToProps = (state: AdminUIState): DatabasesPageData => ({
   loading: selectLoading(state),
   loaded: selectLoaded(state),
+  lastError: selectLastError(state),
   databases: selectDatabases(state),
   sortSetting: sortSettingLocalSetting.selector(state),
   automaticStatsCollectionEnabled: selectAutomaticStatsCollectionEnabled(state),


### PR DESCRIPTION
Previously, when hitting an error on endpoints
used on the database page, we would just keep retrying constantly, without showing a proper error state.
On SQL Activity page, for example, we show the error message and let the user retry if they want.
This commit uses the same logic on the Database page. Since the pages make several requests and just part of them can fail, some of the pages we will still load, but give a warning about unavailable data and show the error message about reload option.

This commit also increases timeout of database endpoints.

Fixes #90596

<img width="636" alt="Screen Shot 2022-10-28 at 6 28 55 PM" src="https://user-images.githubusercontent.com/1017486/198745467-7833de82-4eac-41fe-85ef-5035f99b0f35.png">


<img width="866" alt="Screen Shot 2022-10-28 at 6 29 30 PM" src="https://user-images.githubusercontent.com/1017486/198745476-306ce1af-9476-4d47-9f9d-46c954e69ab8.png">


https://www.loom.com/share/edc46386a6fe408b90fa5b6330870819

Release note: None