### PR TITLE
sql: permit forward indexes on arrays

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning
@@ -1184,3 +1184,45 @@ CREATE TABLE public.partition_by_nothing (
    INDEX partition_by_nothing_b_idx (b ASC),
    FAMILY fam_0_pk_a_b (pk, a, b)
 )
+
+# Verify that it's not possible to partition tables by array columns (#91766).
+
+statement error unimplemented: partitioning by array column
+CREATE TABLE partition_array (
+  pk INT[] PRIMARY KEY
+) PARTITION BY LIST (pk) (PARTITION blah VALUES IN (ARRAY[1], ARRAY[2]))
+
+statement error unimplemented: partitioning by array column
+CREATE TABLE partition_array (
+  pk INT[] PRIMARY KEY
+) PARTITION BY RANGE (pk) (PARTITION blah VALUES FROM (ARRAY[1]) TO (ARRAY[2]))
+
+statement error unimplemented: partitioning by array column
+CREATE TABLE partition_array (
+  a INT[],
+  INDEX (a) PARTITION BY LIST (a) (PARTITION blah VALUES IN (ARRAY[1], ARRAY[2]))
+)
+
+statement error unimplemented: partitioning by array column
+CREATE TABLE partition_array (
+  a INT[],
+  INDEX (a) PARTITION BY RANGE (a) (PARTITION blah VALUES FROM (ARRAY[1]) TO (ARRAY[2]))
+)
+
+statement ok
+CREATE TABLE partition_array (
+  pk INT[] PRIMARY KEY,
+  a INT[]
+)
+
+statement error unimplemented: partitioning by array column
+ALTER TABLE partition_array PARTITION BY LIST (pk) (PARTITION blah VALUES IN (ARRAY[1], ARRAY[2]))
+
+statement error unimplemented: partitioning by array column
+ALTER TABLE partition_array PARTITION BY RANGE (pk) (PARTITION blah VALUES FROM (ARRAY[1]) TO (ARRAY[2]))
+
+statement error unimplemented: partitioning by array column
+CREATE INDEX ON partition_array (a) PARTITION BY LIST (a) (PARTITION blah VALUES IN (ARRAY[1], ARRAY[2]))
+
+statement error unimplemented: partitioning by array column
+CREATE INDEX ON partition_array (a) PARTITION BY RANGE (a) (PARTITION blah VALUES FROM (ARRAY[1]) TO (ARRAY[2]))

--- a/pkg/ccl/partitionccl/BUILD.bazel
+++ b/pkg/ccl/partitionccl/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sem/volatility",
+        "//pkg/sql/types",
         "//pkg/util/encoding",
         "//pkg/util/errorutil/unimplemented",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/ccl/partitionccl/partition.go
+++ b/pkg/ccl/partitionccl/partition.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/volatility"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/errors"
@@ -202,6 +203,10 @@ func createPartitioningImpl(
 			return partDesc, pgerror.Newf(pgcode.Syntax,
 				"declared partition columns (%s) do not match first %d columns in index being partitioned (%s)",
 				partitioningString(), n, strings.Join(newIdxColumnNames[:n], ", "))
+		}
+		if col.GetType().Family() == types.ArrayFamily {
+			return partDesc, unimplemented.NewWithIssuef(91766, "partitioning by array column (%s) not supported",
+				col.GetName())
 		}
 	}
 

