### PR TITLE
storage: optimize EngineComparer.Split

### DIFF
--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -67,6 +67,10 @@ func TestEngineComparer(t *testing.T) {
 	}
 	require.Equal(t, -1, EngineComparer.Compare(suffix(EncodeMVCCKey(keyA2)), suffix(EncodeMVCCKey(keyA1))),
 		"expected bare suffix with higher timestamp to sort first")
+	for _, k := range []MVCCKey{keyAMetadata, keyA2, keyA1, keyB2} {
+		b := EncodeMVCCKey(k)
+		require.Equal(t, 2, EngineComparer.Split(b))
+	}
 }
 
 func TestPebbleIterReuse(t *testing.T) {
@@ -405,6 +409,14 @@ func BenchmarkMVCCKeyEqual(b *testing.B) {
 	b.ResetTimer()
 	for i, j := 0, 0; i < b.N; i, j = i+1, j+3 {
 		_ = EngineKeyEqual(keys[i%len(keys)], keys[j%len(keys)])
+	}
+}
+
+func BenchmarkMVCCKeySplit(b *testing.B) {
+	keys := makeRandEncodedKeys()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = EngineComparer.Split(keys[i%len(keys)])
 	}
 }
 


### PR DESCRIPTION
This is a micro-optimization motivated by the fact that the use of the split function continues to grow in Pebble, since it is becoming more MVCC aware. This growth will continue with the value blocks implementation, which will call split on both the read path in the sstable iterator and on the write path.

We do not need to copy around slice headers to compute split. This change is driven more by distaste for what we were doing previously than any end-to-end benchmarking results.

```
name             old time/op    new time/op    delta
MVCCKeySplit-10    2.48ns ± 4%    1.65ns ± 1%  -33.28%  (p=0.000 n=10+10)
```

Informs https://github.com/cockroachdb/pebble/issues/1170

Epic: CRDB-20378

Release note: None