### PR TITLE
storage: compute isTombstone without decoding MVCCValue

### DIFF
--- a/pkg/ccl/streamingccl/utils.go
+++ b/pkg/ccl/streamingccl/utils.go
@@ -85,11 +85,11 @@ func ScanSST(
 			break
 		}
 		for _, rangeKeyVersion := range rangeIter.RangeKeys().Versions {
-			mvccVal, err := storage.DecodeMVCCValue(rangeKeyVersion.Value)
+			isTombstone, err := storage.EncodedMVCCValueIsTombstone(rangeKeyVersion.Value)
 			if err != nil {
 				return err
 			}
-			if !mvccVal.IsTombstone() {
+			if !isTombstone {
 				return errors.Errorf("only expect range tombstone from MVCC range key: %s", rangeIter.RangeBounds())
 			}
 			intersectedSpan := scanWithin.Intersect(rangeIter.RangeBounds())

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -1163,11 +1163,8 @@ func mvccGetMetadata(
 	}
 
 	// We're now on a point key. Decode its value.
-	var unsafeVal MVCCValue
 	unsafeValRaw := iter.UnsafeValue()
-	if unsafeVal, ok, err = tryDecodeSimpleMVCCValue(unsafeValRaw); !ok && err == nil {
-		unsafeVal, err = decodeExtendedMVCCValue(unsafeValRaw)
-	}
+	isTombstone, err := EncodedMVCCValueIsTombstone(unsafeValRaw)
 	if err != nil {
 		return false, 0, 0, hlc.Timestamp{}, err
 	}
@@ -1183,7 +1180,7 @@ func mvccGetMetadata(
 			meta.Deleted = true
 			meta.Timestamp = rangeKeys.Versions[0].Timestamp.ToLegacyTimestamp()
 			keyLastSeen := v.Timestamp
-			if unsafeVal.IsTombstone() {
+			if isTombstone {
 				keyLastSeen = unsafeKey.Timestamp
 			}
 			return true, int64(EncodedMVCCKeyPrefixLength(metaKey.Key)), 0, keyLastSeen, nil
@@ -1192,7 +1189,7 @@ func mvccGetMetadata(
 
 	// Synthesize metadata for a regular point key.
 	meta.ValBytes = int64(len(unsafeValRaw))
-	meta.Deleted = unsafeVal.IsTombstone()
+	meta.Deleted = isTombstone
 	meta.Timestamp = unsafeKey.Timestamp.ToLegacyTimestamp()
 
 	return true, int64(EncodedMVCCKeyPrefixLength(metaKey.Key)), 0, unsafeKey.Timestamp, nil
@@ -2998,11 +2995,11 @@ func MVCCPredicateDeleteRange(
 			return false, false, false, roachpb.NewWriteTooOldError(endTime, k.Timestamp.Next(),
 				k.Key.Clone())
 		}
-		v, err := DecodeMVCCValue(vRaw)
+		isTombstone, err := EncodedMVCCValueIsTombstone(vRaw)
 		if err != nil {
 			return false, false, false, err
 		}
-		if v.IsTombstone() {
+		if isTombstone {
 			// The latest version of the key is a point tombstone.
 			return true, true, false, nil
 		}

--- a/pkg/storage/pebble_iterator.go
+++ b/pkg/storage/pebble_iterator.go
@@ -557,16 +557,11 @@ func (p *pebbleIterator) UnsafeValue() []byte {
 // MVCCValueLenAndIsTombstone implements the MVCCIterator interface.
 func (p *pebbleIterator) MVCCValueLenAndIsTombstone() (int, bool, error) {
 	val := p.iter.Value()
-	// NB: don't move the following code into a helper since we desire inlining
-	// of tryDecodeSimpleMVCCValue.
-	v, ok, err := tryDecodeSimpleMVCCValue(val)
-	if err == nil && !ok {
-		v, err = decodeExtendedMVCCValue(val)
-	}
+	isTombstone, err := EncodedMVCCValueIsTombstone(val)
 	if err != nil {
 		return 0, false, err
 	}
-	return len(val), v.IsTombstone(), nil
+	return len(val), isTombstone, nil
 }
 
 // ValueLen implements the MVCCIterator interface.

--- a/pkg/storage/sst_iterator.go
+++ b/pkg/storage/sst_iterator.go
@@ -203,16 +203,11 @@ func (r *legacySSTIterator) UnsafeValue() []byte {
 
 // MVCCValueLenAndIsTombstone implements the SimpleMVCCIterator interface.
 func (r *legacySSTIterator) MVCCValueLenAndIsTombstone() (int, bool, error) {
-	// NB: don't move the following code into a helper since we desire inlining
-	// of tryDecodeSimpleMVCCValue.
-	v, ok, err := tryDecodeSimpleMVCCValue(r.value)
-	if err == nil && !ok {
-		v, err = decodeExtendedMVCCValue(r.value)
-	}
+	isTombstone, err := EncodedMVCCValueIsTombstone(r.value)
 	if err != nil {
 		return 0, false, err
 	}
-	return len(r.value), v.IsTombstone(), nil
+	return len(r.value), isTombstone, nil
 
 }
 

--- a/pkg/storage/verifying_iterator.go
+++ b/pkg/storage/verifying_iterator.go
@@ -108,16 +108,11 @@ func (i *verifyingMVCCIterator) UnsafeValue() []byte {
 
 // MVCCValueLenAndIsTombstone implements MVCCIterator.
 func (i *verifyingMVCCIterator) MVCCValueLenAndIsTombstone() (int, bool, error) {
-	// NB: don't move the following code into a helper since we desire inlining
-	// of tryDecodeSimpleMVCCValue.
-	v, ok, err := tryDecodeSimpleMVCCValue(i.value)
-	if err == nil && !ok {
-		v, err = decodeExtendedMVCCValue(i.value)
-	}
+	isTombstone, err := EncodedMVCCValueIsTombstone(i.value)
 	if err != nil {
 		return 0, false, err
 	}
-	return len(i.value), v.IsTombstone(), nil
+	return len(i.value), isTombstone, nil
 }
 
 // ValueLen implements MVCCIterator.


### PR DESCRIPTION
This is a performance optimization that is helpful for some existing cases within CockroachDB, like checking conflicts in ssts, and for callers of SimpleMVCCIterator.MVCCValueLenAndIsTombstone.

It will also be helpful for extraction of the isTombstone attribute in Pebble flushes and compactions, when using value blocks. The compaction code is very performance sensitive.

Some benchmark results are listed below. The DecodeMVCCValue benchmark is unaffected by this change. The results are presented to compare with the new MVCCValueIsTombstone benchmark which uses the same data. There is no inline vs non-inline code path for the latter. There is little improvement compared to decoding, when the decoding uses the inlined fast path (when there is no header). Decoding cost varies from ~1ns to ~30ns, with higher costs when not using the inlineable function, and when there is a header. The optimized isTombstone path is no slower than ~1.5ns.

```
BenchmarkDecodeMVCCValue/header=empty/value=tombstone/inline=false-10         	236381180	         5.044 ns/op	       0 B/op	       0 allocs/op
BenchmarkDecodeMVCCValue/header=empty/value=tombstone/inline=true-10          	1000000000	         0.9404 ns/op	       0 B/op	       0 allocs/op
BenchmarkDecodeMVCCValue/header=empty/value=short/inline=false-10             	212722237	         5.641 ns/op	       0 B/op	       0 allocs/op
BenchmarkDecodeMVCCValue/header=empty/value=short/inline=true-10              	768034614	         1.570 ns/op	       0 B/op	       0 allocs/op
BenchmarkDecodeMVCCValue/header=empty/value=long/inline=false-10              	212707123	         5.635 ns/op	       0 B/op	       0 allocs/op
BenchmarkDecodeMVCCValue/header=empty/value=long/inline=true-10               	768388904	         1.568 ns/op	       0 B/op	       0 allocs/op
BenchmarkDecodeMVCCValue/header=local_walltime/value=tombstone/inline=false-10         	44552938	        26.71 ns/op	       0 B/op	       0 allocs/op
BenchmarkDecodeMVCCValue/header=local_walltime/value=tombstone/inline=true-10          	61364986	        19.59 ns/op	       0 B/op	       0 allocs/op
BenchmarkDecodeMVCCValue/header=local_walltime/value=short/inline=false-10             	44963044	        26.74 ns/op	       0 B/op	       0 allocs/op
BenchmarkDecodeMVCCValue/header=local_walltime/value=short/inline=true-10              	61343288	        19.74 ns/op	       0 B/op	       0 allocs/op
BenchmarkDecodeMVCCValue/header=local_walltime/value=long/inline=false-10              	44975966	        26.75 ns/op	       0 B/op	       0 allocs/op
BenchmarkDecodeMVCCValue/header=local_walltime/value=long/inline=true-10               	61225269	        19.66 ns/op	       0 B/op	       0 allocs/op
BenchmarkDecodeMVCCValue/header=local_walltime+logical/value=tombstone/inline=false-10 	39609243	        30.64 ns/op	       0 B/op	       0 allocs/op
BenchmarkDecodeMVCCValue/header=local_walltime+logical/value=tombstone/inline=true-10  	51561248	        23.34 ns/op	       0 B/op	       0 allocs/op
BenchmarkDecodeMVCCValue/header=local_walltime+logical/value=short/inline=false-10     	39579685	        30.67 ns/op	       0 B/op	       0 allocs/op
BenchmarkDecodeMVCCValue/header=local_walltime+logical/value=short/inline=true-10      	51522969	        23.30 ns/op	       0 B/op	       0 allocs/op
BenchmarkDecodeMVCCValue/header=local_walltime+logical/value=long/inline=false-10      	39044175	        30.70 ns/op	       0 B/op	       0 allocs/op
BenchmarkDecodeMVCCValue/header=local_walltime+logical/value=long/inline=true-10       	51544268	        23.28 ns/op	       0 B/op	       0 allocs/op

BenchmarkMVCCValueIsTombstone/header=empty/value=tombstone-10         	1000000000	         0.6210 ns/op	       0 B/op	       0 allocs/op
BenchmarkMVCCValueIsTombstone/header=empty/value=short-10             	962616391	         1.241 ns/op	       0 B/op	       0 allocs/op
BenchmarkMVCCValueIsTombstone/header=empty/value=long-10              	959706651	         1.243 ns/op	       0 B/op	       0 allocs/op
BenchmarkMVCCValueIsTombstone/header=local_walltime/value=tombstone-10         	770212256	         1.552 ns/op	       0 B/op	       0 allocs/op
BenchmarkMVCCValueIsTombstone/header=local_walltime/value=short-10             	770167766	         1.551 ns/op	       0 B/op	       0 allocs/op
BenchmarkMVCCValueIsTombstone/header=local_walltime/value=long-10              	771195007	         1.553 ns/op	       0 B/op	       0 allocs/op
BenchmarkMVCCValueIsTombstone/header=local_walltime+logical/value=tombstone-10 	769835488	         1.554 ns/op	       0 B/op	       0 allocs/op
BenchmarkMVCCValueIsTombstone/header=local_walltime+logical/value=short-10     	769558615	         1.551 ns/op	       0 B/op	       0 allocs/op
BenchmarkMVCCValueIsTombstone/header=local_walltime+logical/value=long-10      	770600931	         1.551 ns/op	       0 B/op	       0 allocs/op
```

Informs https://github.com/cockroachdb/pebble/issues/1170

Epic: CRDB-20378

Release note: None