### PR TITLE
ui: introduce tenant dropdown selection

### DIFF
--- a/pkg/ui/workspaces/db-console/src/components/dropdown/dropdown.tsx
+++ b/pkg/ui/workspaces/db-console/src/components/dropdown/dropdown.tsx
@@ -30,6 +30,7 @@ export interface DropdownProps {
   dropdownToggleButton?: () => React.ReactNode;
   className?: string;
   menuPlacement?: "right" | "left";
+  icon?: JSX.Element;
 }
 
 interface DropdownState {
@@ -40,16 +41,19 @@ interface DropdownButtonProps {
   children: React.ReactNode;
   isOpen: boolean;
   onClick?: (event: React.MouseEvent<HTMLElement>) => void;
+  icon?: JSX.Element;
 }
 
 function DropdownButton(props: DropdownButtonProps) {
-  const { children } = props;
+  const { children, icon } = props;
   return (
     <Button
       type="flat"
       size="small"
       iconPosition="right"
-      icon={() => <Icon className="collapse-toggle__icon" type="caret-down" />}
+      icon={() =>
+        icon || <Icon className="collapse-toggle__icon" type="caret-down" />
+      }
     >
       {children}
     </Button>
@@ -79,13 +83,17 @@ export class Dropdown extends React.Component<DropdownProps, DropdownState> {
   };
 
   renderDropdownToggleButton = () => {
-    const { children, dropdownToggleButton } = this.props;
+    const { children, dropdownToggleButton, icon } = this.props;
     const { isOpen } = this.state;
 
     if (dropdownToggleButton) {
       return dropdownToggleButton();
     } else {
-      return <DropdownButton isOpen={isOpen}>{children}</DropdownButton>;
+      return (
+        <DropdownButton isOpen={isOpen} icon={icon}>
+          {children}
+        </DropdownButton>
+      );
     }
   };
 

--- a/pkg/ui/workspaces/db-console/src/redux/tenantOptions.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/tenantOptions.ts
@@ -1,0 +1,28 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+export const selectTenantsFromCookies = (): string[] => {
+  const sessionCookieStr = document.cookie
+    .split(";")
+    .filter(row => row.trim().startsWith("session="))[0];
+  return sessionCookieStr
+    ? sessionCookieStr
+        .replace(/["]/g, "")
+        .replace("session=", "")
+        .split(/[,&]/g)
+        .filter((_, idx) => idx % 2 == 1)
+    : [];
+};
+
+export const selectCurrentTenantFromCookies = (): string | null => {
+  const tenantCookieStr = document.cookie
+    .split(";")
+    .filter(row => row.trim().startsWith("tenant="))[0];
+  return tenantCookieStr ? tenantCookieStr.replace("tenant=", "") : null;
+};

--- a/pkg/ui/workspaces/db-console/src/views/app/components/tenantDropdown/tenantDropdown.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/components/tenantDropdown/tenantDropdown.spec.tsx
@@ -1,0 +1,43 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+import {
+  selectTenantsFromCookies,
+  selectCurrentTenantFromCookies,
+} from "src/redux/tenantOptions";
+import React from "react";
+import TenantDropdown from "./tenantDropdown";
+import { shallow } from "enzyme";
+
+jest.mock("src/redux/tenantOptions", () => ({
+  selectTenantsFromCookies: jest.fn(),
+  selectCurrentTenantFromCookies: jest.fn(),
+}));
+
+describe("TenantDropdown", () => {
+  it("returns null if there are no tenants in the session cookie", () => {
+    (
+      selectTenantsFromCookies as jest.MockedFn<typeof selectTenantsFromCookies>
+    ).mockReturnValueOnce([]);
+    const wrapper = shallow(<TenantDropdown />);
+    expect(wrapper.isEmptyRender());
+  });
+  it("returns a dropdown list of tenant options if there are tenant in the session cookie", () => {
+    (
+      selectTenantsFromCookies as jest.MockedFn<typeof selectTenantsFromCookies>
+    ).mockReturnValueOnce(["system", "app"]);
+    (
+      selectCurrentTenantFromCookies as jest.MockedFn<
+        typeof selectCurrentTenantFromCookies
+      >
+    ).mockReturnValueOnce("system");
+    const wrapper = shallow(<TenantDropdown />);
+    expect(wrapper.find({ children: "Tenant system" }).length).toEqual(1);
+  });
+});

--- a/pkg/ui/workspaces/db-console/src/views/app/components/tenantDropdown/tenantDropdown.styl
+++ b/pkg/ui/workspaces/db-console/src/views/app/components/tenantDropdown/tenantDropdown.styl
@@ -1,4 +1,4 @@
-// Copyright 2019 The Cockroach Authors.
+// Copyright 2022 The Cockroach Authors.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt.
@@ -10,19 +10,21 @@
 
 @require '~src/components/core/index.styl'
 
-.page-header
-  height 100%
-  display flex
-  flex-direction row
-  flex-flow wrap
-  align-items center
-  padding $spacing-x-small 0
-  .text
-    font-family $font-family--semi-bold
-    color $colors--neutral-8
-  :last-child
-    margin-left auto
+.tenant-dropdown
+    display flex
+    flex-direction row
+    align-items center
+    padding 8px 12px
+    background $colors--neutral-0
+    border 1px solid $colors--neutral-4
+    border-radius 3px
 
-.page-header > *
-  margin-right $spacing-small
-  margin-bottom 0
+.tenant-selected
+    color $colors--neutral-7
+    padding-right 6px
+    font-weight 600
+    font-size 14px
+    font-family $font-family--semi-bold
+
+.tenant-caret-down
+    fill $colors--neutral-7

--- a/pkg/ui/workspaces/db-console/src/views/app/components/tenantDropdown/tenantDropdown.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/components/tenantDropdown/tenantDropdown.tsx
@@ -1,0 +1,57 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+import {
+  selectCurrentTenantFromCookies,
+  selectTenantsFromCookies,
+} from "src/redux/tenantOptions";
+import React from "react";
+import { Dropdown } from "src/components/dropdown";
+import ErrorBoundary from "../errorMessage/errorBoundary";
+import { CaretDown } from "@cockroachlabs/icons";
+import "./tenantDropdown.styl";
+
+const tenantIDKey = "tenant";
+
+const TenantDropdown = () => {
+  const tenants = selectTenantsFromCookies();
+  const currentTenantID = selectCurrentTenantFromCookies();
+
+  const createDropdownItems = () => {
+    return (
+      tenants?.map(tenantID => {
+        return { name: "Tenant " + tenantID, value: tenantID };
+      }) || []
+    );
+  };
+
+  const setTenantCookie = (tenantID: string) => {
+    document.cookie = `${tenantIDKey}=${tenantID};path=/`;
+    location.reload();
+  };
+
+  if (tenants.length == 0) {
+    return null;
+  }
+
+  return (
+    <ErrorBoundary>
+      <Dropdown
+        className="tenant-dropdown"
+        items={createDropdownItems()}
+        onChange={tenantID => setTenantCookie(tenantID)}
+        icon={<CaretDown className="tenant-caret-down" />}
+      >
+        <div className="tenant-selected">{"Tenant " + currentTenantID}</div>
+      </Dropdown>
+    </ErrorBoundary>
+  );
+};
+
+export default TenantDropdown;

--- a/pkg/ui/workspaces/db-console/src/views/app/containers/layout/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/containers/layout/index.tsx
@@ -40,6 +40,7 @@ import { Badge } from "@cockroachlabs/cluster-ui";
 import "./layout.styl";
 import "./layoutPanel.styl";
 import { getDataFromServer } from "src/util/dataFromServer";
+import TenantDropdown from "../../components/tenantDropdown/tenantDropdown";
 
 export interface LayoutProps {
   clusterName: string;
@@ -99,6 +100,7 @@ class Layout extends React.Component<LayoutProps & RouteComponentProps> {
                 {clusterName || `Cluster id: ${clusterId || ""}`}
               </Text>
               <Badge text={clusterVersion} />
+              <TenantDropdown />
             </PageHeader>
           </div>
           <div className="layout-panel__body">


### PR DESCRIPTION
This change introduces a top-level dropdown which allows users to select which tenant they want to view. This is done by setting a tenant cookie which the http router can redirect traffic by. The dropdown will not be visible if the session cookie is not in the multi-tenant format.

Epic: https://cockroachlabs.atlassian.net/browse/CRDB-14546

Release note (ui change): add tenant dropdown selection for multi tenant clusters.

![Screen Shot 2022-11-28 at 10 09 19 AM](https://user-images.githubusercontent.com/17861665/204312395-1d595de9-cb7c-4073-835b-555ffe83a64a.png)
