### PR TITLE
cloud/amazon: support external ID in AWS assume role

### DIFF
--- a/pkg/cloud/amazon/aws_kms.go
+++ b/pkg/cloud/amazon/aws_kms.go
@@ -43,27 +43,33 @@ func init() {
 }
 
 type kmsURIParams struct {
-	accessKey        string
-	secret           string
-	tempToken        string
-	endpoint         string
-	region           string
-	auth             string
-	roleARN          string
-	delegateRoleARNs []string
+	accessKey             string
+	secret                string
+	tempToken             string
+	endpoint              string
+	region                string
+	auth                  string
+	roleProvider          roleProvider
+	delegateRoleProviders []roleProvider
 }
 
 func resolveKMSURIParams(kmsURI cloud.ConsumeURL) (kmsURIParams, error) {
-	assumeRole, delegateRoles := cloud.ParseRoleString(kmsURI.ConsumeParam(AssumeRoleParam))
+	assumeRoleProto, delegateRoleProtos := cloud.ParseRoleProvidersString(kmsURI.ConsumeParam(AssumeRoleParam))
+	assumeRoleProvider := makeRoleProvider(assumeRoleProto)
+	delegateProviders := make([]roleProvider, len(delegateRoleProtos))
+	for i := range delegateRoleProtos {
+		delegateProviders[i] = makeRoleProvider(delegateRoleProtos[i])
+	}
+
 	params := kmsURIParams{
-		accessKey:        kmsURI.ConsumeParam(AWSAccessKeyParam),
-		secret:           kmsURI.ConsumeParam(AWSSecretParam),
-		tempToken:        kmsURI.ConsumeParam(AWSTempTokenParam),
-		endpoint:         kmsURI.ConsumeParam(AWSEndpointParam),
-		region:           kmsURI.ConsumeParam(KMSRegionParam),
-		auth:             kmsURI.ConsumeParam(cloud.AuthParam),
-		roleARN:          assumeRole,
-		delegateRoleARNs: delegateRoles,
+		accessKey:             kmsURI.ConsumeParam(AWSAccessKeyParam),
+		secret:                kmsURI.ConsumeParam(AWSSecretParam),
+		tempToken:             kmsURI.ConsumeParam(AWSTempTokenParam),
+		endpoint:              kmsURI.ConsumeParam(AWSEndpointParam),
+		region:                kmsURI.ConsumeParam(KMSRegionParam),
+		auth:                  kmsURI.ConsumeParam(cloud.AuthParam),
+		roleProvider:          assumeRoleProvider,
+		delegateRoleProviders: delegateProviders,
 	}
 
 	// Validate that all the passed in parameters are supported.
@@ -167,7 +173,7 @@ func MakeAWSKMS(ctx context.Context, uri string, env cloud.KMSEnv) (cloud.KMS, e
 		return nil, errors.Wrap(err, "new aws session")
 	}
 
-	if kmsURIParams.roleARN != "" {
+	if kmsURIParams.roleProvider != (roleProvider{}) {
 		if !env.ClusterSettings().Version.IsActive(ctx, clusterversion.V22_2SupportAssumeRoleAuth) {
 			return nil, errors.New("cannot authenticate to KMS via assume role until cluster has fully upgraded to 22.2")
 		}
@@ -175,8 +181,8 @@ func MakeAWSKMS(ctx context.Context, uri string, env cloud.KMSEnv) (cloud.KMS, e
 		// If there are delegate roles in the assume-role chain, we create a session
 		// for each role in order for it to fetch the credentials from the next role
 		// in the chain.
-		for _, role := range kmsURIParams.delegateRoleARNs {
-			intermediateCreds := stscreds.NewCredentials(sess, role)
+		for _, delegateProvider := range kmsURIParams.delegateRoleProviders {
+			intermediateCreds := stscreds.NewCredentials(sess, delegateProvider.roleARN, withExternalID(delegateProvider.externalID))
 			opts.Config.Credentials = intermediateCreds
 
 			sess, err = session.NewSessionWithOptions(opts)
@@ -185,7 +191,7 @@ func MakeAWSKMS(ctx context.Context, uri string, env cloud.KMSEnv) (cloud.KMS, e
 			}
 		}
 
-		creds := stscreds.NewCredentials(sess, kmsURIParams.roleARN)
+		creds := stscreds.NewCredentials(sess, kmsURIParams.roleProvider.roleARN, withExternalID(kmsURIParams.roleProvider.externalID))
 		opts.Config.Credentials = creds
 		sess, err = session.NewSessionWithOptions(opts)
 		if err != nil {

--- a/pkg/cloud/amazon/s3_storage.go
+++ b/pkg/cloud/amazon/s3_storage.go
@@ -149,30 +149,76 @@ var usePutObject = settings.RegisterBoolSetting(
 	false,
 )
 
+// roleProvider contains fields about the role that needs to be assumed
+// in order to access the external storage.
+type roleProvider struct {
+	// roleARN, if non-empty, is the ARN of the AWS Role being assumed.
+	roleARN string
+
+	// externalID, if non-empty, is the external ID that must be passed along
+	// with the role in order to assume it. Some additional information about
+	// the issues that external IDs can address can be found on the AWS docs:
+	// https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html
+	externalID string
+}
+
+func makeRoleProvider(provider cloudpb.ExternalStorage_AssumeRoleProvider) roleProvider {
+	return roleProvider{
+		roleARN:    provider.Role,
+		externalID: provider.ExternalID,
+	}
+}
+
 // s3ClientConfig is the immutable config used to initialize an s3 session.
 // It contains values copied from corresponding fields in ExternalStorage_S3
 // which are used by the session (but not those that are only used by individual
 // requests).
 type s3ClientConfig struct {
 	// copied from ExternalStorage_S3.
-	endpoint, region, bucket, accessKey, secret, tempToken, auth, roleARN string
-	delegateRoleARNs                                                      []string
+	endpoint, region, bucket, accessKey, secret, tempToken, auth string
+	assumeRoleProvider                                           roleProvider
+	delegateRoleProviders                                        []roleProvider
+
 	// log.V(2) decides session init params so include it in key.
 	verbose bool
 }
 
 func clientConfig(conf *cloudpb.ExternalStorage_S3) s3ClientConfig {
+	var assumeRoleProvider roleProvider
+	var delegateRoleProviders []roleProvider
+
+	// In order to maintain backwards compatibility, parse both fields where roles
+	// are stored in ExternalStorage, preferring the provider fields.
+	if conf.AssumeRoleProvider.Role == "" && conf.RoleARN != "" {
+		assumeRoleProvider = roleProvider{
+			roleARN: conf.RoleARN,
+		}
+
+		delegateRoleProviders = make([]roleProvider, len(conf.DelegateRoleARNs))
+		for i := range conf.DelegateRoleARNs {
+			delegateRoleProviders[i] = roleProvider{
+				roleARN: conf.DelegateRoleARNs[i],
+			}
+		}
+	} else {
+		assumeRoleProvider = makeRoleProvider(conf.AssumeRoleProvider)
+		delegateRoleProviders = make([]roleProvider, len(conf.DelegateRoleProviders))
+		for i := range conf.DelegateRoleProviders {
+			delegateRoleProviders[i] = makeRoleProvider(conf.DelegateRoleProviders[i])
+		}
+	}
+
 	return s3ClientConfig{
-		endpoint:         conf.Endpoint,
-		region:           conf.Region,
-		bucket:           conf.Bucket,
-		accessKey:        conf.AccessKey,
-		secret:           conf.Secret,
-		tempToken:        conf.TempToken,
-		auth:             conf.Auth,
-		verbose:          log.V(2),
-		roleARN:          conf.RoleARN,
-		delegateRoleARNs: conf.DelegateRoleARNs,
+		endpoint:              conf.Endpoint,
+		region:                conf.Region,
+		bucket:                conf.Bucket,
+		accessKey:             conf.AccessKey,
+		secret:                conf.Secret,
+		tempToken:             conf.TempToken,
+		auth:                  conf.Auth,
+		verbose:               log.V(2),
+		assumeRoleProvider:    assumeRoleProvider,
+		delegateRoleProviders: delegateRoleProviders,
 	}
 }
 
@@ -209,9 +255,13 @@ func S3URI(bucket, path string, conf *cloudpb.ExternalStorage_S3) string {
 	setIf(AWSServerSideEncryptionMode, conf.ServerEncMode)
 	setIf(AWSServerSideEncryptionKMSID, conf.ServerKMSID)
 	setIf(S3StorageClassParam, conf.StorageClass)
-	if conf.RoleARN != "" {
-		roles := append(conf.DelegateRoleARNs, conf.RoleARN)
-		q.Set(AssumeRoleParam, strings.Join(roles, ","))
+	if conf.AssumeRoleProvider.Role != "" {
+		roleProviderStrings := make([]string, 0, len(conf.DelegateRoleProviders)+1)
+		for _, p := range conf.DelegateRoleProviders {
+			roleProviderStrings = append(roleProviderStrings, p.EncodeAsString())
+		}
+		roleProviderStrings = append(roleProviderStrings, conf.AssumeRoleProvider.EncodeAsString())
+		q.Set(AssumeRoleParam, strings.Join(roleProviderStrings, ","))
 	}
 
 	s3URL := url.URL{
@@ -232,21 +282,31 @@ func parseS3URL(_ cloud.ExternalStorageURIContext, uri *url.URL) (cloudpb.Extern
 	}
 
 	conf.Provider = cloudpb.ExternalStorageProvider_s3
-	assumeRole, delegateRoles := cloud.ParseRoleString(s3URL.ConsumeParam(AssumeRoleParam))
+
+	// TODO(rui): currently the value of AssumeRoleParam is written into both of
+	// the RoleARN fields and the RoleProvider fields in order to support a mixed
+	// version cluster with nodes on 22.2.0 and 22.2.1+. The logic around the
+	// RoleARN fields can be removed in 23.2.
+	assumeRoleValue := s3URL.ConsumeParam(AssumeRoleParam)
+	assumeRoleProvider, delegateRoleProviders := cloud.ParseRoleProvidersString(assumeRoleValue)
+	assumeRole, delegateRoles := cloud.ParseRoleString(assumeRoleValue)
+
 	conf.S3Config = &cloudpb.ExternalStorage_S3{
-		Bucket:           s3URL.Host,
-		Prefix:           s3URL.Path,
-		AccessKey:        s3URL.ConsumeParam(AWSAccessKeyParam),
-		Secret:           s3URL.ConsumeParam(AWSSecretParam),
-		TempToken:        s3URL.ConsumeParam(AWSTempTokenParam),
-		Endpoint:         s3URL.ConsumeParam(AWSEndpointParam),
-		Region:           s3URL.ConsumeParam(S3RegionParam),
-		Auth:             s3URL.ConsumeParam(cloud.AuthParam),
-		ServerEncMode:    s3URL.ConsumeParam(AWSServerSideEncryptionMode),
-		ServerKMSID:      s3URL.ConsumeParam(AWSServerSideEncryptionKMSID),
-		StorageClass:     s3URL.ConsumeParam(S3StorageClassParam),
-		RoleARN:          assumeRole,
-		DelegateRoleARNs: delegateRoles,
+		Bucket:                s3URL.Host,
+		Prefix:                s3URL.Path,
+		AccessKey:             s3URL.ConsumeParam(AWSAccessKeyParam),
+		Secret:                s3URL.ConsumeParam(AWSSecretParam),
+		TempToken:             s3URL.ConsumeParam(AWSTempTokenParam),
+		Endpoint:              s3URL.ConsumeParam(AWSEndpointParam),
+		Region:                s3URL.ConsumeParam(S3RegionParam),
+		Auth:                  s3URL.ConsumeParam(cloud.AuthParam),
+		ServerEncMode:         s3URL.ConsumeParam(AWSServerSideEncryptionMode),
+		ServerKMSID:           s3URL.ConsumeParam(AWSServerSideEncryptionKMSID),
+		StorageClass:          s3URL.ConsumeParam(S3StorageClassParam),
+		RoleARN:               assumeRole,
+		DelegateRoleARNs:      delegateRoles,
+		AssumeRoleProvider:    assumeRoleProvider,
+		DelegateRoleProviders: delegateRoleProviders,
 		/* NB: additions here should also update s3QueryParams() serializer */
 	}
 	conf.S3Config.Prefix = strings.TrimLeft(conf.S3Config.Prefix, "/")
@@ -487,13 +547,13 @@ func newClient(
 		}
 	}
 
-	if conf.roleARN != "" {
+	if conf.assumeRoleProvider.roleARN != "" {
 		if !settings.Version.IsActive(ctx, clusterversion.V22_2SupportAssumeRoleAuth) {
 			return s3Client{}, "", errors.New("cannot authenticate to cloud storage via assume role until cluster has fully upgraded to 22.2")
 		}
 
-		for _, role := range conf.delegateRoleARNs {
-			intermediateCreds := stscreds.NewCredentials(sess, role)
+		for _, delegateProvider := range conf.delegateRoleProviders {
+			intermediateCreds := stscreds.NewCredentials(sess, delegateProvider.roleARN, withExternalID(delegateProvider.externalID))
 			opts.Config.Credentials = intermediateCreds
 
 			sess, err = session.NewSessionWithOptions(opts)
@@ -502,7 +562,7 @@ func newClient(
 			}
 		}
 
-		creds := stscreds.NewCredentials(sess, conf.roleARN)
+		creds := stscreds.NewCredentials(sess, conf.assumeRoleProvider.roleARN, withExternalID(conf.assumeRoleProvider.externalID))
 		opts.Config.Credentials = creds
 		sess, err = session.NewSessionWithOptions(opts)
 		if err != nil {
@@ -830,6 +890,14 @@ func s3ErrDelay(err error) time.Duration {
 		}
 	}
 	return 0
+}
+
+func withExternalID(externalID string) func(*stscreds.AssumeRoleProvider) {
+	return func(p *stscreds.AssumeRoleProvider) {
+		if externalID != "" {
+			p.ExternalID = aws.String(externalID)
+		}
+	}
 }
 
 func init() {

--- a/pkg/cloud/amazon/s3_storage_test.go
+++ b/pkg/cloud/amazon/s3_storage_test.go
@@ -276,13 +276,14 @@ func TestPutS3AssumeRole(t *testing.T) {
 		)
 	})
 
-	t.Run("role-chaining", func(t *testing.T) {
+	t.Run("role-chaining-external-id", func(t *testing.T) {
 		roleChainStr := os.Getenv("AWS_ROLE_ARN_CHAIN")
 		if roleChainStr == "" {
 			skip.IgnoreLint(t, "AWS_ROLE_ARN_CHAIN env var must be set")
 		}
 
-		roleChain := strings.Split(roleChainStr, ",")
+		assumeRoleProvider, delegateRoleProviders := cloud.ParseRoleProvidersString(roleChainStr)
+		providerChain := append(delegateRoleProviders, assumeRoleProvider)
 		for _, tc := range []struct {
 			auth      string
 			accessKey string
@@ -293,14 +294,14 @@ func TestPutS3AssumeRole(t *testing.T) {
 		} {
 			t.Run(tc.auth, func(t *testing.T) {
 				// First verify that none of the individual roles in the chain can be used to access the storage.
-				for _, role := range roleChain {
+				for _, p := range providerChain {
 					roleURI := S3URI(bucket, "backup-test",
 						&cloudpb.ExternalStorage_S3{
-							Auth:      tc.auth,
-							RoleARN:   role,
-							AccessKey: tc.accessKey,
-							Secret:    tc.secretKey,
-							Region:    "us-east-1",
+							Auth:               tc.auth,
+							AssumeRoleProvider: p,
+							AccessKey:          tc.accessKey,
+							Secret:             tc.secretKey,
+							Region:             "us-east-1",
 						},
 					)
 					cloudtestutils.CheckNoPermission(t, roleURI, user,
@@ -311,15 +312,40 @@ func TestPutS3AssumeRole(t *testing.T) {
 					)
 				}
 
-				// Finally, check that the chain of roles can be used to access the storage.
+				// Next check that the role chain without any external IDs cannot be used to
+				// access the storage.
+				roleWithoutID := cloudpb.ExternalStorage_AssumeRoleProvider{Role: providerChain[len(providerChain)-1].Role}
+				delegatesWithoutID := make([]cloudpb.ExternalStorage_AssumeRoleProvider, 0, len(providerChain)-1)
+				for _, p := range providerChain[:len(providerChain)-1] {
+					delegatesWithoutID = append(delegatesWithoutID, cloudpb.ExternalStorage_AssumeRoleProvider{Role: p.Role})
+				}
+
 				uri := S3URI(bucket, "backup-test",
 					&cloudpb.ExternalStorage_S3{
-						Auth:             tc.auth,
-						RoleARN:          roleChain[len(roleChain)-1],
-						DelegateRoleARNs: roleChain[:len(roleChain)-1],
-						AccessKey:        tc.accessKey,
-						Secret:           tc.secretKey,
-						Region:           "us-east-1",
+						Auth:                  tc.auth,
+						AssumeRoleProvider:    roleWithoutID,
+						DelegateRoleProviders: delegatesWithoutID,
+						AccessKey:             tc.accessKey,
+						Secret:                tc.secretKey,
+						Region:                "us-east-1",
+					},
+				)
+				cloudtestutils.CheckNoPermission(t, uri, user,
+					nil, /* ie */
+					nil, /* ief */
+					nil, /* kvDB */
+					testSettings,
+				)
+
+				// Finally, check that the chain of roles can be used to access the storage.
+				uri = S3URI(bucket, "backup-test",
+					&cloudpb.ExternalStorage_S3{
+						Auth:                  tc.auth,
+						AssumeRoleProvider:    providerChain[len(providerChain)-1],
+						DelegateRoleProviders: providerChain[:len(providerChain)-1],
+						AccessKey:             tc.accessKey,
+						Secret:                tc.secretKey,
+						Region:                "us-east-1",
 					},
 				)
 

--- a/pkg/cloud/cloudpb/external_storage.go
+++ b/pkg/cloud/cloudpb/external_storage.go
@@ -10,6 +10,11 @@
 
 package cloudpb
 
+import (
+	"fmt"
+	"strings"
+)
+
 const (
 	// ExternalStorageAuthImplicit is used by ExternalStorage instances to
 	// indicate access via a node's "implicit" authorization (e.g. machine acct).
@@ -58,4 +63,36 @@ func (m *ExternalStorage) AccessIsWithExplicitAuth() bool {
 	default:
 		return false
 	}
+}
+
+const assumeRoleProviderExternalIDParam = "external_id"
+
+// EncodeAsString returns the string representation of the provider to be used
+// in URIs.
+func (p ExternalStorage_AssumeRoleProvider) EncodeAsString() string {
+	if p.Role == "" {
+		return ""
+	}
+
+	if p.ExternalID == "" {
+		return p.Role
+	}
+
+	return fmt.Sprintf("%s;%s=%s", p.Role, assumeRoleProviderExternalIDParam, p.ExternalID)
+
+}
+
+// DecodeRoleProviderString decodes a string into an
+// ExternalStorage_AssumeRoleProvider.
+func DecodeRoleProviderString(roleProviderString string) (p ExternalStorage_AssumeRoleProvider) {
+	parts := strings.Split(roleProviderString, ";")
+	p.Role = parts[0]
+
+	for pidx := 1; pidx < len(parts); pidx++ {
+		key, value, _ := strings.Cut(parts[pidx], "=")
+		if key == assumeRoleProviderExternalIDParam {
+			p.ExternalID = value
+		}
+	}
+	return p
 }

--- a/pkg/cloud/cloudpb/external_storage.proto
+++ b/pkg/cloud/cloudpb/external_storage.proto
@@ -38,6 +38,21 @@ message ExternalStorage {
   message Http {
     string baseUri = 1;
   }
+  // AssumeRoleProvider contains fields about the role that needs to be assumed
+  // in order to access the external storage.
+  message AssumeRoleProvider {
+    // Role, if non-empty, is the ARN of the AWS Role or the email address of
+    // the GCP Service Account that is being assumed.
+    string role = 1;
+    // ExternalID, if non-empty, is the external ID that must be passed along
+    // with the role in order to assume it. Some additional information about
+    // the issues that external IDs can address can be found on the AWS docs:
+    // https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html
+    //
+    // Currently only AWS supports external ID, there is an open issue tracker
+    // for support in GCP: https://issuetracker.google.com/issues/217037003
+    string external_id = 2  [(gogoproto.customname) = "ExternalID"];
+  }
   message S3 {
     string bucket = 1;
     string prefix = 2;
@@ -54,12 +69,26 @@ message ExternalStorage {
 
     // RoleARN if non-empty, is the ARN of the role that should be assumed in
     // order to access this storage.
+    // TODO(rui): this field is currently kept for mixed-version state, remove
+    // in 23.2 in favor of AssumeRoleProvider.
     string role_arn = 12 [(gogoproto.customname) = "RoleARN"];
 
     // DelegateRoleARNs are the ARNs of intermediate roles in an assume role
     // chain. These roles will be assumed in the order they appear in the list
     // so that the role specified by RoleARN can be assumed.
+    // TODO(rui): this field is currently kept for mixed-version state, remove
+    // in 23.2 in favor of DelegateRoleProviders.
     repeated string delegate_role_arns = 13 [(gogoproto.customname) = "DelegateRoleARNs"];
+
+    // AssumeRoleProvider, if the role is non-empty, contains the ARN of the
+    // role that should be assumed in order to access this storage, as well as
+    // an optional external ID.
+    AssumeRoleProvider assume_role_provider = 14 [(gogoproto.nullable) = false];
+
+    // DelegateRoleProviders contain the ARNs of intermediate roles in an assume
+    // role chain. These roles will be assumed in the order they appear in the
+    // list so that the role specified in AssumeRoleProvider can be assumed.
+    repeated AssumeRoleProvider delegate_role_providers = 15 [(gogoproto.nullable) = false];
   }
   message GCS {
     string bucket = 1;


### PR DESCRIPTION
Support passing in the optional external ID when assuming a role. This is done by extending the values of the comma-separated string value of the ASSUME_ROLE parameter to the format `<role>;external_id=<id>`. Users can still use the previous format of just `<role>` to specify a role without any external ID.

When using role chaining, each role in the chain can be associated with a different external ID. For example:
`ASSUME_ROLE=<roleA>;external_id=<idA>,<roleB>;external_id=<idB>,<roleC>` will use external ID `<idA>` to assume delegate `<roleA>`, then use external ID `<idB>` to assume delegate `<roleB>`, and finally no external ID to assume the final role `<roleC>`.

Additional documentation about external IDs can be found here: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html

Release note (enterprise change): Support passing in the optional external ID when assuming a role. This is done by extending the values of the comma-separated string value of the ASSUME_ROLE parameter to the format `<role>;external_id=<id>`. Users can still use the previous format of just `<role>` to specify a role without any external ID.

When using role chaining, each role in the chain can be associated with a different external ID. For example:
`ASSUME_ROLE=<roleA>;external_id=<idA>,<roleB>;external_id=<idB>,<roleC>` will use external ID `<idA>` to assume delegate `<roleA>`, then use external ID `<idB>` to assume delegate `<roleB>`, and finally no external ID to assume the final role `<roleC>`.

Addresses https://github.com/cockroachdb/cockroach/issues/90239