### PR TITLE
roachtest: always collect stats when restoring TPCH dataset

### DIFF
--- a/pkg/cmd/roachtest/tests/multitenant_tpch.go
+++ b/pkg/cmd/roachtest/tests/multitenant_tpch.go
@@ -46,10 +46,6 @@ func runMultiTenantTPCH(ctx context.Context, t test.Test, c cluster.Cluster) {
 		); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := conn.Exec("USE tpch;"); err != nil {
-			t.Fatal(err)
-		}
-		createStatsFromTables(t, conn, tpchTables)
 		for queryNum := 1; queryNum <= tpch.NumQueries; queryNum++ {
 			cmd := fmt.Sprintf("./workload run tpch %s --secure "+
 				"--concurrency=1 --db=tpch --max-ops=%d --queries=%d",

--- a/pkg/cmd/roachtest/tests/tpc_utils.go
+++ b/pkg/cmd/roachtest/tests/tpc_utils.go
@@ -29,6 +29,9 @@ import (
 // compatible dataset exists (compatible is defined as a tpch dataset with a
 // scale factor at least as large as the provided scale factor), performing an
 // expensive dataset restore only if it doesn't.
+//
+// The function disables auto stats collection and ensures that table statistics
+// are present for all TPCH tables.
 func loadTPCHDataset(
 	ctx context.Context,
 	t test.Test,
@@ -38,7 +41,20 @@ func loadTPCHDataset(
 	m cluster.Monitor,
 	roachNodes option.NodeListOption,
 	disableMergeQueue bool,
-) error {
+) (retErr error) {
+	_, err := db.Exec("SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false;")
+	if retErr != nil {
+		return err
+	}
+	defer func() {
+		if retErr == nil {
+			if _, err = db.Exec("USE tpch"); err != nil {
+				retErr = err
+			} else {
+				createStatsFromTables(t, db, tpchTables)
+			}
+		}
+	}()
 	if disableMergeQueue {
 		if _, err := db.Exec("SET CLUSTER SETTING kv.range_merge.queue_enabled = false;"); err != nil {
 			t.Fatal(err)
@@ -86,7 +102,7 @@ func loadTPCHDataset(
 		return err
 	}
 	query := fmt.Sprintf(`RESTORE tpch.* FROM '%s' WITH into_db = 'tpch';`, tpchURL)
-	_, err := db.ExecContext(ctx, query)
+	_, err = db.ExecContext(ctx, query)
 	return err
 }
 

--- a/pkg/cmd/roachtest/tests/tpchvec.go
+++ b/pkg/cmd/roachtest/tests/tpchvec.go
@@ -545,14 +545,6 @@ func runTPCHVec(
 	err := WaitFor3XReplication(ctx, t, conn)
 	require.NoError(t, err)
 
-	_, err = conn.Exec("SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false;")
-	require.NoError(t, err)
-	defer func() {
-		_, err := conn.Exec("RESET CLUSTER SETTING sql.stats.automatic_collection.enabled;")
-		require.NoError(t, err)
-	}()
-	createStatsFromTables(t, conn, tpchTables)
-
 	testRun(ctx, t, c, conn, testCase)
 	testCase.postTestRunHook(ctx, t, c, conn)
 }


### PR DESCRIPTION
This commit makes it so that the helper function for restoring the TPCH dataset is also responsible for disabling the auto stats collection as well as manually collecting stats for all of the tables. We were already doing this for some of the test (tpchvec) but not for others (tpch_concurrency or tpchbench), and I believe it is beneficial to always do this in these tests. In particular, this removes one source of non-determinism (due to different plans use for the queries before the stats are automatically collected) and makes different runs more comparable.

Epic: None

Release note: None