### PR TITLE
apply: split up apply.Batch

### DIFF
--- a/pkg/kv/kvserver/apply/task.go
+++ b/pkg/kv/kvserver/apply/task.go
@@ -26,19 +26,20 @@ import (
 // deterministic, which ensures that if each instance is driven from the
 // same consistent shared log, they will all stay in sync.
 type StateMachine interface {
-	// NewBatch creates a new batch that is suitable for accumulating the
-	// effects that a group of Commands will have on the replicated state
-	// machine. Commands are staged in the batch one-by-one and then the
-	// entire batch is committed at once.
+	// NewEphemeralBatch creates an EphemeralBatch. This kind of batch is not able
+	// to make changes to the StateMachine, but can be used for the purpose of
+	// checking commands to determine whether they will be rejected or not when
+	// staged in a real Batch. The principal user of ephemeral batches is
+	// AckCommittedEntriesBeforeApplication.
 	//
-	// Batch comes in two flavors - real batches and ephemeral batches.
-	// Real batches are capable of accumulating updates from commands and
-	// applying them to the state machine. Ephemeral batches are not able
-	// to make changes to the durable state machine, but can still be used
-	// for the purpose of checking commands to determine whether they will
-	// be rejected or not when staged in a real batch. The principal user
-	// of ephemeral batches is AckCommittedEntriesBeforeApplication.
-	NewBatch(ephemeral bool) Batch
+	// There must only be a single EphemeralBatch *or* Batch open at any given
+	// point in time.
+	NewEphemeralBatch() EphemeralBatch
+	// NewBatch creates a new batch that is suitable for accumulating the effects
+	// that a group of Commands will have on the replicated state machine.
+	// Commands are staged in the batch one-by-one and then the entire batch is
+	// applied to the StateMachine at once via its ApplyToStateMachine method.
+	NewBatch() Batch
 	// ApplySideEffects applies the in-memory side-effects of a Command to
 	// the replicated state machine. The method will be called in the order
 	// that the commands are committed to the state machine's log. Once the
@@ -60,19 +61,25 @@ type StateMachine interface {
 // only be thrown by non-trivial commands.
 var ErrRemoved = errors.New("replica removed")
 
+// An EphemeralBatch can stage a number of commands, but lacks the ability
+// to apply them to a state machine.
+type EphemeralBatch interface {
+	// Stage inserts a Command into the Batch. In doing so, the Command is
+	// checked for rejection and a CheckedCommand is returned.
+	Stage(context.Context, Command) (CheckedCommand, error)
+	// Close closes the batch and releases any resources that it holds.
+	Close()
+}
+
 // Batch accumulates a series of updates from Commands and performs them
 // all at once to its StateMachine when applied. Groups of Commands will be
 // staged in the Batch such that one or more trivial Commands are staged or
 // exactly one non-trivial Command is staged.
 type Batch interface {
-	// Stage inserts a Command into the Batch. In doing so, the Command is
-	// checked for rejection and a CheckedCommand is returned.
-	Stage(context.Context, Command) (CheckedCommand, error)
+	EphemeralBatch
 	// ApplyToStateMachine applies the persistent state transitions staged
 	// in the Batch to the StateMachine, atomically.
 	ApplyToStateMachine(context.Context) error
-	// Close closes the batch and releases any resources that it holds.
-	Close()
 }
 
 // Decoder is capable of decoding a list of committed raft entries and
@@ -192,7 +199,7 @@ func (t *Task) AckCommittedEntriesBeforeApplication(ctx context.Context, maxInde
 
 	// Create a new ephemeral application batch. All we're interested in is
 	// whether commands will be rejected or not when staged in a real batch.
-	batch := t.sm.NewBatch(true /* ephemeral */)
+	batch := t.sm.NewEphemeralBatch()
 	defer batch.Close()
 
 	iter := t.dec.NewCommandIter()
@@ -261,7 +268,7 @@ func (t *Task) ApplyCommittedEntries(ctx context.Context) error {
 // b) exactly one non-trivial command
 func (t *Task) applyOneBatch(ctx context.Context, iter CommandIterator) error {
 	// Create a new application batch.
-	batch := t.sm.NewBatch(false /* ephemeral */)
+	batch := t.sm.NewBatch()
 	defer batch.Close()
 
 	// Consume a batch-worth of commands.

--- a/pkg/kv/kvserver/apply/task_test.go
+++ b/pkg/kv/kvserver/apply/task_test.go
@@ -131,7 +131,15 @@ func getTestStateMachine() *testStateMachine {
 	return new(testStateMachine)
 }
 
-func (sm *testStateMachine) NewBatch(ephemeral bool) apply.Batch {
+func (sm *testStateMachine) NewBatch() apply.Batch {
+	return sm.newBatch(false /* ephemeral */)
+}
+
+func (sm *testStateMachine) NewEphemeralBatch() apply.EphemeralBatch {
+	return sm.newBatch(true /* ephemeral */)
+}
+
+func (sm *testStateMachine) newBatch(ephemeral bool) apply.Batch {
 	if sm.batchOpen {
 		panic("batch not closed")
 	}

--- a/pkg/kv/kvserver/replica_application_state_machine_test.go
+++ b/pkg/kv/kvserver/replica_application_state_machine_test.go
@@ -85,7 +85,7 @@ func TestReplicaStateMachineChangeReplicas(t *testing.T) {
 		}
 
 		// Create a new application batch.
-		b := sm.NewBatch(false /* ephemeral */).(*replicaAppBatch)
+		b := sm.NewBatch().(*replicaAppBatch)
 		defer b.Close()
 
 		// Stage a command with the ChangeReplicas trigger.
@@ -166,7 +166,7 @@ func TestReplicaStateMachineRaftLogTruncationStronglyCoupled(t *testing.T) {
 		sm := r.getStateMachine()
 
 		// Create a new application batch.
-		b := sm.NewBatch(false /* ephemeral */).(*replicaAppBatch)
+		b := sm.NewBatch().(*replicaAppBatch)
 		defer b.Close()
 
 		r.mu.Lock()
@@ -291,7 +291,7 @@ func TestReplicaStateMachineRaftLogTruncationLooselyCoupled(t *testing.T) {
 			sm := r.getStateMachine()
 
 			// Create a new application batch.
-			b := sm.NewBatch(false /* ephemeral */).(*replicaAppBatch)
+			b := sm.NewBatch().(*replicaAppBatch)
 			defer b.Close()
 			// Stage a command that truncates one raft log entry which we pretend has a
 			// byte size of 1.


### PR DESCRIPTION
`apply.Batch` allows staging commands and then applying them to the
state machine. But there is also the concept of an "ephemeral" batch
which is used only to check which commands we can ack early to the
client. This ephemeral batch wouldn't ever be applied to the state
machine but the interface made it seem like this was possible (and
an panic-implementation had to be provided).

This commit introduces `apply.EphemeralBatch` and embeds it in
`apply.Batch` to clear this up.

Epic: CRDB-220
Release note: None
