### PR TITLE
*: Improve constraints retrieval in table descriptor

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1526,13 +1526,13 @@ func (e InvalidIndexesError) Error() string {
 func ValidateCheckConstraint(
 	ctx context.Context,
 	tableDesc catalog.TableDescriptor,
-	constraint *descpb.ConstraintDetail,
+	constraint catalog.Constraint,
 	sessionData *sessiondata.SessionData,
 	runHistoricalTxn descs.HistoricalInternalExecTxnRunner,
 	execOverride sessiondata.InternalExecutorOverride,
 ) (err error) {
-	if constraint.CheckConstraint == nil {
-		return errors.AssertionFailedf("%v is not a check constraint", constraint.GetConstraintName())
+	if !constraint.IsCheck() {
+		return errors.AssertionFailedf("%v is not a check constraint", constraint.GetName())
 	}
 
 	tableDesc, err = tableDesc.MakeFirstMutationPublic(catalog.IgnoreConstraints)
@@ -1551,7 +1551,7 @@ func ValidateCheckConstraint(
 		defer func() { descriptors.ReleaseAll(ctx) }()
 
 		return ie.WithSyntheticDescriptors([]catalog.Descriptor{tableDesc}, func() error {
-			return validateCheckExpr(ctx, &semaCtx, txn, sessionData, constraint.CheckConstraint.Expr,
+			return validateCheckExpr(ctx, &semaCtx, txn, sessionData, constraint.Check().Expr,
 				tableDesc.(*tabledesc.Mutable), ie)
 		})
 	})

--- a/pkg/sql/backfill_test.go
+++ b/pkg/sql/backfill_test.go
@@ -22,10 +22,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// constraintToUpdateForTest implements the catalog.ConstraintToUpdate interface.
+// constraintToUpdateForTest implements the catalog.Constraint interface.
 // It's only used for testing
 type constraintToUpdateForTest struct {
-	catalog.ConstraintToUpdate
+	catalog.Constraint
 	desc *descpb.ConstraintToUpdate
 }
 

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -632,8 +632,22 @@ type TableDescriptor interface {
 	// It's only non-nil if IsView is true.
 	GetDependsOnTypes() []descpb.ID
 
+	// AllConstraints returns all constraints from this table.
+	// A constraint is considered
+	// - active if its validity is VALIDATED;
+	// - inactive if its validity is VALIDATING or UNVALIDATED;
+	// - dropping if its validity is DROPPING;
+	AllConstraints() []Constraint
+	// AllActiveAndInactiveConstraints returns all active and inactive constraints from table.
+	AllActiveAndInactiveConstraints() []Constraint
+	// AllActiveConstraints returns all active constraints from table.
+	AllActiveConstraints() []Constraint
+
 	// GetConstraintInfoWithLookup returns a summary of all constraints on the
 	// table using the provided function to fetch a TableDescriptor from an ID.
+	// TODO (xiang): The following two legacy methods (`GetConstraintInfoWithLookup`
+	// and `GetConstraintInfo`) should be replaced with the methods above that
+	// retrieve constraints from the table and expose a `Constraint` interface.
 	GetConstraintInfoWithLookup(fn TableLookupFn) (map[string]descpb.ConstraintDetail, error)
 	// GetConstraintInfo returns a summary of all constraints on the table.
 	GetConstraintInfo() (map[string]descpb.ConstraintDetail, error)

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -652,7 +652,7 @@ type TableDescriptor interface {
 	// GetConstraintInfo returns a summary of all constraints on the table.
 	GetConstraintInfo() (map[string]descpb.ConstraintDetail, error)
 	// FindConstraintWithID returns a constraint given a constraint id.
-	FindConstraintWithID(id descpb.ConstraintID) (*descpb.ConstraintDetail, error)
+	FindConstraintWithID(id descpb.ConstraintID) (Constraint, error)
 
 	// GetUniqueWithoutIndexConstraints returns all the unique constraints defined
 	// on this table that are not enforced by an index.

--- a/pkg/sql/catalog/descriptor_test.go
+++ b/pkg/sql/catalog/descriptor_test.go
@@ -11,6 +11,7 @@
 package catalog_test
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -65,4 +66,193 @@ func TestFormatSafeDescriptorProperties(t *testing.T) {
 			require.NoError(t, yaml.UnmarshalStrict([]byte("{"+redacted+"}"), &m))
 		})
 	}
+}
+
+// TestConstraintRetrieval tests the following three method inside catalog.TableDescriptor interface.
+// - AllConstraints() []Constraint
+// - AllActiveAndInactiveConstraints() []Constraint
+// - AllActiveConstraints() []Constraint
+func TestConstraintRetrieval(t *testing.T) {
+	// Construct a table with the following constraints:
+	//  - Primary Index: [ID_1:validated]
+	//  - Indexes: [a non-unique index, ID_4:validated]
+	//  - Checks: [ID_2:validated], [ID_3:unvalidated]
+	//  - OutboundFKs: [ID_6:validated]
+	//  - InboundFKs: [ID_5:validated]
+	//  - UniqueWithoutIndexConstraints: [ID_7:dropping]
+	//  - mutation slice: [ID_7:dropping:UniqueWithoutIndex, ID_8:validating:Check, ID_9:validating:UniqueIndex, a non-unique index]
+	primaryIndex := descpb.IndexDescriptor{
+		Unique:       true,
+		ConstraintID: 1,
+		EncodingType: descpb.PrimaryIndexEncoding,
+	}
+
+	indexes := make([]descpb.IndexDescriptor, 2)
+	indexes[0] = descpb.IndexDescriptor{
+		Unique: false,
+	}
+	indexes[1] = descpb.IndexDescriptor{
+		Unique:       true,
+		ConstraintID: 4,
+	}
+
+	checks := make([]*descpb.TableDescriptor_CheckConstraint, 2)
+	checks[0] = &descpb.TableDescriptor_CheckConstraint{
+		Validity:     descpb.ConstraintValidity_Validated,
+		ConstraintID: 2,
+	}
+	checks[1] = &descpb.TableDescriptor_CheckConstraint{
+		Validity:     descpb.ConstraintValidity_Unvalidated,
+		ConstraintID: 3,
+	}
+
+	outboundFKs := make([]descpb.ForeignKeyConstraint, 1)
+	outboundFKs[0] = descpb.ForeignKeyConstraint{
+		Validity:     descpb.ConstraintValidity_Validated,
+		ConstraintID: 6,
+	}
+
+	inboundFKs := make([]descpb.ForeignKeyConstraint, 1)
+	inboundFKs[0] = descpb.ForeignKeyConstraint{
+		Validity:     descpb.ConstraintValidity_Validated,
+		ConstraintID: 5,
+	}
+
+	uniqueWithoutIndexConstraints := make([]descpb.UniqueWithoutIndexConstraint, 1)
+	uniqueWithoutIndexConstraints[0] = descpb.UniqueWithoutIndexConstraint{
+		Validity:     descpb.ConstraintValidity_Dropping,
+		ConstraintID: 7,
+	}
+
+	mutations := make([]descpb.DescriptorMutation, 4)
+	mutations[0] = descpb.DescriptorMutation{
+		Descriptor_: &descpb.DescriptorMutation_Constraint{
+			Constraint: &descpb.ConstraintToUpdate{
+				ConstraintType:               descpb.ConstraintToUpdate_UNIQUE_WITHOUT_INDEX,
+				Name:                         "unique_on_k_without_index",
+				UniqueWithoutIndexConstraint: uniqueWithoutIndexConstraints[0],
+			},
+		},
+		State:     descpb.DescriptorMutation_DELETE_ONLY,
+		Direction: descpb.DescriptorMutation_DROP,
+	}
+	mutations[1] = descpb.DescriptorMutation{
+		Descriptor_: &descpb.DescriptorMutation_Constraint{
+			Constraint: &descpb.ConstraintToUpdate{
+				ConstraintType: descpb.ConstraintToUpdate_CHECK,
+				Check: descpb.TableDescriptor_CheckConstraint{
+					Validity:     descpb.ConstraintValidity_Validating,
+					ConstraintID: 8,
+				},
+			}},
+		State:     descpb.DescriptorMutation_DELETE_ONLY,
+		Direction: descpb.DescriptorMutation_ADD,
+	}
+	mutations[2] = descpb.DescriptorMutation{
+		Descriptor_: &descpb.DescriptorMutation_Index{
+			Index: &descpb.IndexDescriptor{
+				Unique:       true,
+				ConstraintID: 9,
+			}},
+		State:     descpb.DescriptorMutation_DELETE_ONLY,
+		Direction: descpb.DescriptorMutation_ADD,
+	}
+	mutations[3] = descpb.DescriptorMutation{
+		Descriptor_: &descpb.DescriptorMutation_Index{
+			Index: &descpb.IndexDescriptor{
+				Unique: false,
+			}},
+		State:     descpb.DescriptorMutation_DELETE_ONLY,
+		Direction: descpb.DescriptorMutation_ADD,
+	}
+
+	tableDesc := tabledesc.NewBuilder(&descpb.TableDescriptor{
+		PrimaryIndex:                  primaryIndex,
+		Indexes:                       indexes,
+		Checks:                        checks,
+		OutboundFKs:                   outboundFKs,
+		InboundFKs:                    inboundFKs,
+		UniqueWithoutIndexConstraints: uniqueWithoutIndexConstraints,
+		Mutations:                     mutations,
+	}).BuildImmutable().(catalog.TableDescriptor)
+
+	t.Run("test-AllConstraints", func(t *testing.T) {
+		all := tableDesc.AllConstraints()
+		sort.Slice(all, func(i, j int) bool {
+			return all[i].GetConstraintID() < all[j].GetConstraintID()
+		})
+		require.Equal(t, len(all), 9)
+		checkIndexBackedConstraint(t, all[0], 1, descpb.ConstraintValidity_Validated, descpb.PrimaryIndexEncoding)
+		checkNonIndexBackedConstraint(t, all[1], 2, descpb.ConstraintValidity_Validated, descpb.ConstraintToUpdate_CHECK)
+		checkNonIndexBackedConstraint(t, all[2], 3, descpb.ConstraintValidity_Unvalidated, descpb.ConstraintToUpdate_CHECK)
+		checkIndexBackedConstraint(t, all[3], 4, descpb.ConstraintValidity_Validated, descpb.SecondaryIndexEncoding)
+		checkNonIndexBackedConstraint(t, all[4], 5, descpb.ConstraintValidity_Validated, descpb.ConstraintToUpdate_FOREIGN_KEY)
+		checkNonIndexBackedConstraint(t, all[5], 6, descpb.ConstraintValidity_Validated, descpb.ConstraintToUpdate_FOREIGN_KEY)
+		checkNonIndexBackedConstraint(t, all[6], 7, descpb.ConstraintValidity_Dropping, descpb.ConstraintToUpdate_UNIQUE_WITHOUT_INDEX)
+		checkNonIndexBackedConstraint(t, all[7], 8, descpb.ConstraintValidity_Validating, descpb.ConstraintToUpdate_CHECK)
+		checkIndexBackedConstraint(t, all[8], 9, descpb.ConstraintValidity_Validating, descpb.SecondaryIndexEncoding)
+	})
+
+	t.Run("test-AllActiveAndInactiveConstraints", func(t *testing.T) {
+		allActiveAndInactive := tableDesc.AllActiveAndInactiveConstraints()
+		sort.Slice(allActiveAndInactive, func(i, j int) bool {
+			return allActiveAndInactive[i].GetConstraintID() < allActiveAndInactive[j].GetConstraintID()
+		})
+		require.Equal(t, len(allActiveAndInactive), 8)
+		checkIndexBackedConstraint(t, allActiveAndInactive[0], 1, descpb.ConstraintValidity_Validated, descpb.PrimaryIndexEncoding)
+		checkNonIndexBackedConstraint(t, allActiveAndInactive[1], 2, descpb.ConstraintValidity_Validated, descpb.ConstraintToUpdate_CHECK)
+		checkNonIndexBackedConstraint(t, allActiveAndInactive[2], 3, descpb.ConstraintValidity_Unvalidated, descpb.ConstraintToUpdate_CHECK)
+		checkIndexBackedConstraint(t, allActiveAndInactive[3], 4, descpb.ConstraintValidity_Validated, descpb.SecondaryIndexEncoding)
+		checkNonIndexBackedConstraint(t, allActiveAndInactive[4], 5, descpb.ConstraintValidity_Validated, descpb.ConstraintToUpdate_FOREIGN_KEY)
+		checkNonIndexBackedConstraint(t, allActiveAndInactive[5], 6, descpb.ConstraintValidity_Validated, descpb.ConstraintToUpdate_FOREIGN_KEY)
+		checkNonIndexBackedConstraint(t, allActiveAndInactive[6], 8, descpb.ConstraintValidity_Validating, descpb.ConstraintToUpdate_CHECK)
+		checkIndexBackedConstraint(t, allActiveAndInactive[7], 9, descpb.ConstraintValidity_Validating, descpb.SecondaryIndexEncoding)
+	})
+
+	t.Run("test-AllActiveConstraints", func(t *testing.T) {
+		allActive := tableDesc.AllActiveConstraints()
+		sort.Slice(allActive, func(i, j int) bool {
+			return allActive[i].GetConstraintID() < allActive[j].GetConstraintID()
+		})
+		require.Equal(t, len(allActive), 5)
+		checkIndexBackedConstraint(t, allActive[0], 1, descpb.ConstraintValidity_Validated, descpb.PrimaryIndexEncoding)
+		checkNonIndexBackedConstraint(t, allActive[1], 2, descpb.ConstraintValidity_Validated, descpb.ConstraintToUpdate_CHECK)
+		checkIndexBackedConstraint(t, allActive[2], 4, descpb.ConstraintValidity_Validated, descpb.SecondaryIndexEncoding)
+		checkNonIndexBackedConstraint(t, allActive[3], 5, descpb.ConstraintValidity_Validated, descpb.ConstraintToUpdate_FOREIGN_KEY)
+		checkNonIndexBackedConstraint(t, allActive[4], 6, descpb.ConstraintValidity_Validated, descpb.ConstraintToUpdate_FOREIGN_KEY)
+	})
+}
+
+// checkIndexBackedConstraint ensures `c` (PRIMARY KEY or UNIQUE)
+// has the expected ID, validity, and type.
+//
+// `expectedEncodingType = secondaryIndexEncoding` is used for
+// UNIQUE constraint type.
+func checkIndexBackedConstraint(
+	t *testing.T,
+	c catalog.Constraint,
+	expectedID descpb.ConstraintID,
+	expectedValidity descpb.ConstraintValidity,
+	expectedEncodingType descpb.IndexDescriptorEncodingType,
+) {
+	require.Equal(t, expectedID, c.GetConstraintID())
+	require.Equal(t, expectedValidity, c.GetConstraintValidity())
+	require.Equal(t, expectedEncodingType, c.IndexDesc().EncodingType)
+	if expectedEncodingType == descpb.SecondaryIndexEncoding {
+		require.Equal(t, true, c.IndexDesc().Unique)
+	}
+}
+
+// checkNonIndexBackedConstraint ensures `c` (CHECK, FK, or UNIQUE_WITHOUT_INDEX)
+// has the expected ID, validity, and type.
+func checkNonIndexBackedConstraint(
+	t *testing.T,
+	c catalog.Constraint,
+	expectedID descpb.ConstraintID,
+	expectedValidity descpb.ConstraintValidity,
+	expectedType descpb.ConstraintToUpdate_ConstraintType,
+) {
+	require.Equal(t, expectedID, c.GetConstraintID())
+	require.Equal(t, expectedValidity, c.GetConstraintValidity())
+	require.Equal(t, expectedType, c.ConstraintToUpdateDesc().ConstraintType)
 }

--- a/pkg/sql/catalog/table_elements.go
+++ b/pkg/sql/catalog/table_elements.go
@@ -71,9 +71,9 @@ type Mutation interface {
 	// nil otherwise.
 	AsIndex() Index
 
-	// AsConstraint returns the corresponding ConstraintToUpdate if the mutation
+	// AsConstraint returns the corresponding Constraint if the mutation
 	// is on a constraint, nil otherwise.
-	AsConstraint() ConstraintToUpdate
+	AsConstraint() Constraint
 
 	// AsPrimaryKeySwap returns the corresponding PrimaryKeySwap if the mutation
 	// is a primary key swap, nil otherwise.
@@ -396,8 +396,8 @@ type Column interface {
 	GetGeneratedAsIdentitySequenceOption(defaultIntSize int32) (*descpb.TableDescriptor_SequenceOpts, error)
 }
 
-// ConstraintToUpdate is an interface around a constraint mutation.
-type ConstraintToUpdate interface {
+// Constraint is an interface around a constraint.
+type Constraint interface {
 	TableElementMaybeMutation
 
 	// ConstraintToUpdateDesc returns the underlying protobuf descriptor.

--- a/pkg/sql/catalog/table_elements.go
+++ b/pkg/sql/catalog/table_elements.go
@@ -400,8 +400,13 @@ type Column interface {
 type Constraint interface {
 	TableElementMaybeMutation
 
-	// ConstraintToUpdateDesc returns the underlying protobuf descriptor.
+	// ConstraintToUpdateDesc returns the underlying protobuf descriptor
+	// for non-index-backed-constraints (CHECK, FK, or UNIQUE_WITHOUT_INDEX).
 	ConstraintToUpdateDesc() *descpb.ConstraintToUpdate
+
+	// IndexDesc returns the underlying protobuf descriptor for
+	// index-backed-constraints (PRIMARY KEY or UNIQUE).
+	IndexDesc() *descpb.IndexDescriptor
 
 	// GetName returns the name of this constraint update mutation.
 	GetName() string
@@ -419,6 +424,12 @@ type Constraint interface {
 	// without index constraint.
 	IsUniqueWithoutIndex() bool
 
+	// IsPrimaryKey returns true iff this is an index-backed PRIMARY KEY constraint.
+	IsPrimaryKey() bool
+
+	// IsUniqueConstraint returns true iff this is an index-backed UNIQUE constraint.
+	IsUniqueConstraint() bool
+
 	// Check returns the underlying check constraint, if there is one.
 	Check() descpb.TableDescriptor_CheckConstraint
 
@@ -432,8 +443,19 @@ type Constraint interface {
 	// there is one.
 	UniqueWithoutIndex() descpb.UniqueWithoutIndexConstraint
 
+	// PrimaryKey returns the index descriptor backing the PRIMARY KEY constraint,
+	// if there is one.
+	PrimaryKey() Index
+
+	// Unique returns the index descriptor backing the UNIQUE constraint,
+	// if there is one.
+	Unique() Index
+
 	// GetConstraintID returns the ID for the constraint.
 	GetConstraintID() descpb.ConstraintID
+
+	// GetConstraintValidity returns the validity of this constraint.
+	GetConstraintValidity() descpb.ConstraintValidity
 }
 
 // PrimaryKeySwap is an interface around a primary key swap mutation.

--- a/pkg/sql/catalog/tabledesc/BUILD.bazel
+++ b/pkg/sql/catalog/tabledesc/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     name = "tabledesc",
     srcs = [
         "column.go",
+        "constraint.go",
         "index.go",
         "mutation.go",
         "safe_format.go",

--- a/pkg/sql/catalog/tabledesc/constraint.go
+++ b/pkg/sql/catalog/tabledesc/constraint.go
@@ -1,0 +1,223 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tabledesc
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/errors"
+)
+
+// constraintCache contains precomputed slices of constraints, categorized by kind and validity.
+// A constraint is considered
+// - active if its validity is VALIDATED;
+// - inactive if its validity is VALIDATING or UNVALIDATED;
+// - dropping if its validity is DROPPING;
+type constraintCache struct {
+	all                  []catalog.Constraint
+	allActiveAndInactive []catalog.Constraint
+	allActive            []catalog.Constraint
+
+	allChecks                  []catalog.Constraint
+	allActiveAndInactiveChecks []catalog.Constraint
+	allActiveChecks            []catalog.Constraint
+
+	allNotNulls                  []catalog.Constraint
+	allActiveAndInactiveNotNulls []catalog.Constraint
+	allActiveNotNulls            []catalog.Constraint
+
+	allFKs                  []catalog.Constraint
+	allActiveAndInactiveFKs []catalog.Constraint
+	allActiveFKs            []catalog.Constraint
+
+	allUniqueWithoutIndexes                  []catalog.Constraint
+	allActiveAndInactiveUniqueWithoutIndexes []catalog.Constraint
+	allActiveUniqueWithoutIndexes            []catalog.Constraint
+}
+
+// newConstraintCache returns a fresh fully-populated constraintCache struct for the
+// TableDescriptor.
+func newConstraintCache(desc *descpb.TableDescriptor, mutations *mutationCache) *constraintCache {
+	c := constraintCache{}
+
+	// addIfNotExists is a function that adds constraint `c` to slice `dest` if this
+	// constraint is not already in it (as determined by using a set of already added
+	// constraint IDs `constraintIDsInDest`).
+	// If `constraintIDsInDest` is nil, blindly append `c` to `dest`.
+	addIfNotExists := func(
+		c catalog.Constraint,
+		dest []catalog.Constraint,
+		constraintIDsInDest map[descpb.ConstraintID]bool,
+	) []catalog.Constraint {
+		if constraintIDsInDest == nil {
+			dest = append(dest, c)
+			return dest
+		}
+
+		if _, exist := constraintIDsInDest[c.GetConstraintID()]; exist {
+			return dest
+		}
+		dest = append(dest, c)
+		constraintIDsInDest[c.GetConstraintID()] = true
+		return dest
+	}
+
+	// addConstraintToSetsByValidity is a function that adds constraint `c` to various slice
+	// categorized by validity.
+	addConstraintToSetsByValidity := func(
+		c catalog.Constraint,
+		all, allActiveAndInactive, allActive []catalog.Constraint,
+	) (
+		updatedAll []catalog.Constraint,
+		updatedAllActiveAndInactive []catalog.Constraint,
+		updatedAllActive []catalog.Constraint,
+	) {
+		cstValidity := c.GetConstraintValidity()
+		all = addIfNotExists(c, all, nil)
+
+		if cstValidity == descpb.ConstraintValidity_Validated ||
+			cstValidity == descpb.ConstraintValidity_Validating ||
+			cstValidity == descpb.ConstraintValidity_Unvalidated {
+			allActiveAndInactive = addIfNotExists(c, allActiveAndInactive, nil)
+		}
+		if cstValidity == descpb.ConstraintValidity_Validated {
+			allActive = addIfNotExists(c, allActive, nil)
+		}
+		return all, allActiveAndInactive, allActive
+	}
+
+	// Glean all constraints from `desc` and `mutations`.
+	var allConstraints []catalog.Constraint
+	constraintIDs := make(map[descpb.ConstraintID]bool)
+	for _, cst := range []descpb.IndexDescriptor{desc.PrimaryIndex} {
+		backingStruct := index{
+			desc:                 &cst,
+			validityIfConstraint: descpb.ConstraintValidity_Validated,
+		}
+		allConstraints = addIfNotExists(backingStruct, allConstraints, constraintIDs)
+	}
+	for _, cst := range desc.Indexes {
+		if cst.Unique {
+			backingStruct := index{
+				desc:                 &cst,
+				validityIfConstraint: descpb.ConstraintValidity_Validated,
+			}
+			allConstraints = addIfNotExists(backingStruct, allConstraints, constraintIDs)
+		}
+	}
+	for _, cst := range desc.Checks {
+		backingStruct := constraint{
+			desc: &descpb.ConstraintToUpdate{
+				ConstraintType: descpb.ConstraintToUpdate_CHECK,
+				Name:           cst.Name,
+				Check:          *cst,
+			},
+		}
+		allConstraints = addIfNotExists(backingStruct, allConstraints, constraintIDs)
+	}
+	for _, cst := range append(desc.OutboundFKs, desc.InboundFKs...) {
+		backingStruct := constraint{
+			desc: &descpb.ConstraintToUpdate{
+				ConstraintType: descpb.ConstraintToUpdate_FOREIGN_KEY,
+				Name:           cst.Name,
+				ForeignKey:     cst,
+			},
+		}
+		allConstraints = addIfNotExists(backingStruct, allConstraints, constraintIDs)
+	}
+	for _, cst := range desc.UniqueWithoutIndexConstraints {
+		backingStruct := constraint{
+			desc: &descpb.ConstraintToUpdate{
+				ConstraintType:               descpb.ConstraintToUpdate_UNIQUE_WITHOUT_INDEX,
+				Name:                         cst.Name,
+				UniqueWithoutIndexConstraint: cst,
+			},
+		}
+		allConstraints = addIfNotExists(backingStruct, allConstraints, constraintIDs)
+	}
+	for _, cstMutation := range mutations.all {
+		if cst := cstMutation.AsConstraint(); cst != nil {
+			backingStruct := constraint{
+				maybeMutation: maybeMutation{
+					mutationID:         cstMutation.MutationID(),
+					mutationDirection:  mutationDirection(cstMutation),
+					mutationState:      mutationState(cstMutation),
+					mutationIsRollback: cstMutation.IsRollback(),
+				},
+				desc: cst.ConstraintToUpdateDesc(),
+			}
+			allConstraints = addIfNotExists(backingStruct, allConstraints, constraintIDs)
+		}
+		if cst := cstMutation.AsIndex(); cst != nil {
+			validity := descpb.ConstraintValidity_Validating
+			if !cstMutation.Adding() {
+				validity = descpb.ConstraintValidity_Dropping
+			}
+			switch cst.GetEncodingType() {
+			case descpb.PrimaryIndexEncoding:
+				backingStruct := index{
+					desc:                 cst.IndexDesc(),
+					validityIfConstraint: validity,
+				}
+				allConstraints = addIfNotExists(backingStruct, allConstraints, constraintIDs)
+			case descpb.SecondaryIndexEncoding:
+				if cst.IsUnique() {
+					backingStruct := index{
+						desc:                 cst.IndexDesc(),
+						validityIfConstraint: validity,
+					}
+					allConstraints = addIfNotExists(backingStruct, allConstraints, constraintIDs)
+				}
+			default:
+				panic("unknown index encoding type")
+			}
+		}
+	}
+
+	// Populate constraintCache `c`.
+	for _, cst := range allConstraints {
+		c.all, c.allActiveAndInactive, c.allActive =
+			addConstraintToSetsByValidity(cst, c.all, c.allActiveAndInactive, c.allActive)
+		c.allChecks, c.allActiveAndInactiveChecks, c.allActiveChecks =
+			addConstraintToSetsByValidity(cst, c.allChecks, c.allActiveAndInactiveChecks, c.allActiveChecks)
+		c.allNotNulls, c.allActiveAndInactiveNotNulls, c.allActiveNotNulls =
+			addConstraintToSetsByValidity(cst, c.allNotNulls, c.allActiveAndInactiveNotNulls, c.allActiveNotNulls)
+		c.allFKs, c.allActiveAndInactiveFKs, c.allActiveFKs =
+			addConstraintToSetsByValidity(cst, c.allFKs, c.allActiveAndInactiveFKs, c.allActiveFKs)
+		c.allUniqueWithoutIndexes, c.allActiveAndInactiveUniqueWithoutIndexes, c.allActiveUniqueWithoutIndexes =
+			addConstraintToSetsByValidity(cst, c.allUniqueWithoutIndexes, c.allActiveAndInactiveUniqueWithoutIndexes, c.allActiveUniqueWithoutIndexes)
+	}
+
+	return &c
+}
+
+func mutationState(mutation catalog.Mutation) (ret descpb.DescriptorMutation_State) {
+	if mutation.DeleteOnly() {
+		ret = descpb.DescriptorMutation_DELETE_ONLY
+	} else if mutation.WriteAndDeleteOnly() {
+		ret = descpb.DescriptorMutation_WRITE_ONLY
+	} else if mutation.Backfilling() {
+		ret = descpb.DescriptorMutation_BACKFILLING
+	} else if mutation.Merging() {
+		ret = descpb.DescriptorMutation_MERGING
+	} else {
+		panic(errors.AssertionFailedf("unknown mutation state"))
+	}
+	return ret
+}
+
+func mutationDirection(mutation catalog.Mutation) descpb.DescriptorMutation_Direction {
+	if mutation.Adding() {
+		return descpb.DescriptorMutation_ADD
+	} else {
+		return descpb.DescriptorMutation_DROP
+	}
+}

--- a/pkg/sql/catalog/tabledesc/mutation.go
+++ b/pkg/sql/catalog/tabledesc/mutation.go
@@ -19,7 +19,7 @@ import (
 )
 
 var _ catalog.TableElementMaybeMutation = maybeMutation{}
-var _ catalog.TableElementMaybeMutation = constraintToUpdate{}
+var _ catalog.TableElementMaybeMutation = constraint{}
 var _ catalog.TableElementMaybeMutation = primaryKeySwap{}
 var _ catalog.TableElementMaybeMutation = computedColumnSwap{}
 var _ catalog.TableElementMaybeMutation = materializedViewRefresh{}
@@ -85,67 +85,69 @@ func (mm maybeMutation) Dropped() bool {
 	return mm.mutationDirection == descpb.DescriptorMutation_DROP
 }
 
-// constraintToUpdate implements the catalog.ConstraintToUpdate interface.
-// It also
-type constraintToUpdate struct {
+// constraint implements the catalog.Constraint interface by wrapping
+// the protobuf descriptor (*descpb.ConstraintToUpdate) along with
+// some metadata if this constraint is a mutation.
+// N.B. This struct is intended for non-index-backed-constraints.
+type constraint struct {
 	maybeMutation
 	desc *descpb.ConstraintToUpdate
 }
 
 // ConstraintToUpdateDesc returns the underlying protobuf descriptor.
-func (c constraintToUpdate) ConstraintToUpdateDesc() *descpb.ConstraintToUpdate {
+func (c constraint) ConstraintToUpdateDesc() *descpb.ConstraintToUpdate {
 	return c.desc
 }
 
 // GetName returns the name of this constraint update mutation.
-func (c constraintToUpdate) GetName() string {
+func (c constraint) GetName() string {
 	return c.desc.Name
 }
 
 // IsCheck returns true iff this is an update for a check constraint.
-func (c constraintToUpdate) IsCheck() bool {
+func (c constraint) IsCheck() bool {
 	return c.desc.ConstraintType == descpb.ConstraintToUpdate_CHECK
 }
 
 // Check returns the underlying check constraint, if there is one.
-func (c constraintToUpdate) Check() descpb.TableDescriptor_CheckConstraint {
+func (c constraint) Check() descpb.TableDescriptor_CheckConstraint {
 	return c.desc.Check
 }
 
 // IsForeignKey returns true iff this is an update for a fk constraint.
-func (c constraintToUpdate) IsForeignKey() bool {
+func (c constraint) IsForeignKey() bool {
 	return c.desc.ConstraintType == descpb.ConstraintToUpdate_FOREIGN_KEY
 }
 
 // ForeignKey returns the underlying fk constraint, if there is one.
-func (c constraintToUpdate) ForeignKey() descpb.ForeignKeyConstraint {
+func (c constraint) ForeignKey() descpb.ForeignKeyConstraint {
 	return c.desc.ForeignKey
 }
 
 // IsNotNull returns true iff this is an update for a not-null constraint.
-func (c constraintToUpdate) IsNotNull() bool {
+func (c constraint) IsNotNull() bool {
 	return c.desc.ConstraintType == descpb.ConstraintToUpdate_NOT_NULL
 }
 
 // NotNullColumnID returns the underlying not-null column ID, if there is one.
-func (c constraintToUpdate) NotNullColumnID() descpb.ColumnID {
+func (c constraint) NotNullColumnID() descpb.ColumnID {
 	return c.desc.NotNullColumn
 }
 
 // IsUniqueWithoutIndex returns true iff this is an update for a unique without
 // index constraint.
-func (c constraintToUpdate) IsUniqueWithoutIndex() bool {
+func (c constraint) IsUniqueWithoutIndex() bool {
 	return c.desc.ConstraintType == descpb.ConstraintToUpdate_UNIQUE_WITHOUT_INDEX
 }
 
 // UniqueWithoutIndex returns the underlying unique without index constraint, if
 // there is one.
-func (c constraintToUpdate) UniqueWithoutIndex() descpb.UniqueWithoutIndexConstraint {
+func (c constraint) UniqueWithoutIndex() descpb.UniqueWithoutIndexConstraint {
 	return c.desc.UniqueWithoutIndexConstraint
 }
 
 // GetConstraintID returns the ID for the constraint.
-func (c constraintToUpdate) GetConstraintID() descpb.ConstraintID {
+func (c constraint) GetConstraintID() descpb.ConstraintID {
 	switch c.desc.ConstraintType {
 	case descpb.ConstraintToUpdate_CHECK:
 		return c.desc.Check.ConstraintID
@@ -295,7 +297,7 @@ type mutation struct {
 	maybeMutation
 	column            catalog.Column
 	index             catalog.Index
-	constraint        catalog.ConstraintToUpdate
+	constraint        catalog.Constraint
 	pkSwap            catalog.PrimaryKeySwap
 	ccSwap            catalog.ComputedColumnSwap
 	mvRefresh         catalog.MaterializedViewRefresh
@@ -315,9 +317,9 @@ func (m mutation) AsIndex() catalog.Index {
 	return m.index
 }
 
-// AsConstraint returns the corresponding ConstraintToUpdate if the
+// AsConstraint returns the corresponding Constraint if the
 // mutation is on a constraint, nil otherwise.
-func (m mutation) AsConstraint() catalog.ConstraintToUpdate {
+func (m mutation) AsConstraint() catalog.Constraint {
 	return m.constraint
 }
 
@@ -370,7 +372,7 @@ func newMutationCache(desc *descpb.TableDescriptor) *mutationCache {
 	backingStructs := make([]mutation, len(desc.Mutations))
 	var columns []column
 	var indexes []index
-	var constraints []constraintToUpdate
+	var constraints []constraint
 	var pkSwaps []primaryKeySwap
 	var ccSwaps []computedColumnSwap
 	var mvRefreshes []materializedViewRefresh
@@ -401,7 +403,7 @@ func newMutationCache(desc *descpb.TableDescriptor) *mutationCache {
 			})
 			backingStructs[i].index = &indexes[len(indexes)-1]
 		} else if pb := m.GetConstraint(); pb != nil {
-			constraints = append(constraints, constraintToUpdate{
+			constraints = append(constraints, constraint{
 				maybeMutation: mm,
 				desc:          pb,
 			})

--- a/pkg/sql/catalog/tabledesc/mutation.go
+++ b/pkg/sql/catalog/tabledesc/mutation.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
+	"github.com/cockroachdb/errors"
 )
 
 var _ catalog.TableElementMaybeMutation = maybeMutation{}
@@ -99,6 +100,11 @@ func (c constraint) ConstraintToUpdateDesc() *descpb.ConstraintToUpdate {
 	return c.desc
 }
 
+// IndexDesc implements catalog.Constraint interface.
+func (c constraint) IndexDesc() *descpb.IndexDescriptor {
+	return nil
+}
+
 // GetName returns the name of this constraint update mutation.
 func (c constraint) GetName() string {
 	return c.desc.Name
@@ -140,10 +146,30 @@ func (c constraint) IsUniqueWithoutIndex() bool {
 	return c.desc.ConstraintType == descpb.ConstraintToUpdate_UNIQUE_WITHOUT_INDEX
 }
 
+// IsPrimaryKey implements catalog.Constraint interface.
+func (c constraint) IsPrimaryKey() bool {
+	return false
+}
+
+// IsUniqueConstraint implements catalog.Constraint interface.
+func (c constraint) IsUniqueConstraint() bool {
+	return false
+}
+
 // UniqueWithoutIndex returns the underlying unique without index constraint, if
 // there is one.
 func (c constraint) UniqueWithoutIndex() descpb.UniqueWithoutIndexConstraint {
 	return c.desc.UniqueWithoutIndexConstraint
+}
+
+// PrimaryKey implement catalog.Constraint interface.
+func (c constraint) PrimaryKey() catalog.Index {
+	return nil
+}
+
+// Unique implement catalog.Constraint interface.
+func (c constraint) Unique() catalog.Index {
+	return nil
 }
 
 // GetConstraintID returns the ID for the constraint.
@@ -159,6 +185,19 @@ func (c constraint) GetConstraintID() descpb.ConstraintID {
 		return c.UniqueWithoutIndex().ConstraintID
 	}
 	panic("unknown constraint type")
+}
+
+// GetConstraintValidity returns the ID for the constraint.
+func (c constraint) GetConstraintValidity() descpb.ConstraintValidity {
+	if c.IsCheck() || c.IsNotNull() {
+		return c.Check().Validity
+	} else if c.IsForeignKey() {
+		return c.ForeignKey().Validity
+	} else if c.IsUniqueWithoutIndex() {
+		return c.UniqueWithoutIndex().Validity
+	} else {
+		panic(errors.AssertionFailedf("unknown constraint type"))
+	}
 }
 
 // modifyRowLevelTTL implements the catalog.ModifyRowLevelTTL interface.

--- a/pkg/sql/catalog/tabledesc/table.go
+++ b/pkg/sql/catalog/tabledesc/table.go
@@ -329,19 +329,13 @@ func (desc *wrapper) GetConstraintInfo() (map[string]descpb.ConstraintDetail, er
 }
 
 // FindConstraintWithID implements the TableDescriptor interface.
-func (desc *wrapper) FindConstraintWithID(
-	id descpb.ConstraintID,
-) (*descpb.ConstraintDetail, error) {
-	constraintInfo, err := desc.GetConstraintInfo()
-	if err != nil {
-		return nil, err
-	}
-	for _, info := range constraintInfo {
-		if info.ConstraintID == id {
-			return &info, nil
+func (desc *wrapper) FindConstraintWithID(id descpb.ConstraintID) (catalog.Constraint, error) {
+	all := desc.AllConstraints()
+	for _, c := range all {
+		if c.GetConstraintID() == id {
+			return c, nil
 		}
 	}
-
 	return nil, pgerror.Newf(pgcode.UndefinedObject, "constraint-id \"%d\" does not exist", id)
 }
 

--- a/pkg/sql/catalog/tabledesc/table_desc.go
+++ b/pkg/sql/catalog/tabledesc/table_desc.go
@@ -44,9 +44,10 @@ type wrapper struct {
 	// to a struct containing precomputed catalog.Mutation, catalog.Index or
 	// catalog.Column slices.
 	// Those can therefore only be set when creating an immutable.
-	mutationCache *mutationCache
-	indexCache    *indexCache
-	columnCache   *columnCache
+	mutationCache   *mutationCache
+	indexCache      *indexCache
+	columnCache     *columnCache
+	constraintCache *constraintCache
 
 	changes catalog.PostDeserializationChanges
 

--- a/pkg/sql/catalog/tabledesc/table_desc_builder.go
+++ b/pkg/sql/catalog/tabledesc/table_desc_builder.go
@@ -247,6 +247,7 @@ func makeImmutable(tbl *descpb.TableDescriptor) *immutable {
 	desc.mutationCache = newMutationCache(desc.TableDesc())
 	desc.indexCache = newIndexCache(desc.TableDesc(), desc.mutationCache)
 	desc.columnCache = newColumnCache(desc.TableDesc(), desc.mutationCache)
+	desc.constraintCache = newConstraintCache(desc.TableDesc(), desc.mutationCache)
 
 	desc.allChecks = make([]descpb.TableDescriptor_CheckConstraint, len(tbl.Checks))
 	for i, c := range tbl.Checks {

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -2120,7 +2120,7 @@ func (sc *SchemaChanger) updateJobForRollback(
 }
 
 func (sc *SchemaChanger) maybeDropValidatingConstraint(
-	ctx context.Context, desc *tabledesc.Mutable, constraint catalog.ConstraintToUpdate,
+	ctx context.Context, desc *tabledesc.Mutable, constraint catalog.Constraint,
 ) error {
 	if constraint.IsCheck() || constraint.IsNotNull() {
 		if constraint.Check().Validity == descpb.ConstraintValidity_Unvalidated {
@@ -2392,7 +2392,7 @@ type SchemaChangerTestingKnobs struct {
 
 	// RunBeforeConstraintValidation is called just before starting the checks validation,
 	// after setting the job status to validating.
-	RunBeforeConstraintValidation func(constraints []catalog.ConstraintToUpdate) error
+	RunBeforeConstraintValidation func(constraints []catalog.Constraint) error
 
 	// RunBeforeMutationReversal runs at the beginning of maybeReverseMutations.
 	RunBeforeMutationReversal func(jobID jobspb.JobID) error

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -6068,7 +6068,7 @@ func TestSchemaChangeJobRunningStatusValidation(t *testing.T) {
 	var runBeforeConstraintValidation func() error
 	params.Knobs = base.TestingKnobs{
 		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
-			RunBeforeConstraintValidation: func(constraints []catalog.ConstraintToUpdate) error {
+			RunBeforeConstraintValidation: func(constraints []catalog.Constraint) error {
 				return runBeforeConstraintValidation()
 			},
 		},
@@ -6121,7 +6121,7 @@ func TestFKReferencesAddedOnlyOnceOnRetry(t *testing.T) {
 	errorReturned := false
 	params.Knobs = base.TestingKnobs{
 		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
-			RunBeforeConstraintValidation: func(constraints []catalog.ConstraintToUpdate) error {
+			RunBeforeConstraintValidation: func(constraints []catalog.Constraint) error {
 				return runBeforeConstraintValidation()
 			},
 		},
@@ -7515,11 +7515,11 @@ func TestShardColumnConstraintSkipValidation(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	constraintsToValidate := make(chan []catalog.ConstraintToUpdate, 1)
+	constraintsToValidate := make(chan []catalog.Constraint, 1)
 	params, _ := tests.CreateTestServerParams()
 	params.Knobs = base.TestingKnobs{
 		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
-			RunBeforeConstraintValidation: func(constraints []catalog.ConstraintToUpdate) error {
+			RunBeforeConstraintValidation: func(constraints []catalog.Constraint) error {
 				constraintsToValidate <- constraints
 				return nil
 			},

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -986,10 +986,10 @@ func (s *TestState) Validator() scexec.Validator {
 func (s *TestState) ValidateCheckConstraint(
 	ctx context.Context,
 	tbl catalog.TableDescriptor,
-	constraint *descpb.ConstraintDetail,
+	constraint catalog.Constraint,
 	override sessiondata.InternalExecutorOverride,
 ) error {
-	s.LogSideEffectf("validate check constraint %v in table #%d", constraint.GetConstraintName(), tbl.GetID())
+	s.LogSideEffectf("validate check constraint %v in table #%d", constraint.GetName(), tbl.GetID())
 	return nil
 }
 

--- a/pkg/sql/schemachanger/scdeps/validator.go
+++ b/pkg/sql/schemachanger/scdeps/validator.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -57,7 +56,7 @@ type ValidateInvertedIndexesFn func(
 type ValidateCheckConstraintFn func(
 	ctx context.Context,
 	tbl catalog.TableDescriptor,
-	constraint *descpb.ConstraintDetail,
+	constraint catalog.Constraint,
 	sessionData *sessiondata.SessionData,
 	runHistoricalTxn descs.HistoricalInternalExecTxnRunner,
 	execOverride sessiondata.InternalExecutorOverride,
@@ -115,7 +114,7 @@ func (vd validator) ValidateInvertedIndexes(
 func (vd validator) ValidateCheckConstraint(
 	ctx context.Context,
 	tbl catalog.TableDescriptor,
-	constraint *descpb.ConstraintDetail,
+	constraint catalog.Constraint,
 	override sessiondata.InternalExecutorOverride,
 ) error {
 	return vd.validateCheckConstraint(ctx, tbl, constraint, vd.newFakeSessionData(&vd.settings.SV),

--- a/pkg/sql/schemachanger/scexec/dependencies.go
+++ b/pkg/sql/schemachanger/scexec/dependencies.go
@@ -224,7 +224,7 @@ type Validator interface {
 	ValidateCheckConstraint(
 		ctx context.Context,
 		tbl catalog.TableDescriptor,
-		constraint *descpb.ConstraintDetail,
+		constraint catalog.Constraint,
 		override sessiondata.InternalExecutorOverride,
 	) error
 }

--- a/pkg/sql/schemachanger/scexec/exec_validation.go
+++ b/pkg/sql/schemachanger/scexec/exec_validation.go
@@ -69,7 +69,7 @@ func executeValidateCheckConstraint(
 	if err != nil {
 		return err
 	}
-	if constraint.CheckConstraint == nil {
+	if !constraint.IsCheck() {
 		return errors.Newf("constraint ID %v does not identify a check constraint in table %v.",
 			op.ConstraintID, op.TableID)
 	}
@@ -82,7 +82,6 @@ func executeValidateCheckConstraint(
 	if err != nil {
 		return scerrors.SchemaChangerUserError(err)
 	}
-	constraint.CheckConstraint.Validity = descpb.ConstraintValidity_Validated
 	return nil
 }
 

--- a/pkg/sql/schemachanger/scexec/executor_external_test.go
+++ b/pkg/sql/schemachanger/scexec/executor_external_test.go
@@ -488,7 +488,7 @@ func (noopValidator) ValidateInvertedIndexes(
 func (noopValidator) ValidateCheckConstraint(
 	ctx context.Context,
 	tbl catalog.TableDescriptor,
-	constraint *descpb.ConstraintDetail,
+	constraint catalog.Constraint,
 	override sessiondata.InternalExecutorOverride,
 ) error {
 	return nil

--- a/pkg/sql/schemachanger/scexec/scmutationexec/eventlog.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/eventlog.go
@@ -195,7 +195,7 @@ func asCommentEventPayload(
 				return nil, err
 			}
 		} else {
-			constraintName = constraint.GetConstraintName()
+			constraintName = constraint.GetName()
 		}
 		return &eventpb.CommentOnConstraint{
 			TableName:      fullName,


### PR DESCRIPTION
This PR tries to improve how we retrieve constraints in a table descriptor. Previously,
it was mostly legacy code carries over from a while ago and nothing hasn't really
changed.
The main change is to introduce `catalog.Constraint` interface, similar to `catalog.Index`
and `catalog.Column`, as the preferred interface for constraint in this layer. Previously,
we would directly expose the underlying protobuf descriptor.

Commit 1 (easy): Rename `catalog.ConstraintToUpdate` to `catalog.Constraint`. 
It's good that we already have an interface that is suitable to be used for our effort.

Commit 2 (easy): Added methods in just renamed `catalog.Constraint` interface for
index-backed-constraints (i.e. PRIMARY KEY or UNIQUE);

Commit 3 (easy): Let `tabledesc.index` struct implement `catalog.Constraint` interface
as we will use it for index-backed-constraints.

Commit 4 (easy): Add a method in `catalog.Constraint` that gets validity of the constraint.

Commit 5 (moderate): Add logic (`ConstraintCache`) to pre-compute all constraints in a
table, categorized by type and validity, so that we can readily retrieve them later. This is the same
idea/technique used for managing index and columns (in `IndexCache` and `ColumnCache`).

Commit 6 (easy): Introduce the new, preferred methods in `catalog.TableDescriptor` to
retrieve constraints from a table.

Commit 7 (easy): Refactor signature of the existing `FindConstraintWithID` method to use
the newly added interface and retrieval methods.

Informs: #90840 
(this PR can unblock #90840)

Release note: None