### PR TITLE
intentresolver: Add max timeout to RequestBatcher and IntentResolver

### DIFF
--- a/pkg/internal/client/requestbatcher/batcher_test.go
+++ b/pkg/internal/client/requestbatcher/batcher_test.go
@@ -314,45 +314,122 @@ func TestPanicWithNilStopper(t *testing.T) {
 }
 
 // TestBatchTimeout verifies the RequestBatcher uses the context with the
-// deadline from the latest call to send.
+// deadline from the latest call and max timeout to send.
 func TestBatchTimeout(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	const timeout = 5 * time.Millisecond
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
 	sc := make(chanSender)
-	t.Run("WithTimeout", func(t *testing.T) {
+	testCases := []struct {
+		requestTimeout  time.Duration
+		maxTimeout      time.Duration
+		expectedTimeout time.Duration
+	}{
+		{
+			requestTimeout:  timeout,
+			maxTimeout:      0,
+			expectedTimeout: timeout,
+		},
+		{
+			requestTimeout:  0,
+			maxTimeout:      timeout,
+			expectedTimeout: timeout,
+		},
+		{
+			requestTimeout:  7 * time.Millisecond,
+			maxTimeout:      timeout,
+			expectedTimeout: timeout,
+		},
+		{
+			requestTimeout:  timeout,
+			maxTimeout:      7 * time.Millisecond,
+			expectedTimeout: timeout,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("With%sRequestTimeout%sMaxTimeout", tc.requestTimeout, tc.maxTimeout),
+			func(t *testing.T) {
+				b := New(Config{
+					// MaxMsgsPerBatch of 1 is chosen so that the first call to Send will
+					// immediately lead to a batch being sent.
+					MaxMsgsPerBatch: 1,
+					Sender:          sc,
+					Stopper:         stopper,
+					MaxTimeout:      tc.maxTimeout,
+				})
+				// This test attempts to verify that a batch with a request with a
+				// timeout will be sent with that timeout. The test faces challenges of
+				// timing. There are several different phases at which the timeout may
+				// fire; the request may time out before it has been sent to the
+				// batcher, it may timeout while it is being sent or it may not time
+				// out until after it has been sent. Each of these cases are handled
+				// and verified to ensure that the request was indeed sent with a
+				// timeout.
+				ctx, cancel := context.WithTimeout(context.Background(), tc.requestTimeout)
+				defer cancel()
+				respChan := make(chan Response, 1)
+				if err := b.SendWithChan(ctx, respChan, 1, &kvpb.GetRequest{}); err != nil {
+					testutils.IsError(err, context.DeadlineExceeded.Error())
+					return
+				}
+				select {
+				case s := <-sc:
+					deadline, hasDeadline := s.ctx.Deadline()
+					assert.True(t, hasDeadline)
+					assert.True(t, timeutil.Until(deadline) < tc.expectedTimeout)
+					s.respChan <- batchResp{}
+				case resp := <-respChan:
+					assert.Nil(t, resp.Resp)
+					testutils.IsError(resp.Err, context.DeadlineExceeded.Error())
+				}
+			},
+		)
+	}
+	t.Run("WithTimeoutAndPagination", func(t *testing.T) {
+		maxTimeout := 20 * time.Millisecond
+		firstAndSecondSendTimeDiff := 10 * time.Millisecond
 		b := New(Config{
 			// MaxMsgsPerBatch of 1 is chosen so that the first call to Send will
 			// immediately lead to a batch being sent.
 			MaxMsgsPerBatch: 1,
 			Sender:          sc,
 			Stopper:         stopper,
+			MaxTimeout:      maxTimeout,
 		})
-		// This test attempts to verify that a batch with a request with a timeout
-		// will be sent with that timeout. The test faces challenges of timing.
-		// There are several different phases at which the timeout may fire;
-		// the request may time out before it has been sent to the batcher, it
-		// may timeout while it is being sent or it may not time out until after
-		// it has been sent. Each of these cases are handled and verified to ensure
-		// that the request was indeed sent with a timeout.
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
-		defer cancel()
+		// This test will simulate multiple calls to Send (due to pagination) and
+		// test that the MaxTimeout set is a timeout per batch rather than a
+		// timeout per request.
 		respChan := make(chan Response, 1)
-		if err := b.SendWithChan(ctx, respChan, 1, &kvpb.GetRequest{}); err != nil {
+		if err := b.SendWithChan(context.Background(), respChan, 1, &kvpb.GetRequest{}); err != nil {
 			testutils.IsError(err, context.DeadlineExceeded.Error())
 			return
 		}
-		select {
-		case s := <-sc:
-			deadline, hasDeadline := s.ctx.Deadline()
-			assert.True(t, hasDeadline)
-			assert.True(t, timeutil.Until(deadline) < timeout)
-			s.respChan <- batchResp{}
-		case resp := <-respChan:
-			assert.Nil(t, resp.Resp)
-			testutils.IsError(resp.Err, context.DeadlineExceeded.Error())
+		// First call to Send.
+		s := <-sc
+		time.Sleep(firstAndSecondSendTimeDiff)
+		s.respChan <- batchResp{
+			br: &kvpb.BatchResponse{
+				Responses: []kvpb.ResponseUnion{
+					{
+						Value: &kvpb.ResponseUnion_Get{
+							Get: &kvpb.GetResponse{
+								ResponseHeader: kvpb.ResponseHeader{
+									ResumeSpan: &roachpb.Span{},
+								},
+							},
+						},
+					},
+				},
+			},
 		}
+		// Second call to Send occurs at least firstAndSecondSendTimeDiff time
+		// after first call to Send.
+		s = <-sc
+		deadline, hasDeadline := s.ctx.Deadline()
+		assert.True(t, hasDeadline)
+		assert.Less(t, timeutil.Until(deadline), maxTimeout-firstAndSecondSendTimeDiff)
+		s.respChan <- batchResp{}
 	})
 	t.Run("NoTimeout", func(t *testing.T) {
 		b := New(Config{

--- a/pkg/kv/kvserver/intentresolver/BUILD.bazel
+++ b/pkg/kv/kvserver/intentresolver/BUILD.bazel
@@ -57,6 +57,7 @@ go_test(
         "//pkg/storage/enginepb",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/testcluster",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",

--- a/pkg/kv/kvserver/intentresolver/intent_resolver_integration_test.go
+++ b/pkg/kv/kvserver/intentresolver/intent_resolver_integration_test.go
@@ -13,15 +13,19 @@ import (
 	"context"
 	gosql "database/sql"
 	"fmt"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -48,6 +52,15 @@ func getRangeInfoForTable(
 		}))
 	}
 	return startKey, endKey, store
+}
+
+func forceScanOnAllReplicationQueues(tc *testcluster.TestCluster) (err error) {
+	for _, s := range tc.Servers {
+		err = s.Stores().VisitStores(func(store *kvserver.Store) error {
+			return store.ForceReplicationScanAndProcess()
+		})
+	}
+	return err
 }
 
 // TestAsyncIntentResolutionByteSizePagination tests that async intent
@@ -147,4 +160,182 @@ func TestAsyncIntentResolutionByteSizePagination(t *testing.T) {
 		}
 		return nil
 	})
+}
+
+// TestIntentResolutionUnavailableRange tests that InFlightBackpressureLimit
+// resolve intent batches for an unavailable range does not stall indefinitely
+// and times out, allowing other resolve intent requests and queries for
+// available ranges to be unblocked, run, and finish. This test does this by:
+// 1. Setting InFlightBackpressureLimit to 1
+// 2. Configure so that intent resolution on t2 cannot finish successfully and
+// blocks, relying on the timeout to unblock (to simulate t2 being
+// unavailable).
+// 3. Have a transaction update t1 (transaction record) and t2.
+// The intent resolver / request batcher on the store containing t1 will run
+// async intent resolution for t2, which will block and clog up intent
+// resolution on the store containing t1.
+//
+// 4. Have a transaction update t3 (transaction record) and t1, but disable
+// async intent resolution on t3
+// 5. Read from the updated row on t1 and test this step finishes
+// Step 4 will create an intent for t1 that will not be resolved since async
+// intent resolution is disabled. Step 5 cannot finish as we need to resolve
+// the intent for t1 and intent resolution is clogged up on the store
+// containing t1, unless the intent resolution for the "unavailable" t2 times
+// out.
+func TestIntentResolutionUnavailableRange(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// This test sometimes times out trying to replicate 3 tables t1, t2, t3 with
+	// replication factor 1 located on different servers under stress.
+	skip.UnderStress(t)
+
+	ctx := context.Background()
+
+	// Set server args. We set InFlightBackpressureLimit to 1 so that we only
+	// need one intent resolution batch to clog up the intent resolver. For store
+	// containing t1 (node 0), we set TestingAsyncIntentResolution to block async
+	// intent resolution until range containing t2 becomes unavailable. For store
+	// containing t3 (node 2), we set DisableAsyncIntentResolution to true so
+	// that async intent resolution is disabled for store containing t3.
+	const numNodes = 3
+	const inFlightBackpressureLimit = 1
+	const intentResolutionSendBatchTimeout = 1 * time.Second
+	serverArgs := make(map[int]base.TestServerArgs)
+	waitForIntentResolutionForT2 := make(chan struct{})
+	var t2RangeID roachpb.RangeID
+	storeTestingKnobs := []kvserver.StoreTestingKnobs{
+		{
+			IntentResolverKnobs: kvserverbase.IntentResolverTestingKnobs{
+				InFlightBackpressureLimit:           inFlightBackpressureLimit,
+				MaxIntentResolutionSendBatchTimeout: intentResolutionSendBatchTimeout,
+			},
+		},
+		{
+			TestingRequestFilter: func(ctx context.Context, ba *kvpb.BatchRequest) *kvpb.Error {
+				// Configure so that intent resolution on t2 cannot finish
+				// successfully and blocks, relying on the timeout to unblock.
+				for _, req := range ba.Requests {
+					switch req.GetInner().(type) {
+					case *kvpb.ResolveIntentRequest:
+						if ba.RangeID == t2RangeID {
+							close(waitForIntentResolutionForT2)
+							// Block until the request is cancelled.
+							<-ctx.Done()
+							return kvpb.NewError(ctx.Err())
+						}
+					}
+				}
+				return nil
+			},
+		},
+		{
+			IntentResolverKnobs: kvserverbase.IntentResolverTestingKnobs{
+				DisableAsyncIntentResolution: true,
+			},
+		},
+	}
+	for i := 1; i <= numNodes; i++ {
+		serverArgs[i-1] = base.TestServerArgs{
+			Locality: roachpb.Locality{
+				Tiers: []roachpb.Tier{
+					{
+						Key: "rack", Value: strconv.Itoa(i),
+					},
+				},
+			},
+			Knobs: base.TestingKnobs{
+				Store: &storeTestingKnobs[i-1],
+			},
+		}
+	}
+
+	// Start test cluster.
+	clusterArgs := base.TestClusterArgs{
+		ReplicationMode:   base.ReplicationAuto,
+		ServerArgsPerNode: serverArgs,
+	}
+	tc := testcluster.StartTestCluster(t, numNodes, clusterArgs)
+	defer tc.Stopper().Stop(ctx)
+
+	db := tc.ServerConn(0)
+
+	// Create 3 tables t1, t2, t3 with replication factor 1 located on different
+	// servers and wait for replication and rebalancing to finish.
+	const numTables = 3
+	for i := 1; i <= numTables; i++ {
+		_, err := db.Exec(fmt.Sprintf("CREATE TABLE t%d (i INT PRIMARY KEY, j INT)", i))
+		require.NoError(t, err)
+		_, err = db.Exec(fmt.Sprintf("ALTER TABLE t%d CONFIGURE ZONE USING num_replicas = 1, constraints = '{\"+rack=%d\": 1}'", i, i))
+		require.NoError(t, err)
+	}
+	testutils.SucceedsSoon(t, func() error {
+		if err := forceScanOnAllReplicationQueues(tc); err != nil {
+			return err
+		}
+		for i := 1; i <= numTables; i++ {
+			r := db.QueryRow(fmt.Sprintf("select replicas from [show ranges from table t%d]", i))
+			var repl string
+			if err := r.Scan(&repl); err != nil {
+				return err
+			}
+			if repl != fmt.Sprintf("{%d}", i) {
+				return errors.Newf("Expected replicas {%d} for table t%d, got %s", i, i, repl)
+			}
+		}
+		return nil
+	})
+
+	{
+		// Get the range ID for t2.
+		err := db.QueryRow("select range_id from [show ranges from table t2] limit 1").Scan(&t2RangeID)
+		require.NoError(t, err)
+	}
+
+	{
+		// Execute a transaction for t1 (transaction record) and t2 so that the
+		// intent resolver / request batcher of the store containing t1 will run
+		// async intent resolution for t2. Intent resolution on t2 is configured to
+		// not finish successfully and block, relying on the timeout to unblock
+		// (see the TestingRequestFilter for server 1). Thus, async intent
+		// resolution for t2 will be stuck and clog up intent resolution on the
+		// store containing t1, only unclogging after timeout.
+		tx, err := db.Begin()
+		require.NoError(t, err)
+		for _, i := range []int{1, 2} {
+			_, err = tx.Exec(fmt.Sprintf("INSERT INTO t%d (i, j) VALUES (0, 0)", i))
+			require.NoError(t, err)
+		}
+		err = tx.Commit()
+		require.NoError(t, err)
+	}
+
+	// Wait for intent resolution for t2 to start to ensure that intent
+	// resolution on the store containing t1 is clogged before executing the
+	// below transactions.
+	<-waitForIntentResolutionForT2
+
+	{
+		// One transaction updates t3 (transaction record) and t1, which would
+		// create an intent on t1 that will not get resolved as intent resolution
+		// is disabled.
+		tx, err := db.Begin()
+		require.NoError(t, err)
+		for _, i := range []int{3, 1} {
+			_, err = tx.Exec(fmt.Sprintf("INSERT INTO t%d (i, j) VALUES (1, 0)", i))
+			require.NoError(t, err)
+		}
+		err = tx.Commit()
+		require.NoError(t, err)
+	}
+
+	{
+		// Read from t1 and try to resolve the intent, which will be initially
+		// blocked since intent resolution on the store containing t1 is clogged
+		// up. We test this read finishes, which can only happen if the intent
+		// resolution on the unavailable t2 times out and finishes.
+		_, err := db.Exec("SELECT * FROM t1")
+		require.NoError(t, err)
+	}
 }

--- a/pkg/kv/kvserver/intentresolver/intent_resolver_test.go
+++ b/pkg/kv/kvserver/intentresolver/intent_resolver_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
@@ -35,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestCleanupTxnIntentsOnGCAsync exercises the code which is used to
@@ -366,7 +368,7 @@ func TestCleanupMultipleIntentsAsync(t *testing.T) {
 		pushed   []string
 		resolved []string
 	}
-	pushOrResolveFunc := func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+	pushOrResolveFunc := func(_ context.Context, ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
 		switch ba.Requests[0].GetInner().Method() {
 		case kvpb.PushTxn:
 			for _, ru := range ba.Requests {
@@ -374,14 +376,14 @@ func TestCleanupMultipleIntentsAsync(t *testing.T) {
 				reqs.pushed = append(reqs.pushed, string(ru.GetPushTxn().Key))
 				reqs.Unlock()
 			}
-			return pushTxnSendFunc(t, len(ba.Requests))(ba)
+			return pushTxnSendFunc(t, len(ba.Requests))(ctx, ba)
 		case kvpb.ResolveIntent:
 			for _, ru := range ba.Requests {
 				reqs.Lock()
 				reqs.resolved = append(reqs.resolved, string(ru.GetResolveIntent().Key))
 				reqs.Unlock()
 			}
-			return resolveIntentsSendFunc(t)(ba)
+			return resolveIntentsSendFunc(t)(ctx, ba)
 		default:
 			return nil, kvpb.NewErrorf("unexpected")
 		}
@@ -470,7 +472,7 @@ func TestCleanupTxnIntentsAsyncWithPartialRollback(t *testing.T) {
 	txn.IgnoredSeqNums = []enginepb.IgnoredSeqNumRange{{Start: 1, End: 1}}
 
 	var gotResolveIntent, gotResolveIntentRange int32
-	check := func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+	check := func(_ context.Context, ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
 		for _, r := range ba.Requests {
 			if ri, ok := r.GetInner().(*kvpb.ResolveIntentRequest); ok {
 				atomic.StoreInt32(&gotResolveIntent, 1)
@@ -628,7 +630,7 @@ func TestCleanupMultipleTxnIntentsAsync(t *testing.T) {
 		resolved []string
 		gced     []string
 	}
-	resolveOrGCFunc := func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+	resolveOrGCFunc := func(_ context.Context, ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
 		if len(ba.Requests) != 1 {
 			return nil, kvpb.NewErrorf("unexpected")
 		}
@@ -638,19 +640,19 @@ func TestCleanupMultipleTxnIntentsAsync(t *testing.T) {
 			reqs.Lock()
 			reqs.resolved = append(reqs.resolved, string(ru.GetResolveIntent().Key))
 			reqs.Unlock()
-			return resolveIntentsSendFunc(t)(ba)
+			return resolveIntentsSendFunc(t)(ctx, ba)
 		case kvpb.ResolveIntentRange:
 			reqs.Lock()
 			req := ru.GetResolveIntentRange()
 			reqs.resolved = append(reqs.resolved,
 				fmt.Sprintf("%s-%s", string(req.Key), string(req.EndKey)))
 			reqs.Unlock()
-			return resolveIntentsSendFunc(t)(ba)
+			return resolveIntentsSendFunc(t)(ctx, ba)
 		case kvpb.GC:
 			reqs.Lock()
 			reqs.gced = append(reqs.gced, string(ru.GetGc().Key))
 			reqs.Unlock()
-			return gcSendFunc(t)(ba)
+			return gcSendFunc(t)(ctx, ba)
 		default:
 			return nil, kvpb.NewErrorf("unexpected")
 		}
@@ -756,6 +758,75 @@ func TestCleanupIntents(t *testing.T) {
 	}
 }
 
+// TestIntentResolutionTimeout tests that running intent resolution with an
+// unavailable range eventually times out and finishes, and does not block
+// intent resolution on another available range.
+func TestIntentResolutionTimeout(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// c is to ensure that intent resolution on the available range occurs after
+	// intent resolution on the unavailable range.
+	c := make(chan struct{})
+	unavailableRangeSendFunc := func(ctx context.Context, _ *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+		c <- struct{}{}
+		<-ctx.Done()
+		return nil, &kvpb.Error{}
+	}
+	sf := func() *sendFuncs {
+		s := newSendFuncs(t)
+		s.pushFrontLocked(
+			singlePushTxnSendFunc(t),
+			unavailableRangeSendFunc,
+			singlePushTxnSendFunc(t),
+			resolveIntentsSendFunc(t),
+		)
+		return s
+	}()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
+	clock := hlc.NewClockWithSystemTimeSource(time.Nanosecond /* maxOffset */, base.DefaultMaxClockOffset)
+	cfg := Config{
+		Stopper: stopper,
+		Clock:   clock,
+		TestingKnobs: kvserverbase.IntentResolverTestingKnobs{
+			InFlightBackpressureLimit:           1,
+			MaxIntentResolutionSendBatchTimeout: 1 * time.Second,
+		},
+	}
+	ir := newIntentResolverWithSendFuncsConcurrentSend(cfg, sf, stopper, true)
+
+	// Intent resolution on unavailable range.
+	var cleanupIntentsErrFinished int32
+	go func() {
+		num, err := ir.CleanupIntents(context.Background(), makeTxnIntents(t, clock, 1), clock.Now(), kvpb.PUSH_ABORT)
+		require.Error(t, err)
+		require.Equal(t, num, 0)
+		atomic.StoreInt32(&cleanupIntentsErrFinished, 1)
+	}()
+
+	// Intent resolution on available range.
+	var cleanupIntentsSuccessFinished int32
+	go func() {
+		// Ensure intent resolution occurs after that of the unavailable range.
+		<-c
+		num, err := ir.CleanupIntents(context.Background(), makeTxnIntents(t, clock, 1), clock.Now(), kvpb.PUSH_ABORT)
+		require.NoError(t, err)
+		require.Equal(t, num, 1)
+		atomic.StoreInt32(&cleanupIntentsSuccessFinished, 1)
+	}()
+
+	testutils.SucceedsSoon(t, func() error {
+		if atomic.LoadInt32(&cleanupIntentsErrFinished) != 1 {
+			return errors.New("CleanupIntents of unavailable range did not finish")
+		}
+		if atomic.LoadInt32(&cleanupIntentsSuccessFinished) != 1 {
+			return errors.New("CleanupIntents of available range did not finish")
+		}
+		return nil
+	})
+	assert.Equal(t, ir.Metrics.IntentResolutionFailed.Count(), int64(1))
+}
+
 func newTransaction(
 	name string, baseKey roachpb.Key, userPriority roachpb.UserPriority, clock *hlc.Clock,
 ) *roachpb.Transaction {
@@ -784,17 +855,28 @@ func makeTxnIntents(t *testing.T, clock *hlc.Clock, numIntents int) []roachpb.In
 // the IntentResolver tries to send. They are used in conjunction with the below
 // function to create an IntentResolver with a slice of sendFuncs.
 // A library of useful sendFuncs are defined below.
-type sendFunc func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error)
+type sendFunc func(ctx context.Context, ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error)
 
 func newIntentResolverWithSendFuncs(
 	c Config, sf *sendFuncs, stopper *stop.Stopper,
 ) *IntentResolver {
+	return newIntentResolverWithSendFuncsConcurrentSend(c, sf, stopper, false)
+}
+
+func newIntentResolverWithSendFuncsConcurrentSend(
+	c Config, sf *sendFuncs, stopper *stop.Stopper, allowConcurrentSend bool,
+) *IntentResolver {
 	txnSenderFactory := kv.NonTransactionalFactoryFunc(
-		func(_ context.Context, ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+
+		func(ctx context.Context, ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
 			sf.mu.Lock()
-			defer sf.mu.Unlock()
 			f := sf.popLocked()
-			return f(ba)
+			if allowConcurrentSend {
+				sf.mu.Unlock()
+			} else {
+				defer sf.mu.Unlock()
+			}
+			return f(ctx, ba)
 		})
 	db := kv.NewDB(log.MakeTestingAmbientCtxWithNewTracer(), txnSenderFactory, c.Clock, stopper)
 	c.DB = db
@@ -806,7 +888,7 @@ func newIntentResolverWithSendFuncs(
 func pushTxnSendFuncs(sf *sendFuncs, N int) sendFunc {
 	toPush := int64(N)
 	var f sendFunc
-	f = func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+	f = func(_ context.Context, ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
 		if remaining := atomic.LoadInt64(&toPush); len(ba.Requests) > int(remaining) {
 			sf.t.Errorf("expected at most %d PushTxnRequests in batch, got %d",
 				remaining, len(ba.Requests))
@@ -821,7 +903,7 @@ func pushTxnSendFuncs(sf *sendFuncs, N int) sendFunc {
 }
 
 func pushTxnSendFunc(t *testing.T, numPushes int) sendFunc {
-	return func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+	return func(_ context.Context, ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
 		if len(ba.Requests) != numPushes {
 			t.Errorf("expected %d PushTxnRequests in batch, got %d",
 				numPushes, len(ba.Requests))
@@ -857,7 +939,7 @@ func resolveIntentsSendFuncsEx(
 	toResolve := int64(numIntents)
 	reqsSeen := int64(0)
 	var f sendFunc
-	f = func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+	f = func(_ context.Context, ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
 		if remaining := atomic.LoadInt64(&toResolve); len(ba.Requests) > int(remaining) {
 			sf.t.Errorf("expected at most %d ResolveIntentRequests in batch, got %d",
 				remaining, len(ba.Requests))
@@ -876,7 +958,7 @@ func resolveIntentsSendFuncsEx(
 }
 
 func resolveIntentsSendFuncEx(t *testing.T, checkTxnStatusOpt checkTxnStatusOpt) sendFunc {
-	return func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+	return func(_ context.Context, ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
 		return respForResolveIntentBatch(t, ba, checkTxnStatusOpt), nil
 	}
 }
@@ -893,12 +975,12 @@ func resolveIntentsSendFunc(t *testing.T) sendFunc {
 	return resolveIntentsSendFuncEx(t, dontCheckTxnStatus)
 }
 
-func failSendFunc(*kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+func failSendFunc(context.Context, *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
 	return nil, kvpb.NewError(fmt.Errorf("boom"))
 }
 
 func gcSendFunc(t *testing.T) sendFunc {
-	return func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+	return func(_ context.Context, ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
 		resp := &kvpb.BatchResponse{}
 		for _, r := range ba.Requests {
 			if _, ok := r.GetInner().(*kvpb.GCRequest); !ok {

--- a/pkg/kv/kvserver/kvserverbase/knobs.go
+++ b/pkg/kv/kvserver/kvserverbase/knobs.go
@@ -14,6 +14,8 @@
 
 package kvserverbase
 
+import "time"
+
 // BatchEvalTestingKnobs contains testing helpers that are used during batch evaluation.
 type BatchEvalTestingKnobs struct {
 	// TestingEvalFilter is called before evaluating each command.
@@ -70,4 +72,14 @@ type IntentResolverTestingKnobs struct {
 	// MaxIntentResolutionBatchSize overrides the maximum number of intent
 	// resolution requests which can be sent in a single batch.
 	MaxIntentResolutionBatchSize int
+
+	// InFlightBackpressureLimit overrides the number of batches in flight above
+	// which sending intent resolution batch requests should experience
+	// backpressure.
+	InFlightBackpressureLimit int
+
+	// MaxIntentResolutionSendBatchTimeout overrides the maximum amount of time
+	// that sending an intent resolution batch request can run for before timing
+	// out.
+	MaxIntentResolutionSendBatchTimeout time.Duration
 }


### PR DESCRIPTION
Fixes: https://github.com/cockroachdb/cockroach/issues/89299

There is a limit of 1000 in-flight intent resolution request batches that can be processed at a time before backpressure. We saw a case where an unavailable range resulted in many intent resolution request batches to be stuck, clogging up the worker pool and starving the other ranges trying to resolve intents. This resulted in more queries timing out.

To address this, this patch adds a max timeout to RequestBatcher and IntentResolver to ensure that no worker trying to resolve a batch of intents gets stuck indefinitely e.g. due to an unavailable range.

Release note (ops change): Added max timeout to intent resolution, preventing intent resolution from becoming stuck indefinitely and blocking other ranges attempting to resolve intents.