### PR TITLE
server: fixes nodes list on databases page

### DIFF
--- a/pkg/ccl/multiregionccl/BUILD.bazel
+++ b/pkg/ccl/multiregionccl/BUILD.bazel
@@ -57,6 +57,7 @@ go_test(
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
+        "//pkg/server/serverpb",
         "//pkg/sql",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",

--- a/pkg/ccl/multiregionccl/multiregionccltestutils/testutils.go
+++ b/pkg/ccl/multiregionccl/multiregionccltestutils/testutils.go
@@ -61,37 +61,58 @@ func WithUseDatabase(db string) MultiRegionTestClusterParamsOption {
 func TestingCreateMultiRegionCluster(
 	t testing.TB, numServers int, knobs base.TestingKnobs, opts ...MultiRegionTestClusterParamsOption,
 ) (*testcluster.TestCluster, *gosql.DB, func()) {
-	serverArgs := make(map[int]base.TestServerArgs)
-	regionNames := make([]string, numServers)
+	regionNames := make(map[string]int, numServers)
 	for i := 0; i < numServers; i++ {
 		// "us-east1", "us-east2"...
-		regionNames[i] = fmt.Sprintf("us-east%d", i+1)
+		regionNames[fmt.Sprintf("us-east%d", i+1)] = 1
 	}
+
+	return TestingCreateMultiRegionClusterWithRegionList(
+		t,
+		regionNames,
+		knobs,
+		opts...)
+}
+
+// TestingCreateMultiRegionClusterWithRegionList creates a test cluster with numServers number
+// of nodes and the provided testing knobs applied to each of the nodes. Every
+// node is placed in its own locality, named "us-east1", "us-east2", and so on.
+func TestingCreateMultiRegionClusterWithRegionList(
+	t testing.TB,
+	regionToNumServers map[string]int,
+	knobs base.TestingKnobs,
+	opts ...MultiRegionTestClusterParamsOption,
+) (*testcluster.TestCluster, *gosql.DB, func()) {
+	serverArgs := make(map[int]base.TestServerArgs)
 
 	params := &multiRegionTestClusterParams{}
 	for _, opt := range opts {
 		opt(params)
 	}
 
-	for i := 0; i < numServers; i++ {
-		serverArgs[i] = base.TestServerArgs{
-			Knobs:         knobs,
-			ExternalIODir: params.baseDir,
-			UseDatabase:   params.useDatabase,
-			// Disabling this due to failures in the rtt_analysis tests. Ideally
-			// we could disable multi-tenancy just for those tests, but this function
-			// is used to create the MR cluster for all test cases. For
-			// bonus points, the code to re-enable this should also provide more
-			// flexibility in disabling the default test tenant by callers of this
-			// function. Re-enablement is tracked with #76378.
-			DisableDefaultTestTenant: true,
-			Locality: roachpb.Locality{
-				Tiers: []roachpb.Tier{{Key: "region", Value: regionNames[i]}},
-			},
+	totalServerCount := 0
+	for region, numServers := range regionToNumServers {
+		for i := 0; i < numServers; i++ {
+			serverArgs[totalServerCount] = base.TestServerArgs{
+				Knobs:         knobs,
+				ExternalIODir: params.baseDir,
+				UseDatabase:   params.useDatabase,
+				// Disabling this due to failures in the rtt_analysis tests. Ideally
+				// we could disable multi-tenancy just for those tests, but this function
+				// is used to create the MR cluster for all test cases. For
+				// bonus points, the code to re-enable this should also provide more
+				// flexibility in disabling the default test tenant by callers of this
+				// function. Re-enablement is tracked with #76378.
+				DisableDefaultTestTenant: true,
+				Locality: roachpb.Locality{
+					Tiers: []roachpb.Tier{{Key: "region", Value: region}},
+				},
+			}
+			totalServerCount++
 		}
 	}
 
-	tc := testcluster.StartTestCluster(t, numServers, base.TestClusterArgs{
+	tc := testcluster.StartTestCluster(t, totalServerCount, base.TestClusterArgs{
 		ReplicationMode:   params.replicationMode,
 		ServerArgsPerNode: serverArgs,
 	})

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/storepool"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
@@ -1224,59 +1225,26 @@ func (s *adminServer) NonTableStats(
 func (s *adminServer) statsForSpan(
 	ctx context.Context, span roachpb.Span,
 ) (*serverpb.TableStatsResponse, error) {
-	startKey, err := keys.Addr(span.Key)
-	if err != nil {
-		return nil, err
-	}
-	endKey, err := keys.Addr(span.EndKey)
-	if err != nil {
-		return nil, err
-	}
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
-	// Get current range descriptors for table. This is done by scanning over
-	// meta2 keys for the range. A special case occurs if we wish to include
-	// the meta1 key range itself, in which case we'll get KeyMin back and that
-	// cannot be scanned (due to range-local addressing confusion). This is
-	// handled appropriately by adjusting the bounds to grab the descriptors
-	// for all ranges (including range1, which is not only gossiped but also
-	// persisted in meta1).
-	startMetaKey := keys.RangeMetaKey(startKey)
-	if bytes.Equal(startMetaKey, roachpb.RKeyMin) {
-		// This is the special case described above. The following key instructs
-		// the code below to scan all of the addressing, i.e. grab all of the
-		// descriptors including that for r1.
-		startMetaKey = keys.RangeMetaKey(keys.MustAddr(keys.Meta2Prefix))
-	}
-
-	rangeDescKVs, err := s.server.db.Scan(ctx, startMetaKey, keys.RangeMetaKey(endKey), 0)
+	rSpan, err := keys.SpanAddr(span)
 	if err != nil {
 		return nil, err
 	}
 
-	// This map will store the nodes we need to fan out to.
-	nodeIDs := make(map[roachpb.NodeID]struct{})
-	for _, kv := range rangeDescKVs {
-		var rng roachpb.RangeDescriptor
-		if err := kv.Value.GetProto(&rng); err != nil {
-			return nil, err
-		}
-		for _, repl := range rng.Replicas().Descriptors() {
-			nodeIDs[repl.NodeID] = struct{}{}
-		}
+	// Get a list of node ids and range count for the specified span.
+	nodeIDs, rangeCount, err := nodeIDsAndRangeCountForSpan(
+		ctx, s.server.distSender, rSpan,
+	)
+	if err != nil {
+		return nil, err
 	}
-
-	nodeIDList := make([]roachpb.NodeID, 0, len(nodeIDs))
-	for id := range nodeIDs {
-		nodeIDList = append(nodeIDList, id)
-	}
-	sort.Slice(nodeIDList, func(i, j int) bool {
-		return nodeIDList[i] < nodeIDList[j]
-	})
 
 	// Construct TableStatsResponse by sending an RPC to every node involved.
 	tableStatResponse := serverpb.TableStatsResponse{
 		NodeCount: int64(len(nodeIDs)),
-		NodeIDs:   nodeIDList,
+		NodeIDs:   nodeIDs,
 		// TODO(mrtracy): The "RangeCount" returned by TableStats is more
 		// accurate than the "RangeCount" returned by TableDetails, because this
 		// method always consistently queries the meta2 key range for the table;
@@ -1291,7 +1259,7 @@ func (s *adminServer) statsForSpan(
 		// the advantage of populating the cache (without the disadvantage of
 		// potentially returning stale data).
 		// See GitHub #5435 for some discussion.
-		RangeCount: int64(len(rangeDescKVs)),
+		RangeCount: rangeCount,
 	}
 	type nodeResponse struct {
 		nodeID roachpb.NodeID
@@ -1301,7 +1269,7 @@ func (s *adminServer) statsForSpan(
 
 	// Send a SpanStats query to each node.
 	responses := make(chan nodeResponse, len(nodeIDs))
-	for nodeID := range nodeIDs {
+	for _, nodeID := range nodeIDs {
 		nodeID := nodeID // avoid data race
 		if err := s.server.stopper.RunAsyncTaskEx(
 			ctx, stop.TaskOpts{
@@ -1317,8 +1285,8 @@ func (s *adminServer) statsForSpan(
 						client, err := s.server.status.dialNode(ctx, nodeID)
 						if err == nil {
 							req := serverpb.SpanStatsRequest{
-								StartKey: startKey,
-								EndKey:   endKey,
+								StartKey: rSpan.Key,
+								EndKey:   rSpan.EndKey,
 								NodeID:   nodeID.String(),
 							}
 							spanResponse, err = client.SpanStats(ctx, &req)
@@ -1342,6 +1310,10 @@ func (s *adminServer) statsForSpan(
 			// For nodes which returned an error, note that the node's data
 			// is missing. For successful calls, aggregate statistics.
 			if resp.err != nil {
+				if s, ok := status.FromError(errors.UnwrapAll(resp.err)); ok && s.Code() == codes.PermissionDenied {
+					return nil, serverError(ctx, resp.err)
+				}
+
 				tableStatResponse.MissingNodes = append(
 					tableStatResponse.MissingNodes,
 					serverpb.TableStatsResponse_MissingNode{
@@ -1361,6 +1333,36 @@ func (s *adminServer) statsForSpan(
 	}
 
 	return &tableStatResponse, nil
+}
+
+// Returns the list of node ids for the specified span.
+func nodeIDsAndRangeCountForSpan(
+	ctx context.Context, ds *kvcoord.DistSender, rSpan roachpb.RSpan,
+) (nodeIDList []roachpb.NodeID, rangeCount int64, _ error) {
+	nodeIDs := make(map[roachpb.NodeID]struct{})
+	ri := kvcoord.MakeRangeIterator(ds)
+	ri.Seek(ctx, rSpan.Key, kvcoord.Ascending)
+	for ; ri.Valid(); ri.Next(ctx) {
+		rangeCount++
+		for _, repl := range ri.Desc().Replicas().Descriptors() {
+			nodeIDs[repl.NodeID] = struct{}{}
+		}
+		if !ri.NeedAnother(rSpan) {
+			break
+		}
+	}
+	if err := ri.Error(); err != nil {
+		return nil, 0, err
+	}
+
+	nodeIDList = make([]roachpb.NodeID, 0, len(nodeIDs))
+	for id := range nodeIDs {
+		nodeIDList = append(nodeIDList, id)
+	}
+	sort.Slice(nodeIDList, func(i, j int) bool {
+		return nodeIDList[i] < nodeIDList[j]
+	})
+	return nodeIDList, rangeCount, nil
 }
 
 // Users returns a list of users, stripped of any passwords.


### PR DESCRIPTION
The previous scan was returning the results for
multiple databases instead of just the specified
one. This caused the node list to show the incorrect 
nodes. It is fixed by using the new kvcoord.DistSender
which is a higher abstraction designed to handle
multi-tenant scenarios, and properly filtering the
range to just the specified span.

closes: #81674

Release note (bug fix): Fixes a bug which resulted 
in the regions listed for databases and tables
including an incorrect list of regions due to the 
logic including information about tables which 
are adjacent in the keyspace.