### PR TITLE
kv/kvserver: skip TestBehaviorDuringLeaseTransfer

### DIFF
--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -606,6 +606,7 @@ func TestReplicaReadConsistency(t *testing.T) {
 // transfer might still apply.
 func TestBehaviorDuringLeaseTransfer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 91948, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	testutils.RunTrueAndFalse(t, "transferSucceeds", func(t *testing.T, transferSucceeds bool) {


### PR DESCRIPTION
Informs: #91948

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None