### PR TITLE
logictest: make a couple of cluster_locks queries more specific

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cluster_locks
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_locks
@@ -162,14 +162,14 @@ test          public      t           /Table/106/1/"b"/0  None            Replic
 test          public      t           /Table/106/1/"c"/0  Exclusive       Replicated    true    false
 
 query TTTTTTBB colnames,retry
-SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, granted, contended FROM crdb_internal.cluster_locks WHERE contended=true
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, granted, contended FROM crdb_internal.cluster_locks WHERE contended=true AND lock_key_pretty LIKE '/Table/106%'
 ----
 database_name schema_name table_name  lock_key_pretty     lock_strength   durability    granted contended
 test          public      t           /Table/106/1/"b"/0  Exclusive       Replicated    true    true
 test          public      t           /Table/106/1/"b"/0  None            Replicated    false   true
 
 query TTTTTTBB colnames,retry
-SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, granted, contended FROM crdb_internal.cluster_locks WHERE contended=false
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, granted, contended FROM crdb_internal.cluster_locks WHERE contended=false AND lock_key_pretty LIKE '/Table/106%'
 ----
 database_name schema_name table_name  lock_key_pretty     lock_strength   durability    granted contended
 test          public      t           /Table/106/1/"c"/0  Exclusive       Replicated    true    false


### PR DESCRIPTION
This commit adds an additional filter to check only the test table in question in order to avoid flakes on contention on the system tables.

Fixes: #91853.

Release note: None