### PR TITLE
ci: fix regression in stress_impl

### DIFF
--- a/build/teamcity/cockroach/nightlies/stress_impl.sh
+++ b/build/teamcity/cockroach/nightlies/stress_impl.sh
@@ -32,7 +32,7 @@ do
         continue
     fi
     exit_status=0
-    $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- --config=ci test "$test" \
+    $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- test --config=ci "$test" \
                                           --test_env=COCKROACH_NIGHTLY_STRESS=true \
                                           --test_timeout="$TESTTIMEOUTSECS" \
                                           --run_under "@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts 'XML_OUTPUT_FILE=$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci merge-test-xmls' $STRESSFLAGS" \


### PR DESCRIPTION
Fixes a regression introduced in [1] which broke nightly Stress tests. bazci is _sensitive_ to the order of command-line arguments. Specifically, --config cannot be in the first position.

[1] https://github.com/cockroachdb/cockroach/commit/7122bac7602a7f2ba564017d764e2bb76ecc7482

Release note: None
Epic: None