### PR TITLE
bootstrap: add & adopt KVWriter to populate system tables

### DIFF
--- a/pkg/config/BUILD.bazel
+++ b/pkg/config/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/keys",
         "//pkg/roachpb",
         "//pkg/sql/catalog/descpb",
+        "//pkg/util/encoding",
         "//pkg/util/log",
         "//pkg/util/stop",
         "//pkg/util/syncutil",

--- a/pkg/config/keys.go
+++ b/pkg/config/keys.go
@@ -14,17 +14,20 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 )
 
 // MakeZoneKeyPrefix returns the key prefix for id's row in the system.zones
 // table.
 func MakeZoneKeyPrefix(codec keys.SQLCodec, id descpb.ID) roachpb.Key {
-	return codec.ZoneKeyPrefix(uint32(id))
+	k := codec.IndexPrefix(keys.ZonesTableID, keys.ZonesTablePrimaryIndexID)
+	return encoding.EncodeUvarintAscending(k, uint64(id))
 }
 
 // MakeZoneKey returns the key for a given id's entry in the system.zones table.
 func MakeZoneKey(codec keys.SQLCodec, id descpb.ID) roachpb.Key {
-	return codec.ZoneKey(uint32(id))
+	k := MakeZoneKeyPrefix(codec, id)
+	return keys.MakeFamilyKey(k, keys.ZonesTableConfigColFamID)
 }
 
 // DecodeObjectID decodes the object ID for the system-tenant from

--- a/pkg/keys/sql.go
+++ b/pkg/keys/sql.go
@@ -173,18 +173,6 @@ func (e sqlEncoder) DescIDSequenceKey() roachpb.Key {
 	return e.SequenceKey(DescIDSequenceID)
 }
 
