### PR TITLE
release-22.1: opt: do not produce virtual columns from upper paired join

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/lookup_join
+++ b/pkg/sql/logictest/testdata/logic_test/lookup_join
@@ -732,3 +732,38 @@ AND items.author_id != views.user_id
 WHERE views.chat_id = 1 and views.user_id = 1;
 ----
 1  1  NULL  NULL  NULL
+
+
+subtest regression_89576
+
+# Regression test for #89576. Lookup joins should not try to produce virtual
+# computed columns directly from primary indexes.
+statement ok
+CREATE TABLE t89576 (
+  k INT PRIMARY KEY,
+  s STRING,
+  v STRING AS (lower(s)) VIRTUAL NOT NULL,
+  INDEX (v)
+);
+INSERT INTO t89576 VALUES (1, 'foo')
+
+query T
+SELECT t2.v
+FROM t89576 AS t1
+LEFT JOIN t89576 AS t2
+ON (t2.v) = (t1.v)
+AND (t2.s) = (t1.s)
+----
+foo
+
+# TODO(#90771): We no longer explore lookup joins for this query, but it
+# should be possible by projecting virtual computed column expressions after the
+# upper join in the paired joiner. When this is supported, this query should
+# succeed and we should turn this test directive into "query T" and verify the
+# result matches the one in the query above.
+statement error pgcode XXUUU could not produce a query plan conforming to the LOOKUP JOIN hint
+SELECT t2.v
+FROM t89576 AS t1
+LEFT LOOKUP JOIN t89576 AS t2
+ON (t2.v) = (t1.v)
+AND (t2.s) = (t1.s)

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -5436,6 +5436,26 @@ project
       └── filters
            └── j:8 > 0 [outer=(8), constraints=(/8: [/1 - ]; tight)]
 
+opt expect=GenerateLookupJoinsWithVirtualColsAndFilter
+SELECT m, virt.j, virt.v1 FROM small INNER LOOKUP JOIN virt ON m = virt.v1 AND j > 0
+----
+inner-join (lookup virt)
+ ├── columns: m:1!null j:8!null v1:9!null
+ ├── key columns: [6] = [6]
+ ├── lookup columns are key
+ ├── immutable
+ ├── fd: (1)==(9), (9)==(1)
+ ├── inner-join (lookup virt@v1_storing_i)
+ │    ├── columns: m:1!null k:6!null v1:9!null
+ │    ├── flags: force lookup join (into right side)
+ │    ├── key columns: [1] = [9]
+ │    ├── fd: (6)-->(9), (1)==(9), (9)==(1)
+ │    ├── scan small
+ │    │    └── columns: m:1
+ │    └── filters (true)
+ └── filters
+      └── j:8 > 0 [outer=(8), constraints=(/8: [/1 - ]; tight)]
+
 # Non-covering case. Join on virtual column expression with an extra filter on the
 # non-virtual column.
 opt expect=GenerateLookupJoinsWithVirtualColsAndFilter
@@ -5570,29 +5590,45 @@ project
 
 # Left join, non-covering case. Virtual column is the lookup column and there is
 # an extra filter on a column not in the index.
-opt expect=GenerateLookupJoinsWithVirtualColsAndFilter
+# TODO(#90771): To plan a lookup join here, we'd need to project the virtual
+# column expression after the upper join.
+opt expect-not=GenerateLookupJoinsWithVirtualColsAndFilter
 SELECT m, virt.j FROM small LEFT LOOKUP JOIN virt ON m = virt.v1 AND j > 0
 ----
 project
  ├── columns: m:1 j:8
  ├── immutable
- └── left-join (lookup virt)
+ └── left-join (hash)
       ├── columns: m:1 j:8 v1:9
-      ├── key columns: [16] = [6]
-      ├── lookup columns are key
-      ├── second join in paired joiner
+      ├── flags: force lookup join (into right side)
       ├── immutable
-      ├── left-join (lookup virt@v1_storing_i)
-      │    ├── columns: m:1 k:16 i:17 v1:19 continuation:26
-      │    ├── flags: force lookup join (into right side)
-      │    ├── key columns: [1] = [19]
-      │    ├── first join in paired joiner; continuation column: continuation:26
-      │    ├── fd: (16)-->(17,19,26), (17)~~>(19)
-      │    ├── scan small
-      │    │    └── columns: m:1
-      │    └── filters (true)
+      ├── scan small
+      │    └── columns: m:1
+      ├── project
+      │    ├── columns: v1:9 j:8!null
+      │    ├── immutable
+      │    ├── select
+      │    │    ├── columns: i:7 j:8!null
+      │    │    ├── scan virt
+      │    │    │    ├── columns: i:7 j:8!null
+      │    │    │    ├── check constraint expressions
+      │    │    │    │    ├── j:8 IN (10, 20, 30) [outer=(8), constraints=(/8: [/10 - /10] [/20 - /20] [/30 - /30]; tight)]
+      │    │    │    │    └── v4:12 IN (1, 2, 3) [outer=(12), constraints=(/12: [/1 - /1] [/2 - /2] [/3 - /3]; tight)]
+      │    │    │    └── computed column expressions
+      │    │    │         ├── v1:9
+      │    │    │         │    └── i:7 + 10
+      │    │    │         ├── v2:10
+      │    │    │         │    └── i:7 + 100
+      │    │    │         ├── v3:11
+      │    │    │         │    └── i:7 + j:8
+      │    │    │         └── v4:12
+      │    │    │              └── i:7 + 1
+      │    │    └── filters
+      │    │         └── j:8 > 0 [outer=(8), constraints=(/8: [/1 - ]; tight)]
+      │    └── projections
+      │         └── i:7 + 10 [as=v1:9, outer=(7), immutable]
       └── filters
