### PR TITLE
sql: fix logic test multiline and tabbed  output

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -3602,11 +3602,36 @@ func (t *logicTest) formatValues(vals []string, valsPerLine int) []string {
 	var buf bytes.Buffer
 	tw := tabwriter.NewWriter(&buf, 2, 1, 2, ' ', 0)
 
-	for line := 0; line < len(vals)/valsPerLine; line++ {
+	numLines := len(vals) / valsPerLine
+	for line := 0; line < numLines; line++ {
+		maxSubLines := 0
+		lineOffset := line * valsPerLine
+
+		// Split multi-line values into sublines to output correctly formatted rows.
+		lineSubLines := make([][]string, valsPerLine)
 		for i := 0; i < valsPerLine; i++ {
-			fmt.Fprintf(tw, "%s\t", vals[line*valsPerLine+i])
+			cellSubLines := strings.Split(vals[lineOffset+i], "\n")
+			lineSubLines[i] = cellSubLines
+			numSubLines := len(cellSubLines)
+			if numSubLines > maxSubLines {
+				maxSubLines = numSubLines
+			}
 		}
-		fmt.Fprint(tw, "\n")
+
+		for j := 0; j < maxSubLines; j++ {
+			for i := 0; i < len(lineSubLines); i++ {
+				cellSubLines := lineSubLines[i]
+				// If a value's #sublines < #maxSubLines, an empty cell (just a "\t") is written to preserve columns.
+				if j < len(cellSubLines) {
+					cellSubLine := cellSubLines[j]
+					// Replace tabs with spaces to prevent them from being interpreted by tabwriter.
+					cellSubLine = strings.ReplaceAll(cellSubLine, "\t", "  ")
+					fmt.Fprint(tw, cellSubLine)
+				}
+				fmt.Fprint(tw, "\t")
+			}
+			fmt.Fprint(tw, "\n")
+		}
 	}
 	_ = tw.Flush()
 

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -3496,13 +3496,13 @@ query TT
 SHOW CREATE osagg_view
 ----
 osagg_view  CREATE VIEW public.osagg_view (
-            disc,
-            cont
-) AS SELECT
-    percentile_disc(0.50)WITHIN GROUP (ORDER BY f),
-    percentile_cont(0.50)WITHIN GROUP (ORDER BY f DESC)
-  FROM
-    test.public.osagg
+              disc,
+              cont
+            ) AS SELECT
+                percentile_disc(0.50)WITHIN GROUP (ORDER BY f),
+                percentile_cont(0.50)WITHIN GROUP (ORDER BY f DESC)
+              FROM
+                test.public.osagg
 
 # Test malformed ordered-set aggregation.
 statement error ordered-set aggregations must have a WITHIN GROUP clause containing one ORDER BY column

--- a/pkg/sql/logictest/testdata/logic_test/alias_types
+++ b/pkg/sql/logictest/testdata/logic_test/alias_types
@@ -11,13 +11,13 @@ SHOW CREATE TABLE aliases
 ----
 table_name  create_statement
 aliases     CREATE TABLE public.aliases (
-            a OID NULL,
-            b NAME NULL,
-            rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-            CONSTRAINT aliases_pkey PRIMARY KEY (rowid ASC),
-            FAMILY "primary" (a, rowid),
-            FAMILY fam_1_b (b)
-)
+              a OID NULL,
+              b NAME NULL,
+              rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+              CONSTRAINT aliases_pkey PRIMARY KEY (rowid ASC),
+              FAMILY "primary" (a, rowid),
+              FAMILY fam_1_b (b)
+            )
 
 statement ok
 INSERT INTO aliases VALUES (100, 'abc')

--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -72,11 +72,11 @@ show create table t
 ----
 table_name  create_statement
 t           CREATE TABLE public.t (
-            a INT8 NOT NULL,
-            i INT8 NULL,
-            CONSTRAINT t_pkey PRIMARY KEY (a ASC),
-            INDEX idx2 (i ASC)
-)
+              a INT8 NOT NULL,
+              i INT8 NULL,
+              CONSTRAINT t_pkey PRIMARY KEY (a ASC),
+              INDEX idx2 (i ASC)
+            )
 
 statement ok
 ALTER TABLE t RENAME COLUMN i TO b
@@ -266,13 +266,13 @@ query TT
 SHOW CREATE TABLE t6
 ----
 t6  CREATE TABLE public.t6 (
-    id INT8 NULL,
-    id2 STRING NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    CONSTRAINT t6_pkey PRIMARY KEY (rowid ASC),
-    FAMILY f1 (id, rowid),
-    FAMILY f2 (id2)
-)
+      id INT8 NULL,
+      id2 STRING NULL,
+      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+      CONSTRAINT t6_pkey PRIMARY KEY (rowid ASC),
+      FAMILY f1 (id, rowid),
+      FAMILY f2 (id2)
+    )
 
 # Ensure the type of the default column is checked
 statement ok
@@ -298,10 +298,10 @@ query TT
 SHOW CREATE TABLE t8
 ----
 t8  CREATE TABLE public.t8 (
-    x STRING NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    CONSTRAINT t8_pkey PRIMARY KEY (rowid ASC)
-)
+      x STRING NULL,
+      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+      CONSTRAINT t8_pkey PRIMARY KEY (rowid ASC)
+    )
 
 # Ensure ALTER COLUMN TYPE is disallowed if column is part of primary key.
 statement ok
@@ -387,12 +387,12 @@ show create table t17
 ----
 table_name  create_statement
 t17         CREATE TABLE public.t17 (
-            x STRING NULL DEFAULT 'HELLO':::STRING,
-            y STRING NULL ON UPDATE 'HELLO':::STRING,
-            rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-            CONSTRAINT t17_pkey PRIMARY KEY (rowid ASC),
-            FAMILY f1 (x, y, rowid)
-)
+              x STRING NULL DEFAULT 'HELLO':::STRING,
+              y STRING NULL ON UPDATE 'HELLO':::STRING,
+              rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+              CONSTRAINT t17_pkey PRIMARY KEY (rowid ASC),
+              FAMILY f1 (x, y, rowid)
+            )
 
 
 # Ensure ALTER COLUMN TYPE fails if the column is part of an FK relationship.
@@ -468,10 +468,10 @@ show create table t24
 ----
 table_name  create_statement
 t24         CREATE TABLE public.t24 (
-            x STRING NULL,
-            rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-            CONSTRAINT t24_pkey PRIMARY KEY (rowid ASC)
-)
+              x STRING NULL,
+              rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+              CONSTRAINT t24_pkey PRIMARY KEY (rowid ASC)
+            )
 
 # Ensure USING EXPRESSION rolls back if the USING EXPRESSION does not conform
 # to the new type of the column.

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -222,12 +222,12 @@ query TT
 SHOW CREATE t
 ----
 t  CREATE TABLE public.t (
-   rowid INT8 NOT NULL,
-   y INT8 NOT NULL,
-   CONSTRAINT t_pkey PRIMARY KEY (y ASC),
-   UNIQUE INDEX t_rowid_key (rowid ASC),
-   FAMILY fam_0_rowid_y (rowid, y)
-)
+     rowid INT8 NOT NULL,
+     y INT8 NOT NULL,
+     CONSTRAINT t_pkey PRIMARY KEY (y ASC),
+     UNIQUE INDEX t_rowid_key (rowid ASC),
+     FAMILY fam_0_rowid_y (rowid, y)
+   )
 
 subtest index_rewrites
 # Test that indexes that need to get rewritten indeed get rewritten.
@@ -261,23 +261,23 @@ query TT
 SHOW CREATE t
 ----
 t  CREATE TABLE public.t (
-   x INT8 NOT NULL,
-   y INT8 NOT NULL,
-   z INT8 NOT NULL,
-   w INT8 NULL,
-   v JSONB NULL,
-   crdb_internal_z_shard_4 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(z)), 4:::INT8)) VIRTUAL,
-   CONSTRAINT t_pkey PRIMARY KEY (y ASC),
-   UNIQUE INDEX i3 (z ASC) STORING (y),
-   UNIQUE INDEX t_x_key (x ASC),
-   INDEX i1 (w ASC),
-   INDEX i2 (y ASC),
-   UNIQUE INDEX i4 (z ASC),
-   UNIQUE INDEX i5 (w ASC) STORING (y),
-   INVERTED INDEX i6 (v),
-   INDEX i7 (z ASC) USING HASH WITH (bucket_count=4),
-   FAMILY fam_0_x_y_z_w_v (x, y, z, w, v)
-)
+     x INT8 NOT NULL,
+     y INT8 NOT NULL,
+     z INT8 NOT NULL,
+     w INT8 NULL,
+     v JSONB NULL,
+     crdb_internal_z_shard_4 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(z)), 4:::INT8)) VIRTUAL,
+     CONSTRAINT t_pkey PRIMARY KEY (y ASC),
+     UNIQUE INDEX i3 (z ASC) STORING (y),
+     UNIQUE INDEX t_x_key (x ASC),
+     INDEX i1 (w ASC),
+     INDEX i2 (y ASC),
+     UNIQUE INDEX i4 (z ASC),
+     UNIQUE INDEX i5 (w ASC) STORING (y),
+     INVERTED INDEX i6 (v),
+     INDEX i7 (z ASC) USING HASH WITH (bucket_count=4),
+     FAMILY fam_0_x_y_z_w_v (x, y, z, w, v)
+   )
 
 # Test that the indexes we expect got rewritten. All but i3 should have been rewritten,
 # so all but i3's indexID should be larger than 7.
@@ -423,16 +423,16 @@ query TT
 SHOW CREATE t
 ----
 t  CREATE TABLE public.t (
-   x INT8 NOT NULL,
-   y INT8 NOT NULL,
-   z INT8 NULL,
-   crdb_internal_z_shard_5 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(z)), 5:::INT8)) VIRTUAL,
-   crdb_internal_y_shard_10 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(y)), 10:::INT8)) VIRTUAL,
-   CONSTRAINT t_pkey PRIMARY KEY (y ASC) USING HASH WITH (bucket_count=10),
-   UNIQUE INDEX t_x_key (x ASC),
-   INDEX i1 (z ASC) USING HASH WITH (bucket_count=5),
-   FAMILY fam_0_x_y_z (x, y, z)
-)
+     x INT8 NOT NULL,
+     y INT8 NOT NULL,
+     z INT8 NULL,
+     crdb_internal_z_shard_5 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(z)), 5:::INT8)) VIRTUAL,
+     crdb_internal_y_shard_10 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(y)), 10:::INT8)) VIRTUAL,
+     CONSTRAINT t_pkey PRIMARY KEY (y ASC) USING HASH WITH (bucket_count=10),
+     UNIQUE INDEX t_x_key (x ASC),
+     INDEX i1 (z ASC) USING HASH WITH (bucket_count=5),
+     FAMILY fam_0_x_y_z (x, y, z)
+   )
 
 query T
 SELECT * FROM [EXPLAIN INSERT INTO t VALUES (4, 5, 6)] OFFSET 2
@@ -489,15 +489,15 @@ query TT
 SHOW CREATE t
 ----
 t  CREATE TABLE public.t (
-   crdb_internal_x_shard_5 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(x)), 5:::INT8)) VIRTUAL,
-   x INT8 NOT NULL,
-   y INT8 NOT NULL,
-   z INT8 NULL,
-   CONSTRAINT t_pkey PRIMARY KEY (y ASC),
-   UNIQUE INDEX t_x_key (x ASC) USING HASH WITH (bucket_count=5),
-   INDEX i (z ASC),
-   FAMILY fam_0_x_y_z (x, y, z)
-)
+     crdb_internal_x_shard_5 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(x)), 5:::INT8)) VIRTUAL,
+     x INT8 NOT NULL,
+     y INT8 NOT NULL,
+     z INT8 NULL,
+     CONSTRAINT t_pkey PRIMARY KEY (y ASC),
+     UNIQUE INDEX t_x_key (x ASC) USING HASH WITH (bucket_count=5),
+     INDEX i (z ASC),
+     FAMILY fam_0_x_y_z (x, y, z)
+   )
 
 query III
 SELECT * FROM t@t_x_key
@@ -520,10 +520,10 @@ query TT
 SHOW CREATE t
 ----
 t  CREATE TABLE public.t (
-   rowid INT8 NOT NULL,
-   rowid_1 INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   CONSTRAINT t_pkey PRIMARY KEY (rowid_1 ASC)
-)
+     rowid INT8 NOT NULL,
+     rowid_1 INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+     CONSTRAINT t_pkey PRIMARY KEY (rowid_1 ASC)
+   )
 
 statement ok
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (rowid)
@@ -534,9 +534,9 @@ query TT
 SHOW CREATE t
 ----
 t  CREATE TABLE public.t (
-   rowid INT8 NOT NULL,
-   CONSTRAINT t_pkey PRIMARY KEY (rowid ASC)
-)
+     rowid INT8 NOT NULL,
+     CONSTRAINT t_pkey PRIMARY KEY (rowid ASC)
+   )
 
 # Regression for old primary key not using PrimaryIndexEncoding as its encoding type.
 subtest encoding_bug
@@ -622,9 +622,9 @@ query TT
 SHOW CREATE t
 ----
 t  CREATE TABLE public.t (
-   x INT8 NOT NULL,
-   CONSTRAINT t_pkey PRIMARY KEY (x ASC)
-)
+     x INT8 NOT NULL,
+     CONSTRAINT t_pkey PRIMARY KEY (x ASC)
+   )
 
 statement ok
 DROP TABLE IF EXISTS t;
@@ -639,11 +639,11 @@ query TT
 SHOW CREATE t
 ----
 t  CREATE TABLE public.t (
-   x INT8 NOT NULL,
-   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   crdb_internal_x_shard_4 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(x)), 4:::INT8)) VIRTUAL,
-   CONSTRAINT t_pkey PRIMARY KEY (x ASC) USING HASH WITH (bucket_count=4)
-)
+     x INT8 NOT NULL,
+     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+     crdb_internal_x_shard_4 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(x)), 4:::INT8)) VIRTUAL,
+     CONSTRAINT t_pkey PRIMARY KEY (x ASC) USING HASH WITH (bucket_count=4)
+   )
 
 statement ok
 DROP TABLE IF EXISTS t;
@@ -660,9 +660,9 @@ query TT
 SHOW CREATE t
 ----
 t  CREATE TABLE public.t (
-   x INT8 NOT NULL,
-   CONSTRAINT my_pk PRIMARY KEY (x ASC)
-)
+     x INT8 NOT NULL,
+     CONSTRAINT my_pk PRIMARY KEY (x ASC)
+   )
 
 statement ok
 CREATE INDEX i ON t (x);
@@ -734,12 +734,12 @@ query TT
 SHOW CREATE t
 ----
 t  CREATE TABLE public.t (
-   x INT8 NOT NULL,
-   y INT8 NOT NULL,
-   CONSTRAINT t_pkey_v2 PRIMARY KEY (y ASC),
-   FAMILY fam_0_x (x),
-   FAMILY fam_1_y (y)
-)
+     x INT8 NOT NULL,
+     y INT8 NOT NULL,
+     CONSTRAINT t_pkey_v2 PRIMARY KEY (y ASC),
+     FAMILY fam_0_x (x),
+     FAMILY fam_1_y (y)
+   )
 
 statement ok
 ALTER TABLE t ADD CONSTRAINT IF NOT EXISTS "t_pkey" PRIMARY KEY (x)
@@ -786,12 +786,12 @@ query TT
 SHOW CREATE t
 ----
 t  CREATE TABLE public.t (
-   x INT8 NOT NULL,
-   y INT8 NOT NULL,
-   CONSTRAINT t_pkey_v2 PRIMARY KEY (y ASC),
-   FAMILY fam_0_x (x),
-   FAMILY fam_1_y (y)
-)
+     x INT8 NOT NULL,
+     y INT8 NOT NULL,
+     CONSTRAINT t_pkey_v2 PRIMARY KEY (y ASC),
+     FAMILY fam_0_x (x),
+     FAMILY fam_1_y (y)
+   )
 
 # Ensure that we can't use a table with a dropped primary key
 # in any DML statements.
@@ -946,13 +946,13 @@ query TT
 SHOW CREATE t
 ----
 t  CREATE TABLE public.t (
-   x INT8 NOT NULL,
-   y INT8 NULL,
-   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   CONSTRAINT t_pkey PRIMARY KEY (x ASC),
-   INDEX t_y_idx (y ASC),
-   FAMILY fam_0_x_y_rowid (x, y, rowid)
-)
+     x INT8 NOT NULL,
+     y INT8 NULL,
+     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+     CONSTRAINT t_pkey PRIMARY KEY (x ASC),
+     INDEX t_y_idx (y ASC),
+     FAMILY fam_0_x_y_rowid (x, y, rowid)
+   )
 
 # Ensure that index y got rewritten. If it was not rewritten,
 # it would have an id less than 3.
@@ -983,13 +983,13 @@ query TT
 SHOW CREATE t
 ----
 t  CREATE TABLE public.t (
-   x INT8 NOT NULL,
-   y INT8 NULL,
-   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   CONSTRAINT t_pkey PRIMARY KEY (x ASC),
-   INDEX t_y_idx (y ASC),
-   FAMILY fam_0_x_y_rowid (x, y, rowid)
-)
+     x INT8 NOT NULL,
+     y INT8 NULL,
+     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+     CONSTRAINT t_pkey PRIMARY KEY (x ASC),
+     INDEX t_y_idx (y ASC),
+     FAMILY fam_0_x_y_rowid (x, y, rowid)
+   )
 
 # Ensure that index y got rewritten. If it was not rewritten,
 # it would have an id less than 3.
@@ -1024,17 +1024,17 @@ query TT
 SHOW CREATE t
 ----
 t  CREATE TABLE public.t (
-   x INT8 NOT NULL,
-   y INT8 NULL,
-   z INT8 NULL,
-   w INT8 NULL,
-   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   CONSTRAINT t_pkey PRIMARY KEY (x ASC),
-   INDEX i1 (y ASC),
-   UNIQUE INDEX i2 (z ASC),
-   INDEX i3 (w ASC) STORING (y, z),
-   FAMILY fam_0_x_y_z_w_rowid (x, y, z, w, rowid)
-)
+     x INT8 NOT NULL,
+     y INT8 NULL,
+     z INT8 NULL,
+     w INT8 NULL,
+     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+     CONSTRAINT t_pkey PRIMARY KEY (x ASC),
+     INDEX i1 (y ASC),
+     UNIQUE INDEX i2 (z ASC),
+     INDEX i3 (w ASC) STORING (y, z),
+     FAMILY fam_0_x_y_z_w_rowid (x, y, z, w, rowid)
+   )
 
 # All index id's should be larger than 4.
 query IT
@@ -1061,11 +1061,11 @@ query TT
 SHOW CREATE t
 ----
 t  CREATE TABLE public.t (
-   crdb_internal_x_shard_2 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(x)), 2:::INT8)) VIRTUAL,
-   x INT8 NOT NULL,
-   crdb_internal_x_shard_3 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(x)), 3:::INT8)) VIRTUAL,
-   CONSTRAINT t_pkey PRIMARY KEY (x ASC) USING HASH WITH (bucket_count=3)
-)
+     crdb_internal_x_shard_2 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(x)), 2:::INT8)) VIRTUAL,
+     x INT8 NOT NULL,
+     crdb_internal_x_shard_3 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(x)), 3:::INT8)) VIRTUAL,
+     CONSTRAINT t_pkey PRIMARY KEY (x ASC) USING HASH WITH (bucket_count=3)
+   )
 
 # Changes on a hash sharded index that change the columns will cause the old
 # primary key to be copied.
@@ -1082,14 +1082,14 @@ query TT
 SHOW CREATE t
 ----
 t  CREATE TABLE public.t (
-   crdb_internal_x_shard_2 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(x)), 2:::INT8)) VIRTUAL,
-   x INT8 NOT NULL,
-   y INT8 NOT NULL,
-   crdb_internal_y_shard_2 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(y)), 2:::INT8)) VIRTUAL,
-   CONSTRAINT t_pkey PRIMARY KEY (y ASC) USING HASH WITH (bucket_count=2),
-   UNIQUE INDEX t_x_key (x ASC) USING HASH WITH (bucket_count=2),
-   FAMILY fam_0_x_y (x, y)
-)
+     crdb_internal_x_shard_2 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(x)), 2:::INT8)) VIRTUAL,
+     x INT8 NOT NULL,
+     y INT8 NOT NULL,
+     crdb_internal_y_shard_2 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(y)), 2:::INT8)) VIRTUAL,
+     CONSTRAINT t_pkey PRIMARY KEY (y ASC) USING HASH WITH (bucket_count=2),
+     UNIQUE INDEX t_x_key (x ASC) USING HASH WITH (bucket_count=2),
+     FAMILY fam_0_x_y (x, y)
+   )
 
 # Regression for #49079.
 statement ok
@@ -1282,13 +1282,13 @@ query TT
 SHOW CREATE TABLE table_with_virtual_cols
 ----
 table_with_virtual_cols  CREATE TABLE public.table_with_virtual_cols (
-                         id INT8 NOT NULL,
-                         new_pk INT8 NOT NULL,
-                         virtual_col INT8 NULL AS (1:::INT8) VIRTUAL,
-                         CONSTRAINT table_with_virtual_cols_pkey PRIMARY KEY (new_pk ASC),
-                         UNIQUE INDEX table_with_virtual_cols_id_key (id ASC),
-                         FAMILY fam_0_id_new_pk (id, new_pk)
-)
+                           id INT8 NOT NULL,
+                           new_pk INT8 NOT NULL,
+                           virtual_col INT8 NULL AS (1:::INT8) VIRTUAL,
+                           CONSTRAINT table_with_virtual_cols_pkey PRIMARY KEY (new_pk ASC),
+                           UNIQUE INDEX table_with_virtual_cols_id_key (id ASC),
+                           FAMILY fam_0_id_new_pk (id, new_pk)
+                         )
 
 # Test that we do not create new indexes for the old primary key when going
 # from sharded to non-sharded and back.
@@ -1397,12 +1397,12 @@ query T
 SELECT @2 FROM [SHOW CREATE TABLE t];
 ----
 CREATE TABLE public.t (
-   a INT8 NOT NULL,
-   b INT8 NOT NULL,
-   k INT8 NOT NULL AS (a + b) VIRTUAL,
-   CONSTRAINT t_pkey PRIMARY KEY (k ASC),
-   UNIQUE INDEX t_a_key (a ASC),
-   INDEX t_idx_b_k (b ASC, k ASC)
+  a INT8 NOT NULL,
+  b INT8 NOT NULL,
+  k INT8 NOT NULL AS (a + b) VIRTUAL,
+  CONSTRAINT t_pkey PRIMARY KEY (k ASC),
+  UNIQUE INDEX t_a_key (a ASC),
+  INDEX t_idx_b_k (b ASC, k ASC)
 )
 
 query III colnames,rowsort
@@ -1433,13 +1433,13 @@ query T
 SELECT @2 FROM [SHOW CREATE TABLE t];
 ----
 CREATE TABLE public.t (
-   a INT8 NOT NULL,
-   b INT8 NOT NULL,
-   k INT8 NOT NULL AS (a + b) VIRTUAL,
-   CONSTRAINT t_pkey PRIMARY KEY (b ASC, k ASC),
-   UNIQUE INDEX t_k_key (k ASC),
-   UNIQUE INDEX t_a_key (a ASC),
-   INDEX t_idx_b_k (b ASC, k ASC)
+  a INT8 NOT NULL,
+  b INT8 NOT NULL,
+  k INT8 NOT NULL AS (a + b) VIRTUAL,
+  CONSTRAINT t_pkey PRIMARY KEY (b ASC, k ASC),
+  UNIQUE INDEX t_k_key (k ASC),
+  UNIQUE INDEX t_a_key (a ASC),
+  INDEX t_idx_b_k (b ASC, k ASC)
 )
 
 query III colnames,rowsort
@@ -1477,14 +1477,14 @@ query T
 SELECT @2 FROM [SHOW CREATE TABLE t];
 ----
 CREATE TABLE public.t (
-   a INT8 NOT NULL,
-   b INT8 NOT NULL,
-   k INT8 NOT NULL AS (a + b) VIRTUAL,
-   CONSTRAINT t_pkey PRIMARY KEY (a ASC),
-   UNIQUE INDEX t_b_k_key (b ASC, k ASC),
-   UNIQUE INDEX t_k_key (k ASC),
-   UNIQUE INDEX t_a_key (a ASC),
-   INDEX t_idx_b_k (b ASC, k ASC)
+  a INT8 NOT NULL,
+  b INT8 NOT NULL,
+  k INT8 NOT NULL AS (a + b) VIRTUAL,
+  CONSTRAINT t_pkey PRIMARY KEY (a ASC),
+  UNIQUE INDEX t_b_k_key (b ASC, k ASC),
+  UNIQUE INDEX t_k_key (k ASC),
+  UNIQUE INDEX t_a_key (a ASC),
+  INDEX t_idx_b_k (b ASC, k ASC)
 )
 
 query III colnames,rowsort
@@ -1551,12 +1551,12 @@ query T
 SELECT @2 FROM [SHOW CREATE TABLE t_test_param]
 ----
 CREATE TABLE public.t_test_param (
-   a INT8 NOT NULL,
-   b INT8 NOT NULL,
-   crdb_internal_b_shard_5 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(b)), 5:::INT8)) VIRTUAL,
-   CONSTRAINT t_test_param_pkey PRIMARY KEY (b ASC) USING HASH WITH (bucket_count=5),
-   UNIQUE INDEX t_test_param_a_key (a ASC),
-   FAMILY fam_0_a_b (a, b)
+  a INT8 NOT NULL,
+  b INT8 NOT NULL,
+  crdb_internal_b_shard_5 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(b)), 5:::INT8)) VIRTUAL,
+  CONSTRAINT t_test_param_pkey PRIMARY KEY (b ASC) USING HASH WITH (bucket_count=5),
+  UNIQUE INDEX t_test_param_a_key (a ASC),
+  FAMILY fam_0_a_b (a, b)
 )
 
 subtest pkey-comment-carry-over

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -820,10 +820,10 @@ query TT
 show create table decomputed_column
 ----
 decomputed_column  CREATE TABLE public.decomputed_column (
-                   a INT8 NOT NULL,
-                   b INT8 NULL,
-                   CONSTRAINT decomputed_column_pkey PRIMARY KEY (a ASC)
-)
+                     a INT8 NOT NULL,
+                     b INT8 NULL,
+                     CONSTRAINT decomputed_column_pkey PRIMARY KEY (a ASC)
+                   )
 
 # Test for https://github.com/cockroachdb/cockroach/issues/26483
 # We try to create a unique column on an un-indexable type.
@@ -1159,12 +1159,12 @@ query TT
 SHOW CREATE t2
 ----
 t2  CREATE TABLE public.t2 (
-    y INT8 NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    x INT8 NULL,
-    CONSTRAINT t2_pkey PRIMARY KEY (rowid ASC),
-    CONSTRAINT t2_x_fkey FOREIGN KEY (x) REFERENCES public.t1(x)
-)
+      y INT8 NULL,
+      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+      x INT8 NULL,
+      CONSTRAINT t2_pkey PRIMARY KEY (rowid ASC),
+      CONSTRAINT t2_x_fkey FOREIGN KEY (x) REFERENCES public.t1(x)
+    )
 
 # Test that only one index gets created when adding a column
 # with references and unique.
@@ -1178,13 +1178,13 @@ query TT
 SHOW CREATE t3
 ----
 t3  CREATE TABLE public.t3 (
-    y INT8 NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    x INT8 NULL,
-    CONSTRAINT t3_pkey PRIMARY KEY (rowid ASC),
-    CONSTRAINT t3_x_fkey FOREIGN KEY (x) REFERENCES public.t1(x),
-    UNIQUE INDEX t3_x_key (x ASC)
-)
+      y INT8 NULL,
+      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+      x INT8 NULL,
+      CONSTRAINT t3_pkey PRIMARY KEY (rowid ASC),
+      CONSTRAINT t3_x_fkey FOREIGN KEY (x) REFERENCES public.t1(x),
+      UNIQUE INDEX t3_x_key (x ASC)
+    )
 
 # We allowed the foreign key validation code to look into the mutations
 # list to validate what columns / indexes can be used for foreign keys.
@@ -1221,11 +1221,11 @@ query TT
 SHOW CREATE t1
 ----
 t1  CREATE TABLE public.t1 (
-    x INT8 NOT NULL,
-    x2 INT8 NULL,
-    CONSTRAINT t1_pkey PRIMARY KEY (x ASC),
-    CONSTRAINT t1_x2_fkey FOREIGN KEY (x2) REFERENCES public.t1(x)
-)
+      x INT8 NOT NULL,
+      x2 INT8 NULL,
+      CONSTRAINT t1_pkey PRIMARY KEY (x ASC),
+      CONSTRAINT t1_x2_fkey FOREIGN KEY (x2) REFERENCES public.t1(x)
+    )
 
 statement error pq: insert on table "t1" violates foreign key constraint "t1_x2_fkey"
 INSERT INTO t1 VALUES (1, 2)
@@ -1245,12 +1245,12 @@ query TT
 SHOW CREATE t2
 ----
 t2  CREATE TABLE public.t2 (
-    y INT8 NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    x INT8 NULL,
-    CONSTRAINT t2_pkey PRIMARY KEY (rowid ASC),
-    CONSTRAINT t2_x_fkey FOREIGN KEY (x) REFERENCES public.t1(x) NOT VALID
-)
+      y INT8 NULL,
+      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+      x INT8 NULL,
+      CONSTRAINT t2_pkey PRIMARY KEY (rowid ASC),
+      CONSTRAINT t2_x_fkey FOREIGN KEY (x) REFERENCES public.t1(x) NOT VALID
+    )
 
 # Test that we can also add a column and then an FK in the same txn.
 statement ok
@@ -1268,12 +1268,12 @@ query TT
 SHOW CREATE t2
 ----
 t2  CREATE TABLE public.t2 (
-    y INT8 NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    x INT8 NULL,
-    CONSTRAINT t2_pkey PRIMARY KEY (rowid ASC),
-    CONSTRAINT t2_x_fkey FOREIGN KEY (x) REFERENCES public.t1(x) NOT VALID
-)
+      y INT8 NULL,
+      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+      x INT8 NULL,
+      CONSTRAINT t2_pkey PRIMARY KEY (rowid ASC),
+      CONSTRAINT t2_x_fkey FOREIGN KEY (x) REFERENCES public.t1(x) NOT VALID
+    )
 
 # Test that we can add a column and an index to an FK in the same txn.
 statement ok
@@ -1294,13 +1294,13 @@ query TT
 SHOW CREATE t2
 ----
 t2  CREATE TABLE public.t2 (
-    y INT8 NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    x INT8 NULL,
-    CONSTRAINT t2_pkey PRIMARY KEY (rowid ASC),
-    CONSTRAINT t2_x_fkey FOREIGN KEY (x) REFERENCES public.t1(x) NOT VALID,
-    INDEX t2_x_idx (x ASC)
-)
+      y INT8 NULL,
+      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+      x INT8 NULL,
+      CONSTRAINT t2_pkey PRIMARY KEY (rowid ASC),
+      CONSTRAINT t2_x_fkey FOREIGN KEY (x) REFERENCES public.t1(x) NOT VALID,
+      INDEX t2_x_idx (x ASC)
+    )
 
 # Test the above on a table not created in the same txn.
 statement ok
@@ -1321,13 +1321,13 @@ query TT
 SHOW CREATE t2
 ----
 t2  CREATE TABLE public.t2 (
-    y INT8 NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    x INT8 NULL,
-    CONSTRAINT t2_pkey PRIMARY KEY (rowid ASC),
-    CONSTRAINT t2_x_fkey FOREIGN KEY (x) REFERENCES public.t1(x),
-    INDEX t2_x_idx (x ASC)
-)
+      y INT8 NULL,
+      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+      x INT8 NULL,
+      CONSTRAINT t2_pkey PRIMARY KEY (rowid ASC),
+      CONSTRAINT t2_x_fkey FOREIGN KEY (x) REFERENCES public.t1(x),
+      INDEX t2_x_idx (x ASC)
+    )
 
 # Test that an FK can use a newly created index.
 statement ok
@@ -1347,12 +1347,12 @@ query TT
 SHOW CREATE t2
 ----
 t2  CREATE TABLE public.t2 (
-    x INT8 NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    CONSTRAINT t2_pkey PRIMARY KEY (rowid ASC),
-    CONSTRAINT t2_x_fkey FOREIGN KEY (x) REFERENCES public.t1(x),
-    INDEX t2_x_idx (x ASC)
-)
+      x INT8 NULL,
+      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+      CONSTRAINT t2_pkey PRIMARY KEY (rowid ASC),
+      CONSTRAINT t2_x_fkey FOREIGN KEY (x) REFERENCES public.t1(x),
+      INDEX t2_x_idx (x ASC)
+    )
 
 # Test when default column value leads to an FK violation.
 statement ok
@@ -1375,13 +1375,13 @@ query TT
 SHOW CREATE t2
 ----
 t2  CREATE TABLE public.t2 (
-    y INT8 NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    x INT8 NULL DEFAULT 1:::INT8,
-    CONSTRAINT t2_pkey PRIMARY KEY (rowid ASC),
-    CONSTRAINT t2_x_fkey FOREIGN KEY (x) REFERENCES public.t1(x),
-    UNIQUE INDEX t2_x_key (x ASC)
-)
+      y INT8 NULL,
+      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+      x INT8 NULL DEFAULT 1:::INT8,
+      CONSTRAINT t2_pkey PRIMARY KEY (rowid ASC),
+      CONSTRAINT t2_x_fkey FOREIGN KEY (x) REFERENCES public.t1(x),
+      UNIQUE INDEX t2_x_key (x ASC)
+    )
 
 # Regression 50069, computed exprs must only refer to columns inside the
 # current table.
@@ -1410,10 +1410,10 @@ query TT
 SHOW CREATE child
 ----
 child  CREATE TABLE public.child (
-       c INT8 NOT NULL,
-       CONSTRAINT child_pkey PRIMARY KEY (c ASC),
-       FAMILY fam_0_c_p (c)
-)
+         c INT8 NOT NULL,
+         CONSTRAINT child_pkey PRIMARY KEY (c ASC),
+         FAMILY fam_0_c_p (c)
+       )
 
 # Regression test for #52816.
 statement ok
@@ -1856,9 +1856,9 @@ query TT
 SHOW CREATE TABLE visible_table
 ----
 visible_table  CREATE TABLE public.visible_table (
-               a INT8 NOT NULL,
-               CONSTRAINT visible_table_pkey PRIMARY KEY (a ASC)
-)
+                 a INT8 NOT NULL,
+                 CONSTRAINT visible_table_pkey PRIMARY KEY (a ASC)
+               )
 
 statement ok
 ALTER TABLE visible_table ALTER COLUMN a SET NOT VISIBLE
@@ -1867,9 +1867,9 @@ query TT
 SHOW CREATE TABLE visible_table
 ----
 visible_table  CREATE TABLE public.visible_table (
-               a INT8 NOT VISIBLE NOT NULL,
-               CONSTRAINT visible_table_pkey PRIMARY KEY (a ASC)
-)
+                 a INT8 NOT VISIBLE NOT NULL,
+                 CONSTRAINT visible_table_pkey PRIMARY KEY (a ASC)
+               )
 
 subtest if_table_exists_already
 
