### PR TITLE
spanconfigsqltranslator: add sqlutil.InternalExecutor to SQLTranslator

### DIFF
--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/BUILD.bazel
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",
         "//pkg/sql/catalog/tabledesc",
+        "//pkg/sql/sqlutil",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/datadriven_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/datadriven_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
@@ -180,10 +181,10 @@ func TestDataDriven(t *testing.T) {
 
 				var records []spanconfig.Record
 				sqlTranslatorFactory := tenant.SpanConfigSQLTranslatorFactory().(*spanconfigsqltranslator.Factory)
-				err := sql.DescsTxn(ctx, &execCfg, func(
-					ctx context.Context, txn *kv.Txn, descsCol *descs.Collection,
+				err := execCfg.InternalExecutorFactory.DescsTxnWithExecutor(ctx, execCfg.DB, nil /* session data */, func(
+					ctx context.Context, txn *kv.Txn, descsCol *descs.Collection, ie sqlutil.InternalExecutor,
 				) error {
-					sqlTranslator := sqlTranslatorFactory.NewSQLTranslator(txn, descsCol)
+					sqlTranslator := sqlTranslatorFactory.NewSQLTranslator(txn, ie, descsCol)
 					var err error
 					records, _, err = sqlTranslator.Translate(ctx, descIDs, generateSystemSpanConfigs)
 					require.NoError(t, err)
@@ -212,10 +213,10 @@ func TestDataDriven(t *testing.T) {
 			case "full-translate":
 				sqlTranslatorFactory := tenant.SpanConfigSQLTranslatorFactory().(*spanconfigsqltranslator.Factory)
 				var records []spanconfig.Record
-				err := sql.DescsTxn(ctx, &execCfg, func(
-					ctx context.Context, txn *kv.Txn, descsCol *descs.Collection,
+				err := execCfg.InternalExecutorFactory.DescsTxnWithExecutor(ctx, execCfg.DB, nil /* session data */, func(
+					ctx context.Context, txn *kv.Txn, descsCol *descs.Collection, ie sqlutil.InternalExecutor,
 				) error {
-					sqlTranslator := sqlTranslatorFactory.NewSQLTranslator(txn, descsCol)
+					sqlTranslator := sqlTranslatorFactory.NewSQLTranslator(txn, ie, descsCol)
 					var err error
 					records, _, err = spanconfig.FullTranslate(ctx, sqlTranslator)
 					require.NoError(t, err)

--- a/pkg/spanconfig/spanconfigreconciler/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigreconciler/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/sql/catalog/descs",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sqlliveness",
+        "//pkg/sql/sqlutil",
         "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/retry",

--- a/pkg/spanconfig/spanconfigsqltranslator/BUILD.bazel
+++ b/pkg/spanconfig/spanconfigsqltranslator/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",
         "//pkg/sql/sem/tree",
+        "//pkg/sql/sqlutil",
         "//pkg/util/hlc",
         "@com_github_cockroachdb_errors//:errors",
     ],


### PR DESCRIPTION
This commit is part of the effort of having an internal executor better bound to its outer txn if there's one.

The next step after this commit is to replace the executor used in `s.ptsProvider.GetState()` in `SQLTranslator.Translate()` to the one hanging off `SQLTranslator`.

Informs: #91004

Release note: None