### PR TITLE
backupccl: don't pause on error by default for backup

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -2276,6 +2276,7 @@ backup_options ::=
 	| 'DETACHED' '=' 'FALSE'
 	| 'KMS' '=' string_or_placeholder_opt_list
 	| 'INCREMENTAL_LOCATION' '=' string_or_placeholder_opt_list
+	| 'DEBUG_PAUSE_ON' '=' string_or_placeholder
 
 c_expr ::=
 	d_expr

--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "restore_span_covering.go",
         "schedule_exec.go",
         "schedule_pts_chaining.go",
+        "shared_options.go",
         "show.go",
         "split_and_scatter_processor.go",
         "system_schema.go",

--- a/pkg/ccl/backupccl/backup_telemetry.go
+++ b/pkg/ccl/backupccl/backup_telemetry.go
@@ -168,6 +168,7 @@ func createBackupRecoveryEvent(
 		AsOfInterval:            initialDetails.AsOfInterval,
 		Options:                 options,
 		ApplicationName:         initialDetails.ApplicationName,
+		DebugPauseOn:            initialDetails.DebugPauseOn,
 	}
 
 	event.DestinationAuthTypes = make([]string, 0, len(authTypes))

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1418,15 +1418,7 @@ func remapPublicSchemas(
 func (r *restoreResumer) Resume(ctx context.Context, execCtx interface{}) error {
 	if err := r.doResume(ctx, execCtx); err != nil {
 		details := r.job.Details().(jobspb.RestoreDetails)
-		if details.DebugPauseOn == "error" {
-			const errorFmt = "job failed with error (%v) but is being paused due to the %s=%s setting"
-			log.Warningf(ctx, errorFmt, err, restoreOptDebugPauseOn, details.DebugPauseOn)
-
-			return jobs.MarkPauseRequestError(errors.Wrapf(err,
-				"pausing job due to the %s=%s setting",
-				restoreOptDebugPauseOn, details.DebugPauseOn))
-		}
-		return err
+		return errorForDebugPauseOnValue(ctx, details.DebugPauseOn, err)
 	}
 
 	return nil

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -74,17 +74,12 @@ const (
 	restoreOptSkipMissingSequenceOwners = "skip_missing_sequence_owners"
 	restoreOptSkipMissingViews          = "skip_missing_views"
 	restoreOptSkipLocalitiesCheck       = "skip_localities_check"
-	restoreOptDebugPauseOn              = "debug_pause_on"
 	restoreOptAsTenant                  = "tenant"
 
 	// The temporary database system tables will be restored into for full
 	// cluster backups.
 	restoreTempSystemDB = "crdb_temp_system"
 )
-
-var allowedDebugPauseOnValues = map[string]struct{}{
-	"error": {},
-}
 
 // featureRestoreEnabled is used to enable and disable the RESTORE feature.
 var featureRestoreEnabled = settings.RegisterBoolSetting(
@@ -1681,8 +1676,8 @@ func doRestorePlan(
 			return err
 		}
 
-		if _, ok := allowedDebugPauseOnValues[debugPauseOn]; len(debugPauseOn) > 0 && !ok {
-			return errors.Newf("%s cannot be set with the value %s", restoreOptDebugPauseOn, debugPauseOn)
+		if err := validateDebugPauseOn(debugPauseOn); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/ccl/backupccl/shared_options.go
+++ b/pkg/ccl/backupccl/shared_options.go
@@ -1,0 +1,46 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package backupccl
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+)
+
+const (
+	backupRestoreOptDebugPauseOn = "debug_pause_on"
+)
+
+var allowedDebugPauseOnValues = map[string]struct{}{
+	"error": {},
+}
+
+func validateDebugPauseOn(value string) error {
+	if _, ok := allowedDebugPauseOnValues[value]; len(value) > 0 && !ok {
+		return errors.Newf("%s cannot be set with the value %s", backupRestoreOptDebugPauseOn, value)
+	}
+	return nil
+}
+
+func errorForDebugPauseOnValue(ctx context.Context, onPauseValue string, err error) error {
+	switch onPauseValue {
+	case "error":
+		const errorFmt = "job failed with error (%v) but is being paused due to the %s=%s option"
+		log.Warningf(ctx, errorFmt, err, backupRestoreOptDebugPauseOn, onPauseValue)
+
+		return jobs.MarkPauseRequestError(errors.Wrapf(err,
+			"pausing job due to the %s=%s setting",
+			backupRestoreOptDebugPauseOn, onPauseValue))
+	default:
+		return err
+	}
+}

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -76,16 +76,16 @@ message StreamIngestionDetails {
   // StreamAddress locates the stream. It enables the client to find the
   // addresses of the stream's partitions.
   string stream_address = 1;
-  
+
   uint64 stream_id = 4 [(gogoproto.customname) = "StreamID"];
-  
+
   // Span is the keyspan into which this job will ingest KVs.
   //
   // The stream should emit all changes for a given span, and no changes outside
   // a span. Note that KVs received from the stream may need to be re-keyed into
   // this span.
   roachpb.Span span = 2 [(gogoproto.nullable) = false];
-  
+
   reserved 5;
   roachpb.TenantID tenant_id = 6 [(gogoproto.customname) = "TenantID", (gogoproto.nullable) = false];
 
@@ -264,6 +264,10 @@ message BackupDetails {
   // ApplicationName is the application name in the session where the backup was
   // invoked.
   string application_name = 23;
+
+  // DebugPauseOn describes the events that the job should pause
+  // itself on for debugging purposes.
+  string debug_pause_on = 24;
 }
 
 message BackupProgress {
@@ -271,7 +275,7 @@ message BackupProgress {
 }
 
 // DescriptorRewrite specifies a remapping from one descriptor ID to another for
-// use in rewritting descriptors themselves or things that reference them such 
+// use in rewritting descriptors themselves or things that reference them such
 // as is done during RESTORE or IMPORT.
 message DescriptorRewrite {
   uint32 id = 1 [

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -3161,7 +3161,7 @@ backup_options:
   }
 | REVISION_HISTORY '=' a_expr
   {
-		$$.val = &tree.BackupOptions{CaptureRevisionHistory: $3.expr()}
+    $$.val = &tree.BackupOptions{CaptureRevisionHistory: $3.expr()}
   }
 | DETACHED
   {
@@ -3169,7 +3169,7 @@ backup_options:
   }
 | DETACHED '=' TRUE
   {
-		$$.val = &tree.BackupOptions{Detached: tree.MakeDBool(true)}
+    $$.val = &tree.BackupOptions{Detached: tree.MakeDBool(true)}
   }
 | DETACHED '=' FALSE
   {
@@ -3181,9 +3181,12 @@ backup_options:
   }
 | INCREMENTAL_LOCATION '=' string_or_placeholder_opt_list
   {
-  $$.val = &tree.BackupOptions{IncrementalStorage: $3.stringOrPlaceholderOptList()}
+    $$.val = &tree.BackupOptions{IncrementalStorage: $3.stringOrPlaceholderOptList()}
   }
-
+| DEBUG_PAUSE_ON '=' string_or_placeholder
+  {
+    $$.val = &tree.BackupOptions{DebugPauseOn: $3.expr()}
+  }
 
 // %Help: CREATE SCHEDULE FOR BACKUP - backup data periodically
 // %Category: CCL

--- a/pkg/sql/parser/testdata/backup_restore
+++ b/pkg/sql/parser/testdata/backup_restore
@@ -762,6 +762,22 @@ BACKUP TABLE foo TO '_' WITH revision_history = $1, detached -- literals removed
 BACKUP TABLE _ TO 'bar' WITH revision_history = $1, detached -- identifiers removed
 
 parse
+BACKUP TABLE foo TO 'bar' WITH debug_pause_on = $1, detached
+----
+BACKUP TABLE foo TO 'bar' WITH detached, debug_pause_on = $1 -- normalized!
+BACKUP TABLE (foo) TO ('bar') WITH detached, debug_pause_on = ($1) -- fully parenthesized
+BACKUP TABLE foo TO '_' WITH detached, debug_pause_on = $1 -- literals removed
+BACKUP TABLE _ TO 'bar' WITH detached, debug_pause_on = $1 -- identifiers removed
+
+parse
+BACKUP TABLE foo TO 'bar' WITH debug_pause_on = 'error', detached
+----
+BACKUP TABLE foo TO 'bar' WITH detached, debug_pause_on = 'error' -- normalized!
+BACKUP TABLE (foo) TO ('bar') WITH detached, debug_pause_on = ('error') -- fully parenthesized
+BACKUP TABLE foo TO '_' WITH detached, debug_pause_on = '_' -- literals removed
+BACKUP TABLE _ TO 'bar' WITH detached, debug_pause_on = 'error' -- identifiers removed
+
+parse
 RESTORE TABLE foo FROM 'bar' WITH skip_missing_foreign_keys, skip_missing_sequences, detached
 ----
 RESTORE TABLE foo FROM 'bar' WITH skip_missing_foreign_keys, skip_missing_sequences, detached

--- a/pkg/sql/sem/tree/backup.go
+++ b/pkg/sql/sem/tree/backup.go
@@ -42,6 +42,7 @@ const (
 type BackupOptions struct {
 	CaptureRevisionHistory Expr
 	EncryptionPassphrase   Expr
+	DebugPauseOn           Expr
 	Detached               *DBool
 	EncryptionKMSURI       StringOrPlaceholderOptList
 	IncrementalStorage     StringOrPlaceholderOptList
@@ -288,6 +289,12 @@ func (o *BackupOptions) Format(ctx *FmtCtx) {
 		ctx.WriteString("incremental_location = ")
 		ctx.FormatNode(&o.IncrementalStorage)
 	}
+
+	if o.DebugPauseOn != nil {
+		maybeAddSep()
+		ctx.WriteString("debug_pause_on = ")
+		ctx.FormatNode(o.DebugPauseOn)
+	}
 }
 
 // CombineWith merges other backup options into this backup options struct.
@@ -327,6 +334,12 @@ func (o *BackupOptions) CombineWith(other *BackupOptions) error {
 		return errors.New("incremental_location option specified multiple times")
 	}
 
+	if o.DebugPauseOn == nil {
+		o.DebugPauseOn = other.DebugPauseOn
+	} else if other.DebugPauseOn != nil {
+		return errors.New("debug_pause_on specified multiple times")
+	}
+
 	return nil
 }
 
@@ -336,6 +349,7 @@ func (o BackupOptions) IsDefault() bool {
 	return o.CaptureRevisionHistory == options.CaptureRevisionHistory &&
 		o.Detached == options.Detached && cmp.Equal(o.EncryptionKMSURI, options.EncryptionKMSURI) &&
 		o.EncryptionPassphrase == options.EncryptionPassphrase &&
+		o.DebugPauseOn == options.DebugPauseOn &&
 		cmp.Equal(o.IncrementalStorage, options.IncrementalStorage)
 }
 


### PR DESCRIPTION
Many backups happen unattended driven by tools such as cron or CRDB's scheduled backups. Many users may not know to look for PAUSED backups and are rather only monitoring for failures, resulting in problems going unnoticed for longer than intended.

Here, we remove pause-on-retriable-error as the default behaviour for backups. Further, we've added a debug_pause_on option to match the existing option for restore that user's can use to opt-in to pausing on error.

NB: Restore still defaults to pause-on-retriable-error since restore is more likely to be a user-attended activity where they will notice the paused job.

Epic: None

Release note: None