@@ -1923,13 +1923,13 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE t67234]
 ----
 CREATE TABLE public.t67234 (
-   k INT8 NOT NULL,
-   a INT8 NULL,
-   b INT8 NULL,
-   CONSTRAINT t67234_pkey PRIMARY KEY (k ASC),
-   UNIQUE INDEX t67234_c1 (a ASC) WHERE b > 0:::INT8,
-   FAMILY fam_0_k_a_b (k, a, b),
-   CONSTRAINT t67234_c2 UNIQUE WITHOUT INDEX (b) WHERE a > 0:::INT8
+  k INT8 NOT NULL,
+  a INT8 NULL,
+  b INT8 NULL,
+  CONSTRAINT t67234_pkey PRIMARY KEY (k ASC),
+  UNIQUE INDEX t67234_c1 (a ASC) WHERE b > 0:::INT8,
+  FAMILY fam_0_k_a_b (k, a, b),
+  CONSTRAINT t67234_c2 UNIQUE WITHOUT INDEX (b) WHERE a > 0:::INT8
 )
 
 subtest generated_as_identity
@@ -1952,13 +1952,13 @@ query TT
 SHOW CREATE TABLE t
 ----
 t  CREATE TABLE public.t (
-   a INT8 NULL,
-   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   b INT8 NOT NULL GENERATED ALWAYS AS IDENTITY,
-   c INT8 NOT NULL GENERATED BY DEFAULT AS IDENTITY,
-   CONSTRAINT t_pkey PRIMARY KEY (rowid ASC),
-   UNIQUE INDEX t_a_key (a ASC)
-)
+     a INT8 NULL,
+     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+     b INT8 NOT NULL GENERATED ALWAYS AS IDENTITY,
+     c INT8 NOT NULL GENERATED BY DEFAULT AS IDENTITY,
+     CONSTRAINT t_pkey PRIMARY KEY (rowid ASC),
+     UNIQUE INDEX t_a_key (a ASC)
+   )
 
 statement ok
 INSERT INTO t (c) VALUES (2)
@@ -2022,13 +2022,13 @@ query TT
 SHOW CREATE TABLE t
 ----
 t  CREATE TABLE public.t (
-   a INT8 NULL,
-   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   b INT8 NOT NULL GENERATED BY DEFAULT AS IDENTITY (START 1 INCREMENT 3),
-   c INT8 NOT NULL GENERATED BY DEFAULT AS IDENTITY (START 1 INCREMENT 3 CACHE 10),
-   CONSTRAINT t_pkey PRIMARY KEY (rowid ASC),
-   UNIQUE INDEX t_a_key (a ASC)
-)
+     a INT8 NULL,
+     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+     b INT8 NOT NULL GENERATED BY DEFAULT AS IDENTITY (START 1 INCREMENT 3),
+     c INT8 NOT NULL GENERATED BY DEFAULT AS IDENTITY (START 1 INCREMENT 3 CACHE 10),
+     CONSTRAINT t_pkey PRIMARY KEY (rowid ASC),
+     UNIQUE INDEX t_a_key (a ASC)
+   )
 
 statement ok
 ALTER TABLE t DROP COLUMN c
@@ -2075,9 +2075,9 @@ query TT
 SHOW CREATE TABLE t
 ----
 t  CREATE TABLE public.t (
-   id INT8 NOT NULL,
-   CONSTRAINT t_pkey PRIMARY KEY (id ASC)
-)
+     id INT8 NOT NULL,
+     CONSTRAINT t_pkey PRIMARY KEY (id ASC)
+   )
 
 # Table has a PRIMARY KEY named index; check it errors when assinging PRIMARY KEY to id.
 statement ok
@@ -2611,10 +2611,10 @@ query TT
 SHOW CREATE TABLE tbl
 ----
 tbl  CREATE TABLE public.tbl (
-     i INT8 NOT NULL,
-     j INT8 NOT NULL DEFAULT nextval('public.s1'::REGCLASS) ON UPDATE nextval('public.s2'::REGCLASS),
-     CONSTRAINT tbl_pkey PRIMARY KEY (i ASC)
-)
+       i INT8 NOT NULL,
+       j INT8 NOT NULL DEFAULT nextval('public.s1'::REGCLASS) ON UPDATE nextval('public.s2'::REGCLASS),
+       CONSTRAINT tbl_pkey PRIMARY KEY (i ASC)
+     )
 
 # Now use `ALTER COLUMN` to swap the use of sequence 's1' and 's2'
 
@@ -2628,10 +2628,10 @@ query TT
 SHOW CREATE TABLE tbl
 ----
 tbl  CREATE TABLE public.tbl (
-     i INT8 NOT NULL,
-     j INT8 NOT NULL DEFAULT nextval('public.s2'::REGCLASS) ON UPDATE nextval('public.s1'::REGCLASS),
-     CONSTRAINT tbl_pkey PRIMARY KEY (i ASC)
-)
+       i INT8 NOT NULL,
+       j INT8 NOT NULL DEFAULT nextval('public.s2'::REGCLASS) ON UPDATE nextval('public.s1'::REGCLASS),
+       CONSTRAINT tbl_pkey PRIMARY KEY (i ASC)
+     )
 
 # Verify that adding not-null physical column with a default or computed expression
 # fails if the expression evaluates to NULL.

--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -470,10 +470,10 @@ query TT
 SHOW CREATE TABLE a
 ----
 a  CREATE TABLE public.a (
-   b INT8[] NULL,
-   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   CONSTRAINT a_pkey PRIMARY KEY (rowid ASC)
-)
+     b INT8[] NULL,
+     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+     CONSTRAINT a_pkey PRIMARY KEY (rowid ASC)
+   )
 
 statement ok
 DROP TABLE a
@@ -530,10 +530,10 @@ query TT
 SHOW CREATE TABLE a
 ----
 a  CREATE TABLE public.a (
-   b INT8[] NULL,
-   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   CONSTRAINT a_pkey PRIMARY KEY (rowid ASC)
-)
+     b INT8[] NULL,
+     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+     CONSTRAINT a_pkey PRIMARY KEY (rowid ASC)
+   )
 
 statement error could not parse "foo" as type int
 INSERT INTO a VALUES (ARRAY['foo'])
@@ -602,10 +602,10 @@ query TT
 SHOW CREATE TABLE a
 ----
 a  CREATE TABLE public.a (
-   b INT2[] NULL,
-   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   CONSTRAINT a_pkey PRIMARY KEY (rowid ASC)
-)
+     b INT2[] NULL,
+     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+     CONSTRAINT a_pkey PRIMARY KEY (rowid ASC)
+   )
 
 statement error integer out of range for type int2
 INSERT INTO a VALUES (ARRAY[100000])

--- a/pkg/sql/logictest/testdata/logic_test/bit
+++ b/pkg/sql/logictest/testdata/logic_test/bit
@@ -16,13 +16,13 @@ SHOW CREATE TABLE bits
 ----
 table_name  create_statement
 bits        CREATE TABLE public.bits (
-            a BIT NULL,
-            b BIT(4) NULL,
-            c VARBIT NULL,
-            d VARBIT(4) NULL,
-            rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-            CONSTRAINT bits_pkey PRIMARY KEY (rowid ASC)
-)
+              a BIT NULL,
+              b BIT(4) NULL,
+              c VARBIT NULL,
+              d VARBIT(4) NULL,
+              rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+              CONSTRAINT bits_pkey PRIMARY KEY (rowid ASC)
+            )
 
 subtest bit_fixed1
 
@@ -266,9 +266,9 @@ query T
 SELECT create_statement FROM [SHOW CREATE obitsa]
 ----
 CREATE TABLE public.obitsa (
-   x VARBIT(20)[] NULL,
-   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   CONSTRAINT obitsa_pkey PRIMARY KEY (rowid ASC)
+  x VARBIT(20)[] NULL,
+  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+  CONSTRAINT obitsa_pkey PRIMARY KEY (rowid ASC)
 )
 
 # Check unindexed ordering.

--- a/pkg/sql/logictest/testdata/logic_test/case_sensitive_names
+++ b/pkg/sql/logictest/testdata/logic_test/case_sensitive_names
@@ -198,10 +198,10 @@ CREATE VIEW XV AS SELECT X, "Y" FROM foo
 query TT
 SHOW CREATE VIEW xv
 ----
-xv                                       CREATE VIEW public.xv (
-                                         x,
-                                         "Y"
-) AS SELECT x, "Y" FROM test.public.foo
+xv  CREATE VIEW public.xv (
+      x,
+      "Y"
+    ) AS SELECT x, "Y" FROM test.public.foo
 
 query error pgcode 42P01 relation "XV" does not exist
 SHOW CREATE VIEW "XV"
@@ -212,10 +212,10 @@ CREATE VIEW "YV" AS SELECT X, "Y" FROM foo
 query TT
 SHOW CREATE VIEW "YV"
 ----
-"YV"                                     CREATE VIEW public."YV" (
-                                         x,
-                                         "Y"
-) AS SELECT x, "Y" FROM test.public.foo
+"YV"  CREATE VIEW public."YV" (
+        x,
+        "Y"
+      ) AS SELECT x, "Y" FROM test.public.foo
 
 query error pgcode 42P01 relation "yv" does not exist
 SHOW CREATE VIEW YV

--- a/pkg/sql/logictest/testdata/logic_test/check_constraints
+++ b/pkg/sql/logictest/testdata/logic_test/check_constraints
@@ -216,17 +216,17 @@ query TT
 SHOW CREATE TABLE t7
 ----
 t7  CREATE TABLE public.t7 (
-    x INT8 NULL,
-    y INT8 NULL,
-    z INT8 NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    CONSTRAINT t7_pkey PRIMARY KEY (rowid ASC),
-    CONSTRAINT check_x CHECK (x > 0:::INT8),
-    CONSTRAINT check_x_y CHECK ((x + y) > 0:::INT8),
-    CONSTRAINT check_y_z CHECK ((y + z) > 0:::INT8),
-    CONSTRAINT check_y_z1 CHECK ((y + z) = 0:::INT8),
-    CONSTRAINT named_constraint CHECK (z = 1:::INT8)
-)
+      x INT8 NULL,
+      y INT8 NULL,
+      z INT8 NULL,
+      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+      CONSTRAINT t7_pkey PRIMARY KEY (rowid ASC),
+      CONSTRAINT check_x CHECK (x > 0:::INT8),
+      CONSTRAINT check_x_y CHECK ((x + y) > 0:::INT8),
+      CONSTRAINT check_y_z CHECK ((y + z) > 0:::INT8),
+      CONSTRAINT check_y_z1 CHECK ((y + z) = 0:::INT8),
+      CONSTRAINT named_constraint CHECK (z = 1:::INT8)
+    )
 
 # Check that table references are dequalified in their stored representation.
 
@@ -254,13 +254,13 @@ query TT
 SHOW CREATE TABLE t8
 ----
 t8  CREATE TABLE public.t8 (
-    a INT8 NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    CONSTRAINT t8_pkey PRIMARY KEY (rowid ASC),
-    CONSTRAINT check_a CHECK (a > 0:::INT8),
-    CONSTRAINT check_a1 CHECK (a > 0:::INT8),
-    CONSTRAINT check_a2 CHECK (a > 0:::INT8)
-)
+      a INT8 NULL,
+      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+      CONSTRAINT t8_pkey PRIMARY KEY (rowid ASC),
+      CONSTRAINT check_a CHECK (a > 0:::INT8),
+      CONSTRAINT check_a1 CHECK (a > 0:::INT8),
+      CONSTRAINT check_a2 CHECK (a > 0:::INT8)
+    )
 
 statement ok
 CREATE DATABASE test2

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring
@@ -216,10 +216,10 @@ query TT
 SHOW CREATE TABLE t
 ----
 t  CREATE TABLE public.t (
-   a STRING COLLATE en NULL,
-   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   CONSTRAINT t_pkey PRIMARY KEY (rowid ASC)
-)
+     a STRING COLLATE en NULL,
+     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+     CONSTRAINT t_pkey PRIMARY KEY (rowid ASC)
+   )
 
 statement ok
 INSERT INTO t VALUES
@@ -361,14 +361,14 @@ query TT
 SHOW CREATE TABLE quoted_coll
 ----
 quoted_coll  CREATE TABLE public.quoted_coll (
-             a STRING COLLATE en NULL,
-             b STRING COLLATE en_US NULL,
-             c STRING COLLATE en_US NULL DEFAULT 'c':::STRING COLLATE en_US,
-             d STRING COLLATE en_u_ks_level1 NULL DEFAULT 'd':::STRING COLLATE en_u_ks_level1,
-             e STRING COLLATE en_US NULL AS (a COLLATE en_US) STORED,
-             rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-             CONSTRAINT quoted_coll_pkey PRIMARY KEY (rowid ASC)
-)
+               a STRING COLLATE en NULL,
+               b STRING COLLATE en_US NULL,
+               c STRING COLLATE en_US NULL DEFAULT 'c':::STRING COLLATE en_US,
+               d STRING COLLATE en_u_ks_level1 NULL DEFAULT 'd':::STRING COLLATE en_u_ks_level1,
+               e STRING COLLATE en_US NULL AS (a COLLATE en_US) STORED,
+               rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+               CONSTRAINT quoted_coll_pkey PRIMARY KEY (rowid ASC)
+             )
 
 # Regression for #46570.
 statement ok
@@ -467,10 +467,10 @@ query TT
 SHOW CREATE TABLE collation_name_case
 ----
 collation_name_case  CREATE TABLE public.collation_name_case (
-                     s STRING COLLATE en_US_u_ks_level2 NULL,
-                     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                     CONSTRAINT collation_name_case_pkey PRIMARY KEY (rowid ASC)
-)
+                       s STRING COLLATE en_US_u_ks_level2 NULL,
+                       rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                       CONSTRAINT collation_name_case_pkey PRIMARY KEY (rowid ASC)
+                     )
 
 statement error invalid locale en-US-u-ks-le"vel2: language: tag is not well-formed
 CREATE TABLE nocase_strings (s STRING COLLATE "en-US-u-ks-le""vel2");

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -13,12 +13,12 @@ query TT
 SHOW CREATE TABLE with_no_column_refs
 ----
 with_no_column_refs  CREATE TABLE public.with_no_column_refs (
-                     a INT8 NULL,
-                     b INT8 NULL,
-                     c INT8 NULL AS (3:::INT8) STORED,
-                     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                     CONSTRAINT with_no_column_refs_pkey PRIMARY KEY (rowid ASC)
-)
+                       a INT8 NULL,
+                       b INT8 NULL,
+                       c INT8 NULL AS (3:::INT8) STORED,
+                       rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                       CONSTRAINT with_no_column_refs_pkey PRIMARY KEY (rowid ASC)
+                     )
 
 statement ok
 CREATE TABLE extra_parens (
@@ -32,12 +32,12 @@ query TT
 SHOW CREATE TABLE extra_parens
 ----
 extra_parens  CREATE TABLE public.extra_parens (
-              a INT8 NULL,
-              b INT8 NULL,
-              c INT8 NULL AS (3:::INT8) STORED,
-              rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-              CONSTRAINT extra_parens_pkey PRIMARY KEY (rowid ASC)
-)
+                a INT8 NULL,
+                b INT8 NULL,
+                c INT8 NULL AS (3:::INT8) STORED,
+                rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                CONSTRAINT extra_parens_pkey PRIMARY KEY (rowid ASC)
+              )
 
 
 statement error cannot write directly to computed column "c"
@@ -86,13 +86,13 @@ query TT
 SHOW CREATE TABLE x
 ----
 x  CREATE TABLE public.x (
-   a INT8 NULL DEFAULT 3:::INT8,
-   b INT8 NULL DEFAULT 7:::INT8,
-   c INT8 NULL AS (a) STORED,
-   d INT8 NULL AS (a + b) STORED,
-   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   CONSTRAINT x_pkey PRIMARY KEY (rowid ASC)
-)
+     a INT8 NULL DEFAULT 3:::INT8,
+     b INT8 NULL DEFAULT 7:::INT8,
+     c INT8 NULL AS (a) STORED,
+     d INT8 NULL AS (a + b) STORED,
+     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+     CONSTRAINT x_pkey PRIMARY KEY (rowid ASC)
+   )
 
 query TTBTTTB colnames
 SHOW COLUMNS FROM x
@@ -715,11 +715,11 @@ query TT
 SHOW CREATE TABLE x
 ----
 x  CREATE TABLE public.x (
-   a INT8 NULL,
-   b INT8 NULL AS (a) STORED,
-   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   CONSTRAINT x_pkey PRIMARY KEY (rowid ASC)
-)
+     a INT8 NULL,
+     b INT8 NULL AS (a) STORED,
+     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+     CONSTRAINT x_pkey PRIMARY KEY (rowid ASC)
+   )
 
 statement ok
 DROP TABLE x
@@ -739,11 +739,11 @@ query TT
 SHOW CREATE TABLE x
 ----
 x  CREATE TABLE public.x (
-   c INT8 NULL,
-   b INT8 NULL AS (c) STORED,
-   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   CONSTRAINT x_pkey PRIMARY KEY (rowid ASC)
-)
+     c INT8 NULL,
+     b INT8 NULL AS (c) STORED,
+     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+     CONSTRAINT x_pkey PRIMARY KEY (rowid ASC)
+   )
 
 statement ok
 DROP TABLE x
@@ -779,12 +779,12 @@ query TT
 SHOW CREATE TABLE x
 ----
 x  CREATE TABLE public.x (
-   a INT8 NULL,
-   b INT8 NULL AS (a * 2:::INT8) STORED,
-   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   c INT8 NOT NULL AS (a + 4:::INT8) STORED,
-   CONSTRAINT x_pkey PRIMARY KEY (rowid ASC)
-)
+     a INT8 NULL,
+     b INT8 NULL AS (a * 2:::INT8) STORED,
+     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+     c INT8 NOT NULL AS (a + 4:::INT8) STORED,
+     CONSTRAINT x_pkey PRIMARY KEY (rowid ASC)
+   )
 
 statement ok
 INSERT INTO x VALUES (6)
@@ -913,11 +913,11 @@ query TT
 SHOW CREATE t42418
 ----
 t42418  CREATE TABLE public.t42418 (
-        x INT8 NULL AS (1:::INT8) STORED,
-        rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-        y INT8 NULL AS (1:::INT8) STORED,
-        CONSTRAINT t42418_pkey PRIMARY KEY (rowid ASC)
-)
+          x INT8 NULL AS (1:::INT8) STORED,
+          rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+          y INT8 NULL AS (1:::INT8) STORED,
+          CONSTRAINT t42418_pkey PRIMARY KEY (rowid ASC)
+        )
 
 # Tests for computed column rewrites.
 statement error context-dependent operators are not allowed in computed column
@@ -939,11 +939,11 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE trewrite]
 ----
 CREATE TABLE public.trewrite (
-   k INT8 NOT NULL,
-   ts TIMESTAMPTZ NULL,
-   c STRING NULL AS (to_char(timezone('utc':::STRING, ts))) STORED,
-   CONSTRAINT trewrite_pkey PRIMARY KEY (k ASC),
-   FAMILY fam_0_k_ts_c (k, ts, c)
+  k INT8 NOT NULL,
+  ts TIMESTAMPTZ NULL,
+  c STRING NULL AS (to_char(timezone('utc':::STRING, ts))) STORED,
+  CONSTRAINT trewrite_pkey PRIMARY KEY (k ASC),
+  FAMILY fam_0_k_ts_c (k, ts, c)
 )
 
 statement ok
@@ -959,11 +959,11 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE trewrite]
 ----
 CREATE TABLE public.trewrite (
-   k INT8 NOT NULL,
-   ts TIMESTAMPTZ NULL,
-   c STRING NULL AS (to_char(timezone('utc':::STRING, ts))) STORED,
-   CONSTRAINT trewrite_pkey PRIMARY KEY (k ASC),
-   FAMILY fam_0_k_ts (k, ts, c)
+  k INT8 NOT NULL,
+  ts TIMESTAMPTZ NULL,
+  c STRING NULL AS (to_char(timezone('utc':::STRING, ts))) STORED,
+  CONSTRAINT trewrite_pkey PRIMARY KEY (k ASC),
+  FAMILY fam_0_k_ts (k, ts, c)
 )
 
 statement ok
@@ -976,10 +976,10 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE trewrite_copy]
 ----
 CREATE TABLE public.trewrite_copy (
-   k INT8 NOT NULL,
-   ts TIMESTAMPTZ NULL,
-   c STRING NULL AS (to_char(timezone('utc':::STRING, ts))) STORED,
-   CONSTRAINT trewrite_pkey PRIMARY KEY (k ASC)
+  k INT8 NOT NULL,
+  ts TIMESTAMPTZ NULL,
+  c STRING NULL AS (to_char(timezone('utc':::STRING, ts))) STORED,
+  CONSTRAINT trewrite_pkey PRIMARY KEY (k ASC)
 )
 
 statement ok
@@ -1012,15 +1012,15 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE trewrite2]
 ----
 CREATE TABLE public.trewrite2 (
-   k INT8 NOT NULL,
-   ts TIMESTAMPTZ NULL,
-   b BYTES NULL,
-   str STRING NULL,
-   c1 STRING NULL AS (to_char(timezone('utc':::STRING, ts))) STORED,
-   c2 TIMESTAMP NULL AS (parse_timestamp(str)) STORED,
-   c3 INT8 NULL AS (mod(fnv32(b), 4:::INT8)) STORED,
-   CONSTRAINT trewrite2_pkey PRIMARY KEY (k ASC),
-   FAMILY fam_0_k_ts_b_str_c1_c2_c3 (k, ts, b, str, c1, c2, c3)
+  k INT8 NOT NULL,
+  ts TIMESTAMPTZ NULL,
+  b BYTES NULL,
+  str STRING NULL,
+  c1 STRING NULL AS (to_char(timezone('utc':::STRING, ts))) STORED,
+  c2 TIMESTAMP NULL AS (parse_timestamp(str)) STORED,
+  c3 INT8 NULL AS (mod(fnv32(b), 4:::INT8)) STORED,
+  CONSTRAINT trewrite2_pkey PRIMARY KEY (k ASC),
+  FAMILY fam_0_k_ts_b_str_c1_c2_c3 (k, ts, b, str, c1, c2, c3)
 )
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/create_as
+++ b/pkg/sql/logictest/testdata/logic_test/create_as
@@ -161,11 +161,11 @@ query TT
 SHOW CREATE TABLE foo5
 ----
 foo5  CREATE TABLE public.foo5 (
-      a INT8 NULL,
-      b INT8 NOT NULL,
-      c INT8 NULL,
-      CONSTRAINT foo5_pkey PRIMARY KEY (b ASC)
-)
+        a INT8 NULL,
+        b INT8 NOT NULL,
+        c INT8 NULL,
+        CONSTRAINT foo5_pkey PRIMARY KEY (b ASC)
+      )
 
 statement ok
 CREATE TABLE foo6 (
@@ -178,11 +178,11 @@ query TT
 SHOW CREATE TABLE foo6
 ----
 foo6  CREATE TABLE public.foo6 (
-      a INT8 NOT NULL,
-      b INT8 NULL,
-      c INT8 NULL,
-      CONSTRAINT foo6_pkey PRIMARY KEY (a ASC)
-)
+        a INT8 NOT NULL,
+        b INT8 NULL,
+        c INT8 NULL,
+        CONSTRAINT foo6_pkey PRIMARY KEY (a ASC)
+      )
 
 statement error generate insert row: null value in column "x" violates not-null constraint
 CREATE TABLE foo7 (x PRIMARY KEY) AS VALUES (1), (NULL);
@@ -194,10 +194,10 @@ query TT
 SHOW CREATE TABLE foo8
 ----
 foo8  CREATE TABLE public.foo8 (
-      item STRING NOT NULL,
-      qty INT8 NULL,
-      CONSTRAINT foo8_pkey PRIMARY KEY (item ASC)
-)
+        item STRING NOT NULL,
+        qty INT8 NULL,
+        CONSTRAINT foo8_pkey PRIMARY KEY (item ASC)
+      )
 
 # Allow CREATE TABLE AS to specify composite primary keys.
 statement ok
@@ -212,11 +212,11 @@ query TT
 SHOW CREATE TABLE foo9
 ----
 foo9  CREATE TABLE public.foo9 (
-      a INT8 NOT NULL,
-      b INT8 NULL,
-      c INT8 NOT NULL,
-      CONSTRAINT foo9_pkey PRIMARY KEY (a ASC, c ASC)
-)
+        a INT8 NOT NULL,
+        b INT8 NULL,
+        c INT8 NOT NULL,
+        CONSTRAINT foo9_pkey PRIMARY KEY (a ASC, c ASC)
+      )
 
 statement ok
 CREATE TABLE foo10 (a, PRIMARY KEY (c, b, a), b, c, FAMILY "primary" (a, b, c)) AS SELECT * FROM foo9
@@ -225,11 +225,11 @@ query TT
 SHOW CREATE TABLE foo10
 ----
 foo10  CREATE TABLE public.foo10 (
-       a INT8 NOT NULL,
-       b INT8 NOT NULL,
-       c INT8 NOT NULL,
-       CONSTRAINT foo10_pkey PRIMARY KEY (c ASC, b ASC, a ASC)
-)
+         a INT8 NOT NULL,
+         b INT8 NOT NULL,
+         c INT8 NOT NULL,
+         CONSTRAINT foo10_pkey PRIMARY KEY (c ASC, b ASC, a ASC)
+       )
 
 statement ok
 CREATE TABLE foo11 (
@@ -243,11 +243,11 @@ query TT
 SHOW CREATE TABLE foo11
 ----
 foo11  CREATE TABLE public.foo11 (
-       x INT8 NOT NULL,
-       y INT8 NULL,
-       z INT8 NOT NULL,
-       CONSTRAINT foo11_pkey PRIMARY KEY (x ASC, z ASC)
-)
+         x INT8 NOT NULL,
+         y INT8 NULL,
+         z INT8 NOT NULL,
+         CONSTRAINT foo11_pkey PRIMARY KEY (x ASC, z ASC)
+       )
 
 statement error pq: multiple primary keys for table "foo12" are not allowed
 CREATE TABLE foo12 (x PRIMARY KEY, y, PRIMARY KEY(y)) AS VALUES (1, 2), (3, 4);
@@ -269,14 +269,14 @@ query TT
 SHOW CREATE TABLE foo12
 ----
 foo12  CREATE TABLE public.foo12 (
-       a INT8 NOT NULL,
-       b INT8 NULL,
-       c INT8 NULL,
-       d INT8 NULL,
-       CONSTRAINT foo12_pkey PRIMARY KEY (a ASC),
-       FAMILY f1 (a, b, d),
-       FAMILY fam_1_c (c)
-)
+         a INT8 NOT NULL,
+         b INT8 NULL,
+         c INT8 NULL,
+         d INT8 NULL,
+         CONSTRAINT foo12_pkey PRIMARY KEY (a ASC),
+         FAMILY f1 (a, b, d),
+         FAMILY fam_1_c (c)
+       )
 
 # Test constraint style definition of column families.
 statement ok
@@ -286,14 +286,14 @@ query TT
 SHOW CREATE TABLE foo13
 ----
 foo13  CREATE TABLE public.foo13 (
-       a INT8 NOT NULL,
-       b INT8 NOT NULL,
-       c INT8 NULL,
-       d INT8 NULL,
-       CONSTRAINT foo13_pkey PRIMARY KEY (a ASC, b ASC),
-       FAMILY pk (a, b),
-       FAMILY fam_1_c_d (c, d)
-)
+         a INT8 NOT NULL,
+         b INT8 NOT NULL,
+         c INT8 NULL,
+         d INT8 NULL,
+         CONSTRAINT foo13_pkey PRIMARY KEY (a ASC, b ASC),
+         FAMILY pk (a, b),
+         FAMILY fam_1_c_d (c, d)
+       )
 
 # Test renaming columns still preserves the column families.
 statement ok
@@ -306,14 +306,14 @@ query TT
 SHOW CREATE TABLE foo13
 ----
 foo13  CREATE TABLE public.foo13 (
-       a INT8 NOT NULL,
-       b INT8 NOT NULL,
-       e INT8 NULL,
-       z INT8 NULL,
-       CONSTRAINT foo13_pkey PRIMARY KEY (a ASC, b ASC),
-       FAMILY pk (a, b),
-       FAMILY fam_1_c_d (e, z)
-)
+         a INT8 NOT NULL,
+         b INT8 NOT NULL,
+         e INT8 NULL,
+         z INT8 NULL,
+         CONSTRAINT foo13_pkey PRIMARY KEY (a ASC, b ASC),
+         FAMILY pk (a, b),
+         FAMILY fam_1_c_d (e, z)
+       )
 
 # Regression test for #41004
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/create_index
+++ b/pkg/sql/logictest/testdata/logic_test/create_index
@@ -168,11 +168,11 @@ query TT
 SHOW CREATE TABLE create_index_concurrently_tbl
 ----
 create_index_concurrently_tbl  CREATE TABLE public.create_index_concurrently_tbl (
-                               a INT8 NULL,
-                               rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                               CONSTRAINT create_index_concurrently_tbl_pkey PRIMARY KEY (rowid ASC),
-                               INDEX create_index_concurrently_idx (a ASC)
-)
+                                 a INT8 NULL,
+                                 rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                                 CONSTRAINT create_index_concurrently_tbl_pkey PRIMARY KEY (rowid ASC),
+                                 INDEX create_index_concurrently_idx (a ASC)
+                               )
 
 query T noticetrace
 DROP INDEX CONCURRENTLY create_index_concurrently_idx
@@ -190,10 +190,10 @@ query TT
 SHOW CREATE TABLE create_index_concurrently_tbl
 ----
 create_index_concurrently_tbl  CREATE TABLE public.create_index_concurrently_tbl (
-                               a INT8 NULL,
-                               rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                               CONSTRAINT create_index_concurrently_tbl_pkey PRIMARY KEY (rowid ASC)
-)
+                                 a INT8 NULL,
+                                 rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                                 CONSTRAINT create_index_concurrently_tbl_pkey PRIMARY KEY (rowid ASC)
+                               )
 
 statement ok
 DROP TABLE create_index_concurrently_tbl
@@ -382,15 +382,15 @@ query T
 SELECT @2 FROM [SHOW CREATE TABLE t_hash]
 ----
 CREATE TABLE public.t_hash (
-   pk INT8 NOT NULL,
-   a INT8 NULL,
-   b INT8 NULL,
-   crdb_internal_a_shard_5 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 5:::INT8)) VIRTUAL,
-   crdb_internal_b_shard_5 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(b)), 5:::INT8)) VIRTUAL,
-   CONSTRAINT t_hash_pkey PRIMARY KEY (pk ASC),
-   INDEX idx_t_hash_a (a ASC) USING HASH WITH (bucket_count=5),
-   UNIQUE INDEX idx_t_hash_b (b ASC) USING HASH WITH (bucket_count=5),
-   FAMILY fam_0_pk_a_b (pk, a, b)
+  pk INT8 NOT NULL,
+  a INT8 NULL,
+  b INT8 NULL,
+  crdb_internal_a_shard_5 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 5:::INT8)) VIRTUAL,
+  crdb_internal_b_shard_5 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(b)), 5:::INT8)) VIRTUAL,
+  CONSTRAINT t_hash_pkey PRIMARY KEY (pk ASC),
+  INDEX idx_t_hash_a (a ASC) USING HASH WITH (bucket_count=5),
+  UNIQUE INDEX idx_t_hash_b (b ASC) USING HASH WITH (bucket_count=5),
+  FAMILY fam_0_pk_a_b (pk, a, b)
 )
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -6850,9 +6850,9 @@ query TT
 SHOW CREATE TABLE unlogged_tbl
 ----
 unlogged_tbl  CREATE TABLE public.unlogged_tbl (
-              col INT8 NOT NULL,
-              CONSTRAINT unlogged_tbl_pkey PRIMARY KEY (col ASC)
-)
+                col INT8 NOT NULL,
+                CONSTRAINT unlogged_tbl_pkey PRIMARY KEY (col ASC)
+              )
 
 statement error pgcode 22023 invalid storage parameter "foo"
 CREATE TABLE a (b INT) WITH (foo=100);

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -68,12 +68,12 @@ query TT
 SHOW CREATE t
 ----
 t  CREATE TABLE public.t (
-   rowid INT8 NULL,
-   rowid_1 INT8 NULL,
-   rowid_2 INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   CONSTRAINT t_pkey PRIMARY KEY (rowid_2 ASC),
-   FAMILY fam_0_rowid_rowid_1_rowid_2 (rowid, rowid_1, rowid_2)
-)
+     rowid INT8 NULL,
+     rowid_1 INT8 NULL,
+     rowid_2 INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+     CONSTRAINT t_pkey PRIMARY KEY (rowid_2 ASC),
+     FAMILY fam_0_rowid_rowid_1_rowid_2 (rowid, rowid_1, rowid_2)
+   )
 
 subtest regression_qualification_feature_counts
 
@@ -145,16 +145,16 @@ query TT
 SHOW CREATE TABLE like_none
 ----
 like_none  CREATE TABLE public.like_none (
-           a INT8 NOT NULL,
-           b STRING NOT NULL,
-           c DECIMAL NULL,
-           h INT8 NULL,
-           j JSONB NULL,
-           k INT8 NULL,
-           t TIMESTAMPTZ NULL,
-           rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-           CONSTRAINT like_none_pkey PRIMARY KEY (rowid ASC)
-)
+             a INT8 NOT NULL,
+             b STRING NOT NULL,
+             c DECIMAL NULL,
+             h INT8 NULL,
+             j JSONB NULL,
+             k INT8 NULL,
+             t TIMESTAMPTZ NULL,
+             rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+             CONSTRAINT like_none_pkey PRIMARY KEY (rowid ASC)
+           )
 
 statement ok
 CREATE TABLE like_constraints (LIKE like_table INCLUDING CONSTRAINTS)
@@ -163,20 +163,20 @@ query TT
 SHOW CREATE TABLE like_constraints
 ----
 like_constraints  CREATE TABLE public.like_constraints (
-                  a INT8 NOT NULL,
-                  b STRING NOT NULL,
-                  c DECIMAL NULL,
-                  h INT8 NULL,
-                  j JSONB NULL,
-                  k INT8 NULL,
-                  t TIMESTAMPTZ NULL,
-                  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                  CONSTRAINT like_constraints_pkey PRIMARY KEY (rowid ASC),
-                  CONSTRAINT check_a CHECK (a > 3:::INT8),
-                  CONSTRAINT unique_k UNIQUE WITHOUT INDEX (k),
-                  CONSTRAINT unique_h UNIQUE WITHOUT INDEX (h),
-                  CONSTRAINT unique_h_1 UNIQUE WITHOUT INDEX (h) WHERE h > 0:::INT8
-)
+                    a INT8 NOT NULL,
+                    b STRING NOT NULL,
+                    c DECIMAL NULL,
+                    h INT8 NULL,
+                    j JSONB NULL,
+                    k INT8 NULL,
+                    t TIMESTAMPTZ NULL,
+                    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                    CONSTRAINT like_constraints_pkey PRIMARY KEY (rowid ASC),
+                    CONSTRAINT check_a CHECK (a > 3:::INT8),
+                    CONSTRAINT unique_k UNIQUE WITHOUT INDEX (k),
+                    CONSTRAINT unique_h UNIQUE WITHOUT INDEX (h),
+                    CONSTRAINT unique_h_1 UNIQUE WITHOUT INDEX (h) WHERE h > 0:::INT8
+                  )
 
 statement ok
 CREATE TABLE like_indexes (LIKE like_table INCLUDING INDEXES)
