### PR TITLE
release-22.2: ui: fix start time on insights

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/insightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/insightsApi.ts
@@ -98,7 +98,7 @@ function transactionContentionResultsToEventState(
   return response.execution.txn_results[0].rows.map(row => ({
     transactionID: row.waiting_txn_id,
     fingerprintID: row.waiting_txn_fingerprint_id,
-    startTime: moment(row.collection_ts),
+    startTime: moment(row.collection_ts).utc(),
     contentionDuration: moment.duration(row.contention_duration),
     contentionThreshold: moment.duration(row.threshold).asMilliseconds(),
     insightName: InsightNameEnum.highContention,
@@ -375,7 +375,7 @@ function transactionContentionDetailsResultsToEventState(
       blockingExecutionID: value.blocking_txn_id,
       blockingFingerprintID: value.blocking_txn_fingerprint_id,
       blockingQueries: null,
-      collectionTimeStamp: moment(value.collection_ts),
+      collectionTimeStamp: moment(value.collection_ts).utc(),
       contentionTimeMs: contentionTimeInMs,
       contendedKey: value.key,
       schemaName: value.schema_name,
@@ -392,7 +392,7 @@ function transactionContentionDetailsResultsToEventState(
   return {
     executionID: row.waiting_txn_id,
     fingerprintID: row.waiting_txn_fingerprint_id,
-    startTime: moment(row.collection_ts),
+    startTime: moment(row.collection_ts).utc(),
     totalContentionTime: totalContentionTime,
     blockingContentionDetails: blockingContentionDetails,
     contentionThreshold: moment.duration(row.threshold).asMilliseconds(),

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/detailsLinks.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/detailsLinks.tsx
@@ -26,7 +26,7 @@ export function TransactionDetailsLink(
   const path = `/transaction/${txnID}`;
   const timeScale: TimeScale = {
     windowSize: moment.duration(65, "minutes"),
-    fixedWindowEnd: startTime.add(1, "hour"),
+    fixedWindowEnd: moment(startTime).add(1, "hour"),
     sampleSize: moment.duration(1, "hour"),
     key: "Custom",
   };


### PR DESCRIPTION
Backport 1/1 commits from #90715.

/cc @cockroachdb/release

---

A previous commit introduced a bug to the start
time of transaction insights, where it was updating the start time object, instead of just getting a new value.
This commit fixes this issue by creating a new object before adding the 1h.
This commit also properly set start time as UTC for transaction insights start time.

Fixes #90397
Fixes #90405

Release note: None

---
Release justification: bug fix
