### PR TITLE
release-22.2: ui: add loading the explain plan

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementUtils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementUtils.ts
@@ -79,7 +79,6 @@ export function filterActiveStatements(
  * getActiveExecutionsFromSessions returns active statements and
  * transactions from the array of sessions provided.
  * @param sessionsResponse sessions array from which to extract data
- * @param lastUpdated the time the sessions data was last updated
  * @returns
  */
 export function getActiveExecutionsFromSessions(

--- a/pkg/ui/workspaces/cluster-ui/src/api/decodePlanGistApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/decodePlanGistApi.ts
@@ -12,7 +12,7 @@ import { SqlExecutionRequest, executeInternalSql } from "./sqlApi";
 
 export type DecodePlanGistResponse = {
   explainPlan?: string;
-  error?: string;
+  error?: Error;
 };
 
 export type DecodePlanGistRequest = {
@@ -48,14 +48,14 @@ export function getExplainPlanFromGist(
     ) {
       return {
         error: result.execution.txn_results
-          ? result.execution.txn_results[0].error?.message
+          ? result.execution.txn_results[0].error
           : null,
       };
     }
 
     if (result.execution.txn_results[0].error) {
       return {
-        error: result.execution.txn_results[0].error.message,
+        error: result.execution.txn_results[0].error,
       };
     }
 

--- a/pkg/ui/workspaces/cluster-ui/src/selectors/activeExecutionsCommon.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/selectors/activeExecutionsCommon.selectors.ts
@@ -15,7 +15,7 @@ import { executionIdAttr, getMatchParamByName } from "src/util";
 import {
   getActiveExecutionsFromSessions,
   getWaitTimeByTxnIDFromLocks,
-} from "../activeExecutions/activeStatementUtils";
+} from "../activeExecutions";
 
 // The functions in this file are agnostic to the different shape of each
 // state in db-console and cluster-ui. This file contains selector functions

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.module.scss
@@ -148,3 +148,7 @@
 .margin-bottom-large {
   margin-bottom: 40px;
 }
+
+.margin-right {
+  margin-right: 12px !important;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import React, { ReactNode, useEffect } from "react";
+import React, { ReactNode } from "react";
 import { Col, Row, Tabs } from "antd";
 import "antd/lib/col/style";
 import "antd/lib/row/style";


### PR DESCRIPTION
Backport 1/1 commits from #91317.

/cc @cockroachdb/release

---

On Statement Insight Details and Statement Active
Execution Details, the Explain plan tab would not load instantly, making the message of "not available" to show first, before the proper explain plan to be displayed. This commit adds a loading to the pages, and also check for proper errors displaying a message.

Fixes #91242

Before
https://www.loom.com/share/915c87d0313241caba473424f20881b4

After
With loading
https://www.loom.com/share/815a36b72824459692226e00eca8b2d8

with error message
<img width="705" alt="Screen Shot 2022-11-04 at 5 09 01 PM" src="https://user-images.githubusercontent.com/1017486/200076188-ffd0b665-5566-41d2-88bd-e4151182b6ff.png">


Release note: None

---
Release justification: small ui improvement
