### PR TITLE
storage: add MVCCExportFingerprintOptions

### DIFF
--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -5784,7 +5784,7 @@ func MVCCExportFingerprint(
 	defer span.Finish()
 
 	hasher := fnv.New64()
-	fingerprintWriter := makeFingerprintWriter(ctx, hasher, cs, dest)
+	fingerprintWriter := makeFingerprintWriter(ctx, hasher, cs, dest, opts.FingerprintOptions)
 	defer fingerprintWriter.Close()
 
 	summary, resumeKey, err := mvccExportToWriter(ctx, reader, opts, &fingerprintWriter)
@@ -6249,6 +6249,19 @@ type MVCCExportOptions struct {
 	// resources. Export queries limiter in its iteration loop to break out once
 	// resources are exhausted.
 	ResourceLimiter ResourceLimiter
+	// FingerprintOptions controls how fingerprints are generated
+	// when using MVCCExportFingerprint.
+	FingerprintOptions MVCCExportFingerprintOptions
+}
+
+type MVCCExportFingerprintOptions struct {
+	// If StripTenantPrefix is true, keys that appear to be
+	// tenant-prefixed have the tenant-prefix removed before
+	// hashing.
+	StripTenantPrefix bool
+	// If StripValueChecksum is true, checksums are removed from
+	// the value before hashing.
+	StripValueChecksum bool
 }
 
 // MVCCIsSpanEmptyOptions configures the MVCCIsSpanEmpty function.

--- a/pkg/storage/testdata/mvcc_histories/export_fingerprint_tenant
+++ b/pkg/storage/testdata/mvcc_histories/export_fingerprint_tenant
@@ -1,0 +1,52 @@
+# Tests MVCC export fingerprinting configured to be tenant-agnostic.
+#
+# We create a simple set of keys that we expect will produce the same
+# fingerprint when tenant prefixes and value checksums are ignored.
+run ok
+put k=/a ts=2 v=a localTs=2 tenant-prefix=10 init-checksum
+put k=/b ts=2 v=b tenant-prefix=10 init-checksum
+put k=/c ts=2 v=c tenant-prefix=10 init-checksum
+put k=/d ts=2 v=d tenant-prefix=10 init-checksum
+put k=/a ts=2 v=a tenant-prefix=11 init-checksum
+put k=/b ts=2 v=b localTs=4 tenant-prefix=11 init-checksum
+put k=/c ts=2 v=c tenant-prefix=11 init-checksum
+put k=/d ts=2 v=d tenant-prefix=11 init-checksum
+----
+>> at end:
+data: /Tenant/10/Table/1/1/"a"/0/2.000000000,0 -> /BYTES/a
+data: /Tenant/10/Table/1/1/"b"/0/2.000000000,0 -> /BYTES/b
+data: /Tenant/10/Table/1/1/"c"/0/2.000000000,0 -> /BYTES/c
+data: /Tenant/10/Table/1/1/"d"/0/2.000000000,0 -> /BYTES/d
+data: /Tenant/11/Table/1/1/"a"/0/2.000000000,0 -> /BYTES/a
+data: /Tenant/11/Table/1/1/"b"/0/2.000000000,0 -> /BYTES/b
+data: /Tenant/11/Table/1/1/"c"/0/2.000000000,0 -> /BYTES/c
+data: /Tenant/11/Table/1/1/"d"/0/2.000000000,0 -> /BYTES/d
+
+# Fingerprint tenant 10
+run ok
+export fingerprint k=/a end=/z ts=0 allRevisions tenant-prefix=10
+----
+export: data_size:60 deprecated_rows:4 entry_counts:<key:4294967297 value:4 > fingerprint=true
+fingerprint: 9662827328792920765
+
+# Fingerprint tenant 11
+run ok
+export fingerprint k=/a end=/z ts=0 allRevisions tenant-prefix=11
+----
+export: data_size:60 deprecated_rows:4 entry_counts:<key:4294967297 value:4 > fingerprint=true
+fingerprint: 17513934348803083905
+
+# Fingerprint tenant 10 with tenant prefix stripped
+run ok
+export fingerprint k=/a end=/z ts=0 allRevisions tenant-prefix=10 stripTenantPrefix stripValueChecksum
+----
+export: data_size:60 deprecated_rows:4 entry_counts:<key:4294967297 value:4 > fingerprint=true
+fingerprint: 6565009613709557332
+
+# Fingerprint tenant 11 with tenant prefix stripped
+# NOTE: This fingerprint should match the tenant 10 fingerprint.
+run ok
+export fingerprint k=/a end=/z ts=0 allRevisions tenant-prefix=11 stripTenantPrefix stripValueChecksum
+----
+export: data_size:60 deprecated_rows:4 entry_counts:<key:4294967297 value:4 > fingerprint=true
+fingerprint: 6565009613709557332


### PR DESCRIPTION
This adds MVCCExportFingerprintOptions with two new options:

 - StripTenantPrefix
 - StripValueChecksum

The goal of these options is to produce a fingerprint that can be used for comparing data across two tenants.

Note that if arbitrary keys and values are encountered, both options have the possibility of erroneously removing data from the fingerprint that isn't actually a tenant prefix or checksum.

Fixes #91150

Release note: None