### PR TITLE
release-22.1: sql: reduce the overhead of EXPLAIN ANALYZE

### DIFF
--- a/pkg/sql/flowinfra/BUILD.bazel
+++ b/pkg/sql/flowinfra/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
+        "//pkg/util/tracing/tracingpb",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",

--- a/pkg/sql/flowinfra/outbox.go
+++ b/pkg/sql/flowinfra/outbox.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"go.opentelemetry.io/otel/attribute"
 )
 
@@ -210,10 +211,12 @@ func (m *Outbox) mainLoop(ctx context.Context) error {
 	var span *tracing.Span
 	ctx, span = execinfra.ProcessorSpan(ctx, "outbox")
 	defer span.Finish()
-	if span != nil && span.IsVerbose() {
-		m.statsCollectionEnabled = true
-		span.SetTag(execinfrapb.FlowIDTagKey, attribute.StringValue(m.flowCtx.ID.String()))
-		span.SetTag(execinfrapb.StreamIDTagKey, attribute.IntValue(int(m.streamID)))
+	if span != nil {
+		m.statsCollectionEnabled = span.RecordingType() != tracingpb.RecordingOff
+		if span.IsVerbose() {
+			span.SetTag(execinfrapb.FlowIDTagKey, attribute.StringValue(m.flowCtx.ID.String()))
+			span.SetTag(execinfrapb.StreamIDTagKey, attribute.IntValue(int(m.streamID)))
+		}
 	}
 
 	if m.stream == nil {

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -273,7 +273,17 @@ func (ih *instrumentationHelper) Setup(
 
 	ih.collectExecStats = true
 	ih.evalCtx = p.EvalContext()
-	newCtx, ih.sp = tracing.EnsureChildSpan(ctx, cfg.AmbientCtx.Tracer, "traced statement", tracing.WithRecording(tracing.RecordingVerbose))
+	// Execution stats are propagated as structured metadata, so we definitely
+	// need to enable the tracing. We default to the RecordingStructured level
+	// in order to reduce the overhead of EXPLAIN ANALYZE.
+	recType := tracingpb.RecordingStructured
+	if ih.collectBundle || ih.withStatementTrace != nil {
+		// Use the verbose recording only if we're collecting the bundle (the
+		// verbose trace is very helpful during debugging) or if we have a
+		// testing callback.
+		recType = tracingpb.RecordingVerbose
+	}
+	newCtx, ih.sp = tracing.EnsureChildSpan(ctx, cfg.AmbientCtx.Tracer, "traced statement", tracing.WithRecording(recType))
 	ih.shouldFinishSpan = true
 	return newCtx, true
 }

--- a/pkg/sql/rowflow/BUILD.bazel
+++ b/pkg/sql/rowflow/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/util/mon",
         "//pkg/util/syncutil",
         "//pkg/util/tracing",
+        "//pkg/util/tracing/tracingpb",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
         "@io_opentelemetry_go_otel//attribute",


### PR DESCRIPTION
Backport 1/1 commits from #91117.

/cc @cockroachdb/release

---

In order to propagate the execution stats across the distributed query plan we use the tracing infrastructure, where each stats object is added as "structured metadata" to the trace. Thus, whenever we're collecting the exec stats for a statement, we must enable tracing. Previously, in many cases we would enable it at the highest verbosity level which has non-trivial overhead. In some cases this was an overkill (e.g. in `EXPLAIN ANALYZE` we don't really care about the trace containing all of the gory details - we won't expose it anyway), so this is now fixed by using the less verbose "structured" verbosity level. As a concrete example of the difference: for a stmt that without `EXPLAIN ANALYZE` takes around 190ms, with `EXPLAIN ANALYZE` it would previously run for about 1.8s and now it takes around 210ms.

This required some minor changes to the row-by-row outbox and router
setups to collect thats even if the recording is not verbose.

Addresses: #90739.

Epic: None

Release note (performance improvement): The overhead of running `EXPLAIN ANALYZE` and `EXPLAIN ANALYZE (DISTSQL)` has been significantly reduced. The overhead of `EXPLAIN ANALYZE (DEBUG)` didn't change.

Release justification: performance fix.