### PR TITLE
ui: migrate statement diagnostics requests to use sql-over-http endpoint

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/statementDiagnosticsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/statementDiagnosticsApi.ts
@@ -32,15 +32,15 @@ export function getStatementDiagnosticsReports(): Promise<StatementDiagnosticsRe
     statements: [
       {
         sql: `SELECT
-			id::STRING,
-			statement_fingerprint,
-			completed,
-			statement_diagnostics_id::STRING,
-			requested_at,
-			min_execution_latency,
-			expires_at
-		FROM
-			system.statement_diagnostics_requests
+      id::STRING,
+      statement_fingerprint,
+      completed,
+      statement_diagnostics_id::STRING,
+      requested_at,
+      min_execution_latency,
+      expires_at
+    FROM
+      system.statement_diagnostics_requests
     WHERE
       expires_at > now() OR expires_at IS NULL OR completed = true`,
       },
@@ -137,10 +137,10 @@ function checkExistingDiagRequest(stmtFingerprint: string): Promise<void> {
   // Query to check if there's already a pending request for this fingerprint.
   const checkPendingStmtDiag = {
     sql: `SELECT count(1) FROM system.statement_diagnostics_requests
-				WHERE
-					completed = false AND
-					statement_fingerprint = $1 AND
-					(expires_at IS NULL OR expires_at > now())`,
+        WHERE
+          completed = false AND
+          statement_fingerprint = $1 AND
+          (expires_at IS NULL OR expires_at > now())`,
     arguments: [stmtFingerprint],
   };
 

--- a/pkg/ui/workspaces/cluster-ui/src/api/statementDiagnosticsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/statementDiagnosticsApi.ts
@@ -8,48 +8,205 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
-import { fetchData } from "src/api";
+import moment from "moment";
+import {
+  executeInternalSql,
+  SqlExecutionRequest,
+  sqlResultsAreEmpty,
+} from "src/api";
 
-const STATEMENT_DIAGNOSTICS_PATH = "/_status/stmtdiagreports";
-const CREATE_STATEMENT_DIAGNOSTICS_REPORT_PATH = "/_status/stmtdiagreports";
-const CANCEL_STATEMENT_DIAGNOSTICS_REPORT_PATH =
-  "/_status/stmtdiagreports/cancel";
+export type StatementDiagnosticsReport = {
+  id: string;
+  statement_fingerprint: string;
+  completed: boolean;
+  statement_diagnostics_id?: string;
+  requested_at: moment.Moment;
+  min_execution_latency?: moment.Duration;
+  expires_at?: moment.Moment;
+};
 
-type CreateStatementDiagnosticsReportRequestMessage =
-  cockroach.server.serverpb.CreateStatementDiagnosticsReportRequest;
-type CreateStatementDiagnosticsReportResponseMessage =
-  cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse;
-type CancelStatementDiagnosticsReportRequestMessage =
-  cockroach.server.serverpb.CancelStatementDiagnosticsReportRequest;
-type CancelStatementDiagnosticsReportResponseMessage =
-  cockroach.server.serverpb.CancelStatementDiagnosticsReportResponse;
+export type StatementDiagnosticsResponse = StatementDiagnosticsReport[];
 
-export function getStatementDiagnosticsReports(): Promise<cockroach.server.serverpb.StatementDiagnosticsReportsResponse> {
-  return fetchData(
-    cockroach.server.serverpb.StatementDiagnosticsReportsResponse,
-    STATEMENT_DIAGNOSTICS_PATH,
-  );
+export function getStatementDiagnosticsReports(): Promise<StatementDiagnosticsResponse> {
+  const req: SqlExecutionRequest = {
+    statements: [
+      {
+        sql: `SELECT
+			id::STRING,
+			statement_fingerprint,
+			completed,
+			statement_diagnostics_id::STRING,
+			requested_at,
+			min_execution_latency,
+			expires_at
+		FROM
+			system.statement_diagnostics_requests
+    WHERE
+      expires_at > now() OR expires_at IS NULL OR completed = true`,
+      },
+    ],
+    execute: true,
+  };
+
+  return executeInternalSql<StatementDiagnosticsReport>(req).then(res => {
+    // If request succeeded but query failed, throw error (caught by saga/cacheDataReducer).
+    if (res.error) {
+      throw res.error;
+    }
+
+    if (sqlResultsAreEmpty(res)) {
+      return [];
+    }
+
+    return res.execution.txn_results[0].rows;
+  });
 }
 
-export function createStatementDiagnosticsReport(
-  req: CreateStatementDiagnosticsReportRequestMessage,
-): Promise<CreateStatementDiagnosticsReportResponseMessage> {
-  return fetchData(
-    cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse,
-    CREATE_STATEMENT_DIAGNOSTICS_REPORT_PATH,
-    cockroach.server.serverpb.CreateStatementDiagnosticsReportRequest,
-    req,
-  );
+type CheckPendingStmtDiagnosticRow = {
+  count: number;
+};
+
+export type InsertStmtDiagnosticRequest = {
+  stmtFingerprint: string;
+  samplingProbability?: number;
+  minExecutionLatencySeconds?: number;
+  expiresAfterSeconds?: number;
+};
+
+export type InsertStmtDiagnosticResponse = {
+  stmt_diag_req_id: string;
+};
+
+export function createStatementDiagnosticsReport({
+  stmtFingerprint,
+  samplingProbability,
+  minExecutionLatencySeconds,
+  expiresAfterSeconds,
+}: InsertStmtDiagnosticRequest): Promise<InsertStmtDiagnosticResponse> {
+  const requestedAt = moment.now(); // milliseconds
+  const args: any = [stmtFingerprint, moment.utc(requestedAt).toISOString()];
+  const cols = ["statement_fingerprint", "requested_at"];
+
+  if (samplingProbability && samplingProbability !== 0) {
+    args.push(samplingProbability);
+    cols.push("sampling_probability");
+  }
+  if (minExecutionLatencySeconds && minExecutionLatencySeconds !== 0) {
+    args.push(minExecutionLatencySeconds.toString());
+    cols.push("min_execution_latency");
+  }
+  if (expiresAfterSeconds && expiresAfterSeconds !== 0) {
+    const expiresAt = requestedAt + expiresAfterSeconds * 1000;
+    args.push(moment.utc(expiresAt).toISOString());
+    cols.push("expires_at");
+  }
+
+  const queryCols = cols.join(", ");
+  const placeHolders = args.map((elem: any, idx: number) => `$${idx + 1}`);
+
+  const createStmtDiag = {
+    sql: `
+        INSERT INTO system.statement_diagnostics_requests 
+            (${queryCols}) 
+             VALUES (${placeHolders}) RETURNING id as stmt_diag_req_id;`,
+    arguments: args,
+  };
+
+  const req: SqlExecutionRequest = {
+    execute: true,
+    statements: [createStmtDiag],
+  };
+
+  return checkExistingDiagRequest(stmtFingerprint).then(_ => {
+    return executeInternalSql<InsertStmtDiagnosticResponse>(req).then(res => {
+      // If request succeeded but query failed, throw error (caught by saga/cacheDataReducer).
+      if (res.error) {
+        throw res.error;
+      }
+
+      if (res.execution?.txn_results[0]?.rows?.length === 0) {
+        throw new Error("Failed to insert statement diagnostics request");
+      }
+
+      return res.execution.txn_results[0].rows[0];
+    });
+  });
 }
 
-export function cancelStatementDiagnosticsReport(
-  req: CancelStatementDiagnosticsReportRequestMessage,
-): Promise<CancelStatementDiagnosticsReportResponseMessage> {
-  return fetchData(
-    cockroach.server.serverpb.CancelStatementDiagnosticsReportResponse,
-    CANCEL_STATEMENT_DIAGNOSTICS_REPORT_PATH,
-    cockroach.server.serverpb.CancelStatementDiagnosticsReportRequest,
-    req,
-  );
+function checkExistingDiagRequest(stmtFingerprint: string): Promise<void> {
+  // Query to check if there's already a pending request for this fingerprint.
+  const checkPendingStmtDiag = {
+    sql: `SELECT count(1) FROM system.statement_diagnostics_requests
+				WHERE
+					completed = false AND
+					statement_fingerprint = $1 AND
+					(expires_at IS NULL OR expires_at > now())`,
+    arguments: [stmtFingerprint],
+  };
+
+  const req: SqlExecutionRequest = {
+    execute: true,
+    statements: [checkPendingStmtDiag],
+  };
+
+  return executeInternalSql<CheckPendingStmtDiagnosticRow>(req).then(res => {
+    // If request succeeded but query failed, throw error (caught by saga/cacheDataReducer).
+    if (res.error) {
+      throw res.error;
+    }
+
+    if (res.execution?.txn_results[0]?.rows?.length === 0) {
+      throw new Error("Failed to check pending statement diagnostics");
+    }
+
+    if (res.execution.txn_results[0].rows[0].count > 0) {
+      throw new Error(
+        "A pending request for the requested fingerprint already exists. Cancel the existing request first and try again.",
+      );
+    }
+  });
+}
+
+export type CancelStmtDiagnosticRequest = {
+  requestId: string;
+};
+
+export type CancelStmtDiagnosticResponse = {
+  stmt_diag_req_id: string;
+};
+
+export function cancelStatementDiagnosticsReport({
+  requestId,
+}: CancelStmtDiagnosticRequest): Promise<CancelStmtDiagnosticResponse> {
+  const query = `UPDATE system.statement_diagnostics_requests SET expires_at = '1970-01-01' WHERE completed = false AND id = $1::INT8 AND (expires_at IS NULL OR expires_at > now()) RETURNING id as stmt_diag_req_id`;
+  const req: SqlExecutionRequest = {
+    execute: true,
+    statements: [
+      {
+        sql: query,
+        arguments: [requestId],
+      },
+    ],
+  };
+
+  return executeInternalSql<CancelStmtDiagnosticResponse>(req).then(res => {
+    // If request succeeded but query failed, throw error (caught by saga/cacheDataReducer).
+    if (res.error) {
+      throw res.error;
+    }
+
+    if (!res.execution?.txn_results?.length) {
+      throw new Error(
+        "cancelStatementDiagnosticsReport - unexpected zero txn_results",
+      );
+    }
+
+    if (res.execution.txn_results[0].rows?.length === 0) {
+      throw new Error(
+        `No pending request found for the request id: ${requestId}`,
+      );
+    }
+
+    return res.execution.txn_results[0].rows[0];
+  });
 }

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsUtils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsUtils.ts
@@ -9,14 +9,12 @@
 // licenses/APL.txt.
 
 import { isUndefined } from "lodash";
-import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { DiagnosticStatuses } from "src/statementsDiagnostics";
-
-type IStatementDiagnosticsReport =
-  cockroach.server.serverpb.IStatementDiagnosticsReport;
+import { StatementDiagnosticsReport } from "../../api";
+import moment from "moment";
 
 export function getDiagnosticsStatus(
-  diagnosticsRequest: IStatementDiagnosticsReport,
+  diagnosticsRequest: StatementDiagnosticsReport,
 ): DiagnosticStatuses {
   if (diagnosticsRequest.completed) {
     return "READY";
@@ -26,11 +24,11 @@ export function getDiagnosticsStatus(
 }
 
 export function sortByRequestedAtField(
-  a: IStatementDiagnosticsReport,
-  b: IStatementDiagnosticsReport,
+  a: StatementDiagnosticsReport,
+  b: StatementDiagnosticsReport,
 ): number {
-  const activatedOnA = a.requested_at?.seconds?.toNumber();
-  const activatedOnB = b.requested_at?.seconds?.toNumber();
+  const activatedOnA = moment(a.requested_at)?.unix();
+  const activatedOnB = moment(b.requested_at)?.unix();
   if (isUndefined(activatedOnA) && isUndefined(activatedOnB)) {
     return 0;
   }
@@ -44,8 +42,8 @@ export function sortByRequestedAtField(
 }
 
 export function sortByCompletedField(
-  a: IStatementDiagnosticsReport,
-  b: IStatementDiagnosticsReport,
+  a: StatementDiagnosticsReport,
+  b: StatementDiagnosticsReport,
 ): number {
   const completedA = a.completed ? 1 : -1;
   const completedB = b.completed ? 1 : -1;
@@ -59,8 +57,8 @@ export function sortByCompletedField(
 }
 
 export function sortByStatementFingerprintField(
-  a: IStatementDiagnosticsReport,
-  b: IStatementDiagnosticsReport,
+  a: StatementDiagnosticsReport,
+  b: StatementDiagnosticsReport,
 ): number {
   const statementFingerprintA = a.statement_fingerprint;
   const statementFingerprintB = b.statement_fingerprint;

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.spec.tsx
@@ -11,33 +11,31 @@
 import React from "react";
 import { assert } from "chai";
 import { mount, ReactWrapper } from "enzyme";
-import Long from "long";
 import { MemoryRouter } from "react-router-dom";
-import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { Button } from "@cockroachlabs/ui-components";
 
 import { DiagnosticsView } from "./diagnosticsView";
 import { Table } from "src/table";
 import { TestStoreProvider } from "src/test-utils";
-
-type IStatementDiagnosticsReport =
-  cockroach.server.serverpb.IStatementDiagnosticsReport;
+import { StatementDiagnosticsReport } from "../../api";
+import moment from "moment";
 
 const activateDiagnosticsRef = { current: { showModalFor: jest.fn() } };
 
 function generateDiagnosticsRequest(
-  extendObject: Partial<IStatementDiagnosticsReport> = {},
-): IStatementDiagnosticsReport {
-  const diagnosticsRequest = {
+  extendObject: Partial<StatementDiagnosticsReport> = {},
+): StatementDiagnosticsReport {
+  const requestedAt = moment.now();
+  const report: StatementDiagnosticsReport = {
+    id: "124354678574635",
     statement_fingerprint: "SELECT * FROM table",
     completed: true,
-    requested_at: {
-      seconds: Long.fromNumber(Date.now()),
-      nanos: Math.random() * 1000000,
-    },
+    requested_at: moment(requestedAt),
+    min_execution_latency: moment.duration(10),
+    expires_at: moment(requestedAt + 10),
   };
-  Object.assign(diagnosticsRequest, extendObject);
-  return diagnosticsRequest;
+  Object.assign(report, extendObject);
+  return report;
 }
 
 describe("DiagnosticsView", () => {
@@ -70,7 +68,7 @@ describe("DiagnosticsView", () => {
 
   describe("With tracing data", () => {
     beforeEach(() => {
-      const diagnosticsRequests: IStatementDiagnosticsReport[] = [
+      const diagnosticsRequests: StatementDiagnosticsReport[] = [
         generateDiagnosticsRequest(),
         generateDiagnosticsRequest(),
       ];
@@ -103,7 +101,7 @@ describe("DiagnosticsView", () => {
     });
 
     it("Activate button is hidden if diagnostics is requested and waiting query", () => {
-      const diagnosticsRequests: IStatementDiagnosticsReport[] = [
+      const diagnosticsRequests: StatementDiagnosticsReport[] = [
         generateDiagnosticsRequest({ completed: false }),
         generateDiagnosticsRequest(),
       ];
@@ -125,7 +123,7 @@ describe("DiagnosticsView", () => {
     });
 
     it("Cancel request button shows if diagnostics is requested and waiting query", () => {
-      const diagnosticsRequests: IStatementDiagnosticsReport[] = [
+      const diagnosticsRequests: StatementDiagnosticsReport[] = [
         generateDiagnosticsRequest({ completed: false }),
         generateDiagnosticsRequest(),
       ];

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/diagnostics/diagnosticsView.tsx
@@ -30,15 +30,12 @@ import {
 } from "./diagnosticsUtils";
 import { EmptyTable } from "src/empty";
 import styles from "./diagnosticsView.module.scss";
-import { getBasePath } from "../../api";
+import { getBasePath, StatementDiagnosticsReport } from "../../api";
 import { DATE_FORMAT_24_UTC } from "../../util";
-
-type IStatementDiagnosticsReport =
-  cockroach.server.serverpb.IStatementDiagnosticsReport;
 
 export interface DiagnosticsViewStateProps {
   hasData: boolean;
-  diagnosticsReports: cockroach.server.serverpb.IStatementDiagnosticsReport[];
+  diagnosticsReports: StatementDiagnosticsReport[];
   showDiagnosticsViewLink?: boolean;
   activateDiagnosticsRef: React.RefObject<ActivateDiagnosticsModalRef>;
 }
@@ -46,9 +43,7 @@ export interface DiagnosticsViewStateProps {
 export interface DiagnosticsViewDispatchProps {
   dismissAlertMessage: () => void;
   onDownloadDiagnosticBundleClick?: (statementFingerprint: string) => void;
-  onDiagnosticCancelRequestClick?: (
-    report: IStatementDiagnosticsReport,
-  ) => void;
+  onDiagnosticCancelRequestClick?: (report: StatementDiagnosticsReport) => void;
   onSortingChange?: (
     name: string,
     columnTitle: string,
@@ -120,15 +115,14 @@ export class DiagnosticsView extends React.Component<
   static defaultProps: Partial<DiagnosticsViewProps> = {
     showDiagnosticsViewLink: true,
   };
-  columns: ColumnsConfig<IStatementDiagnosticsReport> = [
+  columns: ColumnsConfig<StatementDiagnosticsReport> = [
     {
       key: "activatedOn",
       title: "Activated on",
       sorter: sortByRequestedAtField,
       defaultSortOrder: "descend",
       render: (_text, record) => {
-        const timestamp = record.requested_at.seconds.toNumber() * 1000;
-        return moment.utc(timestamp).format(DATE_FORMAT_24_UTC);
+        return moment.utc(record.requested_at).format(DATE_FORMAT_24_UTC);
       },
     },
     {
@@ -156,7 +150,7 @@ export class DiagnosticsView extends React.Component<
           onDownloadDiagnosticBundleClick,
           onDiagnosticCancelRequestClick,
         } = this.props;
-        return (_text: string, record: IStatementDiagnosticsReport) => {
+        return (_text: string, record: StatementDiagnosticsReport) => {
           if (record.completed) {
             return (
               <div

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetailsConnected.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetailsConnected.ts
@@ -40,19 +40,13 @@ import { actions as localStorageActions } from "src/store/localStorage";
 import { actions as nodesActions } from "../store/nodes";
 import { actions as nodeLivenessActions } from "../store/liveness";
 import { selectTimeScale } from "../statementsPage/statementsPage.selectors";
-import { cockroach, google } from "@cockroachlabs/crdb-protobuf-client";
-import { StatementDetailsRequest } from "../api";
+import {
+  InsertStmtDiagnosticRequest,
+  StatementDetailsRequest,
+  StatementDiagnosticsReport,
+} from "../api";
 import { TimeScale } from "../timeScaleDropdown";
 import { getMatchParamByName, statementAttr } from "../util";
-type IDuration = google.protobuf.IDuration;
-type IStatementDiagnosticsReport =
-  cockroach.server.serverpb.IStatementDiagnosticsReport;
-
-const CreateStatementDiagnosticsReportRequest =
-  cockroach.server.serverpb.CreateStatementDiagnosticsReportRequest;
-
-const CancelStatementDiagnosticsReportRequest =
-  cockroach.server.serverpb.CancelStatementDiagnosticsReportRequest;
 
 // For tenant cases, we don't show information about node, regions and
 // diagnostics.
@@ -108,18 +102,10 @@ const mapDispatchToProps = (
       }),
     ),
   createStatementDiagnosticsReport: (
-    statementFingerprint: string,
-    minExecLatency: IDuration,
-    expiresAfter: IDuration,
+    insertStmtDiagnosticsRequest: InsertStmtDiagnosticRequest,
   ) => {
     dispatch(
-      statementDiagnosticsActions.createReport(
-        new CreateStatementDiagnosticsReportRequest({
-          statement_fingerprint: statementFingerprint,
-          min_execution_latency: minExecLatency,
-          expires_after: expiresAfter,
-        }),
-      ),
+      statementDiagnosticsActions.createReport(insertStmtDiagnosticsRequest),
     );
     dispatch(
       analyticsActions.track({
@@ -145,13 +131,11 @@ const mapDispatchToProps = (
         action: "Downloaded",
       }),
     ),
-  onDiagnosticCancelRequest: (report: IStatementDiagnosticsReport) => {
+  onDiagnosticCancelRequest: (report: StatementDiagnosticsReport) => {
     dispatch(
-      statementDiagnosticsActions.cancelReport(
-        new CancelStatementDiagnosticsReportRequest({
-          request_id: report.id,
-        }),
-      ),
+      statementDiagnosticsActions.cancelReport({
+        requestId: report.id,
+      }),
     );
     dispatch(
       analyticsActions.track({

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
@@ -16,7 +16,7 @@ import Long from "long";
 import { noop } from "lodash";
 import * as protos from "@cockroachlabs/crdb-protobuf-client";
 import { RequestError } from "src/util";
-import {StatementDiagnosticsReport} from "../api";
+import { StatementDiagnosticsReport } from "../api";
 
 type IStatementStatistics = protos.cockroach.sql.IStatementStatistics;
 type IExecStats = protos.cockroach.sql.IExecStats;

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
@@ -15,11 +15,9 @@ import { createMemoryHistory } from "history";
 import Long from "long";
 import { noop } from "lodash";
 import * as protos from "@cockroachlabs/crdb-protobuf-client";
-import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { RequestError } from "src/util";
+import {StatementDiagnosticsReport} from "../api";
 
-type IStatementDiagnosticsReport =
-  cockroach.server.serverpb.IStatementDiagnosticsReport;
 type IStatementStatistics = protos.cockroach.sql.IStatementStatistics;
 type IExecStats = protos.cockroach.sql.IExecStats;
 
@@ -212,37 +210,37 @@ const statementStats: Required<IStatementStatistics> = {
   },
 };
 
-const diagnosticsReports: IStatementDiagnosticsReport[] = [
+const diagnosticsReports: StatementDiagnosticsReport[] = [
   {
-    id: Long.fromNumber(594413966918975489),
+    id: '594413966918975489',
     completed: true,
     statement_fingerprint: "SHOW database",
-    statement_diagnostics_id: Long.fromNumber(594413981435920385),
-    requested_at: { seconds: Long.fromNumber(1601471146), nanos: 737251000 },
+    statement_diagnostics_id: '594413981435920385',
+    requested_at: moment(1601471146),
   },
   {
-    id: Long.fromNumber(594413966918975429),
+    id: '594413966918975429',
     completed: true,
     statement_fingerprint: "SHOW database",
-    statement_diagnostics_id: Long.fromNumber(594413281435920385),
-    requested_at: { seconds: Long.fromNumber(1601491146), nanos: 737251000 },
+    statement_diagnostics_id: '594413281435920385',
+    requested_at: moment(1601491146),
   },
 ];
 
-const diagnosticsReportsInProgress: IStatementDiagnosticsReport[] = [
+const diagnosticsReportsInProgress: StatementDiagnosticsReport[] = [
   {
-    id: Long.fromNumber(594413966918975489),
+    id: '594413966918975489',
     completed: false,
     statement_fingerprint: "SHOW database",
-    statement_diagnostics_id: Long.fromNumber(594413981435920385),
-    requested_at: { seconds: Long.fromNumber(1601471146), nanos: 737251000 },
+    statement_diagnostics_id: '594413981435920385',
+    requested_at: moment(1601471146),
   },
   {
-    id: Long.fromNumber(594413966918975429),
+    id: '594413966918975429',
     completed: true,
     statement_fingerprint: "SHOW database",
-    statement_diagnostics_id: Long.fromNumber(594413281435920385),
-    requested_at: { seconds: Long.fromNumber(1601491146), nanos: 737251000 },
+    statement_diagnostics_id: '594413281435920385',
+    requested_at: moment(1601491146),
   },
 ];
 

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -80,10 +80,11 @@ import { commonStyles } from "../common";
 import { isSelectedColumn } from "src/columnsSelector/utils";
 import { StatementViewType } from "./statementPageTypes";
 import moment from "moment";
+import {
+  InsertStmtDiagnosticRequest,
+  StatementDiagnosticsReport,
+} from "../api";
 
-type IStatementDiagnosticsReport =
-  cockroach.server.serverpb.IStatementDiagnosticsReport;
-type IDuration = google.protobuf.IDuration;
 const cx = classNames.bind(styles);
 const sortableTableCx = classNames.bind(sortableTableStyles);
 
@@ -100,9 +101,7 @@ export interface StatementsPageDispatchProps {
   resetSQLStats: (req: StatementsRequest) => void;
   dismissAlertMessage: () => void;
   onActivateStatementDiagnostics: (
-    statement: string,
-    minExecLatency: IDuration,
-    expiresAfter: IDuration,
+    insertStmtDiagnosticsRequest: InsertStmtDiagnosticRequest,
   ) => void;
   onDiagnosticsModalOpen?: (statement: string) => void;
   onSearchComplete?: (query: string) => void;
@@ -113,7 +112,7 @@ export interface StatementsPageDispatchProps {
     ascending: boolean,
   ) => void;
   onSelectDiagnosticsReportDropdownOption?: (
-    report: IStatementDiagnosticsReport,
+    report: StatementDiagnosticsReport,
   ) => void;
   onFilterChange?: (value: Filters) => void;
   onStatementClick?: (statement: string) => void;

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
@@ -47,11 +47,10 @@ import {
   StatisticType,
 } from "../statsTableUtil/statsTableUtil";
 
-type IStatementDiagnosticsReport =
-  cockroach.server.serverpb.IStatementDiagnosticsReport;
 type ICollectedStatementStatistics =
   cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
 import styles from "./statementsTable.module.scss";
+import { StatementDiagnosticsReport } from "../api";
 const cx = classNames.bind(styles);
 
 function makeCommonColumns(
@@ -230,7 +229,7 @@ export interface AggregateStatistics {
   stats: StatementStatistics;
   drawer?: boolean;
   firstCellBordered?: boolean;
-  diagnosticsReports?: cockroach.server.serverpb.IStatementDiagnosticsReport[];
+  diagnosticsReports?: StatementDiagnosticsReport[];
   // totalWorkload is the sum of service latency of all statements listed on the table.
   totalWorkload?: Long;
   regionNodes?: string[];
@@ -288,7 +287,7 @@ export function makeStatementsColumns(
   search?: string,
   activateDiagnosticsRef?: React.RefObject<ActivateDiagnosticsModalRef>,
   onSelectDiagnosticsReportDropdownOption?: (
-    report: IStatementDiagnosticsReport,
+    report: StatementDiagnosticsReport,
   ) => void,
   onStatementClick?: (statement: string) => void,
 ): ColumnDescriptor<AggregateStatistics>[] {

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTableContent.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTableContent.tsx
@@ -24,19 +24,16 @@ import { Button } from "src/button";
 import { Tooltip } from "@cockroachlabs/ui-components";
 import {
   propsToQueryString,
-  TimestampToMoment,
   computeOrUseStmtSummary,
   appNamesAttr,
 } from "src/util";
 import styles from "./statementsTableContent.module.scss";
-import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { EllipsisVertical } from "@cockroachlabs/icons";
-import { getBasePath } from "../api";
+import { getBasePath, StatementDiagnosticsReport } from "../api";
+import moment from "moment";
 
 export type NodeNames = { [nodeId: string]: string };
 const cx = classNames.bind(styles);
-type IStatementDiagnosticsReport =
-  cockroach.server.serverpb.IStatementDiagnosticsReport;
 
 export const StatementTableCell = {
   statements:
@@ -63,7 +60,7 @@ export const StatementTableCell = {
     (
       activateDiagnosticsRef: React.RefObject<ActivateDiagnosticsModalRef>,
       onSelectDiagnosticsReportDropdownOption: (
-        report: IStatementDiagnosticsReport,
+        report: StatementDiagnosticsReport,
       ) => void = noop,
     ) =>
     (stmt: AggregateStatistics): React.ReactElement => {
@@ -102,7 +99,7 @@ export const StatementTableCell = {
             <DiagnosticStatusBadge status="WAITING" />
           )}
           {(!canActivateDiagnosticReport || hasCompletedDiagnosticsReports) && (
-            <Dropdown<IStatementDiagnosticsReport>
+            <Dropdown<StatementDiagnosticsReport>
               items={stmt.diagnosticsReports
                 // Sort diagnostic reports from incomplete to complete. Incomplete reports are cancellable.
                 .sort(function (a, b) {
@@ -135,9 +132,7 @@ export const StatementTableCell = {
                             dr.statement_diagnostics_id
                           }`}
                         >
-                          {`Download ${TimestampToMoment(
-                            dr.requested_at,
-                          ).format(
+                          {`Download ${moment(dr.requested_at).format(
                             "MMM DD, YYYY [at] H:mm [(UTC)] [diagnostic]",
                           )}`}
                         </a>

--- a/pkg/ui/workspaces/cluster-ui/src/store/statementDiagnostics/statementDiagnostics.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/statementDiagnostics/statementDiagnostics.reducer.ts
@@ -9,18 +9,15 @@
 // licenses/APL.txt.
 
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { DOMAIN_NAME, noopReducer } from "../utils";
-
-type CreateStatementDiagnosticsReportRequest =
-  cockroach.server.serverpb.CreateStatementDiagnosticsReportRequest;
-type CancelStatementDiagnosticsReportRequest =
-  cockroach.server.serverpb.CancelStatementDiagnosticsReportRequest;
-type StatementDiagnosticsReportsResponse =
-  cockroach.server.serverpb.StatementDiagnosticsReportsResponse;
+import {
+  CancelStmtDiagnosticRequest,
+  InsertStmtDiagnosticRequest,
+  StatementDiagnosticsResponse,
+} from "../../api";
 
 export type StatementDiagnosticsState = {
-  data: StatementDiagnosticsReportsResponse;
+  data: StatementDiagnosticsResponse;
   lastError: Error;
   valid: boolean;
 };
@@ -37,7 +34,7 @@ const statementDiagnosticsSlice = createSlice({
   reducers: {
     received: (
       state: StatementDiagnosticsState,
-      action: PayloadAction<StatementDiagnosticsReportsResponse>,
+      action: PayloadAction<StatementDiagnosticsResponse>,
     ) => {
       state.data = action.payload;
       state.lastError = null;
@@ -55,13 +52,13 @@ const statementDiagnosticsSlice = createSlice({
     invalidated: noopReducer,
     createReport: (
       _state,
-      _action: PayloadAction<CreateStatementDiagnosticsReportRequest>,
+      _action: PayloadAction<InsertStmtDiagnosticRequest>,
     ) => {},
     createReportCompleted: noopReducer,
     createReportFailed: (_state, _action: PayloadAction<Error>) => {},
     cancelReport: (
       _state,
-      _action: PayloadAction<CancelStatementDiagnosticsReportRequest>,
+      _action: PayloadAction<CancelStmtDiagnosticRequest>,
     ) => {},
     cancelReportCompleted: noopReducer,
     cancelReportFailed: (_state, _action: PayloadAction<Error>) => {},

--- a/pkg/ui/workspaces/cluster-ui/src/store/statementDiagnostics/statementDiagnostics.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/statementDiagnostics/statementDiagnostics.sagas.ts
@@ -24,9 +24,6 @@ import {
 import { actions } from "./statementDiagnostics.reducer";
 import { CACHE_INVALIDATION_PERIOD, throttleWithReset } from "../utils";
 import { rootActions } from "../reducers";
-import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
-type CancelStatementDiagnosticsReportResponseMessage =
-  cockroach.server.serverpb.CancelStatementDiagnosticsReportResponse;
 
 export function* createDiagnosticsReportSaga(
   action: ReturnType<typeof actions.createReport>,
@@ -52,13 +49,7 @@ export function* cancelDiagnosticsReportSaga(
   action: ReturnType<typeof actions.cancelReport>,
 ) {
   try {
-    const response: CancelStatementDiagnosticsReportResponseMessage =
-      yield call(cancelStatementDiagnosticsReport, action.payload);
-
-    if (response.error !== "") {
-      throw response.error;
-    }
-
+    yield call(cancelStatementDiagnosticsReport, action.payload);
     yield put(actions.cancelReportCompleted());
     yield put(actions.request());
   } catch (e) {

--- a/pkg/ui/workspaces/cluster-ui/src/store/statementDiagnostics/statementDiagnostics.selectors.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/statementDiagnostics/statementDiagnostics.selectors.spec.ts
@@ -10,31 +10,30 @@
 
 import { assert } from "chai";
 import { selectDiagnosticsReportsPerStatement } from "./statementDiagnostics.selectors";
-import Long from "long";
-import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
-import IStatementDiagnosticsReport = cockroach.server.serverpb.IStatementDiagnosticsReport;
+import { StatementDiagnosticsReport } from "../../api";
+import moment from "moment";
 
-const reports: IStatementDiagnosticsReport[] = [
+const reports: StatementDiagnosticsReport[] = [
   {
-    id: Long.fromNumber(1),
+    id: "1",
     completed: false,
     statement_fingerprint: "SHOW database",
-    statement_diagnostics_id: Long.fromNumber(594413981435920385),
-    requested_at: { seconds: Long.fromNumber(100), nanos: 737251000 },
+    statement_diagnostics_id: "594413981435920385",
+    requested_at: moment(100, "s"),
   },
   {
-    id: Long.fromNumber(2),
+    id: "2",
     completed: true,
     statement_fingerprint: "SHOW database",
-    statement_diagnostics_id: Long.fromNumber(594413281435920385),
-    requested_at: { seconds: Long.fromNumber(200), nanos: 737251000 },
+    statement_diagnostics_id: "594413281435920385",
+    requested_at: moment(200, "s"),
   },
   {
-    id: Long.fromNumber(3),
+    id: "3",
     completed: true,
     statement_fingerprint: "SHOW database",
-    statement_diagnostics_id: Long.fromNumber(594413281435920385),
-    requested_at: { seconds: Long.fromNumber(300), nanos: 737251000 },
+    statement_diagnostics_id: "594413281435920385",
+    requested_at: moment(300, "s"),
   },
 ];
 
@@ -43,10 +42,7 @@ describe("statementDiagnostics selectors", () => {
     it("returns diagnostics reports sorted in descending order", () => {
       const diagnosticsPerStatement =
         selectDiagnosticsReportsPerStatement.resultFunc(reports);
-      assert.deepEqual(
-        diagnosticsPerStatement["SHOW database"][0].id,
-        Long.fromNumber(3),
-      );
+      assert.deepEqual(diagnosticsPerStatement["SHOW database"][0].id, "3");
     });
   });
 });

--- a/pkg/ui/workspaces/cluster-ui/src/store/statementDiagnostics/statementDiagnostics.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/statementDiagnostics/statementDiagnostics.selectors.ts
@@ -10,11 +10,9 @@
 
 import { createSelector } from "reselect";
 import { chain, orderBy } from "lodash";
-import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { AppState } from "../reducers";
-
-type IStatementDiagnosticsReport =
-  cockroach.server.serverpb.IStatementDiagnosticsReport;
+import { StatementDiagnosticsReport } from "../../api";
+import moment from "moment";
 
 export const statementDiagnostics = createSelector(
   (state: AppState) => state.adminUI,
@@ -23,27 +21,23 @@ export const statementDiagnostics = createSelector(
 
 export const selectStatementDiagnosticsReports = createSelector(
   statementDiagnostics,
-  state => state.data?.reports,
+  state => state.data,
 );
 
 type StatementDiagnosticsDictionary = {
-  [statementFingerprint: string]: IStatementDiagnosticsReport[];
+  [statementFingerprint: string]: StatementDiagnosticsReport[];
 };
 
 export const selectDiagnosticsReportsPerStatement = createSelector(
   selectStatementDiagnosticsReports,
   (
-    diagnosticsReports: IStatementDiagnosticsReport[],
+    diagnosticsReports: StatementDiagnosticsReport[],
   ): StatementDiagnosticsDictionary =>
     chain(diagnosticsReports)
       .groupBy(diagnosticsReport => diagnosticsReport.statement_fingerprint)
       // Perform DESC sorting to get latest report on top
       .mapValues(diagnostics =>
-        orderBy(
-          diagnostics,
-          [d => d.requested_at.seconds.toNumber()],
-          ["desc"],
-        ),
+        orderBy(diagnostics, [d => moment(d.requested_at).unix()], ["desc"]),
       )
       .value(),
 );

--- a/pkg/ui/workspaces/db-console/src/app.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.spec.tsx
@@ -23,6 +23,7 @@ stubComponentInModule(
   "default",
 );
 stubComponentInModule("src/views/statements/statementsPage", "default");
+stubComponentInModule("src/views/statements/statementDetails", "default");
 stubComponentInModule("src/views/transactions/transactionsPage", "default");
 stubComponentInModule(
   "src/views/statements/activeStatementDetailsConnected",
@@ -63,7 +64,6 @@ const NODE_LOG_HEADER = /Logs Node.*/;
 const EVENTS_HEADER = "Events";
 const JOBS_HEADER = "Jobs";
 const SQL_ACTIVITY_HEADER = "SQL Activity";
-const STATEMENTS_DETAILS_HEADER = "Statement Fingerprint";
 const TRANSACTION_DETAILS_HEADER = "Transaction Details";
 const ADVANCED_DEBUG_HEADER = "Advanced Debugging";
 const REDUX_DEBUG_HEADER = "Redux State";
@@ -356,14 +356,14 @@ describe("Routing to", () => {
   describe("'/statements/:${appAttr}/:${statementAttr}' path", () => {
     test("routes to <StatementDetails> component", () => {
       navigateToPath("/statements/%24+internal/true");
-      screen.getByText(STATEMENTS_DETAILS_HEADER, { selector: "h3" });
+      screen.getByTestId("statementDetails");
     });
   });
 
   describe("'/statements/:${implicitTxnAttr}/:${statementAttr}' path", () => {
     test("routes to <StatementDetails> component", () => {
       navigateToPath("/statements/implicit-txn-attr/statement-attr");
-      screen.getByText(STATEMENTS_DETAILS_HEADER, { selector: "h3" });
+      screen.getByTestId("statementDetails");
     });
   });
 
@@ -379,7 +379,7 @@ describe("Routing to", () => {
   describe("'/statement/:${implicitTxnAttr}/:${statementAttr}' path", () => {
     test("routes to <StatementDetails> component", () => {
       navigateToPath("/statement/implicit-attr/statement-attr/");
-      screen.getByText(STATEMENTS_DETAILS_HEADER, { selector: "h3" });
+      screen.getByTestId("statementDetails");
     });
   });
 

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -364,7 +364,7 @@ export const invalidateUserSQLRoles = userSQLRolesReducerObj.invalidateData;
 export const refreshUserSQLRoles = userSQLRolesReducerObj.refresh;
 
 const statementDiagnosticsReportsReducerObj = new CachedDataReducer(
-  api.getStatementDiagnosticsReports,
+  clusterUiApi.getStatementDiagnosticsReports,
   "statementDiagnosticsReports",
   moment.duration(5, "m"),
   moment.duration(1, "m"),
@@ -515,7 +515,7 @@ export interface APIReducersState {
   statementDetails: KeyedCachedDataReducerState<api.StatementDetailsResponseMessage>;
   dataDistribution: CachedDataReducerState<api.DataDistributionResponseMessage>;
   metricMetadata: CachedDataReducerState<api.MetricMetadataResponseMessage>;
-  statementDiagnosticsReports: CachedDataReducerState<api.StatementDiagnosticsReportsResponseMessage>;
+  statementDiagnosticsReports: CachedDataReducerState<clusterUiApi.StatementDiagnosticsResponse>;
   userSQLRoles: CachedDataReducerState<api.UserSQLRolesResponseMessage>;
   hotRanges: PaginatedCachedDataReducerState<api.HotRangesV2ResponseMessage>;
   clusterLocks: CachedDataReducerState<clusterUiApi.ClusterLocksResponse>;

--- a/pkg/ui/workspaces/db-console/src/redux/statements/statementsActions.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/statements/statementsActions.ts
@@ -10,9 +10,7 @@
 
 import { Action } from "redux";
 import { PayloadAction } from "src/interfaces/action";
-import { google } from "@cockroachlabs/crdb-protobuf-client";
-import IDuration = google.protobuf.IDuration;
-import { TimeScale } from "@cockroachlabs/cluster-ui";
+import { TimeScale, api as clusterUiApi } from "@cockroachlabs/cluster-ui";
 
 export const CREATE_STATEMENT_DIAGNOSTICS_REPORT =
   "cockroachui/statements/CREATE_STATEMENT_DIAGNOSTICS_REPORT";
@@ -33,24 +31,12 @@ export type DiagnosticsReportPayload = {
   statementFingerprint: string;
 };
 
-export type CreateStatementDiagnosticsReportPayload = {
-  statementFingerprint: string;
-  minExecLatency: IDuration;
-  expiresAfter: IDuration;
-};
-
 export function createStatementDiagnosticsReportAction(
-  statementFingerprint: string,
-  minExecLatency: IDuration,
-  expiresAfter: IDuration,
-): PayloadAction<CreateStatementDiagnosticsReportPayload> {
+  insertStmtDiagnosticsRequest: clusterUiApi.InsertStmtDiagnosticRequest,
+): PayloadAction<clusterUiApi.InsertStmtDiagnosticRequest> {
   return {
     type: CREATE_STATEMENT_DIAGNOSTICS_REPORT,
-    payload: {
-      statementFingerprint,
-      minExecLatency,
-      expiresAfter,
-    },
+    payload: insertStmtDiagnosticsRequest,
   };
 }
 
@@ -66,18 +52,12 @@ export function createStatementDiagnosticsReportFailedAction(): Action {
   };
 }
 
-export type CancelStatementDiagnosticsReportPayload = {
-  requestID: Long;
-};
-
 export function cancelStatementDiagnosticsReportAction(
-  requestID: Long,
-): PayloadAction<CancelStatementDiagnosticsReportPayload> {
+  cancelStmtDiagnosticsRequest: clusterUiApi.CancelStmtDiagnosticRequest,
+): PayloadAction<clusterUiApi.CancelStmtDiagnosticRequest> {
   return {
     type: CANCEL_STATEMENT_DIAGNOSTICS_REPORT,
-    payload: {
-      requestID,
-    },
+    payload: cancelStmtDiagnosticsRequest,
   };
 }
 

--- a/pkg/ui/workspaces/db-console/src/util/api.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.ts
@@ -187,26 +187,6 @@ export type MetricMetadataRequestMessage =
 export type MetricMetadataResponseMessage =
   protos.cockroach.server.serverpb.MetricMetadataResponse;
 
-export type StatementDiagnosticsReportsRequestMessage =
-  protos.cockroach.server.serverpb.StatementDiagnosticsReportsRequest;
-export type StatementDiagnosticsReportsResponseMessage =
-  protos.cockroach.server.serverpb.StatementDiagnosticsReportsResponse;
-
-export type CreateStatementDiagnosticsReportRequestMessage =
-  protos.cockroach.server.serverpb.CreateStatementDiagnosticsReportRequest;
-export type CreateStatementDiagnosticsReportResponseMessage =
-  protos.cockroach.server.serverpb.CreateStatementDiagnosticsReportResponse;
-
-export type CancelStatementDiagnosticsReportRequestMessage =
-  protos.cockroach.server.serverpb.CancelStatementDiagnosticsReportRequest;
-export type CancelStatementDiagnosticsReportResponseMessage =
-  protos.cockroach.server.serverpb.CancelStatementDiagnosticsReportResponse;
-
-export type StatementDiagnosticsRequestMessage =
-  protos.cockroach.server.serverpb.StatementDiagnosticsRequest;
-export type StatementDiagnosticsResponseMessage =
-  protos.cockroach.server.serverpb.StatementDiagnosticsResponse;
-
 export type StatementsRequestMessage =
   protos.cockroach.server.serverpb.StatementsRequest;
 export type StatementDetailsRequestMessage =
@@ -831,53 +811,6 @@ export function getStatementDetails(
   return timeoutFetch(
     serverpb.StatementDetailsResponse,
     `${STATUS_PREFIX}/stmtdetails/${req.fingerprint_id}?${queryStr}`,
-    null,
-    timeout,
-  );
-}
-
-export function getStatementDiagnosticsReports(
-  timeout?: moment.Duration,
-): Promise<StatementDiagnosticsReportsResponseMessage> {
-  return timeoutFetch(
-    serverpb.StatementDiagnosticsReportsResponse,
-    `${STATUS_PREFIX}/stmtdiagreports`,
-    null,
-    timeout,
-  );
-}
-
-export function createStatementDiagnosticsReport(
-  req: CreateStatementDiagnosticsReportRequestMessage,
-  timeout?: moment.Duration,
-): Promise<CreateStatementDiagnosticsReportResponseMessage> {
-  return timeoutFetch(
-    serverpb.CreateStatementDiagnosticsReportResponse,
-    `${STATUS_PREFIX}/stmtdiagreports`,
-    req as any,
-    timeout,
-  );
-}
-
-export function cancelStatementDiagnosticsReport(
-  req: CancelStatementDiagnosticsReportRequestMessage,
-  timeout?: moment.Duration,
-): Promise<CancelStatementDiagnosticsReportResponseMessage> {
-  return timeoutFetch(
-    serverpb.CancelStatementDiagnosticsReportResponse,
-    `${STATUS_PREFIX}/stmtdiagreports/cancel`,
-    req as any,
-    timeout,
-  );
-}
-
-export function getStatementDiagnostics(
-  req: StatementDiagnosticsRequestMessage,
-  timeout?: moment.Duration,
-): Promise<StatementDiagnosticsResponseMessage> {
-  return timeoutFetch(
-    serverpb.StatementDiagnosticsResponse,
-    `${STATUS_PREFIX}/stmtdiag/${req.statement_diagnostics_id}`,
     null,
     timeout,
   );

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementDetails.tsx
@@ -45,15 +45,12 @@ import {
   trackDownloadDiagnosticsBundleAction,
   trackStatementDetailsSubnavSelectionAction,
 } from "src/redux/analyticsActions";
-import * as protos from "src/js/protos";
 import { StatementDetailsResponseMessage } from "src/util/api";
 import { getMatchParamByName, queryByName } from "src/util/query";
 
 import { appNamesAttr, statementAttr } from "src/util/constants";
 import { selectTimeScale } from "src/redux/timeScale";
-
-type IStatementDiagnosticsReport =
-  protos.cockroach.server.serverpb.IStatementDiagnosticsReport;
+import { api as clusterUiApi } from "@cockroachlabs/cluster-ui";
 
 const { generateStmtDetailsToID } = util;
 
@@ -127,13 +124,27 @@ const mapDispatchToProps: StatementDetailsDispatchProps = {
   refreshStatementDiagnosticsRequests,
   dismissStatementDiagnosticsAlertMessage: () =>
     createStatementDiagnosticsAlertLocalSetting.set({ show: false }),
-  createStatementDiagnosticsReport: createStatementDiagnosticsReportAction,
+  createStatementDiagnosticsReport: (
+    insertStatementDiagnosticsRequest: clusterUiApi.InsertStmtDiagnosticRequest,
+  ) => {
+    return (dispatch: AppDispatch) => {
+      dispatch(
+        createStatementDiagnosticsReportAction(
+          insertStatementDiagnosticsRequest,
+        ),
+      );
+    };
+  },
   onTabChanged: trackStatementDetailsSubnavSelectionAction,
   onTimeScaleChange: setGlobalTimeScaleAction,
   onDiagnosticBundleDownload: trackDownloadDiagnosticsBundleAction,
-  onDiagnosticCancelRequest: (report: IStatementDiagnosticsReport) => {
+  onDiagnosticCancelRequest: (
+    report: clusterUiApi.StatementDiagnosticsReport,
+  ) => {
     return (dispatch: AppDispatch) => {
-      dispatch(cancelStatementDiagnosticsReportAction(report.id));
+      dispatch(
+        cancelStatementDiagnosticsReportAction({ requestId: report.id }),
+      );
       dispatch(
         trackCancelDiagnosticsBundleAction(report.statement_fingerprint),
       );

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
@@ -64,11 +64,10 @@ import {
 } from "./activeStatementsSelectors";
 import { selectTimeScale } from "src/redux/timeScale";
 import { selectStatementsLastUpdated } from "src/selectors/executionFingerprintsSelectors";
+import { api as clusterUiApi } from "@cockroachlabs/cluster-ui";
 
 type ICollectedStatementStatistics =
   protos.cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
-type IStatementDiagnosticsReport =
-  protos.cockroach.server.serverpb.IStatementDiagnosticsReport;
 
 const {
   aggregateStatementStats,
@@ -301,7 +300,14 @@ const fingerprintsPageActions = {
       );
     };
   },
-  onActivateStatementDiagnostics: createStatementDiagnosticsReportAction,
+  onActivateStatementDiagnostics: (
+    insertStmtDiagnosticRequest: clusterUiApi.InsertStmtDiagnosticRequest,
+  ) => {
+    return (dispatch: AppDispatch) =>
+      dispatch(
+        createStatementDiagnosticsReportAction(insertStmtDiagnosticRequest),
+      );
+  },
   onDiagnosticsModalOpen: createOpenDiagnosticsModalAction,
   onSearchComplete: (query: string) => searchLocalSetting.set(query),
   onPageChanged: trackStatementsPaginationAction,
@@ -316,13 +322,15 @@ const fingerprintsPageActions = {
     }),
   onFilterChange: (filters: Filters) => filtersLocalSetting.set(filters),
   onSelectDiagnosticsReportDropdownOption: (
-    report: IStatementDiagnosticsReport,
+    report: clusterUiApi.StatementDiagnosticsReport,
   ) => {
     if (report.completed) {
       return trackDownloadDiagnosticsBundleAction(report.statement_fingerprint);
     } else {
       return (dispatch: AppDispatch) => {
-        dispatch(cancelStatementDiagnosticsReportAction(report.id));
+        dispatch(
+          cancelStatementDiagnosticsReportAction({ requestId: report.id }),
+        );
         dispatch(
           trackCancelDiagnosticsBundleAction(report.statement_fingerprint),
         );


### PR DESCRIPTION
Part of: #89429

Addresses: #90273, #90274, #90275

Blocked from resolving by https://github.com/cockroachdb/cockroach/issues/80789

DB-Console Demo: https://www.loom.com/share/d74c02eb3dfb41fc913577d0e8992441
CC-Console Demo: https://www.loom.com/share/2adba8a53b8c48ac9f031e4481f284cf

This change migrates the existing statement diagnostics requests to use the sql-over-http endpoint on our apiV2, making these requests tenant-scoped once the sql-over-http endpoint is scoped to tenants (this should be the case when #91323 is completed).