### PR TITLE
ui: move events endpoint to use sql-over-http

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/eventsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/eventsApi.ts
@@ -1,0 +1,108 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import {
+  executeInternalSql,
+  LARGE_RESULT_SIZE,
+  SqlExecutionRequest,
+  sqlResultsAreEmpty,
+  SqlStatement,
+} from "./sqlApi";
+import { withTimeout } from "./util";
+import moment from "moment";
+
+// defaultEventsNumLimit is the default number of events to be returned.
+export const defaultEventsNumLimit = 1000;
+
+export type EventColumns = {
+  timestamp: string;
+  eventType: string;
+  reportingID: string;
+  info: string;
+  uniqueID: string;
+};
+
+export type NonRedactedEventsRequest = {
+  type?: string;
+  limit?: number;
+  offset?: number;
+};
+
+export type EventsResponse = EventColumns[];
+
+export const baseEventsQuery = `SELECT timestamp, "eventType", "reportingID", info, "uniqueID" FROM system.eventlog`;
+
+function buildEventStatement({
+  type,
+  limit,
+  offset,
+}: NonRedactedEventsRequest): SqlStatement {
+  let placeholder = 1;
+  const eventsStmt: SqlStatement = {
+    sql: baseEventsQuery,
+    arguments: [],
+  };
+  if (type) {
+    eventsStmt.sql += ` WHERE "eventType" = ` + type;
+    eventsStmt.arguments.push(type);
+  }
+  eventsStmt.sql += ` ORDER BY timestamp DESC`;
+  if (!limit || limit <= 0) {
+    limit = defaultEventsNumLimit;
+  }
+  if (limit > 0) {
+    eventsStmt.sql += ` LIMIT $${placeholder}`;
+    eventsStmt.arguments.push(limit);
+    placeholder++;
+  }
+  if (offset && offset > 0) {
+    eventsStmt.sql += ` OFFSET $${placeholder}`;
+    eventsStmt.arguments.push(offset);
+  }
+  eventsStmt.sql += ";";
+  return eventsStmt;
+}
+
+export function buildEventsSQLRequest(
+  req: NonRedactedEventsRequest,
+): SqlExecutionRequest {
+  const eventsStmt: SqlStatement = buildEventStatement(req);
+  return {
+    statements: [eventsStmt],
+    execute: true,
+    max_result_size: LARGE_RESULT_SIZE,
+  };
+}
+
+// getNonRedactedEvents fetches events logs from the database. Callers of
+// getNonRedactedEvents from cluster-ui will need to pass a timeout argument for
+// promise timeout handling (callers from db-console already have promise
+// timeout handling as part of the cacheDataReducer).
+// Note that this endpoint is not able to redact event log information.
+export function getNonRedactedEvents(
+  req: NonRedactedEventsRequest = {},
+  timeout?: moment.Duration,
+): Promise<EventsResponse> {
+  const eventsRequest: SqlExecutionRequest = buildEventsSQLRequest(req);
+  return withTimeout(
+    executeInternalSql<EventColumns>(eventsRequest),
+    timeout,
+  ).then(result => {
+    // If request succeeded but query failed, throw error (caught by saga/cacheDataReducer).
+    if (result.error) {
+      throw result.error;
+    }
+
+    if (sqlResultsAreEmpty(result)) {
+      return [];
+    }
+    return result.execution.txn_results[0].rows;
+  });
+}

--- a/pkg/ui/workspaces/cluster-ui/src/api/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/index.ts
@@ -21,3 +21,4 @@ export * from "./schedulesApi";
 export * from "./sqlApi";
 export * from "./tracezApi";
 export * from "./databasesApi";
+export * from "./eventsApi";

--- a/pkg/ui/workspaces/db-console/src/app.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.spec.tsx
@@ -9,6 +9,8 @@
 // licenses/APL.txt.
 
 import { stubComponentInModule } from "./test-utils/mockComponent";
