### PR TITLE
ui: Removing prerelease tag from Cluster UI version

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "22.2.0-prerelease-8",
+  "version": "22.2.0",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",
@@ -22,7 +22,8 @@
     "test": "jest --watch",
     "start": "npm-run-all -p build:watch tsc:watch",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook"
+    "build-storybook": "build-storybook",
+    "bump": "yarn version --patch --no-git-tag-version"
   },
   "keywords": [],
   "license": "MIT",


### PR DESCRIPTION
Ahead of the 22.2 CRDB release, I am removing the prerelease version from the Cluster UI version.

As a convinience, I also added an npm lifecycle script for bumping future versions of Cluster UI. To increase the version of Cluster UI you can run the command,

`npm run bump` or `yarn bump`

Release note: None