### PR TITLE
dev: allow whitespace separated regexps for testlogic files

### DIFF
--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=58
+DEV_VERSION=59
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions


### PR DESCRIPTION
This was a feature of `make testlogic` and it was liked.

Fixes #91125

Release note: None