### PR TITLE
release-22.1: ui: add scroll to explain table

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/planDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/planDetails.tsx
@@ -19,6 +19,10 @@ import {
 import { Button } from "../../button";
 import { SqlBox, SqlBoxSize } from "../../sql";
 import { SortSetting } from "../../sortedtable";
+import classNames from "classnames/bind";
+import styles from "../statementDetails.module.scss";
+
+const cx = classNames.bind(styles);
 
 interface PlanDetailsProps {
   plans: PlanHashStats[];
@@ -59,13 +63,15 @@ function renderPlanTable(
 ): React.ReactElement {
   const columns = makeExplainPlanColumns(handleDetails);
   return (
-    <PlansSortedTable
-      columns={columns}
-      data={plans}
-      className="statements-table"
-      sortSetting={sortSetting}
-      onChangeSortSetting={onChangeSortSetting}
-    />
+    <div className={cx("table-area")}>
+      <PlansSortedTable
+        columns={columns}
+        data={plans}
+        className="statements-table"
+        sortSetting={sortSetting}
+        onChangeSortSetting={onChangeSortSetting}
+      />
+    </div>
   );
 }
 

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.module.scss
@@ -71,6 +71,10 @@
   }
 }
 
+.table-area {
+  overflow-x: scroll;
+}
+
 .last-cleared-tooltip, .numeric-stats-table, .plan-view-table {
   &__tooltip {
     width: 36px;


### PR DESCRIPTION
Backport 1/1 commits from #91281.

/cc @cockroachdb/release

---

Previously, the table on Explain Plan table didn't have horizontal scroll. This commit introduces the proper scroll to the table.

Fix #91201

Before
https://www.loom.com/share/cf0169cb9afb41f19e05eacbfa4d7e50

After
https://www.loom.com/share/bf0b2ed0a4d541e4957b728d4cb92df3

Release note (bug fix): A horizontal scroll is now added to the table on Explain Plan tab under Statement Details.

---
Release justification: bug fix
