### PR TITLE
systemschema: remove static list of system tables

### DIFF
--- a/pkg/ccl/backupccl/system_schema.go
+++ b/pkg/ccl/backupccl/system_schema.go
@@ -488,7 +488,7 @@ var systemTableBackupConfiguration = map[string]systemBackupConfiguration{
 	systemschema.ReplicationStatsTable.GetName(): {
 		shouldIncludeInClusterBackup: optOutOfClusterBackup,
 	},
-	systemschema.SqllivenessTable.GetName(): {
+	systemschema.SqllivenessTable().GetName(): {
 		shouldIncludeInClusterBackup: optOutOfClusterBackup,
 	},
 	systemschema.StatementBundleChunksTable.GetName(): {

--- a/pkg/sql/catalog/bootstrap/metadata.go
+++ b/pkg/sql/catalog/bootstrap/metadata.go
@@ -332,7 +332,7 @@ func addSystemDescriptorsToSchema(target *MetadataSchema) {
 	// Tables introduced in 20.2.
 
 	target.AddDescriptor(systemschema.ScheduledJobsTable)
-	target.AddDescriptor(systemschema.SqllivenessTable)
+	target.AddDescriptor(systemschema.SqllivenessTable())
 	target.AddDescriptor(systemschema.MigrationsTable)
 
 	// Tables introduced in 21.1.

--- a/pkg/sql/tests/system_table_test.go
+++ b/pkg/sql/tests/system_table_test.go
@@ -180,13 +180,13 @@ func TestSystemTableLiterals(t *testing.T) {
 	s := tc.Servers[0]
 
 	testcases := make(map[string]testcase)
-	for schema, desc := range systemschema.SystemTableDescriptors {
-		if _, alreadyExists := testcases[desc.GetName()]; alreadyExists {
-			t.Fatalf("system table %q already exists", desc.GetName())
+	for _, table := range systemschema.MakeSystemTables() {
+		if _, alreadyExists := testcases[table.GetName()]; alreadyExists {
+			t.Fatalf("system table %q already exists", table.GetName())
 		}
-		testcases[desc.GetName()] = testcase{
-			schema: schema,
-			pkg:    desc,
+		testcases[table.GetName()] = testcase{
+			schema: table.Schema,
+			pkg:    table,
 		}
 	}
 


### PR DESCRIPTION
This removes the static map of system table descriptors and replaces it with the MakeSystemTables() function. Removing the static registration makes it possible to change the value of the COCKROACH_MR_SYSTEM_DATABASE environment variable and have that change picked up in tests.

Part of #85736

Release note: None