### PR TITLE
release-22.1: cluster-ui: fetch databases using sql-over-http endpoint

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/databasesApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/databasesApi.ts
@@ -1,0 +1,65 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import {
+  executeInternalSql,
+  SqlExecutionRequest,
+  sqlResultsAreEmpty,
+} from "./sqlApi";
+import { withTimeout } from "./util";
+import moment from "moment";
+
+export type DatabasesColumns = {
+  database_name: string;
+  owner: string;
+  primary_region: string;
+  secondary_region: string;
+  regions: string[];
+  survival_goal: string;
+};
+
+export type DatabasesListResponse = { databases: string[] };
+
+export const databasesRequest: SqlExecutionRequest = {
+  statements: [
+    {
+      sql: `SHOW DATABASES`,
+    },
+  ],
+  execute: true,
+};
+
+// getDatabasesList fetches databases names from the database. Callers of
+// getDatabasesList from cluster-ui will need to pass a timeout argument for
+// promise timeout handling (callers from db-console already have promise
+// timeout handling as part of the cacheDataReducer).
+export function getDatabasesList(
+  timeout?: moment.Duration,
+): Promise<DatabasesListResponse> {
+  return withTimeout(
+    executeInternalSql<DatabasesColumns>(databasesRequest),
+    timeout,
+  ).then(result => {
+    // If request succeeded but query failed, throw error (caught by saga/cacheDataReducer).
+    if (result.error) {
+      throw result.error;
+    }
+
+    if (sqlResultsAreEmpty(result)) {
+      return { databases: [] };
+    }
+
+    const dbNames: string[] = result.execution.txn_results[0].rows.map(
+      row => row.database_name,
+    );
+
+    return { databases: dbNames };
+  });
+}

--- a/pkg/ui/workspaces/cluster-ui/src/api/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/index.ts
@@ -14,3 +14,4 @@ export * from "./statementsApi";
 export * from "./basePath";
 export * from "./nodesApi";
 export * from "./sqlApi";
+export * from "./databasesApi";

