### PR TITLE
roachtest: reassign tests to replication team

### DIFF
--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -40,6 +40,10 @@ cockroachdb/kv:
     cockroachdb/kv-triage: roachtest
     cockroachdb/kv-prs: other
   triage_column_id: 14242655
+cockroachdb/replication:
+  aliases:
+    cockroachdb/repl-prs: other
+  label: T-kv-replication
 cockroachdb/geospatial:
   triage_column_id: 9487269
 cockroachdb/dev-inf:

--- a/pkg/cmd/roachtest/github_test.go
+++ b/pkg/cmd/roachtest/github_test.go
@@ -31,6 +31,7 @@ var (
     cockroachdb/rfc-prs: other
   triage_column_id: 0
 cockroachdb/test-eng:
+  label: T-testeng
   triage_column_id: 14041337
 cockroachdb/dev-inf:
   triage_column_id: 10210759`
@@ -204,6 +205,7 @@ func TestCreatePostRequest(t *testing.T) {
 
 			expectedTeam := "@cockroachdb/unowned"
 			expectedName := "github_test"
+			expectedLabel := ""
 			expectedMessagePrefix := ""
 
 			if c.category == clusterCreationErr {
@@ -212,6 +214,7 @@ func TestCreatePostRequest(t *testing.T) {
 				expectedMessagePrefix = "test github_test was skipped due to "
 			} else if c.category == sshErr {
 				expectedTeam = "@cockroachdb/test-eng"
+				expectedLabel = "T-testeng"
 				expectedName = "ssh_problem"
 				expectedMessagePrefix = "test github_test failed due to "
 			}
@@ -219,6 +222,9 @@ func TestCreatePostRequest(t *testing.T) {
 			require.Contains(t, req.MentionOnCreate, expectedTeam)
 			require.Equal(t, expectedName, req.TestName)
 			require.True(t, strings.HasPrefix(req.Message, expectedMessagePrefix), req.Message)
+			if expectedLabel != "" {
+				require.Contains(t, req.ExtraLabels, expectedLabel)
+			}
 		}
 	}
 }

--- a/pkg/cmd/roachtest/registry/owners.go
+++ b/pkg/cmd/roachtest/registry/owners.go
@@ -20,6 +20,7 @@ const (
 	OwnerDisasterRecovery Owner = `disaster-recovery`
 	OwnerCDC              Owner = `cdc`
 	OwnerKV               Owner = `kv`
+	OwnerReplication      Owner = `replication`
 	OwnerAdmissionControl Owner = `admission-control`
 	OwnerMultiRegion      Owner = `multiregion`
 	OwnerObsInf           Owner = `obs-inf-prs`

--- a/pkg/cmd/roachtest/tests/inconsistency.go
+++ b/pkg/cmd/roachtest/tests/inconsistency.go
@@ -25,7 +25,7 @@ import (
 func registerInconsistency(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:    "inconsistency",
-		Owner:   registry.OwnerKV,
+		Owner:   registry.OwnerReplication,
 		Cluster: r.MakeClusterSpec(3),
 		Run:     runInconsistency,
 	})

--- a/pkg/cmd/roachtest/tests/loss_of_quorum_recovery.go
+++ b/pkg/cmd/roachtest/tests/loss_of_quorum_recovery.go
@@ -62,7 +62,7 @@ func registerLOQRecovery(r registry.Registry) {
 		testSpec := s
 		r.Add(registry.TestSpec{
 			Name:              s.String(),
-			Owner:             registry.OwnerKV,
+			Owner:             registry.OwnerReplication,
 			Tags:              []string{`default`},
 			Cluster:           spec,
 			NonReleaseBlocker: true,

--- a/pkg/cmd/roachtest/tests/replicagc.go
+++ b/pkg/cmd/roachtest/tests/replicagc.go
@@ -31,7 +31,7 @@ func registerReplicaGC(r registry.Registry) {
 	for _, restart := range []bool{true, false} {
 		r.Add(registry.TestSpec{
 			Name:    fmt.Sprintf("replicagc-changed-peers/restart=%t", restart),
-			Owner:   registry.OwnerKV,
+			Owner:   registry.OwnerReplication,
 			Cluster: r.MakeClusterSpec(6),
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runReplicaGCChangedPeers(ctx, t, c, restart)

--- a/pkg/internal/team/team.go
+++ b/pkg/internal/team/team.go
@@ -37,6 +37,8 @@ type Team struct {
 	// CODEOWNERS, code reviews for the @cockroachdb/kv team). This map
 	// does not contain TeamName.
 	Aliases map[Alias]Purpose `yaml:"aliases"`
+	// GitHub label will be added to issues posted for this team.
+	Label string `yaml:"label"`
 	// TriageColumnID is the GitHub Column ID to assign issues to.
 	TriageColumnID int `yaml:"triage_column_id"`
 	// Email is the email address for this team.


### PR DESCRIPTION
**internal/team: add support for team labels**

Previously, roachtest issues were assigned to a GitHub project board,
and Blathers would assign a team label based on that. However, some
teams don't use GitHub project boards.

This patch adds an explicit team label, and makes roachtest set it when
posting issues.

Release note: None
  
**TEAMS: add replication**

Release note: None
  
**roachtest: reassign tests to replication team**

Resolves #90125.

Release note: None