### PR TITLE
release: rename Mac Intel release archives

### DIFF
--- a/build/teamcity/internal/cockroach/release/publish/sign_macos_release.sh
+++ b/build/teamcity/internal/cockroach/release/publish/sign_macos_release.sh
@@ -47,9 +47,7 @@ mkdir -p artifacts
 cd artifacts
 
 for product in cockroach cockroach-sql; do
-  # TODO: add Intel binaries too.
-  # for platform in darwin-11.0-aarch64 darwin-10.9-amd64; do
-  for platform in darwin-11.0-aarch64; do
+  for platform in darwin-11.0-aarch64 darwin-10.9-amd64; do
     base=${product}-${VERSION}.${platform}
     unsigned_base=${product}-${VERSION}.${platform}.unsigned
     unsigned_file=${unsigned_base}.tgz

--- a/pkg/cmd/publish-provisional-artifacts/main.go
+++ b/pkg/cmd/publish-provisional-artifacts/main.go
@@ -154,9 +154,15 @@ func run(providers []release.ObjectPutGetter, flags runFlags, execFn release.Exe
 		updateLatest = true
 	}
 
+	// For release builds (that generate release archives) we use the ".unsigned" suffix in the file name.
+	// The edge uploads will still use the same name (without the "unsigned" suffix) in case there are external consumers.
+	macOSPlatform := release.PlatformMacOS
+	if flags.isRelease {
+		macOSPlatform = release.PlatformMacOSUnsigned
+	}
 	platforms := []release.Platform{
 		release.PlatformLinux,
-		release.PlatformMacOS,
+		macOSPlatform,
 		release.PlatformMacOSArm,
 		release.PlatformWindows,
 		release.PlatformLinuxArm,

--- a/pkg/cmd/publish-provisional-artifacts/main_test.go
+++ b/pkg/cmd/publish-provisional-artifacts/main_test.go
@@ -109,7 +109,7 @@ func (r *mockExecRunner) run(c *exec.Cmd) ([]byte, error) {
 				case "crosslinuxarmbase":
 					platform = release.PlatformLinuxArm
 				case "crossmacosbase":
-					platform = release.PlatformMacOS
+					platform = release.PlatformMacOSUnsigned
 				case "crossmacosarmbase":
 					platform = release.PlatformMacOSArm
 				case "crosswindowsbase":
@@ -186,10 +186,10 @@ func TestProvisional(t *testing.T) {
 				"s3://binaries.cockroachdb.com/cockroach-v0.0.1-alpha.linux-amd64.tgz.sha256sum CONTENTS <sha256sum>",
 				"s3://binaries.cockroachdb.com/cockroach-sql-v0.0.1-alpha.linux-amd64.tgz CONTENTS <binary stuff>",
 				"s3://binaries.cockroachdb.com/cockroach-sql-v0.0.1-alpha.linux-amd64.tgz.sha256sum CONTENTS <sha256sum>",
-				"s3://binaries.cockroachdb.com/cockroach-v0.0.1-alpha.darwin-10.9-amd64.tgz CONTENTS <binary stuff>",
-				"s3://binaries.cockroachdb.com/cockroach-v0.0.1-alpha.darwin-10.9-amd64.tgz.sha256sum CONTENTS <sha256sum>",
-				"s3://binaries.cockroachdb.com/cockroach-sql-v0.0.1-alpha.darwin-10.9-amd64.tgz CONTENTS <binary stuff>",
-				"s3://binaries.cockroachdb.com/cockroach-sql-v0.0.1-alpha.darwin-10.9-amd64.tgz.sha256sum CONTENTS <sha256sum>",
+				"s3://binaries.cockroachdb.com/cockroach-v0.0.1-alpha.darwin-10.9-amd64.unsigned.tgz CONTENTS <binary stuff>",
+				"s3://binaries.cockroachdb.com/cockroach-v0.0.1-alpha.darwin-10.9-amd64.unsigned.tgz.sha256sum CONTENTS <sha256sum>",
+				"s3://binaries.cockroachdb.com/cockroach-sql-v0.0.1-alpha.darwin-10.9-amd64.unsigned.tgz CONTENTS <binary stuff>",
+				"s3://binaries.cockroachdb.com/cockroach-sql-v0.0.1-alpha.darwin-10.9-amd64.unsigned.tgz.sha256sum CONTENTS <sha256sum>",
 				"s3://binaries.cockroachdb.com/cockroach-v0.0.1-alpha.darwin-11.0-aarch64.unsigned.tgz CONTENTS <binary stuff>",
 				"s3://binaries.cockroachdb.com/cockroach-v0.0.1-alpha.darwin-11.0-aarch64.unsigned.tgz.sha256sum CONTENTS <sha256sum>",
 				"s3://binaries.cockroachdb.com/cockroach-sql-v0.0.1-alpha.darwin-11.0-aarch64.unsigned.tgz CONTENTS <binary stuff>",
@@ -372,10 +372,10 @@ func TestBless(t *testing.T) {
 					"REDIRECT /cockroach-v0.0.1.linux-amd64.tgz",
 				"s3://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz.sha256sum/no-cache " +
 					"REDIRECT /cockroach-v0.0.1.linux-amd64.tgz.sha256sum",
-				"s3://binaries.cockroachdb.com/cockroach-latest.darwin-10.9-amd64.tgz/no-cache " +
-					"REDIRECT /cockroach-v0.0.1.darwin-10.9-amd64.tgz",
-				"s3://binaries.cockroachdb.com/cockroach-latest.darwin-10.9-amd64.tgz.sha256sum/no-cache " +
-					"REDIRECT /cockroach-v0.0.1.darwin-10.9-amd64.tgz.sha256sum",
+				"s3://binaries.cockroachdb.com/cockroach-latest.darwin-10.9-amd64.unsigned.tgz/no-cache " +
+					"REDIRECT /cockroach-v0.0.1.darwin-10.9-amd64.unsigned.tgz",
+				"s3://binaries.cockroachdb.com/cockroach-latest.darwin-10.9-amd64.unsigned.tgz.sha256sum/no-cache " +
+					"REDIRECT /cockroach-v0.0.1.darwin-10.9-amd64.unsigned.tgz.sha256sum",
 				"s3://binaries.cockroachdb.com/cockroach-latest.darwin-11.0-aarch64.unsigned.tgz/no-cache " +
 					"REDIRECT /cockroach-v0.0.1.darwin-11.0-aarch64.unsigned.tgz",
 				"s3://binaries.cockroachdb.com/cockroach-latest.darwin-11.0-aarch64.unsigned.tgz.sha256sum/no-cache " +

--- a/pkg/release/build.go
+++ b/pkg/release/build.go
@@ -52,6 +52,8 @@ func SuffixFromPlatform(platform Platform) string {
 		// TODO(#release): The architecture is at least 10.10 until v20.2 and 10.15 for
 		// v21.1 and after. Check whether this can be changed.
 		return ".darwin-10.9-amd64"
+	case PlatformMacOSUnsigned:
+		return ".darwin-10.9-amd64.unsigned"
 	case PlatformMacOSArm:
 		return ".darwin-11.0-aarch64.unsigned"
 	case PlatformWindows:
@@ -69,7 +71,7 @@ func CrossConfigFromPlatform(platform Platform) string {
 		return "crosslinuxbase"
 	case PlatformLinuxArm:
 		return "crosslinuxarmbase"
-	case PlatformMacOS:
+	case PlatformMacOS, PlatformMacOSUnsigned:
 		return "crossmacosbase"
 	case PlatformMacOSArm:
 		return "crossmacosarmbase"
@@ -88,7 +90,7 @@ func TargetTripleFromPlatform(platform Platform) string {
 		return "x86_64-pc-linux-gnu"
 	case PlatformLinuxArm:
 		return "aarch64-unknown-linux-gnu"
-	case PlatformMacOS:
+	case PlatformMacOS, PlatformMacOSUnsigned:
 		return "x86_64-apple-darwin19"
 	case PlatformMacOSArm:
 		return "aarch64-apple-darwin21.2"
@@ -106,7 +108,7 @@ func SharedLibraryExtensionFromPlatform(platform Platform) string {
 		return ".so"
 	case PlatformWindows:
 		return ".dll"
-	case PlatformMacOS, PlatformMacOSArm:
+	case PlatformMacOS, PlatformMacOSArm, PlatformMacOSUnsigned:
 		return ".dylib"
 	default:
 		panic(errors.Newf("unknown platform %d", platform))
@@ -242,6 +244,8 @@ const (
 	PlatformLinuxArm
 	// PlatformMacOS is the Darwin x86_64 target.
 	PlatformMacOS
+	// PlatformMacOSUnsigned is the Darwin x86_64 target.
+	PlatformMacOSUnsigned
 	// PlatformMacOSArm is the Darwin aarch6 target.
 	PlatformMacOSArm
 	// PlatformWindows is the Windows (mingw) x86_64 target.


### PR DESCRIPTION
Previously, we published Mac Intel binaries unsigned, but the file name had no ".unsigned" suffix.

This PR renames the Mac Intel release archives to use ".unsigned" suffix. This change doesn't affect the "edge" binary names, because they can have external consumers and we don't have plans to sign them.

Release note: None
Epic: None