### PR TITLE
randgen: fix adjustment of interesting strings to NAME type

### DIFF
--- a/pkg/sql/randgen/datum.go
+++ b/pkg/sql/randgen/datum.go
@@ -368,6 +368,12 @@ func adjustDatum(datum tree.Datum, typ *types.T) tree.Datum {
 		}
 		return &tree.DBitArray{BitArray: datum.(*tree.DBitArray).ToWidth(uint(typ.Width()))}
 
+	case types.StringFamily:
+		if typ.Oid() == oid.T_name {
+			datum = tree.NewDName(string(*datum.(*tree.DString)))
+		}
+		return datum
+
 	default:
 		return datum
 	}


### PR DESCRIPTION
Previously, when picking an interesting string for NAME type we didn't appropriately wrap it with the `T_name` oid. This resulted in quite rare flakes and is now fixed.

Fixes: #90691.

Release note: None