### PR TITLE
sql: `SET DEFAULT NULL` means a nil default expr instead of "NULL"

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -953,6 +953,10 @@ func applyColumnMutation(
 		); err != nil {
 			return err
 		}
+		if col.HasNullDefault() {
+			// `SET DEFAULT NULL` means a nil default expression.
+			col.ColumnDesc().DefaultExpr = nil
+		}
 
 	case *tree.AlterTableSetOnUpdate:
 		// We want to reject uses of ON UPDATE where there is also a foreign key ON

--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -593,3 +593,15 @@ INSERT INTO regression_54844 VALUES (-9223372036854775807)
 
 statement error integer out of range for type int2
 ALTER TABLE regression_54844 ALTER COLUMN i TYPE int2
+
+# Regression test for alter column type after setting default to NULL.
+subtest regression_91069
+
+statement ok
+CREATE TABLE t_91069 (i INT PRIMARY KEY, j VARCHAR(64) NULL)
+
+statement ok
+ALTER TABLE t_91069 ALTER COLUMN j SET DEFAULT NULL
+
+statement ok
+ALTER TABLE t_91069 ALTER COLUMN j TYPE VARCHAR(32)


### PR DESCRIPTION
Previously, `SET DEFAULT NULL` resulted in a column whose DefaultExpr is "NULL". This is problematic when used with `ALTER COLUMN TYPE` where a temporary computed column will be created, hence violating validation that "a computed column cannot have default expression". This PR fixes that by setting DefaultExpr to nil when `SET DEFAULT NULL`.

Fixes #91069 
Release note (bug fix): Fixed a bug described in #91069.