### PR TITLE
streamingccl: centralize cutover time polling

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamingest/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     name = "streamingest",
     srcs = [
         "alter_replication_job.go",
+        "cutover_time_processor.go",
         "metrics.go",
         "stream_ingest_manager.go",
         "stream_ingestion_frontier_processor.go",

--- a/pkg/ccl/streamingccl/streamingest/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamingest/BUILD.bazel
@@ -92,8 +92,6 @@ go_test(
         "//pkg/base",
         "//pkg/ccl",
         "//pkg/ccl/backupccl",
-        "//pkg/ccl/changefeedccl",
-        "//pkg/ccl/changefeedccl/changefeedbase",
         "//pkg/ccl/kvccl/kvtenantccl",
         "//pkg/ccl/storageccl",
         "//pkg/ccl/streamingccl",

--- a/pkg/ccl/streamingccl/streamingest/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamingest/BUILD.bazel
@@ -135,6 +135,7 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/protoutil",
         "//pkg/util/randutil",
+        "//pkg/util/retry",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/ccl/streamingccl/streamingest/cutover_time_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/cutover_time_processor.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
@@ -34,9 +35,10 @@ import (
 type cutoverProcessor struct {
 	execinfra.ProcessorBase
 
-	settings *cluster.Settings
-	registry *jobs.Registry
-	jobID    jobspb.JobID
+	settings     *cluster.Settings
+	registry     *jobs.Registry
+	jobID        jobspb.JobID
+	testingKnobs *sql.StreamingTestingKnobs
 
 	doneCh        chan struct{}
 	cutoverTimeCh chan hlc.Timestamp
@@ -190,6 +192,12 @@ func (cm *cutoverProcessor) getPollError() error {
 }
 
 func (cm *cutoverProcessor) loadCutoverTime(ctx context.Context) (hlc.Timestamp, error) {
+	if cm.testingKnobs != nil && cm.testingKnobs.BeforePollCutoverTime != nil {
+		if err := cm.testingKnobs.BeforePollCutoverTime(); err != nil {
+			return hlc.Timestamp{}, err
+		}
+	}
+
 	j, err := cm.registry.LoadJob(ctx, cm.jobID)
 	if err != nil {
 		return hlc.Timestamp{}, err

--- a/pkg/ccl/streamingccl/streamingest/cutover_time_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/cutover_time_processor.go
@@ -1,0 +1,242 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package streamingest
+
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/errors"
+)
+
+// cutoverProcessor is a local processor that polls a stream ingestion
+// job and sends the current cutover time to all downstream
+// processors.
+type cutoverProcessor struct {
+	execinfra.ProcessorBase
+
+	settings *cluster.Settings
+	registry *jobs.Registry
+	jobID    jobspb.JobID
+
+	doneCh        chan struct{}
+	cutoverTimeCh chan hlc.Timestamp
+	wg            ctxgroup.Group
+
+	mu struct {
+		syncutil.Mutex
+
+		pollError error
+	}
+}
+
+// InputWithOutput implements LocalProcessor.
+func (cm *cutoverProcessor) InitWithOutput(
+	ctx context.Context,
+	flowCtx *execinfra.FlowCtx,
+	post *execinfrapb.PostProcessSpec,
+	output execinfra.RowReceiver,
+) error {
+	return cm.Init(
+		ctx,
+		cm,
+		post,
+		streamIngestionCutoverProcessorTypes,
+		flowCtx,
+		0, /* processorID */
+		output,
+		nil, /* memMonitor */
+		execinfra.ProcStateOpts{
+			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {
+				cm.close()
+				return nil
+			},
+		},
+	)
+
+}
+
+// SetInput implmenents LocalProcessor.
+func (cm *cutoverProcessor) SetInput(ctx context.Context, input execinfra.RowSource) error {
+	return nil
+}
+
+var _ execinfra.LocalProcessor = (*cutoverProcessor)(nil)
+
+// MustBeStreaming implements the execinfra.Processor interface.
+func (cm *cutoverProcessor) MustBeStreaming() bool { return true }
+
+// Start is part of the RowSource interface.
+func (cm *cutoverProcessor) Start(ctx context.Context) {
+	ctx = cm.StartInternal(ctx, "stream-ingestion-cutover-processor")
+
+	cm.wg = ctxgroup.WithContext(ctx)
+	cm.doneCh = make(chan struct{})
+	cm.cutoverTimeCh = make(chan hlc.Timestamp)
+
+	cm.wg.GoCtx(func(ctx context.Context) error {
+		tick := time.NewTicker(cutoverSignalPollInterval.Get(&cm.settings.SV))
+		defer tick.Stop()
+		defer close(cm.cutoverTimeCh)
+
+		var (
+			failureCount        = 0
+			maxRepeatedFailures = 10
+		)
+		for {
+			select {
+			case <-cm.doneCh:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-tick.C:
+				ts, err := cm.loadCutoverTime(ctx)
+				if err != nil {
+					if failureCount >= maxRepeatedFailures {
+						cm.setPollError(err)
+						return err
+					}
+					failureCount++
+					log.Warningf(ctx, "cutover-time-poller: failed to load cutover time from job: %s (attempt %d/%d)",
+						err.Error(), failureCount, maxRepeatedFailures)
+					continue
+				}
+				failureCount = 0
+				// NOTE: We purposefully always send
+				// the cutover time here, even if it
+				// is empty or the same as a previous
+				// timestamp. Without sending it
+				// peridically, we may never learn
+				// that our consumers are closing.
+				cm.cutoverTimeCh <- ts
+			}
+		}
+	})
+}
+
+// Next is part of the RowSource interface.
+func (cm *cutoverProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata) {
+	if cm.State != execinfra.StateRunning {
+		return nil, cm.DrainHelper()
+	}
+
+	select {
+	case cutoverTime, ok := <-cm.cutoverTimeCh:
+		if ok {
+			row, err := encodeCutoverTimeRow(cutoverTime)
+			if err != nil {
+				cm.MoveToDraining(err)
+				return nil, cm.DrainHelper()
+			}
+			return row, nil
+		}
+	case <-cm.Ctx().Done():
+	case <-cm.doneCh:
+		cm.MoveToDraining(nil)
+		return nil, cm.DrainHelper()
+	}
+
+	cm.MoveToDraining(cm.getPollError())
+	return nil, cm.DrainHelper()
+}
+
+// ConsumerClosed is part of the RowSource interface.
+func (cm *cutoverProcessor) ConsumerClosed() {
+	cm.close()
+}
+
+func (cm *cutoverProcessor) close() {
+	if cm.Closed {
+		return
+	}
+	if cm.doneCh != nil {
+		close(cm.doneCh)
+	}
+	_ = cm.wg.Wait()
+	cm.InternalClose()
+}
+
+func (cm *cutoverProcessor) setPollError(err error) {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	cm.mu.pollError = err
+}
+
+func (cm *cutoverProcessor) getPollError() error {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	return cm.mu.pollError
+}
+
+func (cm *cutoverProcessor) loadCutoverTime(ctx context.Context) (hlc.Timestamp, error) {
+	j, err := cm.registry.LoadJob(ctx, cm.jobID)
+	if err != nil {
+		return hlc.Timestamp{}, err
+	}
+	progress := j.Progress()
+	var sp *jobspb.Progress_StreamIngest
+	var ok bool
+	if sp, ok = progress.GetDetails().(*jobspb.Progress_StreamIngest); !ok {
+		return hlc.Timestamp{}, errors.Newf("unknown progress type %T in stream ingestion job %d",
+			j.Progress().Progress, cm.jobID)
+	}
+	return sp.StreamIngest.CutoverTime, nil
+}
+
+var streamIngestionCutoverProcessorTypes = []*types.T{
+	types.Bytes, // hlc.Timestamp
+}
+
+func encodeCutoverTimeRow(ts hlc.Timestamp) (rowenc.EncDatumRow, error) {
+	cutoverTimeBytes, err := protoutil.Marshal(&ts)
+	if err != nil {
+		return nil, err
+	}
+
+	return rowenc.EncDatumRow{
+		rowenc.DatumToEncDatum(types.Bytes, tree.NewDBytes(tree.DBytes(cutoverTimeBytes))),
+	}, nil
+}
+
+func decodeCutoverTimeRow(row rowenc.EncDatumRow, alloc *tree.DatumAlloc) (hlc.Timestamp, error) {
+	if len(row) != 1 {
+		return hlc.Timestamp{}, errors.AssertionFailedf("unexpected number of datums: %d", len(row))
+	}
+
+	if err := row[0].EnsureDecoded(types.Bytes, alloc); err != nil {
+		return hlc.Timestamp{}, err
+	}
+
+	datum := row[0].Datum
+	cutoverDatumBytes, ok := datum.(*tree.DBytes)
+	if !ok {
+		return hlc.Timestamp{}, errors.AssertionFailedf("unexpected datum type %T: %+v", datum, row)
+	}
+
+	var cutoverTime hlc.Timestamp
+	if err := protoutil.Unmarshal([]byte(*cutoverDatumBytes), &cutoverTime); err != nil {
+		return hlc.Timestamp{}, err
+	}
+	return cutoverTime, nil
+}

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor_test.go
@@ -87,6 +87,7 @@ func TestStreamIngestionFrontierProcessor(t *testing.T) {
 		DiskMonitor: testDiskMonitor,
 	}
 
+	in := &distsqlutils.RowBuffer{}
 	out := &distsqlutils.RowBuffer{}
 	post := execinfrapb.PostProcessSpec{}
 
@@ -251,7 +252,7 @@ func TestStreamIngestionFrontierProcessor(t *testing.T) {
 				spec.InitialScanTimestamp = hlc.Timestamp{WallTime: timeutil.Now().UnixNano()}
 			}
 			spec.Checkpoint.ResolvedSpans = tc.jobCheckpoint
-			proc, err := newStreamIngestionDataProcessor(ctx, &flowCtx, 0 /* processorID */, spec, &post, out)
+			proc, err := newStreamIngestionDataProcessor(ctx, &flowCtx, 0 /* processorID */, spec, &post, in, out)
 			require.NoError(t, err)
 			sip, ok := proc.(*streamIngestionProcessor)
 			if !ok {

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
@@ -289,7 +289,7 @@ func ingest(ctx context.Context, execCtx sql.JobExecContext, ingestionJob *jobs.
 		log.Infof(ctx, "starting to run DistSQL flow for stream ingestion job %d",
 			ingestionJob.ID())
 		updateRunningStatus(ctx, ingestionJob, "running the SQL flow for the stream ingestion job")
-		if err = distStreamIngest(ctx, execCtx, sqlInstanceIDs, planCtx, dsp,
+		if err = distStreamIngest(ctx, execCtx, sqlInstanceIDs, ingestionJob.ID(), planCtx, dsp,
 			streamIngestionSpecs, streamIngestionFrontierSpec); err != nil {
 			return err
 		}

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
@@ -333,19 +333,28 @@ func ingest(ctx context.Context, execCtx sql.JobExecContext, ingestionJob *jobs.
 	return errors.CombineErrors(ingestWithClient(), client.Close(ctx))
 }
 
+var defaultIngestionRetryOptions = retry.Options{
+	InitialBackoff: 3 * time.Second,
+	Multiplier:     2,
+	MaxBackoff:     1 * time.Minute,
+	MaxRetries:     60,
+}
+var ingestionRetryOptions = defaultIngestionRetryOptions
+
+func TestingSetRetryOptions(ro retry.Options) func() {
+	ingestionRetryOptions = ro
+	return func() {
+		ingestionRetryOptions = defaultIngestionRetryOptions
+	}
+}
+
 func ingestWithRetries(
 	ctx context.Context, execCtx sql.JobExecContext, ingestionJob *jobs.Job,
 ) error {
-	ro := retry.Options{
-		InitialBackoff: 3 * time.Second,
-		Multiplier:     2,
-		MaxBackoff:     1 * time.Minute,
-		MaxRetries:     60,
-	}
 
 	var err error
 	retryCount := 0
-	for r := retry.Start(ro); r.Next(); {
+	for r := retry.Start(ingestionRetryOptions); r.Next(); {
 		err = ingest(ctx, execCtx, ingestionJob)
 		if err == nil {
 			break

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
@@ -11,13 +11,10 @@ package streamingest
 import (
 	"context"
 	"net/url"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	_ "github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl"
-	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/streamingtest"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/streamproducer"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
@@ -79,48 +76,24 @@ func TestTenantStreaming(t *testing.T) {
 	// sourceSQL refers to the tenant generating the data.
 	sourceSQL := sqlutils.MakeSQLRunner(tenantConn)
 
-	// Make changefeeds run faster.
-	resetFreq := changefeedbase.TestingSetDefaultMinCheckpointFrequency(50 * time.Millisecond)
-	defer resetFreq()
 	// Set required cluster settings.
 	sourceDBRunner := sqlutils.MakeSQLRunner(sourceDB)
-	sourceDBRunner.ExecMultiple(t, strings.Split(`
-SET CLUSTER SETTING kv.rangefeed.enabled = true;
-SET CLUSTER SETTING kv.closed_timestamp.target_duration = '1s';
-SET CLUSTER SETTING changefeed.experimental_poll_interval = '10ms';
-SET CLUSTER SETTING stream_replication.min_checkpoint_frequency = '1s';
-SET CLUSTER SETTING stream_replication.stream_liveness_track_frequency = '500ms';
-`,
-		";")...)
+	sourceDBRunner.ExecMultiple(t, configureClusterSettings(defaultSrcClusterSetting)...)
 
 	// Start the destination server.
-	hDest, cleanupDest := streamingtest.NewReplicationHelper(t,
-		// Test fails when run from within the test tenant. More investigation
-		// is required. Tracked with #76378.
-		// TODO(ajstorm): This may be the right course of action here as the
-		//  replication is now being run inside a tenant.
-		base.TestServerArgs{DisableDefaultTestTenant: true})
+	hDest, cleanupDest := streamingtest.NewReplicationHelper(t, args)
 	defer cleanupDest()
 	// destSQL refers to the system tenant as that's the one that's running the
 	// job.
 	destSQL := hDest.SysSQL
-	destSQL.ExecMultiple(t, strings.Split(`
-SET CLUSTER SETTING stream_replication.consumer_heartbeat_frequency = '100ms';
-SET CLUSTER SETTING bulkio.stream_ingestion.minimum_flush_interval = '500ms';
-SET CLUSTER SETTING bulkio.stream_ingestion.cutover_signal_poll_interval = '100ms';
-SET CLUSTER SETTING stream_replication.job_checkpoint_frequency = '100ms';
-SET enable_experimental_stream_replication = true;
-`,
-		";")...)
+	destSQL.ExecMultiple(t, configureClusterSettings(defaultDestClusterSetting)...)
+	destSQL.Exec(t, `SET enable_experimental_stream_replication = true`)
 
 	// Sink to read data from.
 	pgURL, cleanupSink := sqlutils.PGUrl(t, source.ServingSQLAddr(), t.Name(), url.User(username.RootUser))
 	defer cleanupSink()
 
 	var ingestionJobID, streamProducerJobID int64
-	var startTime string
-	sourceSQL.QueryRow(t, "SELECT cluster_logical_timestamp()").Scan(&startTime)
-
 	destSQL.QueryRow(t,
 		`CREATE TENANT "destination-tenant" FROM REPLICATION OF "source-tenant" ON $1 `,
 		pgURL.String(),

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_planning.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_planning.go
@@ -120,9 +120,10 @@ func distStreamIngest(
 	// The first stage contains a single processor running on the gateway.
 	// This is responsible for sending the cutover signal to the stream ingestion processors.
 	cutoverProcessor := &cutoverProcessor{
-		settings: planCtx.ExtendedEvalCtx.Settings,
-		registry: planCtx.ExtendedEvalCtx.ExecCfg.JobRegistry,
-		jobID:    jobID,
+		settings:     planCtx.ExtendedEvalCtx.Settings,
+		registry:     planCtx.ExtendedEvalCtx.ExecCfg.JobRegistry,
+		jobID:        jobID,
+		testingKnobs: execCfg.StreamingTestingKnobs,
 	}
 	cutoverProcessorIdx := p.AddLocalProcessor(cutoverProcessor)
 	stageID := p.NewStage(false /* containsRemoteProcessor */, false /* allowPartialDistribution */)
@@ -137,7 +138,7 @@ func distStreamIngest(
 			Core: execinfrapb.ProcessorCoreUnion{LocalPlanNode: &execinfrapb.LocalPlanNodeSpec{
 				RowSourceIdx: uint32(cutoverProcessorIdx),
 				NumInputs:    0,
-				Name:         "stream-ingestion-cutover-monitor",
+				Name:         "stream-ingestion-cutover-processor",
 			}},
 			Post: execinfrapb.PostProcessSpec{},
 			Output: []execinfrapb.OutputRouterSpec{{

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_planning.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_planning.go
@@ -95,6 +95,7 @@ func distStreamIngest(
 	ctx context.Context,
 	execCtx sql.JobExecContext,
 	sqlInstanceIDs []base.SQLInstanceID,
+	jobID jobspb.JobID,
 	planCtx *sql.PlanningCtx,
 	dsp *sql.DistSQLPlanner,
 	streamIngestionSpecs []*execinfrapb.StreamIngestionDataSpec,
@@ -108,25 +109,68 @@ func distStreamIngest(
 		return nil
 	}
 
-	// Setup a one-stage plan with one proc per input spec.
-	corePlacement := make([]physicalplan.ProcessorCorePlacement, len(streamIngestionSpecs))
-	for i := range streamIngestionSpecs {
-		corePlacement[i].SQLInstanceID = sqlInstanceIDs[i]
-		corePlacement[i].Core.StreamIngestionData = streamIngestionSpecs[i]
-	}
-
-	p := planCtx.NewPhysicalPlan()
-	p.AddNoInputStage(
-		corePlacement,
-		execinfrapb.PostProcessSpec{},
-		streamIngestionResultTypes,
-		execinfrapb.Ordering{},
-	)
-
 	execCfg := execCtx.ExecCfg()
 	gatewayNodeID, err := execCfg.NodeInfo.NodeID.OptionalNodeIDErr(48274)
 	if err != nil {
 		return err
+	}
+
+	p := planCtx.NewPhysicalPlan()
+
+	// The first stage contains a single processor running on the gateway.
+	// This is responsible for sending the cutover signal to the stream ingestion processors.
+	cutoverProcessor := &cutoverProcessor{
+		settings: planCtx.ExtendedEvalCtx.Settings,
+		registry: planCtx.ExtendedEvalCtx.ExecCfg.JobRegistry,
+		jobID:    jobID,
+	}
+	cutoverProcessorIdx := p.AddLocalProcessor(cutoverProcessor)
+	stageID := p.NewStage(false /* containsRemoteProcessor */, false /* allowPartialDistribution */)
+
+	outputRouterType := execinfrapb.OutputRouterSpec_MIRROR
+	if len(streamIngestionSpecs) == 1 {
+		outputRouterType = execinfrapb.OutputRouterSpec_PASS_THROUGH
+	}
+	p.AddProcessor(physicalplan.Processor{
+		SQLInstanceID: base.SQLInstanceID(gatewayNodeID),
+		Spec: execinfrapb.ProcessorSpec{
+			Core: execinfrapb.ProcessorCoreUnion{LocalPlanNode: &execinfrapb.LocalPlanNodeSpec{
+				RowSourceIdx: uint32(cutoverProcessorIdx),
+				NumInputs:    0,
+				Name:         "stream-ingestion-cutover-monitor",
+			}},
+			Post: execinfrapb.PostProcessSpec{},
+			Output: []execinfrapb.OutputRouterSpec{{
+				Type: outputRouterType,
+			}},
+			StageID:     stageID,
+			ResultTypes: streamIngestionCutoverProcessorTypes,
+		},
+	})
+
+	ingestionStageID := p.NewStageOnNodes(sqlInstanceIDs)
+	for i := range streamIngestionSpecs {
+		proc := physicalplan.Processor{
+			SQLInstanceID: sqlInstanceIDs[i],
+			Spec: execinfrapb.ProcessorSpec{
+				Input: []execinfrapb.InputSyncSpec{
+					{ColumnTypes: streamIngestionCutoverProcessorTypes},
+				},
+				Core:        execinfrapb.ProcessorCoreUnion{StreamIngestionData: streamIngestionSpecs[i]},
+				Post:        execinfrapb.PostProcessSpec{},
+				Output:      []execinfrapb.OutputRouterSpec{{Type: execinfrapb.OutputRouterSpec_PASS_THROUGH}},
+				StageID:     ingestionStageID,
+				ResultTypes: streamIngestionResultTypes,
+			},
+		}
+		pIdx := p.AddProcessor(proc)
+		p.ResultRouters = append(p.ResultRouters, pIdx)
+		p.Streams = append(p.Streams, physicalplan.Stream{
+			SourceProcessor:  physicalplan.ProcessorIdx(cutoverProcessorIdx),
+			SourceRouterSlot: i,
+			DestProcessor:    pIdx,
+			DestInput:        0,
+		})
 	}
 
 	// The ResultRouters from the previous stage will feed in to the
@@ -139,7 +183,6 @@ func distStreamIngest(
 	dsp.FinalizePlan(planCtx, p)
 
 	rw := sql.NewRowResultWriter(nil /* rowContainer */)
-
 	recv := sql.MakeDistSQLReceiver(
 		ctx,
 		rw,

--- a/pkg/ccl/streamingccl/streamingest/stream_replication_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_replication_e2e_test.go
@@ -134,8 +134,14 @@ func (c *tenantStreamingClusters) compareResult(query string) {
 func (c *tenantStreamingClusters) waitUntilHighWatermark(
 	highWatermark hlc.Timestamp, ingestionJobID jobspb.JobID,
 ) {
-	testutils.SucceedsSoon(c.t, func() error {
-		progress := jobutils.GetJobProgress(c.t, c.destSysSQL, ingestionJobID)
+	waitUntilHighWatermark(c.t, c.destSysSQL, highWatermark, ingestionJobID)
+}
+
+func waitUntilHighWatermark(
+	t *testing.T, sql *sqlutils.SQLRunner, highWatermark hlc.Timestamp, ingestionJobID jobspb.JobID,
+) {
+	testutils.SucceedsSoon(t, func() error {
+		progress := jobutils.GetJobProgress(t, sql, ingestionJobID)
 		if progress.GetHighWater() == nil {
 			return errors.Newf("stream ingestion has not recorded any progress yet, waiting to advance pos %s",
 				highWatermark.String())

--- a/pkg/ccl/streamingccl/streamingest/stream_replication_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_replication_e2e_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -593,6 +594,67 @@ func TestTenantStreamingPauseOnPermanentJobError(t *testing.T) {
 
 	// Ingestion happened one more time after resuming the ingestion job.
 	require.Equal(t, 3, ingestionStarts)
+}
+
+func TestTenantStreamingJobPollErrorsRetries(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	args := defaultTenantStreamingClustersArgs
+	failureCount := 0
+	args.testingKnobs = &sql.StreamingTestingKnobs{
+		BeforePollCutoverTime: func() error {
+			if failureCount < 5 {
+				failureCount++
+				return errors.New("test failure")
+			}
+			failureCount = 0
+			return nil
+		},
+	}
+	c, cleanup := createTenantStreamingClusters(ctx, t, args)
+	defer cleanup()
+
+	producerJobID, ingestionJobID := c.startStreamReplication()
+	jobutils.WaitForJobToRun(c.t, c.srcSysSQL, jobspb.JobID(producerJobID))
+	c.waitUntilHighWatermark(c.srcSysServer.Clock().Now(), jobspb.JobID(ingestionJobID))
+
+	c.srcTenantSQL.Exec(t, "INSERT INTO d.t2 VALUES (3);")
+
+	c.cutover(producerJobID, ingestionJobID, c.srcSysServer.Clock().Now().GoTime())
+	jobutils.WaitForJobToSucceed(c.t, c.srcSysSQL, jobspb.JobID(producerJobID))
+
+	cleanupTenant := c.createDestTenantSQL(ctx)
+	defer func() {
+		require.NoError(t, cleanupTenant())
+	}()
+
+	c.compareResult("SELECT * FROM d.t1")
+	c.compareResult("SELECT * FROM d.t2")
+}
+
+func TestTenantStreamingJobPollErrorPausesEventually(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	args := defaultTenantStreamingClustersArgs
+	args.testingKnobs = &sql.StreamingTestingKnobs{
+		BeforePollCutoverTime: func() error {
+			return errors.New("test failure")
+		},
+	}
+	resetRetries := TestingSetRetryOptions(retry.Options{
+		InitialBackoff: time.Millisecond,
+		MaxRetries:     1,
+	})
+	defer resetRetries()
+	c, cleanup := createTenantStreamingClusters(ctx, t, args)
+	defer cleanup()
+
+	_, ingestionJobID := c.startStreamReplication()
+	jobutils.WaitForJobToPause(c.t, c.destSysSQL, jobspb.JobID(ingestionJobID))
 }
 
 func TestTenantStreamingCheckpoint(t *testing.T) {

--- a/pkg/ccl/streamingccl/streamingtest/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamingtest/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
-        "//pkg/ccl/changefeedccl/changefeedbase",
         "//pkg/ccl/streamingccl",
         "//pkg/jobs/jobspb",
         "//pkg/keys",

--- a/pkg/ccl/streamingccl/streamingtest/replication_helpers.go
+++ b/pkg/ccl/streamingccl/streamingtest/replication_helpers.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -205,7 +204,7 @@ type ReplicationHelper struct {
 	PGUrl url.URL
 }
 
-// NewReplicationHelper starts test server with the required cluster settings for streming
+// NewReplicationHelper starts test server with the required cluster settings for streaming.
 func NewReplicationHelper(
 	t *testing.T, serverArgs base.TestServerArgs,
 ) (*ReplicationHelper, func()) {
@@ -214,15 +213,11 @@ func NewReplicationHelper(
 	// Start server
 	s, db, _ := serverutils.StartServer(t, serverArgs)
 
-	// Make changefeeds run faster.
-	resetFreq := changefeedbase.TestingSetDefaultMinCheckpointFrequency(50 * time.Millisecond)
-
 	// Set required cluster settings.
 	sqlDB := sqlutils.MakeSQLRunner(db)
 	sqlDB.ExecMultiple(t, strings.Split(`
 SET CLUSTER SETTING kv.rangefeed.enabled = true;
 SET CLUSTER SETTING kv.closed_timestamp.target_duration = '1s';
-SET CLUSTER SETTING changefeed.experimental_poll_interval = '10ms';
 SET CLUSTER SETTING sql.defaults.experimental_stream_replication.enabled = 'on';
 `, `;`)...)
 
@@ -237,7 +232,6 @@ SET CLUSTER SETTING sql.defaults.experimental_stream_replication.enabled = 'on';
 
 	return h, func() {
 		cleanupSink()
-		resetFreq()
 		s.Stopper().Stop(ctx)
 	}
 }

--- a/pkg/ccl/streamingccl/streamproducer/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamproducer/BUILD.bazel
@@ -63,7 +63,6 @@ go_test(
     deps = [
         "//pkg/base",
         "//pkg/ccl",
-        "//pkg/ccl/changefeedccl",
         "//pkg/ccl/kvccl/kvtenantccl",
         "//pkg/ccl/storageccl",
         "//pkg/ccl/streamingccl",

--- a/pkg/ccl/streamingccl/streamproducer/replication_stream_test.go
+++ b/pkg/ccl/streamingccl/streamproducer/replication_stream_test.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	_ "github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl"     // Ensure changefeed init hooks run.
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/kvccl/kvtenantccl" // Ensure we can start tenant.
 	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/streamingtest"

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1642,6 +1642,10 @@ type StreamingTestingKnobs struct {
 	// OverrideReplicationTTLSeconds will override the default value of the
 	// `ReplicationTTLSeconds` field on the StreamIngestion job details.
 	OverrideReplicationTTLSeconds int
+
+	// BeforePollCutoverTime runs before the cutover time
+	// processor polls the job table for the cutover time.
+	BeforePollCutoverTime func() error
 }
 
 var _ base.ModuleTestingKnobs = &StreamingTestingKnobs{}

--- a/pkg/sql/rowexec/processors.go
+++ b/pkg/sql/rowexec/processors.go
@@ -270,13 +270,13 @@ func NewProcessor(
 		return NewRestoreDataProcessor(ctx, flowCtx, processorID, *core.RestoreData, post, inputs[0], outputs[0])
 	}
 	if core.StreamIngestionData != nil {
-		if err := checkNumInOut(inputs, outputs, 0, 1); err != nil {
+		if err := checkNumInOut(inputs, outputs, 1, 1); err != nil {
 			return nil, err
 		}
 		if NewStreamIngestionDataProcessor == nil {
 			return nil, errors.New("StreamIngestionData processor unimplemented")
 		}
-		return NewStreamIngestionDataProcessor(ctx, flowCtx, processorID, *core.StreamIngestionData, post, outputs[0])
+		return NewStreamIngestionDataProcessor(ctx, flowCtx, processorID, *core.StreamIngestionData, post, inputs[0], outputs[0])
 	}
 	if core.Exporter != nil {
 		if err := checkNumInOut(inputs, outputs, 1, 1); err != nil {
@@ -392,7 +392,7 @@ var NewSplitAndScatterProcessor func(context.Context, *execinfra.FlowCtx, int32,
 var NewRestoreDataProcessor func(context.Context, *execinfra.FlowCtx, int32, execinfrapb.RestoreDataSpec, *execinfrapb.PostProcessSpec, execinfra.RowSource, execinfra.RowReceiver) (execinfra.Processor, error)
 
 // NewStreamIngestionDataProcessor is implemented in the non-free (CCL) codebase and then injected here via runtime initialization.
-var NewStreamIngestionDataProcessor func(context.Context, *execinfra.FlowCtx, int32, execinfrapb.StreamIngestionDataSpec, *execinfrapb.PostProcessSpec, execinfra.RowReceiver) (execinfra.Processor, error)
+var NewStreamIngestionDataProcessor func(context.Context, *execinfra.FlowCtx, int32, execinfrapb.StreamIngestionDataSpec, *execinfrapb.PostProcessSpec, execinfra.RowSource, execinfra.RowReceiver) (execinfra.Processor, error)
 
 // NewCSVWriterProcessor is implemented in the non-free (CCL) codebase and then injected here via runtime initialization.
 var NewCSVWriterProcessor func(context.Context, *execinfra.FlowCtx, int32, execinfrapb.ExportSpec, execinfra.RowSource, execinfra.RowReceiver) (execinfra.Processor, error)


### PR DESCRIPTION
Previously, ever stream ingestion processor polled the job table for
updates to the cutover time and only stopped processing KVs when the
persisted high watermark was higher than the cutover time.

Now, a single processor polls the cutover time and broadcasts it to
all ingestion processors. The ingestion processors exit when the local
frontier reaches the cutover time.

This flow is peculiar when compared to others in a few of ways:

- The cutover processor runs forever. To shutdown it depends on
  eventually learning that its output has closed in order to shut
  down. To learn of this shutdown it must periodically push rows to the
  output. As a result, we push the cutover time even when it is empty or
  unchanged.

- The ingestion processor reads from the input outside of its main
  Next() loop. As a result special care must be take to ensure that
  Next() isn't called on the input after the ingestion processor has
  moved to the draining state. This is important because a number of
  execinfra components panic if you call Next() on an input after
  moving to draining

- The cutover processor is implemented as a LocalPlanNode. This was
  done for convenience and isn't essential. We could implement it as
  it own processor type with a protobuf.

In future work we could stop polling the jobs table and instead move
to using a rangefeed if we wanted lower latency notification of new
cutover times.

Release note: None