### PR TITLE
backupccl: rewrite database names in views with new_db_name

### DIFF
--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -2003,9 +2003,14 @@ func doRestorePlan(
 		types = append(types, desc)
 	}
 
+	overrideDBName := intoDB
+	if newDBName != "" {
+		overrideDBName = newDBName
+	}
+
 	// We attempt to rewrite ID's in the collected type and table descriptors
 	// to catch errors during this process here, rather than in the job itself.
-	if err := rewrite.TableDescs(tables, descriptorRewrites, intoDB); err != nil {
+	if err := rewrite.TableDescs(tables, descriptorRewrites, overrideDBName); err != nil {
 		return err
 	}
 	if err := rewrite.DatabaseDescs(databases, descriptorRewrites); err != nil {
@@ -2033,7 +2038,7 @@ func doRestorePlan(
 		BackupLocalityInfo: localityInfo,
 		TableDescs:         encodedTables,
 		Tenants:            tenants,
-		OverrideDB:         intoDB,
+		OverrideDB:         overrideDBName,
 		DescriptorCoverage: restoreStmt.DescriptorCoverage,
 		Encryption:         encryption,
 		RevalidateIndexes:  revalidateIndexes,

--- a/pkg/ccl/backupccl/testdata/backup-restore/views
+++ b/pkg/ccl/backupccl/testdata/backup-restore/views
@@ -1,0 +1,56 @@
+# Make sure that db names are rewritten in a view restored to a new db name.
+new-server name=s
+----
+
+exec-sql
+CREATE DATABASE db1;
+USE db1;
+CREATE SCHEMA sc1;
+CREATE TABLE sc1.tbl1(a INT PRIMARY KEY);
+CREATE VIEW sc1.v1 AS SELECT a FROM sc1.tbl1;
+----
+
+exec-sql
+INSERT INTO sc1.tbl1 VALUES (123);
+----
+
+query-sql
+SELECT * FROM sc1.v1;
+----
+123
+
+query-sql
+SHOW CREATE VIEW sc1.v1;
+----
+sc1.v1 CREATE VIEW sc1.v1 (
+	a
+) AS SELECT a FROM db1.sc1.tbl1
+
+exec-sql
+BACKUP DATABASE db1 INTO 'nodelocal://0/test/'
+----
+
+exec-sql
+DROP DATABASE db1;
+----
+
+exec-sql
+RESTORE DATABASE db1 FROM LATEST IN 'nodelocal://0/test/' WITH new_db_name = db1_new
+----
+
+
+exec-sql
+USE db1_new
+----
+
+query-sql
+SELECT * FROM sc1.v1;
+----
+123
+
+query-sql
+SHOW CREATE VIEW db1_new.sc1.v1;
+----
+db1_new.sc1.v1 CREATE VIEW sc1.v1 (
+	a
+) AS SELECT a FROM db1_new.sc1.tbl1


### PR DESCRIPTION
We need to pass new_db_name if we have one so that views are correctly rewritten.

This is a partial backport of a fix that was included in a https://github.com/cockroachdb/cockroach/pull/87561

Co-authored-by: Chengxiong Ruan <chengxiongruan@gmail.com>

Release note (bug fix): Fixes a bug in which a database restore using the `new_db_name` option did not update views with the new database names, resulting in failures when querying those views.