### PR TITLE
kvserver,allocator: decouple allocator from storepool

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
@@ -478,6 +478,7 @@ type AllocatorMetrics struct {
 // in the cluster.
 type Allocator struct {
 	st            *cluster.Settings
+	deterministic bool
 	StorePool     storepool.AllocatorStorePool
 	nodeLatencyFn func(addr string) (time.Duration, bool)
 	// TODO(aayush): Let's replace this with a *rand.Rand that has a rand.Source
@@ -516,17 +517,19 @@ func MakeAllocator(
 	knobs *allocator.TestingKnobs,
 ) Allocator {
 	var randSource rand.Source
+	var deterministic bool
 	// There are number of test cases that make a test store but don't add
 	// gossip or a store pool. So we can't rely on the existence of the
 	// store pool in those cases.
 	if storePool != nil && storePool.IsDeterministic() {
 		randSource = rand.NewSource(777)
+		deterministic = true
 	} else {
-
 		randSource = rand.NewSource(rand.Int63())
 	}
 	allocator := Allocator{
 		st:            st,
+		deterministic: deterministic,
 		StorePool:     storePool,
 		nodeLatencyFn: nodeLatencyFn,
 		randGen:       makeAllocatorRand(randSource),
@@ -597,9 +600,12 @@ func GetNeededNonVoters(numVoters, zoneConfigNonVoterCount, clusterNodes int) in
 // supplied range, as governed by the supplied zone configuration. It
 // returns the required action that should be taken and a priority.
 func (a *Allocator) ComputeAction(
-	ctx context.Context, conf roachpb.SpanConfig, desc *roachpb.RangeDescriptor,
+	ctx context.Context,
+	storePool storepool.AllocatorStorePool,
+	conf roachpb.SpanConfig,
+	desc *roachpb.RangeDescriptor,
 ) (action AllocatorAction, priority float64) {
-	if a.StorePool == nil {
+	if storePool == nil {
 		// Do nothing if storePool is nil for some unittests.
 		action = AllocatorNoop
 		return action, action.Priority()
@@ -657,13 +663,13 @@ func (a *Allocator) ComputeAction(
 		return action, action.Priority()
 	}
 
-	return a.computeAction(ctx, conf, desc.Replicas().VoterDescriptors(),
+	return a.computeAction(ctx, storePool, conf, desc.Replicas().VoterDescriptors(),
 		desc.Replicas().NonVoterDescriptors())
-
 }
 
 func (a *Allocator) computeAction(
 	ctx context.Context,
+	storePool storepool.AllocatorStorePool,
 	conf roachpb.SpanConfig,
 	voterReplicas []roachpb.ReplicaDescriptor,
 	nonVoterReplicas []roachpb.ReplicaDescriptor,
@@ -681,10 +687,10 @@ func (a *Allocator) computeAction(
 	// After that we handle rebalancing related actions, followed by removal
 	// actions.
 	haveVoters := len(voterReplicas)
-	decommissioningVoters := a.StorePool.DecommissioningReplicas(voterReplicas)
+	decommissioningVoters := storePool.DecommissioningReplicas(voterReplicas)
 	// Node count including dead nodes but excluding
 	// decommissioning/decommissioned nodes.
-	clusterNodes := a.StorePool.ClusterNodeCount()
+	clusterNodes := storePool.ClusterNodeCount()
 	neededVoters := GetNeededVoters(conf.GetNumVoters(), clusterNodes)
 	desiredQuorum := computeQuorum(neededVoters)
 	quorum := computeQuorum(haveVoters)
@@ -710,7 +716,7 @@ func (a *Allocator) computeAction(
 	// heartbeat in the recent past. This means we won't move those replicas
 	// elsewhere (for a regular rebalance or for decommissioning).
 	const includeSuspectAndDrainingStores = true
-	liveVoters, deadVoters := a.StorePool.LiveAndDeadReplicas(voterReplicas, includeSuspectAndDrainingStores)
+	liveVoters, deadVoters := storePool.LiveAndDeadReplicas(voterReplicas, includeSuspectAndDrainingStores)
 
 	if len(liveVoters) < quorum {
 		// Do not take any replacement/removal action if we do not have a quorum of
@@ -789,7 +795,7 @@ func (a *Allocator) computeAction(
 		return action, action.Priority()
 	}
 
-	liveNonVoters, deadNonVoters := a.StorePool.LiveAndDeadReplicas(
+	liveNonVoters, deadNonVoters := storePool.LiveAndDeadReplicas(
 		nonVoterReplicas, includeSuspectAndDrainingStores,
 	)
 	if haveNonVoters == neededNonVoters && len(deadNonVoters) > 0 {
@@ -800,7 +806,7 @@ func (a *Allocator) computeAction(
 		return action, action.Priority()
 	}
 
-	decommissioningNonVoters := a.StorePool.DecommissioningReplicas(nonVoterReplicas)
+	decommissioningNonVoters := storePool.DecommissioningReplicas(nonVoterReplicas)
 	if haveNonVoters == neededNonVoters && len(decommissioningNonVoters) > 0 {
 		// The range has non-voter(s) on a decommissioning node that we should
 		// replace.
@@ -922,12 +928,13 @@ func (s *GoodCandidateSelector) selectOne(cl candidateList) *candidate {
 
 func (a *Allocator) allocateTarget(
 	ctx context.Context,
+	storePool storepool.AllocatorStorePool,
 	conf roachpb.SpanConfig,
 	existingVoters, existingNonVoters []roachpb.ReplicaDescriptor,
 	replicaStatus ReplicaStatus,
 	targetType TargetReplicaType,
 ) (roachpb.ReplicationTarget, string, error) {
-	candidateStoreList, aliveStoreCount, throttled := a.StorePool.GetStoreList(storepool.StoreFilterThrottled)
+	candidateStoreList, aliveStoreCount, throttled := storePool.GetStoreList(storepool.StoreFilterThrottled)
 
 	// If the replica is alive we are upreplicating, and in that case we want to
 	// allocate new replicas on the best possible store. Otherwise, the replica is
@@ -941,8 +948,9 @@ func (a *Allocator) allocateTarget(
 		selector = a.NewGoodCandidateSelector()
 	}
 
-	target, details := a.AllocateTargetFromList(
+	target, details := a.allocateTargetFromList(
 		ctx,
+		storePool,
 		candidateStoreList,
 		conf,
 		existingVoters,
@@ -984,11 +992,12 @@ func (a *Allocator) allocateTarget(
 // voting replicas are ruled out as targets.
 func (a *Allocator) AllocateVoter(
 	ctx context.Context,
+	storePool storepool.AllocatorStorePool,
 	conf roachpb.SpanConfig,
 	existingVoters, existingNonVoters []roachpb.ReplicaDescriptor,
 	replicaStatus ReplicaStatus,
 ) (roachpb.ReplicationTarget, string, error) {
-	return a.allocateTarget(ctx, conf, existingVoters, existingNonVoters, replicaStatus, VoterTarget)
+	return a.allocateTarget(ctx, storePool, conf, existingVoters, existingNonVoters, replicaStatus, VoterTarget)
 }
 
 // AllocateNonVoter returns a suitable store for a new allocation of a
@@ -996,11 +1005,12 @@ func (a *Allocator) AllocateVoter(
 // _any_ existing replicas are ruled out as targets.
 func (a *Allocator) AllocateNonVoter(
 	ctx context.Context,
+	storePool storepool.AllocatorStorePool,
 	conf roachpb.SpanConfig,
 	existingVoters, existingNonVoters []roachpb.ReplicaDescriptor,
 	replicaStatus ReplicaStatus,
 ) (roachpb.ReplicationTarget, string, error) {
-	return a.allocateTarget(ctx, conf, existingVoters, existingNonVoters, replicaStatus, NonVoterTarget)
+	return a.allocateTarget(ctx, storePool, conf, existingVoters, existingNonVoters, replicaStatus, NonVoterTarget)
 }
 
 // AllocateTargetFromList returns a suitable store for a new allocation of a
@@ -1008,6 +1018,22 @@ func (a *Allocator) AllocateNonVoter(
 // existing set of voters and non-voters..
 func (a *Allocator) AllocateTargetFromList(
 	ctx context.Context,
+	storePool storepool.AllocatorStorePool,
+	candidateStores storepool.StoreList,
+	conf roachpb.SpanConfig,
+	existingVoters, existingNonVoters []roachpb.ReplicaDescriptor,
+	options ScorerOptions,
+	selector CandidateSelector,
+	allowMultipleReplsPerNode bool,
+	targetType TargetReplicaType,
+) (roachpb.ReplicationTarget, string) {
+	return a.allocateTargetFromList(ctx, storePool, candidateStores, conf, existingVoters,
+		existingNonVoters, options, selector, allowMultipleReplsPerNode, targetType)
+}
+
+func (a *Allocator) allocateTargetFromList(
+	ctx context.Context,
+	storePool storepool.AllocatorStorePool,
 	candidateStores storepool.StoreList,
 	conf roachpb.SpanConfig,
 	existingVoters, existingNonVoters []roachpb.ReplicaDescriptor,
@@ -1018,13 +1044,13 @@ func (a *Allocator) AllocateTargetFromList(
 ) (roachpb.ReplicationTarget, string) {
 	existingReplicas := append(existingVoters, existingNonVoters...)
 	analyzedOverallConstraints := constraint.AnalyzeConstraints(
-		a.StorePool,
+		storePool,
 		existingReplicas,
 		conf.NumReplicas,
 		conf.Constraints,
 	)
 	analyzedVoterConstraints := constraint.AnalyzeConstraints(
-		a.StorePool,
+		storePool,
 		existingVoters,
 		conf.GetNumVoters(),
 		conf.VoterConstraints,
@@ -1056,8 +1082,8 @@ func (a *Allocator) AllocateTargetFromList(
 		constraintsChecker,
 		existingReplicaSet,
 		existingNonVoters,
-		a.StorePool.GetLocalitiesByStore(existingReplicaSet),
-		a.StorePool.IsStoreReadyForRoutineReplicaTransfer,
+		storePool.GetLocalitiesByStore(existingReplicaSet),
+		storePool.IsStoreReadyForRoutineReplicaTransfer,
 		allowMultipleReplsPerNode,
 		options,
 		targetType,
@@ -1081,6 +1107,7 @@ func (a *Allocator) AllocateTargetFromList(
 
 func (a Allocator) simulateRemoveTarget(
 	ctx context.Context,
+	storePool storepool.AllocatorStorePool,
 	targetStore roachpb.StoreID,
 	conf roachpb.SpanConfig,
 	candidates []roachpb.ReplicaDescriptor,
@@ -1103,8 +1130,8 @@ func (a Allocator) simulateRemoveTarget(
 	// Update statistics first
 	switch t := targetType; t {
 	case VoterTarget:
-		a.StorePool.UpdateLocalStoreAfterRebalance(targetStore, rangeUsageInfo, roachpb.ADD_VOTER)
-		defer a.StorePool.UpdateLocalStoreAfterRebalance(
+		storePool.UpdateLocalStoreAfterRebalance(targetStore, rangeUsageInfo, roachpb.ADD_VOTER)
+		defer storePool.UpdateLocalStoreAfterRebalance(
 			targetStore,
 			rangeUsageInfo,
 			roachpb.REMOVE_VOTER,
@@ -1113,12 +1140,12 @@ func (a Allocator) simulateRemoveTarget(
 			targetStore)
 
 		return a.RemoveTarget(
-			ctx, conf, storepool.MakeStoreList(candidateStores),
+			ctx, storePool, conf, storepool.MakeStoreList(candidateStores),
 			existingVoters, existingNonVoters, VoterTarget, options,
 		)
 	case NonVoterTarget:
-		a.StorePool.UpdateLocalStoreAfterRebalance(targetStore, rangeUsageInfo, roachpb.ADD_NON_VOTER)
-		defer a.StorePool.UpdateLocalStoreAfterRebalance(
+		storePool.UpdateLocalStoreAfterRebalance(targetStore, rangeUsageInfo, roachpb.ADD_NON_VOTER)
+		defer storePool.UpdateLocalStoreAfterRebalance(
 			targetStore,
 			rangeUsageInfo,
 			roachpb.REMOVE_NON_VOTER,
@@ -1126,7 +1153,7 @@ func (a Allocator) simulateRemoveTarget(
 		log.KvDistribution.VEventf(ctx, 3, "simulating which non-voter would be removed after adding s%d",
 			targetStore)
 		return a.RemoveTarget(
-			ctx, conf, storepool.MakeStoreList(candidateStores),
+			ctx, storePool, conf, storepool.MakeStoreList(candidateStores),
 			existingVoters, existingNonVoters, NonVoterTarget, options,
 		)
 	default:
@@ -1134,24 +1161,11 @@ func (a Allocator) simulateRemoveTarget(
 	}
 }
 
-// StoreListForTargets converts the set of replica targets to a StoreList.
-func (a Allocator) StoreListForTargets(candidates []roachpb.ReplicationTarget) storepool.StoreList {
-	result := make([]roachpb.StoreDescriptor, 0, len(candidates))
-	sl, _, _ := a.StorePool.GetStoreList(storepool.StoreFilterNone)
-	for _, cand := range candidates {
-		for _, store := range sl.Stores {
-			if cand.StoreID == store.StoreID {
-				result = append(result, store)
-			}
-		}
-	}
-	return storepool.MakeStoreList(result)
-}
-
 // RemoveTarget returns a suitable replica (of the given type) to remove from
 // the provided set of replicas.
 func (a Allocator) RemoveTarget(
 	ctx context.Context,
+	storePool storepool.AllocatorStorePool,
 	conf roachpb.SpanConfig,
 	candidateStoreList storepool.StoreList,
 	existingVoters []roachpb.ReplicaDescriptor,
@@ -1168,13 +1182,13 @@ func (a Allocator) RemoveTarget(
 
 	existingReplicas := append(existingVoters, existingNonVoters...)
 	analyzedOverallConstraints := constraint.AnalyzeConstraints(
-		a.StorePool,
+		storePool,
 		existingReplicas,
 		conf.NumReplicas,
 		conf.Constraints,
 	)
 	analyzedVoterConstraints := constraint.AnalyzeConstraints(
-		a.StorePool,
+		storePool,
 		existingVoters,
 		conf.GetNumVoters(),
 		conf.VoterConstraints,
@@ -1201,7 +1215,7 @@ func (a Allocator) RemoveTarget(
 		ctx,
 		candidateStoreList,
 		constraintsChecker,
-		a.StorePool.GetLocalitiesByStore(replicaSetForDiversityCalc),
+		storePool.GetLocalitiesByStore(replicaSetForDiversityCalc),
 		options,
 	)
 
@@ -1231,6 +1245,7 @@ func (a Allocator) RemoveTarget(
 // back to selecting a random target from any of the existing voting replicas.
 func (a Allocator) RemoveVoter(
 	ctx context.Context,
+	storePool storepool.AllocatorStorePool,
 	conf roachpb.SpanConfig,
 	voterCandidates []roachpb.ReplicaDescriptor,
 	existingVoters []roachpb.ReplicaDescriptor,
@@ -1242,10 +1257,11 @@ func (a Allocator) RemoveVoter(
 	for i, exist := range voterCandidates {
 		candidateStoreIDs[i] = exist.StoreID
 	}
-	candidateStoreList, _, _ := a.StorePool.GetStoreListFromIDs(candidateStoreIDs, storepool.StoreFilterNone)
+	candidateStoreList, _, _ := storePool.GetStoreListFromIDs(candidateStoreIDs, storepool.StoreFilterNone)
 
 	return a.RemoveTarget(
 		ctx,
+		storePool,
 		conf,
 		candidateStoreList,
 		existingVoters,
@@ -1262,6 +1278,7 @@ func (a Allocator) RemoveVoter(
 // non-voting replicas.
 func (a Allocator) RemoveNonVoter(
 	ctx context.Context,
+	storePool storepool.AllocatorStorePool,
 	conf roachpb.SpanConfig,
 	nonVoterCandidates []roachpb.ReplicaDescriptor,
 	existingVoters []roachpb.ReplicaDescriptor,
@@ -1273,10 +1290,11 @@ func (a Allocator) RemoveNonVoter(
 	for i, exist := range nonVoterCandidates {
 		candidateStoreIDs[i] = exist.StoreID
 	}
-	candidateStoreList, _, _ := a.StorePool.GetStoreListFromIDs(candidateStoreIDs, storepool.StoreFilterNone)
+	candidateStoreList, _, _ := storePool.GetStoreListFromIDs(candidateStoreIDs, storepool.StoreFilterNone)
 
 	return a.RemoveTarget(
 		ctx,
+		storePool,
 		conf,
 		candidateStoreList,
 		existingVoters,
@@ -1290,6 +1308,7 @@ func (a Allocator) RemoveNonVoter(
 // type) with required attributes.
 func (a Allocator) RebalanceTarget(
 	ctx context.Context,
+	storePool storepool.AllocatorStorePool,
 	conf roachpb.SpanConfig,
 	raftStatus *raft.Status,
 	existingVoters, existingNonVoters []roachpb.ReplicaDescriptor,
@@ -1298,7 +1317,7 @@ func (a Allocator) RebalanceTarget(
 	targetType TargetReplicaType,
 	options ScorerOptions,
 ) (add, remove roachpb.ReplicationTarget, details string, ok bool) {
-	sl, _, _ := a.StorePool.GetStoreList(filter)
+	sl, _, _ := storePool.GetStoreList(filter)
 
 	// If we're considering a rebalance due to an `AdminScatterRequest`, we'd like
 	// to ensure that we're returning a random rebalance target to a new store
@@ -1310,13 +1329,13 @@ func (a Allocator) RebalanceTarget(
 
 	zero := roachpb.ReplicationTarget{}
 	analyzedOverallConstraints := constraint.AnalyzeConstraints(
-		a.StorePool,
+		storePool,
 		existingReplicas,
 		conf.NumReplicas,
 		conf.Constraints,
 	)
 	analyzedVoterConstraints := constraint.AnalyzeConstraints(
-		a.StorePool,
+		storePool,
 		existingVoters,
 		conf.GetNumVoters(),
 		conf.VoterConstraints,
@@ -1360,8 +1379,8 @@ func (a Allocator) RebalanceTarget(
 		rebalanceConstraintsChecker,
 		replicaSetToRebalance,
 		replicasWithExcludedStores,
-		a.StorePool.GetLocalitiesByStore(replicaSetForDiversityCalc),
-		a.StorePool.IsStoreReadyForRoutineReplicaTransfer,
+		storePool.GetLocalitiesByStore(replicaSetForDiversityCalc),
+		storePool.IsStoreReadyForRoutineReplicaTransfer,
 		options,
 		a.Metrics,
 	)
@@ -1411,6 +1430,7 @@ func (a Allocator) RebalanceTarget(
 		var err error
 		removeReplica, removeDetails, err = a.simulateRemoveTarget(
 			ctx,
+			storePool,
 			target.store.StoreID,
 			conf,
 			replicaCandidates,
@@ -1484,6 +1504,7 @@ func (a Allocator) RebalanceTarget(
 //     opportunity was found).
 func (a Allocator) RebalanceVoter(
 	ctx context.Context,
+	storePool storepool.AllocatorStorePool,
 	conf roachpb.SpanConfig,
 	raftStatus *raft.Status,
 	existingVoters, existingNonVoters []roachpb.ReplicaDescriptor,
@@ -1493,6 +1514,7 @@ func (a Allocator) RebalanceVoter(
 ) (add, remove roachpb.ReplicationTarget, details string, ok bool) {
 	return a.RebalanceTarget(
 		ctx,
+		storePool,
 		conf,
 		raftStatus,
 		existingVoters,
@@ -1518,6 +1540,7 @@ func (a Allocator) RebalanceVoter(
 // replicas.
 func (a Allocator) RebalanceNonVoter(
 	ctx context.Context,
+	storePool storepool.AllocatorStorePool,
 	conf roachpb.SpanConfig,
 	raftStatus *raft.Status,
 	existingVoters, existingNonVoters []roachpb.ReplicaDescriptor,
@@ -1527,6 +1550,7 @@ func (a Allocator) RebalanceNonVoter(
 ) (add, remove roachpb.ReplicationTarget, details string, ok bool) {
 	return a.RebalanceTarget(
 		ctx,
+		storePool,
 		conf,
 		raftStatus,
 		existingVoters,
@@ -1543,7 +1567,7 @@ func (a Allocator) RebalanceNonVoter(
 func (a *Allocator) ScorerOptions(ctx context.Context) *RangeCountScorerOptions {
 	return &RangeCountScorerOptions{
 		StoreHealthOptions:      a.StoreHealthOptions(ctx),
-		deterministic:           a.StorePool.IsDeterministic(),
+		deterministic:           a.deterministic,
 		rangeRebalanceThreshold: RangeRebalanceThreshold.Get(&a.st.SV),
 	}
 }
@@ -1553,7 +1577,7 @@ func (a *Allocator) ScorerOptionsForScatter(ctx context.Context) *ScatterScorerO
 	return &ScatterScorerOptions{
 		RangeCountScorerOptions: RangeCountScorerOptions{
 			StoreHealthOptions:      a.StoreHealthOptions(ctx),
-			deterministic:           a.StorePool.IsDeterministic(),
+			deterministic:           a.deterministic,
 			rangeRebalanceThreshold: 0,
 		},
 		// We set jitter to be equal to the padding around replica-count rebalancing
@@ -1578,6 +1602,7 @@ func (a *Allocator) ScorerOptionsForScatter(ctx context.Context) *ScatterScorerO
 // replicas need a snapshot or not), produces no results.
 func (a *Allocator) ValidLeaseTargets(
 	ctx context.Context,
+	storePool storepool.AllocatorStorePool,
 	conf roachpb.SpanConfig,
 	existing []roachpb.ReplicaDescriptor,
 	leaseRepl interface {
@@ -1601,7 +1626,7 @@ func (a *Allocator) ValidLeaseTargets(
 		}
 		candidates = append(candidates, existing[i])
 	}
-	candidates, _ = a.StorePool.LiveAndDeadReplicas(
+	candidates, _ = storePool.LiveAndDeadReplicas(
 		candidates, false, /* includeSuspectAndDrainingStores */
 	)
 
@@ -1653,7 +1678,7 @@ func (a *Allocator) ValidLeaseTargets(
 
 	// Determine which store(s) is preferred based on user-specified preferences.
 	// If any stores match, only consider those stores as candidates.
-	preferred := a.PreferredLeaseholders(conf, candidates)
+	preferred := a.PreferredLeaseholders(storePool, conf, candidates)
 	if len(preferred) > 0 {
 		candidates = preferred
 	}
@@ -1666,6 +1691,7 @@ func (a *Allocator) ValidLeaseTargets(
 // some existing replica.
 func (a *Allocator) leaseholderShouldMoveDueToPreferences(
 	ctx context.Context,
+	storePool storepool.AllocatorStorePool,
 	conf roachpb.SpanConfig,
 	leaseRepl interface {
 		StoreID() roachpb.StoreID
@@ -1693,12 +1719,12 @@ func (a *Allocator) leaseholderShouldMoveDueToPreferences(
 	}
 
 	// Exclude suspect/draining/dead stores.
-	candidates, _ := a.StorePool.LiveAndDeadReplicas(
+	candidates, _ := storePool.LiveAndDeadReplicas(
 		allExistingReplicas, false, /* includeSuspectAndDrainingStores */
 	)
 	// If there are any replicas that do match lease preferences, then we check if
 	// the existing leaseholder is one of them.
-	preferred := a.PreferredLeaseholders(conf, candidates)
+	preferred := a.PreferredLeaseholders(storePool, conf, candidates)
 	preferred = excludeReplicasInNeedOfSnapshots(
 		ctx, leaseRepl.RaftStatus(), leaseRepl.GetFirstIndex(), preferred)
 	if len(preferred) == 0 {
@@ -1742,6 +1768,7 @@ func (a *Allocator) StoreHealthOptions(_ context.Context) StoreHealthOptions {
 // to a learner.
 func (a *Allocator) TransferLeaseTarget(
 	ctx context.Context,
+	storePool storepool.AllocatorStorePool,
 	conf roachpb.SpanConfig,
 	existing []roachpb.ReplicaDescriptor,
 	leaseRepl interface {
@@ -1756,26 +1783,26 @@ func (a *Allocator) TransferLeaseTarget(
 	opts allocator.TransferLeaseOptions,
 ) roachpb.ReplicaDescriptor {
 	excludeLeaseRepl := opts.ExcludeLeaseRepl
-	if a.leaseholderShouldMoveDueToPreferences(ctx, conf, leaseRepl, existing) {
+	if a.leaseholderShouldMoveDueToPreferences(ctx, storePool, conf, leaseRepl, existing) {
 		// Explicitly exclude the current leaseholder from the result set if it is
 		// in violation of lease preferences that can be satisfied by some other
 		// replica.
 		excludeLeaseRepl = true
 	}
 
-	allStoresList, _, _ := a.StorePool.GetStoreList(storepool.StoreFilterNone)
+	allStoresList, _, _ := storePool.GetStoreList(storepool.StoreFilterNone)
 	storeDescMap := allStoresList.ToMap()
-	sl, _, _ := a.StorePool.GetStoreList(storepool.StoreFilterSuspect)
+	sl, _, _ := storePool.GetStoreList(storepool.StoreFilterSuspect)
 	sl = sl.ExcludeInvalid(conf.Constraints)
 	sl = sl.ExcludeInvalid(conf.VoterConstraints)
 	candidateLeasesMean := sl.CandidateLeases.Mean
 
-	source, ok := a.StorePool.GetStoreDescriptor(leaseRepl.StoreID())
+	source, ok := storePool.GetStoreDescriptor(leaseRepl.StoreID())
 	if !ok {
 		return roachpb.ReplicaDescriptor{}
 	}
 
-	existing = a.ValidLeaseTargets(ctx, conf, existing, leaseRepl, opts)
+	existing = a.ValidLeaseTargets(ctx, storePool, conf, existing, leaseRepl, opts)
 	// Short-circuit if there are no valid targets out there.
 	if len(existing) == 0 || (len(existing) == 1 && existing[0].StoreID == leaseRepl.StoreID()) {
 		log.KvDistribution.VEventf(ctx, 2, "no lease transfer target found for r%d", leaseRepl.GetRangeID())
@@ -1793,7 +1820,7 @@ func (a *Allocator) TransferLeaseTarget(
 		// falls back to `leaseCountConvergence`. Rationalize this or refactor this
 		// logic to be more clear.
 		transferDec, repl := a.shouldTransferLeaseForAccessLocality(
-			ctx, source, existing, statSummary, nil, candidateLeasesMean,
+			ctx, storePool, source, existing, statSummary, nil, candidateLeasesMean,
 		)
 		if !excludeLeaseRepl {
 			switch transferDec {
@@ -1803,7 +1830,7 @@ func (a *Allocator) TransferLeaseTarget(
 				}
 				fallthrough
 			case decideWithoutStats:
-				if !a.shouldTransferLeaseForLeaseCountConvergence(ctx, sl, source, existing) {
+				if !a.shouldTransferLeaseForLeaseCountConvergence(ctx, storePool, sl, source, existing) {
 					return roachpb.ReplicaDescriptor{}
 				}
 			case shouldTransfer:
@@ -1839,7 +1866,7 @@ func (a *Allocator) TransferLeaseTarget(
 			if leaseRepl.StoreID() == repl.StoreID {
 				continue
 			}
-			storeDesc, ok := a.StorePool.GetStoreDescriptor(repl.StoreID)
+			storeDesc, ok := storePool.GetStoreDescriptor(repl.StoreID)
 			if !ok {
 				continue
 			}
@@ -1996,6 +2023,7 @@ func getQPSDelta(storeQPSMap map[roachpb.StoreID]float64, domain []roachpb.Store
 // attributes.
 func (a *Allocator) ShouldTransferLease(
 	ctx context.Context,
+	storePool storepool.AllocatorStorePool,
 	conf roachpb.SpanConfig,
 	existing []roachpb.ReplicaDescriptor,
 	leaseRepl interface {
@@ -2006,11 +2034,12 @@ func (a *Allocator) ShouldTransferLease(
 	},
 	statSummary *replicastats.RatedSummary,
 ) bool {
-	if a.leaseholderShouldMoveDueToPreferences(ctx, conf, leaseRepl, existing) {
+	if a.leaseholderShouldMoveDueToPreferences(ctx, storePool, conf, leaseRepl, existing) {
 		return true
 	}
 	existing = a.ValidLeaseTargets(
 		ctx,
+		storePool,
 		conf,
 		existing,
 		leaseRepl,
@@ -2021,18 +2050,19 @@ func (a *Allocator) ShouldTransferLease(
 	if len(existing) == 0 || (len(existing) == 1 && existing[0].StoreID == leaseRepl.StoreID()) {
 		return false
 	}
-	source, ok := a.StorePool.GetStoreDescriptor(leaseRepl.StoreID())
+	source, ok := storePool.GetStoreDescriptor(leaseRepl.StoreID())
 	if !ok {
 		return false
 	}
 
-	sl, _, _ := a.StorePool.GetStoreList(storepool.StoreFilterSuspect)
+	sl, _, _ := storePool.GetStoreList(storepool.StoreFilterSuspect)
 	sl = sl.ExcludeInvalid(conf.Constraints)
 	sl = sl.ExcludeInvalid(conf.VoterConstraints)
 	log.KvDistribution.VEventf(ctx, 3, "ShouldTransferLease (lease-holder=s%d):\n%s", leaseRepl.StoreID(), sl)
 
 	transferDec, _ := a.shouldTransferLeaseForAccessLocality(
 		ctx,
+		storePool,
 		source,
 		existing,
 		statSummary,
@@ -2046,7 +2076,7 @@ func (a *Allocator) ShouldTransferLease(
 	case shouldTransfer:
 		result = true
 	case decideWithoutStats:
-		result = a.shouldTransferLeaseForLeaseCountConvergence(ctx, sl, source, existing)
+		result = a.shouldTransferLeaseForLeaseCountConvergence(ctx, storePool, sl, source, existing)
 	default:
 		log.KvDistribution.Fatalf(ctx, "unexpected transfer decision %d", transferDec)
 	}
@@ -2061,6 +2091,7 @@ func (a *Allocator) ShouldTransferLease(
 // follow-the-workload strategy would still prefer selecting the local store.
 func (a Allocator) FollowTheWorkloadPrefersLocal(
 	ctx context.Context,
+	storePool storepool.AllocatorStorePool,
 	sl storepool.StoreList,
 	source roachpb.StoreDescriptor,
 	candidate roachpb.StoreID,
@@ -2068,7 +2099,7 @@ func (a Allocator) FollowTheWorkloadPrefersLocal(
 	statSummary *replicastats.RatedSummary,
 ) bool {
 	adjustments := make(map[roachpb.StoreID]float64)
-	decision, _ := a.shouldTransferLeaseForAccessLocality(ctx, source, existing, statSummary, adjustments, sl.CandidateLeases.Mean)
+	decision, _ := a.shouldTransferLeaseForAccessLocality(ctx, storePool, source, existing, statSummary, adjustments, sl.CandidateLeases.Mean)
 	if decision == decideWithoutStats {
 		return false
 	}
@@ -2084,6 +2115,7 @@ func (a Allocator) FollowTheWorkloadPrefersLocal(
 
 func (a Allocator) shouldTransferLeaseForAccessLocality(
 	ctx context.Context,
+	storePool storepool.AllocatorStorePool,
 	source roachpb.StoreDescriptor,
 	existing []roachpb.ReplicaDescriptor,
 	statSummary *replicastats.RatedSummary,
@@ -2097,7 +2129,7 @@ func (a Allocator) shouldTransferLeaseForAccessLocality(
 		!EnableLoadBasedLeaseRebalancing.Get(&a.st.SV) {
 		return decideWithoutStats, roachpb.ReplicaDescriptor{}
 	}
-	replicaLocalities := a.StorePool.GetLocalitiesByNode(existing)
+	replicaLocalities := storePool.GetLocalitiesByNode(existing)
 	for _, locality := range replicaLocalities {
 		if len(locality.Tiers) == 0 {
 			return decideWithoutStats, roachpb.ReplicaDescriptor{}
@@ -2152,11 +2184,11 @@ func (a Allocator) shouldTransferLeaseForAccessLocality(
 		if repl.NodeID == source.Node.NodeID {
 			continue
 		}
-		storeDesc, ok := a.StorePool.GetStoreDescriptor(repl.StoreID)
+		storeDesc, ok := storePool.GetStoreDescriptor(repl.StoreID)
 		if !ok {
 			continue
 		}
-		addr, err := a.StorePool.GossipNodeIDAddress(repl.NodeID)
+		addr, err := storePool.GossipNodeIDAddress(repl.NodeID)
 		if err != nil {
 			log.KvDistribution.Errorf(ctx, "missing address for n%d: %+v", repl.NodeID, err)
 			continue
@@ -2273,6 +2305,7 @@ func loadBasedLeaseRebalanceScore(
 
 func (a Allocator) shouldTransferLeaseForLeaseCountConvergence(
 	ctx context.Context,
+	storePool storepool.AllocatorStorePool,
 	sl storepool.StoreList,
 	source roachpb.StoreDescriptor,
 	existing []roachpb.ReplicaDescriptor,
@@ -2301,7 +2334,7 @@ func (a Allocator) shouldTransferLeaseForLeaseCountConvergence(
 		}
 
 		for _, repl := range existing {
-			storeDesc, ok := a.StorePool.GetStoreDescriptor(repl.StoreID)
+			storeDesc, ok := storePool.GetStoreDescriptor(repl.StoreID)
 			if !ok {
 				continue
 			}
@@ -2316,7 +2349,7 @@ func (a Allocator) shouldTransferLeaseForLeaseCountConvergence(
 // PreferredLeaseholders returns a slice of replica descriptors corresponding to
 // replicas that meet lease preferences (among the `existing` replicas).
 func (a Allocator) PreferredLeaseholders(
-	conf roachpb.SpanConfig, existing []roachpb.ReplicaDescriptor,
+	storePool storepool.AllocatorStorePool, conf roachpb.SpanConfig, existing []roachpb.ReplicaDescriptor,
 ) []roachpb.ReplicaDescriptor {
 	// Go one preference at a time. As soon as we've found replicas that match a
 	// preference, we don't need to look at the later preferences, because
@@ -2327,7 +2360,7 @@ func (a Allocator) PreferredLeaseholders(
 			// TODO(a-robinson): Do all these lookups at once, up front? We could
 			// easily be passing a slice of StoreDescriptors around all the Allocator
 			// functions instead of ReplicaDescriptors.
-			storeDesc, ok := a.StorePool.GetStoreDescriptor(repl.StoreID)
+			storeDesc, ok := storePool.GetStoreDescriptor(repl.StoreID)
 			if !ok {
 				continue
 			}

--- a/pkg/kv/kvserver/allocator/allocatorimpl/test_helpers.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/test_helpers.go
@@ -42,7 +42,7 @@ func CreateTestAllocatorWithKnobs(
 		storepool.TestTimeUntilStoreDeadOff, deterministic,
 		func() int { return numNodes },
 		livenesspb.NodeLivenessStatus_LIVE)
-	a := MakeAllocator(st, storePool, func(string) (time.Duration, bool) {
+	a := MakeAllocator(st, deterministic, func(string) (time.Duration, bool) {
 		return 0, true
 	}, knobs)
 	return stopper, g, storePool, a, manual

--- a/pkg/kv/kvserver/allocator/storepool/override_store_pool.go
+++ b/pkg/kv/kvserver/allocator/storepool/override_store_pool.go
@@ -89,6 +89,21 @@ func (o *OverrideStorePool) GetStoreListFromIDs(
 	return o.sp.getStoreListFromIDsLocked(storeIDs, o.overrideNodeLivenessFn, filter)
 }
 
+// GetStoreListForTargets implements the AllocatorStorePool interface.
+func (o *OverrideStorePool) GetStoreListForTargets(
+	candidates []roachpb.ReplicationTarget, filter StoreFilter,
+) (StoreList, int, ThrottledStoreReasons) {
+	o.sp.DetailsMu.Lock()
+	defer o.sp.DetailsMu.Unlock()
+
+	storeIDs := make(roachpb.StoreIDSlice, 0, len(candidates))
+	for _, tgt := range candidates {
+		storeIDs = append(storeIDs, tgt.StoreID)
+	}
+
+	return o.sp.getStoreListFromIDsLocked(storeIDs, o.overrideNodeLivenessFn, filter)
+}
+
 // LiveAndDeadReplicas implements the AllocatorStorePool interface.
 func (o *OverrideStorePool) LiveAndDeadReplicas(
 	repls []roachpb.ReplicaDescriptor, includeSuspectAndDrainingStores bool,

--- a/pkg/kv/kvserver/allocator/storepool/store_pool.go
+++ b/pkg/kv/kvserver/allocator/storepool/store_pool.go
@@ -385,6 +385,14 @@ type AllocatorStorePool interface {
 		filter StoreFilter,
 	) (StoreList, int, ThrottledStoreReasons)
 
+	// GetStoreListForTargets is the same as GetStoreList, but only returns stores
+	// from the subset of stores present in the passed in replication targets,
+	// converting to a StoreList.
+	GetStoreListForTargets(
+		candidates []roachpb.ReplicationTarget,
+		filter StoreFilter,
+	) (StoreList, int, ThrottledStoreReasons)
+
 	// GossipNodeIDAddress looks up the RPC address for the given node via gossip.
 	GossipNodeIDAddress(nodeID roachpb.NodeID) (*util.UnresolvedAddr, error)
 
@@ -1069,6 +1077,24 @@ func (sp *StorePool) GetStoreListFromIDs(
 ) (StoreList, int, ThrottledStoreReasons) {
 	sp.DetailsMu.Lock()
 	defer sp.DetailsMu.Unlock()
+	return sp.getStoreListFromIDsLocked(storeIDs, sp.NodeLivenessFn, filter)
+}
+
+// GetStoreListForTargets is the same as GetStoreList, but only returns stores
+// from the subset of stores present in the passed in replication targets,
+// converting to a StoreList.
+func (sp *StorePool) GetStoreListForTargets(
+	candidates []roachpb.ReplicationTarget,
+	filter StoreFilter,
+) (StoreList, int, ThrottledStoreReasons) {
+	sp.DetailsMu.Lock()
+	defer sp.DetailsMu.Unlock()
+
+	storeIDs := make(roachpb.StoreIDSlice, 0, len(candidates))
+	for _, tgt := range candidates {
+		storeIDs = append(storeIDs, tgt.StoreID)
+	}
+
 	return sp.getStoreListFromIDsLocked(storeIDs, sp.NodeLivenessFn, filter)
 }
 

--- a/pkg/kv/kvserver/allocator/storepool/store_pool.go
+++ b/pkg/kv/kvserver/allocator/storepool/store_pool.go
@@ -1084,8 +1084,7 @@ func (sp *StorePool) GetStoreListFromIDs(
 // from the subset of stores present in the passed in replication targets,
 // converting to a StoreList.
 func (sp *StorePool) GetStoreListForTargets(
-	candidates []roachpb.ReplicationTarget,
-	filter StoreFilter,
+	candidates []roachpb.ReplicationTarget, filter StoreFilter,
 ) (StoreList, int, ThrottledStoreReasons) {
 	sp.DetailsMu.Lock()
 	defer sp.DetailsMu.Unlock()

--- a/pkg/kv/kvserver/allocator_impl_test.go
+++ b/pkg/kv/kvserver/allocator_impl_test.go
@@ -66,7 +66,7 @@ func TestAllocatorRebalanceTarget(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	clock := hlc.NewClock(timeutil.NewManualTime(timeutil.Unix(0, 123)), time.Nanosecond /* maxOffset */)
 	ctx := context.Background()
-	stopper, g, _, a, _ := allocatorimpl.CreateTestAllocator(ctx, 5, false /* deterministic */)
+	stopper, g, sp, a, _ := allocatorimpl.CreateTestAllocator(ctx, 5, false /* deterministic */)
 	defer stopper.Stop(ctx)
 	// We make 5 stores in this test -- 3 in the same datacenter, and 1 each in
 	// 2 other datacenters. All of our replicas are distributed within these 3
@@ -180,7 +180,7 @@ func TestAllocatorRebalanceTarget(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		result, _, details, ok := a.RebalanceVoter(
 			ctx,
-			a.StorePool,
+			sp,
 			roachpb.SpanConfig{},
 			status,
 			replicas,
@@ -206,7 +206,7 @@ func TestAllocatorRebalanceTarget(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		target, _, details, ok := a.RebalanceVoter(
 			ctx,
-			a.StorePool,
+			sp,
 			roachpb.SpanConfig{},
 			status,
 			replicas,
@@ -226,7 +226,7 @@ func TestAllocatorRebalanceTarget(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		target, origin, details, ok := a.RebalanceVoter(
 			ctx,
-			a.StorePool,
+			sp,
 			roachpb.SpanConfig{},
 			status,
 			replicas,
@@ -251,18 +251,18 @@ func TestAllocatorThrottled(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	stopper, g, _, a, _ := allocatorimpl.CreateTestAllocator(ctx, 10, false /* deterministic */)
+	stopper, g, sp, a, _ := allocatorimpl.CreateTestAllocator(ctx, 10, false /* deterministic */)
 	defer stopper.Stop(ctx)
 
 	// First test to make sure we would send the replica to purgatory.
-	_, _, err := a.AllocateVoter(ctx, a.StorePool, simpleSpanConfig, []roachpb.ReplicaDescriptor{}, nil, allocatorimpl.Dead)
+	_, _, err := a.AllocateVoter(ctx, sp, simpleSpanConfig, []roachpb.ReplicaDescriptor{}, nil, allocatorimpl.Dead)
 	if _, ok := IsPurgatoryError(err); !ok {
 		t.Fatalf("expected a purgatory error, got: %+v", err)
 	}
 
 	// Second, test the normal case in which we can allocate to the store.
 	gossiputil.NewStoreGossiper(g).GossipStores(singleStore, t)
-	result, _, err := a.AllocateVoter(ctx, a.StorePool, simpleSpanConfig, []roachpb.ReplicaDescriptor{}, nil, allocatorimpl.Dead)
+	result, _, err := a.AllocateVoter(ctx, sp, simpleSpanConfig, []roachpb.ReplicaDescriptor{}, nil, allocatorimpl.Dead)
 	if err != nil {
 		t.Fatalf("unable to perform allocation: %+v", err)
 	}
@@ -272,15 +272,14 @@ func TestAllocatorThrottled(t *testing.T) {
 
 	// Finally, set that store to be throttled and ensure we don't send the
 	// replica to purgatory.
-	storePool := a.StorePool.(*storepool.StorePool)
-	storePool.DetailsMu.Lock()
-	storeDetail, ok := storePool.DetailsMu.StoreDetails[singleStore[0].StoreID]
+	sp.DetailsMu.Lock()
+	storeDetail, ok := sp.DetailsMu.StoreDetails[singleStore[0].StoreID]
 	if !ok {
 		t.Fatalf("store:%d was not found in the store pool", singleStore[0].StoreID)
 	}
 	storeDetail.ThrottledUntil = timeutil.Now().Add(24 * time.Hour)
-	storePool.DetailsMu.Unlock()
-	_, _, err = a.AllocateVoter(ctx, a.StorePool, simpleSpanConfig, []roachpb.ReplicaDescriptor{}, nil, allocatorimpl.Dead)
+	sp.DetailsMu.Unlock()
+	_, _, err = a.AllocateVoter(ctx, sp, simpleSpanConfig, []roachpb.ReplicaDescriptor{}, nil, allocatorimpl.Dead)
 	if _, ok := IsPurgatoryError(err); ok {
 		t.Fatalf("expected a non purgatory error, got: %+v", err)
 	}

--- a/pkg/kv/kvserver/allocator_impl_test.go
+++ b/pkg/kv/kvserver/allocator_impl_test.go
@@ -180,6 +180,7 @@ func TestAllocatorRebalanceTarget(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		result, _, details, ok := a.RebalanceVoter(
 			ctx,
+			a.StorePool,
 			roachpb.SpanConfig{},
 			status,
 			replicas,
@@ -205,6 +206,7 @@ func TestAllocatorRebalanceTarget(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		target, _, details, ok := a.RebalanceVoter(
 			ctx,
+			a.StorePool,
 			roachpb.SpanConfig{},
 			status,
 			replicas,
@@ -224,6 +226,7 @@ func TestAllocatorRebalanceTarget(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		target, origin, details, ok := a.RebalanceVoter(
 			ctx,
+			a.StorePool,
 			roachpb.SpanConfig{},
 			status,
 			replicas,
@@ -252,14 +255,14 @@ func TestAllocatorThrottled(t *testing.T) {
 	defer stopper.Stop(ctx)
 
 	// First test to make sure we would send the replica to purgatory.
-	_, _, err := a.AllocateVoter(ctx, simpleSpanConfig, []roachpb.ReplicaDescriptor{}, nil, allocatorimpl.Dead)
+	_, _, err := a.AllocateVoter(ctx, a.StorePool, simpleSpanConfig, []roachpb.ReplicaDescriptor{}, nil, allocatorimpl.Dead)
 	if _, ok := IsPurgatoryError(err); !ok {
 		t.Fatalf("expected a purgatory error, got: %+v", err)
 	}
 
 	// Second, test the normal case in which we can allocate to the store.
 	gossiputil.NewStoreGossiper(g).GossipStores(singleStore, t)
-	result, _, err := a.AllocateVoter(ctx, simpleSpanConfig, []roachpb.ReplicaDescriptor{}, nil, allocatorimpl.Dead)
+	result, _, err := a.AllocateVoter(ctx, a.StorePool, simpleSpanConfig, []roachpb.ReplicaDescriptor{}, nil, allocatorimpl.Dead)
 	if err != nil {
 		t.Fatalf("unable to perform allocation: %+v", err)
 	}
@@ -277,7 +280,7 @@ func TestAllocatorThrottled(t *testing.T) {
 	}
 	storeDetail.ThrottledUntil = timeutil.Now().Add(24 * time.Hour)
 	storePool.DetailsMu.Unlock()
-	_, _, err = a.AllocateVoter(ctx, simpleSpanConfig, []roachpb.ReplicaDescriptor{}, nil, allocatorimpl.Dead)
+	_, _, err = a.AllocateVoter(ctx, a.StorePool, simpleSpanConfig, []roachpb.ReplicaDescriptor{}, nil, allocatorimpl.Dead)
 	if _, ok := IsPurgatoryError(err); ok {
 		t.Fatalf("expected a non purgatory error, got: %+v", err)
 	}

--- a/pkg/kv/kvserver/asim/asim.go
+++ b/pkg/kv/kvserver/asim/asim.go
@@ -81,6 +81,7 @@ func NewSimulator(
 	for _, store := range initialState.Stores() {
 		storeID := store.StoreID()
 		allocator := initialState.MakeAllocator(storeID)
+		storePool := initialState.StorePool(storeID)
 		// TODO(kvoli): Instead of passing in individual settings to construct
 		// the each ticking component, pass a pointer to the simulation
 		// settings struct. That way, the settings may be adjusted dynamically
@@ -90,6 +91,7 @@ func NewSimulator(
 			changer,
 			settings.ReplicaChangeDelayFn(),
 			allocator,
+			storePool,
 			start,
 		)
 		sqs[storeID] = queue.NewSplitQueue(
@@ -109,6 +111,7 @@ func NewSimulator(
 		controllers[storeID] = op.NewController(
 			changer,
 			allocator,
+			storePool,
 			settings,
 		)
 		srs[storeID] = storerebalancer.NewStoreRebalancer(
@@ -116,6 +119,7 @@ func NewSimulator(
 			storeID,
 			controllers[storeID],
 			allocator,
+			storePool,
 			settings,
 			storerebalancer.GetStateRaftStatusFn(initialState),
 		)

--- a/pkg/kv/kvserver/asim/op/BUILD.bazel
+++ b/pkg/kv/kvserver/asim/op/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     deps = [
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/allocator/allocatorimpl",
+        "//pkg/kv/kvserver/allocator/storepool",
         "//pkg/kv/kvserver/asim/config",
         "//pkg/kv/kvserver/asim/state",
         "//pkg/roachpb",
@@ -29,6 +30,7 @@ go_test(
     embed = [":operator"],
     deps = [
         "//pkg/kv/kvserver/allocator/allocatorimpl",
+        "//pkg/kv/kvserver/allocator/storepool",
         "//pkg/kv/kvserver/asim/config",
         "//pkg/kv/kvserver/asim/state",
         "//pkg/roachpb",
@@ -50,6 +52,7 @@ go_library(
     deps = [
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/allocator/allocatorimpl",
+        "//pkg/kv/kvserver/allocator/storepool",
         "//pkg/kv/kvserver/asim/config",
         "//pkg/kv/kvserver/asim/state",
         "//pkg/roachpb",

--- a/pkg/kv/kvserver/asim/op/controller_test.go
+++ b/pkg/kv/kvserver/asim/op/controller_test.go
@@ -85,7 +85,7 @@ func TestLeaseTransferOp(t *testing.T) {
 			s := state.NewTestStateReplCounts(map[state.StoreID]int{1: tc.ranges + 1, 2: tc.ranges + 1, 3: tc.ranges + 1}, 3, 1000 /* keyspace */)
 			settings := config.DefaultSimulationSettings()
 			changer := state.NewReplicaChanger()
-			controller := NewController(changer, allocatorimpl.Allocator{}, settings)
+			controller := NewController(changer, allocatorimpl.Allocator{}, nil /* storePool */, settings)
 
 			for i := 2; i <= tc.ranges+1; i++ {
 				s.TransferLease(state.RangeID(i), 1)
@@ -270,7 +270,8 @@ func TestRelocateRangeOp(t *testing.T) {
 			s := state.NewTestStateReplCounts(map[state.StoreID]int{1: 3, 2: 3, 3: 3, 4: 0, 5: 0, 6: 0}, 3, 1000 /* keyspace */)
 			changer := state.NewReplicaChanger()
 			allocator := s.MakeAllocator(state.StoreID(1))
-			controller := NewController(changer, allocator, settings)
+			storePool := s.StorePool(state.StoreID(1))
+			controller := NewController(changer, allocator, storePool, settings)
 
 			// Transfer the lease to store 1 for all ranges.
 			for i := 2; i < 4; i++ {

--- a/pkg/kv/kvserver/asim/op/relocate_range.go
+++ b/pkg/kv/kvserver/asim/op/relocate_range.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/allocatorimpl"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/storepool"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/state"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/errors"
@@ -54,12 +55,18 @@ func (rro *RelocateRangeOp) error(err error) {
 // to generate a suggested replication change.
 type SimRelocateOneOptions struct {
 	allocator allocatorimpl.Allocator
+	storePool storepool.AllocatorStorePool
 	state     state.State
 }
 
 // Allocator returns the allocator for the store this replica is on.
 func (s *SimRelocateOneOptions) Allocator() allocatorimpl.Allocator {
 	return s.allocator
+}
+
+// StorePool returns the store's configured store pool.
+func (s *SimRelocateOneOptions) StorePool() storepool.AllocatorStorePool {
+	return s.storePool
 }
 
 // SpanConfig returns the span configuration for the range with start key.

--- a/pkg/kv/kvserver/asim/queue/replicate_queue.go
+++ b/pkg/kv/kvserver/asim/queue/replicate_queue.go
@@ -25,6 +25,7 @@ import (
 type replicateQueue struct {
 	baseQueue
 	allocator allocatorimpl.Allocator
+	storePool storepool.AllocatorStorePool
 	delay     func(rangeSize int64, add bool) time.Duration
 }
 
@@ -34,6 +35,7 @@ func NewReplicateQueue(
 	stateChanger state.Changer,
 	delay func(rangeSize int64, add bool) time.Duration,
 	allocator allocatorimpl.Allocator,
+	storePool storepool.AllocatorStorePool,
 	start time.Time,
 ) RangeQueue {
 	return &replicateQueue{
@@ -45,6 +47,7 @@ func NewReplicateQueue(
 		},
 		delay:     delay,
 		allocator: allocator,
+		storePool: storePool,
 	}
 }
 
@@ -59,7 +62,7 @@ func (rq *replicateQueue) MaybeAdd(
 		return false
 	}
 
-	action, priority := rq.allocator.ComputeAction(ctx, rq.allocator.StorePool, rng.SpanConfig(), rng.Descriptor())
+	action, priority := rq.allocator.ComputeAction(ctx, rq.storePool, rng.SpanConfig(), rng.Descriptor())
 	if action == allocatorimpl.AllocatorNoop {
 		return false
 	}
@@ -98,7 +101,7 @@ func (rq *replicateQueue) Tick(ctx context.Context, tick time.Time, s state.Stat
 			return
 		}
 
-		action, _ := rq.allocator.ComputeAction(ctx, rq.allocator.StorePool, rng.SpanConfig(), rng.Descriptor())
+		action, _ := rq.allocator.ComputeAction(ctx, rq.storePool, rng.SpanConfig(), rng.Descriptor())
 
 		switch action {
 		case allocatorimpl.AllocatorConsiderRebalance:
@@ -125,7 +128,7 @@ func (rq *replicateQueue) considerRebalance(
 ) {
 	add, remove, _, ok := rq.allocator.RebalanceVoter(
 		ctx,
-		rq.allocator.StorePool,
+		rq.storePool,
 		rng.SpanConfig(),
 		nil, /* raftStatus */
 		rng.Descriptor().Replicas().VoterDescriptors(),

--- a/pkg/kv/kvserver/asim/queue/replicate_queue.go
+++ b/pkg/kv/kvserver/asim/queue/replicate_queue.go
@@ -59,7 +59,7 @@ func (rq *replicateQueue) MaybeAdd(
 		return false
 	}
 
-	action, priority := rq.allocator.ComputeAction(ctx, rng.SpanConfig(), rng.Descriptor())
+	action, priority := rq.allocator.ComputeAction(ctx, rq.allocator.StorePool, rng.SpanConfig(), rng.Descriptor())
 	if action == allocatorimpl.AllocatorNoop {
 		return false
 	}
@@ -98,7 +98,7 @@ func (rq *replicateQueue) Tick(ctx context.Context, tick time.Time, s state.Stat
 			return
 		}
 
-		action, _ := rq.allocator.ComputeAction(ctx, rng.SpanConfig(), rng.Descriptor())
+		action, _ := rq.allocator.ComputeAction(ctx, rq.allocator.StorePool, rng.SpanConfig(), rng.Descriptor())
 
 		switch action {
 		case allocatorimpl.AllocatorConsiderRebalance:
@@ -125,6 +125,7 @@ func (rq *replicateQueue) considerRebalance(
 ) {
 	add, remove, _, ok := rq.allocator.RebalanceVoter(
 		ctx,
+		rq.allocator.StorePool,
 		rng.SpanConfig(),
 		nil, /* raftStatus */
 		rng.Descriptor().Replicas().VoterDescriptors(),

--- a/pkg/kv/kvserver/asim/queue/replicate_queue_test.go
+++ b/pkg/kv/kvserver/asim/queue/replicate_queue_test.go
@@ -129,6 +129,7 @@ func TestReplicateQueue(t *testing.T) {
 				changer,
 				testSettings.ReplicaChangeDelayFn(),
 				s.MakeAllocator(store.StoreID()),
+				s.StorePool(store.StoreID()),
 				start,
 			)
 			s.TickClock(start)

--- a/pkg/kv/kvserver/asim/state/impl.go
+++ b/pkg/kv/kvserver/asim/state/impl.go
@@ -760,12 +760,17 @@ func (s *state) NodeCountFn() storepool.NodeCountFunc {
 func (s *state) MakeAllocator(storeID StoreID) allocatorimpl.Allocator {
 	return allocatorimpl.MakeAllocator(
 		s.stores[storeID].settings,
-		s.stores[storeID].storepool,
+		s.stores[storeID].storepool.IsDeterministic(),
 		func(addr string) (time.Duration, bool) { return 0, true },
 		&allocator.TestingKnobs{
 			AllowLeaseTransfersToReplicasNeedingSnapshots: true,
 		},
 	)
+}
+
+// StorePool returns the store pool for the given storeID.
+func (s *state) StorePool(storeID StoreID) storepool.AllocatorStorePool {
+	return s.stores[storeID].storepool
 }
 
 // LeaseHolderReplica returns the replica which holds a lease for the range

--- a/pkg/kv/kvserver/asim/state/state.go
+++ b/pkg/kv/kvserver/asim/state/state.go
@@ -152,6 +152,8 @@ type State interface {
 	// the allocator and storepool should both be separated out of this
 	// interface, instead using it to populate themselves.
 	MakeAllocator(StoreID) allocatorimpl.Allocator
+	// StorePool returns the store pool for the given storeID.
+	StorePool(StoreID) storepool.AllocatorStorePool
 	// LoadSplitterFor returns the load splitter for the Store with ID StoreID.
 	LoadSplitterFor(StoreID) LoadSplitter
 	// RaftStatus returns the current raft status for the replica of the Range

--- a/pkg/kv/kvserver/asim/storerebalancer/BUILD.bazel
+++ b/pkg/kv/kvserver/asim/storerebalancer/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/allocator",
         "//pkg/kv/kvserver/allocator/allocatorimpl",
+        "//pkg/kv/kvserver/allocator/storepool",
         "//pkg/kv/kvserver/asim/config",
         "//pkg/kv/kvserver/asim/op",
         "//pkg/kv/kvserver/asim/state",

--- a/pkg/kv/kvserver/asim/storerebalancer/store_rebalancer.go
+++ b/pkg/kv/kvserver/asim/storerebalancer/store_rebalancer.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/allocatorimpl"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/storepool"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/config"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/op"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/state"
@@ -79,10 +80,11 @@ func NewStoreRebalancer(
 	storeID state.StoreID,
 	controller op.Controller,
 	allocator allocatorimpl.Allocator,
+	storePool storepool.AllocatorStorePool,
 	settings *config.SimulationSettings,
 	getRaftStatusFn func(replica kvserver.CandidateReplica) *raft.Status,
 ) StoreRebalancer {
-	return newStoreRebalancerControl(start, storeID, controller, allocator, settings, getRaftStatusFn)
+	return newStoreRebalancerControl(start, storeID, controller, allocator, storePool, settings, getRaftStatusFn)
 }
 
 func newStoreRebalancerControl(
@@ -90,12 +92,14 @@ func newStoreRebalancerControl(
 	storeID state.StoreID,
 	controller op.Controller,
 	allocator allocatorimpl.Allocator,
+	storePool storepool.AllocatorStorePool,
 	settings *config.SimulationSettings,
 	getRaftStatusFn func(replica kvserver.CandidateReplica) *raft.Status,
 ) *storeRebalancerControl {
 	sr := kvserver.SimulatorStoreRebalancer(
 		roachpb.StoreID(storeID),
 		allocator,
+		storePool,
 		getRaftStatusFn,
 	)
 

--- a/pkg/kv/kvserver/asim/storerebalancer/store_rebalancer_test.go
+++ b/pkg/kv/kvserver/asim/storerebalancer/store_rebalancer_test.go
@@ -190,9 +190,10 @@ func TestStoreRebalancer(t *testing.T) {
 			s.UpdateStorePool(testingStore, exchange.Get(state.OffsetTick(start, 1), roachpb.StoreID(testingStore)))
 
 			allocator := s.MakeAllocator(testingStore)
+			storePool := s.StorePool(testingStore)
 			changer := state.NewReplicaChanger()
-			controller := op.NewController(changer, allocator, testSettings)
-			src := newStoreRebalancerControl(start, testingStore, controller, allocator, testSettings, GetStateRaftStatusFn(s))
+			controller := op.NewController(changer, allocator, storePool, testSettings)
+			src := newStoreRebalancerControl(start, testingStore, controller, allocator, storePool, testSettings, GetStateRaftStatusFn(s))
 			s.TickClock(start)
 
 			resultsQPS := []map[state.StoreID]float64{}
@@ -298,9 +299,10 @@ func TestStoreRebalancerBalances(t *testing.T) {
 			s.UpdateStorePool(testingStore, exchange.Get(state.OffsetTick(start, 1), roachpb.StoreID(testingStore)))
 
 			allocator := s.MakeAllocator(testingStore)
+			storePool := s.StorePool(testingStore)
 			changer := state.NewReplicaChanger()
-			controller := op.NewController(changer, allocator, testSettings)
-			src := newStoreRebalancerControl(start, testingStore, controller, allocator, testSettings, GetStateRaftStatusFn(s))
+			controller := op.NewController(changer, allocator, storePool, testSettings)
+			src := newStoreRebalancerControl(start, testingStore, controller, allocator, storePool, testSettings, GetStateRaftStatusFn(s))
 			s.TickClock(start)
 
 			results := []map[state.StoreID]float64{}

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -3339,6 +3339,7 @@ func RelocateOne(
 
 		additionTarget, _ = allocator.AllocateTargetFromList(
 			ctx,
+			allocator.StorePool,
 			candidateStoreList,
 			conf,
 			existingVoters,
@@ -3407,10 +3408,14 @@ func RelocateOne(
 		// (s1,s2,s3,s4) which is a reasonable request; that replica set is
 		// overreplicated. If we asked it instead to remove s3 from (s1,s2,s3) it
 		// may not want to do that due to constraints.
+		candidatesStoreList, _, _ := allocator.StorePool.GetStoreListForTargets(
+			args.targetsToRemove(), storepool.StoreFilterNone,
+		)
 		targetStore, _, err := allocator.RemoveTarget(
 			ctx,
+			allocator.StorePool,
 			conf,
-			allocator.StoreListForTargets(args.targetsToRemove()),
+			candidatesStoreList,
 			existingVoters,
 			existingNonVoters,
 			args.targetType,
@@ -3678,7 +3683,7 @@ func (r *Replica) adminScatter(
 	if args.RandomizeLeases && r.OwnsValidLease(ctx, r.store.Clock().NowAsClockTimestamp()) {
 		desc := r.Desc()
 		potentialLeaseTargets := r.store.allocator.ValidLeaseTargets(
-			ctx, r.SpanConfig(), desc.Replicas().VoterDescriptors(), r, allocator.TransferLeaseOptions{})
+			ctx, r.store.allocator.StorePool, r.SpanConfig(), desc.Replicas().VoterDescriptors(), r, allocator.TransferLeaseOptions{})
 		if len(potentialLeaseTargets) > 0 {
 			newLeaseholderIdx := rand.Intn(len(potentialLeaseTargets))
 			targetStoreID := potentialLeaseTargets[newLeaseholderIdx].StoreID

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -3223,6 +3223,8 @@ func (r *relocationArgs) finalRelocationTargets() []roachpb.ReplicationTarget {
 type RelocateOneOptions interface {
 	// Allocator returns the allocator for the store this replica is on.
 	Allocator() allocatorimpl.Allocator
+	// StorePool returns the store's configured store pool.
+	StorePool() storepool.AllocatorStorePool
 	// SpanConfig returns the span configuration for the range with start key.
 	SpanConfig(ctx context.Context, startKey roachpb.RKey) (roachpb.SpanConfig, error)
 	// LeaseHolder returns the descriptor of the replica which holds the lease
@@ -3237,6 +3239,11 @@ type replicaRelocateOneOptions struct {
 // Allocator returns the allocator for the store this replica is on.
 func (roo *replicaRelocateOneOptions) Allocator() allocatorimpl.Allocator {
 	return roo.store.allocator
+}
+
+// StorePool returns the store's configured store pool.
+func (roo *replicaRelocateOneOptions) StorePool() storepool.AllocatorStorePool {
+	return roo.store.cfg.StorePool
 }
 
 // SpanConfig returns the span configuration for the range with start key.
@@ -3289,7 +3296,7 @@ func RelocateOne(
 	}
 
 	allocator := options.Allocator()
-	storePool := allocator.StorePool
+	storePool := options.StorePool()
 
 	conf, err := options.SpanConfig(ctx, desc.StartKey)
 	if err != nil {
@@ -3339,7 +3346,7 @@ func RelocateOne(
 
 		additionTarget, _ = allocator.AllocateTargetFromList(
 			ctx,
-			allocator.StorePool,
+			storePool,
 			candidateStoreList,
 			conf,
 			existingVoters,
@@ -3408,12 +3415,12 @@ func RelocateOne(
 		// (s1,s2,s3,s4) which is a reasonable request; that replica set is
 		// overreplicated. If we asked it instead to remove s3 from (s1,s2,s3) it
 		// may not want to do that due to constraints.
-		candidatesStoreList, _, _ := allocator.StorePool.GetStoreListForTargets(
+		candidatesStoreList, _, _ := storePool.GetStoreListForTargets(
 			args.targetsToRemove(), storepool.StoreFilterNone,
 		)
 		targetStore, _, err := allocator.RemoveTarget(
 			ctx,
-			allocator.StorePool,
+			storePool,
 			conf,
 			candidatesStoreList,
 			existingVoters,
@@ -3683,7 +3690,7 @@ func (r *Replica) adminScatter(
 	if args.RandomizeLeases && r.OwnsValidLease(ctx, r.store.Clock().NowAsClockTimestamp()) {
 		desc := r.Desc()
 		potentialLeaseTargets := r.store.allocator.ValidLeaseTargets(
-			ctx, r.store.allocator.StorePool, r.SpanConfig(), desc.Replicas().VoterDescriptors(), r, allocator.TransferLeaseOptions{})
+			ctx, r.store.cfg.StorePool, r.SpanConfig(), desc.Replicas().VoterDescriptors(), r, allocator.TransferLeaseOptions{})
 		if len(potentialLeaseTargets) > 0 {
 			newLeaseholderIdx := rand.Intn(len(potentialLeaseTargets))
 			targetStoreID := potentialLeaseTargets[newLeaseholderIdx].StoreID

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -530,6 +530,7 @@ type replicateQueue struct {
 	*baseQueue
 	metrics   ReplicateQueueMetrics
 	allocator allocatorimpl.Allocator
+	storePool storepool.AllocatorStorePool
 
 	// purgCh is signalled every replicateQueuePurgatoryCheckInterval.
 	purgCh <-chan time.Time
@@ -546,9 +547,14 @@ var _ queueImpl = &replicateQueue{}
 
 // newReplicateQueue returns a new instance of replicateQueue.
 func newReplicateQueue(store *Store, allocator allocatorimpl.Allocator) *replicateQueue {
+	var storePool storepool.AllocatorStorePool
+	if store.cfg.StorePool != nil {
+		storePool = store.cfg.StorePool
+	}
 	rq := &replicateQueue{
 		metrics:   makeReplicateQueueMetrics(),
 		allocator: allocator,
+		storePool: storePool,
 		purgCh:    time.NewTicker(replicateQueuePurgatoryCheckInterval).C,
 		updateCh:  make(chan time.Time, 1),
 		logTracesThresholdFunc: makeRateLimitedTimeoutFuncByPermittedSlowdown(
@@ -611,7 +617,7 @@ func (rq *replicateQueue) shouldQueue(
 	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, _ spanconfig.StoreReader,
 ) (shouldQueue bool, priority float64) {
 	desc, conf := repl.DescAndSpanConfig()
-	action, priority := rq.allocator.ComputeAction(ctx, rq.allocator.StorePool, conf, desc)
+	action, priority := rq.allocator.ComputeAction(ctx, rq.storePool, conf, desc)
 
 	if action == allocatorimpl.AllocatorNoop {
 		log.KvDistribution.VEventf(ctx, 2, "no action to take")
@@ -627,7 +633,7 @@ func (rq *replicateQueue) shouldQueue(
 		rangeUsageInfo := rangeUsageInfoForRepl(repl)
 		_, _, _, ok := rq.allocator.RebalanceVoter(
 			ctx,
-			rq.allocator.StorePool,
+			rq.storePool,
 			conf,
 			repl.RaftStatus(),
 			voterReplicas,
@@ -642,7 +648,7 @@ func (rq *replicateQueue) shouldQueue(
 		}
 		_, _, _, ok = rq.allocator.RebalanceNonVoter(
 			ctx,
-			rq.allocator.StorePool,
+			rq.storePool,
 			conf,
 			repl.RaftStatus(),
 			voterReplicas,
@@ -662,7 +668,7 @@ func (rq *replicateQueue) shouldQueue(
 	if rq.canTransferLeaseFrom(ctx, repl) &&
 		rq.allocator.ShouldTransferLease(
 			ctx,
-			rq.allocator.StorePool,
+			rq.storePool,
 			conf,
 			voterReplicas,
 			repl,
@@ -983,7 +989,7 @@ func (rq *replicateQueue) processOneChange(
 
 	// Update the local storepool state to reflect the successful application
 	// of the change.
-	change.Op.applyImpact(rq.allocator.StorePool)
+	change.Op.applyImpact(rq.storePool)
 
 	// Requeue the replica if it meets the criteria in ShouldRequeue.
 	return rq.ShouldRequeue(ctx, change), nil
@@ -1028,10 +1034,10 @@ func (rq *replicateQueue) PlanOneChange(
 
 	voterReplicas := desc.Replicas().VoterDescriptors()
 	nonVoterReplicas := desc.Replicas().NonVoterDescriptors()
-	liveVoterReplicas, deadVoterReplicas := rq.store.cfg.StorePool.LiveAndDeadReplicas(
+	liveVoterReplicas, deadVoterReplicas := rq.storePool.LiveAndDeadReplicas(
 		voterReplicas, true, /* includeSuspectAndDrainingStores */
 	)
-	liveNonVoterReplicas, deadNonVoterReplicas := rq.store.cfg.StorePool.LiveAndDeadReplicas(
+	liveNonVoterReplicas, deadNonVoterReplicas := rq.storePool.LiveAndDeadReplicas(
 		nonVoterReplicas, true, /* includeSuspectAndDrainingStores */
 	)
 
@@ -1039,7 +1045,7 @@ func (rq *replicateQueue) PlanOneChange(
 	// unavailability; see:
 	_ = execChangeReplicasTxn
 
-	action, allocatorPrio := rq.allocator.ComputeAction(ctx, rq.allocator.StorePool, conf, desc)
+	action, allocatorPrio := rq.allocator.ComputeAction(ctx, rq.storePool, conf, desc)
 	log.KvDistribution.VEventf(ctx, 1, "next replica action: %s", action)
 
 	var err error
@@ -1097,7 +1103,7 @@ func (rq *replicateQueue) PlanOneChange(
 			ctx, repl, liveVoterReplicas, liveNonVoterReplicas, removeIdx, allocatorimpl.Dead, allocatorPrio)
 	// Replace decommissioning replicas.
 	case allocatorimpl.AllocatorReplaceDecommissioningVoter:
-		decommissioningVoterReplicas := rq.store.cfg.StorePool.DecommissioningReplicas(voterReplicas)
+		decommissioningVoterReplicas := rq.storePool.DecommissioningReplicas(voterReplicas)
 		if len(decommissioningVoterReplicas) == 0 {
 			// Nothing to do.
 			break
@@ -1112,7 +1118,7 @@ func (rq *replicateQueue) PlanOneChange(
 		op, err = rq.addOrReplaceVoters(
 			ctx, repl, liveVoterReplicas, liveNonVoterReplicas, removeIdx, allocatorimpl.Decommissioning, allocatorPrio)
 	case allocatorimpl.AllocatorReplaceDecommissioningNonVoter:
-		decommissioningNonVoterReplicas := rq.store.cfg.StorePool.DecommissioningReplicas(nonVoterReplicas)
+		decommissioningNonVoterReplicas := rq.storePool.DecommissioningReplicas(nonVoterReplicas)
 		if len(decommissioningNonVoterReplicas) == 0 {
 			// Nothing to do.
 			break
@@ -1252,7 +1258,7 @@ func (rq *replicateQueue) addOrReplaceVoters(
 	// we're removing it (i.e. dead or decommissioning). If we left the replica in
 	// the slice, the allocator would not be guaranteed to pick a replica that
 	// fills the gap removeRepl leaves once it's gone.
-	newVoter, details, err := rq.allocator.AllocateVoter(ctx, rq.allocator.StorePool, conf, remainingLiveVoters, remainingLiveNonVoters, replicaStatus)
+	newVoter, details, err := rq.allocator.AllocateVoter(ctx, rq.storePool, conf, remainingLiveVoters, remainingLiveNonVoters, replicaStatus)
 	if err != nil {
 		return nil, err
 	}
@@ -1260,7 +1266,7 @@ func (rq *replicateQueue) addOrReplaceVoters(
 		return nil, errors.AssertionFailedf("allocator suggested to replace replica on s%d with itself", newVoter.StoreID)
 	}
 
-	clusterNodes := rq.store.cfg.StorePool.ClusterNodeCount()
+	clusterNodes := rq.storePool.ClusterNodeCount()
 	neededVoters := allocatorimpl.GetNeededVoters(conf.GetNumVoters(), clusterNodes)
 
 	// Only up-replicate if there are suitable allocation targets such that,
@@ -1284,7 +1290,7 @@ func (rq *replicateQueue) addOrReplaceVoters(
 			oldPlusNewReplicas,
 			roachpb.ReplicaDescriptor{NodeID: newVoter.NodeID, StoreID: newVoter.StoreID},
 		)
-		_, _, err := rq.allocator.AllocateVoter(ctx, rq.allocator.StorePool, conf, oldPlusNewReplicas, remainingLiveNonVoters, replicaStatus)
+		_, _, err := rq.allocator.AllocateVoter(ctx, rq.storePool, conf, oldPlusNewReplicas, remainingLiveNonVoters, replicaStatus)
 		if err != nil {
 			// It does not seem possible to go to the next odd replica state. Note
 			// that AllocateVoter returns an allocatorError (a PurgatoryError)
@@ -1365,7 +1371,7 @@ func (rq *replicateQueue) addOrReplaceNonVoters(
 	existingNonVoters := desc.Replicas().NonVoterDescriptors()
 	effects := effectBuilder{}
 
-	newNonVoter, details, err := rq.allocator.AllocateNonVoter(ctx, rq.allocator.StorePool, conf, liveVoterReplicas, liveNonVoterReplicas, replicaStatus)
+	newNonVoter, details, err := rq.allocator.AllocateNonVoter(ctx, rq.storePool, conf, liveVoterReplicas, liveNonVoterReplicas, replicaStatus)
 	if err != nil {
 		return nil, err
 	}
@@ -1488,7 +1494,7 @@ func (rq *replicateQueue) findRemoveVoter(
 
 	return rq.allocator.RemoveVoter(
 		ctx,
-		rq.allocator.StorePool,
+		rq.storePool,
 		zone,
 		candidates,
 		existingVoters,
@@ -1531,7 +1537,7 @@ func (rq *replicateQueue) maybeTransferLeaseAwayTarget(
 	// a replica needs to be removed for constraint violations.
 	target := rq.allocator.TransferLeaseTarget(
 		ctx,
-		rq.allocator.StorePool,
+		rq.storePool,
 		conf,
 		desc.Replicas().VoterDescriptors(),
 		repl,
@@ -1611,7 +1617,7 @@ func (rq *replicateQueue) removeNonVoter(
 	_, conf := repl.DescAndSpanConfig()
 	removeNonVoter, details, err := rq.allocator.RemoveNonVoter(
 		ctx,
-		rq.allocator.StorePool,
+		rq.storePool,
 		conf,
 		existingNonVoters,
 		existingVoters,
@@ -1653,11 +1659,11 @@ func (rq *replicateQueue) removeDecommissioning(
 	var decommissioningReplicas []roachpb.ReplicaDescriptor
 	switch targetType {
 	case allocatorimpl.VoterTarget:
-		decommissioningReplicas = rq.store.cfg.StorePool.DecommissioningReplicas(
+		decommissioningReplicas = rq.storePool.DecommissioningReplicas(
 			desc.Replicas().VoterDescriptors(),
 		)
 	case allocatorimpl.NonVoterTarget:
-		decommissioningReplicas = rq.store.cfg.StorePool.DecommissioningReplicas(
+		decommissioningReplicas = rq.storePool.DecommissioningReplicas(
 			desc.Replicas().NonVoterDescriptors(),
 		)
 	default:
@@ -1771,7 +1777,7 @@ func (rq *replicateQueue) considerRebalance(
 	rangeUsageInfo := rangeUsageInfoForRepl(repl)
 	addTarget, removeTarget, details, ok := rq.allocator.RebalanceVoter(
 		ctx,
-		rq.allocator.StorePool,
+		rq.storePool,
 		conf,
 		repl.RaftStatus(),
 		existingVoters,
@@ -1786,7 +1792,7 @@ func (rq *replicateQueue) considerRebalance(
 		log.KvDistribution.Infof(ctx, "no suitable rebalance target for voters")
 		addTarget, removeTarget, details, ok = rq.allocator.RebalanceNonVoter(
 			ctx,
-			rq.allocator.StorePool,
+			rq.storePool,
 			conf,
 			repl.RaftStatus(),
 			existingVoters,
@@ -1970,7 +1976,7 @@ func (rq *replicateQueue) shedLease(
 	// so only consider the `VoterDescriptors` replicas.
 	target := rq.allocator.TransferLeaseTarget(
 		ctx,
-		rq.allocator.StorePool,
+		rq.storePool,
 		conf,
 		desc.Replicas().VoterDescriptors(),
 		repl,
@@ -2047,7 +2053,7 @@ func (rq *replicateQueue) TransferLease(
 		return errors.Wrapf(err, "%s: unable to transfer lease to s%d", rlm, target)
 	}
 
-	rq.allocator.StorePool.UpdateLocalStoresAfterLeaseTransfer(source, target, rangeQPS)
+	rq.storePool.UpdateLocalStoresAfterLeaseTransfer(source, target, rangeQPS)
 	rq.lastLeaseTransfer.Store(timeutil.Now())
 	return nil
 }

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -783,7 +783,7 @@ func (s *Store) raftTickLoop(ctx context.Context) {
 
 func (s *Store) updateIOThresholdMap() {
 	ioThresholdMap := map[roachpb.StoreID]*admissionpb.IOThreshold{}
-	for _, sd := range s.allocator.StorePool.GetStores() {
+	for _, sd := range s.cfg.StorePool.GetStores() {
 		ioThreshold := sd.Capacity.IOThreshold // need a copy
 		ioThresholdMap[sd.StoreID] = &ioThreshold
 	}

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -669,6 +669,7 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 
 		candidate := sr.allocator.TransferLeaseTarget(
 			ctx,
+			sr.allocator.StorePool,
 			conf,
 			candidates,
 			candidateReplica,
@@ -694,6 +695,7 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 		filteredStoreList := rctx.allStoresList.ExcludeInvalid(conf.VoterConstraints)
 		if sr.allocator.FollowTheWorkloadPrefersLocal(
 			ctx,
+			sr.allocator.StorePool,
 			filteredStoreList,
 			rctx.LocalDesc,
 			candidate.StoreID,
@@ -864,6 +866,7 @@ func (sr *StoreRebalancer) chooseRangeToRebalance(
 		// misconfiguration.
 		validTargets := sr.allocator.ValidLeaseTargets(
 			ctx,
+			sr.allocator.StorePool,
 			rebalanceCtx.conf,
 			targetVoterRepls,
 			rebalanceCtx.candidateReplica,
@@ -935,6 +938,7 @@ func (sr *StoreRebalancer) getRebalanceTargetsBasedOnQPS(
 		// `AdminRelocateRange` so that these decisions show up in system.rangelog
 		add, remove, _, shouldRebalance := sr.allocator.RebalanceTarget(
 			ctx,
+			sr.allocator.StorePool,
 			rbCtx.conf,
 			rbCtx.candidateReplica.RaftStatus(),
 			finalVoterTargets,
@@ -999,6 +1003,7 @@ func (sr *StoreRebalancer) getRebalanceTargetsBasedOnQPS(
 	for i := 0; i < len(finalNonVoterTargets); i++ {
 		add, remove, _, shouldRebalance := sr.allocator.RebalanceTarget(
 			ctx,
+			sr.allocator.StorePool,
 			rbCtx.conf,
 			rbCtx.candidateReplica.RaftStatus(),
 			finalVoterTargets,

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -123,6 +123,7 @@ type StoreRebalancer struct {
 	st               *cluster.Settings
 	storeID          roachpb.StoreID
 	allocator        allocatorimpl.Allocator
+	storePool        storepool.AllocatorStorePool
 	rr               RangeRebalancer
 	replicaRankings  *ReplicaRankings
 	getRaftStatusFn  func(replica CandidateReplica) *raft.Status
@@ -134,6 +135,10 @@ type StoreRebalancer struct {
 func NewStoreRebalancer(
 	ambientCtx log.AmbientContext, st *cluster.Settings, rq *replicateQueue, rr *ReplicaRankings,
 ) *StoreRebalancer {
+	var storePool storepool.AllocatorStorePool
+	if rq.store.cfg.StorePool != nil {
+		storePool = rq.store.cfg.StorePool
+	}
 	sr := &StoreRebalancer{
 		AmbientContext:  ambientCtx,
 		metrics:         makeStoreRebalancerMetrics(),
@@ -141,6 +146,7 @@ func NewStoreRebalancer(
 		storeID:         rq.store.StoreID(),
 		rr:              rq,
 		allocator:       rq.allocator,
+		storePool:       storePool,
 		replicaRankings: rr,
 		getRaftStatusFn: func(replica CandidateReplica) *raft.Status {
 			return replica.RaftStatus()
@@ -159,6 +165,7 @@ func NewStoreRebalancer(
 func SimulatorStoreRebalancer(
 	storeID roachpb.StoreID,
 	alocator allocatorimpl.Allocator,
+	storePool storepool.AllocatorStorePool,
 	getRaftStatusFn func(replica CandidateReplica) *raft.Status,
 ) *StoreRebalancer {
 	sr := &StoreRebalancer{
@@ -167,6 +174,7 @@ func SimulatorStoreRebalancer(
 		st:              &cluster.Settings{},
 		storeID:         storeID,
 		allocator:       alocator,
+		storePool:       storePool,
 		getRaftStatusFn: getRaftStatusFn,
 	}
 	return sr
@@ -238,7 +246,7 @@ func (sr *StoreRebalancer) Start(ctx context.Context, stopper *stop.Stopper) {
 func (sr *StoreRebalancer) scorerOptions(ctx context.Context) *allocatorimpl.QPSScorerOptions {
 	return &allocatorimpl.QPSScorerOptions{
 		StoreHealthOptions:    sr.allocator.StoreHealthOptions(ctx),
-		Deterministic:         sr.allocator.StorePool.IsDeterministic(),
+		Deterministic:         sr.storePool.IsDeterministic(),
 		QPSRebalanceThreshold: allocator.QPSRebalanceThreshold.Get(&sr.st.SV),
 		MinRequiredQPSDiff:    allocator.MinQPSDifferenceForTransfers.Get(&sr.st.SV),
 	}
@@ -252,7 +260,7 @@ func (sr *StoreRebalancer) NewRebalanceContext(
 	hottestRanges []CandidateReplica,
 	rebalancingMode LBRebalancingMode,
 ) *RebalanceContext {
-	allStoresList, _, _ := sr.allocator.StorePool.GetStoreList(storepool.StoreFilterSuspect)
+	allStoresList, _, _ := sr.storePool.GetStoreList(storepool.StoreFilterSuspect)
 	// Find the store descriptor for the local store.
 	localDesc, ok := allStoresList.FindStoreByID(sr.storeID)
 	if !ok {
@@ -438,7 +446,7 @@ func (sr *StoreRebalancer) applyLeaseRebalance(
 // latest storepool information. After a rebalance or lease transfer the
 // storepool is updated.
 func (sr *StoreRebalancer) RefreshRebalanceContext(ctx context.Context, rctx *RebalanceContext) {
-	allStoresList, _, _ := sr.allocator.StorePool.GetStoreList(storepool.StoreFilterSuspect)
+	allStoresList, _, _ := sr.storePool.GetStoreList(storepool.StoreFilterSuspect)
 
 	// Find the local descriptor in the all store list. If the store descriptor
 	// doesn't exist, then log an error rather than just a warning.
@@ -611,7 +619,7 @@ func (sr *StoreRebalancer) PostRangeRebalance(
 	// Finally, update our local copies of the descriptors so that if
 	// additional transfers are needed we'll be making the decisions with more
 	// up-to-date info.
-	sr.allocator.StorePool.UpdateLocalStoreAfterRelocate(
+	sr.storePool.UpdateLocalStoreAfterRelocate(
 		voterTargets, nonVoterTargets,
 		oldVoters, oldNonVoters,
 		rctx.LocalDesc.StoreID,
@@ -624,7 +632,7 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 	ctx context.Context, rctx *RebalanceContext,
 ) (CandidateReplica, roachpb.ReplicaDescriptor, []CandidateReplica) {
 	var considerForRebalance []CandidateReplica
-	now := sr.allocator.StorePool.Clock().NowAsClockTimestamp()
+	now := sr.storePool.Clock().NowAsClockTimestamp()
 	for {
 		if len(rctx.hottestRanges) == 0 {
 			return nil, roachpb.ReplicaDescriptor{}, considerForRebalance
@@ -669,7 +677,7 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 
 		candidate := sr.allocator.TransferLeaseTarget(
 			ctx,
-			sr.allocator.StorePool,
+			sr.storePool,
 			conf,
 			candidates,
 			candidateReplica,
@@ -695,7 +703,7 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 		filteredStoreList := rctx.allStoresList.ExcludeInvalid(conf.VoterConstraints)
 		if sr.allocator.FollowTheWorkloadPrefersLocal(
 			ctx,
-			sr.allocator.StorePool,
+			sr.storePool,
 			filteredStoreList,
 			rctx.LocalDesc,
 			candidate.StoreID,
@@ -738,7 +746,7 @@ type rangeRebalanceContext struct {
 func (sr *StoreRebalancer) chooseRangeToRebalance(
 	ctx context.Context, rctx *RebalanceContext,
 ) (candidateReplica CandidateReplica, voterTargets, nonVoterTargets []roachpb.ReplicationTarget) {
-	now := sr.allocator.StorePool.Clock().NowAsClockTimestamp()
+	now := sr.storePool.Clock().NowAsClockTimestamp()
 	if len(rctx.rebalanceCandidates) == 0 && len(rctx.hottestRanges) >= 0 {
 		// NB: In practice, the rebalanceCandidates will be populated with
 		// hottest ranges by the preceeding function call, rebalance leases.
@@ -778,7 +786,7 @@ func (sr *StoreRebalancer) chooseRangeToRebalance(
 		}
 
 		rangeDesc, conf := candidateReplica.DescAndSpanConfig()
-		clusterNodes := sr.allocator.StorePool.ClusterNodeCount()
+		clusterNodes := sr.storePool.ClusterNodeCount()
 		numDesiredVoters := allocatorimpl.GetNeededVoters(conf.GetNumVoters(), clusterNodes)
 		numDesiredNonVoters := allocatorimpl.GetNeededNonVoters(numDesiredVoters, int(conf.GetNumNonVoters()), clusterNodes)
 		if expected, actual := numDesiredVoters, len(rangeDesc.Replicas().VoterDescriptors()); expected != actual {
@@ -866,7 +874,7 @@ func (sr *StoreRebalancer) chooseRangeToRebalance(
 		// misconfiguration.
 		validTargets := sr.allocator.ValidLeaseTargets(
 			ctx,
-			sr.allocator.StorePool,
+			sr.storePool,
 			rebalanceCtx.conf,
 			targetVoterRepls,
 			rebalanceCtx.candidateReplica,
@@ -938,7 +946,7 @@ func (sr *StoreRebalancer) getRebalanceTargetsBasedOnQPS(
 		// `AdminRelocateRange` so that these decisions show up in system.rangelog
 		add, remove, _, shouldRebalance := sr.allocator.RebalanceTarget(
 			ctx,
-			sr.allocator.StorePool,
+			sr.storePool,
 			rbCtx.conf,
 			rbCtx.candidateReplica.RaftStatus(),
 			finalVoterTargets,
@@ -1003,7 +1011,7 @@ func (sr *StoreRebalancer) getRebalanceTargetsBasedOnQPS(
 	for i := 0; i < len(finalNonVoterTargets); i++ {
 		add, remove, _, shouldRebalance := sr.allocator.RebalanceTarget(
 			ctx,
-			sr.allocator.StorePool,
+			sr.storePool,
 			rbCtx.conf,
 			rbCtx.candidateReplica.RaftStatus(),
 			finalVoterTargets,


### PR DESCRIPTION
This change refactors the allocator to accept the store pool as an
argument, moving it closer to being stateless and purely functional.
This is done by moving to using the storepool through its primary 
owner (the store configuration), or through references held by 
users of the allocator.  The refactoring enables the the allocator to
consider potential scenarios rather than those simply based on the
current liveness.

Part of #91570.

Release Note: None