### PR TITLE
multitenant: add admin function `RangeIterator failed to seek` test cases

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1539,6 +1539,10 @@ type TenantTestingKnobs struct {
 	// TABLE ... SPLIT AT and SCATTER SQL commands.
 	AllowSplitAndScatter bool
 
+	// SkipSQLSystemTentantCheck is a temporary knob to test which admin functions fail for secondary tenants.
+	// TODO(ewall): Remove when https://github.com/cockroachdb/cockroach/issues/91434 is fixed.
+	SkipSQLSystemTentantCheck bool
+
 	// BeforeCheckingForDescriptorIDSequence, if set, is called before
 	// the connExecutor checks for the presence of system.descriptor_id_seq after
 	// handling a system tenant descriptor ID generator migration error.
@@ -3487,4 +3491,14 @@ func (cfg *ExecutorConfig) GetRowMetrics(internal bool) *rowinfra.Metrics {
 		return cfg.InternalRowMetrics
 	}
 	return cfg.RowMetrics
+}
+
+// IsSystemTenant returns true either if TenantTestingKnobs.SkipSQLSystemTentantCheck is true
+// or if the ExecutorConfig tenant is the system tenant.
+func (cfg *ExecutorConfig) IsSystemTenant() bool {
+	knobs := cfg.TenantTestingKnobs
+	if knobs != nil && knobs.SkipSQLSystemTentantCheck {
+		return true
+	}
+	return cfg.Codec.ForSystemTenant()
 }

