### PR TITLE
roachtest: cast tenant id in create_tenant call

### DIFF
--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -73,7 +73,7 @@ func registerClusterToCluster(r registry.Registry) {
 			destClusterSettings(t, destSQL)
 
 			srcTenantID, destTenantID := 10, 20
-			srcSQL.Exec(t, `SELECT crdb_internal.create_tenant($1)`, srcTenantID)
+			srcSQL.Exec(t, `SELECT crdb_internal.create_tenant($1::int)`, srcTenantID)
 			pgURL, cleanup, err := copyPGCertsAndMakeURL(ctx, t, c, srcNode, dstCluster, srcClusterSetting.PGUrlCertsDir, addr[0])
 			defer cleanup()
 			require.NoError(t, err)


### PR DESCRIPTION
This is required because of the overloads for create_tenant.

Fixes #91724

Release note: None