### PR TITLE
[DNM] sql: avoid memcpys on mutation data path

### DIFF
--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -361,7 +361,7 @@ func (h *hasher) HashDatum(val tree.Datum) {
 	case *tree.DString:
 		h.HashString(string(*t))
 	case *tree.DBytes:
-		h.HashBytes([]byte(*t))
+		h.HashBytes(encoding.UnsafeConvertStringToBytes(string(*t)))
 	case *tree.DDate:
 		h.HashUint64(uint64(t.PGEpochDays()))
 	case *tree.DTime:
@@ -840,7 +840,9 @@ func (h *hasher) IsDatumEqual(l, r tree.Datum) bool {
 		return lt.Locale == rt.Locale && h.IsStringEqual(lt.Contents, rt.Contents)
 	case *tree.DBytes:
 		rt := r.(*tree.DBytes)
-		return bytes.Equal([]byte(*lt), []byte(*rt))
+		ltv := encoding.UnsafeConvertStringToBytes(string(*lt))
+		rtv := encoding.UnsafeConvertStringToBytes(string(*rt))
+		return h.IsBytesEqual(ltv, rtv)
 	case *tree.DDate:
 		rt := r.(*tree.DDate)
 		return lt.Date == rt.Date

--- a/pkg/sql/pgwire/pgwirebase/encoding.go
+++ b/pkg/sql/pgwire/pgwirebase/encoding.go
@@ -393,7 +393,7 @@ func DecodeDatum(
 			if err != nil {
 				return nil, tree.MakeParseError(string(b), typ, err)
 			}
-			return tree.NewDBytes(tree.DBytes(res)), nil
+			return tree.NewDBytes(tree.DBytes(unsafeBytesToString(res))), nil
 		case oid.T_timestamp:
 			d, _, err := tree.ParseDTimestamp(evalCtx, string(b), time.Microsecond)
 			if err != nil {
@@ -1103,3 +1103,9 @@ const (
 	// AF_NET + 1.
 	PGBinaryIPv6family byte = 3
 )
+
+// unsafeBytesToString constructs a string from a byte slice. It is
+// critical that the byte slice not be modified.
+func unsafeBytesToString(data []byte) string {
+	return *(*string)(unsafe.Pointer(&data))
+}

--- a/pkg/sql/rowenc/valueside/encode.go
+++ b/pkg/sql/rowenc/valueside/encode.go
@@ -47,11 +47,14 @@ func Encode(appendTo []byte, colID ColumnIDDelta, val tree.Datum, scratch []byte
 	case *tree.DDecimal:
 		return encoding.EncodeDecimalValue(appendTo, uint32(colID), &t.Decimal), nil
 	case *tree.DString:
-		return encoding.EncodeBytesValue(appendTo, uint32(colID), []byte(*t)), nil
+		v := encoding.UnsafeConvertStringToBytes(string(*t))
+		return encoding.EncodeBytesValue(appendTo, uint32(colID), v), nil
 	case *tree.DBytes:
-		return encoding.EncodeBytesValue(appendTo, uint32(colID), []byte(*t)), nil
+		v := encoding.UnsafeConvertStringToBytes(string(*t))
+		return encoding.EncodeBytesValue(appendTo, uint32(colID), v), nil
 	case *tree.DEncodedKey:
-		return encoding.EncodeBytesValue(appendTo, uint32(colID), []byte(*t)), nil
+		v := encoding.UnsafeConvertStringToBytes(string(*t))
+		return encoding.EncodeBytesValue(appendTo, uint32(colID), v), nil
 	case *tree.DDate:
 		return encoding.EncodeIntValue(appendTo, uint32(colID), t.UnixEpochDaysWithOrig()), nil
 	case *tree.DBox2D:
@@ -89,7 +92,8 @@ func Encode(appendTo []byte, colID ColumnIDDelta, val tree.Datum, scratch []byte
 	case *tree.DTuple:
 		return encodeTuple(t, appendTo, uint32(colID), scratch)
 	case *tree.DCollatedString:
-		return encoding.EncodeBytesValue(appendTo, uint32(colID), []byte(t.Contents)), nil
+		v := encoding.UnsafeConvertStringToBytes(t.Contents)
+		return encoding.EncodeBytesValue(appendTo, uint32(colID), v), nil
 	case *tree.DOid:
 		return encoding.EncodeIntValue(appendTo, uint32(colID), int64(t.Oid)), nil
 	case *tree.DEnum:

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -1191,7 +1191,7 @@ var regularBuiltins = map[string]builtinDefinition{
 					return nil, pgerror.New(pgcode.InvalidParameterValue,
 						"only 'hex', 'escape', and 'base64' formats are supported for decode()")
 				}
-				res, err := lex.DecodeRawBytesToByteArray(data, be)
+				res, err := lex.DecodeRawBytesToByteArray([]byte(data), be)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -373,7 +373,7 @@ func ParseDBool(s string) (*DBool, error) {
 // the beginning), and the escaped format, which supports "\\" and
 // octal escapes.
 func ParseDByte(s string) (*DBytes, error) {
-	res, err := lex.DecodeRawBytesToByteArrayAuto([]byte(s))
+	res, err := lex.DecodeRawBytesToByteArrayAuto(encoding.UnsafeConvertStringToBytes(s))
 	if err != nil {
 		return nil, MakeParseError(s, types.Bytes, err)
 	}


### PR DESCRIPTION
This PR includes a trio of changes that avoid about 6 memory re-allocations and copies on the `INSERT`/`UPSERT`/`UPDATE` data path. While memcpys are relatively fast (~16 GB/s on my M1 Mac), they do become CPU intensive for large enough values. They are also typically paired with heap allocations, which come with their own upfront (malloc) and deferred (GC) costs. Wherever possible, we should avoid memcpys on the data path because of the variable size of input data.

Most of these memcpys were unfortunate artifacts of casts back and forth between `string` and `[]byte` when manipulating (encoding, decoding, etc.) `DBytes` datum objects. There is likely a more general solution here.

The change also includes a modified benchmark that inserts 256KB byte array values and is sensitive to re-allocation and memcpys. We shouldn't make that change directly, but adding a benchmark like this would be valuable.

```
➜ benchdiff --old=HEAD~3 --count=10 --post-checkout='dev generate go' --run='KV/Insert/SQL/rows=1.?$$' ./pkg/sql/tests

name                      old time/op    new time/op    delta
KV/Insert/SQL/rows=10-10    21.2ms ± 6%    19.7ms ± 2%   -7.07%  (p=0.000 n=10+10)
KV/Insert/SQL/rows=1-10     2.29ms ± 5%    2.18ms ± 3%   -4.72%  (p=0.000 n=10+10)

name                      old alloc/op   new alloc/op   delta
KV/Insert/SQL/rows=10-10     144MB ± 1%     123MB ± 1%  -14.72%  (p=0.000 n=10+10)
KV/Insert/SQL/rows=1-10     10.6MB ± 2%     9.1MB ± 4%  -13.83%  (p=0.000 n=9+10)

name                      old allocs/op  new allocs/op  delta
KV/Insert/SQL/rows=10-10     7.57k ± 9%     7.30k ± 5%   -3.55%  (p=0.022 n=9+10)
KV/Insert/SQL/rows=1-10      1.15k ± 4%     1.12k ± 2%   -3.04%  (p=0.001 n=9+9)
```

The same benchmarks reveal a similar number of memcpys around the Raft log. For instance, we pack a `raftpb.Entry` into a `roachpb.Value`, then into an `enginepb.MVCCMetadata`, then into a `pebble.Batch`, re-allocating and copying at each step along the way. There's ample room for improvement here, which would have a similar benefit. In fact, at the Raft level, the same expensive work is being performed `replication_factor` times across a cluster, so there's even more reason to optimize.

Release note: None
Epic: None