### PR TITLE
Revert "release: rename Mac Intel release archives"

### DIFF
--- a/build/teamcity/internal/cockroach/release/publish/sign_macos_release.sh
+++ b/build/teamcity/internal/cockroach/release/publish/sign_macos_release.sh
@@ -47,7 +47,9 @@ mkdir -p artifacts
 cd artifacts
 
 for product in cockroach cockroach-sql; do
-  for platform in darwin-11.0-aarch64 darwin-10.9-amd64; do
+  # TODO: add Intel binaries too.
+  # for platform in darwin-11.0-aarch64 darwin-10.9-amd64; do
+  for platform in darwin-11.0-aarch64; do
     base=${product}-${VERSION}.${platform}
     unsigned_base=${product}-${VERSION}.${platform}.unsigned
     unsigned_file=${unsigned_base}.tgz

--- a/pkg/cmd/publish-provisional-artifacts/main.go
+++ b/pkg/cmd/publish-provisional-artifacts/main.go
@@ -154,15 +154,9 @@ func run(providers []release.ObjectPutGetter, flags runFlags, execFn release.Exe
 		updateLatest = true
 	}
 
-	// For release builds (that generate release archives) we use the ".unsigned" suffix in the file name.
-	// The edge uploads will still use the same name (without the "unsigned" suffix) in case there are external consumers.
-	macOSPlatform := release.PlatformMacOS
-	if flags.isRelease {
-		macOSPlatform = release.PlatformMacOSUnsigned
-	}
 	platforms := []release.Platform{
 		release.PlatformLinux,
-		macOSPlatform,
+		release.PlatformMacOS,
 		release.PlatformMacOSArm,
 		release.PlatformWindows,
 		release.PlatformLinuxArm,

--- a/pkg/cmd/publish-provisional-artifacts/main_test.go
+++ b/pkg/cmd/publish-provisional-artifacts/main_test.go
@@ -109,7 +109,7 @@ func (r *mockExecRunner) run(c *exec.Cmd) ([]byte, error) {
 				case "crosslinuxarmbase":
 					platform = release.PlatformLinuxArm
 				case "crossmacosbase":
-					platform = release.PlatformMacOSUnsigned
+					platform = release.PlatformMacOS
 				case "crossmacosarmbase":
 					platform = release.PlatformMacOSArm
 				case "crosswindowsbase":
@@ -186,10 +186,10 @@ func TestProvisional(t *testing.T) {
 				"s3://binaries.cockroachdb.com/cockroach-v0.0.1-alpha.linux-amd64.tgz.sha256sum CONTENTS <sha256sum>",
 				"s3://binaries.cockroachdb.com/cockroach-sql-v0.0.1-alpha.linux-amd64.tgz CONTENTS <binary stuff>",
 				"s3://binaries.cockroachdb.com/cockroach-sql-v0.0.1-alpha.linux-amd64.tgz.sha256sum CONTENTS <sha256sum>",
-				"s3://binaries.cockroachdb.com/cockroach-v0.0.1-alpha.darwin-10.9-amd64.unsigned.tgz CONTENTS <binary stuff>",
-				"s3://binaries.cockroachdb.com/cockroach-v0.0.1-alpha.darwin-10.9-amd64.unsigned.tgz.sha256sum CONTENTS <sha256sum>",
-				"s3://binaries.cockroachdb.com/cockroach-sql-v0.0.1-alpha.darwin-10.9-amd64.unsigned.tgz CONTENTS <binary stuff>",
-				"s3://binaries.cockroachdb.com/cockroach-sql-v0.0.1-alpha.darwin-10.9-amd64.unsigned.tgz.sha256sum CONTENTS <sha256sum>",
+				"s3://binaries.cockroachdb.com/cockroach-v0.0.1-alpha.darwin-10.9-amd64.tgz CONTENTS <binary stuff>",
+				"s3://binaries.cockroachdb.com/cockroach-v0.0.1-alpha.darwin-10.9-amd64.tgz.sha256sum CONTENTS <sha256sum>",
+				"s3://binaries.cockroachdb.com/cockroach-sql-v0.0.1-alpha.darwin-10.9-amd64.tgz CONTENTS <binary stuff>",
+				"s3://binaries.cockroachdb.com/cockroach-sql-v0.0.1-alpha.darwin-10.9-amd64.tgz.sha256sum CONTENTS <sha256sum>",
 				"s3://binaries.cockroachdb.com/cockroach-v0.0.1-alpha.darwin-11.0-aarch64.unsigned.tgz CONTENTS <binary stuff>",
 				"s3://binaries.cockroachdb.com/cockroach-v0.0.1-alpha.darwin-11.0-aarch64.unsigned.tgz.sha256sum CONTENTS <sha256sum>",
 				"s3://binaries.cockroachdb.com/cockroach-sql-v0.0.1-alpha.darwin-11.0-aarch64.unsigned.tgz CONTENTS <binary stuff>",
@@ -372,10 +372,10 @@ func TestBless(t *testing.T) {
 					"REDIRECT /cockroach-v0.0.1.linux-amd64.tgz",
 				"s3://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz.sha256sum/no-cache " +
 					"REDIRECT /cockroach-v0.0.1.linux-amd64.tgz.sha256sum",
-				"s3://binaries.cockroachdb.com/cockroach-latest.darwin-10.9-amd64.unsigned.tgz/no-cache " +
-					"REDIRECT /cockroach-v0.0.1.darwin-10.9-amd64.unsigned.tgz",
-				"s3://binaries.cockroachdb.com/cockroach-latest.darwin-10.9-amd64.unsigned.tgz.sha256sum/no-cache " +
-					"REDIRECT /cockroach-v0.0.1.darwin-10.9-amd64.unsigned.tgz.sha256sum",
+				"s3://binaries.cockroachdb.com/cockroach-latest.darwin-10.9-amd64.tgz/no-cache " +
+					"REDIRECT /cockroach-v0.0.1.darwin-10.9-amd64.tgz",
+				"s3://binaries.cockroachdb.com/cockroach-latest.darwin-10.9-amd64.tgz.sha256sum/no-cache " +
+					"REDIRECT /cockroach-v0.0.1.darwin-10.9-amd64.tgz.sha256sum",
 				"s3://binaries.cockroachdb.com/cockroach-latest.darwin-11.0-aarch64.unsigned.tgz/no-cache " +
 					"REDIRECT /cockroach-v0.0.1.darwin-11.0-aarch64.unsigned.tgz",
 				"s3://binaries.cockroachdb.com/cockroach-latest.darwin-11.0-aarch64.unsigned.tgz.sha256sum/no-cache " +

--- a/pkg/release/build.go
+++ b/pkg/release/build.go
@@ -52,8 +52,6 @@ func SuffixFromPlatform(platform Platform) string {
 		// TODO(#release): The architecture is at least 10.10 until v20.2 and 10.15 for
 		// v21.1 and after. Check whether this can be changed.
 		return ".darwin-10.9-amd64"
-	case PlatformMacOSUnsigned:
-		return ".darwin-10.9-amd64.unsigned"
 	case PlatformMacOSArm:
 		return ".darwin-11.0-aarch64.unsigned"
 	case PlatformWindows:
@@ -71,7 +69,7 @@ func CrossConfigFromPlatform(platform Platform) string {
 		return "crosslinuxbase"
 	case PlatformLinuxArm:
 		return "crosslinuxarmbase"
-	case PlatformMacOS, PlatformMacOSUnsigned:
+	case PlatformMacOS:
 		return "crossmacosbase"
 	case PlatformMacOSArm:
 		return "crossmacosarmbase"
@@ -90,7 +88,7 @@ func TargetTripleFromPlatform(platform Platform) string {
 		return "x86_64-pc-linux-gnu"
 	case PlatformLinuxArm:
 		return "aarch64-unknown-linux-gnu"
-	case PlatformMacOS, PlatformMacOSUnsigned:
+	case PlatformMacOS:
 		return "x86_64-apple-darwin19"
 	case PlatformMacOSArm:
 		return "aarch64-apple-darwin21.2"
@@ -108,7 +106,7 @@ func SharedLibraryExtensionFromPlatform(platform Platform) string {
 		return ".so"
 	case PlatformWindows:
 		return ".dll"
-	case PlatformMacOS, PlatformMacOSArm, PlatformMacOSUnsigned:
+	case PlatformMacOS, PlatformMacOSArm:
 		return ".dylib"
 	default:
 		panic(errors.Newf("unknown platform %d", platform))
@@ -244,8 +242,6 @@ const (
 	PlatformLinuxArm
 	// PlatformMacOS is the Darwin x86_64 target.
 	PlatformMacOS
-	// PlatformMacOSUnsigned is the Darwin x86_64 target.
-	PlatformMacOSUnsigned
 	// PlatformMacOSArm is the Darwin aarch6 target.
 	PlatformMacOSArm
 	// PlatformWindows is the Windows (mingw) x86_64 target.


### PR DESCRIPTION
This reverts commit d8ed4f4ff05b5e7a473bbf688c2e768ef1a812ef, a part of #91220

Unfortunately, signing the main binary makes it impossible to use the GEOS libraries.

Release note: None
Epic: None