### PR TITLE
lease: don't delete descriptor entries on draining

### DIFF
--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -1036,7 +1036,7 @@ func (m *Manager) SetDraining(
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	for id, t := range m.mu.descriptors {
+	for _, t := range m.mu.descriptors {
 		leases := func() []*storedLease {
 			t.mu.Lock()
 			defer t.mu.Unlock()
@@ -1045,7 +1045,6 @@ func (m *Manager) SetDraining(
 		for _, l := range leases {
 			releaseLease(ctx, l, m)
 		}
-		delete(m.mu.descriptors, id)
 		if reporter != nil {
 			// Report progress through the Drain RPC.
 			reporter(len(leases), "descriptor leases")


### PR DESCRIPTION
Other code assumes that entries don't get removed. Until that is changed, it's hazardous to remove the entries. This line was added as a good-faith fix as part of #90530.

Release note: None