### PR TITLE
*: rename MakeTenantID to MustMakeTenantID

### DIFF
--- a/pkg/acceptance/cluster/certs.go
+++ b/pkg/acceptance/cluster/certs.go
@@ -60,7 +60,7 @@ func GenerateCerts(ctx context.Context) func() {
 	// Root user.
 	// Scope root user to system tenant and tenant ID 5 which is what we use by default for acceptance
 	// tests.
-	userScopes := []roachpb.TenantID{roachpb.SystemTenantID, roachpb.MakeTenantID(5)}
+	userScopes := []roachpb.TenantID{roachpb.SystemTenantID, roachpb.MustMakeTenantID(5)}
 	maybePanic(security.CreateClientPair(
 		certsDir, filepath.Join(certsDir, certnames.EmbeddedCAKey),
 		keyLen, 48*time.Hour, false, username.RootUserName(), userScopes, true /* generate pk8 key */))

--- a/pkg/ccl/backupccl/backup_metadata_test.go
+++ b/pkg/ccl/backupccl/backup_metadata_test.go
@@ -71,7 +71,7 @@ func TestMetadataSST(t *testing.T) {
 
 	// Check for correct backup metadata on tenant backups.
 	userfile2 := "userfile:///2"
-	_, err := tc.Servers[0].StartTenant(ctx, base.TestTenantArgs{TenantID: roachpb.MakeTenantID(10)})
+	_, err := tc.Servers[0].StartTenant(ctx, base.TestTenantArgs{TenantID: roachpb.MustMakeTenantID(10)})
 	require.NoError(t, err)
 	sqlDB.Exec(t, `BACKUP TENANT 10 TO $1`, userfile2)
 	checkMetadata(ctx, t, tc, userfile2)

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -753,7 +753,7 @@ func backupPlanHook(
 			if !p.ExecCfg().Codec.ForSystemTenant() {
 				return pgerror.Newf(pgcode.InsufficientPrivilege, "only the system tenant can backup other tenants")
 			}
-			initialDetails.SpecificTenantIds = []roachpb.TenantID{roachpb.MakeTenantID(backupStmt.Targets.TenantID.ID)}
+			initialDetails.SpecificTenantIds = []roachpb.TenantID{roachpb.MustMakeTenantID(backupStmt.Targets.TenantID.ID)}
 		}
 
 		jobID := p.ExecCfg().JobRegistry.MakeJobID()
@@ -1134,7 +1134,7 @@ func getProtectedTimestampTargetForBackup(backupManifest backuppb.BackupManifest
 	if len(backupManifest.Tenants) > 0 {
 		tenantID := make([]roachpb.TenantID, 0)
 		for _, tenant := range backupManifest.Tenants {
-			tenantID = append(tenantID, roachpb.MakeTenantID(tenant.ID))
+			tenantID = append(tenantID, roachpb.MustMakeTenantID(tenant.ID))
 		}
 		return ptpb.MakeTenantsTarget(tenantID)
 	}
@@ -1297,7 +1297,7 @@ func getTenantInfo(
 		)
 	}
 	for i := range tenants {
-		prefix := keys.MakeTenantPrefix(roachpb.MakeTenantID(tenants[i].ID))
+		prefix := keys.MakeTenantPrefix(roachpb.MustMakeTenantID(tenants[i].ID))
 		spans = append(spans, roachpb.Span{Key: prefix, EndKey: prefix.PrefixEnd()})
 	}
 	return spans, tenants, nil

--- a/pkg/ccl/backupccl/backup_tenant_test.go
+++ b/pkg/ccl/backupccl/backup_tenant_test.go
@@ -50,7 +50,7 @@ func TestBackupTenantImportingTable(t *testing.T) {
 	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
 
 	tSrv, tSQL := serverutils.StartTenant(t, tc.Server(0), base.TestTenantArgs{
-		TenantID:     roachpb.MakeTenantID(10),
+		TenantID:     roachpb.MustMakeTenantID(10),
 		TestingKnobs: base.TestingKnobs{JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals()},
 	})
 	defer tSQL.Close()
@@ -87,7 +87,7 @@ func TestBackupTenantImportingTable(t *testing.T) {
 		t.Fatal(err)
 	}
 	tSrv, tSQL = serverutils.StartTenant(t, tc.Server(0), base.TestTenantArgs{
-		TenantID:     roachpb.MakeTenantID(10),
+		TenantID:     roachpb.MustMakeTenantID(10),
 		TestingKnobs: base.TestingKnobs{JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals()},
 	})
 	defer tSQL.Close()
@@ -136,7 +136,7 @@ func TestTenantBackupMultiRegionDatabases(t *testing.T) {
 	defer cleanup()
 	sqlDB := sqlutils.MakeSQLRunner(db)
 
-	tenID := roachpb.MakeTenantID(10)
+	tenID := roachpb.MustMakeTenantID(10)
 	_, tSQL := serverutils.StartTenant(t, tc.Server(0), base.TestTenantArgs{
 		TenantID:     tenID,
 		TestingKnobs: base.TestingKnobs{JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals()},

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -3408,7 +3408,7 @@ func TestBackupTenantsWithRevisionHistory(t *testing.T) {
 	tc, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
 	defer cleanupFn()
 
-	_, err := tc.Servers[0].StartTenant(ctx, base.TestTenantArgs{TenantID: roachpb.MakeTenantID(10)})
+	_, err := tc.Servers[0].StartTenant(ctx, base.TestTenantArgs{TenantID: roachpb.MustMakeTenantID(10)})
 	require.NoError(t, err)
 
 	const msg = "can not backup tenants with revision history"
@@ -5856,7 +5856,7 @@ func TestProtectedTimestampsDuringBackup(t *testing.T) {
 
 	// Setup a tenant.
 	ts := tc.Server(0)
-	tenantID := roachpb.MakeTenantID(10)
+	tenantID := roachpb.MustMakeTenantID(10)
 	tt, ttSQLDBRaw := serverutils.StartTenant(
 		t, ts, base.TestTenantArgs{
 			TenantID: tenantID,
@@ -6323,7 +6323,7 @@ func TestPaginatedBackupTenant(t *testing.T) {
 	}
 
 	_, conn10 := serverutils.StartTenant(t, srv,
-		base.TestTenantArgs{TenantID: roachpb.MakeTenantID(10)})
+		base.TestTenantArgs{TenantID: roachpb.MustMakeTenantID(10)})
 	defer conn10.Close()
 	tenant10 := sqlutils.MakeSQLRunner(conn10)
 	tenant10.Exec(t, `
@@ -6423,7 +6423,7 @@ func TestBackupRestoreInsideTenant(t *testing.T) {
 	const numAccounts = 1
 
 	makeTenant := func(srv serverutils.TestServerInterface, tenant uint64) (*sqlutils.SQLRunner, func()) {
-		_, conn := serverutils.StartTenant(t, srv, base.TestTenantArgs{TenantID: roachpb.MakeTenantID(tenant)})
+		_, conn := serverutils.StartTenant(t, srv, base.TestTenantArgs{TenantID: roachpb.MustMakeTenantID(tenant)})
 		cleanup := func() { conn.Close() }
 		return sqlutils.MakeSQLRunner(conn), cleanup
 	}
@@ -6544,7 +6544,7 @@ func TestBackupRestoreTenantSettings(t *testing.T) {
 	const numAccounts = 1
 
 	makeTenant := func(srv serverutils.TestServerInterface, tenant uint64) (*sqlutils.SQLRunner, func()) {
-		_, conn := serverutils.StartTenant(t, srv, base.TestTenantArgs{TenantID: roachpb.MakeTenantID(tenant)})
+		_, conn := serverutils.StartTenant(t, srv, base.TestTenantArgs{TenantID: roachpb.MustMakeTenantID(tenant)})
 		cleanup := func() { conn.Close() }
 		return sqlutils.MakeSQLRunner(conn), cleanup
 	}
@@ -6595,7 +6595,7 @@ func TestBackupRestoreInsideMultiPodTenant(t *testing.T) {
 	const npods = 2
 
 	makeTenant := func(srv serverutils.TestServerInterface, tenant uint64, existing bool) (*sqlutils.SQLRunner, func()) {
-		_, conn := serverutils.StartTenant(t, srv, base.TestTenantArgs{TenantID: roachpb.MakeTenantID(tenant), DisableCreateTenant: existing})
+		_, conn := serverutils.StartTenant(t, srv, base.TestTenantArgs{TenantID: roachpb.MustMakeTenantID(tenant), DisableCreateTenant: existing})
 		cleanup := func() { conn.Close() }
 		return sqlutils.MakeSQLRunner(conn), cleanup
 	}
@@ -6740,7 +6740,7 @@ func TestBackupRestoreTenant(t *testing.T) {
 	_ = security.EmbeddedTenantIDs()
 
 	// Setup a few tenants, each with a different table.
-	_, conn10 := serverutils.StartTenant(t, srv, base.TestTenantArgs{TenantID: roachpb.MakeTenantID(10)})
+	_, conn10 := serverutils.StartTenant(t, srv, base.TestTenantArgs{TenantID: roachpb.MustMakeTenantID(10)})
 	defer conn10.Close()
 	tenant10 := sqlutils.MakeSQLRunner(conn10)
 	tenant10.Exec(t, `CREATE DATABASE foo; CREATE TABLE foo.bar(i int primary key); INSERT INTO foo.bar VALUES (110), (210)`)
@@ -6764,12 +6764,12 @@ func TestBackupRestoreTenant(t *testing.T) {
 	systemDB.Exec(t, `BACKUP system.users TO 'nodelocal://1/users'`)
 	systemDB.CheckQueryResults(t, `SELECT manifest->>'tenants' FROM [SHOW BACKUP 'nodelocal://1/users' WITH as_json]`, [][]string{{"[]"}})
 
-	_, conn11 := serverutils.StartTenant(t, srv, base.TestTenantArgs{TenantID: roachpb.MakeTenantID(11)})
+	_, conn11 := serverutils.StartTenant(t, srv, base.TestTenantArgs{TenantID: roachpb.MustMakeTenantID(11)})
 	defer conn11.Close()
 	tenant11 := sqlutils.MakeSQLRunner(conn11)
 	tenant11.Exec(t, `CREATE DATABASE foo; CREATE TABLE foo.baz(i int primary key); INSERT INTO foo.baz VALUES (111), (211)`)
 
-	_, conn20 := serverutils.StartTenant(t, srv, base.TestTenantArgs{TenantID: roachpb.MakeTenantID(20)})
+	_, conn20 := serverutils.StartTenant(t, srv, base.TestTenantArgs{TenantID: roachpb.MustMakeTenantID(20)})
 	defer conn20.Close()
 	tenant20 := sqlutils.MakeSQLRunner(conn20)
 	tenant20.Exec(t, `CREATE DATABASE foo; CREATE TABLE foo.qux(i int primary key); INSERT INTO foo.qux VALUES (120), (220)`)
@@ -6841,7 +6841,7 @@ func TestBackupRestoreTenant(t *testing.T) {
 		ten10Stopper := stop.NewStopper()
 		_, restoreConn10 := serverutils.StartTenant(
 			t, restoreTC.Server(0), base.TestTenantArgs{
-				TenantID: roachpb.MakeTenantID(10), Stopper: ten10Stopper,
+				TenantID: roachpb.MustMakeTenantID(10), Stopper: ten10Stopper,
 			},
 		)
 		restoreTenant10 := sqlutils.MakeSQLRunner(restoreConn10)
@@ -6873,7 +6873,7 @@ func TestBackupRestoreTenant(t *testing.T) {
 			[][]string{{"succeeded"}},
 		)
 
-		ten10Prefix := keys.MakeTenantPrefix(roachpb.MakeTenantID(10))
+		ten10Prefix := keys.MakeTenantPrefix(roachpb.MustMakeTenantID(10))
 		ten10PrefixEnd := ten10Prefix.PrefixEnd()
 		rows, err := restoreTC.Server(0).DB().Scan(ctx, ten10Prefix, ten10PrefixEnd, 0 /* maxRows */)
 		require.NoError(t, err)
@@ -6889,7 +6889,7 @@ func TestBackupRestoreTenant(t *testing.T) {
 		)
 
 		_, restoreConn10 = serverutils.StartTenant(
-			t, restoreTC.Server(0), base.TestTenantArgs{TenantID: roachpb.MakeTenantID(10)},
+			t, restoreTC.Server(0), base.TestTenantArgs{TenantID: roachpb.MustMakeTenantID(10)},
 		)
 		defer restoreConn10.Close()
 		restoreTenant10 = sqlutils.MakeSQLRunner(restoreConn10)
@@ -6949,7 +6949,7 @@ func TestBackupRestoreTenant(t *testing.T) {
 		)
 
 		_, restoreConn10 := serverutils.StartTenant(
-			t, restoreTC.Server(0), base.TestTenantArgs{TenantID: roachpb.MakeTenantID(10)},
+			t, restoreTC.Server(0), base.TestTenantArgs{TenantID: roachpb.MustMakeTenantID(10)},
 		)
 		defer restoreConn10.Close()
 		restoreTenant10 := sqlutils.MakeSQLRunner(restoreConn10)
@@ -6991,7 +6991,7 @@ func TestBackupRestoreTenant(t *testing.T) {
 		)
 
 		_, restoreConn10 := serverutils.StartTenant(
-			t, restoreTC.Server(0), base.TestTenantArgs{TenantID: roachpb.MakeTenantID(10)},
+			t, restoreTC.Server(0), base.TestTenantArgs{TenantID: roachpb.MustMakeTenantID(10)},
 		)
 		defer restoreConn10.Close()
 		restoreTenant10 := sqlutils.MakeSQLRunner(restoreConn10)
@@ -7004,7 +7004,7 @@ func TestBackupRestoreTenant(t *testing.T) {
 		restoreTenant10.CheckQueryResults(t, `SHOW CLUSTER SETTING tenant_cost_model.write_payload_cost_per_mebibyte`, [][]string{{"456"}})
 
 		_, restoreConn11 := serverutils.StartTenant(
-			t, restoreTC.Server(0), base.TestTenantArgs{TenantID: roachpb.MakeTenantID(11)},
+			t, restoreTC.Server(0), base.TestTenantArgs{TenantID: roachpb.MustMakeTenantID(11)},
 		)
 		defer restoreConn11.Close()
 		restoreTenant11 := sqlutils.MakeSQLRunner(restoreConn11)
@@ -7018,7 +7018,7 @@ func TestBackupRestoreTenant(t *testing.T) {
 
 		restoreDB.Exec(t, `RESTORE TENANT 11 FROM 'nodelocal://1/clusterwide' WITH tenant = '20'`)
 		_, restoreConn20 := serverutils.StartTenant(
-			t, restoreTC.Server(0), base.TestTenantArgs{TenantID: roachpb.MakeTenantID(20), DisableCreateTenant: true},
+			t, restoreTC.Server(0), base.TestTenantArgs{TenantID: roachpb.MustMakeTenantID(20), DisableCreateTenant: true},
 		)
 		defer restoreConn20.Close()
 		restoreTenant20 := sqlutils.MakeSQLRunner(restoreConn20)
@@ -7053,7 +7053,7 @@ func TestBackupRestoreTenant(t *testing.T) {
 		restoreDB.Exec(t, `RESTORE TENANT 10 FROM 'nodelocal://1/t10' AS OF SYSTEM TIME `+ts1)
 
 		_, restoreConn10 := serverutils.StartTenant(
-			t, restoreTC.Server(0), base.TestTenantArgs{TenantID: roachpb.MakeTenantID(10)},
+			t, restoreTC.Server(0), base.TestTenantArgs{TenantID: roachpb.MustMakeTenantID(10)},
 		)
 		defer restoreConn10.Close()
 		restoreTenant10 := sqlutils.MakeSQLRunner(restoreConn10)
@@ -7078,7 +7078,7 @@ func TestBackupRestoreTenant(t *testing.T) {
 		restoreDB.Exec(t, `RESTORE TENANT 20 FROM 'nodelocal://1/t20'`)
 
 		_, restoreConn20 := serverutils.StartTenant(
-			t, restoreTC.Server(0), base.TestTenantArgs{TenantID: roachpb.MakeTenantID(20)},
+			t, restoreTC.Server(0), base.TestTenantArgs{TenantID: roachpb.MustMakeTenantID(20)},
 		)
 		defer restoreConn20.Close()
 		restoreTenant20 := sqlutils.MakeSQLRunner(restoreConn20)

--- a/pkg/ccl/backupccl/key_rewriter_test.go
+++ b/pkg/ccl/backupccl/key_rewriter_test.go
@@ -183,8 +183,8 @@ func TestKeyRewriter(t *testing.T) {
 		}
 	})
 	systemTenant := roachpb.SystemTenantID
-	tenant3 := roachpb.MakeTenantID(3)
-	tenant4 := roachpb.MakeTenantID(4)
+	tenant3 := roachpb.MustMakeTenantID(3)
+	tenant4 := roachpb.MustMakeTenantID(4)
 
 	// Restoring a tenant's data from a backup as another tenant.
 	testTableRekeyAsDiffTenant := func(srcTenant, destTenant roachpb.TenantID) {

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1533,7 +1533,7 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 	}
 
 	for _, tenant := range details.Tenants {
-		to := roachpb.MakeTenantID(tenant.ID)
+		to := roachpb.MustMakeTenantID(tenant.ID)
 		from := to
 		if details.PreRewriteTenantId != nil {
 			from = *details.PreRewriteTenantId

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1097,7 +1097,7 @@ func restorePlanHook(
 			if x < int(roachpb.MinTenantID.ToUint64()) {
 				return nil, errors.New("invalid tenant ID value")
 			}
-			id := roachpb.MakeTenantID(uint64(x))
+			id := roachpb.MustMakeTenantID(uint64(x))
 			return &id, nil
 		}()
 		if err != nil {
@@ -1627,7 +1627,7 @@ func doRestorePlan(
 			if res != nil {
 				return errors.Errorf("tenant %s already exists", newTenantID)
 			}
-			old := roachpb.MakeTenantID(tenants[0].ID)
+			old := roachpb.MustMakeTenantID(tenants[0].ID)
 			tenants[0].ID = newTenantID.ToUint64()
 			oldTenantID = &old
 		} else {

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -882,8 +882,8 @@ func backupShowerDefault(p sql.PlanHookState, showSchemas bool, opts tree.KVOpti
 					row := tree.Datums{
 						tree.DNull, // Database
 						tree.DNull, // Schema
-						tree.NewDString(roachpb.MakeTenantID(t.ID).String()), // Object Name
-						tree.NewDString("TENANT"),                            // Object Type
+						tree.NewDString(roachpb.MustMakeTenantID(t.ID).String()), // Object Name
+						tree.NewDString("TENANT"),                                // Object Type
 						backupType,
 						start,
 						end,

--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -590,7 +590,7 @@ func TestShowBackupTenantView(t *testing.T) {
 
 	_ = security.EmbeddedTenantIDs()
 
-	_, conn10 := serverutils.StartTenant(t, srv, base.TestTenantArgs{TenantID: roachpb.MakeTenantID(10)})
+	_, conn10 := serverutils.StartTenant(t, srv, base.TestTenantArgs{TenantID: roachpb.MustMakeTenantID(10)})
 	defer conn10.Close()
 
 	tenant10 := sqlutils.MakeSQLRunner(conn10)
@@ -629,7 +629,7 @@ func TestShowBackupTenants(t *testing.T) {
 	// NB: tenant certs for 10, 11, 20 are embedded. See:
 	_ = security.EmbeddedTenantIDs()
 
-	_, conn10 := serverutils.StartTenant(t, srv, base.TestTenantArgs{TenantID: roachpb.MakeTenantID(10)})
+	_, conn10 := serverutils.StartTenant(t, srv, base.TestTenantArgs{TenantID: roachpb.MustMakeTenantID(10)})
 	defer conn10.Close()
 	tenant10 := sqlutils.MakeSQLRunner(conn10)
 	tenant10.Exec(t, `CREATE DATABASE foo; CREATE TABLE foo.bar(i int primary key); INSERT INTO foo.bar VALUES (110), (210)`)

--- a/pkg/ccl/cloudccl/externalconn/datadriven_test.go
+++ b/pkg/ccl/cloudccl/externalconn/datadriven_test.go
@@ -69,7 +69,7 @@ func TestDataDriven(t *testing.T) {
 			if d.HasArg("tenant") {
 				var id uint64
 				d.ScanArgs(t, "tenant", &id)
-				tenantID = roachpb.MakeTenantID(id)
+				tenantID = roachpb.MustMakeTenantID(id)
 			}
 
 			tenant, found := externalConnTestCluster.LookupTenant(tenantID)

--- a/pkg/ccl/importerccl/ccl_test.go
+++ b/pkg/ccl/importerccl/ccl_test.go
@@ -390,7 +390,7 @@ func TestExportInsideTenant(t *testing.T) {
 	srv, _, _ := serverutils.StartServer(t, base.TestServerArgs{ExternalIODir: dir})
 	defer srv.Stopper().Stop(context.Background())
 
-	_, conn10 := serverutils.StartTenant(t, srv, base.TestTenantArgs{TenantID: roachpb.MakeTenantID(10)})
+	_, conn10 := serverutils.StartTenant(t, srv, base.TestTenantArgs{TenantID: roachpb.MustMakeTenantID(10)})
 	defer conn10.Close()
 	tenant10 := sqlutils.MakeSQLRunner(conn10)
 
@@ -425,12 +425,12 @@ func TestImportInTenant(t *testing.T) {
 	sqlDB := sqlutils.MakeSQLRunner(conn)
 
 	// Setup a few tenants, each with a different table.
-	_, conn10 := serverutils.StartTenant(t, tc.Server(0), base.TestTenantArgs{TenantID: roachpb.MakeTenantID(10)})
+	_, conn10 := serverutils.StartTenant(t, tc.Server(0), base.TestTenantArgs{TenantID: roachpb.MustMakeTenantID(10)})
 	defer conn10.Close()
 	t10 := sqlutils.MakeSQLRunner(conn10)
 
 	// Setup a few tenants, each with a different table.
-	_, conn11 := serverutils.StartTenant(t, tc.Server(0), base.TestTenantArgs{TenantID: roachpb.MakeTenantID(11)})
+	_, conn11 := serverutils.StartTenant(t, tc.Server(0), base.TestTenantArgs{TenantID: roachpb.MustMakeTenantID(11)})
 	defer conn11.Close()
 	t11 := sqlutils.MakeSQLRunner(conn11)
 
@@ -474,14 +474,14 @@ func TestImportInMultiServerTenant(t *testing.T) {
 
 	// Setup a SQL server on a tenant.
 	_, conn1 := serverutils.StartTenant(t, tc.Server(0), base.TestTenantArgs{
-		TenantID: roachpb.MakeTenantID(10),
+		TenantID: roachpb.MustMakeTenantID(10),
 	})
 	defer conn1.Close()
 	t1 := sqlutils.MakeSQLRunner(conn1)
 
 	// Setup another SQL server on the same tenant.
 	_, conn2 := serverutils.StartTenant(t, tc.Server(0), base.TestTenantArgs{
-		TenantID:            roachpb.MakeTenantID(10),
+		TenantID:            roachpb.MustMakeTenantID(10),
 		DisableCreateTenant: true,
 	})
 	defer conn2.Close()

--- a/pkg/ccl/jobsccl/jobsprotectedtsccl/jobs_protected_ts_test.go
+++ b/pkg/ccl/jobsccl/jobsprotectedtsccl/jobs_protected_ts_test.go
@@ -162,7 +162,7 @@ func TestJobsProtectedTimestamp(t *testing.T) {
 		WHERE name IN ('kv.closed_timestamp.target_duration', 'kv.protectedts.reconciliation.interval')`)
 
 	t.Run("secondary-tenant", func(t *testing.T) {
-		ten10, conn10 := serverutils.StartTenant(t, s0, base.TestTenantArgs{TenantID: roachpb.MakeTenantID(10)})
+		ten10, conn10 := serverutils.StartTenant(t, s0, base.TestTenantArgs{TenantID: roachpb.MustMakeTenantID(10)})
 		defer conn10.Close()
 		ptp := ten10.ExecutorConfig().(sql.ExecutorConfig).ProtectedTimestampProvider
 		execCfg := ten10.ExecutorConfig().(sql.ExecutorConfig)
@@ -283,7 +283,7 @@ func TestSchedulesProtectedTimestamp(t *testing.T) {
 		WHERE name IN ('kv.closed_timestamp.target_duration', 'kv.protectedts.reconciliation.interval')`)
 
 	t.Run("secondary-tenant", func(t *testing.T) {
-		ten10, conn10 := serverutils.StartTenant(t, s0, base.TestTenantArgs{TenantID: roachpb.MakeTenantID(10)})
+		ten10, conn10 := serverutils.StartTenant(t, s0, base.TestTenantArgs{TenantID: roachpb.MustMakeTenantID(10)})
 		defer conn10.Close()
 		ptp := ten10.ExecutorConfig().(sql.ExecutorConfig).ProtectedTimestampProvider
 		execCfg := ten10.ExecutorConfig().(sql.ExecutorConfig)

--- a/pkg/ccl/kvccl/kvtenantccl/setting_overrides_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/setting_overrides_test.go
@@ -40,7 +40,7 @@ func TestConnectorSettingOverrides(t *testing.T) {
 	rpcContext := rpc.NewInsecureTestingContext(ctx, clock, stopper)
 	s := rpc.NewServer(rpcContext)
 
-	tenantID := roachpb.MakeTenantID(5)
+	tenantID := roachpb.MustMakeTenantID(5)
 	gossipSubFn := func(req *roachpb.GossipSubscriptionRequest, stream roachpb.Internal_GossipSubscriptionServer) error {
 		return stream.Send(gossipEventForClusterID(rpcContext.StorageClusterID.Get()))
 	}

--- a/pkg/ccl/kvccl/kvtenantccl/tenant_trace_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/tenant_trace_test.go
@@ -106,7 +106,7 @@ func testTenantTracesAreRedactedImpl(t *testing.T, redactable bool) {
 
 	t.Run("regular-tenant", func(t *testing.T) {
 		_, tenDB := serverutils.StartTenant(t, s, base.TestTenantArgs{
-			TenantID:     roachpb.MakeTenantID(security.EmbeddedTenantIDs()[0]),
+			TenantID:     roachpb.MustMakeTenantID(security.EmbeddedTenantIDs()[0]),
 			TestingKnobs: args.Knobs,
 		})
 		defer tenDB.Close()

--- a/pkg/ccl/kvccl/kvtenantccl/tenant_upgrade_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/tenant_upgrade_test.go
@@ -92,7 +92,7 @@ func TestTenantUpgrade(t *testing.T) {
 		require.NoError(t, clusterversion.Initialize(ctx,
 			clusterversion.TestingBinaryMinSupportedVersion, &settings.SV))
 		tenantArgs := base.TestTenantArgs{
-			TenantID:     roachpb.MakeTenantID(id),
+			TenantID:     roachpb.MustMakeTenantID(id),
 			TestingKnobs: base.TestingKnobs{},
 			Settings:     settings,
 		}
@@ -135,7 +135,7 @@ func TestTenantUpgrade(t *testing.T) {
 		cleanup()
 		{
 			tenantServer, err := tc.Server(0).StartTenant(ctx, base.TestTenantArgs{
-				TenantID: roachpb.MakeTenantID(initialTenantID),
+				TenantID: roachpb.MustMakeTenantID(initialTenantID),
 			})
 			require.NoError(t, err)
 			initialTenant, cleanup = connectToTenant(t, tenantServer.SQLAddr())
@@ -159,7 +159,7 @@ func TestTenantUpgrade(t *testing.T) {
 		cleanup()
 		{
 			tenantServer, err := tc.Server(0).StartTenant(ctx, base.TestTenantArgs{
-				TenantID: roachpb.MakeTenantID(postUpgradeTenantID),
+				TenantID: roachpb.MustMakeTenantID(postUpgradeTenantID),
 			})
 			require.NoError(t, err)
 			postUpgradeTenant, cleanup = connectToTenant(t, tenantServer.SQLAddr())
@@ -248,7 +248,7 @@ func TestTenantUpgradeFailure(t *testing.T) {
 			v0, &settings.SV))
 		tenantArgs := base.TestTenantArgs{
 			Stopper:  v2onMigrationStopper,
-			TenantID: roachpb.MakeTenantID(id),
+			TenantID: roachpb.MustMakeTenantID(id),
 			TestingKnobs: base.TestingKnobs{
 				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 				UpgradeManager: &upgrade.TestingKnobs{

--- a/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
@@ -132,7 +132,7 @@ func (ts *testState) start(t *testing.T) {
 	ts.provider = newTestProvider()
 	ts.controller, err = tenantcostclient.TestingTenantSideCostController(
 		ts.settings,
-		roachpb.MakeTenantID(5),
+		roachpb.MustMakeTenantID(5),
 		ts.provider,
 		ts.timeSrc,
 		ts.eventWait,

--- a/pkg/ccl/multitenantccl/tenantcostserver/server_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostserver/server_test.go
@@ -196,7 +196,7 @@ func (ts *testState) tokenBucketRequest(t *testing.T, d *datadriven.TestData) st
 		TargetRequestPeriod: period,
 	}
 	res := ts.tenantUsage.TokenBucketRequest(
-		context.Background(), roachpb.MakeTenantID(tenantID), &req,
+		context.Background(), roachpb.MustMakeTenantID(tenantID), &req,
 	)
 	if res.Error != (errors.EncodedError{}) {
 		return fmt.Sprintf("error: %v", errors.DecodeError(context.Background(), res.Error))
@@ -251,7 +251,7 @@ func (ts *testState) configure(t *testing.T, d *datadriven.TestData) string {
 			ctx,
 			txn,
 			ie,
-			roachpb.MakeTenantID(tenantID),
+			roachpb.MustMakeTenantID(tenantID),
 			args.AvailableRU,
 			args.RefillRate,
 			args.MaxBurstRU,
@@ -272,7 +272,7 @@ func (ts *testState) inspect(t *testing.T, d *datadriven.TestData) string {
 		context.Background(),
 		ts.s.InternalExecutor().(*sql.InternalExecutor),
 		nil, /* txn */
-		roachpb.MakeTenantID(tenantID),
+		roachpb.MustMakeTenantID(tenantID),
 		timeFormat,
 	)
 	if err != nil {
@@ -360,7 +360,7 @@ func TestInstanceCleanup(t *testing.T) {
 				req.NextLiveInstanceID = uint32(instances[0])
 			}
 			res := ts.tenantUsage.TokenBucketRequest(
-				context.Background(), roachpb.MakeTenantID(5), &req,
+				context.Background(), roachpb.MustMakeTenantID(5), &req,
 			)
 			if res.Error != (errors.EncodedError{}) {
 				t.Fatal(errors.DecodeError(context.Background(), res.Error))

--- a/pkg/ccl/serverccl/server_sql_test.go
+++ b/pkg/ccl/serverccl/server_sql_test.go
@@ -128,11 +128,11 @@ func TestTenantUnauthenticatedAccess(t *testing.T) {
 
 	_, err := tc.Server(0).StartTenant(ctx,
 		base.TestTenantArgs{
-			TenantID: roachpb.MakeTenantID(security.EmbeddedTenantIDs()[0]),
+			TenantID: roachpb.MustMakeTenantID(security.EmbeddedTenantIDs()[0]),
 			TestingKnobs: base.TestingKnobs{
 				TenantTestingKnobs: &sql.TenantTestingKnobs{
 					// Configure the SQL server to access the wrong tenant keyspace.
-					TenantIDCodecOverride: roachpb.MakeTenantID(security.EmbeddedTenantIDs()[1]),
+					TenantIDCodecOverride: roachpb.MustMakeTenantID(security.EmbeddedTenantIDs()[1]),
 				},
 			},
 		})

--- a/pkg/ccl/serverccl/statusccl/tenant_grpc_test.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_grpc_test.go
@@ -107,7 +107,7 @@ func TestTenantGRPCServices(t *testing.T) {
 	})
 
 	tenant3, connTenant3 := serverutils.StartTenant(t, server, base.TestTenantArgs{
-		TenantID:     roachpb.MakeTenantID(11),
+		TenantID:     roachpb.MustMakeTenantID(11),
 		TestingKnobs: testingKnobs,
 	})
 	defer connTenant3.Close()

--- a/pkg/ccl/serverccl/statusccl/tenant_status_test.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_status_test.go
@@ -133,7 +133,7 @@ func TestTenantCannotSeeNonTenantStats(t *testing.T) {
 	server := testCluster.Server(0 /* idx */)
 
 	tenant, sqlDB := serverutils.StartTenant(t, server, base.TestTenantArgs{
-		TenantID: roachpb.MakeTenantID(10 /* id */),
+		TenantID: roachpb.MustMakeTenantID(10 /* id */),
 		TestingKnobs: base.TestingKnobs{
 			SQLStatsKnobs: &sqlstats.TestingKnobs{
 				AOSTClause: "AS OF SYSTEM TIME '-1us'",

--- a/pkg/ccl/serverccl/tenant_test_utils.go
+++ b/pkg/ccl/serverccl/tenant_test_utils.go
@@ -230,7 +230,7 @@ func newTenantClusterHelper(
 	var cluster tenantCluster = make([]TestTenant, tenantClusterSize)
 	for i := 0; i < tenantClusterSize; i++ {
 		cluster[i] =
-			newTestTenant(t, server, roachpb.MakeTenantID(tenantID), knobs)
+			newTestTenant(t, server, roachpb.MustMakeTenantID(tenantID), knobs)
 	}
 
 	return cluster

--- a/pkg/ccl/serverccl/tenant_vars_test.go
+++ b/pkg/ccl/serverccl/tenant_vars_test.go
@@ -44,7 +44,7 @@ func TestTenantVars(t *testing.T) {
 	server := testCluster.Server(0 /* idx */)
 
 	tenant, _ := serverutils.StartTenant(t, server, base.TestTenantArgs{
-		TenantID: roachpb.MakeTenantID(10 /* id */),
+		TenantID: roachpb.MustMakeTenantID(10 /* id */),
 	})
 
 	startNowNanos := timeutil.Now().UnixNano()

--- a/pkg/ccl/spanconfigccl/spanconfigkvaccessorccl/kvaccessor_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigkvaccessorccl/kvaccessor_test.go
@@ -54,7 +54,7 @@ func TestCommitTSIntervals(t *testing.T) {
 	defer ts.Stopper().Stop(ctx)
 
 	tt, _ := serverutils.StartTenant(t, ts, base.TestTenantArgs{
-		TenantID: roachpb.MakeTenantID(10),
+		TenantID: roachpb.MustMakeTenantID(10),
 	})
 
 	manual.Pause() // control the clock manually below

--- a/pkg/ccl/spanconfigccl/spanconfiglimiterccl/datadriven_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfiglimiterccl/datadriven_test.go
@@ -92,7 +92,7 @@ func TestDataDriven(t *testing.T) {
 			if d.HasArg("tenant") {
 				var id uint64
 				d.ScanArgs(t, "tenant", &id)
-				tenantID = roachpb.MakeTenantID(id)
+				tenantID = roachpb.MustMakeTenantID(id)
 			}
 
 			tenant, found := spanConfigTestCluster.LookupTenant(tenantID)

--- a/pkg/ccl/spanconfigccl/spanconfiglimiterccl/drop_table_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfiglimiterccl/drop_table_test.go
@@ -42,7 +42,7 @@ func TestDropTableLowersSpanCount(t *testing.T) {
 	defer tc.Stopper().Stop(ctx)
 	ts := tc.Server(0)
 
-	tenantID := roachpb.MakeTenantID(10)
+	tenantID := roachpb.MustMakeTenantID(10)
 	tenant, err := ts.StartTenant(ctx, base.TestTenantArgs{
 		TenantID: tenantID,
 		TestingKnobs: base.TestingKnobs{

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/datadriven_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/datadriven_test.go
@@ -129,7 +129,7 @@ func TestDataDriven(t *testing.T) {
 
 				var id uint64
 				d.ScanArgs(t, "tenant", &id)
-				tenantID = roachpb.MakeTenantID(id)
+				tenantID = roachpb.MustMakeTenantID(id)
 			}
 
 			tenant, found := spanConfigTestCluster.LookupTenant(tenantID)

--- a/pkg/ccl/spanconfigccl/spanconfigsplitterccl/datadriven_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigsplitterccl/datadriven_test.go
@@ -81,7 +81,7 @@ func TestDataDriven(t *testing.T) {
 
 		var tenant *spanconfigtestcluster.Tenant
 		if strings.Contains(path, "tenant") {
-			tenantID := roachpb.MakeTenantID(10)
+			tenantID := roachpb.MustMakeTenantID(10)
 			tenant = spanConfigTestCluster.InitializeTenant(ctx, tenantID)
 			spanConfigTestCluster.AllowSecondaryTenantToSetZoneConfigurations(t, tenantID)
 			spanConfigTestCluster.EnsureTenantCanSetZoneConfigurationsOrFatal(t, tenant)

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/datadriven_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/datadriven_test.go
@@ -127,7 +127,7 @@ func TestDataDriven(t *testing.T) {
 
 		var tenant *spanconfigtestcluster.Tenant
 		if strings.Contains(path, "tenant") {
-			tenantID := roachpb.MakeTenantID(10)
+			tenantID := roachpb.MustMakeTenantID(10)
 			tenant = spanConfigTestCluster.InitializeTenant(ctx, tenantID)
 			spanConfigTestCluster.AllowSecondaryTenantToSetZoneConfigurations(t, tenantID)
 			spanConfigTestCluster.EnsureTenantCanSetZoneConfigurationsOrFatal(t, tenant)

--- a/pkg/ccl/spanconfigccl/spanconfigsqlwatcherccl/sqlwatcher_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigsqlwatcherccl/sqlwatcher_test.go
@@ -236,7 +236,7 @@ func TestSQLWatcherReactsToUpdates(t *testing.T) {
 				"BACKUP TENANT 2 INTO 'nodelocal://1/foo'",
 			},
 			expectedPTSUpdates: []spanconfig.ProtectedTimestampUpdate{{ClusterTarget: false,
-				TenantTarget: roachpb.MakeTenantID(2)}},
+				TenantTarget: roachpb.MustMakeTenantID(2)}},
 		},
 	}
 

--- a/pkg/ccl/sqlproxyccl/backend_dialer_test.go
+++ b/pkg/ccl/sqlproxyccl/backend_dialer_test.go
@@ -69,11 +69,11 @@ func TestBackendDialTLS(t *testing.T) {
 	})
 	defer storageServer.Stopper().Stop(ctx)
 
-	tenant10 := roachpb.MakeTenantID(10)
+	tenant10 := roachpb.MustMakeTenantID(10)
 	sql10, _ := serverutils.StartTenant(t, storageServer, base.TestTenantArgs{TenantID: tenant10})
 	defer sql10.Stopper().Stop(ctx)
 
-	tenant11 := roachpb.MakeTenantID(11)
+	tenant11 := roachpb.MustMakeTenantID(11)
 	sql11, _ := serverutils.StartTenant(t, storageServer, base.TestTenantArgs{TenantID: tenant11})
 	defer sql11.Stopper().Stop(ctx)
 
@@ -113,7 +113,7 @@ func TestBackendDialTLS(t *testing.T) {
 	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			tenantID := roachpb.MakeTenantID(tc.tenantID)
+			tenantID := roachpb.MustMakeTenantID(tc.tenantID)
 
 			tenantConfig, err := tlsConfigForTenant(tenantID, tc.addr, tlsConfig)
 			require.NoError(t, err)

--- a/pkg/ccl/sqlproxyccl/balancer/assignment_test.go
+++ b/pkg/ccl/sqlproxyccl/balancer/assignment_test.go
@@ -28,7 +28,7 @@ func TestServerAssignment(t *testing.T) {
 	tracker, err := NewConnTracker(ctx, stopper, nil /* timeSource */)
 	require.NoError(t, err)
 
-	tenantID := roachpb.MakeTenantID(10)
+	tenantID := roachpb.MustMakeTenantID(10)
 	handle := &testConnHandle{}
 	sa := NewServerAssignment(tenantID, tracker, handle, "127.0.0.10")
 	require.Equal(t, handle, sa.Owner())

--- a/pkg/ccl/sqlproxyccl/balancer/balancer.go
+++ b/pkg/ccl/sqlproxyccl/balancer/balancer.go
@@ -315,12 +315,12 @@ func (b *Balancer) RebalanceTenant(ctx context.Context, tenantID roachpb.TenantI
 // which returns a ServerAssignment.
 func (b *Balancer) SelectTenantPod(pods []*tenant.Pod) (*tenant.Pod, error) {
 	// The second case should not happen if the directory is returning the
-	// right data. Check it regardless or else roachpb.MakeTenantID will panic
+	// right data. Check it regardless or else roachpb.MustMakeTenantID will panic
 	// on a zero TenantID.
 	if len(pods) == 0 || pods[0].TenantID == 0 {
 		return nil, ErrNoAvailablePods
 	}
-	tenantID := roachpb.MakeTenantID(pods[0].TenantID)
+	tenantID := roachpb.MustMakeTenantID(pods[0].TenantID)
 	tenantEntry := b.connTracker.getEntry(tenantID, true /* allowCreate */)
 	pod := selectTenantPod(pods, tenantEntry)
 	if pod == nil {

--- a/pkg/ccl/sqlproxyccl/balancer/balancer_test.go
+++ b/pkg/ccl/sqlproxyccl/balancer/balancer_test.go
@@ -265,7 +265,7 @@ func TestRebalancer_rebalanceLoop(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	tenantID := roachpb.MakeTenantID(30)
+	tenantID := roachpb.MustMakeTenantID(30)
 	drainingPod := &tenant.Pod{TenantID: tenantID.ToUint64(), Addr: "127.0.0.30:80", State: tenant.DRAINING}
 	require.True(t, directoryCache.upsertPod(drainingPod))
 	runningPods := []*tenant.Pod{
@@ -422,7 +422,7 @@ func TestRebalancer_rebalance(t *testing.T) {
 			// been removed from the cache.
 			name: "no pods",
 			handlesFn: func(t *testing.T) []ConnectionHandle {
-				tenant10 := roachpb.MakeTenantID(10)
+				tenant10 := roachpb.MustMakeTenantID(10)
 
 				// Use a random IP since tenant-10 doesn't have a pod, and it
 				// does not matter.
@@ -438,7 +438,7 @@ func TestRebalancer_rebalance(t *testing.T) {
 			// there's nothing to transfer to.
 			name: "no running pods",
 			handlesFn: func(t *testing.T) []ConnectionHandle {
-				tenant20 := roachpb.MakeTenantID(20)
+				tenant20 := roachpb.MustMakeTenantID(20)
 
 				handle := makeTestHandle()
 				sa := NewServerAssignment(tenant20, b.connTracker, handle, pods[0].Addr)
@@ -452,7 +452,7 @@ func TestRebalancer_rebalance(t *testing.T) {
 			// because minDrainPeriod hasn't elapsed.
 			name: "draining/recently drained pod",
 			handlesFn: func(t *testing.T) []ConnectionHandle {
-				tenant30 := roachpb.MakeTenantID(30)
+				tenant30 := roachpb.MustMakeTenantID(30)
 
 				activeHandle := makeTestHandle()
 				sa := NewServerAssignment(tenant30, b.connTracker, activeHandle, recentlyDrainedPod.Addr)
@@ -505,7 +505,7 @@ func TestRebalancer_rebalance(t *testing.T) {
 				for _, c := range conns {
 					handle := makeTestHandle()
 					sa := NewServerAssignment(
-						roachpb.MakeTenantID(c.TenantID),
+						roachpb.MustMakeTenantID(c.TenantID),
 						b.connTracker,
 						handle,
 						c.Addr,
@@ -518,8 +518,8 @@ func TestRebalancer_rebalance(t *testing.T) {
 				handles[len(handles)-2].(*testConnHandle).setIdle(true)
 
 				// Refresh partitions, and validate idle connections.
-				e30 := b.connTracker.getEntry(roachpb.MakeTenantID(30), false)
-				e40 := b.connTracker.getEntry(roachpb.MakeTenantID(40), false)
+				e30 := b.connTracker.getEntry(roachpb.MustMakeTenantID(30), false)
+				e40 := b.connTracker.getEntry(roachpb.MustMakeTenantID(40), false)
 				e30.refreshPartitions()
 				e40.refreshPartitions()
 				_, idleList30 := e30.listAssignments()
@@ -554,7 +554,7 @@ func TestRebalancer_rebalance(t *testing.T) {
 				for _, c := range conns {
 					handle := makeTestHandle()
 					sa := NewServerAssignment(
-						roachpb.MakeTenantID(c.TenantID),
+						roachpb.MustMakeTenantID(c.TenantID),
 						b.connTracker,
 						handle,
 						c.Addr,
@@ -567,7 +567,7 @@ func TestRebalancer_rebalance(t *testing.T) {
 				}
 
 				// Refresh partitions, and validate idle connection.
-				e60 := b.connTracker.getEntry(roachpb.MakeTenantID(60), false)
+				e60 := b.connTracker.getEntry(roachpb.MustMakeTenantID(60), false)
 				e60.refreshPartitions()
 				_, idleList60 := e60.listAssignments()
 				require.Len(t, idleList60, 30)
@@ -633,7 +633,7 @@ func TestRebalancer_rebalance(t *testing.T) {
 				for _, c := range conns {
 					handle := makeTestHandle()
 					sa := NewServerAssignment(
-						roachpb.MakeTenantID(c.TenantID),
+						roachpb.MustMakeTenantID(c.TenantID),
 						b.connTracker,
 						handle,
 						c.Addr,
@@ -647,8 +647,8 @@ func TestRebalancer_rebalance(t *testing.T) {
 				handles[len(handles)-3].(*testConnHandle).setIdle(true)
 
 				// Refresh partitions, and validate idle connections.
-				e40 := b.connTracker.getEntry(roachpb.MakeTenantID(40), false)
-				e60 := b.connTracker.getEntry(roachpb.MakeTenantID(60), false)
+				e40 := b.connTracker.getEntry(roachpb.MustMakeTenantID(40), false)
+				e60 := b.connTracker.getEntry(roachpb.MustMakeTenantID(60), false)
 				e40.refreshPartitions()
 				e60.refreshPartitions()
 				_, idleList40 := e40.listAssignments()
@@ -741,7 +741,7 @@ func TestBalancer_RebalanceTenant_WithRebalancingDisabled(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	tenantID := roachpb.MakeTenantID(10)
+	tenantID := roachpb.MustMakeTenantID(10)
 	pods := []*tenant.Pod{
 		{TenantID: tenantID.ToUint64(), Addr: "127.0.0.30:80", State: tenant.DRAINING},
 		{TenantID: tenantID.ToUint64(), Addr: "127.0.0.30:81", State: tenant.RUNNING},
@@ -816,7 +816,7 @@ func TestBalancer_RebalanceTenant_WithDefaultDelay(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	tenantID := roachpb.MakeTenantID(10)
+	tenantID := roachpb.MustMakeTenantID(10)
 	pods := []*tenant.Pod{
 		{TenantID: tenantID.ToUint64(), Addr: "127.0.0.30:80", State: tenant.DRAINING},
 		{TenantID: tenantID.ToUint64(), Addr: "127.0.0.30:81", State: tenant.RUNNING},
@@ -1380,7 +1380,7 @@ func (r *testDirectoryCache) upsertPod(pod *tenant.Pod) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	tenantID := roachpb.MakeTenantID(pod.TenantID)
+	tenantID := roachpb.MustMakeTenantID(pod.TenantID)
 	pods := r.mu.pods[tenantID]
 	for i, existing := range pods {
 		if existing.Addr == pod.Addr {

--- a/pkg/ccl/sqlproxyccl/balancer/conn_tracker_test.go
+++ b/pkg/ccl/sqlproxyccl/balancer/conn_tracker_test.go
@@ -37,7 +37,7 @@ func TestConnTracker(t *testing.T) {
 	tracker, err := NewConnTracker(ctx, stopper, nil /* timeSource */)
 	require.NoError(t, err)
 
-	tenant20 := roachpb.MakeTenantID(20)
+	tenant20 := roachpb.MustMakeTenantID(20)
 	sa := &ServerAssignment{addr: "127.0.0.10:8090", owner: &testConnHandle{}}
 
 	// Run twice for idempotency.
@@ -58,9 +58,9 @@ func TestConnTracker(t *testing.T) {
 	require.Equal(t, tenant20, tenantIDs[0])
 
 	// Non-existent.
-	connsMap = tracker.GetConnsMap(roachpb.MakeTenantID(42))
+	connsMap = tracker.GetConnsMap(roachpb.MustMakeTenantID(42))
 	require.Empty(t, connsMap)
-	activeList, idleList = tracker.listAssignments(roachpb.MakeTenantID(42))
+	activeList, idleList = tracker.listAssignments(roachpb.MustMakeTenantID(42))
 	require.Empty(t, activeList)
 	require.Empty(t, idleList)
 
@@ -83,7 +83,7 @@ func TestConnTracker(t *testing.T) {
 	for i := 0; i < clients; i++ {
 		go func() {
 			defer wg.Done()
-			tenantID := roachpb.MakeTenantID(uint64(1 + rand.Intn(5)))
+			tenantID := roachpb.MustMakeTenantID(uint64(1 + rand.Intn(5)))
 			sa := &ServerAssignment{
 				addr:  fmt.Sprintf("127.0.0.10:%d", rand.Intn(5)),
 				owner: &testConnHandle{},
@@ -120,7 +120,7 @@ func TestConnTracker_GetConnsMap(t *testing.T) {
 	require.NoError(t, err)
 
 	makeConn := func(tenID int, addr string) (roachpb.TenantID, *ServerAssignment) {
-		return roachpb.MakeTenantID(uint64(tenID)), &ServerAssignment{
+		return roachpb.MustMakeTenantID(uint64(tenID)), &ServerAssignment{
 			addr:  addr,
 			owner: &testConnHandle{},
 		}
@@ -189,7 +189,7 @@ func TestConnTrackerPartitionsRefresh(t *testing.T) {
 	// Create three assignments: two for tenant-10, and one for tenant-20.
 	// Use a dummy address for all of them.
 	const addr = "127.0.0.10:1020"
-	tenant10, tenant20 := roachpb.MakeTenantID(10), roachpb.MakeTenantID(20)
+	tenant10, tenant20 := roachpb.MustMakeTenantID(10), roachpb.MustMakeTenantID(20)
 	h1, h2, h3 := &testConnHandle{}, &testConnHandle{}, &testConnHandle{}
 	s1 := NewServerAssignment(tenant10, tracker, h1, addr)
 	defer s1.Close()

--- a/pkg/ccl/sqlproxyccl/connector_test.go
+++ b/pkg/ccl/sqlproxyccl/connector_test.go
@@ -406,7 +406,7 @@ func TestConnector_dialTenantCluster(t *testing.T) {
 
 		var reportFailureFnCount int
 		c := &connector{
-			TenantID: roachpb.MakeTenantID(42),
+			TenantID: roachpb.MustMakeTenantID(42),
 			DialTenantLatency: metric.NewHistogram(
 				metaDialTenantLatency, time.Millisecond, metric.NetworkLatencyBuckets,
 			),
@@ -486,7 +486,7 @@ func TestConnector_dialTenantCluster(t *testing.T) {
 			delete(mu.pods, addr)
 		}
 
-		tenantID := roachpb.MakeTenantID(42)
+		tenantID := roachpb.MustMakeTenantID(42)
 		directoryCache := &testTenantDirectoryCache{
 			lookupTenantPodsFn: func(
 				fnCtx context.Context, tenantID roachpb.TenantID, clusterName string,
@@ -576,7 +576,7 @@ func TestConnector_lookupAddr(t *testing.T) {
 
 		c := &connector{
 			ClusterName: "my-foo",
-			TenantID:    roachpb.MakeTenantID(10),
+			TenantID:    roachpb.MustMakeTenantID(10),
 			Balancer:    balancer,
 		}
 		c.DirectoryCache = &testTenantDirectoryCache{
@@ -604,7 +604,7 @@ func TestConnector_lookupAddr(t *testing.T) {
 		var lookupTenantPodsFnCount int
 		c := &connector{
 			ClusterName: "my-foo",
-			TenantID:    roachpb.MakeTenantID(10),
+			TenantID:    roachpb.MustMakeTenantID(10),
 			Balancer:    balancer,
 		}
 		c.DirectoryCache = &testTenantDirectoryCache{
@@ -629,7 +629,7 @@ func TestConnector_lookupAddr(t *testing.T) {
 		var lookupTenantPodsFnCount int
 		c := &connector{
 			ClusterName: "my-foo",
-			TenantID:    roachpb.MakeTenantID(10),
+			TenantID:    roachpb.MustMakeTenantID(10),
 			Balancer:    balancer,
 		}
 		c.DirectoryCache = &testTenantDirectoryCache{
@@ -654,7 +654,7 @@ func TestConnector_lookupAddr(t *testing.T) {
 		var lookupTenantPodsFnCount int
 		c := &connector{
 			ClusterName: "my-foo",
-			TenantID:    roachpb.MakeTenantID(10),
+			TenantID:    roachpb.MustMakeTenantID(10),
 			Balancer:    balancer,
 		}
 		c.DirectoryCache = &testTenantDirectoryCache{
@@ -687,7 +687,7 @@ func TestConnector_dialSQLServer(t *testing.T) {
 	tracker, err := balancer.NewConnTracker(ctx, stopper, nil /* timeSource */)
 	require.NoError(t, err)
 
-	tenantID := roachpb.MakeTenantID(10)
+	tenantID := roachpb.MustMakeTenantID(10)
 
 	t.Run("with tlsConfig", func(t *testing.T) {
 		c := &connector{
@@ -863,7 +863,7 @@ func TestTenantTLSConfig(t *testing.T) {
 				InsecureSkipVerify: tc.skipVerify,
 			}
 
-			config, err := tlsConfigForTenant(roachpb.MakeTenantID(10), "some.dns.address:123", config)
+			config, err := tlsConfigForTenant(roachpb.MustMakeTenantID(10), "some.dns.address:123", config)
 			require.NoError(t, err)
 			require.Equal(t, config.ServerName, "some.dns.address")
 

--- a/pkg/ccl/sqlproxyccl/proxy_handler.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler.go
@@ -554,7 +554,7 @@ func (handler *proxyHandler) startPodWatcher(ctx context.Context, podWatcher cha
 			// gets added (i.e. stamped), or a DRAINING pod transitions to a
 			// RUNNING pod.
 			if pod.State == tenant.RUNNING && pod.TenantID != 0 {
-				handler.balancer.RebalanceTenant(ctx, roachpb.MakeTenantID(pod.TenantID))
+				handler.balancer.RebalanceTenant(ctx, roachpb.MustMakeTenantID(pod.TenantID))
 			}
 		}
 	}
@@ -753,7 +753,7 @@ func parseClusterIdentifier(
 		return "", roachpb.MaxTenantID, err
 	}
 
-	return clusterName, roachpb.MakeTenantID(tenID), nil
+	return clusterName, roachpb.MustMakeTenantID(tenID), nil
 }
 
 // parseDatabaseParam parses the database parameter from the PG connection

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -121,7 +121,7 @@ func TestBackendDownRetry(t *testing.T) {
 		callCount++
 		// After 3 dials, we delete the tenant.
 		if callCount >= 3 {
-			directoryServer.DeleteTenant(roachpb.MakeTenantID(28))
+			directoryServer.DeleteTenant(roachpb.MustMakeTenantID(28))
 		}
 		return nil, newErrorf(codeBackendDown, "SQL pod is down")
 	})()
@@ -768,7 +768,7 @@ func TestDirectoryConnect(t *testing.T) {
 		defer testutils.TestingHook(&reportFailureToDirectoryCache, func(
 			ctx context.Context, tenantID roachpb.TenantID, addr string, directoryCache tenant.DirectoryCache,
 		) error {
-			require.Equal(t, roachpb.MakeTenantID(28), tenantID)
+			require.Equal(t, roachpb.MustMakeTenantID(28), tenantID)
 			pods, err := directoryCache.TryLookupTenantPods(ctx, tenantID)
 			require.NoError(t, err)
 			require.Len(t, pods, 1)
@@ -2004,7 +2004,7 @@ func TestClusterNameAndTenantFromParams(t *testing.T) {
 				require.NoErrorf(t, err, "failed test case\n%+v", tc)
 
 				// When expectedError is specified, we always have a valid expectedTenantID.
-				require.Equal(t, roachpb.MakeTenantID(tc.expectedTenantID), tenantID)
+				require.Equal(t, roachpb.MustMakeTenantID(tc.expectedTenantID), tenantID)
 
 				require.Equal(t, tc.expectedClusterName, clusterName)
 				require.Equal(t, tc.expectedParams, outMsg.Parameters)
@@ -2225,7 +2225,7 @@ func newDirectoryServer(
 
 		tenantStopper := tenantdirsvr.NewSubStopper(tdsStopper)
 		ten, err := srv.StartTenant(ctx, base.TestTenantArgs{
-			TenantID:      roachpb.MakeTenantID(tenantID),
+			TenantID:      roachpb.MustMakeTenantID(tenantID),
 			ForceInsecure: true,
 			Stopper:       tenantStopper,
 		})

--- a/pkg/ccl/sqlproxyccl/tenant/directory_cache.go
+++ b/pkg/ccl/sqlproxyccl/tenant/directory_cache.go
@@ -433,13 +433,13 @@ func (d *directoryCache) watchPods(ctx context.Context, stopper *stop.Stopper) e
 func (d *directoryCache) updateTenantEntry(ctx context.Context, pod *Pod) {
 	if pod.Addr == "" || pod.TenantID == 0 {
 		// Nothing needs to be done if there is no IP address specified.
-		// We also check on TenantID here because roachpb.MakeTenantID will
+		// We also check on TenantID here because roachpb.MustMakeTenantID will
 		// panic with TenantID = 0.
 		return
 	}
 
 	// Ensure that a directory entry exists for this tenant.
-	entry, err := d.getEntry(ctx, roachpb.MakeTenantID(pod.TenantID), true /* allowCreate */)
+	entry, err := d.getEntry(ctx, roachpb.MustMakeTenantID(pod.TenantID), true /* allowCreate */)
 	if err != nil {
 		if !grpcutil.IsContextCanceled(err) {
 			// This should only happen in case of a deleted tenant or a transient

--- a/pkg/ccl/sqlproxyccl/tenant/directory_cache_test.go
+++ b/pkg/ccl/sqlproxyccl/tenant/directory_cache_test.go
@@ -50,23 +50,23 @@ func TestDirectoryErrors(t *testing.T) {
 	tc, dir, _ := newTestDirectoryCache(t)
 	defer tc.Stopper().Stop(ctx)
 
-	_, err := dir.TryLookupTenantPods(ctx, roachpb.MakeTenantID(1000))
+	_, err := dir.TryLookupTenantPods(ctx, roachpb.MustMakeTenantID(1000))
 	require.EqualError(t, err, "rpc error: code = NotFound desc = tenant 1000 not in directory cache")
-	_, err = dir.TryLookupTenantPods(ctx, roachpb.MakeTenantID(1001))
+	_, err = dir.TryLookupTenantPods(ctx, roachpb.MustMakeTenantID(1001))
 	require.EqualError(t, err, "rpc error: code = NotFound desc = tenant 1001 not in directory cache")
-	_, err = dir.TryLookupTenantPods(ctx, roachpb.MakeTenantID(1002))
+	_, err = dir.TryLookupTenantPods(ctx, roachpb.MustMakeTenantID(1002))
 	require.EqualError(t, err, "rpc error: code = NotFound desc = tenant 1002 not in directory cache")
 
 	// Fail to find tenant that does not exist.
-	_, err = dir.LookupTenantPods(ctx, roachpb.MakeTenantID(1000), "")
+	_, err = dir.LookupTenantPods(ctx, roachpb.MustMakeTenantID(1000), "")
 	require.EqualError(t, err, "rpc error: code = NotFound desc = tenant 1000 not found")
 
 	// Fail to find tenant when cluster name doesn't match.
-	_, err = dir.LookupTenantPods(ctx, roachpb.MakeTenantID(tenantID), "unknown")
+	_, err = dir.LookupTenantPods(ctx, roachpb.MustMakeTenantID(tenantID), "unknown")
 	require.EqualError(t, err, "rpc error: code = NotFound desc = cluster name unknown doesn't match expected tenant-cluster")
 
 	// No-op when reporting failure for tenant that doesn't exit.
-	require.NoError(t, dir.ReportFailure(ctx, roachpb.MakeTenantID(1000), ""))
+	require.NoError(t, dir.ReportFailure(ctx, roachpb.MustMakeTenantID(1000), ""))
 }
 
 func TestWatchPods(t *testing.T) {
@@ -90,7 +90,7 @@ func TestWatchPods(t *testing.T) {
 		return nil
 	})
 
-	tenantID := roachpb.MakeTenantID(20)
+	tenantID := roachpb.MustMakeTenantID(20)
 	tds.CreateTenant(tenantID, "my-tenant")
 
 	// Add a new pod to the tenant.
@@ -203,7 +203,7 @@ func TestCancelLookups(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.ScopeWithoutShowLogs(t).Close(t)
 
-	tenantID := roachpb.MakeTenantID(20)
+	tenantID := roachpb.MustMakeTenantID(20)
 	const lookupCount = 1
 
 	// Create the directory.
@@ -238,7 +238,7 @@ func TestResume(t *testing.T) {
 	defer log.ScopeWithoutShowLogs(t).Close(t)
 	skip.UnderDeadlockWithIssue(t, 71365)
 
-	tenantID := roachpb.MakeTenantID(40)
+	tenantID := roachpb.MustMakeTenantID(40)
 	const lookupCount = 5
 
 	// Create the directory.
@@ -289,7 +289,7 @@ func TestDeleteTenant(t *testing.T) {
 	tc, dir, tds := newTestDirectoryCache(t, tenant.RefreshDelay(-1))
 	defer tc.Stopper().Stop(ctx)
 
-	tenantID := roachpb.MakeTenantID(50)
+	tenantID := roachpb.MustMakeTenantID(50)
 	// Create test tenant.
 	require.NoError(t, createTenant(tc, tenantID))
 
@@ -347,7 +347,7 @@ func TestRefreshThrottling(t *testing.T) {
 	defer tc.Stopper().Stop(ctx)
 
 	// Create test tenant.
-	tenantID := roachpb.MakeTenantID(60)
+	tenantID := roachpb.MustMakeTenantID(60)
 	require.NoError(t, createTenant(tc, tenantID))
 
 	// Perform lookup to create entry in cache.
@@ -424,7 +424,7 @@ func startTenant(
 	t, err := srv.StartTenant(
 		ctx,
 		base.TestTenantArgs{
-			TenantID: roachpb.MakeTenantID(id),
+			TenantID: roachpb.MustMakeTenantID(id),
 			// Disable tenant creation, since this function assumes a tenant
 			// already exists.
 			DisableCreateTenant: true,

--- a/pkg/ccl/sqlproxyccl/tenantdirsvr/test_simple_directory_svr.go
+++ b/pkg/ccl/sqlproxyccl/tenantdirsvr/test_simple_directory_svr.go
@@ -62,7 +62,7 @@ func (d *TestSimpleDirectoryServer) ListPods(
 ) (*tenant.ListPodsResponse, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	if _, ok := d.mu.deleted[roachpb.MakeTenantID(req.TenantID)]; ok {
+	if _, ok := d.mu.deleted[roachpb.MustMakeTenantID(req.TenantID)]; ok {
 		return &tenant.ListPodsResponse{}, nil
 	}
 	return &tenant.ListPodsResponse{
@@ -97,7 +97,7 @@ func (d *TestSimpleDirectoryServer) EnsurePod(
 ) (*tenant.EnsurePodResponse, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	if _, ok := d.mu.deleted[roachpb.MakeTenantID(req.TenantID)]; ok {
+	if _, ok := d.mu.deleted[roachpb.MustMakeTenantID(req.TenantID)]; ok {
 		return nil, status.Errorf(codes.NotFound, "tenant has been deleted")
 	}
 	return &tenant.EnsurePodResponse{}, nil
@@ -112,7 +112,7 @@ func (d *TestSimpleDirectoryServer) GetTenant(
 ) (*tenant.GetTenantResponse, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	if _, ok := d.mu.deleted[roachpb.MakeTenantID(req.TenantID)]; ok {
+	if _, ok := d.mu.deleted[roachpb.MustMakeTenantID(req.TenantID)]; ok {
 		return nil, status.Errorf(codes.NotFound, "tenant has been deleted")
 	}
 	// Note that we do not return a ClusterName field here. Doing this skips

--- a/pkg/ccl/sqlproxyccl/tenantdirsvr/test_static_directory_svr.go
+++ b/pkg/ccl/sqlproxyccl/tenantdirsvr/test_static_directory_svr.go
@@ -101,7 +101,7 @@ func (d *TestStaticDirectoryServer) ListPods(
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	pods, ok := d.mu.tenants[roachpb.MakeTenantID(req.TenantID)]
+	pods, ok := d.mu.tenants[roachpb.MustMakeTenantID(req.TenantID)]
 	if !ok {
 		return &tenant.ListPodsResponse{}, nil
 	}
@@ -189,7 +189,7 @@ func (d *TestStaticDirectoryServer) EnsurePod(
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	pods, ok := d.mu.tenants[roachpb.MakeTenantID(req.TenantID)]
+	pods, ok := d.mu.tenants[roachpb.MustMakeTenantID(req.TenantID)]
 	if !ok {
 		return nil, status.Errorf(codes.NotFound, "tenant does not exist")
 	}
@@ -209,7 +209,7 @@ func (d *TestStaticDirectoryServer) GetTenant(
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	tenantID := roachpb.MakeTenantID(req.TenantID)
+	tenantID := roachpb.MustMakeTenantID(req.TenantID)
 	if _, ok := d.mu.tenants[tenantID]; !ok {
 		return nil, status.Errorf(codes.NotFound, "tenant does not exist")
 	}

--- a/pkg/ccl/streamingccl/streamclient/client_test.go
+++ b/pkg/ccl/streamingccl/streamclient/client_test.go
@@ -174,7 +174,7 @@ func ExampleClient() {
 		_ = client.Close(ctx)
 	}()
 
-	id, err := client.Create(ctx, roachpb.MakeTenantID(1))
+	id, err := client.Create(ctx, roachpb.MustMakeTenantID(1))
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/ccl/streamingccl/streamclient/random_stream_client.go
+++ b/pkg/ccl/streamingccl/streamclient/random_stream_client.go
@@ -177,7 +177,7 @@ func parseRandomStreamConfig(streamURL *url.URL) (randomStreamConfig, error) {
 		if err != nil {
 			return c, err
 		}
-		c.tenantID = roachpb.MakeTenantID(uint64(id))
+		c.tenantID = roachpb.MustMakeTenantID(uint64(id))
 	}
 	return c, nil
 }

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor_test.go
@@ -102,7 +102,7 @@ func TestStreamIngestionFrontierProcessor(t *testing.T) {
 	const tenantID = 20
 	sampleKV := func() roachpb.KeyValue {
 		key, err := keys.RewriteKeyToTenantPrefix(roachpb.Key("key_1"),
-			keys.MakeTenantPrefix(roachpb.MakeTenantID(tenantID)))
+			keys.MakeTenantPrefix(roachpb.MustMakeTenantID(tenantID)))
 		require.NoError(t, err)
 		return roachpb.KeyValue{Key: key, Value: v}
 	}
@@ -235,8 +235,8 @@ func TestStreamIngestionFrontierProcessor(t *testing.T) {
 				}
 			}
 			spec.TenantRekey = execinfrapb.TenantRekey{
-				OldID: roachpb.MakeTenantID(tenantID),
-				NewID: roachpb.MakeTenantID(tenantID + 10),
+				OldID: roachpb.MustMakeTenantID(tenantID),
+				NewID: roachpb.MustMakeTenantID(tenantID + 10),
 			}
 			spec.StartTime = tc.frontierStartTime
 			spec.Checkpoint.ResolvedSpans = tc.jobCheckpoint

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
@@ -185,7 +185,7 @@ INSERT INTO d.t2 VALUES (2);
 	verifyIngestionStats(t, streamProducerJobID, cutoverTime,
 		destSQL.QueryStr(t, "SELECT crdb_internal.stream_ingestion_stats_json($1)", ingestionJobID)[0][0])
 
-	_, destTenantConn := serverutils.StartTenant(t, hDest.SysServer, base.TestTenantArgs{TenantID: roachpb.MakeTenantID(20), DisableCreateTenant: true})
+	_, destTenantConn := serverutils.StartTenant(t, hDest.SysServer, base.TestTenantArgs{TenantID: roachpb.MustMakeTenantID(20), DisableCreateTenant: true})
 	defer func() {
 		require.NoError(t, destTenantConn.Close())
 	}()

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
@@ -128,10 +128,10 @@ func ingestionPlanHook(
 
 		// TODO(adityamaru): Add privileges checks. Probably the same as RESTORE.
 		// TODO(casper): make target to be tenant-only.
-		oldTenantID := roachpb.MakeTenantID(ingestionStmt.Targets.TenantID.ID)
+		oldTenantID := roachpb.MustMakeTenantID(ingestionStmt.Targets.TenantID.ID)
 		newTenantID := oldTenantID
 		if ingestionStmt.AsTenant.Specified {
-			newTenantID = roachpb.MakeTenantID(ingestionStmt.AsTenant.ID)
+			newTenantID = roachpb.MustMakeTenantID(ingestionStmt.AsTenant.ID)
 		}
 		if oldTenantID == roachpb.SystemTenantID || newTenantID == roachpb.SystemTenantID {
 			return errors.Newf("either old tenant ID %d or the new tenant ID %d cannot be system tenant",

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
@@ -182,8 +182,8 @@ func TestStreamIngestionProcessor(t *testing.T) {
 	registry := tc.Server(0).JobRegistry().(*jobs.Registry)
 	const tenantID = 20
 	tenantRekey := execinfrapb.TenantRekey{
-		OldID: roachpb.MakeTenantID(tenantID),
-		NewID: roachpb.MakeTenantID(tenantID + 10),
+		OldID: roachpb.MustMakeTenantID(tenantID),
+		NewID: roachpb.MustMakeTenantID(tenantID + 10),
 	}
 
 	p1 := streamclient.SubscriptionToken("p1")
@@ -197,7 +197,7 @@ func TestStreamIngestionProcessor(t *testing.T) {
 
 	sampleKV := func() roachpb.KeyValue {
 		key, err := keys.RewriteKeyToTenantPrefix(p1Key,
-			keys.MakeTenantPrefix(roachpb.MakeTenantID(tenantID)))
+			keys.MakeTenantPrefix(roachpb.MustMakeTenantID(tenantID)))
 		require.NoError(t, err)
 		return roachpb.KeyValue{Key: key, Value: v}
 	}
@@ -451,7 +451,7 @@ func TestRandomClientGeneration(t *testing.T) {
 
 	randomStreamClient, ok := streamClient.(*streamclient.RandomStreamClient)
 	require.True(t, ok)
-	id, err := randomStreamClient.Create(ctx, roachpb.MakeTenantID(tenantID))
+	id, err := randomStreamClient.Create(ctx, roachpb.MustMakeTenantID(tenantID))
 	require.NoError(t, err)
 
 	topo, err := randomStreamClient.Plan(ctx, id)
@@ -466,10 +466,10 @@ func TestRandomClientGeneration(t *testing.T) {
 	mu := syncutil.Mutex{}
 	cancelAfterCheckpoints := makeCheckpointEventCounter(&mu, 1000, cancel)
 	tenantRekey := execinfrapb.TenantRekey{
-		OldID: roachpb.MakeTenantID(tenantID),
-		NewID: roachpb.MakeTenantID(tenantID + 10),
+		OldID: roachpb.MustMakeTenantID(tenantID),
+		NewID: roachpb.MustMakeTenantID(tenantID + 10),
 	}
-	rekeyer, err := backupccl.MakeKeyRewriterFromRekeys(keys.MakeSQLCodec(roachpb.MakeTenantID(tenantID)),
+	rekeyer, err := backupccl.MakeKeyRewriterFromRekeys(keys.MakeSQLCodec(roachpb.MustMakeTenantID(tenantID)),
 		nil /* tableRekeys */, []execinfrapb.TenantRekey{tenantRekey}, true /* restoreTenantFromStream */)
 	require.NoError(t, err)
 	streamValidator := newStreamClientValidator(rekeyer)

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_test.go
@@ -121,10 +121,10 @@ func TestStreamIngestionJobWithRandomClient(t *testing.T) {
 	// the processors.
 	const oldTenantID = 10
 	const newTenantID = 30
-	rekeyer, err := backupccl.MakeKeyRewriterFromRekeys(keys.MakeSQLCodec(roachpb.MakeTenantID(oldTenantID)),
+	rekeyer, err := backupccl.MakeKeyRewriterFromRekeys(keys.MakeSQLCodec(roachpb.MustMakeTenantID(oldTenantID)),
 		nil /* tableRekeys */, []execinfrapb.TenantRekey{{
-			OldID: roachpb.MakeTenantID(oldTenantID),
-			NewID: roachpb.MakeTenantID(newTenantID),
+			OldID: roachpb.MustMakeTenantID(oldTenantID),
+			NewID: roachpb.MustMakeTenantID(newTenantID),
 		}}, true /* restoreTenantFromStream */)
 	require.NoError(t, err)
 	streamValidator := newStreamClientValidator(rekeyer)
@@ -235,7 +235,7 @@ func TestStreamIngestionJobWithRandomClient(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tenantPrefix := keys.MakeTenantPrefix(roachpb.MakeTenantID(uint64(newTenantID)))
+	tenantPrefix := keys.MakeTenantPrefix(roachpb.MustMakeTenantID(uint64(newTenantID)))
 	t.Logf("counting kvs in span %v", tenantPrefix)
 	maxIngestedTS := assertExactlyEqualKVs(t, tc, streamValidator, revertRangeTargetTime, tenantPrefix)
 	// Sanity check that the max ts in the store is less than the revert range

--- a/pkg/ccl/streamingccl/streamingest/stream_replication_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_replication_e2e_test.go
@@ -63,7 +63,7 @@ type tenantStreamingClustersArgs struct {
 }
 
 var defaultTenantStreamingClustersArgs = tenantStreamingClustersArgs{
-	srcTenantID: roachpb.MakeTenantID(10),
+	srcTenantID: roachpb.MustMakeTenantID(10),
 	srcInitFunc: func(t *testing.T, sysSQL *sqlutils.SQLRunner, tenantSQL *sqlutils.SQLRunner) {
 		tenantSQL.Exec(t, `
 	CREATE DATABASE d;
@@ -76,7 +76,7 @@ var defaultTenantStreamingClustersArgs = tenantStreamingClustersArgs{
 	},
 	srcNumNodes:         1,
 	srcClusterSettings:  defaultSrcClusterSetting,
-	destTenantID:        roachpb.MakeTenantID(20),
+	destTenantID:        roachpb.MustMakeTenantID(20),
 	destNumNodes:        1,
 	destClusterSettings: defaultDestClusterSetting,
 }

--- a/pkg/ccl/streamingccl/streamproducer/producer_job.go
+++ b/pkg/ccl/streamingccl/streamproducer/producer_job.go
@@ -29,7 +29,7 @@ import (
 )
 
 func makeTenantSpan(tenantID uint64) *roachpb.Span {
-	prefix := keys.MakeTenantPrefix(roachpb.MakeTenantID(tenantID))
+	prefix := keys.MakeTenantPrefix(roachpb.MustMakeTenantID(tenantID))
 	return &roachpb.Span{Key: prefix, EndKey: prefix.PrefixEnd()}
 }
 

--- a/pkg/ccl/streamingccl/streamproducer/producer_job_test.go
+++ b/pkg/ccl/streamingccl/streamproducer/producer_job_test.go
@@ -158,7 +158,7 @@ func TestStreamReplicationProducerJob(t *testing.T) {
 	runJobWithProtectedTimestamp := func(ptsID uuid.UUID, ts hlc.Timestamp, jr jobs.Record) error {
 		return source.DB().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 			deprecatedTenantSpan := roachpb.Spans{*makeTenantSpan(30)}
-			tenantTarget := ptpb.MakeTenantsTarget([]roachpb.TenantID{roachpb.MakeTenantID(30)})
+			tenantTarget := ptpb.MakeTenantsTarget([]roachpb.TenantID{roachpb.MustMakeTenantID(30)})
 			if err := ptp.Protect(ctx, txn,
 				jobsprotectedts.MakeRecord(ptsID, int64(jr.JobID), ts,
 					deprecatedTenantSpan, jobsprotectedts.Jobs, tenantTarget)); err != nil {

--- a/pkg/ccl/streamingccl/streamproducer/stream_lifetime.go
+++ b/pkg/ccl/streamingccl/streamproducer/stream_lifetime.go
@@ -72,7 +72,7 @@ func startReplicationStreamJob(
 	}
 
 	deprecatedSpansToProtect := roachpb.Spans{*makeTenantSpan(tenantID)}
-	targetToProtect := ptpb.MakeTenantsTarget([]roachpb.TenantID{roachpb.MakeTenantID(tenantID)})
+	targetToProtect := ptpb.MakeTenantsTarget([]roachpb.TenantID{roachpb.MustMakeTenantID(tenantID)})
 
 	pts := jobsprotectedts.MakeRecord(ptsID, int64(jr.JobID), statementTime,
 		deprecatedSpansToProtect, jobsprotectedts.Jobs, targetToProtect)

--- a/pkg/ccl/testccl/sqlccl/tenant_gc_test.go
+++ b/pkg/ccl/testccl/sqlccl/tenant_gc_test.go
@@ -67,7 +67,7 @@ func TestGCTenantRemovesSpanConfigs(t *testing.T) {
 		return gcjob.TestingGCTenant(ctx, &execCfg, tenID, progress)
 	}
 
-	tenantID := roachpb.MakeTenantID(10)
+	tenantID := roachpb.MustMakeTenantID(10)
 
 	tt, err := ts.StartTenant(ctx, base.TestTenantArgs{
 		TenantID: tenantID,
@@ -188,7 +188,7 @@ func TestGCTableOrIndexWaitsForProtectedTimestamps(t *testing.T) {
 	sqlDB.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'")
 	tsKVAccessor := ts.SpanConfigKVAccessor().(spanconfig.KVAccessor)
 
-	tenantID := roachpb.MakeTenantID(10)
+	tenantID := roachpb.MustMakeTenantID(10)
 
 	tt, ttSQLDBRaw := serverutils.StartTenant(
 		t, ts, base.TestTenantArgs{
@@ -352,7 +352,7 @@ func TestGCTableOrIndexWaitsForProtectedTimestamps(t *testing.T) {
 			// Lastly, we'll also add a PTS set by the host over a different
 			// secondary tenant's keyspace. This should have no bearing on our test.
 			hostOnTenant20, err := spanconfig.MakeTenantKeyspaceTarget(
-				roachpb.SystemTenantID, roachpb.MakeTenantID(20),
+				roachpb.SystemTenantID, roachpb.MustMakeTenantID(20),
 			)
 			require.NoError(t, err)
 			r3, err := spanconfig.MakeRecord(
@@ -532,7 +532,7 @@ func TestGCTenantJobWaitsForProtectedTimestamps(t *testing.T) {
 			Progress: jobspb.SchemaChangeGCProgress{},
 		}
 
-		tenantTarget := ptpb.MakeTenantsTarget([]roachpb.TenantID{roachpb.MakeTenantID(tenID)})
+		tenantTarget := ptpb.MakeTenantsTarget([]roachpb.TenantID{roachpb.MustMakeTenantID(tenID)})
 		rec := mkRecordAndProtect(hlc.Timestamp{WallTime: int64(dropTime - 1)}, tenantTarget)
 		sj, err := jobs.TestingCreateAndStartJob(ctx, jobRegistry, kvDB, record)
 		require.NoError(t, err)
@@ -545,7 +545,7 @@ func TestGCTenantJobWaitsForProtectedTimestamps(t *testing.T) {
 			return nil
 		}))
 
-		checkTenantGCed(t, sj, roachpb.MakeTenantID(tenID))
+		checkTenantGCed(t, sj, roachpb.MustMakeTenantID(tenID))
 	})
 
 	t.Run("protect at and after drop time", func(t *testing.T) {
@@ -566,13 +566,13 @@ func TestGCTenantJobWaitsForProtectedTimestamps(t *testing.T) {
 		clusterRec := mkRecordAndProtect(hlc.Timestamp{WallTime: int64(dropTime + 1)}, clusterTarget)
 
 		// Protect at drop time, so it should not block GC.
-		tenantTarget := ptpb.MakeTenantsTarget([]roachpb.TenantID{roachpb.MakeTenantID(tenID)})
+		tenantTarget := ptpb.MakeTenantsTarget([]roachpb.TenantID{roachpb.MustMakeTenantID(tenID)})
 		tenantRec := mkRecordAndProtect(hlc.Timestamp{WallTime: int64(dropTime)}, tenantTarget)
 
 		sj, err := jobs.TestingCreateAndStartJob(ctx, jobRegistry, kvDB, record)
 		require.NoError(t, err)
 
-		checkTenantGCed(t, sj, roachpb.MakeTenantID(tenID))
+		checkTenantGCed(t, sj, roachpb.MustMakeTenantID(tenID))
 
 		// Cleanup.
 		require.NoError(t, execCfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
@@ -583,7 +583,7 @@ func TestGCTenantJobWaitsForProtectedTimestamps(t *testing.T) {
 	})
 
 	t.Run("tenant set PTS records dont affect tenant GC", func(t *testing.T) {
-		tenID := roachpb.MakeTenantID(10)
+		tenID := roachpb.MustMakeTenantID(10)
 		sqlDB.Exec(t, "ALTER RANGE tenants CONFIGURE ZONE USING gc.ttlseconds = 1;")
 
 		ten, conn10 := serverutils.StartTenant(t, srv,
@@ -639,7 +639,7 @@ func TestGCTenantJobWaitsForProtectedTimestamps(t *testing.T) {
 				return nil
 			}))
 
-			checkTenantGCed(t, sj, roachpb.MakeTenantID(tenID))
+			checkTenantGCed(t, sj, roachpb.MustMakeTenantID(tenID))
 		})
 	})
 }

--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -397,7 +397,7 @@ func (c *transientCluster) Start(ctx context.Context) (err error) {
 					// tenant 1 is the system tenant. We also subtract 2 for the "starting"
 					// SQL/HTTP ports so the first tenant ends up with the desired default
 					// ports.
-					TenantID:              roachpb.MakeTenantID(uint64(i + 2)),
+					TenantID:              roachpb.MustMakeTenantID(uint64(i + 2)),
 					Stopper:               tenantStopper,
 					ForceInsecure:         c.demoCtx.Insecure,
 					SSLCertsDir:           c.demoDir,
@@ -1112,7 +1112,7 @@ func (demoCtx *Context) generateCerts(certsDir string) (err error) {
 			); err != nil {
 				return err
 			}
-			rootUserScope = append(rootUserScope, roachpb.MakeTenantID(tenantID))
+			rootUserScope = append(rootUserScope, roachpb.MustMakeTenantID(tenantID))
 		}
 	}
 	// Create a certificate for the root user. This certificate will be scoped to the

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -971,7 +971,7 @@ func (w *tenantIDWrapper) Set(s string) error {
 	if tenID == 0 {
 		return errors.New("invalid tenant ID")
 	}
-	*w.tenID = roachpb.MakeTenantID(tenID)
+	*w.tenID = roachpb.MustMakeTenantID(tenID)
 	return nil
 }
 

--- a/pkg/config/system.go
+++ b/pkg/config/system.go
@@ -642,7 +642,7 @@ func (s *SystemConfig) tenantBoundarySplitKey(
 			// MaxTenantID already split or outside range.
 			return nil
 		}
-		lowTenID = roachpb.MakeTenantID(lowTenIDExcl.ToUint64() + 1)
+		lowTenID = roachpb.MustMakeTenantID(lowTenIDExcl.ToUint64() + 1)
 	}
 	if searchSpan.EndKey.Compare(tenantSpan.EndKey) >= 0 {
 		// endKey after tenant keyspace.
@@ -663,7 +663,7 @@ func (s *SystemConfig) tenantBoundarySplitKey(
 			// for DecodeTenantPrefix(searchSpan.EndKey) == MinTenantID. This is
 			// because tenantSpan.Key is set to MakeTenantPrefix(MinTenantID),
 			// so we would have already returned early in that case.
-			highTenID = roachpb.MakeTenantID(highTenIDExcl.ToUint64() - 1)
+			highTenID = roachpb.MustMakeTenantID(highTenIDExcl.ToUint64() - 1)
 		} else {
 			highTenID = highTenIDExcl
 		}

--- a/pkg/config/system_test.go
+++ b/pkg/config/system_test.go
@@ -49,11 +49,11 @@ func tkey(tableID uint32, chunks ...string) []byte {
 }
 
 func tenantPrefix(tenID uint64) []byte {
-	return keys.MakeTenantPrefix(roachpb.MakeTenantID(tenID))
+	return keys.MakeTenantPrefix(roachpb.MustMakeTenantID(tenID))
 }
 
 func tenantTkey(tenID uint64, tableID uint32, chunks ...string) []byte {
-	key := keys.MakeSQLCodec(roachpb.MakeTenantID(tenID)).TablePrefix(tableID)
+	key := keys.MakeSQLCodec(roachpb.MustMakeTenantID(tenID)).TablePrefix(tableID)
 	for _, c := range chunks {
 		key = append(key, []byte(c)...)
 	}
@@ -80,7 +80,7 @@ func descriptor(descID uint32) roachpb.KeyValue {
 }
 
 func tenant(tenID uint64) roachpb.KeyValue {
-	k := keys.SystemSQLCodec.TenantMetadataKey(roachpb.MakeTenantID(tenID))
+	k := keys.SystemSQLCodec.TenantMetadataKey(roachpb.MustMakeTenantID(tenID))
 	return kv(k, nil)
 }
 

--- a/pkg/keys/keys_test.go
+++ b/pkg/keys/keys_test.go
@@ -601,7 +601,7 @@ func TestMakeFamilyKey(t *testing.T) {
 
 func TestEnsureSafeSplitKey(t *testing.T) {
 	tenSysCodec := SystemSQLCodec
-	ten5Codec := MakeSQLCodec(roachpb.MakeTenantID(5))
+	ten5Codec := MakeSQLCodec(roachpb.MustMakeTenantID(5))
 	encInt := encoding.EncodeUvarintAscending
 	encInts := func(c SQLCodec, vals ...uint64) roachpb.Key {
 		k := c.TenantPrefix()
@@ -706,9 +706,9 @@ func TestEnsureSafeSplitKey(t *testing.T) {
 func testDecodeTenantPrefixShared(t *testing.T) {
 	tIDs := []roachpb.TenantID{
 		roachpb.SystemTenantID,
-		roachpb.MakeTenantID(2),
-		roachpb.MakeTenantID(999),
-		roachpb.MakeTenantID(math.MaxUint64),
+		roachpb.MustMakeTenantID(2),
+		roachpb.MustMakeTenantID(999),
+		roachpb.MustMakeTenantID(math.MaxUint64),
 	}
 	for _, tID := range tIDs {
 		t.Run(fmt.Sprintf("%v", tID), func(t *testing.T) {

--- a/pkg/keys/printer.go
+++ b/pkg/keys/printer.go
@@ -241,7 +241,7 @@ func tenantKeyParse(input string) (remainder string, output roachpb.Key) {
 	if err != nil {
 		panic(&ErrUglifyUnsupported{err})
 	}
-	output = MakeTenantPrefix(roachpb.MakeTenantID(tenantID))
+	output = MakeTenantPrefix(roachpb.MustMakeTenantID(tenantID))
 	if strings.HasPrefix(remainder, strTable) {
 		var indexKey roachpb.Key
 		remainder = remainder[len(strTable)-1:]

--- a/pkg/keys/printer_test.go
+++ b/pkg/keys/printer_test.go
@@ -143,7 +143,7 @@ func TestSafeFormatKey_Basic(t *testing.T) {
 }
 
 func TestSafeFormatKey_AppTenant(t *testing.T) {
-	ten5Codec := keys.MakeSQLCodec(roachpb.MakeTenantID(5))
+	ten5Codec := keys.MakeSQLCodec(roachpb.MustMakeTenantID(5))
 	testCases := []struct {
 		name string
 		key  roachpb.Key
@@ -208,7 +208,7 @@ func TestSafeFormatKey_AppTenant(t *testing.T) {
 
 func TestPrettyPrint(t *testing.T) {
 	tenSysCodec := keys.SystemSQLCodec
-	ten5Codec := keys.MakeSQLCodec(roachpb.MakeTenantID(5))
+	ten5Codec := keys.MakeSQLCodec(roachpb.MustMakeTenantID(5))
 	tm, _ := time.Parse(time.RFC3339Nano, "2016-03-30T13:40:35.053725008Z")
 	duration := duration.MakeDuration(1*time.Second.Nanoseconds(), 1, 1)
 	durationAsc, _ := encoding.EncodeDurationAscending(nil, duration)
@@ -549,7 +549,7 @@ func massagePrettyPrintedSpanForTest(span string, dirs []encoding.Direction) str
 
 func TestPrettyPrintRange(t *testing.T) {
 	tenSysCodec := keys.SystemSQLCodec
-	ten5Codec := keys.MakeSQLCodec(roachpb.MakeTenantID(5))
+	ten5Codec := keys.MakeSQLCodec(roachpb.MustMakeTenantID(5))
 	key := makeKey([]byte("a"))
 	key2 := makeKey([]byte("z"))
 	tableKey := makeKey(tenSysCodec.TablePrefix(61), encoding.EncodeVarintAscending(nil, 4))

--- a/pkg/keys/sql.go
+++ b/pkg/keys/sql.go
@@ -40,7 +40,7 @@ func DecodeTenantPrefix(key roachpb.Key) ([]byte, roachpb.TenantID, error) {
 	if err != nil {
 		return nil, roachpb.TenantID{}, err
 	}
-	return rem, roachpb.MakeTenantID(tenID), nil
+	return rem, roachpb.MustMakeTenantID(tenID), nil
 }
 
 // DecodeTenantPrefixE determines the tenant ID from the key prefix, returning
@@ -58,7 +58,7 @@ func DecodeTenantPrefixE(key roachpb.Key) ([]byte, roachpb.TenantID, error) {
 	if err != nil {
 		return nil, roachpb.TenantID{}, err
 	}
-	id, err := roachpb.MakeTenantIDNoPanic(tenID)
+	id, err := roachpb.MakeTenantID(tenID)
 	if err != nil {
 		return rem, roachpb.TenantID{}, err
 	}
@@ -258,7 +258,7 @@ func (d sqlDecoder) DecodeTenantMetadataID(key roachpb.Key) (roachpb.TenantID, e
 	if err != nil {
 		return roachpb.TenantID{}, err
 	}
-	return roachpb.MakeTenantID(id), nil
+	return roachpb.MustMakeTenantID(id), nil
 }
 
 // RewriteSpanToTenantPrefix updates the passed Span, potentially in-place, to

--- a/pkg/keys/sql_test.go
+++ b/pkg/keys/sql_test.go
@@ -35,12 +35,12 @@ func TestRewriteKeyToTenantPrefix(t *testing.T) {
 		{1 << 15, 1 << 13, "abc"},
 	} {
 		t.Run(fmt.Sprintf("%d to %d %s", tc.oldTenant, tc.newTenant, tc.suffix), func(t *testing.T) {
-			old := append(MakeSQLCodec(roachpb.MakeTenantID(tc.oldTenant)).TablePrefix(5), tc.suffix...)
-			new := MakeTenantPrefix(roachpb.MakeTenantID(tc.newTenant))
+			old := append(MakeSQLCodec(roachpb.MustMakeTenantID(tc.oldTenant)).TablePrefix(5), tc.suffix...)
+			new := MakeTenantPrefix(roachpb.MustMakeTenantID(tc.newTenant))
 			got, err := RewriteKeyToTenantPrefix(old, new)
 			require.NoError(t, err)
 
-			expect := append(MakeSQLCodec(roachpb.MakeTenantID(tc.newTenant)).TablePrefix(5), tc.suffix...)
+			expect := append(MakeSQLCodec(roachpb.MustMakeTenantID(tc.newTenant)).TablePrefix(5), tc.suffix...)
 			require.Equal(t, expect, got)
 		})
 	}

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -4776,7 +4776,7 @@ func TestTenantID(t *testing.T) {
 	})
 	defer tc.Stopper().Stop(ctx)
 
-	tenant2 := roachpb.MakeTenantID(2)
+	tenant2 := roachpb.MustMakeTenantID(2)
 	tenant2Prefix := keys.MakeTenantPrefix(tenant2)
 	t.Run("(1) initial set", func(t *testing.T) {
 		// Ensure that a normal range has the system tenant.

--- a/pkg/kv/kvserver/metrics_test.go
+++ b/pkg/kv/kvserver/metrics_test.go
@@ -42,7 +42,7 @@ func TestTenantsStorageMetricsConcurrency(t *testing.T) {
 
 	var tenantIDs []roachpb.TenantID
 	for id := uint64(1); id <= tenants; id++ {
-		tenantIDs = append(tenantIDs, roachpb.MakeTenantID(id))
+		tenantIDs = append(tenantIDs, roachpb.MustMakeTenantID(id))
 	}
 	ctx := context.Background()
 	sm := newTenantsStorageMetrics()

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -13858,7 +13858,7 @@ func TestRangeInfoReturned(t *testing.T) {
 func tenantsWithMetrics(m *StoreMetrics) map[roachpb.TenantID]struct{} {
 	metricsTenants := map[roachpb.TenantID]struct{}{}
 	m.tenants.Range(func(tenID int64, _ unsafe.Pointer) bool {
-		metricsTenants[roachpb.MakeTenantID(uint64(tenID))] = struct{}{}
+		metricsTenants[roachpb.MustMakeTenantID(uint64(tenID))] = struct{}{}
 		return true // more
 	})
 	return metricsTenants
@@ -13910,7 +13910,7 @@ func TestStoreTenantMetricsAndRateLimiterRefcount(t *testing.T) {
 	)
 
 	// A range for tenant 123 appears via a split.
-	ten123 := roachpb.MakeTenantID(123)
+	ten123 := roachpb.MustMakeTenantID(123)
 	splitKey := keys.MustAddr(keys.MakeSQLCodec(ten123).TenantPrefix())
 	leftRepl := tc.store.LookupReplica(splitKey)
 	require.NotNil(t, leftRepl)

--- a/pkg/kv/kvserver/tenantrate/limiter_test.go
+++ b/pkg/kv/kvserver/tenantrate/limiter_test.go
@@ -44,7 +44,7 @@ func TestCloser(t *testing.T) {
 	factory := tenantrate.NewLimiterFactory(&st.SV, &tenantrate.TestingKnobs{
 		TimeSource: timeSource,
 	})
-	tenant := roachpb.MakeTenantID(2)
+	tenant := roachpb.MustMakeTenantID(2)
 	closer := make(chan struct{})
 	ctx := context.Background()
 	limiter := factory.GetTenant(ctx, tenant, closer)
@@ -214,7 +214,7 @@ func (ts *testState) launch(t *testing.T, d *datadriven.TestData) string {
 	for _, cmd := range cmds {
 		var s launchState
 		s.id = cmd.ID
-		s.tenantID = roachpb.MakeTenantID(cmd.Tenant)
+		s.tenantID = roachpb.MustMakeTenantID(cmd.Tenant)
 		s.ctx, s.cancel = context.WithCancel(context.Background())
 		s.reserveCh = make(chan error, 1)
 		s.writeRequests = cmd.WriteRequests
@@ -320,7 +320,7 @@ func (ts *testState) recordRead(t *testing.T, d *datadriven.TestData) string {
 		d.Fatalf(t, "failed to unmarshal reads: %v", err)
 	}
 	for _, r := range reads {
-		tid := roachpb.MakeTenantID(r.Tenant)
+		tid := roachpb.MustMakeTenantID(r.Tenant)
 		lims := ts.tenants[tid]
 		if len(lims) == 0 {
 			d.Fatalf(t, "no outstanding limiters for %v", tid)
@@ -459,7 +459,7 @@ func (ts *testState) getTenants(t *testing.T, d *datadriven.TestData) string {
 	ctx := context.Background()
 	tenantIDs := parseTenantIDs(t, d)
 	for i := range tenantIDs {
-		id := roachpb.MakeTenantID(tenantIDs[i])
+		id := roachpb.MustMakeTenantID(tenantIDs[i])
 		ts.tenants[id] = append(ts.tenants[id], ts.rl.GetTenant(ctx, id, nil /* closer */))
 	}
 	return ts.FormatTenants()
@@ -478,7 +478,7 @@ func (ts *testState) getTenants(t *testing.T, d *datadriven.TestData) string {
 func (ts *testState) releaseTenants(t *testing.T, d *datadriven.TestData) string {
 	tenantIDs := parseTenantIDs(t, d)
 	for i := range tenantIDs {
-		id := roachpb.MakeTenantID(tenantIDs[i])
+		id := roachpb.MustMakeTenantID(tenantIDs[i])
 		lims := ts.tenants[id]
 		if len(lims) == 0 {
 			d.Fatalf(t, "no outstanding limiters for %v", id)

--- a/pkg/roachpb/tenant.go
+++ b/pkg/roachpb/tenant.go
@@ -26,25 +26,26 @@ import (
 // 2. the system tenant is created by default during cluster initialization.
 // 3. the system tenant is always present and can never be destroyed.
 // 4. the system tenant has the ability to create and destroy other tenants.
-var SystemTenantID = MakeTenantID(1)
+var SystemTenantID = MustMakeTenantID(1)
 
 // MinTenantID is the minimum ID of a (non-system) tenant in a multi-tenant
 // cluster.
-var MinTenantID = MakeTenantID(2)
+var MinTenantID = MustMakeTenantID(2)
 
 // MaxTenantID is the maximum ID of a (non-system) tenant in a multi-tenant
 // cluster.
-var MaxTenantID = MakeTenantID(math.MaxUint64)
+var MaxTenantID = MustMakeTenantID(math.MaxUint64)
 
-// MakeTenantID constructs a new TenantID from the provided uint64.
-func MakeTenantID(id uint64) TenantID {
+// MustMakeTenantID constructs a new TenantID from the provided uint64.
+// The function panics if an invalid tenant ID is given.
+func MustMakeTenantID(id uint64) TenantID {
 	assertValid(id)
 	return TenantID{id}
 }
 
-// MakeTenantIDNoPanic constructs a new TenantID from the provided uint64.
-// It returns an error rather than panicking on an invalid ID.
-func MakeTenantIDNoPanic(id uint64) (TenantID, error) {
+// MakeTenantID constructs a new TenantID from the provided uint64.
+// It returns an error on an invalid ID.
+func MakeTenantID(id uint64) (TenantID, error) {
 	if err := checkValid(id); err != nil {
 		return TenantID{}, err
 	}
@@ -124,7 +125,7 @@ func TenantIDFromString(tenantID string) (TenantID, error) {
 	if err != nil {
 		return TenantID{}, errors.Wrapf(err, "invalid tenant ID %s, tenant ID should be an unsigned int greater than 0", tenantID)
 	}
-	return MakeTenantID(tID), nil
+	return MustMakeTenantID(tID), nil
 }
 
 // TenantName is a unique name associated with a tenant in a multi-tenant

--- a/pkg/roachpb/tenant_test.go
+++ b/pkg/roachpb/tenant_test.go
@@ -19,11 +19,11 @@ import (
 
 func TestTenantIDString(t *testing.T) {
 	for tID, expStr := range map[TenantID]string{
-		{}:                           "invalid",
-		SystemTenantID:               "system",
-		MakeTenantID(2):              "2",
-		MakeTenantID(999):            "999",
-		MakeTenantID(math.MaxUint64): "18446744073709551615",
+		{}:                               "invalid",
+		SystemTenantID:                   "system",
+		MustMakeTenantID(2):              "2",
+		MustMakeTenantID(999):            "999",
+		MustMakeTenantID(math.MaxUint64): "18446744073709551615",
 	} {
 		require.Equal(t, tID.InternalValue != 0, tID.IsSet())
 		require.Equal(t, expStr, tID.String())

--- a/pkg/rpc/auth_tenant.go
+++ b/pkg/rpc/auth_tenant.go
@@ -38,7 +38,7 @@ func tenantFromCommonName(commonName string) (roachpb.TenantID, error) {
 	if tenID < roachpb.MinTenantID.ToUint64() || tenID > roachpb.MaxTenantID.ToUint64() {
 		return roachpb.TenantID{}, authErrorf("invalid tenant ID %d in Common Name (CN)", tenID)
 	}
-	return roachpb.MakeTenantID(tenID), nil
+	return roachpb.MustMakeTenantID(tenID), nil
 }
 
 // authorize enforces a security boundary around endpoints that tenants
@@ -269,7 +269,7 @@ func (a tenantAuthorizer) authTokenBucket(
 	if args.TenantID == 0 {
 		return authErrorf("token bucket request with unspecified tenant not permitted")
 	}
-	if argTenant := roachpb.MakeTenantID(args.TenantID); argTenant != tenID {
+	if argTenant := roachpb.MustMakeTenantID(args.TenantID); argTenant != tenID {
 		return authErrorf("token bucket request for tenant %s not permitted", argTenant)
 	}
 	return nil

--- a/pkg/rpc/auth_test.go
+++ b/pkg/rpc/auth_test.go
@@ -100,7 +100,7 @@ func TestTenantFromCert(t *testing.T) {
 		expErr      string
 		tenantScope uint64
 	}{
-		{ous: correctOU, commonName: "10", expTenID: roachpb.MakeTenantID(10)},
+		{ous: correctOU, commonName: "10", expTenID: roachpb.MustMakeTenantID(10)},
 		{ous: correctOU, commonName: roachpb.MinTenantID.String(), expTenID: roachpb.MinTenantID},
 		{ous: correctOU, commonName: roachpb.MaxTenantID.String(), expTenID: roachpb.MaxTenantID},
 		{ous: correctOU, commonName: roachpb.SystemTenantID.String() /* "system" */, expErr: `could not parse tenant ID from Common Name \(CN\)`},
@@ -123,7 +123,7 @@ func TestTenantFromCert(t *testing.T) {
 				},
 			}
 			if tc.tenantScope > 0 {
-				tenantSANs, err := security.MakeTenantURISANs(username.MakeSQLUsernameFromPreNormalizedString(tc.commonName), []roachpb.TenantID{roachpb.MakeTenantID(tc.tenantScope)})
+				tenantSANs, err := security.MakeTenantURISANs(username.MakeSQLUsernameFromPreNormalizedString(tc.commonName), []roachpb.TenantID{roachpb.MustMakeTenantID(tc.tenantScope)})
 				require.NoError(t, err)
 				cert.URIs = append(cert.URIs, tenantSANs...)
 			}
@@ -152,9 +152,9 @@ func TestTenantFromCert(t *testing.T) {
 
 func TestTenantAuthRequest(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	tenID := roachpb.MakeTenantID(10)
+	tenID := roachpb.MustMakeTenantID(10)
 	prefix := func(tenID uint64, key string) string {
-		tenPrefix := keys.MakeTenantPrefix(roachpb.MakeTenantID(tenID))
+		tenPrefix := keys.MakeTenantPrefix(roachpb.MustMakeTenantID(tenID))
 		return string(append(tenPrefix, []byte(key)...))
 	}
 	makeSpan := func(key string, endKey ...string) roachpb.Span {
@@ -197,8 +197,8 @@ func TestTenantAuthRequest(t *testing.T) {
 		return roachpb.SpanConfigTarget{
 			Union: &roachpb.SpanConfigTarget_SystemSpanConfigTarget{
 				SystemSpanConfigTarget: &roachpb.SystemSpanConfigTarget{
-					SourceTenantID: roachpb.MakeTenantID(source),
-					Type:           roachpb.NewSpecificTenantKeyspaceTargetType(roachpb.MakeTenantID(target)),
+					SourceTenantID: roachpb.MustMakeTenantID(source),
+					Type:           roachpb.NewSpecificTenantKeyspaceTargetType(roachpb.MustMakeTenantID(target)),
 				},
 			},
 		}
@@ -541,7 +541,7 @@ func TestTenantAuthRequest(t *testing.T) {
 				req: makeGetSpanConfigsReq(roachpb.SpanConfigTarget{
 					Union: &roachpb.SpanConfigTarget_SystemSpanConfigTarget{
 						SystemSpanConfigTarget: &roachpb.SystemSpanConfigTarget{
-							SourceTenantID: roachpb.MakeTenantID(10),
+							SourceTenantID: roachpb.MustMakeTenantID(10),
 							Type:           roachpb.NewEntireKeyspaceTargetType(),
 						},
 					},
@@ -552,7 +552,7 @@ func TestTenantAuthRequest(t *testing.T) {
 				req: makeGetSpanConfigsReq(roachpb.SpanConfigTarget{
 					Union: &roachpb.SpanConfigTarget_SystemSpanConfigTarget{
 						SystemSpanConfigTarget: &roachpb.SystemSpanConfigTarget{
-							SourceTenantID: roachpb.MakeTenantID(20),
+							SourceTenantID: roachpb.MustMakeTenantID(20),
 							Type:           roachpb.NewEntireKeyspaceTargetType(),
 						},
 					},
@@ -667,7 +667,7 @@ func TestTenantAuthRequest(t *testing.T) {
 				req: makeUpdateSpanConfigsReq(roachpb.SpanConfigTarget{
 					Union: &roachpb.SpanConfigTarget_SystemSpanConfigTarget{
 						SystemSpanConfigTarget: &roachpb.SystemSpanConfigTarget{
-							SourceTenantID: roachpb.MakeTenantID(10),
+							SourceTenantID: roachpb.MustMakeTenantID(10),
 							Type:           roachpb.NewEntireKeyspaceTargetType(),
 						},
 					},
@@ -692,7 +692,7 @@ func TestTenantAuthRequest(t *testing.T) {
 				req: makeUpdateSpanConfigsReq(roachpb.SpanConfigTarget{
 					Union: &roachpb.SpanConfigTarget_SystemSpanConfigTarget{
 						SystemSpanConfigTarget: &roachpb.SystemSpanConfigTarget{
-							SourceTenantID: roachpb.MakeTenantID(10),
+							SourceTenantID: roachpb.MustMakeTenantID(10),
 							Type:           roachpb.NewEntireKeyspaceTargetType(),
 						},
 					},
@@ -707,7 +707,7 @@ func TestTenantAuthRequest(t *testing.T) {
 			},
 			{
 				req: &roachpb.GetAllSystemSpanConfigsThatApplyRequest{
-					TenantID: roachpb.MakeTenantID(20),
+					TenantID: roachpb.MustMakeTenantID(20),
 				},
 				expErr: "GetAllSystemSpanConfigsThatApply request for tenant 20 not permitted",
 			},
@@ -719,7 +719,7 @@ func TestTenantAuthRequest(t *testing.T) {
 			},
 			{
 				req: &roachpb.GetAllSystemSpanConfigsThatApplyRequest{
-					TenantID: roachpb.MakeTenantID(10),
+					TenantID: roachpb.MustMakeTenantID(10),
 				},
 				expErr: noError,
 			},

--- a/pkg/rpc/heartbeat_test.go
+++ b/pkg/rpc/heartbeat_test.go
@@ -280,7 +280,7 @@ func TestTenantVersionCheck(t *testing.T) {
 	})
 	// Ensure that the same ping succeeds with a secondary tenant context.
 	t.Run("old, secondary tenant", func(t *testing.T) {
-		tenantCtx := roachpb.NewContextForTenant(context.Background(), roachpb.MakeTenantID(2))
+		tenantCtx := roachpb.NewContextForTenant(context.Background(), roachpb.MustMakeTenantID(2))
 		_, err := heartbeat.Ping(tenantCtx, request)
 		require.NoError(t, err)
 	})

--- a/pkg/security/auth_test.go
+++ b/pkg/security/auth_test.go
@@ -143,7 +143,7 @@ func TestGetCertificateUserScope(t *testing.T) {
 		} else {
 			require.Equal(t, 1, len(userScopes))
 			require.Equal(t, "foo", userScopes[0].Username)
-			require.Equal(t, roachpb.MakeTenantID(123), userScopes[0].TenantID)
+			require.Equal(t, roachpb.MustMakeTenantID(123), userScopes[0].TenantID)
 			require.False(t, userScopes[0].Global)
 		}
 	})
@@ -155,7 +155,7 @@ func TestGetCertificateUserScope(t *testing.T) {
 		} else {
 			require.Equal(t, 1, len(userScopes))
 			require.Equal(t, "foo", userScopes[0].Username)
-			require.Equal(t, roachpb.MakeTenantID(123), userScopes[0].TenantID)
+			require.Equal(t, roachpb.MustMakeTenantID(123), userScopes[0].TenantID)
 			require.False(t, userScopes[0].Global)
 		}
 	})
@@ -293,11 +293,11 @@ func TestAuthenticationHook(t *testing.T) {
 		// Secure mode, principal map.
 		{false, "foo,dns:bar", blahUser, "foo:blah", true, true, false, roachpb.SystemTenantID},
 		{false, "foo,dns:bar", blahUser, "bar:blah", true, true, false, roachpb.SystemTenantID},
-		{false, "foo,uri:crdb://tenant/123/user/foo", fooUser, "", true, true, false, roachpb.MakeTenantID(123)},
+		{false, "foo,uri:crdb://tenant/123/user/foo", fooUser, "", true, true, false, roachpb.MustMakeTenantID(123)},
 		{false, "foo,uri:crdb://tenant/123/user/foo", fooUser, "", true, false, false, roachpb.SystemTenantID},
-		{false, "foo", fooUser, "", true, true, false, roachpb.MakeTenantID(123)},
-		{false, "foo,uri:crdb://tenant/1/user/foo", fooUser, "", true, false, false, roachpb.MakeTenantID(123)},
-		{false, "foo,uri:crdb://tenant/123/user/foo", blahUser, "", true, false, false, roachpb.MakeTenantID(123)},
+		{false, "foo", fooUser, "", true, true, false, roachpb.MustMakeTenantID(123)},
+		{false, "foo,uri:crdb://tenant/1/user/foo", fooUser, "", true, false, false, roachpb.MustMakeTenantID(123)},
+		{false, "foo,uri:crdb://tenant/123/user/foo", blahUser, "", true, false, false, roachpb.MustMakeTenantID(123)},
 	}
 
 	ctx := context.Background()

--- a/pkg/security/certs_test.go
+++ b/pkg/security/certs_test.go
@@ -188,7 +188,7 @@ func TestGenerateClientCerts(t *testing.T) {
 	require.NoError(t, security.CreateCAPair(certsDir, caKeyFile, testKeySize,
 		time.Hour*72, false /* allowReuse */, false /* overwrite */))
 	user := username.MakeSQLUsernameFromPreNormalizedString("user")
-	tenantIDs := []roachpb.TenantID{roachpb.SystemTenantID, roachpb.MakeTenantID(123)}
+	tenantIDs := []roachpb.TenantID{roachpb.SystemTenantID, roachpb.MustMakeTenantID(123)}
 	// Create tenant-scoped client cert.
 	require.NoError(t, security.CreateClientPair(
 		certsDir,

--- a/pkg/security/x509.go
+++ b/pkg/security/x509.go
@@ -348,5 +348,5 @@ func ParseTenantURISAN(rawURL string) (roachpb.TenantID, string, error) {
 	if err != nil {
 		return roachpb.TenantID{}, "", errors.Errorf("invalid tenant URI SAN %s", rawURL)
 	}
-	return roachpb.MakeTenantID(tID), username, nil
+	return roachpb.MustMakeTenantID(tID), username, nil
 }

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1763,7 +1763,7 @@ func (n *Node) TokenBucket(
 			)),
 		}, nil
 	}
-	tenantID := roachpb.MakeTenantID(in.TenantID)
+	tenantID := roachpb.MustMakeTenantID(in.TenantID)
 	return n.tenantUsage.TokenBucketRequest(ctx, tenantID, in), nil
 }
 

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -723,7 +723,7 @@ func TestGetTenantWeights(t *testing.T) {
 	// another tenant, which will cause that tenant to have a weight of 1 in the
 	// relevant store(s).
 	const otherTenantID = 5
-	prefix := keys.MakeTenantPrefix(roachpb.MakeTenantID(otherTenantID))
+	prefix := keys.MakeTenantPrefix(roachpb.MustMakeTenantID(otherTenantID))
 	require.NoError(t, s.DB().AdminSplit(
 		ctx,
 		prefix,           /* splitKey */

--- a/pkg/server/settingswatcher/settings_watcher_external_test.go
+++ b/pkg/server/settingswatcher/settings_watcher_external_test.go
@@ -61,7 +61,7 @@ func TestSettingWatcherOnTenant(t *testing.T) {
 		// value (which would cause a panic in test builds).
 		systemOnlySetting: {2 << 20, 4 << 20},
 	}
-	fakeTenant := roachpb.MakeTenantID(2)
+	fakeTenant := roachpb.MustMakeTenantID(2)
 	systemTable := keys.SystemSQLCodec.TablePrefix(keys.SettingsTableID)
 	fakeCodec := keys.MakeSQLCodec(fakeTenant)
 	fakeTenantPrefix := keys.MakeTenantPrefix(fakeTenant)
@@ -443,7 +443,7 @@ func TestStaleRowsDoNotCauseSettingsToRegress(t *testing.T) {
 	// Make a bogus tenant ID and codec we'll use to prefix the events
 	// we want to observe. Below, inject a testing knob to plumb the stream
 	// into the test logic to make injecting rangefeed events straightforward.
-	bogusTenantID := roachpb.MakeTenantID(42)
+	bogusTenantID := roachpb.MustMakeTenantID(42)
 	bogusCodec := keys.MakeSQLCodec(bogusTenantID)
 	settingsStart := bogusCodec.TablePrefix(keys.SettingsTableID)
 	interceptedStreamCh := make(chan roachpb.RangeFeedEventSink)

--- a/pkg/server/systemconfigwatcher/cache_test.go
+++ b/pkg/server/systemconfigwatcher/cache_test.go
@@ -45,7 +45,7 @@ func TestNewWithAdditionalProvider(t *testing.T) {
 	tdb := sqlutils.MakeSQLRunner(sqlDB)
 	tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '20ms'`)
 	tdb.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '20ms'`)
-	fakeTenant := roachpb.MakeTenantID(10)
+	fakeTenant := roachpb.MustMakeTenantID(10)
 	codec := keys.MakeSQLCodec(fakeTenant)
 	fp := &fakeProvider{
 		ch: make(chan struct{}, 1),

--- a/pkg/server/tenantsettingswatcher/overrides_store_test.go
+++ b/pkg/server/tenantsettingswatcher/overrides_store_test.go
@@ -26,8 +26,8 @@ func TestOverridesStore(t *testing.T) {
 
 	var s overridesStore
 	s.Init()
-	t1 := roachpb.MakeTenantID(1)
-	t2 := roachpb.MakeTenantID(2)
+	t1 := roachpb.MustMakeTenantID(1)
+	t2 := roachpb.MustMakeTenantID(2)
 	st := func(name, val string) roachpb.TenantSetting {
 		return roachpb.TenantSetting{
 			Name: name,
@@ -82,7 +82,7 @@ func TestOverridesStore(t *testing.T) {
 	expect(o1, "a=aa c=cc d=dd")
 
 	// Set an override for a tenant that has no existing data.
-	t3 := roachpb.MakeTenantID(3)
+	t3 := roachpb.MustMakeTenantID(3)
 	s.SetTenantOverride(t3, st("x", "xx"))
 	o3 := s.GetTenantOverrides(t3)
 	expect(o3, "x=xx")

--- a/pkg/server/tenantsettingswatcher/row_decoder.go
+++ b/pkg/server/tenantsettingswatcher/row_decoder.go
@@ -58,7 +58,7 @@ func (d *RowDecoder) DecodeRow(
 			return roachpb.TenantID{}, roachpb.TenantSetting{}, false, err
 		}
 	}
-	// We do not use MakeTenantID because we want to tolerate the 0 value.
+	// We do not use MustMakeTenantID because we want to tolerate the 0 value.
 	tenantID := roachpb.TenantID{InternalValue: uint64(tree.MustBeDInt(keyVals[0].Datum))}
 	var setting roachpb.TenantSetting
 	setting.Name = string(tree.MustBeDString(keyVals[1].Datum))

--- a/pkg/server/tenantsettingswatcher/watcher_test.go
+++ b/pkg/server/tenantsettingswatcher/watcher_test.go
@@ -65,9 +65,9 @@ func TestWatcher(t *testing.T) {
 			t.Errorf("expected: %s; got: %s", expected, actual)
 		}
 	}
-	t1 := roachpb.MakeTenantID(1)
-	t2 := roachpb.MakeTenantID(2)
-	t3 := roachpb.MakeTenantID(3)
+	t1 := roachpb.MustMakeTenantID(1)
+	t2 := roachpb.MustMakeTenantID(2)
+	t3 := roachpb.MustMakeTenantID(3)
 	all, allCh := w.GetAllTenantOverrides()
 	expect(all, "foo=foo-all")
 

--- a/pkg/spanconfig/protectedts_state_reader_test.go
+++ b/pkg/spanconfig/protectedts_state_reader_test.go
@@ -61,9 +61,9 @@ func TestProtectedTimestampStateReader(t *testing.T) {
 	protectSchemaObject(state, ts(1), []descpb.ID{56})
 	protectSchemaObject(state, ts(2), []descpb.ID{56, 57})
 	protectCluster(state, ts(3))
-	protectTenants(state, ts(4), []roachpb.TenantID{roachpb.MakeTenantID(1)})
-	protectTenants(state, ts(5), []roachpb.TenantID{roachpb.MakeTenantID(2)})
-	protectTenants(state, ts(6), []roachpb.TenantID{roachpb.MakeTenantID(2)})
+	protectTenants(state, ts(4), []roachpb.TenantID{roachpb.MustMakeTenantID(1)})
+	protectTenants(state, ts(5), []roachpb.TenantID{roachpb.MustMakeTenantID(2)})
+	protectTenants(state, ts(6), []roachpb.TenantID{roachpb.MustMakeTenantID(2)})
 
 	ptsStateReader := spanconfig.NewProtectedTimestampStateReader(context.Background(), *state)
 	clusterTimestamps := ptsStateReader.GetProtectionPoliciesForCluster()
@@ -77,11 +77,11 @@ func TestProtectedTimestampStateReader(t *testing.T) {
 	require.Len(t, tenantTimestamps, 2)
 	require.Equal(t, []spanconfig.TenantProtectedTimestamps{
 		{
-			TenantID:    roachpb.MakeTenantID(1),
+			TenantID:    roachpb.MustMakeTenantID(1),
 			Protections: []roachpb.ProtectionPolicy{{ProtectedTimestamp: ts(4)}},
 		},
 		{
-			TenantID: roachpb.MakeTenantID(2),
+			TenantID: roachpb.MustMakeTenantID(2),
 			Protections: []roachpb.ProtectionPolicy{{ProtectedTimestamp: ts(5)},
 				{ProtectedTimestamp: ts(6)}},
 		},

--- a/pkg/spanconfig/record_test.go
+++ b/pkg/spanconfig/record_test.go
@@ -112,8 +112,8 @@ func TestRecordSystemTargetValidation(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			emptyScfg := roachpb.SpanConfig{}
-			systemTarget := TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.MakeTenantID(2),
-				roachpb.MakeTenantID(2))
+			systemTarget := TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.MustMakeTenantID(2),
+				roachpb.MustMakeTenantID(2))
 			target := MakeTargetFromSystemTarget(systemTarget)
 			_, err := MakeRecord(target, emptyScfg)
 			testutils.IsError(err, tc.expectedErr)

--- a/pkg/spanconfig/spanconfigkvaccessor/kvaccessor_test.go
+++ b/pkg/spanconfig/spanconfigkvaccessor/kvaccessor_test.go
@@ -113,7 +113,7 @@ func TestDataDriven(t *testing.T) {
 			case "kvaccessor-get-all-system-span-configs-that-apply":
 				var tenID uint64
 				d.ScanArgs(t, "tenant-id", &tenID)
-				spanConfigs, err := accessor.GetAllSystemSpanConfigsThatApply(ctx, roachpb.MakeTenantID(tenID))
+				spanConfigs, err := accessor.GetAllSystemSpanConfigsThatApply(ctx, roachpb.MustMakeTenantID(tenID))
 				if err != nil {
 					return fmt.Sprintf("err: %s", err.Error())
 				}

--- a/pkg/spanconfig/spanconfigkvaccessor/validation_test.go
+++ b/pkg/spanconfig/spanconfigkvaccessor/validation_test.go
@@ -30,7 +30,7 @@ func TestValidateUpdateArgs(t *testing.T) {
 	)
 
 	makeTenantTarget := func(id uint64) spanconfig.Target {
-		target, err := spanconfig.MakeTenantKeyspaceTarget(roachpb.MakeTenantID(id), roachpb.MakeTenantID(id))
+		target, err := spanconfig.MakeTenantKeyspaceTarget(roachpb.MustMakeTenantID(id), roachpb.MustMakeTenantID(id))
 		require.NoError(t, err)
 		return spanconfig.MakeTargetFromSystemTarget(target)
 	}
@@ -194,7 +194,7 @@ func TestValidateUpdateArgs(t *testing.T) {
 			// tenant.
 			toDelete: []spanconfig.Target{
 				spanconfig.MakeTargetFromSystemTarget(
-					spanconfig.MakeAllTenantKeyspaceTargetsSet(roachpb.MakeTenantID(10)),
+					spanconfig.MakeAllTenantKeyspaceTargetsSet(roachpb.MustMakeTenantID(10)),
 				),
 			},
 			expErr: "cannot use read only system target .* as an update argument",

--- a/pkg/spanconfig/spanconfigkvsubscriber/spanconfigdecoder_test.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/spanconfigdecoder_test.go
@@ -97,7 +97,7 @@ func TestDecodeSystemTargets(t *testing.T) {
 	for i, systemTarget := range []spanconfig.SystemTarget{
 		// Tenant targeting its keyspace.
 		spanconfig.TestingMakeTenantKeyspaceTargetOrFatal(
-			t, roachpb.MakeTenantID(10), roachpb.MakeTenantID(10),
+			t, roachpb.MustMakeTenantID(10), roachpb.MustMakeTenantID(10),
 		),
 		// System tenant targeting its keyspace.
 		spanconfig.TestingMakeTenantKeyspaceTargetOrFatal(
@@ -105,7 +105,7 @@ func TestDecodeSystemTargets(t *testing.T) {
 		),
 		// System tenant targeting a secondary tenant's keyspace.
 		spanconfig.TestingMakeTenantKeyspaceTargetOrFatal(
-			t, roachpb.SystemTenantID, roachpb.MakeTenantID(10),
+			t, roachpb.SystemTenantID, roachpb.MustMakeTenantID(10),
 		),
 		// System tenant targeting the entire keyspace.
 		spanconfig.MakeEntireKeyspaceTarget(),

--- a/pkg/spanconfig/spanconfigsqlwatcher/buffer_test.go
+++ b/pkg/spanconfig/spanconfigsqlwatcher/buffer_test.go
@@ -174,9 +174,9 @@ func TestBuffer(t *testing.T) {
 	// and interact as expected with descriptor SQLUpdates.
 	require.NoError(t, buffer.add(makePTSEvent(true, roachpb.TenantID{}, ts(16))))
 	require.NoError(t, buffer.add(
-		makePTSEvent(false, roachpb.MakeTenantID(1), ts(17))))
+		makePTSEvent(false, roachpb.MustMakeTenantID(1), ts(17))))
 	require.NoError(t, buffer.add(
-		makePTSEvent(false, roachpb.MakeTenantID(1), ts(18))))
+		makePTSEvent(false, roachpb.MustMakeTenantID(1), ts(18))))
 	require.NoError(t, buffer.add(makePTSEvent(true, roachpb.TenantID{}, ts(19))))
 
 	require.NoError(t, buffer.add(makeDescriptorEvent(2, ts(20))))
@@ -188,7 +188,7 @@ func TestBuffer(t *testing.T) {
 	expectedUpdates := makeDescriptorUpdates(1, 2)
 	expectedUpdates = append(expectedUpdates,
 		makePTSUpdates(
-			*ptpb.MakeTenantsTarget([]roachpb.TenantID{roachpb.MakeTenantID(1)}),
+			*ptpb.MakeTenantsTarget([]roachpb.TenantID{roachpb.MustMakeTenantID(1)}),
 			*ptpb.MakeClusterTarget())...,
 	)
 	require.Equal(t, expectedUpdates, updates)
@@ -323,9 +323,9 @@ func TestBufferedEventsSort(t *testing.T) {
 	evs = append(evs, makePTSEvent(true, roachpb.TenantID{}, ts(2)))
 
 	// Insert a few tenant updates that should sort before the cluster updates.
-	evs = append(evs, makePTSEvent(false, roachpb.MakeTenantID(2), ts(3)))
-	evs = append(evs, makePTSEvent(false, roachpb.MakeTenantID(1), ts(7)))
-	evs = append(evs, makePTSEvent(false, roachpb.MakeTenantID(2), ts(2)))
+	evs = append(evs, makePTSEvent(false, roachpb.MustMakeTenantID(2), ts(3)))
+	evs = append(evs, makePTSEvent(false, roachpb.MustMakeTenantID(1), ts(7)))
+	evs = append(evs, makePTSEvent(false, roachpb.MustMakeTenantID(2), ts(2)))
 
 	// Insert a few more descriptor updates to interleave the updates.
 	evs = append(evs, makeDescriptorEvent(4, ts(12)))
@@ -344,9 +344,9 @@ func TestBufferedEventsSort(t *testing.T) {
 		makeDescriptorEvent(2, ts(6)),
 		makeDescriptorEvent(4, ts(12)),
 		makeDescriptorEvent(5, ts(11)),
-		makePTSEvent(false, roachpb.MakeTenantID(1), ts(7)),
-		makePTSEvent(false, roachpb.MakeTenantID(2), ts(2)),
-		makePTSEvent(false, roachpb.MakeTenantID(2), ts(3)),
+		makePTSEvent(false, roachpb.MustMakeTenantID(1), ts(7)),
+		makePTSEvent(false, roachpb.MustMakeTenantID(2), ts(2)),
+		makePTSEvent(false, roachpb.MustMakeTenantID(2), ts(3)),
 		makePTSEvent(true, roachpb.TenantID{}, ts(2)),
 		makePTSEvent(true, roachpb.TenantID{}, ts(3)),
 	}, evs)

--- a/pkg/spanconfig/spanconfigsqlwatcher/protectedtsdecoder_test.go
+++ b/pkg/spanconfig/spanconfigsqlwatcher/protectedtsdecoder_test.go
@@ -54,8 +54,8 @@ func TestProtectedTimestampDecoder(t *testing.T) {
 		},
 		{
 			name: "tenant",
-			target: ptpb.MakeTenantsTarget([]roachpb.TenantID{roachpb.MakeTenantID(1),
-				roachpb.MakeTenantID(2)}),
+			target: ptpb.MakeTenantsTarget([]roachpb.TenantID{roachpb.MustMakeTenantID(1),
+				roachpb.MustMakeTenantID(2)}),
 		},
 		{
 			name:   "schema-object",

--- a/pkg/spanconfig/spanconfigstore/store_test.go
+++ b/pkg/spanconfig/spanconfigstore/store_test.go
@@ -245,13 +245,13 @@ func TestStoreClone(t *testing.T) {
 		),
 		makeSpanConfigAddition(
 			spanconfig.MakeTargetFromSystemTarget(spanconfig.TestingMakeTenantKeyspaceTargetOrFatal(
-				t, roachpb.SystemTenantID, roachpb.MakeTenantID(10),
+				t, roachpb.SystemTenantID, roachpb.MustMakeTenantID(10),
 			)),
 			spanconfigtestutils.ParseConfig(t, "H"),
 		),
 		makeSpanConfigAddition(
 			spanconfig.MakeTargetFromSystemTarget(spanconfig.TestingMakeTenantKeyspaceTargetOrFatal(
-				t, roachpb.MakeTenantID(10), roachpb.MakeTenantID(10),
+				t, roachpb.MustMakeTenantID(10), roachpb.MustMakeTenantID(10),
 			)),
 			spanconfigtestutils.ParseConfig(t, "I"),
 		),

--- a/pkg/spanconfig/spanconfigstore/system_store_test.go
+++ b/pkg/spanconfig/spanconfigstore/system_store_test.go
@@ -74,28 +74,28 @@ func TestSystemSpanConfigStoreCombine(t *testing.T) {
 		),
 		makeSpanConfigAddition(spanconfig.MakeTargetFromSystemTarget(
 			spanconfig.TestingMakeTenantKeyspaceTargetOrFatal(
-				t, roachpb.SystemTenantID, roachpb.MakeTenantID(10),
+				t, roachpb.SystemTenantID, roachpb.MustMakeTenantID(10),
 			),
 		),
 			makeSystemSpanConfig(150),
 		),
 		makeSpanConfigAddition(spanconfig.MakeTargetFromSystemTarget(
 			spanconfig.TestingMakeTenantKeyspaceTargetOrFatal(
-				t, roachpb.MakeTenantID(10), roachpb.MakeTenantID(10),
+				t, roachpb.MustMakeTenantID(10), roachpb.MustMakeTenantID(10),
 			),
 		),
 			makeSystemSpanConfig(200),
 		),
 		makeSpanConfigAddition(spanconfig.MakeTargetFromSystemTarget(
 			spanconfig.TestingMakeTenantKeyspaceTargetOrFatal(
-				t, roachpb.MakeTenantID(20), roachpb.MakeTenantID(20),
+				t, roachpb.MustMakeTenantID(20), roachpb.MustMakeTenantID(20),
 			),
 		),
 			makeSystemSpanConfig(300),
 		),
 		makeSpanConfigAddition(spanconfig.MakeTargetFromSystemTarget(
 			spanconfig.TestingMakeTenantKeyspaceTargetOrFatal(
-				t, roachpb.SystemTenantID, roachpb.MakeTenantID(30),
+				t, roachpb.SystemTenantID, roachpb.MustMakeTenantID(30),
 			),
 		),
 			makeSystemSpanConfig(500),
@@ -116,21 +116,21 @@ func TestSystemSpanConfigStoreCombine(t *testing.T) {
 			expectedPTSs: []hlc.Timestamp{ts(1), ts(100), ts(120)},
 		},
 		{
-			key:          roachpb.RKey(append(keys.MakeTenantPrefix(roachpb.MakeTenantID(10)), byte('a'))),
+			key:          roachpb.RKey(append(keys.MakeTenantPrefix(roachpb.MustMakeTenantID(10)), byte('a'))),
 			expectedPTSs: []hlc.Timestamp{ts(1), ts(100), ts(150), ts(200)},
 		},
 		{
-			key:          roachpb.RKey(append(keys.MakeTenantPrefix(roachpb.MakeTenantID(20)), byte('a'))),
+			key:          roachpb.RKey(append(keys.MakeTenantPrefix(roachpb.MustMakeTenantID(20)), byte('a'))),
 			expectedPTSs: []hlc.Timestamp{ts(1), ts(100), ts(300)},
 		},
 		{
-			key:          roachpb.RKey(append(keys.MakeTenantPrefix(roachpb.MakeTenantID(30)), byte('a'))),
+			key:          roachpb.RKey(append(keys.MakeTenantPrefix(roachpb.MustMakeTenantID(30)), byte('a'))),
 			expectedPTSs: []hlc.Timestamp{ts(1), ts(100), ts(500)},
 		},
 		{
 			// Only the system span config over the entire keyspace should apply to
 			// tenant 40.
-			key:          roachpb.RKey(append(keys.MakeTenantPrefix(roachpb.MakeTenantID(40)), byte('a'))),
+			key:          roachpb.RKey(append(keys.MakeTenantPrefix(roachpb.MustMakeTenantID(40)), byte('a'))),
 			expectedPTSs: []hlc.Timestamp{ts(1), ts(100)},
 		},
 	} {

--- a/pkg/spanconfig/spanconfigtestutils/utils.go
+++ b/pkg/spanconfig/spanconfigtestutils/utils.go
@@ -73,12 +73,12 @@ func parseSystemTarget(t testing.TB, systemTarget string) spanconfig.SystemTarge
 	sourceID, err := strconv.Atoi(matches[3])
 	require.NoError(t, err)
 	if matches[4] == "all-tenant-keyspace-targets-set" {
-		return spanconfig.MakeAllTenantKeyspaceTargetsSet(roachpb.MakeTenantID(uint64(sourceID)))
+		return spanconfig.MakeAllTenantKeyspaceTargetsSet(roachpb.MustMakeTenantID(uint64(sourceID)))
 	}
 	targetID, err := strconv.Atoi(matches[6])
 	require.NoError(t, err)
 	target, err := spanconfig.MakeTenantKeyspaceTarget(
-		roachpb.MakeTenantID(uint64(sourceID)), roachpb.MakeTenantID(uint64(targetID)),
+		roachpb.MustMakeTenantID(uint64(sourceID)), roachpb.MustMakeTenantID(uint64(targetID)),
 	)
 	require.NoError(t, err)
 	return target
@@ -516,7 +516,7 @@ func ParseProtectionTarget(t testing.TB, input string) *ptpb.Target {
 		for _, tenID := range tenantIDs {
 			id, err := strconv.Atoi(tenID)
 			require.NoError(t, err)
-			ids = append(ids, roachpb.MakeTenantID(uint64(id)))
+			ids = append(ids, roachpb.MustMakeTenantID(uint64(id)))
 		}
 		return ptpb.MakeTenantsTarget(ids)
 	case strings.HasPrefix(target, schemaObjectPrefix):

--- a/pkg/spanconfig/systemtarget.go
+++ b/pkg/spanconfig/systemtarget.go
@@ -329,7 +329,7 @@ func decodeSystemTarget(span roachpb.Span) (SystemTarget, error) {
 		if err != nil {
 			return SystemTarget{}, err
 		}
-		tenID := roachpb.MakeTenantID(tenIDRaw)
+		tenID := roachpb.MustMakeTenantID(tenIDRaw)
 		return MakeTenantKeyspaceTarget(roachpb.SystemTenantID, tenID)
 	case bytes.HasPrefix(span.Key, keys.SystemSpanConfigSecondaryTenantOnEntireKeyspace):
 		// System span config was applied by a secondary tenant over its entire
@@ -339,7 +339,7 @@ func decodeSystemTarget(span roachpb.Span) (SystemTarget, error) {
 		if err != nil {
 			return SystemTarget{}, err
 		}
-		tenID := roachpb.MakeTenantID(tenIDRaw)
+		tenID := roachpb.MustMakeTenantID(tenIDRaw)
 		return MakeTenantKeyspaceTarget(tenID, tenID)
 	default:
 		return SystemTarget{},

--- a/pkg/spanconfig/target_test.go
+++ b/pkg/spanconfig/target_test.go
@@ -29,11 +29,11 @@ func TestEncodeDecodeSystemTarget(t *testing.T) {
 
 	for _, testTarget := range []SystemTarget{
 		// Tenant targeting its logical cluster.
-		TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.MakeTenantID(10), roachpb.MakeTenantID(10)),
+		TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.MustMakeTenantID(10), roachpb.MustMakeTenantID(10)),
 		// System tenant targeting its logical cluster.
 		TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.SystemTenantID),
 		// System tenant targeting a secondary tenant.
-		TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.MakeTenantID(10)),
+		TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.MustMakeTenantID(10)),
 		// System tenant targeting the entire keyspace.
 		MakeEntireKeyspaceTarget(),
 	} {
@@ -55,11 +55,11 @@ func TestTargetToFromProto(t *testing.T) {
 
 	for _, testSystemTarget := range []SystemTarget{
 		// Tenant targeting its logical cluster.
-		TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.MakeTenantID(10), roachpb.MakeTenantID(10)),
+		TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.MustMakeTenantID(10), roachpb.MustMakeTenantID(10)),
 		// System tenant targeting its logical cluster.
 		TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.SystemTenantID),
 		// System tenant targeting a secondary tenant.
-		TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.MakeTenantID(10)),
+		TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.MustMakeTenantID(10)),
 		// System tenant targeting the entire keyspace.
 		MakeEntireKeyspaceTarget(),
 		// System tenant's read-only target to fetch all system span configurations
@@ -67,7 +67,7 @@ func TestTargetToFromProto(t *testing.T) {
 		MakeAllTenantKeyspaceTargetsSet(roachpb.SystemTenantID),
 		// A secondary tenant's read-only target to fetch all system span
 		// configurations it has set over secondary tenant keyspaces.
-		MakeAllTenantKeyspaceTargetsSet(roachpb.MakeTenantID(10)),
+		MakeAllTenantKeyspaceTargetsSet(roachpb.MustMakeTenantID(10)),
 	} {
 		systemTarget, err := makeSystemTargetFromProto(testSystemTarget.toProto())
 		require.NoError(t, err)
@@ -86,7 +86,7 @@ func TestTargetToFromProto(t *testing.T) {
 func TestKeyspaceTargeted(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	ten10 := roachpb.MakeTenantID(10)
+	ten10 := roachpb.MustMakeTenantID(10)
 
 	for _, tc := range []struct {
 		target  Target
@@ -176,8 +176,8 @@ func TestDecodeInvalidSpanAsSystemTarget(t *testing.T) {
 func TestSystemTargetValidation(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	tenant10 := roachpb.MakeTenantID(10)
-	tenant20 := roachpb.MakeTenantID(20)
+	tenant10 := roachpb.MustMakeTenantID(10)
+	tenant20 := roachpb.MustMakeTenantID(20)
 	for _, tc := range []struct {
 		sourceTenantID roachpb.TenantID
 		targetTenantID roachpb.TenantID
@@ -308,22 +308,22 @@ func TestTargetSortingRandomized(t *testing.T) {
 	// Construct a set of sorted targets.
 	sortedTargets := Targets{
 		MakeTargetFromSystemTarget(MakeAllTenantKeyspaceTargetsSet(roachpb.SystemTenantID)),
-		MakeTargetFromSystemTarget(MakeAllTenantKeyspaceTargetsSet(roachpb.MakeTenantID(10))),
+		MakeTargetFromSystemTarget(MakeAllTenantKeyspaceTargetsSet(roachpb.MustMakeTenantID(10))),
 		MakeTargetFromSystemTarget(MakeEntireKeyspaceTarget()),
 		MakeTargetFromSystemTarget(
 			TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.SystemTenantID),
 		),
 		MakeTargetFromSystemTarget(
-			TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.MakeTenantID(10)),
+			TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.MustMakeTenantID(10)),
 		),
 		MakeTargetFromSystemTarget(
-			TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.MakeTenantID(20)),
+			TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.MustMakeTenantID(20)),
 		),
 		MakeTargetFromSystemTarget(
-			TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.MakeTenantID(5), roachpb.MakeTenantID(5)),
+			TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.MustMakeTenantID(5), roachpb.MustMakeTenantID(5)),
 		),
 		MakeTargetFromSystemTarget(
-			TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.MakeTenantID(10), roachpb.MakeTenantID(10)),
+			TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.MustMakeTenantID(10), roachpb.MustMakeTenantID(10)),
 		),
 		MakeTargetFromSpan(roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")}),
 		MakeTargetFromSpan(roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("d")}),
@@ -351,9 +351,9 @@ func TestSpanTargetsConstructedInSystemSpanConfigKeyspace(t *testing.T) {
 
 	for _, tc := range []roachpb.Span{
 		MakeEntireKeyspaceTarget().encode(),
-		TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.MakeTenantID(10), roachpb.MakeTenantID(10)).encode(),
+		TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.MustMakeTenantID(10), roachpb.MustMakeTenantID(10)).encode(),
 		TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.SystemTenantID).encode(),
-		TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.MakeTenantID(10)).encode(),
+		TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.SystemTenantID, roachpb.MustMakeTenantID(10)).encode(),
 		{
 			// Extends into from the left
 			Key:    keys.TimeseriesKeyMax,

--- a/pkg/sql/catalog/catalogkeys/keys_test.go
+++ b/pkg/sql/catalog/catalogkeys/keys_test.go
@@ -21,7 +21,7 @@ import (
 func TestKeyAddress(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tenSysCodec := keys.SystemSQLCodec
-	ten5Codec := keys.MakeSQLCodec(roachpb.MakeTenantID(5))
+	ten5Codec := keys.MakeSQLCodec(roachpb.MustMakeTenantID(5))
 	testCases := []struct {
 		key roachpb.Key
 	}{

--- a/pkg/sql/colexec/colexecspan/span_assembler_test.go
+++ b/pkg/sql/colexec/colexecspan/span_assembler_test.go
@@ -84,7 +84,7 @@ func TestSpanAssembler(t *testing.T) {
 								codec := keys.SystemSQLCodec
 								if !useSystemTenant {
 									tenantName = "SecondaryTenant"
-									codec = keys.MakeSQLCodec(roachpb.MakeTenantID(5))
+									codec = keys.MakeSQLCodec(roachpb.MustMakeTenantID(5))
 								}
 								t.Run(tenantName, func(t *testing.T) {
 									testTable, err := makeTable(useColFamilies)

--- a/pkg/sql/contention/registry_test.go
+++ b/pkg/sql/contention/registry_test.go
@@ -232,7 +232,7 @@ func TestSerializedRegistryInvariants(t *testing.T) {
 			// Always append a tenant ID at the start of the key so that in case
 			// we choose to generate a non-SQL key, it doesn't have the first
 			// byte randomly equal to tenantPrefixByte.
-			key := keys.MakeTenantPrefix(roachpb.MakeTenantID(1 + uint64(rng.Uint32())))
+			key := keys.MakeTenantPrefix(roachpb.MustMakeTenantID(1 + uint64(rng.Uint32())))
 			if rng.Float64() > nonSQLKeyProbability {
 				// Create a key with a valid SQL prefix.
 				tableID := uint32(1 + rng.Intn(testIndexMapMaxSize+1))

--- a/pkg/sql/gcjob/refresh_statuses.go
+++ b/pkg/sql/gcjob/refresh_statuses.go
@@ -474,7 +474,7 @@ func refreshTenant(
 		// If the tenant's GC TTL has elapsed, check if there are any protected timestamp records
 		// that apply to the tenant keyspace.
 		atTime := hlc.Timestamp{WallTime: dropTime}
-		isProtected, err := isTenantProtected(ctx, atTime, roachpb.MakeTenantID(tenID), execCfg)
+		isProtected, err := isTenantProtected(ctx, atTime, roachpb.MustMakeTenantID(tenID), execCfg)
 		if err != nil {
 			return false, time.Time{}, err
 		}

--- a/pkg/sql/gcjob/tenant_garbage_collection.go
+++ b/pkg/sql/gcjob/tenant_garbage_collection.go
@@ -42,7 +42,7 @@ func gcTenant(
 		)
 	}
 
-	info, err := sql.GetTenantRecordByID(ctx, execCfg, nil /* txn */, roachpb.MakeTenantID(tenID))
+	info, err := sql.GetTenantRecordByID(ctx, execCfg, nil /* txn */, roachpb.MustMakeTenantID(tenID))
 	if err != nil {
 		if pgerror.GetPGCode(err) == pgcode.UndefinedObject {
 			// The tenant row is deleted only after its data is cleared so there is

--- a/pkg/sql/gcjob_test/gc_job_test.go
+++ b/pkg/sql/gcjob_test/gc_job_test.go
@@ -344,7 +344,7 @@ func TestGCResumer(t *testing.T) {
 		job, err := jobRegistry.LoadJob(ctx, sj.ID())
 		require.NoError(t, err)
 		require.Equal(t, jobs.StatusSucceeded, job.Status())
-		_, err = sql.GetTenantRecordByID(ctx, &execCfg, nil /* txn */, roachpb.MakeTenantID(tenID))
+		_, err = sql.GetTenantRecordByID(ctx, &execCfg, nil /* txn */, roachpb.MustMakeTenantID(tenID))
 		require.EqualError(t, err, `tenant "10" does not exist`)
 		progress := job.Progress()
 		require.Equal(t, jobspb.SchemaChangeGCProgress_CLEARED, progress.GetSchemaChangeGC().Tenant.Status)
@@ -372,7 +372,7 @@ func TestGCResumer(t *testing.T) {
 		job, err := jobRegistry.LoadJob(ctx, sj.ID())
 		require.NoError(t, err)
 		require.Equal(t, jobs.StatusSucceeded, job.Status())
-		_, err = sql.GetTenantRecordByID(ctx, &execCfg, nil /* txn */, roachpb.MakeTenantID(tenID))
+		_, err = sql.GetTenantRecordByID(ctx, &execCfg, nil /* txn */, roachpb.MustMakeTenantID(tenID))
 		require.EqualError(t, err, `tenant "10" does not exist`)
 		progress := job.Progress()
 		require.Equal(t, jobspb.SchemaChangeGCProgress_CLEARED, progress.GetSchemaChangeGC().Tenant.Status)
@@ -488,7 +488,7 @@ func TestGCTenant(t *testing.T) {
 		}
 
 		descKey := catalogkeys.MakeDescMetadataKey(
-			keys.MakeSQLCodec(roachpb.MakeTenantID(dropTenID)), keys.NamespaceTableID,
+			keys.MakeSQLCodec(roachpb.MustMakeTenantID(dropTenID)), keys.NamespaceTableID,
 		)
 		require.NoError(t, kvDB.Put(ctx, descKey, "foo"))
 
@@ -500,7 +500,7 @@ func TestGCTenant(t *testing.T) {
 
 		require.NoError(t, gcClosure(dropTenID, progress))
 		require.Equal(t, jobspb.SchemaChangeGCProgress_CLEARED, progress.Tenant.Status)
-		_, err = sql.GetTenantRecordByID(ctx, &execCfg, nil /* txn */, roachpb.MakeTenantID(dropTenID))
+		_, err = sql.GetTenantRecordByID(ctx, &execCfg, nil /* txn */, roachpb.MustMakeTenantID(dropTenID))
 		require.EqualError(t, err, `tenant "11" does not exist`)
 		require.NoError(t, gcClosure(dropTenID, progress))
 

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -2297,7 +2297,7 @@ func ruleFromString(str string) (opt.RuleName, error) {
 func (ot *OptTester) ExecBuild(f exec.Factory, mem *memo.Memo, expr opt.Expr) (exec.Plan, error) {
 	// For DDL we need a fresh root transaction that isn't system tenant.
 	if opt.IsDDLOp(expr) {
-		ot.evalCtx.Codec = keys.MakeSQLCodec(roachpb.MakeTenantID(5))
+		ot.evalCtx.Codec = keys.MakeSQLCodec(roachpb.MustMakeTenantID(5))
 		factory := kv.MockTxnSenderFactory{}
 		clock := hlc.NewClockWithSystemTimeSource(time.Nanosecond /* maxOffset */)
 		stopper := stop.NewStopper()

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -5383,7 +5383,7 @@ value if you rely on the HLC for accuracy.`,
 				if err != nil {
 					return nil, err
 				}
-				start := keys.MakeTenantPrefix(roachpb.MakeTenantID(uint64(sTenID)))
+				start := keys.MakeTenantPrefix(roachpb.MustMakeTenantID(uint64(sTenID)))
 				end := start.PrefixEnd()
 
 				result := tree.NewDArray(types.Bytes)

--- a/pkg/sql/sqlliveness/slstorage/key_encoder_test.go
+++ b/pkg/sql/sqlliveness/slstorage/key_encoder_test.go
@@ -41,7 +41,7 @@ func TestKeyEncoder(t *testing.T) {
 }
 
 func testKeyEncoder(t *testing.T) {
-	codec := keys.MakeSQLCodec(roachpb.MakeTenantID(1337))
+	codec := keys.MakeSQLCodec(roachpb.MustMakeTenantID(1337))
 	keyCodec := makeKeyCodec(codec, 42, 2)
 
 	t.Run("Prefix", func(t *testing.T) {
@@ -49,7 +49,7 @@ func testKeyEncoder(t *testing.T) {
 
 		rem, tenant, err := keys.DecodeTenantPrefix(prefix)
 		require.NoError(t, err)
-		require.Equal(t, tenant, roachpb.MakeTenantID(1337))
+		require.Equal(t, tenant, roachpb.MustMakeTenantID(1337))
 
 		rem, tableID, indexID, err := keys.DecodeTableIDIndexID(rem)
 		require.NoError(t, err)

--- a/pkg/sql/tenant_settings.go
+++ b/pkg/sql/tenant_settings.go
@@ -184,7 +184,7 @@ func resolveTenantID(
 	if *tenantID == 0 {
 		return 0, nil, pgerror.Newf(pgcode.InvalidParameterValue, "tenant ID must be non-zero")
 	}
-	if roachpb.MakeTenantID(uint64(*tenantID)) == roachpb.SystemTenantID {
+	if roachpb.MustMakeTenantID(uint64(*tenantID)) == roachpb.SystemTenantID {
 		return 0, nil, errors.WithHint(pgerror.Newf(pgcode.InvalidParameterValue,
 			"cannot use this statement to access cluster settings in system tenant"),
 			"Use a regular SHOW/SET CLUSTER SETTING statement.")

--- a/pkg/sql/tenant_test.go
+++ b/pkg/sql/tenant_test.go
@@ -34,7 +34,7 @@ func TestDestroyTenantSynchronous(t *testing.T) {
 	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
-	tenantID := roachpb.MakeTenantID(10)
+	tenantID := roachpb.MustMakeTenantID(10)
 	codec := keys.MakeSQLCodec(tenantID)
 	const tenantStateQuery = `
 SELECT id, active FROM system.tenants WHERE id = 10

--- a/pkg/sql/tests/system_table_test.go
+++ b/pkg/sql/tests/system_table_test.go
@@ -53,7 +53,7 @@ func TestInitialKeys(t *testing.T) {
 			codec = keys.SystemSQLCodec
 			nonDescKeys = 14
 		} else {
-			codec = keys.MakeSQLCodec(roachpb.MakeTenantID(5))
+			codec = keys.MakeSQLCodec(roachpb.MustMakeTenantID(5))
 			nonDescKeys = 4
 		}
 
@@ -127,7 +127,7 @@ func TestInitialKeysAndSplits(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				codec = keys.MakeSQLCodec(roachpb.MakeTenantID(id))
+				codec = keys.MakeSQLCodec(roachpb.MustMakeTenantID(id))
 			}
 
 			ms := bootstrap.MakeMetadataSchema(

--- a/pkg/sql/ttl/ttljob/ttljob_keydecoder_test.go
+++ b/pkg/sql/ttl/ttljob/ttljob_keydecoder_test.go
@@ -71,7 +71,7 @@ func TestKeyToDatums(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			tenantID := roachpb.MakeTenantID(tenantID)
+			tenantID := roachpb.MustMakeTenantID(tenantID)
 			codec := keys.MakeSQLCodec(tenantID)
 			keyBytes := tc.keyBytes
 			var alloc tree.DatumAlloc

--- a/pkg/startupmigrations/migrations_test.go
+++ b/pkg/startupmigrations/migrations_test.go
@@ -299,7 +299,7 @@ func TestClusterWideMigrationOnlyRunBySystemTenant(t *testing.T) {
 		if systemTenant {
 			codec = keys.SystemSQLCodec
 		} else {
-			codec = keys.MakeSQLCodec(roachpb.MakeTenantID(5))
+			codec = keys.MakeSQLCodec(roachpb.MustMakeTenantID(5))
 		}
 
 		ctx := context.Background()

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -421,7 +421,7 @@ func StartTenant(
 // starting a test Tenant. The returned tenant IDs match those built
 // into the test certificates.
 func TestTenantID() roachpb.TenantID {
-	return roachpb.MakeTenantID(security.EmbeddedTenantIDs()[0])
+	return roachpb.MustMakeTenantID(security.EmbeddedTenantIDs()[0])
 }
 
 // GetJSONProto uses the supplied client to GET the URL specified by the parameters

--- a/pkg/util/admission/work_queue_test.go
+++ b/pkg/util/admission/work_queue_test.go
@@ -316,7 +316,7 @@ func TestWorkQueueBasic(t *testing.T) {
 func scanTenantID(t *testing.T, d *datadriven.TestData) roachpb.TenantID {
 	var id int
 	d.ScanArgs(t, "tenant", &id)
-	return roachpb.MakeTenantID(uint64(id))
+	return roachpb.MustMakeTenantID(uint64(id))
 }
 
 // TestWorkQueueTokenResetRace induces racing between tenantInfo.used
@@ -349,7 +349,7 @@ func TestWorkQueueTokenResetRace(t *testing.T) {
 			select {
 			case <-ticker.C:
 				ctx, cancel := context.WithCancel(context.Background())
-				work2 := &testWork{tenantID: roachpb.MakeTenantID(tenantID), cancel: cancel}
+				work2 := &testWork{tenantID: roachpb.MustMakeTenantID(tenantID), cancel: cancel}
 				tenantID++
 				go func(ctx context.Context, w *testWork, createTime int64) {
 					enabled, err := q.Admit(ctx, WorkInfo{

--- a/pkg/util/metric/aggmetric/agg_metric_test.go
+++ b/pkg/util/metric/aggmetric/agg_metric_test.go
@@ -69,8 +69,8 @@ func TestAggMetric(t *testing.T) {
 	}, base.DefaultHistogramWindowInterval(), metric.Count1KBuckets, "tenant_id")
 	r.AddMetric(h)
 
-	tenant2 := roachpb.MakeTenantID(2)
-	tenant3 := roachpb.MakeTenantID(3)
+	tenant2 := roachpb.MustMakeTenantID(2)
+	tenant3 := roachpb.MustMakeTenantID(3)
 	c2 := c.AddChild(tenant2.String())
 	c3 := c.AddChild(tenant3.String())
 	g2 := g.AddChild(tenant2.String())
@@ -139,7 +139,7 @@ func TestAggMetricBuilder(t *testing.T) {
 		base.DefaultHistogramWindowInterval(), metric.Count1KBuckets)
 
 	for i := 5; i < 10; i++ {
-		tenantLabel := roachpb.MakeTenantID(uint64(i)).String()
+		tenantLabel := roachpb.MustMakeTenantID(uint64(i)).String()
 		c.AddChild(tenantLabel)
 		g.AddChild(tenantLabel)
 		f.AddChild(tenantLabel)


### PR DESCRIPTION
This renames MakeTenantID to MustMakeTenantID and renames MakeTenantIDNoPanic to MakeTenantID. The Must prefix may help us remember that this function panics.

Epic: None

Release note: None