### PR TITLE
ui: update cluster-ui to 22.2.0-prerelease-8

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "22.2.0-prerelease-6",
+  "version": "22.2.0-prerelease-8",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This commit updates the cluster-ui npm version to [22.2.0-prerelease-8](https://www.npmjs.com/package/@cockroachlabs/cluster-ui/v/22.2.0-prerelease-8).

Release note: None
Release justification: non-production change