### PR TITLE
release-22.2: changefeedccl: allow sarama compression options for kafka sink

### DIFF
--- a/pkg/ccl/changefeedccl/sink_kafka.go
+++ b/pkg/ccl/changefeedccl/sink_kafka.go
@@ -134,6 +134,37 @@ type kafkaSink struct {
 	disableInternalRetry bool
 }
 
+var saramaCompressionCodecOptions = map[string]sarama.CompressionCodec{
+	"NONE":   sarama.CompressionNone,
+	"GZIP":   sarama.CompressionGZIP,
+	"SNAPPY": sarama.CompressionSnappy,
+	"LZ4":    sarama.CompressionLZ4,
+	"ZSTD":   sarama.CompressionZSTD,
+}
+
+func validateCompressionCodec(s string) (sarama.CompressionCodec, error) {
+	codec, ok := saramaCompressionCodecOptions[s]
+	if !ok {
+		return -1, errors.Newf("could not validate compression codec '%s'", s)
+	}
+	return codec, nil
+}
+
+type compressionCodec sarama.CompressionCodec
+
+func (j *compressionCodec) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	codec, err := validateCompressionCodec(s)
+	if err != nil {
+		return err
+	}
+	*j = compressionCodec(codec)
+	return nil
+}
+
 type saramaConfig struct {
 	// These settings mirror ones in sarama config.
 	// We just tag them w/ JSON annotations.
@@ -145,6 +176,8 @@ type saramaConfig struct {
 		Frequency   jsonDuration `json:",omitempty"`
 		MaxMessages int          `json:",omitempty"`
 	}
+
+	Compression compressionCodec `json:",omitempty"`
 
 	RequiredAcks string `json:",omitempty"`
 
@@ -181,6 +214,10 @@ func defaultSaramaConfig() *saramaConfig {
 	config.Flush.Messages = 0
 	config.Flush.Frequency = jsonDuration(0)
 	config.Flush.Bytes = 0
+
+	// The default compression protocol is sarama.CompressionNone,
+	// which is 0.
+	config.Compression = 0
 
 	// This works around what seems to be a bug in sarama where it isn't
 	// computing the right value to compare against `Producer.MaxMessageBytes`
@@ -722,6 +759,7 @@ func (c *saramaConfig) Apply(kafka *sarama.Config) error {
 		}
 		kafka.Producer.RequiredAcks = parsedAcks
 	}
+	kafka.Producer.Compression = sarama.CompressionCodec(c.Compression)
 	return nil
 }
 

--- a/pkg/ccl/changefeedccl/sink_test.go
+++ b/pkg/ccl/changefeedccl/sink_test.go
@@ -10,6 +10,7 @@ package changefeedccl
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"strconv"
 	"sync"
@@ -675,6 +676,21 @@ func TestSaramaConfigOptionParsing(t *testing.T) {
 		err = cfg.Apply(saramaCfg)
 		require.Error(t, err)
 
+	})
+	t.Run("compression options validation", func(t *testing.T) {
+		for option := range saramaCompressionCodecOptions {
+			opts := changefeedbase.SinkSpecificJSONConfig(fmt.Sprintf(`{"Compression": "%s"}`, option))
+			cfg, err := getSaramaConfig(opts)
+			require.NoError(t, err)
+
+			saramaCfg := &sarama.Config{}
+			err = cfg.Apply(saramaCfg)
+			require.NoError(t, err)
+		}
+
+		opts := changefeedbase.SinkSpecificJSONConfig(`{"Compression": "invalid"}`)
+		_, err := getSaramaConfig(opts)
+		require.Error(t, err)
 	})
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #90270.

/cc @cockroachdb/release


---

Previously, the kafka sink would emit uncompressed data to kafka. This change updates the kafka sink to accept a "Compression" field in the `kafka_sink_config`, which gets passed to Sarama.

Release note (enterprise change): For kafka sinks, you can now add the optional JSON field "Compression" to the `kafka_sink_config` option. This field can be set to "none" (default), "gzip", "snappy", "lz4", or "zstd". Setting this field will result in the specified compression protocol to be used when emitting events.

Fixes: https://github.com/cockroachdb/cockroach/issues/89580
Epic: none
Release Justification: low danger/high impact fix to enable compression in supported changefeed sink.
