### PR TITLE
release-21.2: vendor: bump Pebble to 441910e2cef5

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -733,8 +733,8 @@ def go_deps():
         name = "com_github_cockroachdb_pebble",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/cockroachdb/pebble",
-        sum = "h1:tHoVW9i9oRYCG/p0fhqd8vToBWNnaM9oriF058L8elE=",
-        version = "v0.0.0-20220701231217-36e8e9214699",
+        sum = "h1:iytq3LdG0eeUCi8LMu9N+J9pnM2z6fPpEyrGYgNTiaU=",
+        version = "v0.0.0-20221028163947-441910e2cef5",
     )
 
     go_repository(
@@ -2749,6 +2749,7 @@ def go_deps():
         name = "com_github_lib_pq",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/lib/pq",
+        sum = "h1:jbk+ZieJ0D7EVGJYpL9QTz7/YW6UHbmdnZWYyK5cdBs=",
         version = "v1.10.6",
     )
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/cockroachdb/go-test-teamcity v0.0.0-20191211140407-cff980ad0a55
 	github.com/cockroachdb/gostdlib v1.13.0
 	github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f
-	github.com/cockroachdb/pebble v0.0.0-20220701231217-36e8e9214699
+	github.com/cockroachdb/pebble v0.0.0-20221028163947-441910e2cef5
 	github.com/cockroachdb/redact v1.1.3
 	github.com/cockroachdb/returncheck v0.0.0-20200612231554-92cdbca611dd
 	github.com/cockroachdb/stress v0.0.0-20170808184505-29b5d31b4c3a

--- a/go.sum
+++ b/go.sum
@@ -305,8 +305,8 @@ github.com/cockroachdb/gostdlib v1.13.0/go.mod h1:eXX95p9QDrYwJfJ6AgeN9QnRa/lqqi
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f h1:6jduT9Hfc0njg5jJ1DdKCFPdMBrp/mdZfCpa5h+WM74=
 github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f/go.mod h1:Vz9DsVWQQhf3vs21MhPMZpMGSht7O/2vFW2xusFUVOs=
-github.com/cockroachdb/pebble v0.0.0-20220701231217-36e8e9214699 h1:tHoVW9i9oRYCG/p0fhqd8vToBWNnaM9oriF058L8elE=
-github.com/cockroachdb/pebble v0.0.0-20220701231217-36e8e9214699/go.mod h1:buxOO9GBtOcq1DiXDpIPYrmxY020K2A8lOrwno5FetU=
+github.com/cockroachdb/pebble v0.0.0-20221028163947-441910e2cef5 h1:iytq3LdG0eeUCi8LMu9N+J9pnM2z6fPpEyrGYgNTiaU=
+github.com/cockroachdb/pebble v0.0.0-20221028163947-441910e2cef5/go.mod h1:buxOO9GBtOcq1DiXDpIPYrmxY020K2A8lOrwno5FetU=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/redact v1.1.3 h1:AKZds10rFSIj7qADf0g46UixK8NNLwWTNdCIGS5wfSQ=
 github.com/cockroachdb/redact v1.1.3/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=


### PR DESCRIPTION
```
441910e2 vfs: use `Frsize` for computing total size on Linux
09f3473d metamorphic: Flush before close if DisableWAL is
true ce79ad15 metamorphic: Use same WAL directory as later versions
5bce6801 metamorphic: use testkeys comparer
```

Release note: None.

Release justification: pulls in a minor, development-only bug fix.