### PR TITLE
roachtest: use ANALYZE for computing table statistics

### DIFF
--- a/pkg/cmd/roachtest/tests/import_cancellation.go
+++ b/pkg/cmd/roachtest/tests/import_cancellation.go
@@ -305,7 +305,7 @@ func (t *importCancellationTest) runImportSequence(
 	// Up-to-date statistics on the table helps the optimizer during the query
 	// phase of the test. The stats job also requires scanning a large swath of
 	// the keyspace, which results in greater test coverage.
-	stmt := fmt.Sprintf(`CREATE STATISTICS %s_stats FROM csv.%s`, tableName, tableName)
+	stmt := fmt.Sprintf(`ANALYZE csv.%s`, tableName)
 	_, err := conn.ExecContext(ctx, stmt)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
The `import-cancellation` roachtest computes table statistics after each table has been successfully imported. Using the `CREATE STATISTICS` syntax, without an `AS OF SYSTEM TIME` clause cause trigger issues such as those observed in #90841.

Switch the table statistics collection to use the `ANALYZE` syntax, which is shorthand for using an `AS OF SYSTEM TIME '-0.001ms'` clause.

Touches #90841.

Release note: None.
Epic: CRDB-2624.