### PR TITLE
multiregionccl: fix recently introduced flake

### DIFF
--- a/pkg/ccl/multiregionccl/multiregionccltestutils/testutils.go
+++ b/pkg/ccl/multiregionccl/multiregionccltestutils/testutils.go
@@ -61,25 +61,28 @@ func WithUseDatabase(db string) MultiRegionTestClusterParamsOption {
 func TestingCreateMultiRegionCluster(
 	t testing.TB, numServers int, knobs base.TestingKnobs, opts ...MultiRegionTestClusterParamsOption,
 ) (*testcluster.TestCluster, *gosql.DB, func()) {
-	regionNames := make(map[string]int, numServers)
+	regionNames := make([]string, numServers)
 	for i := 0; i < numServers; i++ {
 		// "us-east1", "us-east2"...
-		regionNames[fmt.Sprintf("us-east%d", i+1)] = 1
+		regionNames[i] = fmt.Sprintf("us-east%d", i+1)
 	}
 
 	return TestingCreateMultiRegionClusterWithRegionList(
 		t,
 		regionNames,
+		1, /* serversPerRegion */
 		knobs,
 		opts...)
 }
 
-// TestingCreateMultiRegionClusterWithRegionList creates a test cluster with numServers number
-// of nodes and the provided testing knobs applied to each of the nodes. Every
-// node is placed in its own locality, named "us-east1", "us-east2", and so on.
+// TestingCreateMultiRegionClusterWithRegionList creates a test cluster with
+// serversPerRegion number of nodes in each of the provided regions and the
+// provided testing knobs applied to each of the nodes. Every node is placed in
+// its own locality, named according to the given region names.
 func TestingCreateMultiRegionClusterWithRegionList(
 	t testing.TB,
-	regionToNumServers map[string]int,
+	regionNames []string,
+	serversPerRegion int,
 	knobs base.TestingKnobs,
 	opts ...MultiRegionTestClusterParamsOption,
 ) (*testcluster.TestCluster, *gosql.DB, func()) {
@@ -91,8 +94,8 @@ func TestingCreateMultiRegionClusterWithRegionList(
 	}
 
 	totalServerCount := 0
-	for region, numServers := range regionToNumServers {
-		for i := 0; i < numServers; i++ {
+	for _, region := range regionNames {
+		for i := 0; i < serversPerRegion; i++ {
 			serverArgs[totalServerCount] = base.TestServerArgs{
 				Knobs:         knobs,
 				ExternalIODir: params.baseDir,

--- a/pkg/ccl/multiregionccl/region_test.go
+++ b/pkg/ccl/multiregionccl/region_test.go
@@ -45,13 +45,10 @@ func TestMultiRegionDatabaseStats(t *testing.T) {
 	ctx := context.Background()
 	knobs := base.TestingKnobs{}
 
-	regionToNumServers := make(map[string]int, 6)
-	regionToNumServers["us-east"] = 3
-	regionToNumServers["us-west"] = 3
-
 	tc, db, cleanup := multiregionccltestutils.TestingCreateMultiRegionClusterWithRegionList(
 		t,
-		regionToNumServers, /* numServers */
+		[]string{"us-east", "us-west"},
+		3, /* serversPerRegion */
 		knobs,
 		multiregionccltestutils.WithUseDatabase("d"),
 	)


### PR DESCRIPTION
This commit fixes a flake introduced in
20fc3ae6103d077b059f2b55be80fc063a7c28be where the order of iteration of the map of region names was made non-deterministic resulting in unexpected order of regions relative to the node IDs.

Fixes: #91415.

Release note: None