-           └── j:8 > 0 [outer=(8), constraints=(/8: [/1 - ]; tight)]
+           └── m:1 = v1:9 [outer=(1,9), constraints=(/1: (/NULL - ]; /9: (/NULL - ]), fd=(1)==(9), (9)==(1)]
 
 # Left join, non-covering case. Virtual column is the lookup column and there is
 # an extra filter on a column not in the index, but the column is not selected.
@@ -6560,31 +6596,56 @@ project
            └── j:8 > 0 [outer=(8), constraints=(/8: [/1 - ]; tight)]
 
 # Left join, same case as above.
-opt expect=GenerateLookupJoinsWithVirtualColsAndFilter
+# TODO(#90771): To plan a lookup join here, we'd need to project the virtual
+# column expression after the upper join.
+opt expect-not=GenerateLookupJoinsWithVirtualColsAndFilter
 SELECT m, virt.k, virt.j FROM small LEFT LOOKUP JOIN virt ON m = virt.v3 AND j > 0
 ----
 project
  ├── columns: m:1 k:6 j:8
  ├── immutable
  ├── fd: (6)-->(8)
- └── left-join (lookup virt)
+ └── left-join (hash)
       ├── columns: m:1 k:6 j:8 v3:11
-      ├── key columns: [16] = [6]
-      ├── lookup columns are key
-      ├── second join in paired joiner
+      ├── flags: force lookup join (into right side)
       ├── immutable
       ├── fd: (6)-->(8,11)
-      ├── left-join (lookup virt@v3_partial,partial)
-      │    ├── columns: m:1 k:16 i:17 v3:21 continuation:26
-      │    ├── flags: force lookup join (into right side)
-      │    ├── key columns: [1] = [21]
-      │    ├── first join in paired joiner; continuation column: continuation:26
-      │    ├── fd: (16)-->(17,21,26)
-      │    ├── scan small
-      │    │    └── columns: m:1
-      │    └── filters (true)
+      ├── scan small
+      │    └── columns: m:1
+      ├── project
+      │    ├── columns: v3:11 k:6!null j:8!null
+      │    ├── immutable
+      │    ├── key: (6)
+      │    ├── fd: (6)-->(8,11)
+      │    ├── select
+      │    │    ├── columns: k:6!null i:7 j:8!null
+      │    │    ├── key: (6)
+      │    │    ├── fd: (6)-->(7,8)
+      │    │    ├── scan virt
+      │    │    │    ├── columns: k:6!null i:7 j:8!null
+      │    │    │    ├── check constraint expressions
+      │    │    │    │    ├── j:8 IN (10, 20, 30) [outer=(8), constraints=(/8: [/10 - /10] [/20 - /20] [/30 - /30]; tight)]
+      │    │    │    │    └── v4:12 IN (1, 2, 3) [outer=(12), constraints=(/12: [/1 - /1] [/2 - /2] [/3 - /3]; tight)]
+      │    │    │    ├── computed column expressions
+      │    │    │    │    ├── v1:9
+      │    │    │    │    │    └── i:7 + 10
+      │    │    │    │    ├── v2:10
+      │    │    │    │    │    └── i:7 + 100
+      │    │    │    │    ├── v3:11
+      │    │    │    │    │    └── i:7 + j:8
+      │    │    │    │    └── v4:12
+      │    │    │    │         └── i:7 + 1
+      │    │    │    ├── partial index predicates
+      │    │    │    │    └── v3_partial: filters
+      │    │    │    │         └── (((i:7 > 0) OR (j:8 > 0)) OR (i:7 > -100)) OR ((i:7 + j:8) > 0) [outer=(7,8), immutable]
+      │    │    │    ├── key: (6)
+      │    │    │    └── fd: (6)-->(7,8)
+      │    │    └── filters
+      │    │         └── j:8 > 0 [outer=(8), constraints=(/8: [/1 - ]; tight)]
+      │    └── projections
+      │         └── i:7 + j:8 [as=v3:11, outer=(7,8), immutable]
       └── filters
-           └── j:8 > 0 [outer=(8), constraints=(/8: [/1 - ]; tight)]
+           └── m:1 = v3:11 [outer=(1,11), constraints=(/1: (/NULL - ]; /11: (/NULL - ]), fd=(1)==(11), (11)==(1)]
 
 # Semi-join, same case as above.
 # TODO(mgartner): We don't currently handle this case, but we should be able to.
@@ -6696,31 +6757,57 @@ project
            └── (i:7 + j:8) > 0 [outer=(7,8), immutable]
 
 # Left join, same case as above.
