### PR TITLE
release-22.2.0: metrics: add tsdb persistence to AggHistogram

### DIFF
--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -1221,7 +1221,7 @@ func TestStoreRangeSplitBackpressureWrites(t *testing.T) {
 
 			// Set maxBytes to something small so we can exceed the maximum split
 			// size without adding 2x64MB of data.
-			const maxBytes = 1 << 16
+			const maxBytes = 1 << 17
 			zoneConfig := zonepb.DefaultZoneConfig()
 			zoneConfig.RangeMaxBytes = proto.Int64(maxBytes)
 
@@ -2539,7 +2539,7 @@ func TestUnsplittableRange(t *testing.T) {
 
 	ctx := context.Background()
 	ttl := 1 * time.Hour
-	const maxBytes = 1 << 16
+	const maxBytes = 1 << 17
 	manualClock := hlc.NewHybridManualClock()
 	zoneConfig := zonepb.DefaultZoneConfig()
 	zoneConfig.RangeMaxBytes = proto.Int64(maxBytes)

--- a/pkg/util/metric/aggmetric/histogram.go
+++ b/pkg/util/metric/aggmetric/histogram.go
@@ -31,6 +31,7 @@ type AggHistogram struct {
 var _ metric.Iterable = (*AggHistogram)(nil)
 var _ metric.PrometheusIterable = (*AggHistogram)(nil)
 var _ metric.PrometheusExportable = (*AggHistogram)(nil)
+var _ metric.WindowedHistogram = (*AggHistogram)(nil)
 
 // NewHistogram constructs a new AggHistogram.
 func NewHistogram(
@@ -64,6 +65,21 @@ func (a *AggHistogram) GetMetadata() metric.Metadata { return a.h.GetMetadata() 
 
 // Inspect is part of the metric.Iterable interface.
 func (a *AggHistogram) Inspect(f func(interface{})) { f(a) }
+
+// TotalCountWindowed is part of the metric.WindowedHistogram interface
+func (a *AggHistogram) TotalCountWindowed() int64 {
+	return a.h.TotalCountWindowed()
+}
+
+// TotalSumWindowed is part of the metric.WindowedHistogram interface
+func (a *AggHistogram) TotalSumWindowed() float64 {
+	return a.h.TotalSumWindowed()
+}
+
+// ValueAtQuantileWindowed is part of the metric.WindowedHistogram interface
+func (a *AggHistogram) ValueAtQuantileWindowed(q float64) float64 {
+	return a.h.ValueAtQuantileWindowed(q)
+}
 
 // GetType is part of the metric.PrometheusExportable interface.
 func (a *AggHistogram) GetType() *io_prometheus_client.MetricType {


### PR DESCRIPTION
Backport 1/1 commits from #90769.

/cc @cockroachdb/release

---

Previously, `AggHistogram` instances would not persist their quantiles to tsdb due to a missing interface implementation of `metrics.WindowedHistogram`. This PR adds a trivial implementation that delegates to the aggregate histogram instance within the struct.

This is relatively safe to do even though an `AggHistogram` could contain many children because we are only exporting a single set of aggregate quantiles per-`AggHistogram`. The children are only iterated over via the `PrometheusIterable` interface which is used by the prometheus exporter, but not by the metrics recorder.

NOTE: This backported commit includes a test fix to the `kv` package that was
lifted from https://github.com/cockroachdb/cockroach/pull/88076.

Release note (bug fix, ops change): Previously, certain aggregate histograms would appear in `_status/vars` but not be available for graphing in the DB Console. These are now made available. They include changefeed-related histograms, and row-level-TTL histograms.

Epic: None

Release Justification: Category 3: Fixes for high-priority or high-severity bugs in existing functionality