### PR TITLE
release-22.1: sql/catalog: break descpb->parser dep

### DIFF
--- a/pkg/sql/catalog/descpb/BUILD.bazel
+++ b/pkg/sql/catalog/descpb/BUILD.bazel
@@ -23,7 +23,6 @@ go_library(
         "//pkg/keys",
         "//pkg/sql/catalog/catconstants",
         "//pkg/sql/catalog/catpb",
-        "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/protoreflect",

--- a/pkg/sql/catalog/descpb/column.go
+++ b/pkg/sql/catalog/descpb/column.go
@@ -11,26 +11,11 @@
 package descpb
 
 import (
-	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
-	"github.com/cockroachdb/errors"
 )
-
-// HasNullDefault checks that the column descriptor has a default of NULL.
-func (desc *ColumnDescriptor) HasNullDefault() bool {
-	if !desc.HasDefault() {
-		return false
-	}
-	defaultExpr, err := parser.ParseExpr(*desc.DefaultExpr)
-	if err != nil {
-		panic(errors.NewAssertionErrorWithWrappedErrf(err,
-			"failed to parse default expression %s", *desc.DefaultExpr))
-	}
-	return defaultExpr == tree.DNull
-}
 
 // HasDefault returns true if the column has a default value.
 func (desc *ColumnDescriptor) HasDefault() bool {

--- a/pkg/sql/catalog/table_elements.go
+++ b/pkg/sql/catalog/table_elements.go
@@ -277,6 +277,10 @@ type Column interface {
 	// HasDefault returns true iff the column has a default expression set.
 	HasDefault() bool
 
+	// HasNullDefault returns true if the column has a default expression and
+	// that expression is NULL.
+	HasNullDefault() bool
+
 	// GetDefaultExpr returns the column default expression if it exists,
 	// empty string otherwise.
 	GetDefaultExpr() string
@@ -791,7 +795,7 @@ func ColumnNeedsBackfill(col Column) bool {
 	//  - computed columns
 	//  - non-nullable columns (note: if a non-nullable column doesn't have a
 	//    default value, the backfill will fail unless the table is empty).
-	if col.ColumnDesc().HasNullDefault() {
+	if col.HasNullDefault() {
 		return false
 	}
 	return col.HasDefault() || !col.IsNullable() || col.IsComputed()

--- a/pkg/sql/catalog/tabledesc/column.go
+++ b/pkg/sql/catalog/tabledesc/column.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -100,6 +101,19 @@ func (w column) IsNullable() bool {
 // HasDefault returns true iff the column has a default expression set.
 func (w column) HasDefault() bool {
 	return w.desc.HasDefault()
+}
+
+// HasNullDefault checks that the column descriptor has a default of NULL.
+func (w column) HasNullDefault() bool {
+	if !w.HasDefault() {
+		return false
+	}
+	// We ignore the error because what are we going to do with it? It means
+	// that the default expressions is not parsable. Somebody with a context
+	// who needs to use it will be in a better place to log it. If it is not
+	// parsable, it is not NULL.
+	defaultExpr, _ := parser.ParseExpr(w.GetDefaultExpr())
+	return defaultExpr == tree.DNull
 }
 
 // GetDefaultExpr returns the column default expression if it exists,


### PR DESCRIPTION
Backport 1/1 commits from #90552.

/cc @cockroachdb/release

---

There was no need for this. Saw it as I was looking at something else.
The only difference between this backport PR and the original PR is that we deleted the `disallowed_imports_test`
since they are not supported in v22.1.

Epic: None

Release note: None

Release justification: unblock another [backport PR](https://github.com/cockroachdb/cockroach/pull/91089).
