### PR TITLE
jobs: do not include nil error into a log message when stepping

### DIFF
--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -1216,7 +1216,11 @@ func (r *Registry) stepThroughStateMachine(
 ) error {
 	payload := job.Payload()
 	jobType := payload.Type()
-	log.Infof(ctx, "%s job %d: stepping through state %s with error: %+v", jobType, job.ID(), status, jobErr)
+	if jobErr != nil {
+		log.Infof(ctx, "%s job %d: stepping through state %s with error: %+v", jobType, job.ID(), status, jobErr)
+	} else {
+		log.Infof(ctx, "%s job %d: stepping through state %s", jobType, job.ID(), status)
+	}
 	jm := r.metrics.JobMetrics[jobType]
 	onExecutionFailed := func(cause error) error {
 		log.InfofDepth(


### PR DESCRIPTION
This is a bit annoying and makes things a bit more difficult to search for actual errors.

Epic: None

Release note: None