### PR TITLE
ui: use relative paths for /uiconfig and /api/v2

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/basePath.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/basePath.ts
@@ -10,6 +10,13 @@
 
 let path = "";
 
+/**
+ * Sets the base URL to use that all API paths are appended to in
+ * the app. When running Cluster UI components embedded elsewhere, this is
+ * helpful to ensure that requests are routed to your particular cluster when
+ * it's not served from the Base URL of your application. This path should
+ * **not** include a trailing slash.
+ */
 export const setBasePath = (basePath: string): string => (path = basePath);
 
 export const getBasePath = (): string => path;

--- a/pkg/ui/workspaces/cluster-ui/src/api/fetchData.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/fetchData.ts
@@ -115,7 +115,7 @@ export function fetchDataJSON<ResponseType, RequestType>(
 
   const basePath = getBasePath();
 
-  return fetch(`${basePath}${path}`, params).then(response => {
+  return fetch(`${basePath}/${path}`, params).then(response => {
     if (!response.ok) {
       throw new RequestError(
         response.statusText,

--- a/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
@@ -60,7 +60,7 @@ export type SqlExecutionErrorMessage = {
   source: { file: string; line: number; function: "string" };
 };
 
-export const SQL_API_PATH = "/api/v2/sql/";
+export const SQL_API_PATH = "api/v2/sql/";
 
 /**
  * executeSql executes the provided SQL statements in a single transaction

--- a/pkg/ui/workspaces/db-console/src/util/api.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.spec.ts
@@ -37,7 +37,7 @@ describe("rest api", function () {
           "Content-Type": "application/json",
           "X-Cockroach-API-Session": "cookie",
         },
-        matcher: clusterUiApi.SQL_API_PATH,
+        matcher: `/${clusterUiApi.SQL_API_PATH}`,
         method: "POST",
         response: (_url: string, requestObj: RequestInit) => {
           expect(JSON.parse(requestObj.body.toString())).toEqual(
@@ -52,7 +52,7 @@ describe("rest api", function () {
       });
 
       return clusterUiApi.getDatabasesList().then(result => {
-        expect(fetchMock.calls(clusterUiApi.SQL_API_PATH).length).toBe(1);
+        expect(fetchMock.calls(`/${clusterUiApi.SQL_API_PATH}`).length).toBe(1);
         expect(result.databases.length).toBe(2);
       });
     });
@@ -60,7 +60,7 @@ describe("rest api", function () {
     it("correctly handles an error", function (done) {
       // Mock out the fetch query to /databases, but return a promise that's never resolved to test the timeout
       fetchMock.mock({
-        matcher: clusterUiApi.SQL_API_PATH,
+        matcher: `/${clusterUiApi.SQL_API_PATH}`,
         method: "POST",
         response: (_url: string, requestObj: RequestInit) => {
           expect(JSON.parse(requestObj.body.toString())).toEqual(
@@ -84,7 +84,7 @@ describe("rest api", function () {
     it("correctly times out", function (done) {
       // Mock out the fetch query to /databases, but return a promise that's never resolved to test the timeout
       fetchMock.mock({
-        matcher: clusterUiApi.SQL_API_PATH,
+        matcher: `/${clusterUiApi.SQL_API_PATH}`,
         method: "POST",
         response: (_url: string, requestObj: RequestInit) => {
           expect(JSON.parse(requestObj.body.toString())).toEqual(
@@ -305,7 +305,7 @@ describe("rest api", function () {
     it("correctly requests events", function () {
       // Mock out the fetch query
       fetchMock.mock({
-        matcher: clusterUiApi.SQL_API_PATH,
+        matcher: `/${clusterUiApi.SQL_API_PATH}`,
         method: "POST",
         response: (_url: string, requestObj: RequestInit) => {
           expect(JSON.parse(requestObj.body.toString())).toEqual({
@@ -329,7 +329,7 @@ describe("rest api", function () {
       });
 
       return clusterUiApi.getNonRedactedEvents().then(result => {
-        expect(fetchMock.calls(clusterUiApi.SQL_API_PATH).length).toBe(1);
+        expect(fetchMock.calls(`/${clusterUiApi.SQL_API_PATH}`).length).toBe(1);
         expect(result.length).toBe(1);
       });
     });
@@ -339,7 +339,7 @@ describe("rest api", function () {
 
       // Mock out the fetch query
       fetchMock.mock({
-        matcher: clusterUiApi.SQL_API_PATH,
+        matcher: `/${clusterUiApi.SQL_API_PATH}`,
         method: "POST",
         response: (_url: string, requestObj: RequestInit) => {
           expect(JSON.parse(requestObj.body.toString())).toEqual({
@@ -363,7 +363,7 @@ describe("rest api", function () {
       });
 
       return clusterUiApi.getNonRedactedEvents(req).then(result => {
-        expect(fetchMock.calls(clusterUiApi.SQL_API_PATH).length).toBe(1);
+        expect(fetchMock.calls(`/${clusterUiApi.SQL_API_PATH}`).length).toBe(1);
         expect(result.length).toBe(1);
       });
     });
@@ -371,7 +371,7 @@ describe("rest api", function () {
     it("correctly handles an error", function (done) {
       // Mock out the fetch query, but return a 500 status code
       fetchMock.mock({
-        matcher: clusterUiApi.SQL_API_PATH,
+        matcher: `/${clusterUiApi.SQL_API_PATH}`,
         method: "POST",
         response: (_url: string, requestObj: RequestInit) => {
           expect(JSON.parse(requestObj.body.toString())).toEqual({
@@ -396,7 +396,7 @@ describe("rest api", function () {
     it("correctly times out", function (done) {
       // Mock out the fetch query, but return a promise that's never resolved to test the timeout
       fetchMock.mock({
-        matcher: clusterUiApi.SQL_API_PATH,
+        matcher: `/${clusterUiApi.SQL_API_PATH}`,
         method: "POST",
         response: (_url: string, requestObj: RequestInit) => {
           expect(JSON.parse(requestObj.body.toString())).toEqual({

--- a/pkg/ui/workspaces/db-console/src/util/dataFromServer.ts
+++ b/pkg/ui/workspaces/db-console/src/util/dataFromServer.ts
@@ -33,7 +33,7 @@ declare global {
 }
 
 export function fetchDataFromServer(): Promise<DataFromServer> {
-  return fetch("/uiconfig", {
+  return fetch("uiconfig", {
     method: "GET",
     headers: {
       Accept: "application/json",


### PR DESCRIPTION
Previously, we were using absolute paths for newer endpoints, mostly by accident, not by design. When the DB Console and CRDB were behind a proxy with a different Base URL than `/`, these absolute paths would fail since they were not relative to the new base. This would cause various DB Console features to break.

This change modifies the paths to be relative in order to adapt to various base paths.

Resolves: #91429

Epic: None

Release note (ops change): Fixed a bug that would break certain DB Console requests when CRDB was run behind a proxy that changed the base URL.