### PR TITLE
batcheval: deflake `TestAddSSTableSSTTimestampToRequestTimestampRespectsClosedTS`

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -1711,7 +1711,11 @@ func TestAddSSTableSSTTimestampToRequestTimestampRespectsClosedTS(t *testing.T) 
 
 	ctx := context.Background()
 	si, _, db := serverutils.StartServer(t, base.TestServerArgs{
-		Knobs: base.TestingKnobs{},
+		Knobs: base.TestingKnobs{
+			Store: &kvserver.StoreTestingKnobs{
+				DisableCanAckBeforeApplication: true,
+			},
+		},
 	})
 	defer si.Stopper().Stop(ctx)
 	s := si.(*server.TestServer)


### PR DESCRIPTION
Flake introduced by #87264. @tbg Can you just quickly verify that this flake is expected given your Raft changes? Seems reasonable to me.

Resolves #91211.

Release note: None