### PR TITLE
tenant: add apiv2 support for sql-over-http

### DIFF
--- a/pkg/ccl/serverccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
     size = "enormous",
     srcs = [
         "admin_test.go",
+        "api_v2_tenant_test.go",
         "chart_catalog_test.go",
         "main_test.go",
         "role_authentication_test.go",
@@ -41,6 +42,7 @@ go_test(
         "tenant_vars_test.go",
     ],
     args = ["-test.timeout=3595s"],
+    data = glob(["testdata/**"]),
     embed = [":serverccl"],
     deps = [
         "//pkg/base",
@@ -78,6 +80,7 @@ go_test(
         "//pkg/util/protoutil",
         "//pkg/util/randutil",
         "//pkg/util/timeutil",
+        "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_elastic_gosigar//:gosigar",
         "@com_github_lib_pq//:pq",
         "@com_github_prometheus_client_model//go",

--- a/pkg/ccl/serverccl/api_v2_tenant_test.go
+++ b/pkg/ccl/serverccl/api_v2_tenant_test.go
@@ -1,26 +1,22 @@
 // Copyright 2022 The Cockroach Authors.
 //
-// Use of this software is governed by the Business Source License
-// included in the file licenses/BSL.txt.
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
 //
-// As of the Change Date specified in that file, in accordance with
-// the Business Source License, use of this software will be governed
-// by the Apache License, Version 2.0, included in the file
-// licenses/APL.txt.
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
 
-package server
+package serverccl
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/datadriven"
@@ -29,20 +25,19 @@ import (
 
 func TestExecSQL(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	SQLAPIClock = timeutil.NewManualTime(timeutil.FromUnixMicros(0))
+	server.SQLAPIClock = timeutil.NewManualTime(timeutil.FromUnixMicros(0))
 	defer func() {
-		SQLAPIClock = timeutil.DefaultTimeSource{}
+		server.SQLAPIClock = timeutil.DefaultTimeSource{}
 	}()
 
-	server, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	ctx := context.Background()
-	defer server.Stopper().Stop(ctx)
 
-	adminClient, err := server.GetAdminHTTPClient()
-	require.NoError(t, err)
+	testHelper := NewTestTenantHelper(t, 3 /* tenantClusterSize */, base.TestingKnobs{})
+	defer testHelper.Cleanup(ctx, t)
 
-	nonAdminClient, err := server.GetAuthenticatedHTTPClient(false)
-	require.NoError(t, err)
+	tenantCluster := testHelper.TestCluster()
+	adminClient := tenantCluster.TenantAdminHTTPClient(t, 0)
+	nonAdminClient := tenantCluster.TenantHTTPClient(t, 0, false)
 
 	datadriven.RunTest(t, "testdata/api_v2_sql",
 		func(t *testing.T, d *datadriven.TestData) string {
@@ -50,7 +45,7 @@ func TestExecSQL(t *testing.T) {
 				t.Fatal("Only sql command is accepted in this test")
 			}
 
-			var client http.Client
+			var client *httpClient
 			if d.HasArg("admin") {
 				client = adminClient
 			}
@@ -58,9 +53,9 @@ func TestExecSQL(t *testing.T) {
 				client = nonAdminClient
 			}
 
-			resp, err := client.Post(
-				server.AdminURL()+"/api/v2/sql/", "application/json",
-				bytes.NewReader([]byte(d.Input)),
+			resp, err := client.PostJSONRawChecked(
+				"/api/v2/sql/",
+				[]byte(d.Input),
 			)
 			require.NoError(t, err)
 			defer resp.Body.Close()

--- a/pkg/ccl/serverccl/tenant_test_utils.go
+++ b/pkg/ccl/serverccl/tenant_test_utils.go
@@ -314,6 +314,10 @@ func (c *httpClient) PostJSONChecked(
 	return httputil.PostJSON(c.client, c.baseURL+path, request, response)
 }
 
+func (c *httpClient) PostJSONRawChecked(path string, request []byte) (*http.Response, error) {
+	return httputil.PostJSONRaw(c.client, c.baseURL+path, request)
+}
+
 func (c *httpClient) Close() {
 	c.client.CloseIdleConnections()
 }

--- a/pkg/ccl/serverccl/testdata/api_v2_sql
+++ b/pkg/ccl/serverccl/testdata/api_v2_sql
@@ -1,0 +1,500 @@
+subtest sql_select_no_execute
+
+sql admin
+{
+  "database": "system",
+  "statements": [{"sql": "SELECT username FROM users where username = $1", "arguments": ["admin"]}]
+}
+----
+{
+ "num_statements": 1,
+ "request": {
+  "application_name": "$ api-v2-sql",
+  "database": "system",
+  "execute": false,
+  "max_result_size": 10000,
+  "statements": [
+   {
+    "arguments": [
+     "admin"
+    ],
+    "sql": "SELECT username FROM users WHERE username = $1"
+   }
+  ],
+  "timeout": "5s"
+ }
+}
+
+subtest end
+
+subtest sql_select_users
+
+sql admin
+{
+  "database": "system",
+  "execute": true,
+  "statements": [{"sql": "SELECT username FROM users where username = $1", "arguments": ["admin"]}]
+}
+----
+{
+ "execution": {
+  "txn_results": [
+   {
+    "columns": [
+     {
+      "name": "username",
+      "oid": 25,
+      "type": "STRING"
+     }
+    ],
+    "end": "1970-01-01T00:00:00Z",
+    "rows": [
+     {
+      "username": "admin"
+     }
+    ],
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 1,
+    "tag": "SELECT"
+   }
+  ]
+ },
+ "num_statements": 1
+}
+
+subtest end
+
+subtest regression_test_for_84385
+
+# Regression test for #84385.
+sql admin
+{
+  "database": "system",
+  "execute": true,
+  "statements": [{"sql": "SELECT 1, 2"}]
+}
+----
+{
+ "execution": {
+  "txn_results": [
+   {
+    "columns": [
+     {
+      "name": "?column?",
+      "oid": 20,
+      "type": "INT8"
+     },
+     {
+      "name": "?column?",
+      "oid": 20,
+      "type": "INT8"
+     }
+    ],
+    "end": "1970-01-01T00:00:00Z",
+    "rows": [
+     {
+      "?column?": 2
+     }
+    ],
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 1,
+    "tag": "SELECT"
+   }
+  ]
+ },
+ "num_statements": 1
+}
+
+subtest end
+
+subtest select_user_no_admin
+
+sql non-admin expect-error
+{
+  "database": "system",
+  "execute": true,
+  "statements": [{"sql": "SELECT username FROM users where username = 'admin'"}]
+}
+----
+42501|executing stmt 1: run-query-via-api: user authentic_user_noadmin does not have SELECT privilege on relation users
+
+subtest end
+
+subtest sql_multiple_statements
+
+sql admin
+{
+  "database": "system",
+  "execute": true,
+  "statements": [
+    {"sql": "SELECT username FROM users where username = 'admin'"},
+    {"sql": "SELECT \"eventType\" FROM eventlog where \"eventType\" = 'node_restart'"}
+  ]
+}
+----
+{
+ "execution": {
+  "txn_results": [
+   {
+    "columns": [
+     {
+      "name": "username",
+      "oid": 25,
+      "type": "STRING"
+     }
+    ],
+    "end": "1970-01-01T00:00:00Z",
+    "rows": [
+     {
+      "username": "admin"
+     }
+    ],
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 1,
+    "tag": "SELECT"
+   },
+   {
+    "columns": [
+     {
+      "name": "eventType",
+      "oid": 25,
+      "type": "STRING"
+     }
+    ],
+    "end": "1970-01-01T00:00:00Z",
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 2,
+    "tag": "SELECT"
+   }
+  ]
+ },
+ "num_statements": 2
+}
+
+subtest end
+
+subtest sql_schema_changes
+
+sql admin
+{
+  "database": "mydb",
+  "execute": true,
+  "statements": [
+    {"sql": "CREATE database mydb"},
+    {"sql": "CREATE table mydb.test (id int)"},
+    {"sql": "INSERT INTO test VALUES (1)"}
+  ]
+}
+----
+{
+ "execution": {
+  "txn_results": [
+   {
+    "columns": [
+     {
+      "name": "rows_affected",
+      "oid": 20,
+      "type": "INT8"
+     }
+    ],
+    "end": "1970-01-01T00:00:00Z",
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 1,
+    "tag": "CREATE DATABASE"
+   },
+   {
+    "columns": [
+     {
+      "name": "rows_affected",
+      "oid": 20,
+      "type": "INT8"
+     }
+    ],
+    "end": "1970-01-01T00:00:00Z",
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 2,
+    "tag": "CREATE TABLE"
+   },
+   {
+    "columns": [
+     {
+      "name": "rows_affected",
+      "oid": 20,
+      "type": "INT8"
+     }
+    ],
+    "end": "1970-01-01T00:00:00Z",
+    "rows_affected": 1,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 3,
+    "tag": "INSERT"
+   }
+  ]
+ },
+ "num_statements": 3
+}
+
+subtest end
+
+subtest sql_syntax_error
+
+sql admin expect-error
+{
+  "statements": [
+    {"sql": "INSERT INTO WHERE"}
+  ]
+}
+----
+42601|parsing statement 1: at or near "where": syntax error
+
+subtest end
+
+subtest invalid_duration
+
+sql admin expect-error
+{
+  "timeout": "abcdef",
+  "statements": [
+    {"sql": "INSERT INTO WHERE"}
+  ]
+}
+----
+XXUUU|time: invalid duration "abcdef"
+
+subtest end
+
+subtest sql_multiple_statements_in_one_line
+
+sql admin expect-error
+{
+  "statements": [
+    {"sql": "SELECT username FROM users where username = 'admin'; SELECT username FROM users where username = 'admin'"}
+  ]
+}
+----
+XXUUU|parsing statement 1: expecting 1 statement, found 2
+
+subtest end
+
+subtest sql_placeholder_errors
+
+sql admin expect-error
+{
+  "statements": [
+    {"sql": "SELECT username FROM users where username = $1"}
+  ]
+}
+----
+XXUUU|parsing statement 1: expected 1 placeholder(s), got 0
+
+
+sql admin expect-error
+{
+  "statements": [
+    {"sql": "SELECT username FROM users where username = $1", "arguments": ["blah", "blah"]}
+  ]
+}
+----
+XXUUU|parsing statement 1: expected 1 placeholder(s), got 2
+
+subtest end
+
+subtest sql_create_table
+
+sql admin
+{
+  "database": "mydb",
+  "execute": true,
+  "statements": [{"sql": "CREATE TABLE foo (i INT PRIMARY KEY, j INT UNIQUE)"}]
+}
+----
+{
+ "execution": {
+  "txn_results": [
+   {
+    "columns": [
+     {
+      "name": "rows_affected",
+      "oid": 20,
+      "type": "INT8"
+     }
+    ],
+    "end": "1970-01-01T00:00:00Z",
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 1,
+    "tag": "CREATE TABLE"
+   }
+  ]
+ },
+ "num_statements": 1
+}
+
+subtest end
+
+subtest sql_alter_table
+
+sql admin
+{
+  "database": "mydb",
+  "execute": true,
+  "statements": [
+    {"sql": "ALTER TABLE foo RENAME TO bar"},
+    {"sql": "INSERT INTO bar (i) VALUES (1), (2)"},
+    {"sql": "ALTER TABLE bar DROP COLUMN j"},
+    {"sql": "ALTER TABLE bar ADD COLUMN k INT DEFAULT 42"}
+  ]
+}
+----
+{
+ "execution": {
+  "txn_results": [
+   {
+    "columns": [
+     {
+      "name": "rows_affected",
+      "oid": 20,
+      "type": "INT8"
+     }
+    ],
+    "end": "1970-01-01T00:00:00Z",
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 1,
+    "tag": "ALTER TABLE"
+   },
+   {
+    "columns": [
+     {
+      "name": "rows_affected",
+      "oid": 20,
+      "type": "INT8"
+     }
+    ],
+    "end": "1970-01-01T00:00:00Z",
+    "rows_affected": 2,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 2,
+    "tag": "INSERT"
+   },
+   {
+    "columns": [
+     {
+      "name": "rows_affected",
+      "oid": 20,
+      "type": "INT8"
+     }
+    ],
+    "end": "1970-01-01T00:00:00Z",
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 3,
+    "tag": "ALTER TABLE"
+   },
+   {
+    "columns": [
+     {
+      "name": "rows_affected",
+      "oid": 20,
+      "type": "INT8"
+     }
+    ],
+    "end": "1970-01-01T00:00:00Z",
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 4,
+    "tag": "ALTER TABLE"
+   }
+  ]
+ },
+ "num_statements": 4
+}
+
+sql admin
+{
+  "database": "mydb",
+  "execute": true,
+  "statements": [
+    {"sql": "SELECT * FROM bar"}
+  ]
+}
+----
+{
+ "execution": {
+  "txn_results": [
+   {
+    "columns": [
+     {
+      "name": "i",
+      "oid": 20,
+      "type": "INT8"
+     },
+     {
+      "name": "k",
+      "oid": 20,
+      "type": "INT8"
+     }
+    ],
+    "end": "1970-01-01T00:00:00Z",
+    "rows": [
+     {
+      "i": 1,
+      "k": 42
+     },
+     {
+      "i": 2,
+      "k": 42
+     }
+    ],
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 1,
+    "tag": "SELECT"
+   }
+  ]
+ },
+ "num_statements": 1
+}
+
+subtest end
+
+subtest sql_drop_table
+
+sql admin
+{
+  "database": "mydb",
+  "execute": true,
+  "statements": [
+    {"sql": "DROP TABLE bar"}
+  ]
+}
+----
+{
+ "execution": {
+  "txn_results": [
+   {
+    "columns": [
+     {
+      "name": "rows_affected",
+      "oid": 20,
+      "type": "INT8"
+     }
+    ],
+    "end": "1970-01-01T00:00:00Z",
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 1,
+    "tag": "DROP TABLE"
+   }
+  ]
+ },
+ "num_statements": 1
+}
+
+subtest end

--- a/pkg/server/api_v2.go
+++ b/pkg/server/api_v2.go
@@ -43,6 +43,8 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
@@ -76,6 +78,15 @@ func getSQLUsername(ctx context.Context) username.SQLUsername {
 	return username.MakeSQLUsernameFromPreNormalizedString(ctx.Value(webSessionUserKey{}).(string))
 }
 
+type apiV2ServerOpts struct {
+	admin            *adminServer
+	status           *statusServer
+	promRuleExporter *metric.PrometheusRuleExporter
+	tenantID         roachpb.TenantID
+	sqlServer        *SQLServer
+	db               *kv.DB
+}
+
 // apiV2Server implements version 2 API endpoints, under apiV2Path. The
 // implementation of some endpoints is delegated to sub-servers (eg. auth
 // endpoints like `/login` and `/logout` are passed onto authServer), while
@@ -89,21 +100,25 @@ type apiV2Server struct {
 	status           *statusServer
 	promRuleExporter *metric.PrometheusRuleExporter
 	mux              *mux.Router
+	tenantID         roachpb.TenantID
+	sqlServer        *SQLServer
+	db               *kv.DB
 }
 
 // newAPIV2Server returns a new apiV2Server.
-func newAPIV2Server(ctx context.Context, s *Server) *apiV2Server {
-	authServer := newAuthenticationV2Server(ctx, s, apiV2Path)
+func newAPIV2Server(ctx context.Context, opts *apiV2ServerOpts) *apiV2Server {
+	authServer := newAuthenticationV2Server(ctx, opts.sqlServer, opts.sqlServer.cfg.Config, apiV2Path)
 	innerMux := mux.NewRouter()
-
 	authMux := newAuthenticationV2Mux(authServer, innerMux)
 	outerMux := mux.NewRouter()
 	a := &apiV2Server{
-		admin:            s.admin,
+		admin:            opts.admin,
 		authServer:       authServer,
-		status:           s.status,
+		status:           opts.status,
 		mux:              outerMux,
-		promRuleExporter: s.promRuleExporter,
+		promRuleExporter: opts.promRuleExporter,
+		sqlServer:        opts.sqlServer,
+		db:               opts.db,
 	}
 	a.registerRoutes(innerMux, authMux)
 	return a
@@ -130,35 +145,36 @@ func (a *apiV2Server) registerRoutes(innerMux *mux.Router, authMux http.Handler)
 	//    `role`, or does not have the roleoption `option`, an HTTP 403 forbidden
 	//    error is returned.
 	routeDefinitions := []struct {
-		url          string
-		handler      http.HandlerFunc
-		requiresAuth bool
-		role         apiRole
-		option       roleoption.Option
+		url           string
+		handler       http.HandlerFunc
+		requiresAuth  bool
+		role          apiRole
+		option        roleoption.Option
+		tenantEnabled bool
 	}{
 		// Pass through auth-related endpoints to the auth server.
-		{"login/", a.authServer.ServeHTTP, false /* requiresAuth */, regularRole, noOption},
-		{"logout/", a.authServer.ServeHTTP, false /* requiresAuth */, regularRole, noOption},
+		{"login/", a.authServer.ServeHTTP, false /* requiresAuth */, regularRole, noOption, false},
+		{"logout/", a.authServer.ServeHTTP, false /* requiresAuth */, regularRole, noOption, false},
 
 		// Directly register other endpoints in the api server.
-		{"sessions/", a.listSessions, true /* requiresAuth */, adminRole, noOption},
-		{"nodes/", a.listNodes, true, adminRole, noOption},
+		{"sessions/", a.listSessions, true /* requiresAuth */, adminRole, noOption, false},
+		{"nodes/", a.listNodes, true, adminRole, noOption, false},
 		// Any endpoint returning range information requires an admin user. This is because range start/end keys
 		// are sensitive info.
-		{"nodes/{node_id}/ranges/", a.listNodeRanges, true, adminRole, noOption},
-		{"ranges/hot/", a.listHotRanges, true, adminRole, noOption},
-		{"ranges/{range_id:[0-9]+}/", a.listRange, true, adminRole, noOption},
-		{"health/", a.health, false, regularRole, noOption},
-		{"users/", a.listUsers, true, regularRole, noOption},
-		{"events/", a.listEvents, true, adminRole, noOption},
-		{"databases/", a.listDatabases, true, regularRole, noOption},
-		{"databases/{database_name:[\\w.]+}/", a.databaseDetails, true, regularRole, noOption},
-		{"databases/{database_name:[\\w.]+}/grants/", a.databaseGrants, true, regularRole, noOption},
-		{"databases/{database_name:[\\w.]+}/tables/", a.databaseTables, true, regularRole, noOption},
-		{"databases/{database_name:[\\w.]+}/tables/{table_name:[\\w.]+}/", a.tableDetails, true, regularRole, noOption},
-		{"rules/", a.listRules, false, regularRole, noOption},
+		{"nodes/{node_id}/ranges/", a.listNodeRanges, true, adminRole, noOption, false},
+		{"ranges/hot/", a.listHotRanges, true, adminRole, noOption, false},
+		{"ranges/{range_id:[0-9]+}/", a.listRange, true, adminRole, noOption, false},
+		{"health/", a.health, false, regularRole, noOption, false},
+		{"users/", a.listUsers, true, regularRole, noOption, false},
+		{"events/", a.listEvents, true, adminRole, noOption, false},
+		{"databases/", a.listDatabases, true, regularRole, noOption, false},
+		{"databases/{database_name:[\\w.]+}/", a.databaseDetails, true, regularRole, noOption, false},
+		{"databases/{database_name:[\\w.]+}/grants/", a.databaseGrants, true, regularRole, noOption, false},
+		{"databases/{database_name:[\\w.]+}/tables/", a.databaseTables, true, regularRole, noOption, false},
+		{"databases/{database_name:[\\w.]+}/tables/{table_name:[\\w.]+}/", a.tableDetails, true, regularRole, noOption, false},
+		{"rules/", a.listRules, false, regularRole, noOption, false},
 
-		{"sql/", a.execSQL, true, regularRole, noOption},
+		{"sql/", a.execSQL, true, regularRole, noOption, true},
 	}
 
 	// For all routes requiring authentication, have the outer mux (a.mux)
@@ -170,11 +186,16 @@ func (a *apiV2Server) registerRoutes(innerMux *mux.Router, authMux http.Handler)
 			counter: telemetry.GetCounter(fmt.Sprintf("api.v2.%s", route.url)),
 			inner:   route.handler,
 		}
+		if !route.tenantEnabled && !a.sqlServer.execCfg.Codec.ForSystemTenant() {
+			a.mux.Handle(apiV2Path+route.url, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, "Not Available on Tenants", http.StatusNotImplemented)
+			}))
+		}
 		if route.requiresAuth {
 			a.mux.Handle(apiV2Path+route.url, authMux)
 			if route.role != regularRole {
 				handler = &roleAuthorizationMux{
-					ie:     a.admin.ie,
+					ie:     a.sqlServer.internalExecutor,
 					role:   route.role,
 					option: route.option,
 					inner:  handler,

--- a/pkg/server/api_v2_auth.go
+++ b/pkg/server/api_v2_auth.go
@@ -15,6 +15,7 @@ import (
 	"encoding/base64"
 	"net/http"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -44,13 +45,13 @@ type authenticationV2Server struct {
 // newAuthenticationV2Server creates a new authenticationV2Server for the given
 // outer Server, and base path.
 func newAuthenticationV2Server(
-	ctx context.Context, s *Server, basePath string,
+	ctx context.Context, s *SQLServer, cfg *base.Config, basePath string,
 ) *authenticationV2Server {
 	simpleMux := http.NewServeMux()
 
 	authServer := &authenticationV2Server{
-		sqlServer:  s.sqlServer,
-		authServer: newAuthenticationServer(s.cfg.Config, s.sqlServer),
+		sqlServer:  s,
+		authServer: newAuthenticationServer(cfg, s),
 		mux:        simpleMux,
 		ctx:        ctx,
 		basePath:   basePath,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1653,13 +1653,20 @@ func (s *Server) PreStart(ctx context.Context) error {
 	// endpoints served by gwMux by the HTTP cookie authentication
 	// check.
 	if err := s.http.setupRoutes(ctx,
-		s.authentication,       /* authnServer */
-		s.adminAuthzCheck,      /* adminAuthzCheck */
-		s.recorder,             /* metricSource */
-		s.runtime,              /* runtimeStatsSampler */
-		gwMux,                  /* handleRequestsUnauthenticated */
-		s.debug,                /* handleDebugUnauthenticated */
-		newAPIV2Server(ctx, s), /* apiServer */
+		s.authentication,  /* authnServer */
+		s.adminAuthzCheck, /* adminAuthzCheck */
+		s.recorder,        /* metricSource */
+		s.runtime,         /* runtimeStatsSampler */
+		gwMux,             /* handleRequestsUnauthenticated */
+		s.debug,           /* handleDebugUnauthenticated */
+		newAPIV2Server(ctx, &apiV2ServerOpts{
+			admin:            s.admin,
+			status:           s.status,
+			promRuleExporter: s.promRuleExporter,
+			tenantID:         roachpb.SystemTenantID,
+			sqlServer:        s.sqlServer,
+			db:               s.db,
+		}), /* apiServer */
 	); err != nil {
 		return err
 	}

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -570,9 +570,11 @@ func (s *SQLServerWrapper) PreStart(ctx context.Context) error {
 		s.runtime,         /* runtimeStatsSampler */
 		gwMux,             /* handleRequestsUnauthenticated */
 		s.debug,           /* handleDebugUnauthenticated */
-		// TODO(knz): the apiV2 server should be enabled for secondary tenants.
-		// See: https://github.com/cockroachdb/cockroach/issues/80789
-		nil, /* apiServer */
+		newAPIV2Server(workersCtx, &apiV2ServerOpts{
+			sqlServer: s.sqlServer,
+			tenantID:  s.sqlCfg.TenantID,
+			db:        s.db,
+		}), /* apiServer */
 	); err != nil {
 		return err
 	}

--- a/pkg/util/httputil/http.go
+++ b/pkg/util/httputil/http.go
@@ -75,6 +75,17 @@ func PostJSON(httpClient http.Client, path string, request, response protoutil.M
 	return err
 }
 
+// PostJSONRaw uses the supplied client to POST request to the URL specified by
+// the parameters and returns the response.
+func PostJSONRaw(httpClient http.Client, path string, request []byte) (*http.Response, error) {
+	buf := bytes.NewBuffer(request)
+	req, err := http.NewRequest("POST", path, buf)
+	if err != nil {
+		return nil, err
+	}
+	return doJSONRawRequest(httpClient, req)
+}
+
 // PostJSONWithRequest uses the supplied client to POST request to the URL
 // specified by the parameters and unmarshals the result into response.
 //
@@ -120,4 +131,12 @@ func doJSONRequest(
 		)
 	}
 	return resp, jsonpb.Unmarshal(resp.Body, response)
+}
+
+func doJSONRawRequest(httpClient http.Client, req *http.Request) (*http.Response, error) {
+	if timeout := httpClient.Timeout; timeout > 0 {
+		req.Header.Set("Grpc-Timeout", strconv.FormatInt(timeout.Nanoseconds(), 10)+"n")
+	}
+	req.Header.Set(AcceptHeader, JSONContentType)
+	return httpClient.Do(req)
 }


### PR DESCRIPTION
This commit adds partial support for the `/api/v2` HTTP server on tenants. Currently, we *only* support the SQL endpoint since this functionality is needed by newer DB Console features.

The API V2 Server initialization no longer relies on the global `Server` object, and only requires a `SQLServer` instead which makes it easier to play nicely with tenants. However, we still have the problem of incompatible status and admin servers which are in use on other endpoints. Future work will unify the tenant scoped versions of these servers and allow them to be used here, enabling full API V2 compatibility on tenants.

Informs: #80789

Release note (ops change): sql tenants now support the HTTP endpoint under `/api/v2/sql` which allows the caller to execute an HTTP request containing SQL statements to execute. The JSON response contains the results. This endpoints works identically as on a non-tenant server, except that it naturally scopes to the target tenant for SQL execution.

Epic: CRDB-17356