@@ -185,18 +185,18 @@ query TT
 SHOW CREATE TABLE like_indexes
 ----
 like_indexes  CREATE TABLE public.like_indexes (
-              a INT8 NOT NULL,
-              b STRING NOT NULL,
-              c DECIMAL NULL,
-              h INT8 NULL,
-              j JSONB NULL,
-              k INT8 NULL,
-              t TIMESTAMPTZ NULL,
-              CONSTRAINT like_table_pkey PRIMARY KEY (a ASC, b ASC),
-              UNIQUE INDEX foo (b DESC, c ASC),
-              INDEX like_table_c_idx (c ASC) STORING (j),
-              INVERTED INDEX like_table_j_idx (j)
-)
+                a INT8 NOT NULL,
+                b STRING NOT NULL,
+                c DECIMAL NULL,
+                h INT8 NULL,
+                j JSONB NULL,
+                k INT8 NULL,
+                t TIMESTAMPTZ NULL,
+                CONSTRAINT like_table_pkey PRIMARY KEY (a ASC, b ASC),
+                UNIQUE INDEX foo (b DESC, c ASC),
+                INDEX like_table_c_idx (c ASC) STORING (j),
+                INVERTED INDEX like_table_j_idx (j)
+              )
 
 # INCLUDING GENERATED adds "generated columns", aka stored columns.
 statement ok
@@ -206,16 +206,16 @@ query TT
 SHOW CREATE TABLE like_generated
 ----
 like_generated  CREATE TABLE public.like_generated (
-                a INT8 NOT NULL,
-                b STRING NOT NULL,
-                c DECIMAL NULL AS (a + 3:::DECIMAL) STORED,
-                h INT8 NULL,
-                j JSONB NULL,
-                k INT8 NULL,
-                t TIMESTAMPTZ NULL,
-                rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                CONSTRAINT like_generated_pkey PRIMARY KEY (rowid ASC)
-)
+                  a INT8 NOT NULL,
+                  b STRING NOT NULL,
+                  c DECIMAL NULL AS (a + 3:::DECIMAL) STORED,
+                  h INT8 NULL,
+                  j JSONB NULL,
+                  k INT8 NULL,
+                  t TIMESTAMPTZ NULL,
+                  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                  CONSTRAINT like_generated_pkey PRIMARY KEY (rowid ASC)
+                )
 
 statement ok
 CREATE TABLE like_defaults (LIKE like_table INCLUDING DEFAULTS)
@@ -224,16 +224,16 @@ query TT
 SHOW CREATE TABLE like_defaults
 ----
 like_defaults  CREATE TABLE public.like_defaults (
-               a INT8 NOT NULL,
-               b STRING NOT NULL DEFAULT 'foo':::STRING,
-               c DECIMAL NULL,
-               h INT8 NULL,
-               j JSONB NULL,
-               k INT8 NULL,
-               t TIMESTAMPTZ NULL DEFAULT current_timestamp():::TIMESTAMPTZ - '00:00:05':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ,
-               rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-               CONSTRAINT like_defaults_pkey PRIMARY KEY (rowid ASC)
-)
+                 a INT8 NOT NULL,
+                 b STRING NOT NULL DEFAULT 'foo':::STRING,
+                 c DECIMAL NULL,
+                 h INT8 NULL,
+                 j JSONB NULL,
+                 k INT8 NULL,
+                 t TIMESTAMPTZ NULL DEFAULT current_timestamp():::TIMESTAMPTZ - '00:00:05':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ,
+                 rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                 CONSTRAINT like_defaults_pkey PRIMARY KEY (rowid ASC)
+               )
 
 statement ok
 CREATE TABLE like_all (LIKE like_table INCLUDING ALL)
@@ -242,32 +242,6 @@ query TT
 SHOW CREATE TABLE like_all
 ----
 like_all  CREATE TABLE public.like_all (
-          a INT8 NOT NULL,
-          b STRING NOT NULL DEFAULT 'foo':::STRING,
-          c DECIMAL NULL AS (a + 3:::DECIMAL) STORED,
-          h INT8 NULL,
-          j JSONB NULL,
-          k INT8 NULL,
-          t TIMESTAMPTZ NULL DEFAULT current_timestamp():::TIMESTAMPTZ - '00:00:05':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ,
-          CONSTRAINT like_table_pkey PRIMARY KEY (a ASC, b ASC),
-          UNIQUE INDEX foo (b DESC, c ASC),
-          INDEX like_table_c_idx (c ASC) STORING (j),
-          INVERTED INDEX like_table_j_idx (j),
-          CONSTRAINT check_a CHECK (a > 3:::INT8),
-          CONSTRAINT unique_k UNIQUE WITHOUT INDEX (k),
-          CONSTRAINT unique_h UNIQUE WITHOUT INDEX (h),
-          CONSTRAINT unique_h_1 UNIQUE WITHOUT INDEX (h) WHERE h > 0:::INT8
-)
-
-statement ok
-CREATE TABLE like_mixed (LIKE like_table INCLUDING ALL EXCLUDING GENERATED EXCLUDING CONSTRAINTS INCLUDING GENERATED)
-
-# We expect that this table will be missing the check constraint from the first
-# table, but will include everything else.
-query TT
-SHOW CREATE TABLE like_mixed
-----
-like_mixed  CREATE TABLE public.like_mixed (
             a INT8 NOT NULL,
             b STRING NOT NULL DEFAULT 'foo':::STRING,
             c DECIMAL NULL AS (a + 3:::DECIMAL) STORED,
@@ -278,8 +252,34 @@ like_mixed  CREATE TABLE public.like_mixed (
             CONSTRAINT like_table_pkey PRIMARY KEY (a ASC, b ASC),
             UNIQUE INDEX foo (b DESC, c ASC),
             INDEX like_table_c_idx (c ASC) STORING (j),
-            INVERTED INDEX like_table_j_idx (j)
-)
+            INVERTED INDEX like_table_j_idx (j),
+            CONSTRAINT check_a CHECK (a > 3:::INT8),
+            CONSTRAINT unique_k UNIQUE WITHOUT INDEX (k),
+            CONSTRAINT unique_h UNIQUE WITHOUT INDEX (h),
+            CONSTRAINT unique_h_1 UNIQUE WITHOUT INDEX (h) WHERE h > 0:::INT8
+          )
+
+statement ok
+CREATE TABLE like_mixed (LIKE like_table INCLUDING ALL EXCLUDING GENERATED EXCLUDING CONSTRAINTS INCLUDING GENERATED)
+
+# We expect that this table will be missing the check constraint from the first
+# table, but will include everything else.
+query TT
+SHOW CREATE TABLE like_mixed
+----
+like_mixed  CREATE TABLE public.like_mixed (
+              a INT8 NOT NULL,
+              b STRING NOT NULL DEFAULT 'foo':::STRING,
+              c DECIMAL NULL AS (a + 3:::DECIMAL) STORED,
+              h INT8 NULL,
+              j JSONB NULL,
+              k INT8 NULL,
+              t TIMESTAMPTZ NULL DEFAULT current_timestamp():::TIMESTAMPTZ - '00:00:05':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ,
+              CONSTRAINT like_table_pkey PRIMARY KEY (a ASC, b ASC),
+              UNIQUE INDEX foo (b DESC, c ASC),
+              INDEX like_table_c_idx (c ASC) STORING (j),
+              INVERTED INDEX like_table_j_idx (j)
+            )
 
 statement ok
 CREATE TABLE like_no_pk_table (
@@ -293,11 +293,11 @@ query TT
 SHOW CREATE TABLE like_no_pk_rowid_hidden
 ----
 like_no_pk_rowid_hidden  CREATE TABLE public.like_no_pk_rowid_hidden (
-                         a INT8 NULL,
-                         b INT8 NULL,
-                         rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                         CONSTRAINT like_no_pk_rowid_hidden_pkey PRIMARY KEY (rowid ASC)
-)
+                           a INT8 NULL,
+                           b INT8 NULL,
+                           rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                           CONSTRAINT like_no_pk_rowid_hidden_pkey PRIMARY KEY (rowid ASC)
+                         )
 
 statement error duplicate column name
 CREATE TABLE duplicate_column (LIKE like_table, c DECIMAL)
@@ -314,19 +314,19 @@ query TT
 SHOW CREATE TABLE like_more_specifiers
 ----
 like_more_specifiers  CREATE TABLE public.like_more_specifiers (
-                      a INT8 NOT NULL,
-                      b STRING NOT NULL,
-                      c DECIMAL NULL,
-                      h INT8 NULL,
-                      j JSONB NULL,
-                      k INT8 NULL,
-                      t TIMESTAMPTZ NULL,
-                      z DECIMAL NULL,
-                      blah INT8 NULL,
-                      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                      CONSTRAINT like_more_specifiers_pkey PRIMARY KEY (rowid ASC),
-                      INDEX like_more_specifiers_a_blah_z_idx (a ASC, blah ASC, z ASC)
-)
+                        a INT8 NOT NULL,
+                        b STRING NOT NULL,
+                        c DECIMAL NULL,
+                        h INT8 NULL,
+                        j JSONB NULL,
+                        k INT8 NULL,
+                        t TIMESTAMPTZ NULL,
+                        z DECIMAL NULL,
+                        blah INT8 NULL,
+                        rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                        CONSTRAINT like_more_specifiers_pkey PRIMARY KEY (rowid ASC),
+                        INDEX like_more_specifiers_a_blah_z_idx (a ASC, blah ASC, z ASC)
+                      )
 
 statement ok
 CREATE TABLE like_hash_base (a INT, INDEX (a) USING HASH WITH (bucket_count=4))
@@ -338,12 +338,12 @@ query TT
 SHOW CREATE TABLE like_hash
 ----
 like_hash  CREATE TABLE public.like_hash (
-           a INT8 NULL,
-           crdb_internal_a_shard_4 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 4:::INT8)) VIRTUAL,
-           rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-           CONSTRAINT like_hash_pkey PRIMARY KEY (rowid ASC),
-           INDEX like_hash_base_a_idx (a ASC) USING HASH WITH (bucket_count=4)
-)
+             a INT8 NULL,
+             crdb_internal_a_shard_4 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 4:::INT8)) VIRTUAL,
+             rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+             CONSTRAINT like_hash_pkey PRIMARY KEY (rowid ASC),
+             INDEX like_hash_base_a_idx (a ASC) USING HASH WITH (bucket_count=4)
+           )
 
 statement ok
 DROP TABLE like_hash;
@@ -355,12 +355,12 @@ query TT
 SHOW CREATE TABLE like_hash
 ----
 like_hash  CREATE TABLE public.like_hash (
-           a INT8 NULL,
-           crdb_internal_a_shard_4 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 4:::INT8)) VIRTUAL,
-           rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-           CONSTRAINT like_hash_pkey PRIMARY KEY (rowid ASC),
-           INDEX like_hash_base_a_idx (a ASC) USING HASH WITH (bucket_count=4)
-)
+             a INT8 NULL,
+             crdb_internal_a_shard_4 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 4:::INT8)) VIRTUAL,
+             rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+             CONSTRAINT like_hash_pkey PRIMARY KEY (rowid ASC),
+             INDEX like_hash_base_a_idx (a ASC) USING HASH WITH (bucket_count=4)
+           )
 
 statement ok
 CREATE TABLE regression_67196 (pk INT PRIMARY KEY, hidden INT NOT VISIBLE);
@@ -372,11 +372,11 @@ query TT
 SHOW CREATE TABLE regression_67196_like
 ----
 regression_67196_like  CREATE TABLE public.regression_67196_like (
-                       pk INT8 NOT NULL,
-                       hidden INT8 NOT VISIBLE NULL,
-                       rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                       CONSTRAINT regression_67196_like_pkey PRIMARY KEY (rowid ASC)
-)
+                         pk INT8 NOT NULL,
+                         hidden INT8 NOT VISIBLE NULL,
+                         rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                         CONSTRAINT regression_67196_like_pkey PRIMARY KEY (rowid ASC)
+                       )
 
 statement error unimplemented
 CREATE TABLE error (LIKE like_hash_base INCLUDING COMMENTS)
@@ -487,13 +487,13 @@ query TT
 SHOW CREATE TABLE generated_always_t
 ----
 generated_always_t  CREATE TABLE public.generated_always_t (
-                    a INT8 NULL,
-                    b INT8 NOT NULL GENERATED ALWAYS AS IDENTITY,
-                    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                    CONSTRAINT generated_always_t_pkey PRIMARY KEY (rowid ASC),
-                    UNIQUE INDEX generated_always_t_a_key (a ASC),
-                    FAMILY f1 (a, b, rowid)
-)
+                      a INT8 NULL,
+                      b INT8 NOT NULL GENERATED ALWAYS AS IDENTITY,
+                      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                      CONSTRAINT generated_always_t_pkey PRIMARY KEY (rowid ASC),
+                      UNIQUE INDEX generated_always_t_a_key (a ASC),
+                      FAMILY f1 (a, b, rowid)
+                    )
 
 statement ok
 CREATE TABLE generated_by_default_t (
@@ -506,13 +506,13 @@ query TT
 SHOW CREATE TABLE generated_by_default_t
 ----
 generated_by_default_t  CREATE TABLE public.generated_by_default_t (
-                        a INT8 NULL,
-                        b INT8 NOT NULL GENERATED BY DEFAULT AS IDENTITY,
-                        rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                        CONSTRAINT generated_by_default_t_pkey PRIMARY KEY (rowid ASC),
-                        UNIQUE INDEX generated_by_default_t_a_key (a ASC),
-                        FAMILY f1 (a, b, rowid)
-)
+                          a INT8 NULL,
+                          b INT8 NOT NULL GENERATED BY DEFAULT AS IDENTITY,
+                          rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                          CONSTRAINT generated_by_default_t_pkey PRIMARY KEY (rowid ASC),
+                          UNIQUE INDEX generated_by_default_t_a_key (a ASC),
+                          FAMILY f1 (a, b, rowid)
+                        )
 
 statement ok
 CREATE TABLE generated_always_t_notnull (a INT UNIQUE, b INT NOT NULL GENERATED ALWAYS AS IDENTITY)
@@ -547,13 +547,13 @@ query TT
 SHOW CREATE TABLE gen_always_as_id_seqopt
 ----
 gen_always_as_id_seqopt  CREATE TABLE public.gen_always_as_id_seqopt (
-                         a INT8 NULL,
-                         b INT8 NOT NULL GENERATED ALWAYS AS IDENTITY (START 2 INCREMENT 3),
-                         rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                         CONSTRAINT gen_always_as_id_seqopt_pkey PRIMARY KEY (rowid ASC),
-                         UNIQUE INDEX gen_always_as_id_seqopt_a_key (a ASC),
-                         FAMILY f1 (a, b, rowid)
-)
+                           a INT8 NULL,
+                           b INT8 NOT NULL GENERATED ALWAYS AS IDENTITY (START 2 INCREMENT 3),
+                           rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                           CONSTRAINT gen_always_as_id_seqopt_pkey PRIMARY KEY (rowid ASC),
+                           UNIQUE INDEX gen_always_as_id_seqopt_a_key (a ASC),
+                           FAMILY f1 (a, b, rowid)
+                         )
 
 statement ok
 CREATE TABLE gen_always_as_id_seqopt_cache (
@@ -566,13 +566,13 @@ query TT
 SHOW CREATE TABLE gen_always_as_id_seqopt_cache
 ----
 gen_always_as_id_seqopt_cache  CREATE TABLE public.gen_always_as_id_seqopt_cache (
-                               a INT8 NULL,
-                               b INT8 NOT NULL GENERATED ALWAYS AS IDENTITY (START 2 INCREMENT 3 CACHE 10),
-                               rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                               CONSTRAINT gen_always_as_id_seqopt_cache_pkey PRIMARY KEY (rowid ASC),
-                               UNIQUE INDEX gen_always_as_id_seqopt_cache_a_key (a ASC),
-                               FAMILY f1 (a, b, rowid)
-)
+                                 a INT8 NULL,
+                                 b INT8 NOT NULL GENERATED ALWAYS AS IDENTITY (START 2 INCREMENT 3 CACHE 10),
+                                 rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                                 CONSTRAINT gen_always_as_id_seqopt_cache_pkey PRIMARY KEY (rowid ASC),
+                                 UNIQUE INDEX gen_always_as_id_seqopt_cache_a_key (a ASC),
+                                 FAMILY f1 (a, b, rowid)
+                               )
 
 statement ok
 CREATE TABLE gen_by_default_as_id_seqopt (
@@ -585,13 +585,13 @@ query TT
 SHOW CREATE TABLE gen_by_default_as_id_seqopt
 ----
 gen_by_default_as_id_seqopt  CREATE TABLE public.gen_by_default_as_id_seqopt (
-                             a INT8 NULL,
-                             b INT8 NOT NULL GENERATED BY DEFAULT AS IDENTITY (START 2 INCREMENT 3),
-                             rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                             CONSTRAINT gen_by_default_as_id_seqopt_pkey PRIMARY KEY (rowid ASC),
-                             UNIQUE INDEX gen_by_default_as_id_seqopt_a_key (a ASC),
-                             FAMILY f1 (a, b, rowid)
-)
+                               a INT8 NULL,
+                               b INT8 NOT NULL GENERATED BY DEFAULT AS IDENTITY (START 2 INCREMENT 3),
+                               rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                               CONSTRAINT gen_by_default_as_id_seqopt_pkey PRIMARY KEY (rowid ASC),
+                               UNIQUE INDEX gen_by_default_as_id_seqopt_a_key (a ASC),
+                               FAMILY f1 (a, b, rowid)
+                             )
 
 statement ok
 CREATE TABLE gen_by_default_as_id_seqopt_cache (
@@ -604,13 +604,13 @@ query TT
 SHOW CREATE TABLE gen_by_default_as_id_seqopt_cache
 ----
 gen_by_default_as_id_seqopt_cache  CREATE TABLE public.gen_by_default_as_id_seqopt_cache (
-                                   a INT8 NULL,
-                                   b INT8 NOT NULL GENERATED BY DEFAULT AS IDENTITY (START 2 INCREMENT 3 CACHE 10),
-                                   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                                   CONSTRAINT gen_by_default_as_id_seqopt_cache_pkey PRIMARY KEY (rowid ASC),
-                                   UNIQUE INDEX gen_by_default_as_id_seqopt_cache_a_key (a ASC),
-                                   FAMILY f1 (a, b, rowid)
-)
+                                     a INT8 NULL,
+                                     b INT8 NOT NULL GENERATED BY DEFAULT AS IDENTITY (START 2 INCREMENT 3 CACHE 10),
+                                     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                                     CONSTRAINT gen_by_default_as_id_seqopt_cache_pkey PRIMARY KEY (rowid ASC),
+                                     UNIQUE INDEX gen_by_default_as_id_seqopt_cache_a_key (a ASC),
+                                     FAMILY f1 (a, b, rowid)
+                                   )
 
 statement ok
 CREATE SEQUENCE serial_test_sequence start 1 increment 1
@@ -850,13 +850,13 @@ query T
 SELECT @2 FROM [SHOW CREATE TABLE t_good_hash_indexes_1];
 ----
 CREATE TABLE public.t_good_hash_indexes_1 (
-   crdb_internal_a_shard_5 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 5:::INT8)) VIRTUAL,
-   a INT8 NOT NULL,
-   b INT8 NULL,
-   c INT8 NULL,
-   crdb_internal_b_shard_5 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(b)), 5:::INT8)) VIRTUAL,
-   CONSTRAINT t_good_hash_indexes_1_pkey PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=5),
-   INDEX t_good_hash_indexes_1_b_idx (b ASC) USING HASH WITH (bucket_count=5)
+  crdb_internal_a_shard_5 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 5:::INT8)) VIRTUAL,
+  a INT8 NOT NULL,
+  b INT8 NULL,
+  c INT8 NULL,
+  crdb_internal_b_shard_5 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(b)), 5:::INT8)) VIRTUAL,
+  CONSTRAINT t_good_hash_indexes_1_pkey PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=5),
+  INDEX t_good_hash_indexes_1_b_idx (b ASC) USING HASH WITH (bucket_count=5)
 )
 
 statement ok
@@ -869,9 +869,9 @@ query T
 SELECT @2 FROM [SHOW CREATE TABLE t_good_hash_indexes_2];
 ----
 CREATE TABLE public.t_good_hash_indexes_2 (
-   a INT8 NOT NULL,
-   crdb_internal_a_shard_5 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 5:::INT8)) VIRTUAL,
-   CONSTRAINT t_good_hash_indexes_2_pkey PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=5)
+  a INT8 NOT NULL,
+  crdb_internal_a_shard_5 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 5:::INT8)) VIRTUAL,
+  CONSTRAINT t_good_hash_indexes_2_pkey PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=5)
 )
 
 subtest table_settings
@@ -959,11 +959,11 @@ query TT
 SHOW CREATE TABLE tbl
 ----
 tbl  CREATE TABLE public.tbl (
-     i INT8 NOT NULL,
-     j INT8 NOT NULL ON UPDATE nextval('public.s'::REGCLASS),
-     CONSTRAINT tbl_pkey PRIMARY KEY (i ASC),
-     FAMILY f1 (i, j)
-)
+       i INT8 NOT NULL,
+       j INT8 NOT NULL ON UPDATE nextval('public.s'::REGCLASS),
+       CONSTRAINT tbl_pkey PRIMARY KEY (i ASC),
+       FAMILY f1 (i, j)
+     )
 
 statement ok
 CREATE SEQUENCE IF NOT EXISTS s1
@@ -981,8 +981,8 @@ query TT
 SHOW CREATE TABLE tbl
 ----
 tbl  CREATE TABLE public.tbl (
-     i INT8 NOT NULL,
-     j INT8 NOT NULL DEFAULT nextval('public.s1'::REGCLASS) ON UPDATE nextval('public.s2'::REGCLASS),
-     CONSTRAINT tbl_pkey PRIMARY KEY (i ASC),
-     FAMILY f1 (i, j)
-)
+       i INT8 NOT NULL,
+       j INT8 NOT NULL DEFAULT nextval('public.s1'::REGCLASS) ON UPDATE nextval('public.s2'::REGCLASS),
+       CONSTRAINT tbl_pkey PRIMARY KEY (i ASC),
+       FAMILY f1 (i, j)
+     )

--- a/pkg/sql/logictest/testdata/logic_test/delete
+++ b/pkg/sql/logictest/testdata/logic_test/delete
@@ -238,8 +238,8 @@ query T
 SELECT create_statement FROM [SHOW CREATE t29494]
 ----
 CREATE TABLE public.t29494 (
-   x INT8 NOT NULL,
-   CONSTRAINT t29494_pkey PRIMARY KEY (x ASC)
+  x INT8 NOT NULL,
+  CONSTRAINT t29494_pkey PRIMARY KEY (x ASC)
 )
 
 # Check that the new column is not usable in RETURNING

--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -326,12 +326,12 @@ query TT
 SHOW CREATE fk1
 ----
 fk1  CREATE TABLE public.fk1 (
-     x INT8 NULL,
-     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-     CONSTRAINT fk1_pkey PRIMARY KEY (rowid ASC),
-     CONSTRAINT fk1 FOREIGN KEY (x) REFERENCES public.fk2(x),
-     INDEX i2 (x ASC)
-)
+       x INT8 NULL,
+       rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+       CONSTRAINT fk1_pkey PRIMARY KEY (rowid ASC),
+       CONSTRAINT fk1 FOREIGN KEY (x) REFERENCES public.fk2(x),
+       INDEX i2 (x ASC)
+     )
 
 # test that notices are generated on index drops
 subtest notice_on_drop_index

--- a/pkg/sql/logictest/testdata/logic_test/drop_sequence
+++ b/pkg/sql/logictest/testdata/logic_test/drop_sequence
@@ -37,10 +37,10 @@ query TT
 SHOW CREATE TABLE t1
 ----
 t1  CREATE TABLE public.t1 (
-    i INT8 NOT NULL DEFAULT nextval('public.drop_test'::REGCLASS),
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    CONSTRAINT t1_pkey PRIMARY KEY (rowid ASC)
-)
+      i INT8 NOT NULL DEFAULT nextval('public.drop_test'::REGCLASS),
+      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+      CONSTRAINT t1_pkey PRIMARY KEY (rowid ASC)
+    )
 
 query T
 SELECT pg_get_serial_sequence('t1', 'i')
@@ -57,10 +57,10 @@ query TT
 SHOW CREATE TABLE t1
 ----
 t1  CREATE TABLE public.t1 (
-    i INT8 NOT NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    CONSTRAINT t1_pkey PRIMARY KEY (rowid ASC)
-)
+      i INT8 NOT NULL,
+      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+      CONSTRAINT t1_pkey PRIMARY KEY (rowid ASC)
+    )
 
 query T
 SELECT pg_get_serial_sequence('t1', 'i')
@@ -96,12 +96,12 @@ query TT
 SHOW CREATE TABLE foo
 ----
 foo  CREATE TABLE public.foo (
-     i INT8 NOT NULL DEFAULT nextval('other_db.public.s'::REGCLASS),
-     j INT8 NOT NULL DEFAULT nextval('public.s'::REGCLASS),
-     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-     CONSTRAINT foo_pkey PRIMARY KEY (rowid ASC),
-     FAMILY fam_0_i_j_rowid (i, j, rowid)
-)
+       i INT8 NOT NULL DEFAULT nextval('other_db.public.s'::REGCLASS),
+       j INT8 NOT NULL DEFAULT nextval('public.s'::REGCLASS),
+       rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+       CONSTRAINT foo_pkey PRIMARY KEY (rowid ASC),
+       FAMILY fam_0_i_j_rowid (i, j, rowid)
+     )
 
 query TT
 SELECT pg_get_serial_sequence('foo', 'i'), pg_get_serial_sequence('foo', 'j')
@@ -118,12 +118,12 @@ query TT
 SHOW CREATE TABLE foo
 ----
 foo  CREATE TABLE public.foo (
-     i INT8 NOT NULL,
-     j INT8 NOT NULL DEFAULT nextval('public.s'::REGCLASS),
-     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-     CONSTRAINT foo_pkey PRIMARY KEY (rowid ASC),
-     FAMILY fam_0_i_j_rowid (i, j, rowid)
-)
+       i INT8 NOT NULL,
+       j INT8 NOT NULL DEFAULT nextval('public.s'::REGCLASS),
+       rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+       CONSTRAINT foo_pkey PRIMARY KEY (rowid ASC),
+       FAMILY fam_0_i_j_rowid (i, j, rowid)
+     )
 
 query TT
 SELECT pg_get_serial_sequence('foo', 'i'), pg_get_serial_sequence('foo', 'j')
@@ -155,12 +155,12 @@ query TT
 SHOW CREATE TABLE bar
 ----
 bar  CREATE TABLE public.bar (
-     i INT8 NOT NULL DEFAULT nextval('other_sc.s'::REGCLASS),
-     j INT8 NOT NULL DEFAULT nextval('public.s'::REGCLASS),
-     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-     CONSTRAINT bar_pkey PRIMARY KEY (rowid ASC),
-     FAMILY fam_0_i_j_rowid (i, j, rowid)
-)
+       i INT8 NOT NULL DEFAULT nextval('other_sc.s'::REGCLASS),
+       j INT8 NOT NULL DEFAULT nextval('public.s'::REGCLASS),
+       rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+       CONSTRAINT bar_pkey PRIMARY KEY (rowid ASC),
+       FAMILY fam_0_i_j_rowid (i, j, rowid)
+     )
 
 query TT
 SELECT pg_get_serial_sequence('bar', 'i'), pg_get_serial_sequence('bar', 'j')
@@ -177,12 +177,12 @@ query TT
 SHOW CREATE TABLE bar
 ----
 bar  CREATE TABLE public.bar (
-     i INT8 NOT NULL,
-     j INT8 NOT NULL DEFAULT nextval('public.s'::REGCLASS),
-     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-     CONSTRAINT bar_pkey PRIMARY KEY (rowid ASC),
-     FAMILY fam_0_i_j_rowid (i, j, rowid)
-)
+       i INT8 NOT NULL,
+       j INT8 NOT NULL DEFAULT nextval('public.s'::REGCLASS),
+       rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+       CONSTRAINT bar_pkey PRIMARY KEY (rowid ASC),
+       FAMILY fam_0_i_j_rowid (i, j, rowid)
+     )
 
 query TT
 SELECT pg_get_serial_sequence('bar', 'i'), pg_get_serial_sequence('bar', 'j')
@@ -221,10 +221,10 @@ query TT
 SHOW CREATE TABLE t3
 ----
 t3  CREATE TABLE public.t3 (
-    i INT8 NOT NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    CONSTRAINT t3_pkey PRIMARY KEY (rowid ASC)
-)
+      i INT8 NOT NULL,
+      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+      CONSTRAINT t3_pkey PRIMARY KEY (rowid ASC)
+    )
 
 query T
 SELECT pg_get_serial_sequence('t3', 'i')
@@ -255,10 +255,10 @@ query TT
 SHOW CREATE TABLE t4
 ----
 t4  CREATE TABLE public.t4 (
-    i INT8 NOT NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    CONSTRAINT t4_pkey PRIMARY KEY (rowid ASC)
-)
+      i INT8 NOT NULL,
+      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+      CONSTRAINT t4_pkey PRIMARY KEY (rowid ASC)
+    )
 
 query T
 SELECT pg_get_serial_sequence('t4', 'i')
@@ -300,10 +300,10 @@ query TT
 SHOW CREATE TABLE t6
 ----
 t6  CREATE TABLE public.t6 (
-    i INT8 NOT NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    CONSTRAINT t6_pkey PRIMARY KEY (rowid ASC)
-)
+      i INT8 NOT NULL,
+      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+      CONSTRAINT t6_pkey PRIMARY KEY (rowid ASC)
+    )
 
 query T
 SELECT pg_get_serial_sequence('t6', 'i')

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -389,11 +389,11 @@ query TT
 SHOW CREATE t1
 ----
 t1  CREATE TABLE public.t1 (
-    x test.public.greeting NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    CONSTRAINT t1_pkey PRIMARY KEY (rowid ASC),
-    INDEX i (x ASC)
-)
+      x test.public.greeting NULL,
+      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+      CONSTRAINT t1_pkey PRIMARY KEY (rowid ASC),
+      INDEX i (x ASC)
+    )
 
 # SHOW CREATE uses a virtual index, so also check the code path where a
 # descriptor scan is used.
@@ -503,13 +503,13 @@ query TT
 SHOW CREATE enum_default
 ----
 enum_default  CREATE TABLE public.enum_default (
-              x INT8 NULL,
-              y test.public.greeting NULL DEFAULT 'hello':::test.public.greeting,
-              z BOOL NULL DEFAULT 'hello':::test.public.greeting IS OF (test.public.greeting, test.public.greeting),
-              rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-              CONSTRAINT enum_default_pkey PRIMARY KEY (rowid ASC),
-              FAMILY fam_0_x_y_z_rowid (x, y, z, rowid)
-)
+                x INT8 NULL,
+                y test.public.greeting NULL DEFAULT 'hello':::test.public.greeting,
+                z BOOL NULL DEFAULT 'hello':::test.public.greeting IS OF (test.public.greeting, test.public.greeting),
+                rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                CONSTRAINT enum_default_pkey PRIMARY KEY (rowid ASC),
+                FAMILY fam_0_x_y_z_rowid (x, y, z, rowid)
+              )
 
 # Test crdb_internal.table_columns.
 query TT
@@ -560,14 +560,14 @@ query TT
 SHOW CREATE enum_computed
 ----
 enum_computed  CREATE TABLE public.enum_computed (
-               x INT8 NULL,
-               y test.public.greeting NULL AS ('hello':::test.public.greeting) STORED,
-               z BOOL NULL AS (w = 'howdy':::test.public.greeting) STORED,
-               w test.public.greeting NULL,
-               rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-               CONSTRAINT enum_computed_pkey PRIMARY KEY (rowid ASC),
-               FAMILY fam_0_x_y_z_w_rowid (x, y, z, w, rowid)
-)
+                 x INT8 NULL,
+                 y test.public.greeting NULL AS ('hello':::test.public.greeting) STORED,
+                 z BOOL NULL AS (w = 'howdy':::test.public.greeting) STORED,
+                 w test.public.greeting NULL,
+                 rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                 CONSTRAINT enum_computed_pkey PRIMARY KEY (rowid ASC),
+                 FAMILY fam_0_x_y_z_w_rowid (x, y, z, w, rowid)
+               )
 
 # Test information_schema.columns. generation_expression should not be
 # formatted with type annotations.
@@ -597,12 +597,12 @@ query TT
 SHOW CREATE enum_checks
 ----
 enum_checks  CREATE TABLE public.enum_checks (
-             x test.public.greeting NULL,
-             rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-             CONSTRAINT enum_checks_pkey PRIMARY KEY (rowid ASC),
-             CONSTRAINT check_x CHECK (x = 'hello':::test.public.greeting),
-             CONSTRAINT "check" CHECK ('hello':::test.public.greeting = 'hello':::test.public.greeting)
-)
+               x test.public.greeting NULL,
+               rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+               CONSTRAINT enum_checks_pkey PRIMARY KEY (rowid ASC),
+               CONSTRAINT check_x CHECK (x = 'hello':::test.public.greeting),
+               CONSTRAINT "check" CHECK ('hello':::test.public.greeting = 'hello':::test.public.greeting)
+             )
 
 # Ensure that we can add check constraints to tables with enums.
 statement ok
@@ -1530,13 +1530,13 @@ query TT
 SHOW CREATE TABLE arr_t6
 ----
 arr_t6  CREATE TABLE public.arr_t6 (
-        i test_57196.public.arr_typ2[] NULL DEFAULT ARRAY['a':::test_57196.public.arr_typ2]:::test_57196.public.arr_typ2[],
-        j test_57196.public.arr_typ2 NULL DEFAULT (ARRAY['b':::test_57196.public.arr_typ2]:::test_57196.public.arr_typ2[])[1:::INT8],
-        k test_57196.public.arr_typ2[] NULL DEFAULT ARRAY['c':::test_57196.public.arr_typ2]:::test_57196.public.arr_typ2[],
-        rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-        CONSTRAINT arr_t6_pkey PRIMARY KEY (rowid ASC),
-        FAMILY fam_0_i_j_k_rowid (i, j, k, rowid)
-)
+          i test_57196.public.arr_typ2[] NULL DEFAULT ARRAY['a':::test_57196.public.arr_typ2]:::test_57196.public.arr_typ2[],
+          j test_57196.public.arr_typ2 NULL DEFAULT (ARRAY['b':::test_57196.public.arr_typ2]:::test_57196.public.arr_typ2[])[1:::INT8],
+          k test_57196.public.arr_typ2[] NULL DEFAULT ARRAY['c':::test_57196.public.arr_typ2]:::test_57196.public.arr_typ2[],
+          rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+          CONSTRAINT arr_t6_pkey PRIMARY KEY (rowid ASC),
+          FAMILY fam_0_i_j_k_rowid (i, j, k, rowid)
+        )
 
 
 subtest regression_63138

--- a/pkg/sql/logictest/testdata/logic_test/exclude_data_from_backup
+++ b/pkg/sql/logictest/testdata/logic_test/exclude_data_from_backup
@@ -13,10 +13,10 @@ ALTER TABLE t SET (exclude_data_from_backup = true);
 query TT
 SHOW CREATE TABLE t
 ----
