### PR TITLE
jobs: add pprof labels with job type and id

### DIFF
--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime/pprof"
 	"sort"
 	"strings"
 	"sync/atomic"
@@ -251,6 +252,12 @@ func (rts *registryTestSuite) setUp(t *testing.T) {
 			TraceRealSpan: rts.traceRealSpan,
 			OnResume: func(ctx context.Context) error {
 				t.Log("Starting resume")
+				l, ok := pprof.Label(ctx, "job")
+				assert.True(t, ok)
+				assert.Contains(t, l, fmt.Sprintf("%d", job.ID()))
+				payload := job.Payload()
+				jobType := payload.Type().String()
+				assert.Contains(t, l, jobType)
 				if rts.traceRealSpan {
 					// Add a dummy recording so we actually see something in the trace.
 					span := tracing.SpanFromContext(ctx)

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -12,7 +12,9 @@ package jobs
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"runtime/pprof"
 	"strconv"
 	"strings"
 	"time"
@@ -1237,6 +1239,7 @@ func (r *Registry) stepThroughStateMachine(
 				"job %d: resuming with non-nil error", job.ID())
 		}
 		resumeCtx := logtags.AddTag(ctx, "job", job.ID())
+		labels := pprof.Labels("job", fmt.Sprintf("%s id=%d", jobType, job.ID()))
 
 		if err := job.started(ctx, nil /* txn */); err != nil {
 			return err
@@ -1250,7 +1253,9 @@ func (r *Registry) stepThroughStateMachine(
 				jm.CurrentlyRunning.Dec(1)
 				r.metrics.RunningNonIdleJobs.Dec(1)
 			}()
-			err = resumer.Resume(resumeCtx, execCtx)
+			pprof.Do(resumeCtx, labels, func(ctx context.Context) {
+				err = resumer.Resume(ctx, execCtx)
+			})
 		}()
 
 		r.MarkIdle(job, false)


### PR DESCRIPTION
Currently the job id is added as a log tag, and this PR adds the job type and job id as a pprof label.

For example:

```
(pprof) tags

 ...

 job: Total 120.0ms
      70.0ms (58.33%): BACKUP id=810503562236035073
      40.0ms (33.33%): BACKUP id=810503570072272897
      10.0ms ( 8.33%): AUTO SPAN CONFIG RECONCILIATION id=810469809772462081
```

Epic: None
Release note: None