### PR TITLE
dev: support multiple configs in testlogic

### DIFF
--- a/pkg/cmd/dev/util.go
+++ b/pkg/cmd/dev/util.go
@@ -52,6 +52,14 @@ func mustGetFlagString(cmd *cobra.Command, name string) string {
 	return val
 }
 
+func mustGetFlagStringSlice(cmd *cobra.Command, name string) []string {
+	val, err := cmd.Flags().GetStringSlice(name)
+	if err != nil {
+		log.Fatalf("unexpected error: %v", err)
+	}
+	return val
+}
+
 func mustGetFlagBool(cmd *cobra.Command, name string) bool {
 	val, err := cmd.Flags().GetBool(name)
 	if err != nil {


### PR DESCRIPTION
Before this change, if you specified the config flag more than once, it'd only use the latter one. Now the config flag supports multiple specifications or a csv of values and will run all of the specified configs.

Epic: None

Release note: None