### PR TITLE
server, ui: update prettify parameter

### DIFF
--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -541,20 +542,14 @@ func getTotalStatementDetails(
 	}
 	statistics.Stats.SensitiveInfo.MostRecentPlanDescription = *plan
 
-	args = []interface{}{}
-	args = append(args, aggregatedMetadata.Query)
-	query = fmt.Sprintf(
-		`SELECT prettify_statement($1, %d, %d, %d)`,
-		tree.ConsoleLineWidth, tree.PrettyAlignAndDeindent, tree.UpperCase)
-	row, err = ie.QueryRowEx(ctx, "combined-stmts-details-format-query", nil,
-		sessiondata.InternalExecutorOverride{
-			User: username.NodeUserName(),
-		}, query, args...)
-
+	queryTree, err := parser.ParseOne(aggregatedMetadata.Query)
 	if err != nil {
 		return statement, serverError(ctx, err)
 	}
-	aggregatedMetadata.FormattedQuery = string(tree.MustBeDString(row[0]))
+	cfg := tree.DefaultPrettyCfg()
+	cfg.Align = tree.PrettyAlignOnly
+	cfg.LineWidth = tree.ConsoleLineWidth
+	aggregatedMetadata.FormattedQuery = cfg.Pretty(queryTree.AST)
 
 	statement = serverpb.StatementDetailsResponse_CollectedStatementSummary{
 		Metadata:            aggregatedMetadata,

--- a/pkg/ui/workspaces/cluster-ui/src/api/insightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/insightsApi.ts
@@ -166,7 +166,7 @@ type FingerprintStmtsResponseColumns = {
 const fingerprintStmtsQuery = (
   stmt_fingerprint_ids: string[],
 ) => `SELECT DISTINCT ON (fingerprint_id) encode(fingerprint_id, 'hex') AS statement_fingerprint_id,
-                                          prettify_statement(metadata ->> 'query', 108, 2, 1) AS query
+                                          prettify_statement(metadata ->> 'query', 108, 1, 1) AS query
       FROM crdb_internal.statement_statistics
       WHERE encode(fingerprint_id, 'hex') = ANY (string_to_array('${stmt_fingerprint_ids}'
         , ','))`;
@@ -648,7 +648,7 @@ const statementInsightsQuery: InsightQuery<
 > = {
   name: InsightNameEnum.highContention,
   // We only surface the most recently observed problem for a given statement.
-  query: `SELECT *, prettify_statement(non_prettified_query, 108, 2, 1) AS query from (
+  query: `SELECT *, prettify_statement(non_prettified_query, 108, 1, 1) AS query from (
     SELECT
       session_id,
       txn_id,


### PR DESCRIPTION
Previously, we were using `PrettyAlignAndDeindent`
parameter option for the usage of `prettify_statement`
on statement details endpoint and insights details
endpoints, which was subjected to a quadratic explosion.

This commit updates those uses to parameter
`PrettyAlignOnly` (1) on sql api and changes the
statement details endpoint to use the Go function of
Pretty instead, so it doesn't required a SQL
connection/execution.

Part Of #91197

Release note: None