### PR TITLE
builtins: add create_tenant(<tenant-name>) overload

### DIFF
--- a/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
@@ -922,7 +922,7 @@ func TestSQLLivenessExemption(t *testing.T) {
 
 	// Create a tenant with ridiculously low resource limits.
 	host := sqlutils.MakeSQLRunner(hostDB)
-	host.Exec(t, "SELECT crdb_internal.create_tenant($1)", tenantID.ToUint64())
+	host.Exec(t, "SELECT crdb_internal.create_tenant($1::INT)", tenantID.ToUint64())
 	host.Exec(t, "SELECT crdb_internal.update_tenant_resource_limits($1, 0, 0.001, 0, now(), 0)", tenantID.ToUint64())
 
 	st := cluster.MakeTestingClusterSettings()

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
@@ -227,7 +227,7 @@ func TestTenantStreamingCreationErrors(t *testing.T) {
 		srcPgURL.String())
 
 	existingTenantID := uint64(100)
-	destSysSQL.Exec(t, "SELECT crdb_internal.create_tenant($1)", existingTenantID)
+	destSysSQL.Exec(t, "SELECT crdb_internal.create_tenant($1::INT)", existingTenantID)
 	destSysSQL.ExpectErr(t, fmt.Sprintf("pq: tenant with id %d already exists", existingTenantID),
 		`RESTORE TENANT 10 FROM REPLICATION STREAM FROM $1 AS TENANT `+fmt.Sprintf("%d", existingTenantID),
 		srcPgURL.String())

--- a/pkg/cmd/roachtest/tests/multitenant.go
+++ b/pkg/cmd/roachtest/tests/multitenant.go
@@ -29,7 +29,7 @@ func runAcceptanceMultitenant(ctx context.Context, t test.Test, c cluster.Cluste
 
 	const tenantID = 123
 	{
-		_, err := c.Conn(ctx, t.L(), 1).Exec(`SELECT crdb_internal.create_tenant($1)`, tenantID)
+		_, err := c.Conn(ctx, t.L(), 1).Exec(`SELECT crdb_internal.create_tenant($1::INT)`, tenantID)
 		require.NoError(t, err)
 	}
 

--- a/pkg/sql/faketreeeval/BUILD.bazel
+++ b/pkg/sql/faketreeeval/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/clusterversion",
+        "//pkg/roachpb",
         "//pkg/security/username",
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/descpb",

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -559,9 +560,14 @@ var _ eval.TenantOperator = &DummyTenantOperator{}
 var errEvalTenant = pgerror.New(pgcode.ScalarOperationCannotRunWithoutFullSessionContext,
 	"cannot evaluate tenant operation in this context")
 
-// CreateTenant is part of the tree.TenantOperator interface.
-func (c *DummyTenantOperator) CreateTenant(_ context.Context, _ uint64, _ string) error {
+// CreateTenantWithID is part of the tree.TenantOperator interface.
+func (c *DummyTenantOperator) CreateTenantWithID(_ context.Context, _ uint64, _ string) error {
 	return errors.WithStack(errEvalTenant)
+}
+
+// CreateTenant is part of the tree.TenantOperator interface.
+func (c *DummyTenantOperator) CreateTenant(_ context.Context, _ string) (roachpb.TenantID, error) {
+	return roachpb.MakeTenantID(0), errors.WithStack(errEvalTenant)
 }
 
 // RenameTenant is part of the tree.TenantOperator interface.

--- a/pkg/sql/logictest/testdata/logic_test/tenant
+++ b/pkg/sql/logictest/testdata/logic_test/tenant
@@ -5,7 +5,7 @@ SELECT id, active, length(info), name FROM system.tenants ORDER BY id
 id  active  length  name
 1   true    12      system
 
-# Create two tenants.
+# Create three tenants.
 
 query I
 SELECT crdb_internal.create_tenant(5)
@@ -17,15 +17,21 @@ SELECT crdb_internal.create_tenant(10, 'tenant-number-ten')
 ----
 10
 
+query I
+SELECT crdb_internal.create_tenant('tenant-number-eleven')
+----
+2
+
 query IBTT colnames
 SELECT id, active, name, crdb_internal.pb_to_json('cockroach.sql.sqlbase.TenantInfo', info, true)
 FROM system.tenants
 ORDER BY id
 ----
-id  active  name               crdb_internal.pb_to_json
-1   true    system             {"id": "1", "name": "system", "state": "ACTIVE"}
-5   true    NULL               {"id": "5", "name": "", "state": "ACTIVE"}
-10  true    tenant-number-ten  {"id": "10", "name": "tenant-number-ten", "state": "ACTIVE"}
+id  active  name                  crdb_internal.pb_to_json
+1   true    system                {"id": "1", "name": "system", "state": "ACTIVE"}
+2   true    tenant-number-eleven  {"id": "2", "name": "tenant-number-eleven", "state": "ACTIVE"}
+5   true    NULL                  {"id": "5", "name": "", "state": "ACTIVE"}
+10  true    tenant-number-ten     {"id": "10", "name": "tenant-number-ten", "state": "ACTIVE"}
 
 # Check we can add a name where none existed before.
 query I
@@ -38,6 +44,7 @@ SELECT id, active, name FROM system.tenants ORDER BY id
 ----
 id  active  name
 1   true    system
+2   true    tenant-number-eleven
 5   true    my-tenant
 10  true    tenant-number-ten
 
@@ -52,11 +59,15 @@ SELECT crdb_internal.rename_tenant(5, 'my-new-tenant-name')
 query error name "tenant-number-ten" is already taken
 SELECT crdb_internal.rename_tenant(5, 'tenant-number-ten')
 
+query error tenant with name "tenant-number-eleven" already exists
+SELECT crdb_internal.create_tenant('tenant-number-eleven')
+
 query IBT colnames
 SELECT id, active, name FROM system.tenants ORDER BY id
 ----
 id  active  name
 1   true    system
+2   true    tenant-number-eleven
 5   true    my-new-tenant-name
 10  true    tenant-number-ten
 
@@ -77,10 +88,11 @@ SELECT id, active, name, crdb_internal.pb_to_json('cockroach.sql.sqlbase.TenantI
 FROM system.tenants
 ORDER BY id
 ----
-id  active  name                crdb_internal.pb_to_json
-1   true    system              {"id": "1", "name": "system", "state": "ACTIVE"}
-5   false   my-new-tenant-name  {"id": "5", "name": "my-new-tenant-name", "state": "DROP"}
-10  true    tenant-number-ten   {"id": "10", "name": "tenant-number-ten", "state": "ACTIVE"}
+id  active  name                  crdb_internal.pb_to_json
+1   true    system                {"id": "1", "name": "system", "state": "ACTIVE"}
+2   true    tenant-number-eleven  {"id": "2", "name": "tenant-number-eleven", "state": "ACTIVE"}
+5   false   my-new-tenant-name    {"id": "5", "name": "my-new-tenant-name", "state": "DROP"}
+10  true    tenant-number-ten     {"id": "10", "name": "tenant-number-ten", "state": "ACTIVE"}
 
 
 # Try to recreate an existing tenant.
@@ -188,6 +200,7 @@ ORDER BY id
 ----
 id  active  crdb_internal.pb_to_json
 1   true    {"id": "1", "name": "system", "state": "ACTIVE"}
+2   true    {"id": "2", "name": "tenant-number-eleven", "state": "ACTIVE"}
 10  true    {"id": "10", "name": "tenant-number-ten", "state": "ACTIVE"}
 
 query error tenant resource limits require a CCL binary
@@ -197,6 +210,9 @@ user testuser
 
 statement error only users with the admin role are allowed to create tenant
 SELECT crdb_internal.create_tenant(314)
+
+statement error only users with the admin role are allowed to create tenant
+SELECT crdb_internal.create_tenant('not-allowed')
 
 statement error only users with the admin role are allowed to destroy tenant
 SELECT crdb_internal.destroy_tenant(314)

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4853,7 +4853,7 @@ value if you rely on the HLC for accuracy.`,
 				if err != nil {
 					return nil, err
 				}
-				if err := evalCtx.Tenant.CreateTenant(ctx, uint64(sTenID), ""); err != nil {
+				if err := evalCtx.Tenant.CreateTenantWithID(ctx, uint64(sTenID), ""); err != nil {
 					return nil, err
 				}
 				return args[0], nil
@@ -4873,12 +4873,29 @@ value if you rely on the HLC for accuracy.`,
 					return nil, err
 				}
 				tenantName := tree.MustBeDString(args[1])
-				if err := evalCtx.Tenant.CreateTenant(ctx, uint64(sTenID), string(tenantName)); err != nil {
+				if err := evalCtx.Tenant.CreateTenantWithID(ctx, uint64(sTenID), string(tenantName)); err != nil {
 					return nil, err
 				}
 				return args[0], nil
 			},
-			Info:       "Creates a new tenant with the provided ID. Must be run by the System tenant.",
+			Info:       "Creates a new tenant with the provided ID and name. Must be run by the System tenant.",
+			Volatility: volatility.Volatile,
+		},
+		tree.Overload{
+			Types: tree.ArgTypes{
+				{"name", types.String},
+			},
+			ReturnType: tree.FixedReturnType(types.Int),
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				tenantName := tree.MustBeDString(args[0])
+				var tenantID roachpb.TenantID
+				var err error
+				if tenantID, err = evalCtx.Tenant.CreateTenant(ctx, string(tenantName)); err != nil {
+					return nil, err
+				}
+				return tree.NewDInt(tree.DInt(tenantID.ToUint64())), nil
+			},
+			Info:       "Creates a new tenant with the provided name. Must be run by the System tenant.",
 			Volatility: volatility.Volatile,
 		},
 	),

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -390,6 +390,7 @@ var builtinOidsBySignature = map[string]oid.Oid{
 	`crdb_internal.create_sql_schema_telemetry_job() -> int`:                                                                            1378,
 	`crdb_internal.create_tenant(id: int) -> int`:                                                                                       1302,
 	`crdb_internal.create_tenant(id: int, name: string) -> int`:                                                                         2036,
+	`crdb_internal.create_tenant(name: string) -> int`:                                                                                  2043,
 	`crdb_internal.datums_to_bytes(anyelement...) -> bytes`:                                                                             1276,
 	`crdb_internal.decode_cluster_setting(setting: string, value: string) -> string`:                                                    1294,
 	`crdb_internal.decode_external_plan_gist(gist: string) -> string`:                                                                   355,

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -549,10 +549,17 @@ type ChangefeedState interface {
 // builtin functions to create, configure, and destroy tenants. The methods will
 // return errors when run by any tenant other than the system tenant.
 type TenantOperator interface {
-	// CreateTenant attempts to install a new tenant in the system. It returns
-	// an error if the tenant already exists. The new tenant is created at the
-	// current active version of the cluster performing the create.
-	CreateTenant(ctx context.Context, tenantID uint64, tenantName string) error
+	// CreateTenantWithID attempts to install a new tenant in the system, with the
+	// provided tenantID. It returns an error if the tenant already exists. The
+	// new tenant is created at the current active version of the cluster
+	// performing the create.
+	CreateTenantWithID(ctx context.Context, tenantID uint64, tenantName string) error
+
+	// CreateTenant attempts to install a new tenant in the system and returns the
+	// ID that is assigned to the tenant. It returns an error if another tenant
+	// with `tenantName` already exists. The new tenant is created at the current
+	// active version of the cluster performing the create.
+	CreateTenant(ctx context.Context, tenantName string) (roachpb.TenantID, error)
 
 	// RenameTenant renames the specified tenant. An error is returned if
 	// the tenant does not exist or the name is already taken.


### PR DESCRIPTION
This change adds another overload to the `crdb_internal.create_tenant` builtin that only accepts the name the of the tenant to be created. The underlying logic automatically picks the next unique ID based on the existing tenants in the `system.tenants` table. The builtin returns the ID assigned to the newly created tenant or an error if a tenant with the same name already exists. Just like other overloads this buitlin is admin-only and can only be run by the system tenant.

Informs: #91235

Release note: None