### PR TITLE
colexecargs: fix the monitor names

### DIFF
--- a/pkg/sql/colexec/colexecargs/monitor_registry.go
+++ b/pkg/sql/colexec/colexecargs/monitor_registry.go
@@ -46,8 +46,8 @@ func (r *MonitorRegistry) NewStreamingMemAccount(flowCtx *execinfra.FlowCtx) *mo
 func (r *MonitorRegistry) getMemMonitorName(
 	opName redact.RedactableString, processorID int32, suffix redact.RedactableString,
 ) redact.RedactableString {
-	return opName + redact.RedactableString(strconv.Itoa(int(processorID))) + suffix +
-		redact.RedactableString(strconv.Itoa(len(r.monitors)))
+	return opName + "-" + redact.RedactableString(strconv.Itoa(int(processorID))) + "-" +
+		suffix + "-" + redact.RedactableString(strconv.Itoa(len(r.monitors)))
 }
 
 // CreateMemAccountForSpillStrategy instantiates a memory monitor and a memory


### PR DESCRIPTION
In 649113dbbc567efa0198c903cf07407ef00d0b7b we removed the dashes between different parts of the monitor names by mistake, so we now have something like `sort-all0limited0` instead of `sort-all-0-limited-0`. This is now fixed.

Epic: None

Release note: None