### PR TITLE
nightlies: enable crdb_test randomization for sqlite

### DIFF
--- a/build/teamcity/cockroach/nightlies/sqlite_logic_test_impl.sh
+++ b/build/teamcity/cockroach/nightlies/sqlite_logic_test_impl.sh
@@ -7,7 +7,7 @@ dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
 bazel build //pkg/cmd/bazci --config=ci
 BAZEL_BIN=$(bazel info bazel-bin --config=ci)
 exit_status=0
-$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- test --config=ci --config=crdb_test_off \
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- test --config=ci \
     //pkg/sql/sqlitelogictest/tests/... \
     --test_arg -bigtest --test_arg -flex-types --test_timeout 86400 \
     || exit_status=$?

--- a/pkg/ccl/sqlitelogictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/sqlitelogictestccl/tests/3node-tenant/generated_test.go
@@ -69,9 +69,12 @@ func runSqliteLogicTest(t *testing.T, file string) {
 		skip.IgnoreLint(t, "-bigtest flag must be specified to run this test")
 	}
 	// SQLLite logic tests can be very memory intensive, so we give them larger
-	// limit than other logic tests get.
+	// limit than other logic tests get. Also some of the 'delete' files become
+	// extremely slow when MVCC range tombstones are enabled for point deletes,
+	// so we disable that.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
+		DisableUseMVCCRangeTombstonesForPointDeletes: true,
 	}
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(sqliteLogicTestDir, file))
 }

--- a/pkg/cmd/generate-logictest/templates.go
+++ b/pkg/cmd/generate-logictest/templates.go
@@ -88,9 +88,12 @@ func runSqliteLogicTest(t *testing.T, file string) {
 		skip.IgnoreLint(t, "-bigtest flag must be specified to run this test")
 	}
 	// SQLLite logic tests can be very memory intensive, so we give them larger
-	// limit than other logic tests get.
+	// limit than other logic tests get. Also some of the 'delete' files become
+	// extremely slow when MVCC range tombstones are enabled for point deletes,
+	// so we disable that.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
+		DisableUseMVCCRangeTombstonesForPointDeletes: true,
 	}
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(sqliteLogicTestDir, file))
 }

--- a/pkg/sql/sqlitelogictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/sqlitelogictest/tests/fakedist-disk/generated_test.go
@@ -68,9 +68,12 @@ func runSqliteLogicTest(t *testing.T, file string) {
 		skip.IgnoreLint(t, "-bigtest flag must be specified to run this test")
 	}
 	// SQLLite logic tests can be very memory intensive, so we give them larger
-	// limit than other logic tests get.
+	// limit than other logic tests get. Also some of the 'delete' files become
+	// extremely slow when MVCC range tombstones are enabled for point deletes,
+	// so we disable that.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
+		DisableUseMVCCRangeTombstonesForPointDeletes: true,
 	}
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(sqliteLogicTestDir, file))
 }

--- a/pkg/sql/sqlitelogictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/sqlitelogictest/tests/fakedist-vec-off/generated_test.go
@@ -68,9 +68,12 @@ func runSqliteLogicTest(t *testing.T, file string) {
 		skip.IgnoreLint(t, "-bigtest flag must be specified to run this test")
 	}
 	// SQLLite logic tests can be very memory intensive, so we give them larger
-	// limit than other logic tests get.
+	// limit than other logic tests get. Also some of the 'delete' files become
+	// extremely slow when MVCC range tombstones are enabled for point deletes,
+	// so we disable that.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
+		DisableUseMVCCRangeTombstonesForPointDeletes: true,
 	}
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(sqliteLogicTestDir, file))
 }

--- a/pkg/sql/sqlitelogictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/sqlitelogictest/tests/fakedist/generated_test.go
@@ -68,9 +68,12 @@ func runSqliteLogicTest(t *testing.T, file string) {
 		skip.IgnoreLint(t, "-bigtest flag must be specified to run this test")
 	}
 	// SQLLite logic tests can be very memory intensive, so we give them larger
-	// limit than other logic tests get.
+	// limit than other logic tests get. Also some of the 'delete' files become
+	// extremely slow when MVCC range tombstones are enabled for point deletes,
+	// so we disable that.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
+		DisableUseMVCCRangeTombstonesForPointDeletes: true,
 	}
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(sqliteLogicTestDir, file))
 }

--- a/pkg/sql/sqlitelogictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/sqlitelogictest/tests/local-legacy-schema-changer/generated_test.go
@@ -68,9 +68,12 @@ func runSqliteLogicTest(t *testing.T, file string) {
 		skip.IgnoreLint(t, "-bigtest flag must be specified to run this test")
 	}
 	// SQLLite logic tests can be very memory intensive, so we give them larger
-	// limit than other logic tests get.
+	// limit than other logic tests get. Also some of the 'delete' files become
+	// extremely slow when MVCC range tombstones are enabled for point deletes,
+	// so we disable that.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
+		DisableUseMVCCRangeTombstonesForPointDeletes: true,
 	}
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(sqliteLogicTestDir, file))
 }

--- a/pkg/sql/sqlitelogictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/sqlitelogictest/tests/local-vec-off/generated_test.go
@@ -68,9 +68,12 @@ func runSqliteLogicTest(t *testing.T, file string) {
 		skip.IgnoreLint(t, "-bigtest flag must be specified to run this test")
 	}
 	// SQLLite logic tests can be very memory intensive, so we give them larger
-	// limit than other logic tests get.
+	// limit than other logic tests get. Also some of the 'delete' files become
+	// extremely slow when MVCC range tombstones are enabled for point deletes,
+	// so we disable that.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
+		DisableUseMVCCRangeTombstonesForPointDeletes: true,
 	}
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(sqliteLogicTestDir, file))
 }

--- a/pkg/sql/sqlitelogictest/tests/local/generated_test.go
+++ b/pkg/sql/sqlitelogictest/tests/local/generated_test.go
@@ -68,9 +68,12 @@ func runSqliteLogicTest(t *testing.T, file string) {
 		skip.IgnoreLint(t, "-bigtest flag must be specified to run this test")
 	}
 	// SQLLite logic tests can be very memory intensive, so we give them larger
-	// limit than other logic tests get.
+	// limit than other logic tests get. Also some of the 'delete' files become
+	// extremely slow when MVCC range tombstones are enabled for point deletes,
+	// so we disable that.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
+		DisableUseMVCCRangeTombstonesForPointDeletes: true,
 	}
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(sqliteLogicTestDir, file))
 }


### PR DESCRIPTION
This required disabling
`logictest-use-mvcc-range-tombstones-for-point-deletes` metamorphic boolean because when we use MVCC range tombstones for point deletes some of the `delete` files become extremely slow (in one example I saw a file go from 2 min to almost 2 hours).

Fixes: #91486.

Release note: None