### PR TITLE
spanconfigsqltranslator: remove SQLTranslator.txn

### DIFF
--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/datadriven_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/datadriven_test.go
@@ -183,9 +183,9 @@ func TestDataDriven(t *testing.T) {
 				err := sql.DescsTxn(ctx, &execCfg, func(
 					ctx context.Context, txn *kv.Txn, descsCol *descs.Collection,
 				) error {
-					sqlTranslator := sqlTranslatorFactory.NewSQLTranslator(txn, descsCol)
+					sqlTranslator := sqlTranslatorFactory.NewSQLTranslator(descsCol)
 					var err error
-					records, _, err = sqlTranslator.Translate(ctx, descIDs, generateSystemSpanConfigs)
+					records, _, err = sqlTranslator.Translate(ctx, txn, descIDs, generateSystemSpanConfigs)
 					require.NoError(t, err)
 					return nil
 				})
@@ -215,9 +215,9 @@ func TestDataDriven(t *testing.T) {
 				err := sql.DescsTxn(ctx, &execCfg, func(
 					ctx context.Context, txn *kv.Txn, descsCol *descs.Collection,
 				) error {
-					sqlTranslator := sqlTranslatorFactory.NewSQLTranslator(txn, descsCol)
+					sqlTranslator := sqlTranslatorFactory.NewSQLTranslator(descsCol)
 					var err error
-					records, _, err = spanconfig.FullTranslate(ctx, sqlTranslator)
+					records, _, err = spanconfig.FullTranslate(ctx, txn, sqlTranslator)
 					require.NoError(t, err)
 					return nil
 				})

--- a/pkg/spanconfig/spanconfig.go
+++ b/pkg/spanconfig/spanconfig.go
@@ -137,19 +137,19 @@ type SQLTranslator interface {
 	// for each one of these accumulated IDs, we generate <span, config> tuples
 	// by following up the inheritance chain to fully hydrate the span
 	// configuration. Translate also accounts for and negotiates subzone spans.
-	Translate(ctx context.Context, ids descpb.IDs,
-		generateSystemSpanConfigurations bool) ([]Record, hlc.Timestamp, error)
+	Translate(ctx context.Context, txn *kv.Txn, ids descpb.IDs, generateSystemSpanConfigurations bool) ([]Record, hlc.Timestamp, error)
 }
 
 // FullTranslate translates the entire SQL zone configuration state to the span
 // configuration state. The timestamp at which such a translation is valid is
 // also returned.
-func FullTranslate(ctx context.Context, s SQLTranslator) ([]Record, hlc.Timestamp, error) {
+func FullTranslate(
+	ctx context.Context, txn *kv.Txn, s SQLTranslator,
+) ([]Record, hlc.Timestamp, error) {
 	// As RANGE DEFAULT is the root of all zone configurations (including other
 	// named zones for the system tenant), we can construct the entire span
 	// configuration state by starting from RANGE DEFAULT.
-	return s.Translate(ctx, descpb.IDs{keys.RootNamespaceID},
-		true /* generateSystemSpanConfigurations */)
+	return s.Translate(ctx, txn, descpb.IDs{keys.RootNamespaceID}, true)
 }
 
 // SQLWatcherHandler is the signature of a handler that can be passed into

--- a/pkg/spanconfig/spanconfigreconciler/reconciler.go
+++ b/pkg/spanconfig/spanconfigreconciler/reconciler.go
@@ -233,8 +233,8 @@ func (f *fullReconciler) reconcile(
 	if err := sql.DescsTxn(ctx, f.execCfg, func(
 		ctx context.Context, txn *kv.Txn, descsCol *descs.Collection,
 	) error {
-		translator := f.sqlTranslatorFactory.NewSQLTranslator(txn, descsCol)
-		records, reconciledUpUntil, err = spanconfig.FullTranslate(ctx, translator)
+		translator := f.sqlTranslatorFactory.NewSQLTranslator(descsCol)
+		records, reconciledUpUntil, err = spanconfig.FullTranslate(ctx, txn, translator)
 		return err
 	}); err != nil {
 		return nil, hlc.Timestamp{}, err
@@ -495,8 +495,8 @@ func (r *incrementalReconciler) reconcile(
 						return err
 					}
 
-					translator := r.sqlTranslatorFactory.NewSQLTranslator(txn, descsCol)
-					records, _, err = translator.Translate(ctx, allIDs, generateSystemSpanConfigurations)
+					translator := r.sqlTranslatorFactory.NewSQLTranslator(descsCol)
+					records, _, err = translator.Translate(ctx, txn, allIDs, generateSystemSpanConfigurations)
 					return err
 				}); err != nil {
 				return err


### PR DESCRIPTION
This is part of the effort to let the internal executor's creation better bound to the txn.

This commit changes the txn used in SQLTranslator.Translate() from `SQLTranslator.txn` to the txn passed as a parameter to the function. In this case, we can better trace up where the txn is from, and bind the creation of an internal executor with the txn.

Release note: None

Epic: CRDB-19135