### PR TITLE
ui: add scroll to explain table

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/planDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/planDetails.tsx
@@ -69,12 +69,14 @@ export function PlanDetails({
     );
   } else {
     return (
-      <PlanTable
-        plans={plans}
-        handleDetails={handleDetails}
-        sortSetting={plansSortSetting}
-        onChangeSortSetting={setPlansSortSetting}
-      />
+      <div className={cx("table-area")}>
+        <PlanTable
+          plans={plans}
+          handleDetails={handleDetails}
+          sortSetting={plansSortSetting}
+          onChangeSortSetting={setPlansSortSetting}
+        />
+      </div>
     );
   }
 }

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.module.scss
@@ -73,6 +73,10 @@
   }
 }
 
+.table-area {
+  overflow-x: scroll;
+}
+
 .last-cleared-tooltip,
 .numeric-stats-table,
 .plan-view-table {


### PR DESCRIPTION
Previously, the table on Explain Plan table didn't have horizontal scroll. This commit introduces the proper scroll to the table.

Fix #91201

Before
https://www.loom.com/share/cf0169cb9afb41f19e05eacbfa4d7e50

After
https://www.loom.com/share/bf0b2ed0a4d541e4957b728d4cb92df3

Release note (bug fix): A horizontal scroll is now added to the table on Explain Plan tab under Statement Details.