### PR TITLE
pkg/util/cgroups: fix cgroup memory lookup when using systemd

### DIFF
--- a/pkg/util/cgroups/cgroups.go
+++ b/pkg/util/cgroups/cgroups.go
@@ -102,18 +102,26 @@ func getCgroupMemInactiveFileUsage(root string) (usage int64, warnings string, e
 		return 0, "no cgroup memory controller detected", nil
 	}
 
-	mount, ver, err := getCgroupDetails(filepath.Join(root, "/proc/self/mountinfo"), path, "memory")
+	versionedMounts, err := getCgroupDetails(filepath.Join(root, "/proc/self/mountinfo"), path, "memory")
 	if err != nil {
 		return 0, "", err
 	}
-
-	switch ver {
-	case 1:
-		usage, warnings, err = detectMemInactiveFileUsageInV1(filepath.Join(root, mount))
-	case 2:
-		usage, warnings, err = detectMemInactiveFileUsageInV2(filepath.Join(root, mount, path))
-	default:
-		usage, err = 0, fmt.Errorf("detected unknown cgroup version index: %d", ver)
+	if len(versionedMounts) == 2 {
+		// Look up against V2 first. Fall back to V1.
+		usage, warnings, err = detectMemInactiveFileUsageInV2(filepath.Join(root, versionedMounts[1].mount, path))
+		if err != nil {
+			usage, warnings, err = detectMemInactiveFileUsageInV1(filepath.Join(root, versionedMounts[0].mount))
+		}
+	} else {
+		if len(versionedMounts) != 1 {
+			return usage, warnings, errors.AssertionFailedf("expected len(versionedMounts)==1 instead of %d", len(versionedMounts))
+		}
+		switch versionedMounts[0].version {
+		case 1:
+			usage, warnings, err = detectMemInactiveFileUsageInV1(filepath.Join(root, versionedMounts[0].mount))
+		case 2:
+			usage, warnings, err = detectMemInactiveFileUsageInV2(filepath.Join(root, versionedMounts[0].mount, path))
+		}
 	}
 
 	return usage, warnings, err
@@ -143,18 +151,27 @@ func getCgroupMemUsage(root string) (usage int64, warnings string, err error) {
 		return 0, "no cgroup memory controller detected", nil
 	}
 
-	mount, ver, err := getCgroupDetails(filepath.Join(root, "/proc/self/mountinfo"), path, "memory")
+	versionedMounts, err := getCgroupDetails(filepath.Join(root, "/proc/self/mountinfo"), path, "memory")
 	if err != nil {
 		return 0, "", err
 	}
 
-	switch ver {
-	case 1:
-		usage, warnings, err = detectMemUsageInV1(filepath.Join(root, mount))
-	case 2:
-		usage, warnings, err = detectMemUsageInV2(filepath.Join(root, mount, path))
-	default:
-		usage, err = 0, fmt.Errorf("detected unknown cgroup version index: %d", ver)
+	if len(versionedMounts) == 2 {
+		// Look up against V2 first. Fall back to V1.
+		usage, warnings, err = detectMemUsageInV2(filepath.Join(root, versionedMounts[1].mount, path))
+		if err != nil {
+			usage, warnings, err = detectMemUsageInV1(filepath.Join(root, versionedMounts[0].mount))
+		}
+	} else {
+		if len(versionedMounts) != 1 {
+			return usage, warnings, errors.AssertionFailedf("expected len(versionedMounts)==1 instead of %d", len(versionedMounts))
+		}
+		switch versionedMounts[0].version {
+		case 1:
+			usage, warnings, err = detectMemUsageInV1(filepath.Join(root, versionedMounts[0].mount))
+		case 2:
+			usage, warnings, err = detectMemUsageInV2(filepath.Join(root, versionedMounts[0].mount, path))
+		}
 	}
 
 	return usage, warnings, err
@@ -184,18 +201,27 @@ func getCgroupMemLimit(root string) (limit int64, warnings string, err error) {
 		return 0, "no cgroup memory controller detected", nil
 	}
 
-	mount, ver, err := getCgroupDetails(filepath.Join(root, "/proc/self/mountinfo"), path, "memory")
+	versionedMounts, err := getCgroupDetails(filepath.Join(root, "/proc/self/mountinfo"), path, "memory")
 	if err != nil {
 		return 0, "", err
 	}
 
-	switch ver {
-	case 1:
-		limit, warnings, err = detectMemLimitInV1(filepath.Join(root, mount))
-	case 2:
-		limit, warnings, err = detectMemLimitInV2(filepath.Join(root, mount, path))
-	default:
-		limit, err = 0, fmt.Errorf("detected unknown cgroup version index: %d", ver)
+	if len(versionedMounts) == 2 {
+		// Look up against V2 first. Fall back to V1.
+		limit, warnings, err = detectMemLimitInV2(filepath.Join(root, versionedMounts[1].mount, path))
+		if err != nil {
+			limit, warnings, err = detectMemLimitInV1(filepath.Join(root, versionedMounts[0].mount))
+		}
+	} else {
+		if len(versionedMounts) != 1 {
+			return limit, warnings, errors.AssertionFailedf("expected len(versionedMounts)==1 instead of %d", len(versionedMounts))
+		}
+		switch versionedMounts[0].version {
+		case 1:
+			limit, warnings, err = detectMemLimitInV1(filepath.Join(root, versionedMounts[0].mount))
+		case 2:
+			limit, warnings, err = detectMemLimitInV2(filepath.Join(root, versionedMounts[0].mount, path))
+		}
 	}
 
 	return limit, warnings, err
@@ -452,8 +478,12 @@ func detectCntrlPath(cgroupFilePath string, controller string) (string, error) {
 
 		f0, f1 := string(fields[0]), string(fields[1])
 		// First case if v2, second - v1. We give v2 the priority here.
-		// There is also a `hybrid` mode when both  versions are enabled,
-		// but no known container solutions support it afaik
+		// There is also a `hybrid` mode when both versions are enabled, e.g. systemd may use v1 by default.
+		// However, in this case, both versions are expected to have the same control path; e.g., cat /proc/2020550/cgroup
+		// ...
+		// 13:memory:/system.slice/cockroach.service
+		// 0::/system.slice/cockroach.service
+		/// ...
 		if f0 == "0" && f1 == "" {
 			unifiedPathIfFound = string(fields[2])
 		} else if f1 == controller {
@@ -464,16 +494,35 @@ func detectCntrlPath(cgroupFilePath string, controller string) (string, error) {
 	return unifiedPathIfFound, nil
 }
 
-// Reads /proc/[pid]/mountinfo for cgoup or cgroup2 mount which defines the used version.
+// versionedMounts contains a cgroup mount and the corresponding cgroup version, either 1 or 2.
+type versionedMounts struct {
+	mount   string
+	version int
+}
+
+// Reads /proc/[pid]/mountinfo for cgroup or cgroup2 mount which defines the used version.
+// Returns found mountpoints, versions or error.
+//
+// NOTE: per https://github.com/cockroachdb/cockroach/issues/59236, _both_ versions of cgroups may be enabled.
+//
+//	Thus, if both are detected, we return version1 and version2 mountpoints so that downstream checks both.
+//	If only one version was found, we return the corresponding mountpoint.
+//	Otherwise, an error is returned.
+//
 // See http://man7.org/linux/man-pages/man5/proc.5.html for `mountinfo` format.
-func getCgroupDetails(mountinfoPath string, cRoot string, controller string) (string, int, error) {
+func getCgroupDetails(
+	mountinfoPath string, cRoot string, controller string,
+) ([]versionedMounts, error) {
 	info, err := os.Open(mountinfoPath)
 	if err != nil {
-		return "", 0, errors.Wrapf(err, "failed to read mounts info from file: %s", log.SafeManaged(mountinfoPath))
+		return []versionedMounts{}, errors.Wrapf(err, "failed to read mounts info from file: %s", log.SafeManaged(mountinfoPath))
 	}
 	defer func() {
 		_ = info.Close()
 	}()
+
+	var foundVer1, foundVer2 = false, false
+	var mountPointVer1, mountPointVer2 string
 
 	scanner := bufio.NewScanner(info)
 	for scanner.Scan() {
@@ -486,7 +535,9 @@ func getCgroupDetails(mountinfoPath string, cRoot string, controller string) (st
 		if ok {
 			mountPoint := string(fields[4])
 			if ver == 2 {
-				return mountPoint, ver, nil
+				foundVer2 = true
+				mountPointVer2 = mountPoint
+				continue
 			}
 			// It is possible that the controller mount and the cgroup path are not the same (both are relative to the NS root).
 			// So start with the mount and construct the relative path of the cgroup.
@@ -503,13 +554,24 @@ func getCgroupDetails(mountinfoPath string, cRoot string, controller string) (st
 				// the best action is to ignore the line and hope that the rest of the lines
 				// will allow us to extract a valid path.
 				if relPath, err := filepath.Rel(nsRelativePath, cRoot); err == nil {
-					return filepath.Join(mountPoint, relPath), ver, nil
+					mountPointVer1 = filepath.Join(mountPoint, relPath)
+					foundVer1 = true
 				}
 			}
 		}
 	}
 
-	return "", 0, fmt.Errorf("failed to detect cgroup root mount and version")
+	if foundVer1 && foundVer2 {
+		return []versionedMounts{{mountPointVer1, 1}, {mountPointVer2, 2}}, nil
+	}
+	if foundVer1 {
+		return []versionedMounts{{mountPointVer1, 1}}, nil
+	}
+	if foundVer2 {
+		return []versionedMounts{{mountPointVer2, 2}}, nil
+	}
+
+	return []versionedMounts{}, fmt.Errorf("failed to detect cgroup root mount and version")
 }
 
 // Return version of cgroup mount for memory controller if found
@@ -590,34 +652,53 @@ func getCgroupCPU(root string) (CPUUsage, error) {
 		return CPUUsage{}, errors.New("no cpu controller detected")
 	}
 
-	mount, ver, err := getCgroupDetails(filepath.Join(root, "/proc/self/mountinfo"), path, "cpu,cpuacct")
+	versionedMounts, err := getCgroupDetails(filepath.Join(root, "/proc/self/mountinfo"), path, "cpu,cpuacct")
 	if err != nil {
 		return CPUUsage{}, err
 	}
 
 	var res CPUUsage
 
-	switch ver {
-	case 1:
-		res.Period, res.Quota, err = detectCPUQuotaInV1(filepath.Join(root, mount))
+	if len(versionedMounts) == 2 {
+		// Look up against V2 first. Fall back to V1.
+		res.Period, res.Quota, err = detectCPUQuotaInV2(filepath.Join(root, versionedMounts[1].mount, path))
+		if err != nil {
+			res.Period, res.Quota, err = detectCPUQuotaInV1(filepath.Join(root, versionedMounts[0].mount))
+		}
 		if err != nil {
 			return res, err
 		}
-		res.Stime, res.Utime, err = detectCPUUsageInV1(filepath.Join(root, mount))
+		res.Stime, res.Utime, err = detectCPUUsageInV2(filepath.Join(root, versionedMounts[1].mount, path))
+		if err != nil {
+			res.Stime, res.Utime, err = detectCPUUsageInV1(filepath.Join(root, versionedMounts[0].mount))
+		}
 		if err != nil {
 			return res, err
 		}
-	case 2:
-		res.Period, res.Quota, err = detectCPUQuotaInV2(filepath.Join(root, mount, path))
-		if err != nil {
-			return res, err
+	} else {
+		if len(versionedMounts) != 1 {
+			return res, errors.AssertionFailedf("expected len(versionedMounts)==1 instead of %d", len(versionedMounts))
 		}
-		res.Stime, res.Utime, err = detectCPUUsageInV2(filepath.Join(root, mount, path))
-		if err != nil {
-			return res, err
+		switch versionedMounts[0].version {
+		case 1:
+			res.Period, res.Quota, err = detectCPUQuotaInV1(filepath.Join(root, versionedMounts[0].mount))
+			if err != nil {
+				return res, err
+			}
+			res.Stime, res.Utime, err = detectCPUUsageInV1(filepath.Join(root, versionedMounts[0].mount))
+			if err != nil {
+				return res, err
+			}
+		case 2:
+			res.Period, res.Quota, err = detectCPUQuotaInV2(filepath.Join(root, versionedMounts[0].mount, path))
+			if err != nil {
+				return res, err
+			}
+			res.Stime, res.Utime, err = detectCPUUsageInV2(filepath.Join(root, versionedMounts[0].mount, path))
+			if err != nil {
+				return res, err
+			}
 		}
-	default:
-		return CPUUsage{}, fmt.Errorf("detected unknown cgroup version index: %d", ver)
 	}
 
 	return res, nil

--- a/pkg/util/cgroups/cgroups_test.go
+++ b/pkg/util/cgroups/cgroups_test.go
@@ -68,6 +68,15 @@ func TestCgroupsGetMemoryUsage(t *testing.T) {
 			value: 276328448,
 		},
 		{
+			name: "fetches the usage for cgroup v1 (mixed version mounts)",
+			paths: map[string]string{
+				"/proc/self/cgroup":                           v1CgroupWithMemoryController,
+				"/proc/self/mountinfo":                        mixedMounts,
+				"/sys/fs/cgroup/memory/memory.usage_in_bytes": v1MemoryUsageInBytes,
+			},
+			value: 276328448,
+		},
+		{
 			name: "fetches the value for cgroup v1 when the NS relative paths of mount and cgroup don't match",
 			paths: map[string]string{
 				"/proc/self/cgroup":    v1CgroupWithMemoryControllerNS,
@@ -98,6 +107,15 @@ func TestCgroupsGetMemoryUsage(t *testing.T) {
 			paths: map[string]string{
 				"/proc/self/cgroup":    v2CgroupWithMemoryController,
 				"/proc/self/mountinfo": v2Mounts,
+				"/sys/fs/cgroup/machine.slice/libpod-f1c6b44c0d61f273952b8daecf154cee1be2d503b7e9184ebf7fcaf48e139810.scope/memory.current": "276328448",
+			},
+			value: 276328448,
+		},
+		{
+			name: "fetches the usage for cgroup v2 (mixed version mounts))",
+			paths: map[string]string{
+				"/proc/self/cgroup":    v2CgroupWithMemoryController,
+				"/proc/self/mountinfo": mixedMounts,
 				"/sys/fs/cgroup/machine.slice/libpod-f1c6b44c0d61f273952b8daecf154cee1be2d503b7e9184ebf7fcaf48e139810.scope/memory.current": "276328448",
 			},
 			value: 276328448,
@@ -164,6 +182,15 @@ func TestCgroupsGetMemoryInactiveFileUsage(t *testing.T) {
 			value: 1363746816,
 		},
 		{
+			name: "fetches the usage for cgroup v1 (mixed version mounts)",
+			paths: map[string]string{
+				"/proc/self/cgroup":                 v1CgroupWithMemoryController,
+				"/proc/self/mountinfo":              mixedMounts,
+				"/sys/fs/cgroup/memory/memory.stat": v1MemoryStat,
+			},
+			value: 1363746816,
+		},
+		{
 			name: "fetches the value for cgroup v1 when the NS relative paths of mount and cgroup don't match",
 			paths: map[string]string{
 				"/proc/self/cgroup":                             v1CgroupWithMemoryControllerNS,
@@ -194,6 +221,15 @@ func TestCgroupsGetMemoryInactiveFileUsage(t *testing.T) {
 			paths: map[string]string{
 				"/proc/self/cgroup":    v2CgroupWithMemoryController,
 				"/proc/self/mountinfo": v2Mounts,
+				"/sys/fs/cgroup/machine.slice/libpod-f1c6b44c0d61f273952b8daecf154cee1be2d503b7e9184ebf7fcaf48e139810.scope/memory.stat": v2MemoryStat,
+			},
+			value: 1363746816,
+		},
+		{
+			name: "fetches the usage for cgroup v2 (mixed version mounts)",
+			paths: map[string]string{
+				"/proc/self/cgroup":    v2CgroupWithMemoryController,
+				"/proc/self/mountinfo": mixedMounts,
 				"/sys/fs/cgroup/machine.slice/libpod-f1c6b44c0d61f273952b8daecf154cee1be2d503b7e9184ebf7fcaf48e139810.scope/memory.stat": v2MemoryStat,
 			},
 			value: 1363746816,
@@ -257,6 +293,15 @@ func TestCgroupsGetMemoryLimit(t *testing.T) {
 			limit: 2936016896,
 		},
 		{
+			name: "fetches the limit for cgroup v1 (mixed version mounts)",
+			paths: map[string]string{
+				"/proc/self/cgroup":                 v1CgroupWithMemoryController,
+				"/proc/self/mountinfo":              mixedMounts,
+				"/sys/fs/cgroup/memory/memory.stat": v1MemoryStat,
+			},
+			limit: 2936016896,
+		},
+		{
 			name: "fetches the limit for cgroup v1 when the NS relative paths of mount and cgroup don't match",
 			paths: map[string]string{
 				"/proc/self/cgroup":                             v1CgroupWithMemoryControllerNS,
@@ -287,6 +332,15 @@ func TestCgroupsGetMemoryLimit(t *testing.T) {
 			paths: map[string]string{
 				"/proc/self/cgroup":    v2CgroupWithMemoryController,
 				"/proc/self/mountinfo": v2Mounts,
+				"/sys/fs/cgroup/machine.slice/libpod-f1c6b44c0d61f273952b8daecf154cee1be2d503b7e9184ebf7fcaf48e139810.scope/memory.max": "1073741824\n",
+			},
+			limit: 1073741824,
+		},
+		{
+			name: "fetches the limit for cgroup v2 (mixed version mounts)",
+			paths: map[string]string{
+				"/proc/self/cgroup":    v2CgroupWithMemoryController,
+				"/proc/self/mountinfo": mixedMounts,
 				"/sys/fs/cgroup/machine.slice/libpod-f1c6b44c0d61f273952b8daecf154cee1be2d503b7e9184ebf7fcaf48e139810.scope/memory.max": "1073741824\n",
 			},
 			limit: 1073741824,
@@ -355,6 +409,21 @@ func TestCgroupsGetCPU(t *testing.T) {
 			paths: map[string]string{
 				"/proc/self/cgroup":                             v1CgroupWithCPUController,
 				"/proc/self/mountinfo":                          v1MountsWithCPUController,
+				"/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us":   "12345",
+				"/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us":  "67890",
+				"/sys/fs/cgroup/cpu,cpuacct/cpuacct.usage_sys":  "123",
+				"/sys/fs/cgroup/cpu,cpuacct/cpuacct.usage_user": "456",
+			},
+			quota:  int64(12345),
+			period: int64(67890),
+			system: uint64(123),
+			user:   uint64(456),
+		},
+		{
+			name: "fetches the cpu quota and usage for cgroup v1 (mixed version mounts)",
+			paths: map[string]string{
+				"/proc/self/cgroup":                             v1CgroupWithCPUController,
+				"/proc/self/mountinfo":                          mixedMounts,
 				"/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us":   "12345",
 				"/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us":  "67890",
 				"/sys/fs/cgroup/cpu,cpuacct/cpuacct.usage_sys":  "123",
@@ -452,6 +521,19 @@ func TestCgroupsGetCPU(t *testing.T) {
 			paths: map[string]string{
 				"/proc/self/cgroup":    v2CgroupWithMemoryController,
 				"/proc/self/mountinfo": v2Mounts,
+				"/sys/fs/cgroup/machine.slice/libpod-f1c6b44c0d61f273952b8daecf154cee1be2d503b7e9184ebf7fcaf48e139810.scope/cpu.max":  "100 1000\n",
+				"/sys/fs/cgroup/machine.slice/libpod-f1c6b44c0d61f273952b8daecf154cee1be2d503b7e9184ebf7fcaf48e139810.scope/cpu.stat": "user_usec 100\nsystem_usec 200",
+			},
+			quota:  int64(100),
+			period: int64(1000),
+			user:   uint64(100),
+			system: uint64(200),
+		},
+		{
+			name: "fetches the cpu quota and usage for cgroup v2 (mixed version mounts)",
+			paths: map[string]string{
+				"/proc/self/cgroup":    v2CgroupWithMemoryController,
+				"/proc/self/mountinfo": mixedMounts,
 				"/sys/fs/cgroup/machine.slice/libpod-f1c6b44c0d61f273952b8daecf154cee1be2d503b7e9184ebf7fcaf48e139810.scope/cpu.max":  "100 1000\n",
 				"/sys/fs/cgroup/machine.slice/libpod-f1c6b44c0d61f273952b8daecf154cee1be2d503b7e9184ebf7fcaf48e139810.scope/cpu.stat": "user_usec 100\nsystem_usec 200",
 			},
@@ -739,6 +821,39 @@ const (
 389 372 0:42 / /proc/scsi ro,relatime - tmpfs tmpfs rw,context="system_u:object_r:container_file_t:s0:c200,c321",size=0k
 390 374 0:43 / /sys/firmware ro,relatime - tmpfs tmpfs rw,context="system_u:object_r:container_file_t:s0:c200,c321",size=0k
 391 374 0:44 / /sys/fs/selinux ro,relatime - tmpfs tmpfs rw,context="system_u:object_r:container_file_t:s0:c200,c321",size=0k
+392 372 0:37 /bus /proc/bus ro,relatime - proc proc rw
+393 372 0:37 /fs /proc/fs ro,relatime - proc proc rw
+394 372 0:37 /irq /proc/irq ro,relatime - proc proc rw
+395 372 0:37 /sys /proc/sys ro,relatime - proc proc rw
+396 372 0:37 /sysrq-trigger /proc/sysrq-trigger ro,relatime - proc proc rw
+345 373 0:40 /0 /dev/console rw,nosuid,noexec,relatime - devpts devpts rw,context="system_u:object_r:container_file_t:s0:c200,c321",gid=5,mode=620,ptmxmode=666
+`
+	// mixes v1 and v2 mounts
+	mixedMounts = `371 344 0:35 / / rw,relatime - overlay overlay rw,context="system_u:object_r:container_file_t:s0:c200,c321",lowerdir=/var/lib/containers/storage/overlay/l/SPNDOAU3AZNJMNKU3F5THCA36R,upperdir=/var/lib/containers/storage/overlay/7dcd88f815bded7b833fb5dc0f25de897250bcfa828624c0d78393689d0bc312/diff,workdir=/var/lib/containers/storage/overlay/7dcd88f815bded7b833fb5dc0f25de897250bcfa828624c0d78393689d0bc312/work
+372 371 0:37 / /proc rw,nosuid,nodev,noexec,relatime - proc proc rw
+373 371 0:38 / /dev rw,nosuid - tmpfs tmpfs rw,context="system_u:object_r:container_file_t:s0:c200,c321",size=65536k,mode=755
+374 371 0:39 / /sys ro,nosuid,nodev,noexec,relatime - sysfs sysfs rw,seclabel
+375 373 0:40 / /dev/pts rw,nosuid,noexec,relatime - devpts devpts rw,context="system_u:object_r:container_file_t:s0:c200,c321",gid=5,mode=620,ptmxmode=666
+376 373 0:36 / /dev/mqueue rw,nosuid,nodev,noexec,relatime - mqueue mqueue rw,seclabel
+377 371 0:24 /containers/storage/overlay-containers/f1c6b44c0d61f273952b8daecf154cee1be2d503b7e9184ebf7fcaf48e139810/userdata/hostname /etc/hostname rw,nosuid,nodev - tmpfs tmpfs rw,seclabel,mode=755
+378 371 0:24 /containers/storage/overlay-containers/f1c6b44c0d61f273952b8daecf154cee1be2d503b7e9184ebf7fcaf48e139810/userdata/.containerenv /run/.containerenv rw,nosuid,nodev - tmpfs tmpfs rw,seclabel,mode=755
+379 371 0:24 /containers/storage/overlay-containers/f1c6b44c0d61f273952b8daecf154cee1be2d503b7e9184ebf7fcaf48e139810/userdata/run/secrets /run/secrets rw,nosuid,nodev - tmpfs tmpfs rw,seclabel,mode=755
+380 371 0:24 /containers/storage/overlay-containers/f1c6b44c0d61f273952b8daecf154cee1be2d503b7e9184ebf7fcaf48e139810/userdata/resolv.conf /etc/resolv.conf rw,nosuid,nodev - tmpfs tmpfs rw,seclabel,mode=755
+381 371 0:24 /containers/storage/overlay-containers/f1c6b44c0d61f273952b8daecf154cee1be2d503b7e9184ebf7fcaf48e139810/userdata/hosts /etc/hosts rw,nosuid,nodev - tmpfs tmpfs rw,seclabel,mode=755
+382 373 0:33 / /dev/shm rw,nosuid,nodev,noexec,relatime - tmpfs shm rw,context="system_u:object_r:container_file_t:s0:c200,c321",size=64000k
+383 374 0:25 / /sys/fs/cgroup ro,nosuid,nodev,noexec,relatime - cgroup2 cgroup2 rw,seclabel
+384 372 0:41 / /proc/acpi ro,relatime - tmpfs tmpfs rw,context="system_u:object_r:container_file_t:s0:c200,c321",size=0k
+385 372 0:6 /null /proc/kcore rw,nosuid - devtmpfs devtmpfs rw,seclabel,size=1869464k,nr_inodes=467366,mode=755
+386 372 0:6 /null /proc/keys rw,nosuid - devtmpfs devtmpfs rw,seclabel,size=1869464k,nr_inodes=467366,mode=755
+387 372 0:6 /null /proc/timer_list rw,nosuid - devtmpfs devtmpfs rw,seclabel,size=1869464k,nr_inodes=467366,mode=755
+388 372 0:6 /null /proc/sched_debug rw,nosuid - devtmpfs devtmpfs rw,seclabel,size=1869464k,nr_inodes=467366,mode=755
+389 372 0:42 / /proc/scsi ro,relatime - tmpfs tmpfs rw,context="system_u:object_r:container_file_t:s0:c200,c321",size=0k
+390 374 0:43 / /sys/firmware ro,relatime - tmpfs tmpfs rw,context="system_u:object_r:container_file_t:s0:c200,c321",size=0k
+391 374 0:44 / /sys/fs/selinux ro,relatime - tmpfs tmpfs rw,context="system_u:object_r:container_file_t:s0:c200,c321",size=0k
+41 33 0:36 /kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3 /sys/fs/cgroup/pids rw,nosuid,nodev,noexec,relatime shared:18 - cgroup cgroup rw,pids
+46 33 0:41 /kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3 /sys/fs/cgroup/cpuset rw,nosuid,nodev,noexec,relatime shared:23 - cgroup cgroup rw,cpuset
+49 33 0:44 /kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3 /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime shared:26 - cgroup cgroup rw,cpu,cpuacct
+50 33 0:45 /kubepods/besteffort/pod1bf924dd-3f6f-11ea-983d-0abc95f90166/c17eb535a47774285717e40bbda777ee72e81471272a5b8ebffd51fdf7f624e3 /sys/fs/cgroup/memory rw,nosuid,nodev,noexec,relatime shared:27 - cgroup cgroup rw,memory
 392 372 0:37 /bus /proc/bus ro,relatime - proc proc rw
 393 372 0:37 /fs /proc/fs ro,relatime - proc proc rw
 394 372 0:37 /irq /proc/irq ro,relatime - proc proc rw


### PR DESCRIPTION
As described in the linked issue, most linux distros enable both v1 and v2 cgroups. This means that /proc/[pid]/mountinfo may contain mounts from both versions.

Previously, the detected version was based on the first match found by parsing /proc/[pid]/mountinfo. Thus, if v2 is found first and systemd is using v1, the memory limit will be looked up against v2, thereby missing the limit specified via systemd.

This change returns both versions and their corresponding mounts. The lookups proceed against v2 and fallback to v1, and only report an error then.
We also add a special case for unlimited cgroup memory in order to formulate a more accurate message lest we mislead the user in thinking they have 8 exabytes of RAM.

Fixes: https://github.com/cockroachdb/cockroach/issues/59236

Release note (bug fix): Fixes a bug pre-v21.1 wherein cgroup memory limit was undetected when using systemd.