### PR TITLE
ui: fix filter cut off on Sessions page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionPage.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionPage.module.scss
@@ -24,3 +24,7 @@
 .session-column-selector {
   margin-bottom: $spacing-smaller;
 }
+
+.session-table-area {
+  min-height: 500px;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
@@ -407,7 +407,7 @@ export class SessionsPage extends React.Component<
             timeLabel={timeLabel}
           />
         </div>
-        <section>
+        <section className={sessionsPageCx("sessions-table-area")}>
           <div className={statementsPageCx("cl-table-statistic")}>
             <div className={"session-column-selector"}>
               <ColumnsSelector


### PR DESCRIPTION
Previously, the filter on the Sessions page was getting cut off if the table area was too small.
This commit increases the min-height for that area, similar to the Statements and Transactions pages.

Fix #91202

Before
<img width="566" alt="Screen Shot 2022-11-04 at 9 51 34 AM" src="https://user-images.githubusercontent.com/1017486/199990970-7d571587-18cd-4394-86c8-cd8c59c09c85.png">


After
<img width="1119" alt="Screen Shot 2022-11-04 at 9 51 12 AM" src="https://user-images.githubusercontent.com/1017486/199991002-ff9967c0-03a7-4db3-aa18-c2403aece91b.png">


Release note (bug fix): Filter is no longer getting cut on the Sessions page.