### PR TITLE
ci: delete `--process_test_failures` wherever used

### DIFF
--- a/build/teamcity/cockroach/nightlies/cloud_unit_tests_impl.sh
+++ b/build/teamcity/cockroach/nightlies/cloud_unit_tests_impl.sh
@@ -44,13 +44,13 @@ bazel_test_env=(--test_env=GO_TEST_WRAP_TESTV=1 \
   --test_env=AWS_CONFIG_FILE="$AWS_CONFIG_FILE")
 exit_status=0
 
-$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --process_test_failures -- test --config=ci \
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- test --config=ci \
     //pkg/cloud/gcp:gcp_test //pkg/cloud/amazon:amazon_test //pkg/ccl/cloudccl/gcp:gcp_test //pkg/ccl/cloudccl/amazon:amazon_test \
     "${bazel_test_env[@]}" \
     --test_timeout=900 \
     || exit_status=$?
 
-$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --process_test_failures -- test --config=ci \
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- test --config=ci \
     //pkg/ccl/backupccl:backupccl_test --test_filter='^TestCloudBackupRestore' \
     "${bazel_test_env[@]}" \
     --test_timeout=900 \

--- a/build/teamcity/cockroach/nightlies/compose.sh
+++ b/build/teamcity/cockroach/nightlies/compose.sh
@@ -20,7 +20,7 @@ ARTIFACTS_DIR=$PWD/artifacts
 mkdir -p $ARTIFACTS_DIR
 
 exit_status=0
-$BAZCI --process_test_failures --artifacts_dir=$ARTIFACTS_DIR -- \
+$BAZCI --artifacts_dir=$ARTIFACTS_DIR -- \
        test --config=ci //pkg/compose:compose_test \
        "--sandbox_writable_path=$ARTIFACTS_DIR" \
        "--test_tmpdir=$ARTIFACTS_DIR" \

--- a/build/teamcity/cockroach/nightlies/optimizer_tests_impl.sh
+++ b/build/teamcity/cockroach/nightlies/optimizer_tests_impl.sh
@@ -12,7 +12,7 @@ tc_start_block "Run opt tests with fast_int_set_large"
 ARTIFACTS_DIR=/artifacts/fast_int_set_large
 mkdir $ARTIFACTS_DIR
 exit_status_large=0
-$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --artifacts_dir $ARTIFACTS_DIR --process_test_failures -- \
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --artifacts_dir $ARTIFACTS_DIR -- \
     test //pkg/sql/opt:opt_test --config=ci \
     --define gotags=bazel,crdb_test,fast_int_set_large \
     || exit_status_large=$?
@@ -25,7 +25,7 @@ tc_start_block "Run opt tests with fast_int_set_small"
 ARTIFACTS_DIR=/artifacts/fast_int_set_small
 mkdir $ARTIFACTS_DIR
 exit_status_small=0
