### PR TITLE
log: provide clearer error message when decoder is given empty file

### DIFF
--- a/pkg/util/log/log_decoder.go
+++ b/pkg/util/log/log_decoder.go
@@ -70,6 +70,10 @@ func NewEntryDecoderWithFormat(
 		var err error
 		read, format, err = ReadFormatFromLogFile(in)
 		if err != nil {
+			if err == io.EOF {
+				return nil, errors.Wrap(err,
+					"cannot read format from empty log file")
+			}
 			return nil, err
 		}
 		in = io.MultiReader(read, in)

--- a/pkg/util/log/log_decoder_test.go
+++ b/pkg/util/log/log_decoder_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/datadriven"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReadLogFormat(t *testing.T) {
@@ -33,4 +34,11 @@ func TestReadLogFormat(t *testing.T) {
 			// unreachable
 			return ""
 		})
+}
+
+func TestNewEntryDecoder_EmptyFile(t *testing.T) {
+	in := strings.NewReader("")
+	decoder, err := NewEntryDecoder(in, SelectEditMode(true /* redact */, true /*keepRedactable*/))
+	require.Nil(t, decoder)
+	require.ErrorContains(t, err, "cannot read format from empty log file")
 }


### PR DESCRIPTION
Some users of debug zip were confused about the error messages they were receiving when the LogFile endpoint attempted to read a log file containing 0 bytes. Instead of the error indicating that the file might be empty, it simply said:
```
rpc error: code = Unknown desc = EOF
```

This patch simply updates the log decoder constructor function to detect when it's given an empty file, and return a more meaningful error message. The new error will instead look like:
```
rpc error: code = Unknown desc = cannot read format from empty log file```
```

Release note: none

Fixes: #90770