### PR TITLE
colexecop: remove stale TODO

### DIFF
--- a/pkg/sql/colexecop/operator.go
+++ b/pkg/sql/colexecop/operator.go
@@ -157,11 +157,6 @@ type Closer interface {
 	// (wherever necessary) by the implementation. This is so since the span in
 	// the context from Init() might be already finished when Close() is called
 	// whereas the argument context will contain an unfinished span.
-	//
-	// If this Closer is an execinfra.Releasable, the implementation must be
-	// safe to execute even after Release() was called.
-	// TODO(yuzefovich): refactor this because the Release()'d objects should
-	// not be used anymore.
 	Close(context.Context) error
 }
 

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -682,9 +682,6 @@ func (s *ColIndexJoin) closeInternal() {
 	// span.
 	ctx := s.EnsureCtx()
 	s.cf.Close(ctx)
-	if s.spanAssembler != nil {
-		// spanAssembler can be nil if Release() has already been called.
-		s.spanAssembler.Close()
-	}
+	s.spanAssembler.Close()
 	s.batch = nil
 }


### PR DESCRIPTION
This commit removes now-stale TODO about `Closer.Close` being safe to execute even after `Release` call. The root cause was the intertwining of planning and execution infrastructure and has been recently addressed in #89052.

Epic: None

Release note: None