### PR TITLE
multi-tenant: Bump uninitialized storage cluster version

### DIFF
--- a/pkg/upgrade/upgrademanager/manager.go
+++ b/pkg/upgrade/upgrademanager/manager.go
@@ -117,7 +117,7 @@ func safeToUpgradeTenant(
 	if overrides == nil {
 		return false, errors.AssertionFailedf("overrides informer is nil in secondary tenant")
 	}
-	hostClusterVersion := overrides.(*settingswatcher.SettingsWatcher).GetHostClusterVersion(ctx)
+	hostClusterVersion := overrides.(*settingswatcher.SettingsWatcher).GetStorageClusterVersion()
 	if hostClusterVersion.Less(tenantClusterVersion.Version) {
 		// We assert here if we find a tenant with a higher cluster version than
 		// the host cluster. It's dangerous to run in this mode because the


### PR DESCRIPTION
Previously, in cases where the version value in system.tenant_settings was uninitialized, we assumed that that the version was 22.1. With the change of the build tag to 23.1, we need to adjust the previous version to 22.1.76. This will need one more bump when we finally mint the 22.2 version number in master.

Resolves: #91589

Release note: None