### PR TITLE
kvserver: add logStore type with storeEntries method

### DIFF
--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -703,9 +703,9 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	var rd raft.Ready
 	r.mu.Lock()
 	state := raftLogState{ // used for append below
-		lastIndex:   r.mu.lastIndex,
-		lastTerm:    r.mu.lastTerm,
-		raftLogSize: r.mu.raftLogSize,
+		lastIndex: r.mu.lastIndex,
+		lastTerm:  r.mu.lastTerm,
+		byteSize:  r.mu.raftLogSize,
 	}
 	leaderID := r.mu.leaderID
 	lastLeaderID := leaderID
@@ -810,9 +810,9 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 			// the local variables we're tracking here.
 			r.mu.RLock()
 			state = raftLogState{
-				lastIndex:   r.mu.lastIndex,
-				lastTerm:    r.mu.lastTerm,
-				raftLogSize: r.mu.raftLogSize,
+				lastIndex: r.mu.lastIndex,
+				lastTerm:  r.mu.lastTerm,
+				byteSize:  r.mu.raftLogSize,
 			}
 			r.mu.RUnlock()
 
@@ -942,7 +942,7 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 			const expl = "during sideloading"
 			return stats, expl, errors.Wrap(err, expl)
 		}
-		state.raftLogSize += sideLoadedEntriesSize
+		state.byteSize += sideLoadedEntriesSize
 		if state, err = logAppend(
 			ctx, r.raftMu.stateLoader.RaftLogPrefix(), batch, state, thinEntries,
 		); err != nil {
@@ -1014,10 +1014,10 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 			const expl = "while purging sideloaded storage"
 			return stats, expl, err
 		}
-		state.raftLogSize -= purgedSize
-		if state.raftLogSize < 0 {
+		state.byteSize -= purgedSize
+		if state.byteSize < 0 {
 			// Might have gone negative if node was recently restarted.
-			state.raftLogSize = 0
+			state.byteSize = 0
 		}
 	}
 
@@ -1027,7 +1027,7 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	// TODO(pavelkalinnikov): put raftLogState to r.mu directly instead of fields.
 	r.mu.lastIndex = state.lastIndex
 	r.mu.lastTerm = state.lastTerm
