### PR TITLE
sql: fix newly introduced race

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1697,7 +1697,7 @@ func ValidateInvertedIndexes(
 			span := tableDesc.IndexSpan(codec, idx.GetID())
 			key := span.Key
 			endKey := span.EndKey
-			if err = runHistoricalTxn.Exec(ctx, func(
+			if err := runHistoricalTxn.Exec(ctx, func(
 				ctx context.Context, txn *kv.Txn, _ sqlutil.InternalExecutor, _ *descs.Collection,
 			) error {
 				for {


### PR DESCRIPTION
All of the goroutines were writing to the same `err` variable. This race was introduced in #89540.

Epic: None

Release note: None