### PR TITLE
roachtest: update gorm version to 1.24.1

### DIFF
--- a/pkg/cmd/roachtest/tests/gorm.go
+++ b/pkg/cmd/roachtest/tests/gorm.go
@@ -24,7 +24,7 @@ import (
 )
 
 var gormReleaseTag = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
-var gormSupportedTag = "v1.24.0"
+var gormSupportedTag = "v1.24.1"
 
 func registerGORM(r registry.Registry) {
 	runGORM := func(ctx context.Context, t test.Test, c cluster.Cluster) {


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/90311 
fixes https://github.com/cockroachdb/cockroach/issues/90310 
fixes https://github.com/cockroachdb/cockroach/issues/90309

The error 
```
/home/ubuntu/go/pkg/mod/gorm.io/driver/postgres@v1.4.5/migrator.go:710:8: pdb.Reset undefined (type *gorm.PreparedStmtDB has no field or method Reset)
```
was due to the lack of this commit in the gorm we used: https://github.com/go-gorm/gorm/commit/5dd2bb482755f5e8eb5ecaff39e675fb62f19a20
which is merged to gorm 1.24.1.

Release note: None