### PR TITLE
kvserver: return DeprecatedLeaseHolder field in NLHEs

### DIFF
--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -1036,6 +1036,10 @@ func newNotLeaseHolderError(
 		if stillMember {
 			err.Lease = new(roachpb.Lease)
 			*err.Lease = l
+			// TODO(arul): We only need to return this for the 22.1 <-> 22.2 mixed
+			// version state, as v22.1 use this field to log NLHE messages. We can
+			// get rid of this, and the field, in v23.1.
+			err.DeprecatedLeaseHolder = &err.Lease.Replica
 		}
 	}
 	return err


### PR DESCRIPTION
v22.1 binaries assume that the leaseholder is unknown when logging NLHE errors if the (Deprecated)LeaseHolder field is unset -- regardless of if the Lease is set or not. We broke this logging in 0402f47 (for mixed version clusters) when we stopped shipping back leaseholder information (in favour of only shipping lease information) on NLHEs. This patch fixes this by populating the (Deprecated)LeaseHolder field when constructing NLHEs.

Release note: None