### PR TITLE
lint: remove Golint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -402,7 +402,6 @@ bin/.bootstrap: $(GITHOOKS) vendor/modules.txt | bin/.submodules-initialized
 		github.com/mmatczuk/go_generics/cmd/go_generics \
 		github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc \
 		github.com/wadey/gocovmerge \
-		golang.org/x/lint/golint \
 		golang.org/x/perf/cmd/benchstat \
 		golang.org/x/tools/cmd/goyacc \
 		golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow \

--- a/build/bazelutil/lint.bzl
+++ b/build/bazelutil/lint.bzl
@@ -50,7 +50,6 @@ def lint_binary(name, test):
             "//pkg/sql/opt/optgen/cmd/optfmt",
             "@com_github_cockroachdb_crlfmt//:crlfmt",
             "@go_sdk//:bin/go",
-            "@org_golang_x_lint//golint:golint",
         ],
         deps = ["@bazel_tools//tools/bash/runfiles"],
         testonly = 1,

--- a/build/bazelutil/lint.sh.in
+++ b/build/bazelutil/lint.sh.in
@@ -28,7 +28,6 @@ rlocation_ck () {
 test_bin="$(rlocation_ck com_github_cockroachdb_cockroach/$PACKAGE/${NAME}_/$NAME)"
 go_bin="$(rlocation_ck go_sdk/bin/go)"
 crlfmt_bin="$(rlocation_ck com_github_cockroachdb_crlfmt/crlfmt_/crlfmt)"
-golint_bin="$(rlocation_ck org_golang_x_lint/golint/golint_/golint)"
 optfmt_bin="$(rlocation_ck com_github_cockroachdb_cockroach/pkg/sql/opt/optgen/cmd/optfmt/optfmt_/optfmt)"
 
 # Need to run this so that Go can find the runfiles.
@@ -42,6 +41,6 @@ fi
 cd "$BUILD_WORKSPACE_DIRECTORY/$PACKAGE"
 
 TEST_WORKSPACE=com_github_cockroachdb_cockroach \
-    PATH="$(dirname $go_bin):$(dirname $crlfmt_bin):$(dirname $golint_bin):$(dirname $optfmt_bin):$PATH" \
+    PATH="$(dirname $go_bin):$(dirname $crlfmt_bin):$(dirname $optfmt_bin):$PATH" \
     GOROOT="$(dirname $(dirname $go_bin))" \
     "$test_bin" "$@"

--- a/go.mod
+++ b/go.mod
@@ -211,7 +211,6 @@ require (
 	go.opentelemetry.io/otel/exporters/zipkin v1.0.0-RC3
 	go.opentelemetry.io/otel/sdk v1.0.0-RC3
 	go.opentelemetry.io/otel/trace v1.0.0-RC3
-	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
 	golang.org/x/perf v0.0.0-20180704124530-6e6d33e29852
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	gopkg.in/yaml.v2 v2.4.0

--- a/pkg/cmd/import-tools/main.go
+++ b/pkg/cmd/import-tools/main.go
@@ -40,7 +40,6 @@ import (
 	_ "github.com/mmatczuk/go_generics/cmd/go_generics"
 	_ "github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc"
 	_ "github.com/wadey/gocovmerge"
-	_ "golang.org/x/lint/golint"
 	_ "golang.org/x/perf/cmd/benchstat"
 	_ "golang.org/x/tools/cmd/goyacc"
 	_ "golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow"

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1672,56 +1672,6 @@ func TestLint(t *testing.T) {
 		}
 	})
 
-	t.Run("TestGolint", func(t *testing.T) {
-		t.Parallel()
-		cmd, stderr, filter, err := dirCmd(crdb.Dir, "golint", pkgScope)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if err := cmd.Start(); err != nil {
-			t.Fatal(err)
-		}
-
-		if err := stream.ForEach(
-			stream.Sequence(
-				filter,
-				stream.GrepNot("migration/.*exported func TestingNewCluster returns unexported type"),
-				stream.GrepNot("sql/.*exported func .* returns unexported type sql.planNode"),
-				stream.GrepNot("pkg/sql/types/types.go.* var Uuid should be UUID"),
-				stream.GrepNot("pkg/sql/oidext/oidext.go.*don't use underscores in Go names; const T_"),
-				stream.GrepNot("server/api_v2.go.*package comment should be of the form"),
-				stream.GrepNot("pkg/util/timeutil/time_zone_util.go.*error strings should not be capitalized or end with punctuation or a newline"),
-
-				// The Observability Service doesn't want this blunt rule.
-				stream.GrepNot("pkg/obsservice.*error strings should not be capitalized or end with punctuation or a newline"),
-
-				// The constants here are copied from PG.
-				stream.GrepNot("pkg/util/tochar/constants.go.*don't use ALL_CAPS in Go names"),
-				stream.GrepNot("pkg/util/tochar/constants.go.*don't use underscores in Go names"),
-
-				stream.GrepNot("pkg/sql/job_exec_context_test_util.go.*exported method ExtendedEvalContext returns unexported type"),
-				stream.GrepNot("pkg/sql/job_exec_context_test_util.go.*exported method SessionDataMutatorIterator returns unexported type"),
-
-				stream.GrepNot("type name will be used as password.PasswordHash by other packages, and that stutters; consider calling this Hash"),
-				stream.GrepNot("type name will be used as ptp.PTPClock by other packages, and that stutters; consider calling this Limit"),
-				stream.GrepNot("type name will be used as row.RowLimit by other packages, and that stutters; consider calling this Limit"),
-				stream.GrepNot("type name will be used as tracing.TracingMode by other packages, and that stutters; consider calling this Mode"),
-				stream.GrepNot("pkg/build/bazel/bes/.*empty.go.*don't use an underscore in package name"),
-				stream.GrepNot("pkg/sql/types/types.go.*var Json should be JSON"),
-			), func(s string) {
-				t.Errorf("\n%s", s)
-			}); err != nil {
-			t.Error(err)
-		}
-
-		if err := cmd.Wait(); err != nil {
-			if out := stderr.String(); len(out) > 0 {
-				t.Fatalf("err=%s, stderr=%s", err, out)
-			}
-		}
-	})
-
 	t.Run("TestStaticCheck", func(t *testing.T) {
 		// staticcheck uses 2.4GB of ram (as of 2019-05-10), so don't parallelize it.
 		skip.UnderShort(t)


### PR DESCRIPTION
This commit removes `TestGolint` linter as well as all mentions of `golint` I could find. The rationale is that
- the linter is no longer maintained
- is partially duplicated with the `staticcheck`
- due to a recent change in `gcexportdata.Find`, if we bump some dependencies, it takes on the order of an hour when run via bazel, and we'd need to fork `golint` to go around that.

Epic: None

Release note: None