### PR TITLE
kvserver: misc cleanup of allocation code

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
@@ -1841,10 +1841,9 @@ func (a *Allocator) TransferLeaseTarget(
 			candidates,
 			storeDescMap,
 			&QPSScorerOptions{
-				StoreHealthOptions:                a.StoreHealthOptions(ctx),
-				DeprecatedRangeRebalanceThreshold: RangeRebalanceThreshold.Get(&a.StorePool.St.SV),
-				QPSRebalanceThreshold:             allocator.QPSRebalanceThreshold.Get(&a.StorePool.St.SV),
-				MinRequiredQPSDiff:                allocator.MinQPSDifferenceForTransfers.Get(&a.StorePool.St.SV),
+				StoreHealthOptions:    a.StoreHealthOptions(ctx),
+				QPSRebalanceThreshold: allocator.QPSRebalanceThreshold.Get(&a.StorePool.St.SV),
+				MinRequiredQPSDiff:    allocator.MinQPSDifferenceForTransfers.Get(&a.StorePool.St.SV),
 			},
 		)
 

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -218,9 +218,6 @@ func NewRebalanceContext(
 // individual ranges. This means that there are two different workers that
 // could potentially be making decisions about a given range, so they have to
 // be careful to avoid stepping on each others' toes.
-//
-// TODO(a-robinson): Expose metrics to make this understandable without having
-// to dive into logspy.
 func (sr *StoreRebalancer) Start(ctx context.Context, stopper *stop.Stopper) {
 	ctx = sr.AnnotateCtx(ctx)
 

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -704,6 +704,7 @@ var charts = []sectionDescription{
 			{
 				Title: "Allocator Load-Based Lease Transfer Decisions",
 				Metrics: []string{
+					"kv.allocator.load_based_lease_transfers.follow_the_workload",
 					"kv.allocator.load_based_lease_transfers.should_transfer",
 					"kv.allocator.load_based_lease_transfers.missing_stats_for_existing_stores",
 					"kv.allocator.load_based_lease_transfers.delta_not_significant",


### PR DESCRIPTION
This patch removes the deprecated method `rangeRebalanceThreshold` which
was used for mixed version compatibility between 21.2 and 22.1.

This patch adds a metric
`kv.allocator.load_based_lease_transfers.follow_the_workload` which
tracks the number of times the allocator returned a range lease transfer
target based based on access locality.

Previously there was no insight into how often this condition was hit.

Part of #91152