### PR TITLE
kv,kvcoord: poison the txn coordinator when forcing an error

### DIFF
--- a/pkg/kv/BUILD.bazel
+++ b/pkg/kv/BUILD.bazel
@@ -81,6 +81,7 @@ go_test(
         "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
+        "//pkg/util/encoding",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",

--- a/pkg/kv/kvclient/kvcoord/testdata/savepoints
+++ b/pkg/kv/kvclient/kvcoord/testdata/savepoints
@@ -333,6 +333,11 @@ retry
 synthetic error: TransactionRetryWithProtoRefreshError: forced retry
 epoch: 0 -> 1
 
+reset
+----
+txn error cleared
+txn id not changed
+
 release x
 ----
 0 <noignore>


### PR DESCRIPTION
This PR changes the behavior of GenerateForcedRetryableError():
A retryable func given to DB.Txn() can GenerateForcedRetryableError() and
then return the generated error. Before this PR the retryable func had to
return the error, which signaled the DB.Txn() retry loop to reset
(PrepareForRetry) the txn handle, and then retry the retryable func.
With this PR, the error doesn't need to be returned because when
GenerateForcedRetryableError() is called it poisons the txn handle.
Then, the DB.Txn retry loop can get the error and retry.

This means that with this PR, calling GenerateForcedRetryableError() is more
like having an error during an operation such as Get or Put (those retryable
failures will also poison the txn handle).

Adding a few tests to verify and demonstrate these behaviors. Note that
only TestGenerateForcedRetryableErrorByPoisoning() fails without this PR.

Informs: https://github.com/cockroachdb/cockroach/issues/86594

Release note: None
Epic: None
