### PR TITLE
colexec: protect columnarizer when closing not started input

### DIFF
--- a/pkg/sql/colexec/columnarizer.go
+++ b/pkg/sql/colexec/columnarizer.go
@@ -300,6 +300,13 @@ func (c *Columnarizer) Close(context.Context) error {
 		return nil
 	}
 	c.helper.Release()
+	if c.Ctx == nil {
+		// The columnarizer wasn't initialized, so the wrapped processors might
+		// not have been started leaving them in a state unsafe for the
+		// InternalClose, so we skip that. Mostly likely this happened because a
+		// panic was encountered in Init.
+		return nil
+	}
 	c.InternalClose()
 	return nil
 }


### PR DESCRIPTION
This commit makes sure that the columnarizer calls `InternalClose` only if it has been initialized. Previously, if `Columnarizer.Init` wasn't performed (most likely due to a panic in `Init` of another operator), the columnarizer's input would not be started, so when `InternalClose` called `input.ConsumerClosed`, that could lead to a nil pointer panic since `input.Ctx` would be `nil` if the input tried to do some logging (some processors do that). We now protect against this by short-circuiting `InternalClose` call altogether, similar to what we do in `Columnarizer.DrainMeta`. This makes it so that the columnarizer satisfies `Closer.Close` contract properly.

Fixes: #84902.

Release note: None