-t                                         CREATE TABLE public.t (
-                                          x INT8 NOT NULL,
-                                          CONSTRAINT t_pkey PRIMARY KEY (x ASC)
-) WITH (exclude_data_from_backup = true)
+t  CREATE TABLE public.t (
+     x INT8 NOT NULL,
+     CONSTRAINT t_pkey PRIMARY KEY (x ASC)
+   ) WITH (exclude_data_from_backup = true)
 
 statement ok
 ALTER TABLE t SET (exclude_data_from_backup = false);
@@ -25,9 +25,9 @@ query TT
 SHOW CREATE TABLE t
 ----
 t  CREATE TABLE public.t (
-   x INT8 NOT NULL,
-   CONSTRAINT t_pkey PRIMARY KEY (x ASC)
-)
+     x INT8 NOT NULL,
+     CONSTRAINT t_pkey PRIMARY KEY (x ASC)
+   )
 
 # Ensure we cannot set schema to a temporary schema.
 statement ok
@@ -53,12 +53,12 @@ ALTER TABLE t2 SET (exclude_data_from_backup = 'true');
 query TT
 SHOW CREATE TABLE t2
 ----
-t2                                        CREATE TABLE public.t2 (
-                                          x INT8 NULL,
-                                          rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                                          CONSTRAINT t2_pkey PRIMARY KEY (rowid ASC),
-                                          CONSTRAINT t2_x_fkey FOREIGN KEY (x) REFERENCES public.t(x) ON DELETE CASCADE
-) WITH (exclude_data_from_backup = true)
+t2  CREATE TABLE public.t2 (
+      x INT8 NULL,
+      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+      CONSTRAINT t2_pkey PRIMARY KEY (rowid ASC),
+      CONSTRAINT t2_x_fkey FOREIGN KEY (x) REFERENCES public.t(x) ON DELETE CASCADE
+    ) WITH (exclude_data_from_backup = true)
 
 # Check that we can reset exclude_data_from_backup on a table.
 statement ok
@@ -68,8 +68,8 @@ query TT
 SHOW CREATE TABLE t2
 ----
 t2  CREATE TABLE public.t2 (
-    x INT8 NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    CONSTRAINT t2_pkey PRIMARY KEY (rowid ASC),
-    CONSTRAINT t2_x_fkey FOREIGN KEY (x) REFERENCES public.t(x) ON DELETE CASCADE
-)
+      x INT8 NULL,
+      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+      CONSTRAINT t2_pkey PRIMARY KEY (rowid ASC),
+      CONSTRAINT t2_x_fkey FOREIGN KEY (x) REFERENCES public.t(x) ON DELETE CASCADE
+    )

--- a/pkg/sql/logictest/testdata/logic_test/expression_index
+++ b/pkg/sql/logictest/testdata/logic_test/expression_index
@@ -16,17 +16,17 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE t]
 ----
 CREATE TABLE public.t (
-   k INT8 NOT NULL,
-   a INT8 NULL,
-   b INT8 NULL,
-   c STRING NULL,
-   j JSONB NULL,
-   comp INT8 NULL AS (a + 10:::INT8) VIRTUAL,
-   CONSTRAINT t_pkey PRIMARY KEY (k ASC),
-   INDEX t_a_plus_b_idx ((a + b) ASC),
-   INDEX t_lower_c_a_plus_b_idx (lower(c) ASC, (a + b) ASC),
-   INVERTED INDEX t_b_j_a_asc (b DESC, (j->'a':::STRING)),
-   FAMILY fam_0_k_a_b_c_j (k, a, b, c, j)
+  k INT8 NOT NULL,
+  a INT8 NULL,
+  b INT8 NULL,
+  c STRING NULL,
+  j JSONB NULL,
+  comp INT8 NULL AS (a + 10:::INT8) VIRTUAL,
+  CONSTRAINT t_pkey PRIMARY KEY (k ASC),
+  INDEX t_a_plus_b_idx ((a + b) ASC),
+  INDEX t_lower_c_a_plus_b_idx (lower(c) ASC, (a + b) ASC),
+  INVERTED INDEX t_b_j_a_asc (b DESC, (j->'a':::STRING)),
+  FAMILY fam_0_k_a_b_c_j (k, a, b, c, j)
 )
 
 query TTBTTTB colnames
@@ -166,18 +166,18 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE t]
 ----
 CREATE TABLE public.t (
-   k INT8 NOT NULL,
-   a INT8 NULL,
-   b INT8 NULL,
-   c STRING NULL,
-   j JSONB NULL,
-   comp INT8 NULL AS (a + 10:::INT8) VIRTUAL,
-   CONSTRAINT t_pkey PRIMARY KEY (k ASC),
-   INDEX t_a_plus_b_idx ((a + b) ASC),
-   INDEX t_lower_c_idx (lower(c) ASC),
-   INDEX t_lower_c_a_plus_b_idx (lower(c) ASC, (a + b) ASC),
-   INDEX t_a_plus_ten_idx ((a + 10:::INT8) ASC),
-   FAMILY fam_0_k_a_b_c_j (k, a, b, c, j)
+  k INT8 NOT NULL,
+  a INT8 NULL,
+  b INT8 NULL,
+  c STRING NULL,
+  j JSONB NULL,
+  comp INT8 NULL AS (a + 10:::INT8) VIRTUAL,
+  CONSTRAINT t_pkey PRIMARY KEY (k ASC),
+  INDEX t_a_plus_b_idx ((a + b) ASC),
+  INDEX t_lower_c_idx (lower(c) ASC),
+  INDEX t_lower_c_a_plus_b_idx (lower(c) ASC, (a + b) ASC),
+  INDEX t_a_plus_ten_idx ((a + 10:::INT8) ASC),
+  FAMILY fam_0_k_a_b_c_j (k, a, b, c, j)
 )
 
 # Referencing an inaccessible column in a CHECK constraint is not allowed.
@@ -378,13 +378,13 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE copy]
 ----
 CREATE TABLE public.copy (
-   k INT8 NOT NULL,
-   a INT8 NULL,
-   b INT8 NULL,
-   j JSONB NULL,
-   comp INT8 NULL,
-   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   CONSTRAINT copy_pkey PRIMARY KEY (rowid ASC)
+  k INT8 NOT NULL,
+  a INT8 NULL,
+  b INT8 NULL,
+  j JSONB NULL,
+  comp INT8 NULL,
+  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+  CONSTRAINT copy_pkey PRIMARY KEY (rowid ASC)
 )
 
 # Inaccessible expression index columns should not be copied if the indexes are
@@ -402,13 +402,13 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE copy_generated]
 ----
 CREATE TABLE public.copy_generated (
-   k INT8 NOT NULL,
-   a INT8 NULL,
-   b INT8 NULL,
-   j JSONB NULL,
-   comp INT8 NULL AS (1:::INT8 + 10:::INT8) VIRTUAL,
-   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   CONSTRAINT copy_generated_pkey PRIMARY KEY (rowid ASC)
+  k INT8 NOT NULL,
+  a INT8 NULL,
+  b INT8 NULL,
+  j JSONB NULL,
+  comp INT8 NULL AS (1:::INT8 + 10:::INT8) VIRTUAL,
+  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+  CONSTRAINT copy_generated_pkey PRIMARY KEY (rowid ASC)
 )
 
 # Inaccessible expression index columns should not be copied if the indexes are
@@ -426,16 +426,16 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE copy_indexes]
 ----
 CREATE TABLE public.copy_indexes (
-   k INT8 NOT NULL,
-   a INT8 NULL,
-   b INT8 NULL,
-   j JSONB NULL,
-   comp INT8 NULL,
-   CONSTRAINT src_pkey PRIMARY KEY (k ASC),
-   INDEX src_expr_idx ((a + b) ASC),
-   INDEX named_idx ((a + 1:::INT8) ASC),
-   UNIQUE INDEX src_expr_key ((a + 10:::INT8) ASC),
-   INVERTED INDEX src_expr_expr1_idx ((a + b) ASC, (j->'a':::STRING))
+  k INT8 NOT NULL,
+  a INT8 NULL,
+  b INT8 NULL,
+  j JSONB NULL,
+  comp INT8 NULL,
+  CONSTRAINT src_pkey PRIMARY KEY (k ASC),
+  INDEX src_expr_idx ((a + b) ASC),
+  INDEX named_idx ((a + 1:::INT8) ASC),
+  UNIQUE INDEX src_expr_key ((a + 10:::INT8) ASC),
+  INVERTED INDEX src_expr_expr1_idx ((a + b) ASC, (j->'a':::STRING))
 )
 
 # Inaccessible expression index columns should be copied if the indexes are
@@ -453,16 +453,16 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE copy_all]
 ----
 CREATE TABLE public.copy_all (
-   k INT8 NOT NULL,
-   a INT8 NULL,
-   b INT8 NULL,
-   j JSONB NULL,
-   comp INT8 NULL AS (1:::INT8 + 10:::INT8) VIRTUAL,
-   CONSTRAINT src_pkey PRIMARY KEY (k ASC),
-   INDEX src_expr_idx ((a + b) ASC),
-   INDEX named_idx ((a + 1:::INT8) ASC),
-   UNIQUE INDEX src_expr_key ((a + 10:::INT8) ASC),
-   INVERTED INDEX src_expr_expr1_idx ((a + b) ASC, (j->'a':::STRING))
+  k INT8 NOT NULL,
+  a INT8 NULL,
+  b INT8 NULL,
+  j JSONB NULL,
+  comp INT8 NULL AS (1:::INT8 + 10:::INT8) VIRTUAL,
+  CONSTRAINT src_pkey PRIMARY KEY (k ASC),
+  INDEX src_expr_idx ((a + b) ASC),
+  INDEX named_idx ((a + 1:::INT8) ASC),
+  UNIQUE INDEX src_expr_key ((a + 10:::INT8) ASC),
+  INVERTED INDEX src_expr_expr1_idx ((a + b) ASC, (j->'a':::STRING))
 )
 
 # Inaccessible expression index columns should be copied if the indexes are
@@ -496,17 +496,17 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE anon]
 ----
 CREATE TABLE public.anon (
-   k INT8 NOT NULL,
-   a INT8 NULL,
-   b INT8 NULL,
-   c STRING NULL,
-   CONSTRAINT anon_pkey PRIMARY KEY (k ASC),
-   INDEX anon_expr_idx ((a + b) ASC),
-   INDEX anon_expr_b_idx ((a + 10:::INT8) ASC, b ASC),
-   UNIQUE INDEX anon_expr_b_key (lower(c) ASC, b ASC),
-   INDEX anon_expr_b_expr1_idx ((a + 10:::INT8) ASC, b ASC, lower(c) ASC),
-   INDEX anon_expr_expr1_expr2_idx ((a + 10:::INT8) ASC, (b + 100:::INT8) ASC, lower(c) ASC),
-   FAMILY fam_0_k_a_b_c (k, a, b, c)
+  k INT8 NOT NULL,
+  a INT8 NULL,
+  b INT8 NULL,
+  c STRING NULL,
+  CONSTRAINT anon_pkey PRIMARY KEY (k ASC),
+  INDEX anon_expr_idx ((a + b) ASC),
+  INDEX anon_expr_b_idx ((a + 10:::INT8) ASC, b ASC),
+  UNIQUE INDEX anon_expr_b_key (lower(c) ASC, b ASC),
+  INDEX anon_expr_b_expr1_idx ((a + 10:::INT8) ASC, b ASC, lower(c) ASC),
+  INDEX anon_expr_expr1_expr2_idx ((a + 10:::INT8) ASC, (b + 100:::INT8) ASC, lower(c) ASC),
+  FAMILY fam_0_k_a_b_c (k, a, b, c)
 )
 
 statement ok
@@ -530,17 +530,17 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE anon]
 ----
 CREATE TABLE public.anon (
-   k INT8 NOT NULL,
-   a INT8 NULL,
-   b INT8 NULL,
-   c STRING NULL,
-   CONSTRAINT anon_pkey PRIMARY KEY (k ASC),
-   INDEX anon_expr_idx ((a + b) ASC),
-   INDEX anon_expr_b_idx ((a + 10:::INT8) ASC, b ASC),
-   UNIQUE INDEX anon_expr_b_key (lower(c) ASC, b ASC),
-   INDEX anon_expr_b_expr1_idx ((a + 10:::INT8) ASC, b ASC, lower(c) ASC),
-   INDEX anon_expr_expr1_expr2_idx ((a + 10:::INT8) ASC, (b + 100:::INT8) ASC, lower(c) ASC),
-   FAMILY fam_0_k_a_b_c (k, a, b, c)
+  k INT8 NOT NULL,
+  a INT8 NULL,
+  b INT8 NULL,
+  c STRING NULL,
+  CONSTRAINT anon_pkey PRIMARY KEY (k ASC),
+  INDEX anon_expr_idx ((a + b) ASC),
+  INDEX anon_expr_b_idx ((a + 10:::INT8) ASC, b ASC),
+  UNIQUE INDEX anon_expr_b_key (lower(c) ASC, b ASC),
+  INDEX anon_expr_b_expr1_idx ((a + 10:::INT8) ASC, b ASC, lower(c) ASC),
+  INDEX anon_expr_expr1_expr2_idx ((a + 10:::INT8) ASC, (b + 100:::INT8) ASC, lower(c) ASC),
+  FAMILY fam_0_k_a_b_c (k, a, b, c)
 )
 
 # Querying expression indexes.
@@ -936,11 +936,11 @@ query TT
 SHOW CREATE TABLE t72012
 ----
 t72012  CREATE TABLE public.t72012 (
-        col INT8 NOT NULL,
-        rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-        CONSTRAINT t72012_pkey PRIMARY KEY (rowid ASC),
-        INDEX t72012_idx (abs(col) ASC)
-)
+          col INT8 NOT NULL,
+          rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+          CONSTRAINT t72012_pkey PRIMARY KEY (rowid ASC),
+          INDEX t72012_idx (abs(col) ASC)
+        )
 
 statement ok
 ALTER TABLE t72012 ALTER COLUMN col DROP NOT NULL;

--- a/pkg/sql/logictest/testdata/logic_test/family
+++ b/pkg/sql/logictest/testdata/logic_test/family
@@ -14,14 +14,14 @@ query TT
 SHOW CREATE TABLE abcd
 ----
 abcd  CREATE TABLE public.abcd (
-      a INT8 NOT NULL,
-      b INT8 NULL,
-      c INT8 NULL,
-      d INT8 NULL,
-      CONSTRAINT abcd_pkey PRIMARY KEY (a ASC),
-      FAMILY f1 (a, b),
-      FAMILY fam_1_c_d (c, d)
-)
+        a INT8 NOT NULL,
+        b INT8 NULL,
+        c INT8 NULL,
+        d INT8 NULL,
+        CONSTRAINT abcd_pkey PRIMARY KEY (a ASC),
+        FAMILY f1 (a, b),
+        FAMILY fam_1_c_d (c, d)
+      )
 
 statement ok
 CREATE INDEX d_idx ON abcd(d)
@@ -148,24 +148,24 @@ query TT
 SHOW CREATE TABLE abcd
 ----
 abcd  CREATE TABLE public.abcd (
-      a INT8 NOT NULL,
-      b INT8 NULL,
-      c INT8 NULL,
-      d INT8 NULL,
-      e STRING NULL,
-      f DECIMAL NULL,
-      g INT8 NULL,
-      h INT8 NULL,
-      i INT8 NULL,
-      j INT8 NULL,
-      CONSTRAINT abcd_pkey PRIMARY KEY (a ASC),
-      INDEX d_idx (d ASC),
-      FAMILY f1 (a, b, e, f),
-      FAMILY fam_1_c_d (c, d),
-      FAMILY fam_2_g (g),
-      FAMILY f_h (h, i),
-      FAMILY f_j (j)
-)
+        a INT8 NOT NULL,
+        b INT8 NULL,
+        c INT8 NULL,
+        d INT8 NULL,
+        e STRING NULL,
+        f DECIMAL NULL,
+        g INT8 NULL,
+        h INT8 NULL,
+        i INT8 NULL,
+        j INT8 NULL,
+        CONSTRAINT abcd_pkey PRIMARY KEY (a ASC),
+        INDEX d_idx (d ASC),
+        FAMILY f1 (a, b, e, f),
+        FAMILY fam_1_c_d (c, d),
+        FAMILY fam_2_g (g),
+        FAMILY f_h (h, i),
+        FAMILY f_j (j)
+      )
 
 statement ok
 ALTER TABLE abcd DROP c, DROP d, DROP e, DROP h, DROP i, DROP j
@@ -174,14 +174,14 @@ query TT
 SHOW CREATE TABLE abcd
 ----
 abcd  CREATE TABLE public.abcd (
-      a INT8 NOT NULL,
-      b INT8 NULL,
-      f DECIMAL NULL,
-      g INT8 NULL,
-      CONSTRAINT abcd_pkey PRIMARY KEY (a ASC),
-      FAMILY f1 (a, b, f),
-      FAMILY fam_2_g (g)
-)
+        a INT8 NOT NULL,
+        b INT8 NULL,
+        f DECIMAL NULL,
+        g INT8 NULL,
+        CONSTRAINT abcd_pkey PRIMARY KEY (a ASC),
+        FAMILY f1 (a, b, f),
+        FAMILY fam_2_g (g)
+      )
 
 statement ok
 CREATE TABLE f1 (
@@ -193,11 +193,11 @@ query TT
 SHOW CREATE TABLE f1
 ----
 f1  CREATE TABLE public.f1 (
-    a INT8 NOT NULL,
-    b STRING NULL,
-    c STRING NULL,
-    CONSTRAINT f1_pkey PRIMARY KEY (a ASC)
-)
+      a INT8 NOT NULL,
+      b STRING NULL,
+      c STRING NULL,
+      CONSTRAINT f1_pkey PRIMARY KEY (a ASC)
+    )
 
 statement ok
 CREATE TABLE assign_at_create (a INT PRIMARY KEY FAMILY pri, b INT FAMILY foo, c INT CREATE FAMILY)
@@ -206,14 +206,14 @@ query TT
 SHOW CREATE TABLE assign_at_create
 ----
 assign_at_create  CREATE TABLE public.assign_at_create (
-                  a INT8 NOT NULL,
-                  b INT8 NULL,
-                  c INT8 NULL,
-                  CONSTRAINT assign_at_create_pkey PRIMARY KEY (a ASC),
-                  FAMILY pri (a),
-                  FAMILY foo (b),
-                  FAMILY fam_2_c (c)
-)
+                    a INT8 NOT NULL,
+                    b INT8 NULL,
+                    c INT8 NULL,
+                    CONSTRAINT assign_at_create_pkey PRIMARY KEY (a ASC),
+                    FAMILY pri (a),
+                    FAMILY foo (b),
+                    FAMILY fam_2_c (c)
+                  )
 
 # Check the the diff-column-id storage
 statement ok
@@ -244,13 +244,13 @@ query TT
 SHOW CREATE TABLE rename_col
 ----
 rename_col  CREATE TABLE public.rename_col (
-            a INT8 NOT NULL,
-            d INT8 NULL,
-            e STRING NULL,
-            CONSTRAINT rename_col_pkey PRIMARY KEY (a ASC),
-            FAMILY fam_0_a_b (a, d),
-            FAMILY fam_1_c (e)
-)
+              a INT8 NOT NULL,
+              d INT8 NULL,
+              e STRING NULL,
+              CONSTRAINT rename_col_pkey PRIMARY KEY (a ASC),
+              FAMILY fam_0_a_b (a, d),
+              FAMILY fam_1_c (e)
+            )
 
 # Regression tests for https://github.com/cockroachdb/cockroach/issues/41007.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -498,16 +498,16 @@ query TT
 SHOW CREATE TABLE delivery
 ----
 delivery  CREATE TABLE public.delivery (
-          ts TIMESTAMP NULL DEFAULT now():::TIMESTAMP,
-          "order" INT8 NULL,
-          shipment INT8 NULL,
-          item STRING NULL,
-          rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-          CONSTRAINT delivery_pkey PRIMARY KEY (rowid ASC),
-          CONSTRAINT delivery_order_shipment_fkey FOREIGN KEY ("order", shipment) REFERENCES public.orders(id, shipment),
-          CONSTRAINT delivery_item_fkey FOREIGN KEY (item) REFERENCES public.products(upc),
-          INDEX delivery_item_idx (item ASC)
-)
+            ts TIMESTAMP NULL DEFAULT now():::TIMESTAMP,
+            "order" INT8 NULL,
+            shipment INT8 NULL,
+            item STRING NULL,
+            rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+            CONSTRAINT delivery_pkey PRIMARY KEY (rowid ASC),
+            CONSTRAINT delivery_order_shipment_fkey FOREIGN KEY ("order", shipment) REFERENCES public.orders(id, shipment),
+            CONSTRAINT delivery_item_fkey FOREIGN KEY (item) REFERENCES public.products(upc),
+            INDEX delivery_item_idx (item ASC)
+          )
 
 statement ok
 INSERT INTO delivery ("order", shipment, item) VALUES
@@ -837,14 +837,14 @@ query TT
 SHOW CREATE TABLE refpairs
 ----
 refpairs  CREATE TABLE public.refpairs (
-          a INT8 NULL,
-          b STRING NULL,
-          c INT8 NULL,
-          rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-          CONSTRAINT refpairs_pkey PRIMARY KEY (rowid ASC),
-          CONSTRAINT refpairs_a_b_fkey FOREIGN KEY (a, b) REFERENCES public.pairs(src, dest) ON UPDATE RESTRICT,
-          INDEX refpairs_a_b_c_idx (a ASC, b ASC, c ASC)
-)
+            a INT8 NULL,
+            b STRING NULL,
+            c INT8 NULL,
+            rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+            CONSTRAINT refpairs_pkey PRIMARY KEY (rowid ASC),
+            CONSTRAINT refpairs_a_b_fkey FOREIGN KEY (a, b) REFERENCES public.pairs(src, dest) ON UPDATE RESTRICT,
+            INDEX refpairs_a_b_c_idx (a ASC, b ASC, c ASC)
+          )
 
 statement error pgcode 23503 insert on table "refpairs" violates foreign key constraint "refpairs_a_b_fkey"\nDETAIL: Key \(a, b\)=\(100, 'two'\) is not present in table "pairs".
 INSERT INTO refpairs VALUES (100, 'two'), (200, 'two')
@@ -1056,14 +1056,14 @@ query TT
 SHOW CREATE TABLE refers
 ----
 refers  CREATE TABLE public.refers (
-        a INT8 NULL,
-        b INT8 NULL,
-        rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-        CONSTRAINT refers_pkey PRIMARY KEY (rowid ASC),
-        CONSTRAINT refers_a_fkey FOREIGN KEY (a) REFERENCES public.referee(id),
-        INDEX another_idx (b ASC),
-        INDEX foo (a ASC)
-)
+          a INT8 NULL,
+          b INT8 NULL,
+          rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+          CONSTRAINT refers_pkey PRIMARY KEY (rowid ASC),
+          CONSTRAINT refers_a_fkey FOREIGN KEY (a) REFERENCES public.referee(id),
+          INDEX another_idx (b ASC),
+          INDEX foo (a ASC)
+        )
 
 statement ok
 DROP INDEX refers@another_idx
@@ -1139,10 +1139,10 @@ query TT
 SHOW CREATE TABLE pkref_b
 ----
 pkref_b  CREATE TABLE public.pkref_b (
-         b INT8 NOT NULL,
-         CONSTRAINT pkref_b_pkey PRIMARY KEY (b ASC),
-         CONSTRAINT pkref_b_b_fkey FOREIGN KEY (b) REFERENCES public.pkref_a(a) ON DELETE RESTRICT
-)
+           b INT8 NOT NULL,
+           CONSTRAINT pkref_b_pkey PRIMARY KEY (b ASC),
+           CONSTRAINT pkref_b_b_fkey FOREIGN KEY (b) REFERENCES public.pkref_a(a) ON DELETE RESTRICT
+         )
 
 subtest 20042
 

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -75,9 +75,9 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE geom_table_negative_values]
 ----
 CREATE TABLE public.geom_table_negative_values (
-   a GEOMETRY(GEOMETRY) NULL,
-   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   CONSTRAINT geom_table_negative_values_pkey PRIMARY KEY (rowid ASC)
+  a GEOMETRY(GEOMETRY) NULL,
+  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+  CONSTRAINT geom_table_negative_values_pkey PRIMARY KEY (rowid ASC)
 )
 
 statement ok
@@ -89,9 +89,9 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE geog_table_negative_values]
 ----
 CREATE TABLE public.geog_table_negative_values (
-   a GEOGRAPHY(GEOMETRY) NULL,
-   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   CONSTRAINT geog_table_negative_values_pkey PRIMARY KEY (rowid ASC)
+  a GEOGRAPHY(GEOMETRY) NULL,
+  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+  CONSTRAINT geog_table_negative_values_pkey PRIMARY KEY (rowid ASC)
 )
 
 statement error SRID 3857 cannot be used for geography as it is not in a lon/lat coordinate system

--- a/pkg/sql/logictest/testdata/logic_test/geospatial_index
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial_index
@@ -48,19 +48,19 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE geo_table]
 ----
 CREATE TABLE public.geo_table (
-   id INT8 NOT NULL,
-   geog GEOGRAPHY(GEOMETRY,4326) NULL,
-   geom GEOMETRY(GEOMETRY,3857) NULL,
-   CONSTRAINT geo_table_pkey PRIMARY KEY (id ASC),
-   INVERTED INDEX geom_idx_1 (geom) WITH (s2_max_level=15, geometry_min_x=0),
-   INVERTED INDEX geom_idx_2 (geom) WITH (geometry_min_x=0),
-   INVERTED INDEX geom_idx_3 (geom) WITH (s2_max_level=10),
-   INVERTED INDEX geom_idx_4 (geom),
-   INVERTED INDEX geog_idx_1 (geog) WITH (s2_level_mod=2),
-   INVERTED INDEX geog_idx_2 (geog),
-   FAMILY fam_0_geog (geog),
-   FAMILY fam_1_geom (geom),
-   FAMILY fam_2_id (id)
+  id INT8 NOT NULL,
+  geog GEOGRAPHY(GEOMETRY,4326) NULL,
+  geom GEOMETRY(GEOMETRY,3857) NULL,
+  CONSTRAINT geo_table_pkey PRIMARY KEY (id ASC),
+  INVERTED INDEX geom_idx_1 (geom) WITH (s2_max_level=15, geometry_min_x=0),
+  INVERTED INDEX geom_idx_2 (geom) WITH (geometry_min_x=0),
+  INVERTED INDEX geom_idx_3 (geom) WITH (s2_max_level=10),
+  INVERTED INDEX geom_idx_4 (geom),
+  INVERTED INDEX geog_idx_1 (geog) WITH (s2_level_mod=2),
+  INVERTED INDEX geog_idx_2 (geog),
+  FAMILY fam_0_geog (geog),
+  FAMILY fam_1_geom (geom),
+  FAMILY fam_2_id (id)
 )
 
 let $create_table
@@ -76,17 +76,17 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE geo_table]
 ----
 CREATE TABLE public.geo_table (
-   id INT8 NOT NULL,
-   geog GEOGRAPHY(GEOMETRY,4326) NULL,
-   geom GEOMETRY(GEOMETRY,3857) NULL,
-   CONSTRAINT geo_table_pkey PRIMARY KEY (id ASC),
-   INVERTED INDEX geom_idx_1 (geom) WITH (s2_max_level=15, geometry_min_x=0),
-   INVERTED INDEX geom_idx_2 (geom) WITH (geometry_min_x=0),
-   INVERTED INDEX geom_idx_3 (geom) WITH (s2_max_level=10),
-   INVERTED INDEX geom_idx_4 (geom),
-   INVERTED INDEX geog_idx_1 (geog) WITH (s2_level_mod=2),
-   INVERTED INDEX geog_idx_2 (geog),
-   FAMILY fam_0_geog (geog),
-   FAMILY fam_1_geom (geom),
-   FAMILY fam_2_id (id)
+  id INT8 NOT NULL,
+  geog GEOGRAPHY(GEOMETRY,4326) NULL,
+  geom GEOMETRY(GEOMETRY,3857) NULL,
+  CONSTRAINT geo_table_pkey PRIMARY KEY (id ASC),
+  INVERTED INDEX geom_idx_1 (geom) WITH (s2_max_level=15, geometry_min_x=0),
+  INVERTED INDEX geom_idx_2 (geom) WITH (geometry_min_x=0),
+  INVERTED INDEX geom_idx_3 (geom) WITH (s2_max_level=10),
+  INVERTED INDEX geom_idx_4 (geom),
+  INVERTED INDEX geog_idx_1 (geog) WITH (s2_level_mod=2),
+  INVERTED INDEX geog_idx_2 (geog),
+  FAMILY fam_0_geog (geog),
+  FAMILY fam_1_geom (geom),
+  FAMILY fam_2_id (id)
 )

--- a/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
+++ b/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
@@ -6,10 +6,10 @@ query TT
 SHOW CREATE TABLE sharded_primary
 ----
 sharded_primary  CREATE TABLE public.sharded_primary (
-                 crdb_internal_a_shard_10 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 10:::INT8)) VIRTUAL,
-                 a INT8 NOT NULL,
-                 CONSTRAINT sharded_primary_pkey PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=10)
-)
+                   crdb_internal_a_shard_10 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 10:::INT8)) VIRTUAL,
+                   a INT8 NOT NULL,
+                   CONSTRAINT sharded_primary_pkey PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=10)
+                 )
 
 statement error pgcode 22023 hash sharded index bucket count must be in range \[2, 2048\], got -1
 CREATE TABLE invalid_bucket_count (k INT PRIMARY KEY USING HASH WITH (bucket_count=-1))
@@ -41,10 +41,10 @@ query TT
 SHOW CREATE TABLE sharded_primary
 ----
 sharded_primary  CREATE TABLE public.sharded_primary (
-                 a INT8 NOT NULL,
-                 crdb_internal_a_shard_10 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 10:::INT8)) VIRTUAL,
-                 CONSTRAINT "primary" PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=10)
-)
+                   a INT8 NOT NULL,
+                   crdb_internal_a_shard_10 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 10:::INT8)) VIRTUAL,
+                   CONSTRAINT "primary" PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=10)
+                 )
 
 query TTT colnames
 SELECT
@@ -93,15 +93,15 @@ query TT
 SHOW CREATE TABLE specific_family
 ----
 specific_family  CREATE TABLE public.specific_family (
-                 a INT8 NULL,
-                 b INT8 NULL,
-                 crdb_internal_b_shard_10 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(b)), 10:::INT8)) VIRTUAL,
-                 rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                 CONSTRAINT specific_family_pkey PRIMARY KEY (rowid ASC),
-                 INDEX specific_family_b_idx (b ASC) USING HASH WITH (bucket_count=10),
-                 FAMILY a_family (a, rowid),
-                 FAMILY b_family (b)
-)
+                   a INT8 NULL,
+                   b INT8 NULL,
+                   crdb_internal_b_shard_10 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(b)), 10:::INT8)) VIRTUAL,
+                   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                   CONSTRAINT specific_family_pkey PRIMARY KEY (rowid ASC),
+                   INDEX specific_family_b_idx (b ASC) USING HASH WITH (bucket_count=10),
+                   FAMILY a_family (a, rowid),
+                   FAMILY b_family (b)
+                 )
 
 # Tests for secondary sharded indexes
 statement ok
@@ -111,12 +111,12 @@ query TT
 SHOW CREATE TABLE sharded_secondary
 ----
 sharded_secondary  CREATE TABLE public.sharded_secondary (
-                   a INT8 NULL,
-                   crdb_internal_a_shard_4 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 4:::INT8)) VIRTUAL,
-                   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                   CONSTRAINT sharded_secondary_pkey PRIMARY KEY (rowid ASC),
-                   INDEX sharded_secondary_a_idx (a ASC) USING HASH WITH (bucket_count=4)
-)
+                     a INT8 NULL,
+                     crdb_internal_a_shard_4 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 4:::INT8)) VIRTUAL,
+                     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                     CONSTRAINT sharded_secondary_pkey PRIMARY KEY (rowid ASC),
+                     INDEX sharded_secondary_a_idx (a ASC) USING HASH WITH (bucket_count=4)
+                   )
 
 statement ok
 DROP TABLE sharded_secondary
@@ -132,12 +132,12 @@ query TT
 SHOW CREATE TABLE sharded_secondary
 ----
 sharded_secondary  CREATE TABLE public.sharded_secondary (
-                   a INT8 NULL,
-                   crdb_internal_a_shard_4 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 4:::INT8)) VIRTUAL,
-                   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                   CONSTRAINT sharded_secondary_pkey PRIMARY KEY (rowid ASC),
-                   INDEX sharded_secondary_crdb_internal_a_shard_4_a_idx (a ASC) USING HASH WITH (bucket_count=4)
-)
+                     a INT8 NULL,
+                     crdb_internal_a_shard_4 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 4:::INT8)) VIRTUAL,
+                     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                     CONSTRAINT sharded_secondary_pkey PRIMARY KEY (rowid ASC),
+                     INDEX sharded_secondary_crdb_internal_a_shard_4_a_idx (a ASC) USING HASH WITH (bucket_count=4)
+                   )
 
 statement ok
 INSERT INTO sharded_secondary values (1), (2), (1)
@@ -160,12 +160,12 @@ query TT
 SHOW CREATE TABLE sharded_secondary
 ----
 sharded_secondary  CREATE TABLE public.sharded_secondary (
-                   a INT8 NULL,
-                   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                   crdb_internal_a_shard_10 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 10:::INT8)) VIRTUAL,
-                   CONSTRAINT sharded_secondary_pkey PRIMARY KEY (rowid ASC),
-                   INDEX sharded_secondary_a_idx (a ASC) USING HASH WITH (bucket_count=10)
-)
+                     a INT8 NULL,
+                     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                     crdb_internal_a_shard_10 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 10:::INT8)) VIRTUAL,
+                     CONSTRAINT sharded_secondary_pkey PRIMARY KEY (rowid ASC),
+                     INDEX sharded_secondary_a_idx (a ASC) USING HASH WITH (bucket_count=10)
+                   )
 
 statement ok
 INSERT INTO sharded_secondary values (3), (2), (1)
@@ -178,14 +178,14 @@ query TT
 SHOW CREATE TABLE sharded_secondary
 ----
 sharded_secondary  CREATE TABLE public.sharded_secondary (
-                   a INT8 NULL,
-                   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                   crdb_internal_a_shard_10 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 10:::INT8)) VIRTUAL,
-                   crdb_internal_a_shard_4 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 4:::INT8)) VIRTUAL,
-                   CONSTRAINT sharded_secondary_pkey PRIMARY KEY (rowid ASC),
-                   INDEX sharded_secondary_a_idx (a ASC) USING HASH WITH (bucket_count=10),
-                   INDEX sharded_secondary_a_idx1 (a ASC) USING HASH WITH (bucket_count=4)
-)
+                     a INT8 NULL,
+                     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                     crdb_internal_a_shard_10 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 10:::INT8)) VIRTUAL,
+                     crdb_internal_a_shard_4 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 4:::INT8)) VIRTUAL,
+                     CONSTRAINT sharded_secondary_pkey PRIMARY KEY (rowid ASC),
+                     INDEX sharded_secondary_a_idx (a ASC) USING HASH WITH (bucket_count=10),
+                     INDEX sharded_secondary_a_idx1 (a ASC) USING HASH WITH (bucket_count=4)
+                   )
 
 # Drop a sharded index and ensure that the shard column is dropped with it.
 statement ok
