### PR TITLE
roach{prod,test}: harden grafana installation

### DIFF
--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -209,7 +209,8 @@ func runTPCC(ctx context.Context, t test.Test, c cluster.Cluster, opts tpccOptio
 		workloadInstances = append(
 			workloadInstances,
 			workloadInstance{
-				nodes: c.Range(1, c.Spec().NodeCount-1),
+				nodes:          c.Range(1, c.Spec().NodeCount-1),
+				prometheusPort: 2112,
 			},
 		)
 	}

--- a/pkg/roachprod/prometheus/prometheus.go
+++ b/pkg/roachprod/prometheus/prometheus.go
@@ -288,11 +288,13 @@ sudo systemd-run --unit prometheus --same-dir \
 		if err := c.RepeatRun(ctx, l,
 			l.Stdout,
 			l.Stderr, cfg.PrometheusNode, "install grafana",
-			`sudo apt-get install -qqy apt-transport-https &&
+			`
+sudo apt-get install -qqy apt-transport-https &&
 sudo apt-get install -qqy software-properties-common wget &&
-wget -q -O - https://packages.grafana.com/gpg.key | sudo apt-key add - &&
-echo "deb https://packages.grafana.com/enterprise/deb stable main" | sudo tee -a /etc/apt/sources.list.d/grafana.list &&
-sudo apt-get update -qqy && sudo apt-get install -qqy grafana-enterprise && sudo mkdir -p /var/lib/grafana/dashboards`,
+sudo apt-get install -y adduser libfontconfig1 &&
+wget https://dl.grafana.com/enterprise/release/grafana-enterprise_9.2.3_amd64.deb -O grafana-enterprise_9.2.3_amd64.deb &&
+sudo dpkg -i grafana-enterprise_9.2.3_amd64.deb &&
+sudo mkdir -p /var/lib/grafana/dashboards`,
 		); err != nil {
 			return nil, err
 		}
@@ -301,7 +303,7 @@ sudo apt-get update -qqy && sudo apt-get install -qqy grafana-enterprise && sudo
 		if err := c.RepeatRun(ctx, l,
 			l.Stdout,
 			l.Stderr, cfg.PrometheusNode, "permissions",
-			`sudo chmod 777 /etc/grafana/provisioning/datasources /etc/grafana/provisioning/dashboards /var/lib/grafana/dashboards /etc/grafana/grafana.ini`,
+			`sudo chmod -R 777 /etc/grafana/provisioning/datasources /etc/grafana/provisioning/dashboards /var/lib/grafana/dashboards /etc/grafana/grafana.ini`,
 		); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Installing grafana through the APT repository upstream got busted (didn't look into why/how/when):

```
  $ roachprod grafana-start irfansharif-1667423209-01-n4cpu8
  [...]
  deb https://packages.grafana.com/enterprise/deb stable main
  E: The repository 'https://packages.grafana.com/enterprise/deb stable Release' does not have a Release file.
  [...]
  21:21:18 cluster_synced.go:799: error - retrying: COMMAND_PROBLEM: exit status 100
```

But installing the .deb package by wget-ting it works so just do that instead. Also fix prometheus scraping of the TPC-C workload generator in TPC-C harness.

Release note: None