### PR TITLE
release-22.1: cloud: direct S3 logs to CRDB logger

### DIFF
--- a/pkg/ccl/backupccl/alter_backup_planning.go
+++ b/pkg/ccl/backupccl/alter_backup_planning.go
@@ -158,7 +158,7 @@ func doAlterBackupPlan(
 	oldKMSFound := false
 	for _, old := range oldKms {
 		for _, encFile := range opts {
-			defaultKMSInfo, err = validateKMSURIsAgainstFullBackup([]string{old},
+			defaultKMSInfo, err = validateKMSURIsAgainstFullBackup(ctx, []string{old},
 				newEncryptedDataKeyMapFromProtoMap(encFile.EncryptedDataKeyByKMSMasterKeyID), &backupKMSEnv{
 					baseStore.Settings(),
 					&ioConf,

--- a/pkg/ccl/backupccl/backup_destination.go
+++ b/pkg/ccl/backupccl/backup_destination.go
@@ -344,7 +344,7 @@ func getEncryptionFromBase(
 		case jobspb.EncryptionMode_KMS:
 			var defaultKMSInfo *jobspb.BackupEncryptionOptions_KMSInfo
 			for _, encFile := range opts {
-				defaultKMSInfo, err = validateKMSURIsAgainstFullBackup(encryptionParams.RawKmsUris,
+				defaultKMSInfo, err = validateKMSURIsAgainstFullBackup(ctx, encryptionParams.RawKmsUris,
 					newEncryptedDataKeyMapFromProtoMap(encFile.EncryptedDataKeyByKMSMasterKeyID), kmsEnv)
 				if err == nil {
 					break

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -476,11 +476,14 @@ func backupJobDescription(
 // encryption/decryption operations during this BACKUP. By default it is the
 // first KMS URI passed during the incremental BACKUP.
 func validateKMSURIsAgainstFullBackup(
-	kmsURIs []string, kmsMasterKeyIDToDataKey *encryptedDataKeyMap, kmsEnv cloud.KMSEnv,
+	ctx context.Context,
+	kmsURIs []string,
+	kmsMasterKeyIDToDataKey *encryptedDataKeyMap,
+	kmsEnv cloud.KMSEnv,
 ) (*jobspb.BackupEncryptionOptions_KMSInfo, error) {
 	var defaultKMSInfo *jobspb.BackupEncryptionOptions_KMSInfo
 	for _, kmsURI := range kmsURIs {
-		kms, err := cloud.KMSFromURI(kmsURI, kmsEnv)
+		kms, err := cloud.KMSFromURI(ctx, kmsURI, kmsEnv)
 		if err != nil {
 			return nil, err
 		}
@@ -1637,7 +1640,7 @@ func protectTimestampForBackup(
 func getEncryptedDataKeyFromURI(
 	ctx context.Context, plaintextDataKey []byte, kmsURI string, kmsEnv cloud.KMSEnv,
 ) (string, []byte, error) {
-	kms, err := cloud.KMSFromURI(kmsURI, kmsEnv)
+	kms, err := cloud.KMSFromURI(ctx, kmsURI, kmsEnv)
 	if err != nil {
 		return "", nil, err
 	}

--- a/pkg/ccl/backupccl/backup_processor_planning.go
+++ b/pkg/ccl/backupccl/backup_processor_planning.go
@@ -65,7 +65,7 @@ func distBackupPlanSpecs(
 	}
 
 	if encryption != nil && encryption.Mode == jobspb.EncryptionMode_KMS {
-		kms, err := cloud.KMSFromURI(encryption.KMSInfo.Uri, &backupKMSEnv{
+		kms, err := cloud.KMSFromURI(ctx, encryption.KMSInfo.Uri, &backupKMSEnv{
 			settings: execCfg.Settings,
 			conf:     &execCfg.ExternalIODirConfig,
 		})

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -4354,7 +4354,7 @@ func (k *testKMS) Close() error {
 	return nil
 }
 
-func MakeTestKMS(uri string, _ cloud.KMSEnv) (cloud.KMS, error) {
+func MakeTestKMS(_ context.Context, uri string, _ cloud.KMSEnv) (cloud.KMS, error) {
 	return &testKMS{uri}, nil
 }
 
@@ -4425,7 +4425,7 @@ func TestValidateKMSURIsAgainstFullBackup(t *testing.T) {
 			}
 		}
 
-		kmsInfo, err := validateKMSURIsAgainstFullBackup(
+		kmsInfo, err := validateKMSURIsAgainstFullBackup(context.Background(),
 			tc.incrementalBackupURIs, masterKeyIDToDataKey,
 			&testKMSEnv{cluster.NoSettings, &base.ExternalIODirConfig{}})
 		if tc.expectError {
@@ -4465,7 +4465,7 @@ func TestGetEncryptedDataKeyByKMSMasterKeyID(t *testing.T) {
 		expectedMap := newEncryptedDataKeyMap()
 		var defaultKMSInfo *jobspb.BackupEncryptionOptions_KMSInfo
 		for _, uri := range tc.fullBackupURIs {
-			testKMS, err := MakeTestKMS(uri, nil)
+			testKMS, err := MakeTestKMS(ctx, uri, nil)
 			require.NoError(t, err)
 
 			masterKeyID, err := testKMS.MasterKeyID()

--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -565,7 +565,7 @@ func getEncryptionKey(
 		// Contact the selected KMS to derive the decrypted data key.
 		// TODO(pbardea): Add a check here if encryption.KMSInfo is unexpectedly nil
 		// here to avoid a panic, and return an error instead.
-		kms, err := cloud.KMSFromURI(encryption.KMSInfo.Uri, &backupKMSEnv{
+		kms, err := cloud.KMSFromURI(ctx, encryption.KMSInfo.Uri, &backupKMSEnv{
 			settings: settings,
 			conf:     &ioConf,
 		})

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1646,7 +1646,7 @@ func doRestorePlan(
 		// restore has been used to encrypt the backup at least once.
 		var defaultKMSInfo *jobspb.BackupEncryptionOptions_KMSInfo
 		for _, encFile := range opts {
-			defaultKMSInfo, err = validateKMSURIsAgainstFullBackup(kms,
+			defaultKMSInfo, err = validateKMSURIsAgainstFullBackup(ctx, kms,
 				newEncryptedDataKeyMapFromProtoMap(encFile.EncryptedDataKeyByKMSMasterKeyID), &backupKMSEnv{
 					baseStores[0].Settings(),
 					&ioConf,

--- a/pkg/ccl/backupccl/restore_processor_planning.go
+++ b/pkg/ccl/backupccl/restore_processor_planning.go
@@ -56,7 +56,7 @@ func distRestore(
 	evalCtx := execCtx.ExtendedEvalContext()
 
 	if encryption != nil && encryption.Mode == jobspb.EncryptionMode_KMS {
-		kms, err := cloud.KMSFromURI(encryption.KMSInfo.Uri, &backupKMSEnv{
+		kms, err := cloud.KMSFromURI(ctx, encryption.KMSInfo.Uri, &backupKMSEnv{
 			settings: execCtx.ExecCfg().Settings,
 			conf:     &execCtx.ExecCfg().ExternalIODirConfig,
 		})

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -349,7 +349,7 @@ func showBackupPlanHook(
 			defer encStore.Close()
 		}
 		var encryption *jobspb.BackupEncryptionOptions
-		showEncErr := `If you are running SHOW BACKUP exclusively on an incremental backup, 
+		showEncErr := `If you are running SHOW BACKUP exclusively on an incremental backup,
 you must pass the 'encryption_info_dir' parameter that points to the directory of your full backup`
 		if passphrase, ok := opts[backupOptEncPassphrase]; ok {
 			opts, err := readEncryptionOptions(ctx, encStore)
@@ -376,7 +376,7 @@ you must pass the 'encryption_info_dir' parameter that points to the directory o
 			env := &backupKMSEnv{p.ExecCfg().Settings, &p.ExecCfg().ExternalIODirConfig}
 			var defaultKMSInfo *jobspb.BackupEncryptionOptions_KMSInfo
 			for _, encFile := range opts {
-				defaultKMSInfo, err = validateKMSURIsAgainstFullBackup([]string{kms},
+				defaultKMSInfo, err = validateKMSURIsAgainstFullBackup(ctx, []string{kms},
 					newEncryptedDataKeyMapFromProtoMap(encFile.EncryptedDataKeyByKMSMasterKeyID), env)
 				if err == nil {
 					break

--- a/pkg/cloud/amazon/BUILD.bazel
+++ b/pkg/cloud/amazon/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "@com_github_aws_aws_sdk_go//service/s3",
         "@com_github_aws_aws_sdk_go//service/s3/s3manager",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_gogo_protobuf//types",
     ],
 )

--- a/pkg/cloud/amazon/aws_kms_test.go
+++ b/pkg/cloud/amazon/aws_kms_test.go
@@ -10,6 +10,7 @@
 package amazon
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"os"
@@ -80,7 +81,7 @@ func TestEncryptDecryptAWS(t *testing.T) {
 			params.Add(KMSRegionParam, kmsRegion)
 
 			uri := fmt.Sprintf("aws:///%s?%s", keyID, params.Encode())
-			_, err := cloud.KMSFromURI(uri, &cloud.TestKMSEnv{ExternalIOConfig: &base.ExternalIODirConfig{}})
+			_, err := cloud.KMSFromURI(context.Background(), uri, &cloud.TestKMSEnv{ExternalIOConfig: &base.ExternalIODirConfig{}})
 			require.EqualError(t, err, fmt.Sprintf(
 				`%s is set to '%s', but %s is not set`,
 				cloud.AuthParam,
@@ -158,7 +159,7 @@ func TestPutAWSKMSEndpoint(t *testing.T) {
 
 	t.Run("disallow-endpoints", func(t *testing.T) {
 		uri := fmt.Sprintf("aws:///%s?%s", keyARN, q.Encode())
-		_, err := cloud.KMSFromURI(uri, &cloud.TestKMSEnv{
+		_, err := cloud.KMSFromURI(context.Background(), uri, &cloud.TestKMSEnv{
 			Settings:         awsKMSTestSettings,
 			ExternalIOConfig: &base.ExternalIODirConfig{DisableHTTP: true}})
 		require.True(t, testutils.IsError(err, "custom endpoints disallowed"))
@@ -178,7 +179,7 @@ func TestAWSKMSDisallowImplicitCredentials(t *testing.T) {
 		skip.IgnoreLint(t, "AWS_KMS_KEY_ARN_A env var must be set")
 	}
 	uri := fmt.Sprintf("aws:///%s?%s", keyARN, q.Encode())
-	_, err := cloud.KMSFromURI(uri, &cloud.TestKMSEnv{
+	_, err := cloud.KMSFromURI(context.Background(), uri, &cloud.TestKMSEnv{
 		Settings:         cluster.NoSettings,
 		ExternalIOConfig: &base.ExternalIODirConfig{DisableImplicitCredentials: true}})
 	require.True(t, testutils.IsError(err, "implicit credentials disallowed"))

--- a/pkg/cloud/amazon/s3_storage.go
+++ b/pkg/cloud/amazon/s3_storage.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/logtags"
 	"github.com/gogo/protobuf/types"
 )
 
@@ -323,6 +324,22 @@ func MakeS3Storage(
 	return s, nil
 }
 
+type awsLogAdapter struct {
+	ctx context.Context
+}
+
+func (l *awsLogAdapter) Log(vals ...interface{}) {
+	log.Infof(l.ctx, "s3: %s", fmt.Sprint(vals...))
+}
+
+func newLogAdapter(ctx context.Context) *awsLogAdapter {
+	return &awsLogAdapter{
+		ctx: logtags.AddTags(context.Background(), logtags.FromContext(ctx)),
+	}
+}
+
+var awsVerboseLogging = aws.LogLevel(aws.LogDebugWithRequestRetries | aws.LogDebugWithRequestErrors)
+
 // newClient creates a client from the passed s3ClientConfig and if the passed
 // config's region is empty, used the passed bucket to determine a region and
 // configures the client with it as well as returning it (so the caller can
@@ -330,11 +347,10 @@ func MakeS3Storage(
 func newClient(
 	ctx context.Context, conf s3ClientConfig, settings *cluster.Settings,
 ) (s3Client, string, error) {
-
 	// Open a span if client creation will do IO/RPCs to find creds/bucket region.
 	if conf.region == "" || conf.auth == cloud.AuthParamImplicit {
 		var sp *tracing.Span
-		ctx, sp = tracing.ChildSpan(ctx, "open s3 client")
+		ctx, sp = tracing.ChildSpan(ctx, "s3.newClient")
 		defer sp.Finish()
 	}
 
@@ -367,8 +383,9 @@ func newClient(
 
 	opts.Config.CredentialsChainVerboseErrors = aws.Bool(true)
 
+	opts.Config.Logger = newLogAdapter(ctx)
 	if conf.verbose {
-		opts.Config.LogLevel = aws.LogLevel(aws.LogDebugWithRequestRetries | aws.LogDebugWithRequestErrors)
+		opts.Config.LogLevel = awsVerboseLogging
 	}
 
 	retryer := &customRetryer{

--- a/pkg/cloud/gcp/gcs_kms.go
+++ b/pkg/cloud/gcp/gcs_kms.go
@@ -55,7 +55,7 @@ func resolveKMSURIParams(kmsURI url.URL) kmsURIParams {
 
 // MakeGCSKMS is the factory method which returns a configured, ready-to-use
 // GCS KMS object.
-func MakeGCSKMS(uri string, env cloud.KMSEnv) (cloud.KMS, error) {
+func MakeGCSKMS(ctx context.Context, uri string, env cloud.KMSEnv) (cloud.KMS, error) {
 	if env.KMSConfig().DisableOutbound {
 		return nil, errors.New("external IO must be enabled to use GCS KMS")
 	}
@@ -100,10 +100,7 @@ func MakeGCSKMS(uri string, env cloud.KMSEnv) (cloud.KMS, error) {
 		return nil, errors.Errorf("unsupported value %s for %s", kmsURIParams.auth, cloud.AuthParam)
 	}
 
-	ctx := context.Background()
-
 	kmc, err := kms.NewKeyManagementClient(ctx, credentialsOpt...)
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloud/gcp/gcs_kms_test.go
+++ b/pkg/cloud/gcp/gcs_kms_test.go
@@ -62,7 +62,7 @@ func TestEncryptDecryptGCS(t *testing.T) {
 
 			uri := fmt.Sprintf("gs:///%s?%s", keyID, params.Encode())
 
-			_, err := cloud.KMSFromURI(uri, &cloud.TestKMSEnv{ExternalIOConfig: &base.ExternalIODirConfig{}})
+			_, err := cloud.KMSFromURI(context.Background(), uri, &cloud.TestKMSEnv{ExternalIOConfig: &base.ExternalIODirConfig{}})
 			require.EqualError(t, err, fmt.Sprintf(
 				`%s is set to '%s', but %s is not set`,
 				cloud.AuthParam,
@@ -134,7 +134,7 @@ func TestGCSKMSDisallowImplicitCredentials(t *testing.T) {
 			skip.IgnoreLint(t, "%s env var must be set", id)
 		}
 		uri := fmt.Sprintf("gs:///%s?%s", keyID, q.Encode())
-		_, err := cloud.KMSFromURI(uri, &cloud.TestKMSEnv{
+		_, err := cloud.KMSFromURI(context.Background(), uri, &cloud.TestKMSEnv{
 			Settings:         cluster.NoSettings,
 			ExternalIOConfig: &base.ExternalIODirConfig{DisableImplicitCredentials: true}})
 		require.True(t, testutils.IsError(err,

--- a/pkg/cloud/kms.go
+++ b/pkg/cloud/kms.go
@@ -42,7 +42,7 @@ type KMSEnv interface {
 }
 
 // KMSFromURIFactory describes a factory function for KMS given a URI.
-type KMSFromURIFactory func(uri string, env KMSEnv) (KMS, error)
+type KMSFromURIFactory func(ctx context.Context, uri string, env KMSEnv) (KMS, error)
 
 // Mapping from KMS scheme to its registered factory method.
 var kmsFactoryMap = make(map[string]KMSFromURIFactory)
@@ -57,7 +57,7 @@ func RegisterKMSFromURIFactory(factory KMSFromURIFactory, scheme string) {
 }
 
 // KMSFromURI is the method used to create a KMS instance from the provided URI.
-func KMSFromURI(uri string, env KMSEnv) (KMS, error) {
+func KMSFromURI(ctx context.Context, uri string, env KMSEnv) (KMS, error) {
 	var kmsURL *url.URL
 	var err error
 	if kmsURL, err = url.ParseRequestURI(uri); err != nil {
@@ -71,5 +71,5 @@ func KMSFromURI(uri string, env KMSEnv) (KMS, error) {
 		return nil, errors.Newf("no factory method found for scheme %s", kmsURL.Scheme)
 	}
 
-	return factory(uri, env)
+	return factory(ctx, uri, env)
 }

--- a/pkg/cloud/kms_test_utils.go
+++ b/pkg/cloud/kms_test_utils.go
@@ -42,7 +42,7 @@ func (e *TestKMSEnv) KMSConfig() *base.ExternalIODirConfig {
 // correctly encrypt and decrypt a string
 func KMSEncryptDecrypt(t *testing.T, kmsURI string, env TestKMSEnv) {
 	ctx := context.Background()
-	kms, err := KMSFromURI(kmsURI, &env)
+	kms, err := KMSFromURI(ctx, kmsURI, &env)
 	require.NoError(t, err)
 
 	t.Run("simple encrypt decrypt", func(t *testing.T) {


### PR DESCRIPTION
Backport 1/1 commits from #88798.

/cc @cockroachdb/release

---

By default, verbose logging from the s3_storage module would be sent to STDOUT. This has proven confusing in some production situations.

This change installs sets the required configuration to direct S3 logs to the DEV channel.

A side-effect of this is that we will need to be sure to ask for unredacted logs if we want to see any meaningful content.

Release note (ops change): Logs produced by setting an increased vmodule setting for s3_storage are now directed to the DEV channel rather than STDOUT.

Release justification: Low risk change to improve debugging of S3 problems.