### PR TITLE
[DNM] [hack] sql: add some more information on restart txn error

### DIFF
--- a/pkg/roachpb/errors.go
+++ b/pkg/roachpb/errors.go
@@ -700,6 +700,18 @@ func NewTransactionRetryError(
 	}
 }
 
+// NewTransactionRetryError initializes a new TransactionRetryError.
+func NewTransactionRetryErrorWithKey(
+	reason TransactionRetryReason, extraMsg string, key Key, timestamp hlc.Timestamp,
+) *TransactionRetryError {
+	return &TransactionRetryError{
+		Reason:         reason,
+		ExtraMsg:       extraMsg,
+		ConflictingKey: key,
+		Timestamp:      timestamp,
+	}
+}
+
 func (e *TransactionRetryError) Error() string {
 	msg := ""
 	if e.ExtraMsg != "" {

--- a/pkg/roachpb/errors.proto
+++ b/pkg/roachpb/errors.proto
@@ -244,6 +244,8 @@ enum TransactionRetryReason {
 message TransactionRetryError {
   optional TransactionRetryReason reason = 1 [(gogoproto.nullable) = false];
   optional string extra_msg = 2 [(gogoproto.nullable) = false];
+  optional bytes conflicting_key = 3 [(gogoproto.casttype) = "Key"];
+  optional util.hlc.Timestamp timestamp = 4 [(gogoproto.nullable) = false];
 }
 
 // A TransactionStatusError indicates that the transaction status is
@@ -464,6 +466,8 @@ message TransactionRetryWithProtoRefreshError {
   // before, but with an incremented epoch and timestamp, or a completely new
   // Transaction.
   optional roachpb.Transaction transaction = 3 [(gogoproto.nullable) = false];
+  optional bytes conflicting_key = 4 [(gogoproto.casttype) = "Key"];
+  optional util.hlc.Timestamp timestamp = 5 [(gogoproto.nullable) = false];
 }
 
 // TxnAlreadyEncounteredErrorError indicates that an operation tried to use a


### PR DESCRIPTION
This commit adds some more information to the error message that's returned when asking the client to restart the transaction. It attempts to decode the key that caused the transaction to conflict into user-understandable strings that explain which table, index and key values encountered the conflict.

Release note (sql change): improve error message on transaction retry error