@@ -195,12 +195,12 @@ query TT
 SHOW CREATE TABLE sharded_secondary
 ----
 sharded_secondary  CREATE TABLE public.sharded_secondary (
-                   a INT8 NULL,
-                   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                   crdb_internal_a_shard_4 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 4:::INT8)) VIRTUAL,
-                   CONSTRAINT sharded_secondary_pkey PRIMARY KEY (rowid ASC),
-                   INDEX sharded_secondary_a_idx1 (a ASC) USING HASH WITH (bucket_count=4)
-)
+                     a INT8 NULL,
+                     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                     crdb_internal_a_shard_4 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 4:::INT8)) VIRTUAL,
+                     CONSTRAINT sharded_secondary_pkey PRIMARY KEY (rowid ASC),
+                     INDEX sharded_secondary_a_idx1 (a ASC) USING HASH WITH (bucket_count=4)
+                   )
 
 statement ok
 DROP INDEX sharded_secondary_a_idx1
@@ -210,10 +210,10 @@ query TT
 SHOW CREATE TABLE sharded_secondary
 ----
 sharded_secondary  CREATE TABLE public.sharded_secondary (
-                   a INT8 NULL,
-                   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                   CONSTRAINT sharded_secondary_pkey PRIMARY KEY (rowid ASC)
-)
+                     a INT8 NULL,
+                     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                     CONSTRAINT sharded_secondary_pkey PRIMARY KEY (rowid ASC)
+                   )
 
 # Ensure that the shard column cannot be used in the same txn if its dropped along with
 # the sharded index.
@@ -252,14 +252,14 @@ query TT
 SHOW CREATE TABLE sharded_secondary
 ----
 sharded_secondary  CREATE TABLE public.sharded_secondary (
-                   a INT8 NULL,
-                   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                   crdb_internal_a_shard_10 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 10:::INT8)) VIRTUAL,
-                   CONSTRAINT sharded_secondary_pkey PRIMARY KEY (rowid ASC),
-                   INDEX sharded_secondary_a_idx (a ASC) USING HASH WITH (bucket_count=10),
-                   INDEX sharded_secondary_a_idx1 (a ASC) USING HASH WITH (bucket_count=10),
-                   INDEX sharded_secondary_a_idx2 (a ASC) USING HASH WITH (bucket_count=10)
-)
+                     a INT8 NULL,
+                     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                     crdb_internal_a_shard_10 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 10:::INT8)) VIRTUAL,
+                     CONSTRAINT sharded_secondary_pkey PRIMARY KEY (rowid ASC),
+                     INDEX sharded_secondary_a_idx (a ASC) USING HASH WITH (bucket_count=10),
+                     INDEX sharded_secondary_a_idx1 (a ASC) USING HASH WITH (bucket_count=10),
+                     INDEX sharded_secondary_a_idx2 (a ASC) USING HASH WITH (bucket_count=10)
+                   )
 
 
 # Ensure that the table descriptor was left in a "valid" state
@@ -275,12 +275,12 @@ query TT
 SHOW CREATE TABLE sharded_primary
 ----
 sharded_primary  CREATE TABLE public.sharded_primary (
-                 a INT8 NOT NULL,
-                 crdb_internal_a_shard_10 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 10:::INT8)) VIRTUAL,
-                 crdb_internal_a_shard_4 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 4:::INT8)) VIRTUAL,
-                 CONSTRAINT "primary" PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=10),
-                 INDEX sharded_primary_a_idx (a ASC) USING HASH WITH (bucket_count=4)
-)
+                   a INT8 NOT NULL,
+                   crdb_internal_a_shard_10 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 10:::INT8)) VIRTUAL,
+                   crdb_internal_a_shard_4 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 4:::INT8)) VIRTUAL,
+                   CONSTRAINT "primary" PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=10),
+                   INDEX sharded_primary_a_idx (a ASC) USING HASH WITH (bucket_count=4)
+                 )
 
 statement ok
 DROP INDEX sharded_primary_a_idx
@@ -292,10 +292,10 @@ query TT
 SHOW CREATE TABLE sharded_primary
 ----
 sharded_primary  CREATE TABLE public.sharded_primary (
-                 a INT8 NOT NULL,
-                 crdb_internal_a_shard_10 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 10:::INT8)) VIRTUAL,
-                 CONSTRAINT "primary" PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=10)
-)
+                   a INT8 NOT NULL,
+                   crdb_internal_a_shard_10 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 10:::INT8)) VIRTUAL,
+                   CONSTRAINT "primary" PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=10)
+                 )
 
 statement ok
 CREATE INDEX on sharded_primary (a) USING HASH WITH (bucket_count=10);
@@ -304,11 +304,11 @@ query TT
 SHOW CREATE TABLE sharded_primary
 ----
 sharded_primary  CREATE TABLE public.sharded_primary (
-                 a INT8 NOT NULL,
-                 crdb_internal_a_shard_10 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 10:::INT8)) VIRTUAL,
-                 CONSTRAINT "primary" PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=10),
-                 INDEX sharded_primary_a_idx (a ASC) USING HASH WITH (bucket_count=10)
-)
+                   a INT8 NOT NULL,
+                   crdb_internal_a_shard_10 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 10:::INT8)) VIRTUAL,
+                   CONSTRAINT "primary" PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=10),
+                   INDEX sharded_primary_a_idx (a ASC) USING HASH WITH (bucket_count=10)
+                 )
 
 statement ok
 DROP INDEX sharded_primary_a_idx
@@ -382,12 +382,12 @@ query TT
 SHOW CREATE TABLE column_used_on_unsharded
 ----
 column_used_on_unsharded  CREATE TABLE public.column_used_on_unsharded (
-                          a INT8 NULL,
-                          crdb_internal_a_shard_10 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 10:::INT8)) VIRTUAL,
-                          rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                          CONSTRAINT column_used_on_unsharded_pkey PRIMARY KEY (rowid ASC),
-                          INDEX column_used_on_unsharded_crdb_internal_a_shard_10_idx (crdb_internal_a_shard_10 ASC)
-)
+                            a INT8 NULL,
+                            crdb_internal_a_shard_10 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 10:::INT8)) VIRTUAL,
+                            rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                            CONSTRAINT column_used_on_unsharded_pkey PRIMARY KEY (rowid ASC),
+                            INDEX column_used_on_unsharded_crdb_internal_a_shard_10_idx (crdb_internal_a_shard_10 ASC)
+                          )
 
 statement ok
 DROP INDEX column_used_on_unsharded_crdb_internal_a_shard_10_idx
@@ -406,12 +406,12 @@ query TT
 SHOW CREATE TABLE column_used_on_unsharded_create_table
 ----
 column_used_on_unsharded_create_table  CREATE TABLE public.column_used_on_unsharded_create_table (
-                                       a INT8 NULL,
-                                       crdb_internal_a_shard_10 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 10:::INT8)) VIRTUAL,
-                                       rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                                       CONSTRAINT column_used_on_unsharded_create_table_pkey PRIMARY KEY (rowid ASC),
-                                       INDEX column_used_on_unsharded_create_table_crdb_internal_a_shard_10_idx (crdb_internal_a_shard_10 ASC)
-)
+                                         a INT8 NULL,
+                                         crdb_internal_a_shard_10 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 10:::INT8)) VIRTUAL,
+                                         rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                                         CONSTRAINT column_used_on_unsharded_create_table_pkey PRIMARY KEY (rowid ASC),
+                                         INDEX column_used_on_unsharded_create_table_crdb_internal_a_shard_10_idx (crdb_internal_a_shard_10 ASC)
+                                       )
 
 statement ok
 DROP INDEX column_used_on_unsharded_create_table_crdb_internal_a_shard_10_idx
@@ -442,13 +442,13 @@ query TT
 SHOW CREATE TABLE weird_names
 ----
 weird_names  CREATE TABLE public.weird_names (
-             "crdb_internal_I am a column with spaces_shard_12" INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes("I am a column with spaces")), 12:::INT8)) VIRTUAL,
-             "I am a column with spaces" INT8 NOT NULL,
-             "'quotes' in the column's name" INT8 NULL,
-             "crdb_internal_'quotes' in the column's name_shard_4" INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes("'quotes' in the column's name")), 4:::INT8)) VIRTUAL,
-             CONSTRAINT weird_names_pkey PRIMARY KEY ("I am a column with spaces" ASC) USING HASH WITH (bucket_count=12),
-             INDEX foo ("'quotes' in the column's name" ASC) USING HASH WITH (bucket_count=4)
-)
+               "crdb_internal_I am a column with spaces_shard_12" INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes("I am a column with spaces")), 12:::INT8)) VIRTUAL,
+               "I am a column with spaces" INT8 NOT NULL,
+               "'quotes' in the column's name" INT8 NULL,
+               "crdb_internal_'quotes' in the column's name_shard_4" INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes("'quotes' in the column's name")), 4:::INT8)) VIRTUAL,
+               CONSTRAINT weird_names_pkey PRIMARY KEY ("I am a column with spaces" ASC) USING HASH WITH (bucket_count=12),
+               INDEX foo ("'quotes' in the column's name" ASC) USING HASH WITH (bucket_count=4)
+             )
 
 subtest column_does_not_exist
 
@@ -516,14 +516,14 @@ query TT
 SHOW CREATE TABLE rename_column
 ----
 rename_column  CREATE TABLE public.rename_column (
-               c0 INT8 NOT NULL,
-               c1 INT8 NOT NULL,
-               c2 INT8 NULL,
-               crdb_internal_c0_c1_shard_8 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(c0, c1)), 8:::INT8)) VIRTUAL,
-               crdb_internal_c2_shard_8 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(c2)), 8:::INT8)) VIRTUAL,
-               CONSTRAINT rename_column_pkey PRIMARY KEY (c0 ASC, c1 ASC) USING HASH WITH (bucket_count=8),
-               INDEX rename_column_c2_idx (c2 ASC) USING HASH WITH (bucket_count=8)
-)
+                 c0 INT8 NOT NULL,
+                 c1 INT8 NOT NULL,
+                 c2 INT8 NULL,
+                 crdb_internal_c0_c1_shard_8 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(c0, c1)), 8:::INT8)) VIRTUAL,
+                 crdb_internal_c2_shard_8 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(c2)), 8:::INT8)) VIRTUAL,
+                 CONSTRAINT rename_column_pkey PRIMARY KEY (c0 ASC, c1 ASC) USING HASH WITH (bucket_count=8),
+                 INDEX rename_column_c2_idx (c2 ASC) USING HASH WITH (bucket_count=8)
+               )
 
 statement ok
 ALTER TABLE rename_column RENAME c2 TO c3;
@@ -539,14 +539,14 @@ query TT
 SHOW CREATE TABLE rename_column
 ----
 rename_column  CREATE TABLE public.rename_column (
-               c1 INT8 NOT NULL,
-               c2 INT8 NOT NULL,
-               c3 INT8 NULL,
-               crdb_internal_c1_c2_shard_8 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(c1, c2)), 8:::INT8)) VIRTUAL,
-               crdb_internal_c3_shard_8 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(c3)), 8:::INT8)) VIRTUAL,
-               CONSTRAINT rename_column_pkey PRIMARY KEY (c1 ASC, c2 ASC) USING HASH WITH (bucket_count=8),
-               INDEX rename_column_c2_idx (c3 ASC) USING HASH WITH (bucket_count=8)
-)
+                 c1 INT8 NOT NULL,
+                 c2 INT8 NOT NULL,
+                 c3 INT8 NULL,
+                 crdb_internal_c1_c2_shard_8 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(c1, c2)), 8:::INT8)) VIRTUAL,
+                 crdb_internal_c3_shard_8 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(c3)), 8:::INT8)) VIRTUAL,
+                 CONSTRAINT rename_column_pkey PRIMARY KEY (c1 ASC, c2 ASC) USING HASH WITH (bucket_count=8),
+                 INDEX rename_column_c2_idx (c3 ASC) USING HASH WITH (bucket_count=8)
+               )
 
 query III
 SELECT c3, c2, c1 FROM rename_column
@@ -561,14 +561,14 @@ query TT
 SHOW CREATE TABLE rename_column
 ----
 rename_column  CREATE TABLE public.rename_column (
-               c0 INT8 NOT NULL,
-               c1 INT8 NOT NULL,
-               c2 INT8 NULL,
-               crdb_internal_c0_c1_shard_8 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(c0, c1)), 8:::INT8)) VIRTUAL,
-               crdb_internal_c2_shard_8 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(c2)), 8:::INT8)) VIRTUAL,
-               CONSTRAINT rename_column_pkey PRIMARY KEY (c0 ASC, c1 ASC) USING HASH WITH (bucket_count=8),
-               INDEX rename_column_c2_idx (c2 ASC) USING HASH WITH (bucket_count=8)
-)
+                 c0 INT8 NOT NULL,
+                 c1 INT8 NOT NULL,
+                 c2 INT8 NULL,
+                 crdb_internal_c0_c1_shard_8 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(c0, c1)), 8:::INT8)) VIRTUAL,
+                 crdb_internal_c2_shard_8 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(c2)), 8:::INT8)) VIRTUAL,
+                 CONSTRAINT rename_column_pkey PRIMARY KEY (c0 ASC, c1 ASC) USING HASH WITH (bucket_count=8),
+                 INDEX rename_column_c2_idx (c2 ASC) USING HASH WITH (bucket_count=8)
+               )
 
 query III
 SELECT c2, c1, c0 FROM rename_column
@@ -772,9 +772,9 @@ query T
 SELECT @2 FROM [SHOW CREATE TABLE t]
 ----
 CREATE TABLE public.t (
-   crdb_internal_a_shard_8 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 8:::INT8)) VIRTUAL,
-   a INT8 NOT NULL,
-   CONSTRAINT t_pkey PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=8)
+  crdb_internal_a_shard_8 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 8:::INT8)) VIRTUAL,
+  a INT8 NOT NULL,
+  CONSTRAINT t_pkey PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=8)
 )
 
 # Make sure user defined constraint is used if it's equivalent to the shard
@@ -795,10 +795,10 @@ query T
 SELECT @2 FROM [SHOW CREATE TABLE t]
 ----
 CREATE TABLE public.t (
-   crdb_internal_a_shard_8 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 8:::INT8)) VIRTUAL,
-   a INT8 NOT NULL,
-   CONSTRAINT t_pkey PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=8),
-   CONSTRAINT check_crdb_internal_a_shard_8 CHECK (crdb_internal_a_shard_8 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8))
+  crdb_internal_a_shard_8 INT4 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 8:::INT8)) VIRTUAL,
+  a INT8 NOT NULL,
+  CONSTRAINT t_pkey PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=8),
+  CONSTRAINT check_crdb_internal_a_shard_8 CHECK (crdb_internal_a_shard_8 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8))
 )
 
 subtest test_hash_index_presplit
@@ -859,17 +859,17 @@ query T
 SELECT @2 FROM [SHOW CREATE TABLE t_default_bucket_16]
 ----
 CREATE TABLE public.t_default_bucket_16 (
-   crdb_internal_a_shard_16 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 16:::INT8)) VIRTUAL,
-   a INT8 NOT NULL,
-   b INT8 NULL,
-   c INT8 NULL,
-   crdb_internal_b_shard_16 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(b)), 16:::INT8)) VIRTUAL,
-   crdb_internal_c_shard_4 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(c)), 4:::INT8)) VIRTUAL,
-   CONSTRAINT t_default_bucket_16_pkey PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=16),
-   INDEX idx_t_default_bucket_16_b (b ASC) USING HASH WITH (bucket_count=16),
-   INDEX idx_t_default_bucket_16_c (c ASC) USING HASH WITH (bucket_count=4),
-   FAMILY fam_0_a (a),
-   FAMILY fam_1_c_b (c, b)
+  crdb_internal_a_shard_16 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 16:::INT8)) VIRTUAL,
+  a INT8 NOT NULL,
+  b INT8 NULL,
+  c INT8 NULL,
+  crdb_internal_b_shard_16 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(b)), 16:::INT8)) VIRTUAL,
+  crdb_internal_c_shard_4 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(c)), 4:::INT8)) VIRTUAL,
+  CONSTRAINT t_default_bucket_16_pkey PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=16),
+  INDEX idx_t_default_bucket_16_b (b ASC) USING HASH WITH (bucket_count=16),
+  INDEX idx_t_default_bucket_16_c (c ASC) USING HASH WITH (bucket_count=4),
+  FAMILY fam_0_a (a),
+  FAMILY fam_1_c_b (c, b)
 )
 
 statement ok
@@ -882,9 +882,9 @@ query T
 SELECT @2 FROM [SHOW CREATE TABLE t_default_bucket_8]
 ----
 CREATE TABLE public.t_default_bucket_8 (
-   crdb_internal_a_shard_8 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 8:::INT8)) VIRTUAL,
-   a INT8 NOT NULL,
-   CONSTRAINT t_default_bucket_8_pkey PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=8)
+  crdb_internal_a_shard_8 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(crdb_internal.datums_to_bytes(a)), 8:::INT8)) VIRTUAL,
+  a INT8 NOT NULL,
+  CONSTRAINT t_default_bucket_8_pkey PRIMARY KEY (a ASC) USING HASH WITH (bucket_count=8)
 )
 
 # Make sure that uniqueness is guaranteed with hash index.

--- a/pkg/sql/logictest/testdata/logic_test/hidden_columns
+++ b/pkg/sql/logictest/testdata/logic_test/hidden_columns
@@ -27,10 +27,10 @@ query TT
 SHOW CREATE TABLE t
 ----
 t  CREATE TABLE public.t (
-   x INT8 NOT VISIBLE NULL,
-   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   CONSTRAINT t_pkey PRIMARY KEY (rowid ASC)
-)
+     x INT8 NOT VISIBLE NULL,
+     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+     CONSTRAINT t_pkey PRIMARY KEY (rowid ASC)
+   )
 
 # Check that stars expand to no columns.
 

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -325,13 +325,13 @@ SHOW CREATE TABLE information_schema.tables
 ----
 table_name                 create_statement
 information_schema.tables  CREATE TABLE information_schema.tables (
-                           table_catalog STRING NOT NULL,
-                           table_schema STRING NOT NULL,
-                           table_name STRING NOT NULL,
-                           table_type STRING NOT NULL,
-                           is_insertable_into STRING NOT NULL,
-                           version INT8 NULL
-)
+                             table_catalog STRING NOT NULL,
+                             table_schema STRING NOT NULL,
+                             table_name STRING NOT NULL,
+                             table_type STRING NOT NULL,
+                             is_insertable_into STRING NOT NULL,
+                             version INT8 NULL
+                           )
 
 query TTBTTTB colnames
 SHOW COLUMNS FROM information_schema.tables

--- a/pkg/sql/logictest/testdata/logic_test/insert
+++ b/pkg/sql/logictest/testdata/logic_test/insert
@@ -478,21 +478,21 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE sw]
 ----
 CREATE TABLE public.sw (
-   a CHAR NULL,
-   b CHAR(3) NULL,
-   c VARCHAR NULL,
-   d VARCHAR(3) NULL,
-   e STRING NULL,
-   f STRING(3) NULL,
-   g "char" NULL,
-   ac CHAR COLLATE en NULL,
-   bc CHAR(3) COLLATE en NULL,
-   cc VARCHAR COLLATE en NULL,
-   dc VARCHAR(3) COLLATE en NULL,
-   ec STRING COLLATE en NULL,
-   fc STRING(3) COLLATE en NULL,
-   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   CONSTRAINT sw_pkey PRIMARY KEY (rowid ASC)
+  a CHAR NULL,
+  b CHAR(3) NULL,
+  c VARCHAR NULL,
+  d VARCHAR(3) NULL,
+  e STRING NULL,
+  f STRING(3) NULL,
+  g "char" NULL,
+  ac CHAR COLLATE en NULL,
+  bc CHAR(3) COLLATE en NULL,
+  cc VARCHAR COLLATE en NULL,
+  dc VARCHAR(3) COLLATE en NULL,
+  ec STRING COLLATE en NULL,
+  fc STRING(3) COLLATE en NULL,
+  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+  CONSTRAINT sw_pkey PRIMARY KEY (rowid ASC)
 )
 
 statement ok
@@ -602,9 +602,9 @@ query T
 SELECT create_statement FROM [SHOW CREATE t29494]
 ----
 CREATE TABLE public.t29494 (
-   x INT8 NULL,
-   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   CONSTRAINT t29494_pkey PRIMARY KEY (rowid ASC)
+  x INT8 NULL,
+  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+  CONSTRAINT t29494_pkey PRIMARY KEY (rowid ASC)
 )
 
 # Check that the new column is not usable in RETURNING.
@@ -641,10 +641,10 @@ query T
 SELECT create_statement FROM [SHOW CREATE t32759]
 ----
 CREATE TABLE public.t32759 (
-   x INT8 NULL,
-   z INT8 NULL,
-   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   CONSTRAINT t32759_pkey PRIMARY KEY (rowid ASC)
+  x INT8 NULL,
+  z INT8 NULL,
+  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+  CONSTRAINT t32759_pkey PRIMARY KEY (rowid ASC)
 )
 
 # Check that values cannot be inserted into the dropped column.

--- a/pkg/sql/logictest/testdata/logic_test/int_size
+++ b/pkg/sql/logictest/testdata/logic_test/int_size
@@ -22,10 +22,10 @@ query TT
 SHOW CREATE TABLE i4
 ----
 i4  CREATE TABLE public.i4 (
-    i4 INT4 NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    CONSTRAINT i4_pkey PRIMARY KEY (rowid ASC)
-)
+      i4 INT4 NULL,
+      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+      CONSTRAINT i4_pkey PRIMARY KEY (rowid ASC)
+    )
 
 subtest set_int8
 
@@ -44,10 +44,10 @@ query TT
 SHOW CREATE TABLE i8
 ----
 i8  CREATE TABLE public.i8 (
-    i8 INT8 NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    CONSTRAINT i8_pkey PRIMARY KEY (rowid ASC)
-)
+      i8 INT8 NULL,
+      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+      CONSTRAINT i8_pkey PRIMARY KEY (rowid ASC)
+    )
 
 # https://github.com/cockroachdb/cockroach/issues/32846
 subtest issue_32846
@@ -64,10 +64,10 @@ query TT
 SHOW CREATE TABLE late4
 ----
 late4  CREATE TABLE public.late4 (
-       a INT8 NULL,
-       rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-       CONSTRAINT late4_pkey PRIMARY KEY (rowid ASC)
-)
+         a INT8 NULL,
+         rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+         CONSTRAINT late4_pkey PRIMARY KEY (rowid ASC)
+       )
 
 query T
 SHOW default_int_size
@@ -96,10 +96,10 @@ query TT
 SHOW CREATE TABLE i4_rowid
 ----
 i4_rowid  CREATE TABLE public.i4_rowid (
-          a INT8 NOT NULL DEFAULT unique_rowid(),
-          rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-          CONSTRAINT i4_rowid_pkey PRIMARY KEY (rowid ASC)
-)
+            a INT8 NOT NULL DEFAULT unique_rowid(),
+            rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+            CONSTRAINT i4_rowid_pkey PRIMARY KEY (rowid ASC)
+          )
 
 statement ok
 SET default_int_size=8; SET serial_normalization='rowid';
@@ -111,10 +111,10 @@ query TT
 SHOW CREATE TABLE i8_rowid
 ----
 i8_rowid  CREATE TABLE public.i8_rowid (
-          a INT8 NOT NULL DEFAULT unique_rowid(),
-          rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-          CONSTRAINT i8_rowid_pkey PRIMARY KEY (rowid ASC)
-)
+            a INT8 NOT NULL DEFAULT unique_rowid(),
+            rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+            CONSTRAINT i8_rowid_pkey PRIMARY KEY (rowid ASC)
+          )
 
 subtest serial_sql_sequence
 # When using rowid, we should see an INTx that matches the current size setting.
@@ -129,10 +129,10 @@ query TT
 SHOW CREATE TABLE i4_sql_sequence
 ----
 i4_sql_sequence  CREATE TABLE public.i4_sql_sequence (
-                 a INT4 NOT NULL DEFAULT nextval('public.i4_sql_sequence_a_seq'::REGCLASS),
-                 rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                 CONSTRAINT i4_sql_sequence_pkey PRIMARY KEY (rowid ASC)
-)
+                   a INT4 NOT NULL DEFAULT nextval('public.i4_sql_sequence_a_seq'::REGCLASS),
+                   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                   CONSTRAINT i4_sql_sequence_pkey PRIMARY KEY (rowid ASC)
+                 )
 
 statement ok
 SET default_int_size=8; SET serial_normalization='sql_sequence';
@@ -144,10 +144,10 @@ query TT
 SHOW CREATE TABLE i8_sql_sequence
 ----
 i8_sql_sequence  CREATE TABLE public.i8_sql_sequence (
-                 a INT8 NOT NULL DEFAULT nextval('public.i8_sql_sequence_a_seq'::REGCLASS),
-                 rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                 CONSTRAINT i8_sql_sequence_pkey PRIMARY KEY (rowid ASC)
-)
+                   a INT8 NOT NULL DEFAULT nextval('public.i8_sql_sequence_a_seq'::REGCLASS),
+                   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                   CONSTRAINT i8_sql_sequence_pkey PRIMARY KEY (rowid ASC)
+                 )
 
 subtest serial_virtual_sequence
 # Virtual sequences are a wrapper around unique_rowid(), so they will also
@@ -163,10 +163,10 @@ query TT
 SHOW CREATE TABLE i4_virtual_sequence
 ----
 i4_virtual_sequence  CREATE TABLE public.i4_virtual_sequence (
-                     a INT8 NOT NULL DEFAULT nextval('public.i4_virtual_sequence_a_seq'::REGCLASS),
-                     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                     CONSTRAINT i4_virtual_sequence_pkey PRIMARY KEY (rowid ASC)
-)
+                       a INT8 NOT NULL DEFAULT nextval('public.i4_virtual_sequence_a_seq'::REGCLASS),
+                       rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                       CONSTRAINT i4_virtual_sequence_pkey PRIMARY KEY (rowid ASC)
+                     )
 
 statement ok
 SET default_int_size=8; SET serial_normalization='virtual_sequence';
@@ -178,7 +178,7 @@ query TT
 SHOW CREATE TABLE i8_virtual_sequence
 ----
 i8_virtual_sequence  CREATE TABLE public.i8_virtual_sequence (
-                     a INT8 NOT NULL DEFAULT nextval('public.i8_virtual_sequence_a_seq'::REGCLASS),
-                     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                     CONSTRAINT i8_virtual_sequence_pkey PRIMARY KEY (rowid ASC)
-)
+                       a INT8 NOT NULL DEFAULT nextval('public.i8_virtual_sequence_a_seq'::REGCLASS),
+                       rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                       CONSTRAINT i8_virtual_sequence_pkey PRIMARY KEY (rowid ASC)
+                     )

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -37,14 +37,14 @@ query TT
 SHOW CREATE TABLE c
 ----
 c  CREATE TABLE public.c (
-   id INT8 NOT NULL,
-   foo JSONB NULL,
-   "bAr" JSONB NULL,
-   "qUuX" JSONB NULL,
-   CONSTRAINT c_pkey PRIMARY KEY (id ASC),
-   INVERTED INDEX c_foo_idx (foo),
-   INVERTED INDEX "c_bAr_idx" ("bAr")
-)
+     id INT8 NOT NULL,
+     foo JSONB NULL,
+     "bAr" JSONB NULL,
+     "qUuX" JSONB NULL,
+     CONSTRAINT c_pkey PRIMARY KEY (id ASC),
+     INVERTED INDEX c_foo_idx (foo),
+     INVERTED INDEX "c_bAr_idx" ("bAr")
+   )
 
 # Test that only the permitted opclasses are usable to make an inverted index.
 statement error operator class \"blah_ops\" does not exist
@@ -1220,13 +1220,13 @@ query TT
 SHOW CREATE TABLE c
 ----
 c  CREATE TABLE public.c (
-   id INT8 NOT NULL,
-   foo INT8[] NULL,
-   bar STRING[] NULL,
-   CONSTRAINT c_pkey PRIMARY KEY (id ASC),
-   INVERTED INDEX c_foo_idx (foo),
-   INVERTED INDEX c_bar_idx (bar)
-)
+     id INT8 NOT NULL,
+     foo INT8[] NULL,
+     bar STRING[] NULL,
+     CONSTRAINT c_pkey PRIMARY KEY (id ASC),
+     INVERTED INDEX c_foo_idx (foo),
+     INVERTED INDEX c_bar_idx (bar)
+   )
 
 query ITT
 SELECT * from c WHERE bar @> ARRAY['foo']
@@ -1592,13 +1592,13 @@ query T
 SELECT @2 FROM [SHOW CREATE TABLE table_desc_inverted_index];
 ----
 CREATE TABLE public.table_desc_inverted_index (
-   id INT8 NOT NULL,
-   last_accessed TIMESTAMP NULL,
-   testdata JSONB NULL,
-   CONSTRAINT table_desc_inverted_index_pkey PRIMARY KEY (id ASC),
-   INVERTED INDEX inv_idx_testdata (last_accessed DESC, testdata),
-   FAMILY f1 (id, last_accessed),
-   FAMILY f2 (testdata)
+  id INT8 NOT NULL,
+  last_accessed TIMESTAMP NULL,
+  testdata JSONB NULL,
+  CONSTRAINT table_desc_inverted_index_pkey PRIMARY KEY (id ASC),
+  INVERTED INDEX inv_idx_testdata (last_accessed DESC, testdata),
+  FAMILY f1 (id, last_accessed),
+  FAMILY f2 (testdata)
 )
 
 subtest overlaps_with_array

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index_multi_column
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index_multi_column
@@ -46,14 +46,14 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE s]
 ----
 CREATE TABLE public.s (
-   k INT8 NOT NULL,
-   a INT8 NULL,
-   geom GEOMETRY NULL,
-   CONSTRAINT s_pkey PRIMARY KEY (k ASC),
-   INVERTED INDEX s_a_geom_idx (a ASC, geom) WITH (geometry_min_x=0),
-   FAMILY fam_0_k (k),
-   FAMILY fam_1_a (a),
-   FAMILY fam_2_geom (geom)
+  k INT8 NOT NULL,
+  a INT8 NULL,
+  geom GEOMETRY NULL,
+  CONSTRAINT s_pkey PRIMARY KEY (k ASC),
+  INVERTED INDEX s_a_geom_idx (a ASC, geom) WITH (geometry_min_x=0),
+  FAMILY fam_0_k (k),
+  FAMILY fam_1_a (a),
+  FAMILY fam_2_geom (geom)
 )
 
 # Dropping the inverted column of the index drops the index.
@@ -72,11 +72,11 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE drop_j]
 ----
 CREATE TABLE public.drop_j (
-   a INT8 NULL,
-   b INT8 NULL,
-   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   CONSTRAINT drop_j_pkey PRIMARY KEY (rowid ASC),
-   FAMILY fam_0_a_b_j_rowid (a, b, rowid)
+  a INT8 NULL,
+  b INT8 NULL,
+  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+  CONSTRAINT drop_j_pkey PRIMARY KEY (rowid ASC),
+  FAMILY fam_0_a_b_j_rowid (a, b, rowid)
 )
 
 # Dropping the non-inverted column of the index drops the index.
@@ -95,11 +95,11 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE drop_a]
 ----
 CREATE TABLE public.drop_a (
-   b INT8 NULL,
-   j JSONB NULL,
-   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   CONSTRAINT drop_a_pkey PRIMARY KEY (rowid ASC),
-   FAMILY fam_0_a_b_j_rowid (b, j, rowid)
+  b INT8 NULL,
+  j JSONB NULL,
+  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+  CONSTRAINT drop_a_pkey PRIMARY KEY (rowid ASC),
+  FAMILY fam_0_a_b_j_rowid (b, j, rowid)
 )
 
 # CREATE TABLE LIKE ... INCLUDING INDEXES copies multi-column inverted indexes.
@@ -111,13 +111,13 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE dst]
 ----
 CREATE TABLE public.dst (
-   a INT8 NULL,
-   b INT8 NULL,
-   j JSONB NULL,
-   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   CONSTRAINT dst_pkey PRIMARY KEY (rowid ASC),
-   INVERTED INDEX src_a_j_idx (a ASC, j),
-   INVERTED INDEX src_a_b_j_idx (a ASC, b ASC, j)
+  a INT8 NULL,
+  b INT8 NULL,
+  j JSONB NULL,
+  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+  CONSTRAINT dst_pkey PRIMARY KEY (rowid ASC),
+  INVERTED INDEX src_a_j_idx (a ASC, j),
+  INVERTED INDEX src_a_b_j_idx (a ASC, b ASC, j)
 )
 
 # Test dropping a table with a multi-column inverted index.

