### PR TITLE
acceptance: deflake `TestDockerCLI/test_txn_prompt`

### DIFF
--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -69,6 +69,15 @@ proc eexpect {text} {
     }
 }
 
+# eexpect_re is like eexpect, but takes a regular expression argument
+# instead of a text string
+proc eexpect_re {text} {
+  expect {
+    -re $text {}
+    timeout { handle_timeout $text }
+  }
+}
+
 # Convenience function that sends Ctrl+C to the monitored process.
 proc interrupt {} {
     report "INTERRUPT TO FOREGROUND PROCESS"
@@ -178,4 +187,3 @@ proc stop_tenant {tenant_id argv} {
 
     report "END STOP TENANT $tenant_id"
 }
-

--- a/pkg/cli/interactive_tests/test_txn_prompt.tcl
+++ b/pkg/cli/interactive_tests/test_txn_prompt.tcl
@@ -43,7 +43,11 @@ eexpect abcdefaultdbdef
 
 # Check prompt with no formatting code.
 send "\\set prompt1 woo \r"
-eexpect woo
+# use a regular expression to match the `woo` prompt (beginning of
+# line). If we use `eexpect` here, the match would happen
+# instantaneously as it would match the previous `set prompt1 woo`
+# command, as it also contains the string `woo`.
+eexpect_re "(?n)^woo $"
 
 send "SET database \r"
 eexpect "\r\n -> "


### PR DESCRIPTION
That test would sometimes fail because of the semantics of `expect` and `send` when the expected string was previously written using `send`.

When `expect` is called, the buffer looked at includes content previously sent using `send`. This means that if one runs `send "foo"; expect foo`, the `expect` call will match instataneously even if the program's output after the send does not contain `foo`.

In the case of the test fixed here, we are supposed to expect for the new prompt to be printed after setting it with `\set prompt1`. In order to properly check whether the prompt changed, this PR changes the prompt `expect` call to use a regular expression that matches the new prompt only if it sits in the beginning of a line.

Prior to this commit, since the `expect` call would return immediately, there was a chance the `send "SET DATABASE"` command could run before the cockroach CLI had the chance to print the new prompt, leading to the following error:

```
abcdefaultdbdef \set prompt1 woo
SET database
woo  ->
.221103 18:13:35.539667600 EXPECT TEST: TIMEOUT WAITING FOR "
 -> "
non-zero exit code: 1
```

Epic: None
Release note: None