### PR TITLE
ui: fixes on sql activity filter

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.module.scss
@@ -52,6 +52,7 @@ $dropdown-hover-color: darken($colors--background, 2.5%);
       letter-spacing: 0.3px;
       font-style: normal;
       margin-bottom: 8px;
+      color: $colors--neutral-7;
 
       &__transaction-type {
         margin-top: 25px;

--- a/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.tsx
@@ -58,11 +58,6 @@ interface FilterState {
   filters: Filters;
 }
 
-export interface SelectOptions {
-  label: string;
-  value: string;
-}
-
 export interface Filters extends Record<string, string | boolean> {
   app?: string;
   timeNumber?: string;
@@ -681,7 +676,7 @@ export class Filter extends React.Component<QueryFilter, FilterState> {
               <>
                 <div className={filterLabel.margin}>
                   {timeLabel
-                    ? timeLabel
+                    ? `${timeLabel} runs longer than`
                     : "Statement fingerprint runs longer than"}
                 </div>
                 <section className={timePair.wrapper}>

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
@@ -389,7 +389,6 @@ export class SessionsPage extends React.Component<
         }),
       );
 
-    const timeLabel = "Session duration runs longer than";
     const displayColumns = columns.filter(c => isColumnSelected(c));
 
     return (
@@ -404,7 +403,7 @@ export class SessionsPage extends React.Component<
             sessionStatuses={sessionStatuses}
             activeFilters={activeFilters}
             filters={filters}
-            timeLabel={timeLabel}
+            timeLabel={"Session duration"}
           />
         </div>
         <section>

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -461,6 +461,7 @@ export class TransactionsPage extends React.Component<
               onSubmitFilters={this.onSubmitFilters}
               appNames={appNames}
               regions={regions}
+              timeLabel={"Transaction fingerprint"}
               nodes={nodes.map(n => "n" + n)}
               activeFilters={activeFilters}
               filters={filters}


### PR DESCRIPTION
This commit fixes the label of Transaction
filter and add the proper color for the filter
styles (previously was being loaded as a different color on the Sessions page because it was being inherit from another component)

Fixes #91206

Transactions Before
<img width="457" alt="Screen Shot 2022-11-03 at 7 07 13 PM" src="https://user-images.githubusercontent.com/1017486/199851829-b747102a-ac70-4720-97b5-7911b742345c.png">


Transactions After
<img width="477" alt="Screen Shot 2022-11-03 at 6 55 14 PM" src="https://user-images.githubusercontent.com/1017486/199851704-71641bb6-8247-4d92-8f2d-3efd27846594.png">


Sessions Before
<img width="317" alt="Screen Shot 2022-11-03 at 6 36 51 PM" src="https://user-images.githubusercontent.com/1017486/199851596-313646b9-0188-48aa-9392-7dd7f3eded99.png">


Sessions After
<img width="309" alt="Screen Shot 2022-11-03 at 6 55 06 PM" src="https://user-images.githubusercontent.com/1017486/199851671-02d4db08-4f2b-4ac3-95ff-e1d98e2d6ede.png">


Before/After of Statement page continues the same
<img width="604" alt="Screen Shot 2022-11-03 at 6 55 28 PM" src="https://user-images.githubusercontent.com/1017486/199851734-06a8a131-3528-4d17-a856-9d39d67e7017.png">


Release note (ui change): Fix Transaction filter label on SQL Activity page.