### PR TITLE
sql: add nil-check gate for stmt passed to InternalExecutor.checkIfStmtIsAllowed

### DIFF
--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -1043,6 +1043,9 @@ func (ie *InternalExecutor) commitTxn(ctx context.Context) error {
 // TODO (janexing): this will be deprecate soon since it's not a good idea
 // to have `extraTxnState` to store the info from a outer txn.
 func (ie *InternalExecutor) checkIfStmtIsAllowed(stmt tree.Statement, txn *kv.Txn) error {
+	if stmt == nil {
+		return nil
+	}
 	if tree.CanModifySchema(stmt) && txn != nil && ie.extraTxnState == nil {
 		return errors.New("DDL statement is disallowed if internal " +
 			"executor is not bound with txn metadata")


### PR DESCRIPTION
Currently, if the stmt passed to InternalExecutor.checkIfStmtIsAllowed() is nil, we will get invalid memory address error, since we need to check if the stmt is a DDL or not.

Now we add a gate to take care of this edge case.

fixes #89149

Release note: None