### PR TITLE
release-22.2.0: upgrades: repair broken 22.1 migration so 22.2 migration works

### DIFF
--- a/pkg/upgrade/upgrades/sampled_stmt_diagnostics_requests.go
+++ b/pkg/upgrade/upgrades/sampled_stmt_diagnostics_requests.go
@@ -28,6 +28,8 @@ const (
 ALTER TABLE system.statement_diagnostics_requests
   ADD COLUMN sampling_probability FLOAT NULL FAMILY "primary"`
 
+	dropCompletedIdxV1 = `DROP INDEX IF EXISTS system.statement_diagnostics_requests@completed_idx`
+
 	createCompletedIdxV3 = `
 CREATE INDEX completed_idx ON system.statement_diagnostics_requests (completed, ID)
   STORING (statement_fingerprint, sampling_probability, min_execution_latency, expires_at)`
@@ -47,6 +49,25 @@ func sampledStmtDiagReqsMigration(
 			schemaList:     []string{"sampling_probability"},
 			query:          addSamplingProbColToStmtDiagReqs,
 			schemaExistsFn: hasColumn,
+		},
+		{
+			name:       "drop-stmt-diag-reqs-v1-index",
+			schemaList: []string{"completed_idx"},
+			query:      dropCompletedIdxV1,
+			schemaExistsFn: func(existing, _ catalog.TableDescriptor, _ string) (bool, error) {
+				// We want to determine whether the old index from 21.2 exists.
+				// That index has one stored column. The index we introduce below has
+				// four.
+				idx, _ := existing.FindIndexWithName("completed_idx")
+				// If the index does not exist, we're good to proceed.
+				if idx == nil {
+					return true, nil
+				}
+				// Say that the schema does exist if the column count does not
+				// correspond to the old 21.2 count. If we return true, then
+				// the drop index command will not happen.
+				return idx.NumSecondaryStoredColumns() != 1, nil
+			},
 		},
 		{
 			name:           "create-stmt-diag-reqs-v3-index",


### PR DESCRIPTION
Backport 1/1 commits from #91304.

/cc @cockroachdb/release

---

This also fixes the logic which allowed the 22.1 migration to proceed in the
first place. This will need to be backported to 22.2. Any users which upgraded
from 21.2->22.1->22.2.did_not_contain_this_patch will not have the correct
indexes on their system.statement_diagnostics_requests table.

Fixes https://github.com/cockroachdb/cockroach/issues/91300

Release justification: fixes a migration which impacts the usability of a new feature

Release note (bug fix): Fixed a bug which caused a migration in 22.1 to fail
to drop an index on system.statement_diagnostics_requests and, in turn, caused
upgrades from 22.1->22.2 which had used the previous, faulty upgrade migration
to now fail to create a new index with the same name as the index which had
been thought to have been dropped.
