### PR TITLE
ui: Changed css styling on metrics graph tooltips to prevent collapse

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/linegraph.styl
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/linegraph.styl
@@ -37,7 +37,7 @@ $viz-sides = 62px
       margin-top 20px
       z-index 100
       pointer-events: none;
-      width: fit-content;
+      width: max-content;
       border-radius: 5px
       padding: 10px;
       border 1px solid rgba(0,0,0,0.1)


### PR DESCRIPTION
Currently the time series graphs tooltip overlay has css properties that allow the content to collapse when it reaches the boundary of the graph. This can make the information in the tooltip unreadable in certain cases.

<img width="676" alt="Screen Shot 2022-11-04 at 11 35 45 AM" src="https://user-images.githubusercontent.com/397448/200025745-74fdf4e4-5583-4d61-a692-b5eee2b850e8.png">

By changing the style controlling the tooltip width, this collapse can be prevented, maintaining the readability of the content.

<img width="778" alt="Screen Shot 2022-11-04 at 11 35 22 AM" src="https://user-images.githubusercontent.com/397448/200025794-4c66d3b1-a6f1-468f-b167-99121ef1df34.png">

fixes #86778 