### PR TITLE
changfeedccl: deflake TestAlterChangefeedTelemetry 

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -250,7 +250,6 @@ go_test(
         "//pkg/sql/types",
         "//pkg/storage",
         "//pkg/testutils",
-        "//pkg/testutils/jobutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",

--- a/pkg/testutils/jobutils/jobs_verification.go
+++ b/pkg/testutils/jobutils/jobs_verification.go
@@ -98,7 +98,7 @@ func WaitForJobToHaveNoLease(t testing.TB, db *sqlutils.SQLRunner, jobID jobspb.
 		if sessionID == nil && !instanceID.Valid {
 			return nil
 		}
-		return errors.Newf("job %d still has claim information")
+		return errors.Newf("job %d still has claim information", jobID)
 	}, 2*time.Minute)
 }
 

--- a/pkg/testutils/jobutils/jobs_verification.go
+++ b/pkg/testutils/jobutils/jobs_verification.go
@@ -89,19 +89,6 @@ func waitForJobToHaveStatus(
 	}, 2*time.Minute)
 }
 
-func WaitForJobToHaveNoLease(t testing.TB, db *sqlutils.SQLRunner, jobID jobspb.JobID) {
-	t.Helper()
-	testutils.SucceedsWithin(t, func() error {
-		var sessionID []byte
-		var instanceID gosql.NullInt64
-		db.QueryRow(t, `SELECT claim_session_id, claim_instance_id FROM system.jobs WHERE id = $1`, jobID).Scan(&sessionID, &instanceID)
-		if sessionID == nil && !instanceID.Valid {
-			return nil
-		}
-		return errors.Newf("job %d still has claim information", jobID)
-	}, 2*time.Minute)
-}
-
 // RunJob runs the provided job control statement, initializing, notifying and
 // closing the chan at the passed pointer (see below for why) and returning the
 // jobID and error result. PAUSE JOB and CANCEL JOB are racy in that it's hard


### PR DESCRIPTION
The job system clears the lease asyncronously after cancelation. This
lease clearing transaction can cause a restart in the alter changefeed
transaction, which will lead to different feature counter
counts. Thus, we want to wait for the lease clear. However, the lease
clear isn't guaranteed to happen, so we only wait a few seconds for
it.

Epic: None

Release note: None