### PR TITLE
zip: move `--redact-logs` deprecation warning to end of zip output

### DIFF
--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -155,11 +155,9 @@ func runDebugZip(_ *cobra.Command, args []string) (retErr error) {
 
 	zr := zipCtx.newZipReporter("cluster")
 	// Interpret the deprecated `--redact-logs` the same as the new `--redact` flag.
+	// We later print a deprecation warning at the end of the zip operation for visibility.
 	if zipCtx.redactLogs {
 		zipCtx.redact = true
-		zr.info("WARNING: The --" + cliflags.ZipRedactLogs.Name +
-			" flag has been deprecated in favor of the --" + cliflags.ZipRedact.Name + " flag. " +
-			"Interpreting as --" + cliflags.ZipRedact.Name + " and continuing.")
 	}
 
 	s := zr.start("establishing RPC connection to %s", serverCfg.AdvertiseAddr)
@@ -293,6 +291,13 @@ find . -path './nodes/*/ranges/*.json' -print0 | xargs -0 grep per_second | sort
 find . -path './tenant_ranges/*/*.json' -print0 | xargs -0 grep per_second | sort -rhk3 | head -n 20`)); err != nil {
 			return err
 		}
+	}
+
+	// TODO(obs-infra): remove deprecation warning once process completed in v23.2.
+	if zipCtx.redactLogs {
+		zr.info("WARNING: The --" + cliflags.ZipRedactLogs.Name +
+			" flag has been deprecated in favor of the --" + cliflags.ZipRedact.Name + " flag. " +
+			"The flag has been interpreted as --" + cliflags.ZipRedact.Name + " instead.")
 	}
 
 	return nil


### PR DESCRIPTION
This patch simply moves the deprecation notice for the `--redact-logs` flag to the bottom of the debug zip output. Previously, the message was logged at the beginning of the output, which was quickly drowned out by the rest of the output indicating the debug zip progress.

Release note: none

Addresses https://github.com/cockroachdb/cockroach/issues/91685

Epic: CRDB-12732