### PR TITLE
release-22.2: ui: change height of column selector

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/columnsSelector/columnsSelector.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/columnsSelector/columnsSelector.tsx
@@ -81,6 +81,10 @@ const customStyles = {
     position: "relative",
     boxShadow: "none",
   }),
+  menuList: (provided: any) => ({
+    ...provided,
+    maxHeight: "310px",
+  }),
   option: (provided: any, state: any) => ({
     ...provided,
     backgroundColor: "white",


### PR DESCRIPTION
Backport 1/1 commits from #91867.

/cc @cockroachdb/release

---

Previosuly, it was hard to identify there was more items on the columns selector, since the scrollbar is confugured by the user and might not show up right away (it will show once you hover with mouse and scroll).
This commit changes the height of the filter, making part of the next options to show up, hinting there is more options when scrolling.

Part Of #91763

Before
<img width="322" alt="Screen Shot 2022-11-14 at 2 59 39 PM" src="https://user-images.githubusercontent.com/1017486/201755400-1276e45b-62b8-44c0-a7ff-c337090ad94a.png">

After
<img width="308" alt="Screen Shot 2022-11-14 at 3 02 47 PM" src="https://user-images.githubusercontent.com/1017486/201755427-906e1c3b-e9fa-443b-9508-b2957b38d90b.png">


Release note (ui change): Change the height of column selector, so it can hint there are more options to be selected once scrolled.

---
Release justification: small ui fix
