### PR TITLE
kvserver: move command size setting to kvserverbase

### DIFF
--- a/pkg/kv/bulk/BUILD.bazel
+++ b/pkg/kv/bulk/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/kv/kvclient/rangecache",
-        "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/roachpb",
         "//pkg/settings",

--- a/pkg/kv/bulk/setting.go
+++ b/pkg/kv/bulk/setting.go
@@ -11,7 +11,7 @@
 package bulk
 
 import (
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 )
@@ -30,7 +30,7 @@ var (
 // It returns the smaller of the IngestBatchSize and Raft command size settings.
 func ingestFileSize(st *cluster.Settings) int64 {
 	desiredSize := IngestBatchSize.Get(&st.SV)
-	maxCommandSize := kvserver.MaxCommandSize.Get(&st.SV)
+	maxCommandSize := kvserverbase.MaxCommandSize.Get(&st.SV)
 	if desiredSize > maxCommandSize {
 		return maxCommandSize
 	}

--- a/pkg/kv/kvserver/kvserverbase/BUILD.bazel
+++ b/pkg/kv/kvserver/kvserverbase/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/settings",
         "//pkg/util/errorutil",
         "//pkg/util/hlc",
+        "//pkg/util/humanizeutil",
         "//pkg/util/log",
         "//pkg/util/quotapool",
         "//pkg/util/tracing/tracingpb",

--- a/pkg/kv/kvserver/kvserverbase/base.go
+++ b/pkg/kv/kvserver/kvserverbase/base.go
@@ -215,6 +215,12 @@ var SplitByLoadMergeDelay = settings.RegisterDurationSetting(
 	},
 )
 
-// MaxCommandSizeDefault is the default for the kv.raft.command.max_size
-// cluster setting.
-const MaxCommandSizeDefault = 64 << 20
+const (
+	// MaxCommandSizeDefault is the default for the kv.raft.command.max_size
+	// cluster setting.
+	MaxCommandSizeDefault = 64 << 20 // 64 MB
+
+	// MaxCommandSizeFloor is the minimum allowed value for the
+	// kv.raft.command.max_size cluster setting.
+	MaxCommandSizeFloor = 4 << 20 // 4 MB
+)

--- a/pkg/kv/kvserver/kvserverbase/base.go
+++ b/pkg/kv/kvserver/kvserverbase/base.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
@@ -223,4 +224,18 @@ const (
 	// MaxCommandSizeFloor is the minimum allowed value for the
 	// kv.raft.command.max_size cluster setting.
 	MaxCommandSizeFloor = 4 << 20 // 4 MB
+)
+
+// MaxCommandSize wraps "kv.raft.command.max_size".
+var MaxCommandSize = settings.RegisterByteSizeSetting(
+	settings.TenantWritable,
+	"kv.raft.command.max_size",
+	"maximum size of a raft command",
+	MaxCommandSizeDefault,
+	func(size int64) error {
+		if size < MaxCommandSizeFloor {
+			return fmt.Errorf("max_size must be greater than %s", humanizeutil.IBytes(MaxCommandSizeFloor))
+		}
+		return nil
+	},
 )

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -12,7 +12,6 @@ package kvserver
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"sync/atomic"
 	"time"
@@ -40,7 +39,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -89,20 +87,6 @@ var disableSyncRaftLog = settings.RegisterBoolSetting(
 		"Setting to true risks data loss or data corruption on server crashes. "+
 		"The setting is meant for internal testing only and SHOULD NOT be used in production.",
 	false,
-)
-
-// MaxCommandSize wraps "kv.raft.command.max_size".
-var MaxCommandSize = settings.RegisterByteSizeSetting(
-	settings.TenantWritable,
-	"kv.raft.command.max_size",
-	"maximum size of a raft command",
-	kvserverbase.MaxCommandSizeDefault,
-	func(size int64) error {
-		if size < kvserverbase.MaxCommandSizeFloor {
-			return fmt.Errorf("max_size must be greater than %s", humanizeutil.IBytes(kvserverbase.MaxCommandSizeFloor))
-		}
-		return nil
-	},
 )
 
 // StrictGCEnforcement controls whether requests are rejected based on the GC

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -91,12 +91,6 @@ var disableSyncRaftLog = settings.RegisterBoolSetting(
 	false,
 )
 
-const (
-	// MaxCommandSizeFloor is the minimum allowed value for the
-	// kv.raft.command.max_size cluster setting.
-	MaxCommandSizeFloor = 4 << 20 // 4MB
-)
-
 // MaxCommandSize wraps "kv.raft.command.max_size".
 var MaxCommandSize = settings.RegisterByteSizeSetting(
 	settings.TenantWritable,
@@ -104,8 +98,8 @@ var MaxCommandSize = settings.RegisterByteSizeSetting(
 	"maximum size of a raft command",
 	kvserverbase.MaxCommandSizeDefault,
 	func(size int64) error {
-		if size < MaxCommandSizeFloor {
-			return fmt.Errorf("max_size must be greater than %s", humanizeutil.IBytes(MaxCommandSizeFloor))
+		if size < kvserverbase.MaxCommandSizeFloor {
+			return fmt.Errorf("max_size must be greater than %s", humanizeutil.IBytes(kvserverbase.MaxCommandSizeFloor))
 		}
 		return nil
 	},

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -253,7 +253,7 @@ func (r *Replica) evalAndPropose(
 	// commands can evaluate but then be blocked on quota, which has worse memory
 	// behavior.
 	quotaSize := uint64(proposal.command.Size())
-	if maxSize := uint64(MaxCommandSize.Get(&r.store.cfg.Settings.SV)); quotaSize > maxSize {
+	if maxSize := uint64(kvserverbase.MaxCommandSize.Get(&r.store.cfg.Settings.SV)); quotaSize > maxSize {
 		return nil, nil, "", nil, roachpb.NewError(errors.Errorf(
 			"command is too large: %d bytes (max: %d)", quotaSize, maxSize,
 		))

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -9576,10 +9576,10 @@ func TestCommandTooLarge(t *testing.T) {
 
 	st := tc.store.cfg.Settings
 	st.Manual.Store(true)
-	MaxCommandSize.Override(ctx, &st.SV, 1024)
+	kvserverbase.MaxCommandSize.Override(ctx, &st.SV, 1024)
 
 	args := putArgs(roachpb.Key("k"),
-		[]byte(strings.Repeat("a", int(MaxCommandSize.Get(&st.SV)))))
+		[]byte(strings.Repeat("a", int(kvserverbase.MaxCommandSize.Get(&st.SV)))))
 	if _, pErr := tc.SendWrapped(&args); !testutils.IsPError(pErr, "command is too large") {
 		t.Fatalf("did not get expected error: %v", pErr)
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/storepool"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/ctpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/sidetransport"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
@@ -535,7 +536,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 				if !serverrangefeed.RangefeedBudgetsEnabled.Get(&st.SV) {
 					return 0
 				}
-				if raftCmdLimit := kvserver.MaxCommandSize.Get(&st.SV); raftCmdLimit > limit {
+				if raftCmdLimit := kvserverbase.MaxCommandSize.Get(&st.SV); raftCmdLimit > limit {
 					return raftCmdLimit
 				}
 				return limit


### PR DESCRIPTION
This PR moves the command size setting into `kvserverbase`, to avoid circular dependencies on `kvserver` in a separated log storage.

Part of #91899
Release note: None