### PR TITLE
release-22.1: colexec: use tree.DNull when projection is called on null input

### DIFF
--- a/pkg/sql/colexec/colexecproj/proj_const_left_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_const_left_ops.eg.go
@@ -71,14 +71,12 @@ func (p projBitandInt16ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -90,7 +88,7 @@ func (p projBitandInt16ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -152,14 +150,12 @@ func (p projBitandInt16ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -171,7 +167,7 @@ func (p projBitandInt16ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -233,14 +229,12 @@ func (p projBitandInt16ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -252,7 +246,7 @@ func (p projBitandInt16ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -314,14 +308,12 @@ func (p projBitandInt32ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -333,7 +325,7 @@ func (p projBitandInt32ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -395,14 +387,12 @@ func (p projBitandInt32ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -414,7 +404,7 @@ func (p projBitandInt32ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -476,14 +466,12 @@ func (p projBitandInt32ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -495,7 +483,7 @@ func (p projBitandInt32ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -557,14 +545,12 @@ func (p projBitandInt64ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -576,7 +562,7 @@ func (p projBitandInt64ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -638,14 +624,12 @@ func (p projBitandInt64ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -657,7 +641,7 @@ func (p projBitandInt64ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -719,14 +703,12 @@ func (p projBitandInt64ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -738,7 +720,7 @@ func (p projBitandInt64ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -802,16 +784,17 @@ func (p projBitandDatumConstDatumOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
@@ -828,9 +811,12 @@ func (p projBitandDatumConstDatumOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
@@ -844,7 +830,9 @@ func (p projBitandDatumConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
+			if !p.nullableArgs {
+				projVec.SetNulls(_outNulls.Or(*colNulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -909,14 +897,12 @@ func (p projBitorInt16ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -928,7 +914,7 @@ func (p projBitorInt16ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -990,14 +976,12 @@ func (p projBitorInt16ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1009,7 +993,7 @@ func (p projBitorInt16ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1071,14 +1055,12 @@ func (p projBitorInt16ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1090,7 +1072,7 @@ func (p projBitorInt16ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1152,14 +1134,12 @@ func (p projBitorInt32ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1171,7 +1151,7 @@ func (p projBitorInt32ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1233,14 +1213,12 @@ func (p projBitorInt32ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1252,7 +1230,7 @@ func (p projBitorInt32ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1314,14 +1292,12 @@ func (p projBitorInt32ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1333,7 +1309,7 @@ func (p projBitorInt32ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1395,14 +1371,12 @@ func (p projBitorInt64ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1414,7 +1388,7 @@ func (p projBitorInt64ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1476,14 +1450,12 @@ func (p projBitorInt64ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1495,7 +1467,7 @@ func (p projBitorInt64ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1557,14 +1529,12 @@ func (p projBitorInt64ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1576,7 +1546,7 @@ func (p projBitorInt64ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1640,16 +1610,17 @@ func (p projBitorDatumConstDatumOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
@@ -1666,9 +1637,12 @@ func (p projBitorDatumConstDatumOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
@@ -1682,7 +1656,9 @@ func (p projBitorDatumConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
+			if !p.nullableArgs {
+				projVec.SetNulls(_outNulls.Or(*colNulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1747,14 +1723,12 @@ func (p projBitxorInt16ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1766,7 +1740,7 @@ func (p projBitxorInt16ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1828,14 +1802,12 @@ func (p projBitxorInt16ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1847,7 +1819,7 @@ func (p projBitxorInt16ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1909,14 +1881,12 @@ func (p projBitxorInt16ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1928,7 +1898,7 @@ func (p projBitxorInt16ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1990,14 +1960,12 @@ func (p projBitxorInt32ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2009,7 +1977,7 @@ func (p projBitxorInt32ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2071,14 +2039,12 @@ func (p projBitxorInt32ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2090,7 +2056,7 @@ func (p projBitxorInt32ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2152,14 +2118,12 @@ func (p projBitxorInt32ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2171,7 +2135,7 @@ func (p projBitxorInt32ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2233,14 +2197,12 @@ func (p projBitxorInt64ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2252,7 +2214,7 @@ func (p projBitxorInt64ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2314,14 +2276,12 @@ func (p projBitxorInt64ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2333,7 +2293,7 @@ func (p projBitxorInt64ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2395,14 +2355,12 @@ func (p projBitxorInt64ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2414,7 +2372,7 @@ func (p projBitxorInt64ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2478,16 +2436,17 @@ func (p projBitxorDatumConstDatumOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
@@ -2504,9 +2463,12 @@ func (p projBitxorDatumConstDatumOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
@@ -2520,7 +2482,9 @@ func (p projBitxorDatumConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
+			if !p.nullableArgs {
+				projVec.SetNulls(_outNulls.Or(*colNulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2585,14 +2549,12 @@ func (p projPlusDecimalConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2611,7 +2573,7 @@ func (p projPlusDecimalConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2694,14 +2656,12 @@ func (p projPlusDecimalConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2720,7 +2680,7 @@ func (p projPlusDecimalConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2803,14 +2763,12 @@ func (p projPlusDecimalConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2829,7 +2787,7 @@ func (p projPlusDecimalConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2912,14 +2870,12 @@ func (p projPlusDecimalConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2937,7 +2893,7 @@ func (p projPlusDecimalConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -3017,14 +2973,12 @@ func (p projPlusInt16ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3042,7 +2996,7 @@ func (p projPlusInt16ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -3122,14 +3076,12 @@ func (p projPlusInt16ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3147,7 +3099,7 @@ func (p projPlusInt16ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -3227,14 +3179,12 @@ func (p projPlusInt16ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3252,7 +3202,7 @@ func (p projPlusInt16ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -3332,14 +3282,12 @@ func (p projPlusInt16ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3359,7 +3307,7 @@ func (p projPlusInt16ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -3447,14 +3395,12 @@ func (p projPlusInt16ConstDatumOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3477,7 +3423,7 @@ func (p projPlusInt16ConstDatumOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -3572,14 +3518,12 @@ func (p projPlusInt32ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3597,7 +3541,7 @@ func (p projPlusInt32ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -3677,14 +3621,12 @@ func (p projPlusInt32ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3702,7 +3644,7 @@ func (p projPlusInt32ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -3782,14 +3724,12 @@ func (p projPlusInt32ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3807,7 +3747,7 @@ func (p projPlusInt32ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -3887,14 +3827,12 @@ func (p projPlusInt32ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3914,7 +3852,7 @@ func (p projPlusInt32ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -4002,14 +3940,12 @@ func (p projPlusInt32ConstDatumOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -4032,7 +3968,7 @@ func (p projPlusInt32ConstDatumOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -4127,14 +4063,12 @@ func (p projPlusInt64ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -4152,7 +4086,7 @@ func (p projPlusInt64ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -4232,14 +4166,12 @@ func (p projPlusInt64ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -4257,7 +4189,7 @@ func (p projPlusInt64ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -4337,14 +4269,12 @@ func (p projPlusInt64ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -4362,7 +4292,7 @@ func (p projPlusInt64ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -4442,14 +4372,12 @@ func (p projPlusInt64ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -4469,7 +4397,7 @@ func (p projPlusInt64ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -4557,14 +4485,12 @@ func (p projPlusInt64ConstDatumOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -4587,7 +4513,7 @@ func (p projPlusInt64ConstDatumOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -4682,14 +4608,12 @@ func (p projPlusFloat64ConstFloat64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -4704,7 +4628,7 @@ func (p projPlusFloat64ConstFloat64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -4775,14 +4699,12 @@ func (p projPlusTimestampConstIntervalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Timestamp()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						t_res := duration.Add(p.constArg, arg)
@@ -4797,7 +4719,7 @@ func (p projPlusTimestampConstIntervalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -4868,14 +4790,12 @@ func (p projPlusIntervalConstTimestampOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Timestamp()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						t_res := duration.Add(arg, p.constArg)
@@ -4890,7 +4810,7 @@ func (p projPlusIntervalConstTimestampOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -4961,14 +4881,12 @@ func (p projPlusIntervalConstIntervalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = p.constArg.Add(arg)
@@ -4978,7 +4896,7 @@ func (p projPlusIntervalConstIntervalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -5036,14 +4954,12 @@ func (p projPlusIntervalConstDatumOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5066,7 +4982,7 @@ func (p projPlusIntervalConstDatumOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -5163,14 +5079,12 @@ func (p projPlusDatumConstIntervalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5193,7 +5107,7 @@ func (p projPlusDatumConstIntervalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5288,14 +5202,12 @@ func (p projPlusDatumConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5318,7 +5230,7 @@ func (p projPlusDatumConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5413,14 +5325,12 @@ func (p projPlusDatumConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5443,7 +5353,7 @@ func (p projPlusDatumConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5538,14 +5448,12 @@ func (p projPlusDatumConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5568,7 +5476,7 @@ func (p projPlusDatumConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5661,14 +5569,12 @@ func (p projMinusDecimalConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5687,7 +5593,7 @@ func (p projMinusDecimalConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -5770,14 +5676,12 @@ func (p projMinusDecimalConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5796,7 +5700,7 @@ func (p projMinusDecimalConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -5879,14 +5783,12 @@ func (p projMinusDecimalConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5905,7 +5807,7 @@ func (p projMinusDecimalConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -5988,14 +5890,12 @@ func (p projMinusDecimalConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6013,7 +5913,7 @@ func (p projMinusDecimalConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -6093,14 +5993,12 @@ func (p projMinusInt16ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6118,7 +6016,7 @@ func (p projMinusInt16ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -6198,14 +6096,12 @@ func (p projMinusInt16ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6223,7 +6119,7 @@ func (p projMinusInt16ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -6303,14 +6199,12 @@ func (p projMinusInt16ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6328,7 +6222,7 @@ func (p projMinusInt16ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -6408,14 +6302,12 @@ func (p projMinusInt16ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6435,7 +6327,7 @@ func (p projMinusInt16ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -6523,14 +6415,12 @@ func (p projMinusInt16ConstDatumOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6553,7 +6443,7 @@ func (p projMinusInt16ConstDatumOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -6648,14 +6538,12 @@ func (p projMinusInt32ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6673,7 +6561,7 @@ func (p projMinusInt32ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -6753,14 +6641,12 @@ func (p projMinusInt32ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6778,7 +6664,7 @@ func (p projMinusInt32ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -6858,14 +6744,12 @@ func (p projMinusInt32ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6883,7 +6767,7 @@ func (p projMinusInt32ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -6963,14 +6847,12 @@ func (p projMinusInt32ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6990,7 +6872,7 @@ func (p projMinusInt32ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -7078,14 +6960,12 @@ func (p projMinusInt32ConstDatumOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7108,7 +6988,7 @@ func (p projMinusInt32ConstDatumOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -7203,14 +7083,12 @@ func (p projMinusInt64ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7228,7 +7106,7 @@ func (p projMinusInt64ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -7308,14 +7186,12 @@ func (p projMinusInt64ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7333,7 +7209,7 @@ func (p projMinusInt64ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -7413,14 +7289,12 @@ func (p projMinusInt64ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7438,7 +7312,7 @@ func (p projMinusInt64ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -7518,14 +7392,12 @@ func (p projMinusInt64ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7545,7 +7417,7 @@ func (p projMinusInt64ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -7633,14 +7505,12 @@ func (p projMinusInt64ConstDatumOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7663,7 +7533,7 @@ func (p projMinusInt64ConstDatumOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -7758,14 +7628,12 @@ func (p projMinusFloat64ConstFloat64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7780,7 +7648,7 @@ func (p projMinusFloat64ConstFloat64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -7851,14 +7719,12 @@ func (p projMinusTimestampConstTimestampOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7871,7 +7737,7 @@ func (p projMinusTimestampConstTimestampOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -7936,14 +7802,12 @@ func (p projMinusTimestampConstIntervalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Timestamp()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						t_res := duration.Add(p.constArg, arg.Mul(-1))
@@ -7958,7 +7822,7 @@ func (p projMinusTimestampConstIntervalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -8029,14 +7893,12 @@ func (p projMinusIntervalConstIntervalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = p.constArg.Sub(arg)
@@ -8046,7 +7908,7 @@ func (p projMinusIntervalConstIntervalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -8104,14 +7966,12 @@ func (p projMinusIntervalConstDatumOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8134,7 +7994,7 @@ func (p projMinusIntervalConstDatumOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -8229,14 +8089,12 @@ func (p projMinusJSONConstBytesOp) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8255,7 +8113,7 @@ func (p projMinusJSONConstBytesOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8336,14 +8194,12 @@ func (p projMinusJSONConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8358,7 +8214,7 @@ func (p projMinusJSONConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8427,14 +8283,12 @@ func (p projMinusJSONConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8449,7 +8303,7 @@ func (p projMinusJSONConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8518,14 +8372,12 @@ func (p projMinusJSONConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8540,7 +8392,7 @@ func (p projMinusJSONConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8611,16 +8463,17 @@ func (p projMinusDatumConstDatumOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
@@ -8637,9 +8490,12 @@ func (p projMinusDatumConstDatumOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
@@ -8653,7 +8509,9 @@ func (p projMinusDatumConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
+			if !p.nullableArgs {
+				projVec.SetNulls(_outNulls.Or(*colNulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8720,14 +8578,12 @@ func (p projMinusDatumConstIntervalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8750,7 +8606,7 @@ func (p projMinusDatumConstIntervalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8845,14 +8701,12 @@ func (p projMinusDatumConstBytesOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8875,7 +8729,7 @@ func (p projMinusDatumConstBytesOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8970,14 +8824,12 @@ func (p projMinusDatumConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9000,7 +8852,7 @@ func (p projMinusDatumConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9095,14 +8947,12 @@ func (p projMinusDatumConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9125,7 +8975,7 @@ func (p projMinusDatumConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9220,14 +9070,12 @@ func (p projMinusDatumConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9250,7 +9098,7 @@ func (p projMinusDatumConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9343,14 +9191,12 @@ func (p projMultDecimalConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9369,7 +9215,7 @@ func (p projMultDecimalConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -9452,14 +9298,12 @@ func (p projMultDecimalConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9478,7 +9322,7 @@ func (p projMultDecimalConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -9561,14 +9405,12 @@ func (p projMultDecimalConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9587,7 +9429,7 @@ func (p projMultDecimalConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -9670,14 +9512,12 @@ func (p projMultDecimalConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9695,7 +9535,7 @@ func (p projMultDecimalConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -9775,14 +9615,12 @@ func (p projMultDecimalConstIntervalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9797,7 +9635,7 @@ func (p projMultDecimalConstIntervalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -9868,14 +9706,12 @@ func (p projMultInt16ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9901,7 +9737,7 @@ func (p projMultInt16ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -10005,14 +9841,12 @@ func (p projMultInt16ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -10038,7 +9872,7 @@ func (p projMultInt16ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -10142,14 +9976,12 @@ func (p projMultInt16ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -10175,7 +10007,7 @@ func (p projMultInt16ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -10279,14 +10111,12 @@ func (p projMultInt16ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -10306,7 +10136,7 @@ func (p projMultInt16ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -10392,14 +10222,12 @@ func (p projMultInt16ConstIntervalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = arg.Mul(int64(p.constArg))
@@ -10409,7 +10237,7 @@ func (p projMultInt16ConstIntervalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -10465,14 +10293,12 @@ func (p projMultInt32ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -10498,7 +10324,7 @@ func (p projMultInt32ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -10602,14 +10428,12 @@ func (p projMultInt32ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -10635,7 +10459,7 @@ func (p projMultInt32ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -10739,14 +10563,12 @@ func (p projMultInt32ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -10772,7 +10594,7 @@ func (p projMultInt32ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -10876,14 +10698,12 @@ func (p projMultInt32ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -10903,7 +10723,7 @@ func (p projMultInt32ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -10989,14 +10809,12 @@ func (p projMultInt32ConstIntervalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = arg.Mul(int64(p.constArg))
@@ -11006,7 +10824,7 @@ func (p projMultInt32ConstIntervalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11062,14 +10880,12 @@ func (p projMultInt64ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -11095,7 +10911,7 @@ func (p projMultInt64ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11199,14 +11015,12 @@ func (p projMultInt64ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -11232,7 +11046,7 @@ func (p projMultInt64ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11336,14 +11150,12 @@ func (p projMultInt64ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -11369,7 +11181,7 @@ func (p projMultInt64ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11473,14 +11285,12 @@ func (p projMultInt64ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -11500,7 +11310,7 @@ func (p projMultInt64ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11586,14 +11396,12 @@ func (p projMultInt64ConstIntervalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = arg.Mul(int64(p.constArg))
@@ -11603,7 +11411,7 @@ func (p projMultInt64ConstIntervalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11659,14 +11467,12 @@ func (p projMultFloat64ConstFloat64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -11681,7 +11487,7 @@ func (p projMultFloat64ConstFloat64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11752,14 +11558,12 @@ func (p projMultFloat64ConstIntervalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = arg.MulFloat(float64(p.constArg))
@@ -11769,7 +11573,7 @@ func (p projMultFloat64ConstIntervalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11825,14 +11629,12 @@ func (p projMultIntervalConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = p.constArg.Mul(int64(arg))
@@ -11842,7 +11644,7 @@ func (p projMultIntervalConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11898,14 +11700,12 @@ func (p projMultIntervalConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = p.constArg.Mul(int64(arg))
@@ -11915,7 +11715,7 @@ func (p projMultIntervalConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11971,14 +11771,12 @@ func (p projMultIntervalConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = p.constArg.Mul(int64(arg))
@@ -11988,7 +11786,7 @@ func (p projMultIntervalConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -12044,14 +11842,12 @@ func (p projMultIntervalConstFloat64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = p.constArg.MulFloat(float64(arg))
@@ -12061,7 +11857,7 @@ func (p projMultIntervalConstFloat64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -12117,14 +11913,12 @@ func (p projMultIntervalConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -12139,7 +11933,7 @@ func (p projMultIntervalConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -12210,14 +12004,12 @@ func (p projDivDecimalConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -12240,7 +12032,7 @@ func (p projDivDecimalConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -12335,14 +12127,12 @@ func (p projDivDecimalConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -12365,7 +12155,7 @@ func (p projDivDecimalConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -12460,14 +12250,12 @@ func (p projDivDecimalConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -12490,7 +12278,7 @@ func (p projDivDecimalConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -12585,14 +12373,12 @@ func (p projDivDecimalConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -12614,7 +12400,7 @@ func (p projDivDecimalConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -12706,14 +12492,12 @@ func (p projDivInt16ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -12735,7 +12519,7 @@ func (p projDivInt16ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -12827,14 +12611,12 @@ func (p projDivInt16ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -12856,7 +12638,7 @@ func (p projDivInt16ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -12948,14 +12730,12 @@ func (p projDivInt16ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -12977,7 +12757,7 @@ func (p projDivInt16ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -13069,14 +12849,12 @@ func (p projDivInt16ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -13100,7 +12878,7 @@ func (p projDivInt16ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -13198,14 +12976,12 @@ func (p projDivInt32ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -13227,7 +13003,7 @@ func (p projDivInt32ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -13319,14 +13095,12 @@ func (p projDivInt32ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -13348,7 +13122,7 @@ func (p projDivInt32ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -13440,14 +13214,12 @@ func (p projDivInt32ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -13469,7 +13241,7 @@ func (p projDivInt32ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -13561,14 +13333,12 @@ func (p projDivInt32ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -13592,7 +13362,7 @@ func (p projDivInt32ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -13690,14 +13460,12 @@ func (p projDivInt64ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -13719,7 +13487,7 @@ func (p projDivInt64ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -13811,14 +13579,12 @@ func (p projDivInt64ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -13840,7 +13606,7 @@ func (p projDivInt64ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -13932,14 +13698,12 @@ func (p projDivInt64ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -13961,7 +13725,7 @@ func (p projDivInt64ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -14053,14 +13817,12 @@ func (p projDivInt64ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -14084,7 +13846,7 @@ func (p projDivInt64ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -14182,14 +13944,12 @@ func (p projDivFloat64ConstFloat64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -14208,7 +13968,7 @@ func (p projDivFloat64ConstFloat64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -14291,14 +14051,12 @@ func (p projDivIntervalConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -14312,7 +14070,7 @@ func (p projDivIntervalConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -14380,14 +14138,12 @@ func (p projDivIntervalConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -14401,7 +14157,7 @@ func (p projDivIntervalConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -14469,14 +14225,12 @@ func (p projDivIntervalConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -14490,7 +14244,7 @@ func (p projDivIntervalConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -14558,14 +14312,12 @@ func (p projDivIntervalConstFloat64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -14579,7 +14331,7 @@ func (p projDivIntervalConstFloat64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -14647,14 +14399,12 @@ func (p projFloorDivDecimalConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -14677,7 +14427,7 @@ func (p projFloorDivDecimalConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -14772,14 +14522,12 @@ func (p projFloorDivDecimalConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -14802,7 +14550,7 @@ func (p projFloorDivDecimalConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -14897,14 +14645,12 @@ func (p projFloorDivDecimalConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -14927,7 +14673,7 @@ func (p projFloorDivDecimalConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -15022,14 +14768,12 @@ func (p projFloorDivDecimalConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -15051,7 +14795,7 @@ func (p projFloorDivDecimalConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -15143,14 +14887,12 @@ func (p projFloorDivInt16ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -15167,7 +14909,7 @@ func (p projFloorDivInt16ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -15244,14 +14986,12 @@ func (p projFloorDivInt16ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -15268,7 +15008,7 @@ func (p projFloorDivInt16ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -15345,14 +15085,12 @@ func (p projFloorDivInt16ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -15369,7 +15107,7 @@ func (p projFloorDivInt16ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -15446,14 +15184,12 @@ func (p projFloorDivInt16ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -15477,7 +15213,7 @@ func (p projFloorDivInt16ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -15575,14 +15311,12 @@ func (p projFloorDivInt32ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -15599,7 +15333,7 @@ func (p projFloorDivInt32ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -15676,14 +15410,12 @@ func (p projFloorDivInt32ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -15700,7 +15432,7 @@ func (p projFloorDivInt32ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -15777,14 +15509,12 @@ func (p projFloorDivInt32ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -15801,7 +15531,7 @@ func (p projFloorDivInt32ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -15878,14 +15608,12 @@ func (p projFloorDivInt32ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -15909,7 +15637,7 @@ func (p projFloorDivInt32ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16007,14 +15735,12 @@ func (p projFloorDivInt64ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16031,7 +15757,7 @@ func (p projFloorDivInt64ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16108,14 +15834,12 @@ func (p projFloorDivInt64ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16132,7 +15856,7 @@ func (p projFloorDivInt64ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16209,14 +15933,12 @@ func (p projFloorDivInt64ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16233,7 +15955,7 @@ func (p projFloorDivInt64ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16310,14 +16032,12 @@ func (p projFloorDivInt64ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16341,7 +16061,7 @@ func (p projFloorDivInt64ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16439,14 +16159,12 @@ func (p projFloorDivFloat64ConstFloat64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16465,7 +16183,7 @@ func (p projFloorDivFloat64ConstFloat64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16548,14 +16266,12 @@ func (p projModDecimalConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16578,7 +16294,7 @@ func (p projModDecimalConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16673,14 +16389,12 @@ func (p projModDecimalConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16703,7 +16417,7 @@ func (p projModDecimalConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16798,14 +16512,12 @@ func (p projModDecimalConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16828,7 +16540,7 @@ func (p projModDecimalConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16923,14 +16635,12 @@ func (p projModDecimalConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16952,7 +16662,7 @@ func (p projModDecimalConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17044,14 +16754,12 @@ func (p projModInt16ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -17068,7 +16776,7 @@ func (p projModInt16ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17145,14 +16853,12 @@ func (p projModInt16ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -17169,7 +16875,7 @@ func (p projModInt16ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17246,14 +16952,12 @@ func (p projModInt16ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -17270,7 +16974,7 @@ func (p projModInt16ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17347,14 +17051,12 @@ func (p projModInt16ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -17378,7 +17080,7 @@ func (p projModInt16ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17476,14 +17178,12 @@ func (p projModInt32ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -17500,7 +17200,7 @@ func (p projModInt32ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17577,14 +17277,12 @@ func (p projModInt32ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -17601,7 +17299,7 @@ func (p projModInt32ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17678,14 +17376,12 @@ func (p projModInt32ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -17702,7 +17398,7 @@ func (p projModInt32ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17779,14 +17475,12 @@ func (p projModInt32ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -17810,7 +17504,7 @@ func (p projModInt32ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17908,14 +17602,12 @@ func (p projModInt64ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -17932,7 +17624,7 @@ func (p projModInt64ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -18009,14 +17701,12 @@ func (p projModInt64ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -18033,7 +17723,7 @@ func (p projModInt64ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -18110,14 +17800,12 @@ func (p projModInt64ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -18134,7 +17822,7 @@ func (p projModInt64ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -18211,14 +17899,12 @@ func (p projModInt64ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -18242,7 +17928,7 @@ func (p projModInt64ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -18340,14 +18026,12 @@ func (p projModFloat64ConstFloat64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -18366,7 +18050,7 @@ func (p projModFloat64ConstFloat64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -18449,14 +18133,12 @@ func (p projPowDecimalConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -18475,7 +18157,7 @@ func (p projPowDecimalConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -18558,14 +18240,12 @@ func (p projPowDecimalConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -18584,7 +18264,7 @@ func (p projPowDecimalConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -18667,14 +18347,12 @@ func (p projPowDecimalConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -18693,7 +18371,7 @@ func (p projPowDecimalConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -18776,14 +18454,12 @@ func (p projPowDecimalConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -18801,7 +18477,7 @@ func (p projPowDecimalConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -18881,14 +18557,12 @@ func (p projPowInt16ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -18912,7 +18586,7 @@ func (p projPowInt16ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -19010,14 +18684,12 @@ func (p projPowInt16ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -19041,7 +18713,7 @@ func (p projPowInt16ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -19139,14 +18811,12 @@ func (p projPowInt16ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -19170,7 +18840,7 @@ func (p projPowInt16ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -19268,14 +18938,12 @@ func (p projPowInt16ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -19295,7 +18963,7 @@ func (p projPowInt16ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -19381,14 +19049,12 @@ func (p projPowInt32ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -19412,7 +19078,7 @@ func (p projPowInt32ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -19510,14 +19176,12 @@ func (p projPowInt32ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -19541,7 +19205,7 @@ func (p projPowInt32ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -19639,14 +19303,12 @@ func (p projPowInt32ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -19670,7 +19332,7 @@ func (p projPowInt32ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -19768,14 +19430,12 @@ func (p projPowInt32ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -19795,7 +19455,7 @@ func (p projPowInt32ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -19881,14 +19541,12 @@ func (p projPowInt64ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -19912,7 +19570,7 @@ func (p projPowInt64ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -20010,14 +19668,12 @@ func (p projPowInt64ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20041,7 +19697,7 @@ func (p projPowInt64ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -20139,14 +19795,12 @@ func (p projPowInt64ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20170,7 +19824,7 @@ func (p projPowInt64ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -20268,14 +19922,12 @@ func (p projPowInt64ConstDecimalOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20295,7 +19947,7 @@ func (p projPowInt64ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -20381,14 +20033,12 @@ func (p projPowFloat64ConstFloat64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20403,7 +20053,7 @@ func (p projPowFloat64ConstFloat64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -20474,14 +20124,12 @@ func (p projConcatBytesConstBytesOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20498,7 +20146,7 @@ func (p projConcatBytesConstBytesOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20573,14 +20221,12 @@ func (p projConcatJSONConstJSONOp) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20596,7 +20242,7 @@ func (p projConcatJSONConstJSONOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20670,16 +20316,17 @@ func (p projConcatDatumConstDatumOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
@@ -20696,9 +20343,12 @@ func (p projConcatDatumConstDatumOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
@@ -20712,7 +20362,9 @@ func (p projConcatDatumConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
+			if !p.nullableArgs {
+				projVec.SetNulls(_outNulls.Or(*colNulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20777,14 +20429,12 @@ func (p projLShiftInt16ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20802,7 +20452,7 @@ func (p projLShiftInt16ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -20882,14 +20532,12 @@ func (p projLShiftInt16ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20907,7 +20555,7 @@ func (p projLShiftInt16ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -20987,14 +20635,12 @@ func (p projLShiftInt16ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21012,7 +20658,7 @@ func (p projLShiftInt16ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -21092,14 +20738,12 @@ func (p projLShiftInt32ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21117,7 +20761,7 @@ func (p projLShiftInt32ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -21197,14 +20841,12 @@ func (p projLShiftInt32ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21222,7 +20864,7 @@ func (p projLShiftInt32ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -21302,14 +20944,12 @@ func (p projLShiftInt32ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21327,7 +20967,7 @@ func (p projLShiftInt32ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -21407,14 +21047,12 @@ func (p projLShiftInt64ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21432,7 +21070,7 @@ func (p projLShiftInt64ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -21512,14 +21150,12 @@ func (p projLShiftInt64ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21537,7 +21173,7 @@ func (p projLShiftInt64ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -21617,14 +21253,12 @@ func (p projLShiftInt64ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21642,7 +21276,7 @@ func (p projLShiftInt64ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -21724,14 +21358,12 @@ func (p projLShiftDatumConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21754,7 +21386,7 @@ func (p projLShiftDatumConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21849,14 +21481,12 @@ func (p projLShiftDatumConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21879,7 +21509,7 @@ func (p projLShiftDatumConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21974,14 +21604,12 @@ func (p projLShiftDatumConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22004,7 +21632,7 @@ func (p projLShiftDatumConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22097,14 +21725,12 @@ func (p projRShiftInt16ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22122,7 +21748,7 @@ func (p projRShiftInt16ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -22202,14 +21828,12 @@ func (p projRShiftInt16ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22227,7 +21851,7 @@ func (p projRShiftInt16ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -22307,14 +21931,12 @@ func (p projRShiftInt16ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22332,7 +21954,7 @@ func (p projRShiftInt16ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -22412,14 +22034,12 @@ func (p projRShiftInt32ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22437,7 +22057,7 @@ func (p projRShiftInt32ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -22517,14 +22137,12 @@ func (p projRShiftInt32ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22542,7 +22160,7 @@ func (p projRShiftInt32ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -22622,14 +22240,12 @@ func (p projRShiftInt32ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22647,7 +22263,7 @@ func (p projRShiftInt32ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -22727,14 +22343,12 @@ func (p projRShiftInt64ConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22752,7 +22366,7 @@ func (p projRShiftInt64ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -22832,14 +22446,12 @@ func (p projRShiftInt64ConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22857,7 +22469,7 @@ func (p projRShiftInt64ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -22937,14 +22549,12 @@ func (p projRShiftInt64ConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22962,7 +22572,7 @@ func (p projRShiftInt64ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -23044,14 +22654,12 @@ func (p projRShiftDatumConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23074,7 +22682,7 @@ func (p projRShiftDatumConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23169,14 +22777,12 @@ func (p projRShiftDatumConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23199,7 +22805,7 @@ func (p projRShiftDatumConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23294,14 +22900,12 @@ func (p projRShiftDatumConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23324,7 +22928,7 @@ func (p projRShiftDatumConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23417,14 +23021,12 @@ func (p projJSONFetchValJSONConstBytesOp) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23446,7 +23048,7 @@ func (p projJSONFetchValJSONConstBytesOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23536,14 +23138,12 @@ func (p projJSONFetchValJSONConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23562,7 +23162,7 @@ func (p projJSONFetchValJSONConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23643,14 +23243,12 @@ func (p projJSONFetchValJSONConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23669,7 +23267,7 @@ func (p projJSONFetchValJSONConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23750,14 +23348,12 @@ func (p projJSONFetchValJSONConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23776,7 +23372,7 @@ func (p projJSONFetchValJSONConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23857,14 +23453,12 @@ func (p projJSONFetchTextJSONConstBytesOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23895,7 +23489,7 @@ func (p projJSONFetchTextJSONConstBytesOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -24012,14 +23606,12 @@ func (p projJSONFetchTextJSONConstInt16Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -24047,7 +23639,7 @@ func (p projJSONFetchTextJSONConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -24155,14 +23747,12 @@ func (p projJSONFetchTextJSONConstInt32Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -24190,7 +23780,7 @@ func (p projJSONFetchTextJSONConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -24298,14 +23888,12 @@ func (p projJSONFetchTextJSONConstInt64Op) Next() coldata.Batch {
 		}
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -24333,7 +23921,7 @@ func (p projJSONFetchTextJSONConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -24441,14 +24029,12 @@ func (p projJSONFetchValPathJSONConstDatumOp) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -24467,7 +24053,7 @@ func (p projJSONFetchValPathJSONConstDatumOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -24548,14 +24134,12 @@ func (p projJSONFetchTextPathJSONConstDatumOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -24584,7 +24168,7 @@ func (p projJSONFetchTextPathJSONConstDatumOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 

--- a/pkg/sql/colexec/colexecproj/proj_const_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecproj/proj_const_ops_tmpl.go
@@ -134,23 +134,7 @@ func (p _OP_CONST_NAME) Next() coldata.Batch {
 		// of a projection is Null.
 		// */}}
 		_outNulls := projVec.Nulls()
-
-		// {{/*
-		// If nullableArgs is true, the function’s definition can handle null
-		// arguments. We would still want to perform the projection, and there is no
-		// need to call projVec.SetNulls(). The behaviour will just be the same as
-		// _HAS_NULLS is false. Since currently only ConcatDatumDatum needs this
-		// nullableArgs == true behaviour, logic for nullableArgs is only added to
-		// the if statement for function with Datum, Datum. If we later introduce
-		// another projection operation that has nullableArgs == true, we should
-		// update this code accordingly.
-		// */}}
-		// {{if and (eq .Left.VecMethod "Datum") (eq .Right.VecMethod "Datum")}}
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
-		// {{else}}
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		// {{end}}
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			_SET_PROJECTION(true)
 		} else {
 			_SET_PROJECTION(false)
@@ -167,6 +151,7 @@ func _SET_PROJECTION(_HAS_NULLS bool) {
 	// {{define "setProjection" -}}
 	// {{$hasNulls := $.HasNulls}}
 	// {{with $.Overload}}
+	// {{$isDatum := (and (eq .Left.VecMethod "Datum") (eq .Right.VecMethod "Datum"))}}
 	// {{if _HAS_NULLS}}
 	colNulls := vec.Nulls()
 	// {{end}}
@@ -190,7 +175,13 @@ func _SET_PROJECTION(_HAS_NULLS bool) {
 	// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	// */}}
 	// {{if _HAS_NULLS}}
-	projVec.SetNulls(_outNulls.Or(*colNulls))
+	// {{if $isDatum}}
+	if !p.nullableArgs {
+		// {{end}}
+		projVec.SetNulls(_outNulls.Or(*colNulls))
+		// {{if $isDatum}}
+	}
+	// {{end}}
 	// {{end}}
 	// {{end}}
 	// {{end}}
@@ -205,8 +196,9 @@ func _SET_SINGLE_TUPLE_PROJECTION(_HAS_NULLS bool, _HAS_SEL bool) { // */}}
 	// {{$hasNulls := $.HasNulls}}
 	// {{$hasSel := $.HasSel}}
 	// {{with $.Overload}}
+	// {{$isDatum := (and (eq .Left.VecMethod "Datum") (eq .Right.VecMethod "Datum"))}}
 	// {{if _HAS_NULLS}}
-	if !colNulls.NullAt(i) {
+	if p.nullableArgs || !colNulls.NullAt(i) {
 		// We only want to perform the projection operation if the value is not null.
 		// {{end}}
 		// {{if _IS_CONST_LEFT}}
@@ -219,6 +211,19 @@ func _SET_SINGLE_TUPLE_PROJECTION(_HAS_NULLS bool, _HAS_SEL bool) { // */}}
 		// {{end}}
 		// {{end}}
 		arg := col.Get(i)
+		// {{if (and _HAS_NULLS $isDatum)}}
+		if colNulls.NullAt(i) {
+			// {{/*
+			// If we entered this branch for a null value, nullableArgs must be
+			// true. This means the projection should be calculated on null arguments.
+			// When a value is null, the underlying data in the slice is invalid and
+			// can be anything, so we need to overwrite it here. nullableArgs is
+			// currently only true for ConcatDatumDatum, so only the datum case needs
+			// to be handled.
+			// */}}
+			arg = tree.DNull
+		}
+		// {{end}}
 		// {{if _IS_CONST_LEFT}}
 		_ASSIGN(projCol[i], p.constArg, arg, projCol, _, col)
 		// {{else}}

--- a/pkg/sql/colexec/colexecproj/proj_const_right_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_const_right_ops.eg.go
@@ -74,14 +74,12 @@ func (p projBitandInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -93,7 +91,7 @@ func (p projBitandInt16Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -155,14 +153,12 @@ func (p projBitandInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -174,7 +170,7 @@ func (p projBitandInt16Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -236,14 +232,12 @@ func (p projBitandInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -255,7 +249,7 @@ func (p projBitandInt16Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -317,14 +311,12 @@ func (p projBitandInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -336,7 +328,7 @@ func (p projBitandInt32Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -398,14 +390,12 @@ func (p projBitandInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -417,7 +407,7 @@ func (p projBitandInt32Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -479,14 +469,12 @@ func (p projBitandInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -498,7 +486,7 @@ func (p projBitandInt32Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -560,14 +548,12 @@ func (p projBitandInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -579,7 +565,7 @@ func (p projBitandInt64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -641,14 +627,12 @@ func (p projBitandInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -660,7 +644,7 @@ func (p projBitandInt64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -722,14 +706,12 @@ func (p projBitandInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -741,7 +723,7 @@ func (p projBitandInt64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -805,16 +787,17 @@ func (p projBitandDatumDatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
@@ -831,9 +814,12 @@ func (p projBitandDatumDatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
@@ -847,7 +833,9 @@ func (p projBitandDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
+			if !p.nullableArgs {
+				projVec.SetNulls(_outNulls.Or(*colNulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -912,14 +900,12 @@ func (p projBitorInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -931,7 +917,7 @@ func (p projBitorInt16Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -993,14 +979,12 @@ func (p projBitorInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1012,7 +996,7 @@ func (p projBitorInt16Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1074,14 +1058,12 @@ func (p projBitorInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1093,7 +1075,7 @@ func (p projBitorInt16Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1155,14 +1137,12 @@ func (p projBitorInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1174,7 +1154,7 @@ func (p projBitorInt32Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1236,14 +1216,12 @@ func (p projBitorInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1255,7 +1233,7 @@ func (p projBitorInt32Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1317,14 +1295,12 @@ func (p projBitorInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1336,7 +1312,7 @@ func (p projBitorInt32Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1398,14 +1374,12 @@ func (p projBitorInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1417,7 +1391,7 @@ func (p projBitorInt64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1479,14 +1453,12 @@ func (p projBitorInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1498,7 +1470,7 @@ func (p projBitorInt64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1560,14 +1532,12 @@ func (p projBitorInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1579,7 +1549,7 @@ func (p projBitorInt64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1643,16 +1613,17 @@ func (p projBitorDatumDatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
@@ -1669,9 +1640,12 @@ func (p projBitorDatumDatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
@@ -1685,7 +1659,9 @@ func (p projBitorDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
+			if !p.nullableArgs {
+				projVec.SetNulls(_outNulls.Or(*colNulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1750,14 +1726,12 @@ func (p projBitxorInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1769,7 +1743,7 @@ func (p projBitxorInt16Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1831,14 +1805,12 @@ func (p projBitxorInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1850,7 +1822,7 @@ func (p projBitxorInt16Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1912,14 +1884,12 @@ func (p projBitxorInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1931,7 +1901,7 @@ func (p projBitxorInt16Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1993,14 +1963,12 @@ func (p projBitxorInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2012,7 +1980,7 @@ func (p projBitxorInt32Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2074,14 +2042,12 @@ func (p projBitxorInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2093,7 +2059,7 @@ func (p projBitxorInt32Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2155,14 +2121,12 @@ func (p projBitxorInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2174,7 +2138,7 @@ func (p projBitxorInt32Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2236,14 +2200,12 @@ func (p projBitxorInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2255,7 +2217,7 @@ func (p projBitxorInt64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2317,14 +2279,12 @@ func (p projBitxorInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2336,7 +2296,7 @@ func (p projBitxorInt64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2398,14 +2358,12 @@ func (p projBitxorInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2417,7 +2375,7 @@ func (p projBitxorInt64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2481,16 +2439,17 @@ func (p projBitxorDatumDatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
@@ -2507,9 +2466,12 @@ func (p projBitxorDatumDatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
@@ -2523,7 +2485,9 @@ func (p projBitxorDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
+			if !p.nullableArgs {
+				projVec.SetNulls(_outNulls.Or(*colNulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2588,14 +2552,12 @@ func (p projPlusDecimalInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2614,7 +2576,7 @@ func (p projPlusDecimalInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2697,14 +2659,12 @@ func (p projPlusDecimalInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2723,7 +2683,7 @@ func (p projPlusDecimalInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2806,14 +2766,12 @@ func (p projPlusDecimalInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2832,7 +2790,7 @@ func (p projPlusDecimalInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2915,14 +2873,12 @@ func (p projPlusDecimalDecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2940,7 +2896,7 @@ func (p projPlusDecimalDecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -3020,14 +2976,12 @@ func (p projPlusInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3045,7 +2999,7 @@ func (p projPlusInt16Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -3125,14 +3079,12 @@ func (p projPlusInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3150,7 +3102,7 @@ func (p projPlusInt16Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -3230,14 +3182,12 @@ func (p projPlusInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3255,7 +3205,7 @@ func (p projPlusInt16Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -3335,14 +3285,12 @@ func (p projPlusInt16DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3362,7 +3310,7 @@ func (p projPlusInt16DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -3450,14 +3398,12 @@ func (p projPlusInt16DatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3480,7 +3426,7 @@ func (p projPlusInt16DatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3573,14 +3519,12 @@ func (p projPlusInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3598,7 +3542,7 @@ func (p projPlusInt32Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -3678,14 +3622,12 @@ func (p projPlusInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3703,7 +3645,7 @@ func (p projPlusInt32Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -3783,14 +3725,12 @@ func (p projPlusInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3808,7 +3748,7 @@ func (p projPlusInt32Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -3888,14 +3828,12 @@ func (p projPlusInt32DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3915,7 +3853,7 @@ func (p projPlusInt32DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -4003,14 +3941,12 @@ func (p projPlusInt32DatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -4033,7 +3969,7 @@ func (p projPlusInt32DatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -4126,14 +4062,12 @@ func (p projPlusInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -4151,7 +4085,7 @@ func (p projPlusInt64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -4231,14 +4165,12 @@ func (p projPlusInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -4256,7 +4188,7 @@ func (p projPlusInt64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -4336,14 +4268,12 @@ func (p projPlusInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -4361,7 +4291,7 @@ func (p projPlusInt64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -4441,14 +4371,12 @@ func (p projPlusInt64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -4468,7 +4396,7 @@ func (p projPlusInt64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -4556,14 +4484,12 @@ func (p projPlusInt64DatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -4586,7 +4512,7 @@ func (p projPlusInt64DatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -4679,14 +4605,12 @@ func (p projPlusFloat64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -4701,7 +4625,7 @@ func (p projPlusFloat64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -4772,14 +4696,12 @@ func (p projPlusTimestampIntervalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Timestamp()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						t_res := duration.Add(arg, p.constArg)
@@ -4794,7 +4716,7 @@ func (p projPlusTimestampIntervalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -4865,14 +4787,12 @@ func (p projPlusIntervalTimestampConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Timestamp()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						t_res := duration.Add(p.constArg, arg)
@@ -4887,7 +4807,7 @@ func (p projPlusIntervalTimestampConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -4958,14 +4878,12 @@ func (p projPlusIntervalIntervalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = arg.Add(p.constArg)
@@ -4975,7 +4893,7 @@ func (p projPlusIntervalIntervalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -5033,14 +4951,12 @@ func (p projPlusIntervalDatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5063,7 +4979,7 @@ func (p projPlusIntervalDatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5158,14 +5074,12 @@ func (p projPlusDatumIntervalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5188,7 +5102,7 @@ func (p projPlusDatumIntervalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -5285,14 +5199,12 @@ func (p projPlusDatumInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5315,7 +5227,7 @@ func (p projPlusDatumInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -5412,14 +5324,12 @@ func (p projPlusDatumInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5442,7 +5352,7 @@ func (p projPlusDatumInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -5539,14 +5449,12 @@ func (p projPlusDatumInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5569,7 +5477,7 @@ func (p projPlusDatumInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -5664,14 +5572,12 @@ func (p projMinusDecimalInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5690,7 +5596,7 @@ func (p projMinusDecimalInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -5773,14 +5679,12 @@ func (p projMinusDecimalInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5799,7 +5703,7 @@ func (p projMinusDecimalInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -5882,14 +5786,12 @@ func (p projMinusDecimalInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5908,7 +5810,7 @@ func (p projMinusDecimalInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -5991,14 +5893,12 @@ func (p projMinusDecimalDecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6016,7 +5916,7 @@ func (p projMinusDecimalDecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -6096,14 +5996,12 @@ func (p projMinusInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6121,7 +6019,7 @@ func (p projMinusInt16Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -6201,14 +6099,12 @@ func (p projMinusInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6226,7 +6122,7 @@ func (p projMinusInt16Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -6306,14 +6202,12 @@ func (p projMinusInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6331,7 +6225,7 @@ func (p projMinusInt16Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -6411,14 +6305,12 @@ func (p projMinusInt16DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6438,7 +6330,7 @@ func (p projMinusInt16DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -6526,14 +6418,12 @@ func (p projMinusInt16DatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6556,7 +6446,7 @@ func (p projMinusInt16DatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6649,14 +6539,12 @@ func (p projMinusInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6674,7 +6562,7 @@ func (p projMinusInt32Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -6754,14 +6642,12 @@ func (p projMinusInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6779,7 +6665,7 @@ func (p projMinusInt32Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -6859,14 +6745,12 @@ func (p projMinusInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6884,7 +6768,7 @@ func (p projMinusInt32Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -6964,14 +6848,12 @@ func (p projMinusInt32DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6991,7 +6873,7 @@ func (p projMinusInt32DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -7079,14 +6961,12 @@ func (p projMinusInt32DatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7109,7 +6989,7 @@ func (p projMinusInt32DatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7202,14 +7082,12 @@ func (p projMinusInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7227,7 +7105,7 @@ func (p projMinusInt64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -7307,14 +7185,12 @@ func (p projMinusInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7332,7 +7208,7 @@ func (p projMinusInt64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -7412,14 +7288,12 @@ func (p projMinusInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7437,7 +7311,7 @@ func (p projMinusInt64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -7517,14 +7391,12 @@ func (p projMinusInt64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7544,7 +7416,7 @@ func (p projMinusInt64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -7632,14 +7504,12 @@ func (p projMinusInt64DatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7662,7 +7532,7 @@ func (p projMinusInt64DatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7755,14 +7625,12 @@ func (p projMinusFloat64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7777,7 +7645,7 @@ func (p projMinusFloat64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -7848,14 +7716,12 @@ func (p projMinusTimestampTimestampConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7868,7 +7734,7 @@ func (p projMinusTimestampTimestampConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -7933,14 +7799,12 @@ func (p projMinusTimestampIntervalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Timestamp()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						t_res := duration.Add(arg, p.constArg.Mul(-1))
@@ -7955,7 +7819,7 @@ func (p projMinusTimestampIntervalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -8026,14 +7890,12 @@ func (p projMinusIntervalIntervalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = arg.Sub(p.constArg)
@@ -8043,7 +7905,7 @@ func (p projMinusIntervalIntervalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -8101,14 +7963,12 @@ func (p projMinusIntervalDatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8131,7 +7991,7 @@ func (p projMinusIntervalDatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8224,14 +8084,12 @@ func (p projMinusJSONBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8250,7 +8108,7 @@ func (p projMinusJSONBytesConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8331,14 +8189,12 @@ func (p projMinusJSONInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8353,7 +8209,7 @@ func (p projMinusJSONInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -8424,14 +8280,12 @@ func (p projMinusJSONInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8446,7 +8300,7 @@ func (p projMinusJSONInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -8517,14 +8371,12 @@ func (p projMinusJSONInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8539,7 +8391,7 @@ func (p projMinusJSONInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -8612,16 +8464,17 @@ func (p projMinusDatumDatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
@@ -8638,9 +8491,12 @@ func (p projMinusDatumDatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
@@ -8654,7 +8510,9 @@ func (p projMinusDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
+			if !p.nullableArgs {
+				projVec.SetNulls(_outNulls.Or(*colNulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8721,14 +8579,12 @@ func (p projMinusDatumIntervalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8751,7 +8607,7 @@ func (p projMinusDatumIntervalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -8848,14 +8704,12 @@ func (p projMinusDatumBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8878,7 +8732,7 @@ func (p projMinusDatumBytesConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8973,14 +8827,12 @@ func (p projMinusDatumInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9003,7 +8855,7 @@ func (p projMinusDatumInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -9100,14 +8952,12 @@ func (p projMinusDatumInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9130,7 +8980,7 @@ func (p projMinusDatumInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -9227,14 +9077,12 @@ func (p projMinusDatumInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9257,7 +9105,7 @@ func (p projMinusDatumInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -9352,14 +9200,12 @@ func (p projMultDecimalInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9378,7 +9224,7 @@ func (p projMultDecimalInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -9461,14 +9307,12 @@ func (p projMultDecimalInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9487,7 +9331,7 @@ func (p projMultDecimalInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -9570,14 +9414,12 @@ func (p projMultDecimalInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9596,7 +9438,7 @@ func (p projMultDecimalInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -9679,14 +9521,12 @@ func (p projMultDecimalDecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9704,7 +9544,7 @@ func (p projMultDecimalDecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -9784,14 +9624,12 @@ func (p projMultDecimalIntervalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9806,7 +9644,7 @@ func (p projMultDecimalIntervalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -9877,14 +9715,12 @@ func (p projMultInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9910,7 +9746,7 @@ func (p projMultInt16Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -10014,14 +9850,12 @@ func (p projMultInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -10047,7 +9881,7 @@ func (p projMultInt16Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -10151,14 +9985,12 @@ func (p projMultInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -10184,7 +10016,7 @@ func (p projMultInt16Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -10288,14 +10120,12 @@ func (p projMultInt16DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -10315,7 +10145,7 @@ func (p projMultInt16DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -10401,14 +10231,12 @@ func (p projMultInt16IntervalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = p.constArg.Mul(int64(arg))
@@ -10418,7 +10246,7 @@ func (p projMultInt16IntervalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -10474,14 +10302,12 @@ func (p projMultInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -10507,7 +10333,7 @@ func (p projMultInt32Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -10611,14 +10437,12 @@ func (p projMultInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -10644,7 +10468,7 @@ func (p projMultInt32Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -10748,14 +10572,12 @@ func (p projMultInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -10781,7 +10603,7 @@ func (p projMultInt32Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -10885,14 +10707,12 @@ func (p projMultInt32DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -10912,7 +10732,7 @@ func (p projMultInt32DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -10998,14 +10818,12 @@ func (p projMultInt32IntervalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = p.constArg.Mul(int64(arg))
@@ -11015,7 +10833,7 @@ func (p projMultInt32IntervalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11071,14 +10889,12 @@ func (p projMultInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -11104,7 +10920,7 @@ func (p projMultInt64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11208,14 +11024,12 @@ func (p projMultInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -11241,7 +11055,7 @@ func (p projMultInt64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11345,14 +11159,12 @@ func (p projMultInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -11378,7 +11190,7 @@ func (p projMultInt64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11482,14 +11294,12 @@ func (p projMultInt64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -11509,7 +11319,7 @@ func (p projMultInt64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11595,14 +11405,12 @@ func (p projMultInt64IntervalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = p.constArg.Mul(int64(arg))
@@ -11612,7 +11420,7 @@ func (p projMultInt64IntervalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11668,14 +11476,12 @@ func (p projMultFloat64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -11690,7 +11496,7 @@ func (p projMultFloat64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11761,14 +11567,12 @@ func (p projMultFloat64IntervalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = p.constArg.MulFloat(float64(arg))
@@ -11778,7 +11582,7 @@ func (p projMultFloat64IntervalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11834,14 +11638,12 @@ func (p projMultIntervalInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = arg.Mul(int64(p.constArg))
@@ -11851,7 +11653,7 @@ func (p projMultIntervalInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11907,14 +11709,12 @@ func (p projMultIntervalInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = arg.Mul(int64(p.constArg))
@@ -11924,7 +11724,7 @@ func (p projMultIntervalInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11980,14 +11780,12 @@ func (p projMultIntervalInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = arg.Mul(int64(p.constArg))
@@ -11997,7 +11795,7 @@ func (p projMultIntervalInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -12053,14 +11851,12 @@ func (p projMultIntervalFloat64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = arg.MulFloat(float64(p.constArg))
@@ -12070,7 +11866,7 @@ func (p projMultIntervalFloat64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -12126,14 +11922,12 @@ func (p projMultIntervalDecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -12148,7 +11942,7 @@ func (p projMultIntervalDecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -12219,14 +12013,12 @@ func (p projDivDecimalInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -12249,7 +12041,7 @@ func (p projDivDecimalInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -12344,14 +12136,12 @@ func (p projDivDecimalInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -12374,7 +12164,7 @@ func (p projDivDecimalInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -12469,14 +12259,12 @@ func (p projDivDecimalInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -12499,7 +12287,7 @@ func (p projDivDecimalInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -12594,14 +12382,12 @@ func (p projDivDecimalDecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -12623,7 +12409,7 @@ func (p projDivDecimalDecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -12715,14 +12501,12 @@ func (p projDivInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -12744,7 +12528,7 @@ func (p projDivInt16Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -12836,14 +12620,12 @@ func (p projDivInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -12865,7 +12647,7 @@ func (p projDivInt16Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -12957,14 +12739,12 @@ func (p projDivInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -12986,7 +12766,7 @@ func (p projDivInt16Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -13078,14 +12858,12 @@ func (p projDivInt16DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -13109,7 +12887,7 @@ func (p projDivInt16DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -13207,14 +12985,12 @@ func (p projDivInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -13236,7 +13012,7 @@ func (p projDivInt32Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -13328,14 +13104,12 @@ func (p projDivInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -13357,7 +13131,7 @@ func (p projDivInt32Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -13449,14 +13223,12 @@ func (p projDivInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -13478,7 +13250,7 @@ func (p projDivInt32Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -13570,14 +13342,12 @@ func (p projDivInt32DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -13601,7 +13371,7 @@ func (p projDivInt32DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -13699,14 +13469,12 @@ func (p projDivInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -13728,7 +13496,7 @@ func (p projDivInt64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -13820,14 +13588,12 @@ func (p projDivInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -13849,7 +13615,7 @@ func (p projDivInt64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -13941,14 +13707,12 @@ func (p projDivInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -13970,7 +13734,7 @@ func (p projDivInt64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -14062,14 +13826,12 @@ func (p projDivInt64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -14093,7 +13855,7 @@ func (p projDivInt64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -14191,14 +13953,12 @@ func (p projDivFloat64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -14217,7 +13977,7 @@ func (p projDivFloat64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -14300,14 +14060,12 @@ func (p projDivIntervalInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -14321,7 +14079,7 @@ func (p projDivIntervalInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -14389,14 +14147,12 @@ func (p projDivIntervalInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -14410,7 +14166,7 @@ func (p projDivIntervalInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -14478,14 +14234,12 @@ func (p projDivIntervalInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -14499,7 +14253,7 @@ func (p projDivIntervalInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -14567,14 +14321,12 @@ func (p projDivIntervalFloat64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -14588,7 +14340,7 @@ func (p projDivIntervalFloat64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -14656,14 +14408,12 @@ func (p projFloorDivDecimalInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -14686,7 +14436,7 @@ func (p projFloorDivDecimalInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -14781,14 +14531,12 @@ func (p projFloorDivDecimalInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -14811,7 +14559,7 @@ func (p projFloorDivDecimalInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -14906,14 +14654,12 @@ func (p projFloorDivDecimalInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -14936,7 +14682,7 @@ func (p projFloorDivDecimalInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -15031,14 +14777,12 @@ func (p projFloorDivDecimalDecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -15060,7 +14804,7 @@ func (p projFloorDivDecimalDecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -15152,14 +14896,12 @@ func (p projFloorDivInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -15176,7 +14918,7 @@ func (p projFloorDivInt16Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -15253,14 +14995,12 @@ func (p projFloorDivInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -15277,7 +15017,7 @@ func (p projFloorDivInt16Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -15354,14 +15094,12 @@ func (p projFloorDivInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -15378,7 +15116,7 @@ func (p projFloorDivInt16Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -15455,14 +15193,12 @@ func (p projFloorDivInt16DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -15486,7 +15222,7 @@ func (p projFloorDivInt16DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -15584,14 +15320,12 @@ func (p projFloorDivInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -15608,7 +15342,7 @@ func (p projFloorDivInt32Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -15685,14 +15419,12 @@ func (p projFloorDivInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -15709,7 +15441,7 @@ func (p projFloorDivInt32Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -15786,14 +15518,12 @@ func (p projFloorDivInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -15810,7 +15540,7 @@ func (p projFloorDivInt32Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -15887,14 +15617,12 @@ func (p projFloorDivInt32DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -15918,7 +15646,7 @@ func (p projFloorDivInt32DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16016,14 +15744,12 @@ func (p projFloorDivInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16040,7 +15766,7 @@ func (p projFloorDivInt64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16117,14 +15843,12 @@ func (p projFloorDivInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16141,7 +15865,7 @@ func (p projFloorDivInt64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16218,14 +15942,12 @@ func (p projFloorDivInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16242,7 +15964,7 @@ func (p projFloorDivInt64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16319,14 +16041,12 @@ func (p projFloorDivInt64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16350,7 +16070,7 @@ func (p projFloorDivInt64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16448,14 +16168,12 @@ func (p projFloorDivFloat64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16474,7 +16192,7 @@ func (p projFloorDivFloat64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16557,14 +16275,12 @@ func (p projModDecimalInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16587,7 +16303,7 @@ func (p projModDecimalInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16682,14 +16398,12 @@ func (p projModDecimalInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16712,7 +16426,7 @@ func (p projModDecimalInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16807,14 +16521,12 @@ func (p projModDecimalInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16837,7 +16549,7 @@ func (p projModDecimalInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16932,14 +16644,12 @@ func (p projModDecimalDecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16961,7 +16671,7 @@ func (p projModDecimalDecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17053,14 +16763,12 @@ func (p projModInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -17077,7 +16785,7 @@ func (p projModInt16Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17154,14 +16862,12 @@ func (p projModInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -17178,7 +16884,7 @@ func (p projModInt16Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17255,14 +16961,12 @@ func (p projModInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -17279,7 +16983,7 @@ func (p projModInt16Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17356,14 +17060,12 @@ func (p projModInt16DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -17387,7 +17089,7 @@ func (p projModInt16DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17485,14 +17187,12 @@ func (p projModInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -17509,7 +17209,7 @@ func (p projModInt32Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17586,14 +17286,12 @@ func (p projModInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -17610,7 +17308,7 @@ func (p projModInt32Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17687,14 +17385,12 @@ func (p projModInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -17711,7 +17407,7 @@ func (p projModInt32Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17788,14 +17484,12 @@ func (p projModInt32DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -17819,7 +17513,7 @@ func (p projModInt32DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17917,14 +17611,12 @@ func (p projModInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -17941,7 +17633,7 @@ func (p projModInt64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -18018,14 +17710,12 @@ func (p projModInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -18042,7 +17732,7 @@ func (p projModInt64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -18119,14 +17809,12 @@ func (p projModInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -18143,7 +17831,7 @@ func (p projModInt64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -18220,14 +17908,12 @@ func (p projModInt64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -18251,7 +17937,7 @@ func (p projModInt64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -18349,14 +18035,12 @@ func (p projModFloat64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -18375,7 +18059,7 @@ func (p projModFloat64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -18458,14 +18142,12 @@ func (p projPowDecimalInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -18484,7 +18166,7 @@ func (p projPowDecimalInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -18567,14 +18249,12 @@ func (p projPowDecimalInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -18593,7 +18273,7 @@ func (p projPowDecimalInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -18676,14 +18356,12 @@ func (p projPowDecimalInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -18702,7 +18380,7 @@ func (p projPowDecimalInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -18785,14 +18463,12 @@ func (p projPowDecimalDecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -18810,7 +18486,7 @@ func (p projPowDecimalDecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -18890,14 +18566,12 @@ func (p projPowInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -18921,7 +18595,7 @@ func (p projPowInt16Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -19019,14 +18693,12 @@ func (p projPowInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -19050,7 +18722,7 @@ func (p projPowInt16Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -19148,14 +18820,12 @@ func (p projPowInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -19179,7 +18849,7 @@ func (p projPowInt16Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -19277,14 +18947,12 @@ func (p projPowInt16DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -19304,7 +18972,7 @@ func (p projPowInt16DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -19390,14 +19058,12 @@ func (p projPowInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -19421,7 +19087,7 @@ func (p projPowInt32Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -19519,14 +19185,12 @@ func (p projPowInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -19550,7 +19214,7 @@ func (p projPowInt32Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -19648,14 +19312,12 @@ func (p projPowInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -19679,7 +19341,7 @@ func (p projPowInt32Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -19777,14 +19439,12 @@ func (p projPowInt32DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -19804,7 +19464,7 @@ func (p projPowInt32DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -19890,14 +19550,12 @@ func (p projPowInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -19921,7 +19579,7 @@ func (p projPowInt64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -20019,14 +19677,12 @@ func (p projPowInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20050,7 +19706,7 @@ func (p projPowInt64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -20148,14 +19804,12 @@ func (p projPowInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20179,7 +19833,7 @@ func (p projPowInt64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -20277,14 +19931,12 @@ func (p projPowInt64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20304,7 +19956,7 @@ func (p projPowInt64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -20390,14 +20042,12 @@ func (p projPowFloat64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20412,7 +20062,7 @@ func (p projPowFloat64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -20483,14 +20133,12 @@ func (p projConcatBytesBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20507,7 +20155,7 @@ func (p projConcatBytesBytesConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20582,14 +20230,12 @@ func (p projConcatJSONJSONConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20605,7 +20251,7 @@ func (p projConcatJSONJSONConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20679,16 +20325,17 @@ func (p projConcatDatumDatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
@@ -20705,9 +20352,12 @@ func (p projConcatDatumDatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
@@ -20721,7 +20371,9 @@ func (p projConcatDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
+			if !p.nullableArgs {
+				projVec.SetNulls(_outNulls.Or(*colNulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -20786,14 +20438,12 @@ func (p projLShiftInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20811,7 +20461,7 @@ func (p projLShiftInt16Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -20891,14 +20541,12 @@ func (p projLShiftInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20916,7 +20564,7 @@ func (p projLShiftInt16Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -20996,14 +20644,12 @@ func (p projLShiftInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21021,7 +20667,7 @@ func (p projLShiftInt16Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -21101,14 +20747,12 @@ func (p projLShiftInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21126,7 +20770,7 @@ func (p projLShiftInt32Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -21206,14 +20850,12 @@ func (p projLShiftInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21231,7 +20873,7 @@ func (p projLShiftInt32Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -21311,14 +20953,12 @@ func (p projLShiftInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21336,7 +20976,7 @@ func (p projLShiftInt32Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -21416,14 +21056,12 @@ func (p projLShiftInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21441,7 +21079,7 @@ func (p projLShiftInt64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -21521,14 +21159,12 @@ func (p projLShiftInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21546,7 +21182,7 @@ func (p projLShiftInt64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -21626,14 +21262,12 @@ func (p projLShiftInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21651,7 +21285,7 @@ func (p projLShiftInt64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -21733,14 +21367,12 @@ func (p projLShiftDatumInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21763,7 +21395,7 @@ func (p projLShiftDatumInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -21860,14 +21492,12 @@ func (p projLShiftDatumInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21890,7 +21520,7 @@ func (p projLShiftDatumInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -21987,14 +21617,12 @@ func (p projLShiftDatumInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22017,7 +21645,7 @@ func (p projLShiftDatumInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -22112,14 +21740,12 @@ func (p projRShiftInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22137,7 +21763,7 @@ func (p projRShiftInt16Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -22217,14 +21843,12 @@ func (p projRShiftInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22242,7 +21866,7 @@ func (p projRShiftInt16Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -22322,14 +21946,12 @@ func (p projRShiftInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22347,7 +21969,7 @@ func (p projRShiftInt16Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -22427,14 +22049,12 @@ func (p projRShiftInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22452,7 +22072,7 @@ func (p projRShiftInt32Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -22532,14 +22152,12 @@ func (p projRShiftInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22557,7 +22175,7 @@ func (p projRShiftInt32Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -22637,14 +22255,12 @@ func (p projRShiftInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22662,7 +22278,7 @@ func (p projRShiftInt32Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -22742,14 +22358,12 @@ func (p projRShiftInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22767,7 +22381,7 @@ func (p projRShiftInt64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -22847,14 +22461,12 @@ func (p projRShiftInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22872,7 +22484,7 @@ func (p projRShiftInt64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -22952,14 +22564,12 @@ func (p projRShiftInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22977,7 +22587,7 @@ func (p projRShiftInt64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -23059,14 +22669,12 @@ func (p projRShiftDatumInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23089,7 +22697,7 @@ func (p projRShiftDatumInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -23186,14 +22794,12 @@ func (p projRShiftDatumInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23216,7 +22822,7 @@ func (p projRShiftDatumInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -23313,14 +22919,12 @@ func (p projRShiftDatumInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23343,7 +22947,7 @@ func (p projRShiftDatumInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -23438,14 +23042,12 @@ func (p projJSONFetchValJSONBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23467,7 +23069,7 @@ func (p projJSONFetchValJSONBytesConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23557,14 +23159,12 @@ func (p projJSONFetchValJSONInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23583,7 +23183,7 @@ func (p projJSONFetchValJSONInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -23666,14 +23266,12 @@ func (p projJSONFetchValJSONInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23692,7 +23290,7 @@ func (p projJSONFetchValJSONInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -23775,14 +23373,12 @@ func (p projJSONFetchValJSONInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23801,7 +23397,7 @@ func (p projJSONFetchValJSONInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -23884,14 +23480,12 @@ func (p projJSONFetchTextJSONBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23922,7 +23516,7 @@ func (p projJSONFetchTextJSONBytesConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -24039,14 +23633,12 @@ func (p projJSONFetchTextJSONInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -24074,7 +23666,7 @@ func (p projJSONFetchTextJSONInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -24184,14 +23776,12 @@ func (p projJSONFetchTextJSONInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -24219,7 +23809,7 @@ func (p projJSONFetchTextJSONInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -24329,14 +23919,12 @@ func (p projJSONFetchTextJSONInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -24364,7 +23952,7 @@ func (p projJSONFetchTextJSONInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -24474,14 +24062,12 @@ func (p projJSONFetchValPathJSONDatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -24500,7 +24086,7 @@ func (p projJSONFetchValPathJSONDatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -24581,14 +24167,12 @@ func (p projJSONFetchTextPathJSONDatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -24617,7 +24201,7 @@ func (p projJSONFetchTextPathJSONDatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -24728,14 +24312,12 @@ func (p projEQBoolBoolConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -24759,7 +24341,7 @@ func (p projEQBoolBoolConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -24857,14 +24439,12 @@ func (p projEQBytesBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -24880,7 +24460,7 @@ func (p projEQBytesBytesConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -24952,14 +24532,12 @@ func (p projEQDecimalInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -24981,7 +24559,7 @@ func (p projEQDecimalInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -25073,14 +24651,12 @@ func (p projEQDecimalInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -25102,7 +24678,7 @@ func (p projEQDecimalInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -25194,14 +24770,12 @@ func (p projEQDecimalInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -25223,7 +24797,7 @@ func (p projEQDecimalInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -25315,14 +24889,12 @@ func (p projEQDecimalFloat64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -25346,7 +24918,7 @@ func (p projEQDecimalFloat64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -25444,14 +25016,12 @@ func (p projEQDecimalDecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -25467,7 +25037,7 @@ func (p projEQDecimalDecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -25541,14 +25111,12 @@ func (p projEQInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -25575,7 +25143,7 @@ func (p projEQInt16Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -25682,14 +25250,12 @@ func (p projEQInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -25716,7 +25282,7 @@ func (p projEQInt16Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -25823,14 +25389,12 @@ func (p projEQInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -25857,7 +25421,7 @@ func (p projEQInt16Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -25964,14 +25528,12 @@ func (p projEQInt16Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -26006,7 +25568,7 @@ func (p projEQInt16Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -26137,14 +25699,12 @@ func (p projEQInt16DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -26166,7 +25726,7 @@ func (p projEQInt16DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -26258,14 +25818,12 @@ func (p projEQInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -26292,7 +25850,7 @@ func (p projEQInt32Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -26399,14 +25957,12 @@ func (p projEQInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -26433,7 +25989,7 @@ func (p projEQInt32Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -26540,14 +26096,12 @@ func (p projEQInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -26574,7 +26128,7 @@ func (p projEQInt32Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -26681,14 +26235,12 @@ func (p projEQInt32Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -26723,7 +26275,7 @@ func (p projEQInt32Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -26854,14 +26406,12 @@ func (p projEQInt32DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -26883,7 +26433,7 @@ func (p projEQInt32DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -26975,14 +26525,12 @@ func (p projEQInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -27009,7 +26557,7 @@ func (p projEQInt64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -27116,14 +26664,12 @@ func (p projEQInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -27150,7 +26696,7 @@ func (p projEQInt64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -27257,14 +26803,12 @@ func (p projEQInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -27291,7 +26835,7 @@ func (p projEQInt64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -27398,14 +26942,12 @@ func (p projEQInt64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -27440,7 +26982,7 @@ func (p projEQInt64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -27571,14 +27113,12 @@ func (p projEQInt64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -27600,7 +27140,7 @@ func (p projEQInt64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -27692,14 +27232,12 @@ func (p projEQFloat64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -27734,7 +27272,7 @@ func (p projEQFloat64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -27865,14 +27403,12 @@ func (p projEQFloat64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -27907,7 +27443,7 @@ func (p projEQFloat64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -28038,14 +27574,12 @@ func (p projEQFloat64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -28080,7 +27614,7 @@ func (p projEQFloat64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -28211,14 +27745,12 @@ func (p projEQFloat64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -28253,7 +27785,7 @@ func (p projEQFloat64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -28384,14 +27916,12 @@ func (p projEQFloat64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -28415,7 +27945,7 @@ func (p projEQFloat64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -28513,14 +28043,12 @@ func (p projEQTimestampTimestampConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -28543,7 +28071,7 @@ func (p projEQTimestampTimestampConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -28638,14 +28166,12 @@ func (p projEQIntervalIntervalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -28661,7 +28187,7 @@ func (p projEQIntervalIntervalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -28735,14 +28261,12 @@ func (p projEQJSONJSONConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -28764,7 +28288,7 @@ func (p projEQJSONJSONConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -28854,16 +28378,17 @@ func (p projEQDatumDatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -28879,9 +28404,12 @@ func (p projEQDatumDatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -28894,7 +28422,9 @@ func (p projEQDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
+			if !p.nullableArgs {
+				projVec.SetNulls(_outNulls.Or(*colNulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -28957,14 +28487,12 @@ func (p projNEBoolBoolConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -28988,7 +28516,7 @@ func (p projNEBoolBoolConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -29086,14 +28614,12 @@ func (p projNEBytesBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -29109,7 +28635,7 @@ func (p projNEBytesBytesConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -29181,14 +28707,12 @@ func (p projNEDecimalInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -29210,7 +28734,7 @@ func (p projNEDecimalInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -29302,14 +28826,12 @@ func (p projNEDecimalInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -29331,7 +28853,7 @@ func (p projNEDecimalInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -29423,14 +28945,12 @@ func (p projNEDecimalInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -29452,7 +28972,7 @@ func (p projNEDecimalInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -29544,14 +29064,12 @@ func (p projNEDecimalFloat64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -29575,7 +29093,7 @@ func (p projNEDecimalFloat64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -29673,14 +29191,12 @@ func (p projNEDecimalDecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -29696,7 +29212,7 @@ func (p projNEDecimalDecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -29770,14 +29286,12 @@ func (p projNEInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -29804,7 +29318,7 @@ func (p projNEInt16Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -29911,14 +29425,12 @@ func (p projNEInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -29945,7 +29457,7 @@ func (p projNEInt16Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -30052,14 +29564,12 @@ func (p projNEInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -30086,7 +29596,7 @@ func (p projNEInt16Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -30193,14 +29703,12 @@ func (p projNEInt16Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -30235,7 +29743,7 @@ func (p projNEInt16Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -30366,14 +29874,12 @@ func (p projNEInt16DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -30395,7 +29901,7 @@ func (p projNEInt16DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -30487,14 +29993,12 @@ func (p projNEInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -30521,7 +30025,7 @@ func (p projNEInt32Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -30628,14 +30132,12 @@ func (p projNEInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -30662,7 +30164,7 @@ func (p projNEInt32Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -30769,14 +30271,12 @@ func (p projNEInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -30803,7 +30303,7 @@ func (p projNEInt32Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -30910,14 +30410,12 @@ func (p projNEInt32Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -30952,7 +30450,7 @@ func (p projNEInt32Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -31083,14 +30581,12 @@ func (p projNEInt32DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -31112,7 +30608,7 @@ func (p projNEInt32DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -31204,14 +30700,12 @@ func (p projNEInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -31238,7 +30732,7 @@ func (p projNEInt64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -31345,14 +30839,12 @@ func (p projNEInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -31379,7 +30871,7 @@ func (p projNEInt64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -31486,14 +30978,12 @@ func (p projNEInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -31520,7 +31010,7 @@ func (p projNEInt64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -31627,14 +31117,12 @@ func (p projNEInt64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -31669,7 +31157,7 @@ func (p projNEInt64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -31800,14 +31288,12 @@ func (p projNEInt64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -31829,7 +31315,7 @@ func (p projNEInt64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -31921,14 +31407,12 @@ func (p projNEFloat64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -31963,7 +31447,7 @@ func (p projNEFloat64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -32094,14 +31578,12 @@ func (p projNEFloat64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -32136,7 +31618,7 @@ func (p projNEFloat64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -32267,14 +31749,12 @@ func (p projNEFloat64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -32309,7 +31789,7 @@ func (p projNEFloat64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -32440,14 +31920,12 @@ func (p projNEFloat64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -32482,7 +31960,7 @@ func (p projNEFloat64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -32613,14 +32091,12 @@ func (p projNEFloat64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -32644,7 +32120,7 @@ func (p projNEFloat64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -32742,14 +32218,12 @@ func (p projNETimestampTimestampConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -32772,7 +32246,7 @@ func (p projNETimestampTimestampConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -32867,14 +32341,12 @@ func (p projNEIntervalIntervalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -32890,7 +32362,7 @@ func (p projNEIntervalIntervalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -32964,14 +32436,12 @@ func (p projNEJSONJSONConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -32993,7 +32463,7 @@ func (p projNEJSONJSONConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -33083,16 +32553,17 @@ func (p projNEDatumDatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -33108,9 +32579,12 @@ func (p projNEDatumDatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -33123,7 +32597,9 @@ func (p projNEDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
+			if !p.nullableArgs {
+				projVec.SetNulls(_outNulls.Or(*colNulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -33186,14 +32662,12 @@ func (p projLTBoolBoolConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -33217,7 +32691,7 @@ func (p projLTBoolBoolConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -33315,14 +32789,12 @@ func (p projLTBytesBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -33338,7 +32810,7 @@ func (p projLTBytesBytesConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -33410,14 +32882,12 @@ func (p projLTDecimalInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -33439,7 +32909,7 @@ func (p projLTDecimalInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -33531,14 +33001,12 @@ func (p projLTDecimalInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -33560,7 +33028,7 @@ func (p projLTDecimalInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -33652,14 +33120,12 @@ func (p projLTDecimalInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -33681,7 +33147,7 @@ func (p projLTDecimalInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -33773,14 +33239,12 @@ func (p projLTDecimalFloat64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -33804,7 +33268,7 @@ func (p projLTDecimalFloat64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -33902,14 +33366,12 @@ func (p projLTDecimalDecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -33925,7 +33387,7 @@ func (p projLTDecimalDecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -33999,14 +33461,12 @@ func (p projLTInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -34033,7 +33493,7 @@ func (p projLTInt16Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -34140,14 +33600,12 @@ func (p projLTInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -34174,7 +33632,7 @@ func (p projLTInt16Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -34281,14 +33739,12 @@ func (p projLTInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -34315,7 +33771,7 @@ func (p projLTInt16Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -34422,14 +33878,12 @@ func (p projLTInt16Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -34464,7 +33918,7 @@ func (p projLTInt16Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -34595,14 +34049,12 @@ func (p projLTInt16DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -34624,7 +34076,7 @@ func (p projLTInt16DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -34716,14 +34168,12 @@ func (p projLTInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -34750,7 +34200,7 @@ func (p projLTInt32Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -34857,14 +34307,12 @@ func (p projLTInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -34891,7 +34339,7 @@ func (p projLTInt32Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -34998,14 +34446,12 @@ func (p projLTInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -35032,7 +34478,7 @@ func (p projLTInt32Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -35139,14 +34585,12 @@ func (p projLTInt32Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -35181,7 +34625,7 @@ func (p projLTInt32Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -35312,14 +34756,12 @@ func (p projLTInt32DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -35341,7 +34783,7 @@ func (p projLTInt32DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -35433,14 +34875,12 @@ func (p projLTInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -35467,7 +34907,7 @@ func (p projLTInt64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -35574,14 +35014,12 @@ func (p projLTInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -35608,7 +35046,7 @@ func (p projLTInt64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -35715,14 +35153,12 @@ func (p projLTInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -35749,7 +35185,7 @@ func (p projLTInt64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -35856,14 +35292,12 @@ func (p projLTInt64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -35898,7 +35332,7 @@ func (p projLTInt64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -36029,14 +35463,12 @@ func (p projLTInt64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -36058,7 +35490,7 @@ func (p projLTInt64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -36150,14 +35582,12 @@ func (p projLTFloat64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -36192,7 +35622,7 @@ func (p projLTFloat64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -36323,14 +35753,12 @@ func (p projLTFloat64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -36365,7 +35793,7 @@ func (p projLTFloat64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -36496,14 +35924,12 @@ func (p projLTFloat64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -36538,7 +35964,7 @@ func (p projLTFloat64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -36669,14 +36095,12 @@ func (p projLTFloat64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -36711,7 +36135,7 @@ func (p projLTFloat64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -36842,14 +36266,12 @@ func (p projLTFloat64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -36873,7 +36295,7 @@ func (p projLTFloat64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -36971,14 +36393,12 @@ func (p projLTTimestampTimestampConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -37001,7 +36421,7 @@ func (p projLTTimestampTimestampConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -37096,14 +36516,12 @@ func (p projLTIntervalIntervalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -37119,7 +36537,7 @@ func (p projLTIntervalIntervalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -37193,14 +36611,12 @@ func (p projLTJSONJSONConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -37222,7 +36638,7 @@ func (p projLTJSONJSONConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -37312,16 +36728,17 @@ func (p projLTDatumDatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -37337,9 +36754,12 @@ func (p projLTDatumDatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -37352,7 +36772,9 @@ func (p projLTDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
+			if !p.nullableArgs {
+				projVec.SetNulls(_outNulls.Or(*colNulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -37415,14 +36837,12 @@ func (p projLEBoolBoolConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -37446,7 +36866,7 @@ func (p projLEBoolBoolConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -37544,14 +36964,12 @@ func (p projLEBytesBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -37567,7 +36985,7 @@ func (p projLEBytesBytesConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -37639,14 +37057,12 @@ func (p projLEDecimalInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -37668,7 +37084,7 @@ func (p projLEDecimalInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -37760,14 +37176,12 @@ func (p projLEDecimalInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -37789,7 +37203,7 @@ func (p projLEDecimalInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -37881,14 +37295,12 @@ func (p projLEDecimalInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -37910,7 +37322,7 @@ func (p projLEDecimalInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -38002,14 +37414,12 @@ func (p projLEDecimalFloat64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -38033,7 +37443,7 @@ func (p projLEDecimalFloat64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -38131,14 +37541,12 @@ func (p projLEDecimalDecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -38154,7 +37562,7 @@ func (p projLEDecimalDecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -38228,14 +37636,12 @@ func (p projLEInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -38262,7 +37668,7 @@ func (p projLEInt16Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -38369,14 +37775,12 @@ func (p projLEInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -38403,7 +37807,7 @@ func (p projLEInt16Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -38510,14 +37914,12 @@ func (p projLEInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -38544,7 +37946,7 @@ func (p projLEInt16Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -38651,14 +38053,12 @@ func (p projLEInt16Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -38693,7 +38093,7 @@ func (p projLEInt16Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -38824,14 +38224,12 @@ func (p projLEInt16DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -38853,7 +38251,7 @@ func (p projLEInt16DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -38945,14 +38343,12 @@ func (p projLEInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -38979,7 +38375,7 @@ func (p projLEInt32Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -39086,14 +38482,12 @@ func (p projLEInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -39120,7 +38514,7 @@ func (p projLEInt32Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -39227,14 +38621,12 @@ func (p projLEInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -39261,7 +38653,7 @@ func (p projLEInt32Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -39368,14 +38760,12 @@ func (p projLEInt32Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -39410,7 +38800,7 @@ func (p projLEInt32Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -39541,14 +38931,12 @@ func (p projLEInt32DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -39570,7 +38958,7 @@ func (p projLEInt32DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -39662,14 +39050,12 @@ func (p projLEInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -39696,7 +39082,7 @@ func (p projLEInt64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -39803,14 +39189,12 @@ func (p projLEInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -39837,7 +39221,7 @@ func (p projLEInt64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -39944,14 +39328,12 @@ func (p projLEInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -39978,7 +39360,7 @@ func (p projLEInt64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -40085,14 +39467,12 @@ func (p projLEInt64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -40127,7 +39507,7 @@ func (p projLEInt64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -40258,14 +39638,12 @@ func (p projLEInt64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -40287,7 +39665,7 @@ func (p projLEInt64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -40379,14 +39757,12 @@ func (p projLEFloat64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -40421,7 +39797,7 @@ func (p projLEFloat64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -40552,14 +39928,12 @@ func (p projLEFloat64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -40594,7 +39968,7 @@ func (p projLEFloat64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -40725,14 +40099,12 @@ func (p projLEFloat64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -40767,7 +40139,7 @@ func (p projLEFloat64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -40898,14 +40270,12 @@ func (p projLEFloat64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -40940,7 +40310,7 @@ func (p projLEFloat64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -41071,14 +40441,12 @@ func (p projLEFloat64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -41102,7 +40470,7 @@ func (p projLEFloat64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -41200,14 +40568,12 @@ func (p projLETimestampTimestampConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -41230,7 +40596,7 @@ func (p projLETimestampTimestampConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -41325,14 +40691,12 @@ func (p projLEIntervalIntervalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -41348,7 +40712,7 @@ func (p projLEIntervalIntervalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -41422,14 +40786,12 @@ func (p projLEJSONJSONConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -41451,7 +40813,7 @@ func (p projLEJSONJSONConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -41541,16 +40903,17 @@ func (p projLEDatumDatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -41566,9 +40929,12 @@ func (p projLEDatumDatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -41581,7 +40947,9 @@ func (p projLEDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
+			if !p.nullableArgs {
+				projVec.SetNulls(_outNulls.Or(*colNulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -41644,14 +41012,12 @@ func (p projGTBoolBoolConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -41675,7 +41041,7 @@ func (p projGTBoolBoolConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -41773,14 +41139,12 @@ func (p projGTBytesBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -41796,7 +41160,7 @@ func (p projGTBytesBytesConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -41868,14 +41232,12 @@ func (p projGTDecimalInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -41897,7 +41259,7 @@ func (p projGTDecimalInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -41989,14 +41351,12 @@ func (p projGTDecimalInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -42018,7 +41378,7 @@ func (p projGTDecimalInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -42110,14 +41470,12 @@ func (p projGTDecimalInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -42139,7 +41497,7 @@ func (p projGTDecimalInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -42231,14 +41589,12 @@ func (p projGTDecimalFloat64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -42262,7 +41618,7 @@ func (p projGTDecimalFloat64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -42360,14 +41716,12 @@ func (p projGTDecimalDecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -42383,7 +41737,7 @@ func (p projGTDecimalDecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -42457,14 +41811,12 @@ func (p projGTInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -42491,7 +41843,7 @@ func (p projGTInt16Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -42598,14 +41950,12 @@ func (p projGTInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -42632,7 +41982,7 @@ func (p projGTInt16Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -42739,14 +42089,12 @@ func (p projGTInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -42773,7 +42121,7 @@ func (p projGTInt16Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -42880,14 +42228,12 @@ func (p projGTInt16Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -42922,7 +42268,7 @@ func (p projGTInt16Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -43053,14 +42399,12 @@ func (p projGTInt16DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -43082,7 +42426,7 @@ func (p projGTInt16DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -43174,14 +42518,12 @@ func (p projGTInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -43208,7 +42550,7 @@ func (p projGTInt32Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -43315,14 +42657,12 @@ func (p projGTInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -43349,7 +42689,7 @@ func (p projGTInt32Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -43456,14 +42796,12 @@ func (p projGTInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -43490,7 +42828,7 @@ func (p projGTInt32Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -43597,14 +42935,12 @@ func (p projGTInt32Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -43639,7 +42975,7 @@ func (p projGTInt32Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -43770,14 +43106,12 @@ func (p projGTInt32DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -43799,7 +43133,7 @@ func (p projGTInt32DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -43891,14 +43225,12 @@ func (p projGTInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -43925,7 +43257,7 @@ func (p projGTInt64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -44032,14 +43364,12 @@ func (p projGTInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -44066,7 +43396,7 @@ func (p projGTInt64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -44173,14 +43503,12 @@ func (p projGTInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -44207,7 +43535,7 @@ func (p projGTInt64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -44314,14 +43642,12 @@ func (p projGTInt64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -44356,7 +43682,7 @@ func (p projGTInt64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -44487,14 +43813,12 @@ func (p projGTInt64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -44516,7 +43840,7 @@ func (p projGTInt64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -44608,14 +43932,12 @@ func (p projGTFloat64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -44650,7 +43972,7 @@ func (p projGTFloat64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -44781,14 +44103,12 @@ func (p projGTFloat64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -44823,7 +44143,7 @@ func (p projGTFloat64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -44954,14 +44274,12 @@ func (p projGTFloat64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -44996,7 +44314,7 @@ func (p projGTFloat64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -45127,14 +44445,12 @@ func (p projGTFloat64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -45169,7 +44485,7 @@ func (p projGTFloat64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -45300,14 +44616,12 @@ func (p projGTFloat64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -45331,7 +44645,7 @@ func (p projGTFloat64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -45429,14 +44743,12 @@ func (p projGTTimestampTimestampConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -45459,7 +44771,7 @@ func (p projGTTimestampTimestampConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -45554,14 +44866,12 @@ func (p projGTIntervalIntervalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -45577,7 +44887,7 @@ func (p projGTIntervalIntervalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -45651,14 +44961,12 @@ func (p projGTJSONJSONConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -45680,7 +44988,7 @@ func (p projGTJSONJSONConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -45770,16 +45078,17 @@ func (p projGTDatumDatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -45795,9 +45104,12 @@ func (p projGTDatumDatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -45810,7 +45122,9 @@ func (p projGTDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
+			if !p.nullableArgs {
+				projVec.SetNulls(_outNulls.Or(*colNulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -45873,14 +45187,12 @@ func (p projGEBoolBoolConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -45904,7 +45216,7 @@ func (p projGEBoolBoolConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -46002,14 +45314,12 @@ func (p projGEBytesBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -46025,7 +45335,7 @@ func (p projGEBytesBytesConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -46097,14 +45407,12 @@ func (p projGEDecimalInt16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -46126,7 +45434,7 @@ func (p projGEDecimalInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -46218,14 +45526,12 @@ func (p projGEDecimalInt32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -46247,7 +45553,7 @@ func (p projGEDecimalInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -46339,14 +45645,12 @@ func (p projGEDecimalInt64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -46368,7 +45672,7 @@ func (p projGEDecimalInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -46460,14 +45764,12 @@ func (p projGEDecimalFloat64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -46491,7 +45793,7 @@ func (p projGEDecimalFloat64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -46589,14 +45891,12 @@ func (p projGEDecimalDecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -46612,7 +45912,7 @@ func (p projGEDecimalDecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -46686,14 +45986,12 @@ func (p projGEInt16Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -46720,7 +46018,7 @@ func (p projGEInt16Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -46827,14 +46125,12 @@ func (p projGEInt16Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -46861,7 +46157,7 @@ func (p projGEInt16Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -46968,14 +46264,12 @@ func (p projGEInt16Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -47002,7 +46296,7 @@ func (p projGEInt16Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -47109,14 +46403,12 @@ func (p projGEInt16Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -47151,7 +46443,7 @@ func (p projGEInt16Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -47282,14 +46574,12 @@ func (p projGEInt16DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -47311,7 +46601,7 @@ func (p projGEInt16DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -47403,14 +46693,12 @@ func (p projGEInt32Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -47437,7 +46725,7 @@ func (p projGEInt32Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -47544,14 +46832,12 @@ func (p projGEInt32Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -47578,7 +46864,7 @@ func (p projGEInt32Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -47685,14 +46971,12 @@ func (p projGEInt32Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -47719,7 +47003,7 @@ func (p projGEInt32Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -47826,14 +47110,12 @@ func (p projGEInt32Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -47868,7 +47150,7 @@ func (p projGEInt32Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -47999,14 +47281,12 @@ func (p projGEInt32DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -48028,7 +47308,7 @@ func (p projGEInt32DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -48120,14 +47400,12 @@ func (p projGEInt64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -48154,7 +47432,7 @@ func (p projGEInt64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -48261,14 +47539,12 @@ func (p projGEInt64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -48295,7 +47571,7 @@ func (p projGEInt64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -48402,14 +47678,12 @@ func (p projGEInt64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -48436,7 +47710,7 @@ func (p projGEInt64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -48543,14 +47817,12 @@ func (p projGEInt64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -48585,7 +47857,7 @@ func (p projGEInt64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -48716,14 +47988,12 @@ func (p projGEInt64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -48745,7 +48015,7 @@ func (p projGEInt64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -48837,14 +48107,12 @@ func (p projGEFloat64Int16ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -48879,7 +48147,7 @@ func (p projGEFloat64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -49010,14 +48278,12 @@ func (p projGEFloat64Int32ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -49052,7 +48318,7 @@ func (p projGEFloat64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -49183,14 +48449,12 @@ func (p projGEFloat64Int64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -49225,7 +48489,7 @@ func (p projGEFloat64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -49356,14 +48620,12 @@ func (p projGEFloat64Float64ConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -49398,7 +48660,7 @@ func (p projGEFloat64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -49529,14 +48791,12 @@ func (p projGEFloat64DecimalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -49560,7 +48820,7 @@ func (p projGEFloat64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -49658,14 +48918,12 @@ func (p projGETimestampTimestampConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -49688,7 +48946,7 @@ func (p projGETimestampTimestampConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -49783,14 +49041,12 @@ func (p projGEIntervalIntervalConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -49806,7 +49062,7 @@ func (p projGEIntervalIntervalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -49880,14 +49136,12 @@ func (p projGEJSONJSONConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -49909,7 +49163,7 @@ func (p projGEJSONJSONConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -49999,16 +49253,17 @@ func (p projGEDatumDatumConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls() && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -50024,9 +49279,12 @@ func (p projGEDatumDatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -50039,7 +49297,9 @@ func (p projGEDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
+			if !p.nullableArgs {
+				projVec.SetNulls(_outNulls.Or(*colNulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]

--- a/pkg/sql/colexec/colexecproj/proj_like_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_like_ops.eg.go
@@ -43,14 +43,12 @@ func (p projPrefixBytesBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = bytes.HasPrefix(arg, p.constArg)
@@ -60,7 +58,7 @@ func (p projPrefixBytesBytesConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = bytes.HasPrefix(arg, p.constArg)
@@ -114,14 +112,12 @@ func (p projSuffixBytesBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = bytes.HasSuffix(arg, p.constArg)
@@ -131,7 +127,7 @@ func (p projSuffixBytesBytesConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = bytes.HasSuffix(arg, p.constArg)
@@ -185,14 +181,12 @@ func (p projContainsBytesBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = bytes.Contains(arg, p.constArg)
@@ -202,7 +196,7 @@ func (p projContainsBytesBytesConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = bytes.Contains(arg, p.constArg)
@@ -256,14 +250,12 @@ func (p projRegexpBytesBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = p.constArg.Match(arg)
@@ -273,7 +265,7 @@ func (p projRegexpBytesBytesConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = p.constArg.Match(arg)
@@ -327,14 +319,12 @@ func (p projNotPrefixBytesBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = !bytes.HasPrefix(arg, p.constArg)
@@ -344,7 +334,7 @@ func (p projNotPrefixBytesBytesConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = !bytes.HasPrefix(arg, p.constArg)
@@ -398,14 +388,12 @@ func (p projNotSuffixBytesBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = !bytes.HasSuffix(arg, p.constArg)
@@ -415,7 +403,7 @@ func (p projNotSuffixBytesBytesConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = !bytes.HasSuffix(arg, p.constArg)
@@ -469,14 +457,12 @@ func (p projNotContainsBytesBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = !bytes.Contains(arg, p.constArg)
@@ -486,7 +472,7 @@ func (p projNotContainsBytesBytesConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = !bytes.Contains(arg, p.constArg)
@@ -540,14 +526,12 @@ func (p projNotRegexpBytesBytesConstOp) Next() coldata.Batch {
 		}
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotNullable {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = !p.constArg.Match(arg)
@@ -557,7 +541,7 @@ func (p projNotRegexpBytesBytesConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.nullableArgs || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = !p.constArg.Match(arg)

--- a/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
@@ -92,15 +92,13 @@ func (p projBitandInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -115,7 +113,7 @@ func (p projBitandInt16Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -181,15 +179,13 @@ func (p projBitandInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -204,7 +200,7 @@ func (p projBitandInt16Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -270,15 +266,13 @@ func (p projBitandInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -293,7 +287,7 @@ func (p projBitandInt16Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -359,15 +353,13 @@ func (p projBitandInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -382,7 +374,7 @@ func (p projBitandInt32Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -448,15 +440,13 @@ func (p projBitandInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -471,7 +461,7 @@ func (p projBitandInt32Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -537,15 +527,13 @@ func (p projBitandInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -560,7 +548,7 @@ func (p projBitandInt32Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -626,15 +614,13 @@ func (p projBitandInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -649,7 +635,7 @@ func (p projBitandInt64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -715,15 +701,13 @@ func (p projBitandInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -738,7 +722,7 @@ func (p projBitandInt64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -804,15 +788,13 @@ func (p projBitandInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -827,7 +809,7 @@ func (p projBitandInt64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -895,19 +877,23 @@ func (p projBitandDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
@@ -925,11 +911,17 @@ func (p projBitandDatumDatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
@@ -943,7 +935,9 @@ func (p projBitandDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			if !p.nullableArgs {
+				projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1008,15 +1002,13 @@ func (p projBitorInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -1031,7 +1023,7 @@ func (p projBitorInt16Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -1097,15 +1089,13 @@ func (p projBitorInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -1120,7 +1110,7 @@ func (p projBitorInt16Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -1186,15 +1176,13 @@ func (p projBitorInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -1209,7 +1197,7 @@ func (p projBitorInt16Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -1275,15 +1263,13 @@ func (p projBitorInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -1298,7 +1284,7 @@ func (p projBitorInt32Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -1364,15 +1350,13 @@ func (p projBitorInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -1387,7 +1371,7 @@ func (p projBitorInt32Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -1453,15 +1437,13 @@ func (p projBitorInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -1476,7 +1458,7 @@ func (p projBitorInt32Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -1542,15 +1524,13 @@ func (p projBitorInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -1565,7 +1545,7 @@ func (p projBitorInt64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -1631,15 +1611,13 @@ func (p projBitorInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -1654,7 +1632,7 @@ func (p projBitorInt64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -1720,15 +1698,13 @@ func (p projBitorInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -1743,7 +1719,7 @@ func (p projBitorInt64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -1811,19 +1787,23 @@ func (p projBitorDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
@@ -1841,11 +1821,17 @@ func (p projBitorDatumDatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
@@ -1859,7 +1845,9 @@ func (p projBitorDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			if !p.nullableArgs {
+				projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1924,15 +1912,13 @@ func (p projBitxorInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -1947,7 +1933,7 @@ func (p projBitxorInt16Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -2013,15 +1999,13 @@ func (p projBitxorInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -2036,7 +2020,7 @@ func (p projBitxorInt16Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -2102,15 +2086,13 @@ func (p projBitxorInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -2125,7 +2107,7 @@ func (p projBitxorInt16Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -2191,15 +2173,13 @@ func (p projBitxorInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -2214,7 +2194,7 @@ func (p projBitxorInt32Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -2280,15 +2260,13 @@ func (p projBitxorInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -2303,7 +2281,7 @@ func (p projBitxorInt32Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -2369,15 +2347,13 @@ func (p projBitxorInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -2392,7 +2368,7 @@ func (p projBitxorInt32Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -2458,15 +2434,13 @@ func (p projBitxorInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -2481,7 +2455,7 @@ func (p projBitxorInt64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -2547,15 +2521,13 @@ func (p projBitxorInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -2570,7 +2542,7 @@ func (p projBitxorInt64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -2636,15 +2608,13 @@ func (p projBitxorInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -2659,7 +2629,7 @@ func (p projBitxorInt64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -2727,19 +2697,23 @@ func (p projBitxorDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
@@ -2757,11 +2731,17 @@ func (p projBitxorDatumDatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
@@ -2775,7 +2755,9 @@ func (p projBitxorDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			if !p.nullableArgs {
+				projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2840,15 +2822,13 @@ func (p projPlusDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -2870,7 +2850,7 @@ func (p projPlusDecimalInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -2957,15 +2937,13 @@ func (p projPlusDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -2987,7 +2965,7 @@ func (p projPlusDecimalInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -3074,15 +3052,13 @@ func (p projPlusDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -3104,7 +3080,7 @@ func (p projPlusDecimalInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -3191,15 +3167,13 @@ func (p projPlusDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -3220,7 +3194,7 @@ func (p projPlusDecimalDecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -3304,15 +3278,13 @@ func (p projPlusInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -3333,7 +3305,7 @@ func (p projPlusInt16Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -3417,15 +3389,13 @@ func (p projPlusInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -3446,7 +3416,7 @@ func (p projPlusInt16Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -3530,15 +3500,13 @@ func (p projPlusInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -3559,7 +3527,7 @@ func (p projPlusInt16Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -3643,15 +3611,13 @@ func (p projPlusInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -3674,7 +3640,7 @@ func (p projPlusInt16DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -3766,15 +3732,13 @@ func (p projPlusInt16DatumOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -3800,7 +3764,7 @@ func (p projPlusInt16DatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -3897,15 +3861,13 @@ func (p projPlusInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -3926,7 +3888,7 @@ func (p projPlusInt32Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -4010,15 +3972,13 @@ func (p projPlusInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -4039,7 +3999,7 @@ func (p projPlusInt32Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -4123,15 +4083,13 @@ func (p projPlusInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -4152,7 +4110,7 @@ func (p projPlusInt32Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -4236,15 +4194,13 @@ func (p projPlusInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -4267,7 +4223,7 @@ func (p projPlusInt32DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -4359,15 +4315,13 @@ func (p projPlusInt32DatumOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -4393,7 +4347,7 @@ func (p projPlusInt32DatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -4490,15 +4444,13 @@ func (p projPlusInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -4519,7 +4471,7 @@ func (p projPlusInt64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -4603,15 +4555,13 @@ func (p projPlusInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -4632,7 +4582,7 @@ func (p projPlusInt64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -4716,15 +4666,13 @@ func (p projPlusInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -4745,7 +4693,7 @@ func (p projPlusInt64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -4829,15 +4777,13 @@ func (p projPlusInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -4860,7 +4806,7 @@ func (p projPlusInt64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -4952,15 +4898,13 @@ func (p projPlusInt64DatumOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -4986,7 +4930,7 @@ func (p projPlusInt64DatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -5083,15 +5027,13 @@ func (p projPlusFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -5109,7 +5051,7 @@ func (p projPlusFloat64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -5184,15 +5126,13 @@ func (p projPlusTimestampIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Timestamp()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -5210,7 +5150,7 @@ func (p projPlusTimestampIntervalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -5285,15 +5225,13 @@ func (p projPlusIntervalTimestampOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -5311,7 +5249,7 @@ func (p projPlusIntervalTimestampOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -5386,15 +5324,13 @@ func (p projPlusIntervalIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -5407,7 +5343,7 @@ func (p projPlusIntervalIntervalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -5469,15 +5405,13 @@ func (p projPlusIntervalDatumOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -5503,7 +5437,7 @@ func (p projPlusIntervalDatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -5602,15 +5536,13 @@ func (p projPlusDatumIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -5636,7 +5568,7 @@ func (p projPlusDatumIntervalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -5735,15 +5667,13 @@ func (p projPlusDatumInt16Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -5769,7 +5699,7 @@ func (p projPlusDatumInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -5868,15 +5798,13 @@ func (p projPlusDatumInt32Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -5902,7 +5830,7 @@ func (p projPlusDatumInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -6001,15 +5929,13 @@ func (p projPlusDatumInt64Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -6035,7 +5961,7 @@ func (p projPlusDatumInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -6132,15 +6058,13 @@ func (p projMinusDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -6162,7 +6086,7 @@ func (p projMinusDecimalInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -6249,15 +6173,13 @@ func (p projMinusDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -6279,7 +6201,7 @@ func (p projMinusDecimalInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -6366,15 +6288,13 @@ func (p projMinusDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -6396,7 +6316,7 @@ func (p projMinusDecimalInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -6483,15 +6403,13 @@ func (p projMinusDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -6512,7 +6430,7 @@ func (p projMinusDecimalDecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -6596,15 +6514,13 @@ func (p projMinusInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -6625,7 +6541,7 @@ func (p projMinusInt16Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -6709,15 +6625,13 @@ func (p projMinusInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -6738,7 +6652,7 @@ func (p projMinusInt16Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -6822,15 +6736,13 @@ func (p projMinusInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -6851,7 +6763,7 @@ func (p projMinusInt16Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -6935,15 +6847,13 @@ func (p projMinusInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -6966,7 +6876,7 @@ func (p projMinusInt16DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -7058,15 +6968,13 @@ func (p projMinusInt16DatumOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -7092,7 +7000,7 @@ func (p projMinusInt16DatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -7189,15 +7097,13 @@ func (p projMinusInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -7218,7 +7124,7 @@ func (p projMinusInt32Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -7302,15 +7208,13 @@ func (p projMinusInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -7331,7 +7235,7 @@ func (p projMinusInt32Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -7415,15 +7319,13 @@ func (p projMinusInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -7444,7 +7346,7 @@ func (p projMinusInt32Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -7528,15 +7430,13 @@ func (p projMinusInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -7559,7 +7459,7 @@ func (p projMinusInt32DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -7651,15 +7551,13 @@ func (p projMinusInt32DatumOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -7685,7 +7583,7 @@ func (p projMinusInt32DatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -7782,15 +7680,13 @@ func (p projMinusInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -7811,7 +7707,7 @@ func (p projMinusInt64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -7895,15 +7791,13 @@ func (p projMinusInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -7924,7 +7818,7 @@ func (p projMinusInt64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -8008,15 +7902,13 @@ func (p projMinusInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -8037,7 +7929,7 @@ func (p projMinusInt64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -8121,15 +8013,13 @@ func (p projMinusInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -8152,7 +8042,7 @@ func (p projMinusInt64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -8244,15 +8134,13 @@ func (p projMinusInt64DatumOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -8278,7 +8166,7 @@ func (p projMinusInt64DatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -8375,15 +8263,13 @@ func (p projMinusFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -8401,7 +8287,7 @@ func (p projMinusFloat64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -8476,15 +8362,13 @@ func (p projMinusTimestampTimestampOp) Next() coldata.Batch {
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -8500,7 +8384,7 @@ func (p projMinusTimestampTimestampOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -8569,15 +8453,13 @@ func (p projMinusTimestampIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Timestamp()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -8595,7 +8477,7 @@ func (p projMinusTimestampIntervalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -8670,15 +8552,13 @@ func (p projMinusIntervalIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -8691,7 +8571,7 @@ func (p projMinusIntervalIntervalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -8753,15 +8633,13 @@ func (p projMinusIntervalDatumOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -8787,7 +8665,7 @@ func (p projMinusIntervalDatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -8884,15 +8762,13 @@ func (p projMinusJSONBytesOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -8914,7 +8790,7 @@ func (p projMinusJSONBytesOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -8997,15 +8873,13 @@ func (p projMinusJSONInt16Op) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -9023,7 +8897,7 @@ func (p projMinusJSONInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -9096,15 +8970,13 @@ func (p projMinusJSONInt32Op) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -9122,7 +8994,7 @@ func (p projMinusJSONInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -9195,15 +9067,13 @@ func (p projMinusJSONInt64Op) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -9221,7 +9091,7 @@ func (p projMinusJSONInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -9296,19 +9166,23 @@ func (p projMinusDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
@@ -9326,11 +9200,17 @@ func (p projMinusDatumDatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
@@ -9344,7 +9224,9 @@ func (p projMinusDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			if !p.nullableArgs {
+				projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -9411,15 +9293,13 @@ func (p projMinusDatumIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -9445,7 +9325,7 @@ func (p projMinusDatumIntervalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -9544,15 +9424,13 @@ func (p projMinusDatumBytesOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -9578,7 +9456,7 @@ func (p projMinusDatumBytesOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -9675,15 +9553,13 @@ func (p projMinusDatumInt16Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -9709,7 +9585,7 @@ func (p projMinusDatumInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -9808,15 +9684,13 @@ func (p projMinusDatumInt32Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -9842,7 +9716,7 @@ func (p projMinusDatumInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -9941,15 +9815,13 @@ func (p projMinusDatumInt64Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -9975,7 +9847,7 @@ func (p projMinusDatumInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -10072,15 +9944,13 @@ func (p projMultDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -10102,7 +9972,7 @@ func (p projMultDecimalInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -10189,15 +10059,13 @@ func (p projMultDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -10219,7 +10087,7 @@ func (p projMultDecimalInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -10306,15 +10174,13 @@ func (p projMultDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -10336,7 +10202,7 @@ func (p projMultDecimalInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -10423,15 +10289,13 @@ func (p projMultDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -10452,7 +10316,7 @@ func (p projMultDecimalDecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -10536,15 +10400,13 @@ func (p projMultDecimalIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -10562,7 +10424,7 @@ func (p projMultDecimalIntervalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -10637,15 +10499,13 @@ func (p projMultInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -10674,7 +10534,7 @@ func (p projMultInt16Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -10782,15 +10642,13 @@ func (p projMultInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -10819,7 +10677,7 @@ func (p projMultInt16Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -10927,15 +10785,13 @@ func (p projMultInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -10964,7 +10820,7 @@ func (p projMultInt16Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -11072,15 +10928,13 @@ func (p projMultInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -11103,7 +10957,7 @@ func (p projMultInt16DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -11193,15 +11047,13 @@ func (p projMultInt16IntervalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -11214,7 +11066,7 @@ func (p projMultInt16IntervalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -11274,15 +11126,13 @@ func (p projMultInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -11311,7 +11161,7 @@ func (p projMultInt32Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -11419,15 +11269,13 @@ func (p projMultInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -11456,7 +11304,7 @@ func (p projMultInt32Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -11564,15 +11412,13 @@ func (p projMultInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -11601,7 +11447,7 @@ func (p projMultInt32Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -11709,15 +11555,13 @@ func (p projMultInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -11740,7 +11584,7 @@ func (p projMultInt32DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -11830,15 +11674,13 @@ func (p projMultInt32IntervalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -11851,7 +11693,7 @@ func (p projMultInt32IntervalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -11911,15 +11753,13 @@ func (p projMultInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -11948,7 +11788,7 @@ func (p projMultInt64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -12056,15 +11896,13 @@ func (p projMultInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -12093,7 +11931,7 @@ func (p projMultInt64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -12201,15 +12039,13 @@ func (p projMultInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -12238,7 +12074,7 @@ func (p projMultInt64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -12346,15 +12182,13 @@ func (p projMultInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -12377,7 +12211,7 @@ func (p projMultInt64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -12467,15 +12301,13 @@ func (p projMultInt64IntervalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -12488,7 +12320,7 @@ func (p projMultInt64IntervalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -12548,15 +12380,13 @@ func (p projMultFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -12574,7 +12404,7 @@ func (p projMultFloat64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -12649,15 +12479,13 @@ func (p projMultFloat64IntervalOp) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -12670,7 +12498,7 @@ func (p projMultFloat64IntervalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -12730,15 +12558,13 @@ func (p projMultIntervalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -12751,7 +12577,7 @@ func (p projMultIntervalInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -12811,15 +12637,13 @@ func (p projMultIntervalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -12832,7 +12656,7 @@ func (p projMultIntervalInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -12892,15 +12716,13 @@ func (p projMultIntervalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -12913,7 +12735,7 @@ func (p projMultIntervalInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -12973,15 +12795,13 @@ func (p projMultIntervalFloat64Op) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -12994,7 +12814,7 @@ func (p projMultIntervalFloat64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -13054,15 +12874,13 @@ func (p projMultIntervalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -13080,7 +12898,7 @@ func (p projMultIntervalDecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -13155,15 +12973,13 @@ func (p projDivDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -13189,7 +13005,7 @@ func (p projDivDecimalInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -13288,15 +13104,13 @@ func (p projDivDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -13322,7 +13136,7 @@ func (p projDivDecimalInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -13421,15 +13235,13 @@ func (p projDivDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -13455,7 +13267,7 @@ func (p projDivDecimalInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -13554,15 +13366,13 @@ func (p projDivDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -13587,7 +13397,7 @@ func (p projDivDecimalDecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -13683,15 +13493,13 @@ func (p projDivInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -13716,7 +13524,7 @@ func (p projDivInt16Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -13812,15 +13620,13 @@ func (p projDivInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -13845,7 +13651,7 @@ func (p projDivInt16Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -13941,15 +13747,13 @@ func (p projDivInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -13974,7 +13778,7 @@ func (p projDivInt16Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -14070,15 +13874,13 @@ func (p projDivInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -14105,7 +13907,7 @@ func (p projDivInt16DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -14207,15 +14009,13 @@ func (p projDivInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -14240,7 +14040,7 @@ func (p projDivInt32Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -14336,15 +14136,13 @@ func (p projDivInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -14369,7 +14167,7 @@ func (p projDivInt32Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -14465,15 +14263,13 @@ func (p projDivInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -14498,7 +14294,7 @@ func (p projDivInt32Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -14594,15 +14390,13 @@ func (p projDivInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -14629,7 +14423,7 @@ func (p projDivInt32DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -14731,15 +14525,13 @@ func (p projDivInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -14764,7 +14556,7 @@ func (p projDivInt64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -14860,15 +14652,13 @@ func (p projDivInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -14893,7 +14683,7 @@ func (p projDivInt64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -14989,15 +14779,13 @@ func (p projDivInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -15022,7 +14810,7 @@ func (p projDivInt64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -15118,15 +14906,13 @@ func (p projDivInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -15153,7 +14939,7 @@ func (p projDivInt64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -15255,15 +15041,13 @@ func (p projDivFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -15285,7 +15069,7 @@ func (p projDivFloat64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -15372,15 +15156,13 @@ func (p projDivIntervalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -15397,7 +15179,7 @@ func (p projDivIntervalInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -15469,15 +15251,13 @@ func (p projDivIntervalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -15494,7 +15274,7 @@ func (p projDivIntervalInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -15566,15 +15346,13 @@ func (p projDivIntervalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -15591,7 +15369,7 @@ func (p projDivIntervalInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -15663,15 +15441,13 @@ func (p projDivIntervalFloat64Op) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -15688,7 +15464,7 @@ func (p projDivIntervalFloat64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -15760,15 +15536,13 @@ func (p projFloorDivDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -15794,7 +15568,7 @@ func (p projFloorDivDecimalInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -15893,15 +15667,13 @@ func (p projFloorDivDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -15927,7 +15699,7 @@ func (p projFloorDivDecimalInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -16026,15 +15798,13 @@ func (p projFloorDivDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -16060,7 +15830,7 @@ func (p projFloorDivDecimalInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -16159,15 +15929,13 @@ func (p projFloorDivDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -16192,7 +15960,7 @@ func (p projFloorDivDecimalDecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -16288,15 +16056,13 @@ func (p projFloorDivInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -16316,7 +16082,7 @@ func (p projFloorDivInt16Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -16397,15 +16163,13 @@ func (p projFloorDivInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -16425,7 +16189,7 @@ func (p projFloorDivInt16Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -16506,15 +16270,13 @@ func (p projFloorDivInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -16534,7 +16296,7 @@ func (p projFloorDivInt16Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -16615,15 +16377,13 @@ func (p projFloorDivInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -16650,7 +16410,7 @@ func (p projFloorDivInt16DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -16752,15 +16512,13 @@ func (p projFloorDivInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -16780,7 +16538,7 @@ func (p projFloorDivInt32Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -16861,15 +16619,13 @@ func (p projFloorDivInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -16889,7 +16645,7 @@ func (p projFloorDivInt32Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -16970,15 +16726,13 @@ func (p projFloorDivInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -16998,7 +16752,7 @@ func (p projFloorDivInt32Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -17079,15 +16833,13 @@ func (p projFloorDivInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -17114,7 +16866,7 @@ func (p projFloorDivInt32DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -17216,15 +16968,13 @@ func (p projFloorDivInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -17244,7 +16994,7 @@ func (p projFloorDivInt64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -17325,15 +17075,13 @@ func (p projFloorDivInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -17353,7 +17101,7 @@ func (p projFloorDivInt64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -17434,15 +17182,13 @@ func (p projFloorDivInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -17462,7 +17208,7 @@ func (p projFloorDivInt64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -17543,15 +17289,13 @@ func (p projFloorDivInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -17578,7 +17322,7 @@ func (p projFloorDivInt64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -17680,15 +17424,13 @@ func (p projFloorDivFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -17710,7 +17452,7 @@ func (p projFloorDivFloat64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -17797,15 +17539,13 @@ func (p projModDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -17831,7 +17571,7 @@ func (p projModDecimalInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -17930,15 +17670,13 @@ func (p projModDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -17964,7 +17702,7 @@ func (p projModDecimalInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -18063,15 +17801,13 @@ func (p projModDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -18097,7 +17833,7 @@ func (p projModDecimalInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -18196,15 +17932,13 @@ func (p projModDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -18229,7 +17963,7 @@ func (p projModDecimalDecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -18325,15 +18059,13 @@ func (p projModInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -18353,7 +18085,7 @@ func (p projModInt16Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -18434,15 +18166,13 @@ func (p projModInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -18462,7 +18192,7 @@ func (p projModInt16Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -18543,15 +18273,13 @@ func (p projModInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -18571,7 +18299,7 @@ func (p projModInt16Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -18652,15 +18380,13 @@ func (p projModInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -18687,7 +18413,7 @@ func (p projModInt16DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -18789,15 +18515,13 @@ func (p projModInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -18817,7 +18541,7 @@ func (p projModInt32Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -18898,15 +18622,13 @@ func (p projModInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -18926,7 +18648,7 @@ func (p projModInt32Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -19007,15 +18729,13 @@ func (p projModInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -19035,7 +18755,7 @@ func (p projModInt32Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -19116,15 +18836,13 @@ func (p projModInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -19151,7 +18869,7 @@ func (p projModInt32DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -19253,15 +18971,13 @@ func (p projModInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -19281,7 +18997,7 @@ func (p projModInt64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -19362,15 +19078,13 @@ func (p projModInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -19390,7 +19104,7 @@ func (p projModInt64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -19471,15 +19185,13 @@ func (p projModInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -19499,7 +19211,7 @@ func (p projModInt64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -19580,15 +19292,13 @@ func (p projModInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -19615,7 +19325,7 @@ func (p projModInt64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -19717,15 +19427,13 @@ func (p projModFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -19747,7 +19455,7 @@ func (p projModFloat64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -19834,15 +19542,13 @@ func (p projPowDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -19864,7 +19570,7 @@ func (p projPowDecimalInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -19951,15 +19657,13 @@ func (p projPowDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -19981,7 +19685,7 @@ func (p projPowDecimalInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -20068,15 +19772,13 @@ func (p projPowDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -20098,7 +19800,7 @@ func (p projPowDecimalInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -20185,15 +19887,13 @@ func (p projPowDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -20214,7 +19914,7 @@ func (p projPowDecimalDecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -20298,15 +19998,13 @@ func (p projPowInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -20333,7 +20031,7 @@ func (p projPowInt16Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -20435,15 +20133,13 @@ func (p projPowInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -20470,7 +20166,7 @@ func (p projPowInt16Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -20572,15 +20268,13 @@ func (p projPowInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -20607,7 +20301,7 @@ func (p projPowInt16Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -20709,15 +20403,13 @@ func (p projPowInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -20740,7 +20432,7 @@ func (p projPowInt16DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -20830,15 +20522,13 @@ func (p projPowInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -20865,7 +20555,7 @@ func (p projPowInt32Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -20967,15 +20657,13 @@ func (p projPowInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -21002,7 +20690,7 @@ func (p projPowInt32Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -21104,15 +20792,13 @@ func (p projPowInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -21139,7 +20825,7 @@ func (p projPowInt32Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -21241,15 +20927,13 @@ func (p projPowInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -21272,7 +20956,7 @@ func (p projPowInt32DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -21362,15 +21046,13 @@ func (p projPowInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -21397,7 +21079,7 @@ func (p projPowInt64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -21499,15 +21181,13 @@ func (p projPowInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -21534,7 +21214,7 @@ func (p projPowInt64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -21636,15 +21316,13 @@ func (p projPowInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -21671,7 +21349,7 @@ func (p projPowInt64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -21773,15 +21451,13 @@ func (p projPowInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -21804,7 +21480,7 @@ func (p projPowInt64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -21894,15 +21570,13 @@ func (p projPowFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -21920,7 +21594,7 @@ func (p projPowFloat64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -21995,15 +21669,13 @@ func (p projConcatBytesBytesOp) Next() coldata.Batch {
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -22023,7 +21695,7 @@ func (p projConcatBytesBytesOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -22100,15 +21772,13 @@ func (p projConcatJSONJSONOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -22127,7 +21797,7 @@ func (p projConcatJSONJSONOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -22203,19 +21873,23 @@ func (p projConcatDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
@@ -22233,11 +21907,17 @@ func (p projConcatDatumDatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						_res, err := _overloadHelper.BinFn(_overloadHelper.EvalCtx, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
@@ -22251,7 +21931,9 @@ func (p projConcatDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			if !p.nullableArgs {
+				projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -22316,15 +21998,13 @@ func (p projLShiftInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -22345,7 +22025,7 @@ func (p projLShiftInt16Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -22429,15 +22109,13 @@ func (p projLShiftInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -22458,7 +22136,7 @@ func (p projLShiftInt16Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -22542,15 +22220,13 @@ func (p projLShiftInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -22571,7 +22247,7 @@ func (p projLShiftInt16Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -22655,15 +22331,13 @@ func (p projLShiftInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -22684,7 +22358,7 @@ func (p projLShiftInt32Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -22768,15 +22442,13 @@ func (p projLShiftInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -22797,7 +22469,7 @@ func (p projLShiftInt32Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -22881,15 +22553,13 @@ func (p projLShiftInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -22910,7 +22580,7 @@ func (p projLShiftInt32Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -22994,15 +22664,13 @@ func (p projLShiftInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -23023,7 +22691,7 @@ func (p projLShiftInt64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -23107,15 +22775,13 @@ func (p projLShiftInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -23136,7 +22802,7 @@ func (p projLShiftInt64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -23220,15 +22886,13 @@ func (p projLShiftInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -23249,7 +22913,7 @@ func (p projLShiftInt64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -23335,15 +22999,13 @@ func (p projLShiftDatumInt16Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -23369,7 +23031,7 @@ func (p projLShiftDatumInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -23468,15 +23130,13 @@ func (p projLShiftDatumInt32Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -23502,7 +23162,7 @@ func (p projLShiftDatumInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -23601,15 +23261,13 @@ func (p projLShiftDatumInt64Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -23635,7 +23293,7 @@ func (p projLShiftDatumInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -23732,15 +23390,13 @@ func (p projRShiftInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -23761,7 +23417,7 @@ func (p projRShiftInt16Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -23845,15 +23501,13 @@ func (p projRShiftInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -23874,7 +23528,7 @@ func (p projRShiftInt16Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -23958,15 +23612,13 @@ func (p projRShiftInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -23987,7 +23639,7 @@ func (p projRShiftInt16Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -24071,15 +23723,13 @@ func (p projRShiftInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -24100,7 +23750,7 @@ func (p projRShiftInt32Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -24184,15 +23834,13 @@ func (p projRShiftInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -24213,7 +23861,7 @@ func (p projRShiftInt32Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -24297,15 +23945,13 @@ func (p projRShiftInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -24326,7 +23972,7 @@ func (p projRShiftInt32Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -24410,15 +24056,13 @@ func (p projRShiftInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -24439,7 +24083,7 @@ func (p projRShiftInt64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -24523,15 +24167,13 @@ func (p projRShiftInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -24552,7 +24194,7 @@ func (p projRShiftInt64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -24636,15 +24278,13 @@ func (p projRShiftInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -24665,7 +24305,7 @@ func (p projRShiftInt64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -24751,15 +24391,13 @@ func (p projRShiftDatumInt16Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -24785,7 +24423,7 @@ func (p projRShiftDatumInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -24884,15 +24522,13 @@ func (p projRShiftDatumInt32Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -24918,7 +24554,7 @@ func (p projRShiftDatumInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -25017,15 +24653,13 @@ func (p projRShiftDatumInt64Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -25051,7 +24685,7 @@ func (p projRShiftDatumInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -25148,15 +24782,13 @@ func (p projJSONFetchValJSONBytesOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -25181,7 +24813,7 @@ func (p projJSONFetchValJSONBytesOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -25273,15 +24905,13 @@ func (p projJSONFetchValJSONInt16Op) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -25303,7 +24933,7 @@ func (p projJSONFetchValJSONInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -25388,15 +25018,13 @@ func (p projJSONFetchValJSONInt32Op) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -25418,7 +25046,7 @@ func (p projJSONFetchValJSONInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -25503,15 +25131,13 @@ func (p projJSONFetchValJSONInt64Op) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -25533,7 +25159,7 @@ func (p projJSONFetchValJSONInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -25618,15 +25244,13 @@ func (p projJSONFetchTextJSONBytesOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -25660,7 +25284,7 @@ func (p projJSONFetchTextJSONBytesOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -25779,15 +25403,13 @@ func (p projJSONFetchTextJSONInt16Op) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -25818,7 +25440,7 @@ func (p projJSONFetchTextJSONInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -25930,15 +25552,13 @@ func (p projJSONFetchTextJSONInt32Op) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -25969,7 +25589,7 @@ func (p projJSONFetchTextJSONInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -26081,15 +25701,13 @@ func (p projJSONFetchTextJSONInt64Op) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -26120,7 +25738,7 @@ func (p projJSONFetchTextJSONInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -26232,15 +25850,13 @@ func (p projJSONFetchValPathJSONDatumOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -26262,7 +25878,7 @@ func (p projJSONFetchValPathJSONDatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -26345,15 +25961,13 @@ func (p projJSONFetchTextPathJSONDatumOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -26385,7 +25999,7 @@ func (p projJSONFetchTextPathJSONDatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -26498,15 +26112,13 @@ func (p projEQBoolBoolOp) Next() coldata.Batch {
 		col1 := vec1.Bool()
 		col2 := vec2.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -26533,7 +26145,7 @@ func (p projEQBoolBoolOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -26635,15 +26247,13 @@ func (p projEQBytesBytesOp) Next() coldata.Batch {
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -26662,7 +26272,7 @@ func (p projEQBytesBytesOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -26736,15 +26346,13 @@ func (p projEQDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -26769,7 +26377,7 @@ func (p projEQDecimalInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -26865,15 +26473,13 @@ func (p projEQDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -26898,7 +26504,7 @@ func (p projEQDecimalInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -26994,15 +26600,13 @@ func (p projEQDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -27027,7 +26631,7 @@ func (p projEQDecimalInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -27123,15 +26727,13 @@ func (p projEQDecimalFloat64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -27158,7 +26760,7 @@ func (p projEQDecimalFloat64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -27260,15 +26862,13 @@ func (p projEQDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -27287,7 +26887,7 @@ func (p projEQDecimalDecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -27365,15 +26965,13 @@ func (p projEQInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -27403,7 +27001,7 @@ func (p projEQInt16Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -27514,15 +27112,13 @@ func (p projEQInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -27552,7 +27148,7 @@ func (p projEQInt16Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -27663,15 +27259,13 @@ func (p projEQInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -27701,7 +27295,7 @@ func (p projEQInt16Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -27812,15 +27406,13 @@ func (p projEQInt16Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -27858,7 +27450,7 @@ func (p projEQInt16Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -27993,15 +27585,13 @@ func (p projEQInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -28026,7 +27616,7 @@ func (p projEQInt16DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -28122,15 +27712,13 @@ func (p projEQInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -28160,7 +27748,7 @@ func (p projEQInt32Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -28271,15 +27859,13 @@ func (p projEQInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -28309,7 +27895,7 @@ func (p projEQInt32Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -28420,15 +28006,13 @@ func (p projEQInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -28458,7 +28042,7 @@ func (p projEQInt32Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -28569,15 +28153,13 @@ func (p projEQInt32Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -28615,7 +28197,7 @@ func (p projEQInt32Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -28750,15 +28332,13 @@ func (p projEQInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -28783,7 +28363,7 @@ func (p projEQInt32DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -28879,15 +28459,13 @@ func (p projEQInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -28917,7 +28495,7 @@ func (p projEQInt64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -29028,15 +28606,13 @@ func (p projEQInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -29066,7 +28642,7 @@ func (p projEQInt64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -29177,15 +28753,13 @@ func (p projEQInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -29215,7 +28789,7 @@ func (p projEQInt64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -29326,15 +28900,13 @@ func (p projEQInt64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -29372,7 +28944,7 @@ func (p projEQInt64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -29507,15 +29079,13 @@ func (p projEQInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -29540,7 +29110,7 @@ func (p projEQInt64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -29636,15 +29206,13 @@ func (p projEQFloat64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -29682,7 +29250,7 @@ func (p projEQFloat64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -29817,15 +29385,13 @@ func (p projEQFloat64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -29863,7 +29429,7 @@ func (p projEQFloat64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -29998,15 +29564,13 @@ func (p projEQFloat64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -30044,7 +29608,7 @@ func (p projEQFloat64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -30179,15 +29743,13 @@ func (p projEQFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -30225,7 +29787,7 @@ func (p projEQFloat64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -30360,15 +29922,13 @@ func (p projEQFloat64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -30395,7 +29955,7 @@ func (p projEQFloat64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -30497,15 +30057,13 @@ func (p projEQTimestampTimestampOp) Next() coldata.Batch {
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -30531,7 +30089,7 @@ func (p projEQTimestampTimestampOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -30630,15 +30188,13 @@ func (p projEQIntervalIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -30657,7 +30213,7 @@ func (p projEQIntervalIntervalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -30735,15 +30291,13 @@ func (p projEQJSONJSONOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -30768,7 +30322,7 @@ func (p projEQJSONJSONOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -30860,19 +30414,23 @@ func (p projEQDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -30889,11 +30447,17 @@ func (p projEQDatumDatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -30906,7 +30470,9 @@ func (p projEQDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			if !p.nullableArgs {
+				projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -30969,15 +30535,13 @@ func (p projNEBoolBoolOp) Next() coldata.Batch {
 		col1 := vec1.Bool()
 		col2 := vec2.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -31004,7 +30568,7 @@ func (p projNEBoolBoolOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -31106,15 +30670,13 @@ func (p projNEBytesBytesOp) Next() coldata.Batch {
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -31133,7 +30695,7 @@ func (p projNEBytesBytesOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -31207,15 +30769,13 @@ func (p projNEDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -31240,7 +30800,7 @@ func (p projNEDecimalInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -31336,15 +30896,13 @@ func (p projNEDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -31369,7 +30927,7 @@ func (p projNEDecimalInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -31465,15 +31023,13 @@ func (p projNEDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -31498,7 +31054,7 @@ func (p projNEDecimalInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -31594,15 +31150,13 @@ func (p projNEDecimalFloat64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -31629,7 +31183,7 @@ func (p projNEDecimalFloat64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -31731,15 +31285,13 @@ func (p projNEDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -31758,7 +31310,7 @@ func (p projNEDecimalDecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -31836,15 +31388,13 @@ func (p projNEInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -31874,7 +31424,7 @@ func (p projNEInt16Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -31985,15 +31535,13 @@ func (p projNEInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -32023,7 +31571,7 @@ func (p projNEInt16Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -32134,15 +31682,13 @@ func (p projNEInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -32172,7 +31718,7 @@ func (p projNEInt16Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -32283,15 +31829,13 @@ func (p projNEInt16Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -32329,7 +31873,7 @@ func (p projNEInt16Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -32464,15 +32008,13 @@ func (p projNEInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -32497,7 +32039,7 @@ func (p projNEInt16DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -32593,15 +32135,13 @@ func (p projNEInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -32631,7 +32171,7 @@ func (p projNEInt32Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -32742,15 +32282,13 @@ func (p projNEInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -32780,7 +32318,7 @@ func (p projNEInt32Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -32891,15 +32429,13 @@ func (p projNEInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -32929,7 +32465,7 @@ func (p projNEInt32Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -33040,15 +32576,13 @@ func (p projNEInt32Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -33086,7 +32620,7 @@ func (p projNEInt32Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -33221,15 +32755,13 @@ func (p projNEInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -33254,7 +32786,7 @@ func (p projNEInt32DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -33350,15 +32882,13 @@ func (p projNEInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -33388,7 +32918,7 @@ func (p projNEInt64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -33499,15 +33029,13 @@ func (p projNEInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -33537,7 +33065,7 @@ func (p projNEInt64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -33648,15 +33176,13 @@ func (p projNEInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -33686,7 +33212,7 @@ func (p projNEInt64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -33797,15 +33323,13 @@ func (p projNEInt64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -33843,7 +33367,7 @@ func (p projNEInt64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -33978,15 +33502,13 @@ func (p projNEInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -34011,7 +33533,7 @@ func (p projNEInt64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -34107,15 +33629,13 @@ func (p projNEFloat64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -34153,7 +33673,7 @@ func (p projNEFloat64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -34288,15 +33808,13 @@ func (p projNEFloat64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -34334,7 +33852,7 @@ func (p projNEFloat64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -34469,15 +33987,13 @@ func (p projNEFloat64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -34515,7 +34031,7 @@ func (p projNEFloat64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -34650,15 +34166,13 @@ func (p projNEFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -34696,7 +34210,7 @@ func (p projNEFloat64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -34831,15 +34345,13 @@ func (p projNEFloat64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -34866,7 +34378,7 @@ func (p projNEFloat64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -34968,15 +34480,13 @@ func (p projNETimestampTimestampOp) Next() coldata.Batch {
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -35002,7 +34512,7 @@ func (p projNETimestampTimestampOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -35101,15 +34611,13 @@ func (p projNEIntervalIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -35128,7 +34636,7 @@ func (p projNEIntervalIntervalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -35206,15 +34714,13 @@ func (p projNEJSONJSONOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -35239,7 +34745,7 @@ func (p projNEJSONJSONOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -35331,19 +34837,23 @@ func (p projNEDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -35360,11 +34870,17 @@ func (p projNEDatumDatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -35377,7 +34893,9 @@ func (p projNEDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			if !p.nullableArgs {
+				projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -35440,15 +34958,13 @@ func (p projLTBoolBoolOp) Next() coldata.Batch {
 		col1 := vec1.Bool()
 		col2 := vec2.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -35475,7 +34991,7 @@ func (p projLTBoolBoolOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -35577,15 +35093,13 @@ func (p projLTBytesBytesOp) Next() coldata.Batch {
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -35604,7 +35118,7 @@ func (p projLTBytesBytesOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -35678,15 +35192,13 @@ func (p projLTDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -35711,7 +35223,7 @@ func (p projLTDecimalInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -35807,15 +35319,13 @@ func (p projLTDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -35840,7 +35350,7 @@ func (p projLTDecimalInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -35936,15 +35446,13 @@ func (p projLTDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -35969,7 +35477,7 @@ func (p projLTDecimalInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -36065,15 +35573,13 @@ func (p projLTDecimalFloat64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -36100,7 +35606,7 @@ func (p projLTDecimalFloat64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -36202,15 +35708,13 @@ func (p projLTDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -36229,7 +35733,7 @@ func (p projLTDecimalDecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -36307,15 +35811,13 @@ func (p projLTInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -36345,7 +35847,7 @@ func (p projLTInt16Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -36456,15 +35958,13 @@ func (p projLTInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -36494,7 +35994,7 @@ func (p projLTInt16Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -36605,15 +36105,13 @@ func (p projLTInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -36643,7 +36141,7 @@ func (p projLTInt16Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -36754,15 +36252,13 @@ func (p projLTInt16Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -36800,7 +36296,7 @@ func (p projLTInt16Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -36935,15 +36431,13 @@ func (p projLTInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -36968,7 +36462,7 @@ func (p projLTInt16DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -37064,15 +36558,13 @@ func (p projLTInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -37102,7 +36594,7 @@ func (p projLTInt32Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -37213,15 +36705,13 @@ func (p projLTInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -37251,7 +36741,7 @@ func (p projLTInt32Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -37362,15 +36852,13 @@ func (p projLTInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -37400,7 +36888,7 @@ func (p projLTInt32Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -37511,15 +36999,13 @@ func (p projLTInt32Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -37557,7 +37043,7 @@ func (p projLTInt32Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -37692,15 +37178,13 @@ func (p projLTInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -37725,7 +37209,7 @@ func (p projLTInt32DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -37821,15 +37305,13 @@ func (p projLTInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -37859,7 +37341,7 @@ func (p projLTInt64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -37970,15 +37452,13 @@ func (p projLTInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -38008,7 +37488,7 @@ func (p projLTInt64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -38119,15 +37599,13 @@ func (p projLTInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -38157,7 +37635,7 @@ func (p projLTInt64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -38268,15 +37746,13 @@ func (p projLTInt64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -38314,7 +37790,7 @@ func (p projLTInt64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -38449,15 +37925,13 @@ func (p projLTInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -38482,7 +37956,7 @@ func (p projLTInt64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -38578,15 +38052,13 @@ func (p projLTFloat64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -38624,7 +38096,7 @@ func (p projLTFloat64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -38759,15 +38231,13 @@ func (p projLTFloat64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -38805,7 +38275,7 @@ func (p projLTFloat64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -38940,15 +38410,13 @@ func (p projLTFloat64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -38986,7 +38454,7 @@ func (p projLTFloat64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -39121,15 +38589,13 @@ func (p projLTFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -39167,7 +38633,7 @@ func (p projLTFloat64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -39302,15 +38768,13 @@ func (p projLTFloat64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -39337,7 +38801,7 @@ func (p projLTFloat64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -39439,15 +38903,13 @@ func (p projLTTimestampTimestampOp) Next() coldata.Batch {
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -39473,7 +38935,7 @@ func (p projLTTimestampTimestampOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -39572,15 +39034,13 @@ func (p projLTIntervalIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -39599,7 +39059,7 @@ func (p projLTIntervalIntervalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -39677,15 +39137,13 @@ func (p projLTJSONJSONOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -39710,7 +39168,7 @@ func (p projLTJSONJSONOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -39802,19 +39260,23 @@ func (p projLTDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -39831,11 +39293,17 @@ func (p projLTDatumDatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -39848,7 +39316,9 @@ func (p projLTDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			if !p.nullableArgs {
+				projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -39911,15 +39381,13 @@ func (p projLEBoolBoolOp) Next() coldata.Batch {
 		col1 := vec1.Bool()
 		col2 := vec2.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -39946,7 +39414,7 @@ func (p projLEBoolBoolOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -40048,15 +39516,13 @@ func (p projLEBytesBytesOp) Next() coldata.Batch {
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -40075,7 +39541,7 @@ func (p projLEBytesBytesOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -40149,15 +39615,13 @@ func (p projLEDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -40182,7 +39646,7 @@ func (p projLEDecimalInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -40278,15 +39742,13 @@ func (p projLEDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -40311,7 +39773,7 @@ func (p projLEDecimalInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -40407,15 +39869,13 @@ func (p projLEDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -40440,7 +39900,7 @@ func (p projLEDecimalInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -40536,15 +39996,13 @@ func (p projLEDecimalFloat64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -40571,7 +40029,7 @@ func (p projLEDecimalFloat64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -40673,15 +40131,13 @@ func (p projLEDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -40700,7 +40156,7 @@ func (p projLEDecimalDecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -40778,15 +40234,13 @@ func (p projLEInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -40816,7 +40270,7 @@ func (p projLEInt16Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -40927,15 +40381,13 @@ func (p projLEInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -40965,7 +40417,7 @@ func (p projLEInt16Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -41076,15 +40528,13 @@ func (p projLEInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -41114,7 +40564,7 @@ func (p projLEInt16Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -41225,15 +40675,13 @@ func (p projLEInt16Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -41271,7 +40719,7 @@ func (p projLEInt16Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -41406,15 +40854,13 @@ func (p projLEInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -41439,7 +40885,7 @@ func (p projLEInt16DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -41535,15 +40981,13 @@ func (p projLEInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -41573,7 +41017,7 @@ func (p projLEInt32Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -41684,15 +41128,13 @@ func (p projLEInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -41722,7 +41164,7 @@ func (p projLEInt32Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -41833,15 +41275,13 @@ func (p projLEInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -41871,7 +41311,7 @@ func (p projLEInt32Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -41982,15 +41422,13 @@ func (p projLEInt32Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -42028,7 +41466,7 @@ func (p projLEInt32Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -42163,15 +41601,13 @@ func (p projLEInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -42196,7 +41632,7 @@ func (p projLEInt32DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -42292,15 +41728,13 @@ func (p projLEInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -42330,7 +41764,7 @@ func (p projLEInt64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -42441,15 +41875,13 @@ func (p projLEInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -42479,7 +41911,7 @@ func (p projLEInt64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -42590,15 +42022,13 @@ func (p projLEInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -42628,7 +42058,7 @@ func (p projLEInt64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -42739,15 +42169,13 @@ func (p projLEInt64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -42785,7 +42213,7 @@ func (p projLEInt64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -42920,15 +42348,13 @@ func (p projLEInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -42953,7 +42379,7 @@ func (p projLEInt64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -43049,15 +42475,13 @@ func (p projLEFloat64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -43095,7 +42519,7 @@ func (p projLEFloat64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -43230,15 +42654,13 @@ func (p projLEFloat64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -43276,7 +42698,7 @@ func (p projLEFloat64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -43411,15 +42833,13 @@ func (p projLEFloat64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -43457,7 +42877,7 @@ func (p projLEFloat64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -43592,15 +43012,13 @@ func (p projLEFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -43638,7 +43056,7 @@ func (p projLEFloat64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -43773,15 +43191,13 @@ func (p projLEFloat64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -43808,7 +43224,7 @@ func (p projLEFloat64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -43910,15 +43326,13 @@ func (p projLETimestampTimestampOp) Next() coldata.Batch {
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -43944,7 +43358,7 @@ func (p projLETimestampTimestampOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -44043,15 +43457,13 @@ func (p projLEIntervalIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -44070,7 +43482,7 @@ func (p projLEIntervalIntervalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -44148,15 +43560,13 @@ func (p projLEJSONJSONOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -44181,7 +43591,7 @@ func (p projLEJSONJSONOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -44273,19 +43683,23 @@ func (p projLEDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -44302,11 +43716,17 @@ func (p projLEDatumDatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -44319,7 +43739,9 @@ func (p projLEDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			if !p.nullableArgs {
+				projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -44382,15 +43804,13 @@ func (p projGTBoolBoolOp) Next() coldata.Batch {
 		col1 := vec1.Bool()
 		col2 := vec2.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -44417,7 +43837,7 @@ func (p projGTBoolBoolOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -44519,15 +43939,13 @@ func (p projGTBytesBytesOp) Next() coldata.Batch {
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -44546,7 +43964,7 @@ func (p projGTBytesBytesOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -44620,15 +44038,13 @@ func (p projGTDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -44653,7 +44069,7 @@ func (p projGTDecimalInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -44749,15 +44165,13 @@ func (p projGTDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -44782,7 +44196,7 @@ func (p projGTDecimalInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -44878,15 +44292,13 @@ func (p projGTDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -44911,7 +44323,7 @@ func (p projGTDecimalInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -45007,15 +44419,13 @@ func (p projGTDecimalFloat64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -45042,7 +44452,7 @@ func (p projGTDecimalFloat64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -45144,15 +44554,13 @@ func (p projGTDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -45171,7 +44579,7 @@ func (p projGTDecimalDecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -45249,15 +44657,13 @@ func (p projGTInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -45287,7 +44693,7 @@ func (p projGTInt16Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -45398,15 +44804,13 @@ func (p projGTInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -45436,7 +44840,7 @@ func (p projGTInt16Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -45547,15 +44951,13 @@ func (p projGTInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -45585,7 +44987,7 @@ func (p projGTInt16Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -45696,15 +45098,13 @@ func (p projGTInt16Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -45742,7 +45142,7 @@ func (p projGTInt16Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -45877,15 +45277,13 @@ func (p projGTInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -45910,7 +45308,7 @@ func (p projGTInt16DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -46006,15 +45404,13 @@ func (p projGTInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -46044,7 +45440,7 @@ func (p projGTInt32Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -46155,15 +45551,13 @@ func (p projGTInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -46193,7 +45587,7 @@ func (p projGTInt32Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -46304,15 +45698,13 @@ func (p projGTInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -46342,7 +45734,7 @@ func (p projGTInt32Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -46453,15 +45845,13 @@ func (p projGTInt32Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -46499,7 +45889,7 @@ func (p projGTInt32Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -46634,15 +46024,13 @@ func (p projGTInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -46667,7 +46055,7 @@ func (p projGTInt32DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -46763,15 +46151,13 @@ func (p projGTInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -46801,7 +46187,7 @@ func (p projGTInt64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -46912,15 +46298,13 @@ func (p projGTInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -46950,7 +46334,7 @@ func (p projGTInt64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -47061,15 +46445,13 @@ func (p projGTInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -47099,7 +46481,7 @@ func (p projGTInt64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -47210,15 +46592,13 @@ func (p projGTInt64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -47256,7 +46636,7 @@ func (p projGTInt64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -47391,15 +46771,13 @@ func (p projGTInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -47424,7 +46802,7 @@ func (p projGTInt64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -47520,15 +46898,13 @@ func (p projGTFloat64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -47566,7 +46942,7 @@ func (p projGTFloat64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -47701,15 +47077,13 @@ func (p projGTFloat64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -47747,7 +47121,7 @@ func (p projGTFloat64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -47882,15 +47256,13 @@ func (p projGTFloat64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -47928,7 +47300,7 @@ func (p projGTFloat64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -48063,15 +47435,13 @@ func (p projGTFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -48109,7 +47479,7 @@ func (p projGTFloat64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -48244,15 +47614,13 @@ func (p projGTFloat64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -48279,7 +47647,7 @@ func (p projGTFloat64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -48381,15 +47749,13 @@ func (p projGTTimestampTimestampOp) Next() coldata.Batch {
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -48415,7 +47781,7 @@ func (p projGTTimestampTimestampOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -48514,15 +47880,13 @@ func (p projGTIntervalIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -48541,7 +47905,7 @@ func (p projGTIntervalIntervalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -48619,15 +47983,13 @@ func (p projGTJSONJSONOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -48652,7 +48014,7 @@ func (p projGTJSONJSONOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -48744,19 +48106,23 @@ func (p projGTDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -48773,11 +48139,17 @@ func (p projGTDatumDatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -48790,7 +48162,9 @@ func (p projGTDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			if !p.nullableArgs {
+				projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -48853,15 +48227,13 @@ func (p projGEBoolBoolOp) Next() coldata.Batch {
 		col1 := vec1.Bool()
 		col2 := vec2.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -48888,7 +48260,7 @@ func (p projGEBoolBoolOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -48990,15 +48362,13 @@ func (p projGEBytesBytesOp) Next() coldata.Batch {
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -49017,7 +48387,7 @@ func (p projGEBytesBytesOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -49091,15 +48461,13 @@ func (p projGEDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -49124,7 +48492,7 @@ func (p projGEDecimalInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -49220,15 +48588,13 @@ func (p projGEDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -49253,7 +48619,7 @@ func (p projGEDecimalInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -49349,15 +48715,13 @@ func (p projGEDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -49382,7 +48746,7 @@ func (p projGEDecimalInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -49478,15 +48842,13 @@ func (p projGEDecimalFloat64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -49513,7 +48875,7 @@ func (p projGEDecimalFloat64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -49615,15 +48977,13 @@ func (p projGEDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -49642,7 +49002,7 @@ func (p projGEDecimalDecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -49720,15 +49080,13 @@ func (p projGEInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -49758,7 +49116,7 @@ func (p projGEInt16Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -49869,15 +49227,13 @@ func (p projGEInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -49907,7 +49263,7 @@ func (p projGEInt16Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -50018,15 +49374,13 @@ func (p projGEInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -50056,7 +49410,7 @@ func (p projGEInt16Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -50167,15 +49521,13 @@ func (p projGEInt16Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -50213,7 +49565,7 @@ func (p projGEInt16Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -50348,15 +49700,13 @@ func (p projGEInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -50381,7 +49731,7 @@ func (p projGEInt16DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -50477,15 +49827,13 @@ func (p projGEInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -50515,7 +49863,7 @@ func (p projGEInt32Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -50626,15 +49974,13 @@ func (p projGEInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -50664,7 +50010,7 @@ func (p projGEInt32Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -50775,15 +50121,13 @@ func (p projGEInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -50813,7 +50157,7 @@ func (p projGEInt32Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -50924,15 +50268,13 @@ func (p projGEInt32Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -50970,7 +50312,7 @@ func (p projGEInt32Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -51105,15 +50447,13 @@ func (p projGEInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -51138,7 +50478,7 @@ func (p projGEInt32DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -51234,15 +50574,13 @@ func (p projGEInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -51272,7 +50610,7 @@ func (p projGEInt64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -51383,15 +50721,13 @@ func (p projGEInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -51421,7 +50757,7 @@ func (p projGEInt64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -51532,15 +50868,13 @@ func (p projGEInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -51570,7 +50904,7 @@ func (p projGEInt64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -51681,15 +51015,13 @@ func (p projGEInt64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -51727,7 +51059,7 @@ func (p projGEInt64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -51862,15 +51194,13 @@ func (p projGEInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -51895,7 +51225,7 @@ func (p projGEInt64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -51991,15 +51321,13 @@ func (p projGEFloat64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -52037,7 +51365,7 @@ func (p projGEFloat64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -52172,15 +51500,13 @@ func (p projGEFloat64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -52218,7 +51544,7 @@ func (p projGEFloat64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -52353,15 +51679,13 @@ func (p projGEFloat64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -52399,7 +51723,7 @@ func (p projGEFloat64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -52534,15 +51858,13 @@ func (p projGEFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -52580,7 +51902,7 @@ func (p projGEFloat64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -52715,15 +52037,13 @@ func (p projGEFloat64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -52750,7 +52070,7 @@ func (p projGEFloat64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -52852,15 +52172,13 @@ func (p projGETimestampTimestampOp) Next() coldata.Batch {
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -52886,7 +52204,7 @@ func (p projGETimestampTimestampOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -52985,15 +52303,13 @@ func (p projGEIntervalIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -53012,7 +52328,7 @@ func (p projGEIntervalIntervalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -53090,15 +52406,13 @@ func (p projGEJSONJSONOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -53123,7 +52437,7 @@ func (p projGEJSONJSONOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -53215,19 +52529,23 @@ func (p projGEDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotNullable := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.nullableArgs
-		if hasNullsAndNotNullable {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -53244,11 +52562,17 @@ func (p projGEDatumDatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.nullableArgs || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -53261,7 +52585,9 @@ func (p projGEDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			if !p.nullableArgs {
+				projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]

--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -2271,3 +2271,25 @@ SELECT ('foo'::STRING || col::STRING[])::STRING[] FROM (VALUES (ARRAY['bar':::ST
 ----
 {foo,bar}
 {foo,baz}
+
+# Regression test for #87919 - datum concatenation should be performed for
+# null arguments.
+statement ok
+CREATE TABLE t1_87919 (
+  a  INT
+);
+CREATE TABLE t2_87919 (
+  b INT,
+  c TIME[]
+);
+INSERT INTO t1_87919 (a) VALUES (NULL);
+INSERT INTO t2_87919 (c) VALUES (ARRAY['03:23:06.042923']);
+
+query T rowsort
+SELECT ('09:20:35.19023'::TIME || c)::TIME[] AS col_25551
+FROM t1_87919
+FULL JOIN t2_87919 ON a = b
+ORDER BY a;
+----
+{09:20:35.19023}
+{09:20:35.19023,03:23:06.042923}


### PR DESCRIPTION
Backport 1/1 commits from #88425.

/cc @cockroachdb/release

---

Most projections skip rows for which one or more arguments are null, and just output a null for those rows. However, some projections can actually accept null arguments. Previously, we were using the values from the vec even when the `Nulls` bitmap was set for that row, which invalidates the data in the vec for that row. This could cause a non-null value to be unexpectedly concatenated to an array when an argument was null (nothing should be added to the array in this case).

This commit modifies the projection operators that operate on datum-backed vectors to explicitly set the argument to `tree.DNull` in the case when the `Nulls` bitmap is set. This ensures that the projection is not performed with the invalid (and arbitrary) value in the datum vec at that index.

Fixes #87919

Release note (bug fix): Fixed a bug in `Concat` projection operators for arrays that could cause non-null values to be added to the array when one of the arguments was null.

Release justification: low-risk fix for correctness bug