### PR TITLE
bazci: don't immediately fail if `GITHUB_API_TOKEN` is not set

### DIFF
--- a/pkg/cmd/bazci/bazci.go
+++ b/pkg/cmd/bazci/bazci.go
@@ -416,7 +416,11 @@ func processTestXmls(testXmls []string) error {
 		// env var on PR builds, but we'll have it for builds that are triggered
 		// from the release branches.
 		if os.Getenv("GITHUB_API_TOKEN") == "" {
-			return errors.New("GITHUB_API_TOKEN must be set")
+			fmt.Println("GITHUB_API_TOKEN must be set to post results to GitHub; skipping error reporting")
+			// TODO(ricky): Certain jobs (nightlies) probably really
+			// do need to fail outright in this case rather than
+			// silently continuing here. How do we handle them?
+			return nil
 		}
 		var postErrors []string
 		for _, testXml := range testXmls {


### PR DESCRIPTION
This was breaking some tests on `master` which have never had `GITHUB_API_TOKEN` set and so this turned out to be a regression. Instead we log and continue silently. I've also added a TODO for a follow-up.

Release note: None
Epic: None