### PR TITLE
logictest: only run create_as_non_metamorphic under local

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -463,13 +463,6 @@ func TestTenantLogic_create_as(
 	runLogicTest(t, "create_as")
 }
 
-func TestTenantLogic_create_as_non_metamorphic(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "create_as_non_metamorphic")
-}
-
 func TestTenantLogic_create_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/testdata/logic_test/create_as_non_metamorphic
+++ b/pkg/sql/logictest/testdata/logic_test/create_as_non_metamorphic
@@ -1,15 +1,15 @@
-# LogicTest: !metamorphic-batch-sizes
+# LogicTest: !metamorphic-batch-sizes local
 # Disabled to allow us to validate create as with large batch sizes.
 
 # Regression test for #81554, where tried to do gigantic batches for CTAS in
 # explicit transactions. Use a fixed command size, so that an error is decoupled
 # fom the default size.
 statement ok
-SET CLUSTER SETTING kv.raft.command.max_size='5m'
+SET CLUSTER SETTING kv.raft.command.max_size='4.01MiB'
 
 statement ok
 BEGIN;
-CREATE TABLE source_tbl_huge AS SELECT 1::CHAR(256) FROM generate_series(1, 500000);
+CREATE TABLE source_tbl_huge AS SELECT 1::CHAR(256) FROM generate_series(1, 50000);
 COMMIT;
 
 statement ok

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -436,13 +436,6 @@ func TestLogic_create_as(
 	runLogicTest(t, "create_as")
 }
 
-func TestLogic_create_as_non_metamorphic(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "create_as_non_metamorphic")
-}
-
 func TestLogic_create_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -436,13 +436,6 @@ func TestLogic_create_as(
 	runLogicTest(t, "create_as")
 }
 
-func TestLogic_create_as_non_metamorphic(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "create_as_non_metamorphic")
-}
-
 func TestLogic_create_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -436,13 +436,6 @@ func TestLogic_create_as(
 	runLogicTest(t, "create_as")
 }
 
-func TestLogic_create_as_non_metamorphic(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "create_as_non_metamorphic")
-}
-
 func TestLogic_create_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -436,13 +436,6 @@ func TestLogic_create_as(
 	runLogicTest(t, "create_as")
 }
 
-func TestLogic_create_as_non_metamorphic(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "create_as_non_metamorphic")
-}
-
 func TestLogic_create_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -436,13 +436,6 @@ func TestLogic_create_as(
 	runLogicTest(t, "create_as")
 }
 
-func TestLogic_create_as_non_metamorphic(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "create_as_non_metamorphic")
-}
-
 func TestLogic_create_index(
 	t *testing.T,
 ) {


### PR DESCRIPTION
This test is very expensive because it was writing 100Mib of data. It now writes more like 10. Nevertheless, let's not run it in so many places. I did verify that it still tests what it was intended to test.

Fixes #91080

Release note: None