### PR TITLE
release-22.2.0: ttl: add key decoder tests, remove RKey wrapping

### DIFF
--- a/pkg/sql/ttl/ttljob/BUILD.bazel
+++ b/pkg/sql/ttl/ttljob/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     name = "ttljob",
     srcs = [
         "ttljob.go",
+        "ttljob_keydecoder.go",
         "ttljob_metrics.go",
         "ttljob_processor.go",
         "ttljob_query_builder.go",
@@ -56,6 +57,7 @@ go_test(
     name = "ttljob_test",
     srcs = [
         "main_test.go",
+        "ttljob_keydecoder_test.go",
         "ttljob_query_builder_test.go",
         "ttljob_test.go",
     ],
@@ -88,6 +90,7 @@ go_test(
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
+        "//pkg/util/encoding",
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/protoutil",

--- a/pkg/sql/ttl/ttljob/ttljob_keydecoder.go
+++ b/pkg/sql/ttl/ttljob/ttljob_keydecoder.go
@@ -1,0 +1,72 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package ttljob
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/errors"
+)
+
+const (
+	stripTenantPrefixErrorFmt      = "error decoding tenant prefix of %x"
+	decodePartialTableIDIndexIDFmt = "error decoding table/index ID of %x"
+	encDatumFromBufferFmt          = "error decoding EncDatum of %x"
+	ensureDecodedFmt               = "error ensuring encoding of %x"
+)
+
+// keyToDatums translates a Key on a span for a table to the appropriate datums.
+func keyToDatums(
+	key roachpb.Key, codec keys.SQLCodec, pkTypes []*types.T, alloc *tree.DatumAlloc,
+) (tree.Datums, error) {
+
+	// Decode the datums ourselves, instead of using rowenc.DecodeKeyVals.
+	// We cannot use rowenc.DecodeKeyVals because we may not have the entire PK
+	// as the key for the span (e.g. a PK (a, b) may only be split on (a)).
+	partialKey, err := codec.StripTenantPrefix(key)
+	if err != nil {
+		// Convert key to []byte to prevent hex encoding output of Key.String().
+		return nil, errors.Wrapf(err, stripTenantPrefixErrorFmt, []byte(key))
+	}
+	partialKey, _, _, err = rowenc.DecodePartialTableIDIndexID(partialKey)
+	if err != nil {
+		// Convert key to []byte to prevent hex encoding output of Key.String().
+		return nil, errors.Wrapf(err, decodePartialTableIDIndexIDFmt, []byte(key))
+	}
+	encDatums := make([]rowenc.EncDatum, 0, len(pkTypes))
+	for len(partialKey) > 0 && len(encDatums) < len(pkTypes) {
+		i := len(encDatums)
+		// We currently assume all PRIMARY KEY columns are ascending, and block
+		// creation otherwise.
+		enc := descpb.DatumEncoding_ASCENDING_KEY
+		var val rowenc.EncDatum
+		val, partialKey, err = rowenc.EncDatumFromBuffer(pkTypes[i], enc, partialKey)
+		if err != nil {
+			// Convert key to []byte to prevent hex encoding output of Key.String().
+			return nil, errors.Wrapf(err, encDatumFromBufferFmt, []byte(key))
+		}
+		encDatums = append(encDatums, val)
+	}
+
+	datums := make(tree.Datums, len(encDatums))
+	for i, encDatum := range encDatums {
+		if err := encDatum.EnsureDecoded(pkTypes[i], alloc); err != nil {
+			// Convert key to []byte to prevent hex encoding output of Key.String().
+			return nil, errors.Wrapf(err, ensureDecodedFmt, []byte(key))
+		}
+		datums[i] = encDatum.Datum
+	}
+	return datums, nil
+}

--- a/pkg/sql/ttl/ttljob/ttljob_keydecoder_test.go
+++ b/pkg/sql/ttl/ttljob/ttljob_keydecoder_test.go
@@ -1,0 +1,97 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package ttljob
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeyToDatums(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	const tenantID = 111
+
+	testCases := []struct {
+		desc                 string
+		keyBytes             []byte
+		errorFmt             string
+		expectedErrorMessage string
+		expectedDatums       tree.Datums
+	}{
+		{
+			desc:                 "StripTenantPrefix error",
+			keyBytes:             []byte{1, 2, 3},
+			errorFmt:             stripTenantPrefixErrorFmt,
+			expectedErrorMessage: `error decoding tenant prefix of 010203: invalid tenant id prefix: /Local/"` + "\u0002\u0003" + `"`,
+		},
+		{
+			desc:                 "DecodePartialTableIDIndexID error",
+			keyBytes:             []byte{254, 246, tenantID},
+			errorFmt:             decodePartialTableIDIndexIDFmt,
+			expectedErrorMessage: `error decoding table/index ID of fef66f: insufficient bytes to decode uvarint value`,
+		},
+		{
+			desc:                 "EncDatumFromBuffer error",
+			keyBytes:             []byte{254, 246, tenantID, 1, 1, 5},
+			errorFmt:             encDatumFromBufferFmt,
+			expectedErrorMessage: `error decoding EncDatum of fef66f010105: slice too short for float (1)`,
+		},
+		{
+			desc:                 "EnsureDecoded error",
+			keyBytes:             []byte{254, 246, tenantID, 1, 1, 1},
+			errorFmt:             ensureDecodedFmt,
+			expectedErrorMessage: `error ensuring encoding of fef66f010101: error decoding 1 bytes: insufficient bytes to decode varint value: ""`,
+		},
+		{
+			desc:           "success",
+			keyBytes:       encoding.EncodeVarintAscending([]byte{254, 246, tenantID, 1, 1}, 100),
+			expectedDatums: []tree.Datum{tree.NewDInt(100)},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			tenantID := roachpb.MakeTenantID(tenantID)
+			codec := keys.MakeSQLCodec(tenantID)
+			keyBytes := tc.keyBytes
+			var alloc tree.DatumAlloc
+			datums, err := keyToDatums(keyBytes, codec, []*types.T{types.Int}, &alloc)
+			expectedErrorMessage := tc.expectedErrorMessage
+			if expectedErrorMessage != "" {
+				require.Error(t, err)
+				actualErrorMessage := err.Error()
+				require.Equal(t, expectedErrorMessage, actualErrorMessage)
+				parts := strings.Split(actualErrorMessage, ":")
+				// Verify that the hex encoded key from the error message matches the original key.
+				var errorKeyBytes []byte
+				_, err := fmt.Sscanf(parts[0], tc.errorFmt, &errorKeyBytes)
+				require.NoError(t, err)
+				require.Equal(t, keyBytes, errorKeyBytes)
+			}
+			expectedDatums := tc.expectedDatums
+			if expectedDatums != nil {
+				require.Equal(t, expectedDatums, datums)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Backport 1/1 commits from #90829.

/cc @cockroachdb/release

---

See also https://github.com/cockroachdb/cockroach/issues/90707

Add tests for keyToDatums to help with debugging prod decoding errors.

Remove unnecessary Key -> RKey -> Key conversion.

Release note: None

Release justification: TTL key decoding tests.
