### PR TITLE
release: fix download url

### DIFF
--- a/build/teamcity/internal/release/process/publish-cockroach-release.sh
+++ b/build/teamcity/internal/release/process/publish-cockroach-release.sh
@@ -119,7 +119,7 @@ for platform_name in "${platform_names[@]}"; do
     --silent \
     --show-error \
     --output /dev/stdout \
-    --url "https://${bucket}.s3.amazonaws.com/cockroach-${build_name}.${linux_platform}-${tarball_arch}.tgz" \
+    --url "https://${s3_download_hostname}/cockroach-${build_name}.${linux_platform}-${tarball_arch}.tgz" \
     | tar \
     --directory="build/deploy-${docker_arch}" \
     --extract \


### PR DESCRIPTION
Previously, we changed the download url to always use `s3.amazonaws.com` as the suffix. In cases when a bucket name contains dots, it breaks the SSL verification procedure.

This change will revert the change and curl will be using an explicit download domain.

Release note: None
Epic: None