### PR TITLE
workflow: Correcting path to package.json

### DIFF
--- a/.github/workflows/cluster-ui-release-next.yml
+++ b/.github/workflows/cluster-ui-release-next.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   publish_cluster_ui:
+    if: github.repository == 'cockroachdb/cockroach'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -39,7 +40,7 @@ jobs:
       id: version-check
       shell: bash
       run: |
-        PACKAGE_VERSION=$(cat ./pkg/ui/workspaces/cluster-ui/package.json | jq -r ".version");
+        PACKAGE_VERSION=$(cat ./package.json | jq -r ".version");
         VERSIONS=$(npm view @cockroachlabs/cluster-ui versions)
         if [[ $VERSIONS == *"$PACKAGE_VERSION"* ]]; then
           echo "published=yes" >> $GITHUB_OUTPUT
@@ -57,4 +58,4 @@ jobs:
 
     - name: Publish prerelease version
       if: steps.version-check.outputs.published == 'no'
-      run: npm publish --access public --tag next --dry-run"
+      run: npm publish --access public --tag next --dry-run

--- a/.github/workflows/cluster-ui-release.yml
+++ b/.github/workflows/cluster-ui-release.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   publish_cluster_ui:
+    if: github.repository == 'cockroachdb/cockroach'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -39,7 +40,7 @@ jobs:
       id: version-check
       shell: bash
       run: |
-        PACKAGE_VERSION=$(cat ./pkg/ui/workspaces/cluster-ui/package.json | jq -r ".version");
+        PACKAGE_VERSION=$(cat ./package.json | jq -r ".version");
         VERSIONS=$(npm view @cockroachlabs/cluster-ui versions)
         if [[ $VERSIONS == *"$PACKAGE_VERSION"* ]]; then
           echo "published=yes" >> $GITHUB_OUTPUT
@@ -62,4 +63,4 @@ jobs:
 
     - name: Publish patch version
       if: steps.version-check.outputs.published == 'no'
-      run: npm publish --access public --tag ${{ steps.branch_name.outputs.branch }} --dry-run"
+      run: npm publish --access public --tag ${{ steps.branch_name.outputs.branch }} --dry-run


### PR DESCRIPTION
Corrected the path to Cluster UI package.json, based on working directory for the job. There was also an erroneous quote left in the npm command that was removed.

Epic CC-7999
see also CC-7959

Release note: None