### PR TITLE
cli/start: ensure startup panics are reported to stderr

### DIFF
--- a/pkg/sql/rowexec/aggregator_test.go
+++ b/pkg/sql/rowexec/aggregator_test.go
@@ -394,8 +394,8 @@ func TestAggregator(t *testing.T) {
 
 	ctx := context.Background()
 	test := MakeProcessorTest(DefaultProcessorTestConfig())
+	defer test.Close(ctx)
 	test.RunTestCases(ctx, t, testCases)
-	test.Close(ctx)
 }
 
 func BenchmarkAggregation(b *testing.B) {

--- a/pkg/sql/rowexec/inverted_filterer_test.go
+++ b/pkg/sql/rowexec/inverted_filterer_test.go
@@ -131,8 +131,8 @@ func TestInvertedFilterer(t *testing.T) {
 	testConfig.FlowCtx.DiskMonitor = diskMonitor
 	testConfig.FlowCtx.Txn = kv.NewTxn(ctx, server.DB(), server.NodeID())
 	test := MakeProcessorTest(testConfig)
+	defer test.Close(ctx)
 
 	// Run test.
 	test.RunTestCases(ctx, t, testCases)
-	test.Close(ctx)
 }

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -15,7 +15,7 @@ import (
 	"math"
 	"time"
 
-	"github.com/cockroachdb/apd/v3"
+	apd "github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -420,6 +420,14 @@ func NewTestingEvalContext(st *cluster.Settings) *Context {
 }
 
 // Stop closes out the EvalContext and must be called once it is no longer in use.
+//
+// Note: Stop is intended to gracefully handle panics. For this to work
+// properly, use `defer evalctx.Stop()`, i.e. have `Stop` be called by `defer` directly.
+//
+// If `Stop()` is called via an intermediate function (e.g. `defer
+// func() { ... evalCtx.Stop() ... }`) the panic will not be handled
+// gracefully and some memory monitors may complain that they are being shut down
+// with some allocated bytes remaining.
 func (ec *Context) Stop(c context.Context) {
 	if r := recover(); r != nil {
 		ec.TestingMon.EmergencyStop(c)

--- a/pkg/util/log/logcrash/crash_reporting.go
+++ b/pkg/util/log/logcrash/crash_reporting.go
@@ -118,6 +118,13 @@ func ReportPanicWithGlobalSettings(ctx context.Context, r interface{}, depth int
 // RecoverAndReportPanic can be invoked on goroutines that run with
 // stderr redirected to logs to ensure the user gets informed on the
 // real stderr a panic has occurred.
+// The argument sv may be nil; if it is, no Sentry report is sent.
+//
+// Note: this function _must_ be called with `defer log.RecoverAndReportPanic()`.
+// Do not use `defer func() { ... log.RecoverAndReportPanic() ...}` as this
+// will fail to actually catch the panic.
+// If you need more code around the call in your defer, use ReportPanic()
+// instead and do not forget to re-panic afterwards.
 func RecoverAndReportPanic(ctx context.Context, sv *settings.Values) {
 	if r := recover(); r != nil {
 		ReportPanic(ctx, sv, r, depthForRecoverAndReportPanic)
@@ -127,6 +134,13 @@ func RecoverAndReportPanic(ctx context.Context, sv *settings.Values) {
 
 // RecoverAndReportNonfatalPanic is an alternative RecoverAndReportPanic that
 // does not re-panic in Release builds.
+// The caller is responsible for ensuring that the argument sv is non-nil.
+//
+// Note: this function _must_ be called with `defer log.RecoverAndReportNonfatalPanic()`.
+// Do not use `defer func() { ... log.RecoverAndReportNonfatalPanic() ...}` as this
+// will fail to actually catch the panic.
+// If you need more code around the call in your defer, use ReportNonfatalPanic()
+// instead. The caller should not explicitly re-panic afterwards.
 func RecoverAndReportNonfatalPanic(ctx context.Context, sv *settings.Values) {
 	if r := recover(); r != nil {
 		ReportPanic(ctx, sv, r, depthForRecoverAndReportPanic)
@@ -141,7 +155,7 @@ func RecoverAndReportNonfatalPanic(ctx context.Context, sv *settings.Values) {
 // Note that ReportPanic() does not assume that the panic object
 // will be left uncaught to terminate the process. For example,
 // at the time of this writing, ReportPanic() is called from
-// RecoverAndReportNonfatalPanic() above.
+// ReportNonfatalPanic() above.
 func ReportPanic(ctx context.Context, sv *settings.Values, r interface{}, depth int) {
 	// Announce the panic has occurred to all places. The purpose
 	// of this call is threefold:

--- a/pkg/util/stop/stopper_test.go
+++ b/pkg/util/stop/stopper_test.go
@@ -299,49 +299,6 @@ func TestStopperNumTasks(t *testing.T) {
 	}
 }
 
-// TestStopperRunTaskPanic ensures that a panic handler can recover panicking
-// tasks, and that no tasks are leaked when they panic.
-func TestStopperRunTaskPanic(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	ch := make(chan interface{})
-	s := stop.NewStopper(stop.OnPanic(func(ctx context.Context, v interface{}) {
-		log.Infof(ctx, "recovering from panic")
-		ch <- v
-	}))
-	defer s.Stop(context.Background())
-	// If RunTask were not panic-safe, Stop() would deadlock.
-	type testFn func()
-	explode := func(context.Context) { panic(ch) }
-	ctx := context.Background()
-	for i, test := range []testFn{
-		func() {
-			_ = s.RunTask(ctx, "test", explode)
-		},
-		func() {
-			_ = s.RunAsyncTask(ctx, "test", func(ctx context.Context) { explode(ctx) })
-		},
-		func() {
-			_ = s.RunAsyncTaskEx(
-				context.Background(),
-				stop.TaskOpts{
-					TaskName:   "test",
-					Sem:        quotapool.NewIntPool("test", 1),
-					WaitForSem: true,
-				},
-				func(ctx context.Context) { explode(ctx) },
-			)
-		},
-	} {
-		t.Run("", func(t *testing.T) {
-			go test()
-			recovered := <-ch
-			if recovered != ch {
-				t.Errorf("%d: unexpected recovered value: %+v", i, recovered)
-			}
-		})
-	}
-}
-
 func TestStopperWithCancel(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s := stop.NewStopper()


### PR DESCRIPTION
Fixes #91700.

This fixes a regression introduced in
fc7bfdf48d40a6a54126c2ade52e72dde8a0b968 (in 2017!)

The `recover()` call from `RecoverAndReportPanic` doesn't work unless the function is called via `defer` directly.  It can't be called from another function e.g. a closure with `defer func() { ... myPanicCatcher() ... }`.


This commit clarifies this in the API docs for the `logcrash` package and fixes the only call site that was incorrect.

Release note (bug fix): Server crashes that occur during startup are now more clearly reported in logs and the standard error output.