### PR TITLE
ui: fiz size chart when first load

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -279,6 +279,7 @@ export class StatementDetails extends React.Component<
   }
 
   componentDidUpdate(prevProps: StatementDetailsProps): void {
+    this.handleResize();
     if (
       prevProps.timeScale != this.props.timeScale ||
       prevProps.statementFingerprintID != this.props.statementFingerprintID ||


### PR DESCRIPTION
Previously, the chart sizes were being properly
updated when resized, but the initial value was not correct.
This commit adds the call to handle resize so it
can load the correct size on first load.

Fix #91207

https://www.loom.com/share/3faf00b251e849d59120ce0b6e94047f

Release note: None