### PR TITLE
flowinfra: use the flow context in FlowStream RPC in outbox

### DIFF
--- a/pkg/sql/colflow/colrpc/BUILD.bazel
+++ b/pkg/sql/colflow/colrpc/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/sql/colmem",
         "//pkg/sql/execinfra",
         "//pkg/sql/execinfrapb",
+        "//pkg/sql/flowinfra",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/types",

--- a/pkg/sql/colflow/colrpc/outbox.go
+++ b/pkg/sql/colflow/colrpc/outbox.go
@@ -13,7 +13,6 @@ package colrpc
 import (
 	"bytes"
 	"context"
-	"io"
 	"sync/atomic"
 	"time"
 
@@ -26,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -225,25 +225,6 @@ func (o *Outbox) Run(
 	log.VEvent(ctx, 2, "Outbox exiting")
 }
 
-// handleStreamErr is a utility method used to handle an error when calling
-// a method on a flowStreamClient. If err is an io.EOF, outboxCtxCancel is
-// called, for all other errors flowCtxCancel is. The given error is logged with
-// the associated opName.
-func handleStreamErr(
-	ctx context.Context,
-	opName redact.SafeString,
-	err error,
-	flowCtxCancel, outboxCtxCancel context.CancelFunc,
-) {
-	if err == io.EOF {
-		log.VEventf(ctx, 2, "Outbox calling outboxCtxCancel after %s EOF", opName)
-		outboxCtxCancel()
-	} else {
-		log.VEventf(ctx, 1, "Outbox calling flowCtxCancel after %s connection error: %+v", opName, err)
-		flowCtxCancel()
-	}
-}
-
 func (o *Outbox) moveToDraining(ctx context.Context, reason redact.RedactableString) {
 	if atomic.CompareAndSwapUint32(&o.draining, 0, 1) {
 		log.VEventf(ctx, 2, "Outbox moved to draining (%s)", reason)
@@ -321,7 +302,7 @@ func (o *Outbox) sendBatches(
 			// soon as the message is written to the control buffer. The message is
 			// marshaled (bytes are copied) before writing.
 			if err := stream.Send(o.scratch.msg); err != nil {
-				handleStreamErr(ctx, "Send (batches)", err, flowCtxCancel, outboxCtxCancel)
+				flowinfra.HandleStreamErr(ctx, "Send (batches)", err, flowCtxCancel, outboxCtxCancel)
 				return
 			}
 		}
@@ -399,12 +380,12 @@ func (o *Outbox) runWithStream(
 		for {
 			msg, err := stream.Recv()
 			if err != nil {
-				handleStreamErr(ctx, "watchdog Recv", err, flowCtxCancel, outboxCtxCancel)
+				flowinfra.HandleStreamErr(ctx, "watchdog Recv", err, flowCtxCancel, outboxCtxCancel)
 				break
 			}
 			switch {
 			case msg.Handshake != nil:
-				log.VEventf(ctx, 2, "Outbox received handshake: %v", msg.Handshake)
+				log.VEventf(ctx, 2, "Outbox received handshake: %s", msg.Handshake)
 			case msg.DrainRequest != nil:
 				log.VEventf(ctx, 2, "Outbox received drain request")
 				o.moveToDraining(ctx, "consumer requested draining" /* reason */)
@@ -423,14 +404,14 @@ func (o *Outbox) runWithStream(
 		}
 		o.moveToDraining(ctx, reason)
 		if err := o.sendMetadata(ctx, stream, errToSend); err != nil {
-			handleStreamErr(ctx, "Send (metadata)", err, flowCtxCancel, outboxCtxCancel)
+			flowinfra.HandleStreamErr(ctx, "Send (metadata)", err, flowCtxCancel, outboxCtxCancel)
 		} else {
 			// Close the stream. Note that if this block isn't reached, the stream
 			// is unusable.
 			// The receiver goroutine will read from the stream until any error
 			// is returned (most likely an io.EOF).
 			if err := stream.CloseSend(); err != nil {
-				handleStreamErr(ctx, "CloseSend", err, flowCtxCancel, outboxCtxCancel)
+				flowinfra.HandleStreamErr(ctx, "CloseSend", err, flowCtxCancel, outboxCtxCancel)
 			}
 		}
 	}

--- a/pkg/sql/flowinfra/flow_registry_test.go
+++ b/pkg/sql/flowinfra/flow_registry_test.go
@@ -247,13 +247,10 @@ func TestStreamConnectionTimeout(t *testing.T) {
 	})
 
 	// Create a dummy server stream to pass to ConnectInboundStream.
-	serverStream, _ /* clientStream */, cleanup, err := createDummyStream()
-	if err != nil {
-		t.Fatal(err)
-	}
+	serverStream, _ /* clientStream */, cleanup := createDummyStream(t)
 	defer cleanup()
 
-	_, _, _, err = reg.ConnectInboundStream(context.Background(), id1, streamID1, serverStream, jiffy)
+	_, _, _, err := reg.ConnectInboundStream(context.Background(), id1, streamID1, serverStream, jiffy)
 	if !testutils.IsError(err, "came too late") {
 		t.Fatalf("expected %q, got: %v", "came too late", err)
 	}
@@ -295,10 +292,7 @@ func TestHandshake(t *testing.T) {
 			flowID := execinfrapb.FlowID{UUID: uuid.MakeV4()}
 			streamID := execinfrapb.StreamID(1)
 
-			serverStream, clientStream, cleanup, err := createDummyStream()
-			if err != nil {
-				t.Fatal(err)
-			}
+			serverStream, clientStream, cleanup := createDummyStream(t)
 			defer cleanup()
 
 			connectProducer := func() {

--- a/pkg/sql/flowinfra/utils_test.go
+++ b/pkg/sql/flowinfra/utils_test.go
@@ -12,6 +12,8 @@ package flowinfra
 
 import (
 	"context"
+	"io"
+	"testing"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -23,44 +25,58 @@ import (
 )
 
 // createDummyStream creates the server and client side of a FlowStream stream.
-// This can be use by tests to pretend that then have received a FlowStream RPC.
+// This can be use by tests to pretend that they have received a FlowStream RPC.
 // The stream can be used to send messages (ConsumerSignal's) on it (within a
 // gRPC window limit since nobody's reading from the stream), for example
 // Handshake messages.
 //
 // We do this by creating a mock server, dialing into it and capturing the
 // server stream. The server-side RPC call will be blocked until the caller
-// calls the returned cleanup function.
-func createDummyStream() (
+// calls the returned cleanup function. The cleanup function also "drains" the
+// client-side stream.
+func createDummyStream(
+	t *testing.T,
+) (
 	serverStream execinfrapb.DistSQL_FlowStreamServer,
 	clientStream execinfrapb.DistSQL_FlowStreamClient,
 	cleanup func(),
-	err error,
 ) {
 	stopper := stop.NewStopper()
 	ctx := context.Background()
 	clock := hlc.NewClockWithSystemTimeSource(time.Nanosecond /* maxOffset */)
 	storageClusterID, mockServer, addr, err := execinfrapb.StartMockDistSQLServer(ctx, clock, stopper, execinfra.StaticSQLInstanceID)
 	if err != nil {
-		return nil, nil, nil, err
+		t.Fatal(err)
 	}
 
 	rpcContext := rpc.NewInsecureTestingContextWithClusterID(ctx, clock, stopper, storageClusterID)
 	conn, err := rpcContext.GRPCDialNode(addr.String(), roachpb.NodeID(execinfra.StaticSQLInstanceID),
 		rpc.DefaultClass).Connect(ctx)
 	if err != nil {
-		return nil, nil, nil, err
+		t.Fatal(err)
 	}
 	client := execinfrapb.NewDistSQLClient(conn)
 	clientStream, err = client.FlowStream(ctx)
 	if err != nil {
-		return nil, nil, nil, err
+		t.Fatal(err)
 	}
 	streamNotification := <-mockServer.InboundStreams
 	serverStream = streamNotification.Stream
 	cleanup = func() {
 		close(streamNotification.Donec)
+		// After the RPC is unblocked, we have to drain the client side in order
+		// to simulate what happens in production (where the watchdog goroutine
+		// of the outbox does this).
+		for {
+			_, err := clientStream.Recv()
+			if err != nil {
+				if err == io.EOF {
+					break
+				}
+				t.Fatal(err)
+			}
+		}
 		stopper.Stop(ctx)
 	}
-	return serverStream, clientStream, cleanup, nil
+	return serverStream, clientStream, cleanup
 }

--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -157,6 +157,7 @@ func TestTrace(t *testing.T) {
 			optionalSpans: []string{
 				"setup-flow-async",
 				"/cockroach.sql.distsqlrun.DistSQL/SetupFlow",
+				"/cockroach.sql.distsqlrun.DistSQL/FlowStream",
 				"noop",
 			},
 		},
@@ -230,6 +231,7 @@ func TestTrace(t *testing.T) {
 			optionalSpans: []string{
 				"setup-flow-async",
 				"/cockroach.sql.distsqlrun.DistSQL/SetupFlow",
+				"/cockroach.sql.distsqlrun.DistSQL/FlowStream",
 				"noop",
 			},
 		},


### PR DESCRIPTION
Previously, we used the background context when performing the
`FlowStream` RPC in the row-based outbox rather than the flow context.
This has been the case for like four years now, but I believe it is
incorrect. In particular, if the flow context is canceled, this would
not shutdown the gRPC stream, possibly leaking some of the goroutines
(e.g. the goroutine listening for the drain signal from the inbox). This
is now fixed by correctly using the flow context.

This commit also fixes the outbox to satisfy the gRPC contract hidden in
[1] where the listener goroutine would not `Recv` everything from the
stream which could result in leakage of gRPC goroutines.

This required the cleanup of the outbox infrastructure to bring it more
in line with what we have in the vectorized engine (which has been
updated some time ago with recent learnings). In particular, the
following problems have been fixed:
- `CloseSend` signal from the main goroutine of the outbox previously
could have been omitted in some cases (I'm not sure what the impact of
this is though)
- the listener ("watchdog") goroutine is now tracked by the wait group
of the flow which makes it so that `Flow.Wait` blocks until the watchdog
exits. That goroutine now exits only after it `Recv`es an error from the
server side (the inbox) of `FlowStream` RPC.

[1] https://pkg.go.dev/google.golang.org/grpc#ClientConn.NewStream

Informs: #90841.

Epic: None

Release note: None