### PR TITLE
sql: add tracing span on client side of SetupFlow RPC

### DIFF
--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -154,6 +154,7 @@ func TestTrace(t *testing.T) {
 			// Depending on whether the data is local or not, we may not see these
 			// spans.
 			optionalSpans: []string{
+				"setup-flow-async",
 				"/cockroach.sql.distsqlrun.DistSQL/SetupFlow",
 				"noop",
 			},
@@ -226,6 +227,7 @@ func TestTrace(t *testing.T) {
 			// Depending on whether the data is local or not, we may not see these
 			// spans.
 			optionalSpans: []string{
+				"setup-flow-async",
 				"/cockroach.sql.distsqlrun.DistSQL/SetupFlow",
 				"noop",
 			},


### PR DESCRIPTION
This commit restores the creation of the tracing span for the clients side of the SetupFlow RPC when it is issued in parallel (by the DistSQL worker). This was lost in a recent refactor.

Epic: None

Release note: None