### PR TITLE
release-22.1: changefeedccl: allow sarama compression options for kafka sink

### DIFF
--- a/pkg/ccl/changefeedccl/sink_test.go
+++ b/pkg/ccl/changefeedccl/sink_test.go
@@ -10,6 +10,7 @@ package changefeedccl
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"strconv"
 	"sync"
@@ -651,6 +652,21 @@ func TestSaramaConfigOptionParsing(t *testing.T) {
 		err = cfg.Apply(saramaCfg)
 		require.Error(t, err)
 
+	})
+	t.Run("compression options validation", func(t *testing.T) {
+		for option := range saramaCompressionCodecOptions {
+			opts := map[string]string{changefeedbase.OptKafkaSinkConfig: fmt.Sprintf(`{"Compression": "%s"}`, option)}
+			cfg, err := getSaramaConfig(opts)
+			require.NoError(t, err)
+
+			saramaCfg := &sarama.Config{}
+			err = cfg.Apply(saramaCfg)
+			require.NoError(t, err)
+		}
+
+		opts := map[string]string{changefeedbase.OptKafkaSinkConfig: `{"Compression": "invalid"}`}
+		_, err := getSaramaConfig(opts)
+		require.Error(t, err)
 	})
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #90270.

/cc @cockroachdb/release

---

Previously, the kafka sink would emit uncompressed data to kafka. This change updates the kafka sink to accept a "Compression" field in the `kafka_sink_config`, which gets passed to Sarama.

Release note (enterprise change): For kafka sinks, you can now add the optional JSON field "Compression" to the `kafka_sink_config` option. This field can be set to "none" (default), "gzip", "snappy", "lz4", or "zstd". Setting this field will result in the specified compression protocol to be used when emitting events.

Fixes: https://github.com/cockroachdb/cockroach/issues/89580
Epic: none
Release Justification: low danger/high impact change to enable compression configuration for supported changefeed sink.
Release Justification: low danger/high impact fix to enable compression in supported changefeed sink.