-opt expect=GenerateLookupJoinsWithVirtualColsAndFilter
+# TODO(#90771): To plan a lookup join here, we'd need to project the virtual
+# column expression after the upper join.
+opt expect-not=GenerateLookupJoinsWithVirtualColsAndFilter
 SELECT m, virt.k, virt.i, virt.j FROM small LEFT LOOKUP JOIN virt ON m = virt.v3 AND v3 > 0
 ----
 project
  ├── columns: m:1 k:6 i:7 j:8
  ├── immutable
  ├── fd: (6)-->(7,8)
- └── left-join (lookup virt)
+ └── left-join (hash)
       ├── columns: m:1 k:6 i:7 j:8 v3:11
-      ├── key columns: [16] = [6]
-      ├── lookup columns are key
-      ├── second join in paired joiner
+      ├── flags: force lookup join (into right side)
       ├── immutable
       ├── fd: (6)-->(7,8), (7,8)-->(11)
-      ├── left-join (lookup virt@v3_partial,partial)
-      │    ├── columns: m:1 k:16 i:17 v3:21 continuation:26
-      │    ├── flags: force lookup join (into right side)
-      │    ├── key columns: [1] = [21]
-      │    ├── first join in paired joiner; continuation column: continuation:26
-      │    ├── fd: (16)-->(17,21,26)
-      │    ├── scan small
-      │    │    └── columns: m:1
-      │    └── filters (true)
+      ├── scan small
+      │    └── columns: m:1
+      ├── project
+      │    ├── columns: v3:11 k:6!null i:7 j:8!null
+      │    ├── immutable
+      │    ├── key: (6)
+      │    ├── fd: (6)-->(7,8), (7,8)-->(11)
+      │    ├── select
+      │    │    ├── columns: k:6!null i:7 j:8!null
+      │    │    ├── immutable
+      │    │    ├── key: (6)
+      │    │    ├── fd: (6)-->(7,8)
+      │    │    ├── scan virt
+      │    │    │    ├── columns: k:6!null i:7 j:8!null
+      │    │    │    ├── check constraint expressions
+      │    │    │    │    ├── j:8 IN (10, 20, 30) [outer=(8), constraints=(/8: [/10 - /10] [/20 - /20] [/30 - /30]; tight)]
+      │    │    │    │    └── v4:12 IN (1, 2, 3) [outer=(12), constraints=(/12: [/1 - /1] [/2 - /2] [/3 - /3]; tight)]
+      │    │    │    ├── computed column expressions
+      │    │    │    │    ├── v1:9
+      │    │    │    │    │    └── i:7 + 10
+      │    │    │    │    ├── v2:10
+      │    │    │    │    │    └── i:7 + 100
+      │    │    │    │    ├── v3:11
+      │    │    │    │    │    └── i:7 + j:8
+      │    │    │    │    └── v4:12
+      │    │    │    │         └── i:7 + 1
+      │    │    │    ├── partial index predicates
+      │    │    │    │    └── v3_partial: filters
+      │    │    │    │         └── (((i:7 > 0) OR (j:8 > 0)) OR (i:7 > -100)) OR ((i:7 + j:8) > 0) [outer=(7,8), immutable]
+      │    │    │    ├── key: (6)
+      │    │    │    └── fd: (6)-->(7,8)
+      │    │    └── filters
+      │    │         └── (i:7 + j:8) > 0 [outer=(7,8), immutable]
+      │    └── projections
+      │         └── i:7 + j:8 [as=v3:11, outer=(7,8), immutable]
       └── filters
-           └── (i:7 + j:8) > 0 [outer=(7,8), immutable]
+           └── m:1 = v3:11 [outer=(1,11), constraints=(/1: (/NULL - ]; /11: (/NULL - ]), fd=(1)==(11), (11)==(1)]
 
 # We cannot currently generate a lookup join with filters remaining after
 # partial index implication that contain a virtual column if the columns


### PR DESCRIPTION
Backport 1/1 commits from #90773.

/cc @cockroachdb/release

---

Previously, the optimizer would generate paired lookup joins that attempted to produce virtual computed columns from the upper join in a paired join. The upper join always reads from the primary index, and the primary index never contains virtual columns. This could incorrectly produce `NULL` values for these virtual columns, or internal errors if the columns had `NOT NULL` constraints.

This commit fixes the problem by not generating paired joins when a virtual computed column must be included in the output columns of the join. As a result, we no longer generate lookup joins in some cases that we previously did. In the future, we should be able to generate lookup joins in these cases by adding Project above the upper join to produce the virtual columns. This is left as future-work, see #90771.

Fixes #89576

Release note (bug fix): A bug has been fixed that caused incorrect results and internal errors when a `LEFT JOIN` operated on a table with virtual computed columns. The bug only presented when the optimizer planned a "paired joiner". Only values of the virtual columns would be incorrect - they could be be `NULL` when their correct value was not `NULL`. An internal error would occur in the same situation if the virtual column had a `NOT NULL` constraint. This bug was present since version 22.1.0.

----

Release justification: Fixes correctness bug with virtual columns.
