### PR TITLE
release-22.2: colexecdisk: limit number of FDs used by a single disk-backed op

### DIFF
--- a/pkg/sql/colexec/colexecdisk/external_sort.go
+++ b/pkg/sql/colexec/colexecdisk/external_sort.go
@@ -243,6 +243,9 @@ func NewExternalSorter(
 		// the external sorter.
 		// TODO(asubiotto): this number should be tuned.
 		maxNumberPartitions = fdSemaphore.GetLimit() / 16
+		if maxNumberPartitions > maxFDsForSingleOperator {
+			maxNumberPartitions = maxFDsForSingleOperator
+		}
 	}
 	if maxNumberPartitions < colexecop.ExternalSorterMinPartitions {
 		maxNumberPartitions = colexecop.ExternalSorterMinPartitions


### PR DESCRIPTION
Backport 1/1 commits from #91785.

/cc @cockroachdb/release

---

This commit fixes an oversight in how we're computing the number of file descriptors that a single disk-backed operator can use. Previously, we would start the calculation at 1/16 of the node-wide limit, regardless of what that comes down to. If an operator cannot acquire the FDs, we have a hint suggesting to increase that node-wide limit, but then it wouldn't actually do much - the node would still support the same number of concurrent disk-spilling queries. This is now fixed by capping the number at 16 (which is the number that an operator gets with the default limit value). I don't think there is much upside in going higher - it seems more important to support higher concurrency of disk-spilling queries rather than to speed up a smaller number of queries by a percent.

Addresses: #91784.

Epic: CRDB-20535

Release note: None

Release justification: bug fix.