--- a/pkg/ui/workspaces/cluster-ui/src/api/util.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/util.ts
@@ -1,0 +1,42 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import moment from "moment";
+
+export const PROMISE_TIMEOUT = moment.duration(30, "s"); // seconds
+
+// withTimeout wraps a promise in a timeout (cribbed from db-console).
+export function withTimeout<T>(
+  promise: Promise<T>,
+  timeout?: moment.Duration,
+): Promise<T> {
+  if (timeout) {
+    return new Promise<T>((resolve, reject) => {
+      setTimeout(
+        () => reject(new TimeoutError(timeout)),
+        timeout.asMilliseconds(),
+      );
+      promise.then(resolve, reject);
+    });
+  } else {
+    return promise;
+  }
+}
+
+export class TimeoutError extends Error {
+  timeout: moment.Duration;
+  constructor(timeout: moment.Duration) {
+    const message = `Promise timed out after ${timeout.asMilliseconds()} ms`;
+    super(message);
+
+    this.name = this.constructor.name;
+    this.timeout = timeout;
+  }
+}

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -89,7 +89,7 @@ export const locationsReducerObj = new CachedDataReducer(
 export const refreshLocations = locationsReducerObj.refresh;
 
 const databasesReducerObj = new CachedDataReducer(
-  api.getDatabaseList,
+  clusterUiApi.getDatabasesList,
   "databases",
   null,
   moment.duration(10, "m"),
@@ -391,10 +391,8 @@ export interface APIReducersState {
   raft: CachedDataReducerState<api.RaftDebugResponseMessage>;
   version: CachedDataReducerState<VersionList>;
   locations: CachedDataReducerState<api.LocationsResponseMessage>;
-  databases: CachedDataReducerState<api.DatabasesResponseMessage>;
-  databaseDetails: KeyedCachedDataReducerState<
-    api.DatabaseDetailsResponseMessage
-  >;
+  databases: CachedDataReducerState<clusterUiApi.DatabasesListResponse>;
+  databaseDetails: KeyedCachedDataReducerState<api.DatabaseDetailsResponseMessage>;
   tableDetails: KeyedCachedDataReducerState<api.TableDetailsResponseMessage>;
   tableStats: KeyedCachedDataReducerState<api.TableStatsResponseMessage>;
   indexStats: KeyedCachedDataReducerState<api.IndexStatsResponseMessage>;

--- a/pkg/ui/workspaces/db-console/src/util/api.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.spec.ts
@@ -18,8 +18,10 @@ import fetchMock from "./fetch-mock";
 import * as protos from "src/js/protos";
 import { cockroach } from "src/js/protos";
 import * as api from "./api";
+import { api as clusterUiApi } from "@cockroachlabs/cluster-ui";
 import { REMOTE_DEBUGGING_ERROR_TEXT } from "src/util/constants";
 import Severity = cockroach.util.log.Severity;
+import { buildSQLApiDatabasesResponse } from "src/util/fakeApi";
 
 describe("rest api", function() {
   describe("databases request", function() {
@@ -29,47 +31,46 @@ describe("rest api", function() {
       this.timeout(1000);
       // Mock out the fetch query to /databases
       fetchMock.mock({
-        matcher: api.API_PREFIX + "/databases",
-        method: "GET",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          "X-Cockroach-API-Session": "cookie",
+        },
+        matcher: clusterUiApi.SQL_API_PATH,
+        method: "POST",
         response: (_url: string, requestObj: RequestInit) => {
-          assert.isUndefined(requestObj.body);
-          const encodedResponse = protos.cockroach.server.serverpb.DatabasesResponse.encode(
-            {
-              databases: ["system", "test"],
-            },
-          ).finish();
+          expect(JSON.parse(requestObj.body.toString())).toEqual(
+            clusterUiApi.databasesRequest,
+          );
           return {
-            body: api.toArrayBuffer(encodedResponse),
+            body: JSON.stringify(
+              buildSQLApiDatabasesResponse(["system", "test"]),
+            ),
           };
         },
       });
-
-      return api
-        .getDatabaseList(
-          new protos.cockroach.server.serverpb.DatabasesRequest(),
-        )
-        .then(result => {
-          assert.lengthOf(fetchMock.calls(api.API_PREFIX + "/databases"), 1);
-          assert.lengthOf(result.databases, 2);
-        });
+      return clusterUiApi.getDatabasesList().then(result => {
+        expect(fetchMock.calls(clusterUiApi.SQL_API_PATH).length).toBe(1);
+        expect(result.databases.length).toBe(2);
+      });
     });
 
     it("correctly handles an error", function(done) {
       this.timeout(1000);
       // Mock out the fetch query to /databases, but return a promise that's never resolved to test the timeout
       fetchMock.mock({
-        matcher: api.API_PREFIX + "/databases",
-        method: "GET",
+        matcher: clusterUiApi.SQL_API_PATH,
+        method: "POST",
         response: (_url: string, requestObj: RequestInit) => {
-          assert.isUndefined(requestObj.body);
+          expect(JSON.parse(requestObj.body.toString())).toEqual(
+            clusterUiApi.databasesRequest,
+          );
           return { throws: new Error() };
         },
       });
 
-      api
-        .getDatabaseList(
-          new protos.cockroach.server.serverpb.DatabasesRequest(),
-        )
+      clusterUiApi
+        .getDatabasesList()
         .then(_result => {
           done(new Error("Request unexpectedly succeeded."));
         })
@@ -83,19 +84,18 @@ describe("rest api", function() {
       this.timeout(1000);
       // Mock out the fetch query to /databases, but return a promise that's never resolved to test the timeout
       fetchMock.mock({
-        matcher: api.API_PREFIX + "/databases",
-        method: "GET",
+        matcher: clusterUiApi.SQL_API_PATH,
+        method: "POST",
         response: (_url: string, requestObj: RequestInit) => {
-          assert.isUndefined(requestObj.body);
+          expect(JSON.parse(requestObj.body.toString())).toEqual(
+            clusterUiApi.databasesRequest,
+          );
           return new Promise<any>(() => {});
         },
       });
 
-      api
-        .getDatabaseList(
-          new protos.cockroach.server.serverpb.DatabasesRequest(),
-          moment.duration(0),
-        )
+      clusterUiApi
+        .getDatabasesList(moment.duration(0))
         .then(_result => {
           done(new Error("Request unexpectedly succeeded."));
         })

--- a/pkg/ui/workspaces/db-console/src/util/api.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.ts
@@ -21,11 +21,10 @@ import { propsToQueryString } from "src/util/query";
 import { cockroach } from "src/js/protos";
 import TakeTracingSnapshotRequest = cockroach.server.serverpb.TakeTracingSnapshotRequest;
 
-export type DatabasesRequestMessage = protos.cockroach.server.serverpb.DatabasesRequest;
-export type DatabasesResponseMessage = protos.cockroach.server.serverpb.DatabasesResponse;
-
-export type DatabaseDetailsRequestMessage = protos.cockroach.server.serverpb.DatabaseDetailsRequest;
-export type DatabaseDetailsResponseMessage = protos.cockroach.server.serverpb.DatabaseDetailsResponse;
+export type DatabaseDetailsRequestMessage =
+  protos.cockroach.server.serverpb.DatabaseDetailsRequest;
+export type DatabaseDetailsResponseMessage =
+  protos.cockroach.server.serverpb.DatabaseDetailsResponse;
 
 export type TableDetailsRequestMessage = protos.cockroach.server.serverpb.TableDetailsRequest;
 export type TableDetailsResponseMessage = protos.cockroach.server.serverpb.TableDetailsResponse;
@@ -303,19 +302,6 @@ export type APIRequestFn<TReq, TResponse> = (
 
 const serverpb = protos.cockroach.server.serverpb;
 const tspb = protos.cockroach.ts.tspb;
-
-// getDatabaseList gets a list of all database names
-export function getDatabaseList(
-  _req: DatabasesRequestMessage,
-  timeout?: moment.Duration,
-): Promise<DatabasesResponseMessage> {
-  return timeoutFetch(
-    serverpb.DatabasesResponse,
-    `${API_PREFIX}/databases`,
-    null,
-    timeout,
-  );
-}
 
 // getDatabaseDetails gets details for a specific database
 export function getDatabaseDetails(

--- a/pkg/ui/workspaces/db-console/src/util/fakeApi.ts
+++ b/pkg/ui/workspaces/db-console/src/util/fakeApi.ts
@@ -10,12 +10,12 @@
 
 import * as $protobuf from "protobufjs";
 
+import { api as clusterUiApi } from "@cockroachlabs/cluster-ui";
 import { cockroach } from "src/js/protos";
 import { API_PREFIX, STATUS_PREFIX, toArrayBuffer } from "src/util/api";
 import fetchMock from "src/util/fetch-mock";
 
 const {
-  DatabasesResponse,
   DatabaseDetailsResponse,
   SettingsResponse,
   TableDetailsResponse,
@@ -65,10 +65,88 @@ export function stubClusterSettings(
   );
 }
 
-export function stubDatabases(
-  response: cockroach.server.serverpb.IDatabasesResponse,
-) {
-  stubGet("/databases", DatabasesResponse.encode(response), API_PREFIX);
+export function buildSQLApiDatabasesResponse(databases: string[]) {
+  const rows: clusterUiApi.DatabasesColumns[] = [];
+  databases.forEach(database => {
+    rows.push({
+      database_name: database,
+      owner: "root",
+      primary_region: null,
+      secondary_region: null,
+      regions: [],
+      survival_goal: null,
+    });
+  });
+  return {
+    num_statements: 1,
+    execution: {
+      txn_results: [
+        {
+          statement: 1,
+          tag: "SHOW DATABASES",
+          start: "2022-10-27T17:42:05.582744Z",
+          end: "2022-10-27T17:42:05.588454Z",
+          rows_affected: 0,
+          columns: [
+            {
+              name: "database_name",
+              type: "STRING",
+              oid: 25,
+            },
+            {
+              name: "owner",
+              type: "NAME",
+              oid: 19,
+            },
+            {
+              name: "primary_region",
+              type: "STRING",
+              oid: 25,
+            },
+            {
+              name: "secondary_region",
+              type: "STRING",
+              oid: 25,
+            },
+            {
+              name: "regions",
+              type: "STRING[]",
+              oid: 1009,
+            },
+            {
+              name: "survival_goal",
+              type: "STRING",
+              oid: 25,
+            },
+          ],
+          rows: rows,
+        },
+      ],
+    },
+  };
+}
+
+export function stubDatabases(databases: string[]) {
+  const response = buildSQLApiDatabasesResponse(databases);
+  console.log("SQL API PATH", clusterUiApi.SQL_API_PATH);
+  fetchMock.mock({
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      "X-Cockroach-API-Session": "cookie",
+    },
+    matcher: clusterUiApi.SQL_API_PATH,
+    method: "POST",
+    response: (_url: string, requestObj: RequestInit) => {
+      expect(JSON.parse(requestObj.body.toString())).toEqual(
+        clusterUiApi.databasesRequest,
+      );
+      console.log("STRINGIFY", JSON.stringify(response));
+      return {
+        body: JSON.stringify(response),
+      };
+    },
+  });
 }
 
 export function stubDatabaseDetails(

--- a/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.spec.ts
@@ -75,26 +75,26 @@ class TestDriver {
   }
 
   private findDatabase(name: string) {
-    return _.find(this.properties().databases, row => row.name == name);
+    return _.find(this.properties().databases, (row) => row.name == name);
   }
 
   private findMissingTable(database: DatabasesPageDataDatabase, name: string) {
-    return _.find(database.missingTables, table => table.name == name);
+    return _.find(database.missingTables, (table) => table.name == name);
   }
 }
 
-describe("Databases Page", function() {
+describe("Databases Page", function () {
   let driver: TestDriver;
 
-  beforeEach(function() {
+  beforeEach(function () {
     driver = new TestDriver(createAdminUIStore(createMemoryHistory()));
   });
 
-  afterEach(function() {
+  afterEach(function () {
     fakeApi.restore();
   });
 
-  it("starts in a pre-loading state", async function() {
+  it("starts in a pre-loading state", async function () {
     fakeApi.stubClusterSettings({
       key_values: {
         "sql.stats.automatic_collection.enabled": { value: "true" },
@@ -114,10 +114,8 @@ describe("Databases Page", function() {
     });
   });
 
-  it("makes a row for each database", async function() {
-    fakeApi.stubDatabases({
-      databases: ["system", "test"],
-    });
+  it("makes a row for each database", async function () {
+    fakeApi.stubDatabases(["system", "test"]);
     fakeApi.stubClusterSettings({
       key_values: {
         "sql.stats.automatic_collection.enabled": { value: "true" },
@@ -161,10 +159,8 @@ describe("Databases Page", function() {
     });
   });
 
-  it("fills in database details", async function() {
-    fakeApi.stubDatabases({
-      databases: ["system", "test"],
-    });
+  it("fills in database details", async function () {
+    fakeApi.stubDatabases(["system", "test"]);
 
     fakeApi.stubDatabaseDetails("system", {
       table_names: ["foo", "bar"],
@@ -213,12 +209,10 @@ describe("Databases Page", function() {
     });
   });
 
-  describe("fallback cases", function() {
-    describe("missing tables", function() {
-      it("exposes them so the component can refresh them", async function() {
-        fakeApi.stubDatabases({
-          databases: ["system"],
-        });
+  describe("fallback cases", function () {
+    describe("missing tables", function () {
+      it("exposes them so the component can refresh them", async function () {
+        fakeApi.stubDatabases(["system"]);
 
         fakeApi.stubDatabaseDetails("system", {
           table_names: ["foo", "bar"],
@@ -245,10 +239,8 @@ describe("Databases Page", function() {
         });
       });
 
-      it("merges available individual stats into the totals", async function() {
-        fakeApi.stubDatabases({
-          databases: ["system"],
-        });
+      it("merges available individual stats into the totals", async function () {
+        fakeApi.stubDatabases(["system"]);
 
         fakeApi.stubDatabaseDetails("system", {
           table_names: ["foo", "bar"],
@@ -282,11 +274,9 @@ describe("Databases Page", function() {
       });
     });
 
-    describe("missing stats", function() {
-      it("builds a list of missing tables", async function() {
-        fakeApi.stubDatabases({
-          databases: ["system"],
-        });
+    describe("missing stats", function () {
+      it("builds a list of missing tables", async function () {
+        fakeApi.stubDatabases(["system"]);
 
         fakeApi.stubDatabaseDetails("system", {
           table_names: ["foo", "bar"],
@@ -311,10 +301,8 @@ describe("Databases Page", function() {
         });
       });
 
-      it("merges individual stats into the totals", async function() {
-        fakeApi.stubDatabases({
-          databases: ["system"],
-        });
+      it("merges individual stats into the totals", async function () {
+        fakeApi.stubDatabases(["system"]);
 
         fakeApi.stubDatabaseDetails("system", {
           table_names: ["foo", "bar"],


### PR DESCRIPTION
Backport 1/1 commits from #90613.

/cc @cockroachdb/release

---

Addresses: #90257 (blocked from resolving by #80789)

This commit introduces a function to cluster-ui that fetches database names using the sql-over-http endpoint. This removes the need to use the admin server's `/databases` endpoint.

Loom (DB-Console): https://www.loom.com/share/e9f773b93b0c46528c39abd4767ced23

-----
Initially considered creating the cluster-ui connected component within this PR as well, but decided to save it for a followup PR.

Release note: None

Release justification: Category 4: Low risk, high benefit changes to existing functionality