### PR TITLE
release-22.1: opt: backport optimizer settings for randomized testing

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3262,6 +3262,10 @@ func (m *sessionDataMutator) SetTroubleshootingModeEnabled(val bool) {
 	m.data.TroubleshootingMode = val
 }
 
+func (m *sessionDataMutator) SetTestingOptimizerRandomCostSeed(val int64) {
+	m.data.TestingOptimizerRandomCostSeed = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3270,6 +3270,10 @@ func (m *sessionDataMutator) SetTestingOptimizerCostPerturbation(val float64) {
 	m.data.TestingOptimizerCostPerturbation = val
 }
 
+func (m *sessionDataMutator) SetTestingOptimizerDisableRuleProbability(val float64) {
+	m.data.TestingOptimizerDisableRuleProbability = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3262,8 +3262,12 @@ func (m *sessionDataMutator) SetTroubleshootingModeEnabled(val bool) {
 	m.data.TroubleshootingMode = val
 }
 
-func (m *sessionDataMutator) SetTestingOptimizerRandomCostSeed(val int64) {
-	m.data.TestingOptimizerRandomCostSeed = val
+func (m *sessionDataMutator) SetTestingOptimizerRandomSeed(val int64) {
+	m.data.TestingOptimizerRandomSeed = val
+}
+
+func (m *sessionDataMutator) SetTestingOptimizerCostPerturbation(val float64) {
+	m.data.TestingOptimizerCostPerturbation = val
 }
 
 // Utility functions related to scrubbing sensitive information on SQL Stats.

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4800,6 +4800,7 @@ statement_timeout                                     0
 stub_catalog_tables                                   on
 synchronize_seqscans                                  on
 synchronous_commit                                    on
+testing_optimizer_random_cost_seed                    0
 testing_vectorize_inject_panics                       off
 timezone                                              UTC
 tracing                                               off

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4800,7 +4800,8 @@ statement_timeout                                     0
 stub_catalog_tables                                   on
 synchronize_seqscans                                  on
 synchronous_commit                                    on
-testing_optimizer_random_cost_seed                    0
+testing_optimizer_cost_perturbation                   0
+testing_optimizer_random_seed                         0
 testing_vectorize_inject_panics                       off
 timezone                                              UTC
 tracing                                               off

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4801,6 +4801,7 @@ stub_catalog_tables                                   on
 synchronize_seqscans                                  on
 synchronous_commit                                    on
 testing_optimizer_cost_perturbation                   0
+testing_optimizer_disable_rule_probability            0
 testing_optimizer_random_seed                         0
 testing_vectorize_inject_panics                       off
 timezone                                              UTC

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4227,6 +4227,7 @@ statement_timeout                                     0                   NULL  
 stub_catalog_tables                                   on                  NULL      NULL        NULL        string
 synchronize_seqscans                                  on                  NULL      NULL        NULL        string
 synchronous_commit                                    on                  NULL      NULL        NULL        string
+testing_optimizer_random_cost_seed                    0                   NULL      NULL        NULL        string
 testing_vectorize_inject_panics                       off                 NULL      NULL        NULL        string
 timezone                                              UTC                 NULL      NULL        NULL        string
 tracing                                               off                 NULL      NULL        NULL        string
@@ -4353,6 +4354,7 @@ statement_timeout                                     0                   NULL  
 stub_catalog_tables                                   on                  NULL  user     NULL      on                  on
 synchronize_seqscans                                  on                  NULL  user     NULL      on                  on
 synchronous_commit                                    on                  NULL  user     NULL      on                  on
+testing_optimizer_random_cost_seed                    0                   NULL  user     NULL      0                   0
 testing_vectorize_inject_panics                       off                 NULL  user     NULL      off                 off
 timezone                                              UTC                 NULL  user     NULL      UTC                 UTC
 tracing                                               off                 NULL  user     NULL      off                 off
@@ -4476,6 +4478,7 @@ statement_timeout                                     NULL    NULL     NULL     
 stub_catalog_tables                                   NULL    NULL     NULL     NULL        NULL
 synchronize_seqscans                                  NULL    NULL     NULL     NULL        NULL
 synchronous_commit                                    NULL    NULL     NULL     NULL        NULL
+testing_optimizer_random_cost_seed                    NULL    NULL     NULL     NULL        NULL
 testing_vectorize_inject_panics                       NULL    NULL     NULL     NULL        NULL
 timezone                                              NULL    NULL     NULL     NULL        NULL
 tracing                                               NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4227,7 +4227,8 @@ statement_timeout                                     0                   NULL  
 stub_catalog_tables                                   on                  NULL      NULL        NULL        string
 synchronize_seqscans                                  on                  NULL      NULL        NULL        string
 synchronous_commit                                    on                  NULL      NULL        NULL        string
-testing_optimizer_random_cost_seed                    0                   NULL      NULL        NULL        string
+testing_optimizer_cost_perturbation                   0                   NULL      NULL        NULL        string
+testing_optimizer_random_seed                         0                   NULL      NULL        NULL        string
 testing_vectorize_inject_panics                       off                 NULL      NULL        NULL        string
 timezone                                              UTC                 NULL      NULL        NULL        string
 tracing                                               off                 NULL      NULL        NULL        string
@@ -4354,7 +4355,8 @@ statement_timeout                                     0                   NULL  
 stub_catalog_tables                                   on                  NULL  user     NULL      on                  on
 synchronize_seqscans                                  on                  NULL  user     NULL      on                  on
 synchronous_commit                                    on                  NULL  user     NULL      on                  on
-testing_optimizer_random_cost_seed                    0                   NULL  user     NULL      0                   0
+testing_optimizer_cost_perturbation                   0                   NULL  user     NULL      0                   0
+testing_optimizer_random_seed                         0                   NULL  user     NULL      0                   0
 testing_vectorize_inject_panics                       off                 NULL  user     NULL      off                 off
 timezone                                              UTC                 NULL  user     NULL      UTC                 UTC
 tracing                                               off                 NULL  user     NULL      off                 off
@@ -4478,7 +4480,8 @@ statement_timeout                                     NULL    NULL     NULL     
 stub_catalog_tables                                   NULL    NULL     NULL     NULL        NULL
 synchronize_seqscans                                  NULL    NULL     NULL     NULL        NULL
 synchronous_commit                                    NULL    NULL     NULL     NULL        NULL
-testing_optimizer_random_cost_seed                    NULL    NULL     NULL     NULL        NULL
+testing_optimizer_cost_perturbation                   NULL    NULL     NULL     NULL        NULL
+testing_optimizer_random_seed                         NULL    NULL     NULL     NULL        NULL
 testing_vectorize_inject_panics                       NULL    NULL     NULL     NULL        NULL
 timezone                                              NULL    NULL     NULL     NULL        NULL
 tracing                                               NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4228,6 +4228,7 @@ stub_catalog_tables                                   on                  NULL  
 synchronize_seqscans                                  on                  NULL      NULL        NULL        string
 synchronous_commit                                    on                  NULL      NULL        NULL        string
 testing_optimizer_cost_perturbation                   0                   NULL      NULL        NULL        string
+testing_optimizer_disable_rule_probability            0                   NULL      NULL        NULL        string
 testing_optimizer_random_seed                         0                   NULL      NULL        NULL        string
 testing_vectorize_inject_panics                       off                 NULL      NULL        NULL        string
 timezone                                              UTC                 NULL      NULL        NULL        string
@@ -4356,6 +4357,7 @@ stub_catalog_tables                                   on                  NULL  
 synchronize_seqscans                                  on                  NULL  user     NULL      on                  on
 synchronous_commit                                    on                  NULL  user     NULL      on                  on
 testing_optimizer_cost_perturbation                   0                   NULL  user     NULL      0                   0
+testing_optimizer_disable_rule_probability            0                   NULL  user     NULL      0                   0
 testing_optimizer_random_seed                         0                   NULL  user     NULL      0                   0
 testing_vectorize_inject_panics                       off                 NULL  user     NULL      off                 off
 timezone                                              UTC                 NULL  user     NULL      UTC                 UTC
@@ -4481,6 +4483,7 @@ stub_catalog_tables                                   NULL    NULL     NULL     
 synchronize_seqscans                                  NULL    NULL     NULL     NULL        NULL
 synchronous_commit                                    NULL    NULL     NULL     NULL        NULL
 testing_optimizer_cost_perturbation                   NULL    NULL     NULL     NULL        NULL
+testing_optimizer_disable_rule_probability            NULL    NULL     NULL     NULL        NULL
 testing_optimizer_random_seed                         NULL    NULL     NULL     NULL        NULL
 testing_vectorize_inject_panics                       NULL    NULL     NULL     NULL        NULL
 timezone                                              NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -126,7 +126,8 @@ statement_timeout                                     0
 stub_catalog_tables                                   on
 synchronize_seqscans                                  on
 synchronous_commit                                    on
-testing_optimizer_random_cost_seed                    0
+testing_optimizer_cost_perturbation                   0
+testing_optimizer_random_seed                         0
 testing_vectorize_inject_panics                       off
 timezone                                              UTC
 tracing                                               off

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -126,6 +126,7 @@ statement_timeout                                     0
 stub_catalog_tables                                   on
 synchronize_seqscans                                  on
 synchronous_commit                                    on
+testing_optimizer_random_cost_seed                    0
 testing_vectorize_inject_panics                       off
 timezone                                              UTC
 tracing                                               off

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -127,6 +127,7 @@ stub_catalog_tables                                   on
 synchronize_seqscans                                  on
 synchronous_commit                                    on
 testing_optimizer_cost_perturbation                   0
+testing_optimizer_disable_rule_probability            0
 testing_optimizer_random_seed                         0
 testing_vectorize_inject_panics                       off
 timezone                                              UTC

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -135,23 +135,25 @@ type Memo struct {
 	// planning. We need to cross-check these before reusing a cached memo.
 	// NOTE: If you add new fields here, be sure to add them to the relevant
 	//       fields in explain_bundle.go.
-	reorderJoinsLimit           int
-	zigzagJoinEnabled           bool
-	useHistograms               bool
-	useMultiColStats            bool
-	localityOptimizedSearch     bool
-	safeUpdates                 bool
-	preferLookupJoinsForFKs     bool
-	saveTablesPrefix            string
-	dateStyleEnabled            bool
-	intervalStyleEnabled        bool
-	dateStyle                   pgdate.DateStyle
-	intervalStyle               duration.IntervalStyle
-	propagateInputOrdering      bool
-	disallowFullTableScans      bool
-	largeFullScanRows           float64
-	nullOrderedLast             bool
-	costScansWithDefaultColSize bool
+	reorderJoinsLimit                int
+	zigzagJoinEnabled                bool
+	useHistograms                    bool
+	useMultiColStats                 bool
+	localityOptimizedSearch          bool
+	safeUpdates                      bool
+	preferLookupJoinsForFKs          bool
+	saveTablesPrefix                 string
+	dateStyleEnabled                 bool
+	intervalStyleEnabled             bool
+	dateStyle                        pgdate.DateStyle
+	intervalStyle                    duration.IntervalStyle
+	propagateInputOrdering           bool
+	disallowFullTableScans           bool
+	largeFullScanRows                float64
+	nullOrderedLast                  bool
+	costScansWithDefaultColSize      bool
+	testingOptimizerRandomSeed       int64
+	testingOptimizerCostPerturbation float64
 
 	// curRank is the highest currently in-use scalar expression rank.
 	curRank opt.ScalarRank
@@ -181,24 +183,26 @@ func (m *Memo) Init(evalCtx *tree.EvalContext) {
 	// This initialization pattern ensures that fields are not unwittingly
 	// reused. Field reuse must be explicit.
 	*m = Memo{
-		metadata:                    m.metadata,
-		reorderJoinsLimit:           int(evalCtx.SessionData().ReorderJoinsLimit),
-		zigzagJoinEnabled:           evalCtx.SessionData().ZigzagJoinEnabled,
-		useHistograms:               evalCtx.SessionData().OptimizerUseHistograms,
-		useMultiColStats:            evalCtx.SessionData().OptimizerUseMultiColStats,
-		localityOptimizedSearch:     evalCtx.SessionData().LocalityOptimizedSearch,
-		safeUpdates:                 evalCtx.SessionData().SafeUpdates,
-		preferLookupJoinsForFKs:     evalCtx.SessionData().PreferLookupJoinsForFKs,
-		saveTablesPrefix:            evalCtx.SessionData().SaveTablesPrefix,
-		intervalStyleEnabled:        evalCtx.SessionData().IntervalStyleEnabled,
-		dateStyleEnabled:            evalCtx.SessionData().DateStyleEnabled,
-		dateStyle:                   evalCtx.SessionData().GetDateStyle(),
-		intervalStyle:               evalCtx.SessionData().GetIntervalStyle(),
-		propagateInputOrdering:      evalCtx.SessionData().PropagateInputOrdering,
-		disallowFullTableScans:      evalCtx.SessionData().DisallowFullTableScans,
-		largeFullScanRows:           evalCtx.SessionData().LargeFullScanRows,
-		nullOrderedLast:             evalCtx.SessionData().NullOrderedLast,
-		costScansWithDefaultColSize: evalCtx.SessionData().CostScansWithDefaultColSize,
+		metadata:                         m.metadata,
+		reorderJoinsLimit:                int(evalCtx.SessionData().ReorderJoinsLimit),
+		zigzagJoinEnabled:                evalCtx.SessionData().ZigzagJoinEnabled,
+		useHistograms:                    evalCtx.SessionData().OptimizerUseHistograms,
+		useMultiColStats:                 evalCtx.SessionData().OptimizerUseMultiColStats,
+		localityOptimizedSearch:          evalCtx.SessionData().LocalityOptimizedSearch,
+		safeUpdates:                      evalCtx.SessionData().SafeUpdates,
+		preferLookupJoinsForFKs:          evalCtx.SessionData().PreferLookupJoinsForFKs,
+		saveTablesPrefix:                 evalCtx.SessionData().SaveTablesPrefix,
+		intervalStyleEnabled:             evalCtx.SessionData().IntervalStyleEnabled,
+		dateStyleEnabled:                 evalCtx.SessionData().DateStyleEnabled,
+		dateStyle:                        evalCtx.SessionData().GetDateStyle(),
+		intervalStyle:                    evalCtx.SessionData().GetIntervalStyle(),
+		propagateInputOrdering:           evalCtx.SessionData().PropagateInputOrdering,
+		disallowFullTableScans:           evalCtx.SessionData().DisallowFullTableScans,
+		largeFullScanRows:                evalCtx.SessionData().LargeFullScanRows,
+		nullOrderedLast:                  evalCtx.SessionData().NullOrderedLast,
+		costScansWithDefaultColSize:      evalCtx.SessionData().CostScansWithDefaultColSize,
+		testingOptimizerRandomSeed:       evalCtx.SessionData().TestingOptimizerRandomSeed,
+		testingOptimizerCostPerturbation: evalCtx.SessionData().TestingOptimizerCostPerturbation,
 	}
 	m.metadata.Init()
 	m.logPropsBuilder.init(evalCtx, m)
@@ -323,7 +327,9 @@ func (m *Memo) IsStale(
 		m.disallowFullTableScans != evalCtx.SessionData().DisallowFullTableScans ||
 		m.largeFullScanRows != evalCtx.SessionData().LargeFullScanRows ||
 		m.nullOrderedLast != evalCtx.SessionData().NullOrderedLast ||
-		m.costScansWithDefaultColSize != evalCtx.SessionData().CostScansWithDefaultColSize {
+		m.costScansWithDefaultColSize != evalCtx.SessionData().CostScansWithDefaultColSize ||
+		m.testingOptimizerRandomSeed != evalCtx.SessionData().TestingOptimizerRandomSeed ||
+		m.testingOptimizerCostPerturbation != evalCtx.SessionData().TestingOptimizerCostPerturbation {
 		return true, nil
 	}
 

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -135,25 +135,26 @@ type Memo struct {
 	// planning. We need to cross-check these before reusing a cached memo.
 	// NOTE: If you add new fields here, be sure to add them to the relevant
 	//       fields in explain_bundle.go.
-	reorderJoinsLimit                int
-	zigzagJoinEnabled                bool
-	useHistograms                    bool
-	useMultiColStats                 bool
-	localityOptimizedSearch          bool
-	safeUpdates                      bool
-	preferLookupJoinsForFKs          bool
-	saveTablesPrefix                 string
-	dateStyleEnabled                 bool
-	intervalStyleEnabled             bool
-	dateStyle                        pgdate.DateStyle
-	intervalStyle                    duration.IntervalStyle
-	propagateInputOrdering           bool
-	disallowFullTableScans           bool
-	largeFullScanRows                float64
-	nullOrderedLast                  bool
-	costScansWithDefaultColSize      bool
-	testingOptimizerRandomSeed       int64
-	testingOptimizerCostPerturbation float64
+	reorderJoinsLimit                      int
+	zigzagJoinEnabled                      bool
+	useHistograms                          bool
+	useMultiColStats                       bool
+	localityOptimizedSearch                bool
+	safeUpdates                            bool
+	preferLookupJoinsForFKs                bool
+	saveTablesPrefix                       string
+	dateStyleEnabled                       bool
+	intervalStyleEnabled                   bool
+	dateStyle                              pgdate.DateStyle
+	intervalStyle                          duration.IntervalStyle
+	propagateInputOrdering                 bool
+	disallowFullTableScans                 bool
+	largeFullScanRows                      float64
+	nullOrderedLast                        bool
+	costScansWithDefaultColSize            bool
+	testingOptimizerRandomSeed             int64
+	testingOptimizerCostPerturbation       float64
+	testingOptimizerDisableRuleProbability float64
 
 	// curRank is the highest currently in-use scalar expression rank.
 	curRank opt.ScalarRank
@@ -183,26 +184,27 @@ func (m *Memo) Init(evalCtx *tree.EvalContext) {
 	// This initialization pattern ensures that fields are not unwittingly
 	// reused. Field reuse must be explicit.
 	*m = Memo{
-		metadata:                         m.metadata,
-		reorderJoinsLimit:                int(evalCtx.SessionData().ReorderJoinsLimit),
-		zigzagJoinEnabled:                evalCtx.SessionData().ZigzagJoinEnabled,
-		useHistograms:                    evalCtx.SessionData().OptimizerUseHistograms,
-		useMultiColStats:                 evalCtx.SessionData().OptimizerUseMultiColStats,
-		localityOptimizedSearch:          evalCtx.SessionData().LocalityOptimizedSearch,
-		safeUpdates:                      evalCtx.SessionData().SafeUpdates,
-		preferLookupJoinsForFKs:          evalCtx.SessionData().PreferLookupJoinsForFKs,
-		saveTablesPrefix:                 evalCtx.SessionData().SaveTablesPrefix,
-		intervalStyleEnabled:             evalCtx.SessionData().IntervalStyleEnabled,
-		dateStyleEnabled:                 evalCtx.SessionData().DateStyleEnabled,
-		dateStyle:                        evalCtx.SessionData().GetDateStyle(),
-		intervalStyle:                    evalCtx.SessionData().GetIntervalStyle(),
-		propagateInputOrdering:           evalCtx.SessionData().PropagateInputOrdering,
-		disallowFullTableScans:           evalCtx.SessionData().DisallowFullTableScans,
-		largeFullScanRows:                evalCtx.SessionData().LargeFullScanRows,
-		nullOrderedLast:                  evalCtx.SessionData().NullOrderedLast,
-		costScansWithDefaultColSize:      evalCtx.SessionData().CostScansWithDefaultColSize,
-		testingOptimizerRandomSeed:       evalCtx.SessionData().TestingOptimizerRandomSeed,
-		testingOptimizerCostPerturbation: evalCtx.SessionData().TestingOptimizerCostPerturbation,
+		metadata:                               m.metadata,
+		reorderJoinsLimit:                      int(evalCtx.SessionData().ReorderJoinsLimit),
+		zigzagJoinEnabled:                      evalCtx.SessionData().ZigzagJoinEnabled,
+		useHistograms:                          evalCtx.SessionData().OptimizerUseHistograms,
+		useMultiColStats:                       evalCtx.SessionData().OptimizerUseMultiColStats,
+		localityOptimizedSearch:                evalCtx.SessionData().LocalityOptimizedSearch,
+		safeUpdates:                            evalCtx.SessionData().SafeUpdates,
+		preferLookupJoinsForFKs:                evalCtx.SessionData().PreferLookupJoinsForFKs,
+		saveTablesPrefix:                       evalCtx.SessionData().SaveTablesPrefix,
+		intervalStyleEnabled:                   evalCtx.SessionData().IntervalStyleEnabled,
+		dateStyleEnabled:                       evalCtx.SessionData().DateStyleEnabled,
+		dateStyle:                              evalCtx.SessionData().GetDateStyle(),
+		intervalStyle:                          evalCtx.SessionData().GetIntervalStyle(),
+		propagateInputOrdering:                 evalCtx.SessionData().PropagateInputOrdering,
+		disallowFullTableScans:                 evalCtx.SessionData().DisallowFullTableScans,
+		largeFullScanRows:                      evalCtx.SessionData().LargeFullScanRows,
+		nullOrderedLast:                        evalCtx.SessionData().NullOrderedLast,
+		costScansWithDefaultColSize:            evalCtx.SessionData().CostScansWithDefaultColSize,
+		testingOptimizerRandomSeed:             evalCtx.SessionData().TestingOptimizerRandomSeed,
+		testingOptimizerCostPerturbation:       evalCtx.SessionData().TestingOptimizerCostPerturbation,
+		testingOptimizerDisableRuleProbability: evalCtx.SessionData().TestingOptimizerDisableRuleProbability,
 	}
 	m.metadata.Init()
 	m.logPropsBuilder.init(evalCtx, m)
@@ -329,7 +331,8 @@ func (m *Memo) IsStale(
 		m.nullOrderedLast != evalCtx.SessionData().NullOrderedLast ||
 		m.costScansWithDefaultColSize != evalCtx.SessionData().CostScansWithDefaultColSize ||
 		m.testingOptimizerRandomSeed != evalCtx.SessionData().TestingOptimizerRandomSeed ||
-		m.testingOptimizerCostPerturbation != evalCtx.SessionData().TestingOptimizerCostPerturbation {
+		m.testingOptimizerCostPerturbation != evalCtx.SessionData().TestingOptimizerCostPerturbation ||
+		m.testingOptimizerDisableRuleProbability != evalCtx.SessionData().TestingOptimizerDisableRuleProbability {
 		return true, nil
 	}
 

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -290,6 +290,12 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().TestingOptimizerCostPerturbation = 0
 	notStale()
 
+	// Stale testing_optimizer_disable_rule_probability.
+	evalCtx.SessionData().TestingOptimizerDisableRuleProbability = 1
+	stale()
+	evalCtx.SessionData().TestingOptimizerDisableRuleProbability = 0
+	notStale()
+
 	// Stale data sources and schema. Create new catalog so that data sources are
 	// recreated and can be modified independently.
 	catalog = testcat.New()

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -278,6 +278,18 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().CostScansWithDefaultColSize = false
 	notStale()
 
+	// Stale testing_optimizer_random_seed.
+	evalCtx.SessionData().TestingOptimizerRandomSeed = 100
+	stale()
+	evalCtx.SessionData().TestingOptimizerRandomSeed = 0
+	notStale()
+
+	// Stale testing_optimizer_cost_perturbation.
+	evalCtx.SessionData().TestingOptimizerCostPerturbation = 1
+	stale()
+	evalCtx.SessionData().TestingOptimizerCostPerturbation = 0
+	notStale()
+
 	// Stale data sources and schema. Create new catalog so that data sources are
 	// recreated and can be modified independently.
 	catalog = testcat.New()

--- a/pkg/sql/opt/xform/BUILD.bazel
+++ b/pkg/sql/opt/xform/BUILD.bazel
@@ -48,7 +48,6 @@ go_library(
         "//pkg/util/buildutil",
         "//pkg/util/errorutil",
         "//pkg/util/log",
-        "//pkg/util/randutil",
         "//pkg/util/treeprinter",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",

--- a/pkg/sql/opt/xform/BUILD.bazel
+++ b/pkg/sql/opt/xform/BUILD.bazel
@@ -48,6 +48,7 @@ go_library(
         "//pkg/util/buildutil",
         "//pkg/util/errorutil",
         "//pkg/util/log",
+        "//pkg/util/randutil",
         "//pkg/util/treeprinter",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -83,6 +83,9 @@ type coster struct {
 	// 0.5, and the estimated cost of an expression is c, the cost returned by
 	// ComputeCost will be in the range [c - 0.5 * c, c + 0.5 * c).
 	perturbation float64
+
+	// rng is used for deterministic perturbation.
+	rng *rand.Rand
 }
 
 var _ Coster = &coster{}
@@ -439,7 +442,9 @@ var fnCost = map[string]memo.Cost{
 }
 
 // Init initializes a new coster structure with the given memo.
-func (c *coster) Init(evalCtx *tree.EvalContext, mem *memo.Memo, perturbation float64) {
+func (c *coster) Init(
+	evalCtx *tree.EvalContext, mem *memo.Memo, perturbation float64, rng *rand.Rand,
+) {
 	// This initialization pattern ensures that fields are not unwittingly
 	// reused. Field reuse must be explicit.
 	*c = coster{
@@ -447,6 +452,7 @@ func (c *coster) Init(evalCtx *tree.EvalContext, mem *memo.Memo, perturbation fl
 		mem:          mem,
 		locality:     evalCtx.Locality,
 		perturbation: perturbation,
+		rng:          rng,
 	}
 }
 
@@ -555,7 +561,7 @@ func (c *coster) ComputeCost(candidate memo.RelExpr, required *physical.Required
 		// Don't perturb the cost if we are forcing an index.
 		if cost < hugeCost {
 			// Get a random value in the range [-1.0, 1.0)
-			multiplier := 2*rand.Float64() - 1
+			multiplier := 2*c.rng.Float64() - 1
 
 			// If perturbation is p, and the estimated cost of an expression is c,
 			// the new cost is in the range [max(0, c - pc), c + pc). For example,

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -561,7 +561,12 @@ func (c *coster) ComputeCost(candidate memo.RelExpr, required *physical.Required
 		// Don't perturb the cost if we are forcing an index.
 		if cost < hugeCost {
 			// Get a random value in the range [-1.0, 1.0)
-			multiplier := 2*c.rng.Float64() - 1
+			var multiplier float64
+			if c.rng == nil {
+				multiplier = 2*rand.Float64() - 1
+			} else {
+				multiplier = 2*c.rng.Float64() - 1
+			}
 
 			// If perturbation is p, and the estimated cost of an expression is c,
 			// the new cost is in the range [max(0, c - pc), c + pc). For example,

--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -125,14 +126,19 @@ func (o *Optimizer) Init(evalCtx *tree.EvalContext, catalog cat.Catalog) {
 	o.f.Init(evalCtx, catalog)
 	o.mem = o.f.Memo()
 	o.explorer.init(o)
-	seed := evalCtx.SessionData().TestingOptimizerRandomCostSeed
-	if seed != 0 {
+
+	if seed := evalCtx.SessionData().TestingOptimizerRandomSeed; seed != 0 {
 		o.rng = rand.New(rand.NewSource(seed))
-		// If we've been initialized with a random seed but not an explicit
-		// perturbation value, use the max perturbation. This is used for tests
-		// that set the seed with testing_optimizer_random_cost_seed, and will allow
-		// the coster to hop directly into its random costing mode.
-		evalCtx.TestingKnobs.OptimizerCostPerturbation = 1.0
+	}
+	if perturbation := evalCtx.SessionData().TestingOptimizerCostPerturbation; perturbation != 0 {
+		// If non-zero, the setting TestingOptimizerCostPerturbation should
+		// override the equivalent testing knob. This is needed for use by the
+		// costfuzz roachtest.
+		evalCtx.TestingKnobs.OptimizerCostPerturbation = perturbation
+	}
+	if o.rng == nil && (evalCtx.TestingKnobs.OptimizerCostPerturbation != 0 ||
+		evalCtx.TestingKnobs.DisableOptimizerRuleProbability != 0) {
+		o.rng, _ = randutil.NewPseudoRand()
 	}
 	o.defaultCoster.Init(evalCtx, o.mem, evalCtx.TestingKnobs.OptimizerCostPerturbation, o.rng)
 	o.coster = &o.defaultCoster

--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -97,6 +98,9 @@ type Optimizer struct {
 
 	// JoinOrderBuilder adds new join orderings to the memo.
 	jb JoinOrderBuilder
+
+	// rng is used to deterministically perturb costs.
+	rng *rand.Rand
 }
 
 // maxGroupPasses is the maximum allowed number of optimization passes for any
@@ -122,7 +126,17 @@ func (o *Optimizer) Init(evalCtx *tree.EvalContext, catalog cat.Catalog) {
 	o.f.Init(evalCtx, catalog)
 	o.mem = o.f.Memo()
 	o.explorer.init(o)
-	o.defaultCoster.Init(evalCtx, o.mem, evalCtx.TestingKnobs.OptimizerCostPerturbation)
+	seed := evalCtx.SessionData().TestingOptimizerRandomCostSeed
+	o.rng, _ = randutil.NewPseudoRand()
+	if seed != 0 {
+		o.rng.Seed(seed)
+		// If we've been initialized with a random seed but not an explicit
+		// perturbation value, use the max perturbation. This is used for tests
+		// that set the seed with testing_optimizer_random_cost_seed, and will allow
+		// the coster to hop directly into its random costing mode.
+		evalCtx.TestingKnobs.OptimizerCostPerturbation = 1.0
+	}
+	o.defaultCoster.Init(evalCtx, o.mem, evalCtx.TestingKnobs.OptimizerCostPerturbation, o.rng)
 	o.coster = &o.defaultCoster
 	if evalCtx.TestingKnobs.DisableOptimizerRuleProbability > 0 {
 		o.disableRules(evalCtx.TestingKnobs.DisableOptimizerRuleProbability)
@@ -936,6 +950,18 @@ func (o *Optimizer) disableRules(probability float64) {
 		int(opt.NormalizeInConst),
 		// Needed when an index is forced.
 		int(opt.GenerateIndexScans),
+		// The fold null rules are needed to prevent errors like
+		// "expected *DString, found DNull"
+		int(opt.FoldNullBinaryRight),
+		int(opt.FoldNullBinaryLeft),
+		int(opt.FoldNullComparisonRight),
+		int(opt.FoldNullComparisonLeft),
+		// Without PruneAggCols, it's common to receive
+		// "optimizer factory constructor call stack exceeded max depth of 10000"
+		int(opt.PruneAggCols),
+		// Needed to prevent "null rejection requested on non-null column"
+		int(opt.RejectNullsUnderJoinLeft),
+		int(opt.RejectNullsUnderJoinRight),
 		// Needed to prevent "same fingerprint cannot map to different groups."
 		int(opt.PruneJoinLeftCols),
 		int(opt.PruneJoinRightCols),
@@ -952,7 +978,7 @@ func (o *Optimizer) disableRules(probability float64) {
 	)
 
 	for i := opt.RuleName(1); i < opt.NumRuleNames; i++ {
-		if rand.Float64() < probability && !essentialRules.Contains(int(i)) {
+		if o.rng.Float64() < probability && !essentialRules.Contains(int(i)) {
 			o.disabledRules.Add(int(i))
 		}
 	}
@@ -983,7 +1009,7 @@ func (o *Optimizer) FormatMemo(flags FmtFlags) string {
 // the real computed cost, not the perturbed cost.
 func (o *Optimizer) RecomputeCost() {
 	var c coster
-	c.Init(o.evalCtx, o.mem, 0 /* perturbation */)
+	c.Init(o.evalCtx, o.mem, 0 /* perturbation */, nil /* rng */)
 
 	root := o.mem.RootExpr()
 	rootProps := o.mem.RootProps()

--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -127,9 +126,8 @@ func (o *Optimizer) Init(evalCtx *tree.EvalContext, catalog cat.Catalog) {
 	o.mem = o.f.Memo()
 	o.explorer.init(o)
 	seed := evalCtx.SessionData().TestingOptimizerRandomCostSeed
-	o.rng, _ = randutil.NewPseudoRand()
 	if seed != 0 {
-		o.rng.Seed(seed)
+		o.rng = rand.New(rand.NewSource(seed))
 		// If we've been initialized with a random seed but not an explicit
 		// perturbation value, use the max perturbation. This is used for tests
 		// that set the seed with testing_optimizer_random_cost_seed, and will allow

--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -99,7 +98,7 @@ type Optimizer struct {
 	// JoinOrderBuilder adds new join orderings to the memo.
 	jb JoinOrderBuilder
 
-	// rng is used to deterministically perturb costs.
+	// rng is used to deterministically perturb costs and/or disable rules.
 	rng *rand.Rand
 }
 
@@ -130,20 +129,24 @@ func (o *Optimizer) Init(evalCtx *tree.EvalContext, catalog cat.Catalog) {
 	if seed := evalCtx.SessionData().TestingOptimizerRandomSeed; seed != 0 {
 		o.rng = rand.New(rand.NewSource(seed))
 	}
-	if perturbation := evalCtx.SessionData().TestingOptimizerCostPerturbation; perturbation != 0 {
+	costPerturbation := evalCtx.TestingKnobs.OptimizerCostPerturbation
+	if p := evalCtx.SessionData().TestingOptimizerCostPerturbation; p != 0 {
 		// If non-zero, the setting TestingOptimizerCostPerturbation should
 		// override the equivalent testing knob. This is needed for use by the
 		// costfuzz roachtest.
-		evalCtx.TestingKnobs.OptimizerCostPerturbation = perturbation
+		costPerturbation = p
 	}
-	if o.rng == nil && (evalCtx.TestingKnobs.OptimizerCostPerturbation != 0 ||
-		evalCtx.TestingKnobs.DisableOptimizerRuleProbability != 0) {
-		o.rng, _ = randutil.NewPseudoRand()
+	disableRuleProbability := evalCtx.TestingKnobs.DisableOptimizerRuleProbability
+	if p := evalCtx.SessionData().TestingOptimizerDisableRuleProbability; p != 0 {
+		// If non-zero, the setting TestingOptimizerDisableRuleProbability should
+		// override the equivalent testing knob. This is needed for use by the
+		// unoptimized-query-oracle roachtest.
+		disableRuleProbability = p
 	}
-	o.defaultCoster.Init(evalCtx, o.mem, evalCtx.TestingKnobs.OptimizerCostPerturbation, o.rng)
+	o.defaultCoster.Init(evalCtx, o.mem, costPerturbation, o.rng)
 	o.coster = &o.defaultCoster
-	if evalCtx.TestingKnobs.DisableOptimizerRuleProbability > 0 {
-		o.disableRules(evalCtx.TestingKnobs.DisableOptimizerRuleProbability)
+	if disableRuleProbability > 0 {
+		o.disableRules(disableRuleProbability)
 	}
 }
 
@@ -982,7 +985,13 @@ func (o *Optimizer) disableRules(probability float64) {
 	)
 
 	for i := opt.RuleName(1); i < opt.NumRuleNames; i++ {
-		if o.rng.Float64() < probability && !essentialRules.Contains(int(i)) {
+		var r float64
+		if o.rng == nil {
+			r = rand.Float64()
+		} else {
+			r = o.rng.Float64()
+		}
+		if r < probability && !essentialRules.Contains(int(i)) {
 			o.disabledRules.Add(int(i))
 		}
 	}

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -254,6 +254,10 @@ message LocalOnlySessionData {
   // CONSTRAINTS and pg_catalog.pg_constraint will include primary key
   // constraints that only include hidden columns.
   bool show_primary_key_constraint_on_not_visible_columns = 69;
+  // TestingOptimizerRandomCostSeed is non-zero when the coster should randomly
+  // perturb costs with an rng seeded to the given integer. This should only be
+  // used in test scenarios and is very much a non-production setting.
+  int64 testing_optimizer_random_cost_seed = 70;
 
   // disable_hoist_projection_in_join_limitation disables the restrictions
   // placed on projection hoisting during query planning in the optimizer.

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -263,6 +263,11 @@ message LocalOnlySessionData {
   // randomly perturb costs to produce a non-optimal query plan. This should
   // only be used in test scenarios and is very much a non-production setting.
   double testing_optimizer_cost_perturbation = 72;
+  // TestingOptimizerDisableRuleProbability is non-zero when the optimizer
+  // should randomly disable every non-essential transformation rule with the
+  // given probability. This should only be used in test scenarios and is very
+  // much a non-production setting.
+  double testing_optimizer_disable_rule_probability = 73;
   // disable_hoist_projection_in_join_limitation disables the restrictions
   // placed on projection hoisting during query planning in the optimizer.
   bool disable_hoist_projection_in_join_limitation = 76;

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -254,11 +254,15 @@ message LocalOnlySessionData {
   // CONSTRAINTS and pg_catalog.pg_constraint will include primary key
   // constraints that only include hidden columns.
   bool show_primary_key_constraint_on_not_visible_columns = 69;
-  // TestingOptimizerRandomCostSeed is non-zero when the coster should randomly
-  // perturb costs with an rng seeded to the given integer. This should only be
-  // used in test scenarios and is very much a non-production setting.
-  int64 testing_optimizer_random_cost_seed = 70;
-
+  // TestingOptimizerRandomSeed is non-zero when we are testing the optimizer by
+  // randomly perturbing costs or disabling rules. This will initialize a rng
+  // seeded to the given integer. This should only be used in test scenarios and
+  // is very much a non-production setting.
+  int64 testing_optimizer_random_seed = 70;
+  // TestingOptimizerCostPerturbation is non-zero when the coster should
+  // randomly perturb costs to produce a non-optimal query plan. This should
+  // only be used in test scenarios and is very much a non-production setting.
+  double testing_optimizer_cost_perturbation = 72;
   // disable_hoist_projection_in_join_limitation disables the restrictions
   // placed on projection hoisting during query planning in the optimizer.
   bool disable_hoist_projection_in_join_limitation = 76;

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2166,21 +2166,49 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalFalse,
 	},
-	`testing_optimizer_random_cost_seed`: {
-		GetStringVal: makeIntGetStringValFn(`testing_optimizer_random_cost_seed`),
+
+	// CockroachDB extension.
+	`testing_optimizer_random_seed`: {
+		GetStringVal: makeIntGetStringValFn(`testing_optimizer_random_seed`),
 		Set: func(_ context.Context, m sessionDataMutator, s string) error {
 			i, err := strconv.ParseInt(s, 10, 64)
 			if err != nil {
 				return err
 			}
-			m.SetTestingOptimizerRandomCostSeed(i)
+			m.SetTestingOptimizerRandomSeed(i)
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) (string, error) {
-			return strconv.FormatInt(evalCtx.SessionData().TestingOptimizerRandomCostSeed, 10), nil
+			return strconv.FormatInt(evalCtx.SessionData().TestingOptimizerRandomSeed, 10), nil
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return strconv.FormatInt(0, 10)
+		},
+	},
+
+	// CockroachDB extension.
+	`testing_optimizer_cost_perturbation`: {
+		GetStringVal: makeFloatGetStringValFn(`testing_optimizer_cost_perturbation`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			f, err := strconv.ParseFloat(s, 64)
+			if err != nil {
+				return err
+			}
+			if f < 0 {
+				return pgerror.Newf(
+					pgcode.InvalidParameterValue, "testing_optimizer_cost_perturbation must be non-negative",
+				)
+			}
+			m.SetTestingOptimizerCostPerturbation(f)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext) (string, error) {
+			return formatFloatAsPostgresSetting(
+				evalCtx.SessionData().TestingOptimizerCostPerturbation,
+			), nil
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return formatFloatAsPostgresSetting(0)
 		},
 	},
 }

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2166,6 +2166,23 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalFalse,
 	},
+	`testing_optimizer_random_cost_seed`: {
+		GetStringVal: makeIntGetStringValFn(`testing_optimizer_random_cost_seed`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			i, err := strconv.ParseInt(s, 10, 64)
+			if err != nil {
+				return err
+			}
+			m.SetTestingOptimizerRandomCostSeed(i)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext) (string, error) {
+			return strconv.FormatInt(evalCtx.SessionData().TestingOptimizerRandomCostSeed, 10), nil
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return strconv.FormatInt(0, 10)
+		},
+	},
 }
 
 const compatErrMsg = "this parameter is currently recognized only for compatibility and has no effect in CockroachDB."

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2211,6 +2211,33 @@ var varGen = map[string]sessionVar{
 			return formatFloatAsPostgresSetting(0)
 		},
 	},
+
+	// CockroachDB extension.
+	`testing_optimizer_disable_rule_probability`: {
+		GetStringVal: makeFloatGetStringValFn(`testing_optimizer_disable_rule_probability`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			f, err := strconv.ParseFloat(s, 64)
+			if err != nil {
+				return err
+			}
+			if f < 0 || f > 1 {
+				return pgerror.Newf(
+					pgcode.InvalidParameterValue,
+					"testing_optimizer_disable_rule_probability must be in the range [0.0,1.0]",
+				)
+			}
+			m.SetTestingOptimizerDisableRuleProbability(f)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext) (string, error) {
+			return formatFloatAsPostgresSetting(
+				evalCtx.SessionData().TestingOptimizerDisableRuleProbability,
+			), nil
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return formatFloatAsPostgresSetting(0)
+		},
+	},
 }
 
 const compatErrMsg = "this parameter is currently recognized only for compatibility and has no effect in CockroachDB."


### PR DESCRIPTION
Backport:
  * 1/1 commits from "roachtest: add costfuzz test" (#79973)
  * 1/1 commits from "opt: fix performance regression due to getEnv in Optimizer.Init" (#81705)
  * 2/4 commits from "roachtest: add unoptimized-query-oracle test to validate query results" (#83095)

It is common for a bug found by the randomized tests to require setting one or more of `testing_optimizer_cost_perturbation`, `testing_optimizer_disable_rule_probability`, and `testing_optimizer_random_seed` for a reproduction. This patch backports these settings to 22.1 to make reproducing bugs and back-porting fixes easier. Only the portions of the backported commits relevant to these settings are included.

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: testing-only change to make bug reproductions and back-ports easier
