### PR TITLE
opt: prevent null-rejection rule cycle

### DIFF
--- a/pkg/sql/opt/norm/testdata/rules/reject_nulls
+++ b/pkg/sql/opt/norm/testdata/rules/reject_nulls
@@ -1582,3 +1582,112 @@ select
  │         └── COALESCE(x:7, 0) * 5 [as="?column?":11, outer=(7), immutable]
  └── filters
       └── "?column?":11 > 5 [outer=(11), constraints=(/11: [/6 - ]; tight)]
+
+# Regression test for #89986 - don't cause a rule cycle with disabled filter
+# push-down rules.
+exec-ddl
+CREATE TABLE table1_89986 (
+  col1_0 FLOAT8,
+  col1_1 FLOAT4 NOT NULL,
+  col1_2 BOX2D[] NULL,
+  col1_3 "char" NOT NULL,
+  col1_4 BOOL NULL,
+  col1_5 INT2 NOT NULL,
+  col1_6 OID,
+  col1_7 INT4 NULL,
+  col1_8 INT8 NULL AS (col1_7 + col1_5) STORED,
+  col1_9 FLOAT8 AS (col1_0 + col1_1) VIRTUAL,
+  INDEX (col1_7 DESC),
+  FAMILY (col1_8, col1_0),
+  FAMILY (col1_6),
+  FAMILY (col1_5, col1_7),
+  FAMILY (col1_4, col1_1, col1_3),
+  FAMILY (col1_2)
+)
+----
+
+exec-ddl
+CREATE TABLE table2_89986 (
+  col2_0  INT4,
+  col2_3  BIT(5),
+  col2_4  VARCHAR,
+  col2_5  REGCLASS,
+  col2_6  TIME NOT NULL,
+  col2_9  TIMESTAMP,
+  col2_10 REGPROCEDURE,
+  col2_11 INT8,
+  col2_12 STRING
+)
+----
+
+norm disable=(TryDecorrelateProject, MergeSelectInnerJoin, MapFilterIntoJoinLeft)
+SELECT tab_3663.col2_3,
+       0,
+       '23:43:20-08:00:00',
+       '2026-09-17 11:54:13.000946' AS col_12038,
+       tab_3663.col2_6,
+       0
+  FROM table2_89986@[0] AS tab_3663
+ WHERE EXISTS(
+        SELECT tab_3668.col_12032
+          FROM table2_89986@[0] AS tab_3664
+          JOIN table1_89986@[0] AS tab_3665
+               RIGHT JOIN table2_89986@[0] AS tab_3666 ON tab_3665.col1_8 = tab_3666.col2_11
+          JOIN (
+                SELECT tab_3663.col2_9, 0, tab_3663.col2_10, tab_3667.col2_3, -872818994
+                  FROM table2_89986@[0] AS tab_3667
+               ) AS tab_3668 (col_12029, col_12030, col_12031, col_12032, col_12033) ON
+                tab_3666.col2_9 = tab_3668.col_12029 ON tab_3664.col2_12 = tab_3665.col1_3
+       )
+ ORDER BY tab_3663.crdb_internal_mvcc_timestamp DESC, tab_3663.tableoid DESC, tab_3663.col2_5
+----
+project
+ ├── columns: col2_3:2 "?column?":66!null "?column?":67!null col_12038:68!null col2_6:5!null "?column?":66!null  [hidden: tab_3663.col2_5:4 tab_3663.crdb_internal_mvcc_timestamp:11 tab_3663.tableoid:12]
+ ├── fd: ()-->(66-68)
+ ├── ordering: -11,-12,+4 opt(66-68) [actual: -11,-12,+4]
+ ├── sort
+ │    ├── columns: tab_3663.col2_3:2 tab_3663.col2_5:4 tab_3663.col2_6:5!null tab_3663.col2_9:6 tab_3663.crdb_internal_mvcc_timestamp:11 tab_3663.tableoid:12
+ │    ├── ordering: -11,-12,+4
+ │    └── semi-join-apply
+ │         ├── columns: tab_3663.col2_3:2 tab_3663.col2_5:4 tab_3663.col2_6:5!null tab_3663.col2_9:6 tab_3663.crdb_internal_mvcc_timestamp:11 tab_3663.tableoid:12
+ │         ├── scan table2_89986 [as=tab_3663]
+ │         │    └── columns: tab_3663.col2_3:2 tab_3663.col2_5:4 tab_3663.col2_6:5!null tab_3663.col2_9:6 tab_3663.crdb_internal_mvcc_timestamp:11 tab_3663.tableoid:12
+ │         ├── inner-join (hash)
+ │         │    ├── columns: tab_3664.col2_12:21!null col1_3:28!null col1_8:33 tab_3666.col2_9:43!null tab_3666.col2_11:45 col2_9:62!null
+ │         │    ├── outer: (6)
+ │         │    ├── fd: ()-->(43,62), (43)==(62), (62)==(43), (21)==(28), (28)==(21)
+ │         │    ├── scan table2_89986 [as=tab_3664]
+ │         │    │    └── columns: tab_3664.col2_12:21
+ │         │    ├── inner-join (hash)
+ │         │    │    ├── columns: col1_3:28 col1_8:33 tab_3666.col2_9:43!null tab_3666.col2_11:45 col2_9:62!null
+ │         │    │    ├── outer: (6)
+ │         │    │    ├── fd: ()-->(43,62), (43)==(62), (62)==(43)
+ │         │    │    ├── left-join (hash)
+ │         │    │    │    ├── columns: col1_3:28 col1_8:33 tab_3666.col2_9:43 tab_3666.col2_11:45
+ │         │    │    │    ├── scan table2_89986 [as=tab_3666]
+ │         │    │    │    │    └── columns: tab_3666.col2_9:43 tab_3666.col2_11:45
+ │         │    │    │    ├── scan table1_89986
+ │         │    │    │    │    ├── columns: col1_3:28!null col1_8:33
+ │         │    │    │    │    └── computed column expressions
+ │         │    │    │    │         ├── col1_8:33
+ │         │    │    │    │         │    └── col1_7:32 + col1_5:30
+ │         │    │    │    │         └── col1_9:34
+ │         │    │    │    │              └── col1_0:25 + col1_1:26
+ │         │    │    │    └── filters
+ │         │    │    │         └── col1_8:33 = tab_3666.col2_11:45 [outer=(33,45), constraints=(/33: (/NULL - ]; /45: (/NULL - ]), fd=(33)==(45), (45)==(33)]
+ │         │    │    ├── project
+ │         │    │    │    ├── columns: col2_9:62
+ │         │    │    │    ├── outer: (6)
+ │         │    │    │    ├── fd: ()-->(62)
+ │         │    │    │    ├── scan table2_89986 [as=tab_3667]
+ │         │    │    │    └── projections
+ │         │    │    │         └── tab_3663.col2_9:6 [as=col2_9:62, outer=(6)]
+ │         │    │    └── filters
+ │         │    │         └── tab_3666.col2_9:43 = col2_9:62 [outer=(43,62), constraints=(/43: (/NULL - ]; /62: (/NULL - ]), fd=(43)==(62), (62)==(43)]
+ │         │    └── filters
+ │         │         └── tab_3664.col2_12:21 = col1_3:28 [outer=(21,28), constraints=(/21: (/NULL - ]; /28: (/NULL - ]), fd=(21)==(28), (28)==(21)]
+ │         └── filters (true)
+ └── projections
+      ├── 0 [as="?column?":66]
+      ├── '23:43:20-08:00:00' [as="?column?":67]
+      └── '2026-09-17 11:54:13.000946' [as=col_12038:68]


### PR DESCRIPTION
This patch adds checks to the null-rejection logic to ensure that null-rejection is not attempted when the necessary filter push-down rules are disabled. This prevents rule cycles that occur when decorrelation or filter elimination rules fire after the `col IS NOT NULL` filter isn't pushed all the way down to the outer join.

Fixes #89986

Release note: None