### PR TITLE
cluster-ui: fix index usage stats reset for CC

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/indexDetailsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/indexDetailsApi.ts
@@ -45,7 +45,7 @@ export const resetIndexStats = (
   return fetchData(
     cockroach.server.serverpb.ResetIndexUsageStatsResponse,
     "/_status/resetindexusagestats",
-    null,
+    cockroach.server.serverpb.ResetIndexUsageStatsRequest,
     req,
     "30M",
   );


### PR DESCRIPTION
Resolves: #90144

Previously, the 'Reset all index stats' button on the Index Details page did not fire a request to actually reset the index statistics. This bug was caused by a missing `ReqBuilder` field when issuing the fetch request. Consequently, the request payload was unable to encode correctly and silently errored, preventing the request from being sent. This change adds the missing `ReqBuilder` field, fixing the fetch request.

Release note (bug fix): Fix the 'Reset all index stats' button on Cloud Console.