### PR TITLE
workload/schemachange: fixes to improve stability of the test

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -246,7 +246,7 @@ func init() {
 var opWeights = []int{
 	addColumn:               1,
 	addConstraint:           0, // TODO(spaskob): unimplemented
-	addForeignKeyConstraint: 1,
+	addForeignKeyConstraint: 0, // Disabled and tracked with #91195
 	addRegion:               1,
 	addUniqueConstraint:     0,
 	alterTableLocality:      1,
@@ -2992,41 +2992,25 @@ func (og *operationGenerator) randParentColumnForFkRelation(
 	var typName string
 	var nullable string
 
-	for {
-		nestedTxn, err := tx.Begin(ctx)
-		if err != nil {
-			return nil, nil, err
-		}
-		err = nestedTxn.QueryRow(ctx, fmt.Sprintf(`
+	nestedTxn, err := tx.Begin(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	err = nestedTxn.QueryRow(ctx, fmt.Sprintf(`
 	SELECT table_schema, table_name, column_name, crdb_sql_type, is_nullable FROM (
 		%s
 	)`, subQuery.String())).Scan(&tableSchema, &tableName, &columnName, &typName, &nullable)
-		if err == nil {
-			err := nestedTxn.Commit(ctx)
-			if err != nil {
-				return nil, nil, err
-			}
-			break
-		}
-		pgErr := (*pgconn.PgError)(nil)
-		if !errors.As(err, &pgErr) {
+	if err == nil {
+		err := nestedTxn.Commit(ctx)
+		if err != nil {
 			return nil, nil, err
 		}
-		// Intermittent undefined table errors are valid for the query above, since
-		// we are not leasing out the tables, when picking our random table.
-		if code := pgcode.MakeCode(pgErr.Code); code == pgcode.UndefinedTable ||
-			code == pgcode.UndefinedSchema {
-			err := nestedTxn.Rollback(ctx)
-			if err != nil {
-				return nil, nil, err
-			}
-			continue
-		}
-		if rbErr := nestedTxn.Rollback(ctx); rbErr != nil {
-			err = errors.CombineErrors(err, rbErr)
-		}
-		return nil, nil, err
+		break
 	}
+	if rbErr := nestedTxn.Rollback(ctx); rbErr != nil {
+		err = errors.CombineErrors(err, rbErr)
+	}
+	return nil, nil, err
 
 	columnToReturn := column{
 		name:     columnName,
@@ -3566,6 +3550,10 @@ func (og *operationGenerator) selectStmt(ctx context.Context, tx pgx.Tx) (stmt *
 	// TODO(fqazi): Temporarily allow out of memory errors on select queries. Not
 	// sure where we are hitting these, need to investigate further.
 	stmt.potentialExecErrors.add(pgcode.OutOfMemory)
+	// Disk errors can happen since there are limits on spill, and cross
+	// joins which are deep cannot do much of the FETCH FIRST X ROWS ONLY
+	// limit
+	stmt.potentialExecErrors.add(pgcode.DiskFull)
 	return stmt, nil
 }
 

--- a/pkg/workload/schemachange/watch_dog.go
+++ b/pkg/workload/schemachange/watch_dog.go
@@ -12,6 +12,7 @@ package schemachange
 
 import (
 	"context"
+	gosql "database/sql"
 	"fmt"
 	"time"
 
@@ -31,9 +32,9 @@ type schemaChangeWatchDog struct {
 	// cmdChannel used to communicate from thread executing commands on the session.
 	cmdChannel chan chan struct{}
 	// activeQuery last active query observed on the monitored connection.
-	activeQuery string
+	activeQuery gosql.NullString
 	// txnID last active transaction ID observed on the target connection.
-	txnID string
+	txnID gosql.NullString
 	// numRetries number of transaction retries observed.
 	numRetries int
 }
@@ -136,8 +137,8 @@ func (w *schemaChangeWatchDog) Start(ctx context.Context, tx pgx.Tx) error {
 // reset prepares the watch dog for re-use.
 func (w *schemaChangeWatchDog) reset() {
 	w.sessionID = ""
-	w.activeQuery = ""
-	w.txnID = ""
+	w.activeQuery = gosql.NullString{}
+	w.txnID = gosql.NullString{}
 }
 
 // Stop stops monitoring the connection and waits for the watch dog thread to


### PR DESCRIPTION
These changes do the following:

Fixes: #91131
Informs: #90695

1. Eliminate log spam inside the schema changer workload due to the watchdog thread incorrectly dealing with null values
2. Expecting disk full errors due to large selects, since spilling does have a limit out of the box inside cockroach
3. Reducing a hang inside the workload due to a no longer necessary retry loop.