--- a/pkg/sql/catalog/colinfo/col_type_info.go
+++ b/pkg/sql/catalog/colinfo/col_type_info.go
@@ -130,7 +130,7 @@ func ColumnTypeIsIndexable(t *types.T) bool {
 // using an inverted index.
 func ColumnTypeIsInvertedIndexable(t *types.T) bool {
 	switch t.Family() {
-	case types.StringFamily:
+	case types.ArrayFamily, types.StringFamily:
 		return true
 	}
 	return ColumnTypeIsOnlyInvertedIndexable(t)
@@ -142,9 +142,11 @@ func ColumnTypeIsOnlyInvertedIndexable(t *types.T) bool {
 	if t.IsAmbiguous() || t.Family() == types.TupleFamily {
 		return false
 	}
+	if t.Family() == types.ArrayFamily {
+		t = t.ArrayContents()
+	}
 	switch t.Family() {
 	case types.JsonFamily:
-	case types.ArrayFamily:
 	case types.GeographyFamily:
 	case types.GeometryFamily:
 	default:

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -2668,13 +2668,13 @@ ALTER TABLE t81448 ADD COLUMN b INT PRIMARY KEY
 statement ok
 DROP TABLE t81448
 
-subtest add_column_non_indexable_type
+subtest add_unique_array_column
 
 statement ok
-CREATE TABLE t1_non_indexable (n INT8);
+CREATE TABLE t1_unique_array (n INT8);
 
-statement error pq: unimplemented: column x is of type char\[\] and thus is not indexable
-ALTER TABLE t1_non_indexable ADD COLUMN x CHAR(256)[] UNIQUE;
+statement ok
+ALTER TABLE t1_unique_array ADD COLUMN x CHAR(256)[] UNIQUE;
 
 subtest regression_89025
 

--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -1373,8 +1373,8 @@ subtest array_indexes
 statement ok
 DROP TABLE IF EXISTS t
 
-statement error column x is of type int\[\] and thus is not indexable
-CREATE TABLE t (x INT[] PRIMARY KEY)
+statement ok
+CREATE TABLE t_indexed (x INT[] PRIMARY KEY)
 
 statement ok
 CREATE TABLE t (x INT[])
@@ -1455,20 +1455,18 @@ SELECT x FROM t WHERE x > ARRAY[NULL, NULL]:::INT[] ORDER BY x
 {5}
 
 # Test some operations on a descending index.
-statement error column x is of type int\[\] and thus is not indexable
+statement ok
 CREATE INDEX i ON t(x DESC)
 
-# Add "t@i" index annotation once #50659 is fixed.
 query T
-SELECT x FROM t WHERE x <= ARRAY[1] ORDER BY x DESC
+SELECT x FROM t@i WHERE x <= ARRAY[1] ORDER BY x DESC
 ----
 {1}
 {NULL,NULL,NULL}
 {NULL}
 
-# Add "t@i" index annotation once #50659 is fixed.
 query T
-SELECT x FROM t WHERE x > ARRAY[1] ORDER BY x
+SELECT x FROM t@i WHERE x > ARRAY[1] ORDER BY x
 ----
 {1,NULL,10}
 {1,4,5}
@@ -1478,10 +1476,10 @@ SELECT x FROM t WHERE x > ARRAY[1] ORDER BY x
 
 # Ensure that we can order by the arrays without any indexes.
 statement ok
-DROP TABLE t;
+DROP TABLE t
 
 statement ok
-CREATE TABLE t (x INT[]);
+CREATE TABLE t (x INT[])
 
 statement ok
 INSERT INTO t VALUES
@@ -1518,9 +1516,36 @@ SELECT x FROM t ORDER BY x DESC
 {NULL,NULL,NULL}
 {NULL}
 
-# Enable index creation once #50659 is fixed.
 statement ok
---CREATE INDEX i ON t (x);
+CREATE INDEX i ON t (x);
+
+# Ensure selecting works fine on the index.
+
+query T
+SELECT x FROM t@i ORDER BY x
+----
+{NULL}
+{NULL,NULL,NULL}
+{1}
+{1,NULL,10}
+{1,4,5}
+{1,4,6}
+{4}
+{5}
+
+query T
+SELECT x FROM t@i ORDER BY x DESC
+----
+{5}
+{4}
+{1,4,6}
+{1,4,5}
+{1,NULL,10}
+{1}
+{NULL,NULL,NULL}
+{NULL}
+
+statement ok
 INSERT INTO t VALUES (NULL), (NULL)
 
 # Test that NULL's are differentiated from {NULL}.
@@ -1536,6 +1561,22 @@ SELECT x FROM t WHERE x IS NOT NULL ORDER BY x
 {1,4,6}
 {4}
 {5}
+
+# Ensure that unique indexes on array columns work okay.
+statement ok
+CREATE TABLE unique_array (a INT[] UNIQUE, b INT[])
+
+statement ok
+INSERT INTO unique_array VALUES (ARRAY[1], ARRAY[2, 3])
+
+statement error duplicate key value violates unique constraint
+INSERT INTO unique_array VALUES (ARRAY[1], ARRAY[2, 3])
+
+statement ok
+INSERT INTO unique_array VALUES (ARRAY[2], ARRAY[2, 3])
+
+statement error duplicate key value violates unique constraint
+CREATE UNIQUE INDEX ON unique_array(b)
 
 # Create an indexes on a bad type.
 statement error pq: unimplemented: column x is of type geography\[\] and thus is not indexable

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -864,7 +864,7 @@ ORDER BY statistics_name, column_names::STRING
 ----
 statistics_name  column_names  row_count  distinct_count  null_count  has_histogram
 arr_stats        {rowid}       4          4               0           true
-arr_stats_x      {x}           4          3               1           false
+arr_stats_x      {x}           4          3               1           true
 
 # Test that enum columns always have histograms collected for them.
 statement ok
@@ -1900,3 +1900,58 @@ u_defaults       {d,c}
 u_defaults       {d,c,a}
 u_c_d_b          {d,c,b}
 u_defaults       {d,c,b,a}
+
+# Make sure that we can properly collect statistics on an array column that's
+# both forward and inverted indexable.
+
+statement ok
+CREATE TABLE indexed_arr(a INT[]);
+CREATE INDEX ON indexed_arr(a)
+
+statement ok
+INSERT INTO indexed_arr SELECT ARRAY[g] FROM generate_series(1,10000) g(g)
+
+statement ok
+ANALYZE indexed_arr
+
+query TTIB
+SELECT statistics_name, column_names, row_count, histogram_id IS NOT NULL AS has_histogram
+FROM [SHOW STATISTICS FOR TABLE indexed_arr]
+ORDER BY statistics_name, column_names::STRING
+----
+NULL  {a}      10000  true
+NULL  {rowid}  10000  true
+
+statement ok
+CREATE INDEX ON indexed_arr USING GIN (a)
+
+query T
+SELECT * FROM indexed_arr WHERE a = ARRAY[100]
+----
+{100}
+
+query T
+SELECT * FROM indexed_arr WHERE a @> ARRAY[100]
+----
+{100}
+
+statement ok
+ANALYZE indexed_arr
+
+query TTIB
+SELECT statistics_name, column_names, row_count, histogram_id IS NOT NULL AS has_histogram
+FROM [SHOW STATISTICS FOR TABLE indexed_arr]
+ORDER BY statistics_name, column_names::STRING
+----
+NULL  {a}      10000  true
+NULL  {rowid}  10000  true
+
+query T
+SELECT * FROM indexed_arr WHERE a = ARRAY[100]
+----
+{100}
+
+query T
+SELECT * FROM indexed_arr WHERE a @> ARRAY[100]
+----
+{100}

--- a/pkg/sql/opt/exec/execbuilder/testdata/array
+++ b/pkg/sql/opt/exec/execbuilder/testdata/array
@@ -1,8 +1,7 @@
 # LogicTest: local
 
-# Add x to PRIMARY KEY once #50659 is fixed.
 statement ok
-CREATE TABLE t (x INT[])
+CREATE TABLE t (x INT[] PRIMARY KEY)
 
 # Test some scans of constrained spans on arrays.
 
@@ -12,13 +11,10 @@ EXPLAIN SELECT x FROM t WHERE x = ARRAY[1,4,6]
 distribution: local
 vectorized: true
 ·
-• filter
-│ filter: x = ARRAY[1,4,6]
-│
-└── • scan
-      missing stats
-      table: t@t_pkey
-      spans: FULL SCAN
+• scan
+  missing stats
+  table: t@t_pkey
+  spans: [/ARRAY[1,4,6] - /ARRAY[1,4,6]]
 
 query T
 EXPLAIN SELECT x FROM t WHERE x < ARRAY[1, 4, 3]
@@ -26,13 +22,10 @@ EXPLAIN SELECT x FROM t WHERE x < ARRAY[1, 4, 3]
 distribution: local
 vectorized: true
 ·
-• filter
-│ filter: x < ARRAY[1,4,3]
-│
-└── • scan
-      missing stats
-      table: t@t_pkey
-      spans: FULL SCAN
+• scan
+  missing stats
+  table: t@t_pkey
+  spans: [ - /ARRAY[1,4,3])
 
 query T
 EXPLAIN SELECT x FROM t WHERE x > ARRAY [1, NULL]
@@ -40,13 +33,10 @@ EXPLAIN SELECT x FROM t WHERE x > ARRAY [1, NULL]
 distribution: local
 vectorized: true
 ·
-• filter
-│ filter: x > ARRAY[1,NULL]
-│
-└── • scan
-      missing stats
-      table: t@t_pkey
-      spans: FULL SCAN
+• scan
+  missing stats
+  table: t@t_pkey
+  spans: [/ARRAY[1,NULL,NULL] - ]
 
 query T
 EXPLAIN SELECT x FROM t WHERE x > ARRAY[1, 3] AND x < ARRAY[1, 4, 10] ORDER BY x
@@ -54,16 +44,10 @@ EXPLAIN SELECT x FROM t WHERE x > ARRAY[1, 3] AND x < ARRAY[1, 4, 10] ORDER BY x
 distribution: local
 vectorized: true
 ·
-• sort
-│ order: +x
-│
-└── • filter
-    │ filter: (x > ARRAY[1,3]) AND (x < ARRAY[1,4,10])
-    │
-    └── • scan
-          missing stats
-          table: t@t_pkey
-          spans: FULL SCAN
+• scan
+  missing stats
+  table: t@t_pkey
+  spans: [/ARRAY[1,3,NULL] - /ARRAY[1,4,10])
 
 query T
 EXPLAIN SELECT x FROM t WHERE x > ARRAY[1, 3] AND x < ARRAY[1, 4, 10] ORDER BY x DESC
@@ -71,23 +55,18 @@ EXPLAIN SELECT x FROM t WHERE x > ARRAY[1, 3] AND x < ARRAY[1, 4, 10] ORDER BY x
 distribution: local
 vectorized: true
 ·
-• sort
-│ order: -x
-│
-└── • filter
-    │ filter: (x > ARRAY[1,3]) AND (x < ARRAY[1,4,10])
-    │
-    └── • scan
-          missing stats
-          table: t@t_pkey
-          spans: FULL SCAN
+• revscan
+  missing stats
+  table: t@t_pkey
+  spans: [/ARRAY[1,3,NULL] - /ARRAY[1,4,10])
 
 statement ok
 DROP TABLE t
 
-# Add multicolumn INDEX i (x, y, z) once #50659 is fixed.
+# Multicolumn index, including arrays.
+
 statement ok
-CREATE TABLE t (x INT, y INT[], z INT)
+CREATE TABLE t (x INT, y INT[], z INT, INDEX i (x, y, z))
 
 query T
 EXPLAIN SELECT x, y, z FROM t WHERE x = 2 AND y < ARRAY[10] ORDER BY y
@@ -95,13 +74,7 @@ EXPLAIN SELECT x, y, z FROM t WHERE x = 2 AND y < ARRAY[10] ORDER BY y
 distribution: local
 vectorized: true
 ·
-• sort
-│ order: +y
-│
-└── • filter
-    │ filter: (x = 2) AND (y < ARRAY[10])
-    │
-    └── • scan
-          missing stats
-          table: t@t_pkey
-          spans: FULL SCAN
+• scan
+  missing stats
+  table: t@i
+  spans: (/2/NULL - /2/ARRAY[10])

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -130,6 +130,65 @@ INSERT INTO e VALUES(3, ARRAY[NULL])
 CPut /Table/107/1/3/0 -> /TUPLE/
 InitPut /Table/107/2/NULL/3/0 -> /BYTES/
 
+# Make sure that we're emitting the right plan for array index scans even if
+# a column is both forward and inverted indexed.
+
+query T
+EXPLAIN SELECT * FROM e WHERE b @> ARRAY[8]
+----
+distribution: local
+vectorized: true
+·
+• index join
+│ table: e@e_pkey
+│
+└── • scan
+      missing stats
+      table: e@bidx
+      spans: 1 span
+
+query T
+EXPLAIN SELECT * FROM e WHERE b = ARRAY[8]
+----
+distribution: local
+vectorized: true
+·
+• filter
+│ filter: b = ARRAY[8]
+│
+└── • scan
+      missing stats
+      table: e@e_pkey
+      spans: FULL SCAN
+
+statement ok
+CREATE INDEX ON e(b)
+
+query T
+EXPLAIN SELECT * FROM e WHERE b @> ARRAY[8]
+----
+distribution: local
+vectorized: true
+·
+• index join
+│ table: e@e_pkey
+│
+└── • scan
+      missing stats
+      table: e@bidx
+      spans: 1 span
+
+query T
+EXPLAIN SELECT * FROM e WHERE b = ARRAY[8]
+----
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: e@e_b_idx
+  spans: [/ARRAY[8] - /ARRAY[8]]
+
 # Test that array inverted indexes work okay with decimals (a type with
 # composite encoding). Also, make sure that the composite encoding is
 # de-duplicated - 1.0 and 1.00 should just have one entry.
@@ -1314,16 +1373,11 @@ EXPLAIN (VERBOSE) SELECT * from e where b IS NULL
 distribution: local
 vectorized: true
 ·
-• filter
-│ columns: (a, b)
-│ estimated row count: 10 (missing stats)
-│ filter: b IS NULL
-│
-└── • scan
-      columns: (a, b)
-      estimated row count: 1,000 (missing stats)
-      table: e@e_pkey
-      spans: FULL SCAN
+• scan
+  columns: (a, b)
+  estimated row count: 10 (missing stats)
+  table: e@e_b_idx
+  spans: /NULL-/!NULL
 
 # This should use a zigzag join.
 query T

--- a/pkg/sql/opt/indexrec/testdata/index
+++ b/pkg/sql/opt/indexrec/testdata/index
@@ -1355,21 +1355,17 @@ t4:
 index-recommendations
 SELECT k, f FROM t4 WHERE a IS NULL
 ----
-no index recommendations
+creation: CREATE INDEX ON t4 (a) STORING (k, f);
 --
 optimal plan:
 project
  ├── columns: k:1 f:3
- ├── cost: 1125.07
- └── select
+ ├── cost: 25.0400002
+ └── scan t4@_hyp_1
       ├── columns: k:1 f:3 a:5
-      ├── cost: 1124.95
-      ├── fd: ()-->(5)
-      ├── scan t4
-      │    ├── columns: k:1 f:3 a:5
-      │    └── cost: 1114.92
-      └── filters
-           └── a:5 IS NULL [outer=(5), constraints=(/5: [/NULL - /NULL]; tight), fd=()-->(5)]
+      ├── constraint: /5/6: [/NULL - /NULL]
+      ├── cost: 24.9200002
+      └── fd: ()-->(5)
 
 index-candidates
 SELECT k, f FROM t4 WHERE a @> ARRAY[1]
@@ -1377,26 +1373,30 @@ SELECT k, f FROM t4 WHERE a @> ARRAY[1]
 t4:
  (a)
 
+# This test generates no index recommendations because the index recommended
+# doesn't yet support recommending inverted indexes on types that are also
+# forward indexable, such as trigrams and arrays.
+# See #91777.
+
 index-recommendations
 SELECT k, f FROM t4 WHERE a @> ARRAY[1]
 ----
-creation: CREATE INVERTED INDEX ON t4 (a);
+no index recommendations
 --
 optimal plan:
 project
  ├── columns: k:1 f:3
  ├── immutable
- ├── cost: 805.048889
- └── index-join t4
+ ├── cost: 1126.07
+ └── select
       ├── columns: k:1 f:3 a:5!null
       ├── immutable
-      ├── cost: 803.928889
-      └── scan t4@_hyp_1
-           ├── columns: rowid:6!null
-           ├── inverted constraint: /9/6
-           │    └── spans: ["\x89", "\x89"]
-           ├── cost: 128.464444
-           └── key: (6)
+      ├── cost: 1124.95
+      ├── scan t4
+      │    ├── columns: k:1 f:3 a:5
+      │    └── cost: 1114.92
+      └── filters
+           └── a:5 @> ARRAY[1] [outer=(5), immutable, constraints=(/5: (/NULL - ])]
 
 index-candidates
 SELECT k, f FROM t4 WHERE a = ARRAY[1]
@@ -1407,21 +1407,17 @@ t4:
 index-recommendations
 SELECT k, f FROM t4 WHERE a = ARRAY[1]
 ----
-no index recommendations
+creation: CREATE INDEX ON t4 (a) STORING (k, f);
 --
 optimal plan:
 project
  ├── columns: k:1 f:3
- ├── cost: 1125.07
- └── select
+ ├── cost: 25.0400001
+ └── scan t4@_hyp_1
       ├── columns: k:1 f:3 a:5!null
-      ├── cost: 1124.95
-      ├── fd: ()-->(5)
-      ├── scan t4
-      │    ├── columns: k:1 f:3 a:5
-      │    └── cost: 1114.92
-      └── filters
-           └── a:5 = ARRAY[1] [outer=(5), constraints=(/5: [/ARRAY[1] - /ARRAY[1]]; tight), fd=()-->(5)]
+      ├── constraint: /5/6: [/ARRAY[1] - /ARRAY[1]]
+      ├── cost: 24.9200001
+      └── fd: ()-->(5)
 
 index-candidates
 SELECT k, f FROM t4 WHERE a @> ARRAY[1] AND i = 1
@@ -1429,30 +1425,29 @@ SELECT k, f FROM t4 WHERE a @> ARRAY[1] AND i = 1
 t4:
  (a)
  (i)
- (i, a)
 
 index-recommendations
 SELECT k, f FROM t4 WHERE a @> ARRAY[1] AND i = 1
 ----
-creation: CREATE INVERTED INDEX ON t4 (i, a);
+creation: CREATE INDEX ON t4 (i) STORING (k, f, a);
 --
 optimal plan:
 project
  ├── columns: k:1 f:3
  ├── immutable
- ├── cost: 21.9920001
- └── index-join t4
+ ├── cost: 25.1810001
+ └── select
       ├── columns: k:1 i:2!null f:3 a:5!null
       ├── immutable
-      ├── cost: 21.9610001
+      ├── cost: 25.1500001
       ├── fd: ()-->(2)
-      └── scan t4@_hyp_3
-           ├── columns: rowid:6!null
-           ├── constraint: /2: [/1 - /1]
-           ├── inverted constraint: /10/6
-           │    └── spans: ["\x89", "\x89"]
-           ├── cost: 15.1755556
-           └── key: (6)
+      ├── scan t4@_hyp_2
+      │    ├── columns: k:1 i:2!null f:3 a:5
+      │    ├── constraint: /2/6: [/1 - /1]
+      │    ├── cost: 25.0200001
+      │    └── fd: ()-->(2)
+      └── filters
+           └── a:5 @> ARRAY[1] [outer=(5), immutable, constraints=(/5: (/NULL - ])]
 
 index-candidates
 SELECT k, f FROM t4 WHERE a @> ARRAY[1] AND f > 3
@@ -1475,7 +1470,7 @@ project
       ├── columns: k:1 f:3!null a:5!null
       ├── immutable
       ├── cost: 380.716667
-      ├── scan t4@_hyp_1
+      ├── scan t4@_hyp_2
       │    ├── columns: k:1 f:3!null a:5
       │    ├── constraint: /3/6: [/3.0000000000000004 - ]
       │    └── cost: 377.353333


### PR DESCRIPTION
Closes #17154

This functionality has been unlocked since we added trigram indexes - the blocker before was the ability to support both forward and inverted indexes on a given type.

This commit simply permits forward indexes on arrays, where they were previously not supported at all.

Release note (sql change): enable forward indexes on arrays