### PR TITLE
colexecdisk: try harder to deflake TestExternalSortMemoryAccounting

### DIFF
--- a/pkg/sql/colexec/colexecdisk/external_sort_test.go
+++ b/pkg/sql/colexec/colexecdisk/external_sort_test.go
@@ -163,7 +163,7 @@ func TestExternalSortMemoryAccounting(t *testing.T) {
 	}
 	// We cannot guarantee a fixed value, so we use an allowed range.
 	expMin := memoryLimit
-	expMax := int64(float64(memoryLimit) * 2.3)
+	expMax := int64(float64(memoryLimit) * 2.5)
 	require.GreaterOrEqualf(t, totalMaxMemUsage, expMin, "minimum memory bound not satisfied: "+
 		"actual %d, expected min %d", totalMaxMemUsage, expMin)
 	require.GreaterOrEqualf(t, expMax, totalMaxMemUsage, "maximum memory bound not satisfied: "+


### PR DESCRIPTION
Somehow it failed yet again, after increasing the limit from 2.2 to 2.3. The failure was off by .4%. To be safe, I'm going all the way to 2.5.

Epic: None

Release note: None