### PR TITLE
release-22.2: roachtest: update gorm 1.24.1

### DIFF
--- a/pkg/cmd/roachtest/tests/gorm.go
+++ b/pkg/cmd/roachtest/tests/gorm.go
@@ -24,7 +24,7 @@ import (
 )
 
 var gormReleaseTag = regexp.MustCompile(`^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
-var gormSupportedTag = "v1.24.0"
+var gormSupportedTag = "v1.24.1"
 
 func registerGORM(r registry.Registry) {
 	runGORM := func(ctx context.Context, t test.Test, c cluster.Cluster) {


### PR DESCRIPTION
fixes #91471

Release note: None
Release justification: only test-related code change