### PR TITLE
kv: recycle SpanSets returned during optimistic eval validation

### DIFF
--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -139,6 +139,8 @@ func (r *Replica) executeReadOnlyBatch(
 			if err != nil {
 				return nil, g, nil, roachpb.NewError(err)
 			}
+			defer latchSpansRead.Release()
+			defer lockSpansRead.Release()
 			if ok := g.CheckOptimisticNoConflicts(latchSpansRead, lockSpansRead); !ok {
 				return nil, g, nil, roachpb.NewError(roachpb.NewOptimisticEvalConflictsError())
 			}


### PR DESCRIPTION
This commit adds `Release` calls for both SpanSets returned by `collectSpansRead` on the optimistic eval validation path. The failure to recycle these SpanSets was causing a leak from the `SpanSet` memory pool of both top level objects and the recycled inner slices.

We have the same issue at the other caller of `collectSpansRead`, which is being tracked more broadly in #91374.

Release note: None
Epic: None