-	r.mu.raftLogSize = state.raftLogSize
+	r.mu.raftLogSize = state.byteSize
 	var becameLeader bool
 	if r.mu.leaderID != leaderID {
 		r.mu.leaderID = leaderID

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -927,77 +927,10 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	r.traceMessageSends(msgApps, "sending msgApp")
 	r.sendRaftMessagesRaftMuLocked(ctx, msgApps, pausedFollowers)
 
-	// Use a more efficient write-only batch because we don't need to do any
-	// reads from the batch. Any reads are performed on the underlying DB.
-	batch := r.store.Engine().NewUnindexedBatch(false /* writeOnly */)
-	defer batch.Close()
-
 	prevLastIndex := state.lastIndex
-	if len(rd.Entries) > 0 {
-		stats.tAppendBegin = timeutil.Now()
-		// All of the entries are appended to distinct keys, returning a new
-		// last index.
-		thinEntries, numSideloaded, sideLoadedEntriesSize, otherEntriesSize, err := maybeSideloadEntries(ctx, rd.Entries, r.raftMu.sideloaded)
-		if err != nil {
-			const expl = "during sideloading"
-			return stats, expl, errors.Wrap(err, expl)
-		}
-		state.byteSize += sideLoadedEntriesSize
-		if state, err = logAppend(
-			ctx, r.raftMu.stateLoader.RaftLogPrefix(), batch, state, thinEntries,
-		); err != nil {
-			const expl = "during append"
-			return stats, expl, errors.Wrap(err, expl)
-		}
-		stats.appendedRegularCount += len(thinEntries) - numSideloaded
-		stats.appendedRegularBytes += otherEntriesSize
-		stats.appendedSideloadedCount += numSideloaded
-		stats.appendedSideloadedBytes += sideLoadedEntriesSize
-		stats.tAppendEnd = timeutil.Now()
-	}
-
-	if !raft.IsEmptyHardState(rd.HardState) {
-		if !r.IsInitialized() && rd.HardState.Commit != 0 {
-			log.Fatalf(ctx, "setting non-zero HardState.Commit on uninitialized replica %s. HS=%+v", r, rd.HardState)
-		}
-		// NB: Note that without additional safeguards, it's incorrect to write
-		// the HardState before appending rd.Entries. When catching up, a follower
-		// will receive Entries that are immediately Committed in the same
-		// Ready. If we persist the HardState but happen to lose the Entries,
-		// assertions can be tripped.
-		//
-		// We have both in the same batch, so there's no problem. If that ever
-		// changes, we must write and sync the Entries before the HardState.
-		if err := r.raftMu.stateLoader.SetHardState(ctx, batch, rd.HardState); err != nil {
-			const expl = "during setHardState"
-			return stats, expl, errors.Wrap(err, expl)
-		}
-	}
-	// Synchronously commit the batch with the Raft log entries and Raft hard
-	// state as we're promising not to lose this data.
-	//
-	// Note that the data is visible to other goroutines before it is synced to
-	// disk. This is fine. The important constraints are that these syncs happen
-	// before Raft messages are sent and before the call to RawNode.Advance. Our
-	// regular locking is sufficient for this and if other goroutines can see the
-	// data early, that's fine. In particular, snapshots are not a problem (I
-	// think they're the only thing that might access log entries or HardState
-	// from other goroutines). Snapshots do not include either the HardState or
-	// uncommitted log entries, and even if they did include log entries that
-	// were not persisted to disk, it wouldn't be a problem because raft does not
-	// infer the that entries are persisted on the node that sends a snapshot.
-	stats.tPebbleCommitBegin = timeutil.Now()
-	stats.pebbleBatchBytes = int64(batch.Len())
-	sync := rd.MustSync && !disableSyncRaftLog.Get(&r.store.cfg.Settings.SV)
-	if err := batch.Commit(sync); err != nil {
-		const expl = "while committing batch"
-		return stats, expl, errors.Wrap(err, expl)
-	}
-	stats.sync = sync
-	stats.tPebbleCommitEnd = timeutil.Now()
-	if rd.MustSync {
-		r.store.metrics.RaftLogCommitLatency.RecordValue(
-			stats.tPebbleCommitEnd.Sub(stats.tPebbleCommitBegin).Nanoseconds())
+	if state, err = r.storeLogEntries(ctx, state, rd, &stats); err != nil {
+		const expl = "while storing log entries"
+		return stats, expl, err
 	}
 
 	if len(rd.Entries) > 0 {
@@ -1144,6 +1077,91 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	// get blocked.
 	r.updateProposalQuotaRaftMuLocked(ctx, lastLeaderID)
 	return stats, "", nil
+}
+
+// storeLogEntries persists newly appended raft Entries to the log storage.
+// Accepts the state of the log before the operation, returns the state after.
+// Persists HardState atomically with, or strictly after Entries.
+//
+// TODO(pavelkalinnikov): raft.Ready combines multiple roles. For a stricter
+// separation between log and state storage, introduce a log-specific Ready,
+// consisting of committed Entries, HardState, and MustSync.
+func (r *Replica) storeLogEntries(
+	ctx context.Context, state raftLogState, rd raft.Ready, stats *handleRaftReadyStats,
+) (raftLogState, error) {
+	// TODO(pavelkalinnikov): Doesn't this comment contradict the code?
+	// Use a more efficient write-only batch because we don't need to do any
+	// reads from the batch. Any reads are performed on the underlying DB.
+	batch := r.store.Engine().NewUnindexedBatch(false /* writeOnly */)
+	defer batch.Close()
+
+	if len(rd.Entries) > 0 {
+		stats.tAppendBegin = timeutil.Now()
+		// All of the entries are appended to distinct keys, returning a new
+		// last index.
+		thinEntries, numSideloaded, sideLoadedEntriesSize, otherEntriesSize, err := maybeSideloadEntries(ctx, rd.Entries, r.raftMu.sideloaded)
+		if err != nil {
+			const expl = "during sideloading"
+			return raftLogState{}, errors.Wrap(err, expl)
+		}
+		state.byteSize += sideLoadedEntriesSize
+		if state, err = logAppend(
+			ctx, r.raftMu.stateLoader.RaftLogPrefix(), batch, state, thinEntries,
+		); err != nil {
+			const expl = "during append"
+			return raftLogState{}, errors.Wrap(err, expl)
+		}
+		stats.appendedRegularCount += len(thinEntries) - numSideloaded
+		stats.appendedRegularBytes += otherEntriesSize
+		stats.appendedSideloadedCount += numSideloaded
+		stats.appendedSideloadedBytes += sideLoadedEntriesSize
+		stats.tAppendEnd = timeutil.Now()
+	}
+
+	if !raft.IsEmptyHardState(rd.HardState) {
+		if !r.IsInitialized() && rd.HardState.Commit != 0 {
+			log.Fatalf(ctx, "setting non-zero HardState.Commit on uninitialized replica %s. HS=%+v", r, rd.HardState)
+		}
+		// NB: Note that without additional safeguards, it's incorrect to write
+		// the HardState before appending rd.Entries. When catching up, a follower
+		// will receive Entries that are immediately Committed in the same
+		// Ready. If we persist the HardState but happen to lose the Entries,
+		// assertions can be tripped.
+		//
+		// We have both in the same batch, so there's no problem. If that ever
+		// changes, we must write and sync the Entries before the HardState.
+		if err := r.raftMu.stateLoader.SetHardState(ctx, batch, rd.HardState); err != nil {
+			const expl = "during setHardState"
+			return raftLogState{}, errors.Wrap(err, expl)
+		}
+	}
+	// Synchronously commit the batch with the Raft log entries and Raft hard
+	// state as we're promising not to lose this data.
+	//
+	// Note that the data is visible to other goroutines before it is synced to
+	// disk. This is fine. The important constraints are that these syncs happen
+	// before Raft messages are sent and before the call to RawNode.Advance. Our
+	// regular locking is sufficient for this and if other goroutines can see the
+	// data early, that's fine. In particular, snapshots are not a problem (I
+	// think they're the only thing that might access log entries or HardState
+	// from other goroutines). Snapshots do not include either the HardState or
+	// uncommitted log entries, and even if they did include log entries that
+	// were not persisted to disk, it wouldn't be a problem because raft does not
+	// infer the that entries are persisted on the node that sends a snapshot.
+	stats.tPebbleCommitBegin = timeutil.Now()
+	stats.pebbleBatchBytes = int64(batch.Len())
+	sync := rd.MustSync && !disableSyncRaftLog.Get(&r.store.cfg.Settings.SV)
+	if err := batch.Commit(sync); err != nil {
+		const expl = "while committing batch"
+		return raftLogState{}, errors.Wrap(err, expl)
+	}
+	stats.sync = sync
+	stats.tPebbleCommitEnd = timeutil.Now()
+	if rd.MustSync {
+		r.store.metrics.RaftLogCommitLatency.RecordValue(
+			stats.tPebbleCommitEnd.Sub(stats.tPebbleCommitBegin).Nanoseconds())
+	}
+	return state, nil
 }
 
 // splitMsgApps splits the Raft message slice into two slices, one containing

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/uncertainty"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -928,7 +929,22 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	r.sendRaftMessagesRaftMuLocked(ctx, msgApps, pausedFollowers)
 
 	prevLastIndex := state.lastIndex
-	if state, err = r.storeLogEntries(ctx, state, rd, &stats); err != nil {
+
+	// TODO(pavelkalinnikov): find a way to move it to storeEntries.
+	if !raft.IsEmptyHardState(rd.HardState) {
+		if !r.IsInitialized() && rd.HardState.Commit != 0 {
+			log.Fatalf(ctx, "setting non-zero HardState.Commit on uninitialized replica %s. HS=%+v", r, rd.HardState)
+		}
+	}
+	// TODO(pavelkalinnikov): construct and store this in Replica.
+	s := logStore{
+		engine:      r.store.engine,
+		sideload:    r.raftMu.sideloaded,
+		stateLoader: r.raftMu.stateLoader,
+		settings:    r.store.cfg.Settings,
+		metrics:     r.store.metrics,
+	}
+	if state, err = s.storeEntries(ctx, state, rd, &stats); err != nil {
 		const expl = "while storing log entries"
 		return stats, expl, err
 	}
@@ -1079,34 +1095,45 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	return stats, "", nil
 }
 
-// storeLogEntries persists newly appended raft Entries to the log storage.
+// logStore is a stub of a separated Raft log storage.
+//
+// TODO(pavelkalinnikov): move to its own package.
+type logStore struct {
+	engine      storage.Engine
+	sideload    SideloadStorage
+	stateLoader stateloader.StateLoader
+	settings    *cluster.Settings
+	metrics     *StoreMetrics
+}
+
+// storeEntries persists newly appended Raft log Entries to the log storage.
 // Accepts the state of the log before the operation, returns the state after.
 // Persists HardState atomically with, or strictly after Entries.
 //
 // TODO(pavelkalinnikov): raft.Ready combines multiple roles. For a stricter
 // separation between log and state storage, introduce a log-specific Ready,
 // consisting of committed Entries, HardState, and MustSync.
-func (r *Replica) storeLogEntries(
+func (s *logStore) storeEntries(
 	ctx context.Context, state raftLogState, rd raft.Ready, stats *handleRaftReadyStats,
 ) (raftLogState, error) {
 	// TODO(pavelkalinnikov): Doesn't this comment contradict the code?
 	// Use a more efficient write-only batch because we don't need to do any
 	// reads from the batch. Any reads are performed on the underlying DB.
-	batch := r.store.Engine().NewUnindexedBatch(false /* writeOnly */)
+	batch := s.engine.NewUnindexedBatch(false /* writeOnly */)
 	defer batch.Close()
 
 	if len(rd.Entries) > 0 {
 		stats.tAppendBegin = timeutil.Now()
 		// All of the entries are appended to distinct keys, returning a new
 		// last index.
-		thinEntries, numSideloaded, sideLoadedEntriesSize, otherEntriesSize, err := maybeSideloadEntries(ctx, rd.Entries, r.raftMu.sideloaded)
+		thinEntries, numSideloaded, sideLoadedEntriesSize, otherEntriesSize, err := maybeSideloadEntries(ctx, rd.Entries, s.sideload)
 		if err != nil {
 			const expl = "during sideloading"
 			return raftLogState{}, errors.Wrap(err, expl)
 		}
 		state.byteSize += sideLoadedEntriesSize
 		if state, err = logAppend(
-			ctx, r.raftMu.stateLoader.RaftLogPrefix(), batch, state, thinEntries,
+			ctx, s.stateLoader.RaftLogPrefix(), batch, state, thinEntries,
 		); err != nil {
 			const expl = "during append"
 			return raftLogState{}, errors.Wrap(err, expl)
@@ -1119,9 +1146,6 @@ func (r *Replica) storeLogEntries(
 	}
 
 	if !raft.IsEmptyHardState(rd.HardState) {
-		if !r.IsInitialized() && rd.HardState.Commit != 0 {
-			log.Fatalf(ctx, "setting non-zero HardState.Commit on uninitialized replica %s. HS=%+v", r, rd.HardState)
-		}
 		// NB: Note that without additional safeguards, it's incorrect to write
 		// the HardState before appending rd.Entries. When catching up, a follower
 		// will receive Entries that are immediately Committed in the same
@@ -1130,7 +1154,7 @@ func (r *Replica) storeLogEntries(
 		//
 		// We have both in the same batch, so there's no problem. If that ever
 		// changes, we must write and sync the Entries before the HardState.
-		if err := r.raftMu.stateLoader.SetHardState(ctx, batch, rd.HardState); err != nil {
+		if err := s.stateLoader.SetHardState(ctx, batch, rd.HardState); err != nil {
 			const expl = "during setHardState"
 			return raftLogState{}, errors.Wrap(err, expl)
 		}
@@ -1150,7 +1174,7 @@ func (r *Replica) storeLogEntries(
 	// infer the that entries are persisted on the node that sends a snapshot.
 	stats.tPebbleCommitBegin = timeutil.Now()
 	stats.pebbleBatchBytes = int64(batch.Len())
-	sync := rd.MustSync && !disableSyncRaftLog.Get(&r.store.cfg.Settings.SV)
+	sync := rd.MustSync && !disableSyncRaftLog.Get(&s.settings.SV)
 	if err := batch.Commit(sync); err != nil {
 		const expl = "while committing batch"
 		return raftLogState{}, errors.Wrap(err, expl)
@@ -1158,7 +1182,7 @@ func (r *Replica) storeLogEntries(
 	stats.sync = sync
 	stats.tPebbleCommitEnd = timeutil.Now()
 	if rd.MustSync {
-		r.store.metrics.RaftLogCommitLatency.RecordValue(
+		s.metrics.RaftLogCommitLatency.RecordValue(
 			stats.tPebbleCommitEnd.Sub(stats.tPebbleCommitBegin).Nanoseconds())
 	}
 	return state, nil

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -619,10 +619,17 @@ func snapshot(
 	}, nil
 }
 
-// logAppend adds the given entries to the raft log. Takes the previous
-// lastIndex, lastTerm, raftLogSize, and returns new values. It's the
-// caller's responsibility to maintain exclusive access to the raft log
-// for the duration of the method call.
+// raftLogState stores information about the last entry and the size of the log.
+type raftLogState struct {
+	lastIndex   uint64
+	lastTerm    uint64
+	raftLogSize int64
+}
+
+// logAppend adds the given entries to the raft log. Takes the previous log
+// state, and returns the updated state. It's the caller's responsibility to
+// maintain exclusive access to the raft log for the duration of the method
+// call.
 //
 // logAppend is intentionally oblivious to the existence of sideloaded
 // proposals. They are managed by the caller, including cleaning up obsolete
@@ -631,13 +638,11 @@ func logAppend(
 	ctx context.Context,
 	raftLogPrefix roachpb.Key,
 	rw storage.ReadWriter,
-	prevLastIndex uint64,
-	prevLastTerm uint64,
-	prevRaftLogSize int64,
+	prev raftLogState,
 	entries []raftpb.Entry,
-) (uint64, uint64, int64, error) {
+) (raftLogState, error) {
 	if len(entries) == 0 {
-		return prevLastIndex, prevLastTerm, prevRaftLogSize, nil
+		return prev, nil
 	}
 	var diff enginepb.MVCCStats
 	var value roachpb.Value
@@ -646,37 +651,38 @@ func logAppend(
 		key := keys.RaftLogKeyFromPrefix(raftLogPrefix, ent.Index)
 
 		if err := value.SetProto(ent); err != nil {
-			return 0, 0, 0, err
+			return raftLogState{}, err
 		}
 		value.InitChecksum(key)
 		var err error
-		if ent.Index > prevLastIndex {
+		if ent.Index > prev.lastIndex {
 			err = storage.MVCCBlindPut(ctx, rw, &diff, key, hlc.Timestamp{}, hlc.ClockTimestamp{}, value, nil /* txn */)
 		} else {
 			err = storage.MVCCPut(ctx, rw, &diff, key, hlc.Timestamp{}, hlc.ClockTimestamp{}, value, nil /* txn */)
 		}
 		if err != nil {
-			return 0, 0, 0, err
+			return raftLogState{}, err
 		}
 	}
 
-	lastIndex := entries[len(entries)-1].Index
-	lastTerm := entries[len(entries)-1].Term
+	newLastIndex := entries[len(entries)-1].Index
 	// Delete any previously appended log entries which never committed.
-	if prevLastIndex > 0 {
-		for i := lastIndex + 1; i <= prevLastIndex; i++ {
+	if prev.lastIndex > 0 {
+		for i := newLastIndex + 1; i <= prev.lastIndex; i++ {
 			// Note that the caller is in charge of deleting any sideloaded payloads
 			// (which they must only do *after* the batch has committed).
 			_, err := storage.MVCCDelete(ctx, rw, &diff, keys.RaftLogKeyFromPrefix(raftLogPrefix, i),
 				hlc.Timestamp{}, hlc.ClockTimestamp{}, nil)
 			if err != nil {
-				return 0, 0, 0, err
+				return raftLogState{}, err
 			}
 		}
 	}
-
-	raftLogSize := prevRaftLogSize + diff.SysBytes
-	return lastIndex, lastTerm, raftLogSize, nil
+	return raftLogState{
+		lastIndex:   newLastIndex,
+		lastTerm:    entries[len(entries)-1].Term,
+		raftLogSize: prev.raftLogSize + diff.SysBytes,
+	}, nil
 }
 
 // updateRangeInfo is called whenever a range is updated by ApplySnapshot

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -621,9 +621,9 @@ func snapshot(
 
 // raftLogState stores information about the last entry and the size of the log.
 type raftLogState struct {
-	lastIndex   uint64
-	lastTerm    uint64
-	raftLogSize int64
+	lastIndex uint64
+	lastTerm  uint64
+	byteSize  int64
 }
 
 // logAppend adds the given entries to the raft log. Takes the previous log
@@ -679,9 +679,9 @@ func logAppend(
 		}
 	}
 	return raftLogState{
-		lastIndex:   newLastIndex,
-		lastTerm:    entries[len(entries)-1].Term,
-		raftLogSize: prev.raftLogSize + diff.SysBytes,
+		lastIndex: newLastIndex,
+		lastTerm:  entries[len(entries)-1].Term,
+		byteSize:  prev.byteSize + diff.SysBytes,
 	}, nil
 }
 


### PR DESCRIPTION
This change factors out a `logStore` type stub as a foundation for a separated log storage, and moves the log entries persistence code to be its `storeEntries` method.

Epic: CRDB-220
Release note: None