### PR TITLE
allocator: refactor StorePool usage to interface

### DIFF
--- a/pkg/kv/kvserver/allocation_op.go
+++ b/pkg/kv/kvserver/allocation_op.go
@@ -27,7 +27,7 @@ type AllocationOp interface {
 	trackPlanningMetrics()
 	// applyImpact updates the given storepool to reflect the result of
 	// applying this operation.
-	applyImpact(storepool *storepool.StorePool)
+	applyImpact(storepool storepool.AllocatorStorePool)
 	// lhBeingRemoved returns true when the leaseholder is will be removed if
 	// this operation succeeds, otherwise false.
 	lhBeingRemoved() bool
@@ -49,7 +49,7 @@ func (o AllocationTransferLeaseOp) lhBeingRemoved() bool {
 	return true
 }
 
-func (o AllocationTransferLeaseOp) applyImpact(storepool *storepool.StorePool) {
+func (o AllocationTransferLeaseOp) applyImpact(storepool storepool.AllocatorStorePool) {
 	// TODO(kvoli): Currently the local storepool is updated directly in the
 	// lease transfer call, rather than in this function. Move the storepool
 	// tracking from rq.TransferLease to this function once #89771 is merged.
@@ -89,7 +89,7 @@ func (o AllocationChangeReplicasOp) lhBeingRemoved() bool {
 
 // applyEstimatedImpact updates the given storepool to reflect the result
 // of applying this operation.
-func (o AllocationChangeReplicasOp) applyImpact(storepool *storepool.StorePool) {
+func (o AllocationChangeReplicasOp) applyImpact(storepool storepool.AllocatorStorePool) {
 	for _, chg := range o.chgs {
 		storepool.UpdateLocalStoreAfterRebalance(chg.Target.StoreID, o.usage, chg.ChangeType)
 	}
@@ -109,16 +109,16 @@ type AllocationFinalizeAtomicReplicationOp struct{}
 
 // TODO(kvoli): This always returns false, however it is possible that the LH
 // may have been removed here.
-func (o AllocationFinalizeAtomicReplicationOp) lhBeingRemoved() bool                       { return false }
-func (o AllocationFinalizeAtomicReplicationOp) applyImpact(storepool *storepool.StorePool) {}
-func (o AllocationFinalizeAtomicReplicationOp) trackPlanningMetrics()                      {}
+func (o AllocationFinalizeAtomicReplicationOp) lhBeingRemoved() bool                               { return false }
+func (o AllocationFinalizeAtomicReplicationOp) applyImpact(storepool storepool.AllocatorStorePool) {}
+func (o AllocationFinalizeAtomicReplicationOp) trackPlanningMetrics()                              {}
 
 // AllocationNoop represents no operation.
 type AllocationNoop struct{}
 
-func (o AllocationNoop) lhBeingRemoved() bool                       { return false }
-func (o AllocationNoop) applyImpact(storepool *storepool.StorePool) {}
-func (o AllocationNoop) trackPlanningMetrics()                      {}
+func (o AllocationNoop) lhBeingRemoved() bool                               { return false }
+func (o AllocationNoop) applyImpact(storepool storepool.AllocatorStorePool) {}
+func (o AllocationNoop) trackPlanningMetrics()                              {}
 
 // effectBuilder is a utility struct to track a list of effects, which may be
 // used to construct a single effect function that in turn calls all tracked

--- a/pkg/kv/kvserver/allocator/allocatorimpl/test_helpers.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/test_helpers.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/storepool"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
@@ -36,11 +37,12 @@ func CreateTestAllocator(
 func CreateTestAllocatorWithKnobs(
 	ctx context.Context, numNodes int, deterministic bool, knobs *allocator.TestingKnobs,
 ) (*stop.Stopper, *gossip.Gossip, *storepool.StorePool, Allocator, *timeutil.ManualTime) {
-	stopper, g, manual, storePool, _ := storepool.CreateTestStorePool(ctx,
+	st := cluster.MakeTestingClusterSettings()
+	stopper, g, manual, storePool, _ := storepool.CreateTestStorePool(ctx, st,
 		storepool.TestTimeUntilStoreDeadOff, deterministic,
 		func() int { return numNodes },
 		livenesspb.NodeLivenessStatus_LIVE)
-	a := MakeAllocator(storePool, func(string) (time.Duration, bool) {
+	a := MakeAllocator(st, storePool, func(string) (time.Duration, bool) {
 		return 0, true
 	}, knobs)
 	return stopper, g, storePool, a, manual

--- a/pkg/kv/kvserver/allocator/storepool/BUILD.bazel
+++ b/pkg/kv/kvserver/allocator/storepool/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/rpc",
         "//pkg/settings",
         "//pkg/settings/cluster",
+        "//pkg/util",
         "//pkg/util/hlc",
         "//pkg/util/humanizeutil",
         "//pkg/util/log",
@@ -40,6 +41,7 @@ go_test(
     deps = [
         "//pkg/kv/kvserver/liveness/livenesspb",
         "//pkg/roachpb",
+        "//pkg/settings/cluster",
         "//pkg/testutils/gossiputil",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",

--- a/pkg/kv/kvserver/allocator/storepool/test_helpers.go
+++ b/pkg/kv/kvserver/allocator/storepool/test_helpers.go
@@ -71,6 +71,7 @@ func (m *MockNodeLiveness) NodeLivenessFunc(
 // tests. Stopper must be stopped by the caller.
 func CreateTestStorePool(
 	ctx context.Context,
+	st *cluster.Settings,
 	timeUntilStoreDeadValue time.Duration,
 	deterministic bool,
 	nodeCount NodeCountFunc,
@@ -79,7 +80,6 @@ func CreateTestStorePool(
 	stopper := stop.NewStopper()
 	mc := timeutil.NewManualTime(timeutil.Unix(0, 123))
 	clock := hlc.NewClock(mc, time.Nanosecond /* maxOffset */)
-	st := cluster.MakeTestingClusterSettings()
 	ambientCtx := log.MakeTestingAmbientContext(stopper.Tracer())
 	rpcContext := rpc.NewContext(ctx,
 		rpc.ContextOptions{

--- a/pkg/kv/kvserver/allocator_impl_test.go
+++ b/pkg/kv/kvserver/allocator_impl_test.go
@@ -269,13 +269,14 @@ func TestAllocatorThrottled(t *testing.T) {
 
 	// Finally, set that store to be throttled and ensure we don't send the
 	// replica to purgatory.
-	a.StorePool.DetailsMu.Lock()
-	storeDetail, ok := a.StorePool.DetailsMu.StoreDetails[singleStore[0].StoreID]
+	storePool := a.StorePool.(*storepool.StorePool)
+	storePool.DetailsMu.Lock()
+	storeDetail, ok := storePool.DetailsMu.StoreDetails[singleStore[0].StoreID]
 	if !ok {
 		t.Fatalf("store:%d was not found in the store pool", singleStore[0].StoreID)
 	}
 	storeDetail.ThrottledUntil = timeutil.Now().Add(24 * time.Hour)
-	a.StorePool.DetailsMu.Unlock()
+	storePool.DetailsMu.Unlock()
 	_, _, err = a.AllocateVoter(ctx, simpleSpanConfig, []roachpb.ReplicaDescriptor{}, nil, allocatorimpl.Dead)
 	if _, ok := IsPurgatoryError(err); ok {
 		t.Fatalf("expected a non purgatory error, got: %+v", err)

--- a/pkg/kv/kvserver/asim/state/helpers.go
+++ b/pkg/kv/kvserver/asim/state/helpers.go
@@ -55,7 +55,7 @@ func TestingSetRangeQPS(s State, rangeID RangeID, qps float64) bool {
 // for configuration.
 func NewStorePool(
 	nodeCountFn storepool.NodeCountFunc, nodeLivenessFn storepool.NodeLivenessFunc, hlc *hlc.Clock,
-) *storepool.StorePool {
+) (*storepool.StorePool, *cluster.Settings) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
 
@@ -73,7 +73,7 @@ func NewStorePool(
 		nodeLivenessFn,
 		/* deterministic */ true,
 	)
-	return sp
+	return sp, st
 }
 
 // OffsetTick offsets start time by adding tick number of seconds to it.

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1219,10 +1219,14 @@ func NewStore(
 		ioThresholds: &iot,
 	}
 	s.ioThreshold.t = &admissionpb.IOThreshold{}
+	var allocatorStorePool storepool.AllocatorStorePool
+	if cfg.StorePool != nil {
+		allocatorStorePool = cfg.StorePool
+	}
 	if cfg.RPCContext != nil {
-		s.allocator = allocatorimpl.MakeAllocator(cfg.StorePool, cfg.RPCContext.RemoteClocks.Latency, cfg.TestingKnobs.AllocatorKnobs)
+		s.allocator = allocatorimpl.MakeAllocator(cfg.Settings, allocatorStorePool, cfg.RPCContext.RemoteClocks.Latency, cfg.TestingKnobs.AllocatorKnobs)
 	} else {
-		s.allocator = allocatorimpl.MakeAllocator(cfg.StorePool, func(string) (time.Duration, bool) {
+		s.allocator = allocatorimpl.MakeAllocator(cfg.Settings, allocatorStorePool, func(string) (time.Duration, bool) {
 			return 0, false
 		}, cfg.TestingKnobs.AllocatorKnobs)
 	}

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -258,7 +258,7 @@ func (sr *StoreRebalancer) Start(ctx context.Context, stopper *stop.Stopper) {
 func (sr *StoreRebalancer) scorerOptions(ctx context.Context) *allocatorimpl.QPSScorerOptions {
 	return &allocatorimpl.QPSScorerOptions{
 		StoreHealthOptions:    sr.allocator.StoreHealthOptions(ctx),
-		Deterministic:         sr.allocator.StorePool.Deterministic,
+		Deterministic:         sr.allocator.StorePool.IsDeterministic(),
 		QPSRebalanceThreshold: allocator.QPSRebalanceThreshold.Get(&sr.st.SV),
 		MinRequiredQPSDiff:    allocator.MinQPSDifferenceForTransfers.Get(&sr.st.SV),
 	}
@@ -616,7 +616,7 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 	ctx context.Context, rctx *RebalanceContext,
 ) (CandidateReplica, roachpb.ReplicaDescriptor, []CandidateReplica) {
 	var considerForRebalance []CandidateReplica
-	now := sr.allocator.StorePool.Clock.NowAsClockTimestamp()
+	now := sr.allocator.StorePool.Clock().NowAsClockTimestamp()
 	for {
 		if len(rctx.hottestRanges) == 0 {
 			return nil, roachpb.ReplicaDescriptor{}, considerForRebalance
@@ -728,7 +728,7 @@ type rangeRebalanceContext struct {
 func (sr *StoreRebalancer) chooseRangeToRebalance(
 	ctx context.Context, rctx *RebalanceContext,
 ) (candidateReplica CandidateReplica, voterTargets, nonVoterTargets []roachpb.ReplicationTarget) {
-	now := sr.allocator.StorePool.Clock.NowAsClockTimestamp()
+	now := sr.allocator.StorePool.Clock().NowAsClockTimestamp()
 	if len(rctx.rebalanceCandidates) == 0 && len(rctx.hottestRanges) >= 0 {
 		// NB: In practice, the rebalanceCandidates will be populated with
 		// hottest ranges by the preceeding function call, rebalance leases.


### PR DESCRIPTION
This change refactors the usage of `StorePool` in the allocator to a new interface, `AllocatorStorePool`, in order to be able to utilize a store pool with overriden liveness to properly evaluate decommission pre-flight checks.

Part of #91570.

Release note: None