### PR TITLE
roachprod: improve error in ParallelE

### DIFF
--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -2282,7 +2282,11 @@ func (c *SyncedCluster) ParallelE(
 	}
 
 	if len(failed) > 0 {
-		return failed, errors.New("one or more parallel execution failure")
+		var err error
+		for _, res := range failed {
+			err = errors.CombineErrors(err, res.Err)
+		}
+		return nil, errors.Wrap(err, "parallel execution failure")
 	}
 	return nil, nil
 }


### PR DESCRIPTION
Prior to this commit, the error's stack trace did not link back
to the caller of `ParallelE`. Now it does.

Epic: none
Release note: None