+stubComponentInModule("src/views/cluster/containers/nodeGraphs", "default");
+stubComponentInModule("src/views/cluster/containers/events", "EventPage");
 stubComponentInModule("src/views/databases/databasesPage", "DatabasesPage");
 stubComponentInModule(
   "src/views/databases/databaseDetailsPage",
@@ -57,11 +59,9 @@ import { AdminUIState, createAdminUIStore } from "src/redux/state";
 
 const CLUSTER_OVERVIEW_CAPACITY_LABEL = "Capacity Usage";
 const CLUSTER_VIZ_NODE_MAP_LABEL = "Node Map";
-const METRICS_HEADER = "Metrics";
 const NODE_LIST_LABEL = /Nodes \([\d]\)/;
 const LOADING_CLUSTER_STATUS = /Loading cluster status.*/;
 const NODE_LOG_HEADER = /Logs Node.*/;
-const EVENTS_HEADER = "Events";
 const JOBS_HEADER = "Jobs";
 const SQL_ACTIVITY_HEADER = "SQL Activity";
 const TRANSACTION_DETAILS_HEADER = "Transaction Details";
@@ -142,7 +142,7 @@ describe("Routing to", () => {
   describe("'/metrics' path", () => {
     test("routes to <NodeGraphs> component", () => {
       navigateToPath("/metrics");
-      screen.getByText(METRICS_HEADER, { selector: "h3" });
+      screen.getByTestId("nodeGraphs");
     });
 
     test("redirected to '/metrics/overview/cluster'", () => {
@@ -154,21 +154,21 @@ describe("Routing to", () => {
   describe("'/metrics/overview/cluster' path", () => {
     test("routes to <NodeGraphs> component", () => {
       navigateToPath("/metrics/overview/cluster");
-      screen.getByText(METRICS_HEADER, { selector: "h3" });
+      screen.getByTestId("nodeGraphs");
     });
   });
 
   describe("'/metrics/overview/node' path", () => {
     test("routes to <NodeGraphs> component", () => {
       navigateToPath("/metrics/overview/node");
-      screen.getByText(METRICS_HEADER, { selector: "h3" });
+      screen.getByTestId("nodeGraphs");
     });
   });
 
   describe("'/metrics/:dashboardNameAttr' path", () => {
     test("routes to <NodeGraphs> component", () => {
       navigateToPath("/metrics/some-dashboard");
-      screen.getByText(METRICS_HEADER, { selector: "h3" });
+      screen.getByTestId("nodeGraphs");
     });
 
     test("redirected to '/metrics/:${dashboardNameAttr}/cluster'", () => {
@@ -180,14 +180,14 @@ describe("Routing to", () => {
   describe("'/metrics/:dashboardNameAttr/cluster' path", () => {
     test("routes to <NodeGraphs> component", () => {
       navigateToPath("/metrics/some-dashboard/cluster");
-      screen.getByText(METRICS_HEADER, { selector: "h3" });
+      screen.getByTestId("nodeGraphs");
     });
   });
 
   describe("'/metrics/:dashboardNameAttr/node' path", () => {
     test("routes to <NodeGraphs> component", () => {
       navigateToPath("/metrics/some-dashboard/node");
-      screen.getByText(METRICS_HEADER, { selector: "h3" });
+      screen.getByTestId("nodeGraphs");
     });
 
     test("redirected to '/metrics/:${dashboardNameAttr}/cluster'", () => {
@@ -199,7 +199,7 @@ describe("Routing to", () => {
   describe("'/metrics/:dashboardNameAttr/node/:nodeIDAttr' path", () => {
     test("routes to <NodeGraphs> component", () => {
       navigateToPath("/metrics/some-dashboard/node/123");
-      screen.getByText(METRICS_HEADER, { selector: "h3" });
+      screen.getByTestId("nodeGraphs");
     });
   });
 
@@ -238,7 +238,7 @@ describe("Routing to", () => {
   describe("'/events' path", () => {
     test("routes to <EventPageUnconnected> component", () => {
       navigateToPath("/events");
-      screen.getByText(EVENTS_HEADER, { selector: "h1" });
+      screen.getByTestId("EventPage");
     });
   });
 

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -49,7 +49,7 @@ export const clusterReducerObj = new CachedDataReducer(
 export const refreshCluster = clusterReducerObj.refresh;
 
 const eventsReducerObj = new CachedDataReducer(
-  api.getEvents,
+  clusterUiApi.getNonRedactedEvents,
   "events",
   moment.duration(10, "s"),
 );
@@ -515,7 +515,7 @@ export const refreshSnapshot = snapshotReducerObj.refresh;
 
 export interface APIReducersState {
   cluster: CachedDataReducerState<api.ClusterResponseMessage>;
-  events: CachedDataReducerState<api.EventsResponseMessage>;
+  events: CachedDataReducerState<clusterUiApi.EventsResponse>;
   health: HealthState;
   nodes: CachedDataReducerState<INodeStatus[]>;
   raft: CachedDataReducerState<api.RaftDebugResponseMessage>;

--- a/pkg/ui/workspaces/db-console/src/redux/events.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/events.ts
@@ -14,7 +14,7 @@ import { AdminUIState } from "src/redux/state";
  * eventsSelector selects the list of events from the store.
  */
 export function eventsSelector(state: AdminUIState) {
-  return state.cachedData.events.data && state.cachedData.events.data.events;
+  return state.cachedData.events.data;
 }
 
 /**

--- a/pkg/ui/workspaces/db-console/src/util/api.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.ts
@@ -31,11 +31,6 @@ export type TableDetailsRequestMessage =
 export type TableDetailsResponseMessage =
   protos.cockroach.server.serverpb.TableDetailsResponse;
 
-export type EventsRequestMessage =
-  protos.cockroach.server.serverpb.EventsRequest;
-export type EventsResponseMessage =
-  protos.cockroach.server.serverpb.EventsResponse;
-
 export type LocationsRequestMessage =
   protos.cockroach.server.serverpb.LocationsRequest;
 export type LocationsResponseMessage =
@@ -425,20 +420,6 @@ export function setUIData(
     serverpb.SetUIDataResponse,
     `${API_PREFIX}/uidata`,
     req as any,
-    timeout,
-  );
-}
-
-// getEvents gets event data
-export function getEvents(
-  req: EventsRequestMessage,
-  timeout?: moment.Duration,
-): Promise<EventsResponseMessage> {
-  const queryString = propsToQueryString(_.pick(req, ["type"]));
-  return timeoutFetch(
-    serverpb.EventsResponse,
-    `${API_PREFIX}/events?unredacted_events=true&${queryString}`,
-    null,
     timeout,
   );
 }

--- a/pkg/ui/workspaces/db-console/src/util/eventTypes.ts
+++ b/pkg/ui/workspaces/db-console/src/util/eventTypes.ts
@@ -12,10 +12,6 @@
 
 import _ from "lodash";
 
-import * as protos from "src/js/protos";
-
-type Event = protos.cockroach.server.serverpb.EventsResponse.Event;
-
 // Recorded when a database is created.
 export const CREATE_DATABASE = "create_database";
 // Recorded when a database is dropped.
@@ -180,29 +176,3 @@ export const allEvents = [
   ...settingsEvents,
   ...jobEvents,
 ];
-
-const nodeEventSet = _.invert(nodeEvents);
-const databaseEventSet = _.invert(databaseEvents);
-const tableEventSet = _.invert(tableEvents);
-const settingsEventSet = _.invert(settingsEvents);
-const jobsEventSet = _.invert(jobEvents);
-
-export function isNodeEvent(e: Event): boolean {
-  return !_.isUndefined(nodeEventSet[e.event_type]);
-}
-
-export function isDatabaseEvent(e: Event): boolean {
-  return !_.isUndefined(databaseEventSet[e.event_type]);
-}
-
-export function isTableEvent(e: Event): boolean {
-  return !_.isUndefined(tableEventSet[e.event_type]);
-}
-
-export function isSettingsEvent(e: Event): boolean {
-  return !_.isUndefined(settingsEventSet[e.event_type]);
-}
-
-export function isJobsEvent(e: Event): boolean {
-  return !_.isUndefined(jobsEventSet[e.event_type]);
-}

--- a/pkg/ui/workspaces/db-console/src/util/events.ts
+++ b/pkg/ui/workspaces/db-console/src/util/events.ts
@@ -8,24 +8,18 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import * as protobuf from "protobufjs/minimal";
-
-import * as protos from "src/js/protos";
 import * as eventTypes from "src/util/eventTypes";
-
-type Event$Properties = protos.cockroach.server.serverpb.EventsResponse.IEvent;
+import { api as clusterUiApi } from "@cockroachlabs/cluster-ui";
 
 /**
  * getEventDescription returns a short summary of an event.
  */
-export function getEventDescription(e: Event$Properties): string {
-  const info: EventInfo = protobuf.util.isset(e, "info")
-    ? JSON.parse(e.info)
-    : {};
+export function getEventDescription(e: clusterUiApi.EventColumns): string {
+  const info: EventInfo = e.info ? JSON.parse(e.info) : {};
   let privs = "";
   let comment = "";
 
-  switch (e.event_type) {
+  switch (e.eventType) {
     case eventTypes.CREATE_DATABASE:
       return `Database Created: User ${info.User} created database ${info.DatabaseName}`;
     case eventTypes.DROP_DATABASE: {
@@ -203,14 +197,10 @@ export function getEventDescription(e: Event$Properties): string {
     eventTypes.UNSAFE_UPSERT_DESCRIPTOR,
     eventTypes.UNSAFE_DELETE_DESCRIPTOR):
       return `Unsafe: User ${info.User} executed crdb_internal.${
-        e.event_type
+        e.eventType
       }, Info: ${JSON.stringify(info, null, 2)}`;
     default:
-      return `Event: ${e.event_type}, content: ${JSON.stringify(
-        info,
-        null,
-        2,
-      )}`;
+      return `Event: ${e.eventType}, content: ${JSON.stringify(info, null, 2)}`;
   }
 }
 

--- a/pkg/ui/workspaces/db-console/src/util/fakeApi.ts
+++ b/pkg/ui/workspaces/db-console/src/util/fakeApi.ts
@@ -66,16 +66,15 @@ export function stubClusterSettings(
 }
 
 export function buildSQLApiDatabasesResponse(databases: string[]) {
-  const rows: clusterUiApi.DatabasesColumns[] = [];
-  databases.forEach(database => {
-    rows.push({
+  const rows: clusterUiApi.DatabasesColumns[] = databases.map(database => {
+    return {
       database_name: database,
       owner: "root",
       primary_region: null,
       secondary_region: null,
       regions: [],
       survival_goal: null,
-    });
+    };
   });
   return {
     num_statements: 1,
@@ -126,9 +125,53 @@ export function buildSQLApiDatabasesResponse(databases: string[]) {
   };
 }
 
+export function buildSQLApiEventsResponse(events: clusterUiApi.EventsResponse) {
+  return {
+    num_statements: 1,
+    execution: {
+      txn_results: [
+        {
+          statement: 1,
+          tag: "SELECT",
+          start: "2022-11-14T16:26:45.06819Z",
+          end: "2022-11-14T16:26:45.073657Z",
+          rows_affected: 0,
+          columns: [
+            {
+              name: "timestamp",
+              type: "TIMESTAMP",
+              oid: 1114,
+            },
+            {
+              name: "eventType",
+              type: "STRING",
+              oid: 25,
+            },
+            {
+              name: "reportingID",
+              type: "INT8",
+              oid: 20,
+            },
+            {
+              name: "info",
+              type: "STRING",
+              oid: 25,
+            },
+            {
+              name: "uniqueID",
+              type: "BYTES",
+              oid: 17,
+            },
+          ],
+          rows: events,
+        },
+      ],
+    },
+  };
+}
+
 export function stubDatabases(databases: string[]) {
   const response = buildSQLApiDatabasesResponse(databases);
-  console.log("SQL API PATH", clusterUiApi.SQL_API_PATH);
   fetchMock.mock({
     headers: {
       Accept: "application/json",
@@ -141,7 +184,6 @@ export function stubDatabases(databases: string[]) {
       expect(JSON.parse(requestObj.body.toString())).toEqual(
         clusterUiApi.databasesRequest,
       );
-      console.log("STRINGIFY", JSON.stringify(response));
       return {
         body: JSON.stringify(response),
       };

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/events/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/events/index.tsx
@@ -14,7 +14,6 @@ import React from "react";
 import { Helmet } from "react-helmet";
 import { Link, RouteComponentProps, withRouter } from "react-router-dom";
 import { connect } from "react-redux";
-import * as protos from "src/js/protos";
 import { refreshEvents } from "src/redux/apiReducers";
 import {
   eventsLastErrorSelector,
@@ -30,10 +29,9 @@ import {
   SortSetting,
   SortedTable,
   util,
+  api as clusterUiApi,
 } from "@cockroachlabs/cluster-ui";
 import "./events.styl";
-
-type Event$Properties = protos.cockroach.server.serverpb.EventsResponse.IEvent;
 
 // Number of events to show in the sidebar.
 const EVENT_BOX_NUM_EVENTS = 5;
@@ -53,18 +51,17 @@ export interface SimplifiedEvent {
 class EventSortedTable extends SortedTable<SimplifiedEvent> {}
 
 export interface EventRowProps {
-  event: Event$Properties;
+  event: clusterUiApi.EventColumns;
 }
 
-export function getEventInfo(e: Event$Properties): SimplifiedEvent {
+export function getEventInfo(e: clusterUiApi.EventColumns): SimplifiedEvent {
   return {
-    fromNowString: util
-      .TimestampToMoment(e.timestamp)
+    fromNowString: moment(e.timestamp)
       .format(util.DATE_FORMAT_24_UTC)
       .replace("second", "sec")
       .replace("minute", "min"),
     content: <span>{getEventDescription(e)}</span>,
-    sortableTimestamp: util.TimestampToMoment(e.timestamp),
+    sortableTimestamp: moment(e.timestamp),
   };
 }
 
@@ -86,7 +83,7 @@ export class EventRow extends React.Component<EventRowProps, {}> {
 }
 
 export interface EventBoxProps {
-  events: Event$Properties[];
+  events: clusterUiApi.EventsResponse;
   // eventsValid is needed so that this component will re-render when the events
   // data becomes invalid, and thus trigger a refresh.
   eventsValid: boolean;
@@ -112,7 +109,7 @@ export class EventBoxUnconnected extends React.Component<EventBoxProps, {}> {
           <tbody>
             {_.map(
               _.take(events, EVENT_BOX_NUM_EVENTS),
-              (e: Event$Properties, i: number) => {
+              (e: clusterUiApi.EventColumns, i: number) => {
                 return <EventRow event={e} key={i} />;
               },
             )}
@@ -129,7 +126,7 @@ export class EventBoxUnconnected extends React.Component<EventBoxProps, {}> {
 }
 
 export interface EventPageProps {
-  events: Event$Properties[];
+  events: clusterUiApi.EventsResponse;
   // eventsValid is needed so that this component will re-render when the events
   // data becomes invalid, and thus trigger a refresh.
   eventsValid: boolean;


### PR DESCRIPTION
Part of: #89429

Addresses: #90272 (blocked from resolving by #80789)

Demo (DB-Console only): https://www.loom.com/share/bb67044a8560407fb703af2a6bbb2d9a

This change migrates the existing `/events` request to use the sql-over-http endpoint on apiV2, making this request tenant-scoped once the sql-over-http endpoint is scoped to tenants (this should be the case when #91323 is completed).

Release note: None