### PR TITLE
docs issue generation: Run script over a specified period of time

### DIFF
--- a/pkg/cmd/docs-issue-generation/BUILD.bazel
+++ b/pkg/cmd/docs-issue-generation/BUILD.bazel
@@ -9,7 +9,10 @@ go_library(
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/docs-issue-generation",
     visibility = ["//visibility:private"],
-    deps = ["@com_github_spf13_cobra//:cobra"],
+    deps = [
+        "//pkg/util/timeutil",
+        "@com_github_spf13_cobra//:cobra",
+    ],
 )
 
 go_binary(

--- a/pkg/cmd/docs-issue-generation/docs_issue_generation.go
+++ b/pkg/cmd/docs-issue-generation/docs_issue_generation.go
@@ -15,112 +15,265 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
-// docsIssue contains details about each formatted commit to be committed to the docs repo
+// docsIssue contains details about each formatted commit to be committed to the docs repo.
 type docsIssue struct {
 	sourceCommitSha string
 	title           string
 	body            string
+	labels          []string
 }
 
-// pr contains details about the cockroach pull request
-type pr struct {
-	number      int
-	mergeBranch string
-	docsIssues  []docsIssue
-}
-
-// ghSearch contains a list of search items (in this case, cockroach PRs) based on a given commit from the GitHub API.
-type ghSearch struct {
-	Items []ghSearchItem `json:"items"`
-}
-
-// ghSearchItem contains details about a specific cockroach PR,
-// including its number, from the GitHub API.
-type ghSearchItem struct {
-	PRNumber    int            `json:"number"`
-	PullRequest ghSearchItemPr `json:"pull_request"`
-}
-
-// ghSearchItemPr contains the time a PR was merged from the GitHub API
-type ghSearchItemPr struct {
-	MergedAt *time.Time `json:"merged_at"`
-}
-
-// ghPull holds the base branch for a cockroach PR from the GitHub API.
-// It directly mirrors the structure of the PR where the branch name
-// field (Ref) is nested within the Base field.
-type ghPull struct {
-	Base struct {
-		Ref string `json:"ref"` // this is the destination branch of the PR
-	} `json:"base"`
-}
-
-// ghPullCommit holds the SHA and commit message for a particular commit, from the GitHub API
-type ghPullCommit struct {
-	Sha    string          `json:"sha"`
-	Commit ghPullCommitMsg `json:"commit"`
-}
-
-// ghPullCommitMsg holds the commit message in the cockroach PR from the GitHub API
-type ghPullCommitMsg struct {
-	Message string `json:"message"` // the commit message
-}
-
-// parameters holds the GitHub access token and the SHA (BUILD_VCS_NUMBER).
+// parameters stores the GitHub API token, a dry run flag to output the issues it would create, and the
+// start and end times of the search.
 type parameters struct {
-	Token string // GitHub API token
-	Sha   string
+	Token     string // GitHub API token
+	DryRun    bool
+	StartTime time.Time
+	EndTime   time.Time
 }
+
+// pageInfo contains pagination information for querying the GraphQL API.
+type pageInfo struct {
+	HasNextPage bool   `json:"hasNextPage"`
+	EndCursor   string `json:"endCursor"`
+}
+
+// gqlCockroachPRCommit contains details about commits within PRs in the cockroach repo.
+type gqlCockroachPRCommit struct {
+	Data struct {
+		Repository struct {
+			PullRequest struct {
+				Commits struct {
+					Edges []struct {
+						Node struct {
+							Commit struct {
+								Oid             string `json:"oid"`
+								MessageHeadline string `json:"messageHeadline"`
+								MessageBody     string `json:"messageBody"`
+							} `json:"commit"`
+						} `json:"node"`
+					} `json:"edges"`
+					PageInfo pageInfo `json:"pageInfo"`
+				} `json:"commits"`
+			} `json:"pullRequest"`
+		} `json:"repository"`
+	} `json:"data"`
+}
+
+// gqlCockroachPR contains details about PRs within the cockroach repo.
+type gqlCockroachPR struct {
+	Data struct {
+		Search struct {
+			Nodes []struct {
+				Title       string `json:"title"`
+				Number      int    `json:"number"`
+				Body        string `json:"body"`
+				BaseRefName string `json:"baseRefName"`
+				Commits     struct {
+					Edges []struct {
+						Node struct {
+							Commit struct {
+								Oid             string `json:"oid"`
+								MessageHeadline string `json:"messageHeadline"`
+								MessageBody     string `json:"messageBody"`
+							} `json:"commit"`
+						} `json:"node"`
+					} `json:"edges"`
+					PageInfo pageInfo `json:"pageInfo"`
+				} `json:"commits"`
+			} `json:"nodes"`
+			PageInfo pageInfo `json:"pageInfo"`
+		} `json:"search"`
+	} `json:"data"`
+}
+
+// gqlDocsIssue contains details about existing issues within the docs repo.
+type gqlDocsIssue struct {
+	Data struct {
+		Search struct {
+			Nodes []struct {
+				Number int    `json:"number"`
+				Body   string `json:"body"`
+			} `json:"nodes"`
+			PageInfo pageInfo `json:"pageInfo"`
+		} `json:"search"`
+	} `json:"data"`
+}
+
+// gqlDocsRepoLabels contains details about the labels within the cockroach repo. In order to create issues using the
+// GraphQL API, we need to use the label IDs and no
+type gqlDocsRepoLabels struct {
+	Data struct {
+		Repository struct {
+			ID     string `json:"id"`
+			Labels struct {
+				Edges []struct {
+					Node struct {
+						Name string `json:"name"`
+						ID   string `json:"id"`
+					} `json:"node"`
+				} `json:"edges"`
+				PageInfo pageInfo `json:"pageInfo"`
+			} `json:"labels"`
+		} `json:"repository"`
+	} `json:"data"`
+}
+
+type gqlCreateIssueMutation struct {
+	Data struct {
+		CreateIssue struct {
+			ClientMutationID interface{} `json:"clientMutationId"`
+		} `json:"createIssue"`
+	} `json:"data"`
+}
+
+type cockroachPR struct {
+	Title       string `json:"title"`
+	Number      int    `json:"number"`
+	Body        string `json:"body"`
+	BaseRefName string `json:"baseRefName"`
+	Commits     []cockroachCommit
+}
+
+type cockroachCommit struct {
+	Sha             string `json:"oid"`
+	MessageHeadline string `json:"messageHeadline"`
+	MessageBody     string `json:"messageBody"`
+}
+
+var (
+	releaseNoteNoneRE      = regexp.MustCompile(`(?i)release note:? [nN]one`)
+	allRNRE                = regexp.MustCompile(`(?i)release note:? \(.*`)
+	nonBugFixRNRE          = regexp.MustCompile(`(?i)release note:? \(([^b]|b[^u]|bu[^g]|bug\S|bug [^f]|bug f[^i]|bug fi[^x]).*`)
+	bugFixRNRE             = regexp.MustCompile(`(?i)release note:? \(bug fix\):.*`)
+	releaseJustificationRE = regexp.MustCompile(`(?i)release justification:.*`)
+	prNumberRE             = regexp.MustCompile(`Related PR: \[?https://github.com/cockroachdb/cockroach/pull/(\d+)\D`)
+	commitShaRE            = regexp.MustCompile(`Commit: \[?https://github.com/cockroachdb/cockroach/commit/(\w+)\W`)
+)
+
+const (
+	docsOrganization = "cockroachdb"
+	docsRepo         = "docs"
+)
 
 // the heart of the script to fetch and manipulate all data and create the individual docs issues
 func docsIssueGeneration(params parameters) {
-	var search ghSearch // a search for all PRs based on a given commit SHA
-	var prs []pr
-	err := httpGet(
-		"https://api.github.com/search/issues?q=sha:"+params.Sha+"+repo:cockroachdb/cockroach+is:merged",
-		params.Token,
-		&search,
-	)
+	repoID, labelMap, err := searchDocsRepoLabels(params.Token)
 	if err != nil {
-		log.Fatal(err)
+		fmt.Println(err)
 	}
-	prs = prNums(search)     // populate slice of PRs of type pr
-	for _, pr := range prs { // for each PR in the list, get the merge branch and the list of eligible commits
-		var pull ghPull
-		err := httpGet(
-			"https://api.github.com/repos/cockroachdb/cockroach/pulls/"+strconv.Itoa(pr.number),
-			params.Token,
-			&pull,
-		)
-		if err != nil {
-			log.Fatal(err)
+	prs, err := searchCockroachPRs(params.StartTime, params.EndTime, params.Token)
+	if err != nil {
+		fmt.Println(err)
+	}
+	docsIssues := constructDocsIssues(prs)
+	if params.DryRun {
+		fmt.Printf("Start time: %#v\n", params.StartTime.Format(time.RFC3339))
+		fmt.Printf("End time: %#v\n", params.EndTime.Format(time.RFC3339))
+		if len(docsIssues) > 0 {
+			fmt.Printf("Dry run is enabled. The following %d docs issue(s) would be created:\n", len(docsIssues))
+			fmt.Println(docsIssues)
+		} else {
+			fmt.Println("No docs issues need to be created.")
 		}
-		pr.mergeBranch = pull.Base.Ref
-		var commits []ghPullCommit
-		err = httpGet(
-			"https://api.github.com/repos/cockroachdb/cockroach/pulls/"+strconv.Itoa(pr.number)+"/commits?per_page:250",
-			params.Token,
-			&commits,
-		)
-		if err != nil {
-			log.Fatal(err)
+	} else {
+		for _, di := range docsIssues {
+			err := di.createDocsIssues(params.Token, repoID, labelMap)
+			if err != nil {
+				fmt.Println(err)
+			}
 		}
-		pr.docsIssues = getIssues(commits, pr.number)
-		pr.createDocsIssues(params.Token)
 	}
 }
 
-func httpGet(url string, token string, out interface{}) error {
+// searchDocsRepoLabels passes in a GitHub API token and returns the repo ID of the docs repo as well as a map
+// of all the labels and their respective label IDs in GitHub.
+func searchDocsRepoLabels(token string) (string, map[string]string, error) {
+	var labels = map[string]string{}
+	var repoID string
+	repoID, hasNextPage, nextCursor, err := searchDocsRepoLabelsSingle("", labels, token)
+	if err != nil {
+		fmt.Println(err)
+		return "", nil, err
+	}
+	for hasNextPage {
+		_, hasNextPage, nextCursor, err = searchDocsRepoLabelsSingle(nextCursor, labels, token)
+		if err != nil {
+			fmt.Println(err)
+			return "", nil, err
+		}
+	}
+	return repoID, labels, nil
+}
+
+// searchDocsRepoLabelsSingle runs once per page of 100 labels within the docs repo. It returns the repo ID,
+// whether or not there is another page after the one that just ran, the next cursor value used to query the next
+// page, and any error.
+func searchDocsRepoLabelsSingle(
+	cursor string, m map[string]string, token string,
+) (string, bool, string, error) {
+	docsIssueGQLQuery := fmt.Sprintf(`query ($cursor: String) {
+		repository(owner: "%s", name: "%s") {
+			id
+			labels(first: 100, after: $cursor) {
+				edges {
+					node {
+						name
+						id
+					}
+				}
+				pageInfo {
+					hasNextPage
+					endCursor
+				}
+			}
+		}
+	}`, docsOrganization, docsRepo)
+	var search gqlDocsRepoLabels
+	queryVariables := map[string]interface{}{}
+	if cursor != "" {
+		queryVariables["cursor"] = cursor
+	}
+	err := queryGraphQL(docsIssueGQLQuery, queryVariables, token, &search)
+	if err != nil {
+		fmt.Println(err)
+		return "", false, "", err
+	}
+	repoID := search.Data.Repository.ID
+	for _, x := range search.Data.Repository.Labels.Edges {
+		m[x.Node.Name] = x.Node.ID
+	}
+	pageInfo := search.Data.Repository.Labels.PageInfo
+	return repoID, pageInfo.HasNextPage, pageInfo.EndCursor, nil
+}
+
+// queryGraphQL is the function that interfaces directly with the GitHub GraphQL API. Given a query, variables, and
+// token, it will return a struct containing the requested data or an error if one exists.
+func queryGraphQL(
+	query string, queryVariables map[string]interface{}, token string, out interface{},
+) error {
+	const graphQLURL = "https://api.github.com/graphql"
 	client := &http.Client{}
-	req, err := http.NewRequest("GET", url, nil)
+	bodyInt := map[string]interface{}{
+		"query": query,
+	}
+	if queryVariables != nil {
+		bodyInt["variables"] = queryVariables
+	}
+	requestBody, err := json.Marshal(bodyInt)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest("POST", graphQLURL, bytes.NewBuffer(requestBody))
 	if err != nil {
 		return err
 	}
@@ -134,58 +287,332 @@ func httpGet(url string, token string, out interface{}) error {
 		return err
 	}
 	// unmarshal (convert) the byte slice into an interface
-	if err := json.Unmarshal(bs, out); err != nil {
+	var tmp interface{}
+	err = json.Unmarshal(bs, &tmp)
+	if err != nil {
+		fmt.Println("Error: unable to unmarshal JSON into an empty interface")
+		fmt.Println(string(bs[:]))
+		return err
+	}
+	err = json.Unmarshal(bs, out)
+	if err != nil {
 		return err
 	}
 	return nil
 }
 
-// prNums returns an array of PRS for the given GH search of PRs against a given commit.
-func prNums(search ghSearch) []pr {
-	var result []pr
-	// each PR returned from the search is iterated through, and a new pr object is created for each
-	for _, x := range search.Items {
-		if x.PullRequest.MergedAt != nil {
-			// a new object of type pr containing the PR number is appended to the result slice
-			result = append(result, pr{number: x.PRNumber})
+func searchCockroachPRs(
+	startTime time.Time, endTime time.Time, token string,
+) ([]cockroachPR, error) {
+	prCommitsToExclude, err := searchDocsIssues(startTime, token)
+	if err != nil {
+		fmt.Println(err)
+	}
+	hasNextPage, nextCursor, prs, err := searchCockroachPRsSingle(startTime, endTime, "", prCommitsToExclude, token)
+	if err != nil {
+		fmt.Println(err)
+		return nil, err
+	}
+	result := prs
+	for hasNextPage {
+		hasNextPage, nextCursor, prs, err = searchCockroachPRsSingle(startTime, endTime, nextCursor, prCommitsToExclude, token)
+		if err != nil {
+			fmt.Println(err)
+			return nil, err
+		}
+		result = append(result, prs...)
+	}
+	return result, nil
+}
+
+// searchDocsIssues returns a map containing all the product change docs issues that have been created since the given
+// start time. For reference, it's structured as map[crdb_pr_number]map[crdb_commit]docs_pr_number.
+func searchDocsIssues(startTime time.Time, token string) (map[int]map[string]int, error) {
+	var result = map[int]map[string]int{}
+	hasNextPage, nextCursor, err := searchDocsIssuesSingle(startTime, "", result, token)
+	if err != nil {
+		fmt.Println(err)
+		return nil, err
+	}
+	for hasNextPage {
+		hasNextPage, nextCursor, err = searchDocsIssuesSingle(startTime, nextCursor, result, token)
+		if err != nil {
+			fmt.Println(err)
+			return nil, err
 		}
 	}
-	return result // return a slice of prs
+	return result, nil
+}
+
+// searchDocsIssuesSingle searches one page of docs issues at a time. These docs issues will ultimately be excluded
+// from the PRs through which we iterate to create new product change docs issues. This function returns a bool to
+// check if there are more than 100 results, the cursor to query for the next page of results, and an error if
+// one exists.
+func searchDocsIssuesSingle(
+	startTime time.Time, cursor string, m map[int]map[string]int, token string,
+) (bool, string, error) {
+	query := `query ($cursor: String, $ghSearchQuery: String!) {
+		search(first: 100, query: $ghSearchQuery, type: ISSUE, after: $cursor) {
+			nodes {
+				... on Issue {
+					number
+					body
+				}
+			}
+			pageInfo {
+				hasNextPage
+				endCursor
+			}
+		}
+	}`
+	var search gqlDocsIssue
+	today := timeutil.Now().Format(time.RFC3339)
+	queryVariables := map[string]interface{}{
+		"ghSearchQuery": fmt.Sprintf(`repo:%s/%s is:issue label:C-product-change created:%s..%s`, docsOrganization, docsRepo, startTime.Format(time.RFC3339), today),
+	}
+	if cursor != "" {
+		queryVariables["cursor"] = cursor
+	}
+	err := queryGraphQL(query, queryVariables, token, &search)
+	if err != nil {
+		fmt.Println(err)
+		return false, "", err
+	}
+	for _, x := range search.Data.Search.Nodes {
+		prNumber, commitSha, err := parseDocsIssueBody(x.Body)
+		if err != nil {
+			fmt.Println(err)
+		}
+		if prNumber != 0 && commitSha != "" {
+			_, ok := m[prNumber]
+			if !ok {
+				m[prNumber] = make(map[string]int)
+			}
+			m[prNumber][commitSha] = x.Number
+		}
+	}
+	pageInfo := search.Data.Search.PageInfo
+	return pageInfo.HasNextPage, pageInfo.EndCursor, nil
+}
+
+func parseDocsIssueBody(body string) (int, string, error) {
+	prMatches := prNumberRE.FindStringSubmatch(body)
+	if len(prMatches) < 2 {
+		return 0, "", fmt.Errorf("error: No PR number found in issue body")
+	}
+	prNumber, err := strconv.Atoi(prMatches[1])
+	if err != nil {
+		fmt.Println(err)
+		return 0, "", err
+	}
+	commitShaMatches := commitShaRE.FindStringSubmatch(body)
+	if len(commitShaMatches) < 2 {
+		return 0, "", fmt.Errorf("error: No commit SHA found in issue body")
+	}
+	return prNumber, commitShaMatches[1], nil
+}
+
+func searchCockroachPRsSingle(
+	startTime time.Time,
+	endTime time.Time,
+	cursor string,
+	prCommitsToExclude map[int]map[string]int,
+	token string,
+) (bool, string, []cockroachPR, error) {
+	var search gqlCockroachPR
+	var result []cockroachPR
+	query := `query ($cursor: String, $ghSearchQuery: String!) {
+	  search(first: 100, query: $ghSearchQuery, type: ISSUE, after: $cursor) {
+	    nodes {
+	      ... on PullRequest {
+	        title
+	        number
+	        body
+	        baseRefName
+	        commits(first: 100) {
+	          edges {
+	            node {
+	              commit {
+	                oid
+	                messageHeadline
+	                messageBody
+	              }
+	            }
+	          }
+	          pageInfo {
+	            hasNextPage
+	            endCursor
+	          }
+	        }
+	      }
+	    }
+	    pageInfo {
+	      hasNextPage
+	      endCursor
+	    }
+	  }
+	}`
+	queryVariables := map[string]interface{}{
+		"ghSearchQuery": fmt.Sprintf(
+			`repo:cockroachdb/cockroach is:pr is:merged merged:%s..%s`,
+			startTime.Format(time.RFC3339),
+			endTime.Format(time.RFC3339),
+		),
+	}
+	if cursor != "" {
+		queryVariables["cursor"] = cursor
+	}
+	err := queryGraphQL(query, queryVariables, token, &search)
+	if err != nil {
+		fmt.Println(err)
+		return false, "", nil, err
+	}
+	for _, x := range search.Data.Search.Nodes {
+		var commits []cockroachCommit
+		for _, y := range x.Commits.Edges {
+			matchingDocsIssue := prCommitsToExclude[x.Number][y.Node.Commit.Oid]
+			if nonBugFixRNRE.MatchString(y.Node.Commit.MessageBody) && matchingDocsIssue == 0 {
+				commit := cockroachCommit{
+					Sha:             y.Node.Commit.Oid,
+					MessageHeadline: y.Node.Commit.MessageHeadline,
+					MessageBody:     y.Node.Commit.MessageBody,
+				}
+				commits = append(commits, commit)
+			}
+		}
+		// runs if there are more than 100 results
+		if x.Commits.PageInfo.HasNextPage {
+			additionalCommits, err := searchCockroachPRCommits(x.Number, x.Commits.PageInfo.EndCursor, prCommitsToExclude, token)
+			if err != nil {
+				return false, "", nil, err
+			}
+			commits = append(commits, additionalCommits...)
+		}
+		if len(commits) > 0 {
+			pr := cockroachPR{
+				Number:      x.Number,
+				Title:       x.Title,
+				Body:        x.Body,
+				BaseRefName: x.BaseRefName,
+				Commits:     commits,
+			}
+			result = append(result, pr)
+		}
+	}
+	pageInfo := search.Data.Search.PageInfo
+	return pageInfo.HasNextPage, pageInfo.EndCursor, result, nil
+}
+
+func searchCockroachPRCommits(
+	pr int, cursor string, prCommitsToExclude map[int]map[string]int, token string,
+) ([]cockroachCommit, error) {
+	hasNextPage, nextCursor, commits, err := searchCockroachPRCommitsSingle(pr, cursor, prCommitsToExclude, token)
+	if err != nil {
+		fmt.Println(err)
+		return nil, err
+	}
+	result := commits
+	for hasNextPage {
+		hasNextPage, nextCursor, commits, err = searchCockroachPRCommitsSingle(pr, nextCursor, prCommitsToExclude, token)
+		if err != nil {
+			fmt.Println(err)
+			return nil, err
+		}
+		result = append(result, commits...)
+	}
+	return result, nil
+}
+
+func searchCockroachPRCommitsSingle(
+	prNumber int, cursor string, prCommitsToExclude map[int]map[string]int, token string,
+) (bool, string, []cockroachCommit, error) {
+	var result []cockroachCommit
+	var search gqlCockroachPRCommit
+	query := `query ($cursor: String, $prNumber: Int!) {
+	  repository(owner: "cockroachdb", name: "cockroach") {
+	    pullRequest(number: $prNumber) {
+	      commits(first: 100, after: $cursor) {
+	        edges {
+	          node {
+	            commit {
+	              oid
+	              messageHeadline
+	              messageBody
+	            }
+	          }
+	        }
+	      }
+	    }
+	  }
+	}`
+	queryVariables := map[string]interface{}{
+		"prNumber": prNumber,
+	}
+	if cursor != "" {
+		queryVariables["cursor"] = cursor
+	}
+	err := queryGraphQL(
+		query,
+		queryVariables,
+		token,
+		&search,
+	)
+	if err != nil {
+		fmt.Println(err)
+		return false, "", nil, err
+	}
+	for _, x := range search.Data.Repository.PullRequest.Commits.Edges {
+		matchingDocsIssue := prCommitsToExclude[prNumber][x.Node.Commit.Oid]
+		if nonBugFixRNRE.MatchString(x.Node.Commit.MessageHeadline) && matchingDocsIssue == 0 {
+			commit := cockroachCommit{
+				Sha:             x.Node.Commit.Oid,
+				MessageHeadline: x.Node.Commit.MessageHeadline,
+				MessageBody:     x.Node.Commit.MessageHeadline,
+			}
+			result = append(result, commit)
+		}
+	}
+	pageInfo := search.Data.Repository.PullRequest.Commits.PageInfo
+	return pageInfo.HasNextPage, pageInfo.EndCursor, result, nil
 }
 
 // getIssues takes a list of commits from GitHub as well as the PR number associated with those commits and outputs a
 // formatted list of docs issues with valid release notes
-func getIssues(pullCommit []ghPullCommit, prNumber int) []docsIssue {
+func constructDocsIssues(prs []cockroachPR) []docsIssue {
 	var result []docsIssue
-	for _, c := range pullCommit {
-		message := c.Commit.Message
-		// return a slice of data that locates every instance of the phrase "release note (", case-insensitive
-		rns := formatReleaseNotes(message, prNumber, c.Sha)
-		for i, rn := range rns {
-			{ // checks to make sure a match was returned
-				x := docsIssue{ // declare a new commit object
-					sourceCommitSha: c.Sha,
-					title:           formatTitle(message, prNumber, i+1, len(rns)),
+	for _, pr := range prs {
+		for _, commit := range pr.Commits {
+			rns := formatReleaseNotes(commit.MessageBody, pr.Number, commit.Sha)
+			for i, rn := range rns {
+				x := docsIssue{
+					sourceCommitSha: commit.Sha,
+					title:           formatTitle(commit.MessageHeadline, pr.Number, i+1, len(rns)),
 					body:            rn,
+					labels: []string{
+						"C-product-change",
+						pr.BaseRefName,
+					},
 				}
 				result = append(result, x)
+
 			}
 		}
 	}
 	return result
 }
 
-var (
-	noRNRE                 = regexp.MustCompile(`[rR]elease [nN]ote: [nN]one`)
-	allRNRE                = regexp.MustCompile(`[rR]elease [nN]ote \(.*`)
-	bugFixRNRE             = regexp.MustCompile(`([rR]elease [nN]ote \(bug fix\):.*)`)
-	releaseJustificationRE = regexp.MustCompile(`[rR]elease [jJ]ustification:.*`)
-)
+func formatTitle(title string, prNumber int, index int, totalLength int) string {
+	result := fmt.Sprintf("PR #%d - %s", prNumber, title)
+	if totalLength > 1 {
+		result += fmt.Sprintf(" (%d of %d)", index, totalLength)
+	}
+	return result
+}
 
 // formatReleaseNotes generates a list of docsIssue bodies for the docs repo based on a given CRDB sha
 func formatReleaseNotes(message string, prNumber int, crdbSha string) []string {
 	rnBodySlice := []string{}
-	if noRNRE.MatchString(message) {
+	if releaseNoteNoneRE.MatchString(message) {
 		return rnBodySlice
 	}
 	splitString := strings.Split(message, "\n")
@@ -226,37 +653,35 @@ func formatReleaseNotes(message string, prNumber int, crdbSha string) []string {
 	return rnBodySlice
 }
 
-func formatTitle(message string, prNumber int, index int, totalLength int) string {
-	var commitTitle string
-	if i := strings.IndexRune(message, '\n'); i > 0 { //
-		commitTitle = message[:i]
-	} else {
-		commitTitle = message
-	}
-	result := fmt.Sprintf("PR #%d - %s", prNumber, commitTitle)
-	if totalLength > 1 {
-		result += fmt.Sprintf(" (%d of %d)", index, totalLength)
-	}
-	return result
-}
+// TODO: Redo this function
 
-func (p pr) createDocsIssues(token string) {
-	postURL := "https://api.github.com/repos/cockroachdb/docs/issues"
-	for _, issue := range p.docsIssues {
-		reqBody, err := json.Marshal(map[string]interface{}{
-			"title":  issue.title,
-			"labels": []string{"C-product-change", p.mergeBranch},
-			"body":   issue.body,
-		})
-		if err != nil {
-			log.Fatal(err)
+func (di docsIssue) createDocsIssues(
+	token string, repoID string, labelMap map[string]string,
+) error {
+	var output gqlCreateIssueMutation
+	mutation := `mutation ($repoId: ID!, $title: String!, $body: String!, $labelIds: [ID!]) {
+		createIssue(
+			input: {repositoryId: $repoId, title: $title, body: $body, labelIds: $labelIds}
+		) {
+			clientMutationId
 		}
-		client := &http.Client{}
-		req, _ := http.NewRequest("POST", postURL, bytes.NewBuffer(reqBody))
-		req.Header.Set("Authorization", "token "+token)
-		_, err = client.Do(req)
-		if err != nil {
-			log.Fatal(err)
-		}
+	}`
+	var labelIds []string
+	for _, x := range di.labels {
+		labelIds = append(labelIds, labelMap[x])
 	}
+	mutationVariables := map[string]interface{}{
+		"repoId": repoID,
+		"title":  di.title,
+		"body":   di.body,
+	}
+	if len(labelIds) > 0 {
+		mutationVariables["labelIds"] = labelIds
+	}
+	err := queryGraphQL(mutation, mutationVariables, token, &output)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+	return nil
 }

--- a/pkg/cmd/docs-issue-generation/docs_issue_generation_test.go
+++ b/pkg/cmd/docs-issue-generation/docs_issue_generation_test.go
@@ -11,568 +11,180 @@
 package main
 
 import (
-	"log"
+	"fmt"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func timeFromGhTime(t string) *time.Time {
-	x, err := time.Parse(time.RFC3339, t)
-	if err != nil {
-		log.Fatal(err)
-	}
-	return &x
-}
-
-func TestPrNums(t *testing.T) {
+func TestParseDocsIssueBody(t *testing.T) {
 	testCases := []struct {
 		testName string
-		search   ghSearch
-		prs      []pr
+		body     string
+		result   struct {
+			prNumber  int
+			commitSha string
+			err       error
+		}
 	}{
 		{
-			testName: "Single merged commit",
-			search: ghSearch{
-				Items: []ghSearchItem{
-					{
-						PRNumber: 80158,
-						PullRequest: ghSearchItemPr{
-							MergedAt: timeFromGhTime("2022-04-19T17:48:55Z"),
-						},
-					},
-				},
-			},
-			prs: []pr{
-				{
-					number: 80158,
-				},
+			testName: "no PR or commit",
+			body:     "Test test 12345",
+			result: struct {
+				prNumber  int
+				commitSha string
+				err       error
+			}{
+				prNumber:  0,
+				commitSha: "",
+				err:       fmt.Errorf("error: No PR number found in issue body"),
 			},
 		},
 		{
-			testName: "Single unmerged commit",
-			search: ghSearch{
-				Items: []ghSearchItem{
-					{
-						PRNumber: 80157,
-						PullRequest: ghSearchItemPr{
-							MergedAt: nil,
-						},
-					},
-				},
+			testName: "Result with markdown URLs",
+			body: `Exalate commented:
+
+Related PR: [https://github.com/cockroachdb/cockroach/pull/80670](https://github.com/cockroachdb/cockroach/pull/80670) 
+
+Commit: [https://github.com/cockroachdb/cockroach/commit/84a3833ee30eed278de0571c8c7d9f2f5e3b8b5d](https://github.com/cockroachdb/cockroach/commit/84a3833ee30eed278de0571c8c7d9f2f5e3b8b5d)
+
+— Release note (enterprise change): Backups run by secondary tenants now write protected timestamp records to protect their target schema objects from garbage collection during backup execution.
+
+Jira Issue: DOC-3619`,
+			result: struct {
+				prNumber  int
+				commitSha string
+				err       error
+			}{
+				prNumber:  80670,
+				commitSha: "84a3833ee30eed278de0571c8c7d9f2f5e3b8b5d",
+				err:       nil,
 			},
-			prs: nil,
 		},
 		{
-			testName: "Multiple merged and unmerged commits",
-			search: ghSearch{
-				Items: []ghSearchItem{
-					{
-						PRNumber: 66328,
-						PullRequest: ghSearchItemPr{
-							MergedAt: timeFromGhTime("2021-12-01T06:00:00Z"),
-						},
-					},
-					{
-						PRNumber: 74525,
-						PullRequest: ghSearchItemPr{
-							MergedAt: nil,
-						},
-					},
-					{
-						PRNumber: 75077,
-						PullRequest: ghSearchItemPr{
-							MergedAt: nil,
-						},
-					},
-				},
-			},
-			prs: []pr{
-				{
-					number: 66328,
-				},
+			testName: "Result with regular URLs",
+			body: `Related PR: https://github.com/cockroachdb/cockroach/pull/90789
+Commit: https://github.com/cockroachdb/cockroach/commit/c7ce65697535daacf2a75df245c3bae1179faeda
+
+---
+
+Release note (ops change): The cluster setting
+` + "server.web_session.auto_logout.timeout" + ` has been removed. It had
+never been effective.`,
+			result: struct {
+				prNumber  int
+				commitSha string
+				err       error
+			}{
+				prNumber:  90789,
+				commitSha: "c7ce65697535daacf2a75df245c3bae1179faeda",
+				err:       nil,
 			},
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
-			result := prNums(tc.search)
-			assert.Equal(t, tc.prs, result)
+			prNumber, commitSha, err := parseDocsIssueBody(tc.body)
+			result := struct {
+				prNumber  int
+				commitSha string
+				err       error
+			}{prNumber: prNumber, commitSha: commitSha, err: err}
+			assert.Equal(t, tc.result, result)
 		})
 	}
 }
 
-func TestGetIssues(t *testing.T) {
+func TestConstructDocsIssues(t *testing.T) {
 	testCases := []struct {
-		testName   string
-		pullCommit []ghPullCommit
-		prNumber   int
-		issues     []docsIssue
+		testName     string
+		cockroachPRs []cockroachPR
+		docsIssues   []docsIssue
 	}{
 		{
-			testName: "66328",
-			pullCommit: []ghPullCommit{
-				{
-					Sha: "4dd8da9609adb3acce6795cea93b67ccacfc0270",
-					Commit: ghPullCommitMsg{
-						Message: `util/log: move the crdb-v1 test code to a separate file
-
-Release note: None`,
-					},
-				},
-				{
-					Sha: "cae4e525511a7d87f3f5ce74f02a6cf6edab4f3d",
-					Commit: ghPullCommitMsg{
-						Message: `util/log: use a datadriven test for the crdb-v1 format/parse test
-
-This simplifies the test and makes it more extensible.
-
-Release note: None`,
-					},
-				},
-				{
-					Sha: "3be8458eda90aa922fa2a22ad7d6531c57aa12e1",
-					Commit: ghPullCommitMsg{
-						Message: "util/log: make " + "`logpb.Entry`" + ` slightly more able to represent crdb-v2 entries
-
-Prior to this change, we did not have a public data structure able to
-represent the various fields available in a ` + "`crdb-v2`" + ` log entry: the
-existing ` + "`logpb.Entry`" + ` was not able to distinguish structured and
-non-structured entries, and did not have the ability to delimit the
-message and the stack trace.
-
-This patch extends ` + "`logpb.Entry`" + ` to make it more able to represent
-` + "`crdb-v2`" + " entries, at least for the purpose of extending " + "`debug\nmerge-log`" +
-							` towards conversion between logging formats.
-
-Additionally, the patch adds a *best effort* attempt at populating
-the new fields in the ` + "`crdb-v1`" + ` entry parser. This is best effort
-because the crdb-v1 parser is lossy so we cannot faithfully
-parse its entries reliably.
-
-Release note: None`,
-					},
-				},
-				{
-					Sha: "0f329965acccb3e771ec1657c7def9e881dc78bb",
-					Commit: ghPullCommitMsg{
-						Message: `util/log: report the logging format at the start of new files
-
-Release note (cli change): When log entries are written to disk,
-the first few header lines written at the start of every new file
-now report the configured logging format.`,
-					},
-				},
-				{
-					Sha: "934c7da83035fb78108daa23fa9cb8925d7b6d10",
-					Commit: ghPullCommitMsg{
-						Message: `logconfig: fix the handling of crdb-v1 explicit config
-
-Release note (bug fix): Previously, ` + "`--log='file-defaults: {format:\ncrdb-v1}'`" +
-							` was not handled properly. This has been fixed. This bug
-existed since v21.1.0.`,
-					},
-				},
-				{
-					Sha: "fb249c7140b634a53dca2967c946bc78ba927e1a",
-					Commit: ghPullCommitMsg{
-						Message: `cli: report explicit log config in logs
-
-This increases troubleshootability.
-
-Release note: None`,
-					},
-				},
-				{
-					Sha: "e22a0ebb46806a0054115edbeef0d6205203eef5",
-					Commit: ghPullCommitMsg{
-						Message: `util/log,logspy: make the logspy mechanism better
-
-Prior to this patch, the logspy mechanism was utterly broken: any time
-it was running, it would cut off any and all log entries from going to
-files, stderr, network sinks etc. This was a gross violation
-of the guarantees we have constructed around structured logging,
-as well as a security vulnerability (see release note below).
-
-Additionally, it was impossible to launch multiple logspy sessions
-simultaneously on the same node, for example using different grep
-filters.
-
-This commit rectifies the situation.
-
-At a technical level, we have two changes: one in the logging Go API
-and one in the ` + "`/debug/logspy`" + ` HTTP API.
-
-**For the logging changes**, this patch replaces the "interceptor" singleton
-callback function that takes over ` + "`(*loggerT).outputLogEntry()`" + `, by a
-new *interceptor sink* that lives alongside the other sinks on every
-channel.
-
-Because the interceptor logic is now a regular sink, log entries
-continue to be delivered to other sinks while an interceptor is
-active.
-
-Reusing the sink abstraction, with its own sink configuration with no
-severity filter, clarifies that the interceptor accepts all the log
-entries regardless of which filters are configured on other sinks.
-
-Additionally, the interceptor sink now supports multiple concurrent
-interception sessions. Each log entry is delivered to all current
-interceptors. The ` + "`logspy`" + ` logic is adapted to use this facility,
-so that multiple ` + "`logspy`" + ` requests can run side-by-side.
-
-**For the HTTP API change**, we are changing the ` + "`/debug/logspy`" + `
-semantics. This is explained in the release note below.
-
-Release note (security update): All the logging output to files
-or network sinks was previously disabled temporarily while an operator
-was using the ` + "`/debug/logspy`" + ` HTTP API, resulting in lost entries
-and a breach of auditability guarantees. This behavior has been corrected.
-
-Release note (bug fix): Log entries are not lost any more while the
-` + "`/debug/logspy`" + ` HTTP API is being used. This bug had existed since
-CockroachDB v1.1.
-
-Release note (api change): The ` + "`/debug/logspy`" + ` HTTP API has changed.
-The endpoint now returns JSON data by default.
-This change is motivated as follows:
-
-- the previous format, ` + "`crdb-v1`" + `, cannot be parsed reliably.
-- using JSON entries guarantees that the text of each entry
-  all fits on a single line of output (newline characters
-  inside the messages are escaped). This makes filtering
-  easier and more reliable.
-- using JSON enables the user to apply ` + "`jq`" + ` on the output, for
-  example via ` + "`curl -s .../debug/logspy | jq ...`" + `
-
-If the previous format is desired, the user can pass the query
-argument ` + "`&flatten=1`" + " to the " + "`logspy`" + ` URL to obtain the previous flat
-text format (` + "`crdb-v1`" + `) instead.
-
-Co-authored-by: Yevgeniy Miretskiy <yevgeniy@cockroachlabs.com>`,
-					},
-				},
-				{
-					Sha: "44836265f924a14f8c996a714d954e0e7e35dff7",
-					Commit: ghPullCommitMsg{
-						Message: "util/log,server/debug: new API " + "`/debug/vmodule`" + ", change " + "`logspy`" + `
-
-Prior to this patch, any ongoing ` + "`/debug/logspy`" + ` query would
-trigger maximum verbosity in the logging package - i.e.
-cause all logging API calls under ` + "`log.V`" + ` to be activated.
-
-This was problematic, as it would cause a large amount
-of logging traffic to be pumped through the interceptor logic,
-increasing the chance for entries to be dropped (especially
-when ` + "`logspy?grep=...`" + ` is not used).
-
-Additionally, since the previous change to make the interceptor logic
-a regular sink, all the entries captured by the interceptors are now
-also duplicated to the other sinks (this is a feature / bug fix,
-as explained in the previous commit message).
-
-However, this change also meant that any ongoing ` + "`logspy`" + ` request
-would cause maximum verbosity to all the sinks with threshold
-INFO (most logging calls under ` + "`log.V`" + ` have severity INFO). For
-example, the DEV channel accepts all entries at level INFO or higher
-in the default config. This in turn could incur unacceptable disk
-space or IOPS consumption in certain deployments.
-
-In orde to mitigate this new problem, this patch removes the special
-conditional from the logging package. From this point forward,
-the verbosity of the entries delivered via ` + "`/debug/logspy`" + ` are those
-configured via ` + "`vmodule`" + ` -- no more and no less.
-
-To make this configurable for a running server, including one where
-the SQL endpoint may not be available yet, this patch also introduces
-a new ` + "`/debug/vmodule`" + " HTTP API and extends " + "`/debug/logspy`" + ` with
-the ability to temporarily change ` + "`vmodule`" + ` *upon explicit request*.
-
-Release note (api change): The ` + "`/debug/logspy`" + ` API does not any more
-enable maximum logging verbosity automatically. To change the
-verbosity, use the new ` + "`/debug/vmodule`" + ` endpoint or pass the
-` + "`&vmodule=`" + " query parameter to the " + "`/debug/logspy`" + ` endpoint.
-
-For example, suppose you wish to run a 20s logspy session:
-
-- Before:
-
-  ` + "```\n  curl 'https://.../debug/logspy?duration=20s&...'\n  ```" + `
-
-- Now:
-
-  ` + "```\n  curl 'https://.../debug/logspy?duration=20s&vmodule=...'\n  ```" + `
-
-  OR
-
-  ` +
-							"```\n  curl 'https://.../debug/vmodule?duration=22s&vmodule=...'\n  curl 'https://.../debug/logspy?duration=20s'\n  ```" + `
-
-As for the regular ` + "`vmodule`" + ` command-line flag, the maximum verbosity
-across all the source code can be selected with the pattern ` + "`*=4`" + `.
-
-Note: at most one in-flight HTTP API request is allowed to modify the
-` + "`vmodule`" + ` parameter. This maintain the invariant that the
-configuration restored at the end of each request is the same as when
-the request started.
-
-Release note (api change): The new ` + "`/debug/vmodule`" + ` API makes it
-possible for an operator to configure the logging verbosity in a
-similar way as the SQL built-in function
-` + "`crdb_internal.set_vmodule()`" + `, or to query the current configuration
-as in ` + "`crdb_internal.get_vmodule()`" + `. Additionally, any configuration
-change performed via this API can be automatically reverted after a
-configurable delay. The API forms are:
-
-- ` + "`/debug/vmodule`" + ` - retrieve the current configuration.
-- ` + "`/debug/vmodule?set=[vmodule config]&duration=[duration]`" + ` - change
-  the configuration to ` + "`[vmodule config]`" + ` . The previous configuration
-  at the time the ` + "`/debug/vmodule`" + ` request started is restored after
-  ` + "`[duration]`" + `. This duration, if not specified, defaults to twice the
-  default duration of a ` + "`logspy`" + " request (currently, the " + "`logspy`" + `
-  default duration is 5s, so the ` + "`vmodule`" + ` default duration is 10s).
-  If the duration is zero or negative, the previous configuration
-  is never restored.`,
-					},
-				},
-			},
-			prNumber: 66328,
-			issues: []docsIssue{
-				{
-					sourceCommitSha: "0f329965acccb3e771ec1657c7def9e881dc78bb",
-					title:           "PR #66328 - util/log: report the logging format at the start of new files",
-					body: `Related PR: https://github.com/cockroachdb/cockroach/pull/66328
-Commit: https://github.com/cockroachdb/cockroach/commit/0f329965acccb3e771ec1657c7def9e881dc78bb
-
----
-
-Release note (cli change): When log entries are written to disk,
-the first few header lines written at the start of every new file
-now report the configured logging format.`,
-				},
-				{
-					sourceCommitSha: "e22a0ebb46806a0054115edbeef0d6205203eef5",
-					title:           "PR #66328 - util/log,logspy: make the logspy mechanism better (1 of 2)",
-					body: `Related PR: https://github.com/cockroachdb/cockroach/pull/66328
-Commit: https://github.com/cockroachdb/cockroach/commit/e22a0ebb46806a0054115edbeef0d6205203eef5
-
----
-
-Release note (security update): All the logging output to files
-or network sinks was previously disabled temporarily while an operator
-was using the ` + "`/debug/logspy`" + ` HTTP API, resulting in lost entries
-and a breach of auditability guarantees. This behavior has been corrected.`,
-				},
-				{
-					sourceCommitSha: "e22a0ebb46806a0054115edbeef0d6205203eef5",
-					title:           "PR #66328 - util/log,logspy: make the logspy mechanism better (2 of 2)",
-					body: `Related PR: https://github.com/cockroachdb/cockroach/pull/66328
-Commit: https://github.com/cockroachdb/cockroach/commit/e22a0ebb46806a0054115edbeef0d6205203eef5
-
----
-
-Release note (api change): The ` + "`/debug/logspy`" + ` HTTP API has changed.
-The endpoint now returns JSON data by default.
-This change is motivated as follows:
-
-- the previous format, ` + "`crdb-v1`" + `, cannot be parsed reliably.
-- using JSON entries guarantees that the text of each entry
-  all fits on a single line of output (newline characters
-  inside the messages are escaped). This makes filtering
-  easier and more reliable.
-- using JSON enables the user to apply ` + "`jq`" + ` on the output, for
-  example via ` + "`curl -s .../debug/logspy | jq ...`" + `
-
-If the previous format is desired, the user can pass the query
-argument ` + "`&flatten=1`" + " to the " + "`logspy`" + ` URL to obtain the previous flat
-text format (` + "`crdb-v1`" + `) instead.
-
-Co-authored-by: Yevgeniy Miretskiy <yevgeniy@cockroachlabs.com>`,
-				},
-				{
-					sourceCommitSha: "44836265f924a14f8c996a714d954e0e7e35dff7",
-					title:           "PR #66328 - util/log,server/debug: new API `/debug/vmodule`, change `logspy` (1 of 2)",
-					body: `Related PR: https://github.com/cockroachdb/cockroach/pull/66328
-Commit: https://github.com/cockroachdb/cockroach/commit/44836265f924a14f8c996a714d954e0e7e35dff7
-
----
-
-Release note (api change): The ` + "`/debug/logspy`" + ` API does not any more
-enable maximum logging verbosity automatically. To change the
-verbosity, use the new ` + "`/debug/vmodule`" + ` endpoint or pass the
-` + "`&vmodule=`" + " query parameter to the " + "`/debug/logspy`" + ` endpoint.
-
-For example, suppose you wish to run a 20s logspy session:
-
-- Before:
-
-  ` + "```\n  curl 'https://.../debug/logspy?duration=20s&...'\n  ```" + `
-
-- Now:
-
-  ` + "```\n  curl 'https://.../debug/logspy?duration=20s&vmodule=...'\n  ```" + `
-
-  OR
-
-  ` + "```\n  curl 'https://.../debug/vmodule?duration=22s&vmodule=...'\n  curl 'https://.../debug/logspy?duration=20s'\n  ```" + `
-
-As for the regular ` + "`vmodule`" + ` command-line flag, the maximum verbosity
-across all the source code can be selected with the pattern ` + "`*=4`" + `.
-
-Note: at most one in-flight HTTP API request is allowed to modify the
-` + "`vmodule`" + ` parameter. This maintain the invariant that the
-configuration restored at the end of each request is the same as when
-the request started.`,
-				},
-				{
-					sourceCommitSha: "44836265f924a14f8c996a714d954e0e7e35dff7",
-					title:           "PR #66328 - util/log,server/debug: new API `/debug/vmodule`, change `logspy` (2 of 2)",
-					body: `Related PR: https://github.com/cockroachdb/cockroach/pull/66328
-Commit: https://github.com/cockroachdb/cockroach/commit/44836265f924a14f8c996a714d954e0e7e35dff7
-
----
-
-Release note (api change): The new ` + "`/debug/vmodule`" + ` API makes it
-possible for an operator to configure the logging verbosity in a
-similar way as the SQL built-in function
-` + "`crdb_internal.set_vmodule()`" + `, or to query the current configuration
-as in ` + "`crdb_internal.get_vmodule()`" + `. Additionally, any configuration
-change performed via this API can be automatically reverted after a
-configurable delay. The API forms are:
-
-- ` + "`/debug/vmodule`" + ` - retrieve the current configuration.
-- ` + "`/debug/vmodule?set=[vmodule config]&duration=[duration]`" + ` - change
-  the configuration to ` + "`[vmodule config]`" + ` . The previous configuration
-  at the time the ` + "`/debug/vmodule`" + ` request started is restored after
-  ` + "`[duration]`" + `. This duration, if not specified, defaults to twice the
-  default duration of a ` + "`logspy`" + " request (currently, the " + "`logspy`" + `
-  default duration is 5s, so the ` + "`vmodule`" + ` default duration is 10s).
-  If the duration is zero or negative, the previous configuration
-  is never restored.`,
-				},
-			},
+			testName: "Single PR - 91345",
+			cockroachPRs: []cockroachPR{{
+				Title:       "release-22.2: clusterversion: allow forcing release binary to dev version",
+				Number:      91345,
+				Body:        "Backport 1/1 commits from #90002, using the simplifications from #91344\r\n\r\n/cc @cockroachdb/release\r\n\r\n---\r\n\r\nPreviously it was impossible to start a release binary that supported up to say, 23.1, in a cluster where the cluster version was in the 'development' range (+1m). While this was somewhat intentional -- to mark a dev cluster as dev forever -- we still want the option to try to run release binaries in that cluster.\r\n\r\nThe new environment variable COCKROACH_FORCE_DEV_VERSION will cause a binary to identify itself as development and offset its version even if it is a release binary.\r\n\r\nEpic: none.\r\n\r\nRelease note (ops change): Release version binaries can now be instructed via the enviroment variable COCKROACH_FORCE_DEV_VERSION to override their cluster version support to match that of develeopment builds, which can allow a release binary to be started in a cluster that is run or has previously run a development build.\r\n\r\nRelease justification: bug fix in new functionality.",
+				BaseRefName: "release-22.2",
+				Commits: []cockroachCommit{{
+					Sha:             "8dc44d23bb7e0688cd435b6f7908fab615f1aa39",
+					MessageHeadline: "clusterversion: allow forcing release binary to dev version",
+					MessageBody:     "Previously it was impossible to start a release binary that supported up\nto say, 23.1, in a cluster where the cluster version was in the 'development'\nrange (+1m). While this was somewhat intentional -- to mark a dev cluster as dev\nforever -- we still want the option to try to run release binaries in that cluster.\n\nThe new environment variable COCKROACH_FORCE_DEV_VERSION will cause a binary to\nidentify itself as development and offset its version even if it is a release binary.\n\nEpic: none.\n\nRelease note (ops change): Release version binaries can now be instructed via the enviroment\nvariable COCKROACH_FORCE_DEV_VERSION to override their cluster version support to match that\nof develeopment builds, which can allow a release binary to be started in a cluster that is\nrun or has previously run a development build.",
+				}},
+			}},
+			docsIssues: []docsIssue{{
+				sourceCommitSha: "8dc44d23bb7e0688cd435b6f7908fab615f1aa39",
+				title:           "PR #91345 - clusterversion: allow forcing release binary to dev version",
+				body:            "Related PR: https://github.com/cockroachdb/cockroach/pull/91345\nCommit: https://github.com/cockroachdb/cockroach/commit/8dc44d23bb7e0688cd435b6f7908fab615f1aa39\n\n---\n\nRelease note (ops change): Release version binaries can now be instructed via the enviroment\nvariable COCKROACH_FORCE_DEV_VERSION to override their cluster version support to match that\nof develeopment builds, which can allow a release binary to be started in a cluster that is\nrun or has previously run a development build.",
+				labels:          []string{"C-product-change", "release-22.2"},
+			}},
 		},
 		{
-			testName: "78685",
-			pullCommit: []ghPullCommit{
+			testName: "Multiple PRs",
+			cockroachPRs: []cockroachPR{
 				{
-					Sha: "1d7811d5d14f9c7e106c3ec92de9c66192f19604",
-					Commit: ghPullCommitMsg{
-						Message: `opt: do not cross-join input of semi-join
-
-This commit fixes a logical correctness bug caused when
-` + "`GenerateLookupJoins`" + ` cross-joins the input of a semi-join with a set of
-constant values to constrain the prefix columns of the lookup index. The
-cross-join is an invalid transformation because it increases the size of
-the join's input and can increase the size of the join's output.
-
-We already avoid these cross-joins for left and anti-joins (see #59646).
-When addressing those cases, the semi-join case was incorrectly assumed
-to be safe.
-
-Fixes #78681
-
-Release note (bug fix): A bug has been fixed which caused the optimizer
-to generate invalid query plans which could result in incorrect query
-results. The bug, which has been present since version 21.1.0, can
-appear if all of the following conditions are true: 1) the query
-contains a semi-join, such as queries in the form:
-` + "`SELECT * FROM t1 WHERE EXISTS (SELECT * FROM t2 WHERE t1.a = t2.a);`" + `,
-2) the inner table has an index containing the equality column, like
-` + "`t2.a`" + ` in the example query, 3) the index contains one or more
-columns that prefix the equality column, and 4) the prefix columns are
-` + "`NOT NULL`" + " and are constrained to a set of constant values via a " + "`CHECK`" + `
-constraint or an ` + "`IN`" + " condition in the filter.",
-					},
+					Title:       "release-22.1: ui: update filter labels",
+					Number:      91294,
+					Body:        "Backport 1/1 commits from #88078.\r\n\r\n/cc @cockroachdb/release\r\n\r\n---\r\n\r\nUpdate filter label from \"App\" to \"Application Name\" on SQL Activity.\r\n\r\nFixes #87960\r\n\r\n<img width=\"467\" alt=\"Screen Shot 2022-09-16 at 6 40 51 PM\" src=\"https://user-images.githubusercontent.com/1017486/190827281-36a9c6df-3e16-4689-bcae-6649b1c2ff86.png\">\r\n\r\n\r\nRelease note (ui change): Update filter labels from \"App\" to \"Application Name\" and from \"Username\" to \"User Name\" on SQL Activity and Insights pages.\r\n\r\n---\r\n\r\nRelease justification: small change\r\n",
+					BaseRefName: "release-22.1",
+					Commits: []cockroachCommit{{
+						Sha:             "8d15073f329cf8d72e09977b34a3b339d1436000",
+						MessageHeadline: "ui: update filter labels",
+						MessageBody:     "Update filter label from \"App\" to \"Application Name\"\nand \"Username\" to \"User Name\" on SQL Activity pages.\n\nFixes #87960\n\nRelease note (ui change): Update filter labels from\n\"App\" to \"Application Name\" and from \"Username\" to\n\"User Name\" on SQL Activity pages.",
+					}},
+				},
+				{
+					Title:       "release-22.2.0: sql/ttl: rename num_active_ranges metrics",
+					Number:      90381,
+					Body:        "Backport 1/1 commits from #90175.\r\n\r\n/cc @cockroachdb/release\r\n\r\nRelease justification: metrics rename that should be done in a major release\r\n\r\n---\r\n\r\nfixes https://github.com/cockroachdb/cockroach/issues/90094\r\n\r\nRelease note (ops change): These TTL metrics have been renamed: \r\njobs.row_level_ttl.range_total_duration -> jobs.row_level_ttl.span_total_duration\r\njobs.row_level_ttl.num_active_ranges -> jobs.row_level_ttl.num_active_spans\r\n",
+					BaseRefName: "release-22.2.0",
+					Commits: []cockroachCommit{{
+						Sha:             "1829a72664f28ddfa50324c9ff5352380029560b",
+						MessageHeadline: "sql/ttl: rename num_active_ranges metrics",
+						MessageBody:     "fixes https://github.com/cockroachdb/cockroach/issues/90094\n\nRelease note (ops change): These TTL metrics have been renamed:\njobs.row_level_ttl.range_total_duration -> jobs.row_level_ttl.span_total_duration\njobs.row_level_ttl.num_active_ranges -> jobs.row_level_ttl.num_active_spans",
+					}},
+				},
+				{
+					Title:       "release-22.2: opt/props: shallow-copy props.Histogram when applying selectivity",
+					Number:      89957,
+					Body:        "Backport 2/2 commits from #88526 on behalf of @michae2.\r\n\r\n/cc @cockroachdb/release\r\n\r\n----\r\n\r\n**opt/props: add benchmark for props.Histogram**\r\n\r\nAdd a benchmark that measures various common props.Histogram operations.\r\n\r\nRelease note: None\r\n\r\n**opt/props: shallow-copy props.Histogram when applying selectivity**\r\n\r\n`pkg/sql/opt/props.(*Histogram).copy` showed up as a heavy allocator in\r\na recent customer OOM. The only caller of this function is\r\n`Histogram.ApplySelectivity` which deep-copies the histogram before\r\nadjusting each bucket's `NumEq`, `NumRange`, and `DistinctRange` by the\r\ngiven selectivity.\r\n\r\nInstead of deep-copying the histogram, we can change `ApplySelectivity`\r\nto shallow-copy the histogram and remember the current selectivity. We\r\ncan then wait to adjust counts in each bucket by the selectivity until\r\nsomeone actually calls `ValuesCount` or `DistinctValuesCount`.\r\n\r\nThis doesn't eliminate all copying of histograms. We're still doing some\r\ncopying in `Filter` when applying a constraint to the histogram.\r\n\r\nFixes: #89941\r\n\r\nRelease note (performance improvement): The optimizer now does less\r\ncopying of histograms while planning queries, which will reduce memory\r\npressure a little.\r\n\r\n----\r\n\r\nRelease justification: Low risk, high reward change to existing functionality.",
+					BaseRefName: "release-22.2",
+					Commits: []cockroachCommit{{
+						Sha:             "43de8ff30e3e6e1d9b2272ed4f62c543dc0a037c",
+						MessageHeadline: "opt/props: shallow-copy props.Histogram when applying selectivity",
+						MessageBody:     "`pkg/sql/opt/props.(*Histogram).copy` showed up as a heavy allocator in\na recent customer OOM. The only caller of this function is\n`Histogram.ApplySelectivity` which deep-copies the histogram before\nadjusting each bucket's `NumEq`, `NumRange`, and `DistinctRange` by the\ngiven selectivity.\n\nInstead of deep-copying the histogram, we can change `ApplySelectivity`\nto shallow-copy the histogram and remember the current selectivity. We\ncan then wait to adjust counts in each bucket by the selectivity until\nsomeone actually calls `ValuesCount` or `DistinctValuesCount`.\n\nThis doesn't eliminate all copying of histograms. We're still doing some\ncopying in `Filter` when applying a constraint to the histogram.\n\nFixes: #89941\n\nRelease note (performance improvement): The optimizer now does less\ncopying of histograms while planning queries, which will reduce memory\npressure a little.",
+					}},
 				},
 			},
-			prNumber: 78685,
-			issues:   nil,
-		},
-		{
-			testName: "79069",
-			pullCommit: []ghPullCommit{
+			docsIssues: []docsIssue{
 				{
-					Sha: "5ec9343b0e0a00bfd4603e55ca6533e2b77db2f9",
-					Commit: ghPullCommitMsg{
-						Message: `sql: ignore non-existent columns when injecting stats
-
-Previously, an ` + "`ALTER TABLE ... INJECT STATS`" + ` command would return an
-error if the given stats JSON included any columns that were not present
-in the table descriptor. Statistics in statement bundles often include
-dropped columns, so reproducing docsIssues with a bundle required tediously
-removing stats for these columns. This commit changes the stats
-injection behavior so that a notice is issued for stats with
-non-existent columns rather than an error. Any stats for existing
-columns will be injected successfully.
-
-Informs #68184
-
-Release note (sql change): ` + "`ALTER TABLE ... INJECT STATISTICS ...`" + ` will
-now docsIssue notices when the given statistics JSON includes non-existent
-columns, rather than resulting in an error. Any statistics in the JSON
-for existing columns will be injected successfully.`,
-					},
+					sourceCommitSha: "8d15073f329cf8d72e09977b34a3b339d1436000",
+					title:           "PR #91294 - ui: update filter labels",
+					body:            "Related PR: https://github.com/cockroachdb/cockroach/pull/91294\nCommit: https://github.com/cockroachdb/cockroach/commit/8d15073f329cf8d72e09977b34a3b339d1436000\n\n---\n\nRelease note (ui change): Update filter labels from\n\"App\" to \"Application Name\" and from \"Username\" to\n\"User Name\" on SQL Activity pages.",
+					labels:          []string{"C-product-change", "release-22.1"},
 				},
-			},
-			prNumber: 79069,
-			issues: []docsIssue{
 				{
-					sourceCommitSha: "5ec9343b0e0a00bfd4603e55ca6533e2b77db2f9",
-					title:           "PR #79069 - sql: ignore non-existent columns when injecting stats",
-					body: `Related PR: https://github.com/cockroachdb/cockroach/pull/79069
-Commit: https://github.com/cockroachdb/cockroach/commit/5ec9343b0e0a00bfd4603e55ca6533e2b77db2f9
-
----
-
-Release note (sql change): ` + "`ALTER TABLE ... INJECT STATISTICS ...`" + ` will
-now docsIssue notices when the given statistics JSON includes non-existent
-columns, rather than resulting in an error. Any statistics in the JSON
-for existing columns will be injected successfully.`,
+					sourceCommitSha: "1829a72664f28ddfa50324c9ff5352380029560b",
+					title:           "PR #90381 - sql/ttl: rename num_active_ranges metrics",
+					body:            "Related PR: https://github.com/cockroachdb/cockroach/pull/90381\nCommit: https://github.com/cockroachdb/cockroach/commit/1829a72664f28ddfa50324c9ff5352380029560b\n\n---\n\nRelease note (ops change): These TTL metrics have been renamed:\njobs.row_level_ttl.range_total_duration -> jobs.row_level_ttl.span_total_duration\njobs.row_level_ttl.num_active_ranges -> jobs.row_level_ttl.num_active_spans",
+					labels:          []string{"C-product-change", "release-22.2.0"},
 				},
-			},
-		},
-		{
-			testName: "79361",
-			pullCommit: []ghPullCommit{
 				{
-					Sha: "88be04bd64283b1d77000a3f88588e603465e81b",
-					Commit: ghPullCommitMsg{
-						Message: `changefeedccl: remove the default values from SHOW
-CHANGEFEED JOB output
-
-Currently, when a user alters a changefeed, we
-include the default options in the SHOW CHANGEFEED
-JOB output. In this PR we prevent the default values
-from being displayed.
-
-Release note (enterprise change): Remove the default
-values from the SHOW CHANGEFEED JOB output`,
-					},
-				},
-			},
-			prNumber: 79361,
-			issues: []docsIssue{
-				{
-					sourceCommitSha: "88be04bd64283b1d77000a3f88588e603465e81b",
-					title:           "PR #79361 - changefeedccl: remove the default values from SHOW",
-					body: `Related PR: https://github.com/cockroachdb/cockroach/pull/79361
-Commit: https://github.com/cockroachdb/cockroach/commit/88be04bd64283b1d77000a3f88588e603465e81b
-
----
-
-Release note (enterprise change): Remove the default
-values from the SHOW CHANGEFEED JOB output`,
+					sourceCommitSha: "43de8ff30e3e6e1d9b2272ed4f62c543dc0a037c",
+					title:           "PR #89957 - opt/props: shallow-copy props.Histogram when applying selectivity",
+					body:            "Related PR: https://github.com/cockroachdb/cockroach/pull/89957\nCommit: https://github.com/cockroachdb/cockroach/commit/43de8ff30e3e6e1d9b2272ed4f62c543dc0a037c\n\n---\n\nRelease note (performance improvement): The optimizer now does less\ncopying of histograms while planning queries, which will reduce memory\npressure a little.",
+					labels:          []string{"C-product-change", "release-22.2"},
 				},
 			},
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
-			result := getIssues(tc.pullCommit, tc.prNumber)
-			assert.Equal(t, tc.issues, result)
+			result := constructDocsIssues(tc.cockroachPRs)
+			assert.Equal(t, tc.docsIssues, result)
 		})
 	}
 }
@@ -712,159 +324,56 @@ func TestFormatTitle(t *testing.T) {
 		title       string
 	}{
 		{
-			testName: "Format Title 1",
-			message: `sql: ignore non-existent columns when injecting stats
-
-Previously, an ` + "`ALTER TABLE ... INJECT STATS`" + ` command would return an
-error if the given stats JSON included any columns that were not present
-in the table descriptor. Statistics in statement bundles often include
-dropped columns, so reproducing docsIssues with a bundle required tediously
-removing stats for these columns. This commit changes the stats
-injection behavior so that a notice is issued for stats with
-non-existent columns rather than an error. Any stats for existing
-columns will be injected successfully.
-
-Informs #68184
-
-Release note (sql change): ` + "`ALTER TABLE ... INJECT STATISTICS ...`" + ` will
-now docsIssue notices when the given statistics JSON includes non-existent
-columns, rather than resulting in an error. Any statistics in the JSON
-for existing columns will be injected successfully.`,
+			testName:    "Format Title 1",
+			message:     `sql: ignore non-existent columns when injecting stats`,
 			prNumber:    12345,
 			index:       1,
 			totalLength: 1,
 			title:       "PR #12345 - sql: ignore non-existent columns when injecting stats",
 		},
 		{
-			testName: "Format Title 2",
-			message: `changefeedccl: remove the default values from SHOW
-CHANGEFEED JOB output
-
-Currently, when a user alters a changefeed, we
-include the default options in the SHOW CHANGEFEED
-JOB output. In this PR we prevent the default values
-from being displayed.
-
-Release note (enterprise change): Remove the default
-values from the SHOW CHANGEFEED JOB output`,
+			testName:    "Format Title 2",
+			message:     `changefeedccl: remove the default values from SHOW CHANGEFEED JOB output`,
 			prNumber:    54321,
 			index:       1,
 			totalLength: 1,
-			title:       "PR #54321 - changefeedccl: remove the default values from SHOW",
+			title:       "PR #54321 - changefeedccl: remove the default values from SHOW CHANGEFEED JOB output",
 		},
 		{
-			testName: "Format Title 3",
-			message: `opt: do not cross-join input of semi-join
-
-This commit fixes a logical correctness bug caused when
-` + "`GenerateLookupJoins`" + ` cross-joins the input of a semi-join with a set of
-constant values to constrain the prefix columns of the lookup index. The
-cross-join is an invalid transformation because it increases the size of
-the join's input and can increase the size of the join's output.
-
-We already avoid these cross-joins for left and anti-joins (see #59646).
-When addressing those cases, the semi-join case was incorrectly assumed
-to be safe.
-
-Fixes #78681
-
-Release note (bug fix): A bug has been fixed which caused the optimizer
-to generate invalid query plans which could result in incorrect query
-results. The bug, which has been present since version 21.1.0, can
-appear if all of the following conditions are true: 1) the query
-contains a semi-join, such as queries in the form:
-` + "`SELECT * FROM t1 WHERE EXISTS (SELECT * FROM t2 WHERE t1.a = t2.a);`" + `,
-2) the inner table has an index containing the equality column, like
-` + "`t2.a`" + ` in the example query, 3) the index contains one or more
-columns that prefix the equality column, and 4) the prefix columns are
-` + "`NOT NULL`" + " and are constrained to a set of constant values via a " + "`CHECK`" + `
-constraint or an ` + "`IN`" + " condition in the filter.",
+			testName:    "Format Title 3",
+			message:     `opt: do not cross-join input of semi-join`,
 			prNumber:    65432,
 			index:       1,
 			totalLength: 1,
 			title:       "PR #65432 - opt: do not cross-join input of semi-join",
 		},
 		{
-			testName: "Format Title 4",
-			message: `util/log: report the logging format at the start of new files
-
-Release note (cli change): When log entries are written to disk,
-the first few header lines written at the start of every new file
-now report the configured logging format.`,
+			testName:    "Format Title 4",
+			message:     `util/log: report the logging format at the start of new files`,
 			prNumber:    23456,
 			index:       1,
 			totalLength: 1,
 			title:       "PR #23456 - util/log: report the logging format at the start of new files",
 		},
 		{
-			testName: "Format Title 5",
-			message: `sql: ignore non-existent columns when injecting stats
-
-Previously, an ` + "`ALTER TABLE ... INJECT STATS`" + ` command would return an
-error if the given stats JSON included any columns that were not present
-in the table descriptor. Statistics in statement bundles often include
-dropped columns, so reproducing docsIssues with a bundle required tediously
-removing stats for these columns. This commit changes the stats
-injection behavior so that a notice is issued for stats with
-non-existent columns rather than an error. Any stats for existing
-columns will be injected successfully.
-
-Informs #68184
-
-Release note (sql change): ` + "`ALTER TABLE ... INJECT STATISTICS ...`" + ` will
-now docsIssue notices when the given statistics JSON includes non-existent
-columns, rather than resulting in an error. Any statistics in the JSON
-for existing columns will be injected successfully.`,
+			testName:    "Format Title 5",
+			message:     `sql: ignore non-existent columns when injecting stats`,
 			prNumber:    34567,
 			index:       2,
 			totalLength: 3,
 			title:       "PR #34567 - sql: ignore non-existent columns when injecting stats (2 of 3)",
 		},
 		{
-			testName: "Format Title 6",
-			message: `changefeedccl: remove the default values from SHOW
-CHANGEFEED JOB output
-
-Currently, when a user alters a changefeed, we
-include the default options in the SHOW CHANGEFEED
-JOB output. In this PR we prevent the default values
-from being displayed.
-
-Release note (enterprise change): Remove the default
-values from the SHOW CHANGEFEED JOB output`,
+			testName:    "Format Title 6",
+			message:     `changefeedccl: remove the default values from SHOW CHANGEFEED JOB output`,
 			prNumber:    76543,
 			index:       1,
 			totalLength: 6,
-			title:       "PR #76543 - changefeedccl: remove the default values from SHOW (1 of 6)",
+			title:       "PR #76543 - changefeedccl: remove the default values from SHOW CHANGEFEED JOB output (1 of 6)",
 		},
 		{
-			testName: "Format Title 7",
-			message: `opt: do not cross-join input of semi-join
-
-This commit fixes a logical correctness bug caused when
-` + "`GenerateLookupJoins`" + ` cross-joins the input of a semi-join with a set of
-constant values to constrain the prefix columns of the lookup index. The
-cross-join is an invalid transformation because it increases the size of
-the join's input and can increase the size of the join's output.
-
-We already avoid these cross-joins for left and anti-joins (see #59646).
-When addressing those cases, the semi-join case was incorrectly assumed
-to be safe.
-
-Fixes #78681
-
-Release note (bug fix): A bug has been fixed which caused the optimizer
-to generate invalid query plans which could result in incorrect query
-results. The bug, which has been present since version 21.1.0, can
-appear if all of the following conditions are true: 1) the query
-contains a semi-join, such as queries in the form:
-` +
-				"`SELECT * FROM t1 WHERE EXISTS (SELECT * FROM t2 WHERE t1.a = t2.a);`" + `,
-2) the inner table has an index containing the equality column, like
-` + "`t2.a`" + ` in the example query, 3) the index contains one or more
-columns that prefix the equality column, and 4) the prefix columns are
-` + "`NOT NULL`" + " and are constrained to a set of constant values via a " + "`CHECK`" + `
-constraint or an ` + "`IN`" + " condition in the filter.",
+			testName:    "Format Title 7",
+			message:     `opt: do not cross-join input of semi-join`,
 			prNumber:    45678,
 			index:       5,
 			totalLength: 7,

--- a/pkg/cmd/docs-issue-generation/main.go
+++ b/pkg/cmd/docs-issue-generation/main.go
@@ -14,7 +14,9 @@ package main
 
 import (
 	"os"
+	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/spf13/cobra"
 )
 
@@ -36,12 +38,24 @@ func main() {
 func defaultEnvParameters() parameters {
 	const (
 		githubAPITokenEnv = "GITHUB_API_TOKEN"
-		buildVcsNumberEnv = "BUILD_VCS_NUMBER"
+		dryRunEnv         = "DRY_RUN_DOCS_ISSUE_GEN"
+		startTimeEnv      = "DOCS_ISSUE_GEN_START_TIME"
+		endTimeEnv        = "DOCS_ISSUE_GEN_END_TIME"
 	)
+	defaultStartTimeStr := timeutil.Now().Add(time.Hour * (-48)).Format(time.RFC3339)
+	defaultEndTimeStr := timeutil.Now().Format(time.RFC3339)
+
+	startTimeStr := maybeEnv(startTimeEnv, defaultStartTimeStr)
+	endTimeStr := maybeEnv(endTimeEnv, defaultEndTimeStr)
+
+	startTimeTime, _ := time.Parse(time.RFC3339, startTimeStr)
+	endTimeTime, _ := time.Parse(time.RFC3339, endTimeStr)
 
 	return parameters{
-		Token: maybeEnv(githubAPITokenEnv, ""),
-		Sha:   maybeEnv(buildVcsNumberEnv, "4dd8da9609adb3acce6795cea93b67ccacfc0270"),
+		Token:     maybeEnv(githubAPITokenEnv, ""),
+		DryRun:    stringToBool(maybeEnv(dryRunEnv, "false")),
+		StartTime: startTimeTime,
+		EndTime:   endTimeTime,
 	}
 }
 
@@ -51,4 +65,8 @@ func maybeEnv(envKey, defaultValue string) string {
 		return defaultValue
 	}
 	return v
+}
+
+func stringToBool(input string) bool {
+	return input == "true"
 }


### PR DESCRIPTION
The docs issue generation (DIG) script now runs nightly and uses a start and end time to calculate the PRs it needs to scan to determine if a docs issue must be created. This also utilizes GraphQL queries against GitHub's GraphQL API.

Release note: None

Fixes: #72910