### PR TITLE
ui: add horizontal scroll txn insight details

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
@@ -177,7 +177,7 @@ export class TransactionInsightDetails extends React.Component<TransactionInsigh
                   insightDetails.execType,
                 )}
               </Heading>
-              <div className={tableCx("margin-bottom-large")}>
+              <div className={tableCx("table-area")}>
                 <WaitTimeDetailsTable
                   data={blockingExecutions}
                   execType={insightDetails.execType}

--- a/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.module.scss
@@ -23,6 +23,11 @@
   }
 }
 
+.table-area {
+  overflow-x: scroll;
+  padding-bottom: 30px;
+}
+
 .margin-bottom {
   margin-bottom: 20px;
 }

--- a/pkg/ui/workspaces/db-console/src/views/app/containers/layout/layout.styl
+++ b/pkg/ui/workspaces/db-console/src/views/app/containers/layout/layout.styl
@@ -64,8 +64,7 @@ $subnav-background  = $background-color
 
 .section
   flex 0 0 auto
-  padding 12px 24px 12px 0px
-  max-width $max-window-width
+  padding 12px 40px 12px 0px
   clearfix()
 
   &--heading


### PR DESCRIPTION
Previously, the table of "waiten on" inside the Transaction Insights details didn't have a horizontal scroll, not letting the user to see the full page on CC console. This commits adds the proper scroll to it.

Fixes #91199

Before
https://www.loom.com/share/80437381cd4546cfad9692c7718de38c

After
https://www.loom.com/share/7363d53bec1d49a0be1b90ab0c9069f2

Release note (bug fix): Add horizontal scroll on "waited on" table on Transaction Insight details page.