### PR TITLE
sql: remove testing argument from MakeDistSQLReceiver

### DIFF
--- a/pkg/ccl/backupccl/backup_processor_planning.go
+++ b/pkg/ccl/backupccl/backup_processor_planning.go
@@ -202,7 +202,6 @@ func distBackup(
 		nil,   /* clockUpdater */
 		evalCtx.Tracing,
 		evalCtx.ExecCfg.ContentionRegistry,
-		nil, /* testingPushCallback */
 	)
 	defer recv.Release()
 

--- a/pkg/ccl/backupccl/restore_processor_planning.go
+++ b/pkg/ccl/backupccl/restore_processor_planning.go
@@ -272,7 +272,6 @@ func distRestore(
 			nil,   /* clockUpdater */
 			evalCtx.Tracing,
 			evalCtx.ExecCfg.ContentionRegistry,
-			nil, /* testingPushCallback */
 		)
 		defer recv.Release()
 

--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -287,7 +287,6 @@ func startDistChangefeed(
 			nil, /* clockUpdater */
 			evalCtx.Tracing,
 			execCtx.ExecCfg().ContentionRegistry,
-			nil, /* testingPushCallback */
 		)
 		defer recv.Release()
 

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_planning.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_planning.go
@@ -148,7 +148,6 @@ func distStreamIngest(
 		nil, /* clockUpdater */
 		evalCtx.Tracing,
 		execCfg.ContentionRegistry,
-		nil, /* testingPushCallback */
 	)
 	defer recv.Release()
 

--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -273,7 +273,6 @@ func runPlanInsidePlan(
 		params.ExecCfg().Clock,
 		params.p.extendedEvalCtx.Tracing,
 		params.p.ExecCfg().ContentionRegistry,
-		nil, /* testingPushCallback */
 	)
 	defer recv.Release()
 

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1090,7 +1090,6 @@ func (sc *SchemaChanger) distIndexBackfill(
 		sc.clock,
 		evalCtx.Tracing,
 		sc.execCfg.ContentionRegistry,
-		nil, /* testingPushCallback */
 	)
 	defer recv.Release()
 
@@ -1336,7 +1335,6 @@ func (sc *SchemaChanger) distColumnBackfill(
 				sc.clock,
 				evalCtx.Tracing,
 				sc.execCfg.ContentionRegistry,
-				nil, /* testingPushCallback */
 			)
 			defer recv.Release()
 

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -207,7 +207,6 @@ func TestDistSQLReceiverUpdatesCaches(t *testing.T) {
 		nil, /* clockUpdater */
 		&SessionTracing{},
 		nil, /* contentionRegistry */
-		nil, /* testingPushCallback */
 	)
 
 	replicas := []roachpb.ReplicaDescriptor{{ReplicaID: 1}, {ReplicaID: 2}, {ReplicaID: 3}}

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -303,7 +303,6 @@ func (dsp *DistSQLPlanner) planAndRunCreateStats(
 		evalCtx.ExecCfg.Clock,
 		evalCtx.Tracing,
 		evalCtx.ExecCfg.ContentionRegistry,
-		nil, /* testingPushCallback */
 	)
 	defer recv.Release()
 

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -961,7 +961,6 @@ func MakeDistSQLReceiver(
 	clockUpdater clockUpdater,
 	tracing *SessionTracing,
 	contentionRegistry *contention.Registry,
-	testingPushCallback func(rowenc.EncDatumRow, *execinfrapb.ProducerMetadata),
 ) *DistSQLReceiver {
 	consumeCtx, cleanup := tracing.TraceExecConsume(ctx)
 	r := receiverSyncPool.Get().(*DistSQLReceiver)
@@ -986,7 +985,6 @@ func MakeDistSQLReceiver(
 		tracing:            tracing,
 		contentionRegistry: contentionRegistry,
 	}
-	r.testingKnobs.pushCallback = testingPushCallback
 	return r
 }
 

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -163,7 +163,6 @@ func TestDistSQLRunningInAbortedTxn(t *testing.T) {
 			execCfg.Clock,
 			p.ExtendedEvalContext().Tracing,
 			execCfg.ContentionRegistry,
-			nil, /* testingPushCallback */
 		)
 
 		// We need to re-plan every time, since the plan is closed automatically
