### PR TITLE
kvserver: add metric for raft leaders that hold invalid leases

### DIFF
--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -63,6 +63,12 @@ var (
 		Measurement: "Replicas",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaRaftLeaderInvalidLeaseCount = metric.Metadata{
+		Name:        "replicas.leaders_invalid_lease",
+		Help:        "Number of replicas that are Raft leaders whose lease is invalid",
+		Measurement: "Replicas",
+		Unit:        metric.Unit_COUNT,
+	}
 	metaLeaseHolderCount = metric.Metadata{
 		Name:        "replicas.leaseholders",
 		Help:        "Number of lease holders",
@@ -1691,6 +1697,7 @@ type StoreMetrics struct {
 	ReservedReplicaCount          *metric.Gauge
 	RaftLeaderCount               *metric.Gauge
 	RaftLeaderNotLeaseHolderCount *metric.Gauge
+	RaftLeaderInvalidLeaseCount   *metric.Gauge
 	LeaseHolderCount              *metric.Gauge
 	QuiescentCount                *metric.Gauge
 	UninitializedCount            *metric.Gauge
@@ -2229,6 +2236,7 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		ReservedReplicaCount:          metric.NewGauge(metaReservedReplicaCount),
 		RaftLeaderCount:               metric.NewGauge(metaRaftLeaderCount),
 		RaftLeaderNotLeaseHolderCount: metric.NewGauge(metaRaftLeaderNotLeaseHolderCount),
+		RaftLeaderInvalidLeaseCount:   metric.NewGauge(metaRaftLeaderInvalidLeaseCount),
 		LeaseHolderCount:              metric.NewGauge(metaLeaseHolderCount),
 		QuiescentCount:                metric.NewGauge(metaQuiescentCount),
 		UninitializedCount:            metric.NewGauge(metaUninitializedCount),

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3189,6 +3189,7 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 		leaseExpirationCount          int64
 		leaseEpochCount               int64
 		raftLeaderNotLeaseHolderCount int64
+		raftLeaderInvalidLeaseCount   int64
 		quiescentCount                int64
 		uninitializedCount            int64
 		averageQueriesPerSecond       float64
@@ -3242,6 +3243,9 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 			raftLeaderCount++
 			if metrics.LeaseValid && !metrics.Leaseholder {
 				raftLeaderNotLeaseHolderCount++
+			}
+			if !metrics.LeaseValid {
+				raftLeaderInvalidLeaseCount++
 			}
 		}
 		if metrics.Leaseholder {
@@ -3314,6 +3318,7 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 
 	s.metrics.RaftLeaderCount.Update(raftLeaderCount)
 	s.metrics.RaftLeaderNotLeaseHolderCount.Update(raftLeaderNotLeaseHolderCount)
+	s.metrics.RaftLeaderInvalidLeaseCount.Update(raftLeaderInvalidLeaseCount)
 	s.metrics.LeaseHolderCount.Update(leaseHolderCount)
 	s.metrics.LeaseExpirationCount.Update(leaseExpirationCount)
 	s.metrics.LeaseEpochCount.Update(leaseEpochCount)

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1671,6 +1671,7 @@ var charts = []sectionDescription{
 					"leases.expiration",
 					"replicas.leaseholders",
 					"replicas.leaders_not_leaseholders",
+					"replicas.leaders_invalid_lease",
 				},
 			},
 			{


### PR DESCRIPTION
This change adds a metric to export count of raft leaders that hold invalid leases. Fixes #84656.

