### PR TITLE
roachprod,roachtest: change default zones and cluster size for some tests

### DIFF
--- a/pkg/cmd/roachtest/tests/costfuzz.go
+++ b/pkg/cmd/roachtest/tests/costfuzz.go
@@ -31,7 +31,7 @@ func registerCostFuzz(r registry.Registry) {
 		var clusterSpec spec.ClusterSpec
 		switch setupName {
 		case sqlsmith.SeedMultiRegionSetupName:
-			clusterSpec = r.MakeClusterSpec(4, spec.Geo())
+			clusterSpec = r.MakeClusterSpec(9, spec.Geo())
 		default:
 			clusterSpec = r.MakeClusterSpec(1)
 		}

--- a/pkg/cmd/roachtest/tests/unoptimized_query_oracle.go
+++ b/pkg/cmd/roachtest/tests/unoptimized_query_oracle.go
@@ -46,7 +46,7 @@ func registerUnoptimizedQueryOracle(r registry.Registry) {
 			var clusterSpec spec.ClusterSpec
 			switch setupName {
 			case sqlsmith.SeedMultiRegionSetupName:
-				clusterSpec = r.MakeClusterSpec(4, spec.Geo())
+				clusterSpec = r.MakeClusterSpec(9, spec.Geo())
 			default:
 				clusterSpec = r.MakeClusterSpec(1)
 			}

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -246,10 +246,18 @@ type ProjectsVal struct {
 
 // defaultZones is the list of  zones used by default for cluster creation.
 // If the geo flag is specified, nodes are distributed between zones.
+// These are GCP zones available according to this page:
+// https://cloud.google.com/compute/docs/regions-zones#available
 var defaultZones = []string{
 	"us-east1-b",
 	"us-west1-b",
 	"europe-west2-b",
+	"us-east1-c",
+	"us-west1-c",
+	"europe-west2-c",
+	"us-east1-d",
+	"us-west1-a",
+	"europe-west2-a",
 }
 
 // Set is part of the pflag.Value interface.


### PR DESCRIPTION
This commit updates the default zones used for roachprod clusters to include three different zones from three different regions.

This commit also changes the cluster size for the multi-region versions of `costfuzz` and `unoptimized-query-oracle` to 9, so that we won't get errors related to a fragile quorum and underreplicated ranges.

Fixes #90504

Release note: None