### PR TITLE
sql: Cleanup constant name and comments

### DIFF
--- a/pkg/util/json/config.go
+++ b/pkg/util/json/config.go
@@ -39,7 +39,7 @@ func WithGoStandardParser() ParseOption {
 // WithFastJSONParser returns an option that forces the use of fast json parser.
 func WithFastJSONParser() ParseOption {
 	return funcOpt(func(cfg *parseConfig) {
-		cfg.impl = useJSONLexer
+		cfg.impl = useFastJSONParser
 	})
 }
 
@@ -50,11 +50,11 @@ type parseJSONImplType int
 const (
 	// useStdGoJSON : encoding/json
 	useStdGoJSON parseJSONImplType = iota
-	// useJSONLexer : uses json lexer (built on top of pkg/json high performance library)
-	useJSONLexer
+	// useFastJSONParser : uses fast JSON parser (built on top of pkg/json high performance library)
+	useFastJSONParser
 
 	// Note: Other libraries tested and rejected include:
-	//  * json-iter: A fine library; however, json lexer consistently
+	//  * json-iter: A fine library; however, fastJSONParser consistently
 	//    performed better, with much better memory allocation behavior.
 	//  * go-json: universally slower, worse (allocation) than either
 	//    standard or json-iter for larger inputs.
@@ -68,7 +68,7 @@ const (
 // default configuration for parsing JSON.
 var parseJSONDefaultConfig = func() (cfg parseConfig) {
 	cfg.impl = util.ConstantWithMetamorphicTestChoice(
-		"parse-json-impl", useJSONLexer, useStdGoJSON,
+		"parse-json-impl", useFastJSONParser, useStdGoJSON,
 	).(parseJSONImplType)
 	return cfg
 }()
@@ -82,7 +82,7 @@ func (c parseConfig) parseJSON(s string) (JSON, error) {
 	switch c.impl {
 	case useStdGoJSON:
 		return parseJSONGoStd(s, c)
-	case useJSONLexer:
+	case useFastJSONParser:
 		return parseUsingFastParser(s, c)
 	default:
 		return nil, errors.AssertionFailedf("invalid ParseJSON implementation %v", c.impl)

--- a/pkg/util/json/json_test.go
+++ b/pkg/util/json/json_test.go
@@ -155,7 +155,7 @@ var parseJSONImpls = []struct {
 	opts []ParseOption
 }{
 	{name: "gostd", typ: useStdGoJSON, opts: []ParseOption{WithGoStandardParser()}},
-	{name: "lexer", typ: useJSONLexer, opts: []ParseOption{WithFastJSONParser()}},
+	{name: "lexer", typ: useFastJSONParser, opts: []ParseOption{WithFastJSONParser()}},
 }
 
 func TestJSONRoundTrip(t *testing.T) {
@@ -311,63 +311,63 @@ func TestJSONErrors(t *testing.T) {
 
 	testCases := []testCaseDef{
 		testCase(`true false`, trailingChars, useStdGoJSON),
-		testCase(`true false`, trailingChars, useJSONLexer),
+		testCase(`true false`, trailingChars, useFastJSONParser),
 		testCase(`trues`, trailingChars, useStdGoJSON),
-		testCase(`trues`, trailingChars, useJSONLexer),
+		testCase(`trues`, trailingChars, useFastJSONParser),
 		testCase(`1 2 3`, trailingChars, useStdGoJSON),
-		testCase(`1 2 3`, trailingChars, useJSONLexer),
+		testCase(`1 2 3`, trailingChars, useFastJSONParser),
 		testCase(`[1, 2, 3]]`, trailingChars, useStdGoJSON),
-		testCase(`[1, 2, 3]]`, trailingChars, useJSONLexer),
+		testCase(`[1, 2, 3]]`, trailingChars, useFastJSONParser),
 		testCase(`[1, 2, 3]   }   `, trailingChars, useStdGoJSON),
-		testCase(`[1, 2, 3]   }   `, trailingChars, useJSONLexer),
+		testCase(`[1, 2, 3]   }   `, trailingChars, useFastJSONParser),
 		// Here the decoder just grabs the 0 and leaves the 1. JSON numbers can't have
 		// leading 0s.
 		testCase(`01`, trailingChars, useStdGoJSON),
-		testCase(`01`, trailingChars, useJSONLexer),
+		testCase(`01`, trailingChars, useFastJSONParser),
 		testCase(`--01`, `invalid character '-' in numeric literal`, useStdGoJSON),
-		testCase(`--01`, `invalid JSON token`, useJSONLexer),
+		testCase(`--01`, `invalid JSON token`, useFastJSONParser),
 		testCase(`-`, `unexpected EOF`, useStdGoJSON),
-		testCase(`-`, `unable to decode JSON`, useJSONLexer),
+		testCase(`-`, `unable to decode JSON`, useFastJSONParser),
 
 		testCase(`{foo: 1}`,
 			`invalid character 'f' looking for beginning of object key string`, useStdGoJSON),
 		testCase(`{foo: 1}`, `
 ...|{foo: 1}|...
-...|.^......|...: invalid JSON token`, useJSONLexer),
+...|.^......|...: invalid JSON token`, useFastJSONParser),
 
 		testCase(`{'foo': 1}`,
 			`invalid character '\\'' looking for beginning of object key string`, useStdGoJSON),
 		testCase(`{'foo': 1}`, `
 ...|{'foo': 1}|...
-...|.^.........|...: invalid JSON token`, useJSONLexer),
+...|.^.........|...: invalid JSON token`, useFastJSONParser),
 
 		testCase(`{"foo": 01}`,
 			`invalid character '1' after object key:value pair`, useStdGoJSON),
 		testCase(`{"foo": 01}`, `
 ...|{"foo": 01}|...
-...|.........^.|...: stateObjectComma: expecting comma`, useJSONLexer),
+...|.........^.|...: stateObjectComma: expecting comma`, useFastJSONParser),
 
 		testCase(`{`, `unexpected EOF`, useStdGoJSON),
-		testCase(`{`, `unable to decode JSON`, useJSONLexer),
+		testCase(`{`, `unable to decode JSON`, useFastJSONParser),
 
 		testCase(`"\v"`, `invalid character 'v' in string escape code`, useStdGoJSON),
 		testCase(`"\v"`, `
 ...|"\v"|...
-...|^...|...: invalid string literal token`, useJSONLexer),
+...|^...|...: invalid string literal token`, useFastJSONParser),
 
 		testCase(`"\x00"`, `invalid character 'x' in string escape code`, useStdGoJSON),
 		testCase(`"\x00"`, `
 ...|"\x00"|...
-...|^.....|...: invalid string literal token`, useJSONLexer),
+...|^.....|...: invalid string literal token`, useFastJSONParser),
 
 		testCase(string([]byte{'"', '\n', '"'}), `invalid character`, useStdGoJSON),
-		testCase(string([]byte{'"', '\n', '"'}), `while decoding 3 bytes at offset 0`, useJSONLexer),
+		testCase(string([]byte{'"', '\n', '"'}), `while decoding 3 bytes at offset 0`, useFastJSONParser),
 
 		testCase(string([]byte{'"', 8, '"'}), `invalid character`, useStdGoJSON),
-		testCase(string([]byte{'"', 8, '"'}), `while decoding 3 bytes at offset 0`, useJSONLexer),
+		testCase(string([]byte{'"', 8, '"'}), `while decoding 3 bytes at offset 0`, useFastJSONParser),
 
 		testCase(`{"a":["b","c"]}]`, trailingChars, useStdGoJSON),
-		testCase(`{"a":["b","c"]}]`, trailingChars, useJSONLexer),
+		testCase(`{"a":["b","c"]}]`, trailingChars, useFastJSONParser),
 	}
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%s/%s", tc.implName, tc.input), func(t *testing.T) {


### PR DESCRIPTION
Cleanup json parser comments and constants to use
correct naming.

Epic: None

Release note: None