### PR TITLE
colexecdisk: fix a rare flake in TestExternalSortMemoryAccounting

### DIFF
--- a/pkg/sql/colexec/colexecdisk/external_sort_test.go
+++ b/pkg/sql/colexec/colexecdisk/external_sort_test.go
@@ -50,7 +50,6 @@ func TestExternalSortMemoryAccounting(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.WithIssue(t, 91850) // flaky test
 	skip.UnderStress(t, "the test is very memory-intensive and is likely to OOM under stress")
 
 	ctx := context.Background()
@@ -134,12 +133,14 @@ func TestExternalSortMemoryAccounting(t *testing.T) {
 	// numInMemoryBufferedBatches (first merge = 2x, second merge = 3x, third
 	// merge 4x, etc, so we expect 2*numNewPartitions-1 partitions).
 	expMaxTotalPartitionsCreated := 2*numNewPartitions - 1
-	// Because of the fact that we are creating partitions slightly larger than
-	// memoryLimit in size and because of our "after the fact" memory
-	// accounting, we might create less partitions than maximum defined above
-	// (e.g., if numNewPartitions is 4, then we will create 3 partitions when
-	// batch size is 3).
-	expMinTotalPartitionsCreated := numNewPartitions - 1
+	// Since we are creating partitions slightly larger than memoryLimit in size
+	// and because of our "after the fact" memory accounting, we might create
+	// fewer partitions than the target (e.g., if numNewPartitions is 4, then we
+	// will create 3 partitions when batch size is 3). However, we might not
+	// even create numNewPartitions-1 in edge cases (due to how we grow
+	// coldata.Bytes.buffer when setting values), so we opt for a sanity check
+	// that at least two partitions were created that must always be true.
+	expMinTotalPartitionsCreated := 2
 	require.GreaterOrEqualf(t, numPartitionsCreated, expMinTotalPartitionsCreated,
 		"didn't create enough partitions: actual %d, min expected %d",
 		numPartitionsCreated, expMinTotalPartitionsCreated,


### PR DESCRIPTION
We recently made a change in how we're growing the flat buffer for non-inlined values in the Bytes vector (we now double the capacity). This means that we now might exceed the memory limit sooner (in terms of the batches buffered) than previously since we now have larger allocated capacity. This also triggers a difference in how we're calculating the "proportional size" of the first `n` elements of the Bytes vector. As a result, a test became flaky since we now might create less partitions than the test expects, so this commit relaxes the assertion.

I did spend some time looking into whether the new behavior is concerning, and I don't think it is.

Fixes: #91850.

Release note: None