### PR TITLE
release-22.1: admission: temporary knob to disable AC for user requests 

### DIFF
--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3728,6 +3728,12 @@ func (n KVAdmissionControllerImpl) AdmitKVWork(
 		if source == roachpb.AdmissionHeader_OTHER {
 			bypassAdmission = true
 		}
+		// TODO(abaptist): Revisit and deprecate this setting in v23.1.
+		if admission.KVBulkOnlyAdmissionControlEnabled.Get(&n.settings.SV) {
+			if admission.WorkPriority(ba.AdmissionHeader.Priority) >= admission.NormalPri {
+				bypassAdmission = true
+			}
+		}
 		createTime := ba.AdmissionHeader.CreateTime
 		if !bypassAdmission && createTime == 0 {
 			// TODO(sumeer): revisit this for multi-tenant. Specifically, the SQL use

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -49,6 +49,20 @@ var KVAdmissionControlEnabled = settings.RegisterBoolSetting(
 	"when true, work performed by the KV layer is subject to admission control",
 	true).WithPublic()
 
+// KVBulkOnlyAdmissionControlEnabled controls whether user (normal and above
+// priority) work is subject to admission control. If it is set to true, then
+// user work will not be throttled by admission control but bulk work still will
+// be. This setting is a preferable alternative to completely disabling
+// admission control. It can be used reactively in cases where index backfill,
+// schema modifications or other bulk operations are causing high latency due to
+// io_overload on nodes.
+// TODO(baptist): Find a better solution to this in v23.1.
+var KVBulkOnlyAdmissionControlEnabled = settings.RegisterBoolSetting(
+	settings.SystemOnly,
+	"admission.kv.bulk_only.enabled",
+	"when both admission.kv.enabled and this is true, only throttle bulk work",
+	false)
+
 // SQLKVResponseAdmissionControlEnabled controls whether response processing
 // in SQL, for KV requests, is enabled.
 var SQLKVResponseAdmissionControlEnabled = settings.RegisterBoolSetting(


### PR DESCRIPTION
Backport 1/1 commits from #90448.

/cc @cockroachdb/release

---

informs: #85641

Only leave admission control in place for elastic / bulk requests.

Release note: None

Release justification: This adds a configurable flag that can help us in cases where a large job (like index creation) is affecting user traffic. Testing on TPC-E index creation has shown long delays to user traffic (2 minutes) without this setting. There are plans to address this in v23.1, however, until then this is a "last resort" lever for those types of customers.