### PR TITLE
release: update OS packages before publishing to Red Hat Connect

### DIFF
--- a/build/deploy-redhat/Dockerfile.in
+++ b/build/deploy-redhat/Dockerfile.in
@@ -1,5 +1,10 @@
 FROM @repository@:@tag@
 
+RUN microdnf install yum && \
+  yum -v -y update --all && \
+  microdnf clean all && \
+  rm -rf /var/cache/yum
+
 LABEL name="CockroachDB"
 LABEL vendor="Cockroach Labs"
 LABEL summary="CockroachDB is a distributed SQL database."


### PR DESCRIPTION
Previously, the Red Hat Connect images are built by taking the current cockroachdb docker image as a base and applying a few labels on top of it. In some cases we may end up with images that contain outdated OS packages, what makes the generated image useless - Red Hat won't let you publish it.

This patch adds an extra command to update all OS packages, [similar to what we do for the operator](https://github.com/cockroachdb/cockroach-operator/blob/f476ff308a53205512cf64ab70b8fb22748b0aae/cmd/cockroach-operator/BUILD.bazel#L46-L54).

Release note: None
Epic: None