### PR TITLE
multi-tenant: Add guardrails around tenant upgrade

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/tenant_settings
+++ b/pkg/ccl/logictestccl/testdata/logic_test/tenant_settings
@@ -7,6 +7,12 @@ true
 
 user host-cluster-root
 
+# Ensure that the version is set the same in the system tenant and in the tenant override.
+query I
+select count(*) from system.settings JOIN system.tenant_settings on tenant_settings.name = settings.name where tenant_settings.name = 'version' and tenant_settings.value = settings.value;
+----
+1
+
 statement ok
 ALTER TENANT 10 SET CLUSTER SETTING sql.notices.enabled = false
 

--- a/pkg/server/auto_upgrade.go
+++ b/pkg/server/auto_upgrade.go
@@ -67,9 +67,8 @@ func (s *Server) startAttemptUpgrade(ctx context.Context) {
 				Closer:         s.stopper.ShouldQuiesce(),
 			}
 
-			// Run the set cluster setting version statement and reset cluster setting
-			// `cluster.preserve_downgrade_option` statement in a transaction until
-			// success.
+			// Run the set cluster setting version statement in a transaction
+			// until success.
 			for ur := retry.StartWithCtx(ctx, upgradeRetryOpts); ur.Next(); {
 				if _, err := s.sqlServer.internalExecutor.ExecEx(
 					ctx, "set-version", nil, /* txn */

--- a/pkg/server/settingswatcher/settings_watcher.go
+++ b/pkg/server/settingswatcher/settings_watcher.go
@@ -51,6 +51,10 @@ type SettingsWatcher struct {
 		updater   settings.Updater
 		values    map[string]settingsValue
 		overrides map[string]settings.EncodedValue
+		// hostClusterVersion is the cache of the host cluster version
+		// inside secondary tenants. It will not be initialized in a system
+		// tenant.
+		hostClusterVersion clusterversion.ClusterVersion
 	}
 
 	// testingWatcherKnobs allows the client to inject testing knobs into
@@ -304,16 +308,20 @@ const versionSettingKey = "version"
 func (s *SettingsWatcher) setLocked(ctx context.Context, key string, val settings.EncodedValue) {
 	// The system tenant (i.e. the KV layer) does not use the SettingsWatcher
 	// to propagate cluster version changes (it uses the BumpClusterVersion
-	// RPC). However, non-system tenants (i.e. SQL pods) (asynchronously) get
-	// word of the new cluster version below.
+	// RPC). However, secondary tenants get word of the new cluster version
+	// below. This is to handle the case where there are multiple SQL pods
+	// working on behalf of the same secondary tenant. If one pod performs the
+	// upgrade, we want to make the other SQL pods aware of the fact that the
+	// upgrade occurred.
 	if key == versionSettingKey && !s.codec.ForSystemTenant() {
-		var v clusterversion.ClusterVersion
-		if err := protoutil.Unmarshal([]byte(val.Value), &v); err != nil {
-			log.Warningf(ctx, "failed to set cluster version: %v", err)
-		} else if err := s.settings.Version.SetActiveVersion(ctx, v); err != nil {
-			log.Warningf(ctx, "failed to set cluster version: %v", err)
-		} else {
-			log.Infof(ctx, "set cluster version to: %v", v)
+		var newVersion clusterversion.ClusterVersion
+		oldVersion := s.settings.Version.ActiveVersion(ctx)
+		if err := protoutil.Unmarshal([]byte(val.Value), &newVersion); err != nil {
+			log.Warningf(ctx, "failed to set cluster version: %s", err.Error())
+		} else if err := s.settings.Version.SetActiveVersion(ctx, newVersion); err != nil {
+			log.Warningf(ctx, "failed to set cluster version: %s", err.Error())
+		} else if newVersion != oldVersion {
+			log.Infof(ctx, "set cluster version to: %v", newVersion)
 		}
 		return
 	}
@@ -351,7 +359,21 @@ func (s *SettingsWatcher) updateOverrides(ctx context.Context) {
 
 	for key, val := range newOverrides {
 		if key == versionSettingKey {
-			log.Warningf(ctx, "ignoring attempt to override %s", key)
+			var newVersion clusterversion.ClusterVersion
+			if err := protoutil.Unmarshal([]byte(val.Value), &newVersion); err != nil {
+				log.Warningf(ctx, "ignoring invalid cluster version: %newVersion - "+
+					"the lack of a refreshed host cluster version in a secondary tenant may prevent tenant upgrade", err)
+			} else {
+				// We don't want to fully process the override in the case
+				// where we're dealing with the "version" setting, as we want
+				// the tenant to have full control over its version setting.
+				// Instead, we take the override value and cache it as the
+				// hostClusterVersion for use in determining if it's safe to
+				// upgrade the tenant (since we don't want to upgrade tenants
+				// to a version that's beyond that of the host cluster).
+				log.Infof(ctx, "updating host cluster cached version from: %v to: %v", s.mu.hostClusterVersion, newVersion)
+				s.mu.hostClusterVersion = newVersion
+			}
 			continue
 		}
 		if oldVal, hasExisting := s.mu.overrides[key]; hasExisting && oldVal == val {
@@ -396,4 +418,26 @@ func (s *SettingsWatcher) IsOverridden(settingName string) bool {
 	defer s.mu.Unlock()
 	_, exists := s.mu.overrides[settingName]
 	return exists
+}
+
+// GetHostClusterVersion returns the host cluster version cached in the
+// SettingsWatcher. The host cluster version info in the settings watcher is
+// populated by a cluster settings override sent from the system tenant to all
+// tenants, anytime the cluster version changes (or when a new cluster is
+// initialized in version 23.1 or later). In cases where the host cluster
+// version is not initialized, we assume that it's running version 22.2,
+// the last version which did not properly initialize this value.
+func (s *SettingsWatcher) GetHostClusterVersion(ctx context.Context) clusterversion.ClusterVersion {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.mu.hostClusterVersion.Equal(clusterversion.ClusterVersion{Version: roachpb.Version{Major: 0, Minor: 0}}) {
+		// If the host cluster version is not initialized in the
+		// settingswatcher, it means that the cluster has not yet been upgraded
+		// to 23.1, or was initialized before version 23.1. As a result, assume
+		// that host cluster is at version 22.2.
+		// TODO(ajstorm): change this to 22.2 once the new version is minted.
+		hostClusterVersion := roachpb.Version{Major: 22, Minor: 1}
+		return clusterversion.ClusterVersion{Version: hostClusterVersion}
+	}
+	return s.mu.hostClusterVersion
 }

--- a/pkg/sql/tenant_settings.go
+++ b/pkg/sql/tenant_settings.go
@@ -88,12 +88,6 @@ func (p *planner) AlterTenantSetClusterSetting(
 		return nil, errors.AssertionFailedf("expected writable setting, got %T", v)
 	}
 
-	// We don't support changing the version for another tenant.
-	// See discussion on issue https://github.com/cockroachdb/cockroach/issues/77733 (wontfix).
-	if _, isVersion := setting.(*settings.VersionSetting); isVersion {
-		return nil, errors.Newf("cannot change the version of another tenant")
-	}
-
 	value, err := p.getAndValidateTypedClusterSetting(ctx, name, n.Value, setting)
 	if err != nil {
 		return nil, err

--- a/pkg/upgrade/upgrademanager/BUILD.bazel
+++ b/pkg/upgrade/upgrademanager/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/kv",
         "//pkg/security/username",
         "//pkg/server/serverpb",
+        "//pkg/server/settingswatcher",
         "//pkg/settings/cluster",
         "//pkg/sql",
         "//pkg/sql/catalog/descs",


### PR DESCRIPTION
This commit adds guardrails around tenant upgrades to ensure that the tenant can never be upgraded if it means that it will no longer be operable with the existing host/storage cluster. Before this change, it was possible to upgrade a tenant at any time. This was unsafe as it implied that the tenant could end up on a higher version that the host/storage cluster and may require upgrades that were not yet present.

To communicate the host/storage cluster version to the secondary tenants we leverage the existing cluster settings override mechanism and override the "version" setting. In practice this doesn't override the version value for the tenant because the tenant will always have a version setting thus negating the override. Instead, it communicates to the settingswatcher that the version has been overridden and upon getting that communication (or on startup) the settingswatcher caches the override value as the host cluster version.

The change also requires sending a new override on upgrade, and seeding a new value in a startup migration.

Release note: None

Closes: #66606

Original PR explanation follows for historical purposes (the approach proposed herein was deemed acceptable)
---------------------------------------------------------------------------------------------------------------

This PR contains a proposal for how we may want to solve the problem of guardrails around tenant upgrades.  This is a known problem as described in #66606, with the solution being to block tenant upgrades if they will push the tenant version beyond the host cluster version.  The problem however, is that there's no existing way for a secondary tenant to read the host cluster version.  The commit below proposes a solution whereby we plumb the host cluster version into secondary tenants by leveraging the existing cluster settings override mechanism. 

 When a cluster is initialized or upgraded, it will populate the version information in `system.tenant_settings` using the `version` key.  When secondary tenants see this value in their `settingswatcher` they will not actually override the tenant's cluster version, but instead will cache the value as the host cluster version.  

In a recent multi-tenant conversation, there was some debate as to whether or not this was a reasonable way to inform secondary tenants as to the updated cluster version.  An alternative approach was proposed as follows:

* Teach the tenant `settingswatcher` to also watch the settings table via a rangefeed.
* Filter updates to settings that aren't meant to be visible to the tenant.
* Deliver the updates to the `settingswatcher` via the existing streaming RPC (but with a new field in the TenantSettingsEvent).
* On the settingswatcher side, on receipt of this RPC, cache the host cluster version

Since I had most of the first approach implemented, I present it here as an option (with accompanying code) and we can debate on this PR review if I should abandon the first approach in favour of the second (or some entirely different approach).