### PR TITLE
insights: fix a nil pointer when observing txn with no stmts

### DIFF
--- a/pkg/sql/sqlstats/insights/registry.go
+++ b/pkg/sql/sqlstats/insights/registry.go
@@ -66,7 +66,10 @@ func (r *lockingRegistry) ObserveTransaction(sessionID clusterunique.ID, transac
 	if !r.enabled() {
 		return
 	}
-	statements := r.statements[sessionID]
+	statements, ok := r.statements[sessionID]
+	if !ok {
+		return
+	}
 	delete(r.statements, sessionID)
 	defer statements.release()
 

--- a/pkg/sql/sqlstats/insights/registry_test.go
+++ b/pkg/sql/sqlstats/insights/registry_test.go
@@ -218,4 +218,10 @@ func TestRegistry(t *testing.T) {
 
 		require.Equal(t, expected, actual)
 	})
+
+	t.Run("txn with no stmts", func(t *testing.T) {
+		st := cluster.MakeTestingClusterSettings()
+		registry := newRegistry(st, &latencyThresholdDetector{st: st}, newStore(st))
+		require.NotPanics(t, func() { registry.ObserveTransaction(session.ID, transaction) })
+	})
 }


### PR DESCRIPTION
The bug was introduced in 6ed0eb148f6ef2162eccffa66439a78e1e69ae96.

Fixes: #91795.

Release note: None