### PR TITLE
kv: perform range lookups optimistically on followers

### DIFF
--- a/pkg/kv/kvclient/kvcoord/range_iter.go
+++ b/pkg/kv/kvclient/kvcoord/range_iter.go
@@ -196,8 +196,12 @@ func (ri *RangeIterator) Seek(ctx context.Context, key roachpb.RKey, scanDir Sca
 	// deals with retryable range descriptor lookups.
 	var err error
 	for r := retry.StartWithCtx(ctx, ri.ds.rpcRetryOptions); r.Next(); {
+		// Note that we pass an empty eviction token here because ri.token
+		// corresponds to the previous range.
 		var rngInfo rangecache.EvictionToken
-		rngInfo, err = ri.ds.getRoutingInfo(ctx, ri.key, ri.token, ri.scanDir == Descending)
+		rngInfo, err = ri.ds.getRoutingInfo(
+			ctx, ri.key, rangecache.EvictionToken{}, ri.scanDir == Descending,
+		)
 
 		// getRoutingInfo may fail retryably if, for example, the first
 		// range isn't available via Gossip. Assume that all errors at

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner_test.go
@@ -1655,7 +1655,7 @@ func (s descriptorDBRangeIterator) Valid() bool {
 }
 
 func (s *descriptorDBRangeIterator) Seek(ctx context.Context, key roachpb.RKey, dir ScanDirection) {
-	descs, _, err := s.db.RangeLookup(ctx, key, dir == Descending)
+	descs, _, err := s.db.RangeLookup(ctx, key, roachpb.READ_UNCOMMITTED, dir == Descending)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/kv/kvclient/rangecache/range_cache.go
+++ b/pkg/kv/kvclient/rangecache/range_cache.go
@@ -72,6 +72,20 @@ func (k *rangeCacheKey) Compare(o llrb.Comparable) int {
 	return bytes.Compare(*k, *o.(*rangeCacheKey))
 }
 
+// RangeLookupConsistency is an alias for ReadConsistencyType. In the
+// cases it is referenced, the only acceptable values are READ_UNCOMMITTED
+// and INCONSISTENT. The hope with this alias and the consts below
+// it increase code clarity and lead readers of the code here.
+type RangeLookupConsistency = roachpb.ReadConsistencyType
+
+const (
+	// ReadFromFollower is the RangeLookupConsistency used to read from a follower.
+	ReadFromFollower = roachpb.INCONSISTENT
+	// ReadFromLeaseholder is the RangeLookupConsistency used to read from the
+	// leaseholder.
+	ReadFromLeaseholder = roachpb.READ_UNCOMMITTED
+)
+
 // RangeDescriptorDB is a type which can query range descriptors from an
 // underlying datastore. This interface is used by RangeCache to
 // initially retrieve information which will be cached.
@@ -80,8 +94,17 @@ type RangeDescriptorDB interface {
 	// descriptors are returned. The first of these slices holds descriptors
 	// whose [startKey,endKey) spans contain the given key (possibly from
 	// intents), and the second holds prefetched adjacent descriptors.
+	//
+	// Note that the acceptable consistency values are the constants defined
+	// in this package: ReadFromFollower and ReadFromLeaseholder. The
+	// RangeLookupConsistency type is aliased to roachpb.ReadConsistencyType
+	// in order to permit implementations of this interface to import this
+	// package.
 	RangeLookup(
-		ctx context.Context, key roachpb.RKey, useReverseScan bool,
+		ctx context.Context,
+		key roachpb.RKey,
+		consistency RangeLookupConsistency,
+		useReverseScan bool,
 	) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error)
 
 	// FirstRange returns the descriptor for the first Range. This is the
@@ -587,6 +610,23 @@ func (et *EvictionToken) evictAndReplaceLocked(ctx context.Context, newDescs ...
 // The returned EvictionToken contains the descriptor and, possibly, the lease.
 // It can also be used to evict information from the cache if it's found to be
 // stale.
+//
+// In the common cache miss case, the lookup will be routed to a
+// follower replica. In cases where a stale view of the range descriptor
+// no longer corresponds to any replicas in the range, relying on a stale
+// view of the range addressing as might be served from a follower does not
+// ensure that the client will be able to make progress. Fortunately, this
+// scenario can be detected through the use of evictToken.
+//
+// This method is called with a non-zero evictToken after a sendError is
+// returned from (*DistSender).sendToReplicas. In this case, the eviction
+// token from the previous iteration of the sendPartialBatch loop (the one
+// that failed) is provided. In this case, the method will ensure that the
+// optimistic read which may have been evaluated on follower returns a
+// result with a generation number greater than the generation stored in
+// evictToken. If the initial read which maybe routed to followers returns
+// a result that is not newer, the request will be re-issued to the
+// leaseholder.
 func (rc *RangeCache) LookupWithEvictionToken(
 	ctx context.Context, key roachpb.RKey, evictToken EvictionToken, useReverseScan bool,
 ) (EvictionToken, error) {
@@ -720,14 +760,31 @@ func (rc *RangeCache) tryLookup(
 	}
 	requestKey := makeLookupRequestKey(key, prevDesc, useReverseScan)
 
-	// Enforce that the causality token actually applies to the key we're
-	// looking up.
-	if evictToken.Valid() && (useReverseScan && !evictToken.desc.ContainsKeyInverted(key)) ||
-		(!useReverseScan && !evictToken.desc.ContainsKey(key)) {
-		return EvictionToken{}, errors.AssertionFailedf(
-			"invalid eviction token for lookup %v (reverse=%v) does not contain %v",
-			evictToken.desc.RSpan(), useReverseScan, key,
-		)
+	// lookupResult wraps the EvictionToken to report to the callers the
+	// consistency level ultimately used for this lookup.
+	type lookupResult struct {
+		EvictionToken
+		consistency RangeLookupConsistency
+	}
+
+	// lookupResultIsStale is used to determine if the result of a lookup which
+	// was performed on a follower is known to be stale given the current
+	// eviction token. In many cases, there is no previous descriptor. The case
+	// of interest is when we're doing a lookup
+	lookupResultIsStale := func(lookupResult) bool { return false }
+	if evictToken.Valid() {
+		// Enforce that the causality token actually applies to the key we're
+		// looking up.
+		if (useReverseScan && !evictToken.desc.ContainsKeyInverted(key)) ||
+			(!useReverseScan && !evictToken.desc.ContainsKey(key)) {
+			return EvictionToken{}, errors.AssertionFailedf(
+				"invalid eviction token for lookup %v (reverse=%v) does not contain %v",
+				evictToken.desc.RSpan(), useReverseScan, key,
+			)
+		}
+		lookupResultIsStale = func(res lookupResult) bool {
+			return res.Desc().Generation <= evictToken.desc.Generation
+		}
 	}
 
 	// Fork a context with a new span before reqCtx is captured by the DoChan
@@ -737,8 +794,8 @@ func (rc *RangeCache) tryLookup(
 	reqCtx, reqSpan := tracing.EnsureChildSpan(ctx, rc.tracer, "range lookup")
 	resC, leader := rc.lookupRequests.DoChan(requestKey, func() (interface{}, error) {
 		defer reqSpan.Finish()
-		var lookupRes EvictionToken
-		if err := rc.stopper.RunTaskWithErr(reqCtx, "rangecache: range lookup", func(ctx context.Context) error {
+		var lookupRes lookupResult
+		if err := rc.stopper.RunTaskWithErr(reqCtx, "rangecache: range lookup", func(ctx context.Context) (err error) {
 			// Clear the context's cancelation. This request services potentially many
 			// callers waiting for its result, and using the flight's leader's
 			// cancelation doesn't make sense.
@@ -747,84 +804,25 @@ func (rc *RangeCache) tryLookup(
 			defer cancel()
 			ctx = tracing.ContextWithSpan(ctx, reqSpan)
 
-			// Since we don't inherit any other cancelation, let's put in a generous
-			// timeout as some protection against unavailable meta ranges.
-			var rs, preRs []roachpb.RangeDescriptor
-			if err := contextutil.RunWithTimeout(ctx, "range lookup", 10*time.Second,
-				func(ctx context.Context) error {
-					var err error
-					rs, preRs, err = rc.performRangeLookup(ctx, key, useReverseScan)
+			// Attempt to perform the lookup by reading from a follower. If the
+			// result is too old for the leader of this group, then we'll fall back
+			// to reading from the leaseholder. Note that it's possible that the
+			// leader will have no freshness constraints on its view of the range
+			// addressing but one of the shared members of the group will see the
+			// result as too old. That case will be detected below and will result
+			// in that goroutine re-fetching.
+			lookupRes.consistency = ReadFromFollower
+			{
+				lookupRes.EvictionToken, err = tryLookupImpl(ctx, rc, key, lookupRes.consistency, useReverseScan)
+				shouldReturnError := err != nil && !errors.Is(err, errFailedToFindNewerDescriptor)
+				gotFreshResult := err == nil && !lookupResultIsStale(lookupRes)
+				if shouldReturnError || gotFreshResult {
 					return err
-				}); err != nil {
-				return err
-			}
-
-			switch {
-			case len(rs) == 0:
-				return fmt.Errorf("no range descriptors returned for %s", key)
-			case len(rs) > 2:
-				panic(fmt.Sprintf("more than 2 matching range descriptors returned for %s: %v", key, rs))
-			}
-
-			// We want to be assured that all goroutines which experienced a cache miss
-			// have joined our in-flight request, and all others will experience a
-			// cache hit. This requires atomicity across cache population and
-			// notification, hence this exclusive lock.
-			rc.rangeCache.Lock()
-			defer rc.rangeCache.Unlock()
-
-			// Insert the descriptor and the prefetched ones. We don't insert rs[1]
-			// (if any), since it overlaps with rs[0]; rs[1] will be handled by
-			// rs[0]'s eviction token. Note that ranges for which the cache has more
-			// up-to-date information will not be clobbered - for example ranges for
-			// which the cache has the prefetched descriptor already plus a lease.
-			newEntries := make([]*CacheEntry, len(preRs)+1)
-			newEntries[0] = &CacheEntry{
-				desc: rs[0],
-				// We don't have any lease information.
-				lease: roachpb.Lease{},
-				// We don't know the closed timestamp policy.
-				closedts: roachpb.LAG_BY_CLUSTER_SETTING,
-			}
-			for i, preR := range preRs {
-				newEntries[i+1] = &CacheEntry{desc: preR}
-			}
-			insertedEntries := rc.insertLockedInner(ctx, newEntries)
-			// entry corresponds to rs[0], which is the descriptor covering the key
-			// we're interested in.
-			entry := insertedEntries[0]
-			// There's 3 cases here:
-			//
-			//  1. We succeeded in inserting rs[0].
-			//  2. We didn't succeed in inserting rs[0], but insertedEntries[0] still
-			//     was non-nil. This means that the cache had a newer version of the
-			//     descriptor. In that case it's all good, we just pretend that
-			//     that's the version we were inserting; we put it in our token and
-			//     continue.
-			//  3. insertedEntries[0] is nil. The cache has newer entries in them
-			//     and they're not compatible with the descriptor we were trying to
-			//     insert. This case should be rare, since very recently (before
-			//     starting the singleflight), the cache didn't have any entry for
-			//     the requested key. We'll continue with the stale rs[0]; we'll
-			//     pretend that we did by putting a dummy entry in the eviction
-			//     token. This will make eviction no-ops (which makes sense -
-			//     there'll be nothing to evict since we didn't insert anything).
-			//
-			// TODO(andrei): It'd be better to retry the cache/database lookup in
-			// case 3.
-			if entry == nil {
-				entry = &CacheEntry{
-					desc:     rs[0],
-					lease:    roachpb.Lease{},
-					closedts: roachpb.LAG_BY_CLUSTER_SETTING,
 				}
 			}
-			if len(rs) == 1 {
-				lookupRes = rc.makeEvictionToken(entry, nil /* nextDesc */)
-			} else {
-				lookupRes = rc.makeEvictionToken(entry, &rs[1] /* nextDesc */)
-			}
-			return nil
+			lookupRes.consistency = ReadFromLeaseholder
+			lookupRes.EvictionToken, err = tryLookupImpl(ctx, rc, key, lookupRes.consistency, useReverseScan)
+			return err
 		}); err != nil {
 			return nil, err
 		}
@@ -858,7 +856,7 @@ func (rc *RangeCache) tryLookup(
 	if res.Err != nil {
 		s = res.Err.Error()
 	} else {
-		s = res.Val.(EvictionToken).String()
+		s = res.Val.(lookupResult).String()
 	}
 	if res.Shared {
 		log.VEventf(ctx, 2, "looked up range descriptor with shared request: %s", s)
@@ -878,14 +876,144 @@ func (rc *RangeCache) tryLookup(
 	// a retry at a higher level inside the cache. Note that the retry might find
 	// the descriptor it's looking for in the cache if it was pre-fetched by the
 	// original lookup.
-	lookupRes := res.Val.(EvictionToken)
+	lookupRes := res.Val.(lookupResult)
 	desc := lookupRes.Desc()
 	containsFn := (*roachpb.RangeDescriptor).ContainsKey
 	if useReverseScan {
 		containsFn = (*roachpb.RangeDescriptor).ContainsKeyInverted
 	}
-	if !containsFn(desc, key) {
+	if !containsFn(desc, key) ||
+		// The result may be stale relative to the requirements implied by the
+		// eviction token, but our goroutine joined a single-flight which was
+		// content to accept a result we know was stale. If the read was
+		// performed against a follower and is stale, then we should try again.
+		(lookupRes.consistency == ReadFromFollower && lookupResultIsStale(lookupRes)) {
+
+		// The singleflight leader should never get this error: the
+		// kv.RangeLookup code will ensure that the returned descriptor contains
+		// the key that this goroutine was looking for. The lookup logic in the
+		// singleflight should ensure that if we get back a stale response, it's
+		// only after going to the leaseholder.
+		if !res.Shared {
+			return EvictionToken{}, errors.AssertionFailedf(
+				"singleflight leader in range lookup received a stale response",
+			)
+		}
+
 		return EvictionToken{}, newLookupCoalescingError(key, desc)
+	}
+	return lookupRes.EvictionToken, nil
+}
+
+var errFailedToFindNewerDescriptor = errors.New("failed to find descriptor")
+
+// tryLookupImpl is the implementation of one attempt of rc.tryLookupImpl at a
+// specified consistency. Note that if the consistency is ReadFromFollower,
+// this call may return errFailedToFindNewerDescriptor, which the caller
+// should handle by performing a fresh lookup at ReadFromLeaseholder. If
+// the consistency is ReadFromLeaseholder, that error will not be returned.
+func tryLookupImpl(
+	ctx context.Context,
+	rc *RangeCache,
+	key roachpb.RKey,
+	consistency RangeLookupConsistency,
+	useReverseScan bool,
+) (lookupRes EvictionToken, _ error) {
+	// Since we don't inherit any other cancelation, let's put in a generous
+	// timeout as some protection against unavailable meta ranges.
+	var rs, preRs []roachpb.RangeDescriptor
+	if err := contextutil.RunWithTimeout(ctx, "range lookup", 10*time.Second,
+		func(ctx context.Context) error {
+			var err error
+			rs, preRs, err = rc.performRangeLookup(ctx, key, consistency, useReverseScan)
+			return err
+		}); err != nil {
+		return EvictionToken{}, err
+	}
+
+	switch {
+	case len(rs) == 0 && consistency == ReadFromFollower:
+		// If we don't find any matching descriptors, but we read from a follower,
+		// return the sentinel error to retry on the leaseholder.
+		return EvictionToken{}, errFailedToFindNewerDescriptor
+	case len(rs) == 0:
+		// The lookup code, when routed to a leaseholder, ought to retry
+		// internally, so this case is not expected.
+		return EvictionToken{}, errors.AssertionFailedf(
+			"no range descriptors returned for %s", key,
+		)
+	case len(rs) > 2:
+		// Only one intent is allowed to exist on a key at a time. The results
+		// should, at most, be one committed value and one intent. Anything else
+		// is unexpected.
+		return EvictionToken{}, errors.AssertionFailedf(
+			"more than 2 matching range descriptors returned for %s: %v", key, rs,
+		)
+	}
+
+	// We want to be assured that all goroutines which experienced a cache miss
+	// have joined our in-flight request, and all others will experience a
+	// cache hit. This requires atomicity across cache population and
+	// notification, hence this exclusive lock.
+	rc.rangeCache.Lock()
+	defer rc.rangeCache.Unlock()
+
+	// Insert the descriptor and the prefetched ones. We don't insert rs[1]
+	// (if any), since it overlaps with rs[0]; rs[1] will be handled by
+	// rs[0]'s eviction token. Note that ranges for which the cache has more
+	// up-to-date information will not be clobbered - for example ranges for
+	// which the cache has the prefetched descriptor already plus a lease.
+	newEntries := make([]*CacheEntry, len(preRs)+1)
+	newEntries[0] = &CacheEntry{
+		desc: rs[0],
+		// We don't have any lease information.
+		lease: roachpb.Lease{},
+		// We don't know the closed timestamp policy.
+		closedts: roachpb.LAG_BY_CLUSTER_SETTING,
+	}
+	for i, preR := range preRs {
+		newEntries[i+1] = &CacheEntry{desc: preR}
+	}
+	insertedEntries := rc.insertLockedInner(ctx, newEntries)
+	// entry corresponds to rs[0], which is the descriptor covering the key
+	// we're interested in.
+	entry := insertedEntries[0]
+	// There's 4 cases here:
+	//
+	//  1. We succeeded in inserting rs[0].
+	//  2. We didn't succeed in inserting rs[0], but insertedEntries[0] still
+	//     was non-nil. This means that the cache had a newer version of the
+	//     descriptor. In that case it's all good, we just pretend that
+	//     that's the version we were inserting; we put it in our token and
+	//     continue.
+	//  3. insertedEntries[0] is nil and we did a consistent read. The cache
+	//     has newer entries in them and they're not compatible with the
+	//     descriptor we were trying to insert. This case should be rare, since
+	//     very recently (before starting the singleflight), the cache didn't
+	//     have any entry for the requested key. We'll continue with the stale
+	//     rs[0]; we'll pretend that we did by putting a dummy entry in the
+	//     eviction token. This will make eviction no-ops (which makes sense -
+	//     there'll be nothing to evict since we didn't insert anything).
+	//  4. insertedEntries[0] is nil and we did a potentially stale read. The
+	//     caller should retry by routing a request to the leaseholder for the
+	//     meta range.
+	//
+	// TODO(andrei): It'd be better to retry the cache/database lookup in
+	// case 3.
+	if entry == nil {
+		if consistency == ReadFromFollower {
+			return EvictionToken{}, errFailedToFindNewerDescriptor
+		}
+		entry = &CacheEntry{
+			desc:     rs[0],
+			lease:    roachpb.Lease{},
+			closedts: roachpb.LAG_BY_CLUSTER_SETTING,
+		}
+	}
+	if len(rs) == 1 {
+		lookupRes = rc.makeEvictionToken(entry, nil /* nextDesc */)
+	} else {
+		lookupRes = rc.makeEvictionToken(entry, &rs[1] /* nextDesc */)
 	}
 	return lookupRes, nil
 }
@@ -893,7 +1021,7 @@ func (rc *RangeCache) tryLookup(
 // performRangeLookup handles delegating the range lookup to the cache's
 // RangeDescriptorDB.
 func (rc *RangeCache) performRangeLookup(
-	ctx context.Context, key roachpb.RKey, useReverseScan bool,
+	ctx context.Context, key roachpb.RKey, consistency RangeLookupConsistency, useReverseScan bool,
 ) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error) {
 	// Tag inner operations.
 	ctx = logtags.AddTag(ctx, "range-lookup", key)
@@ -909,7 +1037,7 @@ func (rc *RangeCache) performRangeLookup(
 		return []roachpb.RangeDescriptor{*desc}, nil, nil
 	}
 
-	return rc.db.RangeLookup(ctx, key, useReverseScan)
+	return rc.db.RangeLookup(ctx, key, consistency, useReverseScan)
 }
 
 // Clear clears all RangeDescriptors from the RangeCache.

--- a/pkg/kv/kvclient/rangecache/range_cache_test.go
+++ b/pkg/kv/kvclient/rangecache/range_cache_test.go
@@ -123,7 +123,7 @@ func (db *testDescriptorDB) FirstRange() (*roachpb.RangeDescriptor, error) {
 }
 
 func (db *testDescriptorDB) RangeLookup(
-	ctx context.Context, key roachpb.RKey, useReverseScan bool,
+	ctx context.Context, key roachpb.RKey, _ RangeLookupConsistency, useReverseScan bool,
 ) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error) {
 	// Notify the test of the lookup, if the test wants notifications.
 	if ch, ok := db.listeners[key.String()]; ok {

--- a/pkg/kv/kvclient/rangecache/rangecachemock/mocks_generated.go
+++ b/pkg/kv/kvclient/rangecache/rangecachemock/mocks_generated.go
@@ -51,9 +51,9 @@ func (mr *MockRangeDescriptorDBMockRecorder) FirstRange() *gomock.Call {
 }
 
 // RangeLookup mocks base method.
-func (m *MockRangeDescriptorDB) RangeLookup(arg0 context.Context, arg1 roachpb.RKey, arg2 bool) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error) {
+func (m *MockRangeDescriptorDB) RangeLookup(arg0 context.Context, arg1 roachpb.RKey, arg2 roachpb.ReadConsistencyType, arg3 bool) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RangeLookup", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "RangeLookup", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].([]roachpb.RangeDescriptor)
 	ret1, _ := ret[1].([]roachpb.RangeDescriptor)
 	ret2, _ := ret[2].(error)
@@ -61,7 +61,7 @@ func (m *MockRangeDescriptorDB) RangeLookup(arg0 context.Context, arg1 roachpb.R
 }
 
 // RangeLookup indicates an expected call of RangeLookup.
-func (mr *MockRangeDescriptorDBMockRecorder) RangeLookup(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockRangeDescriptorDBMockRecorder) RangeLookup(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RangeLookup", reflect.TypeOf((*MockRangeDescriptorDB)(nil).RangeLookup), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RangeLookup", reflect.TypeOf((*MockRangeDescriptorDB)(nil).RangeLookup), arg0, arg1, arg2, arg3)
 }


### PR DESCRIPTION
This change exposes the choice of consistency level to the `RangeDescriptorDB`,
and to ensure that the `kv.RangeLookup` code sets the `RoutingPolicy`
appropriately.

The change adopts the INCONSISTENT consistency level in the `RangeCache` when
performing lookups. The commentary in the change explains the logic. The gist
is that we're going to first try to read from a follower, and, when we know
the result we read is too stale, we'll try again from the leaseholder.

One short-coming of this approach is that we won't get intents on the
optimistic reads. The reason we don't is because the INCONSISTENT
ReadConsistencyType won't return intents.

Fixes https://github.com/cockroachdb/cockroach/issues/91432

#### kvclient: make EvictionToken contract more strict

We should only pass an eviction token which corresponds to the key being looked
up. Prior to this change, there was a scenario when iterating whereby we'd pass
the eviction token from the previous range. It's possible in some cases this
might have helped to pipeline lookups in the case of rapid splits. Hopefully
the work to do optimistic follower lookups will make any of that moot.

Release note (performance improvement): In some cases, the key-value store client needs to look up where to send requests. Prior to this change, such lookup requests were always routed to the leaseholder of the metadata range storing that information. Now the client can attempt to look up this metadata from followers. This can improve tail latency in multi-region clusters in cases where the range addressing cache is cold.