--- a/pkg/sql/multitenant_admin_function_test.go
+++ b/pkg/sql/multitenant_admin_function_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 const createTable = "CREATE TABLE t(i int PRIMARY KEY);"
+const rangeErrorMessage = "RangeIterator failed to seek"
 
 func createTestServer(t *testing.T) (serverutils.TestServerInterface, func()) {
 	testCluster := serverutils.StartNewTestCluster(t, 1, base.TestClusterArgs{})
@@ -43,13 +44,17 @@ func createSystemTenantDB(t *testing.T, testServer serverutils.TestServerInterfa
 }
 
 func createSecondaryTenantDB(
-	t *testing.T, testServer serverutils.TestServerInterface, allowSplitAndScatter bool,
+	t *testing.T,
+	testServer serverutils.TestServerInterface,
+	allowSplitAndScatter bool,
+	skipSQLSystemTenantCheck bool,
 ) *gosql.DB {
 	_, db := serverutils.StartTenant(
 		t, testServer, base.TestTenantArgs{
 			TestingKnobs: base.TestingKnobs{
 				TenantTestingKnobs: &TenantTestingKnobs{
-					AllowSplitAndScatter: allowSplitAndScatter,
+					AllowSplitAndScatter:      allowSplitAndScatter,
+					SkipSQLSystemTentantCheck: skipSQLSystemTenantCheck,
 				},
 			},
 			TenantID: serverutils.TestTenantID(),
@@ -63,32 +68,63 @@ func TestMultiTenantAdminFunction(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	testCases := []struct {
-		desc                 string
-		setup                string
-		setups               []string
-		query                string
-		errorMessage         string
-		allowSplitAndScatter bool
+		desc                     string
+		setup                    string
+		setups                   []string
+		query                    string
+		errorMessage             string
+		allowSplitAndScatter     bool
+		skipSQLSystemTenantCheck bool
 	}{
 		{
 			desc:  "ALTER RANGE x RELOCATE LEASE",
 			query: "ALTER RANGE (SELECT min(range_id) FROM [SHOW RANGES FROM TABLE t]) RELOCATE LEASE TO 1;",
 		},
 		{
+			desc:                     "ALTER RANGE x RELOCATE LEASE SkipSQLSystemTenantCheck",
+			query:                    "ALTER RANGE (SELECT min(range_id) FROM [SHOW RANGES FROM TABLE t]) RELOCATE LEASE TO 1;",
+			errorMessage:             rangeErrorMessage,
+			skipSQLSystemTenantCheck: true,
+		},
+		{
 			desc:  "ALTER RANGE RELOCATE LEASE",
 			query: "ALTER RANGE RELOCATE LEASE TO 1 FOR (SELECT min(range_id) FROM [SHOW RANGES FROM TABLE t]);",
+		},
+		{
+			desc:                     "ALTER RANGE RELOCATE LEASE SkipSQLSystemTenantCheck",
+			query:                    "ALTER RANGE RELOCATE LEASE TO 1 FOR (SELECT min(range_id) FROM [SHOW RANGES FROM TABLE t]);",
+			errorMessage:             rangeErrorMessage,
+			skipSQLSystemTenantCheck: true,
 		},
 		{
 			desc:  "ALTER RANGE x RELOCATE VOTERS",
 			query: "ALTER RANGE (SELECT min(range_id) FROM [SHOW RANGES FROM TABLE t]) RELOCATE VOTERS FROM 1 TO 1;",
 		},
 		{
+			desc:                     "ALTER RANGE x RELOCATE VOTERS SkipSQLSystemTenantCheck",
+			query:                    "ALTER RANGE (SELECT min(range_id) FROM [SHOW RANGES FROM TABLE t]) RELOCATE VOTERS FROM 1 TO 1;",
+			errorMessage:             rangeErrorMessage,
+			skipSQLSystemTenantCheck: true,
+		},
+		{
 			desc:  "ALTER RANGE RELOCATE VOTERS",
 			query: "ALTER RANGE RELOCATE VOTERS FROM 1 TO 1 FOR (SELECT min(range_id) FROM [SHOW RANGES FROM TABLE t]);",
 		},
 		{
+			desc:                     "ALTER RANGE RELOCATE VOTERS SkipSQLSystemTenantCheck",
+			query:                    "ALTER RANGE RELOCATE VOTERS FROM 1 TO 1 FOR (SELECT min(range_id) FROM [SHOW RANGES FROM TABLE t]);",
+			errorMessage:             rangeErrorMessage,
+			skipSQLSystemTenantCheck: true,
+		},
+		{
 			desc:  "ALTER TABLE x EXPERIMENTAL_RELOCATE LEASE",
 			query: "ALTER TABLE t EXPERIMENTAL_RELOCATE LEASE SELECT 1, 1;",
+		},
+		{
+			desc:                     "ALTER TABLE x EXPERIMENTAL_RELOCATE LEASE SkipSQLSystemTenantCheck",
+			query:                    "ALTER TABLE t EXPERIMENTAL_RELOCATE LEASE SELECT 1, 1;",
+			errorMessage:             rangeErrorMessage,
+			skipSQLSystemTenantCheck: true,
 		},
 		{
 			desc:  "ALTER TABLE x EXPERIMENTAL_RELOCATE VOTERS",
@@ -128,9 +164,22 @@ func TestMultiTenantAdminFunction(t *testing.T) {
 			query: "ALTER TABLE t UNSPLIT ALL;",
 		},
 		{
+			desc:                     "ALTER TABLE x UNSPLIT ALL SkipSQLSystemTenantCheck",
+			query:                    "ALTER TABLE t UNSPLIT ALL;",
+			errorMessage:             rangeErrorMessage,
+			skipSQLSystemTenantCheck: true,
+		},
+		{
 			desc:  "ALTER INDEX x UNSPLIT ALL",
 			setup: "CREATE INDEX idx on t(i);",
 			query: "ALTER INDEX t@idx UNSPLIT ALL;",
+		},
+		{
+			desc:                     "ALTER INDEX x UNSPLIT ALL SkipSQLSystemTenantCheck",
+			setup:                    "CREATE INDEX idx on t(i);",
+			query:                    "ALTER INDEX t@idx UNSPLIT ALL;",
+			errorMessage:             rangeErrorMessage,
+			skipSQLSystemTenantCheck: true,
 		},
 		{
 			desc:  "ALTER TABLE x SCATTER",
@@ -180,7 +229,7 @@ func TestMultiTenantAdminFunction(t *testing.T) {
 			func() {
 				testServer, cleanup := createTestServer(t)
 				defer cleanup()
-				db := createSecondaryTenantDB(t, testServer, tc.allowSplitAndScatter)
+				db := createSecondaryTenantDB(t, testServer, tc.allowSplitAndScatter, tc.skipSQLSystemTenantCheck)
 				err := execQueries(db)
 				require.Error(t, err)
 				errorMessage := tc.errorMessage
@@ -223,8 +272,14 @@ func TestTruncateTable(t *testing.T) {
 	func() {
 		testServer, cleanup := createTestServer(t)
 		defer cleanup()
-		db := createSecondaryTenantDB(t, testServer, true /* allowSplitAndScatter */)
+		db := createSecondaryTenantDB(
+			t,
+			testServer,
+			true,  /* allowSplitAndScatter */
+			false, /* skipSQLSystemTenantCheck */
+		)
 		err := execQueries(db)
 		require.Error(t, err)
+		require.Contains(t, err.Error(), rangeErrorMessage)
 	}()
 }

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1988,7 +1988,7 @@ func (ef *execFactory) ConstructAlterTableUnsplitAll(index cat.Index) (exec.Node
 		return nil, err
 	}
 
-	if !ef.planner.ExecCfg().Codec.ForSystemTenant() {
+	if !ef.planner.ExecCfg().IsSystemTenant() {
 		return nil, errorutil.UnsupportedWithMultiTenancy(54254)
 	}
 
@@ -2002,7 +2002,7 @@ func (ef *execFactory) ConstructAlterTableUnsplitAll(index cat.Index) (exec.Node
 func (ef *execFactory) ConstructAlterTableRelocate(
 	index cat.Index, input exec.Node, relocateSubject tree.RelocateSubject,
 ) (exec.Node, error) {
-	if !ef.planner.ExecCfg().Codec.ForSystemTenant() {
+	if !ef.planner.ExecCfg().IsSystemTenant() {
 		return nil, errorutil.UnsupportedWithMultiTenancy(54250)
 	}
 
@@ -2021,7 +2021,7 @@ func (ef *execFactory) ConstructAlterRangeRelocate(
 	toStoreID tree.TypedExpr,
 	fromStoreID tree.TypedExpr,
 ) (exec.Node, error) {
-	if !ef.planner.ExecCfg().Codec.ForSystemTenant() {
+	if !ef.planner.ExecCfg().IsSystemTenant() {
 		return nil, errorutil.UnsupportedWithMultiTenancy(54250)
 	}
 


### PR DESCRIPTION
refs #91434

This change adds test cases for admin functions (see #91434) that fail because of a `RangeIterator failed to seek` error once the multitenant check is bypassed. This needs to be addressed before those admin functions can be supported for secondary tenants.

Release note: None