### PR TITLE
storage: make `storage.mvcc.range_tombstones.enabled` tenant-readable

### DIFF
--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -82,7 +82,7 @@ var minWALSyncInterval = settings.RegisterDurationSetting(
 // being written, but already written tombstones will remain until GCed. The
 // above note on jobs also applies in this case.
 var MVCCRangeTombstonesEnabled = settings.RegisterBoolSetting(
-	settings.SystemOnly,
+	settings.TenantReadOnly,
 	"storage.mvcc.range_tombstones.enabled",
 	"enables the use of MVCC range tombstones",
 	true)


### PR DESCRIPTION
This setting needs to be readable by tenants, in order to be used by schema GC and import jobs.

Appropriate tests will be added separately.

Epic: CRDB-2624

Release note: None