### PR TITLE
loqrecovery: prohibit plans with any descriptor changes

### DIFF
--- a/pkg/kv/kvserver/loqrecovery/plan.go
+++ b/pkg/kv/kvserver/loqrecovery/plan.go
@@ -503,15 +503,14 @@ func checkDescriptor(rankedDescriptors rankedReplicas) (problems []Problem) {
 				},
 			})
 		case loqrecoverypb.DescriptorChangeType_ReplicaChange:
-			// Check if our own replica is being removed as part of descriptor
-			// change.
-			_, ok := change.Desc.GetReplicaDescriptor(rankedDescriptors.storeID())
-			if !ok {
-				problems = append(problems, rangeReplicaRemoval{
-					rangeID: rankedDescriptors.rangeID(),
-					span:    rankedDescriptors.span(),
-				})
-			}
+			// Any change of descriptor even if it doesn't change current replica
+			// is not safe to apply if we change replica id.
+			// Until we have a way to remove this change, we should treat this as
+			// a problem.
+			problems = append(problems, rangeReplicaChange{
+				rangeID: rankedDescriptors.rangeID(),
+				span:    rankedDescriptors.span(),
+			})
 		}
 	}
 	return

--- a/pkg/kv/kvserver/loqrecovery/testdata/force_inconsistent_plans
+++ b/pkg/kv/kvserver/loqrecovery/testdata/force_inconsistent_plans
@@ -40,7 +40,7 @@ ok
 make-plan
 ----
 ERROR: loss of quorum recovery error
-range has unapplied descriptor change that removes current replica
+range has unapplied descriptor change
   r2: /{Table/1-Max}
 
 make-plan force=true

--- a/pkg/kv/kvserver/loqrecovery/testdata/pending_descriptor_changes
+++ b/pkg/kv/kvserver/loqrecovery/testdata/pending_descriptor_changes
@@ -49,7 +49,7 @@ ok
 make-plan
 ----
 ERROR: loss of quorum recovery error
-range has unapplied descriptor change that removes current replica
+range has unapplied descriptor change
   r2: /{Table/1-Max}
 
 
@@ -109,7 +109,8 @@ range has unapplied merge operation
 
 
 # Check that ranges with pending descriptor changes where the change removes other replicas are
-# considered safe to proceed with.
+# considered unsafe to proceed with. This is forbidden because any change will fail if replica
+# id of survivor replica reverts.
 replication-data
 - StoreID: 1
   RangeID: 1
@@ -132,7 +133,7 @@ replication-data
   RangeAppliedIndex: 11
   RaftCommittedIndex: 14
   DescriptorUpdates:
-  - Type: 2  # pending descriptor update where replicas 2 3 are replaced with 4 which is considered safe
+  - Type: 2  # pending descriptor update where replicas 2 3 are replaced with 4 which is not considered safe
     Replicas:
     - { NodeID: 1, StoreID: 1, ReplicaID: 1}
     - { NodeID: 4, StoreID: 4, ReplicaID: 4}
@@ -145,22 +146,9 @@ ok
 
 make-plan
 ----
-- RangeID: 1
-  StartKey: /Min
-  OldReplicaID: 1
-  NewReplica:
-    NodeID: 1
-    StoreID: 1
-    ReplicaID: 14
-  NextReplicaID: 15
-- RangeID: 2
-  StartKey: /Table/1
-  OldReplicaID: 1
-  NewReplica:
-    NodeID: 1
-    StoreID: 1
-    ReplicaID: 14
-  NextReplicaID: 15
+ERROR: loss of quorum recovery error
+range has unapplied descriptor change
+  r2: /{Table/1-Max}
 
 
 # Check that if descriptor didn't lose quorum, we should not fail if raft log contains future changes

--- a/pkg/kv/kvserver/loqrecovery/utils.go
+++ b/pkg/kv/kvserver/loqrecovery/utils.go
@@ -137,18 +137,18 @@ func (i rangeMerge) Span() roachpb.Span {
 	return i.span
 }
 
-type rangeReplicaRemoval struct {
+type rangeReplicaChange struct {
 	rangeID roachpb.RangeID
 	span    roachpb.Span
 }
 
-func (i rangeReplicaRemoval) String() string {
-	return fmt.Sprintf("range has unapplied descriptor change that removes current replica\n  r%d: %v",
+func (i rangeReplicaChange) String() string {
+	return fmt.Sprintf("range has unapplied descriptor change\n  r%d: %v",
 		i.rangeID,
 		i.span)
 }
 
-func (i rangeReplicaRemoval) Span() roachpb.Span {
+func (i rangeReplicaChange) Span() roachpb.Span {
 	return i.span
 }
 


### PR DESCRIPTION
Previously, loss of quorum recovery allowed plan creation for cases where descriptor change didn't change survivor replica. This is not sufficient as replica will still be checked against its status and will panic when this entry is applied.
This diff changes validation behaviour to treat this change as a problem and require force flag to override it.

Release note: None

Fixes #91271