### PR TITLE
jobs: replace the ie in Registry.createJobsInBatchWithTxn

### DIFF
--- a/pkg/jobs/adopt.go
+++ b/pkg/jobs/adopt.go
@@ -72,19 +72,21 @@ func (r *Registry) maybeDumpTrace(
 	// could have been canceled at this point.
 	dumpCtx, _ := r.makeCtx()
 
+	ieNotBoundToTxn := r.internalExecutorFactory.MakeInternalExecutorWithoutTxn()
+
 	// If the job has failed, and the dump mode is set to anything
 	// except noDump, then we should dump the trace.
 	// The string comparison is unfortunate but is used to differentiate a job
 	// that has failed from a job that has been canceled.
 	if jobErr != nil && !HasErrJobCanceled(jobErr) && resumerCtx.Err() == nil {
-		r.td.Dump(dumpCtx, strconv.Itoa(int(jobID)), traceID, r.ex)
+		r.td.Dump(dumpCtx, strconv.Itoa(int(jobID)), traceID, ieNotBoundToTxn)
 		return
 	}
 
 	// If the dump mode is set to `dumpOnStop` then we should dump the
 	// trace when the job is any of paused, canceled, succeeded or failed state.
 	if dumpMode == int64(dumpOnStop) {
-		r.td.Dump(dumpCtx, strconv.Itoa(int(jobID)), traceID, r.ex)
+		r.td.Dump(dumpCtx, strconv.Itoa(int(jobID)), traceID, ieNotBoundToTxn)
 	}
 }
 

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -539,6 +539,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 			cfg.clock,
 			cfg.db,
 			cfg.circularInternalExecutor,
+			cfg.internalExecutorFactory,
 			cfg.rpcContext.LogicalClusterID,
 			cfg.nodeIDContainer,
 			cfg.sqlLivenessProvider,

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -1033,6 +1033,9 @@ func (ie *InternalExecutor) commitTxn(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "cannot create conn executor to commit txn")
 	}
+	// TODO(janexing): is this correct?
+	ex.planner.txn = ie.extraTxnState.txn
+
 	defer ex.close(ctx, externalTxnClose)
 	return ex.commitSQLTransactionInternal(ctx)
 }
@@ -1060,7 +1063,7 @@ func (ie *InternalExecutor) checkIfStmtIsAllowed(stmt tree.Statement, txn *kv.Tx
 // deprecated.
 func (ie *InternalExecutor) checkIfTxnIsConsistent(txn *kv.Txn) error {
 	if txn == nil && ie.extraTxnState != nil {
-		return errors.New("the current internal executor was contructed with" +
+		return errors.New("the current internal executor was contructed with " +
 			"a txn. To use an internal executor without a txn, call " +
 			"sqlutil.InternalExecutorFactory.MakeInternalExecutorWithoutTxn()")
 	}

--- a/pkg/sql/schemachanger/scbackup/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbackup/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/sql/schemachanger/scexec",
         "//pkg/sql/schemachanger/scpb",
         "//pkg/sql/schemachanger/screl",
+        "//pkg/sql/sqlutil",
     ],
 )
 

--- a/pkg/sql/schemachanger/scbackup/job.go
+++ b/pkg/sql/schemachanger/scbackup/job.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/screl"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 )
 
 // CreateDeclarativeSchemaChangeJobs is called during the last phase of a
@@ -31,7 +32,11 @@ import (
 // It should only be called for backups which do not restore the jobs table
 // directly.
 func CreateDeclarativeSchemaChangeJobs(
-	ctx context.Context, registry *jobs.Registry, txn *kv.Txn, allMut nstree.Catalog,
+	ctx context.Context,
+	registry *jobs.Registry,
+	txn *kv.Txn,
+	ie sqlutil.InternalExecutor,
+	allMut nstree.Catalog,
 ) error {
 	byJobID := make(map[catpb.JobID][]catalog.MutableDescriptor)
 	_ = allMut.ForEachDescriptorEntry(func(d catalog.Descriptor) error {
@@ -71,6 +76,6 @@ func CreateDeclarativeSchemaChangeJobs(
 			runningStatus,
 		))
 	}
-	_, err := registry.CreateJobsWithTxn(ctx, txn, records)
+	_, err := registry.CreateJobsWithTxn(ctx, txn, ie, records)
 	return err
 }


### PR DESCRIPTION
When creating a job, we should use an internal executor bound to the outer txn and related metadata.

We also found that in this case, if a user changes the timezone and then triggers a schema change job, the job's creation time (i.e.   value `created`column in the `system.jobs`) will automatically switch to the timestamp in the updated timezone, rather than UTC. This is because we have the `created` using `now()` in the SQL statement. We now change it to be inserted always with UTC time.

Informs: #91004
Informs: #91718

Release note: None