### PR TITLE
release-22.2: sql: fix implicit record types for virtual tables

### DIFF
--- a/pkg/sql/catalog/typedesc/table_implicit_record_type.go
+++ b/pkg/sql/catalog/typedesc/table_implicit_record_type.go
@@ -70,7 +70,7 @@ func CreateImplicitRecordTypeFromTableDesc(
 	// names.
 	typ := types.MakeLabeledTuple(typs, names)
 	tableID := descriptor.GetID()
-	typeOID := catid.TypeIDToOID(tableID)
+	typeOID := TableIDToImplicitTypeOID(tableID)
 	// Setting the type's OID allows us to properly report and display this type
 	// as having ID <tableID> + 100000 in the pg_type table and ::REGTYPE casts.
 	// It will also be used to serialize expressions casted to this type for
@@ -84,6 +84,12 @@ func CreateImplicitRecordTypeFromTableDesc(
 		Version: uint32(descriptor.GetVersion()),
 	}
 
+	// Note: Implicit types for virtual tables are hardcoded to have USAGE
+	// privileges and this can't be modified. The virtual table itself does have
+	// synthetic privileges (as of v22.2), but accessing those requires a planner
+	// by using GetPrivilegeDescriptor(ctx, planner).
+	// It is fine to hardcode USAGE for implicit types for virtual tables since
+	// nothing about those types is sensitive.
 	tablePrivs := descriptor.GetPrivileges()
 	newPrivs := make([]catpb.UserPrivileges, len(tablePrivs.Users))
 	for i := range tablePrivs.Users {

--- a/pkg/sql/catalog/typedesc/type_desc.go
+++ b/pkg/sql/catalog/typedesc/type_desc.go
@@ -114,11 +114,28 @@ func UpdateCachedFieldsOnModifiedMutable(desc catalog.TypeDescriptor) (*Mutable,
 	return mutable, nil
 }
 
-// UserDefinedTypeOIDToID converts a user defined type OID into a
-// descriptor ID. OID of a user-defined type must be greater than
-// CockroachPredefinedOIDMax. The function returns an error if the
-// given OID is less than or equals to CockroachPredefinedMax.
+// TableIDToImplicitTypeOID converts the given ID into the ID for the implicit
+// reccord type for that table. We re-use the type ID to OID logic, as type IDs
+// and table IDs do not share the same ID space. For virtual tables, we just use
+// the virtual table ID itself, to avoid addition overflow.
+func TableIDToImplicitTypeOID(id descpb.ID) oid.Oid {
+	if descpb.IsVirtualTable(id) {
+		// Virtual table OIDs start at max UInt32, so doing OID math would overflow.
+		return oid.Oid(id)
+	}
+	return catid.TypeIDToOID(id)
+}
+
+// UserDefinedTypeOIDToID converts a user defined type OID into a descriptor ID.
+// OID of a user-defined type must be greater than CockroachPredefinedOIDMax.
+// The function returns an error if the given OID is less than or equals to
+// CockroachPredefinedMax. If the OID is for a virtual table, then the ID itself
+// is returned, since the type can then be assumed to be the implict record type
+// for that table.
 func UserDefinedTypeOIDToID(oid oid.Oid) (descpb.ID, error) {
+	if descpb.IsVirtualTable(descpb.ID(oid)) {
+		return descpb.ID(oid), nil
+	}
 	return catid.UserDefinedOIDToID(oid)
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -2179,6 +2179,12 @@ text[]
 statement ok
 SELECT format_type(oid, NULL) FROM pg_type
 
+# Ensure that implicit record types for virtual tables can be formatted.
+query T
+select format_type('pg_namespace'::regtype, null);
+----
+pg_namespace
+
 query T
 SELECT pg_catalog.pg_get_userbyid((SELECT oid FROM pg_roles WHERE rolname='root'))
 ----

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1603,1972 +1603,527 @@ oid         enumtypid  enumsortorder  enumlabel
 query OTOOIBT colnames
 SELECT oid, typname, typnamespace, typowner, typlen, typbyval, typtype
 FROM pg_catalog.pg_type
+WHERE oid < 4194967002 -- exclude implicit types for virtual tables
 ORDER BY oid
 ----
-oid         typname                                typnamespace  typowner    typlen  typbyval  typtype
-16          bool                                   591606261     NULL        1       true      b
-17          bytea                                  591606261     NULL        -1      false     b
-18          char                                   591606261     NULL        1       true      b
-19          name                                   591606261     NULL        -1      false     b
-20          int8                                   591606261     NULL        8       true      b
-21          int2                                   591606261     NULL        2       true      b
-22          int2vector                             591606261     NULL        -1      false     b
-23          int4                                   591606261     NULL        4       true      b
-24          regproc                                591606261     NULL        8       true      b
-25          text                                   591606261     NULL        -1      false     b
-26          oid                                    591606261     NULL        8       true      b
-30          oidvector                              591606261     NULL        -1      false     b
-700         float4                                 591606261     NULL        4       true      b
-701         float8                                 591606261     NULL        8       true      b
-705         unknown                                591606261     NULL        0       true      b
-869         inet                                   591606261     NULL        24      true      b
-1000        _bool                                  591606261     NULL        -1      false     b
-1001        _bytea                                 591606261     NULL        -1      false     b
-1002        _char                                  591606261     NULL        -1      false     b
-1003        _name                                  591606261     NULL        -1      false     b
-1005        _int2                                  591606261     NULL        -1      false     b
-1006        _int2vector                            591606261     NULL        -1      false     b
-1007        _int4                                  591606261     NULL        -1      false     b
-1008        _regproc                               591606261     NULL        -1      false     b
-1009        _text                                  591606261     NULL        -1      false     b
-1013        _oidvector                             591606261     NULL        -1      false     b
-1014        _bpchar                                591606261     NULL        -1      false     b
-1015        _varchar                               591606261     NULL        -1      false     b
-1016        _int8                                  591606261     NULL        -1      false     b
-1021        _float4                                591606261     NULL        -1      false     b
-1022        _float8                                591606261     NULL        -1      false     b
-1028        _oid                                   591606261     NULL        -1      false     b
-1041        _inet                                  591606261     NULL        -1      false     b
-1042        bpchar                                 591606261     NULL        -1      false     b
-1043        varchar                                591606261     NULL        -1      false     b
-1082        date                                   591606261     NULL        16      true      b
-1083        time                                   591606261     NULL        8       true      b
-1114        timestamp                              591606261     NULL        24      true      b
-1115        _timestamp                             591606261     NULL        -1      false     b
-1182        _date                                  591606261     NULL        -1      false     b
-1183        _time                                  591606261     NULL        -1      false     b
-1184        timestamptz                            591606261     NULL        24      true      b
-1185        _timestamptz                           591606261     NULL        -1      false     b
-1186        interval                               591606261     NULL        24      true      b
-1187        _interval                              591606261     NULL        -1      false     b
-1231        _numeric                               591606261     NULL        -1      false     b
-1266        timetz                                 591606261     NULL        16      true      b
-1270        _timetz                                591606261     NULL        -1      false     b
-1560        bit                                    591606261     NULL        -1      false     b
-1561        _bit                                   591606261     NULL        -1      false     b
-1562        varbit                                 591606261     NULL        -1      false     b
-1563        _varbit                                591606261     NULL        -1      false     b
-1700        numeric                                591606261     NULL        -1      false     b
-2202        regprocedure                           591606261     NULL        8       true      b
-2205        regclass                               591606261     NULL        8       true      b
-2206        regtype                                591606261     NULL        8       true      b
-2207        _regprocedure                          591606261     NULL        -1      false     b
-2210        _regclass                              591606261     NULL        -1      false     b
-2211        _regtype                               591606261     NULL        -1      false     b
-2249        record                                 591606261     NULL        0       true      p
-2277        anyarray                               591606261     NULL        -1      false     p
-2278        void                                   591606261     NULL        0       true      p
-2283        anyelement                             591606261     NULL        -1      false     p
-2287        _record                                591606261     NULL        -1      false     b
-2950        uuid                                   591606261     NULL        16      true      b
-2951        _uuid                                  591606261     NULL        -1      false     b
-3802        jsonb                                  591606261     NULL        -1      false     b
-3807        _jsonb                                 591606261     NULL        -1      false     b
-4089        regnamespace                           591606261     NULL        8       true      b
-4090        _regnamespace                          591606261     NULL        -1      false     b
-4096        regrole                                591606261     NULL        8       true      b
-4097        _regrole                               591606261     NULL        -1      false     b
-90000       geometry                               591606261     NULL        -1      false     b
-90001       _geometry                              591606261     NULL        -1      false     b
-90002       geography                              591606261     NULL        -1      false     b
-90003       _geography                             591606261     NULL        -1      false     b
-90004       box2d                                  591606261     NULL        32      true      b
-90005       _box2d                                 591606261     NULL        -1      false     b
-100110      t1                                     109           1546506610  -1      false     c
-100111      t1_m_seq                               109           1546506610  -1      false     c
-100112      t1_n_seq                               109           1546506610  -1      false     c
-100113      t2                                     109           1546506610  -1      false     c
-100114      t3                                     109           1546506610  -1      false     c
-100115      v1                                     109           1546506610  -1      false     c
-100116      t4                                     109           1546506610  -1      false     c
-100117      t5                                     109           1546506610  -1      false     c
-100118      mytype                                 109           1546506610  -1      false     e
-100119      _mytype                                109           1546506610  -1      false     b
-100120      t6                                     109           1546506610  -1      false     c
-100121      mv1                                    109           1546506610  -1      false     c
-100128      source_table                           109           1546506610  -1      false     c
-100129      depend_view                            109           1546506610  -1      false     c
-100130      view_dependingon_view                  109           1546506610  -1      false     c
-100131      newtype1                               109           1546506610  -1      false     e
-100132      _newtype1                              109           1546506610  -1      false     b
-100133      newtype2                               109           1546506610  -1      false     e
-100134      _newtype2                              109           1546506610  -1      false     b
-4294967002  spatial_ref_sys                        1700435119    2310524507  -1      false     c
-4294967003  geometry_columns                       1700435119    2310524507  -1      false     c
-4294967004  geography_columns                      1700435119    2310524507  -1      false     c
-4294967006  pg_views                               591606261     2310524507  -1      false     c
-4294967007  pg_user                                591606261     2310524507  -1      false     c
-4294967008  pg_user_mappings                       591606261     2310524507  -1      false     c
-4294967009  pg_user_mapping                        591606261     2310524507  -1      false     c
-4294967010  pg_type                                591606261     2310524507  -1      false     c
-4294967011  pg_ts_template                         591606261     2310524507  -1      false     c
-4294967012  pg_ts_parser                           591606261     2310524507  -1      false     c
-4294967013  pg_ts_dict                             591606261     2310524507  -1      false     c
-4294967014  pg_ts_config                           591606261     2310524507  -1      false     c
-4294967015  pg_ts_config_map                       591606261     2310524507  -1      false     c
-4294967016  pg_trigger                             591606261     2310524507  -1      false     c
-4294967017  pg_transform                           591606261     2310524507  -1      false     c
-4294967018  pg_timezone_names                      591606261     2310524507  -1      false     c
-4294967019  pg_timezone_abbrevs                    591606261     2310524507  -1      false     c
-4294967020  pg_tablespace                          591606261     2310524507  -1      false     c
-4294967021  pg_tables                              591606261     2310524507  -1      false     c
-4294967022  pg_subscription                        591606261     2310524507  -1      false     c
-4294967023  pg_subscription_rel                    591606261     2310524507  -1      false     c
-4294967024  pg_stats                               591606261     2310524507  -1      false     c
-4294967025  pg_stats_ext                           591606261     2310524507  -1      false     c
-4294967026  pg_statistic                           591606261     2310524507  -1      false     c
-4294967027  pg_statistic_ext                       591606261     2310524507  -1      false     c
-4294967028  pg_statistic_ext_data                  591606261     2310524507  -1      false     c
-4294967029  pg_statio_user_tables                  591606261     2310524507  -1      false     c
-4294967030  pg_statio_user_sequences               591606261     2310524507  -1      false     c
-4294967031  pg_statio_user_indexes                 591606261     2310524507  -1      false     c
-4294967032  pg_statio_sys_tables                   591606261     2310524507  -1      false     c
-4294967033  pg_statio_sys_sequences                591606261     2310524507  -1      false     c
-4294967034  pg_statio_sys_indexes                  591606261     2310524507  -1      false     c
-4294967035  pg_statio_all_tables                   591606261     2310524507  -1      false     c
-4294967036  pg_statio_all_sequences                591606261     2310524507  -1      false     c
-4294967037  pg_statio_all_indexes                  591606261     2310524507  -1      false     c
-4294967038  pg_stat_xact_user_tables               591606261     2310524507  -1      false     c
-4294967039  pg_stat_xact_user_functions            591606261     2310524507  -1      false     c
-4294967040  pg_stat_xact_sys_tables                591606261     2310524507  -1      false     c
-4294967041  pg_stat_xact_all_tables                591606261     2310524507  -1      false     c
-4294967042  pg_stat_wal_receiver                   591606261     2310524507  -1      false     c
-4294967043  pg_stat_user_tables                    591606261     2310524507  -1      false     c
-4294967044  pg_stat_user_indexes                   591606261     2310524507  -1      false     c
-4294967045  pg_stat_user_functions                 591606261     2310524507  -1      false     c
-4294967046  pg_stat_sys_tables                     591606261     2310524507  -1      false     c
-4294967047  pg_stat_sys_indexes                    591606261     2310524507  -1      false     c
-4294967048  pg_stat_subscription                   591606261     2310524507  -1      false     c
-4294967049  pg_stat_ssl                            591606261     2310524507  -1      false     c
-4294967050  pg_stat_slru                           591606261     2310524507  -1      false     c
-4294967051  pg_stat_replication                    591606261     2310524507  -1      false     c
-4294967052  pg_stat_progress_vacuum                591606261     2310524507  -1      false     c
-4294967053  pg_stat_progress_create_index          591606261     2310524507  -1      false     c
-4294967054  pg_stat_progress_cluster               591606261     2310524507  -1      false     c
-4294967055  pg_stat_progress_basebackup            591606261     2310524507  -1      false     c
-4294967056  pg_stat_progress_analyze               591606261     2310524507  -1      false     c
-4294967057  pg_stat_gssapi                         591606261     2310524507  -1      false     c
-4294967058  pg_stat_database                       591606261     2310524507  -1      false     c
-4294967059  pg_stat_database_conflicts             591606261     2310524507  -1      false     c
-4294967060  pg_stat_bgwriter                       591606261     2310524507  -1      false     c
-4294967061  pg_stat_archiver                       591606261     2310524507  -1      false     c
-4294967062  pg_stat_all_tables                     591606261     2310524507  -1      false     c
-4294967063  pg_stat_all_indexes                    591606261     2310524507  -1      false     c
-4294967064  pg_stat_activity                       591606261     2310524507  -1      false     c
-4294967065  pg_shmem_allocations                   591606261     2310524507  -1      false     c
-4294967066  pg_shdepend                            591606261     2310524507  -1      false     c
-4294967067  pg_shseclabel                          591606261     2310524507  -1      false     c
-4294967068  pg_shdescription                       591606261     2310524507  -1      false     c
-4294967069  pg_shadow                              591606261     2310524507  -1      false     c
-4294967070  pg_settings                            591606261     2310524507  -1      false     c
-4294967071  pg_sequences                           591606261     2310524507  -1      false     c
-4294967072  pg_sequence                            591606261     2310524507  -1      false     c
-4294967073  pg_seclabel                            591606261     2310524507  -1      false     c
-4294967074  pg_seclabels                           591606261     2310524507  -1      false     c
-4294967075  pg_rules                               591606261     2310524507  -1      false     c
-4294967076  pg_roles                               591606261     2310524507  -1      false     c
-4294967077  pg_rewrite                             591606261     2310524507  -1      false     c
-4294967078  pg_replication_slots                   591606261     2310524507  -1      false     c
-4294967079  pg_replication_origin                  591606261     2310524507  -1      false     c
-4294967080  pg_replication_origin_status           591606261     2310524507  -1      false     c
-4294967081  pg_range                               591606261     2310524507  -1      false     c
-4294967082  pg_publication_tables                  591606261     2310524507  -1      false     c
-4294967083  pg_publication                         591606261     2310524507  -1      false     c
-4294967084  pg_publication_rel                     591606261     2310524507  -1      false     c
-4294967085  pg_proc                                591606261     2310524507  -1      false     c
-4294967086  pg_prepared_xacts                      591606261     2310524507  -1      false     c
-4294967087  pg_prepared_statements                 591606261     2310524507  -1      false     c
-4294967088  pg_policy                              591606261     2310524507  -1      false     c
-4294967089  pg_policies                            591606261     2310524507  -1      false     c
-4294967090  pg_partitioned_table                   591606261     2310524507  -1      false     c
-4294967091  pg_opfamily                            591606261     2310524507  -1      false     c
-4294967092  pg_operator                            591606261     2310524507  -1      false     c
-4294967093  pg_opclass                             591606261     2310524507  -1      false     c
-4294967094  pg_namespace                           591606261     2310524507  -1      false     c
-4294967095  pg_matviews                            591606261     2310524507  -1      false     c
-4294967096  pg_locks                               591606261     2310524507  -1      false     c
-4294967097  pg_largeobject                         591606261     2310524507  -1      false     c
-4294967098  pg_largeobject_metadata                591606261     2310524507  -1      false     c
-4294967099  pg_language                            591606261     2310524507  -1      false     c
-4294967100  pg_init_privs                          591606261     2310524507  -1      false     c
-4294967101  pg_inherits                            591606261     2310524507  -1      false     c
-4294967102  pg_indexes                             591606261     2310524507  -1      false     c
-4294967103  pg_index                               591606261     2310524507  -1      false     c
-4294967104  pg_hba_file_rules                      591606261     2310524507  -1      false     c
-4294967105  pg_group                               591606261     2310524507  -1      false     c
-4294967106  pg_foreign_table                       591606261     2310524507  -1      false     c
-4294967107  pg_foreign_server                      591606261     2310524507  -1      false     c
-4294967108  pg_foreign_data_wrapper                591606261     2310524507  -1      false     c
-4294967109  pg_file_settings                       591606261     2310524507  -1      false     c
-4294967110  pg_extension                           591606261     2310524507  -1      false     c
-4294967111  pg_event_trigger                       591606261     2310524507  -1      false     c
-4294967112  pg_enum                                591606261     2310524507  -1      false     c
-4294967113  pg_description                         591606261     2310524507  -1      false     c
-4294967114  pg_depend                              591606261     2310524507  -1      false     c
-4294967115  pg_default_acl                         591606261     2310524507  -1      false     c
-4294967116  pg_db_role_setting                     591606261     2310524507  -1      false     c
-4294967117  pg_database                            591606261     2310524507  -1      false     c
-4294967118  pg_cursors                             591606261     2310524507  -1      false     c
-4294967119  pg_conversion                          591606261     2310524507  -1      false     c
-4294967120  pg_constraint                          591606261     2310524507  -1      false     c
-4294967121  pg_config                              591606261     2310524507  -1      false     c
-4294967122  pg_collation                           591606261     2310524507  -1      false     c
-4294967123  pg_class                               591606261     2310524507  -1      false     c
-4294967124  pg_cast                                591606261     2310524507  -1      false     c
-4294967125  pg_available_extensions                591606261     2310524507  -1      false     c
-4294967126  pg_available_extension_versions        591606261     2310524507  -1      false     c
-4294967127  pg_auth_members                        591606261     2310524507  -1      false     c
-4294967128  pg_authid                              591606261     2310524507  -1      false     c
-4294967129  pg_attribute                           591606261     2310524507  -1      false     c
-4294967130  pg_attrdef                             591606261     2310524507  -1      false     c
-4294967131  pg_amproc                              591606261     2310524507  -1      false     c
-4294967132  pg_amop                                591606261     2310524507  -1      false     c
-4294967133  pg_am                                  591606261     2310524507  -1      false     c
-4294967134  pg_aggregate                           591606261     2310524507  -1      false     c
-4294967136  views                                  198834802     2310524507  -1      false     c
-4294967137  view_table_usage                       198834802     2310524507  -1      false     c
-4294967138  view_routine_usage                     198834802     2310524507  -1      false     c
-4294967139  view_column_usage                      198834802     2310524507  -1      false     c
-4294967140  user_privileges                        198834802     2310524507  -1      false     c
-4294967141  user_mappings                          198834802     2310524507  -1      false     c
-4294967142  user_mapping_options                   198834802     2310524507  -1      false     c
-4294967143  user_defined_types                     198834802     2310524507  -1      false     c
-4294967144  user_attributes                        198834802     2310524507  -1      false     c
-4294967145  usage_privileges                       198834802     2310524507  -1      false     c
-4294967146  udt_privileges                         198834802     2310524507  -1      false     c
-4294967147  type_privileges                        198834802     2310524507  -1      false     c
-4294967148  triggers                               198834802     2310524507  -1      false     c
-4294967149  triggered_update_columns               198834802     2310524507  -1      false     c
-4294967150  transforms                             198834802     2310524507  -1      false     c
-4294967151  tablespaces                            198834802     2310524507  -1      false     c
-4294967152  tablespaces_extensions                 198834802     2310524507  -1      false     c
-4294967153  tables                                 198834802     2310524507  -1      false     c
-4294967154  tables_extensions                      198834802     2310524507  -1      false     c
-4294967155  table_privileges                       198834802     2310524507  -1      false     c
-4294967156  table_constraints_extensions           198834802     2310524507  -1      false     c
-4294967157  table_constraints                      198834802     2310524507  -1      false     c
-4294967158  statistics                             198834802     2310524507  -1      false     c
-4294967159  st_units_of_measure                    198834802     2310524507  -1      false     c
-4294967160  st_spatial_reference_systems           198834802     2310524507  -1      false     c
-4294967161  st_geometry_columns                    198834802     2310524507  -1      false     c
-4294967162  session_variables                      198834802     2310524507  -1      false     c
-4294967163  sequences                              198834802     2310524507  -1      false     c
-4294967164  schema_privileges                      198834802     2310524507  -1      false     c
-4294967165  schemata                               198834802     2310524507  -1      false     c
-4294967166  schemata_extensions                    198834802     2310524507  -1      false     c
-4294967167  sql_sizing                             198834802     2310524507  -1      false     c
-4294967168  sql_parts                              198834802     2310524507  -1      false     c
-4294967169  sql_implementation_info                198834802     2310524507  -1      false     c
-4294967170  sql_features                           198834802     2310524507  -1      false     c
-4294967171  routines                               198834802     2310524507  -1      false     c
-4294967172  routine_privileges                     198834802     2310524507  -1      false     c
-4294967173  role_usage_grants                      198834802     2310524507  -1      false     c
-4294967174  role_udt_grants                        198834802     2310524507  -1      false     c
-4294967175  role_table_grants                      198834802     2310524507  -1      false     c
-4294967176  role_routine_grants                    198834802     2310524507  -1      false     c
-4294967177  role_column_grants                     198834802     2310524507  -1      false     c
-4294967178  resource_groups                        198834802     2310524507  -1      false     c
-4294967179  referential_constraints                198834802     2310524507  -1      false     c
-4294967180  profiling                              198834802     2310524507  -1      false     c
-4294967181  processlist                            198834802     2310524507  -1      false     c
-4294967182  plugins                                198834802     2310524507  -1      false     c
-4294967183  partitions                             198834802     2310524507  -1      false     c
-4294967184  parameters                             198834802     2310524507  -1      false     c
-4294967185  optimizer_trace                        198834802     2310524507  -1      false     c
-4294967186  keywords                               198834802     2310524507  -1      false     c
-4294967187  key_column_usage                       198834802     2310524507  -1      false     c
-4294967188  information_schema_catalog_name        198834802     2310524507  -1      false     c
-4294967189  foreign_tables                         198834802     2310524507  -1      false     c
-4294967190  foreign_table_options                  198834802     2310524507  -1      false     c
-4294967191  foreign_servers                        198834802     2310524507  -1      false     c
-4294967192  foreign_server_options                 198834802     2310524507  -1      false     c
-4294967193  foreign_data_wrappers                  198834802     2310524507  -1      false     c
-4294967194  foreign_data_wrapper_options           198834802     2310524507  -1      false     c
-4294967195  files                                  198834802     2310524507  -1      false     c
-4294967196  events                                 198834802     2310524507  -1      false     c
-4294967197  engines                                198834802     2310524507  -1      false     c
-4294967198  enabled_roles                          198834802     2310524507  -1      false     c
-4294967199  element_types                          198834802     2310524507  -1      false     c
-4294967200  domains                                198834802     2310524507  -1      false     c
-4294967201  domain_udt_usage                       198834802     2310524507  -1      false     c
-4294967202  domain_constraints                     198834802     2310524507  -1      false     c
-4294967203  data_type_privileges                   198834802     2310524507  -1      false     c
-4294967204  constraint_table_usage                 198834802     2310524507  -1      false     c
-4294967205  constraint_column_usage                198834802     2310524507  -1      false     c
-4294967206  columns                                198834802     2310524507  -1      false     c
-4294967207  columns_extensions                     198834802     2310524507  -1      false     c
-4294967208  column_udt_usage                       198834802     2310524507  -1      false     c
-4294967209  column_statistics                      198834802     2310524507  -1      false     c
-4294967210  column_privileges                      198834802     2310524507  -1      false     c
-4294967211  column_options                         198834802     2310524507  -1      false     c
-4294967212  column_domain_usage                    198834802     2310524507  -1      false     c
-4294967213  column_column_usage                    198834802     2310524507  -1      false     c
-4294967214  collations                             198834802     2310524507  -1      false     c
-4294967215  collation_character_set_applicability  198834802     2310524507  -1      false     c
-4294967216  check_constraints                      198834802     2310524507  -1      false     c
-4294967217  check_constraint_routine_usage         198834802     2310524507  -1      false     c
-4294967218  character_sets                         198834802     2310524507  -1      false     c
-4294967219  attributes                             198834802     2310524507  -1      false     c
-4294967220  applicable_roles                       198834802     2310524507  -1      false     c
-4294967221  administrable_role_authorizations      198834802     2310524507  -1      false     c
-4294967223  super_regions                          194902141     2310524507  -1      false     c
-4294967224  pg_catalog_table_is_implemented        194902141     2310524507  -1      false     c
-4294967225  tenant_usage_details                   194902141     2310524507  -1      false     c
-4294967226  active_range_feeds                     194902141     2310524507  -1      false     c
-4294967227  default_privileges                     194902141     2310524507  -1      false     c
-4294967228  regions                                194902141     2310524507  -1      false     c
-4294967229  cluster_inflight_traces                194902141     2310524507  -1      false     c
-4294967230  lost_descriptors_with_data             194902141     2310524507  -1      false     c
-4294967231  cross_db_references                    194902141     2310524507  -1      false     c
-4294967232  cluster_database_privileges            194902141     2310524507  -1      false     c
-4294967233  invalid_objects                        194902141     2310524507  -1      false     c
-4294967234  zones                                  194902141     2310524507  -1      false     c
-4294967235  transaction_statistics                 194902141     2310524507  -1      false     c
-4294967236  node_transaction_statistics            194902141     2310524507  -1      false     c
-4294967237  table_row_statistics                   194902141     2310524507  -1      false     c
-4294967238  tables                                 194902141     2310524507  -1      false     c
-4294967239  table_indexes                          194902141     2310524507  -1      false     c
-4294967240  table_columns                          194902141     2310524507  -1      false     c
-4294967241  statement_statistics                   194902141     2310524507  -1      false     c
-4294967242  session_variables                      194902141     2310524507  -1      false     c
-4294967243  session_trace                          194902141     2310524507  -1      false     c
-4294967244  schema_changes                         194902141     2310524507  -1      false     c
-4294967245  node_runtime_info                      194902141     2310524507  -1      false     c
-4294967246  ranges                                 194902141     2310524507  -1      false     c
-4294967247  ranges_no_leases                       194902141     2310524507  -1      false     c
-4294967248  predefined_comments                    194902141     2310524507  -1      false     c
-4294967249  partitions                             194902141     2310524507  -1      false     c
-4294967250  node_txn_stats                         194902141     2310524507  -1      false     c
-4294967251  node_statement_statistics              194902141     2310524507  -1      false     c
-4294967252  node_metrics                           194902141     2310524507  -1      false     c
-4294967253  node_sessions                          194902141     2310524507  -1      false     c
-4294967254  node_transactions                      194902141     2310524507  -1      false     c
-4294967255  node_queries                           194902141     2310524507  -1      false     c
-4294967256  node_execution_insights                194902141     2310524507  -1      false     c
-4294967257  node_distsql_flows                     194902141     2310524507  -1      false     c
-4294967258  node_contention_events                 194902141     2310524507  -1      false     c
-4294967259  leases                                 194902141     2310524507  -1      false     c
-4294967260  kv_store_status                        194902141     2310524507  -1      false     c
-4294967261  kv_node_status                         194902141     2310524507  -1      false     c
-4294967262  jobs                                   194902141     2310524507  -1      false     c
-4294967263  node_inflight_trace_spans              194902141     2310524507  -1      false     c
-4294967264  index_usage_statistics                 194902141     2310524507  -1      false     c
-4294967265  index_columns                          194902141     2310524507  -1      false     c
-4294967266  transaction_contention_events          194902141     2310524507  -1      false     c
-4294967267  gossip_network                         194902141     2310524507  -1      false     c
-4294967268  gossip_liveness                        194902141     2310524507  -1      false     c
-4294967269  gossip_alerts                          194902141     2310524507  -1      false     c
-4294967270  gossip_nodes                           194902141     2310524507  -1      false     c
-4294967271  kv_node_liveness                       194902141     2310524507  -1      false     c
-4294967272  forward_dependencies                   194902141     2310524507  -1      false     c
-4294967273  feature_usage                          194902141     2310524507  -1      false     c
-4294967274  databases                              194902141     2310524507  -1      false     c
-4294967275  create_type_statements                 194902141     2310524507  -1      false     c
-4294967276  create_statements                      194902141     2310524507  -1      false     c
-4294967277  create_schema_statements               194902141     2310524507  -1      false     c
-4294967278  create_function_statements             194902141     2310524507  -1      false     c
-4294967279  cluster_transaction_statistics         194902141     2310524507  -1      false     c
-4294967280  cluster_statement_statistics           194902141     2310524507  -1      false     c
-4294967281  cluster_settings                       194902141     2310524507  -1      false     c
-4294967282  cluster_sessions                       194902141     2310524507  -1      false     c
-4294967283  cluster_transactions                   194902141     2310524507  -1      false     c
-4294967284  cluster_queries                        194902141     2310524507  -1      false     c
-4294967285  cluster_locks                          194902141     2310524507  -1      false     c
-4294967286  cluster_execution_insights             194902141     2310524507  -1      false     c
-4294967287  cluster_distsql_flows                  194902141     2310524507  -1      false     c
-4294967288  cluster_contention_events              194902141     2310524507  -1      false     c
-4294967289  cluster_contended_tables               194902141     2310524507  -1      false     c
-4294967290  cluster_contended_keys                 194902141     2310524507  -1      false     c
-4294967291  cluster_contended_indexes              194902141     2310524507  -1      false     c
-4294967292  builtin_functions                      194902141     2310524507  -1      false     c
-4294967293  node_build_info                        194902141     2310524507  -1      false     c
-4294967294  backward_dependencies                  194902141     2310524507  -1      false     c
+oid     typname                typnamespace  typowner    typlen  typbyval  typtype
+16      bool                   591606261     NULL        1       true      b
+17      bytea                  591606261     NULL        -1      false     b
+18      char                   591606261     NULL        1       true      b
+19      name                   591606261     NULL        -1      false     b
+20      int8                   591606261     NULL        8       true      b
+21      int2                   591606261     NULL        2       true      b
+22      int2vector             591606261     NULL        -1      false     b
+23      int4                   591606261     NULL        4       true      b
+24      regproc                591606261     NULL        8       true      b
+25      text                   591606261     NULL        -1      false     b
+26      oid                    591606261     NULL        8       true      b
+30      oidvector              591606261     NULL        -1      false     b
+700     float4                 591606261     NULL        4       true      b
+701     float8                 591606261     NULL        8       true      b
+705     unknown                591606261     NULL        0       true      b
+869     inet                   591606261     NULL        24      true      b
+1000    _bool                  591606261     NULL        -1      false     b
+1001    _bytea                 591606261     NULL        -1      false     b
+1002    _char                  591606261     NULL        -1      false     b
+1003    _name                  591606261     NULL        -1      false     b
+1005    _int2                  591606261     NULL        -1      false     b
+1006    _int2vector            591606261     NULL        -1      false     b
+1007    _int4                  591606261     NULL        -1      false     b
+1008    _regproc               591606261     NULL        -1      false     b
+1009    _text                  591606261     NULL        -1      false     b
+1013    _oidvector             591606261     NULL        -1      false     b
+1014    _bpchar                591606261     NULL        -1      false     b
+1015    _varchar               591606261     NULL        -1      false     b
+1016    _int8                  591606261     NULL        -1      false     b
+1021    _float4                591606261     NULL        -1      false     b
+1022    _float8                591606261     NULL        -1      false     b
+1028    _oid                   591606261     NULL        -1      false     b
+1041    _inet                  591606261     NULL        -1      false     b
+1042    bpchar                 591606261     NULL        -1      false     b
+1043    varchar                591606261     NULL        -1      false     b
+1082    date                   591606261     NULL        16      true      b
+1083    time                   591606261     NULL        8       true      b
+1114    timestamp              591606261     NULL        24      true      b
+1115    _timestamp             591606261     NULL        -1      false     b
+1182    _date                  591606261     NULL        -1      false     b
+1183    _time                  591606261     NULL        -1      false     b
+1184    timestamptz            591606261     NULL        24      true      b
+1185    _timestamptz           591606261     NULL        -1      false     b
+1186    interval               591606261     NULL        24      true      b
+1187    _interval              591606261     NULL        -1      false     b
+1231    _numeric               591606261     NULL        -1      false     b
+1266    timetz                 591606261     NULL        16      true      b
+1270    _timetz                591606261     NULL        -1      false     b
+1560    bit                    591606261     NULL        -1      false     b
+1561    _bit                   591606261     NULL        -1      false     b
+1562    varbit                 591606261     NULL        -1      false     b
+1563    _varbit                591606261     NULL        -1      false     b
+1700    numeric                591606261     NULL        -1      false     b
+2202    regprocedure           591606261     NULL        8       true      b
+2205    regclass               591606261     NULL        8       true      b
+2206    regtype                591606261     NULL        8       true      b
+2207    _regprocedure          591606261     NULL        -1      false     b
+2210    _regclass              591606261     NULL        -1      false     b
+2211    _regtype               591606261     NULL        -1      false     b
+2249    record                 591606261     NULL        0       true      p
+2277    anyarray               591606261     NULL        -1      false     p
+2278    void                   591606261     NULL        0       true      p
+2283    anyelement             591606261     NULL        -1      false     p
+2287    _record                591606261     NULL        -1      false     b
+2950    uuid                   591606261     NULL        16      true      b
+2951    _uuid                  591606261     NULL        -1      false     b
+3802    jsonb                  591606261     NULL        -1      false     b
+3807    _jsonb                 591606261     NULL        -1      false     b
+4089    regnamespace           591606261     NULL        8       true      b
+4090    _regnamespace          591606261     NULL        -1      false     b
+4096    regrole                591606261     NULL        8       true      b
+4097    _regrole               591606261     NULL        -1      false     b
+90000   geometry               591606261     NULL        -1      false     b
+90001   _geometry              591606261     NULL        -1      false     b
+90002   geography              591606261     NULL        -1      false     b
+90003   _geography             591606261     NULL        -1      false     b
+90004   box2d                  591606261     NULL        32      true      b
+90005   _box2d                 591606261     NULL        -1      false     b
+100110  t1                     109           1546506610  -1      false     c
+100111  t1_m_seq               109           1546506610  -1      false     c
+100112  t1_n_seq               109           1546506610  -1      false     c
+100113  t2                     109           1546506610  -1      false     c
+100114  t3                     109           1546506610  -1      false     c
+100115  v1                     109           1546506610  -1      false     c
+100116  t4                     109           1546506610  -1      false     c
+100117  t5                     109           1546506610  -1      false     c
+100118  mytype                 109           1546506610  -1      false     e
+100119  _mytype                109           1546506610  -1      false     b
+100120  t6                     109           1546506610  -1      false     c
+100121  mv1                    109           1546506610  -1      false     c
+100128  source_table           109           1546506610  -1      false     c
+100129  depend_view            109           1546506610  -1      false     c
+100130  view_dependingon_view  109           1546506610  -1      false     c
+100131  newtype1               109           1546506610  -1      false     e
+100132  _newtype1              109           1546506610  -1      false     b
+100133  newtype2               109           1546506610  -1      false     e
+100134  _newtype2              109           1546506610  -1      false     b
 
 query OTTBBTOOO colnames
 SELECT oid, typname, typcategory, typispreferred, typisdefined, typdelim, typrelid, typelem, typarray
 FROM pg_catalog.pg_type
+WHERE oid < 4194967002 -- exclude implicit types for virtual tables
 ORDER BY oid
 ----
-oid         typname                                typcategory  typispreferred  typisdefined  typdelim  typrelid    typelem  typarray
-16          bool                                   B            false           true          ,         0           0        1000
-17          bytea                                  U            false           true          ,         0           0        1001
-18          char                                   S            false           true          ,         0           0        1002
-19          name                                   S            false           true          ,         0           0        1003
-20          int8                                   N            false           true          ,         0           0        1016
-21          int2                                   N            false           true          ,         0           0        1005
-22          int2vector                             A            false           true          ,         0           21       1006
-23          int4                                   N            false           true          ,         0           0        1007
-24          regproc                                N            false           true          ,         0           0        1008
-25          text                                   S            false           true          ,         0           0        1009
-26          oid                                    N            false           true          ,         0           0        1028
-30          oidvector                              A            false           true          ,         0           26       1013
-700         float4                                 N            false           true          ,         0           0        1021
-701         float8                                 N            false           true          ,         0           0        1022
-705         unknown                                X            false           true          ,         0           0        0
-869         inet                                   I            false           true          ,         0           0        1041
-1000        _bool                                  A            false           true          ,         0           16       0
-1001        _bytea                                 A            false           true          ,         0           17       0
-1002        _char                                  A            false           true          ,         0           18       0
-1003        _name                                  A            false           true          ,         0           19       0
-1005        _int2                                  A            false           true          ,         0           21       0
-1006        _int2vector                            A            false           true          ,         0           22       0
-1007        _int4                                  A            false           true          ,         0           23       0
-1008        _regproc                               A            false           true          ,         0           24       0
-1009        _text                                  A            false           true          ,         0           25       0
-1013        _oidvector                             A            false           true          ,         0           30       0
-1014        _bpchar                                A            false           true          ,         0           1042     0
-1015        _varchar                               A            false           true          ,         0           1043     0
-1016        _int8                                  A            false           true          ,         0           20       0
-1021        _float4                                A            false           true          ,         0           700      0
-1022        _float8                                A            false           true          ,         0           701      0
-1028        _oid                                   A            false           true          ,         0           26       0
-1041        _inet                                  A            false           true          ,         0           869      0
-1042        bpchar                                 S            false           true          ,         0           0        1014
-1043        varchar                                S            false           true          ,         0           0        1015
-1082        date                                   D            false           true          ,         0           0        1182
-1083        time                                   D            false           true          ,         0           0        1183
-1114        timestamp                              D            false           true          ,         0           0        1115
-1115        _timestamp                             A            false           true          ,         0           1114     0
-1182        _date                                  A            false           true          ,         0           1082     0
-1183        _time                                  A            false           true          ,         0           1083     0
-1184        timestamptz                            D            false           true          ,         0           0        1185
-1185        _timestamptz                           A            false           true          ,         0           1184     0
-1186        interval                               T            false           true          ,         0           0        1187
-1187        _interval                              A            false           true          ,         0           1186     0
-1231        _numeric                               A            false           true          ,         0           1700     0
-1266        timetz                                 D            false           true          ,         0           0        1270
-1270        _timetz                                A            false           true          ,         0           1266     0
-1560        bit                                    V            false           true          ,         0           0        1561
-1561        _bit                                   A            false           true          ,         0           1560     0
-1562        varbit                                 V            false           true          ,         0           0        1563
-1563        _varbit                                A            false           true          ,         0           1562     0
-1700        numeric                                N            false           true          ,         0           0        1231
-2202        regprocedure                           N            false           true          ,         0           0        2207
-2205        regclass                               N            false           true          ,         0           0        2210
-2206        regtype                                N            false           true          ,         0           0        2211
-2207        _regprocedure                          A            false           true          ,         0           2202     0
-2210        _regclass                              A            false           true          ,         0           2205     0
-2211        _regtype                               A            false           true          ,         0           2206     0
-2249        record                                 P            false           true          ,         0           0        2287
-2277        anyarray                               P            false           true          ,         0           0        0
-2278        void                                   P            false           true          ,         0           0        0
-2283        anyelement                             P            false           true          ,         0           0        2277
-2287        _record                                A            false           true          ,         0           2249     0
-2950        uuid                                   U            false           true          ,         0           0        2951
-2951        _uuid                                  A            false           true          ,         0           2950     0
-3802        jsonb                                  U            false           true          ,         0           0        3807
-3807        _jsonb                                 A            false           true          ,         0           3802     0
-4089        regnamespace                           N            false           true          ,         0           0        4090
-4090        _regnamespace                          A            false           true          ,         0           4089     0
-4096        regrole                                N            false           true          ,         0           0        4097
-4097        _regrole                               A            false           true          ,         0           4096     0
-90000       geometry                               U            false           true          :         0           0        90001
-90001       _geometry                              A            false           true          ,         0           90000    0
-90002       geography                              U            false           true          :         0           0        90003
-90003       _geography                             A            false           true          ,         0           90002    0
-90004       box2d                                  U            false           true          ,         0           0        90005
-90005       _box2d                                 A            false           true          ,         0           90004    0
-100110      t1                                     C            false           true          ,         110         0        0
-100111      t1_m_seq                               C            false           true          ,         111         0        0
-100112      t1_n_seq                               C            false           true          ,         112         0        0
-100113      t2                                     C            false           true          ,         113         0        0
-100114      t3                                     C            false           true          ,         114         0        0
-100115      v1                                     C            false           true          ,         115         0        0
-100116      t4                                     C            false           true          ,         116         0        0
-100117      t5                                     C            false           true          ,         117         0        0
-100118      mytype                                 E            false           true          ,         0           0        100119
-100119      _mytype                                A            false           true          ,         0           100118   0
-100120      t6                                     C            false           true          ,         120         0        0
-100121      mv1                                    C            false           true          ,         121         0        0
-100128      source_table                           C            false           true          ,         128         0        0
-100129      depend_view                            C            false           true          ,         129         0        0
-100130      view_dependingon_view                  C            false           true          ,         130         0        0
-100131      newtype1                               E            false           true          ,         0           0        100132
-100132      _newtype1                              A            false           true          ,         0           100131   0
-100133      newtype2                               E            false           true          ,         0           0        100134
-100134      _newtype2                              A            false           true          ,         0           100133   0
-4294967002  spatial_ref_sys                        C            false           true          ,         4294967002  0        0
-4294967003  geometry_columns                       C            false           true          ,         4294967003  0        0
-4294967004  geography_columns                      C            false           true          ,         4294967004  0        0
-4294967006  pg_views                               C            false           true          ,         4294967006  0        0
-4294967007  pg_user                                C            false           true          ,         4294967007  0        0
-4294967008  pg_user_mappings                       C            false           true          ,         4294967008  0        0
-4294967009  pg_user_mapping                        C            false           true          ,         4294967009  0        0
-4294967010  pg_type                                C            false           true          ,         4294967010  0        0
-4294967011  pg_ts_template                         C            false           true          ,         4294967011  0        0
-4294967012  pg_ts_parser                           C            false           true          ,         4294967012  0        0
-4294967013  pg_ts_dict                             C            false           true          ,         4294967013  0        0
-4294967014  pg_ts_config                           C            false           true          ,         4294967014  0        0
-4294967015  pg_ts_config_map                       C            false           true          ,         4294967015  0        0
-4294967016  pg_trigger                             C            false           true          ,         4294967016  0        0
-4294967017  pg_transform                           C            false           true          ,         4294967017  0        0
-4294967018  pg_timezone_names                      C            false           true          ,         4294967018  0        0
-4294967019  pg_timezone_abbrevs                    C            false           true          ,         4294967019  0        0
-4294967020  pg_tablespace                          C            false           true          ,         4294967020  0        0
-4294967021  pg_tables                              C            false           true          ,         4294967021  0        0
-4294967022  pg_subscription                        C            false           true          ,         4294967022  0        0
-4294967023  pg_subscription_rel                    C            false           true          ,         4294967023  0        0
-4294967024  pg_stats                               C            false           true          ,         4294967024  0        0
-4294967025  pg_stats_ext                           C            false           true          ,         4294967025  0        0
-4294967026  pg_statistic                           C            false           true          ,         4294967026  0        0
-4294967027  pg_statistic_ext                       C            false           true          ,         4294967027  0        0
-4294967028  pg_statistic_ext_data                  C            false           true          ,         4294967028  0        0
-4294967029  pg_statio_user_tables                  C            false           true          ,         4294967029  0        0
-4294967030  pg_statio_user_sequences               C            false           true          ,         4294967030  0        0
-4294967031  pg_statio_user_indexes                 C            false           true          ,         4294967031  0        0
-4294967032  pg_statio_sys_tables                   C            false           true          ,         4294967032  0        0
-4294967033  pg_statio_sys_sequences                C            false           true          ,         4294967033  0        0
-4294967034  pg_statio_sys_indexes                  C            false           true          ,         4294967034  0        0
-4294967035  pg_statio_all_tables                   C            false           true          ,         4294967035  0        0
-4294967036  pg_statio_all_sequences                C            false           true          ,         4294967036  0        0
-4294967037  pg_statio_all_indexes                  C            false           true          ,         4294967037  0        0
-4294967038  pg_stat_xact_user_tables               C            false           true          ,         4294967038  0        0
-4294967039  pg_stat_xact_user_functions            C            false           true          ,         4294967039  0        0
-4294967040  pg_stat_xact_sys_tables                C            false           true          ,         4294967040  0        0
-4294967041  pg_stat_xact_all_tables                C            false           true          ,         4294967041  0        0
-4294967042  pg_stat_wal_receiver                   C            false           true          ,         4294967042  0        0
-4294967043  pg_stat_user_tables                    C            false           true          ,         4294967043  0        0
-4294967044  pg_stat_user_indexes                   C            false           true          ,         4294967044  0        0
-4294967045  pg_stat_user_functions                 C            false           true          ,         4294967045  0        0
-4294967046  pg_stat_sys_tables                     C            false           true          ,         4294967046  0        0
-4294967047  pg_stat_sys_indexes                    C            false           true          ,         4294967047  0        0
-4294967048  pg_stat_subscription                   C            false           true          ,         4294967048  0        0
-4294967049  pg_stat_ssl                            C            false           true          ,         4294967049  0        0
-4294967050  pg_stat_slru                           C            false           true          ,         4294967050  0        0
-4294967051  pg_stat_replication                    C            false           true          ,         4294967051  0        0
-4294967052  pg_stat_progress_vacuum                C            false           true          ,         4294967052  0        0
-4294967053  pg_stat_progress_create_index          C            false           true          ,         4294967053  0        0
-4294967054  pg_stat_progress_cluster               C            false           true          ,         4294967054  0        0
-4294967055  pg_stat_progress_basebackup            C            false           true          ,         4294967055  0        0
-4294967056  pg_stat_progress_analyze               C            false           true          ,         4294967056  0        0
-4294967057  pg_stat_gssapi                         C            false           true          ,         4294967057  0        0
-4294967058  pg_stat_database                       C            false           true          ,         4294967058  0        0
-4294967059  pg_stat_database_conflicts             C            false           true          ,         4294967059  0        0
-4294967060  pg_stat_bgwriter                       C            false           true          ,         4294967060  0        0
-4294967061  pg_stat_archiver                       C            false           true          ,         4294967061  0        0
-4294967062  pg_stat_all_tables                     C            false           true          ,         4294967062  0        0
-4294967063  pg_stat_all_indexes                    C            false           true          ,         4294967063  0        0
-4294967064  pg_stat_activity                       C            false           true          ,         4294967064  0        0
-4294967065  pg_shmem_allocations                   C            false           true          ,         4294967065  0        0
-4294967066  pg_shdepend                            C            false           true          ,         4294967066  0        0
-4294967067  pg_shseclabel                          C            false           true          ,         4294967067  0        0
-4294967068  pg_shdescription                       C            false           true          ,         4294967068  0        0
-4294967069  pg_shadow                              C            false           true          ,         4294967069  0        0
-4294967070  pg_settings                            C            false           true          ,         4294967070  0        0
-4294967071  pg_sequences                           C            false           true          ,         4294967071  0        0
-4294967072  pg_sequence                            C            false           true          ,         4294967072  0        0
-4294967073  pg_seclabel                            C            false           true          ,         4294967073  0        0
-4294967074  pg_seclabels                           C            false           true          ,         4294967074  0        0
-4294967075  pg_rules                               C            false           true          ,         4294967075  0        0
-4294967076  pg_roles                               C            false           true          ,         4294967076  0        0
-4294967077  pg_rewrite                             C            false           true          ,         4294967077  0        0
-4294967078  pg_replication_slots                   C            false           true          ,         4294967078  0        0
-4294967079  pg_replication_origin                  C            false           true          ,         4294967079  0        0
-4294967080  pg_replication_origin_status           C            false           true          ,         4294967080  0        0
-4294967081  pg_range                               C            false           true          ,         4294967081  0        0
-4294967082  pg_publication_tables                  C            false           true          ,         4294967082  0        0
-4294967083  pg_publication                         C            false           true          ,         4294967083  0        0
-4294967084  pg_publication_rel                     C            false           true          ,         4294967084  0        0
-4294967085  pg_proc                                C            false           true          ,         4294967085  0        0
-4294967086  pg_prepared_xacts                      C            false           true          ,         4294967086  0        0
-4294967087  pg_prepared_statements                 C            false           true          ,         4294967087  0        0
-4294967088  pg_policy                              C            false           true          ,         4294967088  0        0
-4294967089  pg_policies                            C            false           true          ,         4294967089  0        0
-4294967090  pg_partitioned_table                   C            false           true          ,         4294967090  0        0
-4294967091  pg_opfamily                            C            false           true          ,         4294967091  0        0
-4294967092  pg_operator                            C            false           true          ,         4294967092  0        0
-4294967093  pg_opclass                             C            false           true          ,         4294967093  0        0
-4294967094  pg_namespace                           C            false           true          ,         4294967094  0        0
-4294967095  pg_matviews                            C            false           true          ,         4294967095  0        0
-4294967096  pg_locks                               C            false           true          ,         4294967096  0        0
-4294967097  pg_largeobject                         C            false           true          ,         4294967097  0        0
-4294967098  pg_largeobject_metadata                C            false           true          ,         4294967098  0        0
-4294967099  pg_language                            C            false           true          ,         4294967099  0        0
-4294967100  pg_init_privs                          C            false           true          ,         4294967100  0        0
-4294967101  pg_inherits                            C            false           true          ,         4294967101  0        0
-4294967102  pg_indexes                             C            false           true          ,         4294967102  0        0
-4294967103  pg_index                               C            false           true          ,         4294967103  0        0
-4294967104  pg_hba_file_rules                      C            false           true          ,         4294967104  0        0
-4294967105  pg_group                               C            false           true          ,         4294967105  0        0
-4294967106  pg_foreign_table                       C            false           true          ,         4294967106  0        0
-4294967107  pg_foreign_server                      C            false           true          ,         4294967107  0        0
-4294967108  pg_foreign_data_wrapper                C            false           true          ,         4294967108  0        0
-4294967109  pg_file_settings                       C            false           true          ,         4294967109  0        0
-4294967110  pg_extension                           C            false           true          ,         4294967110  0        0
-4294967111  pg_event_trigger                       C            false           true          ,         4294967111  0        0
-4294967112  pg_enum                                C            false           true          ,         4294967112  0        0
-4294967113  pg_description                         C            false           true          ,         4294967113  0        0
-4294967114  pg_depend                              C            false           true          ,         4294967114  0        0
-4294967115  pg_default_acl                         C            false           true          ,         4294967115  0        0
-4294967116  pg_db_role_setting                     C            false           true          ,         4294967116  0        0
-4294967117  pg_database                            C            false           true          ,         4294967117  0        0
-4294967118  pg_cursors                             C            false           true          ,         4294967118  0        0
-4294967119  pg_conversion                          C            false           true          ,         4294967119  0        0
-4294967120  pg_constraint                          C            false           true          ,         4294967120  0        0
-4294967121  pg_config                              C            false           true          ,         4294967121  0        0
-4294967122  pg_collation                           C            false           true          ,         4294967122  0        0
-4294967123  pg_class                               C            false           true          ,         4294967123  0        0
-4294967124  pg_cast                                C            false           true          ,         4294967124  0        0
-4294967125  pg_available_extensions                C            false           true          ,         4294967125  0        0
-4294967126  pg_available_extension_versions        C            false           true          ,         4294967126  0        0
-4294967127  pg_auth_members                        C            false           true          ,         4294967127  0        0
-4294967128  pg_authid                              C            false           true          ,         4294967128  0        0
-4294967129  pg_attribute                           C            false           true          ,         4294967129  0        0
-4294967130  pg_attrdef                             C            false           true          ,         4294967130  0        0
-4294967131  pg_amproc                              C            false           true          ,         4294967131  0        0
-4294967132  pg_amop                                C            false           true          ,         4294967132  0        0
-4294967133  pg_am                                  C            false           true          ,         4294967133  0        0
-4294967134  pg_aggregate                           C            false           true          ,         4294967134  0        0
-4294967136  views                                  C            false           true          ,         4294967136  0        0
-4294967137  view_table_usage                       C            false           true          ,         4294967137  0        0
-4294967138  view_routine_usage                     C            false           true          ,         4294967138  0        0
-4294967139  view_column_usage                      C            false           true          ,         4294967139  0        0
-4294967140  user_privileges                        C            false           true          ,         4294967140  0        0
-4294967141  user_mappings                          C            false           true          ,         4294967141  0        0
-4294967142  user_mapping_options                   C            false           true          ,         4294967142  0        0
-4294967143  user_defined_types                     C            false           true          ,         4294967143  0        0
-4294967144  user_attributes                        C            false           true          ,         4294967144  0        0
-4294967145  usage_privileges                       C            false           true          ,         4294967145  0        0
-4294967146  udt_privileges                         C            false           true          ,         4294967146  0        0
-4294967147  type_privileges                        C            false           true          ,         4294967147  0        0
-4294967148  triggers                               C            false           true          ,         4294967148  0        0
-4294967149  triggered_update_columns               C            false           true          ,         4294967149  0        0
-4294967150  transforms                             C            false           true          ,         4294967150  0        0
-4294967151  tablespaces                            C            false           true          ,         4294967151  0        0
-4294967152  tablespaces_extensions                 C            false           true          ,         4294967152  0        0
-4294967153  tables                                 C            false           true          ,         4294967153  0        0
-4294967154  tables_extensions                      C            false           true          ,         4294967154  0        0
-4294967155  table_privileges                       C            false           true          ,         4294967155  0        0
-4294967156  table_constraints_extensions           C            false           true          ,         4294967156  0        0
-4294967157  table_constraints                      C            false           true          ,         4294967157  0        0
-4294967158  statistics                             C            false           true          ,         4294967158  0        0
-4294967159  st_units_of_measure                    C            false           true          ,         4294967159  0        0
-4294967160  st_spatial_reference_systems           C            false           true          ,         4294967160  0        0
-4294967161  st_geometry_columns                    C            false           true          ,         4294967161  0        0
-4294967162  session_variables                      C            false           true          ,         4294967162  0        0
-4294967163  sequences                              C            false           true          ,         4294967163  0        0
-4294967164  schema_privileges                      C            false           true          ,         4294967164  0        0
-4294967165  schemata                               C            false           true          ,         4294967165  0        0
-4294967166  schemata_extensions                    C            false           true          ,         4294967166  0        0
-4294967167  sql_sizing                             C            false           true          ,         4294967167  0        0
-4294967168  sql_parts                              C            false           true          ,         4294967168  0        0
-4294967169  sql_implementation_info                C            false           true          ,         4294967169  0        0
-4294967170  sql_features                           C            false           true          ,         4294967170  0        0
-4294967171  routines                               C            false           true          ,         4294967171  0        0
-4294967172  routine_privileges                     C            false           true          ,         4294967172  0        0
-4294967173  role_usage_grants                      C            false           true          ,         4294967173  0        0
-4294967174  role_udt_grants                        C            false           true          ,         4294967174  0        0
-4294967175  role_table_grants                      C            false           true          ,         4294967175  0        0
-4294967176  role_routine_grants                    C            false           true          ,         4294967176  0        0
-4294967177  role_column_grants                     C            false           true          ,         4294967177  0        0
-4294967178  resource_groups                        C            false           true          ,         4294967178  0        0
-4294967179  referential_constraints                C            false           true          ,         4294967179  0        0
-4294967180  profiling                              C            false           true          ,         4294967180  0        0
-4294967181  processlist                            C            false           true          ,         4294967181  0        0
-4294967182  plugins                                C            false           true          ,         4294967182  0        0
-4294967183  partitions                             C            false           true          ,         4294967183  0        0
-4294967184  parameters                             C            false           true          ,         4294967184  0        0
-4294967185  optimizer_trace                        C            false           true          ,         4294967185  0        0
-4294967186  keywords                               C            false           true          ,         4294967186  0        0
-4294967187  key_column_usage                       C            false           true          ,         4294967187  0        0
-4294967188  information_schema_catalog_name        C            false           true          ,         4294967188  0        0
-4294967189  foreign_tables                         C            false           true          ,         4294967189  0        0
-4294967190  foreign_table_options                  C            false           true          ,         4294967190  0        0
-4294967191  foreign_servers                        C            false           true          ,         4294967191  0        0
-4294967192  foreign_server_options                 C            false           true          ,         4294967192  0        0
-4294967193  foreign_data_wrappers                  C            false           true          ,         4294967193  0        0
-4294967194  foreign_data_wrapper_options           C            false           true          ,         4294967194  0        0
-4294967195  files                                  C            false           true          ,         4294967195  0        0
-4294967196  events                                 C            false           true          ,         4294967196  0        0
-4294967197  engines                                C            false           true          ,         4294967197  0        0
-4294967198  enabled_roles                          C            false           true          ,         4294967198  0        0
-4294967199  element_types                          C            false           true          ,         4294967199  0        0
-4294967200  domains                                C            false           true          ,         4294967200  0        0
-4294967201  domain_udt_usage                       C            false           true          ,         4294967201  0        0
-4294967202  domain_constraints                     C            false           true          ,         4294967202  0        0
-4294967203  data_type_privileges                   C            false           true          ,         4294967203  0        0
-4294967204  constraint_table_usage                 C            false           true          ,         4294967204  0        0
-4294967205  constraint_column_usage                C            false           true          ,         4294967205  0        0
-4294967206  columns                                C            false           true          ,         4294967206  0        0
-4294967207  columns_extensions                     C            false           true          ,         4294967207  0        0
-4294967208  column_udt_usage                       C            false           true          ,         4294967208  0        0
-4294967209  column_statistics                      C            false           true          ,         4294967209  0        0
-4294967210  column_privileges                      C            false           true          ,         4294967210  0        0
-4294967211  column_options                         C            false           true          ,         4294967211  0        0
-4294967212  column_domain_usage                    C            false           true          ,         4294967212  0        0
-4294967213  column_column_usage                    C            false           true          ,         4294967213  0        0
-4294967214  collations                             C            false           true          ,         4294967214  0        0
-4294967215  collation_character_set_applicability  C            false           true          ,         4294967215  0        0
-4294967216  check_constraints                      C            false           true          ,         4294967216  0        0
-4294967217  check_constraint_routine_usage         C            false           true          ,         4294967217  0        0
-4294967218  character_sets                         C            false           true          ,         4294967218  0        0
-4294967219  attributes                             C            false           true          ,         4294967219  0        0
-4294967220  applicable_roles                       C            false           true          ,         4294967220  0        0
-4294967221  administrable_role_authorizations      C            false           true          ,         4294967221  0        0
-4294967223  super_regions                          C            false           true          ,         4294967223  0        0
-4294967224  pg_catalog_table_is_implemented        C            false           true          ,         4294967224  0        0
-4294967225  tenant_usage_details                   C            false           true          ,         4294967225  0        0
-4294967226  active_range_feeds                     C            false           true          ,         4294967226  0        0
-4294967227  default_privileges                     C            false           true          ,         4294967227  0        0
-4294967228  regions                                C            false           true          ,         4294967228  0        0
-4294967229  cluster_inflight_traces                C            false           true          ,         4294967229  0        0
-4294967230  lost_descriptors_with_data             C            false           true          ,         4294967230  0        0
-4294967231  cross_db_references                    C            false           true          ,         4294967231  0        0
-4294967232  cluster_database_privileges            C            false           true          ,         4294967232  0        0
-4294967233  invalid_objects                        C            false           true          ,         4294967233  0        0
-4294967234  zones                                  C            false           true          ,         4294967234  0        0
-4294967235  transaction_statistics                 C            false           true          ,         4294967235  0        0
-4294967236  node_transaction_statistics            C            false           true          ,         4294967236  0        0
-4294967237  table_row_statistics                   C            false           true          ,         4294967237  0        0
-4294967238  tables                                 C            false           true          ,         4294967238  0        0
-4294967239  table_indexes                          C            false           true          ,         4294967239  0        0
-4294967240  table_columns                          C            false           true          ,         4294967240  0        0
-4294967241  statement_statistics                   C            false           true          ,         4294967241  0        0
-4294967242  session_variables                      C            false           true          ,         4294967242  0        0
-4294967243  session_trace                          C            false           true          ,         4294967243  0        0
-4294967244  schema_changes                         C            false           true          ,         4294967244  0        0
-4294967245  node_runtime_info                      C            false           true          ,         4294967245  0        0
-4294967246  ranges                                 C            false           true          ,         4294967246  0        0
-4294967247  ranges_no_leases                       C            false           true          ,         4294967247  0        0
-4294967248  predefined_comments                    C            false           true          ,         4294967248  0        0
-4294967249  partitions                             C            false           true          ,         4294967249  0        0
-4294967250  node_txn_stats                         C            false           true          ,         4294967250  0        0
-4294967251  node_statement_statistics              C            false           true          ,         4294967251  0        0
-4294967252  node_metrics                           C            false           true          ,         4294967252  0        0
-4294967253  node_sessions                          C            false           true          ,         4294967253  0        0
-4294967254  node_transactions                      C            false           true          ,         4294967254  0        0
-4294967255  node_queries                           C            false           true          ,         4294967255  0        0
-4294967256  node_execution_insights                C            false           true          ,         4294967256  0        0
-4294967257  node_distsql_flows                     C            false           true          ,         4294967257  0        0
-4294967258  node_contention_events                 C            false           true          ,         4294967258  0        0
-4294967259  leases                                 C            false           true          ,         4294967259  0        0
-4294967260  kv_store_status                        C            false           true          ,         4294967260  0        0
-4294967261  kv_node_status                         C            false           true          ,         4294967261  0        0
-4294967262  jobs                                   C            false           true          ,         4294967262  0        0
-4294967263  node_inflight_trace_spans              C            false           true          ,         4294967263  0        0
-4294967264  index_usage_statistics                 C            false           true          ,         4294967264  0        0
-4294967265  index_columns                          C            false           true          ,         4294967265  0        0
-4294967266  transaction_contention_events          C            false           true          ,         4294967266  0        0
-4294967267  gossip_network                         C            false           true          ,         4294967267  0        0
-4294967268  gossip_liveness                        C            false           true          ,         4294967268  0        0
-4294967269  gossip_alerts                          C            false           true          ,         4294967269  0        0
-4294967270  gossip_nodes                           C            false           true          ,         4294967270  0        0
-4294967271  kv_node_liveness                       C            false           true          ,         4294967271  0        0
-4294967272  forward_dependencies                   C            false           true          ,         4294967272  0        0
-4294967273  feature_usage                          C            false           true          ,         4294967273  0        0
-4294967274  databases                              C            false           true          ,         4294967274  0        0
-4294967275  create_type_statements                 C            false           true          ,         4294967275  0        0
-4294967276  create_statements                      C            false           true          ,         4294967276  0        0
-4294967277  create_schema_statements               C            false           true          ,         4294967277  0        0
-4294967278  create_function_statements             C            false           true          ,         4294967278  0        0
-4294967279  cluster_transaction_statistics         C            false           true          ,         4294967279  0        0
-4294967280  cluster_statement_statistics           C            false           true          ,         4294967280  0        0
-4294967281  cluster_settings                       C            false           true          ,         4294967281  0        0
-4294967282  cluster_sessions                       C            false           true          ,         4294967282  0        0
-4294967283  cluster_transactions                   C            false           true          ,         4294967283  0        0
-4294967284  cluster_queries                        C            false           true          ,         4294967284  0        0
-4294967285  cluster_locks                          C            false           true          ,         4294967285  0        0
-4294967286  cluster_execution_insights             C            false           true          ,         4294967286  0        0
-4294967287  cluster_distsql_flows                  C            false           true          ,         4294967287  0        0
-4294967288  cluster_contention_events              C            false           true          ,         4294967288  0        0
-4294967289  cluster_contended_tables               C            false           true          ,         4294967289  0        0
-4294967290  cluster_contended_keys                 C            false           true          ,         4294967290  0        0
-4294967291  cluster_contended_indexes              C            false           true          ,         4294967291  0        0
-4294967292  builtin_functions                      C            false           true          ,         4294967292  0        0
-4294967293  node_build_info                        C            false           true          ,         4294967293  0        0
-4294967294  backward_dependencies                  C            false           true          ,         4294967294  0        0
+oid     typname                typcategory  typispreferred  typisdefined  typdelim  typrelid  typelem  typarray
+16      bool                   B            false           true          ,         0         0        1000
+17      bytea                  U            false           true          ,         0         0        1001
+18      char                   S            false           true          ,         0         0        1002
+19      name                   S            false           true          ,         0         0        1003
+20      int8                   N            false           true          ,         0         0        1016
+21      int2                   N            false           true          ,         0         0        1005
+22      int2vector             A            false           true          ,         0         21       1006
+23      int4                   N            false           true          ,         0         0        1007
+24      regproc                N            false           true          ,         0         0        1008
+25      text                   S            false           true          ,         0         0        1009
+26      oid                    N            false           true          ,         0         0        1028
+30      oidvector              A            false           true          ,         0         26       1013
+700     float4                 N            false           true          ,         0         0        1021
+701     float8                 N            false           true          ,         0         0        1022
+705     unknown                X            false           true          ,         0         0        0
+869     inet                   I            false           true          ,         0         0        1041
+1000    _bool                  A            false           true          ,         0         16       0
+1001    _bytea                 A            false           true          ,         0         17       0
+1002    _char                  A            false           true          ,         0         18       0
+1003    _name                  A            false           true          ,         0         19       0
+1005    _int2                  A            false           true          ,         0         21       0
+1006    _int2vector            A            false           true          ,         0         22       0
+1007    _int4                  A            false           true          ,         0         23       0
+1008    _regproc               A            false           true          ,         0         24       0
+1009    _text                  A            false           true          ,         0         25       0
+1013    _oidvector             A            false           true          ,         0         30       0
+1014    _bpchar                A            false           true          ,         0         1042     0
+1015    _varchar               A            false           true          ,         0         1043     0
+1016    _int8                  A            false           true          ,         0         20       0
+1021    _float4                A            false           true          ,         0         700      0
+1022    _float8                A            false           true          ,         0         701      0
+1028    _oid                   A            false           true          ,         0         26       0
+1041    _inet                  A            false           true          ,         0         869      0
+1042    bpchar                 S            false           true          ,         0         0        1014
+1043    varchar                S            false           true          ,         0         0        1015
+1082    date                   D            false           true          ,         0         0        1182
+1083    time                   D            false           true          ,         0         0        1183
+1114    timestamp              D            false           true          ,         0         0        1115
+1115    _timestamp             A            false           true          ,         0         1114     0
+1182    _date                  A            false           true          ,         0         1082     0
+1183    _time                  A            false           true          ,         0         1083     0
+1184    timestamptz            D            false           true          ,         0         0        1185
+1185    _timestamptz           A            false           true          ,         0         1184     0
+1186    interval               T            false           true          ,         0         0        1187
+1187    _interval              A            false           true          ,         0         1186     0
+1231    _numeric               A            false           true          ,         0         1700     0
+1266    timetz                 D            false           true          ,         0         0        1270
+1270    _timetz                A            false           true          ,         0         1266     0
+1560    bit                    V            false           true          ,         0         0        1561
+1561    _bit                   A            false           true          ,         0         1560     0
+1562    varbit                 V            false           true          ,         0         0        1563
+1563    _varbit                A            false           true          ,         0         1562     0
+1700    numeric                N            false           true          ,         0         0        1231
+2202    regprocedure           N            false           true          ,         0         0        2207
+2205    regclass               N            false           true          ,         0         0        2210
+2206    regtype                N            false           true          ,         0         0        2211
+2207    _regprocedure          A            false           true          ,         0         2202     0
+2210    _regclass              A            false           true          ,         0         2205     0
+2211    _regtype               A            false           true          ,         0         2206     0
+2249    record                 P            false           true          ,         0         0        2287
+2277    anyarray               P            false           true          ,         0         0        0
+2278    void                   P            false           true          ,         0         0        0
+2283    anyelement             P            false           true          ,         0         0        2277
+2287    _record                A            false           true          ,         0         2249     0
+2950    uuid                   U            false           true          ,         0         0        2951
+2951    _uuid                  A            false           true          ,         0         2950     0
+3802    jsonb                  U            false           true          ,         0         0        3807
+3807    _jsonb                 A            false           true          ,         0         3802     0
+4089    regnamespace           N            false           true          ,         0         0        4090
+4090    _regnamespace          A            false           true          ,         0         4089     0
+4096    regrole                N            false           true          ,         0         0        4097
+4097    _regrole               A            false           true          ,         0         4096     0
+90000   geometry               U            false           true          :         0         0        90001
+90001   _geometry              A            false           true          ,         0         90000    0
+90002   geography              U            false           true          :         0         0        90003
+90003   _geography             A            false           true          ,         0         90002    0
+90004   box2d                  U            false           true          ,         0         0        90005
+90005   _box2d                 A            false           true          ,         0         90004    0
+100110  t1                     C            false           true          ,         110       0        0
+100111  t1_m_seq               C            false           true          ,         111       0        0
+100112  t1_n_seq               C            false           true          ,         112       0        0
+100113  t2                     C            false           true          ,         113       0        0
+100114  t3                     C            false           true          ,         114       0        0
+100115  v1                     C            false           true          ,         115       0        0
+100116  t4                     C            false           true          ,         116       0        0
+100117  t5                     C            false           true          ,         117       0        0
+100118  mytype                 E            false           true          ,         0         0        100119
+100119  _mytype                A            false           true          ,         0         100118   0
+100120  t6                     C            false           true          ,         120       0        0
+100121  mv1                    C            false           true          ,         121       0        0
+100128  source_table           C            false           true          ,         128       0        0
+100129  depend_view            C            false           true          ,         129       0        0
+100130  view_dependingon_view  C            false           true          ,         130       0        0
+100131  newtype1               E            false           true          ,         0         0        100132
+100132  _newtype1              A            false           true          ,         0         100131   0
+100133  newtype2               E            false           true          ,         0         0        100134
+100134  _newtype2              A            false           true          ,         0         100133   0
 
 query OTOOOOOOO colnames
 SELECT oid, typname, typinput, typoutput, typreceive, typsend, typmodin, typmodout, typanalyze
 FROM pg_catalog.pg_type
+WHERE oid < 4194967002 -- exclude implicit types for virtual tables
 ORDER BY oid
 ----
-oid         typname                                typinput        typoutput        typreceive        typsend           typmodin  typmodout  typanalyze
-16          bool                                   boolin          boolout          boolrecv          boolsend          0         0          0
-17          bytea                                  byteain         byteaout         bytearecv         byteasend         0         0          0
-18          char                                   charin          charout          charrecv          charsend          0         0          0
-19          name                                   namein          nameout          namerecv          namesend          0         0          0
-20          int8                                   int8in          int8out          int8recv          int8send          0         0          0
-21          int2                                   int2in          int2out          int2recv          int2send          0         0          0
-22          int2vector                             int2vectorin    int2vectorout    int2vectorrecv    int2vectorsend    0         0          0
-23          int4                                   int4in          int4out          int4recv          int4send          0         0          0
-24          regproc                                regprocin       regprocout       regprocrecv       regprocsend       0         0          0
-25          text                                   textin          textout          textrecv          textsend          0         0          0
-26          oid                                    oidin           oidout           oidrecv           oidsend           0         0          0
-30          oidvector                              oidvectorin     oidvectorout     oidvectorrecv     oidvectorsend     0         0          0
-700         float4                                 float4in        float4out        float4recv        float4send        0         0          0
-701         float8                                 float8in        float8out        float8recv        float8send        0         0          0
-705         unknown                                unknownin       unknownout       unknownrecv       unknownsend       0         0          0
-869         inet                                   inetin          inetout          inetrecv          inetsend          0         0          0
-1000        _bool                                  array_in        array_out        array_recv        array_send        0         0          0
-1001        _bytea                                 array_in        array_out        array_recv        array_send        0         0          0
-1002        _char                                  array_in        array_out        array_recv        array_send        0         0          0
-1003        _name                                  array_in        array_out        array_recv        array_send        0         0          0
-1005        _int2                                  array_in        array_out        array_recv        array_send        0         0          0
-1006        _int2vector                            array_in        array_out        array_recv        array_send        0         0          0
-1007        _int4                                  array_in        array_out        array_recv        array_send        0         0          0
-1008        _regproc                               array_in        array_out        array_recv        array_send        0         0          0
-1009        _text                                  array_in        array_out        array_recv        array_send        0         0          0
-1013        _oidvector                             array_in        array_out        array_recv        array_send        0         0          0
-1014        _bpchar                                array_in        array_out        array_recv        array_send        0         0          0
-1015        _varchar                               array_in        array_out        array_recv        array_send        0         0          0
-1016        _int8                                  array_in        array_out        array_recv        array_send        0         0          0
-1021        _float4                                array_in        array_out        array_recv        array_send        0         0          0
-1022        _float8                                array_in        array_out        array_recv        array_send        0         0          0
-1028        _oid                                   array_in        array_out        array_recv        array_send        0         0          0
-1041        _inet                                  array_in        array_out        array_recv        array_send        0         0          0
-1042        bpchar                                 bpcharin        bpcharout        bpcharrecv        bpcharsend        0         0          0
-1043        varchar                                varcharin       varcharout       varcharrecv       varcharsend       0         0          0
-1082        date                                   date_in         date_out         date_recv         date_send         0         0          0
-1083        time                                   time_in         time_out         time_recv         time_send         0         0          0
-1114        timestamp                              timestamp_in    timestamp_out    timestamp_recv    timestamp_send    0         0          0
-1115        _timestamp                             array_in        array_out        array_recv        array_send        0         0          0
-1182        _date                                  array_in        array_out        array_recv        array_send        0         0          0
-1183        _time                                  array_in        array_out        array_recv        array_send        0         0          0
-1184        timestamptz                            timestamptz_in  timestamptz_out  timestamptz_recv  timestamptz_send  0         0          0
-1185        _timestamptz                           array_in        array_out        array_recv        array_send        0         0          0
-1186        interval                               interval_in     interval_out     interval_recv     interval_send     0         0          0
-1187        _interval                              array_in        array_out        array_recv        array_send        0         0          0
-1231        _numeric                               array_in        array_out        array_recv        array_send        0         0          0
-1266        timetz                                 timetz_in       timetz_out       timetz_recv       timetz_send       0         0          0
-1270        _timetz                                array_in        array_out        array_recv        array_send        0         0          0
-1560        bit                                    bit_in          bit_out          bit_recv          bit_send          0         0          0
-1561        _bit                                   array_in        array_out        array_recv        array_send        0         0          0
-1562        varbit                                 varbit_in       varbit_out       varbit_recv       varbit_send       0         0          0
-1563        _varbit                                array_in        array_out        array_recv        array_send        0         0          0
-1700        numeric                                numeric_in      numeric_out      numeric_recv      numeric_send      0         0          0
-2202        regprocedure                           regprocedurein  regprocedureout  regprocedurerecv  regproceduresend  0         0          0
-2205        regclass                               regclassin      regclassout      regclassrecv      regclasssend      0         0          0
-2206        regtype                                regtypein       regtypeout       regtyperecv       regtypesend       0         0          0
-2207        _regprocedure                          array_in        array_out        array_recv        array_send        0         0          0
-2210        _regclass                              array_in        array_out        array_recv        array_send        0         0          0
-2211        _regtype                               array_in        array_out        array_recv        array_send        0         0          0
-2249        record                                 record_in       record_out       record_recv       record_send       0         0          0
-2277        anyarray                               anyarray_in     anyarray_out     anyarray_recv     anyarray_send     0         0          0
-2278        void                                   voidin          voidout          voidrecv          voidsend          0         0          0
-2283        anyelement                             anyelement_in   anyelement_out   anyelement_recv   anyelement_send   0         0          0
-2287        _record                                array_in        array_out        array_recv        array_send        0         0          0
-2950        uuid                                   uuid_in         uuid_out         uuid_recv         uuid_send         0         0          0
-2951        _uuid                                  array_in        array_out        array_recv        array_send        0         0          0
-3802        jsonb                                  jsonb_in        jsonb_out        jsonb_recv        jsonb_send        0         0          0
-3807        _jsonb                                 array_in        array_out        array_recv        array_send        0         0          0
-4089        regnamespace                           regnamespacein  regnamespaceout  regnamespacerecv  regnamespacesend  0         0          0
-4090        _regnamespace                          array_in        array_out        array_recv        array_send        0         0          0
-4096        regrole                                regrolein       regroleout       regrolerecv       regrolesend       0         0          0
-4097        _regrole                               array_in        array_out        array_recv        array_send        0         0          0
-90000       geometry                               geometry_in     geometry_out     geometry_recv     geometry_send     0         0          0
-90001       _geometry                              array_in        array_out        array_recv        array_send        0         0          0
-90002       geography                              geography_in    geography_out    geography_recv    geography_send    0         0          0
-90003       _geography                             array_in        array_out        array_recv        array_send        0         0          0
-90004       box2d                                  box2d_in        box2d_out        box2d_recv        box2d_send        0         0          0
-90005       _box2d                                 array_in        array_out        array_recv        array_send        0         0          0
-100110      t1                                     record_in       record_out       record_recv       record_send       0         0          0
-100111      t1_m_seq                               record_in       record_out       record_recv       record_send       0         0          0
-100112      t1_n_seq                               record_in       record_out       record_recv       record_send       0         0          0
-100113      t2                                     record_in       record_out       record_recv       record_send       0         0          0
-100114      t3                                     record_in       record_out       record_recv       record_send       0         0          0
-100115      v1                                     record_in       record_out       record_recv       record_send       0         0          0
-100116      t4                                     record_in       record_out       record_recv       record_send       0         0          0
-100117      t5                                     record_in       record_out       record_recv       record_send       0         0          0
-100118      mytype                                 enum_in         enum_out         enum_recv         enum_send         0         0          0
-100119      _mytype                                array_in        array_out        array_recv        array_send        0         0          0
-100120      t6                                     record_in       record_out       record_recv       record_send       0         0          0
-100121      mv1                                    record_in       record_out       record_recv       record_send       0         0          0
-100128      source_table                           record_in       record_out       record_recv       record_send       0         0          0
-100129      depend_view                            record_in       record_out       record_recv       record_send       0         0          0
-100130      view_dependingon_view                  record_in       record_out       record_recv       record_send       0         0          0
-100131      newtype1                               enum_in         enum_out         enum_recv         enum_send         0         0          0
-100132      _newtype1                              array_in        array_out        array_recv        array_send        0         0          0
-100133      newtype2                               enum_in         enum_out         enum_recv         enum_send         0         0          0
-100134      _newtype2                              array_in        array_out        array_recv        array_send        0         0          0
-4294967002  spatial_ref_sys                        record_in       record_out       record_recv       record_send       0         0          0
-4294967003  geometry_columns                       record_in       record_out       record_recv       record_send       0         0          0
-4294967004  geography_columns                      record_in       record_out       record_recv       record_send       0         0          0
-4294967006  pg_views                               record_in       record_out       record_recv       record_send       0         0          0
-4294967007  pg_user                                record_in       record_out       record_recv       record_send       0         0          0
-4294967008  pg_user_mappings                       record_in       record_out       record_recv       record_send       0         0          0
-4294967009  pg_user_mapping                        record_in       record_out       record_recv       record_send       0         0          0
-4294967010  pg_type                                record_in       record_out       record_recv       record_send       0         0          0
-4294967011  pg_ts_template                         record_in       record_out       record_recv       record_send       0         0          0
-4294967012  pg_ts_parser                           record_in       record_out       record_recv       record_send       0         0          0
-4294967013  pg_ts_dict                             record_in       record_out       record_recv       record_send       0         0          0
-4294967014  pg_ts_config                           record_in       record_out       record_recv       record_send       0         0          0
-4294967015  pg_ts_config_map                       record_in       record_out       record_recv       record_send       0         0          0
-4294967016  pg_trigger                             record_in       record_out       record_recv       record_send       0         0          0
-4294967017  pg_transform                           record_in       record_out       record_recv       record_send       0         0          0
-4294967018  pg_timezone_names                      record_in       record_out       record_recv       record_send       0         0          0
-4294967019  pg_timezone_abbrevs                    record_in       record_out       record_recv       record_send       0         0          0
-4294967020  pg_tablespace                          record_in       record_out       record_recv       record_send       0         0          0
-4294967021  pg_tables                              record_in       record_out       record_recv       record_send       0         0          0
-4294967022  pg_subscription                        record_in       record_out       record_recv       record_send       0         0          0
-4294967023  pg_subscription_rel                    record_in       record_out       record_recv       record_send       0         0          0
-4294967024  pg_stats                               record_in       record_out       record_recv       record_send       0         0          0
-4294967025  pg_stats_ext                           record_in       record_out       record_recv       record_send       0         0          0
-4294967026  pg_statistic                           record_in       record_out       record_recv       record_send       0         0          0
-4294967027  pg_statistic_ext                       record_in       record_out       record_recv       record_send       0         0          0
-4294967028  pg_statistic_ext_data                  record_in       record_out       record_recv       record_send       0         0          0
-4294967029  pg_statio_user_tables                  record_in       record_out       record_recv       record_send       0         0          0
-4294967030  pg_statio_user_sequences               record_in       record_out       record_recv       record_send       0         0          0
-4294967031  pg_statio_user_indexes                 record_in       record_out       record_recv       record_send       0         0          0
-4294967032  pg_statio_sys_tables                   record_in       record_out       record_recv       record_send       0         0          0
-4294967033  pg_statio_sys_sequences                record_in       record_out       record_recv       record_send       0         0          0
-4294967034  pg_statio_sys_indexes                  record_in       record_out       record_recv       record_send       0         0          0
-4294967035  pg_statio_all_tables                   record_in       record_out       record_recv       record_send       0         0          0
-4294967036  pg_statio_all_sequences                record_in       record_out       record_recv       record_send       0         0          0
-4294967037  pg_statio_all_indexes                  record_in       record_out       record_recv       record_send       0         0          0
-4294967038  pg_stat_xact_user_tables               record_in       record_out       record_recv       record_send       0         0          0
-4294967039  pg_stat_xact_user_functions            record_in       record_out       record_recv       record_send       0         0          0
-4294967040  pg_stat_xact_sys_tables                record_in       record_out       record_recv       record_send       0         0          0
-4294967041  pg_stat_xact_all_tables                record_in       record_out       record_recv       record_send       0         0          0
-4294967042  pg_stat_wal_receiver                   record_in       record_out       record_recv       record_send       0         0          0
-4294967043  pg_stat_user_tables                    record_in       record_out       record_recv       record_send       0         0          0
-4294967044  pg_stat_user_indexes                   record_in       record_out       record_recv       record_send       0         0          0
-4294967045  pg_stat_user_functions                 record_in       record_out       record_recv       record_send       0         0          0
-4294967046  pg_stat_sys_tables                     record_in       record_out       record_recv       record_send       0         0          0
-4294967047  pg_stat_sys_indexes                    record_in       record_out       record_recv       record_send       0         0          0
-4294967048  pg_stat_subscription                   record_in       record_out       record_recv       record_send       0         0          0
-4294967049  pg_stat_ssl                            record_in       record_out       record_recv       record_send       0         0          0
-4294967050  pg_stat_slru                           record_in       record_out       record_recv       record_send       0         0          0
-4294967051  pg_stat_replication                    record_in       record_out       record_recv       record_send       0         0          0
-4294967052  pg_stat_progress_vacuum                record_in       record_out       record_recv       record_send       0         0          0
-4294967053  pg_stat_progress_create_index          record_in       record_out       record_recv       record_send       0         0          0
-4294967054  pg_stat_progress_cluster               record_in       record_out       record_recv       record_send       0         0          0
-4294967055  pg_stat_progress_basebackup            record_in       record_out       record_recv       record_send       0         0          0
-4294967056  pg_stat_progress_analyze               record_in       record_out       record_recv       record_send       0         0          0
-4294967057  pg_stat_gssapi                         record_in       record_out       record_recv       record_send       0         0          0
-4294967058  pg_stat_database                       record_in       record_out       record_recv       record_send       0         0          0
-4294967059  pg_stat_database_conflicts             record_in       record_out       record_recv       record_send       0         0          0
-4294967060  pg_stat_bgwriter                       record_in       record_out       record_recv       record_send       0         0          0
-4294967061  pg_stat_archiver                       record_in       record_out       record_recv       record_send       0         0          0
-4294967062  pg_stat_all_tables                     record_in       record_out       record_recv       record_send       0         0          0
-4294967063  pg_stat_all_indexes                    record_in       record_out       record_recv       record_send       0         0          0
-4294967064  pg_stat_activity                       record_in       record_out       record_recv       record_send       0         0          0
-4294967065  pg_shmem_allocations                   record_in       record_out       record_recv       record_send       0         0          0
-4294967066  pg_shdepend                            record_in       record_out       record_recv       record_send       0         0          0
-4294967067  pg_shseclabel                          record_in       record_out       record_recv       record_send       0         0          0
-4294967068  pg_shdescription                       record_in       record_out       record_recv       record_send       0         0          0
-4294967069  pg_shadow                              record_in       record_out       record_recv       record_send       0         0          0
-4294967070  pg_settings                            record_in       record_out       record_recv       record_send       0         0          0
-4294967071  pg_sequences                           record_in       record_out       record_recv       record_send       0         0          0
-4294967072  pg_sequence                            record_in       record_out       record_recv       record_send       0         0          0
-4294967073  pg_seclabel                            record_in       record_out       record_recv       record_send       0         0          0
-4294967074  pg_seclabels                           record_in       record_out       record_recv       record_send       0         0          0
-4294967075  pg_rules                               record_in       record_out       record_recv       record_send       0         0          0
-4294967076  pg_roles                               record_in       record_out       record_recv       record_send       0         0          0
-4294967077  pg_rewrite                             record_in       record_out       record_recv       record_send       0         0          0
-4294967078  pg_replication_slots                   record_in       record_out       record_recv       record_send       0         0          0
-4294967079  pg_replication_origin                  record_in       record_out       record_recv       record_send       0         0          0
-4294967080  pg_replication_origin_status           record_in       record_out       record_recv       record_send       0         0          0
-4294967081  pg_range                               record_in       record_out       record_recv       record_send       0         0          0
-4294967082  pg_publication_tables                  record_in       record_out       record_recv       record_send       0         0          0
-4294967083  pg_publication                         record_in       record_out       record_recv       record_send       0         0          0
-4294967084  pg_publication_rel                     record_in       record_out       record_recv       record_send       0         0          0
-4294967085  pg_proc                                record_in       record_out       record_recv       record_send       0         0          0
-4294967086  pg_prepared_xacts                      record_in       record_out       record_recv       record_send       0         0          0
-4294967087  pg_prepared_statements                 record_in       record_out       record_recv       record_send       0         0          0
-4294967088  pg_policy                              record_in       record_out       record_recv       record_send       0         0          0
-4294967089  pg_policies                            record_in       record_out       record_recv       record_send       0         0          0
-4294967090  pg_partitioned_table                   record_in       record_out       record_recv       record_send       0         0          0
-4294967091  pg_opfamily                            record_in       record_out       record_recv       record_send       0         0          0
-4294967092  pg_operator                            record_in       record_out       record_recv       record_send       0         0          0
-4294967093  pg_opclass                             record_in       record_out       record_recv       record_send       0         0          0
-4294967094  pg_namespace                           record_in       record_out       record_recv       record_send       0         0          0
-4294967095  pg_matviews                            record_in       record_out       record_recv       record_send       0         0          0
-4294967096  pg_locks                               record_in       record_out       record_recv       record_send       0         0          0
-4294967097  pg_largeobject                         record_in       record_out       record_recv       record_send       0         0          0
-4294967098  pg_largeobject_metadata                record_in       record_out       record_recv       record_send       0         0          0
-4294967099  pg_language                            record_in       record_out       record_recv       record_send       0         0          0
-4294967100  pg_init_privs                          record_in       record_out       record_recv       record_send       0         0          0
-4294967101  pg_inherits                            record_in       record_out       record_recv       record_send       0         0          0
-4294967102  pg_indexes                             record_in       record_out       record_recv       record_send       0         0          0
-4294967103  pg_index                               record_in       record_out       record_recv       record_send       0         0          0
-4294967104  pg_hba_file_rules                      record_in       record_out       record_recv       record_send       0         0          0
-4294967105  pg_group                               record_in       record_out       record_recv       record_send       0         0          0
-4294967106  pg_foreign_table                       record_in       record_out       record_recv       record_send       0         0          0
-4294967107  pg_foreign_server                      record_in       record_out       record_recv       record_send       0         0          0
-4294967108  pg_foreign_data_wrapper                record_in       record_out       record_recv       record_send       0         0          0
-4294967109  pg_file_settings                       record_in       record_out       record_recv       record_send       0         0          0
-4294967110  pg_extension                           record_in       record_out       record_recv       record_send       0         0          0
-4294967111  pg_event_trigger                       record_in       record_out       record_recv       record_send       0         0          0
-4294967112  pg_enum                                record_in       record_out       record_recv       record_send       0         0          0
-4294967113  pg_description                         record_in       record_out       record_recv       record_send       0         0          0
-4294967114  pg_depend                              record_in       record_out       record_recv       record_send       0         0          0
-4294967115  pg_default_acl                         record_in       record_out       record_recv       record_send       0         0          0
-4294967116  pg_db_role_setting                     record_in       record_out       record_recv       record_send       0         0          0
-4294967117  pg_database                            record_in       record_out       record_recv       record_send       0         0          0
-4294967118  pg_cursors                             record_in       record_out       record_recv       record_send       0         0          0
-4294967119  pg_conversion                          record_in       record_out       record_recv       record_send       0         0          0
-4294967120  pg_constraint                          record_in       record_out       record_recv       record_send       0         0          0
-4294967121  pg_config                              record_in       record_out       record_recv       record_send       0         0          0
-4294967122  pg_collation                           record_in       record_out       record_recv       record_send       0         0          0
-4294967123  pg_class                               record_in       record_out       record_recv       record_send       0         0          0
-4294967124  pg_cast                                record_in       record_out       record_recv       record_send       0         0          0
-4294967125  pg_available_extensions                record_in       record_out       record_recv       record_send       0         0          0
-4294967126  pg_available_extension_versions        record_in       record_out       record_recv       record_send       0         0          0
-4294967127  pg_auth_members                        record_in       record_out       record_recv       record_send       0         0          0
-4294967128  pg_authid                              record_in       record_out       record_recv       record_send       0         0          0
-4294967129  pg_attribute                           record_in       record_out       record_recv       record_send       0         0          0
-4294967130  pg_attrdef                             record_in       record_out       record_recv       record_send       0         0          0
-4294967131  pg_amproc                              record_in       record_out       record_recv       record_send       0         0          0
-4294967132  pg_amop                                record_in       record_out       record_recv       record_send       0         0          0
-4294967133  pg_am                                  record_in       record_out       record_recv       record_send       0         0          0
-4294967134  pg_aggregate                           record_in       record_out       record_recv       record_send       0         0          0
-4294967136  views                                  record_in       record_out       record_recv       record_send       0         0          0
-4294967137  view_table_usage                       record_in       record_out       record_recv       record_send       0         0          0
-4294967138  view_routine_usage                     record_in       record_out       record_recv       record_send       0         0          0
-4294967139  view_column_usage                      record_in       record_out       record_recv       record_send       0         0          0
-4294967140  user_privileges                        record_in       record_out       record_recv       record_send       0         0          0
-4294967141  user_mappings                          record_in       record_out       record_recv       record_send       0         0          0
-4294967142  user_mapping_options                   record_in       record_out       record_recv       record_send       0         0          0
-4294967143  user_defined_types                     record_in       record_out       record_recv       record_send       0         0          0
-4294967144  user_attributes                        record_in       record_out       record_recv       record_send       0         0          0
-4294967145  usage_privileges                       record_in       record_out       record_recv       record_send       0         0          0
-4294967146  udt_privileges                         record_in       record_out       record_recv       record_send       0         0          0
-4294967147  type_privileges                        record_in       record_out       record_recv       record_send       0         0          0
-4294967148  triggers                               record_in       record_out       record_recv       record_send       0         0          0
-4294967149  triggered_update_columns               record_in       record_out       record_recv       record_send       0         0          0
-4294967150  transforms                             record_in       record_out       record_recv       record_send       0         0          0
-4294967151  tablespaces                            record_in       record_out       record_recv       record_send       0         0          0
-4294967152  tablespaces_extensions                 record_in       record_out       record_recv       record_send       0         0          0
-4294967153  tables                                 record_in       record_out       record_recv       record_send       0         0          0
-4294967154  tables_extensions                      record_in       record_out       record_recv       record_send       0         0          0
-4294967155  table_privileges                       record_in       record_out       record_recv       record_send       0         0          0
-4294967156  table_constraints_extensions           record_in       record_out       record_recv       record_send       0         0          0
-4294967157  table_constraints                      record_in       record_out       record_recv       record_send       0         0          0
-4294967158  statistics                             record_in       record_out       record_recv       record_send       0         0          0
-4294967159  st_units_of_measure                    record_in       record_out       record_recv       record_send       0         0          0
-4294967160  st_spatial_reference_systems           record_in       record_out       record_recv       record_send       0         0          0
-4294967161  st_geometry_columns                    record_in       record_out       record_recv       record_send       0         0          0
-4294967162  session_variables                      record_in       record_out       record_recv       record_send       0         0          0
-4294967163  sequences                              record_in       record_out       record_recv       record_send       0         0          0
-4294967164  schema_privileges                      record_in       record_out       record_recv       record_send       0         0          0
-4294967165  schemata                               record_in       record_out       record_recv       record_send       0         0          0
-4294967166  schemata_extensions                    record_in       record_out       record_recv       record_send       0         0          0
-4294967167  sql_sizing                             record_in       record_out       record_recv       record_send       0         0          0
-4294967168  sql_parts                              record_in       record_out       record_recv       record_send       0         0          0
-4294967169  sql_implementation_info                record_in       record_out       record_recv       record_send       0         0          0
-4294967170  sql_features                           record_in       record_out       record_recv       record_send       0         0          0
-4294967171  routines                               record_in       record_out       record_recv       record_send       0         0          0
-4294967172  routine_privileges                     record_in       record_out       record_recv       record_send       0         0          0
-4294967173  role_usage_grants                      record_in       record_out       record_recv       record_send       0         0          0
-4294967174  role_udt_grants                        record_in       record_out       record_recv       record_send       0         0          0
-4294967175  role_table_grants                      record_in       record_out       record_recv       record_send       0         0          0
-4294967176  role_routine_grants                    record_in       record_out       record_recv       record_send       0         0          0
-4294967177  role_column_grants                     record_in       record_out       record_recv       record_send       0         0          0
-4294967178  resource_groups                        record_in       record_out       record_recv       record_send       0         0          0
-4294967179  referential_constraints                record_in       record_out       record_recv       record_send       0         0          0
-4294967180  profiling                              record_in       record_out       record_recv       record_send       0         0          0
-4294967181  processlist                            record_in       record_out       record_recv       record_send       0         0          0
-4294967182  plugins                                record_in       record_out       record_recv       record_send       0         0          0
-4294967183  partitions                             record_in       record_out       record_recv       record_send       0         0          0
-4294967184  parameters                             record_in       record_out       record_recv       record_send       0         0          0
-4294967185  optimizer_trace                        record_in       record_out       record_recv       record_send       0         0          0
-4294967186  keywords                               record_in       record_out       record_recv       record_send       0         0          0
-4294967187  key_column_usage                       record_in       record_out       record_recv       record_send       0         0          0
-4294967188  information_schema_catalog_name        record_in       record_out       record_recv       record_send       0         0          0
-4294967189  foreign_tables                         record_in       record_out       record_recv       record_send       0         0          0
-4294967190  foreign_table_options                  record_in       record_out       record_recv       record_send       0         0          0
-4294967191  foreign_servers                        record_in       record_out       record_recv       record_send       0         0          0
-4294967192  foreign_server_options                 record_in       record_out       record_recv       record_send       0         0          0
-4294967193  foreign_data_wrappers                  record_in       record_out       record_recv       record_send       0         0          0
-4294967194  foreign_data_wrapper_options           record_in       record_out       record_recv       record_send       0         0          0
-4294967195  files                                  record_in       record_out       record_recv       record_send       0         0          0
-4294967196  events                                 record_in       record_out       record_recv       record_send       0         0          0
-4294967197  engines                                record_in       record_out       record_recv       record_send       0         0          0
-4294967198  enabled_roles                          record_in       record_out       record_recv       record_send       0         0          0
-4294967199  element_types                          record_in       record_out       record_recv       record_send       0         0          0
-4294967200  domains                                record_in       record_out       record_recv       record_send       0         0          0
-4294967201  domain_udt_usage                       record_in       record_out       record_recv       record_send       0         0          0
-4294967202  domain_constraints                     record_in       record_out       record_recv       record_send       0         0          0
-4294967203  data_type_privileges                   record_in       record_out       record_recv       record_send       0         0          0
-4294967204  constraint_table_usage                 record_in       record_out       record_recv       record_send       0         0          0
-4294967205  constraint_column_usage                record_in       record_out       record_recv       record_send       0         0          0
-4294967206  columns                                record_in       record_out       record_recv       record_send       0         0          0
-4294967207  columns_extensions                     record_in       record_out       record_recv       record_send       0         0          0
-4294967208  column_udt_usage                       record_in       record_out       record_recv       record_send       0         0          0
-4294967209  column_statistics                      record_in       record_out       record_recv       record_send       0         0          0
-4294967210  column_privileges                      record_in       record_out       record_recv       record_send       0         0          0
-4294967211  column_options                         record_in       record_out       record_recv       record_send       0         0          0
-4294967212  column_domain_usage                    record_in       record_out       record_recv       record_send       0         0          0
-4294967213  column_column_usage                    record_in       record_out       record_recv       record_send       0         0          0
-4294967214  collations                             record_in       record_out       record_recv       record_send       0         0          0
-4294967215  collation_character_set_applicability  record_in       record_out       record_recv       record_send       0         0          0
-4294967216  check_constraints                      record_in       record_out       record_recv       record_send       0         0          0
-4294967217  check_constraint_routine_usage         record_in       record_out       record_recv       record_send       0         0          0
-4294967218  character_sets                         record_in       record_out       record_recv       record_send       0         0          0
-4294967219  attributes                             record_in       record_out       record_recv       record_send       0         0          0
-4294967220  applicable_roles                       record_in       record_out       record_recv       record_send       0         0          0
-4294967221  administrable_role_authorizations      record_in       record_out       record_recv       record_send       0         0          0
-4294967223  super_regions                          record_in       record_out       record_recv       record_send       0         0          0
-4294967224  pg_catalog_table_is_implemented        record_in       record_out       record_recv       record_send       0         0          0
-4294967225  tenant_usage_details                   record_in       record_out       record_recv       record_send       0         0          0
-4294967226  active_range_feeds                     record_in       record_out       record_recv       record_send       0         0          0
-4294967227  default_privileges                     record_in       record_out       record_recv       record_send       0         0          0
-4294967228  regions                                record_in       record_out       record_recv       record_send       0         0          0
-4294967229  cluster_inflight_traces                record_in       record_out       record_recv       record_send       0         0          0
-4294967230  lost_descriptors_with_data             record_in       record_out       record_recv       record_send       0         0          0
-4294967231  cross_db_references                    record_in       record_out       record_recv       record_send       0         0          0
-4294967232  cluster_database_privileges            record_in       record_out       record_recv       record_send       0         0          0
-4294967233  invalid_objects                        record_in       record_out       record_recv       record_send       0         0          0
-4294967234  zones                                  record_in       record_out       record_recv       record_send       0         0          0
-4294967235  transaction_statistics                 record_in       record_out       record_recv       record_send       0         0          0
-4294967236  node_transaction_statistics            record_in       record_out       record_recv       record_send       0         0          0
-4294967237  table_row_statistics                   record_in       record_out       record_recv       record_send       0         0          0
-4294967238  tables                                 record_in       record_out       record_recv       record_send       0         0          0
-4294967239  table_indexes                          record_in       record_out       record_recv       record_send       0         0          0
-4294967240  table_columns                          record_in       record_out       record_recv       record_send       0         0          0
-4294967241  statement_statistics                   record_in       record_out       record_recv       record_send       0         0          0
-4294967242  session_variables                      record_in       record_out       record_recv       record_send       0         0          0
-4294967243  session_trace                          record_in       record_out       record_recv       record_send       0         0          0
-4294967244  schema_changes                         record_in       record_out       record_recv       record_send       0         0          0
-4294967245  node_runtime_info                      record_in       record_out       record_recv       record_send       0         0          0
-4294967246  ranges                                 record_in       record_out       record_recv       record_send       0         0          0
-4294967247  ranges_no_leases                       record_in       record_out       record_recv       record_send       0         0          0
-4294967248  predefined_comments                    record_in       record_out       record_recv       record_send       0         0          0
-4294967249  partitions                             record_in       record_out       record_recv       record_send       0         0          0
-4294967250  node_txn_stats                         record_in       record_out       record_recv       record_send       0         0          0
-4294967251  node_statement_statistics              record_in       record_out       record_recv       record_send       0         0          0
-4294967252  node_metrics                           record_in       record_out       record_recv       record_send       0         0          0
-4294967253  node_sessions                          record_in       record_out       record_recv       record_send       0         0          0
-4294967254  node_transactions                      record_in       record_out       record_recv       record_send       0         0          0
-4294967255  node_queries                           record_in       record_out       record_recv       record_send       0         0          0
-4294967256  node_execution_insights                record_in       record_out       record_recv       record_send       0         0          0
-4294967257  node_distsql_flows                     record_in       record_out       record_recv       record_send       0         0          0
-4294967258  node_contention_events                 record_in       record_out       record_recv       record_send       0         0          0
-4294967259  leases                                 record_in       record_out       record_recv       record_send       0         0          0
-4294967260  kv_store_status                        record_in       record_out       record_recv       record_send       0         0          0
-4294967261  kv_node_status                         record_in       record_out       record_recv       record_send       0         0          0
-4294967262  jobs                                   record_in       record_out       record_recv       record_send       0         0          0
-4294967263  node_inflight_trace_spans              record_in       record_out       record_recv       record_send       0         0          0
-4294967264  index_usage_statistics                 record_in       record_out       record_recv       record_send       0         0          0
-4294967265  index_columns                          record_in       record_out       record_recv       record_send       0         0          0
-4294967266  transaction_contention_events          record_in       record_out       record_recv       record_send       0         0          0
-4294967267  gossip_network                         record_in       record_out       record_recv       record_send       0         0          0
-4294967268  gossip_liveness                        record_in       record_out       record_recv       record_send       0         0          0
-4294967269  gossip_alerts                          record_in       record_out       record_recv       record_send       0         0          0
-4294967270  gossip_nodes                           record_in       record_out       record_recv       record_send       0         0          0
-4294967271  kv_node_liveness                       record_in       record_out       record_recv       record_send       0         0          0
-4294967272  forward_dependencies                   record_in       record_out       record_recv       record_send       0         0          0
-4294967273  feature_usage                          record_in       record_out       record_recv       record_send       0         0          0
-4294967274  databases                              record_in       record_out       record_recv       record_send       0         0          0
-4294967275  create_type_statements                 record_in       record_out       record_recv       record_send       0         0          0
-4294967276  create_statements                      record_in       record_out       record_recv       record_send       0         0          0
-4294967277  create_schema_statements               record_in       record_out       record_recv       record_send       0         0          0
-4294967278  create_function_statements             record_in       record_out       record_recv       record_send       0         0          0
-4294967279  cluster_transaction_statistics         record_in       record_out       record_recv       record_send       0         0          0
-4294967280  cluster_statement_statistics           record_in       record_out       record_recv       record_send       0         0          0
-4294967281  cluster_settings                       record_in       record_out       record_recv       record_send       0         0          0
-4294967282  cluster_sessions                       record_in       record_out       record_recv       record_send       0         0          0
-4294967283  cluster_transactions                   record_in       record_out       record_recv       record_send       0         0          0
-4294967284  cluster_queries                        record_in       record_out       record_recv       record_send       0         0          0
-4294967285  cluster_locks                          record_in       record_out       record_recv       record_send       0         0          0
-4294967286  cluster_execution_insights             record_in       record_out       record_recv       record_send       0         0          0
-4294967287  cluster_distsql_flows                  record_in       record_out       record_recv       record_send       0         0          0
-4294967288  cluster_contention_events              record_in       record_out       record_recv       record_send       0         0          0
-4294967289  cluster_contended_tables               record_in       record_out       record_recv       record_send       0         0          0
-4294967290  cluster_contended_keys                 record_in       record_out       record_recv       record_send       0         0          0
-4294967291  cluster_contended_indexes              record_in       record_out       record_recv       record_send       0         0          0
-4294967292  builtin_functions                      record_in       record_out       record_recv       record_send       0         0          0
-4294967293  node_build_info                        record_in       record_out       record_recv       record_send       0         0          0
-4294967294  backward_dependencies                  record_in       record_out       record_recv       record_send       0         0          0
+oid     typname                typinput        typoutput        typreceive        typsend           typmodin  typmodout  typanalyze
+16      bool                   boolin          boolout          boolrecv          boolsend          0         0          0
+17      bytea                  byteain         byteaout         bytearecv         byteasend         0         0          0
+18      char                   charin          charout          charrecv          charsend          0         0          0
+19      name                   namein          nameout          namerecv          namesend          0         0          0
+20      int8                   int8in          int8out          int8recv          int8send          0         0          0
+21      int2                   int2in          int2out          int2recv          int2send          0         0          0
+22      int2vector             int2vectorin    int2vectorout    int2vectorrecv    int2vectorsend    0         0          0
+23      int4                   int4in          int4out          int4recv          int4send          0         0          0
+24      regproc                regprocin       regprocout       regprocrecv       regprocsend       0         0          0
+25      text                   textin          textout          textrecv          textsend          0         0          0
+26      oid                    oidin           oidout           oidrecv           oidsend           0         0          0
+30      oidvector              oidvectorin     oidvectorout     oidvectorrecv     oidvectorsend     0         0          0
+700     float4                 float4in        float4out        float4recv        float4send        0         0          0
+701     float8                 float8in        float8out        float8recv        float8send        0         0          0
+705     unknown                unknownin       unknownout       unknownrecv       unknownsend       0         0          0
+869     inet                   inetin          inetout          inetrecv          inetsend          0         0          0
+1000    _bool                  array_in        array_out        array_recv        array_send        0         0          0
+1001    _bytea                 array_in        array_out        array_recv        array_send        0         0          0
+1002    _char                  array_in        array_out        array_recv        array_send        0         0          0
+1003    _name                  array_in        array_out        array_recv        array_send        0         0          0
+1005    _int2                  array_in        array_out        array_recv        array_send        0         0          0
+1006    _int2vector            array_in        array_out        array_recv        array_send        0         0          0
+1007    _int4                  array_in        array_out        array_recv        array_send        0         0          0
+1008    _regproc               array_in        array_out        array_recv        array_send        0         0          0
+1009    _text                  array_in        array_out        array_recv        array_send        0         0          0
+1013    _oidvector             array_in        array_out        array_recv        array_send        0         0          0
+1014    _bpchar                array_in        array_out        array_recv        array_send        0         0          0
+1015    _varchar               array_in        array_out        array_recv        array_send        0         0          0
+1016    _int8                  array_in        array_out        array_recv        array_send        0         0          0
+1021    _float4                array_in        array_out        array_recv        array_send        0         0          0
+1022    _float8                array_in        array_out        array_recv        array_send        0         0          0
+1028    _oid                   array_in        array_out        array_recv        array_send        0         0          0
+1041    _inet                  array_in        array_out        array_recv        array_send        0         0          0
+1042    bpchar                 bpcharin        bpcharout        bpcharrecv        bpcharsend        0         0          0
+1043    varchar                varcharin       varcharout       varcharrecv       varcharsend       0         0          0
+1082    date                   date_in         date_out         date_recv         date_send         0         0          0
+1083    time                   time_in         time_out         time_recv         time_send         0         0          0
+1114    timestamp              timestamp_in    timestamp_out    timestamp_recv    timestamp_send    0         0          0
+1115    _timestamp             array_in        array_out        array_recv        array_send        0         0          0
+1182    _date                  array_in        array_out        array_recv        array_send        0         0          0
+1183    _time                  array_in        array_out        array_recv        array_send        0         0          0
+1184    timestamptz            timestamptz_in  timestamptz_out  timestamptz_recv  timestamptz_send  0         0          0
+1185    _timestamptz           array_in        array_out        array_recv        array_send        0         0          0
+1186    interval               interval_in     interval_out     interval_recv     interval_send     0         0          0
+1187    _interval              array_in        array_out        array_recv        array_send        0         0          0
+1231    _numeric               array_in        array_out        array_recv        array_send        0         0          0
+1266    timetz                 timetz_in       timetz_out       timetz_recv       timetz_send       0         0          0
+1270    _timetz                array_in        array_out        array_recv        array_send        0         0          0
+1560    bit                    bit_in          bit_out          bit_recv          bit_send          0         0          0
+1561    _bit                   array_in        array_out        array_recv        array_send        0         0          0
+1562    varbit                 varbit_in       varbit_out       varbit_recv       varbit_send       0         0          0
+1563    _varbit                array_in        array_out        array_recv        array_send        0         0          0
+1700    numeric                numeric_in      numeric_out      numeric_recv      numeric_send      0         0          0
+2202    regprocedure           regprocedurein  regprocedureout  regprocedurerecv  regproceduresend  0         0          0
+2205    regclass               regclassin      regclassout      regclassrecv      regclasssend      0         0          0
+2206    regtype                regtypein       regtypeout       regtyperecv       regtypesend       0         0          0
+2207    _regprocedure          array_in        array_out        array_recv        array_send        0         0          0
+2210    _regclass              array_in        array_out        array_recv        array_send        0         0          0
+2211    _regtype               array_in        array_out        array_recv        array_send        0         0          0
+2249    record                 record_in       record_out       record_recv       record_send       0         0          0
+2277    anyarray               anyarray_in     anyarray_out     anyarray_recv     anyarray_send     0         0          0
+2278    void                   voidin          voidout          voidrecv          voidsend          0         0          0
+2283    anyelement             anyelement_in   anyelement_out   anyelement_recv   anyelement_send   0         0          0
+2287    _record                array_in        array_out        array_recv        array_send        0         0          0
+2950    uuid                   uuid_in         uuid_out         uuid_recv         uuid_send         0         0          0
+2951    _uuid                  array_in        array_out        array_recv        array_send        0         0          0
+3802    jsonb                  jsonb_in        jsonb_out        jsonb_recv        jsonb_send        0         0          0
+3807    _jsonb                 array_in        array_out        array_recv        array_send        0         0          0
+4089    regnamespace           regnamespacein  regnamespaceout  regnamespacerecv  regnamespacesend  0         0          0
+4090    _regnamespace          array_in        array_out        array_recv        array_send        0         0          0
+4096    regrole                regrolein       regroleout       regrolerecv       regrolesend       0         0          0
+4097    _regrole               array_in        array_out        array_recv        array_send        0         0          0
+90000   geometry               geometry_in     geometry_out     geometry_recv     geometry_send     0         0          0
+90001   _geometry              array_in        array_out        array_recv        array_send        0         0          0
+90002   geography              geography_in    geography_out    geography_recv    geography_send    0         0          0
+90003   _geography             array_in        array_out        array_recv        array_send        0         0          0
+90004   box2d                  box2d_in        box2d_out        box2d_recv        box2d_send        0         0          0
+90005   _box2d                 array_in        array_out        array_recv        array_send        0         0          0
+100110  t1                     record_in       record_out       record_recv       record_send       0         0          0
+100111  t1_m_seq               record_in       record_out       record_recv       record_send       0         0          0
+100112  t1_n_seq               record_in       record_out       record_recv       record_send       0         0          0
+100113  t2                     record_in       record_out       record_recv       record_send       0         0          0
+100114  t3                     record_in       record_out       record_recv       record_send       0         0          0
+100115  v1                     record_in       record_out       record_recv       record_send       0         0          0
+100116  t4                     record_in       record_out       record_recv       record_send       0         0          0
+100117  t5                     record_in       record_out       record_recv       record_send       0         0          0
+100118  mytype                 enum_in         enum_out         enum_recv         enum_send         0         0          0
+100119  _mytype                array_in        array_out        array_recv        array_send        0         0          0
+100120  t6                     record_in       record_out       record_recv       record_send       0         0          0
+100121  mv1                    record_in       record_out       record_recv       record_send       0         0          0
+100128  source_table           record_in       record_out       record_recv       record_send       0         0          0
+100129  depend_view            record_in       record_out       record_recv       record_send       0         0          0
+100130  view_dependingon_view  record_in       record_out       record_recv       record_send       0         0          0
+100131  newtype1               enum_in         enum_out         enum_recv         enum_send         0         0          0
+100132  _newtype1              array_in        array_out        array_recv        array_send        0         0          0
+100133  newtype2               enum_in         enum_out         enum_recv         enum_send         0         0          0
+100134  _newtype2              array_in        array_out        array_recv        array_send        0         0          0
 
 query OTTTBOI colnames
 SELECT oid, typname, typalign, typstorage, typnotnull, typbasetype, typtypmod
 FROM pg_catalog.pg_type
+WHERE oid < 4194967002 -- exclude implicit types for virtual tables
 ORDER BY oid
 ----
-oid         typname                                typalign  typstorage  typnotnull  typbasetype  typtypmod
-16          bool                                   NULL      NULL        false       0            -1
-17          bytea                                  NULL      NULL        false       0            -1
-18          char                                   NULL      NULL        false       0            -1
-19          name                                   NULL      NULL        false       0            -1
-20          int8                                   NULL      NULL        false       0            -1
-21          int2                                   NULL      NULL        false       0            -1
-22          int2vector                             NULL      NULL        false       0            -1
-23          int4                                   NULL      NULL        false       0            -1
-24          regproc                                NULL      NULL        false       0            -1
-25          text                                   NULL      NULL        false       0            -1
-26          oid                                    NULL      NULL        false       0            -1
-30          oidvector                              NULL      NULL        false       0            -1
-700         float4                                 NULL      NULL        false       0            -1
-701         float8                                 NULL      NULL        false       0            -1
-705         unknown                                NULL      NULL        false       0            -1
-869         inet                                   NULL      NULL        false       0            -1
-1000        _bool                                  NULL      NULL        false       0            -1
-1001        _bytea                                 NULL      NULL        false       0            -1
-1002        _char                                  NULL      NULL        false       0            -1
-1003        _name                                  NULL      NULL        false       0            -1
-1005        _int2                                  NULL      NULL        false       0            -1
-1006        _int2vector                            NULL      NULL        false       0            -1
-1007        _int4                                  NULL      NULL        false       0            -1
-1008        _regproc                               NULL      NULL        false       0            -1
-1009        _text                                  NULL      NULL        false       0            -1
-1013        _oidvector                             NULL      NULL        false       0            -1
-1014        _bpchar                                NULL      NULL        false       0            -1
-1015        _varchar                               NULL      NULL        false       0            -1
-1016        _int8                                  NULL      NULL        false       0            -1
-1021        _float4                                NULL      NULL        false       0            -1
-1022        _float8                                NULL      NULL        false       0            -1
-1028        _oid                                   NULL      NULL        false       0            -1
-1041        _inet                                  NULL      NULL        false       0            -1
-1042        bpchar                                 NULL      NULL        false       0            -1
-1043        varchar                                NULL      NULL        false       0            -1
-1082        date                                   NULL      NULL        false       0            -1
-1083        time                                   NULL      NULL        false       0            -1
-1114        timestamp                              NULL      NULL        false       0            -1
-1115        _timestamp                             NULL      NULL        false       0            -1
-1182        _date                                  NULL      NULL        false       0            -1
-1183        _time                                  NULL      NULL        false       0            -1
-1184        timestamptz                            NULL      NULL        false       0            -1
-1185        _timestamptz                           NULL      NULL        false       0            -1
-1186        interval                               NULL      NULL        false       0            -1
-1187        _interval                              NULL      NULL        false       0            -1
-1231        _numeric                               NULL      NULL        false       0            -1
-1266        timetz                                 NULL      NULL        false       0            -1
-1270        _timetz                                NULL      NULL        false       0            -1
-1560        bit                                    NULL      NULL        false       0            -1
-1561        _bit                                   NULL      NULL        false       0            -1
-1562        varbit                                 NULL      NULL        false       0            -1
-1563        _varbit                                NULL      NULL        false       0            -1
-1700        numeric                                NULL      NULL        false       0            -1
-2202        regprocedure                           NULL      NULL        false       0            -1
-2205        regclass                               NULL      NULL        false       0            -1
-2206        regtype                                NULL      NULL        false       0            -1
-2207        _regprocedure                          NULL      NULL        false       0            -1
-2210        _regclass                              NULL      NULL        false       0            -1
-2211        _regtype                               NULL      NULL        false       0            -1
-2249        record                                 NULL      NULL        false       0            -1
-2277        anyarray                               NULL      NULL        false       0            -1
-2278        void                                   NULL      NULL        false       0            -1
-2283        anyelement                             NULL      NULL        false       0            -1
-2287        _record                                NULL      NULL        false       0            -1
-2950        uuid                                   NULL      NULL        false       0            -1
-2951        _uuid                                  NULL      NULL        false       0            -1
-3802        jsonb                                  NULL      NULL        false       0            -1
-3807        _jsonb                                 NULL      NULL        false       0            -1
-4089        regnamespace                           NULL      NULL        false       0            -1
-4090        _regnamespace                          NULL      NULL        false       0            -1
-4096        regrole                                NULL      NULL        false       0            -1
-4097        _regrole                               NULL      NULL        false       0            -1
-90000       geometry                               NULL      NULL        false       0            -1
-90001       _geometry                              NULL      NULL        false       0            -1
-90002       geography                              NULL      NULL        false       0            -1
-90003       _geography                             NULL      NULL        false       0            -1
-90004       box2d                                  NULL      NULL        false       0            -1
-90005       _box2d                                 NULL      NULL        false       0            -1
-100110      t1                                     NULL      NULL        false       0            -1
-100111      t1_m_seq                               NULL      NULL        false       0            -1
-100112      t1_n_seq                               NULL      NULL        false       0            -1
-100113      t2                                     NULL      NULL        false       0            -1
-100114      t3                                     NULL      NULL        false       0            -1
-100115      v1                                     NULL      NULL        false       0            -1
-100116      t4                                     NULL      NULL        false       0            -1
-100117      t5                                     NULL      NULL        false       0            -1
-100118      mytype                                 NULL      NULL        false       0            -1
-100119      _mytype                                NULL      NULL        false       0            -1
-100120      t6                                     NULL      NULL        false       0            -1
-100121      mv1                                    NULL      NULL        false       0            -1
-100128      source_table                           NULL      NULL        false       0            -1
-100129      depend_view                            NULL      NULL        false       0            -1
-100130      view_dependingon_view                  NULL      NULL        false       0            -1
-100131      newtype1                               NULL      NULL        false       0            -1
-100132      _newtype1                              NULL      NULL        false       0            -1
-100133      newtype2                               NULL      NULL        false       0            -1
-100134      _newtype2                              NULL      NULL        false       0            -1
-4294967002  spatial_ref_sys                        NULL      NULL        false       0            -1
-4294967003  geometry_columns                       NULL      NULL        false       0            -1
-4294967004  geography_columns                      NULL      NULL        false       0            -1
-4294967006  pg_views                               NULL      NULL        false       0            -1
-4294967007  pg_user                                NULL      NULL        false       0            -1
-4294967008  pg_user_mappings                       NULL      NULL        false       0            -1
-4294967009  pg_user_mapping                        NULL      NULL        false       0            -1
-4294967010  pg_type                                NULL      NULL        false       0            -1
-4294967011  pg_ts_template                         NULL      NULL        false       0            -1
-4294967012  pg_ts_parser                           NULL      NULL        false       0            -1
-4294967013  pg_ts_dict                             NULL      NULL        false       0            -1
-4294967014  pg_ts_config                           NULL      NULL        false       0            -1
-4294967015  pg_ts_config_map                       NULL      NULL        false       0            -1
-4294967016  pg_trigger                             NULL      NULL        false       0            -1
-4294967017  pg_transform                           NULL      NULL        false       0            -1
-4294967018  pg_timezone_names                      NULL      NULL        false       0            -1
-4294967019  pg_timezone_abbrevs                    NULL      NULL        false       0            -1
-4294967020  pg_tablespace                          NULL      NULL        false       0            -1
-4294967021  pg_tables                              NULL      NULL        false       0            -1
-4294967022  pg_subscription                        NULL      NULL        false       0            -1
-4294967023  pg_subscription_rel                    NULL      NULL        false       0            -1
-4294967024  pg_stats                               NULL      NULL        false       0            -1
-4294967025  pg_stats_ext                           NULL      NULL        false       0            -1
-4294967026  pg_statistic                           NULL      NULL        false       0            -1
-4294967027  pg_statistic_ext                       NULL      NULL        false       0            -1
-4294967028  pg_statistic_ext_data                  NULL      NULL        false       0            -1
-4294967029  pg_statio_user_tables                  NULL      NULL        false       0            -1
-4294967030  pg_statio_user_sequences               NULL      NULL        false       0            -1
-4294967031  pg_statio_user_indexes                 NULL      NULL        false       0            -1
-4294967032  pg_statio_sys_tables                   NULL      NULL        false       0            -1
-4294967033  pg_statio_sys_sequences                NULL      NULL        false       0            -1
-4294967034  pg_statio_sys_indexes                  NULL      NULL        false       0            -1
-4294967035  pg_statio_all_tables                   NULL      NULL        false       0            -1
-4294967036  pg_statio_all_sequences                NULL      NULL        false       0            -1
-4294967037  pg_statio_all_indexes                  NULL      NULL        false       0            -1
-4294967038  pg_stat_xact_user_tables               NULL      NULL        false       0            -1
-4294967039  pg_stat_xact_user_functions            NULL      NULL        false       0            -1
-4294967040  pg_stat_xact_sys_tables                NULL      NULL        false       0            -1
-4294967041  pg_stat_xact_all_tables                NULL      NULL        false       0            -1
-4294967042  pg_stat_wal_receiver                   NULL      NULL        false       0            -1
-4294967043  pg_stat_user_tables                    NULL      NULL        false       0            -1
-4294967044  pg_stat_user_indexes                   NULL      NULL        false       0            -1
-4294967045  pg_stat_user_functions                 NULL      NULL        false       0            -1
-4294967046  pg_stat_sys_tables                     NULL      NULL        false       0            -1
-4294967047  pg_stat_sys_indexes                    NULL      NULL        false       0            -1
-4294967048  pg_stat_subscription                   NULL      NULL        false       0            -1
-4294967049  pg_stat_ssl                            NULL      NULL        false       0            -1
-4294967050  pg_stat_slru                           NULL      NULL        false       0            -1
-4294967051  pg_stat_replication                    NULL      NULL        false       0            -1
-4294967052  pg_stat_progress_vacuum                NULL      NULL        false       0            -1
-4294967053  pg_stat_progress_create_index          NULL      NULL        false       0            -1
-4294967054  pg_stat_progress_cluster               NULL      NULL        false       0            -1
-4294967055  pg_stat_progress_basebackup            NULL      NULL        false       0            -1
-4294967056  pg_stat_progress_analyze               NULL      NULL        false       0            -1
-4294967057  pg_stat_gssapi                         NULL      NULL        false       0            -1
-4294967058  pg_stat_database                       NULL      NULL        false       0            -1
-4294967059  pg_stat_database_conflicts             NULL      NULL        false       0            -1
-4294967060  pg_stat_bgwriter                       NULL      NULL        false       0            -1
-4294967061  pg_stat_archiver                       NULL      NULL        false       0            -1
-4294967062  pg_stat_all_tables                     NULL      NULL        false       0            -1
-4294967063  pg_stat_all_indexes                    NULL      NULL        false       0            -1
-4294967064  pg_stat_activity                       NULL      NULL        false       0            -1
-4294967065  pg_shmem_allocations                   NULL      NULL        false       0            -1
-4294967066  pg_shdepend                            NULL      NULL        false       0            -1
-4294967067  pg_shseclabel                          NULL      NULL        false       0            -1
-4294967068  pg_shdescription                       NULL      NULL        false       0            -1
-4294967069  pg_shadow                              NULL      NULL        false       0            -1
-4294967070  pg_settings                            NULL      NULL        false       0            -1
-4294967071  pg_sequences                           NULL      NULL        false       0            -1
-4294967072  pg_sequence                            NULL      NULL        false       0            -1
-4294967073  pg_seclabel                            NULL      NULL        false       0            -1
-4294967074  pg_seclabels                           NULL      NULL        false       0            -1
-4294967075  pg_rules                               NULL      NULL        false       0            -1
-4294967076  pg_roles                               NULL      NULL        false       0            -1
-4294967077  pg_rewrite                             NULL      NULL        false       0            -1
-4294967078  pg_replication_slots                   NULL      NULL        false       0            -1
-4294967079  pg_replication_origin                  NULL      NULL        false       0            -1
-4294967080  pg_replication_origin_status           NULL      NULL        false       0            -1
-4294967081  pg_range                               NULL      NULL        false       0            -1
-4294967082  pg_publication_tables                  NULL      NULL        false       0            -1
-4294967083  pg_publication                         NULL      NULL        false       0            -1
-4294967084  pg_publication_rel                     NULL      NULL        false       0            -1
-4294967085  pg_proc                                NULL      NULL        false       0            -1
-4294967086  pg_prepared_xacts                      NULL      NULL        false       0            -1
-4294967087  pg_prepared_statements                 NULL      NULL        false       0            -1
-4294967088  pg_policy                              NULL      NULL        false       0            -1
-4294967089  pg_policies                            NULL      NULL        false       0            -1
-4294967090  pg_partitioned_table                   NULL      NULL        false       0            -1
-4294967091  pg_opfamily                            NULL      NULL        false       0            -1
-4294967092  pg_operator                            NULL      NULL        false       0            -1
-4294967093  pg_opclass                             NULL      NULL        false       0            -1
-4294967094  pg_namespace                           NULL      NULL        false       0            -1
-4294967095  pg_matviews                            NULL      NULL        false       0            -1
-4294967096  pg_locks                               NULL      NULL        false       0            -1
-4294967097  pg_largeobject                         NULL      NULL        false       0            -1
-4294967098  pg_largeobject_metadata                NULL      NULL        false       0            -1
-4294967099  pg_language                            NULL      NULL        false       0            -1
-4294967100  pg_init_privs                          NULL      NULL        false       0            -1
-4294967101  pg_inherits                            NULL      NULL        false       0            -1
-4294967102  pg_indexes                             NULL      NULL        false       0            -1
-4294967103  pg_index                               NULL      NULL        false       0            -1
-4294967104  pg_hba_file_rules                      NULL      NULL        false       0            -1
-4294967105  pg_group                               NULL      NULL        false       0            -1
-4294967106  pg_foreign_table                       NULL      NULL        false       0            -1
-4294967107  pg_foreign_server                      NULL      NULL        false       0            -1
-4294967108  pg_foreign_data_wrapper                NULL      NULL        false       0            -1
-4294967109  pg_file_settings                       NULL      NULL        false       0            -1
-4294967110  pg_extension                           NULL      NULL        false       0            -1
-4294967111  pg_event_trigger                       NULL      NULL        false       0            -1
-4294967112  pg_enum                                NULL      NULL        false       0            -1
-4294967113  pg_description                         NULL      NULL        false       0            -1
-4294967114  pg_depend                              NULL      NULL        false       0            -1
-4294967115  pg_default_acl                         NULL      NULL        false       0            -1
-4294967116  pg_db_role_setting                     NULL      NULL        false       0            -1
-4294967117  pg_database                            NULL      NULL        false       0            -1
-4294967118  pg_cursors                             NULL      NULL        false       0            -1
-4294967119  pg_conversion                          NULL      NULL        false       0            -1
-4294967120  pg_constraint                          NULL      NULL        false       0            -1
-4294967121  pg_config                              NULL      NULL        false       0            -1
-4294967122  pg_collation                           NULL      NULL        false       0            -1
-4294967123  pg_class                               NULL      NULL        false       0            -1
-4294967124  pg_cast                                NULL      NULL        false       0            -1
-4294967125  pg_available_extensions                NULL      NULL        false       0            -1
-4294967126  pg_available_extension_versions        NULL      NULL        false       0            -1
-4294967127  pg_auth_members                        NULL      NULL        false       0            -1
-4294967128  pg_authid                              NULL      NULL        false       0            -1
-4294967129  pg_attribute                           NULL      NULL        false       0            -1
-4294967130  pg_attrdef                             NULL      NULL        false       0            -1
-4294967131  pg_amproc                              NULL      NULL        false       0            -1
-4294967132  pg_amop                                NULL      NULL        false       0            -1
-4294967133  pg_am                                  NULL      NULL        false       0            -1
-4294967134  pg_aggregate                           NULL      NULL        false       0            -1
-4294967136  views                                  NULL      NULL        false       0            -1
-4294967137  view_table_usage                       NULL      NULL        false       0            -1
-4294967138  view_routine_usage                     NULL      NULL        false       0            -1
-4294967139  view_column_usage                      NULL      NULL        false       0            -1
-4294967140  user_privileges                        NULL      NULL        false       0            -1
-4294967141  user_mappings                          NULL      NULL        false       0            -1
-4294967142  user_mapping_options                   NULL      NULL        false       0            -1
-4294967143  user_defined_types                     NULL      NULL        false       0            -1
-4294967144  user_attributes                        NULL      NULL        false       0            -1
-4294967145  usage_privileges                       NULL      NULL        false       0            -1
-4294967146  udt_privileges                         NULL      NULL        false       0            -1
-4294967147  type_privileges                        NULL      NULL        false       0            -1
-4294967148  triggers                               NULL      NULL        false       0            -1
-4294967149  triggered_update_columns               NULL      NULL        false       0            -1
-4294967150  transforms                             NULL      NULL        false       0            -1
-4294967151  tablespaces                            NULL      NULL        false       0            -1
-4294967152  tablespaces_extensions                 NULL      NULL        false       0            -1
-4294967153  tables                                 NULL      NULL        false       0            -1
-4294967154  tables_extensions                      NULL      NULL        false       0            -1
-4294967155  table_privileges                       NULL      NULL        false       0            -1
-4294967156  table_constraints_extensions           NULL      NULL        false       0            -1
-4294967157  table_constraints                      NULL      NULL        false       0            -1
-4294967158  statistics                             NULL      NULL        false       0            -1
-4294967159  st_units_of_measure                    NULL      NULL        false       0            -1
-4294967160  st_spatial_reference_systems           NULL      NULL        false       0            -1
-4294967161  st_geometry_columns                    NULL      NULL        false       0            -1
-4294967162  session_variables                      NULL      NULL        false       0            -1
-4294967163  sequences                              NULL      NULL        false       0            -1
-4294967164  schema_privileges                      NULL      NULL        false       0            -1
-4294967165  schemata                               NULL      NULL        false       0            -1
-4294967166  schemata_extensions                    NULL      NULL        false       0            -1
-4294967167  sql_sizing                             NULL      NULL        false       0            -1
-4294967168  sql_parts                              NULL      NULL        false       0            -1
-4294967169  sql_implementation_info                NULL      NULL        false       0            -1
-4294967170  sql_features                           NULL      NULL        false       0            -1
-4294967171  routines                               NULL      NULL        false       0            -1
-4294967172  routine_privileges                     NULL      NULL        false       0            -1
-4294967173  role_usage_grants                      NULL      NULL        false       0            -1
-4294967174  role_udt_grants                        NULL      NULL        false       0            -1
-4294967175  role_table_grants                      NULL      NULL        false       0            -1
-4294967176  role_routine_grants                    NULL      NULL        false       0            -1
-4294967177  role_column_grants                     NULL      NULL        false       0            -1
-4294967178  resource_groups                        NULL      NULL        false       0            -1
-4294967179  referential_constraints                NULL      NULL        false       0            -1
-4294967180  profiling                              NULL      NULL        false       0            -1
-4294967181  processlist                            NULL      NULL        false       0            -1
-4294967182  plugins                                NULL      NULL        false       0            -1
-4294967183  partitions                             NULL      NULL        false       0            -1
-4294967184  parameters                             NULL      NULL        false       0            -1
-4294967185  optimizer_trace                        NULL      NULL        false       0            -1
-4294967186  keywords                               NULL      NULL        false       0            -1
-4294967187  key_column_usage                       NULL      NULL        false       0            -1
-4294967188  information_schema_catalog_name        NULL      NULL        false       0            -1
-4294967189  foreign_tables                         NULL      NULL        false       0            -1
-4294967190  foreign_table_options                  NULL      NULL        false       0            -1
-4294967191  foreign_servers                        NULL      NULL        false       0            -1
-4294967192  foreign_server_options                 NULL      NULL        false       0            -1
-4294967193  foreign_data_wrappers                  NULL      NULL        false       0            -1
-4294967194  foreign_data_wrapper_options           NULL      NULL        false       0            -1
-4294967195  files                                  NULL      NULL        false       0            -1
-4294967196  events                                 NULL      NULL        false       0            -1
-4294967197  engines                                NULL      NULL        false       0            -1
-4294967198  enabled_roles                          NULL      NULL        false       0            -1
-4294967199  element_types                          NULL      NULL        false       0            -1
-4294967200  domains                                NULL      NULL        false       0            -1
-4294967201  domain_udt_usage                       NULL      NULL        false       0            -1
-4294967202  domain_constraints                     NULL      NULL        false       0            -1
-4294967203  data_type_privileges                   NULL      NULL        false       0            -1
-4294967204  constraint_table_usage                 NULL      NULL        false       0            -1
-4294967205  constraint_column_usage                NULL      NULL        false       0            -1
-4294967206  columns                                NULL      NULL        false       0            -1
-4294967207  columns_extensions                     NULL      NULL        false       0            -1
-4294967208  column_udt_usage                       NULL      NULL        false       0            -1
-4294967209  column_statistics                      NULL      NULL        false       0            -1
-4294967210  column_privileges                      NULL      NULL        false       0            -1
-4294967211  column_options                         NULL      NULL        false       0            -1
-4294967212  column_domain_usage                    NULL      NULL        false       0            -1
-4294967213  column_column_usage                    NULL      NULL        false       0            -1
-4294967214  collations                             NULL      NULL        false       0            -1
-4294967215  collation_character_set_applicability  NULL      NULL        false       0            -1
-4294967216  check_constraints                      NULL      NULL        false       0            -1
-4294967217  check_constraint_routine_usage         NULL      NULL        false       0            -1
-4294967218  character_sets                         NULL      NULL        false       0            -1
-4294967219  attributes                             NULL      NULL        false       0            -1
-4294967220  applicable_roles                       NULL      NULL        false       0            -1
-4294967221  administrable_role_authorizations      NULL      NULL        false       0            -1
-4294967223  super_regions                          NULL      NULL        false       0            -1
-4294967224  pg_catalog_table_is_implemented        NULL      NULL        false       0            -1
-4294967225  tenant_usage_details                   NULL      NULL        false       0            -1
-4294967226  active_range_feeds                     NULL      NULL        false       0            -1
-4294967227  default_privileges                     NULL      NULL        false       0            -1
-4294967228  regions                                NULL      NULL        false       0            -1
-4294967229  cluster_inflight_traces                NULL      NULL        false       0            -1
-4294967230  lost_descriptors_with_data             NULL      NULL        false       0            -1
-4294967231  cross_db_references                    NULL      NULL        false       0            -1
-4294967232  cluster_database_privileges            NULL      NULL        false       0            -1
-4294967233  invalid_objects                        NULL      NULL        false       0            -1
-4294967234  zones                                  NULL      NULL        false       0            -1
-4294967235  transaction_statistics                 NULL      NULL        false       0            -1
-4294967236  node_transaction_statistics            NULL      NULL        false       0            -1
-4294967237  table_row_statistics                   NULL      NULL        false       0            -1
-4294967238  tables                                 NULL      NULL        false       0            -1
-4294967239  table_indexes                          NULL      NULL        false       0            -1
-4294967240  table_columns                          NULL      NULL        false       0            -1
-4294967241  statement_statistics                   NULL      NULL        false       0            -1
-4294967242  session_variables                      NULL      NULL        false       0            -1
-4294967243  session_trace                          NULL      NULL        false       0            -1
-4294967244  schema_changes                         NULL      NULL        false       0            -1
-4294967245  node_runtime_info                      NULL      NULL        false       0            -1
-4294967246  ranges                                 NULL      NULL        false       0            -1
-4294967247  ranges_no_leases                       NULL      NULL        false       0            -1
-4294967248  predefined_comments                    NULL      NULL        false       0            -1
-4294967249  partitions                             NULL      NULL        false       0            -1
-4294967250  node_txn_stats                         NULL      NULL        false       0            -1
-4294967251  node_statement_statistics              NULL      NULL        false       0            -1
-4294967252  node_metrics                           NULL      NULL        false       0            -1
-4294967253  node_sessions                          NULL      NULL        false       0            -1
-4294967254  node_transactions                      NULL      NULL        false       0            -1
-4294967255  node_queries                           NULL      NULL        false       0            -1
-4294967256  node_execution_insights                NULL      NULL        false       0            -1
-4294967257  node_distsql_flows                     NULL      NULL        false       0            -1
-4294967258  node_contention_events                 NULL      NULL        false       0            -1
-4294967259  leases                                 NULL      NULL        false       0            -1
-4294967260  kv_store_status                        NULL      NULL        false       0            -1
-4294967261  kv_node_status                         NULL      NULL        false       0            -1
-4294967262  jobs                                   NULL      NULL        false       0            -1
-4294967263  node_inflight_trace_spans              NULL      NULL        false       0            -1
-4294967264  index_usage_statistics                 NULL      NULL        false       0            -1
-4294967265  index_columns                          NULL      NULL        false       0            -1
-4294967266  transaction_contention_events          NULL      NULL        false       0            -1
-4294967267  gossip_network                         NULL      NULL        false       0            -1
-4294967268  gossip_liveness                        NULL      NULL        false       0            -1
-4294967269  gossip_alerts                          NULL      NULL        false       0            -1
-4294967270  gossip_nodes                           NULL      NULL        false       0            -1
-4294967271  kv_node_liveness                       NULL      NULL        false       0            -1
-4294967272  forward_dependencies                   NULL      NULL        false       0            -1
-4294967273  feature_usage                          NULL      NULL        false       0            -1
-4294967274  databases                              NULL      NULL        false       0            -1
-4294967275  create_type_statements                 NULL      NULL        false       0            -1
-4294967276  create_statements                      NULL      NULL        false       0            -1
-4294967277  create_schema_statements               NULL      NULL        false       0            -1
-4294967278  create_function_statements             NULL      NULL        false       0            -1
-4294967279  cluster_transaction_statistics         NULL      NULL        false       0            -1
-4294967280  cluster_statement_statistics           NULL      NULL        false       0            -1
-4294967281  cluster_settings                       NULL      NULL        false       0            -1
-4294967282  cluster_sessions                       NULL      NULL        false       0            -1
-4294967283  cluster_transactions                   NULL      NULL        false       0            -1
-4294967284  cluster_queries                        NULL      NULL        false       0            -1
-4294967285  cluster_locks                          NULL      NULL        false       0            -1
-4294967286  cluster_execution_insights             NULL      NULL        false       0            -1
-4294967287  cluster_distsql_flows                  NULL      NULL        false       0            -1
-4294967288  cluster_contention_events              NULL      NULL        false       0            -1
-4294967289  cluster_contended_tables               NULL      NULL        false       0            -1
-4294967290  cluster_contended_keys                 NULL      NULL        false       0            -1
-4294967291  cluster_contended_indexes              NULL      NULL        false       0            -1
-4294967292  builtin_functions                      NULL      NULL        false       0            -1
-4294967293  node_build_info                        NULL      NULL        false       0            -1
-4294967294  backward_dependencies                  NULL      NULL        false       0            -1
+oid     typname                typalign  typstorage  typnotnull  typbasetype  typtypmod
+16      bool                   NULL      NULL        false       0            -1
+17      bytea                  NULL      NULL        false       0            -1
+18      char                   NULL      NULL        false       0            -1
+19      name                   NULL      NULL        false       0            -1
+20      int8                   NULL      NULL        false       0            -1
+21      int2                   NULL      NULL        false       0            -1
+22      int2vector             NULL      NULL        false       0            -1
+23      int4                   NULL      NULL        false       0            -1
+24      regproc                NULL      NULL        false       0            -1
+25      text                   NULL      NULL        false       0            -1
+26      oid                    NULL      NULL        false       0            -1
+30      oidvector              NULL      NULL        false       0            -1
+700     float4                 NULL      NULL        false       0            -1
+701     float8                 NULL      NULL        false       0            -1
+705     unknown                NULL      NULL        false       0            -1
+869     inet                   NULL      NULL        false       0            -1
+1000    _bool                  NULL      NULL        false       0            -1
+1001    _bytea                 NULL      NULL        false       0            -1
+1002    _char                  NULL      NULL        false       0            -1
+1003    _name                  NULL      NULL        false       0            -1
+1005    _int2                  NULL      NULL        false       0            -1
+1006    _int2vector            NULL      NULL        false       0            -1
+1007    _int4                  NULL      NULL        false       0            -1
+1008    _regproc               NULL      NULL        false       0            -1
+1009    _text                  NULL      NULL        false       0            -1
+1013    _oidvector             NULL      NULL        false       0            -1
+1014    _bpchar                NULL      NULL        false       0            -1
+1015    _varchar               NULL      NULL        false       0            -1
+1016    _int8                  NULL      NULL        false       0            -1
+1021    _float4                NULL      NULL        false       0            -1
+1022    _float8                NULL      NULL        false       0            -1
+1028    _oid                   NULL      NULL        false       0            -1
+1041    _inet                  NULL      NULL        false       0            -1
+1042    bpchar                 NULL      NULL        false       0            -1
+1043    varchar                NULL      NULL        false       0            -1
+1082    date                   NULL      NULL        false       0            -1
+1083    time                   NULL      NULL        false       0            -1
+1114    timestamp              NULL      NULL        false       0            -1
+1115    _timestamp             NULL      NULL        false       0            -1
+1182    _date                  NULL      NULL        false       0            -1
+1183    _time                  NULL      NULL        false       0            -1
+1184    timestamptz            NULL      NULL        false       0            -1
+1185    _timestamptz           NULL      NULL        false       0            -1
+1186    interval               NULL      NULL        false       0            -1
+1187    _interval              NULL      NULL        false       0            -1
+1231    _numeric               NULL      NULL        false       0            -1
+1266    timetz                 NULL      NULL        false       0            -1
+1270    _timetz                NULL      NULL        false       0            -1
+1560    bit                    NULL      NULL        false       0            -1
+1561    _bit                   NULL      NULL        false       0            -1
+1562    varbit                 NULL      NULL        false       0            -1
+1563    _varbit                NULL      NULL        false       0            -1
+1700    numeric                NULL      NULL        false       0            -1
+2202    regprocedure           NULL      NULL        false       0            -1
+2205    regclass               NULL      NULL        false       0            -1
+2206    regtype                NULL      NULL        false       0            -1
+2207    _regprocedure          NULL      NULL        false       0            -1
+2210    _regclass              NULL      NULL        false       0            -1
+2211    _regtype               NULL      NULL        false       0            -1
+2249    record                 NULL      NULL        false       0            -1
+2277    anyarray               NULL      NULL        false       0            -1
+2278    void                   NULL      NULL        false       0            -1
+2283    anyelement             NULL      NULL        false       0            -1
+2287    _record                NULL      NULL        false       0            -1
+2950    uuid                   NULL      NULL        false       0            -1
+2951    _uuid                  NULL      NULL        false       0            -1
+3802    jsonb                  NULL      NULL        false       0            -1
+3807    _jsonb                 NULL      NULL        false       0            -1
+4089    regnamespace           NULL      NULL        false       0            -1
+4090    _regnamespace          NULL      NULL        false       0            -1
+4096    regrole                NULL      NULL        false       0            -1
+4097    _regrole               NULL      NULL        false       0            -1
+90000   geometry               NULL      NULL        false       0            -1
+90001   _geometry              NULL      NULL        false       0            -1
+90002   geography              NULL      NULL        false       0            -1
+90003   _geography             NULL      NULL        false       0            -1
+90004   box2d                  NULL      NULL        false       0            -1
+90005   _box2d                 NULL      NULL        false       0            -1
+100110  t1                     NULL      NULL        false       0            -1
+100111  t1_m_seq               NULL      NULL        false       0            -1
+100112  t1_n_seq               NULL      NULL        false       0            -1
+100113  t2                     NULL      NULL        false       0            -1
+100114  t3                     NULL      NULL        false       0            -1
+100115  v1                     NULL      NULL        false       0            -1
+100116  t4                     NULL      NULL        false       0            -1
+100117  t5                     NULL      NULL        false       0            -1
+100118  mytype                 NULL      NULL        false       0            -1
+100119  _mytype                NULL      NULL        false       0            -1
+100120  t6                     NULL      NULL        false       0            -1
+100121  mv1                    NULL      NULL        false       0            -1
+100128  source_table           NULL      NULL        false       0            -1
+100129  depend_view            NULL      NULL        false       0            -1
+100130  view_dependingon_view  NULL      NULL        false       0            -1
+100131  newtype1               NULL      NULL        false       0            -1
+100132  _newtype1              NULL      NULL        false       0            -1
+100133  newtype2               NULL      NULL        false       0            -1
+100134  _newtype2              NULL      NULL        false       0            -1
 
 query OTIOTTT colnames
 SELECT oid, typname, typndims, typcollation, typdefaultbin, typdefault, typacl
 FROM pg_catalog.pg_type
+WHERE oid < 4194967002 -- exclude implicit types for virtual tables
 ORDER BY oid
 ----
-oid         typname                                typndims  typcollation  typdefaultbin  typdefault  typacl
-16          bool                                   0         0             NULL           NULL        NULL
-17          bytea                                  0         0             NULL           NULL        NULL
-18          char                                   0         3403232968    NULL           NULL        NULL
-19          name                                   0         3403232968    NULL           NULL        NULL
-20          int8                                   0         0             NULL           NULL        NULL
-21          int2                                   0         0             NULL           NULL        NULL
-22          int2vector                             0         0             NULL           NULL        NULL
-23          int4                                   0         0             NULL           NULL        NULL
-24          regproc                                0         0             NULL           NULL        NULL
-25          text                                   0         3403232968    NULL           NULL        NULL
-26          oid                                    0         0             NULL           NULL        NULL
-30          oidvector                              0         0             NULL           NULL        NULL
-700         float4                                 0         0             NULL           NULL        NULL
-701         float8                                 0         0             NULL           NULL        NULL
-705         unknown                                0         0             NULL           NULL        NULL
-869         inet                                   0         0             NULL           NULL        NULL
-1000        _bool                                  0         0             NULL           NULL        NULL
-1001        _bytea                                 0         0             NULL           NULL        NULL
-1002        _char                                  0         3403232968    NULL           NULL        NULL
-1003        _name                                  0         3403232968    NULL           NULL        NULL
-1005        _int2                                  0         0             NULL           NULL        NULL
-1006        _int2vector                            0         0             NULL           NULL        NULL
-1007        _int4                                  0         0             NULL           NULL        NULL
-1008        _regproc                               0         0             NULL           NULL        NULL
-1009        _text                                  0         3403232968    NULL           NULL        NULL
-1013        _oidvector                             0         0             NULL           NULL        NULL
-1014        _bpchar                                0         3403232968    NULL           NULL        NULL
-1015        _varchar                               0         3403232968    NULL           NULL        NULL
-1016        _int8                                  0         0             NULL           NULL        NULL
-1021        _float4                                0         0             NULL           NULL        NULL
-1022        _float8                                0         0             NULL           NULL        NULL
-1028        _oid                                   0         0             NULL           NULL        NULL
-1041        _inet                                  0         0             NULL           NULL        NULL
-1042        bpchar                                 0         3403232968    NULL           NULL        NULL
-1043        varchar                                0         3403232968    NULL           NULL        NULL
-1082        date                                   0         0             NULL           NULL        NULL
-1083        time                                   0         0             NULL           NULL        NULL
-1114        timestamp                              0         0             NULL           NULL        NULL
-1115        _timestamp                             0         0             NULL           NULL        NULL
-1182        _date                                  0         0             NULL           NULL        NULL
-1183        _time                                  0         0             NULL           NULL        NULL
-1184        timestamptz                            0         0             NULL           NULL        NULL
-1185        _timestamptz                           0         0             NULL           NULL        NULL
-1186        interval                               0         0             NULL           NULL        NULL
-1187        _interval                              0         0             NULL           NULL        NULL
-1231        _numeric                               0         0             NULL           NULL        NULL
-1266        timetz                                 0         0             NULL           NULL        NULL
-1270        _timetz                                0         0             NULL           NULL        NULL
-1560        bit                                    0         0             NULL           NULL        NULL
-1561        _bit                                   0         0             NULL           NULL        NULL
-1562        varbit                                 0         0             NULL           NULL        NULL
-1563        _varbit                                0         0             NULL           NULL        NULL
-1700        numeric                                0         0             NULL           NULL        NULL
-2202        regprocedure                           0         0             NULL           NULL        NULL
-2205        regclass                               0         0             NULL           NULL        NULL
-2206        regtype                                0         0             NULL           NULL        NULL
-2207        _regprocedure                          0         0             NULL           NULL        NULL
-2210        _regclass                              0         0             NULL           NULL        NULL
-2211        _regtype                               0         0             NULL           NULL        NULL
-2249        record                                 0         0             NULL           NULL        NULL
-2277        anyarray                               0         3403232968    NULL           NULL        NULL
-2278        void                                   0         0             NULL           NULL        NULL
-2283        anyelement                             0         0             NULL           NULL        NULL
-2287        _record                                0         0             NULL           NULL        NULL
-2950        uuid                                   0         0             NULL           NULL        NULL
-2951        _uuid                                  0         0             NULL           NULL        NULL
-3802        jsonb                                  0         0             NULL           NULL        NULL
-3807        _jsonb                                 0         0             NULL           NULL        NULL
-4089        regnamespace                           0         0             NULL           NULL        NULL
-4090        _regnamespace                          0         0             NULL           NULL        NULL
-4096        regrole                                0         0             NULL           NULL        NULL
-4097        _regrole                               0         0             NULL           NULL        NULL
-90000       geometry                               0         0             NULL           NULL        NULL
-90001       _geometry                              0         0             NULL           NULL        NULL
-90002       geography                              0         0             NULL           NULL        NULL
-90003       _geography                             0         0             NULL           NULL        NULL
-90004       box2d                                  0         0             NULL           NULL        NULL
-90005       _box2d                                 0         0             NULL           NULL        NULL
-100110      t1                                     0         0             NULL           NULL        NULL
-100111      t1_m_seq                               0         0             NULL           NULL        NULL
-100112      t1_n_seq                               0         0             NULL           NULL        NULL
-100113      t2                                     0         0             NULL           NULL        NULL
-100114      t3                                     0         0             NULL           NULL        NULL
-100115      v1                                     0         0             NULL           NULL        NULL
-100116      t4                                     0         0             NULL           NULL        NULL
-100117      t5                                     0         0             NULL           NULL        NULL
-100118      mytype                                 0         0             NULL           NULL        NULL
-100119      _mytype                                0         0             NULL           NULL        NULL
-100120      t6                                     0         0             NULL           NULL        NULL
-100121      mv1                                    0         0             NULL           NULL        NULL
-100128      source_table                           0         0             NULL           NULL        NULL
-100129      depend_view                            0         0             NULL           NULL        NULL
-100130      view_dependingon_view                  0         0             NULL           NULL        NULL
-100131      newtype1                               0         0             NULL           NULL        NULL
-100132      _newtype1                              0         0             NULL           NULL        NULL
-100133      newtype2                               0         0             NULL           NULL        NULL
-100134      _newtype2                              0         0             NULL           NULL        NULL
-4294967002  spatial_ref_sys                        0         0             NULL           NULL        NULL
-4294967003  geometry_columns                       0         0             NULL           NULL        NULL
-4294967004  geography_columns                      0         0             NULL           NULL        NULL
-4294967006  pg_views                               0         0             NULL           NULL        NULL
-4294967007  pg_user                                0         0             NULL           NULL        NULL
-4294967008  pg_user_mappings                       0         0             NULL           NULL        NULL
-4294967009  pg_user_mapping                        0         0             NULL           NULL        NULL
-4294967010  pg_type                                0         0             NULL           NULL        NULL
-4294967011  pg_ts_template                         0         0             NULL           NULL        NULL
-4294967012  pg_ts_parser                           0         0             NULL           NULL        NULL
-4294967013  pg_ts_dict                             0         0             NULL           NULL        NULL
-4294967014  pg_ts_config                           0         0             NULL           NULL        NULL
-4294967015  pg_ts_config_map                       0         0             NULL           NULL        NULL
-4294967016  pg_trigger                             0         0             NULL           NULL        NULL
-4294967017  pg_transform                           0         0             NULL           NULL        NULL
-4294967018  pg_timezone_names                      0         0             NULL           NULL        NULL
-4294967019  pg_timezone_abbrevs                    0         0             NULL           NULL        NULL
-4294967020  pg_tablespace                          0         0             NULL           NULL        NULL
-4294967021  pg_tables                              0         0             NULL           NULL        NULL
-4294967022  pg_subscription                        0         0             NULL           NULL        NULL
-4294967023  pg_subscription_rel                    0         0             NULL           NULL        NULL
-4294967024  pg_stats                               0         0             NULL           NULL        NULL
-4294967025  pg_stats_ext                           0         0             NULL           NULL        NULL
-4294967026  pg_statistic                           0         0             NULL           NULL        NULL
-4294967027  pg_statistic_ext                       0         0             NULL           NULL        NULL
-4294967028  pg_statistic_ext_data                  0         0             NULL           NULL        NULL
-4294967029  pg_statio_user_tables                  0         0             NULL           NULL        NULL
-4294967030  pg_statio_user_sequences               0         0             NULL           NULL        NULL
-4294967031  pg_statio_user_indexes                 0         0             NULL           NULL        NULL
-4294967032  pg_statio_sys_tables                   0         0             NULL           NULL        NULL
-4294967033  pg_statio_sys_sequences                0         0             NULL           NULL        NULL
-4294967034  pg_statio_sys_indexes                  0         0             NULL           NULL        NULL
-4294967035  pg_statio_all_tables                   0         0             NULL           NULL        NULL
-4294967036  pg_statio_all_sequences                0         0             NULL           NULL        NULL
-4294967037  pg_statio_all_indexes                  0         0             NULL           NULL        NULL
-4294967038  pg_stat_xact_user_tables               0         0             NULL           NULL        NULL
-4294967039  pg_stat_xact_user_functions            0         0             NULL           NULL        NULL
-4294967040  pg_stat_xact_sys_tables                0         0             NULL           NULL        NULL
-4294967041  pg_stat_xact_all_tables                0         0             NULL           NULL        NULL
-4294967042  pg_stat_wal_receiver                   0         0             NULL           NULL        NULL
-4294967043  pg_stat_user_tables                    0         0             NULL           NULL        NULL
-4294967044  pg_stat_user_indexes                   0         0             NULL           NULL        NULL
-4294967045  pg_stat_user_functions                 0         0             NULL           NULL        NULL
-4294967046  pg_stat_sys_tables                     0         0             NULL           NULL        NULL
-4294967047  pg_stat_sys_indexes                    0         0             NULL           NULL        NULL
-4294967048  pg_stat_subscription                   0         0             NULL           NULL        NULL
-4294967049  pg_stat_ssl                            0         0             NULL           NULL        NULL
-4294967050  pg_stat_slru                           0         0             NULL           NULL        NULL
-4294967051  pg_stat_replication                    0         0             NULL           NULL        NULL
-4294967052  pg_stat_progress_vacuum                0         0             NULL           NULL        NULL
-4294967053  pg_stat_progress_create_index          0         0             NULL           NULL        NULL
-4294967054  pg_stat_progress_cluster               0         0             NULL           NULL        NULL
-4294967055  pg_stat_progress_basebackup            0         0             NULL           NULL        NULL
-4294967056  pg_stat_progress_analyze               0         0             NULL           NULL        NULL
-4294967057  pg_stat_gssapi                         0         0             NULL           NULL        NULL
-4294967058  pg_stat_database                       0         0             NULL           NULL        NULL
-4294967059  pg_stat_database_conflicts             0         0             NULL           NULL        NULL
-4294967060  pg_stat_bgwriter                       0         0             NULL           NULL        NULL
-4294967061  pg_stat_archiver                       0         0             NULL           NULL        NULL
-4294967062  pg_stat_all_tables                     0         0             NULL           NULL        NULL
-4294967063  pg_stat_all_indexes                    0         0             NULL           NULL        NULL
-4294967064  pg_stat_activity                       0         0             NULL           NULL        NULL
-4294967065  pg_shmem_allocations                   0         0             NULL           NULL        NULL
-4294967066  pg_shdepend                            0         0             NULL           NULL        NULL
-4294967067  pg_shseclabel                          0         0             NULL           NULL        NULL
-4294967068  pg_shdescription                       0         0             NULL           NULL        NULL
-4294967069  pg_shadow                              0         0             NULL           NULL        NULL
-4294967070  pg_settings                            0         0             NULL           NULL        NULL
-4294967071  pg_sequences                           0         0             NULL           NULL        NULL
-4294967072  pg_sequence                            0         0             NULL           NULL        NULL
-4294967073  pg_seclabel                            0         0             NULL           NULL        NULL
-4294967074  pg_seclabels                           0         0             NULL           NULL        NULL
-4294967075  pg_rules                               0         0             NULL           NULL        NULL
-4294967076  pg_roles                               0         0             NULL           NULL        NULL
-4294967077  pg_rewrite                             0         0             NULL           NULL        NULL
-4294967078  pg_replication_slots                   0         0             NULL           NULL        NULL
-4294967079  pg_replication_origin                  0         0             NULL           NULL        NULL
-4294967080  pg_replication_origin_status           0         0             NULL           NULL        NULL
-4294967081  pg_range                               0         0             NULL           NULL        NULL
-4294967082  pg_publication_tables                  0         0             NULL           NULL        NULL
-4294967083  pg_publication                         0         0             NULL           NULL        NULL
-4294967084  pg_publication_rel                     0         0             NULL           NULL        NULL
-4294967085  pg_proc                                0         0             NULL           NULL        NULL
-4294967086  pg_prepared_xacts                      0         0             NULL           NULL        NULL
-4294967087  pg_prepared_statements                 0         0             NULL           NULL        NULL
-4294967088  pg_policy                              0         0             NULL           NULL        NULL
-4294967089  pg_policies                            0         0             NULL           NULL        NULL
-4294967090  pg_partitioned_table                   0         0             NULL           NULL        NULL
-4294967091  pg_opfamily                            0         0             NULL           NULL        NULL
-4294967092  pg_operator                            0         0             NULL           NULL        NULL
-4294967093  pg_opclass                             0         0             NULL           NULL        NULL
-4294967094  pg_namespace                           0         0             NULL           NULL        NULL
-4294967095  pg_matviews                            0         0             NULL           NULL        NULL
-4294967096  pg_locks                               0         0             NULL           NULL        NULL
-4294967097  pg_largeobject                         0         0             NULL           NULL        NULL
-4294967098  pg_largeobject_metadata                0         0             NULL           NULL        NULL
-4294967099  pg_language                            0         0             NULL           NULL        NULL
-4294967100  pg_init_privs                          0         0             NULL           NULL        NULL
-4294967101  pg_inherits                            0         0             NULL           NULL        NULL
-4294967102  pg_indexes                             0         0             NULL           NULL        NULL
-4294967103  pg_index                               0         0             NULL           NULL        NULL
-4294967104  pg_hba_file_rules                      0         0             NULL           NULL        NULL
-4294967105  pg_group                               0         0             NULL           NULL        NULL
-4294967106  pg_foreign_table                       0         0             NULL           NULL        NULL
-4294967107  pg_foreign_server                      0         0             NULL           NULL        NULL
-4294967108  pg_foreign_data_wrapper                0         0             NULL           NULL        NULL
-4294967109  pg_file_settings                       0         0             NULL           NULL        NULL
-4294967110  pg_extension                           0         0             NULL           NULL        NULL
-4294967111  pg_event_trigger                       0         0             NULL           NULL        NULL
-4294967112  pg_enum                                0         0             NULL           NULL        NULL
-4294967113  pg_description                         0         0             NULL           NULL        NULL
-4294967114  pg_depend                              0         0             NULL           NULL        NULL
-4294967115  pg_default_acl                         0         0             NULL           NULL        NULL
-4294967116  pg_db_role_setting                     0         0             NULL           NULL        NULL
-4294967117  pg_database                            0         0             NULL           NULL        NULL
-4294967118  pg_cursors                             0         0             NULL           NULL        NULL
-4294967119  pg_conversion                          0         0             NULL           NULL        NULL
-4294967120  pg_constraint                          0         0             NULL           NULL        NULL
-4294967121  pg_config                              0         0             NULL           NULL        NULL
-4294967122  pg_collation                           0         0             NULL           NULL        NULL
-4294967123  pg_class                               0         0             NULL           NULL        NULL
-4294967124  pg_cast                                0         0             NULL           NULL        NULL
-4294967125  pg_available_extensions                0         0             NULL           NULL        NULL
-4294967126  pg_available_extension_versions        0         0             NULL           NULL        NULL
-4294967127  pg_auth_members                        0         0             NULL           NULL        NULL
-4294967128  pg_authid                              0         0             NULL           NULL        NULL
-4294967129  pg_attribute                           0         0             NULL           NULL        NULL
-4294967130  pg_attrdef                             0         0             NULL           NULL        NULL
-4294967131  pg_amproc                              0         0             NULL           NULL        NULL
-4294967132  pg_amop                                0         0             NULL           NULL        NULL
-4294967133  pg_am                                  0         0             NULL           NULL        NULL
-4294967134  pg_aggregate                           0         0             NULL           NULL        NULL
-4294967136  views                                  0         0             NULL           NULL        NULL
-4294967137  view_table_usage                       0         0             NULL           NULL        NULL
-4294967138  view_routine_usage                     0         0             NULL           NULL        NULL
-4294967139  view_column_usage                      0         0             NULL           NULL        NULL
-4294967140  user_privileges                        0         0             NULL           NULL        NULL
-4294967141  user_mappings                          0         0             NULL           NULL        NULL
-4294967142  user_mapping_options                   0         0             NULL           NULL        NULL
-4294967143  user_defined_types                     0         0             NULL           NULL        NULL
-4294967144  user_attributes                        0         0             NULL           NULL        NULL
-4294967145  usage_privileges                       0         0             NULL           NULL        NULL
-4294967146  udt_privileges                         0         0             NULL           NULL        NULL
-4294967147  type_privileges                        0         0             NULL           NULL        NULL
-4294967148  triggers                               0         0             NULL           NULL        NULL
-4294967149  triggered_update_columns               0         0             NULL           NULL        NULL
-4294967150  transforms                             0         0             NULL           NULL        NULL
-4294967151  tablespaces                            0         0             NULL           NULL        NULL
-4294967152  tablespaces_extensions                 0         0             NULL           NULL        NULL
-4294967153  tables                                 0         0             NULL           NULL        NULL
-4294967154  tables_extensions                      0         0             NULL           NULL        NULL
-4294967155  table_privileges                       0         0             NULL           NULL        NULL
-4294967156  table_constraints_extensions           0         0             NULL           NULL        NULL
-4294967157  table_constraints                      0         0             NULL           NULL        NULL
-4294967158  statistics                             0         0             NULL           NULL        NULL
-4294967159  st_units_of_measure                    0         0             NULL           NULL        NULL
-4294967160  st_spatial_reference_systems           0         0             NULL           NULL        NULL
-4294967161  st_geometry_columns                    0         0             NULL           NULL        NULL
-4294967162  session_variables                      0         0             NULL           NULL        NULL
-4294967163  sequences                              0         0             NULL           NULL        NULL
-4294967164  schema_privileges                      0         0             NULL           NULL        NULL
-4294967165  schemata                               0         0             NULL           NULL        NULL
-4294967166  schemata_extensions                    0         0             NULL           NULL        NULL
-4294967167  sql_sizing                             0         0             NULL           NULL        NULL
-4294967168  sql_parts                              0         0             NULL           NULL        NULL
-4294967169  sql_implementation_info                0         0             NULL           NULL        NULL
-4294967170  sql_features                           0         0             NULL           NULL        NULL
-4294967171  routines                               0         0             NULL           NULL        NULL
-4294967172  routine_privileges                     0         0             NULL           NULL        NULL
-4294967173  role_usage_grants                      0         0             NULL           NULL        NULL
-4294967174  role_udt_grants                        0         0             NULL           NULL        NULL
-4294967175  role_table_grants                      0         0             NULL           NULL        NULL
-4294967176  role_routine_grants                    0         0             NULL           NULL        NULL
-4294967177  role_column_grants                     0         0             NULL           NULL        NULL
-4294967178  resource_groups                        0         0             NULL           NULL        NULL
-4294967179  referential_constraints                0         0             NULL           NULL        NULL
-4294967180  profiling                              0         0             NULL           NULL        NULL
-4294967181  processlist                            0         0             NULL           NULL        NULL
-4294967182  plugins                                0         0             NULL           NULL        NULL
-4294967183  partitions                             0         0             NULL           NULL        NULL
-4294967184  parameters                             0         0             NULL           NULL        NULL
-4294967185  optimizer_trace                        0         0             NULL           NULL        NULL
-4294967186  keywords                               0         0             NULL           NULL        NULL
-4294967187  key_column_usage                       0         0             NULL           NULL        NULL
-4294967188  information_schema_catalog_name        0         0             NULL           NULL        NULL
-4294967189  foreign_tables                         0         0             NULL           NULL        NULL
-4294967190  foreign_table_options                  0         0             NULL           NULL        NULL
-4294967191  foreign_servers                        0         0             NULL           NULL        NULL
-4294967192  foreign_server_options                 0         0             NULL           NULL        NULL
-4294967193  foreign_data_wrappers                  0         0             NULL           NULL        NULL
-4294967194  foreign_data_wrapper_options           0         0             NULL           NULL        NULL
-4294967195  files                                  0         0             NULL           NULL        NULL
-4294967196  events                                 0         0             NULL           NULL        NULL
-4294967197  engines                                0         0             NULL           NULL        NULL
-4294967198  enabled_roles                          0         0             NULL           NULL        NULL
-4294967199  element_types                          0         0             NULL           NULL        NULL
-4294967200  domains                                0         0             NULL           NULL        NULL
-4294967201  domain_udt_usage                       0         0             NULL           NULL        NULL
-4294967202  domain_constraints                     0         0             NULL           NULL        NULL
-4294967203  data_type_privileges                   0         0             NULL           NULL        NULL
-4294967204  constraint_table_usage                 0         0             NULL           NULL        NULL
-4294967205  constraint_column_usage                0         0             NULL           NULL        NULL
-4294967206  columns                                0         0             NULL           NULL        NULL
-4294967207  columns_extensions                     0         0             NULL           NULL        NULL
-4294967208  column_udt_usage                       0         0             NULL           NULL        NULL
-4294967209  column_statistics                      0         0             NULL           NULL        NULL
-4294967210  column_privileges                      0         0             NULL           NULL        NULL
-4294967211  column_options                         0         0             NULL           NULL        NULL
-4294967212  column_domain_usage                    0         0             NULL           NULL        NULL
-4294967213  column_column_usage                    0         0             NULL           NULL        NULL
-4294967214  collations                             0         0             NULL           NULL        NULL
-4294967215  collation_character_set_applicability  0         0             NULL           NULL        NULL
-4294967216  check_constraints                      0         0             NULL           NULL        NULL
-4294967217  check_constraint_routine_usage         0         0             NULL           NULL        NULL
-4294967218  character_sets                         0         0             NULL           NULL        NULL
-4294967219  attributes                             0         0             NULL           NULL        NULL
-4294967220  applicable_roles                       0         0             NULL           NULL        NULL
-4294967221  administrable_role_authorizations      0         0             NULL           NULL        NULL
-4294967223  super_regions                          0         0             NULL           NULL        NULL
-4294967224  pg_catalog_table_is_implemented        0         0             NULL           NULL        NULL
-4294967225  tenant_usage_details                   0         0             NULL           NULL        NULL
-4294967226  active_range_feeds                     0         0             NULL           NULL        NULL
-4294967227  default_privileges                     0         0             NULL           NULL        NULL
-4294967228  regions                                0         0             NULL           NULL        NULL
-4294967229  cluster_inflight_traces                0         0             NULL           NULL        NULL
-4294967230  lost_descriptors_with_data             0         0             NULL           NULL        NULL
-4294967231  cross_db_references                    0         0             NULL           NULL        NULL
-4294967232  cluster_database_privileges            0         0             NULL           NULL        NULL
-4294967233  invalid_objects                        0         0             NULL           NULL        NULL
-4294967234  zones                                  0         0             NULL           NULL        NULL
-4294967235  transaction_statistics                 0         0             NULL           NULL        NULL
-4294967236  node_transaction_statistics            0         0             NULL           NULL        NULL
-4294967237  table_row_statistics                   0         0             NULL           NULL        NULL
-4294967238  tables                                 0         0             NULL           NULL        NULL
-4294967239  table_indexes                          0         0             NULL           NULL        NULL
-4294967240  table_columns                          0         0             NULL           NULL        NULL
-4294967241  statement_statistics                   0         0             NULL           NULL        NULL
-4294967242  session_variables                      0         0             NULL           NULL        NULL
-4294967243  session_trace                          0         0             NULL           NULL        NULL
-4294967244  schema_changes                         0         0             NULL           NULL        NULL
-4294967245  node_runtime_info                      0         0             NULL           NULL        NULL
-4294967246  ranges                                 0         0             NULL           NULL        NULL
-4294967247  ranges_no_leases                       0         0             NULL           NULL        NULL
-4294967248  predefined_comments                    0         0             NULL           NULL        NULL
-4294967249  partitions                             0         0             NULL           NULL        NULL
-4294967250  node_txn_stats                         0         0             NULL           NULL        NULL
-4294967251  node_statement_statistics              0         0             NULL           NULL        NULL
-4294967252  node_metrics                           0         0             NULL           NULL        NULL
-4294967253  node_sessions                          0         0             NULL           NULL        NULL
-4294967254  node_transactions                      0         0             NULL           NULL        NULL
-4294967255  node_queries                           0         0             NULL           NULL        NULL
-4294967256  node_execution_insights                0         0             NULL           NULL        NULL
-4294967257  node_distsql_flows                     0         0             NULL           NULL        NULL
-4294967258  node_contention_events                 0         0             NULL           NULL        NULL
-4294967259  leases                                 0         0             NULL           NULL        NULL
-4294967260  kv_store_status                        0         0             NULL           NULL        NULL
-4294967261  kv_node_status                         0         0             NULL           NULL        NULL
-4294967262  jobs                                   0         0             NULL           NULL        NULL
-4294967263  node_inflight_trace_spans              0         0             NULL           NULL        NULL
-4294967264  index_usage_statistics                 0         0             NULL           NULL        NULL
-4294967265  index_columns                          0         0             NULL           NULL        NULL
-4294967266  transaction_contention_events          0         0             NULL           NULL        NULL
-4294967267  gossip_network                         0         0             NULL           NULL        NULL
-4294967268  gossip_liveness                        0         0             NULL           NULL        NULL
-4294967269  gossip_alerts                          0         0             NULL           NULL        NULL
-4294967270  gossip_nodes                           0         0             NULL           NULL        NULL
-4294967271  kv_node_liveness                       0         0             NULL           NULL        NULL
-4294967272  forward_dependencies                   0         0             NULL           NULL        NULL
-4294967273  feature_usage                          0         0             NULL           NULL        NULL
-4294967274  databases                              0         0             NULL           NULL        NULL
-4294967275  create_type_statements                 0         0             NULL           NULL        NULL
-4294967276  create_statements                      0         0             NULL           NULL        NULL
-4294967277  create_schema_statements               0         0             NULL           NULL        NULL
-4294967278  create_function_statements             0         0             NULL           NULL        NULL
-4294967279  cluster_transaction_statistics         0         0             NULL           NULL        NULL
-4294967280  cluster_statement_statistics           0         0             NULL           NULL        NULL
-4294967281  cluster_settings                       0         0             NULL           NULL        NULL
-4294967282  cluster_sessions                       0         0             NULL           NULL        NULL
-4294967283  cluster_transactions                   0         0             NULL           NULL        NULL
-4294967284  cluster_queries                        0         0             NULL           NULL        NULL
-4294967285  cluster_locks                          0         0             NULL           NULL        NULL
-4294967286  cluster_execution_insights             0         0             NULL           NULL        NULL
-4294967287  cluster_distsql_flows                  0         0             NULL           NULL        NULL
-4294967288  cluster_contention_events              0         0             NULL           NULL        NULL
-4294967289  cluster_contended_tables               0         0             NULL           NULL        NULL
-4294967290  cluster_contended_keys                 0         0             NULL           NULL        NULL
-4294967291  cluster_contended_indexes              0         0             NULL           NULL        NULL
-4294967292  builtin_functions                      0         0             NULL           NULL        NULL
-4294967293  node_build_info                        0         0             NULL           NULL        NULL
-4294967294  backward_dependencies                  0         0             NULL           NULL        NULL
+oid     typname                typndims  typcollation  typdefaultbin  typdefault  typacl
+16      bool                   0         0             NULL           NULL        NULL
+17      bytea                  0         0             NULL           NULL        NULL
+18      char                   0         3403232968    NULL           NULL        NULL
+19      name                   0         3403232968    NULL           NULL        NULL
+20      int8                   0         0             NULL           NULL        NULL
+21      int2                   0         0             NULL           NULL        NULL
+22      int2vector             0         0             NULL           NULL        NULL
+23      int4                   0         0             NULL           NULL        NULL
+24      regproc                0         0             NULL           NULL        NULL
+25      text                   0         3403232968    NULL           NULL        NULL
+26      oid                    0         0             NULL           NULL        NULL
+30      oidvector              0         0             NULL           NULL        NULL
+700     float4                 0         0             NULL           NULL        NULL
+701     float8                 0         0             NULL           NULL        NULL
+705     unknown                0         0             NULL           NULL        NULL
+869     inet                   0         0             NULL           NULL        NULL
+1000    _bool                  0         0             NULL           NULL        NULL
+1001    _bytea                 0         0             NULL           NULL        NULL
+1002    _char                  0         3403232968    NULL           NULL        NULL
+1003    _name                  0         3403232968    NULL           NULL        NULL
+1005    _int2                  0         0             NULL           NULL        NULL
+1006    _int2vector            0         0             NULL           NULL        NULL
+1007    _int4                  0         0             NULL           NULL        NULL
+1008    _regproc               0         0             NULL           NULL        NULL
+1009    _text                  0         3403232968    NULL           NULL        NULL
+1013    _oidvector             0         0             NULL           NULL        NULL
+1014    _bpchar                0         3403232968    NULL           NULL        NULL
+1015    _varchar               0         3403232968    NULL           NULL        NULL
+1016    _int8                  0         0             NULL           NULL        NULL
+1021    _float4                0         0             NULL           NULL        NULL
+1022    _float8                0         0             NULL           NULL        NULL
+1028    _oid                   0         0             NULL           NULL        NULL
+1041    _inet                  0         0             NULL           NULL        NULL
+1042    bpchar                 0         3403232968    NULL           NULL        NULL
+1043    varchar                0         3403232968    NULL           NULL        NULL
+1082    date                   0         0             NULL           NULL        NULL
+1083    time                   0         0             NULL           NULL        NULL
+1114    timestamp              0         0             NULL           NULL        NULL
+1115    _timestamp             0         0             NULL           NULL        NULL
+1182    _date                  0         0             NULL           NULL        NULL
+1183    _time                  0         0             NULL           NULL        NULL
+1184    timestamptz            0         0             NULL           NULL        NULL
+1185    _timestamptz           0         0             NULL           NULL        NULL
+1186    interval               0         0             NULL           NULL        NULL
+1187    _interval              0         0             NULL           NULL        NULL
+1231    _numeric               0         0             NULL           NULL        NULL
+1266    timetz                 0         0             NULL           NULL        NULL
+1270    _timetz                0         0             NULL           NULL        NULL
+1560    bit                    0         0             NULL           NULL        NULL
+1561    _bit                   0         0             NULL           NULL        NULL
+1562    varbit                 0         0             NULL           NULL        NULL
+1563    _varbit                0         0             NULL           NULL        NULL
+1700    numeric                0         0             NULL           NULL        NULL
+2202    regprocedure           0         0             NULL           NULL        NULL
+2205    regclass               0         0             NULL           NULL        NULL
+2206    regtype                0         0             NULL           NULL        NULL
+2207    _regprocedure          0         0             NULL           NULL        NULL
+2210    _regclass              0         0             NULL           NULL        NULL
+2211    _regtype               0         0             NULL           NULL        NULL
+2249    record                 0         0             NULL           NULL        NULL
+2277    anyarray               0         3403232968    NULL           NULL        NULL
+2278    void                   0         0             NULL           NULL        NULL
+2283    anyelement             0         0             NULL           NULL        NULL
+2287    _record                0         0             NULL           NULL        NULL
+2950    uuid                   0         0             NULL           NULL        NULL
+2951    _uuid                  0         0             NULL           NULL        NULL
+3802    jsonb                  0         0             NULL           NULL        NULL
+3807    _jsonb                 0         0             NULL           NULL        NULL
+4089    regnamespace           0         0             NULL           NULL        NULL
+4090    _regnamespace          0         0             NULL           NULL        NULL
+4096    regrole                0         0             NULL           NULL        NULL
+4097    _regrole               0         0             NULL           NULL        NULL
+90000   geometry               0         0             NULL           NULL        NULL
+90001   _geometry              0         0             NULL           NULL        NULL
+90002   geography              0         0             NULL           NULL        NULL
+90003   _geography             0         0             NULL           NULL        NULL
+90004   box2d                  0         0             NULL           NULL        NULL
+90005   _box2d                 0         0             NULL           NULL        NULL
+100110  t1                     0         0             NULL           NULL        NULL
+100111  t1_m_seq               0         0             NULL           NULL        NULL
+100112  t1_n_seq               0         0             NULL           NULL        NULL
+100113  t2                     0         0             NULL           NULL        NULL
+100114  t3                     0         0             NULL           NULL        NULL
+100115  v1                     0         0             NULL           NULL        NULL
+100116  t4                     0         0             NULL           NULL        NULL
+100117  t5                     0         0             NULL           NULL        NULL
+100118  mytype                 0         0             NULL           NULL        NULL
+100119  _mytype                0         0             NULL           NULL        NULL
+100120  t6                     0         0             NULL           NULL        NULL
+100121  mv1                    0         0             NULL           NULL        NULL
+100128  source_table           0         0             NULL           NULL        NULL
+100129  depend_view            0         0             NULL           NULL        NULL
+100130  view_dependingon_view  0         0             NULL           NULL        NULL
+100131  newtype1               0         0             NULL           NULL        NULL
+100132  _newtype1              0         0             NULL           NULL        NULL
+100133  newtype2               0         0             NULL           NULL        NULL
+100134  _newtype2              0         0             NULL           NULL        NULL
 
 user testuser
 
@@ -3634,6 +2189,20 @@ WHERE oid = $sourceid
 ----
 oid     typname       typnamespace  typowner    typlen  typbyval  typtype
 100128  source_table  109           1546506610  -1      false     c
+
+let $vtableSourceId
+SELECT oid
+FROM pg_catalog.pg_type
+WHERE typname = 'pg_proc'
+
+# Verify that the index on pg_type works for virtual tables OIDs.
+query OTOOIBT colnames
+SELECT oid, typname, typnamespace, typowner, typlen, typbyval, typtype
+FROM pg_catalog.pg_type
+WHERE oid = $vtableSourceId
+----
+oid         typname  typnamespace  typowner    typlen  typbyval  typtype
+4294967085  pg_proc  591606261     2310524507  -1      false     c
 
 ## pg_catalog.pg_proc
 

--- a/pkg/sql/logictest/testdata/logic_test/record
+++ b/pkg/sql/logictest/testdata/logic_test/record
@@ -2,6 +2,12 @@ statement ok
 CREATE TABLE a(a INT PRIMARY KEY, b TEXT);
 INSERT INTO a VALUES(1,'2')
 
+# Virtual tables get an implicit record type.
+query TT
+SELECT (1, 'cat', 2, '{}')::pg_catalog.pg_namespace, ((3, 'dog', 4, ARRAY[]::STRING[])::pg_namespace).nspname
+----
+(1,cat,2,{})  dog
+
 query TITIT colnames
 SELECT t, t.a, t.b, t.* FROM a AS t
 ----

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -677,11 +677,12 @@ https://www.postgresql.org/docs/9.5/catalog-pg-class.html`,
 			return err
 		}
 		namespaceOid := h.NamespaceOid(db, scName)
+		implicitTypOID := typedesc.TableIDToImplicitTypeOID(table.GetID())
 		if err := addRow(
 			tableOid(table.GetID()),        // oid
 			tree.NewDName(table.GetName()), // relname
 			namespaceOid,                   // relnamespace
-			tableIDToTypeOID(table),        // reltype (PG creates a composite type in pg_type for each table)
+			tree.NewDOid(implicitTypOID),   // reltype (PG creates a composite type in pg_type for each table)
 			oidZero,                        // reloftype (used for type tables, which is unsupported)
 			ownerOid,                       // relowner
 			relAm,                          // relam
@@ -2955,17 +2956,6 @@ var (
 	commaTypDelim = tree.NewDString(",")
 )
 
-func tableIDToTypeOID(table catalog.TableDescriptor) tree.Datum {
-	// We re-use the type ID to OID logic, as type IDs and table IDs do not share
-	// the same ID space.
-	if !table.IsVirtualTable() {
-		return tree.NewDOid(catid.TypeIDToOID(table.GetID()))
-	}
-	// Virtual table OIDs start at max UInt32, so doing OID math would overflow.
-	// As such, just use the virtual table ID.
-	return tree.NewDOid(oid.Oid(table.GetID()))
-}
-
 func addPGTypeRowForTable(
 	ctx context.Context,
 	p eval.Planner,
@@ -2980,8 +2970,9 @@ func addPGTypeRowForTable(
 	if err != nil {
 		return err
 	}
+	implicitTypOid := typedesc.TableIDToImplicitTypeOID(table.GetID())
 	return addRow(
-		tableIDToTypeOID(table),        // oid
+		tree.NewDOid(implicitTypOid),   // oid
 		tree.NewDName(table.GetName()), // typname
 		nspOid,                         // typnamespace
 		ownerOID,                       // typowner

--- a/pkg/sql/schema_resolver.go
+++ b/pkg/sql/schema_resolver.go
@@ -306,15 +306,19 @@ func (sr *schemaResolver) GetTypeDescriptor(
 	}
 	// Note that the value of required doesn't matter for lookups by ID.
 	flags := sr.CommonLookupFlagsRequired()
-	_, db, err := tc.GetImmutableDatabaseByID(ctx, sr.txn, desc.GetParentID(), flags)
-	if err != nil {
-		return tree.TypeName{}, nil, err
+	dbName := sr.CurrentDatabase()
+	if !descpb.IsVirtualTable(desc.GetID()) {
+		_, db, err := tc.GetImmutableDatabaseByID(ctx, sr.txn, desc.GetParentID(), flags)
+		if err != nil {
+			return tree.TypeName{}, nil, err
+		}
+		dbName = db.GetName()
 	}
 	sc, err := tc.GetImmutableSchemaByID(ctx, sr.txn, desc.GetParentSchemaID(), flags)
 	if err != nil {
 		return tree.TypeName{}, nil, err
 	}
-	name := tree.MakeQualifiedTypeName(db.GetName(), sc.GetName(), desc.GetName())
+	name := tree.MakeQualifiedTypeName(dbName, sc.GetName(), desc.GetName())
 	return name, desc, nil
 }
 

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -17,8 +17,10 @@ import (
 	"sort"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descbuilder"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -29,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -184,7 +187,12 @@ func (t virtualSchemaTable) initVirtualTableDesc(
 		id,
 		nil,       /* regionConfig */
 		startTime, /* creationTime */
-		nil,
+		catpb.NewPrivilegeDescriptor(
+			username.PublicRoleName(),
+			privilege.List{privilege.SELECT},
+			privilege.List{},
+			username.NodeUserName(),
+		),
 		nil,                        /* affected */
 		nil,                        /* semaCtx */
 		nil,                        /* evalCtx */
@@ -293,7 +301,12 @@ func (v virtualSchemaView) initVirtualTableDesc(
 		id,
 		columns,
 		startTime,
-		nil,
+		catpb.NewPrivilegeDescriptor(
+			username.PublicRoleName(),
+			privilege.List{privilege.SELECT},
+			privilege.List{},
+			username.NodeUserName(),
+		),
 		nil, // semaCtx
 		nil, // evalCtx
 		st,
@@ -397,6 +410,34 @@ func (v *virtualSchemaEntry) GetObjectByName(
 	name string, flags tree.ObjectLookupFlags,
 ) (catalog.VirtualObject, error) {
 	switch flags.DesiredObjectKind {
+	case tree.TypeObject:
+		// Currently, we don't allow creation of types in virtual schemas, so
+		// the only types present in the virtual schemas that have types (i.e.
+		// pg_catalog) are types that are known at parse time or implicit record
+		// types for each table. So, first attempt to
+		// parse the input object as a statically known type. Note that an
+		// invalid input type like "notatype" will be parsed successfully as
+		// a ResolvableTypeReference, so the error here does not need to be
+		// intercepted and inspected.
+		if v.containsTypes {
+			typRef, err := parser.GetTypeReferenceFromName(tree.Name(name))
+			if err != nil {
+				return nil, err
+			}
+			// If the parsed reference is actually a statically known type, then
+			// we can return it. We return a simple wrapping of this type as
+			// TypeDescriptor that represents an alias of the result type.
+			typ, ok := tree.GetStaticallyKnownType(typRef)
+			if ok {
+				return &virtualTypeEntry{
+					desc:    typedesc.MakeSimpleAlias(typ, catconstants.PgCatalogID),
+					mutable: flags.RequireMutable,
+				}, nil
+			}
+		}
+		// If the type could not be found statically, then search for a table with
+		// this name so the implicit record type can be used.
+		fallthrough
 	case tree.TableObject:
 		if def, ok := v.defs[name]; ok {
 			if flags.RequireMutable {
@@ -410,33 +451,6 @@ func (v *virtualSchemaEntry) GetObjectByName(
 			return nil, newUnimplementedVirtualTableError(v.desc.GetName(), name)
 		}
 		return nil, nil
-	case tree.TypeObject:
-		if !v.containsTypes {
-			return nil, nil
-		}
-		// Currently, we don't allow creation of types in virtual schemas, so
-		// the only types present in the virtual schemas that have types (i.e.
-		// pg_catalog) are types that are known at parse time. So, attempt to
-		// parse the input object as a statically known type. Note that an
-		// invalid input type like "notatype" will be parsed successfully as
-		// a ResolvableTypeReference, so the error here does not need to be
-		// intercepted and inspected.
-		typRef, err := parser.GetTypeReferenceFromName(tree.Name(name))
-		if err != nil {
-			return nil, err
-		}
-		// If the parsed reference is actually a statically known type, then
-		// we can return it. We return a simple wrapping of this type as
-		// TypeDescriptor that represents an alias of the result type.
-		typ, ok := tree.GetStaticallyKnownType(typRef)
-		if !ok {
-			return nil, nil
-		}
-
-		return &virtualTypeEntry{
-			desc:    typedesc.MakeSimpleAlias(typ, catconstants.PgCatalogID),
-			mutable: flags.RequireMutable,
-		}, nil
 	default:
 		return nil, errors.AssertionFailedf("unknown desired object kind %d", flags.DesiredObjectKind)
 	}


### PR DESCRIPTION
Backport 1/1 commits from #90924.

/cc @cockroachdb/release

Release justification: bug fix

---

fixes https://github.com/cockroachdb/cockroach/issues/90871

The fixes for the pg_type(oid) index and the ability to cast to an
implicit record type for a virtual table were quite related to each
other, since it had to do with how the ID for the implicit type is
calculated.

Release note (bug fix): Fixed a bug where point loookups on the
pg_catalog.pg_type table would fail to find the implicit record type
that gets created for tables in the pg_catalog, information_schema, and
crdb_internal schemas.

Release note (bug fix): Fixed a bug that prevented the usage of implicit
record types for tables in the pg_catalog, information_schema, and
crdb_internal schemas.

