### PR TITLE
multitenant: move UNSPLIT AT tenant check from SQL to KV layer

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/tenant_unsupported
+++ b/pkg/ccl/logictestccl/testdata/logic_test/tenant_unsupported
@@ -48,7 +48,7 @@ SELECT * FROM crdb_internal.kv_node_status
 statement error pq: rpc error: code = Unauthenticated desc = request \[1 AdmSplit\] not permitted
 ALTER TABLE kv SPLIT AT VALUES ('foo')
 
-statement error operation is unsupported in multi-tenancy mode
+statement error pq: could not UNSPLIT AT \('foo'\): rpc error: code = Unauthenticated desc = request \[1 AdmUnsplit\] not permitted
 ALTER TABLE kv UNSPLIT AT VALUES ('foo')
 
 statement error operation is unsupported in multi-tenancy mode

--- a/pkg/kv/batch.go
+++ b/pkg/kv/batch.go
@@ -722,7 +722,7 @@ func (b *Batch) adminSplit(
 	b.initResult(1, 0, notRaw, nil)
 }
 
-func (b *Batch) adminUnsplit(splitKeyIn interface{}) {
+func (b *Batch) adminUnsplit(splitKeyIn interface{}, class roachpb.AdminUnsplitRequest_Class) {
 	splitKey, err := marshalKey(splitKeyIn)
 	if err != nil {
 		b.initResult(0, 0, notRaw, err)
@@ -731,6 +731,7 @@ func (b *Batch) adminUnsplit(splitKeyIn interface{}) {
 		RequestHeader: roachpb.RequestHeader{
 			Key: splitKey,
 		},
+		Class: class,
 	}
 	b.appendReqs(req)
 	b.initResult(1, 0, notRaw, nil)

--- a/pkg/kv/db.go
+++ b/pkg/kv/db.go
@@ -630,9 +630,11 @@ func (db *DB) AdminScatter(
 // If splitKey is not the start key of a range, then this method will throw an
 // error. If the range specified by splitKey does not have a sticky bit set,
 // then this method will not throw an error and is a no-op.
-func (db *DB) AdminUnsplit(ctx context.Context, splitKey interface{}) error {
+func (db *DB) AdminUnsplit(
+	ctx context.Context, splitKey interface{}, class roachpb.AdminUnsplitRequest_Class,
+) error {
 	b := &Batch{}
-	b.adminUnsplit(splitKey)
+	b.adminUnsplit(splitKey, class)
 	return getOneErr(db.Run(ctx, b), b)
 }
 

--- a/pkg/kv/kvclient/kvcoord/split_test.go
+++ b/pkg/kv/kvclient/kvcoord/split_test.go
@@ -320,7 +320,7 @@ func TestRangeSplitsStickyBit(t *testing.T) {
 	}
 
 	// Removing sticky bit.
-	if err := s.DB.AdminUnsplit(ctx, splitKey.AsRawKey()); err != nil {
+	if err := s.DB.AdminUnsplit(ctx, splitKey.AsRawKey(), roachpb.AdminUnsplitRequest_ORGANIZATION); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -1536,7 +1536,7 @@ func TestMergeQueueDoesNotInterruptReplicationChange(t *testing.T) {
 	// Split and then unsplit the range to clear the sticky bit, otherwise the
 	// mergeQueue will ignore the range.
 	tc.SplitRangeOrFatal(t, splitKey)
-	require.NoError(t, tc.Server(0).DB().AdminUnsplit(ctx, splitKey))
+	require.NoError(t, tc.Server(0).DB().AdminUnsplit(ctx, splitKey, roachpb.AdminUnsplitRequest_ORGANIZATION))
 
 	atomic.StoreInt64(&activateSnapshotTestingKnob, 1)
 	replicationChange := make(chan error)
@@ -1601,7 +1601,7 @@ func TestMergeQueueSeesLearnerOrJointConfig(t *testing.T) {
 	splitAndUnsplit := func() roachpb.RangeDescriptor {
 		desc, _ := tc.SplitRangeOrFatal(t, splitKey)
 		// Unsplit the range to clear the sticky bit.
-		require.NoError(t, tc.Server(0).DB().AdminUnsplit(ctx, splitKey))
+		require.NoError(t, tc.Server(0).DB().AdminUnsplit(ctx, splitKey, roachpb.AdminUnsplitRequest_ORGANIZATION))
 		return desc
 	}
 

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -845,7 +845,15 @@ message AdminSplitResponse {
 // Ranges that do not have the sticky bit set are eligible for
 // automatic merging.
 message AdminUnsplitRequest {
+
+  enum Class {
+    ARBITRARY = 0;
+    ORGANIZATION = 1;
+  }
+
   RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+
+  Class class = 2;
 }
 
 // An AdminUnsplitResponse is the return value from the

--- a/pkg/rpc/auth_tenant.go
+++ b/pkg/rpc/auth_tenant.go
@@ -175,8 +175,11 @@ func reqAllowed(r roachpb.Request, tenID roachpb.TenantID) bool {
 		*roachpb.IsSpanEmptyRequest:
 		return true
 	case *roachpb.AdminSplitRequest:
-		return t.Class != roachpb.AdminSplitRequest_ARBITRARY || tenID == roachpb.SystemTenantID
+		return t.Class != roachpb.AdminSplitRequest_ARBITRARY || tenID.IsSystem()
+	case *roachpb.AdminUnsplitRequest:
+		return t.Class != roachpb.AdminUnsplitRequest_ARBITRARY || tenID.IsSystem()
 	}
+
 	return false
 }
 

--- a/pkg/sql/gcjob/BUILD.bazel
+++ b/pkg/sql/gcjob/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",
+        "//pkg/sql/oppurpose",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sem/tree",

--- a/pkg/sql/gcjob/gc_job.go
+++ b/pkg/sql/gcjob/gc_job.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/oppurpose"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -184,7 +185,7 @@ func unsplitRangesInSpan(ctx context.Context, kvDB *kv.DB, span roachpb.Span) er
 			// Swallow "key is not the start of a range" errors because it would mean
 			// that the sticky bit was removed and merged concurrently. DROP TABLE
 			// should not fail because of this.
-			if err := kvDB.AdminUnsplit(ctx, desc.StartKey); err != nil &&
+			if err := kvDB.AdminUnsplit(ctx, desc.StartKey, oppurpose.UnsplitGC); err != nil &&
 				!strings.Contains(err.Error(), "is not the start of a range") {
 				return err
 			}

--- a/pkg/sql/multitenant_admin_function_test.go
+++ b/pkg/sql/multitenant_admin_function_test.go
@@ -109,6 +109,7 @@ func TestMultiTenantAdminFunction(t *testing.T) {
 			desc:                 "ALTER TABLE x UNSPLIT AT",
 			setup:                "ALTER TABLE t SPLIT AT VALUES (1);",
 			query:                "ALTER TABLE t UNSPLIT AT VALUES (1);",
+			errorMessage:         "request [1 AdmUnsplit] not permitted",
 			allowSplitAndScatter: true,
 		},
 		{
@@ -119,6 +120,7 @@ func TestMultiTenantAdminFunction(t *testing.T) {
 				"ALTER INDEX t@idx SPLIT AT VALUES (1);",
 			},
 			query:                "ALTER INDEX t@idx UNSPLIT AT VALUES (1);",
+			errorMessage:         "request [1 AdmUnsplit] not permitted",
 			allowSplitAndScatter: true,
 		},
 		{

--- a/pkg/sql/oppurpose/op_purpose.go
+++ b/pkg/sql/oppurpose/op_purpose.go
@@ -25,4 +25,9 @@ const (
 	SplitManual = roachpb.AdminSplitRequest_ARBITRARY
 	// SplitManualTest is a split caused by a manual action test.
 	SplitManualTest = roachpb.AdminSplitRequest_INGESTION
+
+	// UnsplitManual is a split caused by a manual action.
+	UnsplitManual = roachpb.AdminUnsplitRequest_ARBITRARY
+	// UnsplitGC is a split caused by the GC job.
+	UnsplitGC = roachpb.AdminUnsplitRequest_ORGANIZATION
 )

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1971,10 +1971,6 @@ func (ef *execFactory) ConstructAlterTableUnsplit(
 		return nil, err
 	}
 
-	if !ef.planner.ExecCfg().Codec.ForSystemTenant() {
-		return nil, errorutil.UnsupportedWithMultiTenancy(54254)
-	}
-
 	return &unsplitNode{
 		tableDesc: index.Table().(*optTable).desc,
 		index:     index.(*optIndex).idx,

--- a/pkg/sql/unsplit.go
+++ b/pkg/sql/unsplit.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/oppurpose"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/errors"
@@ -49,7 +50,7 @@ func (n *unsplitNode) Next(params runParams) (bool, error) {
 		return false, err
 	}
 
-	if err := params.extendedEvalCtx.ExecCfg.DB.AdminUnsplit(params.ctx, rowKey); err != nil {
+	if err := params.extendedEvalCtx.ExecCfg.DB.AdminUnsplit(params.ctx, rowKey, oppurpose.UnsplitManual); err != nil {
 		ctx := params.p.EvalContext().FmtCtx(tree.FmtSimple)
 		row.Format(ctx)
 		return false, errors.Wrapf(err, "could not UNSPLIT AT %s", ctx)
@@ -130,7 +131,7 @@ func (n *unsplitAllNode) Next(params runParams) (bool, error) {
 	rowKey := n.run.keys[0]
 	n.run.keys = n.run.keys[1:]
 
-	if err := params.extendedEvalCtx.ExecCfg.DB.AdminUnsplit(params.ctx, rowKey); err != nil {
+	if err := params.extendedEvalCtx.ExecCfg.DB.AdminUnsplit(params.ctx, rowKey, oppurpose.UnsplitManual); err != nil {
 		return false, errors.Wrapf(err, "could not UNSPLIT AT %s", keys.PrettyPrint(nil /* valDirs */, rowKey))
 	}
 


### PR DESCRIPTION
fixes #91390

Move the UNSPLIT AT tenant check from the SQL to KV layer to prepare for tenant permissions work. This check will eventually be replaced by a tenant permissions lookup to determine if the tenant can perform the requested KV operation (AdminUnsplit in this case). `Codec.ForSystemTenant()` checks still exist in the SQL and will be handled in separate PRs.

Release note: None