### PR TITLE
kvserver: reduce GC score threshold for mvcc gc queue

### DIFF
--- a/pkg/kv/kvserver/mvcc_gc_queue_test.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue_test.go
@@ -222,9 +222,9 @@ func TestMVCCGCQueueMakeGCScoreIntentCooldown(t *testing.T) {
 		"just GCed":                {lastGC: now.Add(-1, 0), expectGC: false},
 		"future GC":                {lastGC: now.Add(1, 0), expectGC: false},
 		"MVCC GC ignores cooldown": {lastGC: now.Add(-1, 0), mvccGC: true, expectGC: true},
-		"before GC cooldown":       {lastGC: now.Add(-mvccGCQueueIntentCooldownDuration.Nanoseconds()+1, 0), expectGC: false},
-		"at GC cooldown":           {lastGC: now.Add(-mvccGCQueueIntentCooldownDuration.Nanoseconds(), 0), expectGC: true},
-		"after GC cooldown":        {lastGC: now.Add(-mvccGCQueueIntentCooldownDuration.Nanoseconds()-1, 0), expectGC: true},
+		"before GC cooldown":       {lastGC: now.Add(-mvccGCQueueCooldownDuration.Nanoseconds()+1, 0), expectGC: false},
+		"at GC cooldown":           {lastGC: now.Add(-mvccGCQueueCooldownDuration.Nanoseconds(), 0), expectGC: true},
+		"after GC cooldown":        {lastGC: now.Add(-mvccGCQueueCooldownDuration.Nanoseconds()-1, 0), expectGC: true},
 	}
 	for name, tc := range testcases {
 		tc := tc


### PR DESCRIPTION
Previously mvcc gc queue required score of 2 for data to be collected. This score is a rate of estimated garbage age vs if all garbage was at gc ttl threshold. It was set conservatively high to avoid GC thrashing but this limit could be lowered with a throttling safety added.

Release note: None