--- a/pkg/sql/logictest/testdata/logic_test/name_escapes
+++ b/pkg/sql/logictest/testdata/logic_test/name_escapes
@@ -21,23 +21,23 @@ query TT
 SHOW CREATE TABLE ";--notbetter"
 ----
 ";--notbetter"  CREATE TABLE public.";--notbetter" (
-                x INT8 NOT NULL,
-                y INT8 NULL,
-                "welp INT); -- concerning much
-DROP USER dumpty;
-CREATE TABLE unused (x " INT8 NULL,
-  CONSTRAINT "getmeoutofhere PRIMARY KEY (x ASC)); -- saveme!
-DROP USER madhatter;
-CREATE TABLE unused4(x INT, CONSTRAINT woo " PRIMARY KEY (x ASC),
-  INDEX "helpme ON (x)); -- this must stop!
-DROP USER alice;
-CREATE TABLE unused2(x INT, INDEX woo ON " (x ASC),
-  FAMILY "nonotagain (x)); -- welp!
-DROP USER queenofhearts;
-CREATE TABLE unused3(x INT, y INT, FAMILY woo " (x, y, "welp INT); -- concerning much
-DROP USER dumpty;
-CREATE TABLE unused (x ")
-)
+                  x INT8 NOT NULL,
+                  y INT8 NULL,
+                  "welp INT); -- concerning much
+                DROP USER dumpty;
+                CREATE TABLE unused (x " INT8 NULL,
+                  CONSTRAINT "getmeoutofhere PRIMARY KEY (x ASC)); -- saveme!
+                DROP USER madhatter;
+                CREATE TABLE unused4(x INT, CONSTRAINT woo " PRIMARY KEY (x ASC),
+                  INDEX "helpme ON (x)); -- this must stop!
+                DROP USER alice;
+                CREATE TABLE unused2(x INT, INDEX woo ON " (x ASC),
+                  FAMILY "nonotagain (x)); -- welp!
+                DROP USER queenofhearts;
+                CREATE TABLE unused3(x INT, y INT, FAMILY woo " (x, y, "welp INT); -- concerning much
+                DROP USER dumpty;
+                CREATE TABLE unused (x ")
+                )
 
 # Check that view creates handle strange things properly.
 statement ok
@@ -47,13 +47,10 @@ query TT
 SHOW CREATE VIEW ";--alsoconcerning"
 ----
 ";--alsoconcerning"  CREATE VIEW public.";--alsoconcerning" (
-                     a,
-                     b,
-                     c
-) AS SELECT
-    @1 AS a, @2 AS b, @3 AS c
-  FROM
-    test.public.";--notbetter"
+                       a,
+                       b,
+                       c
+                     ) AS SELECT @1 AS a, @2 AS b, @3 AS c FROM test.public.";--notbetter"
 
 # Check that "create table as" handles strange things properly.
 statement ok
@@ -63,9 +60,9 @@ query TT
 SHOW CREATE TABLE ";--dontask"
 ----
 ";--dontask"  CREATE TABLE public.";--dontask" (
-              a INT8 NULL,
-              b INT8 NULL,
-              c INT8 NULL,
-              rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-              CONSTRAINT ";--dontask_pkey" PRIMARY KEY (rowid ASC)
-)
+                a INT8 NULL,
+                b INT8 NULL,
+                c INT8 NULL,
+                rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                CONSTRAINT ";--dontask_pkey" PRIMARY KEY (rowid ASC)
+              )

--- a/pkg/sql/logictest/testdata/logic_test/new_schema_changer
+++ b/pkg/sql/logictest/testdata/logic_test/new_schema_changer
@@ -819,11 +819,11 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE trewrite]
 ----
 CREATE TABLE public.trewrite (
-   k INT8 NOT NULL,
-   ts TIMESTAMPTZ NULL,
-   c STRING NULL AS (to_char(timezone('utc':::STRING, ts))) STORED,
-   CONSTRAINT trewrite_pkey PRIMARY KEY (k ASC),
-   FAMILY fam_0_k_ts (k, ts, c)
+  k INT8 NOT NULL,
+  ts TIMESTAMPTZ NULL,
+  c STRING NULL AS (to_char(timezone('utc':::STRING, ts))) STORED,
+  CONSTRAINT trewrite_pkey PRIMARY KEY (k ASC),
+  FAMILY fam_0_k_ts (k, ts, c)
 )
 
 subtest create-index
@@ -1431,11 +1431,11 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE t]
 ----
 CREATE TABLE public.t (
-   i INT8 NOT NULL,
-   k INT8 NOT NULL AS (i + 3:::INT8) STORED,
-   j INT8 NULL DEFAULT 42:::INT8,
-   CONSTRAINT t_pkey PRIMARY KEY (i ASC),
-   UNIQUE INDEX t_k_key (k ASC)
+  i INT8 NOT NULL,
+  k INT8 NOT NULL AS (i + 3:::INT8) STORED,
+  j INT8 NULL DEFAULT 42:::INT8,
+  CONSTRAINT t_pkey PRIMARY KEY (i ASC),
+  UNIQUE INDEX t_k_key (k ASC)
 )
 
 query III rowsort

--- a/pkg/sql/logictest/testdata/logic_test/on_update
+++ b/pkg/sql/logictest/testdata/logic_test/on_update
@@ -192,12 +192,12 @@ query TT
 SHOW CREATE TABLE test_show_default
 ----
 test_show_default  CREATE TABLE public.test_show_default (
-                   p STRING NOT NULL,
-                   k STRING NULL DEFAULT 'def':::STRING ON UPDATE 'regress':::STRING,
-                   CONSTRAINT "primary" PRIMARY KEY (p ASC),
-                   FAMILY fam_0_p (p),
-                   FAMILY fam_1_k (k)
-)
+                     p STRING NOT NULL,
+                     k STRING NULL DEFAULT 'def':::STRING ON UPDATE 'regress':::STRING,
+                     CONSTRAINT "primary" PRIMARY KEY (p ASC),
+                     FAMILY fam_0_p (p),
+                     FAMILY fam_1_k (k)
+                   )
 
 statement ok
 CREATE TABLE test_show_fk (
@@ -213,15 +213,15 @@ query TT
 SHOW CREATE TABLE test_show_fk
 ----
 test_show_fk  CREATE TABLE public.test_show_fk (
-              p STRING NOT NULL,
-              j STRING NULL,
-              k STRING NULL ON UPDATE 'regress':::STRING,
-              CONSTRAINT test_show_fk_pkey PRIMARY KEY (p ASC),
-              CONSTRAINT test_show_fk_j_fkey FOREIGN KEY (j) REFERENCES public.test_fk_base(j) ON UPDATE CASCADE,
-              FAMILY fam_0_p (p),
-              FAMILY fam_1_j (j),
-              FAMILY fam_2_k (k)
-)
+                p STRING NOT NULL,
+                j STRING NULL,
+                k STRING NULL ON UPDATE 'regress':::STRING,
+                CONSTRAINT test_show_fk_pkey PRIMARY KEY (p ASC),
+                CONSTRAINT test_show_fk_j_fkey FOREIGN KEY (j) REFERENCES public.test_fk_base(j) ON UPDATE CASCADE,
+                FAMILY fam_0_p (p),
+                FAMILY fam_1_j (j),
+                FAMILY fam_2_k (k)
+              )
 
 # Sequence tests
 subtest SequenceDependencies

--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -114,19 +114,19 @@ query TT
 SHOW CREATE TABLE t6
 ----
 t6  CREATE TABLE public.t6 (
-    a INT8 NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    CONSTRAINT t6_pkey PRIMARY KEY (rowid ASC),
-    INDEX t6_a_idx (a ASC) WHERE a > 0:::INT8,
-    INDEX t6_a_idx1 (a ASC) WHERE a > 1:::INT8,
-    INDEX t6_a_idx2 (a DESC) WHERE a > 2:::INT8,
-    UNIQUE INDEX t6_a_key (a ASC) WHERE a > 3:::INT8,
-    UNIQUE INDEX t6_a_key1 (a ASC) WHERE a > 4:::INT8,
-    UNIQUE INDEX t6_a_key2 (a DESC) WHERE a > 5:::INT8,
-    INDEX t6i1 (a ASC) WHERE a > 6:::INT8,
-    INDEX t6i2 (a ASC) WHERE a > 7:::INT8,
-    INDEX t6i3 (a DESC) WHERE a > 8:::INT8
-)
+      a INT8 NULL,
+      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+      CONSTRAINT t6_pkey PRIMARY KEY (rowid ASC),
+      INDEX t6_a_idx (a ASC) WHERE a > 0:::INT8,
+      INDEX t6_a_idx1 (a ASC) WHERE a > 1:::INT8,
+      INDEX t6_a_idx2 (a DESC) WHERE a > 2:::INT8,
+      UNIQUE INDEX t6_a_key (a ASC) WHERE a > 3:::INT8,
+      UNIQUE INDEX t6_a_key1 (a ASC) WHERE a > 4:::INT8,
+      UNIQUE INDEX t6_a_key2 (a DESC) WHERE a > 5:::INT8,
+      INDEX t6i1 (a ASC) WHERE a > 6:::INT8,
+      INDEX t6i2 (a ASC) WHERE a > 7:::INT8,
+      INDEX t6i3 (a DESC) WHERE a > 8:::INT8
+    )
 
 # Renaming a column updates the index predicates.
 
@@ -137,19 +137,19 @@ query TT
 SHOW CREATE TABLE t6
 ----
 t6  CREATE TABLE public.t6 (
-    b INT8 NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    CONSTRAINT t6_pkey PRIMARY KEY (rowid ASC),
-    INDEX t6_a_idx (b ASC) WHERE b > 0:::INT8,
-    INDEX t6_a_idx1 (b ASC) WHERE b > 1:::INT8,
-    INDEX t6_a_idx2 (b DESC) WHERE b > 2:::INT8,
-    UNIQUE INDEX t6_a_key (b ASC) WHERE b > 3:::INT8,
-    UNIQUE INDEX t6_a_key1 (b ASC) WHERE b > 4:::INT8,
-    UNIQUE INDEX t6_a_key2 (b DESC) WHERE b > 5:::INT8,
-    INDEX t6i1 (b ASC) WHERE b > 6:::INT8,
-    INDEX t6i2 (b ASC) WHERE b > 7:::INT8,
-    INDEX t6i3 (b DESC) WHERE b > 8:::INT8
-)
+      b INT8 NULL,
+      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+      CONSTRAINT t6_pkey PRIMARY KEY (rowid ASC),
+      INDEX t6_a_idx (b ASC) WHERE b > 0:::INT8,
+      INDEX t6_a_idx1 (b ASC) WHERE b > 1:::INT8,
+      INDEX t6_a_idx2 (b DESC) WHERE b > 2:::INT8,
+      UNIQUE INDEX t6_a_key (b ASC) WHERE b > 3:::INT8,
+      UNIQUE INDEX t6_a_key1 (b ASC) WHERE b > 4:::INT8,
+      UNIQUE INDEX t6_a_key2 (b DESC) WHERE b > 5:::INT8,
+      INDEX t6i1 (b ASC) WHERE b > 6:::INT8,
+      INDEX t6i2 (b ASC) WHERE b > 7:::INT8,
+      INDEX t6i3 (b DESC) WHERE b > 8:::INT8
+    )
 
 # Renaming a table keeps the index predicates intact.
 
@@ -160,19 +160,19 @@ query TT
 SHOW CREATE TABLE t7
 ----
 t7  CREATE TABLE public.t7 (
-    b INT8 NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    CONSTRAINT t6_pkey PRIMARY KEY (rowid ASC),
-    INDEX t6_a_idx (b ASC) WHERE b > 0:::INT8,
-    INDEX t6_a_idx1 (b ASC) WHERE b > 1:::INT8,
-    INDEX t6_a_idx2 (b DESC) WHERE b > 2:::INT8,
-    UNIQUE INDEX t6_a_key (b ASC) WHERE b > 3:::INT8,
-    UNIQUE INDEX t6_a_key1 (b ASC) WHERE b > 4:::INT8,
-    UNIQUE INDEX t6_a_key2 (b DESC) WHERE b > 5:::INT8,
-    INDEX t6i1 (b ASC) WHERE b > 6:::INT8,
-    INDEX t6i2 (b ASC) WHERE b > 7:::INT8,
-    INDEX t6i3 (b DESC) WHERE b > 8:::INT8
-)
+      b INT8 NULL,
+      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+      CONSTRAINT t6_pkey PRIMARY KEY (rowid ASC),
+      INDEX t6_a_idx (b ASC) WHERE b > 0:::INT8,
+      INDEX t6_a_idx1 (b ASC) WHERE b > 1:::INT8,
+      INDEX t6_a_idx2 (b DESC) WHERE b > 2:::INT8,
+      UNIQUE INDEX t6_a_key (b ASC) WHERE b > 3:::INT8,
+      UNIQUE INDEX t6_a_key1 (b ASC) WHERE b > 4:::INT8,
+      UNIQUE INDEX t6_a_key2 (b DESC) WHERE b > 5:::INT8,
+      INDEX t6i1 (b ASC) WHERE b > 6:::INT8,
+      INDEX t6i2 (b ASC) WHERE b > 7:::INT8,
+      INDEX t6i3 (b DESC) WHERE b > 8:::INT8
+    )
 
 # Dropping a column referenced in the predicate drops the index.
 
@@ -193,13 +193,13 @@ query TT
 SHOW CREATE TABLE t8
 ----
 t8  CREATE TABLE public.t8 (
-    a INT8 NULL,
-    b INT8 NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    CONSTRAINT t8_pkey PRIMARY KEY (rowid ASC),
-    INDEX t8_a_idx (a ASC) WHERE b > 0:::INT8,
-    FAMILY fam_0_a_b_c_rowid (a, b, rowid)
-)
+      a INT8 NULL,
+      b INT8 NULL,
+      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+      CONSTRAINT t8_pkey PRIMARY KEY (rowid ASC),
+      INDEX t8_a_idx (a ASC) WHERE b > 0:::INT8,
+      FAMILY fam_0_a_b_c_rowid (a, b, rowid)
+    )
 
 # CREATE TABLE LIKE ... INCLUDING INDEXES copies partial index predicate
 # expressions to the new table.
@@ -214,12 +214,12 @@ query TT
 SHOW CREATE TABLE t10
 ----
 t10  CREATE TABLE public.t10 (
-     a INT8 NULL,
-     b INT8 NULL,
-     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-     CONSTRAINT t10_pkey PRIMARY KEY (rowid ASC),
-     INDEX t9_a_idx (a ASC) WHERE b > 1:::INT8
-)
+       a INT8 NULL,
+       b INT8 NULL,
+       rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+       CONSTRAINT t10_pkey PRIMARY KEY (rowid ASC),
+       INDEX t9_a_idx (a ASC) WHERE b > 1:::INT8
+     )
 
 # SHOW CONSTRAINTS includes partial index predicate of UNIQUE partial indexes.
 
@@ -1138,13 +1138,13 @@ query TT
 SHOW CREATE TABLE enum_table_show
 ----
 enum_table_show  CREATE TABLE public.enum_table_show (
-                 a INT8 NULL,
-                 b test.public.enum_type NULL,
-                 rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                 CONSTRAINT enum_table_show_pkey PRIMARY KEY (rowid ASC),
-                 INDEX i (a ASC) WHERE b IN ('foo':::test.public.enum_type, 'bar':::test.public.enum_type),
-                 FAMILY fam_0_a_b_rowid (a, b, rowid)
-)
+                   a INT8 NULL,
+                   b test.public.enum_type NULL,
+                   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                   CONSTRAINT enum_table_show_pkey PRIMARY KEY (rowid ASC),
+                   INDEX i (a ASC) WHERE b IN ('foo':::test.public.enum_type, 'bar':::test.public.enum_type),
+                   FAMILY fam_0_a_b_rowid (a, b, rowid)
+                 )
 
 # Inverted partial indexes.
 subtest inverted

--- a/pkg/sql/logictest/testdata/logic_test/partial_txn_commit
+++ b/pkg/sql/logictest/testdata/logic_test/partial_txn_commit
@@ -31,7 +31,7 @@ query TT
 SHOW CREATE t
 ----
 t  CREATE TABLE public.t (
-   x INT8 NULL,
-   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   CONSTRAINT t_pkey PRIMARY KEY (rowid ASC)
-)
+     x INT8 NULL,
+     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+     CONSTRAINT t_pkey PRIMARY KEY (rowid ASC)
+   )

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -309,11 +309,11 @@ SHOW CREATE TABLE pg_catalog.pg_namespace
 ----
 table_name               create_statement
 pg_catalog.pg_namespace  CREATE TABLE pg_catalog.pg_namespace (
-                         oid OID NULL,
-                         nspname NAME NOT NULL,
-                         nspowner OID NULL,
-                         nspacl STRING[] NULL
-)
+                           oid OID NULL,
+                           nspname NAME NOT NULL,
+                           nspowner OID NULL,
+                           nspacl STRING[] NULL
+                         )
 
 query TTBTTTB colnames
 SHOW COLUMNS FROM pg_catalog.pg_namespace

--- a/pkg/sql/logictest/testdata/logic_test/rename_constraint
+++ b/pkg/sql/logictest/testdata/logic_test/rename_constraint
@@ -11,13 +11,13 @@ query T
 SELECT create_statement FROM [SHOW CREATE t]
 ----
 CREATE TABLE public.t (
-   x INT8 NULL,
-   y INT8 NULL,
-   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   CONSTRAINT t_pkey PRIMARY KEY (rowid ASC),
-   CONSTRAINT cf FOREIGN KEY (x) REFERENCES public.t(x),
-   UNIQUE INDEX cu (x ASC),
-   CONSTRAINT cc CHECK (x > 10:::INT8)
+  x INT8 NULL,
+  y INT8 NULL,
+  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+  CONSTRAINT t_pkey PRIMARY KEY (rowid ASC),
+  CONSTRAINT cf FOREIGN KEY (x) REFERENCES public.t(x),
+  UNIQUE INDEX cu (x ASC),
+  CONSTRAINT cc CHECK (x > 10:::INT8)
 )
 
 query TT
@@ -39,13 +39,13 @@ query T
 SELECT create_statement FROM [SHOW CREATE t]
 ----
 CREATE TABLE public.t (
-   x INT8 NULL,
-   y INT8 NULL,
-   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   CONSTRAINT t_pkey PRIMARY KEY (rowid ASC),
-   CONSTRAINT cf2 FOREIGN KEY (x) REFERENCES public.t(x),
-   UNIQUE INDEX cu2 (x ASC),
-   CONSTRAINT cc2 CHECK (x > 10:::INT8)
+  x INT8 NULL,
+  y INT8 NULL,
+  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+  CONSTRAINT t_pkey PRIMARY KEY (rowid ASC),
+  CONSTRAINT cf2 FOREIGN KEY (x) REFERENCES public.t(x),
+  UNIQUE INDEX cu2 (x ASC),
+  CONSTRAINT cc2 CHECK (x > 10:::INT8)
 )
 
 query TT
@@ -91,13 +91,13 @@ query T
 SELECT create_statement FROM [SHOW CREATE t]
 ----
 CREATE TABLE public.t (
-   x INT8 NULL,
-   y INT8 NULL,
-   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   CONSTRAINT t_pkey PRIMARY KEY (rowid ASC),
-   CONSTRAINT cf4 FOREIGN KEY (x) REFERENCES public.t(x),
-   UNIQUE INDEX cu4 (x ASC),
-   CONSTRAINT cc4 CHECK (x > 10:::INT8)
+  x INT8 NULL,
+  y INT8 NULL,
+  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+  CONSTRAINT t_pkey PRIMARY KEY (rowid ASC),
+  CONSTRAINT cf4 FOREIGN KEY (x) REFERENCES public.t(x),
+  UNIQUE INDEX cu4 (x ASC),
+  CONSTRAINT cc4 CHECK (x > 10:::INT8)
 )
 
 query TT

--- a/pkg/sql/logictest/testdata/logic_test/row_level_ttl
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_ttl
@@ -97,11 +97,11 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl]
 ----
 CREATE TABLE public.tbl (
-                                                                                                                      id INT8 NOT NULL,
-                                                                                                                      text STRING NULL,
-                                                                                                                      crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-                                                                                                                      CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
-                                                                                                                      FAMILY fam_0_id_text_crdb_internal_expiration (id, text, crdb_internal_expiration)
+  id INT8 NOT NULL,
+  text STRING NULL,
+  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
+  FAMILY fam_0_id_text_crdb_internal_expiration (id, text, crdb_internal_expiration)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@hourly')
 
 statement ok
@@ -162,11 +162,11 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl]
 ----
 CREATE TABLE public.tbl (
-                                                                                                                     id INT8 NOT NULL,
-                                                                                                                     text STRING NULL,
-                                                                                                                     crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '10 days':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '10 days':::INTERVAL,
-                                                                                                                     CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
-                                                                                                                     FAMILY fam_0_id_text_crdb_internal_expiration (id, text, crdb_internal_expiration)
+  id INT8 NOT NULL,
+  text STRING NULL,
+  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '10 days':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '10 days':::INTERVAL,
+  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
+  FAMILY fam_0_id_text_crdb_internal_expiration (id, text, crdb_internal_expiration)
 ) WITH (ttl = 'on', ttl_expire_after = '10 days':::INTERVAL, ttl_job_cron = '@hourly')
 
 statement error cannot modify TTL settings while another schema change on the table is being processed
@@ -200,10 +200,10 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl]
 ----
 CREATE TABLE public.tbl (
-   id INT8 NOT NULL,
-   text STRING NULL,
-   CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
-   FAMILY fam_0_id_text_crdb_internal_expiration (id, text)
+  id INT8 NOT NULL,
+  text STRING NULL,
+  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
+  FAMILY fam_0_id_text_crdb_internal_expiration (id, text)
 )
 
 statement ok
@@ -310,11 +310,11 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl]
 ----
 CREATE TABLE public.tbl (
-                                                                                                                      id INT8 NOT NULL,
-                                                                                                                      text STRING NULL,
-                                                                                                                      crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-                                                                                                                      CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
-                                                                                                                      FAMILY fam_0_id_text_crdb_internal_expiration (id, text, crdb_internal_expiration)
+  id INT8 NOT NULL,
+  text STRING NULL,
+  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
+  FAMILY fam_0_id_text_crdb_internal_expiration (id, text, crdb_internal_expiration)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@hourly')
 
 # Test no-ops.
@@ -325,11 +325,11 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl]
 ----
 CREATE TABLE public.tbl (
-                                                                                                                      id INT8 NOT NULL,
-                                                                                                                      text STRING NULL,
-                                                                                                                      crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-                                                                                                                      CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
-                                                                                                                      FAMILY fam_0_id_text_crdb_internal_expiration (id, text, crdb_internal_expiration)
+  id INT8 NOT NULL,
+  text STRING NULL,
+  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
+  FAMILY fam_0_id_text_crdb_internal_expiration (id, text, crdb_internal_expiration)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@hourly')
 
 let $table_id
@@ -367,11 +367,11 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl]
 ----
 CREATE TABLE public.tbl (
-                                                                                                                     id INT8 NOT NULL,
-                                                                                                                     text STRING NULL,
-                                                                                                                     crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-                                                                                                                     CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
-                                                                                                                     FAMILY fam_0_id_text_crdb_internal_expiration (id, text, crdb_internal_expiration)
+  id INT8 NOT NULL,
+  text STRING NULL,
+  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
+  FAMILY fam_0_id_text_crdb_internal_expiration (id, text, crdb_internal_expiration)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@daily')
 
 let $table_id
@@ -390,11 +390,11 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl]
 ----
 CREATE TABLE public.tbl (
-                                                                                                                      id INT8 NOT NULL,
-                                                                                                                      text STRING NULL,
-                                                                                                                      crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-                                                                                                                      CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
-                                                                                                                      FAMILY fam_0_id_text_crdb_internal_expiration (id, text, crdb_internal_expiration)
+  id INT8 NOT NULL,
+  text STRING NULL,
+  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
+  FAMILY fam_0_id_text_crdb_internal_expiration (id, text, crdb_internal_expiration)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@weekly')
 
 
@@ -411,11 +411,11 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl]
 ----
 CREATE TABLE public.tbl (
-                                                                                                                      id INT8 NOT NULL,
-                                                                                                                      text STRING NULL,
-                                                                                                                      crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-                                                                                                                      CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
-                                                                                                                      FAMILY fam_0_id_text_crdb_internal_expiration (id, text, crdb_internal_expiration)
+  id INT8 NOT NULL,
+  text STRING NULL,
+  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
+  FAMILY fam_0_id_text_crdb_internal_expiration (id, text, crdb_internal_expiration)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@hourly')
 
 query TTT
@@ -461,11 +461,11 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl]
 ----
 CREATE TABLE public.tbl (
-                                                                                                                                                                                                                                                                                            id INT8 NOT NULL,
-                                                                                                                                                                                                                                                                                            text STRING NULL,
-                                                                                                                                                                                                                                                                                            crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-                                                                                                                                                                                                                                                                                            CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
-                                                                                                                                                                                                                                                                                            FAMILY fam_0_id_text_crdb_internal_expiration (id, text, crdb_internal_expiration)
+  id INT8 NOT NULL,
+  text STRING NULL,
+  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
+  FAMILY fam_0_id_text_crdb_internal_expiration (id, text, crdb_internal_expiration)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@hourly', ttl_select_batch_size = 50, ttl_delete_rate_limit = 100, ttl_pause = true, ttl_row_stats_poll_interval = '1m0s', ttl_label_metrics = true)
 
 statement ok
@@ -475,11 +475,11 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl]
 ----
 CREATE TABLE public.tbl (
-                                                                                                                                                                                                                                                                                                                         id INT8 NOT NULL,
-                                                                                                                                                                                                                                                                                                                         text STRING NULL,
-                                                                                                                                                                                                                                                                                                                         crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-                                                                                                                                                                                                                                                                                                                         CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
-                                                                                                                                                                                                                                                                                                                         FAMILY fam_0_id_text_crdb_internal_expiration (id, text, crdb_internal_expiration)
+  id INT8 NOT NULL,
+  text STRING NULL,
+  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
+  FAMILY fam_0_id_text_crdb_internal_expiration (id, text, crdb_internal_expiration)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@hourly', ttl_select_batch_size = 50, ttl_delete_batch_size = 100, ttl_delete_rate_limit = 100, ttl_pause = true, ttl_row_stats_poll_interval = '1m0s', ttl_label_metrics = true)
 
 statement error "ttl_select_batch_size" must be at least 1
@@ -501,11 +501,11 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl]
 ----
 CREATE TABLE public.tbl (
-                                                                                                                                                id INT8 NOT NULL,
-                                                                                                                                                text STRING NULL,
-                                                                                                                                                crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-                                                                                                                                                CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
-                                                                                                                                                FAMILY fam_0_id_text_crdb_internal_expiration (id, text, crdb_internal_expiration)
+  id INT8 NOT NULL,
+  text STRING NULL,
+  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+  CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
+  FAMILY fam_0_id_text_crdb_internal_expiration (id, text, crdb_internal_expiration)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@hourly', ttl_label_metrics = true)
 
 subtest end
@@ -523,10 +523,10 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_create_table_ttl_expiration_expression]
 ----
 CREATE TABLE public.tbl_create_table_ttl_expiration_expression (
-                                                                                        id INT8 NOT NULL,
-                                                                                        expire_at TIMESTAMPTZ NULL,
-                                                                                        CONSTRAINT tbl_create_table_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
-                                                                                        FAMILY fam_0_id_expire_at (id, expire_at)
+  id INT8 NOT NULL,
+  expire_at TIMESTAMPTZ NULL,
+  CONSTRAINT tbl_create_table_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
+  FAMILY fam_0_id_expire_at (id, expire_at)
 ) WITH (ttl = 'on', ttl_expiration_expression = 'expire_at', ttl_job_cron = '@hourly')
 
 statement ok
@@ -536,10 +536,10 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_create_table_ttl_expiration_expression]
 ----
 CREATE TABLE public.tbl_create_table_ttl_expiration_expression (
-   id INT8 NOT NULL,
-   expire_at TIMESTAMPTZ NULL,
-   CONSTRAINT tbl_create_table_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
-   FAMILY fam_0_id_expire_at (id, expire_at)
+  id INT8 NOT NULL,
+  expire_at TIMESTAMPTZ NULL,
+  CONSTRAINT tbl_create_table_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
+  FAMILY fam_0_id_expire_at (id, expire_at)
 )
 
 subtest end
@@ -557,10 +557,10 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_create_table_ttl_expiration_expression_escape_sql]
 ----
 CREATE TABLE public.tbl_create_table_ttl_expiration_expression_escape_sql (
-                                                                                                                                                                              id INT8 NOT NULL,
-                                                                                                                                                                              expire_at TIMESTAMPTZ NULL,
-                                                                                                                                                                              CONSTRAINT tbl_create_table_ttl_expiration_expression_escape_sql_pkey PRIMARY KEY (id ASC),
-                                                                                                                                                                              FAMILY fam_0_id_expire_at (id, expire_at)
+  id INT8 NOT NULL,
+  expire_at TIMESTAMPTZ NULL,
+  CONSTRAINT tbl_create_table_ttl_expiration_expression_escape_sql_pkey PRIMARY KEY (id ASC),
+  FAMILY fam_0_id_expire_at (id, expire_at)
 ) WITH (ttl = 'on', ttl_expiration_expression = e'IF(expire_at > parse_timestamp(\'2020-01-01 00:00:00\') AT TIME ZONE \'UTC\', expire_at, NULL)', ttl_job_cron = '@hourly')
 
 
@@ -609,11 +609,11 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_alter_table_ttl_expiration_expression]
 ----
 CREATE TABLE public.tbl_alter_table_ttl_expiration_expression (
-                                                                                        id INT8 NOT NULL,
-                                                                                        text STRING NULL,
-                                                                                        expire_at TIMESTAMPTZ NULL,
-                                                                                        CONSTRAINT tbl_alter_table_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
-                                                                                        FAMILY fam_0_id_text_expire_at (id, text, expire_at)
+  id INT8 NOT NULL,
+  text STRING NULL,
+  expire_at TIMESTAMPTZ NULL,
+  CONSTRAINT tbl_alter_table_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
+  FAMILY fam_0_id_text_expire_at (id, text, expire_at)
 ) WITH (ttl = 'on', ttl_expiration_expression = 'expire_at', ttl_job_cron = '@hourly')
 
 # try setting it again
@@ -624,11 +624,11 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_alter_table_ttl_expiration_expression]
 ----
 CREATE TABLE public.tbl_alter_table_ttl_expiration_expression (
-                                                                                                                                                                  id INT8 NOT NULL,
-                                                                                                                                                                  text STRING NULL,
-                                                                                                                                                                  expire_at TIMESTAMPTZ NULL,
-                                                                                                                                                                  CONSTRAINT tbl_alter_table_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
-                                                                                                                                                                  FAMILY fam_0_id_text_expire_at (id, text, expire_at)
+  id INT8 NOT NULL,
+  text STRING NULL,
+  expire_at TIMESTAMPTZ NULL,
+  CONSTRAINT tbl_alter_table_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
+  FAMILY fam_0_id_text_expire_at (id, text, expire_at)
 ) WITH (ttl = 'on', ttl_expiration_expression = e'((expire_at AT TIME ZONE \'UTC\') + \'5 minutes\':::INTERVAL) AT TIME ZONE \'UTC\'', ttl_job_cron = '@hourly')
 
 statement ok
@@ -638,11 +638,11 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_alter_table_ttl_expiration_expression]
 ----
 CREATE TABLE public.tbl_alter_table_ttl_expiration_expression (
-   id INT8 NOT NULL,
-   text STRING NULL,
-   expire_at TIMESTAMPTZ NULL,
-   CONSTRAINT tbl_alter_table_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
-   FAMILY fam_0_id_text_expire_at (id, text, expire_at)
+  id INT8 NOT NULL,
+  text STRING NULL,
+  expire_at TIMESTAMPTZ NULL,
+  CONSTRAINT tbl_alter_table_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
+  FAMILY fam_0_id_text_expire_at (id, text, expire_at)
 )
 
 subtest end
@@ -663,11 +663,11 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_add_ttl_expiration_expression_to_ttl_expire_after]
 ----
 CREATE TABLE public.tbl_add_ttl_expiration_expression_to_ttl_expire_after (
-                                                                                                                                                 id INT8 NOT NULL,
-                                                                                                                                                 expire_at TIMESTAMPTZ NULL,
-                                                                                                                                                 crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-                                                                                                                                                 CONSTRAINT tbl_add_ttl_expiration_expression_to_ttl_expire_after_pkey PRIMARY KEY (id ASC),
-                                                                                                                                                 FAMILY fam_0_id_expire_at_crdb_internal_expiration (id, expire_at, crdb_internal_expiration)
+  id INT8 NOT NULL,
+  expire_at TIMESTAMPTZ NULL,
+  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+  CONSTRAINT tbl_add_ttl_expiration_expression_to_ttl_expire_after_pkey PRIMARY KEY (id ASC),
+  FAMILY fam_0_id_expire_at_crdb_internal_expiration (id, expire_at, crdb_internal_expiration)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_expiration_expression = 'crdb_internal_expiration', ttl_job_cron = '@hourly')
 
 statement ok
@@ -677,11 +677,11 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_add_ttl_expiration_expression_to_ttl_expire_after]
 ----
 CREATE TABLE public.tbl_add_ttl_expiration_expression_to_ttl_expire_after (
-                                                                                         id INT8 NOT NULL,
-                                                                                         expire_at TIMESTAMPTZ NULL,
-                                                                                         crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-                                                                                         CONSTRAINT tbl_add_ttl_expiration_expression_to_ttl_expire_after_pkey PRIMARY KEY (id ASC),
-                                                                                         FAMILY fam_0_id_expire_at_crdb_internal_expiration (id, expire_at, crdb_internal_expiration)
+  id INT8 NOT NULL,
+  expire_at TIMESTAMPTZ NULL,
+  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+  CONSTRAINT tbl_add_ttl_expiration_expression_to_ttl_expire_after_pkey PRIMARY KEY (id ASC),
+  FAMILY fam_0_id_expire_at_crdb_internal_expiration (id, expire_at, crdb_internal_expiration)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@hourly')
 
 subtest end
@@ -702,11 +702,11 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_add_ttl_expire_after_to_ttl_expiration_expression]
 ----
 CREATE TABLE public.tbl_add_ttl_expire_after_to_ttl_expiration_expression (
-                                                                                                                                  id INT8 NOT NULL,
-                                                                                                                                  expire_at TIMESTAMPTZ NULL,
-                                                                                                                                  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-                                                                                                                                  CONSTRAINT tbl_add_ttl_expire_after_to_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
-                                                                                                                                  FAMILY fam_0_id_expire_at (id, expire_at, crdb_internal_expiration)
+  id INT8 NOT NULL,
+  expire_at TIMESTAMPTZ NULL,
+  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+  CONSTRAINT tbl_add_ttl_expire_after_to_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
+  FAMILY fam_0_id_expire_at (id, expire_at, crdb_internal_expiration)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_expiration_expression = 'expire_at', ttl_job_cron = '@hourly')
 
 statement ok
@@ -716,10 +716,10 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_add_ttl_expire_after_to_ttl_expiration_expression]
 ----
 CREATE TABLE public.tbl_add_ttl_expire_after_to_ttl_expiration_expression (
-   id INT8 NOT NULL,
-   expire_at TIMESTAMPTZ NULL,
-   CONSTRAINT tbl_add_ttl_expire_after_to_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
-   FAMILY fam_0_id_expire_at (id, expire_at)
+  id INT8 NOT NULL,
+  expire_at TIMESTAMPTZ NULL,
+  CONSTRAINT tbl_add_ttl_expire_after_to_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
+  FAMILY fam_0_id_expire_at (id, expire_at)
 )
 
 subtest end
@@ -735,9 +735,9 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE create_table_ttl_expire_after_and_ttl_expiration_expression]
 ----
 CREATE TABLE public.create_table_ttl_expire_after_and_ttl_expiration_expression (
-                                                                                                                                                 id INT8 NOT NULL,
-                                                                                                                                                 crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-                                                                                                                                                 CONSTRAINT create_table_ttl_expire_after_and_ttl_expiration_expression_pkey PRIMARY KEY (id ASC)
+  id INT8 NOT NULL,
+  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+  CONSTRAINT create_table_ttl_expire_after_and_ttl_expiration_expression_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_expiration_expression = 'crdb_internal_expiration', ttl_job_cron = '@hourly')
 
 statement ok
@@ -747,8 +747,8 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE create_table_ttl_expire_after_and_ttl_expiration_expression]
 ----
 CREATE TABLE public.create_table_ttl_expire_after_and_ttl_expiration_expression (
-   id INT8 NOT NULL,
-   CONSTRAINT create_table_ttl_expire_after_and_ttl_expiration_expression_pkey PRIMARY KEY (id ASC)
+  id INT8 NOT NULL,
+  CONSTRAINT create_table_ttl_expire_after_and_ttl_expiration_expression_pkey PRIMARY KEY (id ASC)
 )
 
 subtest end
@@ -767,9 +767,9 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_alter_table_ttl_expire_after_and_ttl_expiration_expression]
 ----
 CREATE TABLE public.tbl_alter_table_ttl_expire_after_and_ttl_expiration_expression (
-                                                                                                                                                 id INT8 NOT NULL,
-                                                                                                                                                 crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-                                                                                                                                                 CONSTRAINT tbl_alter_table_ttl_expire_after_and_ttl_expiration_expression_pkey PRIMARY KEY (id ASC)
+  id INT8 NOT NULL,
+  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+  CONSTRAINT tbl_alter_table_ttl_expire_after_and_ttl_expiration_expression_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_expiration_expression = 'crdb_internal_expiration', ttl_job_cron = '@hourly')
 
 statement ok
