### PR TITLE
kvserver: fix allocator determinism

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_scorer.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_scorer.go
@@ -1365,7 +1365,19 @@ func rankedCandidateListForRebalancing(
 
 	var equivalenceClasses []equivalenceClass
 	var needRebalanceTo bool
-	for _, existing := range existingStores {
+
+	// NB: The existing stores must be sorted during iteration in order to
+	// ensure determinism. When determinism isn't required, we still sort them
+	// as the cases where ordering is relevant are rare enough to not cause
+	// instability.
+	existingStoreList := make(roachpb.StoreIDSlice, 0, len(existingStores))
+	for storeID := range existingStores {
+		existingStoreList = append(existingStoreList, storeID)
+	}
+	sort.Sort(existingStoreList)
+
+	for _, storeID := range existingStoreList {
+		existing := existingStores[storeID]
 		var comparableCands candidateList
 		for _, store := range allStores.Stores {
 			// Only process replacement candidates, not existing stores.

--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
@@ -7366,6 +7366,84 @@ func TestSimulateFilterUnremovableReplicas(t *testing.T) {
 	}
 }
 
+// TestAllocatorRebalanceDeterminism tests that calls to RebalanceVoter are
+// deterministic.
+func TestAllocatorRebalanceDeterminism(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	stores := []*roachpb.StoreDescriptor{
+		{
+			StoreID:    1,
+			Attrs:      roachpb.Attributes{},
+			Node:       roachpb.NodeDescriptor{NodeID: 1},
+			Capacity:   roachpb.StoreCapacity{LeaseCount: 934, RangeCount: 934},
+			Properties: roachpb.StoreProperties{},
+		},
+		{
+			StoreID:  2,
+			Node:     roachpb.NodeDescriptor{NodeID: 3},
+			Capacity: roachpb.StoreCapacity{LeaseCount: 0, RangeCount: 933},
+		},
+		{
+			StoreID:  3,
+			Node:     roachpb.NodeDescriptor{NodeID: 3},
+			Capacity: roachpb.StoreCapacity{LeaseCount: 0, RangeCount: 934},
+		},
+		{
+			StoreID:  4,
+			Node:     roachpb.NodeDescriptor{NodeID: 4},
+			Capacity: roachpb.StoreCapacity{LeaseCount: 118, RangeCount: 349},
+		},
+		{
+			StoreID:  5,
+			Node:     roachpb.NodeDescriptor{NodeID: 5},
+			Capacity: roachpb.StoreCapacity{LeaseCount: 115, RangeCount: 351},
+		},
+		{
+			StoreID:  6,
+			Node:     roachpb.NodeDescriptor{NodeID: 6},
+			Capacity: roachpb.StoreCapacity{LeaseCount: 118, RangeCount: 349},
+		},
+		{
+			StoreID:  7,
+			Node:     roachpb.NodeDescriptor{NodeID: 7},
+			Capacity: roachpb.StoreCapacity{LeaseCount: 105, RangeCount: 350},
+		},
+	}
+
+	runner := func() func() (roachpb.ReplicationTarget, roachpb.ReplicationTarget) {
+		ctx := context.Background()
+		stopper, g, _, a, _ := CreateTestAllocator(ctx, 7 /* numNodes */, true /* deterministic */)
+		defer stopper.Stop(ctx)
+		gossiputil.NewStoreGossiper(g).GossipStores(stores, t)
+		return func() (roachpb.ReplicationTarget, roachpb.ReplicationTarget) {
+			var rangeUsageInfo allocator.RangeUsageInfo
+			// Ensure that we wouldn't normally rebalance when all stores have the same
+			// replica count.
+			add, remove, _, _ := a.RebalanceVoter(
+				ctx,
+				roachpb.TestingDefaultSpanConfig(),
+				nil,
+				replicas(1, 2, 5),
+				nil,
+				rangeUsageInfo,
+				storepool.StoreFilterThrottled,
+				a.ScorerOptions(ctx),
+			)
+			return add, remove
+		}
+	}
+
+	ra, rb := runner(), runner()
+	for i := 0; i < 2000; i++ {
+		addA, removeA := ra()
+		addB, removeB := rb()
+		require.Equal(t, addA, addB, "%d iters", i)
+		require.Equal(t, removeA, removeB, "%d iters", i)
+	}
+}
+
 // TestAllocatorRebalanceWithScatter tests that when `scatter` is set to true,
 // the allocator will produce rebalance opportunities even when it normally
 // wouldn't.


### PR DESCRIPTION
Previously, the allocator when running in deterministic mode, would not be deterministic under all scenarios due to iteration over an unordered map. This patch fixes this by first sorting entries, before iterating.

resolves: #89394

Release note: None