### PR TITLE
colflow: fix closure of router output

### DIFF
--- a/pkg/sql/colflow/routers.go
+++ b/pkg/sql/colflow/routers.go
@@ -285,7 +285,8 @@ func (o *routerOutputOp) DrainMeta() []execinfrapb.ProducerMetadata {
 func (o *routerOutputOp) Close(ctx context.Context) error {
 	o.mu.Lock()
 	defer o.mu.Unlock()
-	return o.mu.data.Close(ctx)
+	o.closeLocked(ctx)
+	return nil
 }
 
 func (o *routerOutputOp) initWithHashRouter(r *HashRouter) {


### PR DESCRIPTION
In 15321ee00583cef96bc9e1e96cd0dd784aaa9e2b we added more redundancy to how we're releasing the disk resources. However, we introduced a subtle bug which could lead to a nil pointer exception around the hash routers.

In particular, we made it so that the router output is closed by its consumer, but we forgot to update the state of the output. Since the hash router is running in a separate goroutine, it could still attempt to add another batch (since the state of the output is "running"), and we'd hit a NPE since the spilling queue has been closed. This is now fixed.

My understanding is that this seems to happen most likely when the query already encountered an error and is being shutdown, and since we're catching this NPE, the error will just be more scary than it should be. Thus, I decided to omit the release note. There is no regression test since it seems quite difficult to trigger.

Fixes: #89904.

Release note: None