### PR TITLE
ui: index recommendation on stmt active details

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -2141,6 +2141,7 @@ ActiveQuery represents a query in flight on some Session.
 | elapsed_time | [google.protobuf.Duration](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Duration) |  | Time elapsed since this query started execution. | [reserved](#support-status) |
 | plan_gist | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The compressed plan that can be converted back into the statement's logical plan. Empty if the statement is in the PREPARING state. | [reserved](#support-status) |
 | placeholders | [string](#cockroach.server.serverpb.ListSessionsResponse-string) | repeated | The placeholders if any. | [reserved](#support-status) |
+| database | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The database the statement was executed on. | [reserved](#support-status) |
 
 
 
@@ -2285,6 +2286,7 @@ ActiveQuery represents a query in flight on some Session.
 | elapsed_time | [google.protobuf.Duration](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Duration) |  | Time elapsed since this query started execution. | [reserved](#support-status) |
 | plan_gist | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The compressed plan that can be converted back into the statement's logical plan. Empty if the statement is in the PREPARING state. | [reserved](#support-status) |
 | placeholders | [string](#cockroach.server.serverpb.ListSessionsResponse-string) | repeated | The placeholders if any. | [reserved](#support-status) |
+| database | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The database the statement was executed on. | [reserved](#support-status) |
 
 
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
@@ -215,15 +215,15 @@ SELECT * FROM crdb_internal.session_variables WHERE variable = ''
 ----
 variable  value  hidden
 
-query TTITTTTTTBTBT colnames
+query TTITTTTTTBTBTT colnames
 SELECT * FROM crdb_internal.node_queries WHERE node_id < 0
 ----
-query_id  txn_id  node_id  session_id  user_name  start  query  client_address  application_name  distributed  phase  full_scan  plan_gist
+query_id  txn_id  node_id  session_id  user_name  start  query  client_address  application_name  distributed  phase  full_scan  plan_gist  database
 
-query TTITTTTTTBTBT colnames
+query TTITTTTTTBTBTT colnames
 SELECT * FROM crdb_internal.cluster_queries WHERE node_id < 0
 ----
-query_id  txn_id  node_id  session_id  user_name  start  query  client_address  application_name  distributed  phase  full_scan  plan_gist
+query_id  txn_id  node_id  session_id  user_name  start  query  client_address  application_name  distributed  phase  full_scan  plan_gist  database
 
 query TITTTTIIIT colnames
 SELECT  * FROM crdb_internal.node_transactions WHERE node_id < 0

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -920,6 +920,8 @@ message ActiveQuery {
   // The placeholders if any.
   repeated string placeholders = 13;
 
+  // The database the statement was executed on.
+  string database = 14;
 }
 
 // Request object for ListSessions and ListLocalSessions.

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3238,6 +3238,7 @@ func (ex *connExecutor) serialize() serverpb.Session {
 			Progress:       float32(progress),
 			IsFullScan:     query.isFullScan,
 			PlanGist:       query.planGist,
+			Database:       query.database,
 		})
 	}
 	lastActiveQuery := ""

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1167,6 +1167,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 		}
 		queryMeta.planGist = planner.instrumentation.planGist.String()
 		queryMeta.phase = executing
+		queryMeta.database = planner.CurrentDatabase()
 		// TODO(yuzefovich): introduce ternary PlanDistribution into queryMeta.
 		queryMeta.isDistributed = distributePlan.WillDistribute()
 		progAtomic := &queryMeta.progressAtomic

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1865,7 +1865,8 @@ CREATE TABLE crdb_internal.%s (
   distributed      BOOL,           -- whether the query is running distributed
   phase            STRING,         -- the current execution phase
   full_scan        BOOL,           -- whether the query contains a full table or index scan
-  plan_gist        STRING          -- Compressed logical plan.
+  plan_gist        STRING,         -- Compressed logical plan.
+  database         STRING          -- the database the statement was executed on
 )`
 
 func (p *planner) makeSessionsRequest(
@@ -2016,6 +2017,7 @@ func populateQueriesTable(
 				tree.NewDString(phase),
 				isFullScanDatum,
 				planGistDatum,
+				tree.NewDString(query.Database),
 			); err != nil {
 				return err
 			}
@@ -2041,6 +2043,7 @@ func populateQueriesTable(
 				tree.DNull,                             // phase
 				tree.DNull,                             // full_scan
 				tree.DNull,                             // plan_gist
+				tree.DNull,                             // database
 			); err != nil {
 				return err
 			}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1968,6 +1968,9 @@ type queryMeta struct {
 	// The compressed plan for this query. This can converted  back into the
 	// logical plan. This field will only be populated in the EXECUTING phase.
 	planGist string
+
+	// The database the statement was executed on.
+	database string
 }
 
 // cancel cancels the query associated with this queryMeta, by closing the

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -347,15 +347,15 @@ SELECT * FROM crdb_internal.session_variables WHERE variable = ''
 ----
 variable  value  hidden
 
-query TTITTTTTTBTBT colnames
+query TTITTTTTTBTBTT colnames
 SELECT * FROM crdb_internal.node_queries WHERE node_id < 0
 ----
-query_id  txn_id  node_id  session_id  user_name  start  query  client_address  application_name  distributed  phase  full_scan  plan_gist
+query_id  txn_id  node_id  session_id  user_name  start  query  client_address  application_name  distributed  phase  full_scan  plan_gist  database
 
-query TTITTTTTTBTBT colnames
+query TTITTTTTTBTBTT colnames
 SELECT * FROM crdb_internal.cluster_queries WHERE node_id < 0
 ----
-query_id  txn_id  node_id  session_id  user_name  start  query  client_address  application_name  distributed  phase  full_scan  plan_gist
+query_id  txn_id  node_id  session_id  user_name  start  query  client_address  application_name  distributed  phase  full_scan  plan_gist  database
 
 query TITTTTIIIT colnames
 SELECT  * FROM crdb_internal.node_transactions WHERE node_id < 0

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -373,7 +373,8 @@ CREATE TABLE crdb_internal.cluster_queries (
    distributed BOOL NULL,
    phase STRING NULL,
    full_scan BOOL NULL,
-   plan_gist STRING NULL
+   plan_gist STRING NULL,
+   database STRING NULL
 )  CREATE TABLE crdb_internal.cluster_queries (
    query_id STRING NULL,
    txn_id UUID NULL,
@@ -387,7 +388,8 @@ CREATE TABLE crdb_internal.cluster_queries (
    distributed BOOL NULL,
    phase STRING NULL,
    full_scan BOOL NULL,
-   plan_gist STRING NULL
+   plan_gist STRING NULL,
+   database STRING NULL
 )  {}  {}
 CREATE TABLE crdb_internal.cluster_sessions (
    node_id INT8 NOT NULL,
@@ -1073,7 +1075,8 @@ CREATE TABLE crdb_internal.node_queries (
    distributed BOOL NULL,
    phase STRING NULL,
    full_scan BOOL NULL,
-   plan_gist STRING NULL
+   plan_gist STRING NULL,
+   database STRING NULL
 )  CREATE TABLE crdb_internal.node_queries (
    query_id STRING NULL,
    txn_id UUID NULL,
@@ -1087,7 +1090,8 @@ CREATE TABLE crdb_internal.node_queries (
    distributed BOOL NULL,
    phase STRING NULL,
    full_scan BOOL NULL,
-   plan_gist STRING NULL
+   plan_gist STRING NULL,
+   database STRING NULL
 )  {}  {}
 CREATE TABLE crdb_internal.node_runtime_info (
    node_id INT8 NOT NULL,

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementUtils.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementUtils.spec.ts
@@ -19,7 +19,7 @@ import {
 } from "./types";
 import * as protos from "@cockroachlabs/crdb-protobuf-client";
 import moment from "moment";
-import { TimestampToMoment } from "../util/convert";
+import { TimestampToMoment } from "../util";
 import Long from "long";
 import {
   getActiveExecutionsFromSessions,
@@ -54,6 +54,7 @@ const defaultActiveStatement: ActiveStatement = {
   start: MOCK_START_TIME,
   elapsedTime: moment.duration(60),
   application: "test",
+  database: "db_test",
   user: "user",
   clientAddress: "clientAddress",
   isFullScan: false,

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementUtils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementUtils.ts
@@ -106,6 +106,7 @@ export function getActiveExecutionsFromSessions(
         const queryTxnID = byteArrayToUuid(query.txn_id);
         activeStmt = {
           statementID: query.id,
+          stmtNoConstants: query.sql_no_constants,
           transactionID: queryTxnID,
           sessionID,
           // VIEWACTIVITYREDACTED users will not have access to the full SQL query.
@@ -117,6 +118,7 @@ export function getActiveExecutionsFromSessions(
           start: TimestampToMoment(query.start),
           elapsedTime: DurationToMomentDuration(query.elapsed_time),
           application: session.application_name,
+          database: query.database,
           user: session.username,
           clientAddress: session.client_address,
           isFullScan: query.is_full_scan || false, // Or here is for conversion in case the field is null.

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/types.ts
@@ -26,12 +26,14 @@ export const SessionStatusType =
 
 export interface ActiveExecution {
   statementID?: string; // Empty for transactions not currently executing a statement.
+  stmtNoConstants?: string; // Empty for transactions not currently executing a statement.
   transactionID: string;
   sessionID: string;
   status: ExecutionStatus;
   start: Moment;
   elapsedTime: moment.Duration;
   application: string;
+  database?: string;
   query?: string; // For transactions, this is the latest query executed.
   timeSpentWaiting?: moment.Duration;
 }

--- a/pkg/ui/workspaces/cluster-ui/src/api/decodePlanGistApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/decodePlanGistApi.ts
@@ -38,7 +38,7 @@ export function getExplainPlanFromGist(
       },
     ],
     execute: true,
-    timeout: "10s",
+    timeout: "30s",
   };
 
   return executeInternalSql<DecodePlanGistColumns>(request).then(result => {
@@ -59,9 +59,9 @@ export function getExplainPlanFromGist(
       };
     }
 
-    const explainPlan = result.execution.txn_results[0].rows
-      .map(col => col.plan_row)
-      .join("\n");
+    const explainPlan =
+      `Plan Gist: ${req.planGist} \n\n` +
+      result.execution.txn_results[0].rows.map(col => col.plan_row).join("\n");
 
     return { explainPlan };
   });

--- a/pkg/ui/workspaces/cluster-ui/src/api/idxRecForStatementApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/idxRecForStatementApi.ts
@@ -1,0 +1,81 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { SqlExecutionRequest, executeInternalSql } from "./sqlApi";
+
+export type IndexRecommendationsResponse = {
+  recommendations?: string[];
+  error?: Error;
+};
+
+export type IndexRecommendationsRequest = {
+  planGist: string;
+  appName: string;
+  query: string;
+};
+
+type IndexRecommendationsColumns = {
+  index_recommendations: string[];
+};
+
+/**
+ * getIdxRecommendationsFromExecution gets the latest index recommendation from the same
+ * plan gist, app name and query combination.
+ * @param req the request providing the planGist
+ */
+export function getIdxRecommendationsFromExecution(
+  req: IndexRecommendationsRequest,
+): Promise<IndexRecommendationsResponse> {
+  const request: SqlExecutionRequest = {
+    statements: [
+      {
+        sql: `SELECT index_recommendations 
+                from 
+                    crdb_internal.statement_statistics 
+                where
+                  statistics -> 'statistics' -> 'planGists' ->> 0 = '${req.planGist}'
+                  AND app_name = '${req.appName}'
+                  AND metadata ->> 'query' = '${req.query}'
+                ORDER BY aggregated_ts DESC 
+                LIMIT 1`,
+      },
+    ],
+    execute: true,
+    timeout: "30s",
+  };
+
+  return executeInternalSql<IndexRecommendationsColumns>(request).then(
+    result => {
+      if (
+        result.execution.txn_results.length === 0 ||
+        !result.execution.txn_results[0].rows
+      ) {
+        return {
+          error: result.execution.txn_results
+            ? result.execution.txn_results[0].error
+            : null,
+        };
+      }
+
+      if (result.execution.txn_results[0].error) {
+        return {
+          error: result.execution.txn_results[0].error,
+        };
+      }
+
+      const recommendations =
+        result.execution.txn_results[0].rows.length > 0
+          ? result.execution.txn_results[0].rows[0].index_recommendations
+          : [];
+
+      return { recommendations };
+    },
+  );
+}

--- a/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.tsx
@@ -241,9 +241,9 @@ function descriptionCell(
 
 function actionCell(
   insightRec: InsightRecommendation,
-  isCockroachCloud: boolean,
+  hideAction: boolean,
 ): React.ReactElement {
-  if (isCockroachCloud) {
+  if (hideAction) {
     return <></>;
   }
   let query = "";
@@ -282,7 +282,7 @@ function actionCell(
 }
 
 export function makeInsightsColumns(
-  isCockroachCloud: boolean,
+  hideAction: boolean,
   disableStmtLink?: boolean,
 ): ColumnDescriptor<InsightRecommendation>[] {
   return [
@@ -302,7 +302,7 @@ export function makeInsightsColumns(
     {
       name: "action",
       title: insightsTableTitles.actions(),
-      cell: (item: InsightRecommendation) => actionCell(item, isCockroachCloud),
+      cell: (item: InsightRecommendation) => actionCell(item, hideAction),
     },
   ];
 }

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/activeStatementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/activeStatementDetails.tsx
@@ -32,6 +32,9 @@ import "antd/lib/row/style";
 import styles from "./statementDetails.module.scss";
 import LoadingError from "../sqlActivity/errorComponent";
 import { Loading } from "../loading";
+import { Insights } from "./planDetails";
+import { getIdxRecommendationsFromExecution } from "../api/idxRecForStatementApi";
+import { SortSetting } from "../sortedtable";
 const cx = classNames.bind(styles);
 
 export type ActiveStatementDetailsStateProps = {
@@ -73,6 +76,11 @@ export const ActiveStatementDetails: React.FC<ActiveStatementDetailsProps> = ({
     loaded: false,
     error: null,
   });
+  const [indexRecommendations, setIndexRecommendations] = useState<string[]>();
+  const [insightsSortSetting, setInsightsSortSetting] = useState<SortSetting>({
+    ascending: false,
+    columnTitle: "insights",
+  });
 
   useEffect(() => {
     if (statement == null) {
@@ -96,6 +104,13 @@ export const ActiveStatementDetails: React.FC<ActiveStatementDetailsProps> = ({
           error: res.error,
         });
       });
+      getIdxRecommendationsFromExecution({
+        planGist: statement.planGist,
+        query: statement.stmtNoConstants,
+        appName: statement.application,
+      }).then(res => {
+        setIndexRecommendations(res.recommendations);
+      });
     }
   };
 
@@ -103,6 +118,7 @@ export const ActiveStatementDetails: React.FC<ActiveStatementDetailsProps> = ({
     history.push("/sql-activity?tab=Statements&view=active");
   };
 
+  const hasInsights = indexRecommendations?.length > 0;
   return (
     <div className={cx("root")}>
       <Helmet title={`Details`} />
@@ -166,6 +182,15 @@ export const ActiveStatementDetails: React.FC<ActiveStatementDetailsProps> = ({
                     value={explainPlanState.explainPlan || "Not available."}
                     size={SqlBoxSize.custom}
                   />
+                  {hasInsights && (
+                    <Insights
+                      idxRecommendations={indexRecommendations}
+                      query={statement.stmtNoConstants}
+                      database={statement.database}
+                      sortSetting={insightsSortSetting}
+                      onChangeSortSetting={setInsightsSortSetting}
+                    />
+                  )}
                 </Loading>
               </Col>
             </Row>


### PR DESCRIPTION
This commit:
- Adds "database" to the ListSessions response
and the `crdb_internal.{node,cluster}_queries` tables.
This field is only populated when the query enters the
EXECUTING phase.
- Refactors the insights components on the plan details
file, so it can be used for both statement fingerprint and
statement active execution details page.
- Add the plan gist at the top of the explain plan
on active execution details
- Adds the index recommendations insights
to the explain plan tab on statement active execution
details.

https://www.loom.com/share/f539a96201774d1fabdb3519f64c31cb

Fixes https://github.com/cockroachdb/cockroach/issues/90876

Release note (ui change): Adding index recommendations
to the statement active execution details page and add the
plan gist as the first line of the explain plan also on the
statement active execution details page.

Release note (sql change): New column "database" added to
`crdb_internal.{node,cluster}_queries` and list sessions endpoint.