### PR TITLE
Cluster UI version bump 23.1 prerelease

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -22,7 +22,8 @@
     "test": "jest --watch",
     "start": "npm-run-all -p build:watch tsc:watch",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook"
+    "build-storybook": "build-storybook",
+    "bump": "yarn version --prerelease --preid prerelease --no-git-tag-version"
   },
   "keywords": [],
   "license": "MIT",

--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "22.2.0-prerelease-5",
+  "version": "23.1.0-prerelease.0",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
After the release branch was cut for 22.2, master once again became work
for the "next" version of CRDB (23.1). Setting the package.json version
of Cluster UI to `23.1.0-prerelease.0` to align with future development
against CRDB v23.1.
    
I also changed the prerelease format of the version slightly to allow
for increasing the version with yarn via the commands,
    
`yarn version --prerelease --preid prerelease`

As a convenience I have also added this command as a lifecycle script, which can be run with

`yarn bump`

Please note, the `--no-git-tag-version` switch has been added so this will only change the version in `package.json` without committing to git or creating a tag.

Epic: CC-7999