### PR TITLE
release-22.1: server, ui: update prettify parameter

### DIFF
--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catconstants"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
@@ -538,20 +539,14 @@ func getTotalStatementDetails(
 	}
 	statistics.Stats.SensitiveInfo.MostRecentPlanDescription = *plan
 
-	args = []interface{}{}
-	args = append(args, aggregatedMetadata.Query)
-	query = fmt.Sprintf(
-		`SELECT prettify_statement($1, %d, %d, %d)`,
-		tree.ConsoleLineWidth, tree.PrettyAlignAndDeindent, tree.UpperCase)
-	row, err = ie.QueryRowEx(ctx, "combined-stmts-details-format-query", nil,
-		sessiondata.InternalExecutorOverride{
-			User: security.NodeUserName(),
-		}, query, args...)
-
+	queryTree, err := parser.ParseOne(aggregatedMetadata.Query)
 	if err != nil {
 		return statement, serverError(ctx, err)
 	}
-	aggregatedMetadata.FormattedQuery = string(tree.MustBeDString(row[0]))
+	cfg := tree.DefaultPrettyCfg()
+	cfg.Align = tree.PrettyAlignOnly
+	cfg.LineWidth = tree.ConsoleLineWidth
+	aggregatedMetadata.FormattedQuery = cfg.Pretty(queryTree.AST)
 
 	statement = serverpb.StatementDetailsResponse_CollectedStatementSummary{
 		Metadata:            aggregatedMetadata,


### PR DESCRIPTION
Backport 1/1 commits from #91214.

/cc @cockroachdb/release

---

Previously, we were using `PrettyAlignAndDeindent`
parameter option for the usage of `prettify_statement`
on statement details endpoint, 
which was subjected to a quadratic explosion.

This commit updates those uses to parameter
`PrettyAlignOnly` and changes the
statement details endpoint to use the Go function of
Pretty instead, so it doesn't required a SQL
connection/execution.

Part Of #91197

Release note: None

---
Release justification: small change, big impact