@@ -225,7 +224,6 @@ func TestDistSQLReceiverErrorRanking(t *testing.T) {
 		nil, /* clockUpdater */
 		&SessionTracing{},
 		nil, /* contentionRegistry */
-		nil, /* testingPushCallback */
 	)
 
 	retryErr := roachpb.NewErrorWithTxn(
@@ -370,7 +368,6 @@ func TestDistSQLReceiverDrainsOnError(t *testing.T) {
 		nil, /* clockUpdater */
 		&SessionTracing{},
 		nil, /* contentionRegistry */
-		nil, /* testingPushCallback */
 	)
 	status := recv.Push(nil /* row */, &execinfrapb.ProducerMetadata{Err: errors.New("some error")})
 	require.Equal(t, execinfra.DrainRequested, status)

--- a/pkg/sql/importer/import_processor_planning.go
+++ b/pkg/sql/importer/import_processor_planning.go
@@ -224,7 +224,6 @@ func distImport(
 		nil, /* clockUpdater */
 		evalCtx.Tracing,
 		evalCtx.ExecCfg.ContentionRegistry,
-		nil, /* testingPushCallback */
 	)
 	defer recv.Release()
 

--- a/pkg/sql/index_backfiller.go
+++ b/pkg/sql/index_backfiller.go
@@ -198,7 +198,6 @@ func (ib *IndexBackfillPlanner) plan(
 			ib.execCfg.Clock,
 			evalCtx.Tracing,
 			ib.execCfg.ContentionRegistry,
-			nil, /* testingPushCallback */
 		)
 		defer recv.Release()
 		evalCtxCopy := evalCtx

--- a/pkg/sql/mvcc_backfiller.go
+++ b/pkg/sql/mvcc_backfiller.go
@@ -152,7 +152,6 @@ func (im *IndexBackfillerMergePlanner) plan(
 			im.execCfg.Clock,
 			evalCtx.Tracing,
 			im.execCfg.ContentionRegistry,
-			nil, /* testingPushCallback */
 		)
 		defer recv.Release()
 		evalCtxCopy := evalCtx

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -337,7 +337,6 @@ func (sc *SchemaChanger) backfillQueryIntoTable(
 			// other fields are used.
 			&SessionTracing{},
 			sc.execCfg.ContentionRegistry,
-			nil, /* testingPushCallback */
 		)
 		defer recv.Release()
 

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -145,7 +145,6 @@ func (dsp *DistSQLPlanner) Exec(
 		execCfg.Clock,
 		p.ExtendedEvalContext().Tracing,
 		execCfg.ContentionRegistry,
-		nil, /* testingPushCallback */
 	)
 	defer recv.Release()
 
@@ -176,7 +175,6 @@ func (dsp *DistSQLPlanner) ExecLocalAll(
 		execCfg.Clock,
 		p.ExtendedEvalContext().Tracing,
 		execCfg.ContentionRegistry,
-		nil, /* testingPushCallback */
 	)
 	defer recv.Release()
 

--- a/pkg/sql/ttl/ttljob/ttljob.go
+++ b/pkg/sql/ttl/ttljob/ttljob.go
@@ -331,7 +331,6 @@ func (t rowLevelTTLResumer) Resume(ctx context.Context, execCtx interface{}) err
 			nil, /* clockUpdater */
 			evalCtx.Tracing,
 			execCfg.ContentionRegistry,
-			nil, /* testingPushCallback */
 		)
 		defer distSQLReceiver.Release()
 


### PR DESCRIPTION
This is used only in one place, so it's just easier to set the argument explicitly in that one spot.

Epic: None

Release note: None