### PR TITLE
keys: accurately size pre-allocated buffers in MakeRangeKey

### DIFF
--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1998,6 +1998,7 @@ func TestLint(t *testing.T) {
 
 		gcassertPaths := []string{
 			"../../col/coldata",
+			"../../keys",
 			"../../kv/kvclient/rangecache",
 			"../../sql/catalog/descs",
 			"../../sql/colcontainer",

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -631,6 +631,21 @@ func EncodeBytesDescending(b []byte, data []byte) []byte {
 	return b
 }
 
+// EncodeBytesSize returns the size of the []byte value when encoded using
+// EncodeBytes{Ascending,Descending}. The function accounts for the encoding
+// marker, escaping, and the terminator.
+func EncodeBytesSize(data []byte) int {
+	// Encoding overhead:
+	// +1 for [bytesMarker] prefix
+	// +2 for [escape, escapedTerm] suffix
+	// +1 for each byte that needs to be escaped
+	//
+	// NOTE: bytes.Count is implemented by the go runtime in assembly and is
+	// much faster than looping over the bytes in the slice, especially when
+	// given a single-byte separator.
+	return len(data) + 3 + bytes.Count(data, []byte{escape})
+}
+
 // DecodeBytesAscending decodes a []byte value from the input buffer
 // which was encoded using EncodeBytesAscending. The decoded bytes
 // are appended to r. The remainder of the input buffer and the

--- a/pkg/util/encoding/encoding_test.go
+++ b/pkg/util/encoding/encoding_test.go
@@ -487,7 +487,7 @@ func testPeekLength(t *testing.T, encoded []byte) {
 	}
 }
 
-func TestEncodeDecodeBytes(t *testing.T) {
+func TestEncodeDecodeBytesAscending(t *testing.T) {
 	testCases := []struct {
 		value   []byte
 		encoded []byte
@@ -515,6 +515,11 @@ func TestEncodeDecodeBytes(t *testing.T) {
 					c.value, testCases[i-1].encoded, enc)
 			}
 		}
+		expSize := EncodeBytesSize(c.value)
+		if len(enc) != expSize {
+			t.Errorf("expected encoded size %d, got %d", expSize, len(enc))
+		}
+
 		remainder, dec, err := DecodeBytesAscending(enc, nil)
 		if err != nil {
 			t.Error(err)
@@ -569,6 +574,11 @@ func TestEncodeDecodeBytesDescending(t *testing.T) {
 					c.value, testCases[i-1].encoded, enc)
 			}
 		}
+		expSize := EncodeBytesSize(c.value)
+		if len(enc) != expSize {
+			t.Errorf("expected encoded size %d, got %d", expSize, len(enc))
+		}
+
 		remainder, dec, err := DecodeBytesDescending(enc, nil)
 		if err != nil {
 			t.Error(err)


### PR DESCRIPTION
This commit includes a trio of changes that accurately size the byte buffers in `MakeRangeKey` and `MakeRangeKeyPrefix` to avoid unnecessary slice resizing (allocation + memcpy) when constructing range-local keys (for example, `RangeDescriptorKey` and `TransactionKey`).

The first change is to include the size of the suffix and detail slices when pre-allocating the byte buffer. We know that `MakeRangeKey` will be appending these to the key, so they will force a resize if not accounted for upfront.

The second change is to correctly account for the overhead of `EncodeBytesAscending`. The code was getting this wrong in two ways. First, it was failing to account for the 3 bytes of unconditional overhead added by the encoding scheme for the encoding type marker and terminator. Second, it was failing to account for the conditional overhead when bytes need to be escaped. We now accurately and efficiently compute the overhead ahead of time to avoid resizing.

The third change is to redefine the transaction tombstone and push marker keys used with the timestamp cache. Previously, the tombstone and push specifiers were additional suffixes that we added after the `LocalTransactionSuffix`. Now, these specifiers are the only suffix added to the key, which avoids an additional key resize.

```
name                         old time/op    new time/op    delta
KV/Update/Native/rows=1-10     70.6µs ± 2%    69.6µs ± 2%  -1.38%  (p=0.000 n=100+93)
KV/Insert/Native/rows=1-10     46.0µs ± 2%    45.7µs ± 2%  -0.62%  (p=0.000 n=95+97)
KV/Delete/Native/rows=1-10     47.3µs ± 2%    47.1µs ± 2%  -0.55%  (p=0.000 n=97+94)
KV/Insert/Native/rows=10-10    74.4µs ± 2%    74.1µs ± 3%  -0.45%  (p=0.000 n=96+98)
KV/Update/Native/rows=10-10     171µs ± 3%     170µs ± 3%  -0.36%  (p=0.045 n=96+98)
KV/Delete/Native/rows=10-10    85.1µs ± 2%    84.8µs ± 2%  -0.29%  (p=0.020 n=98+93)
KV/Update/SQL/rows=1-10         174µs ± 3%     174µs ± 3%  -0.28%  (p=0.041 n=97+89)
KV/Insert/SQL/rows=1-10         131µs ± 2%     131µs ± 4%    ~     (p=0.961 n=89+91)
KV/Insert/SQL/rows=10-10        186µs ± 3%     186µs ± 3%    ~     (p=0.970 n=94+92)
KV/Update/SQL/rows=10-10        336µs ± 2%     336µs ± 3%    ~     (p=0.947 n=92+92)
KV/Delete/SQL/rows=1-10         149µs ± 2%     149µs ± 3%    ~     (p=0.917 n=96+96)
KV/Delete/SQL/rows=10-10        226µs ± 8%     225µs ±10%    ~     (p=0.057 n=97+98)

name                         old alloc/op   new alloc/op   delta
KV/Insert/Native/rows=1-10     17.9kB ± 1%    17.6kB ± 1%  -1.95%  (p=0.000 n=100+100)
KV/Delete/Native/rows=1-10     18.2kB ± 1%    17.9kB ± 1%  -1.92%  (p=0.000 n=94+94)
KV/Update/Native/rows=1-10     25.1kB ± 0%    24.7kB ± 1%  -1.44%  (p=0.000 n=97+97)
KV/Insert/Native/rows=10-10    44.9kB ± 1%    44.5kB ± 1%  -0.88%  (p=0.000 n=100+99)
KV/Delete/Native/rows=10-10    42.4kB ± 1%    42.0kB ± 0%  -0.87%  (p=0.000 n=96+94)
KV/Delete/SQL/rows=1-10        52.9kB ± 1%    52.6kB ± 1%  -0.48%  (p=0.000 n=96+100)
KV/Update/Native/rows=10-10    75.2kB ± 1%    74.8kB ± 1%  -0.43%  (p=0.000 n=98+99)
KV/Update/SQL/rows=1-10        52.6kB ± 1%    52.4kB ± 0%  -0.35%  (p=0.000 n=95+95)
KV/Insert/SQL/rows=1-10        45.4kB ± 1%    45.3kB ± 0%  -0.24%  (p=0.000 n=97+93)
KV/Update/SQL/rows=10-10        119kB ± 1%     119kB ± 1%  -0.16%  (p=0.002 n=97+99)
KV/Delete/SQL/rows=10-10       88.0kB ± 1%    87.8kB ± 1%  -0.14%  (p=0.017 n=91+95)
KV/Insert/SQL/rows=10-10       93.9kB ± 1%    93.7kB ± 1%  -0.14%  (p=0.000 n=98+100)

name                         old allocs/op  new allocs/op  delta
KV/Insert/Native/rows=1-10        142 ± 0%       130 ± 0%  -8.45%  (p=0.000 n=99+100)
KV/Delete/Native/rows=1-10        143 ± 0%       131 ± 0%  -8.39%  (p=0.000 n=96+94)
KV/Update/Native/rows=1-10        198 ± 0%       186 ± 0%  -6.06%  (p=0.000 n=99+98)
KV/Delete/Native/rows=10-10       275 ± 0%       263 ± 0%  -4.36%  (p=0.000 n=90+90)
KV/Insert/Native/rows=10-10       295 ± 0%       283 ± 0%  -4.07%  (p=0.000 n=93+91)
KV/Update/Native/rows=10-10       472 ± 1%       460 ± 1%  -2.55%  (p=0.000 n=98+98)
KV/Insert/SQL/rows=1-10           365 ± 0%       356 ± 0%  -2.53%  (p=0.000 n=97+75)
KV/Delete/SQL/rows=1-10           402 ± 0%       393 ± 0%  -2.24%  (p=0.000 n=97+98)
KV/Update/SQL/rows=1-10           509 ± 0%       500 ± 0%  -1.81%  (p=0.000 n=96+95)
KV/Insert/SQL/rows=10-10          589 ± 0%       580 ± 0%  -1.53%  (p=0.000 n=94+95)
KV/Delete/SQL/rows=10-10          623 ± 1%       614 ± 1%  -1.47%  (p=0.000 n=98+97)
KV/Update/SQL/rows=10-10          858 ± 1%       849 ± 0%  -1.03%  (p=0.000 n=95+93)
```

I confirmed in heap profiles that this change eliminates all resizes of these buffers.

Release note: None

Epic: None