### PR TITLE
release-22.1: sql: use bare name string of new pk  to compare with pk name when altering primary key

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -1451,7 +1451,7 @@ func validateConstraintNameIsNotUsed(
 			// If there is no active primary key, then adding one with the exact
 			// same name is allowed.
 			if !tableDesc.HasPrimaryKey() &&
-				tableDesc.PrimaryIndex.Name == name.String() {
+				tableDesc.PrimaryIndex.Name == string(name) {
 				return false, nil
 			}
 		}

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -1654,3 +1654,11 @@ t_pkey      i            ASC
 t_pkey      j            N/A
 t_j_key     j            ASC
 t_j_key     i            ASC
+
+subtest regression_90836
+
+statement ok
+CREATE TABLE t_90836(a INT NOT NULL, b INT NOT NULL, CONSTRAINT "constraint" PRIMARY KEY (a));
+
+statement ok
+BEGIN; ALTER TABLE t_90836 DROP CONSTRAINT "constraint"; ALTER TABLE t_90836 ADD CONSTRAINT "constraint" PRIMARY KEY (b); COMMIT;


### PR DESCRIPTION
Backport 1/1 commits from #90865.

/cc @cockroachdb/release

---

Fixes #90836

Release note (sql change): previously, the `DROP CONSTRAINT, ADD CONSTRAINT` in one trick to have a new primary key without moving old primary key to be a secondary index didn't work if the primary key name is a reserved SQL keyword. A `constraint already exists` error was returned. This patch fixed the bug, the trick now also works with primary key named as reserved keywords.

Release justification: low risk bug fix asked by customer.