### PR TITLE
sql: let `extendedEvalContext.QueueJob()` use txn from planner

### DIFF
--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -2348,14 +2348,11 @@ func TestJobInTxn(t *testing.T) {
 			}
 			fn := func(ctx context.Context, _ []sql.PlanNode, _ chan<- tree.Datums) error {
 				var err error
-				job, err = execCtx.ExtendedEvalContext().QueueJob(
-					ctx,
-					jobs.Record{
-						Description: st.String(),
-						Details:     jobspb.BackupDetails{},
-						Progress:    jobspb.BackupProgress{},
-					},
-				)
+				job, err = execCtx.ExtendedEvalContext().QueueJob(ctx, execCtx.Txn(), jobs.Record{
+					Description: st.String(),
+					Details:     jobspb.BackupDetails{},
+					Progress:    jobspb.BackupProgress{},
+				})
 				return err
 			}
 			return fn, nil, nil, false, nil
@@ -2390,14 +2387,11 @@ func TestJobInTxn(t *testing.T) {
 			}
 			fn := func(ctx context.Context, _ []sql.PlanNode, _ chan<- tree.Datums) error {
 				var err error
-				job, err = execCtx.ExtendedEvalContext().QueueJob(
-					ctx,
-					jobs.Record{
-						Description: "RESTORE",
-						Details:     jobspb.RestoreDetails{},
-						Progress:    jobspb.RestoreProgress{},
-					},
-				)
+				job, err = execCtx.ExtendedEvalContext().QueueJob(ctx, execCtx.Txn(), jobs.Record{
+					Description: "RESTORE",
+					Details:     jobspb.RestoreDetails{},
+					Progress:    jobspb.RestoreProgress{},
+				})
 				return err
 			}
 			return fn, nil, nil, false, nil

--- a/pkg/sql/drop_schema.go
+++ b/pkg/sql/drop_schema.go
@@ -250,7 +250,7 @@ func (p *planner) createDropSchemaJob(
 		typeIDs = append(typeIDs, t.ID)
 	}
 
-	_, err := p.extendedEvalCtx.QueueJob(ctx, jobs.Record{
+	_, err := p.extendedEvalCtx.QueueJob(ctx, p.Txn(), jobs.Record{
 		Description:   jobDesc,
 		Username:      p.User(),
 		DescriptorIDs: schemas,

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -143,14 +143,14 @@ func (evalCtx *extendedEvalContext) copy() *extendedEvalContext {
 // QueueJob creates a new job from record and queues it for execution after
 // the transaction commits.
 func (evalCtx *extendedEvalContext) QueueJob(
-	ctx context.Context, record jobs.Record,
+	ctx context.Context, txn *kv.Txn, record jobs.Record,
 ) (*jobs.Job, error) {
 	jobID := evalCtx.ExecCfg.JobRegistry.MakeJobID()
 	job, err := evalCtx.ExecCfg.JobRegistry.CreateJobWithTxn(
 		ctx,
 		record,
 		jobID,
-		evalCtx.Txn,
+		txn,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -68,7 +68,7 @@ func (p *planner) createDropDatabaseJob(
 		Progress:      jobspb.SchemaChangeProgress{},
 		NonCancelable: true,
 	}
-	newJob, err := p.extendedEvalCtx.QueueJob(ctx, jobRecord)
+	newJob, err := p.extendedEvalCtx.QueueJob(ctx, p.Txn(), jobRecord)
 	if err != nil {
 		return err
 	}
@@ -93,7 +93,7 @@ func (p *planner) createNonDropDatabaseChangeJob(
 		Progress:      jobspb.SchemaChangeProgress{},
 		NonCancelable: true,
 	}
-	newJob, err := p.extendedEvalCtx.QueueJob(ctx, jobRecord)
+	newJob, err := p.extendedEvalCtx.QueueJob(ctx, p.Txn(), jobRecord)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This commit is part of the effort to reduce usages of `eval.Context.txn`.

We now let `*kv.Txn` be passed in as a parameter to `extendedEvalContext.QueueJob()`.

Informs: #91004

Release note: None