### PR TITLE
sql: skip TestValidationWithProtectedTS

### DIFF
--- a/pkg/sql/backfill_protected_timestamp_test.go
+++ b/pkg/sql/backfill_protected_timestamp_test.go
@@ -55,6 +55,7 @@ func getFirstStoreReplica(
 
 func TestValidationWithProtectedTS(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 90879, "flaky test")
 	defer log.Scope(t).Close(t)
 	skip.UnderStress(t, "test takes too long")
 	skip.UnderRace(t, "test takes too long")


### PR DESCRIPTION
Refs: #90879

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Epic: None

Release note: None