### PR TITLE
release-22.2: opt: mark SimplifyRange as essential

### DIFF
--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -1000,6 +1000,8 @@ func (o *Optimizer) disableRulesRandom(probability float64) {
 		// Needed to prevent rule cycles that lead to timeouts and OOMs.
 		int(opt.EliminateProject),
 		int(opt.EliminateSelect),
+		// Needed to ensure that the input of a RangeExpr is always an AndExpr.
+		int(opt.SimplifyRange),
 	)
 
 	var disabledRules RuleSet


### PR DESCRIPTION
Backport 1/1 commits from #88399.

/cc @cockroachdb/release

---

This commit marks the `SimplifyRange` normalization rule as essential during random rule-disabling tests. This is necessary because `RangeExpr` is expected to maintain the invariant that its input is always an `AndExpr`. Other rules can replace the `AndExpr` with a different expression over the course of normalization, at which point the `RangeExpr` needs to be removed. Otherwise, various code-paths that depend on the invariant may panic (for example, predicate implication).

Fixes #88352

Release note: None

Release justification: testing-only fix for optimizer panic