### PR TITLE
upgrades: repair broken 22.1 migration so 22.2 migration works

### DIFF
--- a/pkg/upgrade/upgrades/sampled_stmt_diagnostics_requests.go
+++ b/pkg/upgrade/upgrades/sampled_stmt_diagnostics_requests.go
@@ -28,6 +28,8 @@ const (
 ALTER TABLE system.statement_diagnostics_requests
   ADD COLUMN sampling_probability FLOAT NULL FAMILY "primary"`
 
+	dropCompletedIdxV1 = `DROP INDEX IF EXISTS system.statement_diagnostics_requests@completed_idx`
+
 	createCompletedIdxV3 = `
 CREATE INDEX completed_idx ON system.statement_diagnostics_requests (completed, ID)
   STORING (statement_fingerprint, sampling_probability, min_execution_latency, expires_at)`
@@ -47,6 +49,25 @@ func sampledStmtDiagReqsMigration(
 			schemaList:     []string{"sampling_probability"},
 			query:          addSamplingProbColToStmtDiagReqs,
 			schemaExistsFn: hasColumn,
+		},
+		{
+			name:       "drop-stmt-diag-reqs-v1-index",
+			schemaList: []string{"completed_idx"},
+			query:      dropCompletedIdxV1,
+			schemaExistsFn: func(existing, _ catalog.TableDescriptor, _ string) (bool, error) {
+				// We want to determine whether the old index from 21.2 exists.
+				// That index has one stored column. The index we introduce below has
+				// four.
+				idx, _ := existing.FindIndexWithName("completed_idx")
+				// If the index does not exist, we're good to proceed.
+				if idx == nil {
+					return true, nil
+				}
+				// Say that the schema does exist if the column count does not
+				// correspond to the old 21.2 count. If we return true, then
+				// the drop index command will not happen.
+				return idx.NumSecondaryStoredColumns() != 1, nil
+			},
 		},
 		{
 			name:           "create-stmt-diag-reqs-v3-index",

--- a/pkg/upgrade/upgrades/schema_changes.go
+++ b/pkg/upgrade/upgrades/schema_changes.go
@@ -252,17 +252,17 @@ func indexDescForComparison(idx catalog.Index) *descpb.IndexDescriptor {
 	// See https://github.com/cockroachdb/cockroach/issues/65929.
 	desc.CreatedExplicitly = false
 
-	// The below clearing of names is just buggy. If an index name is reused with
-	// a different set of stored column IDs, we may avoid a migration we intended
-	// to do. This bug has happened, but for the sake of CI, we'll preserve the
-	// bug for the moment.
-	//
-	// TODO(ajwerner): Fix this bug and respect the length of column IDs and the
-	// names.
-	desc.StoreColumnNames = nil
+	// Clear out the column IDs, but retain their length. Column IDs may
+	// change. Note that we retain the name slices. Those should match.
 	desc.StoreColumnIDs = nil
 	for i := range desc.StoreColumnIDs {
 		desc.StoreColumnIDs[i] = 0
+	}
+	for i := range desc.KeyColumnIDs {
+		desc.KeyColumnIDs[i] = 0
+	}
+	for i := range desc.KeySuffixColumnIDs {
+		desc.KeySuffixColumnIDs[i] = 0
 	}
 
 	desc.CreatedAtNanos = 0


### PR DESCRIPTION
This also fixes the logic which allowed the 22.1 migration to proceed in the
first place. This will need to be backported to 22.2. Any users which upgraded
from 21.2->22.1->22.2.did_not_contain_this_patch will not have the correct
indexes on their system.statement_diagnostics_requests table.

Fixes https://github.com/cockroachdb/cockroach/issues/91300

Release note (bug fix): Fixed a bug which caused a migration in 22.1 to fail
to drop an index on system.statement_diagnostics_requests and, in turn, caused
upgrades from 22.1->22.2 which had used the previous, faulty upgrade migration
to now fail to create a new index with the same name as the index which had
been thought to have been dropped.