### PR TITLE
release-22.2: insights: fix a nil pointer when observing txn with no stmts

### DIFF
--- a/pkg/sql/sqlstats/insights/registry.go
+++ b/pkg/sql/sqlstats/insights/registry.go
@@ -86,6 +86,9 @@ func (r *lockingRegistry) ObserveTransaction(sessionID clusterunique.ID, transac
 		return
 	}
 	statements := r.popSessionStatements(sessionID)
+	if statements == nil {
+		return
+	}
 	defer statements.release()
 
 	var slowStatements util.FastIntSet

--- a/pkg/sql/sqlstats/insights/registry_test.go
+++ b/pkg/sql/sqlstats/insights/registry_test.go
@@ -233,6 +233,12 @@ func TestRegistry(t *testing.T) {
 		observeStatementExecution(r, 10, slow)
 		assertInsightStatementIDs(t, r, []uint64{10, 9})
 	})
+
+	t.Run("txn with no stmts", func(t *testing.T) {
+		st := cluster.MakeTestingClusterSettings()
+		registry := newRegistry(st, &latencyThresholdDetector{st: st})
+		require.NotPanics(t, func() { registry.ObserveTransaction(session.ID, transaction) })
+	})
 }
 
 func observeStatementExecution(registry *lockingRegistry, idBase uint64, latencyInSeconds float64) {


### PR DESCRIPTION
Backport 1/1 commits from #91796.

/cc @cockroachdb/release

---

The bug was introduced in 6ed0eb148f6ef2162eccffa66439a78e1e69ae96.

Fixes: #91795.

Release note: None

Release justification: bug fix.