### PR TITLE
kv: deflake raceTransport after pass-by-ref BatchRequest

### DIFF
--- a/pkg/kv/kvclient/kvcoord/transport.go
+++ b/pkg/kv/kvclient/kvcoord/transport.go
@@ -185,8 +185,6 @@ func (gt *grpcTransport) SendNext(
 	if err != nil {
 		return nil, err
 	}
-
-	ba.Replica = r
 	return gt.sendBatch(ctx, r.NodeID, iface, ba)
 }
 

--- a/pkg/kv/kvclient/kvcoord/transport_race.go
+++ b/pkg/kv/kvclient/kvcoord/transport_race.go
@@ -54,7 +54,7 @@ type raceTransport struct {
 }
 
 func (tr raceTransport) SendNext(
-	ctx context.Context, ba roachpb.BatchRequest,
+	ctx context.Context, ba *roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, error) {
 	// Make a copy of the requests slice, and shallow copies of the requests.
 	// The caller is allowed to mutate the request after the call returns. Since
@@ -69,10 +69,7 @@ func (tr raceTransport) SendNext(
 	}
 	ba.Requests = requestsCopy
 	select {
-	// We have a shallow copy here and so the top level scalar fields can't
-	// really race, but making more copies doesn't make anything more
-	// transparent, so from now on we operate on a pointer.
-	case incoming <- &ba:
+	case incoming <- ba:
 	default:
 		// Avoid slowing down the tests if we're backed up.
 	}

--- a/pkg/rpc/nodedialer/nodedialer.go
+++ b/pkg/rpc/nodedialer/nodedialer.go
@@ -308,11 +308,12 @@ type TracingInternalClient struct {
 
 // Batch overrides the Batch RPC client method and fills in tracing information.
 func (tic TracingInternalClient) Batch(
-	ctx context.Context, req *roachpb.BatchRequest, opts ...grpc.CallOption,
+	ctx context.Context, ba *roachpb.BatchRequest, opts ...grpc.CallOption,
 ) (*roachpb.BatchResponse, error) {
 	sp := tracing.SpanFromContext(ctx)
 	if sp != nil && !sp.IsNoop() {
-		req.TraceInfo = sp.Meta().ToProto()
+		ba = ba.ShallowCopy()
+		ba.TraceInfo = sp.Meta().ToProto()
 	}
-	return tic.InternalClient.Batch(ctx, req, opts...)
+	return tic.InternalClient.Batch(ctx, ba, opts...)
 }


### PR DESCRIPTION
This commit fixes the broken compilation of `raceTransport`, which was broken by e822649. That commit made its way through CI without triggering a race build with the silent log:
```
changed many packages; skipping race detector tests
```

This commit also fixes a few tests that now fail under race due to the `raceTransport` by shallow cloning the BatchRequest before mutation in the `DistSender.sendToReplicas` and `TracingInternalClient.Batch`.

Epic: None

Release note: None