### PR TITLE
spanconfigsqltranslator: translate spanconfigs for offline dbs

### DIFF
--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/BUILD.bazel
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
         "//pkg/spanconfig/spanconfigtestutils",
         "//pkg/spanconfig/spanconfigtestutils/spanconfigtestcluster",
         "//pkg/sql",
+        "//pkg/sql/catalog/dbdesc",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",
         "//pkg/sql/catalog/tabledesc",

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/datadriven_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/datadriven_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigtestutils"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigtestutils/spanconfigtestcluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
@@ -245,6 +246,20 @@ func TestDataDriven(t *testing.T) {
 				d.ScanArgs(t, "database", &dbName)
 				d.ScanArgs(t, "table", &tbName)
 				tenant.WithMutableTableDescriptor(ctx, dbName, tbName, func(mutable *tabledesc.Mutable) {
+					mutable.SetPublic()
+				})
+
+			case "mark-database-offline":
+				var dbName string
+				d.ScanArgs(t, "database", &dbName)
+				tenant.WithMutableDatabaseDescriptor(ctx, dbName, func(mutable *dbdesc.Mutable) {
+					mutable.SetOffline("for testing")
+				})
+
+			case "mark-database-public":
+				var dbName string
+				d.ScanArgs(t, "database", &dbName)
+				tenant.WithMutableDatabaseDescriptor(ctx, dbName, func(mutable *dbdesc.Mutable) {
 					mutable.SetPublic()
 				})
 

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/misc
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/misc
@@ -38,21 +38,56 @@ translate database=db
 translate id=106
 ----
 
-# Mark table t2 as offline, we should still be able to generate a span
-# configuration for it.
-mark-table-offline database=db table=t2
+subtest offline-descriptors
+
+exec-sql
+ALTER DATABASE db CONFIGURE ZONE USING gc.ttlseconds=10;
 ----
 
-# Should work for both when we start from the table and when we start from the
-# table.
-translate database=db table=t2
+# Mark the database as offline, we should still be able to generate a span
+# configuration for it.
+mark-database-offline database=db
 ----
-/Table/10{7-8}                             range default
+
+translate database=db
+----
+/Table/10{7-8}                             ttl_seconds=10
+
+# Delete the bespoke zone config on db. t2 should fallback to the RANGE DEFAULT
+# zone config even though all descriptors are offline.
+exec-sql
+DELETE FROM system.zones WHERE id = 104;
+----
 
 translate database=db
 ----
 /Table/10{7-8}                             range default
 
+translate database=db table=t2
+----
+/Table/10{7-8}                             range default
+
+mark-database-public database=db
+----
+
+exec-sql
+ALTER DATABASE db CONFIGURE ZONE USING gc.ttlseconds=11;
+----
+
+# Mark table db.t2 as offline, we should still be able to generate a span
+# configuration for it.
+mark-table-offline database=db table=t2
+----
+
+# Should work for both when we start from the table and when we start from the
+# database.
+translate database=db table=t2
+----
+/Table/10{7-8}                             ttl_seconds=11
+
+translate database=db
+----
+/Table/10{7-8}                             ttl_seconds=11
 
 # Mark the table as public again.
 mark-table-public database=db table=t2
@@ -60,7 +95,9 @@ mark-table-public database=db table=t2
 
 translate database=db table=t2
 ----
-/Table/10{7-8}                             range default
+/Table/10{7-8}                             ttl_seconds=11
+
+subtest end
 
 # Test schemas/types don't generate a span configuration.
 exec-sql

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/protectedts
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/protectedts
@@ -19,6 +19,33 @@ ALTER DATABASE db CONFIGURE ZONE USING num_replicas=7;
 ALTER TABLE db.t1 CONFIGURE ZONE USING num_voters=5;
 ----
 
+# Mark the database as offline.
+mark-database-offline database=db
+----
+
+# Write a protected timestamp on the offline db.
+protect record-id=9 ts=9
+descs 104
+----
+
+# We should still see the protectedts translate onto the tables in the offline db.
+translate database=db
+----
+/Table/10{6-7}                             num_replicas=7 num_voters=5 protection_policies=[{ts: 9}]
+/Table/10{7-8}                             num_replicas=7 protection_policies=[{ts: 9}]
+
+release record-id=9
+----
+
+mark-database-public database=db
+----
+
+translate database=db
+----
+/Table/10{6-7}                             num_replicas=7 num_voters=5
+/Table/10{7-8}                             num_replicas=7
+
+
 # Write a protected timestamp on t1.
 protect record-id=1 ts=1
 descs 106

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/misc
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/misc
@@ -27,21 +27,56 @@ translate database=db
 translate id=56
 ----
 
-# Mark table t2 as offline, we should still be able to generate a span
-# configuration for it.
-mark-table-offline database=db table=t2
+subtest offline-descriptors
+
+exec-sql
+ALTER DATABASE db CONFIGURE ZONE USING gc.ttlseconds=10;
 ----
 
-# Should work for both when we start from the table and when we start from the
-# table.
-translate database=db table=t2
+# Mark the database as offline, we should still be able to generate a span
+# configuration for it.
+mark-database-offline database=db
 ----
-/Tenant/10/Table/10{7-8}                   range default
+
+translate database=db
+----
+/Tenant/10/Table/10{7-8}                   ttl_seconds=10
+
+# Delete the bespoke zone config on db. t2 should fallback to the RANGE DEFAULT
+# zone config even though all descriptors are offline.
+exec-sql
+DELETE FROM system.zones WHERE id = 104;
+----
 
 translate database=db
 ----
 /Tenant/10/Table/10{7-8}                   range default
 
+translate database=db table=t2
+----
+/Tenant/10/Table/10{7-8}                   range default
+
+mark-database-public database=db
+----
+
+exec-sql
+ALTER DATABASE db CONFIGURE ZONE USING gc.ttlseconds=11;
+----
+
+# Mark table db.t2 as offline, we should still be able to generate a span
+# configuration for it.
+mark-table-offline database=db table=t2
+----
+
+# Should work for both when we start from the table and when we start from the
+# database.
+translate database=db table=t2
+----
+/Tenant/10/Table/10{7-8}                   ttl_seconds=11
+
+translate database=db
+----
+/Tenant/10/Table/10{7-8}                   ttl_seconds=11
 
 # Mark the table as public again.
 mark-table-public database=db table=t2
@@ -49,7 +84,9 @@ mark-table-public database=db table=t2
 
 translate database=db table=t2
 ----
-/Tenant/10/Table/10{7-8}                   range default
+/Tenant/10/Table/10{7-8}                   ttl_seconds=11
+
+subtest end
 
 # Test schemas/types don't generate a span configuration.
 exec-sql
@@ -59,7 +96,7 @@ CREATE TYPE db.typ AS ENUM();
 
 translate database=db
 ----
-/Tenant/10/Table/10{7-8}                   range default
+/Tenant/10/Table/10{7-8}                   ttl_seconds=11
 
 # Schema.
 translate id=58

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/protectedts
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/protectedts
@@ -19,6 +19,32 @@ ALTER DATABASE db CONFIGURE ZONE USING num_replicas=7;
 ALTER TABLE db.t1 CONFIGURE ZONE USING num_voters=5;
 ----
 
+# Mark the database as offline.
+mark-database-offline database=db
+----
+
+# Write a protected timestamp on the offline db.
+protect record-id=9 ts=9
+descs 104
+----
+
+# We should still see the protectedts translate onto the offline db.
+translate database=db
+----
+/Tenant/10/Table/10{6-7}                   num_replicas=7 num_voters=5 protection_policies=[{ts: 9}]
+/Tenant/10/Table/10{7-8}                   num_replicas=7 protection_policies=[{ts: 9}]
+
+release record-id=9
+----
+
+mark-database-public database=db
+----
+
+translate database=db
+----
+/Tenant/10/Table/10{6-7}                   num_replicas=7 num_voters=5
+/Tenant/10/Table/10{7-8}                   num_replicas=7
+
 # Write a protected timestamp on t1.
 protect record-id=1 ts=1
 descs 106

--- a/pkg/spanconfig/spanconfigsqltranslator/sqltranslator.go
+++ b/pkg/spanconfig/spanconfigsqltranslator/sqltranslator.go
@@ -535,9 +535,8 @@ func (s *SQLTranslator) findDescendantLeafIDsForDescriptor(
 		return nil, nil
 	}
 
-	// There's nothing for us to do if the descriptor is offline or has been
-	// dropped.
-	if db.Offline() || db.Dropped() {
+	// There's nothing for us to do if the descriptor has been dropped.
+	if db.Dropped() {
 		return nil, nil
 	}
 

--- a/pkg/spanconfig/spanconfigtestutils/spanconfigtestcluster/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigtestutils/spanconfigtestcluster/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/spanconfig/spanconfigtestutils",
         "//pkg/sql",
         "//pkg/sql/catalog",
+        "//pkg/sql/catalog/dbdesc",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",
         "//pkg/sql/catalog/tabledesc",


### PR DESCRIPTION
Previously, we would ignore sql updates for databases that are offline. As explained in  #91148 in some situations we require writing a protected timestamp to an offline database during a restore. This will require the spanconfig machinery to reconcile the PTS record so that the GC queue can observe and respect it.

We already reconcile sql udpates for offline tables so it seems reasonable to do the same for offline databases.

Fixes: #91149

Release note: None