### PR TITLE
catalog, tabledesc: Add methods to retrieve all constraints in a table

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -353,7 +353,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 			case *tree.CheckConstraintTableDef:
 				var err error
 				params.p.runWithOptions(resolveFlags{contextDatabaseID: n.tableDesc.ParentID}, func() {
-					info, infoErr := n.tableDesc.GetConstraintInfo()
+					info, infoErr := n.tableDesc.GetNonDropConstraintInfo()
 					if infoErr != nil {
 						err = infoErr
 						return
@@ -507,7 +507,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 			}
 			droppedViews = append(droppedViews, colDroppedViews...)
 		case *tree.AlterTableDropConstraint:
-			info, err := n.tableDesc.GetConstraintInfo()
+			info, err := n.tableDesc.GetNonDropConstraintInfo()
 			if err != nil {
 				return err
 			}
@@ -534,7 +534,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 			}
 
 		case *tree.AlterTableValidateConstraint:
-			info, err := n.tableDesc.GetConstraintInfo()
+			info, err := n.tableDesc.GetNonDropConstraintInfo()
 			if err != nil {
 				return err
 			}
@@ -787,7 +787,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 			descriptorChanged = descriptorChanged || descChanged
 
 		case *tree.AlterTableRenameConstraint:
-			info, err := n.tableDesc.GetConstraintInfo()
+			info, err := n.tableDesc.GetNonDropConstraintInfo()
 			if err != nil {
 				return err
 			}
@@ -1037,7 +1037,7 @@ func applyColumnMutation(
 					"constraint in the middle of being dropped")
 			}
 		}
-		info, err := tableDesc.GetConstraintInfo()
+		info, err := tableDesc.GetNonDropConstraintInfo()
 		if err != nil {
 			return err
 		}
