### PR TITLE
multitenant: move SCATTER tenant check from SQL to KV layer

### DIFF
--- a/pkg/ccl/backupccl/split_and_scatter_processor.go
+++ b/pkg/ccl/backupccl/split_and_scatter_processor.go
@@ -140,6 +140,7 @@ func (s dbSplitAndScatterer) scatter(
 		// balancing the span being restored into.
 		RandomizeLeases: true,
 		MaxSize:         1, // don't scatter non-empty ranges on resume.
+		Class:           oppurpose.ScatterBackup,
 	}
 
 	res, pErr := kv.SendWrapped(ctx, s.db.NonTransactionalSender(), req)

--- a/pkg/ccl/logictestccl/testdata/logic_test/tenant_unsupported
+++ b/pkg/ccl/logictestccl/testdata/logic_test/tenant_unsupported
@@ -54,7 +54,7 @@ ALTER TABLE kv UNSPLIT AT VALUES ('foo')
 statement error operation is unsupported in multi-tenancy mode
 ALTER TABLE kv UNSPLIT ALL
 
-statement error operation is unsupported in multi-tenancy mode
+statement error pq: rpc error: code = Unauthenticated desc = request \[1 AdmScatter\] not permitted
 ALTER TABLE kv SCATTER
 
 statement error operation is unsupported in multi-tenancy mode

--- a/pkg/kv/bulk/BUILD.bazel
+++ b/pkg/kv/bulk/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/settings/cluster",
+        "//pkg/sql/oppurpose",
         "//pkg/storage",
         "//pkg/storage/enginepb",
         "//pkg/util/admission/admissionpb",

