### PR TITLE
changefeedccl: fix handling of deletes in multi-column families

### DIFF
--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -862,10 +862,14 @@ func (rf *Fetcher) processKV(
 					}
 				}
 				if defaultColumnID == 0 {
-					return "", "", errors.Errorf("single entry value with no default column id")
+					if kv.Value.GetTag() == roachpb.ValueType_UNKNOWN {
+						// Tombstone for a secondary column family, nothing needs to be done.
+					} else {
+						return "", "", errors.Errorf("single entry value with no default column id")
+					}
+				} else {
+					prettyKey, prettyValue, err = rf.processValueSingle(ctx, table, defaultColumnID, kv, prettyKey)
 				}
-
-				prettyKey, prettyValue, err = rf.processValueSingle(ctx, table, defaultColumnID, kv, prettyKey)
 			}
 		}
 		if err != nil {


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/91862

rowfetchers assume that a value with no column header must be for a single-column column family, for which the column header isn't needed. This doesn't reliably hold true in changefeeds, when such a value might also be a tombstone.
It looks like the only reason we never ran into this before is that if a column family has only one column, the rowfetcher won't throw an error in this situation as that column is set as the default.

Release note (enterprise change): Fixed a bug causing changefeeds to fail when a value is deleted while running on a non-primary column family with multiple columns.
Release note (core change): Fixed a bug causing changefeeds to fail when a value is deleted while running on a non-primary column family with multiple columns.