### PR TITLE
logictest: fix a couple of nits

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -2,8 +2,6 @@
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-vec-off multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 
 statement ok
-
-statement ok
 CREATE DATABASE multi_region_test_db PRIMARY REGION "ca-central-1" REGIONS "ap-southeast-2", "us-east-1" SURVIVE REGION FAILURE
 
 statement error cannot set LOCALITY on a table in a database that is not multi-region enabled\nHINT: database must first be multi-region enabled using ALTER DATABASE ... SET PRIMARY REGION <region>

--- a/pkg/sql/logictest/testdata/logic_test/distsql_union
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_union
@@ -282,13 +282,10 @@ NULL
 2
 
 query I rowsort
-(SELECT y FROM xyz ORDER BY z) INTERSECT ALL (SELECT y FROM xyz ORDER BY z)
+(SELECT y FROM xyz ORDER BY z) INTERSECT (SELECT y FROM xyz ORDER BY z)
 ----
 NULL
 1
-1
-1
-2
 2
 
 # INTERSECT ALL and INTERSECT with a projection on the result.


### PR DESCRIPTION
This commit removes an empty "statement ok" instruction in one place and adjusts the INTERSECT ALL query to be INTERSECT in another (which was the intention).

Epic: None

Release note: None