### PR TITLE
storage: reuse byte buffer for `PointSynthesizingIter.UnsafeRawMVCCKey`

### DIFF
--- a/pkg/storage/bench_pebble_test.go
+++ b/pkg/storage/bench_pebble_test.go
@@ -114,15 +114,20 @@ func BenchmarkMVCCScanGarbage_Pebble(b *testing.B) {
 				b.Run(fmt.Sprintf("versions=%d", numVersions), func(b *testing.B) {
 					for _, numRangeKeys := range []int{0, 1, 100} {
 						b.Run(fmt.Sprintf("numRangeKeys=%d", numRangeKeys), func(b *testing.B) {
-							runMVCCScan(ctx, b, benchScanOptions{
-								mvccBenchData: mvccBenchData{
-									numVersions:  numVersions,
-									numRangeKeys: numRangeKeys,
-									garbage:      true,
-								},
-								numRows: numRows,
-								reverse: false,
-							})
+							for _, tombstones := range []bool{false, true} {
+								b.Run(fmt.Sprintf("tombstones=%t", tombstones), func(b *testing.B) {
+									runMVCCScan(ctx, b, benchScanOptions{
+										mvccBenchData: mvccBenchData{
+											numVersions:  numVersions,
+											numRangeKeys: numRangeKeys,
+											garbage:      true,
+										},
+										numRows:    numRows,
+										tombstones: tombstones,
+										reverse:    false,
+									})
+								})
+							}
 						})
 					}
 				})

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -725,9 +725,10 @@ func loadTestData(dir string, numKeys, numBatches, batchTimeSpan, valueBytes int
 
 type benchScanOptions struct {
 	mvccBenchData
-	numRows   int
-	reverse   bool
-	wholeRows bool
+	numRows    int
+	reverse    bool
+	wholeRows  bool
+	tombstones bool
 }
 
 // runMVCCScan first creates test data (and resets the benchmarking
@@ -792,6 +793,7 @@ func runMVCCScan(ctx context.Context, b *testing.B, opts benchScanOptions) {
 			WholeRowsOfSize: wholeRowsOfSize,
 			AllowEmpty:      wholeRowsOfSize != 0,
 			Reverse:         opts.reverse,
+			Tombstones:      opts.tombstones,
 		})
 		if err != nil {
 			b.Fatalf("failed scan: %+v", err)
@@ -803,7 +805,7 @@ func runMVCCScan(ctx context.Context, b *testing.B, opts benchScanOptions) {
 		if !opts.garbage && len(res.KVs) != expectKVs {
 			b.Fatalf("failed to scan: %d != %d", len(res.KVs), expectKVs)
 		}
-		if opts.garbage && len(res.KVs) != 0 {
+		if opts.garbage && !opts.tombstones && len(res.KVs) != 0 {
 			b.Fatalf("failed to scan garbage: found %d keys", len(res.KVs))
 		}
 	}


### PR DESCRIPTION
**storage: add `BenchmarkMVCCScanGarbage` tombstone variant**

This is useful for benchmarking point tombstone synthesis, since it
disables range key masking and thus enables point synthesis.

Release note: None

**storage: reuse byte buffer for `PointSynthesizingIter.UnsafeRawMVCCKey`**

When positioned on a synthetic point, this method allocated a new byte
slice to encode the key. This is unfortunate, since this method is used
in the `pebbleMVCCScanner` hot path.

This patch instead reuses a byte buffer for the encoding. There is room
for further optimization here, but this is a trivial first step.

In practice, this didn't matter all that much because range key masking
(used by all current `MVCCScan` callers) would prevent point synthesis
in the majority of cases. It does affect point gets, but probably to a
lesser degree considering the other associated costs.

```
name                                                                            old time/op    new time/op    delta
MVCCScanGarbage_Pebble/rows=10000/versions=1/numRangeKeys=1/tombstones=true-24    4.52ms ± 1%    4.26ms ± 0%   -5.71%  (p=0.000 n=10+10)

name                                                                            old alloc/op   new alloc/op   delta
MVCCScanGarbage_Pebble/rows=10000/versions=1/numRangeKeys=1/tombstones=true-24    1.42MB ± 0%    1.18MB ± 0%  -16.97%  (p=0.000 n=9+10)

name                                                                            old allocs/op  new allocs/op  delta
MVCCScanGarbage_Pebble/rows=10000/versions=1/numRangeKeys=1/tombstones=true-24     10.0k ± 0%      0.0k ± 0%  -99.52%  (p=0.000 n=9+9)
```

Resolves #90762.

Release note: None