@@ -1069,7 +1069,7 @@ func applyColumnMutation(
 }
 
 func addNotNullConstraintMutationForCol(tableDesc *tabledesc.Mutable, col catalog.Column) error {
-	info, err := tableDesc.GetConstraintInfo()
+	info, err := tableDesc.GetNonDropConstraintInfo()
 	if err != nil {
 		return err
 	}
@@ -1474,7 +1474,7 @@ func validateConstraintNameIsNotUsed(
 	if name == "" {
 		return false, nil
 	}
-	info, err := tableDesc.GetConstraintInfo()
+	info, err := tableDesc.GetNonDropConstraintInfo()
 	if err != nil {
 		// Unexpected error: table descriptor should be valid at this point.
 		return false, errors.WithAssertionFailure(err)
@@ -1773,7 +1773,7 @@ func dropColumnImpl(
 
 	// Drop check constraints which reference the column.
 	constraintsToDrop := make([]string, 0, len(tableDesc.Checks))
-	constraintInfo, err := tableDesc.GetConstraintInfo()
+	constraintInfo, err := tableDesc.GetNonDropConstraintInfo()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -648,6 +648,11 @@ type TableDescriptor interface {
 	// ones on the table descriptor which are being enforced for all writes, and
 	// "inactive" ones queued in the mutations list.
 	AllActiveAndInactiveUniqueWithoutIndexConstraints() []*descpb.UniqueWithoutIndexConstraint
+	// AllUniqueWithoutIndexConstraints returns all unique constraints that are
+	// not enforced by an index from both the `UniqueWithoutIndex` slice
+	// and mutation slice. It differs from `AllActiveAndInactiveUniqueWithoutIndexConstraints`
+	// in that the return includes UniqueWithoutIndexConstraints that are being dropped.
+	AllUniqueWithoutIndexConstraints() []*descpb.UniqueWithoutIndexConstraint
 
 	// ForeachOutboundFK calls f for every outbound foreign key in desc until an
 	// error is returned.
@@ -661,6 +666,10 @@ type TableDescriptor interface {
 	// returned if multiple foreign keys (including mutations) are found for the
 	// same index.
 	AllActiveAndInactiveForeignKeys() []*descpb.ForeignKeyConstraint
+	// AllForeignKeys returns all foreign keys from both the `outboundFKs` slice
+	// and mutation slice. It differs from `AllActiveAndInactiveForeignKeys` in
+	// that the return includes FKs that are being dropped.
+	AllForeignKeys() []*descpb.ForeignKeyConstraint
 
 	// GetChecks returns information about this table's check constraints, if
 	// there are any. Only valid if IsTable returns true.
@@ -675,6 +684,10 @@ type TableDescriptor interface {
 	// on writes (including constraints being added/validated). The columns
 	// referenced by the returned checks are writable, but not necessarily public.
 	ActiveChecks() []descpb.TableDescriptor_CheckConstraint
+	// AllChecks returns all checks from both the `Checks` slice and mutation slice.
+	// It differs from `AllActiveAndInactiveChecks` in that the return includes checks
+	// that are being dropped.
+	AllChecks() []*descpb.TableDescriptor_CheckConstraint
 
 	// GetLocalityConfig returns the locality config for this table, which
 	// describes the table's multi-region locality policy if one is set (e.g.

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -632,11 +632,11 @@ type TableDescriptor interface {
 	// It's only non-nil if IsView is true.
 	GetDependsOnTypes() []descpb.ID
 
-	// GetConstraintInfoWithLookup returns a summary of all constraints on the
+	// GetNonDropConstraintInfoWithLookup returns a summary of all constraints on the
 	// table using the provided function to fetch a TableDescriptor from an ID.
-	GetConstraintInfoWithLookup(fn TableLookupFn) (map[string]descpb.ConstraintDetail, error)
-	// GetConstraintInfo returns a summary of all constraints on the table.
-	GetConstraintInfo() (map[string]descpb.ConstraintDetail, error)
+	GetNonDropConstraintInfoWithLookup(fn TableLookupFn) (map[string]descpb.ConstraintDetail, error)
+	// GetNonDropConstraintInfo returns a summary of all constraints on the table.
+	GetNonDropConstraintInfo() (map[string]descpb.ConstraintDetail, error)
 	// FindConstraintWithID returns a constraint given a constraint id.
 	FindConstraintWithID(id descpb.ConstraintID) (*descpb.ConstraintDetail, error)
 

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -635,8 +635,18 @@ type TableDescriptor interface {
 	// GetNonDropConstraintInfoWithLookup returns a summary of all constraints on the
 	// table using the provided function to fetch a TableDescriptor from an ID.
 	GetNonDropConstraintInfoWithLookup(fn TableLookupFn) (map[string]descpb.ConstraintDetail, error)
+	// GetAllConstraintInfoWithLookup is similar to GetActiveAndInactiveConstraintInfoWithLookup
+	// except that
+	//  - it also includes constraints that are being dropped;
+	//  - the return uses `descpb.ConstraintID` as unique identifier.
+	GetAllConstraintInfoWithLookup(fn TableLookupFn) (map[descpb.ConstraintID]descpb.ConstraintDetail, error)
 	// GetNonDropConstraintInfo returns a summary of all constraints on the table.
 	GetNonDropConstraintInfo() (map[string]descpb.ConstraintDetail, error)
+	// GetAllConstraintInfo is similar to GetActiveAndInactiveConstraint
+	// except that
+	//  - it also includes constraints that are being dropped;
+	//  - the return uses `descpb.ConstraintID` as unique identifier.
+	GetAllConstraintInfo() (map[descpb.ConstraintID]descpb.ConstraintDetail, error)
 	// FindConstraintWithID returns a constraint given a constraint id.
 	FindConstraintWithID(id descpb.ConstraintID) (*descpb.ConstraintDetail, error)
 

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -2420,7 +2420,7 @@ func ColumnsSelectors(cols []catalog.Column) tree.SelectExprs {
 
 // InvalidateFKConstraints sets all FK constraints to un-validated.
 func (desc *wrapper) InvalidateFKConstraints() {
-	// We don't use GetConstraintInfo because we want to edit the passed desc.
+	// We don't use GetNonDropConstraintInfo because we want to edit the passed desc.
 	for i := range desc.OutboundFKs {
 		fk := &desc.OutboundFKs[i]
 		fk.Validity = descpb.ConstraintValidity_Unvalidated

--- a/pkg/sql/catalog/tabledesc/structured_test.go
+++ b/pkg/sql/catalog/tabledesc/structured_test.go
@@ -663,7 +663,7 @@ func TestUnvalidateConstraints(t *testing.T) {
 		return desc.ImmutableCopy().(catalog.TableDescriptor), nil
 	}
 
-	before, err := desc.GetConstraintInfoWithLookup(lookup)
+	before, err := desc.GetNonDropConstraintInfoWithLookup(lookup)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -672,7 +672,7 @@ func TestUnvalidateConstraints(t *testing.T) {
 	}
 	desc.InvalidateFKConstraints()
 
-	after, err := desc.GetConstraintInfoWithLookup(lookup)
+	after, err := desc.GetNonDropConstraintInfoWithLookup(lookup)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/catalog/tabledesc/table.go
+++ b/pkg/sql/catalog/tabledesc/table.go
@@ -331,16 +331,13 @@ func (desc *wrapper) GetAllConstraintInfo() (
 func (desc *wrapper) FindConstraintWithID(
 	id descpb.ConstraintID,
 ) (*descpb.ConstraintDetail, error) {
-	constraintInfo, err := desc.GetConstraintInfo()
+	constraintInfo, err := desc.GetAllConstraintInfo()
 	if err != nil {
 		return nil, err
 	}
-	for _, info := range constraintInfo {
-		if info.ConstraintID == id {
-			return &info, nil
-		}
+	if info, ok := constraintInfo[id]; ok {
+		return &info, nil
 	}
-
 	return nil, pgerror.Newf(pgcode.UndefinedObject, "constraint-id \"%d\" does not exist", id)
 }
 

--- a/pkg/sql/catalog/tabledesc/table.go
+++ b/pkg/sql/catalog/tabledesc/table.go
@@ -314,9 +314,9 @@ func GetShardColumnName(colNames []string, buckets int32) string {
 	)
 }
 
-// GetConstraintInfo implements the TableDescriptor interface.
-func (desc *wrapper) GetConstraintInfo() (map[string]descpb.ConstraintDetail, error) {
-	return desc.collectConstraintInfo(nil)
+// GetNonDropConstraintInfo implements the TableDescriptor interface.
+func (desc *wrapper) GetNonDropConstraintInfo() (map[string]descpb.ConstraintDetail, error) {
+	return desc.collectNonDropConstraintInfo(nil)
 }
 
 // FindConstraintWithID implements the TableDescriptor interface.
@@ -336,23 +336,23 @@ func (desc *wrapper) FindConstraintWithID(
 	return nil, pgerror.Newf(pgcode.UndefinedObject, "constraint-id \"%d\" does not exist", id)
 }
 
-// GetConstraintInfoWithLookup implements the TableDescriptor interface.
-func (desc *wrapper) GetConstraintInfoWithLookup(
+// GetNonDropConstraintInfoWithLookup implements the TableDescriptor interface.
+func (desc *wrapper) GetNonDropConstraintInfoWithLookup(
 	tableLookup catalog.TableLookupFn,
 ) (map[string]descpb.ConstraintDetail, error) {
-	return desc.collectConstraintInfo(tableLookup)
+	return desc.collectNonDropConstraintInfo(tableLookup)
 }
 
 // CheckUniqueConstraints returns a non-nil error if a descriptor contains two
 // constraints with the same name.
 func (desc *wrapper) CheckUniqueConstraints() error {
-	_, err := desc.collectConstraintInfo(nil)
+	_, err := desc.collectNonDropConstraintInfo(nil)
 	return err
 }
 
 // if `tableLookup` is non-nil, provide a full summary of constraints, otherwise just
 // check that constraints have unique names.
-func (desc *wrapper) collectConstraintInfo(
+func (desc *wrapper) collectNonDropConstraintInfo(
 	tableLookup catalog.TableLookupFn,
 ) (map[string]descpb.ConstraintDetail, error) {
 	info := make(map[string]descpb.ConstraintDetail)

--- a/pkg/sql/catalog/tabledesc/validate.go
+++ b/pkg/sql/catalog/tabledesc/validate.go
@@ -892,7 +892,7 @@ func (desc *wrapper) validateConstraintIDs(vea catalog.ValidationErrorAccumulato
 	if !desc.IsTable() {
 		return
 	}
-	constraints, err := desc.GetConstraintInfo()
+	constraints, err := desc.GetNonDropConstraintInfo()
 	if err != nil {
 		vea.Report(err)
 		return

--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -500,7 +500,7 @@ func (p *planner) IsConstraintActive(
 	if err != nil {
 		return false, err
 	}
-	constraints, err := tableDesc.GetConstraintInfo()
+	constraints, err := tableDesc.GetNonDropConstraintInfo()
 	if err != nil {
 		return false, err
 	}

--- a/pkg/sql/comment_on_constraint.go
+++ b/pkg/sql/comment_on_constraint.go
@@ -67,7 +67,7 @@ func (p *planner) CommentOnConstraint(
 }
 
 func (n *commentOnConstraintNode) startExec(params runParams) error {
-	info, err := n.tableDesc.GetConstraintInfo()
+	info, err := n.tableDesc.GetNonDropConstraintInfo()
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -118,7 +118,7 @@ func (p *planner) maybeSetupConstraintForShard(
 		return err
 	}
 
-	curConstraintInfos, err := tableDesc.GetConstraintInfo()
+	curConstraintInfos, err := tableDesc.GetNonDropConstraintInfo()
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -766,7 +766,7 @@ func ResolveUniqueWithoutIndexConstraint(
 	}
 
 	// Verify we are not writing a constraint over the same name.
-	constraintInfo, err := tbl.GetConstraintInfo()
+	constraintInfo, err := tbl.GetNonDropConstraintInfo()
 	if err != nil {
 		return err
 	}
@@ -976,7 +976,7 @@ func ResolveFK(
 	// or else we can hit other checks that break things with
 	// undesired error codes, e.g. #42858.
 	// It may be removable after #37255 is complete.
-	constraintInfo, err := tbl.GetConstraintInfo()
+	constraintInfo, err := tbl.GetNonDropConstraintInfo()
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -307,7 +307,7 @@ https://www.postgresql.org/docs/9.5/infoschema-check-constraints.html`,
 			table catalog.TableDescriptor,
 			tableLookup tableLookupFn,
 		) error {
-			conInfo, err := table.GetConstraintInfoWithLookup(tableLookup.getTableByID)
+			conInfo, err := table.GetNonDropConstraintInfoWithLookup(tableLookup.getTableByID)
 			if err != nil {
 				return err
 			}
@@ -759,7 +759,7 @@ https://www.postgresql.org/docs/9.5/infoschema-constraint-column-usage.html`,
 			table catalog.TableDescriptor,
 			tableLookup tableLookupFn,
 		) error {
-			conInfo, err := table.GetConstraintInfoWithLookup(tableLookup.getTableByID)
+			conInfo, err := table.GetNonDropConstraintInfoWithLookup(tableLookup.getTableByID)
 			if err != nil {
 				return err
 			}
@@ -813,7 +813,7 @@ https://www.postgresql.org/docs/9.5/infoschema-key-column-usage.html`,
 			table catalog.TableDescriptor,
 			tableLookup tableLookupFn,
 		) error {
-			conInfo, err := table.GetConstraintInfoWithLookup(tableLookup.getTableByID)
+			conInfo, err := table.GetNonDropConstraintInfoWithLookup(tableLookup.getTableByID)
 			if err != nil {
 				return err
 			}
@@ -1276,7 +1276,7 @@ https://www.postgresql.org/docs/9.5/infoschema-table-constraints.html`,
 				table catalog.TableDescriptor,
 				tableLookup tableLookupFn,
 			) error {
-				conInfo, err := table.GetConstraintInfoWithLookup(tableLookup.getTableByID)
+				conInfo, err := table.GetNonDropConstraintInfoWithLookup(tableLookup.getTableByID)
 				if err != nil {
 					return err
 				}

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -869,7 +869,7 @@ func populateTableConstraints(
 	tableLookup simpleSchemaResolver,
 	addRow func(...tree.Datum) error,
 ) error {
-	conInfo, err := table.GetConstraintInfoWithLookup(tableLookup.getTableByID)
+	conInfo, err := table.GetNonDropConstraintInfoWithLookup(tableLookup.getTableByID)
 	if err != nil {
 		return err
 	}
@@ -1517,7 +1517,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-depend.html`,
 				}
 			}
 
-			conInfo, err := table.GetConstraintInfoWithLookup(tableLookup.getTableByID)
+			conInfo, err := table.GetNonDropConstraintInfoWithLookup(tableLookup.getTableByID)
 			if err != nil {
 				return err
 			}
@@ -1638,7 +1638,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-description.html`,
 				if err != nil {
 					return err
 				}
-				constraints, err := tableDesc.GetConstraintInfo()
+				constraints, err := tableDesc.GetNonDropConstraintInfo()
 				if err != nil {
 					return err
 				}

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -406,7 +406,7 @@ func createConstraintCheckOperations(
 	tableName *tree.TableName,
 	asOf hlc.Timestamp,
 ) (results []checkOperation, err error) {
-	constraints, err := tableDesc.GetConstraintInfoWithLookup(func(id descpb.ID) (catalog.TableDescriptor, error) {
+	constraints, err := tableDesc.GetNonDropConstraintInfoWithLookup(func(id descpb.ID) (catalog.TableDescriptor, error) {
 		return p.Descriptors().GetImmutableTableByID(ctx, p.Txn(), id, tree.ObjectLookupFlagsWithRequired())
 	})
 	if err != nil {

--- a/pkg/sql/show_create_clauses.go
+++ b/pkg/sql/show_create_clauses.go
@@ -403,7 +403,7 @@ func showComments(
 	}
 
 	// Get all the constraints for the table and create a map by ID.
-	constraints, err := table.GetConstraintInfo()
+	constraints, err := table.GetNonDropConstraintInfo()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR really just achieves one thing: retrieve all constraints, including ones that
are being dropped, in a table. This will be helpful for PRs that enable adding/dropping
check constraints.

We indeed have existing functions for that, but unfortunately, they will ignore constraints
that are being dropped. It's surprising that for indexes and columns, we have much finer-grained
control over what to retrieve (e.g. NonDropIndex, AllIndex, WriteOnlyIndex, etc.), but we don't
have that for constraint.

The approach is to add new functions to do that, in addition to the old, existing functions. Those
newly added function also use `constraintID` as keys, instead of `name` (which I think it's a
legacy).

Namely,
Commit 1: Add methods to retrieve all (Checks|UniqueWithoutIndexConstraints|FKs).
Commit 2: Rename existing functions to reflect the fact that they only retrieve non-drop constraints.
Commit 3: Add new functions to retrieve all constraints (sister functions to the existing ones).
Commit 4: `FindConstraintByID` now can be implemented simpler with the newly added functions.

Epic: None