### PR TITLE
kv: pool per read-write batch `MVCCStats`

### DIFF
--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -12,6 +12,7 @@ package kvserver
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -432,7 +433,8 @@ func (r *Replica) evaluateWriteBatch(
 			"Require1PC should not have gotten to transactional evaluation. ba: %s", ba.String())
 	}
 
-	ms := new(enginepb.MVCCStats)
+	ms := newMVCCStats()
+	defer releaseMVCCStats(ms)
 	rec := NewReplicaEvalContext(ctx, r, g.LatchSpans(), ba.RequiresClosedTSOlderThanStorageSnapshot())
 	defer rec.Release()
 	batch, br, res, pErr := r.evaluateWriteBatchWithServersideRefreshes(
@@ -513,7 +515,8 @@ func (r *Replica) evaluate1PC(
 	etArg := arg.(*roachpb.EndTxnRequest)
 
 	// Evaluate strippedBa. If the transaction allows, permit refreshes.
-	ms := new(enginepb.MVCCStats)
+	ms := newMVCCStats()
+	defer releaseMVCCStats(ms)
 	if ba.CanForwardReadTimestamp {
 		batch, br, res, pErr = r.evaluateWriteBatchWithServersideRefreshes(
 			ctx, idKey, rec, ms, &strippedBa, g, st, ui, etArg.Deadline)
@@ -551,7 +554,7 @@ func (r *Replica) evaluate1PC(
 		clonedTxn.Status = roachpb.ABORTED
 		batch.Close()
 		batch = r.store.Engine().NewBatch()
-		ms = new(enginepb.MVCCStats)
+		ms.Reset()
 	} else {
 		// Run commit trigger manually.
 		innerResult, err := batcheval.RunCommitTrigger(ctx, rec, batch, ms, etArg, clonedTxn)
@@ -771,4 +774,17 @@ func isOnePhaseCommit(ba *roachpb.BatchRequest) bool {
 	// epochs then they couldn't have left any intents that they now need to
 	// clean up.
 	return ba.Txn.Epoch == 0 || etArg.Require1PC
+}
+
+var mvccStatsPool = sync.Pool{
+	New: func() interface{} { return new(enginepb.MVCCStats) },
+}
+
+func newMVCCStats() *enginepb.MVCCStats {
+	return mvccStatsPool.Get().(*enginepb.MVCCStats)
+}
+
+func releaseMVCCStats(ms *enginepb.MVCCStats) {
+	ms.Reset()
+	mvccStatsPool.Put(ms)
 }


### PR DESCRIPTION
Each read-write BatchRequest uses an `MVCCStats` object to track the impact that its writes will have (when applied) on the Range's aggregated stats. This object is plumbed throughout the stack and is manipulated primarily in the MVCC layer. It is plumbed too far for us to be able to convince escape analysis to keep it on the stack, so we allocate it on the heap.

This commit adds a memory pool for these objects to avoid heap allocations.

```
name                         old time/op    new time/op    delta
KV/Insert/Native/rows=1-10     44.8µs ± 2%    45.1µs ± 2%    ~     (p=0.079 n=19+20)
KV/Insert/Native/rows=10-10    71.3µs ± 4%    70.7µs ± 2%    ~     (p=0.120 n=20+19)
KV/Insert/SQL/rows=1-10         128µs ± 2%     128µs ± 1%    ~     (p=0.251 n=20+18)
KV/Insert/SQL/rows=10-10        177µs ± 1%     177µs ± 3%    ~     (p=0.731 n=17+19)
KV/Update/Native/rows=1-10     67.8µs ± 3%    67.4µs ± 3%    ~     (p=0.166 n=20+19)
KV/Update/Native/rows=10-10     165µs ± 2%     164µs ± 2%    ~     (p=0.235 n=20+19)
KV/Update/SQL/rows=1-10         169µs ± 2%     169µs ± 2%    ~     (p=0.093 n=18+20)
KV/Update/SQL/rows=10-10        331µs ± 2%     330µs ± 2%    ~     (p=0.167 n=20+18)
KV/Delete/Native/rows=1-10     46.2µs ± 1%    46.4µs ± 2%    ~     (p=0.159 n=18+19)
KV/Delete/Native/rows=10-10    84.2µs ± 3%    83.8µs ± 2%    ~     (p=0.529 n=20+20)
KV/Delete/SQL/rows=1-10         145µs ± 1%     144µs ± 1%    ~     (p=0.150 n=19+18)
KV/Delete/SQL/rows=10-10        203µs ± 4%     206µs ± 8%    ~     (p=0.245 n=19+18)

name                         old alloc/op   new alloc/op   delta
KV/Insert/Native/rows=1-10     16.1kB ± 1%    16.0kB ± 1%  -0.98%  (p=0.000 n=20+20)
KV/Delete/Native/rows=1-10     16.7kB ± 0%    16.6kB ± 1%  -0.86%  (p=0.000 n=19+20)
KV/Update/Native/rows=1-10     22.7kB ± 1%    22.5kB ± 1%  -0.74%  (p=0.000 n=19+20)
KV/Insert/Native/rows=10-10    41.5kB ± 0%    41.4kB ± 0%  -0.45%  (p=0.000 n=17+20)
KV/Update/SQL/rows=1-10        50.3kB ± 0%    50.1kB ± 0%  -0.32%  (p=0.000 n=20+20)
KV/Delete/SQL/rows=1-10        51.4kB ± 1%    51.2kB ± 1%  -0.30%  (p=0.010 n=20+19)
KV/Insert/SQL/rows=1-10        43.8kB ± 0%    43.7kB ± 0%  -0.26%  (p=0.000 n=19+20)
KV/Update/SQL/rows=10-10        115kB ± 1%     115kB ± 1%  -0.24%  (p=0.018 n=20+20)
KV/Insert/SQL/rows=10-10       90.4kB ± 0%    90.3kB ± 0%  -0.13%  (p=0.035 n=20+19)
KV/Update/Native/rows=10-10    69.5kB ± 1%    69.3kB ± 1%    ~     (p=0.064 n=20+20)
KV/Delete/Native/rows=10-10    41.9kB ± 2%    41.8kB ± 1%    ~     (p=0.398 n=20+20)
KV/Delete/SQL/rows=10-10       84.0kB ± 0%    83.9kB ± 1%    ~     (p=0.128 n=17+18)

name                         old allocs/op  new allocs/op  delta
KV/Insert/Native/rows=1-10        116 ± 0%       115 ± 0%  -0.86%  (p=0.000 n=20+19)
KV/Delete/Native/rows=1-10        117 ± 0%       116 ± 0%  -0.85%  (p=0.000 n=20+19)
KV/Update/Native/rows=1-10        163 ± 0%       162 ± 0%  -0.84%  (p=0.000 n=19+17)
KV/Update/Native/rows=10-10       438 ± 1%       436 ± 1%  -0.43%  (p=0.031 n=19+20)
KV/Delete/Native/rows=10-10       249 ± 0%       248 ± 0%  -0.40%  (p=0.000 n=20+20)
KV/Insert/Native/rows=10-10       268 ± 0%       267 ± 0%  -0.37%  (p=0.000 n=20+20)
KV/Delete/SQL/rows=1-10           379 ± 0%       378 ± 0%  -0.32%  (p=0.000 n=20+19)
KV/Insert/SQL/rows=1-10           342 ± 0%       341 ± 0%  -0.29%  (p=0.000 n=20+20)
KV/Update/SQL/rows=1-10           477 ± 0%       476 ± 0%  -0.23%  (p=0.000 n=18+20)
KV/Update/SQL/rows=10-10          825 ± 0%       824 ± 1%  -0.21%  (p=0.014 n=19+20)
KV/Insert/SQL/rows=10-10          564 ± 0%       563 ± 0%  -0.13%  (p=0.001 n=12+18)
KV/Delete/SQL/rows=10-10          593 ± 0%       594 ± 1%    ~     (p=0.841 n=16+20)
```

Release note: None
Epic: None