### PR TITLE
dev: add -flex-types argument for sqlite logic tests by default

### DIFF
--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=59
+DEV_VERSION=60
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions


### PR DESCRIPTION
This commit adds a shortcut for specifying `-flex-types` test argument of the logic tests that is needed to run sqlite targets. It also defaults to passing this argument if only sqlite targets are specified. We do use this flag in the CI, so it reduces a possibility of confusion.

Found when working on #58089.

Epic: None

Release note: None