### PR TITLE
release-22.1: backupccl: reduce over-splitting during RESTORE

### DIFF
--- a/pkg/ccl/backupccl/bench_covering_test.go
+++ b/pkg/ccl/backupccl/bench_covering_test.go
@@ -62,7 +62,7 @@ func BenchmarkRestoreEntryCover(b *testing.B) {
 								introducedSpanFrontier, err := createIntroducedSpanFrontier(backups, hlc.Timestamp{})
 								require.NoError(b, err)
 
-								cov := makeSimpleImportSpans(backups[numBackups-1].Spans, backups, nil, introducedSpanFrontier, nil)
+								cov := makeSimpleImportSpans(backups[numBackups-1].Spans, backups, nil, introducedSpanFrontier, nil, 0)
 								b.ReportMetric(float64(len(cov)), "coverSize")
 							}
 						})

--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -984,6 +984,10 @@ func TestReintroduceOfflineSpans(t *testing.T) {
 	// so we don't see memory errors.
 	srcDB.Exec(t, `SET CLUSTER SETTING bulkio.backup.merge_file_buffer_size = '1MiB'`)
 
+	// This test is dependent on the number of restore span entries so we disable
+	// merging.
+	srcDB.Exec(t, `SET CLUSTER SETTING backup.restore_span.target_size = '0MiB'`)
+
 	// Take a backup that we'll use to create an OFFLINE descriptor.
 	srcDB.Exec(t, `CREATE INDEX new_idx ON data.bank (balance)`)
 	srcDB.Exec(t, `BACKUP DATABASE data TO $1 WITH revision_history`, dbBackupLoc)

--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -449,7 +449,7 @@ func (rd *restoreDataProcessor) processRestoreSpanEntry(
 		evalCtx.Settings,
 		disallowShadowingBelow,
 		writeAtBatchTS,
-		false, /* splitFilledRanges */
+		false, /* scatterSplitRanges */
 		rd.flowCtx.Cfg.BackupMonitor.MakeBoundAccount(),
 		rd.flowCtx.Cfg.BulkSenderLimiter,
 	)

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -265,7 +265,7 @@ func restore(
 	highWaterMark := job.Progress().Details.(*jobspb.Progress_Restore).Restore.HighWater
 
 	importSpans := makeSimpleImportSpans(dataToRestore.getSpans(), backupManifests, backupLocalityMap,
-		introducedSpanFrontier, highWaterMark, targetRestoreSpanSize)
+		introducedSpanFrontier, highWaterMark, targetRestoreSpanSize.Get(execCtx.ExecCfg().SV()))
 
 	if len(importSpans) == 0 {
 		// There are no files to restore.

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -265,7 +265,7 @@ func restore(
 	highWaterMark := job.Progress().Details.(*jobspb.Progress_Restore).Restore.HighWater
 
 	importSpans := makeSimpleImportSpans(dataToRestore.getSpans(), backupManifests, backupLocalityMap,
-		introducedSpanFrontier, highWaterMark)
+		introducedSpanFrontier, highWaterMark, targetRestoreSpanSize)
 
 	if len(importSpans) == 0 {
 		// There are no files to restore.

--- a/pkg/ccl/backupccl/restore_span_covering.go
+++ b/pkg/ccl/backupccl/restore_span_covering.go
@@ -30,6 +30,21 @@ func (ie intervalSpan) Range() interval.Range {
 	return interval.Range{Start: []byte(ie.Key), End: []byte(ie.EndKey)}
 }
 
+// targetRestoreSpanSize defines a minimum size for the sum of sizes of files in
+// the initial level (base backup or first inc covering some span) of a restore
+// span. As each restore span is explicitly split, scattered, processed, and
+// explicitly flushed, large numbers of tiny restore spans are costly, both in
+// terms of overhead associated with the splits, scatters and flushes and then
+// in subsequently merging the tiny ranges. Thus making sure this is at least in
+// the neighborhood of a typical range size minimizes that overhead. A restore
+// span may well grow beyond this size when later incremental layer files are
+// added to it, but that's fine: we will split as we fill if needed. 384mb is
+// big enough to avoid the worst of tiny-span overhead, while small enough to be
+// a granular unit of work distribution and progress tracking. If progress were
+// tracked within restore spans, this could become dynamic and much larger (e.g.
+// totalSize/numNodes*someConstant).
+const targetRestoreSpanSize = 384 << 20
+
 // makeSimpleImportSpans partitions the spans of requiredSpans into a covering
 // of RestoreSpanEntry's which each have all overlapping files from the passed
 // backups assigned to them. The spans of requiredSpans are trimmed/removed
@@ -54,12 +69,18 @@ func (ie intervalSpan) Range() interval.Range {
 //	[l, m): 9
 //
 // This example is tested in TestRestoreEntryCoverExample.
+//
+// If targetSize > 0, then spans which would be added to the right-hand side of
+// the first level are instead used to extend the current rightmost span in
+// if its current data size plus that of the new span is less than the target
+// size.
 func makeSimpleImportSpans(
 	requiredSpans []roachpb.Span,
 	backups []BackupManifest,
 	backupLocalityMap map[int]storeByLocalityKV,
 	introducedSpanFrontier *spanUtils.Frontier,
 	lowWaterMark roachpb.Key,
+	targetSize int64,
 ) []execinfrapb.RestoreSpanEntry {
 	if len(backups) < 1 {
 		return nil
@@ -106,6 +127,11 @@ func makeSimpleImportSpans(
 				continue
 			}
 			covPos := spanCoverStart
+
+			// lastCovSpanSize is the size of files added to the right-most span of
+			// the cover so far.
+			var lastCovSpanSize int64
+
 			// TODO(dt): binary search to the first file in required span?
 			for _, f := range backups[layer].Files {
 				if sp := span.Intersect(f.Span); sp.Valid() {
@@ -113,13 +139,49 @@ func makeSimpleImportSpans(
 					if dir, ok := backupLocalityMap[layer][f.LocalityKV]; ok {
 						fileSpec = execinfrapb.RestoreFileSpec{Path: f.Path, Dir: dir}
 					}
+
+					// Lookup the size of the file being added; if the backup didn't
+					// record a file size, just assume it is 16mb for estimating.
+					sz := f.EntryCounts.DataSize
+					if sz == 0 {
+						sz = 16 << 20
+					}
+
 					if len(cover) == spanCoverStart {
 						cover = append(cover, makeEntry(span.Key, sp.EndKey, fileSpec))
+						lastCovSpanSize = sz
 					} else {
-						// Add each file to every matching partition in the cover.
+						// If this file extends beyond the end of the last partition of the
+						// cover, either append a new partition for the uncovered span or
+						// grow the last one if size allows.
+						if covEnd := cover[len(cover)-1].Span.EndKey; sp.EndKey.Compare(covEnd) > 0 {
+							// If adding the item size to the current rightmost span size will
+							// exceed the target size, make a new span, otherwise extend the
+							// rightmost span to include the item.
+							if lastCovSpanSize+sz > targetSize {
+								cover = append(cover, makeEntry(covEnd, sp.EndKey, fileSpec))
+								lastCovSpanSize = sz
+							} else {
+								cover[len(cover)-1].Span.EndKey = sp.EndKey
+								cover[len(cover)-1].Files = append(cover[len(cover)-1].Files, fileSpec)
+								lastCovSpanSize += sz
+							}
+						}
+						// Now ensure the file is included in any partition in the existing
+						// cover which overlaps.
 						for i := covPos; i < len(cover) && cover[i].Span.Key.Compare(sp.EndKey) < 0; i++ {
+							// If file overlaps, it needs to be in this partition.
 							if cover[i].Span.Overlaps(sp) {
-								cover[i].Files = append(cover[i].Files, fileSpec)
+								// If this is the last partition, we might have added it above.
+								if i == len(cover)-1 {
+									if last := len(cover[i].Files) - 1; last < 0 || cover[i].Files[last] != fileSpec {
+										cover[i].Files = append(cover[i].Files, fileSpec)
+										lastCovSpanSize += sz
+									}
+								} else {
+									// If it isn't the last partition, we always need to add it.
+									cover[i].Files = append(cover[i].Files, fileSpec)
+								}
 							}
 							// If partition i of the cover ends before this file starts, we
 							// know it also ends before any remaining files start too, as the
@@ -128,11 +190,6 @@ func makeSimpleImportSpans(
 							if cover[i].Span.EndKey.Compare(sp.Key) <= 0 {
 								covPos = i + 1
 							}
-						}
-						// If this file extends beyond the end of the last partition of the
-						// cover, append a new partition for the uncovered span.
-						if covEnd := cover[len(cover)-1].Span.EndKey; sp.EndKey.Compare(covEnd) > 0 {
-							cover = append(cover, makeEntry(covEnd, sp.EndKey, fileSpec))
 						}
 					}
 				} else if span.EndKey.Compare(f.Span.Key) <= 0 {
@@ -174,6 +231,7 @@ func createIntroducedSpanFrontier(
 
 func makeEntry(start, end roachpb.Key, f execinfrapb.RestoreFileSpec) execinfrapb.RestoreSpanEntry {
 	return execinfrapb.RestoreSpanEntry{
-		Span: roachpb.Span{Key: start, EndKey: end}, Files: []execinfrapb.RestoreFileSpec{f},
+		Span:  roachpb.Span{Key: start, EndKey: end},
+		Files: []execinfrapb.RestoreFileSpec{f},
 	}
 }

--- a/pkg/ccl/backupccl/restore_span_covering.go
+++ b/pkg/ccl/backupccl/restore_span_covering.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/interval"
@@ -43,7 +44,12 @@ func (ie intervalSpan) Range() interval.Range {
 // a granular unit of work distribution and progress tracking. If progress were
 // tracked within restore spans, this could become dynamic and much larger (e.g.
 // totalSize/numNodes*someConstant).
-const targetRestoreSpanSize = 384 << 20
+var targetRestoreSpanSize = settings.RegisterByteSizeSetting(
+	settings.TenantWritable,
+	"backup.restore_span.target_size",
+	"target size to which base spans of a restore are merged to produce a restore span (0 disables)",
+	384<<20,
+)
 
 // makeSimpleImportSpans partitions the spans of requiredSpans into a covering
 // of RestoreSpanEntry's which each have all overlapping files from the passed

--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -618,6 +618,7 @@ func MakeBackupTableEntry(
 		nil, /*backupLocalityInfo*/
 		introducedSpanFrontier,
 		roachpb.Key{}, /*lowWaterMark*/
+		targetRestoreSpanSize,
 	)
 	lastSchemaChangeTime := findLastSchemaChangeTime(backupManifests, tbDesc, endTime)
 

--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -618,7 +618,7 @@ func MakeBackupTableEntry(
 		nil, /*backupLocalityInfo*/
 		introducedSpanFrontier,
 		roachpb.Key{}, /*lowWaterMark*/
-		targetRestoreSpanSize,
+		0,             /* disable merging */
 	)
 	lastSchemaChangeTime := findLastSchemaChangeTime(backupManifests, tbDesc, endTime)
 

--- a/pkg/ccl/backupccl/testdata/backup-restore/column-families
+++ b/pkg/ccl/backupccl/testdata/backup-restore/column-families
@@ -44,12 +44,3 @@ query-sql
 SELECT max(length(start_key)) FROM [SHOW RANGES FROM TABLE orig.cfs];
 ----
 2
-
-# Regression test for #67488.
-# This can return up to 6 if RESTORE improperly splits the ranges in the middle
-# of a SQL row since column family keys are longer. E.g. Keys are expected to be
-# of the form '/1' (row with PK 1), and not '/3/1/1' (row with PK 3, and CF 1).
-query-sql
-SELECT max(length(start_key)) FROM [SHOW RANGES FROM TABLE r1.cfs];
-----
-2

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -129,11 +129,13 @@ type SSTBatcher struct {
 
 	initialSplitDone bool
 
+	// disableScatters controls scatters of the as-we-fill split ranges.
+	disableScatters bool
+
 	// The rest of the fields accumulated state as opposed to configuration. Some,
 	// like totalRows, are accumulated _across_ batches and are not reset between
 	// batches when Reset() is called.
-	stats         ingestionPerformanceStats
-	disableSplits bool
+	stats ingestionPerformanceStats
 
 	// The rest of the fields are per-batch and are reset via Reset() before each
 	// batch is started.
@@ -175,7 +177,7 @@ func MakeSSTBatcher(
 	settings *cluster.Settings,
 	disallowShadowingBelow hlc.Timestamp,
 	writeAtBatchTs bool,
-	splitFilledRanges bool,
+	scatterSplitRanges bool,
 	mem mon.BoundAccount,
 	sendLimiter limit.ConcurrentRequestLimiter,
 ) (*SSTBatcher, error) {
@@ -185,7 +187,7 @@ func MakeSSTBatcher(
 		settings:               settings,
 		disallowShadowingBelow: disallowShadowingBelow,
 		writeAtBatchTS:         writeAtBatchTs,
-		disableSplits:          !splitFilledRanges,
+		disableScatters:        !scatterSplitRanges,
 		mem:                    mem,
 		limiter:                sendLimiter,
 	}
@@ -415,7 +417,7 @@ func (b *SSTBatcher) doFlush(ctx context.Context, reason int) error {
 	// than the size that range had when we last added to it, then we should split
 	// off the suffix of that range where this file starts and add it to that new
 	// range after scattering it.
-	if !b.disableSplits && b.lastRange.span.ContainsKey(start) && size >= b.lastRange.remaining {
+	if b.lastRange.span.ContainsKey(start) && size >= b.lastRange.remaining {
 		log.VEventf(ctx, 2, "%s batcher splitting full range before adding file starting at %s",
 			b.name, start)
 
@@ -458,22 +460,24 @@ func (b *SSTBatcher) doFlush(ctx context.Context, reason int) error {
 			} else {
 				b.stats.splits++
 
-				// Now scatter the RHS before we proceed to ingest into it. We know it
-				// should be empty since we split above if there was a nextExistingKey.
-				beforeScatter := timeutil.Now()
-				resp, err := b.db.AdminScatter(ctx, splitAt, maxScatterSize)
-				b.stats.scatterWait += timeutil.Since(beforeScatter)
-				if err != nil {
-					// err could be a max size violation, but this is unexpected since we
-					// split before, so a warning is probably ok.
-					log.Warningf(ctx, "%s failed to scatter	: %v", b.name, err)
-				} else {
-					b.stats.scatters++
-					if resp.MVCCStats != nil {
-						moved := sz(resp.MVCCStats.Total())
-						b.stats.scatterMoved += moved
-						if moved > 0 {
-							log.VEventf(ctx, 1, "%s split scattered %s in non-empty range %s", b.name, moved, resp.RangeInfos[0].Desc.KeySpan().AsRawSpanWithNoLocals())
+				if !b.disableScatters {
+					// Now scatter the RHS before we proceed to ingest into it. We know it
+					// should be empty since we split above if there was a nextExistingKey.
+					beforeScatter := timeutil.Now()
+					resp, err := b.db.AdminScatter(ctx, splitAt, maxScatterSize)
+					b.stats.scatterWait += timeutil.Since(beforeScatter)
+					if err != nil {
+						// err could be a max size violation, but this is unexpected since we
+						// split before, so a warning is probably ok.
+						log.Warningf(ctx, "%s failed to scatter	: %v", b.name, err)
+					} else {
+						b.stats.scatters++
+						if resp.MVCCStats != nil {
+							moved := sz(resp.MVCCStats.Total())
+							b.stats.scatterMoved += moved
+							if moved > 0 {
+								log.VEventf(ctx, 1, "%s split scattered %s in non-empty range %s", b.name, moved, resp.RangeInfos[0].Desc.KeySpan().AsRawSpanWithNoLocals())
+							}
 						}
 					}
 				}


### PR DESCRIPTION
Backport 2/2 commits from #86496.

/cc @cockroachdb/release

---

When constructing the spans to restore, we can produce fewer, wider spans
that each contain more files to avoid splitting as much.

Previously we split at the bounds of every file in the base backup, then
added incremental layer files to any span they overlapped. This changes
that slightly to keep appending files that would create a new span at the
right-hand-side of the span covering to instead extend current rightmost
entry in the covering if the total size of what has been added to it is
still below our target size per span (384mb).

Release justification: bug fix.

Release note (bug fix):  reduce the amount that RESTORE over-splits ranges. The
behavior is enabled by default.
