### PR TITLE
fix(sec): upgrade junit:junit to 4.13.1

### DIFF
--- a/pkg/acceptance/testdata/java/pom.xml
+++ b/pkg/acceptance/testdata/java/pom.xml
@@ -17,7 +17,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.8.1</version>
+        <version>4.13.1</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in junit:junit 4.8.1
- [CVE-2020-15250](https://www.oscs1024.com/hd/CVE-2020-15250)


### What did I do？
Upgrade junit:junit from 4.8.1 to 4.13.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS