### PR TITLE
sql: support collecting and adding single-column partial table statistics `USING EXTREMES` to `system.table_statistics`

### DIFF
--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -1002,6 +1002,9 @@ message CreateStatsDetails {
 
   // If true, delete old stats for columns not included in this message.
   bool delete_other_stats = 8;
+
+  // If true, will collect partial table statistics at extreme values.
+  bool using_extremes = 9;
 }
 
 message CreateStatsProgress {

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -12,6 +12,7 @@ package sql
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs"
@@ -19,9 +20,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/span"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
@@ -52,6 +58,266 @@ var maxTimestampAge = settings.RegisterDurationSetting(
 	"maximum age of timestamp during table statistics collection",
 	5*time.Minute,
 )
+
+func (dsp *DistSQLPlanner) createAndAttachSamplers(
+	p *PhysicalPlan,
+	desc catalog.TableDescriptor,
+	tableStats []*stats.TableStatistic,
+	details jobspb.CreateStatsDetails,
+	sampledColumnIDs []descpb.ColumnID,
+	jobID jobspb.JobID,
+	reqStats []requestedStat,
+	sketchSpec, invSketchSpec []execinfrapb.SketchSpec,
+) *PhysicalPlan {
+	// Set up the samplers.
+	sampler := &execinfrapb.SamplerSpec{
+		Sketches:         sketchSpec,
+		InvertedSketches: invSketchSpec,
+	}
+	sampler.MaxFractionIdle = details.MaxFractionIdle
+	// For partial statistics this loop should only iterate once
+	// since we only support one reqStat at a time.
+	for _, s := range reqStats {
+		if s.histogram {
+			sampler.SampleSize = histogramSamples
+			// This could be anything >= 2 to produce a histogram, but the max number
+			// of buckets is probably also a reasonable minimum number of samples. (If
+			// there are fewer rows than this in the table, there will be fewer
+			// samples of course, which is fine.)
+			sampler.MinSampleSize = s.histogramMaxBuckets
+		}
+	}
+
+	// The sampler outputs the original columns plus a rank column, five
+	// sketch columns, and two inverted histogram columns.
+	outTypes := make([]*types.T, 0, len(p.GetResultTypes())+5)
+	outTypes = append(outTypes, p.GetResultTypes()...)
+	// An INT column for the rank of each row.
+	outTypes = append(outTypes, types.Int)
+	// An INT column indicating the sketch index.
+	outTypes = append(outTypes, types.Int)
+	// An INT column indicating the number of rows processed.
+	outTypes = append(outTypes, types.Int)
+	// An INT column indicating the number of rows that have a NULL in any sketch
+	// column.
+	outTypes = append(outTypes, types.Int)
+	// An INT column indicating the size of the columns in this sketch.
+	outTypes = append(outTypes, types.Int)
+	// A BYTES column with the sketch data.
+	outTypes = append(outTypes, types.Bytes)
+	// An INT column indicating the inverted sketch index.
+	outTypes = append(outTypes, types.Int)
+	// A BYTES column with the inverted index key datum.
+	outTypes = append(outTypes, types.Bytes)
+
+	p.AddNoGroupingStage(
+		execinfrapb.ProcessorCoreUnion{Sampler: sampler},
+		execinfrapb.PostProcessSpec{},
+		outTypes,
+		execinfrapb.Ordering{},
+	)
+
+	// Estimate the expected number of rows based on existing stats in the cache.
+	var rowsExpected uint64
+	if len(tableStats) > 0 {
+		overhead := stats.AutomaticStatisticsFractionStaleRows.Get(&dsp.st.SV)
+		if autoStatsFractionStaleRowsForTable, ok := desc.AutoStatsFractionStaleRows(); ok {
+			overhead = autoStatsFractionStaleRowsForTable
+		}
+		// Convert to a signed integer first to make the linter happy.
+		rowsExpected = uint64(int64(
+			// The total expected number of rows is the same number that was measured
+			// most recently, plus some overhead for possible insertions.
+			float64(tableStats[0].RowCount) * (1 + overhead),
+		))
+	}
+
+	// Set up the final SampleAggregator stage.
+	agg := &execinfrapb.SampleAggregatorSpec{
+		Sketches:         sketchSpec,
+		InvertedSketches: invSketchSpec,
+		SampleSize:       sampler.SampleSize,
+		MinSampleSize:    sampler.MinSampleSize,
+		SampledColumnIDs: sampledColumnIDs,
+		TableID:          desc.GetID(),
+		JobID:            jobID,
+		RowsExpected:     rowsExpected,
+		DeleteOtherStats: details.DeleteOtherStats,
+	}
+	// Plan the SampleAggregator on the gateway, unless we have a single Sampler.
+	node := dsp.gatewaySQLInstanceID
+	if len(p.ResultRouters) == 1 {
+		node = p.Processors[p.ResultRouters[0]].SQLInstanceID
+	}
+	p.AddSingleGroupStage(
+		node,
+		execinfrapb.ProcessorCoreUnion{SampleAggregator: agg},
+		execinfrapb.PostProcessSpec{},
+		[]*types.T{},
+	)
+	p.PlanToStreamColMap = []int{}
+	return p
+}
+
+func (dsp *DistSQLPlanner) createPartialStatsPlan(
+	ctx context.Context,
+	planCtx *PlanningCtx,
+	desc catalog.TableDescriptor,
+	reqStats []requestedStat,
+	jobID jobspb.JobID,
+	details jobspb.CreateStatsDetails,
+) (*PhysicalPlan, error) {
+
+	// Currently, we limit the number of requests for partial statistics
+	// stats at a given point in time to 1.
+	// TODO (faizaanmadhani): Add support for multiple distinct requested
+	// partial stats in one job.
+	if len(reqStats) > 1 {
+		return nil, pgerror.Newf(pgcode.FeatureNotSupported, "cannot process multiple partial statistics at once")
+	}
+
+	reqStat := reqStats[0]
+
+	if len(reqStat.columns) > 1 {
+		// TODO (faizaanmadhani): Add support for creating multi-column stats
+		return nil, pgerror.Newf(pgcode.FeatureNotSupported, "multi-column partial statistics are not currently supported")
+	}
+
+	// Fetch all stats for the table that matches the given table descriptor.
+	tableStats, err := planCtx.ExtendedEvalCtx.ExecCfg.TableStatsCache.GetTableStats(ctx, desc)
+	if err != nil {
+		return nil, err
+	}
+
+	column, err := desc.FindColumnWithID(reqStat.columns[0])
+	if err != nil {
+		return nil, err
+	}
+
+	// Calculate the column we need to scan
+	// TODO (faizaanmadhani): Iterate through all columns in a requested stat when
+	// when we add support for multi-column statistics.
+	var colCfg scanColumnsConfig
+	colCfg.wantedColumns = append(colCfg.wantedColumns, column.GetID())
+
+	// Initialize a dummy scanNode for the requested statistic.
+	scan := scanNode{desc: desc}
+	err = scan.initDescSpecificCol(colCfg, column)
+	if err != nil {
+		return nil, err
+	}
+	// Map the ColumnIDs to their ordinals in scan.cols
+	// This loop should only iterate once, since we only
+	// handle single column partial statistics.
+	// TODO(faizaanmadhani): Add support for multi-column partial stats next
+	var colIdxMap catalog.TableColMap
+	for i, c := range scan.cols {
+		colIdxMap.Set(c.GetID(), i)
+	}
+
+	var sb span.Builder
+	sb.Init(planCtx.EvalContext(), planCtx.ExtendedEvalCtx.Codec, desc, scan.index)
+
+	var histogram []cat.HistogramBucket
+	// Find the histogram from the newest table statistic for our column
+	// that is not partial and not forecasted. The first one we find will
+	// be the latest due to the newest to oldest ordering property of the
+	// cache.
+	for _, t := range tableStats {
+		if len(t.ColumnIDs) == 1 && column.GetID() == t.ColumnIDs[0] && t.PartialPredicate == "" && t.Name != jobspb.ForecastStatsName {
+			histogram = t.Histogram
+			break
+		}
+	}
+	if len(histogram) == 0 {
+		return nil, pgerror.Newf(
+			pgcode.ObjectNotInPrerequisiteState,
+			"column %s does not have a prior statistic, "+
+				"or the prior histogram has no buckets and a partial statistic cannot be collected",
+			column.GetName())
+	}
+
+	extremesSpans, err := constructUsingExtremesSpans(planCtx, histogram, scan.index)
+	if err != nil {
+		return nil, err
+	}
+	extremesPredicate := constructUsingExtremesPredicate(extremesSpans, column.GetName(), scan.index)
+	// Get roachpb.Spans from constraint.Spans
+	scan.spans, err = sb.SpansFromConstraintSpan(&extremesSpans, span.NoopSplitter())
+	if err != nil {
+		return nil, err
+	}
+	p, err := dsp.createTableReaders(ctx, planCtx, &scan)
+	if err != nil {
+		return nil, err
+	}
+	if details.AsOf != nil {
+		val := maxTimestampAge.Get(&dsp.st.SV)
+		for i := range p.Processors {
+			spec := p.Processors[i].Spec.Core.TableReader
+			spec.MaxTimestampAgeNanos = uint64(val)
+		}
+	}
+
+	sampledColumnIDs := make([]descpb.ColumnID, len(scan.cols))
+	spec := execinfrapb.SketchSpec{
+		SketchType:          execinfrapb.SketchType_HLL_PLUS_PLUS_V1,
+		GenerateHistogram:   reqStat.histogram,
+		HistogramMaxBuckets: reqStat.histogramMaxBuckets,
+		Columns:             make([]uint32, len(reqStat.columns)),
+		StatName:            reqStat.name,
+		PartialPredicate:    extremesPredicate,
+	}
+	// For now, this loop should iterate only once, as we only
+	// handle single-column partial statistics.
+	// TODO(faizaanmadhani): Add support for multi-column partial stats next
+	for i, colID := range reqStat.columns {
+		colIdx, ok := colIdxMap.Get(colID)
+		if !ok {
+			panic("necessary column not scanned")
+		}
+		streamColIdx := uint32(p.PlanToStreamColMap[colIdx])
+		spec.Columns[i] = streamColIdx
+		sampledColumnIDs[streamColIdx] = colID
+	}
+	var sketchSpec, invSketchSpec []execinfrapb.SketchSpec
+	if reqStat.inverted {
+		// Find the first inverted index on the first column for collecting
+		// histograms. Although there may be more than one index, we don't
+		// currently have a way of using more than one or deciding which one
+		// is better.
+		//
+		// We do not generate multi-column stats with histograms, so there
+		// is no need to find an index for multi-column stats here.
+		//
+		// TODO(mjibson): allow multiple inverted indexes on the same column
+		// (i.e., with different configurations). See #50655.
+		if len(reqStat.columns) == 1 {
+			for _, index := range desc.PublicNonPrimaryIndexes() {
+				if index.GetType() == descpb.IndexDescriptor_INVERTED && index.InvertedColumnID() == column.GetID() {
+					spec.Index = index.IndexDesc()
+					break
+				}
+			}
+		}
+		// Even if spec.Index is nil because there isn't an inverted index
+		// on the requested stats column, we can still proceed. We aren't
+		// generating histograms in that case so we don't need an index
+		// descriptor to generate the inverted index entries.
+		invSketchSpec = append(invSketchSpec, spec)
+	} else {
+		sketchSpec = append(sketchSpec, spec)
+	}
+	return dsp.createAndAttachSamplers(
+		p,
+		desc,
+		tableStats,
+		details,
+		sampledColumnIDs,
+		jobID,
+		reqStats,
+		sketchSpec, invSketchSpec), nil
+}
 
 func (dsp *DistSQLPlanner) createStatsPlan(
 	ctx context.Context,
@@ -158,98 +424,20 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 		}
 	}
 
-	// Set up the samplers.
-	sampler := &execinfrapb.SamplerSpec{
-		Sketches:         sketchSpecs,
-		InvertedSketches: invSketchSpecs,
-	}
-	for _, s := range reqStats {
-		sampler.MaxFractionIdle = details.MaxFractionIdle
-		if s.histogram {
-			sampler.SampleSize = histogramSamples
-			// This could be anything >= 2 to produce a histogram, but the max number
-			// of buckets is probably also a reasonable minimum number of samples. (If
-			// there are fewer rows than this in the table, there will be fewer
-			// samples of course, which is fine.)
-			sampler.MinSampleSize = s.histogramMaxBuckets
-		}
-	}
-
-	// The sampler outputs the original columns plus a rank column, five
-	// sketch columns, and two inverted histogram columns.
-	outTypes := make([]*types.T, 0, len(p.GetResultTypes())+5)
-	outTypes = append(outTypes, p.GetResultTypes()...)
-	// An INT column for the rank of each row.
-	outTypes = append(outTypes, types.Int)
-	// An INT column indicating the sketch index.
-	outTypes = append(outTypes, types.Int)
-	// An INT column indicating the number of rows processed.
-	outTypes = append(outTypes, types.Int)
-	// An INT column indicating the number of rows that have a NULL in any sketch
-	// column.
-	outTypes = append(outTypes, types.Int)
-	// An INT column indicating the size of the columns in this sketch.
-	outTypes = append(outTypes, types.Int)
-	// A BYTES column with the sketch data.
-	outTypes = append(outTypes, types.Bytes)
-	// An INT column indicating the inverted sketch index.
-	outTypes = append(outTypes, types.Int)
-	// A BYTES column with the inverted index key datum.
-	outTypes = append(outTypes, types.Bytes)
-
-	p.AddNoGroupingStage(
-		execinfrapb.ProcessorCoreUnion{Sampler: sampler},
-		execinfrapb.PostProcessSpec{},
-		outTypes,
-		execinfrapb.Ordering{},
-	)
-
-	// Estimate the expected number of rows based on existing stats in the cache.
 	tableStats, err := planCtx.ExtendedEvalCtx.ExecCfg.TableStatsCache.GetTableStats(ctx, desc)
 	if err != nil {
 		return nil, err
 	}
 
-	var rowsExpected uint64
-	if len(tableStats) > 0 {
-		overhead := stats.AutomaticStatisticsFractionStaleRows.Get(&dsp.st.SV)
-		if autoStatsFractionStaleRowsForTable, ok := desc.AutoStatsFractionStaleRows(); ok {
-			overhead = autoStatsFractionStaleRowsForTable
-		}
-		// Convert to a signed integer first to make the linter happy.
-		rowsExpected = uint64(int64(
-			// The total expected number of rows is the same number that was measured
-			// most recently, plus some overhead for possible insertions.
-			float64(tableStats[0].RowCount) * (1 + overhead),
-		))
-	}
-
-	// Set up the final SampleAggregator stage.
-	agg := &execinfrapb.SampleAggregatorSpec{
-		Sketches:         sketchSpecs,
-		InvertedSketches: invSketchSpecs,
-		SampleSize:       sampler.SampleSize,
-		MinSampleSize:    sampler.MinSampleSize,
-		SampledColumnIDs: sampledColumnIDs,
-		TableID:          desc.GetID(),
-		JobID:            jobID,
-		RowsExpected:     rowsExpected,
-		DeleteOtherStats: details.DeleteOtherStats,
-	}
-	// Plan the SampleAggregator on the gateway, unless we have a single Sampler.
-	node := dsp.gatewaySQLInstanceID
-	if len(p.ResultRouters) == 1 {
-		node = p.Processors[p.ResultRouters[0]].SQLInstanceID
-	}
-	p.AddSingleGroupStage(
-		node,
-		execinfrapb.ProcessorCoreUnion{SampleAggregator: agg},
-		execinfrapb.PostProcessSpec{},
-		[]*types.T{},
-	)
-
-	p.PlanToStreamColMap = []int{}
-	return p, nil
+	return dsp.createAndAttachSamplers(
+		p,
+		desc,
+		tableStats,
+		details,
+		sampledColumnIDs,
+		jobID,
+		reqStats,
+		sketchSpecs, invSketchSpecs), nil
 }
 
 func (dsp *DistSQLPlanner) createPlanForCreateStats(
@@ -272,7 +460,14 @@ func (dsp *DistSQLPlanner) createPlanForCreateStats(
 		}
 	}
 
+	if len(reqStats) == 0 {
+		return nil, errors.New("no stats requested")
+	}
+
 	tableDesc := tabledesc.NewBuilder(&details.Table).BuildImmutableTable()
+	if details.UsingExtremes {
+		return dsp.createPartialStatsPlan(ctx, planCtx, tableDesc, reqStats, jobID, details)
+	}
 	return dsp.createStatsPlan(ctx, planCtx, tableDesc, reqStats, jobID, details)
 }
 
@@ -308,4 +503,62 @@ func (dsp *DistSQLPlanner) planAndRunCreateStats(
 
 	dsp.Run(ctx, planCtx, txn, physPlan, recv, evalCtx, nil /* finishedSetupFn */)
 	return resultWriter.Err()
+}
+
+// constructUsingExtremesPredicate returns string of a predicate identifying
+// the upper and lower bounds of the stats collection.
+func constructUsingExtremesPredicate(
+	extremesSpans constraint.Spans, columnName string, index catalog.Index,
+) string {
+	var predicate string
+	if index.GetKeyColumnDirection(0) == catpb.IndexColumn_ASC {
+		predicate = fmt.Sprintf("%s < %s OR %s > %s OR %s is NULL", columnName, extremesSpans.Get(0).EndKey().Value(0).String(), columnName, extremesSpans.Get(1).StartKey().Value(0).String(), columnName)
+	} else {
+		predicate = fmt.Sprintf("%s < %s OR %s > %s OR %s is NULL", columnName, extremesSpans.Get(1).StartKey().Value(0).String(), columnName, extremesSpans.Get(0).EndKey().Value(0).String(), columnName)
+	}
+	return predicate
+}
+
+// constructExtremesSpans returns a constraint.Spans consisting of a
+// lowerbound and upperbound span covering the extremes of an index.
+func constructUsingExtremesSpans(
+	planCtx *PlanningCtx, histogram []cat.HistogramBucket, index catalog.Index,
+) (constraint.Spans, error) {
+	var lbSpan constraint.Span
+	var ubSpan constraint.Span
+	lowerBound := histogram[0].UpperBound
+	upperBound := constraint.MakeKey(histogram[len(histogram)-1].UpperBound)
+	// Pick the earliest lowerBound that is not null,
+	// but if none exist, return error
+	for i := range histogram {
+		hist := &histogram[i]
+		if hist.UpperBound.Compare(planCtx.EvalContext(), tree.DNull) != 0 {
+			lowerBound = hist.UpperBound
+			break
+		}
+	}
+	if lowerBound.Compare(planCtx.EvalContext(), tree.DNull) == 0 {
+		return constraint.Spans{},
+			pgerror.Newf(
+				pgcode.ObjectNotInPrerequisiteState,
+				"only NULL values exist in the index, so partial stats cannot be collected")
+	}
+
+	if index.GetKeyColumnDirection(0) == catpb.IndexColumn_ASC {
+		lbSpan.Init(constraint.EmptyKey, constraint.IncludeBoundary, constraint.MakeKey(lowerBound), constraint.ExcludeBoundary)
+		ubSpan.Init(upperBound, constraint.ExcludeBoundary, constraint.EmptyKey, constraint.IncludeBoundary)
+	} else {
+		lbSpan.Init(constraint.MakeKey(lowerBound), constraint.ExcludeBoundary, constraint.EmptyKey, constraint.IncludeBoundary)
+		ubSpan.Init(constraint.EmptyKey, constraint.IncludeBoundary, upperBound, constraint.ExcludeBoundary)
+	}
+	var extremesSpans constraint.Spans
+	if index.GetKeyColumnDirection(0) == catpb.IndexColumn_ASC {
+		extremesSpans.InitSingleSpan(&lbSpan)
+		extremesSpans.Append(&ubSpan)
+	} else {
+		extremesSpans.InitSingleSpan(&ubSpan)
+		extremesSpans.Append(&lbSpan)
+	}
+
+	return extremesSpans, nil
 }

--- a/pkg/sql/execinfrapb/processors_table_stats.proto
+++ b/pkg/sql/execinfrapb/processors_table_stats.proto
@@ -50,6 +50,10 @@ message SketchSpec {
   // Index is needed by some types (for example the geo types) when generating
   // inverted index entries, since it may contain configuration.
   optional sqlbase.IndexDescriptor index = 6 [(gogoproto.nullable) = true];
+
+  // PartialPredicate is a string representing the predicate for a partial statistic,
+  // and is the empty string for a full table statistic.
+  optional string partial_predicate = 7 [(gogoproto.nullable) = false];
 }
 
 // SamplerSpec is the specification of a "sampler" processor which
@@ -173,4 +177,8 @@ message SampleAggregatorSpec {
 
   // If true, delete old stats for columns not included in this message.
   optional bool delete_other_stats = 10 [(gogoproto.nullable) = false];
+
+  // If true, calculate partial table statistics on the extreme values of
+  // the previous full table stat.
+  optional bool using_extremes = 11 [(gogoproto.nullable) = false];
 }

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -1955,3 +1955,237 @@ query T
 SELECT * FROM indexed_arr WHERE a @> ARRAY[100]
 ----
 {100}
+
+# Test single column partial statistics creation.
+
+# Disable auto stats collection to avoid new full stats collection
+# when inserting values into the extremes in the table.
+statement ok
+SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false;
+
+statement ok
+CREATE TABLE abcd (a INT PRIMARY KEY, b INT, c INT, d INT, INDEX (c, d));
+
+statement ok
+CREATE TABLE xy (x INT, y INT, INDEX (x, y))
+
+statement ok
+INSERT INTO xy VALUES (0, 10), (1, 11), (2, 12), (3, 13)
+
+statement ok
+INSERT INTO abcd VALUES
+(1, 10, 100, 1000),
+(2, 20, 200, 2000),
+(3, 30, 300, 3000),
+(4, 40, 400, 4000),
+(5, 50, 500, 5000),
+(6, 60, 600, 6000),
+(7, 70, 700, 7000),
+(8, 80, 800, 8000);
+
+statement ok
+CREATE STATISTICS abcd_a ON a FROM abcd;
+
+statement ok
+CREATE STATISTICS abcd_c ON c FROM abcd;
+
+statement ok
+CREATE STATISTICS xy_x ON x FROM xy;
+
+# insert values at the extremes of column a and c.
+statement ok
+INSERT INTO abcd VALUES
+(-2, -20, 900, 9000),
+(-1, -10, 920, 9200),
+(0, -9, 920, 9300);
+
+# insert values at the extremes of column x.
+statement ok
+INSERT INTO xy VALUES (-1, 9), (-2, 8), (5, 15), (6, 16)
+
+statement ok
+CREATE STATISTICS abcd_a_partial ON a FROM abcd USING EXTREMES;
+
+statement ok
+CREATE STATISTICS abcd_c_partial ON c FROM abcd USING EXTREMES;
+
+statement ok
+CREATE STATISTICS xy_x_partial ON x FROM xy USING EXTREMES;
+
+let $hist_abcd_a_partial
+SELECT histogram_id FROM [SHOW STATISTICS FOR TABLE abcd] WHERE statistics_name = 'abcd_a_partial';
+
+let $hist_abcd_c_partial
+SELECT histogram_id FROM [SHOW STATISTICS FOR TABLE abcd] WHERE statistics_name = 'abcd_c_partial';
+
+let $hist_xy_x_partial
+SELECT histogram_id FROM [SHOW STATISTICS FOR TABLE xy] WHERE statistics_name = 'xy_x_partial';
+
+query TIRI colnames
+SHOW HISTOGRAM $hist_abcd_a_partial
+----
+upper_bound  range_rows  distinct_range_rows  equal_rows
+-2           0           0                    1
+-1           0           0                    1
+0            0           0                    1
+
+query TIRI colnames
+SHOW HISTOGRAM $hist_abcd_c_partial
+----
+upper_bound  range_rows  distinct_range_rows  equal_rows
+900          0           0                    1
+920          0           0                    2
+
+query TIRI colnames
+SHOW HISTOGRAM $hist_xy_x_partial
+----
+upper_bound  range_rows  distinct_range_rows  equal_rows
+-2           0           0                    1
+-1           0           0                    1
+5            0           0                    1
+6            0           0                    1
+
+query TT colnames
+SELECT "name", "partialPredicate" FROM system.table_statistics WHERE name='abcd_a_partial';
+----
+name            partialPredicate
+abcd_a_partial  a < 1 OR a > 8 OR a is NULL
+
+query TT colnames
+SELECT "name", "partialPredicate" FROM system.table_statistics WHERE name='abcd_c_partial';
+----
+name            partialPredicate
+abcd_c_partial  c < 100 OR c > 800 OR c is NULL
+
+query TT colnames
+SELECT "name", "partialPredicate" FROM system.table_statistics WHERE name='xy_x_partial';
+----
+name          partialPredicate
+xy_x_partial  x < 0 OR x > 3 OR x is NULL
+
+# Test if requesting a partial stat again uses the previous full stat and not the previous partial stat.
+statement ok
+CREATE STATISTICS xy_x_partial_2 ON x FROM xy USING EXTREMES
+
+query TTII colnames
+SELECT "statistics_name", "partial_predicate", "row_count", "null_count" FROM [SHOW STATISTICS FOR TABLE xy];
+----
+statistics_name  partial_predicate            row_count  null_count
+xy_x             NULL                         4          0
+xy_x_partial     x < 0 OR x > 3 OR x is NULL  4          0
+xy_x_partial_2   x < 0 OR x > 3 OR x is NULL  4          0
+
+# Test null values.
+statement ok
+CREATE TABLE a_null (a INT, INDEX (a));
+
+statement ok
+INSERT INTO a_null VALUES (NULL), (1), (2);
+
+statement ok
+CREATE STATISTICS a_null_stat ON a FROM a_null;
+
+statement ok
+INSERT INTO a_null VALUES (NULL), (NULL), (NULL);
+
+statement ok
+CREATE STATISTICS a_null_stat_partial ON a FROM a_null USING EXTREMES;
+
+let $hist_a_null_stat_partial
+SELECT histogram_id FROM [SHOW STATISTICS FOR TABLE a_null] WHERE statistics_name = 'a_null_stat_partial';
+
+query TIRI colnames
+SHOW HISTOGRAM $hist_a_null_stat_partial
+----
+upper_bound  range_rows  distinct_range_rows  equal_rows
+
+query TTII colnames
+SELECT "statistics_name", "partial_predicate", "row_count", "null_count" FROM [SHOW STATISTICS FOR TABLE a_null];
+----
+statistics_name      partial_predicate            row_count  null_count
+a_null_stat          NULL                         3          1
+a_null_stat_partial  a < 1 OR a > 2 OR a is NULL  4          4
+
+# Test descending indexes.
+statement ok
+CREATE TABLE d_desc (a INT, b INT, index (a DESC, b));
+
+statement ok
+INSERT INTO d_desc VALUES (1, 10), (2, 20), (3, 30), (4, 40);
+
+statement ok
+CREATE STATISTICS sd ON a FROM d_desc;
+
+statement ok
+INSERT INTO d_desc VALUES (0, 0), (5, 50);
+
+statement ok
+CREATE STATISTICS sdp ON a FROM d_desc USING EXTREMES;
+
+let $hist_d_desc
+SELECT histogram_id FROM [SHOW STATISTICS FOR TABLE d_desc] WHERE statistics_name = 'sdp';
+
+query TIRI colnames
+SHOW HISTOGRAM $hist_d_desc
+----
+upper_bound  range_rows  distinct_range_rows  equal_rows
+0            0           0                    1
+5            0           0                    1
+
+query TTII colnames
+SELECT "statistics_name", "partial_predicate", "row_count", "null_count" FROM [SHOW STATISTICS FOR TABLE d_desc];
+----
+statistics_name  partial_predicate            row_count  null_count
+sd               NULL                         4          0
+sdp              a < 1 OR a > 4 OR a is NULL  2          0
+
+# Test descending index with NULL
+statement ok
+INSERT INTO d_desc VALUES (NULL, NULL), (NULL, 2);
+
+statement ok
+CREATE STATISTICS sdn ON a FROM d_desc;
+
+statement ok
+CREATE STATISTICS sdnp ON a FROM d_desc USING EXTREMES;
+
+query TTII colnames
+SELECT "statistics_name", "partial_predicate", "row_count", "null_count" FROM [SHOW STATISTICS FOR TABLE d_desc];
+----
+statistics_name  partial_predicate            row_count  null_count
+sdn              NULL                         8          2
+sdnp             a < 0 OR a > 5 OR a is NULL  2          2
+
+# Verify errors.
+statement error pq: cannot process multiple partial statistics at once
+CREATE STATISTICS abcd_defaults FROM abcd USING EXTREMES;
+
+statement error pq: multi-column partial statistics are not currently supported
+CREATE STATISTICS abcd_a_b ON a, c FROM abcd USING EXTREMES;
+
+statement ok
+CREATE TABLE xyz (x INT, y INT, z INT, INDEX (x, y));
+
+statement error pq: column x does not have a prior statistic
+CREATE STATISTICS xyz_x ON x FROM xyz USING EXTREMES;
+
+statement error pq: column a does not have a prior statistic, or the prior histogram has no buckets and a partial statistic cannot be collected
+CREATE STATISTICS u_partial ON a FROM u USING EXTREMES;
+
+statement error pq: table xy does not contain a non-partial forward index with y as a prefix column
+CREATE STATISTICS xy_y_partial ON y FROM xy USING EXTREMES;
+
+statement ok
+DELETE FROM a_null WHERE a IS NOT NULL;
+
+statement ok
+CREATE STATISTICS a_null_stat ON a FROM a_null;
+
+statement error pq: only NULL values exist in the index, so partial stats cannot be collected
+CREATE STATISTICS only_null_partial ON a FROM a_null USING EXTREMES;
+
+statement ok
+CREATE INDEX ON xy (y) WHERE y > 5;
+
+statement error pq: table xy does not contain a non-partial forward index with y as a prefix column
+CREATE STATISTICS xy_partial_idx ON y FROM xy USING EXTREMES;

--- a/pkg/sql/span/span_builder.go
+++ b/pkg/sql/span/span_builder.go
@@ -240,6 +240,24 @@ func (s *Builder) SpansFromConstraint(
 	return spans, nil
 }
 
+// SpansFromConstraintSpan generates spans from optimizer
+// spans. A span.Splitter can be used to generate more specific
+// family spans from constraints, datums and encdatums.
+func (s *Builder) SpansFromConstraintSpan(
+	cs *constraint.Spans, splitter Splitter,
+) (roachpb.Spans, error) {
+	var spans roachpb.Spans
+	var err error
+	spans = make(roachpb.Spans, 0, cs.Count())
+	for i := 0; i < cs.Count(); i++ {
+		spans, err = s.appendSpansFromConstraintSpan(spans, cs.Get(i), splitter)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return spans, nil
+}
+
 // UnconstrainedSpans returns the full span corresponding to the Builder's
 // table and index.
 func (s *Builder) UnconstrainedSpans() (roachpb.Spans, error) {

--- a/pkg/sql/stats/BUILD.bazel
+++ b/pkg/sql/stats/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/stats",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/kv",

--- a/pkg/sql/stats/json.go
+++ b/pkg/sql/stats/json.go
@@ -42,6 +42,7 @@ type JSONStatistic struct {
 	HistogramColumnType string            `json:"histo_col_type"`
 	HistogramBuckets    []JSONHistoBucket `json:"histo_buckets,omitempty"`
 	HistogramVersion    HistogramVersion  `json:"histo_version,omitempty"`
+	PartialPredicate    string            `json:"partial_predicate,omitempty"`
 }
 
 // JSONHistoBucket is a struct used for JSON marshaling and unmarshaling of

--- a/pkg/sql/stats/table_statistic.proto
+++ b/pkg/sql/stats/table_statistic.proto
@@ -56,4 +56,7 @@ message TableStatisticProto {
   HistogramData histogram_data = 9;
   // The average row size of the columns in ColumnIDs.
   uint64 avg_size = 10;
+  // A predicate representing the range of a partial statistic,
+  // and the empty string for a full table statistic.
+  string partial_predicate = 11 [(gogoproto.nullable) = true];
 }


### PR DESCRIPTION
This commit adds support to manually create partial statistics
at the extremes of indexes for individual columns. Columns must
be the key of their index, otherwise an error will be returned.
Partial statistics are stored in `system.table_statistics` and are
identified by a predicate indicating their coverage. Additionally,
this PR also adds a partial_predicate column to the output to
`SHOW STATISTICS`.

Epic: [CRDB-19449](https://cockroachlabs.atlassian.net/browse/CRDB-19449)

Release note (sql change): users can now manually create partial
single-column statistics at the extreme values on
columns that are prefixes of their index. The output of SHOW
STATISTICS now includes a column indicating the partial predicate
for a partial statistic, or NULL for a full statistic.