### PR TITLE
kvserver: amortize limiter.WaitN in range scan

### DIFF
--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -500,9 +500,22 @@ func CalcReplicaDigest(
 	var timestampBuf []byte
 	hasher := sha512.New()
 
+	// Request quota from the limiter in chunks of at least targetBatchSize, to
+	// amortize the overhead of the limiter when reading many small KVs.
+	var batchSize int64
+	const targetBatchSize = int64(256 << 10) // 256 KiB
+	wait := func(size int64) error {
+		if batchSize += size; batchSize < targetBatchSize {
+			return nil
+		}
+		tokens := batchSize
+		batchSize = 0
+		return limiter.WaitN(ctx, tokens)
+	}
+
 	pointKeyVisitor := func(unsafeKey storage.MVCCKey, unsafeValue []byte) error {
 		// Rate limit the scan through the range.
-		if err := limiter.WaitN(ctx, int64(len(unsafeKey.Key)+len(unsafeValue))); err != nil {
+		if err := wait(int64(len(unsafeKey.Key) + len(unsafeValue))); err != nil {
 			return err
 		}
 		// Encode the length of the key and value.
@@ -535,8 +548,8 @@ func CalcReplicaDigest(
 
 	rangeKeyVisitor := func(rangeKV storage.MVCCRangeKeyValue) error {
 		// Rate limit the scan through the range.
-		err := limiter.WaitN(ctx,
-			int64(len(rangeKV.RangeKey.StartKey)+len(rangeKV.RangeKey.EndKey)+len(rangeKV.Value)))
+		err := wait(
+			int64(len(rangeKV.RangeKey.StartKey) + len(rangeKV.RangeKey.EndKey) + len(rangeKV.Value)))
 		if err != nil {
 			return err
 		}
@@ -581,6 +594,11 @@ func CalcReplicaDigest(
 	if !statsOnly {
 		ms, err := rditer.ComputeStatsForRangeWithVisitors(&desc, snap, 0, /* nowNanos */
 			pointKeyVisitor, rangeKeyVisitor)
+		// Consume the remaining quota borrowed in the visitors. Do it even on
+		// iteration error, but prioritize returning the latter if it occurs.
+		if wErr := limiter.WaitN(ctx, batchSize); wErr != nil && err == nil {
+			err = wErr
+		}
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This commit reduces the relative cost of quota acquisitions in consistency checker's range scan, by requesting it in chunks of at least 256 KiB at a time.

Fixes #89695

Release note: None