### PR TITLE
storage: adjust range tombstone language to encourage caution

### DIFF
--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -83,7 +83,8 @@ var minWALSyncInterval = settings.RegisterDurationSetting(
 var MVCCRangeTombstonesEnabled = settings.RegisterBoolSetting(
 	settings.SystemOnly,
 	"storage.mvcc.range_tombstones.enabled",
-	"if true, enable the use of MVCC range tombstones",
+	"experimental: if true, enable the use of MVCC range tombstones. Do not enable "+
+		"unless you're aware of the corruption risk.",
 	false)
 
 // CanUseMVCCRangeTombstones returns true if the caller can begin writing


### PR DESCRIPTION
Adjust the MVCC range tombstone cluster setting description to highlight its experimental nature and to be appropriately cautious about the consequence of enabling range tombstones.

Cockroach 22.2.0 will ship with the cluster setting and likely at least one bug that may induce corruption if the setting is enabled (cockroachdb/cockroach#90948).

Epic: None
Release note: None

Close #91001.