### PR TITLE
ttl: use AS OF SYSTEM TIME value relative to SELECT query time

### DIFF
--- a/pkg/sql/execinfrapb/BUILD.bazel
+++ b/pkg/sql/execinfrapb/BUILD.bazel
@@ -123,6 +123,7 @@ proto_library(
         "@com_github_cockroachdb_errors//errorspb:errorspb_proto",
         "@com_github_gogo_protobuf//gogoproto:gogo_proto",
         "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:duration_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],
 )

--- a/pkg/sql/execinfrapb/processors_ttl.proto
+++ b/pkg/sql/execinfrapb/processors_ttl.proto
@@ -20,6 +20,7 @@ package cockroach.sql.distsqlrun;
 option go_package = "execinfrapb";
 
 import "gogoproto/gogo.proto";
+import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 import "roachpb/data.proto";
 import "jobs/jobspb/jobs.proto";
@@ -39,6 +40,8 @@ message TTLSpec {
     (gogoproto.customname) = "RowLevelTTLDetails"
   ];
 
+  // Deprecated: AOST has been replaced with AOSTDuration.
+  // TODO(ewall): remove in 24.1
   // AOST is the AS OF SYSTEM TIME value the ttlProcessor uses to select records.
   optional google.protobuf.Timestamp aost = 3 [
     (gogoproto.nullable) = false,
@@ -81,4 +84,12 @@ message TTLSpec {
   // PreSelectStatement is a test setting to run a SQL statement
   // before selecting records.
   optional string pre_select_statement = 12 [(gogoproto.nullable) = false];
+
+  // AOSTDuration is subtracted from the current time to determine the
+  // AS OF SYSTEM TIME value the ttlProcessor uses to select records.
+  optional google.protobuf.Duration aost_duration = 13 [
+    (gogoproto.nullable) = false,
+    (gogoproto.customname) = "AOSTDuration",
+    (gogoproto.stdduration) = true
+  ];
 }

--- a/pkg/sql/ttl/ttlbase/ttl_helpers.go
+++ b/pkg/sql/ttl/ttlbase/ttl_helpers.go
@@ -24,7 +24,7 @@ const DefaultAOSTDuration = -time.Second * 30
 // SelectTemplate is the format string used to build SELECT queries for the
 // TTL job.
 const SelectTemplate = `SELECT %[1]s FROM [%[2]d AS tbl_name]
-AS OF SYSTEM TIME %[3]s
+AS OF SYSTEM TIME INTERVAL '%[3]d seconds'
 WHERE %[4]s <= $1
 %[5]s%[6]s
 ORDER BY %[1]s

--- a/pkg/sql/ttl/ttljob/ttljob_query_builder.go
+++ b/pkg/sql/ttl/ttljob/ttljob_query_builder.go
@@ -35,7 +35,7 @@ type selectQueryBuilder struct {
 	selectOpName    string
 	spanToProcess   spanToProcess
 	selectBatchSize int64
-	aost            time.Time
+	aostDuration    time.Duration
 	ttlExpr         catpb.Expression
 
 	// isFirst is true if we have not invoked a query using the builder yet.
@@ -62,7 +62,7 @@ func makeSelectQueryBuilder(
 	pkColumns []string,
 	relationName string,
 	spanToProcess spanToProcess,
-	aost time.Time,
+	aostDuration time.Duration,
 	selectBatchSize int64,
 	ttlExpr catpb.Expression,
 ) selectQueryBuilder {
@@ -84,7 +84,7 @@ func makeSelectQueryBuilder(
 		pkColumns:       pkColumns,
 		selectOpName:    fmt.Sprintf("ttl select %s", relationName),
 		spanToProcess:   spanToProcess,
-		aost:            aost,
+		aostDuration:    aostDuration,
 		selectBatchSize: selectBatchSize,
 		ttlExpr:         ttlExpr,
 
@@ -144,7 +144,7 @@ func (b *selectQueryBuilder) buildQuery() string {
 		ttlbase.SelectTemplate,
 		b.pkColumnNamesSQL,
 		b.tableID,
-		tree.MustMakeDTimestampTZ(b.aost, time.Microsecond),
+		int64(b.aostDuration.Seconds()),
 		b.ttlExpr,
 		filterClause,
 		endFilterClause,

--- a/pkg/sql/ttl/ttljob/ttljob_query_builder_test.go
+++ b/pkg/sql/ttl/ttljob/ttljob_query_builder_test.go
@@ -27,6 +27,7 @@ func TestSelectQueryBuilder(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	mockTime := time.Date(2000, 1, 1, 13, 30, 45, 0, time.UTC)
+	mockDuration := -10 * time.Second
 
 	type iteration struct {
 		expectedQuery string
@@ -49,14 +50,14 @@ func TestSelectQueryBuilder(t *testing.T) {
 					startPK: tree.Datums{tree.NewDInt(100), tree.NewDInt(5)},
 					endPK:   tree.Datums{tree.NewDInt(200), tree.NewDInt(15)},
 				},
-				mockTime,
+				mockDuration,
 				2,
 				colinfo.TTLDefaultExpirationColumnName,
 			),
 			iterations: []iteration{
 				{
 					expectedQuery: `SELECT col1, col2 FROM [1 AS tbl_name]
-AS OF SYSTEM TIME '2000-01-01 13:30:45+00:00'
+AS OF SYSTEM TIME INTERVAL '-10 seconds'
 WHERE crdb_internal_expiration <= $1
 AND (col1, col2) >= ($4, $5) AND (col1, col2) < ($2, $3)
 ORDER BY col1, col2
@@ -73,7 +74,7 @@ LIMIT 2`,
 				},
 				{
 					expectedQuery: `SELECT col1, col2 FROM [1 AS tbl_name]
-AS OF SYSTEM TIME '2000-01-01 13:30:45+00:00'
+AS OF SYSTEM TIME INTERVAL '-10 seconds'
 WHERE crdb_internal_expiration <= $1
 AND (col1, col2) > ($4, $5) AND (col1, col2) < ($2, $3)
 ORDER BY col1, col2
@@ -90,7 +91,7 @@ LIMIT 2`,
 				},
 				{
 					expectedQuery: `SELECT col1, col2 FROM [1 AS tbl_name]
-AS OF SYSTEM TIME '2000-01-01 13:30:45+00:00'
+AS OF SYSTEM TIME INTERVAL '-10 seconds'
 WHERE crdb_internal_expiration <= $1
 AND (col1, col2) > ($4, $5) AND (col1, col2) < ($2, $3)
 ORDER BY col1, col2
@@ -112,14 +113,14 @@ LIMIT 2`,
 				[]string{"col1", "col2"},
 				"table_name",
 				spanToProcess{},
-				mockTime,
+				mockDuration,
 				2,
 				colinfo.TTLDefaultExpirationColumnName,
 			),
 			iterations: []iteration{
 				{
 					expectedQuery: `SELECT col1, col2 FROM [1 AS tbl_name]
-AS OF SYSTEM TIME '2000-01-01 13:30:45+00:00'
+AS OF SYSTEM TIME INTERVAL '-10 seconds'
 WHERE crdb_internal_expiration <= $1
 
 ORDER BY col1, col2
@@ -134,7 +135,7 @@ LIMIT 2`,
 				},
 				{
 					expectedQuery: `SELECT col1, col2 FROM [1 AS tbl_name]
-AS OF SYSTEM TIME '2000-01-01 13:30:45+00:00'
+AS OF SYSTEM TIME INTERVAL '-10 seconds'
 WHERE crdb_internal_expiration <= $1
 AND (col1, col2) > ($2, $3)
 ORDER BY col1, col2
@@ -150,7 +151,7 @@ LIMIT 2`,
 				},
 				{
 					expectedQuery: `SELECT col1, col2 FROM [1 AS tbl_name]
-AS OF SYSTEM TIME '2000-01-01 13:30:45+00:00'
+AS OF SYSTEM TIME INTERVAL '-10 seconds'
 WHERE crdb_internal_expiration <= $1
 AND (col1, col2) > ($2, $3)
 ORDER BY col1, col2
@@ -174,14 +175,14 @@ LIMIT 2`,
 					startPK: tree.Datums{tree.NewDInt(100)},
 					endPK:   tree.Datums{tree.NewDInt(181)},
 				},
-				mockTime,
+				mockDuration,
 				2,
 				colinfo.TTLDefaultExpirationColumnName,
 			),
 			iterations: []iteration{
 				{
 					expectedQuery: `SELECT col1, col2 FROM [1 AS tbl_name]
-AS OF SYSTEM TIME '2000-01-01 13:30:45+00:00'
+AS OF SYSTEM TIME INTERVAL '-10 seconds'
 WHERE crdb_internal_expiration <= $1
 AND (col1) >= ($3) AND (col1) < ($2)
 ORDER BY col1, col2
@@ -198,7 +199,7 @@ LIMIT 2`,
 				},
 				{
 					expectedQuery: `SELECT col1, col2 FROM [1 AS tbl_name]
-AS OF SYSTEM TIME '2000-01-01 13:30:45+00:00'
+AS OF SYSTEM TIME INTERVAL '-10 seconds'
 WHERE crdb_internal_expiration <= $1
 AND (col1, col2) > ($3, $4) AND (col1) < ($2)
 ORDER BY col1, col2
@@ -215,7 +216,7 @@ LIMIT 2`,
 				},
 				{
 					expectedQuery: `SELECT col1, col2 FROM [1 AS tbl_name]
-AS OF SYSTEM TIME '2000-01-01 13:30:45+00:00'
+AS OF SYSTEM TIME INTERVAL '-10 seconds'
 WHERE crdb_internal_expiration <= $1
 AND (col1, col2) > ($3, $4) AND (col1) < ($2)
 ORDER BY col1, col2
@@ -239,14 +240,14 @@ LIMIT 2`,
 				spanToProcess{
 					endPK: tree.Datums{tree.NewDInt(200), tree.NewDInt(15)},
 				},
-				mockTime,
+				mockDuration,
 				2,
 				colinfo.TTLDefaultExpirationColumnName,
 			),
 			iterations: []iteration{
 				{
 					expectedQuery: `SELECT col1, col2 FROM [1 AS tbl_name]
-AS OF SYSTEM TIME '2000-01-01 13:30:45+00:00'
+AS OF SYSTEM TIME INTERVAL '-10 seconds'
 WHERE crdb_internal_expiration <= $1
  AND (col1, col2) < ($2, $3)
 ORDER BY col1, col2
@@ -262,7 +263,7 @@ LIMIT 2`,
 				},
 				{
 					expectedQuery: `SELECT col1, col2 FROM [1 AS tbl_name]
-AS OF SYSTEM TIME '2000-01-01 13:30:45+00:00'
+AS OF SYSTEM TIME INTERVAL '-10 seconds'
 WHERE crdb_internal_expiration <= $1
 AND (col1, col2) > ($4, $5) AND (col1, col2) < ($2, $3)
 ORDER BY col1, col2
@@ -279,7 +280,7 @@ LIMIT 2`,
 				},
 				{
 					expectedQuery: `SELECT col1, col2 FROM [1 AS tbl_name]
-AS OF SYSTEM TIME '2000-01-01 13:30:45+00:00'
+AS OF SYSTEM TIME INTERVAL '-10 seconds'
 WHERE crdb_internal_expiration <= $1
 AND (col1, col2) > ($4, $5) AND (col1, col2) < ($2, $3)
 ORDER BY col1, col2
@@ -303,14 +304,14 @@ LIMIT 2`,
 				spanToProcess{
 					startPK: tree.Datums{tree.NewDInt(100), tree.NewDInt(5)},
 				},
-				mockTime,
+				mockDuration,
 				2,
 				colinfo.TTLDefaultExpirationColumnName,
 			),
 			iterations: []iteration{
 				{
 					expectedQuery: `SELECT col1, col2 FROM [1 AS tbl_name]
-AS OF SYSTEM TIME '2000-01-01 13:30:45+00:00'
+AS OF SYSTEM TIME INTERVAL '-10 seconds'
 WHERE crdb_internal_expiration <= $1
 AND (col1, col2) >= ($2, $3)
 ORDER BY col1, col2
@@ -326,7 +327,7 @@ LIMIT 2`,
 				},
 				{
 					expectedQuery: `SELECT col1, col2 FROM [1 AS tbl_name]
-AS OF SYSTEM TIME '2000-01-01 13:30:45+00:00'
+AS OF SYSTEM TIME INTERVAL '-10 seconds'
 WHERE crdb_internal_expiration <= $1
 AND (col1, col2) > ($2, $3)
 ORDER BY col1, col2
@@ -342,7 +343,7 @@ LIMIT 2`,
 				},
 				{
 					expectedQuery: `SELECT col1, col2 FROM [1 AS tbl_name]
-AS OF SYSTEM TIME '2000-01-01 13:30:45+00:00'
+AS OF SYSTEM TIME INTERVAL '-10 seconds'
 WHERE crdb_internal_expiration <= $1
 AND (col1, col2) > ($2, $3)
 ORDER BY col1, col2

--- a/pkg/sql/ttl/ttlschedule/ttlschedule.go
+++ b/pkg/sql/ttl/ttlschedule/ttlschedule.go
@@ -218,10 +218,10 @@ func makeTTLJobDescription(tableDesc catalog.TableDescriptor, tn *tree.TableName
 		ttlbase.SelectTemplate,
 		pkColumnNamesSQL,
 		tableDesc.GetID(),
-		fmt.Sprintf("'%v'", ttlbase.DefaultAOSTDuration),
+		int64(ttlbase.DefaultAOSTDuration.Seconds()),
 		"<crdb_internal_expiration OR ttl_expiration_expression>",
-		fmt.Sprintf("AND (%s) > (<range start>)", pkColumnNamesSQL),
-		fmt.Sprintf(" AND (%s) < (<range end>)", pkColumnNamesSQL),
+		fmt.Sprintf("AND (%s) > (<span start>)", pkColumnNamesSQL),
+		fmt.Sprintf(" AND (%s) < (<span end>)", pkColumnNamesSQL),
 		"<ttl_select_batch_size>",
 	)
 	deleteQuery := fmt.Sprintf(
@@ -232,7 +232,7 @@ func makeTTLJobDescription(tableDesc catalog.TableDescriptor, tn *tree.TableName
 		"<rows selected above>",
 	)
 	return fmt.Sprintf(`ttl for %s
--- for each range, iterate to find rows:
+-- for each span, iterate to find rows:
 %s
 -- then delete with:
 %s`, tn.FQString(), selectQuery, deleteQuery)


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/90979

Release note (sql change): Currently the `AS OF SYSTEM TIME` value is set at the start of the TTL job (TTL cutoff - 30s), but this results in an error for TTL jobs that run longer than `gc.ttlseconds`:
```
error selecting rows to delete: ttl select defaultdb.public.events: batch timestamp 1666883527.780656000,0 must be after replica GC threshold 1666883574.542825089,0
```

Making the `AS OF SYSTEM TIME` value relative to when each SELECT query is run (query time - 30s) will prevent this from happening, but each SELECT query will run against a different table state. This should be ok because if records are missed during one job invocation, they should still be picked up the next.