### PR TITLE
changefeedccl: fix deadlock in mocksyncproducer

### DIFF
--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -1608,7 +1608,10 @@ func (s *fakeKafkaSink) Dial() error {
 						return err
 					}
 				}
-				s.feedCh <- m
+				select {
+				case s.feedCh <- m:
+				case <-s.tg.done:
+				}
 				return nil
 			},
 		}}, nil


### PR DESCRIPTION
Resolves #89028

TestChangefeedKafkaMessageTooLarge would flake sometimes with goroutines blocked on sending into the mocksyncproducer feedCh and would result in a "Slow on quiesce" error. This is likely due to the jobFeed shutting down which also shuts down the consumer of feedCh.

Release note: None