-$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --artifacts_dir $ARTIFACTS_DIR --process_test_failures -- \
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --artifacts_dir $ARTIFACTS_DIR -- \
     test --config=ci \
     //pkg/sql/opt:opt_test \
     --define gotags=bazel,crdb_test,fast_int_set_small \

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_crossversion_impl.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_crossversion_impl.sh
@@ -29,7 +29,7 @@ test_args=$(echo $@ | python3 -c "import sys; print(' '.join(['--test_arg=' +wor
 # Add the verbosity flag.
 test_args="--test_arg=-test.v $test_args"
 
-$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --process_test_failures -- \
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- \
                                       test @com_github_cockroachdb_pebble//internal/metamorphic/crossversion:crossversion_test \
                                       --test_timeout=25200 '--test_filter=TestMetaCrossVersion$' \
                                       --define gotags=bazel,invariants \

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_impl.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_impl.sh
@@ -16,7 +16,7 @@ exit_status=0
 # NB: If adjusting the metamorphic test flags below, be sure to also update
 # pkg/cmd/github-post/main.go to ensure the GitHub issue poster includes the
 # correct flags in the reproduction command.
-$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --process_test_failures --formatter=pebble-metamorphic -- test --config=ci \
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --formatter=pebble-metamorphic -- test --config=ci \
                                       @com_github_cockroachdb_pebble//internal/metamorphic:metamorphic_test \
                                       --test_timeout=25200 '--test_filter=TestMeta$' \
                                       --define gotags=bazel,invariants \

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_race_impl.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_race_impl.sh
@@ -16,7 +16,7 @@ exit_status=0
 # NB: If adjusting the metamorphic test flags below, be sure to also update
 # pkg/cmd/github-post/main.go to ensure the GitHub issue poster includes the
 # correct flags in the reproduction command.
-$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --process_test_failures --formatter=pebble-metamorphic -- test --config=race --config=ci \
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --formatter=pebble-metamorphic -- test --config=race --config=ci \
                                       @com_github_cockroachdb_pebble//internal/metamorphic:metamorphic_test \
                                       --test_timeout=14400 '--test_filter=TestMeta$' \
                                       --define gotags=bazel,invariants \

--- a/build/teamcity/cockroach/nightlies/random_syntax_tests_impl.sh
+++ b/build/teamcity/cockroach/nightlies/random_syntax_tests_impl.sh
@@ -7,7 +7,7 @@ dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
 bazel build //pkg/cmd/bazci --config=ci
 BAZEL_BIN=$(bazel info bazel-bin --config=ci)
 exit_status=0
-$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --process_test_failures -- test --config=ci \
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- test --config=ci \
     //pkg/sql/tests:tests_test \
     --test_arg -rsg=5m --test_arg -rsg-routines=8 --test_arg -rsg-exec-timeout=1m \
     --test_timeout 3600 --test_filter 'TestRandomSyntax' \

--- a/build/teamcity/cockroach/nightlies/sqlite_logic_test_impl.sh
+++ b/build/teamcity/cockroach/nightlies/sqlite_logic_test_impl.sh
@@ -7,7 +7,7 @@ dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
 bazel build //pkg/cmd/bazci --config=ci
 BAZEL_BIN=$(bazel info bazel-bin --config=ci)
 exit_status=0
-$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --process_test_failures -- test --config=ci --config=crdb_test_off \
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- test --config=ci --config=crdb_test_off \
     //pkg/sql/sqlitelogictest/tests/... \
     --test_arg -bigtest --test_arg -flex-types --test_timeout 86400 \
     || exit_status=$?

--- a/build/teamcity/cockroach/nightlies/sqllogic_corpus_nightly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/sqllogic_corpus_nightly_impl.sh
@@ -19,7 +19,7 @@ exit_status=0
 
 # Generate a corpus for all non-mixed version variants
 for config in local multiregion-9node-3region-3azs; do
-$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --process_test_failures test -- --config=ci \
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci test -- --config=ci \
     //pkg/sql/logictest/tests/$config/... \
     --test_arg=--declarative-corpus=$ARTIFACTS_DIR/corpus \
     --test_env=GO_TEST_WRAP_TESTV=1 \
@@ -29,7 +29,7 @@ $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --process_test_failures test -- --config=c
 done
 
 for config in local multiregion-9node-3region-3azs multiregion-9node-3region-3azs-no-los multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-vec-off multiregion-15node-5region-3azs 3node-tenant 3node-tenant-multiregion; do
-$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --process_test_failures test -- --config=ci \
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci test -- --config=ci \
     //pkg/ccl/logictestccl/tests/$config/... \
     --test_arg=--declarative-corpus=$ARTIFACTS_DIR/corpus \
     --test_env=GO_TEST_WRAP_TESTV=1 \
@@ -39,7 +39,7 @@ $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --process_test_failures test -- --config=c
 done
 
 # Generate corpuses from end-to-end-schema changer tests
-$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --process_test_failures test -- --config=ci \
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci test -- --config=ci \
   //pkg/sql/schemachanger:schemachanger_test \
   --test_arg=--declarative-corpus=$ARTIFACTS_DIR/corpus \
   --test_filter='^TestGenerateCorpus.*$' \
@@ -49,7 +49,7 @@ $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --process_test_failures test -- --config=c
   || exit_status=$?
 
 # Generate corpuses from end-to-end-schema changer tests
-$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --process_test_failures test -- --config=ci \
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci test -- --config=ci \
   //pkg/ccl/schemachangerccl:schemachangerccl_test \
   --test_arg=--declarative-corpus=$ARTIFACTS_DIR/corpus \
   --test_filter='^TestGenerateCorpus.*$' \
@@ -60,7 +60,7 @@ $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --process_test_failures test -- --config=c
 
 # Any generated corpus should be validated on the current version first, which
 # indicates we can replay it on the same version.
-$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --process_test_failures test -- --config=ci \
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci test -- --config=ci \
   //pkg/sql/schemachanger/corpus:corpus_test \
   --test_arg=--declarative-corpus=$ARTIFACTS_DIR/corpus \
   --test_filter='^TestValidateCorpuses$' \
@@ -76,7 +76,7 @@ fi
 
 # Generate a corpus for all mixed version variants
 for config in local-mixed-22.2-23.1; do
-  $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --process_test_failures test -- --config=ci \
+  $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci test -- --config=ci \
       //pkg/sql/logictest/tests/$config/... \
       --test_arg=--declarative-corpus=$ARTIFACTS_DIR/corpus-mixed \
       --test_env=GO_TEST_WRAP_TESTV=1 \
@@ -87,7 +87,7 @@ done
 
 # Any generated corpus should be validated on the current version first, which
 # indicates we can replay it on the same version.
-$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --process_test_failures test -- --config=ci \
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci test -- --config=ci \
     //pkg/sql/schemachanger/corpus:corpus_test \
     --test_arg=--declarative-corpus=$ARTIFACTS_DIR/corpus-mixed \
     --test_filter='^TestValidateCorpuses$' \

--- a/build/teamcity/cockroach/nightlies/sqllogic_hi_vmodule_nightly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/sqllogic_hi_vmodule_nightly_impl.sh
@@ -10,7 +10,7 @@ BAZEL_BIN=$(bazel info bazel-bin --config=ci)
 ARTIFACTS_DIR=/artifacts
 
 exit_status=0
-$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --process_test_failures -- test --config=ci \
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- test --config=ci \
     //pkg/sql/logictest/tests/... \
     --test_arg=--vmodule=*=10 \
     --test_arg=-show-sql \

--- a/build/teamcity/cockroach/nightlies/stress_impl.sh
+++ b/build/teamcity/cockroach/nightlies/stress_impl.sh
@@ -32,7 +32,7 @@ do
         continue
     fi
     exit_status=0
-    $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --process_test_failures -- --config=ci test "$test" \
+    $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- --config=ci test "$test" \
                                           --test_env=COCKROACH_NIGHTLY_STRESS=true \
                                           --test_timeout="$TESTTIMEOUTSECS" \
                                           --run_under "@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts 'XML_OUTPUT_FILE=$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci merge-test-xmls' $STRESSFLAGS" \


### PR DESCRIPTION
I deleted the argument in `aa87baa24bf64596d1e000ab831d0675ea88c3ad` but forgot to delete usages.

Release note: None
Epic: None