### PR TITLE
execbuilder: skip flaky sql_activity_stats_compaction tests

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/sql_activity_stats_compaction
+++ b/pkg/sql/opt/exec/execbuilder/testdata/sql_activity_stats_compaction
@@ -15,6 +15,7 @@ SELECT concat('''', date_trunc('hour', '2022-05-04 16:10'::TIMESTAMPTZ - '2h'::I
 let $current_agg_ts
 SELECT concat('''', date_trunc('hour', '2022-05-04 16:10'::TIMESTAMPTZ)::STRING, '''::TIMESTAMPTZ')
 
+skipif config local
 query T
 EXPLAIN (VERBOSE)
 DELETE FROM system.statement_statistics
@@ -73,6 +74,7 @@ vectorized: true
                               spans: /0-/0/2022-05-04T15:59:59.999999001Z
                               limit: 1024
 
+skipif config local
 query T
 EXPLAIN (VERBOSE)
 DELETE FROM system.transaction_statistics
@@ -129,6 +131,7 @@ vectorized: true
                               spans: /0-/0/2022-05-04T15:59:59.999999001Z
                               limit: 1024
 
+skipif config local
 query T
 EXPLAIN (VERBOSE)
 DELETE FROM system.statement_statistics
@@ -197,6 +200,7 @@ vectorized: true
                               spans: /0/2022-05-04T14:00:00Z/"123"/"234"/"345"/"test"/1-/0/2022-05-04T15:59:59.999999001Z
                               limit: 1024
 
+skipif config local
 query T
 EXPLAIN (VERBOSE)
 DELETE FROM system.transaction_statistics

--- a/pkg/sql/sqlstats/persistedsqlstats/compaction_exec.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/compaction_exec.go
@@ -272,9 +272,9 @@ type cleanupOperations struct {
 	constrainedDeleteStmt   string
 }
 
-// N.B. when changing the constraint queries below, make sure also change
-//
-//	the test file in pkg/sql/opt/exec/execbuilder/testdata/sql_activity_stats_compaction.
+// TODO(#91600): Add deterministic execbuilder tests for these queries at
+// pkg/sql/opt/exec/execbuilder/testdata/sql_activity_stats_compaction
+// When changing the constraint queries below, make sure to also change the queries in those tests.
 var (
 	stmtStatsCleanupOps = &cleanupOperations{
 		initialScanStmtTemplate: `


### PR DESCRIPTION
This commit skips flaky sql_activity_stats_compaction execbuilder tests while we investigate the occasional test failures.

Part of #91600.

Release note: none