### PR TITLE
ui: add contention info to insight statement details

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -6671,7 +6671,7 @@ func populateExecutionInsights(
 		contentionEvents := tree.DNull
 		if len(insight.Statement.ContentionEvents) > 0 {
 			var contentionEventsJSON json.JSON
-			contentionEventsJSON, err = sqlstatsutil.BuildContentionEventsJSON(insight.Statement.ContentionEvents)
+			contentionEventsJSON, err = convertContentionEventsToJSON(ctx, p, insight.Statement.ContentionEvents)
 			if err != nil {
 				return err
 			}
@@ -6720,4 +6720,60 @@ func populateExecutionInsights(
 		}
 	}
 	return
+}
+
+func convertContentionEventsToJSON(
+	ctx context.Context, p *planner, contentionEvents []roachpb.ContentionEvent,
+) (json json.JSON, err error) {
+
+	eventWithNames := make([]sqlstatsutil.ContentionEventWithNames, len(contentionEvents))
+	for i, contentionEvent := range contentionEvents {
+		_, rawTableID, rawIndexID, err := keys.DecodeTableIDIndexID(contentionEvent.Key)
+		if err != nil {
+			return nil, err
+		}
+		tableID := int64(rawTableID)
+
+		flags := tree.ObjectLookupFlags{CommonLookupFlags: tree.CommonLookupFlags{
+			Required: true,
+		}}
+
+		desc := p.Descriptors()
+		var tableDesc catalog.TableDescriptor
+		tableDesc, err = desc.GetImmutableTableByID(ctx, p.txn, descpb.ID(tableID), flags)
+		if err != nil {
+			return nil, err
+		}
+
+		idxDesc, err := tableDesc.FindIndexWithID(descpb.IndexID(rawIndexID))
+		if err != nil {
+			return nil, err
+		}
+
+		ok, dbDesc, err := desc.GetImmutableDatabaseByID(ctx, p.txn, tableDesc.GetParentID(), tree.DatabaseLookupFlags{})
+		if err != nil || !ok {
+			return nil, err
+		}
+
+		schemaDesc, err := desc.GetImmutableSchemaByID(ctx, p.txn, tableDesc.GetParentSchemaID(), tree.SchemaLookupFlags{})
+		if err != nil {
+			return nil, err
+		}
+
+		var idxName string
+		if idxDesc != nil {
+			idxName = idxDesc.GetName()
+		}
+
+		eventWithNames[i] = sqlstatsutil.ContentionEventWithNames{
+			BlockingTransactionID: contentionEvent.TxnMeta.ID.String(),
+			SchemaName:            schemaDesc.GetName(),
+			DatabaseName:          dbDesc.GetName(),
+			TableName:             tableDesc.GetName(),
+			IndexName:             idxName,
+			DurationInMs:          float64(contentionEvent.Duration) / float64(time.Millisecond),
+		}
+	}
+
+	return sqlstatsutil.BuildContentionEventsJSON(eventWithNames)
 }

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/BUILD.bazel
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/keys",
         "//pkg/roachpb",
         "//pkg/sql/sem/tree",
         "//pkg/util/encoding",

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding.go
@@ -298,12 +298,14 @@ func BuildStmtDetailsMetadataJSON(
 //	  "type": "object",
 //	  [{
 //	    "blockingTxnID": { "type": "string" },
-//	    "durationMs":    { "type": "number" },
-//	    "indexID":       { "type": "number" },
-//	    "tableID":       { "type": "number" }
+//	    "durationInMs":  { "type": "number" },
+//	    "schemaName":    { "type": "string" },
+//	    "databaseName":  { "type": "string" },
+//	    "tableName":     { "type": "string" },
+//	    "indexName":     { "type": "string" }
 //	  }]
 //	}
-func BuildContentionEventsJSON(events []roachpb.ContentionEvent) (json.JSON, error) {
+func BuildContentionEventsJSON(events []ContentionEventWithNames) (json.JSON, error) {
 	return (*contentionEvents)(&events).encodeJSON()
 }
 

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/apd/v3"
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
@@ -123,7 +122,20 @@ func (s *aggregatedMetadata) jsonFields() jsonFields {
 	}
 }
 
-type contentionEvents []roachpb.ContentionEvent
+// ContentionEventWithNames is used to serialize into
+// cluster_execution_insights as a JSON array. This type
+// has the names instead of ids to avoid doing joins to get
+// the user-friendly names.
+type ContentionEventWithNames struct {
+	BlockingTransactionID string
+	SchemaName            string
+	DatabaseName          string
+	TableName             string
+	IndexName             string
+	DurationInMs          float64
+}
+
+type contentionEvents []ContentionEventWithNames
 
 func (s *contentionEvents) encodeJSON() (json.JSON, error) {
 	builder := json.NewArrayBuilder(len(*s))
@@ -141,24 +153,16 @@ func (s *contentionEvents) encodeJSON() (json.JSON, error) {
 	return builder.Build(), nil
 }
 
-type contentionEvent roachpb.ContentionEvent
+type contentionEvent ContentionEventWithNames
 
 func (s *contentionEvent) jsonFields() jsonFields {
-	var tableID int64 = -1
-	var indexID int64 = -1
-	_, rawTableID, rawIndexID, err := keys.DecodeTableIDIndexID(s.Key)
-	if err == nil {
-		tableID = int64(rawTableID)
-		indexID = int64(rawIndexID)
-	}
-
-	dur := float64(s.Duration) / float64(time.Millisecond)
-	txnID := s.TxnMeta.ID.String()
 	return jsonFields{
-		{"blockingTxnID", (*jsonString)(&txnID)},
-		{"durationMs", (*jsonFloat)(&dur)},
-		{"tableID", (*jsonInt)(&tableID)},
-		{"indexID", (*jsonInt)(&indexID)},
+		{"blockingTxnID", (*jsonString)(&s.BlockingTransactionID)},
+		{"durationInMs", (*jsonFloat)(&s.DurationInMs)},
+		{"schemaName", (*jsonString)(&s.SchemaName)},
+		{"databaseName", (*jsonString)(&s.DatabaseName)},
+		{"tableName", (*jsonString)(&s.TableName)},
+		{"indexName", (*jsonString)(&s.IndexName)},
 	}
 }
 

--- a/pkg/ui/workspaces/cluster-ui/src/api/insightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/insightsApi.ts
@@ -502,6 +502,17 @@ function buildTxnContentionInsightDetails(
   return res;
 }
 
+// Statements
+
+type InsightsContentionResponseEvent = {
+  blockingTxnID: string;
+  durationInMs: number;
+  schemaName: string;
+  databaseName: string;
+  tableName: string;
+  indexName: string;
+};
+
 type ExecutionInsightsResponseRow = {
   session_id: string;
   txn_id: string;
@@ -522,6 +533,7 @@ type ExecutionInsightsResponseRow = {
   retries: number;
   exec_node_ids: number[];
   contention: string; // interval
+  contention_events: InsightsContentionResponseEvent[];
   last_retry_reason?: string;
   causes: string[];
   problem: string;
@@ -578,7 +590,10 @@ function organizeExecutionInsightsResponseIntoTxns(
       isFullScan: row.full_scan,
       rowsRead: row.rows_read,
       rowsWritten: row.rows_written,
-      timeSpentWaiting: row.contention ? moment.duration(row.contention) : null,
+      contentionEvents: row.contention_events,
+      totalContentionTime: row.contention
+        ? moment.duration(row.contention)
+        : null,
       causes: row.causes,
       problem: row.problem,
       indexRecommendations: row.index_recommendations,
@@ -658,6 +673,7 @@ SELECT
   priority,
   retries,
   contention,
+  contention_events,
   last_retry_reason,
   index_recommendations,
   problem,

--- a/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
@@ -113,6 +113,15 @@ export type TxnInsightDetails = Omit<MergedTxnInsightEvent, "contention"> & {
   execType: InsightExecEnum;
 };
 
+export type BlockedStatementContentionDetails = {
+  blockingTxnID: string;
+  durationInMs: number;
+  schemaName: string;
+  databaseName: string;
+  tableName: string;
+  indexName: string;
+};
+
 // Does not contain transaction information.
 // This is what is stored at the transaction insight level, shown
 // on the txn insights overview page.
@@ -122,7 +131,8 @@ export type StatementInsightEvent = {
   startTime: Moment;
   isFullScan: boolean;
   elapsedTimeMillis: number;
-  timeSpentWaiting?: moment.Duration;
+  totalContentionTime?: moment.Duration;
+  contentionEvents?: BlockedStatementContentionDetails[];
   endTime: Moment;
   rowsRead: number;
   rowsWritten: number;

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/insightDetailsTables.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/insightDetailsTables.tsx
@@ -9,9 +9,13 @@
 // licenses/APL.txt.
 
 import React from "react";
-import { ColumnDescriptor, SortedTable } from "src/sortedtable";
+import { ColumnDescriptor, SortedTable, SortSetting } from "src/sortedtable";
 import { DATE_FORMAT, Duration } from "src/util";
-import { ContentionEvent, InsightExecEnum } from "../types";
+import {
+  BlockedStatementContentionDetails,
+  ContentionEvent,
+  InsightExecEnum,
+} from "../types";
 import { insightsTableTitles, QueriesCell } from "../workloadInsights/util";
 
 interface InsightDetailsTableProps {
@@ -86,5 +90,69 @@ export const WaitTimeDetailsTable: React.FC<
   const columns = makeInsightDetailsColumns(props.execType);
   return (
     <SortedTable className="statements-table" columns={columns} {...props} />
+  );
+};
+
+export function makeInsightStatementContentionColumns(): ColumnDescriptor<BlockedStatementContentionDetails>[] {
+  const execType = InsightExecEnum.STATEMENT;
+  return [
+    {
+      name: "executionID",
+      title: insightsTableTitles.executionID(InsightExecEnum.TRANSACTION),
+      cell: (item: BlockedStatementContentionDetails) => item.blockingTxnID,
+      sort: (item: BlockedStatementContentionDetails) => item.blockingTxnID,
+    },
+    {
+      name: "duration",
+      title: insightsTableTitles.contention(execType),
+      cell: (item: BlockedStatementContentionDetails) =>
+        Duration(item.durationInMs * 1e6),
+      sort: (item: BlockedStatementContentionDetails) => item.durationInMs,
+    },
+    {
+      name: "schemaName",
+      title: insightsTableTitles.schemaName(execType),
+      cell: (item: BlockedStatementContentionDetails) => item.schemaName,
+      sort: (item: BlockedStatementContentionDetails) => item.schemaName,
+    },
+    {
+      name: "databaseName",
+      title: insightsTableTitles.databaseName(execType),
+      cell: (item: BlockedStatementContentionDetails) => item.databaseName,
+      sort: (item: BlockedStatementContentionDetails) => item.databaseName,
+    },
+    {
+      name: "tableName",
+      title: insightsTableTitles.tableName(execType),
+      cell: (item: BlockedStatementContentionDetails) => item.tableName,
+      sort: (item: BlockedStatementContentionDetails) => item.tableName,
+    },
+    {
+      name: "indexName",
+      title: insightsTableTitles.indexName(execType),
+      cell: (item: BlockedStatementContentionDetails) => item.indexName,
+      sort: (item: BlockedStatementContentionDetails) => item.indexName,
+    },
+  ];
+}
+
+interface InsightContentionTableProps {
+  data: BlockedStatementContentionDetails[];
+  sortSetting?: SortSetting;
+  onChangeSortSetting?: (ss: SortSetting) => void;
+}
+
+export const ContentionStatementDetailsTable: React.FC<
+  InsightContentionTableProps
+> = props => {
+  const columns = makeInsightStatementContentionColumns();
+  return (
+    <SortedTable
+      className="statements-table"
+      columns={columns}
+      sortSetting={props.sortSetting}
+      onChangeSortSetting={props.onChangeSortSetting}
+      {...props}
+    />
   );
 };

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
-import React, { useContext, useMemo } from "react";
+import React, { useContext, useMemo, useState } from "react";
 import { Col, Row } from "antd";
 import {
   InsightsSortedTable,
@@ -32,6 +32,10 @@ import {
 } from "../workloadInsights/util";
 import { TimeScale } from "../../timeScaleDropdown";
 import { getStmtInsightRecommendations } from "../utils";
+import { ContentionStatementDetailsTable } from "./insightDetailsTables";
+import { WaitTimeInsightsLabels } from "../../detailsPanels/waitTimeInsightsPanel";
+import { Heading } from "@cockroachlabs/ui-components";
+import { SortSetting } from "../../sortedtable";
 
 const cx = classNames.bind(insightsDetailsStyles);
 const tableCx = classNames.bind(insightTableStyles);
@@ -54,6 +58,39 @@ export const StatementInsightDetailsOverviewTab: React.FC<
 
   const insightDetails = insightEventDetails;
   const tableData = getStmtInsightRecommendations(insightDetails);
+
+  const [
+    insightsDetailsContentionSortSetting,
+    setDetailsContentionSortSetting,
+  ] = useState<SortSetting>({
+    ascending: false,
+    columnTitle: "duration",
+  });
+  let contentionTable: JSX.Element = null;
+  if (insightDetails.contentionEvents != null) {
+    contentionTable = (
+      <Row gutter={24} className={tableCx("margin-bottom")}>
+        <Col className="gutter-row">
+          <Heading type="h5">
+            {WaitTimeInsightsLabels.BLOCKED_TXNS_TABLE_TITLE(
+              insightDetails.statementExecutionID,
+              "statement",
+            )}
+          </Heading>
+          <ContentionStatementDetailsTable
+            data={insightDetails.contentionEvents}
+            sortSetting={insightsDetailsContentionSortSetting}
+            onChangeSortSetting={setDetailsContentionSortSetting}
+          />
+        </Col>
+      </Row>
+    );
+  }
+
+  const [insightsSortSetting, setInsightsSortSetting] = useState<SortSetting>({
+    ascending: false,
+    columnTitle: "Insights",
+  });
 
   return (
     <section className={cx("section")}>
@@ -128,9 +165,15 @@ export const StatementInsightDetailsOverviewTab: React.FC<
       </Row>
       <Row gutter={24} className={tableCx("margin-bottom")}>
         <Col>
-          <InsightsSortedTable columns={insightsColumns} data={tableData} />
+          <InsightsSortedTable
+            sortSetting={insightsSortSetting}
+            onChangeSortSetting={setInsightsSortSetting}
+            columns={insightsColumns}
+            data={tableData}
+          />
         </Col>
       </Row>
+      {contentionTable}
     </section>
   );
 };

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsStmtsTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsStmtsTab.tsx
@@ -67,7 +67,7 @@ const stmtColumns: ColumnDescriptor<StatementInsightEvent>[] = [
     name: "waitTime",
     title: "Time Spent Waiting",
     cell: (item: StatementInsightEvent) =>
-      Duration((item.timeSpentWaiting?.asMilliseconds() ?? 0) * 1e6),
+      Duration((item.totalContentionTime?.asMilliseconds() ?? 0) * 1e6),
     sort: (item: StatementInsightEvent) => item.elapsedTimeMillis,
   },
 ];

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsTable.tsx
@@ -137,11 +137,11 @@ export function makeStatementInsightsColumns(
       name: "contention",
       title: insightsTableTitles.contention(execType),
       cell: (item: FlattenedStmtInsightEvent) =>
-        !item.timeSpentWaiting
+        !item.totalContentionTime
           ? "no samples"
-          : Duration(item.timeSpentWaiting.asMilliseconds() * 1e6),
+          : Duration(item.totalContentionTime.asMilliseconds() * 1e6),
       sort: (item: FlattenedStmtInsightEvent) =>
-        item.timeSpentWaiting?.asMilliseconds() ?? -1,
+        item.totalContentionTime?.asMilliseconds() ?? -1,
       showByDefault: false,
     },
     {


### PR DESCRIPTION
This changes the crdb_internal.cluster_execution_insights to store 
the names of contention key instead of
the ids. This avoids complex join logic so the
ui can display a eas format.

This does not currently contain the blocking
transaction fingerprint or the blocking statement
information. The blocking fingerprint will be added in issue #91665 

closes: #91187

https://www.loom.com/share/03e08c5a473844b3a637b9eb618b7866

Release note (ui change): Add the contention
time, schema, database, table, and index info
to insights statement details page.