### PR TITLE
storage: fix `RangeKeyChanged` for `intentInterleavingIter` seeks

### DIFF
--- a/pkg/storage/intent_interleaving_iter.go
+++ b/pkg/storage/intent_interleaving_iter.go
@@ -415,13 +415,64 @@ func (i *intentInterleavingIter) maybeSuppressRangeKeyChanged() {
 	}
 }
 
-// doMaybeSuppressRangeKeyChanges is a helper for maybeSuppressRangeKeyChanged
+// doMaybeSuppressRangeKeyChanged is a helper for maybeSuppressRangeKeyChanged
 // which allows mid-stack inlining of the former.
 func (i *intentInterleavingIter) doMaybeSuppressRangeKeyChanged() {
 	i.rangeKeyChanged = i.iter.RangeBounds().EndKey.Compare(i.intentKey) > 0
 }
 
+// shouldAdjustSeekRangeKeyChanged returns true if a seek (any kind) needs to
+// adjust the RangeKeyChanged signal from the underlying iter. This is necessary
+// when intentInterleavingIter was previously positioned on an intent in the
+// reverse direction, with iter positioned on a previous range key that did
+// not overlap the point key (suppressed via suppressRangeKeyChanged).
+//
+// In this case, a seek may incorrectly emit or omit a RangeKeyChanged signal
+// when iter is seeked, since it's relative to iter's former position rather
+// than the intent's (and thus intentInterleavingIter's) position.
+//
+// This situation is only possible when the intent does not overlap any range
+// keys (otherwise, iter would either have stopped at a point key which overlaps
+// the same range key, or at the range key's start bound). Thus, when this
+// situation occurs, RangeKeyChanged must be set equal to iter's hasRange value
+// after the seek: we know we were not previously positioned on a range key, so
+// if hasRange is true then RangeKeyChanged must be true (we seeked onto a range
+// key), and if hasRange is false then RangeKeyChanged must be false (we did not
+// seek onto a range key).
+//
+// gcassert:inline
+func (i *intentInterleavingIter) shouldAdjustSeekRangeKeyChanged() bool {
+	if i.dir == -1 && i.intentCmp > 0 && i.valid && i.iterValid {
+		return i.doShouldAdjustSeekRangeKeyChanged()
+	}
+	return false
+}
+
+// doShouldAdjustSeekRangeKeyChanged is a shouldAdjustSeekRangeKeyChanged
+// helper, which allows mid-stack inlining of the former.
+func (i *intentInterleavingIter) doShouldAdjustSeekRangeKeyChanged() bool {
+	if _, iterHasRange := i.iter.HasPointAndRange(); iterHasRange {
+		if _, hasRange := i.HasPointAndRange(); !hasRange {
+			return true
+		}
+	}
+	return false
+}
+
+// adjustSeekRangeKeyChanged adjusts i.rangeKeyChanged as described in
+// shouldAdjustSeekRangeKeyChanged.
+func (i *intentInterleavingIter) adjustSeekRangeKeyChanged() {
+	if i.iterValid {
+		_, hasRange := i.iter.HasPointAndRange()
+		i.rangeKeyChanged = hasRange
+	} else {
+		i.rangeKeyChanged = false
+	}
+}
+
 func (i *intentInterleavingIter) SeekGE(key MVCCKey) {
+	adjustRangeKeyChanged := i.shouldAdjustSeekRangeKeyChanged()
+
 	i.dir = +1
 	i.valid = true
 	i.err = nil
@@ -434,6 +485,9 @@ func (i *intentInterleavingIter) SeekGE(key MVCCKey) {
 		return
 	}
 	i.rangeKeyChanged = i.iter.RangeKeyChanged()
+	if adjustRangeKeyChanged {
+		i.adjustSeekRangeKeyChanged()
+	}
 	var intentSeekKey roachpb.Key
 	if key.Timestamp.IsEmpty() {
 		// Common case.
@@ -469,6 +523,8 @@ func (i *intentInterleavingIter) SeekGE(key MVCCKey) {
 }
 
 func (i *intentInterleavingIter) SeekIntentGE(key roachpb.Key, txnUUID uuid.UUID) {
+	adjustRangeKeyChanged := i.shouldAdjustSeekRangeKeyChanged()
+
 	i.dir = +1
 	i.valid = true
 	i.err = nil
@@ -481,6 +537,9 @@ func (i *intentInterleavingIter) SeekIntentGE(key roachpb.Key, txnUUID uuid.UUID
 		return
 	}
 	i.rangeKeyChanged = i.iter.RangeKeyChanged()
+	if adjustRangeKeyChanged {
+		i.adjustSeekRangeKeyChanged()
+	}
 	var engineKey EngineKey
 	engineKey, i.intentKeyBuf = LockTableKey{
 		Key:      key,
@@ -991,6 +1050,8 @@ func (i *intentInterleavingIter) Close() {
 }
 
 func (i *intentInterleavingIter) SeekLT(key MVCCKey) {
+	adjustRangeKeyChanged := i.shouldAdjustSeekRangeKeyChanged()
+
 	i.dir = -1
 	i.valid = true
 	i.err = nil
@@ -1048,6 +1109,9 @@ func (i *intentInterleavingIter) SeekLT(key MVCCKey) {
 	}
 	i.computePos()
 	i.rangeKeyChanged = i.iter.RangeKeyChanged()
+	if adjustRangeKeyChanged {
+		i.adjustSeekRangeKeyChanged()
+	}
 	i.maybeSuppressRangeKeyChanged()
 }
 

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_iter_reverse_intent_seek_rangekeychanged_regression
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_iter_reverse_intent_seek_rangekeychanged_regression
@@ -1,0 +1,268 @@
+# Regression test for https://github.com/cockroachdb/cockroach/issues/90827.
+#
+#  3       [b3]
+#  2    a2
+#  1    [---)
+#       a   b
+#
+# When intentInterleavingeIter is positioned on the intent b@0 in the reverse
+# direction, the underlying iterator will have stepped onto a@2, which is
+# covered by the [a-b)@1 range key. This will cause the underlying iterator to
+# emit RangeKeyChanged, but this is suppressed by intentInterleavingIter.
+# However, a SeekGE(b) would emit RangeKeyChanged, because the underlying
+# iterator's range key did change, although the intentInterleavingIter's didn't.
+# Similarly, this would not emit a RangeKeyChanged when seeking the
+# intentInterleavingIter to a, because the underlying iterator was already
+# positioned on [a-b).
+run ok
+del_range_ts k=a end=b ts=1
+put k=a ts=2 v=a2
+with t=A
+  txn_begin k=b ts=3
+  put k=b v=b3
+----
+>> at end:
+txn: "A" meta={id=00000000 key="b" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 wto=false gul=0,0
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/a2
+meta: "b"/0,0 -> txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "b"/3.000000000,0 -> /BYTES/b3
+
+run ok
+iter_new types=pointsAndRanges
+iter_seek_lt k=b+
+iter_prev
+iter_seek_ge k=b
+----
+iter_seek_lt: "b"/3.000000000,0=/BYTES/b3
+iter_prev: "b"/0,0=txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_ge: "b"/0,0=txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+
+run ok
+iter_new types=pointsAndRanges
+iter_seek_lt k=b+
+iter_prev
+iter_next
+----
+iter_seek_lt: "b"/3.000000000,0=/BYTES/b3
+iter_prev: "b"/0,0=txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_next: "b"/3.000000000,0=/BYTES/b3
+
+run ok
+iter_new types=pointsAndRanges
+iter_seek_lt k=b+
+iter_prev
+iter_seek_ge k=a
+----
+iter_seek_lt: "b"/3.000000000,0=/BYTES/b3
+iter_prev: "b"/0,0=txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_ge: {a-b}/[1.000000000,0=/<empty>] !
+
+# Test the same for SeekIntentGE.
+run ok
+iter_new types=pointsAndRanges
+iter_seek_lt k=b+
+iter_prev
+iter_seek_ge txn=A k=b
+----
+iter_seek_lt: "b"/3.000000000,0=/BYTES/b3
+iter_prev: "b"/0,0=txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_ge: "b"/0,0=txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+
+run ok
+iter_new types=pointsAndRanges
+iter_seek_lt k=b+
+iter_prev
+iter_seek_intent_ge txn=A k=a
+----
+iter_seek_lt: "b"/3.000000000,0=/BYTES/b3
+iter_prev: "b"/0,0=txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_intent_ge: {a-b}/[1.000000000,0=/<empty>] !
+
+# Test the same for SeekLT.
+run ok
+iter_new types=pointsAndRanges
+iter_seek_lt k=b+
+iter_prev
+iter_seek_lt k=b+
+----
+iter_seek_lt: "b"/3.000000000,0=/BYTES/b3
+iter_prev: "b"/0,0=txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_lt: "b"/3.000000000,0=/BYTES/b3
+
+run ok
+iter_new types=pointsAndRanges
+iter_seek_lt k=b+
+iter_prev
+iter_seek_lt k=b
+----
+iter_seek_lt: "b"/3.000000000,0=/BYTES/b3
+iter_prev: "b"/0,0=txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_lt: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>] !
+
+# Test that stepping onto a and then seeking/stepping back to b emits correctly.
+run ok
+iter_new types=pointsAndRanges
+iter_seek_lt k=b+
+iter_prev
+iter_prev
+iter_seek_ge k=b
+----
+iter_seek_lt: "b"/3.000000000,0=/BYTES/b3
+iter_prev: "b"/0,0=txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_prev: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>] !
+iter_seek_ge: "b"/0,0=txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true !
+
+run ok
+iter_new types=pointsAndRanges
+iter_seek_lt k=b+
+iter_prev
+iter_prev
+iter_seek_intent_ge txn=A k=b
+----
+iter_seek_lt: "b"/3.000000000,0=/BYTES/b3
+iter_prev: "b"/0,0=txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_prev: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>] !
+iter_seek_intent_ge: "b"/0,0=txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true !
+
+run ok
+iter_new types=pointsAndRanges
+iter_seek_lt k=b+
+iter_prev
+iter_prev
+iter_seek_lt k=b+
+----
+iter_seek_lt: "b"/3.000000000,0=/BYTES/b3
+iter_prev: "b"/0,0=txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_prev: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>] !
+iter_seek_lt: "b"/3.000000000,0=/BYTES/b3 !
+
+# Add another range tombstone [c-d), and make sure seeking to it also
+# emits RangeKeyChanged.
+run ok
+del_range_ts k=c end=d ts=1
+----
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {c-d}/[1.000000000,0=/<empty>]
+data: "a"/2.000000000,0 -> /BYTES/a2
+meta: "b"/0,0 -> txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "b"/3.000000000,0 -> /BYTES/b3
+
+run ok
+iter_new types=pointsAndRanges
+iter_seek_lt k=b+
+iter_prev
+iter_seek_ge k=c
+----
+iter_seek_lt: "b"/3.000000000,0=/BYTES/b3
+iter_prev: "b"/0,0=txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_ge: {c-d}/[1.000000000,0=/<empty>] !
+
+run ok
+iter_new types=pointsAndRanges
+iter_seek_lt k=b+
+iter_prev
+iter_seek_intent_ge txn=A k=c
+----
+iter_seek_lt: "b"/3.000000000,0=/BYTES/b3
+iter_prev: "b"/0,0=txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_intent_ge: {c-d}/[1.000000000,0=/<empty>] !
+
+run ok
+iter_new types=pointsAndRanges
+iter_seek_lt k=b+
+iter_prev
+iter_seek_lt k=c+
+----
+iter_seek_lt: "b"/3.000000000,0=/BYTES/b3
+iter_prev: "b"/0,0=txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_lt: {c-d}/[1.000000000,0=/<empty>] !
+
+# We also test the same scenario with a double range tombstone.
+run ok
+txn_remove t=A
+clear_range k=a end=z
+del_range_ts k=a end=b ts=1
+del_range_ts k=a end=b ts=2
+with t=A
+  txn_begin k=b ts=3
+  put k=b v=b3
+----
+>> at end:
+txn: "A" meta={id=00000000 key="b" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 wto=false gul=0,0
+rangekey: {a-b}/[2.000000000,0=/<empty> 1.000000000,0=/<empty>]
+meta: "b"/0,0 -> txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "b"/3.000000000,0 -> /BYTES/b3
+
+run ok
+iter_new types=pointsAndRanges
+iter_seek_lt k=b+
+iter_prev
+iter_seek_ge k=b
+----
+iter_seek_lt: "b"/3.000000000,0=/BYTES/b3
+iter_prev: "b"/0,0=txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_ge: "b"/0,0=txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+
+run ok
+iter_new types=pointsAndRanges
+iter_seek_lt k=b+
+iter_prev
+iter_next
+----
+iter_seek_lt: "b"/3.000000000,0=/BYTES/b3
+iter_prev: "b"/0,0=txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_next: "b"/3.000000000,0=/BYTES/b3
+
+run ok
+iter_new types=pointsAndRanges
+iter_seek_lt k=b+
+iter_prev
+iter_seek_ge k=a
+----
+iter_seek_lt: "b"/3.000000000,0=/BYTES/b3
+iter_prev: "b"/0,0=txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_ge: {a-b}/[2.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+
+# Test the same for SeekIntentGE.
+run ok
+iter_new types=pointsAndRanges
+iter_seek_lt k=b+
+iter_prev
+iter_seek_ge txn=A k=b
+----
+iter_seek_lt: "b"/3.000000000,0=/BYTES/b3
+iter_prev: "b"/0,0=txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_ge: "b"/0,0=txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+
+run ok
+iter_new types=pointsAndRanges
+iter_seek_lt k=b+
+iter_prev
+iter_seek_intent_ge txn=A k=a
+----
+iter_seek_lt: "b"/3.000000000,0=/BYTES/b3
+iter_prev: "b"/0,0=txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_intent_ge: {a-b}/[2.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+
+# Test the same for SeekLT.
+run ok
+iter_new types=pointsAndRanges
+iter_seek_lt k=b+
+iter_prev
+iter_seek_lt k=b+
+----
+iter_seek_lt: "b"/3.000000000,0=/BYTES/b3
+iter_prev: "b"/0,0=txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_lt: "b"/3.000000000,0=/BYTES/b3
+
+run ok
+iter_new types=pointsAndRanges
+iter_seek_lt k=b+
+iter_prev
+iter_seek_lt k=b
+----
+iter_seek_lt: "b"/3.000000000,0=/BYTES/b3
+iter_prev: "b"/0,0=txn={id=00000000 key="b" pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_seek_lt: {a-b}/[2.000000000,0=/<empty> 1.000000000,0=/<empty>] !


### PR DESCRIPTION
When `intentInterleavingIter` is positioned on an intent in the reverse direction, it's possible for the underlying iterator `iter` to be positioned on a previous range key that does not overlap the intent. In this case, `iter` will emit a `RangeKeyChanged`, but this is suppressed by `intentInterleavingIter` until it actually steps off the intent and onto the range key.

However, if `intentInterleavingIter` was seeked when positioned on this intent, it might incorrectly emit or omit `RangeKeyChanged` because it was relative to `iter`'s previous position rather than the `intentInterleavingIter`'s position (i.e. the intent).

This patch will detect this situation during seeks and adjust `RangeKeyChanged` appropriately. The performance impact should be negligible, considering the overall cost of a seek.

Resolves #90827.

Release note: None