### PR TITLE
cli: support MVCC range keys in `debug range-keys` batches

### DIFF
--- a/pkg/kv/kvserver/debug_print_test.go
+++ b/pkg/kv/kvserver/debug_print_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -29,11 +30,9 @@ func TestStringifyWriteBatch(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	var wb kvserverpb.WriteBatch
-	swb := stringifyWriteBatch(wb)
-	if str, expStr := swb.String(), "failed to stringify write batch (): batch repr too small: 0 < 12"; str != expStr {
-		t.Errorf("expected %q for stringified write batch; got %q", expStr, str)
-	}
+	wb := &kvserverpb.WriteBatch{}
+	_, err := decodeWriteBatch(wb)
+	require.ErrorContains(t, err, "batch repr too small: 0 < 12")
 
 	batch := pebble.Batch{}
 	require.NoError(t, batch.Set(storage.EncodeMVCCKey(storage.MVCCKey{
@@ -41,21 +40,76 @@ func TestStringifyWriteBatch(t *testing.T) {
 		Timestamp: hlc.Timestamp{WallTime: math.MaxInt64},
 	}), []byte("test value"), nil /* WriteOptions */))
 	wb.Data = batch.Repr()
-	swb = stringifyWriteBatch(wb)
-	if str, expStr := swb.String(), "Put: 9223372036.854775807,0 \"/db1\" (0x2f646231007fffffffffffffff09): \"test value\"\n"; str != expStr {
-		t.Errorf("expected %q for stringified write batch; got %q", expStr, str)
-	}
+	s, err := decodeWriteBatch(wb)
+	require.NoError(t, err)
+	require.Equal(t, "Put: 9223372036.854775807,0 \"/db1\" (0x2f646231007fffffffffffffff09): \"test value\"\n", s)
 
-	var err error
 	batch = pebble.Batch{}
 	encodedKey, err := hex.DecodeString("017a6b12c089f704918df70bee8800010003623a9318c0384d07a6f22b858594df6012")
 	require.NoError(t, err)
 	err = batch.SingleDelete(encodedKey, nil)
 	require.NoError(t, err)
 	wb.Data = batch.Repr()
-	swb = stringifyWriteBatch(wb)
-	if str, expStr := swb.String(), "Single Delete: /Local/Lock/Intent/Table/56/1/1169/5/3054/0 "+
-		"03623a9318c0384d07a6f22b858594df60 (0x017a6b12c089f704918df70bee8800010003623a9318c0384d07a6f22b858594df6012): \n"; str != expStr {
-		t.Errorf("expected %q for stringified write batch; got %q", expStr, str)
-	}
+	s, err = decodeWriteBatch(wb)
+	require.NoError(t, err)
+	require.Equal(t, "Single Delete: /Local/Lock/Intent/Table/56/1/1169/5/3054/0 "+
+		"03623a9318c0384d07a6f22b858594df60 (0x017a6b12c089f704918df70bee8800010003623a9318c0384d07a6f22b858594df6012): \n",
+		s)
+
+	batch = pebble.Batch{}
+	require.NoError(t, batch.RangeKeySet(
+		storage.EncodeMVCCKeyPrefix(roachpb.Key("/db1")),
+		storage.EncodeMVCCKeyPrefix(roachpb.Key("/db2")),
+		storage.EncodeMVCCTimestampSuffix(hlc.Timestamp{WallTime: 1}),
+		[]byte{},
+		nil,
+	))
+	valueRaw, err := storage.EncodeMVCCValue(storage.MVCCValue{
+		MVCCValueHeader: enginepb.MVCCValueHeader{LocalTimestamp: hlc.ClockTimestamp{WallTime: 1}},
+	})
+	require.NoError(t, err)
+	require.NoError(t, batch.RangeKeySet(
+		storage.EncodeMVCCKeyPrefix(roachpb.Key("/db1")),
+		storage.EncodeMVCCKeyPrefix(roachpb.Key("/db2")),
+		storage.EncodeMVCCTimestampSuffix(hlc.Timestamp{WallTime: 2}),
+		valueRaw,
+		nil,
+	))
+	wb.Data = batch.Repr()
+	s, err = decodeWriteBatch(wb)
+	require.NoError(t, err)
+	require.Equal(t, "Set Range Key: 0.000000001,0 /db{1-2} (0x2f64623100-0x2f64623200): \"\"\n"+
+		"Set Range Key: 0.000000002,0 /db{1-2} (0x2f64623100-0x2f64623200): \"\\x00\\x00\\x00\\x04e\\n\\x02\\b\\x01\"\n",
+		s)
+
+	batch = pebble.Batch{}
+	require.NoError(t, batch.RangeKeyUnset(
+		storage.EncodeMVCCKeyPrefix(roachpb.Key("/db1")),
+		storage.EncodeMVCCKeyPrefix(roachpb.Key("/db2")),
+		storage.EncodeMVCCTimestampSuffix(hlc.Timestamp{WallTime: 1}),
+		nil,
+	))
+	require.NoError(t, batch.RangeKeyUnset(
+		storage.EncodeMVCCKeyPrefix(roachpb.Key("/db1")),
+		storage.EncodeMVCCKeyPrefix(roachpb.Key("/db2")),
+		storage.EncodeMVCCTimestampSuffix(hlc.Timestamp{WallTime: 2}),
+		nil,
+	))
+	wb.Data = batch.Repr()
+	s, err = decodeWriteBatch(wb)
+	require.NoError(t, err)
+	require.Equal(t, "Unset Range Key: 0.000000001,0 /db{1-2} (0x2f64623100-0x2f64623200)\n"+
+		"Unset Range Key: 0.000000002,0 /db{1-2} (0x2f64623100-0x2f64623200)\n",
+		s)
+
+	batch = pebble.Batch{}
+	require.NoError(t, batch.RangeKeyDelete(
+		storage.EncodeMVCCKeyPrefix(roachpb.Key("/db1")),
+		storage.EncodeMVCCKeyPrefix(roachpb.Key("/db2")),
+		nil,
+	))
+	wb.Data = batch.Repr()
+	s, err = decodeWriteBatch(wb)
+	require.NoError(t, err)
+	require.Equal(t, "Delete Range Keys: /db{1-2} (0x2f64623100-0x2f64623200)\n", s)
 }


### PR DESCRIPTION
This patch adds support for MVCC range keys in `kvserver.decodeWriteBatch()`, which is used when dumping Pebble batches from the Raft log tail, e.g. during `debug range-keys`.

Resolves #91352.

Release note: None