--- a/pkg/kv/bulk/buffering_adder.go
+++ b/pkg/kv/bulk/buffering_adder.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/oppurpose"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/limit"
@@ -424,7 +425,7 @@ func (b *BufferingAdder) createInitialSplits(ctx context.Context) error {
 	b.sink.currentStats.SplitWait += splitsWait
 
 	for _, splitKey := range toScatter {
-		resp, err := b.sink.db.AdminScatter(ctx, splitKey, 0 /* maxSize */)
+		resp, err := b.sink.db.AdminScatter(ctx, splitKey, 0 /* maxSize */, oppurpose.ScatterBulk)
 		if err != nil {
 			log.Warningf(ctx, "failed to scatter: %v", err)
 			continue

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/oppurpose"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
@@ -547,7 +548,7 @@ func (b *SSTBatcher) doFlush(ctx context.Context, reason int) error {
 					// Now scatter the RHS before we proceed to ingest into it. We know it
 					// should be empty since we split above if there was a nextExistingKey.
 					beforeScatter := timeutil.Now()
-					resp, err := b.db.AdminScatter(ctx, splitAt, maxScatterSize)
+					resp, err := b.db.AdminScatter(ctx, splitAt, maxScatterSize, oppurpose.ScatterBulk)
 					b.currentStats.ScatterWait += timeutil.Since(beforeScatter)
 					if err != nil {
 						// err could be a max size violation, but this is unexpected since we

--- a/pkg/kv/db.go
+++ b/pkg/kv/db.go
@@ -605,12 +605,13 @@ func (db *DB) AdminSplit(
 // to scatter that is conditional on it not resulting in excessive data movement
 // if the range is large.
 func (db *DB) AdminScatter(
-	ctx context.Context, key roachpb.Key, maxSize int64,
+	ctx context.Context, key roachpb.Key, maxSize int64, class roachpb.AdminScatterRequest_Class,
 ) (*roachpb.AdminScatterResponse, error) {
 	scatterReq := &roachpb.AdminScatterRequest{
 		RequestHeader:   roachpb.RequestHeaderFromSpan(roachpb.Span{Key: key, EndKey: key.Next()}),
 		RandomizeLeases: true,
 		MaxSize:         maxSize,
+		Class:           class,
 	}
 	raw, pErr := SendWrapped(ctx, db.NonTransactionalSender(), scatterReq)
 	if pErr != nil {

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -1606,12 +1606,20 @@ message ExportResponse {
 // ranges that cannot be moved will include an error detail in the response and
 // won't fail the request.
 message AdminScatterRequest {
+
+  enum Class {
+    ARBITRARY = 0;
+    INGESTION = 1;
+  }
+
   RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   bool randomize_leases = 2;
 
   // max_size, if > 0, specifies a range's size above with it should reject
   // this scatter request, allowing a "scatter-if-not-full" conditional request.
   int64 max_size = 3;
+
+  Class class = 4;
 }
 
 // ScatterResponse is the response to a Scatter() operation.

--- a/pkg/rpc/auth_tenant.go
+++ b/pkg/rpc/auth_tenant.go
@@ -168,12 +168,13 @@ func reqAllowed(r roachpb.Request, tenID roachpb.TenantID) bool {
 		*roachpb.QueryLocksRequest,
 		*roachpb.InitPutRequest,
 		*roachpb.ExportRequest,
-		*roachpb.AdminScatterRequest,
 		*roachpb.AddSSTableRequest,
 		*roachpb.RefreshRequest,
 		*roachpb.RefreshRangeRequest,
 		*roachpb.IsSpanEmptyRequest:
 		return true
+	case *roachpb.AdminScatterRequest:
+		return t.Class != roachpb.AdminScatterRequest_ARBITRARY || tenID.IsSystem()
 	case *roachpb.AdminSplitRequest:
 		return t.Class != roachpb.AdminSplitRequest_ARBITRARY || tenID.IsSystem()
 	case *roachpb.AdminUnsplitRequest:

--- a/pkg/rpc/auth_test.go
+++ b/pkg/rpc/auth_test.go
@@ -184,7 +184,7 @@ func TestTenantAuthRequest(t *testing.T) {
 	makeAdminScatterReq := func(key string) roachpb.Request {
 		s := makeSpan(key)
 		h := roachpb.RequestHeaderFromSpan(s)
-		return &roachpb.AdminScatterRequest{RequestHeader: h}
+		return &roachpb.AdminScatterRequest{RequestHeader: h, Class: roachpb.AdminScatterRequest_INGESTION}
 	}
 	makeReqs := func(reqs ...roachpb.Request) []roachpb.RequestUnion {
 		ru := make([]roachpb.RequestUnion, len(reqs))

--- a/pkg/sql/multitenant_admin_function_test.go
+++ b/pkg/sql/multitenant_admin_function_test.go
@@ -182,13 +182,15 @@ func TestMultiTenantAdminFunction(t *testing.T) {
 			skipSQLSystemTenantCheck: true,
 		},
 		{
-			desc:  "ALTER TABLE x SCATTER",
-			query: "ALTER TABLE t SCATTER;",
+			desc:         "ALTER TABLE x SCATTER",
+			query:        "ALTER TABLE t SCATTER;",
+			errorMessage: "request [1 AdmScatter] not permitted",
 		},
 		{
-			desc:  "ALTER INDEX x SCATTER",
-			setup: "CREATE INDEX idx on t(i);",
-			query: "ALTER INDEX t@idx SCATTER;",
+			desc:         "ALTER INDEX x SCATTER",
+			setup:        "CREATE INDEX idx on t(i);",
+			query:        "ALTER INDEX t@idx SCATTER;",
+			errorMessage: "request [1 AdmScatter] not permitted",
 		},
 		{
 			desc:  "CONFIGURE ZONE",

--- a/pkg/sql/oppurpose/op_purpose.go
+++ b/pkg/sql/oppurpose/op_purpose.go
@@ -30,4 +30,17 @@ const (
 	UnsplitManual = roachpb.AdminUnsplitRequest_ARBITRARY
 	// UnsplitGC is a split caused by the GC job.
 	UnsplitGC = roachpb.AdminUnsplitRequest_ORGANIZATION
+
+	// ScatterBackup is a split caused by a backup.
+	ScatterBackup = roachpb.AdminScatterRequest_INGESTION
+	// ScatterBulk is a split caused by a bulk operation.
+	ScatterBulk = roachpb.AdminScatterRequest_INGESTION
+	// ScatterSchema is a split caused by a schema change.
+	ScatterSchema = roachpb.AdminScatterRequest_INGESTION
+	// ScatterTruncate is a split caused by a truncation.
+	ScatterTruncate = roachpb.AdminScatterRequest_INGESTION
+	// ScatterManual is a split caused by a manual action.
+	ScatterManual = roachpb.AdminScatterRequest_ARBITRARY
+	// ScatterManualTest is a split caused by a manual action test.
+	ScatterManualTest = roachpb.AdminScatterRequest_INGESTION
 )

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1951,10 +1951,11 @@ func (ef *execFactory) ConstructAlterTableSplit(
 
 	knobs := ef.planner.ExecCfg().TenantTestingKnobs
 	return &splitNode{
-		tableDesc:                index.Table().(*optTable).desc,
-		index:                    index.(*optIndex).idx,
-		rows:                     input.(planNode),
-		expirationTime:           expirationTime,
+		tableDesc:      index.Table().(*optTable).desc,
+		index:          index.(*optIndex).idx,
+		rows:           input.(planNode),
+		expirationTime: expirationTime,
+		// Tests can override tenant split permissions to allow secondary tenants to split.
 		testAllowSplitAndScatter: knobs != nil && knobs.AllowSplitAndScatter,
 	}, nil
 }

--- a/pkg/sql/scatter.go
+++ b/pkg/sql/scatter.go
@@ -16,11 +16,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/oppurpose"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -34,10 +34,6 @@ type scatterNode struct {
 // (`ALTER TABLE/INDEX ... SCATTER ...` statement)
 // Privileges: INSERT on table.
 func (p *planner) Scatter(ctx context.Context, n *tree.Scatter) (planNode, error) {
-	knobs := p.ExecCfg().TenantTestingKnobs
-	if !(knobs != nil && knobs.AllowSplitAndScatter) && !p.ExecCfg().Codec.ForSystemTenant() {
-		return nil, errorutil.UnsupportedWithMultiTenancy(54255)
-	}
 
 	_, tableDesc, index, err := p.getTableAndIndex(ctx, &n.TableOrIndex, privilege.INSERT, true /* skipCache */)
 	if err != nil {
@@ -134,10 +130,17 @@ type scatterRun struct {
 }
 
 func (n *scatterNode) startExec(params runParams) error {
-	db := params.p.ExecCfg().DB
+	execCfg := params.p.ExecCfg()
+	db := execCfg.DB
+	class := oppurpose.ScatterManual
+	// Tests can override tenant scatter permissions to allow secondary tenants to scatter.
+	if knobs := execCfg.TenantTestingKnobs; knobs != nil && knobs.AllowSplitAndScatter {
+		class = oppurpose.ScatterManualTest
+	}
 	req := &roachpb.AdminScatterRequest{
 		RequestHeader:   roachpb.RequestHeader{Key: n.run.span.Key, EndKey: n.run.span.EndKey},
 		RandomizeLeases: true,
+		Class:           class,
 	}
 	res, pErr := kv.SendWrapped(params.ctx, db.NonTransactionalSender(), req)
 	if pErr != nil {

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -3184,7 +3184,7 @@ func splitAndScatter(
 	if err := db.AdminSplit(ctx, key, expirationTime, oppurpose.SplitSchema); err != nil {
 		return err
 	}
-	_, err := db.AdminScatter(ctx, key, 0 /* maxSize */)
+	_, err := db.AdminScatter(ctx, key, 0 /* maxSize */, oppurpose.ScatterSchema)
 	return err
 }
 

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/oppurpose"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -516,6 +517,7 @@ func (p *planner) copySplitPointsToNewIndexes(
 			EndKey: p.execCfg.Codec.IndexPrefix(uint32(tableID), uint32(newIndexIDs[len(newIndexIDs)-1])).PrefixEnd(),
 		},
 		RandomizeLeases: true,
+		Class:           oppurpose.ScatterTruncate,
 	})
 
 	return p.txn.DB().Run(ctx, &b)


### PR DESCRIPTION
Fixes #91501

Move the SCATTER tenant check from the SQL to KV layer to prepare for tenant permissions work. This check will eventually be replaced by a tenant permissions lookup to determine if the tenant can perform the requested KV operation (AdminScatter in this case). `Codec.ForSystemTenant()` checks still exist in the SQL and will be handled in separate PRs.

Release note: None