-// ZoneKeyPrefix returns the key prefix for id's row in the system.zones table.
-func (e sqlEncoder) ZoneKeyPrefix(id uint32) roachpb.Key {
-	k := e.IndexPrefix(ZonesTableID, ZonesTablePrimaryIndexID)
-	return encoding.EncodeUvarintAscending(k, uint64(id))
-}
-
-// ZoneKey returns the key for id's entry in the system.zones table.
-func (e sqlEncoder) ZoneKey(id uint32) roachpb.Key {
-	k := e.ZoneKeyPrefix(id)
-	return MakeFamilyKey(k, uint32(ZonesTableConfigColumnID))
-}
-
 // StartupMigrationKeyPrefix returns the key prefix to store all startup
 // migration details.
 func (e sqlEncoder) StartupMigrationKeyPrefix() roachpb.Key {

--- a/pkg/sql/catalog/bootstrap/BUILD.bazel
+++ b/pkg/sql/catalog/bootstrap/BUILD.bazel
@@ -3,12 +3,16 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "bootstrap",
-    srcs = ["metadata.go"],
+    srcs = [
+        "kv_writer.go",
+        "metadata.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/config/zonepb",
         "//pkg/keys",
+        "//pkg/kv",
         "//pkg/roachpb",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catalogkeys",
@@ -17,7 +21,9 @@ go_library(
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/rowenc",
         "//pkg/sql/sem/catconstants",
+        "//pkg/sql/sem/catid",
         "//pkg/sql/sem/tree",
+        "//pkg/util",
         "//pkg/util/iterutil",
         "//pkg/util/log",
         "//pkg/util/protoutil",

--- a/pkg/sql/catalog/bootstrap/kv_writer.go
+++ b/pkg/sql/catalog/bootstrap/kv_writer.go
@@ -1,0 +1,128 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package bootstrap
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/errors"
+)
+
+// KVWriter is used to transform SQL table records into KV pairs.
+// This is useful for bypassing the internal executor and writing to tables
+// directly.
+//
+// Care should be exercised to only use this in contexts which are known to be
+// safe. Populating system tables while bootstrapping a cluster is one of these.
+type KVWriter struct {
+	codec            keys.SQLCodec
+	tableDesc        catalog.TableDescriptor
+	colIDtoRowIndex  catalog.TableColMap
+	skippedFamilyIDs util.FastIntSet
+}
+
+// RecordToKeyValues transforms a table record into the corresponding key-value
+// pairs.
+func (w KVWriter) RecordToKeyValues(values ...tree.Datum) (ret []roachpb.KeyValue, _ error) {
+	if expected, actual := w.colIDtoRowIndex.Len(), len(values); expected != actual {
+		return nil, errors.AssertionFailedf(
+			"expected %d datum(s), instead got %d", expected, actual,
+		)
+	}
+
+	// Encode the primary index row.
+	{
+		idx := w.tableDesc.GetPrimaryIndex()
+		indexEntries, err := rowenc.EncodePrimaryIndex(
+			w.codec, w.tableDesc, idx, w.colIDtoRowIndex, values, true, /* includeEmpty */
+		)
+		if err != nil {
+			return nil, errors.NewAssertionErrorWithWrappedErrf(
+				err, "encoding for primary index %q (%d)", idx.GetName(), idx.GetID(),
+			)
+		}
+		for _, e := range indexEntries {
+			if w.skippedFamilyIDs.Contains(int(e.Family)) {
+				continue
+			}
+			ret = append(ret, roachpb.KeyValue{Key: e.Key, Value: e.Value})
+		}
+	}
+
+	// Encode the secondary index rows.
+	for _, idx := range w.tableDesc.PublicNonPrimaryIndexes() {
+		indexEntries, err := rowenc.EncodeSecondaryIndex(
+			w.codec, w.tableDesc, idx, w.colIDtoRowIndex, values, true, /* includeEmpty */
+		)
+		if err != nil {
+			return nil, errors.NewAssertionErrorWithWrappedErrf(
+				err, "encoding for secondary index %q (%d)", idx.GetName(), idx.GetID(),
+			)
+		}
+		for _, e := range indexEntries {
+			if w.skippedFamilyIDs.Contains(int(e.Family)) {
+				continue
+			}
+			ret = append(ret, roachpb.KeyValue{Key: e.Key, Value: e.Value})
+		}
+	}
+
+	return ret, nil
+}
+
+// Insert updates a batch with the KV operations required to insert a new record
+// into the table.
+func (w KVWriter) Insert(b *kv.Batch, values ...tree.Datum) error {
+	kvs, err := w.RecordToKeyValues(values...)
+	if err != nil {
+		return err
+	}
+	for _, kv := range kvs {
+		b.CPutAllowingIfNotExists(kv.Key, &kv.Value, nil /* expValue */)
+	}
+	return nil
+}
+
+// Delete updates a batch with the KV operations required to delete an existing
+// record from the table.
+func (w KVWriter) Delete(b *kv.Batch, values ...tree.Datum) error {
+	kvs, err := w.RecordToKeyValues(values...)
+	if err != nil {
+		return err
+	}
+	for _, kv := range kvs {
+		b.Del(kv.Key)
+	}
+	return nil
+}
+
+// MakeKVWriter constructs a KVWriter instance.
+func MakeKVWriter(
+	codec keys.SQLCodec, tableDesc catalog.TableDescriptor, skippedColumnFamilyIDs ...catid.FamilyID,
+) KVWriter {
+	w := KVWriter{
+		codec:     codec,
+		tableDesc: tableDesc,
+	}
+	for i, c := range tableDesc.PublicColumns() {
+		w.colIDtoRowIndex.Set(c.GetID(), i)
+	}
+	for _, id := range skippedColumnFamilyIDs {
+		w.skippedFamilyIDs.Add(int(id))
+	}
+	return w
+}


### PR DESCRIPTION
This commit introduces a KVWriter object which helps generate roachpb.KeyValue for any given table, given a record formed of tree.Datums.

This is used during SQL bootstrapping to populate the zones and tenants system tables.

Release note: None

Epic: CRDB-18596