### PR TITLE
sql: fix data race in session serialization

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/idxrecommendations"
 	"github.com/cockroachdb/cockroach/pkg/sql/idxusage"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirecancel"
@@ -3177,7 +3178,22 @@ func (ex *connExecutor) serialize() serverpb.Session {
 		if query.hidden {
 			continue
 		}
-		sqlNoConstants := truncateSQL(formatStatementHideConstants(query.stmt.AST))
+		// Note: while it may seem tempting to just use query.stmt.AST instead of
+		// re-parsing the original SQL, it's unfortunately NOT SAFE to do so because
+		// the AST is currently not immutable - doing so will produce data races.
+		// See issue https://github.com/cockroachdb/cockroach/issues/90965 for the
+		// last time this was hit.
+		// This can go away if we resolve https://github.com/cockroachdb/cockroach/issues/22847.
+		parsed, err := parser.ParseOne(query.stmt.SQL)
+		if err != nil {
+			// This shouldn't happen, but might as well not completely give up if we
+			// fail to parse a parseable sql for some reason. We unfortunately can't
+			// just log the SQL either as it could contain sensitive information.
+			log.Warningf(ex.Ctx(), "failed to re-parse sql during session "+
+				"serialization")
+			continue
+		}
+		sqlNoConstants := truncateSQL(formatStatementHideConstants(parsed.AST))
 		nPlaceholders := 0
 		if query.placeholders != nil {
 			nPlaceholders = len(query.placeholders.Values)
@@ -3196,7 +3212,7 @@ func (ex *connExecutor) serialize() serverpb.Session {
 			ElapsedTime:    timeNow.Sub(queryStart),
 			Sql:            sql,
 			SqlNoConstants: sqlNoConstants,
-			SqlSummary:     formatStatementSummary(query.stmt.AST),
+			SqlSummary:     formatStatementSummary(parsed.AST),
 			Placeholders:   placeholders,
 			IsDistributed:  query.isDistributed,
 			Phase:          (serverpb.ActiveQuery_Phase)(query.phase),

--- a/pkg/sql/parser/parse.go
+++ b/pkg/sql/parser/parse.go
@@ -41,6 +41,10 @@ func init() {
 // node along with other information.
 type Statement struct {
 	// AST is the root of the AST tree for the parsed statement.
+	// Note that it is NOT SAFE to access this currently with statement execution,
+	// as unfortunately the AST is not immutable.
+	// See issue https://github.com/cockroachdb/cockroach/issues/22847 for more
+	// details on this problem.
 	AST tree.Statement
 
 	// Comments is the list of parsed SQL comments.


### PR DESCRIPTION
Closes #90965

This commit fixes a data race in session serialization that was introduced by ac280a9c6e90310574c52284da4948d84b7a9dfb.

Previously, the session serialization code attempted to read the original, parsed AST to create a redacted statement string. This is invalid because the AST is unfortunately not immutable, and serialization can occur concurrently with statement optimization and execution.

Now, the session serializer re-parses the original SQL to avoid this issue.

Release note: None