### PR TITLE
sql: avoid panic inside scrub command if type descriptors exist

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/scrub
+++ b/pkg/sql/logictest/testdata/logic_test/scrub
@@ -167,3 +167,17 @@ EXPERIMENTAL SCRUB TABLE t0
 
 statement ok
 DROP TABLE t0
+
+
+# Tests that scrubbing a database that contains a type works fine, previously
+# this would panic due to a lack of descriptor type checking.
+subtest scrub_with_database_with_type
+
+statement ok
+CREATE DATABASE typedb;
+
+statement ok
+CREATE TYPE typedb.e as enum('open', 'closed');
+
+statement ok
+EXPERIMENTAL SCRUB DATABASE typedb;

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -185,6 +185,12 @@ func (n *scrubNode) startScrubDatabase(ctx context.Context, p *planner, name *tr
 		if err != nil {
 			return err
 		}
+		// Skip over descriptors that are not tables (like types).
+		// Note: We are asking for table objects above, so It's valid to only
+		// get a prefix, and no descriptor.
+		if objDesc == nil || objDesc.DescriptorType() != catalog.Table {
+			continue
+		}
 		tableDesc := objDesc.(catalog.TableDescriptor)
 		// Skip non-tables and don't throw an error if we encounter one.
 		if !tableDesc.IsTable() {


### PR DESCRIPTION
Informs: #87572

Previously, the experimental scrub command could panic if a database contains a type descriptor. This patch will modify the scrub to handle nil descriptors and not panic on type descriptors.

Release note: (bug fix) The experimental scrub command did not handle type descriptors in database.