### PR TITLE
kvserver: remove RaftCommandNoSplitBit and associated assertion

### DIFF
--- a/pkg/kv/kvserver/kvserverbase/raftversion.go
+++ b/pkg/kv/kvserver/kvserverbase/raftversion.go
@@ -33,14 +33,6 @@ const (
 	RaftCommandIDLen = 8
 	// RaftCommandPrefixLen is the prescribed length of each encoded command's prefix.
 	RaftCommandPrefixLen = 1 + RaftCommandIDLen
-	// RaftCommandNoSplitBit is deprecated.
-	// The no-split bit is now unused, but we still apply the mask to the first
-	// byte of the command for backward compatibility.
-	//
-	// TODO(tschottdorf): predates v1.0 by a significant margin. Remove.
-	RaftCommandNoSplitBit = 1 << 7
-	// RaftCommandNoSplitMask is deprecated.
-	RaftCommandNoSplitMask = RaftCommandNoSplitBit - 1
 )
 
 // EncodeRaftCommand encodes a raft command (including the versioning prefix).
@@ -71,10 +63,6 @@ func EncodeRaftCommandPrefix(b []byte, version RaftCommandEncodingVersion, comma
 // than a real command). Usage is mostly internal to the storage package
 // but is exported for use by debugging tools.
 func DecodeRaftCommand(data []byte) (CmdIDKey, []byte) {
-	v := RaftCommandEncodingVersion(data[0] & RaftCommandNoSplitMask)
-	if v != RaftVersionStandard && v != RaftVersionSideloaded {
-		panic(fmt.Sprintf("unknown command encoding version %v", data[0]))
-	}
 	return CmdIDKey(data[1 : 1+RaftCommandIDLen]), data[1+RaftCommandIDLen:]
 }
 


### PR DESCRIPTION
Remove the long-deprecated and unused `RaftCommandNoSplitBit`.

Remove an assertion that fired whenever we saw an unknown raft command
encoding version. The upgrade machinery already provide enough
protection and as long as a node is allowed to handle a new command
encoding version like `RaftVersionStandard` it doesn't need to know the
actual version. This may allow us to make backports that would otherwise
be impossible. (This is all in theory; I'm not aware of upcoming changes
that would capitalize on this).

Release note: None