@@ -779,8 +779,8 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_alter_table_ttl_expire_after_and_ttl_expiration_expression]
 ----
 CREATE TABLE public.tbl_alter_table_ttl_expire_after_and_ttl_expiration_expression (
-   id INT8 NOT NULL,
-   CONSTRAINT tbl_alter_table_ttl_expire_after_and_ttl_expiration_expression_pkey PRIMARY KEY (id ASC)
+  id INT8 NOT NULL,
+  CONSTRAINT tbl_alter_table_ttl_expire_after_and_ttl_expiration_expression_pkey PRIMARY KEY (id ASC)
 )
 
 subtest end
@@ -801,10 +801,10 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_ttl_expiration_expression_renamed]
 ----
 CREATE TABLE public.tbl_ttl_expiration_expression_renamed (
-                                                                                                 id INT8 NOT NULL,
-                                                                                                 expires_at_renamed TIMESTAMPTZ NULL,
-                                                                                                 CONSTRAINT tbl_ttl_expiration_expression_renamed_pkey PRIMARY KEY (id ASC),
-                                                                                                 FAMILY fam (id, expires_at_renamed)
+  id INT8 NOT NULL,
+  expires_at_renamed TIMESTAMPTZ NULL,
+  CONSTRAINT tbl_ttl_expiration_expression_renamed_pkey PRIMARY KEY (id ASC),
+  FAMILY fam (id, expires_at_renamed)
 ) WITH (ttl = 'on', ttl_expiration_expression = 'expires_at_renamed', ttl_job_cron = '@hourly')
 
 subtest end
@@ -934,11 +934,11 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE create_table_no_ttl_set_ttl_expire_after]
 ----
 CREATE TABLE public.create_table_no_ttl_set_ttl_expire_after (
-                                                                                         id INT8 NOT NULL,
-                                                                                         text STRING NULL,
-                                                                                         crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-                                                                                         CONSTRAINT create_table_no_ttl_set_ttl_expire_after_pkey PRIMARY KEY (id ASC),
-                                                                                         FAMILY fam_0_id_text (id, text, crdb_internal_expiration)
+  id INT8 NOT NULL,
+  text STRING NULL,
+  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+  CONSTRAINT create_table_no_ttl_set_ttl_expire_after_pkey PRIMARY KEY (id ASC),
+  FAMILY fam_0_id_text (id, text, crdb_internal_expiration)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@hourly')
 
 let $table_id
@@ -977,11 +977,11 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE create_table_no_ttl_set_ttl_expiration_expression]
 ----
 CREATE TABLE public.create_table_no_ttl_set_ttl_expiration_expression (
-                                                                                        id INT8 NOT NULL,
-                                                                                        text STRING NULL,
-                                                                                        expire_at TIMESTAMPTZ NULL,
-                                                                                        CONSTRAINT create_table_no_ttl_set_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
-                                                                                        FAMILY fam_0_id_text_expire_at (id, text, expire_at)
+  id INT8 NOT NULL,
+  text STRING NULL,
+  expire_at TIMESTAMPTZ NULL,
+  CONSTRAINT create_table_no_ttl_set_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
+  FAMILY fam_0_id_text_expire_at (id, text, expire_at)
 ) WITH (ttl = 'on', ttl_expiration_expression = 'expire_at', ttl_job_cron = '@hourly')
 
 let $table_id

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -271,14 +271,14 @@ query TT
 SHOW CREATE TABLE b
 ----
 b  CREATE TABLE public.b (
-   parent_id INT8 NULL,
-   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   d INT8 NULL DEFAULT 23:::INT8,
-   CONSTRAINT b_pkey PRIMARY KEY (rowid ASC),
-   CONSTRAINT b_parent_id_fkey FOREIGN KEY (parent_id) REFERENCES public.parent(id),
-   INDEX foo (parent_id ASC),
-   UNIQUE INDEX bar (parent_id ASC)
-)
+     parent_id INT8 NULL,
+     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+     d INT8 NULL DEFAULT 23:::INT8,
+     CONSTRAINT b_pkey PRIMARY KEY (rowid ASC),
+     CONSTRAINT b_parent_id_fkey FOREIGN KEY (parent_id) REFERENCES public.parent(id),
+     INDEX foo (parent_id ASC),
+     UNIQUE INDEX bar (parent_id ASC)
+   )
 
 # table b is not visible to the transaction #17949
 statement error pgcode 55000 table "b" is being added

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -1960,8 +1960,8 @@ CREATE SEQUENCE public.seqas_3 AS int2 START WITH -4 INCREMENT BY -3
 query TT colnames
 SHOW CREATE SEQUENCE seqas_3
 ----
-table_name        create_statement
-seqas_3           CREATE SEQUENCE public.seqas_3 AS INT2 MINVALUE -32768 MAXVALUE -1 INCREMENT -3 START -4
+table_name  create_statement
+seqas_3     CREATE SEQUENCE public.seqas_3 AS INT2 MINVALUE -32768 MAXVALUE -1 INCREMENT -3 START -4
 
 statement ok
 CREATE SEQUENCE seqas_4 AS integer
@@ -1969,8 +1969,8 @@ CREATE SEQUENCE seqas_4 AS integer
 query TT colnames
 SHOW CREATE SEQUENCE seqas_4
 ----
-table_name        create_statement
-seqas_4           CREATE SEQUENCE public.seqas_4 AS INT8 MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1
+table_name  create_statement
+seqas_4     CREATE SEQUENCE public.seqas_4 AS INT8 MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1
 
 statement ok
 CREATE SEQUENCE seqas_5 AS int8
@@ -1993,8 +1993,8 @@ CREATE SEQUENCE seqas_9 AS integer
 query TT colnames
 SHOW CREATE SEQUENCE seqas_9
 ----
-table_name        create_statement
-seqas_9           CREATE SEQUENCE public.seqas_9 AS INT4 MINVALUE 1 MAXVALUE 2147483647 INCREMENT 1 START 1
+table_name  create_statement
+seqas_9     CREATE SEQUENCE public.seqas_9 AS INT4 MINVALUE 1 MAXVALUE 2147483647 INCREMENT 1 START 1
 
 statement ok
 ALTER SEQUENCE seqas_9 AS smallint
@@ -2002,8 +2002,8 @@ ALTER SEQUENCE seqas_9 AS smallint
 query TT colnames
 SHOW CREATE SEQUENCE seqas_9
 ----
-table_name        create_statement
-seqas_9           CREATE SEQUENCE public.seqas_9 AS INT2 MINVALUE 1 MAXVALUE 32767 INCREMENT 1 START 1
+table_name  create_statement
+seqas_9     CREATE SEQUENCE public.seqas_9 AS INT2 MINVALUE 1 MAXVALUE 32767 INCREMENT 1 START 1
 
 statement ok
 CREATE SEQUENCE seqas_10

--- a/pkg/sql/logictest/testdata/logic_test/sequences_regclass
+++ b/pkg/sql/logictest/testdata/logic_test/sequences_regclass
@@ -44,12 +44,12 @@ query TT
 SHOW CREATE TABLE foo
 ----
 foo  CREATE TABLE public.foo (
-     i INT8 NOT NULL DEFAULT nextval('public.foo_i_seq'::REGCLASS),
-     j INT8 NOT NULL DEFAULT nextval('public.test_seq'::REGCLASS),
-     k INT8 NOT NULL DEFAULT nextval('public.foo_k_seq'::REGCLASS),
-     l INT8 NOT NULL DEFAULT currval('diff_db.public.test_seq'::REGCLASS),
-     CONSTRAINT foo_pkey PRIMARY KEY (i ASC)
-)
+       i INT8 NOT NULL DEFAULT nextval('public.foo_i_seq'::REGCLASS),
+       j INT8 NOT NULL DEFAULT nextval('public.test_seq'::REGCLASS),
+       k INT8 NOT NULL DEFAULT nextval('public.foo_k_seq'::REGCLASS),
+       l INT8 NOT NULL DEFAULT currval('diff_db.public.test_seq'::REGCLASS),
+       CONSTRAINT foo_pkey PRIMARY KEY (i ASC)
+     )
 
 statement ok
 INSERT INTO foo VALUES (default, default, default, default)
@@ -135,12 +135,12 @@ query TT
 SHOW CREATE TABLE bar
 ----
 bar  CREATE TABLE public.bar (
-     i INT8 NOT NULL DEFAULT nextval('public.new_bar_i_seq'::REGCLASS),
-     j INT8 NOT NULL DEFAULT currval('public.new_s1'::REGCLASS),
-     k INT8 NOT NULL DEFAULT nextval('public.new_s2'::REGCLASS),
-     CONSTRAINT bar_pkey PRIMARY KEY (i ASC),
-     FAMILY fam_0_i_j_k (i, j, k)
-)
+       i INT8 NOT NULL DEFAULT nextval('public.new_bar_i_seq'::REGCLASS),
+       j INT8 NOT NULL DEFAULT currval('public.new_s1'::REGCLASS),
+       k INT8 NOT NULL DEFAULT nextval('public.new_s2'::REGCLASS),
+       CONSTRAINT bar_pkey PRIMARY KEY (i ASC),
+       FAMILY fam_0_i_j_k (i, j, k)
+     )
 
 # Verify that the table hasn't been corrupted.
 statement ok
@@ -192,12 +192,12 @@ query TT
 SHOW CREATE TABLE new_other_db.t
 ----
 new_other_db.public.t  CREATE TABLE public.t (
-                       i INT8 NOT NULL DEFAULT nextval('new_other_db.public.s'::REGCLASS),
-                       j INT8 NOT NULL DEFAULT currval('new_other_db.public.s2'::REGCLASS),
-                       rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                       CONSTRAINT t_pkey PRIMARY KEY (rowid ASC),
-                       FAMILY fam_0_i_j_rowid (i, j, rowid)
-)
+                         i INT8 NOT NULL DEFAULT nextval('new_other_db.public.s'::REGCLASS),
+                         j INT8 NOT NULL DEFAULT currval('new_other_db.public.s2'::REGCLASS),
+                         rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                         CONSTRAINT t_pkey PRIMARY KEY (rowid ASC),
+                         FAMILY fam_0_i_j_rowid (i, j, rowid)
+                       )
 
 # Verify the table hasn't been corrupted.
 statement ok
@@ -256,12 +256,12 @@ query TT
 SHOW CREATE TABLE tb
 ----
 tb  CREATE TABLE public.tb (
-    i INT8 NOT NULL DEFAULT nextval('test_schema.tb_i_seq'::REGCLASS),
-    j INT8 NOT NULL DEFAULT nextval('test_schema.sc_s1'::REGCLASS),
-    k INT8 NOT NULL DEFAULT currval('test_schema.sc_s2'::REGCLASS),
-    CONSTRAINT tb_pkey PRIMARY KEY (i ASC),
-    FAMILY fam_0_i_j_k (i, j, k)
-)
+      i INT8 NOT NULL DEFAULT nextval('test_schema.tb_i_seq'::REGCLASS),
+      j INT8 NOT NULL DEFAULT nextval('test_schema.sc_s1'::REGCLASS),
+      k INT8 NOT NULL DEFAULT currval('test_schema.sc_s2'::REGCLASS),
+      CONSTRAINT tb_pkey PRIMARY KEY (i ASC),
+      FAMILY fam_0_i_j_k (i, j, k)
+    )
 
 # Verify the table hasn't been corrupted.
 statement ok
@@ -311,12 +311,12 @@ query TT
 SHOW CREATE TABLE new_test_schema.foo
 ----
 new_test_schema.foo  CREATE TABLE new_test_schema.foo (
-                     i INT8 NOT NULL DEFAULT nextval('new_test_schema.foo_i_seq'::REGCLASS),
-                     j INT8 NOT NULL DEFAULT nextval('new_test_schema.s3'::REGCLASS),
-                     k INT8 NOT NULL DEFAULT currval('new_test_schema.s4'::REGCLASS),
-                     CONSTRAINT foo_pkey PRIMARY KEY (i ASC),
-                     FAMILY fam_0_i_j_k (i, j, k)
-)
+                       i INT8 NOT NULL DEFAULT nextval('new_test_schema.foo_i_seq'::REGCLASS),
+                       j INT8 NOT NULL DEFAULT nextval('new_test_schema.s3'::REGCLASS),
+                       k INT8 NOT NULL DEFAULT currval('new_test_schema.s4'::REGCLASS),
+                       CONSTRAINT foo_pkey PRIMARY KEY (i ASC),
+                       FAMILY fam_0_i_j_k (i, j, k)
+                     )
 
 # Verify the table hasn't been corrupted.
 statement ok
@@ -377,12 +377,12 @@ query TT
 SHOW CREATE TABLE t2
 ----
 t2  CREATE TABLE public.t2 (
-    i INT8 NOT NULL DEFAULT nextval('public.s5_new'::REGCLASS),
-    j INT8 NOT NULL DEFAULT nextval('public.s5_new'::REGCLASS),
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    CONSTRAINT t2_pkey PRIMARY KEY (rowid ASC),
-    FAMILY fam_0_i_j_rowid (i, j, rowid)
-)
+      i INT8 NOT NULL DEFAULT nextval('public.s5_new'::REGCLASS),
+      j INT8 NOT NULL DEFAULT nextval('public.s5_new'::REGCLASS),
+      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+      CONSTRAINT t2_pkey PRIMARY KEY (rowid ASC),
+      FAMILY fam_0_i_j_rowid (i, j, rowid)
+    )
 
 query TT
 SELECT pg_get_serial_sequence('t2', 'i'), pg_get_serial_sequence('t2', 'j')
@@ -416,10 +416,10 @@ CREATE VIEW v AS (SELECT i, nextval('view_seq') FROM t3)
 query TT
 SHOW CREATE VIEW v
 ----
-v                                                                          CREATE VIEW public.v (
-                                                                           i,
-                                                                           nextval
-) AS (SELECT i, nextval('public.view_seq'::REGCLASS) FROM test.public.t3)
+v  CREATE VIEW public.v (
+     i,
+     nextval
+   ) AS (SELECT i, nextval('public.view_seq'::REGCLASS) FROM test.public.t3)
 
 # Subquery in FROM clause.
 statement ok
@@ -428,9 +428,9 @@ CREATE VIEW v2 AS SELECT currval FROM (SELECT currval('view_seq'::regclass) FROM
 query TT
 SHOW CREATE VIEW v2
 ----
-v2                                                                                          CREATE VIEW public.v2 (
-                                                                                            currval
-) AS SELECT currval FROM (SELECT currval('public.view_seq'::REGCLASS) FROM test.public.t3)
+v2  CREATE VIEW public.v2 (
+      currval
+    ) AS SELECT currval FROM (SELECT currval('public.view_seq'::REGCLASS) FROM test.public.t3)
 
 # Union containing sequences.
 statement ok
@@ -440,17 +440,10 @@ query TT
 SHOW CREATE VIEW v3
 ----
 v3  CREATE VIEW public.v3 (
-    nextval,
-    i
-) AS SELECT
-    nextval('public.view_seq'::REGCLASS), i
-  FROM
-    test.public.t3
-  UNION
-    SELECT
-      nextval('public.view_seq'::REGCLASS), i
-    FROM
-      test.public.t4
+      nextval,
+      i
+    ) AS SELECT nextval('public.view_seq'::REGCLASS), i FROM test.public.t3
+      UNION SELECT nextval('public.view_seq'::REGCLASS), i FROM test.public.t4
 
 statement ok
 CREATE VIEW v4 AS SELECT t3.i, nextval('view_seq') FROM t3 INNER JOIN (SELECT j, currval($view_seq_id) FROM t4) as t5 ON t3.i = t5.j
@@ -460,14 +453,14 @@ query TT
 SHOW CREATE VIEW v4
 ----
 v4  CREATE VIEW public.v4 (
-    i,
-    nextval
-) AS SELECT
-    t3.i, nextval('public.view_seq'::REGCLASS)
-  FROM
-    test.public.t3
-    INNER JOIN (SELECT j, currval('public.view_seq'::REGCLASS) FROM test.public.t4) AS t5 ON
-        t3.i = t5.j
+      i,
+      nextval
+    ) AS SELECT
+        t3.i, nextval('public.view_seq'::REGCLASS)
+      FROM
+        test.public.t3
+        INNER JOIN (SELECT j, currval('public.view_seq'::REGCLASS) FROM test.public.t4) AS t5 ON
+            t3.i = t5.j
 
 # Materialized view containing sequences.
 statement ok
@@ -477,13 +470,10 @@ query TT
 SHOW CREATE VIEW v5
 ----
 v5  CREATE MATERIALIZED VIEW public.v5 (
-    currval,
-    i,
-    rowid
-) AS SELECT
-    currval('public.view_seq'::REGCLASS), i
-  FROM
-    test.public.t3
+      currval,
+      i,
+      rowid
+    ) AS SELECT currval('public.view_seq'::REGCLASS), i FROM test.public.t3
 
 # Replacing an existing view.
 statement ok
@@ -495,9 +485,9 @@ CREATE OR REPLACE VIEW v6 AS SELECT currval($view_seq_id) AS i
 query TT
 SHOW CREATE VIEW v6
 ----
-v6                                                     CREATE VIEW public.v6 (
-                                                       i
-) AS SELECT currval('public.view_seq'::REGCLASS) AS i
+v6  CREATE VIEW public.v6 (
+      i
+    ) AS SELECT currval('public.view_seq'::REGCLASS) AS i
 
 # Subquery in the SELECT expr.
 statement ok
@@ -506,10 +496,10 @@ CREATE VIEW v7 AS (SELECT i, (SELECT nextval('view_seq')) FROM t3)
 query TT
 SHOW CREATE VIEW v7
 ----
-v7                                                                                  CREATE VIEW public.v7 (
-                                                                                    i,
-                                                                                    nextval
-) AS (SELECT i, (SELECT nextval('public.view_seq'::REGCLASS)) FROM test.public.t3)
+v7  CREATE VIEW public.v7 (
+      i,
+      nextval
+    ) AS (SELECT i, (SELECT nextval('public.view_seq'::REGCLASS)) FROM test.public.t3)
 
 # Sequence in the WHERE clause.
 statement ok
@@ -519,13 +509,8 @@ query TT
 SHOW CREATE VIEW v8
 ----
 v8  CREATE VIEW public.v8 (
-    i
-) AS SELECT
-    i
-  FROM
-    test.public.t3
-  WHERE
-    i = nextval('public.view_seq'::REGCLASS)
+      i
+    ) AS SELECT i FROM test.public.t3 WHERE i = nextval('public.view_seq'::REGCLASS)
 
 # Sequence in the CTE.
 statement ok
@@ -534,9 +519,9 @@ CREATE VIEW v9 AS (WITH w AS (SELECT nextval('view_seq')) SELECT nextval FROM w)
 query TT
 SHOW CREATE VIEW v9
 ----
-v9                                                                                    CREATE VIEW public.v9 (
-                                                                                      nextval
-) AS (WITH w AS (SELECT nextval('public.view_seq'::REGCLASS)) SELECT nextval FROM w)
+v9  CREATE VIEW public.v9 (
+      nextval
+    ) AS (WITH w AS (SELECT nextval('public.view_seq'::REGCLASS)) SELECT nextval FROM w)
 
 # Sequence in the LIMIT clause.
 statement ok
@@ -545,9 +530,9 @@ CREATE VIEW v10 AS (SELECT i FROM t3 LIMIT nextval('view_seq'))
 query TT
 SHOW CREATE VIEW v10
 ----
-v10                                                                             CREATE VIEW public.v10 (
-                                                                                i
-) AS (SELECT i FROM test.public.t3 LIMIT nextval('public.view_seq'::REGCLASS))
+v10  CREATE VIEW public.v10 (
+       i
+     ) AS (SELECT i FROM test.public.t3 LIMIT nextval('public.view_seq'::REGCLASS))
 
 # Test renaming sequences is fine and tables are not corrupted.
 statement ok
@@ -556,10 +541,10 @@ ALTER SEQUENCE view_seq RENAME TO view_seq2
 query TT
 SHOW CREATE VIEW v7
 ----
-v7                                                                                   CREATE VIEW public.v7 (
-                                                                                     i,
-                                                                                     nextval
-) AS (SELECT i, (SELECT nextval('public.view_seq2'::REGCLASS)) FROM test.public.t3)
+v7  CREATE VIEW public.v7 (
+      i,
+      nextval
+    ) AS (SELECT i, (SELECT nextval('public.view_seq2'::REGCLASS)) FROM test.public.t3)
 
 statement ok
 INSERT INTO t3 VALUES (8, 2)

--- a/pkg/sql/logictest/testdata/logic_test/serial
+++ b/pkg/sql/logictest/testdata/logic_test/serial
@@ -13,12 +13,12 @@ query TT
 SHOW CREATE TABLE serial
 ----
 serial  CREATE TABLE public.serial (
-        a INT8 NOT NULL DEFAULT unique_rowid(),
-        b INT8 NULL DEFAULT 7:::INT8,
-        c INT8 NOT NULL DEFAULT unique_rowid(),
-        CONSTRAINT serial_pkey PRIMARY KEY (a ASC),
-        UNIQUE INDEX serial_c_key (c ASC)
-)
+          a INT8 NOT NULL DEFAULT unique_rowid(),
+          b INT8 NULL DEFAULT 7:::INT8,
+          c INT8 NOT NULL DEFAULT unique_rowid(),
+          CONSTRAINT serial_pkey PRIMARY KEY (a ASC),
+          UNIQUE INDEX serial_c_key (c ASC)
+        )
 
 statement ok
 INSERT INTO serial (a, b) VALUES (1, 2), (DEFAULT, DEFAULT), (DEFAULT, 3)
@@ -50,12 +50,12 @@ query TT
 SHOW CREATE TABLE smallbig
 ----
 smallbig  CREATE TABLE public.smallbig (
-          a INT8 NOT NULL DEFAULT unique_rowid(),
-          b INT8 NOT NULL DEFAULT unique_rowid(),
-          c INT8 NULL,
-          rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-          CONSTRAINT smallbig_pkey PRIMARY KEY (rowid ASC)
-)
+            a INT8 NOT NULL DEFAULT unique_rowid(),
+            b INT8 NOT NULL DEFAULT unique_rowid(),
+            c INT8 NULL,
+            rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+            CONSTRAINT smallbig_pkey PRIMARY KEY (rowid ASC)
+          )
 
 query III
 SELECT count(DISTINCT a), count(DISTINCT b), count(DISTINCT c) FROM smallbig
@@ -72,13 +72,13 @@ query TT
 SHOW CREATE TABLE serials
 ----
 serials  CREATE TABLE public.serials (
-         a INT8 NOT NULL DEFAULT unique_rowid(),
-         b INT8 NOT NULL DEFAULT unique_rowid(),
-         c INT8 NOT NULL DEFAULT unique_rowid(),
-         d INT8 NULL,
-         rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-         CONSTRAINT serials_pkey PRIMARY KEY (rowid ASC)
-)
+           a INT8 NOT NULL DEFAULT unique_rowid(),
+           b INT8 NOT NULL DEFAULT unique_rowid(),
+           c INT8 NOT NULL DEFAULT unique_rowid(),
+           d INT8 NULL,
+           rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+           CONSTRAINT serials_pkey PRIMARY KEY (rowid ASC)
+         )
 
 statement ok
 INSERT INTO serials (d) VALUES (9), (9)
@@ -114,12 +114,12 @@ query TT
 SHOW CREATE TABLE serial
 ----
 serial  CREATE TABLE public.serial (
-        a INT8 NOT NULL DEFAULT nextval('public.serial_a_seq'::REGCLASS),
-        b INT8 NULL DEFAULT 7:::INT8,
-        c INT8 NOT NULL DEFAULT nextval('public.serial_c_seq2'::REGCLASS),
-        CONSTRAINT serial_pkey PRIMARY KEY (a ASC),
-        UNIQUE INDEX serial_c_key (c ASC)
-)
+          a INT8 NOT NULL DEFAULT nextval('public.serial_a_seq'::REGCLASS),
+          b INT8 NULL DEFAULT 7:::INT8,
+          c INT8 NOT NULL DEFAULT nextval('public.serial_c_seq2'::REGCLASS),
+          CONSTRAINT serial_pkey PRIMARY KEY (a ASC),
+          UNIQUE INDEX serial_c_key (c ASC)
+        )
 
 query TT
 SHOW CREATE SEQUENCE serial_a_seq
@@ -156,12 +156,12 @@ query TT
 SHOW CREATE TABLE smallbig
 ----
 smallbig  CREATE TABLE public.smallbig (
-          a INT8 NOT NULL DEFAULT nextval('public.smallbig_a_seq'::REGCLASS),
-          b INT8 NOT NULL DEFAULT nextval('public.smallbig_b_seq'::REGCLASS),
-          c INT8 NULL,
-          rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-          CONSTRAINT smallbig_pkey PRIMARY KEY (rowid ASC)
-)
+            a INT8 NOT NULL DEFAULT nextval('public.smallbig_a_seq'::REGCLASS),
+            b INT8 NOT NULL DEFAULT nextval('public.smallbig_b_seq'::REGCLASS),
+            c INT8 NULL,
+            rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+            CONSTRAINT smallbig_pkey PRIMARY KEY (rowid ASC)
+          )
 
 query III
 SELECT count(DISTINCT a), count(DISTINCT b), count(DISTINCT c) FROM smallbig
@@ -178,13 +178,13 @@ query TT
 SHOW CREATE TABLE serials
 ----
 serials  CREATE TABLE public.serials (
-         a INT8 NOT NULL DEFAULT nextval('public.serials_a_seq'::REGCLASS),
-         b INT8 NOT NULL DEFAULT nextval('public.serials_b_seq'::REGCLASS),
-         c INT8 NOT NULL DEFAULT nextval('public.serials_c_seq'::REGCLASS),
-         d INT8 NULL,
-         rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-         CONSTRAINT serials_pkey PRIMARY KEY (rowid ASC)
-)
+           a INT8 NOT NULL DEFAULT nextval('public.serials_a_seq'::REGCLASS),
+           b INT8 NOT NULL DEFAULT nextval('public.serials_b_seq'::REGCLASS),
+           c INT8 NOT NULL DEFAULT nextval('public.serials_c_seq'::REGCLASS),
+           d INT8 NULL,
+           rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+           CONSTRAINT serials_pkey PRIMARY KEY (rowid ASC)
+         )
 
 statement ok
 INSERT INTO serials (d) VALUES (9), (9)
@@ -216,12 +216,12 @@ query TT
 SHOW CREATE TABLE serial
 ----
 serial  CREATE TABLE public.serial (
-        a INT8 NOT NULL DEFAULT nextval('public.serial_a_seq'::REGCLASS),
-        b INT8 NULL DEFAULT 7:::INT8,
-        c INT8 NOT NULL DEFAULT nextval('public.serial_c_seq2'::REGCLASS),
-        CONSTRAINT serial_pkey PRIMARY KEY (a ASC),
-        UNIQUE INDEX serial_c_key (c ASC)
-)
+          a INT8 NOT NULL DEFAULT nextval('public.serial_a_seq'::REGCLASS),
+          b INT8 NULL DEFAULT 7:::INT8,
+          c INT8 NOT NULL DEFAULT nextval('public.serial_c_seq2'::REGCLASS),
+          CONSTRAINT serial_pkey PRIMARY KEY (a ASC),
+          UNIQUE INDEX serial_c_key (c ASC)
+        )
 
 query TT
 SHOW CREATE SEQUENCE serial_a_seq
@@ -271,12 +271,12 @@ query TT
 SHOW CREATE TABLE "serial_MixedCase"
 ----
 "serial_MixedCase"  CREATE TABLE public."serial_MixedCase" (
-                    a INT8 NOT NULL DEFAULT nextval('public."serial_MixedCase_a_seq"'::REGCLASS),
-                    b INT8 NULL DEFAULT 7:::INT8,
-                    c INT8 NOT NULL DEFAULT nextval('public."serial_MixedCase_c_seq"'::REGCLASS),
-                    CONSTRAINT "serial_MixedCase_pkey" PRIMARY KEY (a ASC),
-                    UNIQUE INDEX "serial_MixedCase_c_key" (c ASC)
-)
+                      a INT8 NOT NULL DEFAULT nextval('public."serial_MixedCase_a_seq"'::REGCLASS),
+                      b INT8 NULL DEFAULT 7:::INT8,
+                      c INT8 NOT NULL DEFAULT nextval('public."serial_MixedCase_c_seq"'::REGCLASS),
+                      CONSTRAINT "serial_MixedCase_pkey" PRIMARY KEY (a ASC),
+                      UNIQUE INDEX "serial_MixedCase_c_key" (c ASC)
+                    )
 
 statement error multiple default values specified for column "a" of table "s1"
 CREATE TABLE s1 (a SERIAL DEFAULT 7)
@@ -297,12 +297,12 @@ query TT
 SHOW CREATE TABLE smallbig
 ----
 smallbig  CREATE TABLE public.smallbig (
-          a INT2 NOT NULL DEFAULT nextval('public.smallbig_a_seq'::REGCLASS),
-          b INT8 NOT NULL DEFAULT nextval('public.smallbig_b_seq'::REGCLASS),
-          c INT8 NULL,
-          rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-          CONSTRAINT smallbig_pkey PRIMARY KEY (rowid ASC)
-)
+            a INT2 NOT NULL DEFAULT nextval('public.smallbig_a_seq'::REGCLASS),
+            b INT8 NOT NULL DEFAULT nextval('public.smallbig_b_seq'::REGCLASS),
+            c INT8 NULL,
+            rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+            CONSTRAINT smallbig_pkey PRIMARY KEY (rowid ASC)
+          )
 
 query III
 SELECT count(DISTINCT a), count(DISTINCT b), count(DISTINCT c) FROM smallbig
@@ -319,13 +319,13 @@ query TT
 SHOW CREATE TABLE serials
 ----
 serials  CREATE TABLE public.serials (
-         a INT2 NOT NULL DEFAULT nextval('public.serials_a_seq'::REGCLASS),
-         b INT4 NOT NULL DEFAULT nextval('public.serials_b_seq'::REGCLASS),
-         c INT8 NOT NULL DEFAULT nextval('public.serials_c_seq'::REGCLASS),
-         d INT8 NULL,
-         rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-         CONSTRAINT serials_pkey PRIMARY KEY (rowid ASC)
-)
+           a INT2 NOT NULL DEFAULT nextval('public.serials_a_seq'::REGCLASS),
+           b INT4 NOT NULL DEFAULT nextval('public.serials_b_seq'::REGCLASS),
+           c INT8 NOT NULL DEFAULT nextval('public.serials_c_seq'::REGCLASS),
+           d INT8 NULL,
+           rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+           CONSTRAINT serials_pkey PRIMARY KEY (rowid ASC)
+         )
 
 statement ok
 INSERT INTO serials (d) VALUES (9), (9)

--- a/pkg/sql/logictest/testdata/logic_test/show_create
+++ b/pkg/sql/logictest/testdata/logic_test/show_create
@@ -29,19 +29,19 @@ SHOW CREATE c
 ----
 table_name  create_statement
 c           CREATE TABLE public.c (
-            a INT8 NOT NULL,
-            b INT8 NULL,
-            rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-            CONSTRAINT c_pkey PRIMARY KEY (rowid ASC),
-            INDEX c_a_b_idx (a ASC, b ASC),
-            FAMILY fam_0_a_rowid (a, rowid),
-            FAMILY fam_1_b (b),
-            CONSTRAINT unique_a_b UNIQUE WITHOUT INDEX (a, b),
-            CONSTRAINT unique_a_partial UNIQUE WITHOUT INDEX (a) WHERE b > 0:::INT8
-);
-COMMENT ON TABLE public.c IS 'table';
-COMMENT ON COLUMN public.c.a IS 'column';
-COMMENT ON INDEX public.c@c_a_b_idx IS 'index'
+              a INT8 NOT NULL,
+              b INT8 NULL,
+              rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+              CONSTRAINT c_pkey PRIMARY KEY (rowid ASC),
+              INDEX c_a_b_idx (a ASC, b ASC),
+              FAMILY fam_0_a_rowid (a, rowid),
+              FAMILY fam_1_b (b),
+              CONSTRAINT unique_a_b UNIQUE WITHOUT INDEX (a, b),
+              CONSTRAINT unique_a_partial UNIQUE WITHOUT INDEX (a) WHERE b > 0:::INT8
+            );
+            COMMENT ON TABLE public.c IS 'table';
+            COMMENT ON COLUMN public.c.a IS 'column';
+            COMMENT ON INDEX public.c@c_a_b_idx IS 'index'
 
 # TODO(rytaft): adding a NOT VALID unique constraint in PostgreSQL returns
 # an error. We should consider doing the same unless the constraint is UNIQUE
@@ -57,24 +57,24 @@ query TT
 SHOW CREATE c
 ----
 c  CREATE TABLE public.c (
-   a INT8 NOT NULL,
-   b INT8 NULL,
-   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   CONSTRAINT c_pkey PRIMARY KEY (rowid ASC),
-   CONSTRAINT fk_a FOREIGN KEY (a) REFERENCES public.d(d) NOT VALID,
-   INDEX c_a_b_idx (a ASC, b ASC),
-   UNIQUE INDEX unique_a (a ASC),
-   FAMILY fam_0_a_rowid (a, rowid),
-   FAMILY fam_1_b (b),
-   CONSTRAINT check_b CHECK (b IN (1:::INT8, 2:::INT8, 3:::INT8)) NOT VALID,
-   CONSTRAINT unique_a_b UNIQUE WITHOUT INDEX (a, b),
-   CONSTRAINT unique_a_partial UNIQUE WITHOUT INDEX (a) WHERE b > 0:::INT8,
-   CONSTRAINT unique_b UNIQUE WITHOUT INDEX (b) NOT VALID,
-   CONSTRAINT unique_b_partial UNIQUE WITHOUT INDEX (b) WHERE a > 0:::INT8 NOT VALID
-);
-COMMENT ON TABLE public.c IS 'table';
-COMMENT ON COLUMN public.c.a IS 'column';
-COMMENT ON INDEX public.c@c_a_b_idx IS 'index'
+     a INT8 NOT NULL,
+     b INT8 NULL,
+     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+     CONSTRAINT c_pkey PRIMARY KEY (rowid ASC),
+     CONSTRAINT fk_a FOREIGN KEY (a) REFERENCES public.d(d) NOT VALID,
+     INDEX c_a_b_idx (a ASC, b ASC),
+     UNIQUE INDEX unique_a (a ASC),
+     FAMILY fam_0_a_rowid (a, rowid),
+     FAMILY fam_1_b (b),
+     CONSTRAINT check_b CHECK (b IN (1:::INT8, 2:::INT8, 3:::INT8)) NOT VALID,
+     CONSTRAINT unique_a_b UNIQUE WITHOUT INDEX (a, b),
+     CONSTRAINT unique_a_partial UNIQUE WITHOUT INDEX (a) WHERE b > 0:::INT8,
+     CONSTRAINT unique_b UNIQUE WITHOUT INDEX (b) NOT VALID,
+     CONSTRAINT unique_b_partial UNIQUE WITHOUT INDEX (b) WHERE a > 0:::INT8 NOT VALID
+   );
+   COMMENT ON TABLE public.c IS 'table';
+   COMMENT ON COLUMN public.c.a IS 'column';
+   COMMENT ON INDEX public.c@c_a_b_idx IS 'index'
 
 statement ok
 ALTER TABLE c VALIDATE CONSTRAINT check_b;
