### PR TITLE
kv: deflake TestRangeStatsInit by locking Raft

### DIFF
--- a/pkg/kv/kvserver/stats_test.go
+++ b/pkg/kv/kvserver/stats_test.go
@@ -30,6 +30,11 @@ func TestRangeStatsInit(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 	tc.Start(ctx, t, stopper)
+
+	// Lock the replica's Raft goroutine. We do this to avoid interference from
+	// any other moving parts on the Replica, whatever they may be.
+	tc.repl.raftMu.Lock()
+	defer tc.repl.raftMu.Unlock()
 	ms := enginepb.MVCCStats{
 		LiveBytes:       1,
 		KeyBytes:        2,


### PR DESCRIPTION
Fixes #91670.

This become flaky after 2c1c354. That change must have allowed a write to remain in the Raft pipeline after `testContext.Start` returned, causing a race between two attempts to set the range's stats.

Release note: None