### PR TITLE
sql: use empty roachpb.TenantID for error return

### DIFF
--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -571,7 +571,7 @@ func (c *DummyTenantOperator) CreateTenantWithID(
 func (c *DummyTenantOperator) CreateTenant(
 	ctx context.Context, tenantName roachpb.TenantName,
 ) (roachpb.TenantID, error) {
-	return roachpb.MakeTenantID(0), errors.WithStack(errEvalTenant)
+	return roachpb.TenantID{}, errors.WithStack(errEvalTenant)
 }
 
 // RenameTenant is part of the tree.TenantOperator interface.


### PR DESCRIPTION
MakeTenantID(0) panics. In other error cases in the code base, we return an empty struct.

Epic: None

Release note: None