@@ -88,24 +88,24 @@ query TT
 SHOW CREATE c
 ----
 c  CREATE TABLE public.c (
-   a INT8 NOT NULL,
-   b INT8 NULL,
-   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   CONSTRAINT c_pkey PRIMARY KEY (rowid ASC),
-   CONSTRAINT fk_a FOREIGN KEY (a) REFERENCES public.d(d),
-   INDEX c_a_b_idx (a ASC, b ASC),
-   UNIQUE INDEX unique_a (a ASC),
-   FAMILY fam_0_a_rowid (a, rowid),
-   FAMILY fam_1_b (b),
-   CONSTRAINT check_b CHECK (b IN (1:::INT8, 2:::INT8, 3:::INT8)),
-   CONSTRAINT unique_a_b UNIQUE WITHOUT INDEX (a, b),
-   CONSTRAINT unique_a_partial UNIQUE WITHOUT INDEX (a) WHERE b > 0:::INT8,
-   CONSTRAINT unique_b UNIQUE WITHOUT INDEX (b),
-   CONSTRAINT unique_b_partial UNIQUE WITHOUT INDEX (b) WHERE a > 0:::INT8
-);
-COMMENT ON TABLE public.c IS 'table';
-COMMENT ON COLUMN public.c.a IS 'column';
-COMMENT ON INDEX public.c@c_a_b_idx IS 'index'
+     a INT8 NOT NULL,
+     b INT8 NULL,
+     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+     CONSTRAINT c_pkey PRIMARY KEY (rowid ASC),
+     CONSTRAINT fk_a FOREIGN KEY (a) REFERENCES public.d(d),
+     INDEX c_a_b_idx (a ASC, b ASC),
+     UNIQUE INDEX unique_a (a ASC),
+     FAMILY fam_0_a_rowid (a, rowid),
+     FAMILY fam_1_b (b),
+     CONSTRAINT check_b CHECK (b IN (1:::INT8, 2:::INT8, 3:::INT8)),
+     CONSTRAINT unique_a_b UNIQUE WITHOUT INDEX (a, b),
+     CONSTRAINT unique_a_partial UNIQUE WITHOUT INDEX (a) WHERE b > 0:::INT8,
+     CONSTRAINT unique_b UNIQUE WITHOUT INDEX (b),
+     CONSTRAINT unique_b_partial UNIQUE WITHOUT INDEX (b) WHERE a > 0:::INT8
+   );
+   COMMENT ON TABLE public.c IS 'table';
+   COMMENT ON COLUMN public.c.a IS 'column';
+   COMMENT ON INDEX public.c@c_a_b_idx IS 'index'
 
 subtest alter_column_type_not_break_show_create
 

--- a/pkg/sql/logictest/testdata/logic_test/show_create_all_tables
+++ b/pkg/sql/logictest/testdata/logic_test/show_create_all_tables
@@ -46,26 +46,26 @@ SHOW CREATE ALL TABLES
 ----
 create_statement
 CREATE TABLE public.parent (
-    x INT8 NULL,
-    y INT8 NULL,
-    z INT8 NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    CONSTRAINT parent_pkey PRIMARY KEY (rowid ASC),
-    UNIQUE INDEX parent_x_y_z_key (x ASC, y ASC, z ASC),
-    UNIQUE INDEX parent_x_key (x ASC),
-    FAMILY f1 (x, y, z, rowid)
+  x INT8 NULL,
+  y INT8 NULL,
+  z INT8 NULL,
+  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+  CONSTRAINT parent_pkey PRIMARY KEY (rowid ASC),
+  UNIQUE INDEX parent_x_y_z_key (x ASC, y ASC, z ASC),
+  UNIQUE INDEX parent_x_key (x ASC),
+  FAMILY f1 (x, y, z, rowid)
 );
 CREATE TABLE public.full_test (
-    x INT8 NULL,
-    y INT8 NULL,
-    z INT8 NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    CONSTRAINT full_test_pkey PRIMARY KEY (rowid ASC),
-    UNIQUE INDEX full_test_x_key (x ASC),
-    FAMILY f1 (x, y, z, rowid)
+  x INT8 NULL,
+  y INT8 NULL,
+  z INT8 NULL,
+  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+  CONSTRAINT full_test_pkey PRIMARY KEY (rowid ASC),
+  UNIQUE INDEX full_test_x_key (x ASC),
+  FAMILY f1 (x, y, z, rowid)
 );
 CREATE VIEW public.vx (
-                                                                                                                                                                          "?column?"
+  "?column?"
 ) AS SELECT 1;
 CREATE SEQUENCE public.s MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1;
 ALTER TABLE public.full_test ADD CONSTRAINT full_test_x_y_z_fkey FOREIGN KEY (x, y, z) REFERENCES public.parent(x, y, z) MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE;
@@ -96,26 +96,26 @@ SHOW CREATE ALL TABLES
 ----
 create_statement
 CREATE TABLE public.parent (
-    x INT8 NULL,
-    y INT8 NULL,
-    z INT8 NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    CONSTRAINT parent_pkey PRIMARY KEY (rowid ASC),
-    UNIQUE INDEX parent_x_y_z_key (x ASC, y ASC, z ASC),
-    UNIQUE INDEX parent_x_key (x ASC),
-    FAMILY f1 (x, y, z, rowid)
+  x INT8 NULL,
+  y INT8 NULL,
+  z INT8 NULL,
+  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+  CONSTRAINT parent_pkey PRIMARY KEY (rowid ASC),
+  UNIQUE INDEX parent_x_y_z_key (x ASC, y ASC, z ASC),
+  UNIQUE INDEX parent_x_key (x ASC),
+  FAMILY f1 (x, y, z, rowid)
 );
 CREATE TABLE public.full_test (
-    x INT8 NULL,
-    y INT8 NULL,
-    z INT8 NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    CONSTRAINT full_test_pkey PRIMARY KEY (rowid ASC),
-    UNIQUE INDEX full_test_x_key (x ASC),
-    FAMILY f1 (x, y, z, rowid)
+  x INT8 NULL,
+  y INT8 NULL,
+  z INT8 NULL,
+  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+  CONSTRAINT full_test_pkey PRIMARY KEY (rowid ASC),
+  UNIQUE INDEX full_test_x_key (x ASC),
+  FAMILY f1 (x, y, z, rowid)
 );
 CREATE VIEW public.vx (
-                                                                                                                                                                          "?column?"
+  "?column?"
 ) AS SELECT 1;
 CREATE SEQUENCE public.s MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1;
 ALTER TABLE public.full_test ADD CONSTRAINT full_test_x_y_z_fkey FOREIGN KEY (x, y, z) REFERENCES public.parent(x, y, z) MATCH FULL ON DELETE CASCADE ON UPDATE CASCADE;
@@ -171,46 +171,46 @@ SHOW CREATE ALL TABLES
 ----
 create_statement
 CREATE TABLE public.b (
-    i INT8 NOT NULL,
-    CONSTRAINT b_pkey PRIMARY KEY (i ASC)
+  i INT8 NOT NULL,
+  CONSTRAINT b_pkey PRIMARY KEY (i ASC)
 );
 CREATE TABLE public.a (
-    i INT8 NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    CONSTRAINT a_pkey PRIMARY KEY (rowid ASC)
+  i INT8 NULL,
+  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+  CONSTRAINT a_pkey PRIMARY KEY (rowid ASC)
 );
 CREATE TABLE public.g (
-    i INT8 NOT NULL,
-    CONSTRAINT g_pkey PRIMARY KEY (i ASC)
+  i INT8 NOT NULL,
+  CONSTRAINT g_pkey PRIMARY KEY (i ASC)
 );
 CREATE TABLE public.f (
-    i INT8 NOT NULL,
-    g INT8 NULL,
-    CONSTRAINT f_pkey PRIMARY KEY (i ASC),
-    FAMILY f1 (i, g)
+  i INT8 NOT NULL,
+  g INT8 NULL,
+  CONSTRAINT f_pkey PRIMARY KEY (i ASC),
+  FAMILY f1 (i, g)
 );
 CREATE TABLE public.e (
-    i INT8 NOT NULL,
-    CONSTRAINT e_pkey PRIMARY KEY (i ASC)
+  i INT8 NOT NULL,
+  CONSTRAINT e_pkey PRIMARY KEY (i ASC)
 );
 CREATE TABLE public.d (
-    i INT8 NOT NULL,
-    e INT8 NULL,
-    f INT8 NULL,
-    CONSTRAINT d_pkey PRIMARY KEY (i ASC),
-    FAMILY f1 (i, e, f)
+  i INT8 NOT NULL,
+  e INT8 NULL,
+  f INT8 NULL,
+  CONSTRAINT d_pkey PRIMARY KEY (i ASC),
+  FAMILY f1 (i, e, f)
 );
 CREATE TABLE public.c (
-                                                                                       i INT8 NULL,
-                                                                                       rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                                                                                       CONSTRAINT c_pkey PRIMARY KEY (rowid ASC)
+  i INT8 NULL,
+  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+  CONSTRAINT c_pkey PRIMARY KEY (rowid ASC)
 );
 CREATE SEQUENCE public.s MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1;
 CREATE TABLE public.s_tbl (
-                                                                                                                     id INT8 NOT NULL DEFAULT nextval('public.s'::REGCLASS),
-                                                                                                                     v INT8 NULL,
-                                                                                                                     CONSTRAINT s_tbl_pkey PRIMARY KEY (id ASC),
-                                                                                                                     FAMILY f1 (id, v)
+  id INT8 NOT NULL DEFAULT nextval('public.s'::REGCLASS),
+  v INT8 NULL,
+  CONSTRAINT s_tbl_pkey PRIMARY KEY (id ASC),
+  FAMILY f1 (id, v)
 );
 ALTER TABLE public.a ADD CONSTRAINT a_i_fkey FOREIGN KEY (i) REFERENCES public.b(i);
 ALTER TABLE public.f ADD CONSTRAINT f_g_fkey FOREIGN KEY (g) REFERENCES public.g(i);
@@ -255,17 +255,17 @@ SHOW CREATE ALL TABLES
 ----
 create_statement
 CREATE TABLE public.loop_b (
-    id INT8 NOT NULL,
-    a_id INT8 NULL,
-    CONSTRAINT loop_b_pkey PRIMARY KEY (id ASC),
-    FAMILY f1 (id, a_id)
+  id INT8 NOT NULL,
+  a_id INT8 NULL,
+  CONSTRAINT loop_b_pkey PRIMARY KEY (id ASC),
+  FAMILY f1 (id, a_id)
 );
 CREATE TABLE public.loop_a (
-                                                                                                                                    id INT8 NOT NULL,
-                                                                                                                                    b_id INT8 NULL,
-                                                                                                                                    CONSTRAINT loop_a_pkey PRIMARY KEY (id ASC),
-                                                                                                                                    INDEX loop_a_b_id_idx (b_id ASC),
-                                                                                                                                    FAMILY f1 (id, b_id)
+  id INT8 NOT NULL,
+  b_id INT8 NULL,
+  CONSTRAINT loop_a_pkey PRIMARY KEY (id ASC),
+  INDEX loop_a_b_id_idx (b_id ASC),
+  FAMILY f1 (id, b_id)
 );
 ALTER TABLE public.loop_b ADD CONSTRAINT loop_b_a_id_fkey FOREIGN KEY (a_id) REFERENCES public.loop_a(id) ON DELETE CASCADE;
 ALTER TABLE public.loop_a ADD CONSTRAINT b_id_delete_constraint FOREIGN KEY (b_id) REFERENCES public.loop_b(id) ON DELETE CASCADE;
@@ -291,8 +291,8 @@ SHOW CREATE ALL TABLES
 ----
 create_statement
 CREATE TABLE public.t (
-    i INT8 NOT NULL,
-    CONSTRAINT pk_name PRIMARY KEY (i ASC)
+  i INT8 NOT NULL,
+  CONSTRAINT pk_name PRIMARY KEY (i ASC)
 );
 
 # Test that computed columns are shown correctly.
@@ -310,10 +310,10 @@ SHOW CREATE ALL TABLES
 ----
 create_statement
 CREATE TABLE public.t (
-    a INT8 NOT NULL,
-    b INT8 NULL AS (a + 1:::INT8) STORED,
-    CONSTRAINT t_pkey PRIMARY KEY (a ASC),
-    FAMILY f1 (a, b)
+  a INT8 NOT NULL,
+  b INT8 NULL AS (a + 1:::INT8) STORED,
+  CONSTRAINT t_pkey PRIMARY KEY (a ASC),
+  FAMILY f1 (a, b)
 );
 
 # Test showing a table with a semicolon in the table, index, and
@@ -329,10 +329,10 @@ SHOW CREATE ALL TABLES
 ----
 create_statement
 CREATE TABLE public.";" (
-    ";" INT8 NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    CONSTRAINT ";_pkey" PRIMARY KEY (rowid ASC),
-    INDEX ";_;_idx" (";" ASC)
+  ";" INT8 NULL,
+  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+  CONSTRAINT ";_pkey" PRIMARY KEY (rowid ASC),
+  INDEX ";_;_idx" (";" ASC)
 );
 
 # Ensure quotes in comments are properly escaped, also that the object names
@@ -374,14 +374,14 @@ SHOW CREATE ALL TABLES
 ----
 create_statement
 CREATE TABLE sc1.t (
-    x INT8 NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    CONSTRAINT t_pkey PRIMARY KEY (rowid ASC)
+  x INT8 NULL,
+  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+  CONSTRAINT t_pkey PRIMARY KEY (rowid ASC)
 );
 CREATE TABLE sc2.t (
-    x INT8 NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    CONSTRAINT t_pkey PRIMARY KEY (rowid ASC)
+  x INT8 NULL,
+  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+  CONSTRAINT t_pkey PRIMARY KEY (rowid ASC)
 );
 
 # Ensure sequences are shown correctly.
@@ -408,9 +408,9 @@ SHOW CREATE ALL TABLES
 ----
 create_statement
 CREATE TABLE public.t (
-    x type_test.public.test NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    CONSTRAINT t_pkey PRIMARY KEY (rowid ASC)
+  x type_test.public.test NULL,
+  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+  CONSTRAINT t_pkey PRIMARY KEY (rowid ASC)
 );
 
 # Test with column families.
@@ -424,13 +424,13 @@ SHOW CREATE ALL TABLES
 ----
 create_statement
 CREATE TABLE public.t (
-    x INT8 NULL,
-    y INT8 NULL,
-    z INT8 NULL,
-    h STRING NULL,
-    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-    CONSTRAINT t_pkey PRIMARY KEY (rowid ASC),
-    FAMILY f1 (x, y, rowid),
-    FAMILY f2 (z),
-    FAMILY f3 (h)
+  x INT8 NULL,
+  y INT8 NULL,
+  z INT8 NULL,
+  h STRING NULL,
+  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+  CONSTRAINT t_pkey PRIMARY KEY (rowid ASC),
+  FAMILY f1 (x, y, rowid),
+  FAMILY f2 (z),
+  FAMILY f3 (h)
 );

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -421,20 +421,20 @@ SELECT * FROM [SHOW CREATE TABLE system.descriptor]
 ----
 table_name                create_statement
 system.public.descriptor  CREATE TABLE public.descriptor (
-                          id INT8 NOT NULL,
-                          descriptor BYTES NULL,
-                          CONSTRAINT "primary" PRIMARY KEY (id ASC),
-                          FAMILY "primary" (id),
-                          FAMILY fam_2_descriptor (descriptor)
-)
+                            id INT8 NOT NULL,
+                            descriptor BYTES NULL,
+                            CONSTRAINT "primary" PRIMARY KEY (id ASC),
+                            FAMILY "primary" (id),
+                            FAMILY fam_2_descriptor (descriptor)
+                          )
 
 query TT colnames
 CREATE VIEW v AS SELECT id FROM system.descriptor; SELECT * FROM [SHOW CREATE VIEW v]
 ----
-table_name                                    create_statement
-v                                             CREATE VIEW public.v (
-                                              id
-) AS SELECT id FROM system.public.descriptor
+table_name  create_statement
+v           CREATE VIEW public.v (
+              id
+            ) AS SELECT id FROM system.public.descriptor
 
 
 query TTT colnames

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -227,22 +227,22 @@ query TT
 SHOW CREATE TABLE test.users
 ----
 test.public.users  CREATE TABLE public.users (
-                   id INT8 NOT NULL,
-                   name VARCHAR NOT NULL,
-                   title VARCHAR NULL,
-                   nickname STRING NULL,
-                   username STRING(10) NULL,
-                   email VARCHAR(100) NULL,
-                   CONSTRAINT users_pkey PRIMARY KEY (id ASC),
-                   INDEX foo (name ASC),
-                   UNIQUE INDEX bar (id ASC, name ASC),
-                   FAMILY "primary" (id, name),
-                   FAMILY fam_1_title (title),
-                   FAMILY fam_2_nickname (nickname),
-                   FAMILY fam_3_username_email (username, email),
-                   CONSTRAINT check_nickname_name CHECK (length(nickname) < length(name)),
-                   CONSTRAINT check_nickname CHECK (length(nickname) < 10:::INT8)
-)
+                     id INT8 NOT NULL,
+                     name VARCHAR NOT NULL,
+                     title VARCHAR NULL,
+                     nickname STRING NULL,
+                     username STRING(10) NULL,
+                     email VARCHAR(100) NULL,
+                     CONSTRAINT users_pkey PRIMARY KEY (id ASC),
+                     INDEX foo (name ASC),
+                     UNIQUE INDEX bar (id ASC, name ASC),
+                     FAMILY "primary" (id, name),
+                     FAMILY fam_1_title (title),
+                     FAMILY fam_2_nickname (nickname),
+                     FAMILY fam_3_username_email (username, email),
+                     CONSTRAINT check_nickname_name CHECK (length(nickname) < length(name)),
+                     CONSTRAINT check_nickname CHECK (length(nickname) < 10:::INT8)
+                   )
 
 statement ok
 CREATE TABLE test.dupe_generated (
@@ -284,24 +284,24 @@ query TT
 SHOW CREATE TABLE test.named_constraints
 ----
 test.public.named_constraints  CREATE TABLE public.named_constraints (
-                               id INT8 NOT NULL,
-                               name VARCHAR NOT NULL,
-                               title VARCHAR NULL DEFAULT 'VP of Something':::STRING,
-                               nickname STRING NULL,
-                               username STRING(10) NULL,
-                               email VARCHAR(100) NULL,
-                               CONSTRAINT pk PRIMARY KEY (id ASC),
-                               UNIQUE INDEX uq (email ASC),
-                               INDEX foo (name ASC),
-                               UNIQUE INDEX uq2 (username ASC),
-                               UNIQUE INDEX bar (id ASC, name ASC),
-                               FAMILY "primary" (id, name),
-                               FAMILY fam_1_title (title),
-                               FAMILY fam_2_nickname (nickname),
-                               FAMILY fam_3_username_email (username, email),
-                               CONSTRAINT ck2 CHECK (length(nickname) < length(name)),
-                               CONSTRAINT ck1 CHECK (length(nickname) < 10:::INT8)
-)
+                                 id INT8 NOT NULL,
+                                 name VARCHAR NOT NULL,
+                                 title VARCHAR NULL DEFAULT 'VP of Something':::STRING,
+                                 nickname STRING NULL,
+                                 username STRING(10) NULL,
+                                 email VARCHAR(100) NULL,
+                                 CONSTRAINT pk PRIMARY KEY (id ASC),
+                                 UNIQUE INDEX uq (email ASC),
+                                 INDEX foo (name ASC),
+                                 UNIQUE INDEX uq2 (username ASC),
+                                 UNIQUE INDEX bar (id ASC, name ASC),
+                                 FAMILY "primary" (id, name),
+                                 FAMILY fam_1_title (title),
+                                 FAMILY fam_2_nickname (nickname),
+                                 FAMILY fam_3_username_email (username, email),
+                                 CONSTRAINT ck2 CHECK (length(nickname) < length(name)),
+                                 CONSTRAINT ck1 CHECK (length(nickname) < 10:::INT8)
+                               )
 
 query TTTTB colnames
 SHOW CONSTRAINTS FROM test.named_constraints
@@ -498,10 +498,10 @@ query TT
 SHOW CREATE TABLE test.null_default
 ----
 test.public.null_default  CREATE TABLE public.null_default (
-                          ts TIMESTAMP NULL,
-                          rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                          CONSTRAINT null_default_pkey PRIMARY KEY (rowid ASC)
-)
+                            ts TIMESTAMP NULL,
+                            rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                            CONSTRAINT null_default_pkey PRIMARY KEY (rowid ASC)
+                          )
 
 # Issue #13873: don't permit invalid default columns
 statement error could not parse "blah" as type decimal

--- a/pkg/sql/logictest/testdata/logic_test/trigram_indexes
+++ b/pkg/sql/logictest/testdata/logic_test/trigram_indexes
@@ -243,12 +243,12 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE t86614]
 ----
 CREATE TABLE public.t86614 (
-   a INT8 NULL,
-   s STRING NULL,
-   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   CONSTRAINT t86614_pkey PRIMARY KEY (rowid ASC),
-   INVERTED INDEX t86614_a_s_idx (a ASC, s gin_trgm_ops),
-   FAMILY fam_0_a_s_rowid (a, s, rowid)
+  a INT8 NULL,
+  s STRING NULL,
+  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+  CONSTRAINT t86614_pkey PRIMARY KEY (rowid ASC),
+  INVERTED INDEX t86614_a_s_idx (a ASC, s gin_trgm_ops),
+  FAMILY fam_0_a_s_rowid (a, s, rowid)
 )
 
 # Regression test for #88925. Return correct result with a variable on the RHS

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -136,16 +136,16 @@ query T
 SELECT @2 FROM [SHOW CREATE FUNCTION f];
 ----
 CREATE FUNCTION public.f(IN a test.public.notmyworkday)
-    RETURNS INT8
-    IMMUTABLE
-    NOT LEAKPROOF
-    CALLED ON NULL INPUT
-    LANGUAGE SQL
-    AS $$
-    SELECT a FROM test.public.t;
-    SELECT b FROM test.public.t@t_idx_b;
-    SELECT c FROM test.public.t@t_idx_c;
-    SELECT nextval('public.sq1'::REGCLASS);
+  RETURNS INT8
+  IMMUTABLE
+  NOT LEAKPROOF
+  CALLED ON NULL INPUT
+  LANGUAGE SQL
+  AS $$
+  SELECT a FROM test.public.t;
+  SELECT b FROM test.public.t@t_idx_b;
+  SELECT c FROM test.public.t@t_idx_c;
+  SELECT nextval('public.sq1'::REGCLASS);
 $$
 
 statement error pq: unimplemented: alter function depends on extension not supported.*
@@ -1511,13 +1511,13 @@ query T
 SELECT @2 FROM [SHOW CREATE FUNCTION f_udt_rewrite];
 ----
 CREATE FUNCTION public.f_udt_rewrite()
-    RETURNS test.public.notmyworkday
-    VOLATILE
-    NOT LEAKPROOF
-    CALLED ON NULL INPUT
-    LANGUAGE SQL
-    AS $$
-    SELECT 'Monday':::test.public.notmyworkday;
+  RETURNS test.public.notmyworkday
+  VOLATILE
+  NOT LEAKPROOF
+  CALLED ON NULL INPUT
+  LANGUAGE SQL
+  AS $$
+  SELECT 'Monday':::test.public.notmyworkday;
 $$
 
 query T

--- a/pkg/sql/logictest/testdata/logic_test/update
+++ b/pkg/sql/logictest/testdata/logic_test/update
@@ -483,8 +483,8 @@ query T
 SELECT create_statement FROM [SHOW CREATE t29494]
 ----
 CREATE TABLE public.t29494 (
-   x INT8 NOT NULL,
-   CONSTRAINT t29494_pkey PRIMARY KEY (x ASC)
+  x INT8 NOT NULL,
+  CONSTRAINT t29494_pkey PRIMARY KEY (x ASC)
 )
 
 # Check that the new column is not usable in RETURNING

--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -634,9 +634,9 @@ query T
 SELECT create_statement FROM [SHOW CREATE t29494]
 ----
 CREATE TABLE public.t29494 (
-   x INT8 NULL,
-   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   CONSTRAINT t29494_pkey PRIMARY KEY (rowid ASC)
+  x INT8 NULL,
+  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+  CONSTRAINT t29494_pkey PRIMARY KEY (rowid ASC)
 )
 
 # Check that the new column is not usable in RETURNING

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -194,42 +194,42 @@ x y
 query TT
 SHOW CREATE VIEW v1
 ----
-v1                                   CREATE VIEW public.v1 (
-                                     a,
-                                     b
-) AS SELECT a, b FROM test.public.t
+v1  CREATE VIEW public.v1 (
+      a,
+      b
+    ) AS SELECT a, b FROM test.public.t
 
 query TT
 SHOW CREATE VIEW v2
 ----
-v2                                   CREATE VIEW public.v2 (
-                                     x,
-                                     y
-) AS SELECT a, b FROM test.public.t
+v2  CREATE VIEW public.v2 (
+      x,
+      y
+    ) AS SELECT a, b FROM test.public.t
 
 query TT
 SHOW CREATE VIEW v6
 ----
-v6                                    CREATE VIEW public.v6 (
-                                      x,
-                                      y
-) AS SELECT a, b FROM test.public.v1
+v6  CREATE VIEW public.v6 (
+      x,
+      y
+    ) AS SELECT a, b FROM test.public.v1
 
 query TT
 SHOW CREATE VIEW v7
 ----
-v7                                                            CREATE VIEW public.v7 (
-                                                              x,
-                                                              y
-) AS SELECT a, b FROM test.public.v1 ORDER BY a DESC LIMIT 2
+v7  CREATE VIEW public.v7 (
+      x,
+      y
+    ) AS SELECT a, b FROM test.public.v1 ORDER BY a DESC LIMIT 2
 
 query TT
 SHOW CREATE VIEW test2.v1
 ----
-test2.public.v1                       CREATE VIEW public.v1 (
-                                      x,
-                                      y
-) AS SELECT x, y FROM test.public.v2
+test2.public.v1  CREATE VIEW public.v1 (
+                   x,
+                   y
+                 ) AS SELECT x, y FROM test.public.v2
 
 statement ok
 GRANT SELECT ON t TO testuser
@@ -278,10 +278,10 @@ SELECT * FROM v6
 query TT
 SHOW CREATE VIEW v1
 ----
-v1                                   CREATE VIEW public.v1 (
-                                     a,
-                                     b
-) AS SELECT a, b FROM test.public.t
+v1  CREATE VIEW public.v1 (
+      a,
+      b
+    ) AS SELECT a, b FROM test.public.t
 
 user root
 
@@ -561,7 +561,7 @@ query T
 SELECT create_statement FROM [SHOW CREATE w]
 ----
 CREATE VIEW public.w (
-                                                x
+  x
 ) AS WITH a AS (SELECT 1 AS x) SELECT x FROM a
 
 statement ok
@@ -571,7 +571,7 @@ query T
 SELECT create_statement FROM [SHOW CREATE w2]
 ----
 CREATE VIEW public.w2 (
-                                                              x
+  x
 ) AS WITH t AS (SELECT x FROM test.public.w) SELECT x FROM t
 
 statement ok
@@ -581,7 +581,7 @@ query T
 SELECT create_statement FROM [SHOW CREATE w3]
 ----
 CREATE VIEW public.w3 (
-                                                                x
+  x
 ) AS (WITH t AS (SELECT x FROM test.public.w) SELECT x FROM t)
 
 statement ok
@@ -1126,9 +1126,9 @@ ALTER TYPE view_typ RENAME TO view_typ_new
 query TT
 SHOW CREATE VIEW v10
 ----
-v10                                        CREATE VIEW public.v10 (
-                                           view_typ
-) AS SELECT 'a':::db2.public.view_typ_new
+v10  CREATE VIEW public.v10 (
+       view_typ
+     ) AS SELECT 'a':::db2.public.view_typ_new
 
 query T
 SELECT * FROM v10
@@ -1144,9 +1144,9 @@ ALTER TYPE view_typ_new RENAME TO view_typ
 query TT
 SHOW CREATE VIEW v11
 ----
-v11                                                                       CREATE VIEW public.v11 (
-                                                                          k
-) AS (SELECT 'a':::db2.public.view_typ < 'a':::db2.public.view_typ AS k)
+v11  CREATE VIEW public.v11 (
+       k
+     ) AS (SELECT 'a':::db2.public.view_typ < 'a':::db2.public.view_typ AS k)
 
 query B
 SELECT * FROM v11
@@ -1162,9 +1162,9 @@ ALTER TYPE view_typ RENAME TO view_type_new
 query TT
 SHOW CREATE VIEW v12
 ----
-v12                                                                CREATE VIEW public.v12 (
-                                                                   k
-) AS (SELECT k FROM (SELECT 'a':::db2.public.view_type_new AS k))
+v12  CREATE VIEW public.v12 (
+       k
+     ) AS (SELECT k FROM (SELECT 'a':::db2.public.view_type_new AS k))
 
 query T
 SELECT * FROM v12
@@ -1180,9 +1180,9 @@ ALTER TYPE view_type_new RENAME TO view_type
 query TT
 SHOW CREATE VIEW v13
 ----
-v13                                                                                    CREATE VIEW public.v13 (
-                                                                                       k
-) AS (SELECT 'a':::db2.public.view_type AS k UNION SELECT 'b':::db2.public.view_type)
+v13  CREATE VIEW public.v13 (
+       k
+     ) AS (SELECT 'a':::db2.public.view_type AS k UNION SELECT 'b':::db2.public.view_type)
 
 query T
 SELECT * FROM v13 ORDER BY k
@@ -1200,11 +1200,11 @@ query TT
 SHOW CREATE VIEW v14
 ----
 v14  CREATE VIEW public.v14 (
-     "array"
-) AS (
-     SELECT
-       ARRAY['a':::db2.public.view_type_new, 'b':::db2.public.view_type_new]:::db2.public.view_type_new[]
-  )
+       "array"
+     ) AS (
+         SELECT
+           ARRAY['a':::db2.public.view_type_new, 'b':::db2.public.view_type_new]:::db2.public.view_type_new[]
+       )
 
 query T
 SELECT * FROM v14
@@ -1221,11 +1221,11 @@ query TT
 SHOW CREATE VIEW v15
 ----
 v15  CREATE VIEW public.v15 (
-     view_type_new
-) AS (
-     SELECT
-       ARRAY['a':::db2.public.view_type, 'b':::db2.public.view_type][2:::INT8] AS view_type_new
-  )
+       view_type_new
+     ) AS (
+         SELECT
+           ARRAY['a':::db2.public.view_type, 'b':::db2.public.view_type][2:::INT8] AS view_type_new
+       )
 
 query T
 SELECT * FROM v15
@@ -1279,10 +1279,10 @@ CREATE MATERIALIZED VIEW li AS (SELECT 1 AS test_t1);
 query TT
 SHOW CREATE VIEW li
 ----
-li                          CREATE MATERIALIZED VIEW public.li (
-                                                    test_t1,
-                                                    rowid
-                        ) AS (SELECT 1 AS test_t1)
+li  CREATE MATERIALIZED VIEW public.li (
+      test_t1,
+      rowid
+    ) AS (SELECT 1 AS test_t1)
 
 statement ok
 CREATE TABLE test_view (a INT PRIMARY KEY, b INT)

--- a/pkg/sql/logictest/testdata/logic_test/virtual_columns
+++ b/pkg/sql/logictest/testdata/logic_test/virtual_columns
@@ -1173,10 +1173,10 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE t63167_b]
 ----
 CREATE TABLE public.t63167_b (
-   a INT8 NULL,
-   v INT8 NULL AS (a + 1:::INT8) VIRTUAL,
-   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-   CONSTRAINT t63167_b_pkey PRIMARY KEY (rowid ASC)
+  a INT8 NULL,
+  v INT8 NULL AS (a + 1:::INT8) VIRTUAL,
+  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+  CONSTRAINT t63167_b_pkey PRIMARY KEY (rowid ASC)
 )
 
 # Test that columns backfills to tables with virtual columns work.
@@ -1339,13 +1339,13 @@ query T
 SELECT create_statement FROM [SHOW CREATE TABLE t_added]
 ----
 CREATE TABLE public.t_added (
-   i INT8 NOT NULL,
-   i4n INT4 NULL AS (NULL) VIRTUAL,
-   dn DECIMAL(5,2) NULL AS (NULL) VIRTUAL,
-   d DECIMAL(5,2) NULL AS (123456.000000:::DECIMAL) VIRTUAL,
-   i4 INT4 NULL AS (4:::INT8) VIRTUAL,
-   i2 INT2 NULL AS (2:::INT8) VIRTUAL,
-   CONSTRAINT t_added_pkey PRIMARY KEY (i ASC)
+  i INT8 NOT NULL,
+  i4n INT4 NULL AS (NULL) VIRTUAL,
+  dn DECIMAL(5,2) NULL AS (NULL) VIRTUAL,
+  d DECIMAL(5,2) NULL AS (123456.000000:::DECIMAL) VIRTUAL,
+  i4 INT4 NULL AS (4:::INT8) VIRTUAL,
+  i2 INT2 NULL AS (2:::INT8) VIRTUAL,
+  CONSTRAINT t_added_pkey PRIMARY KEY (i ASC)
 )
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/zone_config
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config
@@ -165,16 +165,16 @@ query TT
 SHOW CREATE TABLE a
 ----
 a  CREATE TABLE public.a (
-   id INT8 NOT NULL,
-   CONSTRAINT a_pkey PRIMARY KEY (id ASC)
-);
-ALTER TABLE test.public.a CONFIGURE ZONE USING
-  range_min_bytes = 200001,
-  range_max_bytes = 400000,
-  gc.ttlseconds = 3600,
-  num_replicas = 1,
-  constraints = '[+region=test]',
-  lease_preferences = '[[+region=test]]'
+     id INT8 NOT NULL,
+     CONSTRAINT a_pkey PRIMARY KEY (id ASC)
+   );
+   ALTER TABLE test.public.a CONFIGURE ZONE USING
+     range_min_bytes = 200001,
+     range_max_bytes = 400000,
+     gc.ttlseconds = 3600,
+     num_replicas = 1,
+     constraints = '[+region=test]',
+     lease_preferences = '[[+region=test]]'
 
 # Check that we can reset the configuration to defaults.
 
@@ -319,18 +319,18 @@ query TT
 SHOW CREATE TABLE same_table_name
 ----
 same_table_name  CREATE TABLE public.same_table_name (
-                 rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                 CONSTRAINT same_table_name_pkey PRIMARY KEY (rowid ASC)
-);
-ALTER TABLE test.public.same_table_name CONFIGURE ZONE USING
-  gc.ttlseconds = 500
+                   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                   CONSTRAINT same_table_name_pkey PRIMARY KEY (rowid ASC)
+                 );
+                 ALTER TABLE test.public.same_table_name CONFIGURE ZONE USING
+                   gc.ttlseconds = 500
 
 query TT
 SHOW CREATE TABLE alternative_schema.same_table_name
 ----
 alternative_schema.same_table_name  CREATE TABLE alternative_schema.same_table_name (
-                                    rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
-                                    CONSTRAINT same_table_name_pkey PRIMARY KEY (rowid ASC)
-);
-ALTER TABLE test.alternative_schema.same_table_name CONFIGURE ZONE USING
-  gc.ttlseconds = 600
+                                      rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                                      CONSTRAINT same_table_name_pkey PRIMARY KEY (rowid ASC)
+                                    );
+                                    ALTER TABLE test.alternative_schema.same_table_name CONFIGURE ZONE USING
+                                      gc.ttlseconds = 600


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/83586

This fixes 2 issues with logic test output:
1) Tabs no longer interfere with tabwriter column output.
2) Newlines no longer interfere with tabwriter row output.

Release note: None