### PR TITLE
server, sql: version gate idx recs in persisted stats iterator, status server

### DIFF
--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
@@ -380,7 +381,7 @@ func getStatementDetails(
 	if err != nil {
 		return nil, serverError(ctx, err)
 	}
-	statementStatisticsPerPlanHash, err := getStatementDetailsPerPlanHash(ctx, ie, whereClause, args, limit)
+	statementStatisticsPerPlanHash, err := getStatementDetailsPerPlanHash(ctx, ie, whereClause, args, limit, settings)
 	if err != nil {
 		return nil, serverError(ctx, err)
 	}
@@ -702,9 +703,28 @@ func getStatementDetailsPerPlanHash(
 	whereClause string,
 	args []interface{},
 	limit int64,
+	settings *cluster.Settings,
 ) ([]serverpb.StatementDetailsResponse_CollectedStatementGroupedByPlanHash, error) {
+
 	query := fmt.Sprintf(
 		`SELECT
+				plan_hash,
+				(statistics -> 'statistics' -> 'planGists'->>0) as plan_gist,
+				crdb_internal.merge_stats_metadata(array_agg(metadata)) AS metadata,
+				crdb_internal.merge_statement_stats(array_agg(statistics)) AS statistics,
+				max(sampled_plan) as sampled_plan,
+				aggregation_interval
+		FROM crdb_internal.statement_statistics %s
+		GROUP BY
+				plan_hash,
+				plan_gist,
+				aggregation_interval
+		LIMIT $%d`, whereClause, len(args)+1)
+	expectedNumDatums := 6
+
+	if settings.Version.IsActive(ctx, clusterversion.V22_2AlterSystemStatementStatisticsAddIndexRecommendations) {
+		query = fmt.Sprintf(
+			`SELECT
 				plan_hash,
 				(statistics -> 'statistics' -> 'planGists'->>0) as plan_gist,
 				crdb_internal.merge_stats_metadata(array_agg(metadata)) AS metadata,
@@ -719,9 +739,10 @@ func getStatementDetailsPerPlanHash(
 				aggregation_interval,
 				index_recommendations
 		LIMIT $%d`, whereClause, len(args)+1)
+		expectedNumDatums = 7
+	}
 
 	args = append(args, limit)
-	const expectedNumDatums = 7
 
 	it, err := ie.QueryIteratorEx(ctx, "combined-stmts-details-by-plan-hash", nil,
 		sessiondata.InternalExecutorOverride{

--- a/pkg/sql/sqlstats/persistedsqlstats/stmt_reader.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/stmt_reader.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -82,7 +83,7 @@ func (s *PersistedSQLStats) IterateStatementStats(
 func (s *PersistedSQLStats) persistedStmtStatsIter(
 	ctx context.Context, options *sqlstats.IteratorOptions,
 ) (iter sqlutil.InternalRows, expectedColCnt int, err error) {
-	query, expectedColCnt := s.getFetchQueryForStmtStatsTable(options)
+	query, expectedColCnt := s.getFetchQueryForStmtStatsTable(ctx, options)
 
 	persistedIter, err := s.cfg.InternalExecutor.QueryIteratorEx(
 		ctx,
@@ -100,7 +101,7 @@ func (s *PersistedSQLStats) persistedStmtStatsIter(
 }
 
 func (s *PersistedSQLStats) getFetchQueryForStmtStatsTable(
-	options *sqlstats.IteratorOptions,
+	ctx context.Context, options *sqlstats.IteratorOptions,
 ) (query string, colCnt int) {
 	selectedColumns := []string{
 		"aggregated_ts",
@@ -112,7 +113,10 @@ func (s *PersistedSQLStats) getFetchQueryForStmtStatsTable(
 		"statistics",
 		"plan",
 		"agg_interval",
-		"index_recommendations",
+	}
+
+	if s.cfg.Settings.Version.IsActive(ctx, clusterversion.V22_2AlterSystemStatementStatisticsAddIndexRecommendations) {
+		selectedColumns = append(selectedColumns, "index_recommendations")
 	}
 
 	// [1]: selection columns


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/91346.

This PR version gates the persisted stats iterator and status server statement details queries.

Release note: None