### PR TITLE
Revert "build/nightlies: enable crdb_test on sqllite logic tests"

### DIFF
--- a/build/teamcity/cockroach/nightlies/sqlite_logic_test_impl.sh
+++ b/build/teamcity/cockroach/nightlies/sqlite_logic_test_impl.sh
@@ -7,7 +7,7 @@ dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
 bazel build //pkg/cmd/bazci --config=ci
 BAZEL_BIN=$(bazel info bazel-bin --config=ci)
 exit_status=0
-$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- test --config=ci \
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- test --config=ci --config=crdb_test_off \
     //pkg/sql/sqlitelogictest/tests/... \
     --test_arg -bigtest --test_arg -flex-types --test_timeout 86400 \
     || exit_status=$?


### PR DESCRIPTION
This reverts commit a4e8bd232611a71c1fc96f92cd0b1e1d9ae52b9e.

Informs: #91486

Epic: None

Release note: None