### PR TITLE
workflow: Added a github workflow to publish Cluster UI

### DIFF
--- a/.github/workflows/cluster-ui-release-next.yml
+++ b/.github/workflows/cluster-ui-release-next.yml
@@ -1,0 +1,45 @@
+name: Publish Cluster UI Pre-release
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'pkg/ui/workspaces/cluster-ui/**/*.tsx?'
+      - 'pkg/ui/workspaces/cluster-ui/yarn.lock'
+
+jobs:
+  publish_cluster_ui:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: pkg/ui/workspaces/cluster-ui
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+
+    - name: Bazel Cache
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/bazel
+        key: ${{ runner.os }}-bazel-cache
+
+    - name: Setup NodeJS
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16
+        cache: 'yarn'
+        cache-dependency-path: pkg/ui/workspaces/cluster-ui/yarn.lock
+      env:
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: Build Cluster UI
+      run: |
+        yarn install --frozen-lockfile
+        bazel build //pkg/ui/workspaces/cluster-ui:cluster-ui
+
+    - name: Publish prerelease version
+      run: |
+        echo "yarn version --prerelease --preid prerelease"
+        echo "yarn publish --access public --tag next"

--- a/.github/workflows/cluster-ui-release.yml
+++ b/.github/workflows/cluster-ui-release.yml
@@ -1,0 +1,50 @@
+name: Publish Cluster UI Release
+on:
+  push:
+    branches:
+      - 'release-*'
+    paths:
+      - 'pkg/ui/workspaces/cluster-ui/**/*.tsx?'
+      - 'pkg/ui/workspaces/cluster-ui/yarn.lock'
+
+jobs:
+  publish_cluster_ui:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: pkg/ui/workspaces/cluster-ui
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+
+    - name: Bazel Cache
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/bazel
+        key: ${{ runner.os }}-bazel-cache
+
+    - name: Setup NodeJS
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16
+        cache: 'yarn'
+        cache-dependency-path: pkg/ui/workspaces/cluster-ui/yarn.lock
+      env:
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    - name: Get Branch name
+      shell: bash
+      run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+      id: branch-name
+
+    - name: Build Cluster UI
+      run: |
+        yarn install --frozen-lockfile
+        bazel build //pkg/ui/workspaces/cluster-ui:cluster-ui
+
+    - name: Publish patch version
+      run: |
+        echo "yarn version --patch"
+        echo "yarn publish --access public --tag ${{ steps.branch_name.outputs.branch }}"


### PR DESCRIPTION
I added two workflows to publish Cluster UI to npm. The workflows are intended to publish when there are changes to Cluster UI (pkg/ui/workspaces/cluster-ui) on a base branch (master or release-*). Since versions published from master differ slightly from versions published from release branches, I thought this called for two separate workflows.

"Publish Cluster UI Release" (cluster-ui-release.yml) will run when there are changes to Cluster UI (pkg/ui/workspaces/cluster-ui) on a release branch (`release-*` branches). This workflow will install dependencies and build Cluster UI, and then as a substitution for a "dry-run" will echo the expected publish commands. When publishing from release branches, we want to increase the patch version and then publish the version with a distribution tag that matches the release branch. To get the release branch I have created a step to echo the branch name into the GITHUB_OUTPUT environmental file, which is used as the distribution tag during publish.

"Publish Cluster UI Pre-release" (cluster-ui-release-next.yml) will run when there are changes to Cluster UI on the master branch. This workflow will install dependencies and build cluster UI, then also output the publish commands to increment a prerelease version of Cluster ui, and publish with a distribution tag of "next".

## Further Context
Currently these workflows **do not** version or publish to npm, but simply echo expected commands to do so. The CRUX team will monitor merges involving Cluster UI files to ensure the flows are set up correctly. There will be a follow up PR that will enable these commands.

In order to publish to npm a token is required. There is an org-level `NPM_TOKEN` that has been shared and is accessible to actions in this repository (dev-inf ticket [DEVINFHD-698](https://cockroachlabs.atlassian.net/browse/DEVINFHD-698)) 

Epic: CC-7999
see also CC-7959

Release note: None