### PR TITLE
sql/catalog/descs,multiregionccl: allow system database to be made MR

### DIFF
--- a/pkg/ccl/multiregionccl/BUILD.bazel
+++ b/pkg/ccl/multiregionccl/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
         "multiregion_system_table_test.go",
         "multiregion_test.go",
         "region_test.go",
+        "regional_by_row_system_database_test.go",
         "regional_by_row_test.go",
         "roundtrips_test.go",
         "show_test.go",

--- a/pkg/ccl/multiregionccl/regional_by_row_system_database_test.go
+++ b/pkg/ccl/multiregionccl/regional_by_row_system_database_test.go
@@ -1,0 +1,79 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package multiregionccl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/multiregionccl/multiregionccltestutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+// This is a rather contrived test to demonstrate that one can successfully,
+// albeit with some arm-twisting, convince the sql layer to make regional-
+// by-row tables in the system database.
+func TestRegionalByRowTablesInTheSystemDatabase(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tc, sqlDB, cleanup := multiregionccltestutils.TestingCreateMultiRegionCluster(t, 3, base.TestingKnobs{})
+	defer cleanup()
+	defer tc.Stopper().Stop(ctx)
+
+	tdb := sqlutils.MakeSQLRunner(sqlDB)
+	tdb.Exec(t, `
+BEGIN;
+ALTER DATABASE system CONFIGURE ZONE DISCARD;
+ALTER DATABASE system SET PRIMARY REGION "us-east1";
+COMMIT;
+`)
+	// Pick an arbitrary table that we don't interact with via KV to make
+	// REGIONAL BY ROW.
+	tdb.Exec(t, `ALTER TABLE system.web_sessions SET LOCALITY REGIONAL BY ROW`)
+	tdb.Exec(t, `ALTER TABLE system.namespace SET LOCALITY GLOBAL`)
+	tdb.CheckQueryResults(t, `
+SELECT create_statement FROM [SHOW CREATE DATABASE system]
+UNION ALL SELECT create_statement FROM [SHOW CREATE TABLE system.web_sessions]
+UNION ALL SELECT create_statement FROM [SHOW CREATE TABLE system.namespace]
+`, [][]string{
+		{`CREATE DATABASE system PRIMARY REGION "us-east1" REGIONS = "us-east1" SURVIVE ZONE FAILURE`},
+		{`CREATE TABLE public.web_sessions (
+	id INT8 NOT NULL DEFAULT unique_rowid(),
+	"hashedSecret" BYTES NOT NULL,
+	username STRING NOT NULL,
+	"createdAt" TIMESTAMP NOT NULL DEFAULT now():::TIMESTAMP,
+	"expiresAt" TIMESTAMP NOT NULL,
+	"revokedAt" TIMESTAMP NULL,
+	"lastUsedAt" TIMESTAMP NOT NULL DEFAULT now():::TIMESTAMP,
+	"auditInfo" STRING NULL,
+	crdb_region system.public.crdb_internal_region NOT VISIBLE NOT NULL DEFAULT default_to_database_primary_region(gateway_region())::system.public.crdb_internal_region,
+	CONSTRAINT "primary" PRIMARY KEY (id ASC),
+	INDEX "web_sessions_expiresAt_idx" ("expiresAt" ASC),
+	INDEX "web_sessions_createdAt_idx" ("createdAt" ASC),
+	INDEX "web_sessions_revokedAt_idx" ("revokedAt" ASC),
+	INDEX "web_sessions_lastUsedAt_idx" ("lastUsedAt" ASC),
+	FAMILY "fam_0_id_hashedSecret_username_createdAt_expiresAt_revokedAt_lastUsedAt_auditInfo" (id, "hashedSecret", username, "createdAt", "expiresAt", "revokedAt", "lastUsedAt", "auditInfo"),
+	FAMILY fam_9_crdb_region (crdb_region)
+) LOCALITY REGIONAL BY ROW`},
+		{`CREATE TABLE public.namespace (
+	"parentID" INT8 NOT NULL,
+	"parentSchemaID" INT8 NOT NULL,
+	name STRING NOT NULL,
+	id INT8 NULL,
+	CONSTRAINT "primary" PRIMARY KEY ("parentID" ASC, "parentSchemaID" ASC, name ASC),
+	FAMILY "primary" ("parentID", "parentSchemaID", name),
+	FAMILY fam_4_id (id)
+) LOCALITY GLOBAL`},
+	})
+}

--- a/pkg/sql/catalog/dbdesc/database_desc_builder.go
+++ b/pkg/sql/catalog/dbdesc/database_desc_builder.go
@@ -107,6 +107,19 @@ func (ddb *databaseDescriptorBuilder) RunPostDeserializationChanges() (err error
 		ddb.changes.Add(catalog.SetModTimeToMVCCTimestamp)
 	}
 
+	// This should only every happen to the system database. Unlike many other
+	// post-deserialization changes, this does not need to last forever to
+	// support restores. It can be removed after a migration performing such a
+	// migration occurs.
+	//
+	// TODO(ajwerner): Write or piggy-back off some other migration to rewrite
+	// the descriptor, and then remove this in a release that is no longer
+	// compatible with the predecessor of the version with the migration.
+	if ddb.maybeModified.Version == 0 {
+		ddb.maybeModified.Version = 1
+		ddb.changes.Add(catalog.SetSystemDatabaseDescriptorVersion)
+	}
+
 	createdDefaultPrivileges := false
 	removedIncompatibleDatabasePrivs := false
 	// Skip converting incompatible privileges to default privileges on the

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -210,7 +210,7 @@ func (tc *Collection) HasUncommittedTypes() (has bool) {
 func (tc *Collection) AddUncommittedDescriptor(
 	ctx context.Context, desc catalog.MutableDescriptor,
 ) (err error) {
-	if desc.GetID() == keys.SystemDatabaseID || !desc.IsUncommittedVersion() {
+	if !desc.IsUncommittedVersion() {
 		return nil
 	}
 	defer func() {

--- a/pkg/sql/catalog/descs/uncommitted_descriptors.go
+++ b/pkg/sql/catalog/descs/uncommitted_descriptors.go
@@ -13,7 +13,6 @@ package descs
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -137,9 +136,6 @@ func (ud *uncommittedDescriptors) ensureMutable(
 	}
 	mut := original.NewBuilder().BuildExistingMutable()
 	newBytes := mut.ByteSize()
-	if original.GetID() == keys.SystemDatabaseID {
-		return mut, nil
-	}
 	ud.mutable.Upsert(mut)
 	original = original.NewBuilder().BuildImmutable()
 	newBytes += original.ByteSize()

--- a/pkg/sql/catalog/internal/catkv/stored_catalog.go
+++ b/pkg/sql/catalog/internal/catkv/stored_catalog.go
@@ -357,9 +357,6 @@ func (sc *StoredCatalog) GetValidationLevelByID(id descpb.ID) catalog.Validation
 	if vl, ok := sc.validationLevels[id]; ok {
 		return vl
 	}
-	if id == keys.SystemDatabaseID {
-		return validate.Write
-	}
 	return catalog.NoValidation
 }
 

--- a/pkg/sql/catalog/post_deserialization_changes.go
+++ b/pkg/sql/catalog/post_deserialization_changes.go
@@ -98,4 +98,8 @@ const (
 	// SetCreateAsOfTimeUsingModTime indicates that a table's CreateAsOfTime field
 	// was unset and the ModificationTime value was assigned to it.
 	SetCreateAsOfTimeUsingModTime
+
+	// SetSystemDatabaseDescriptorVersion indicates that the system database
+	// descriptor did not have its version set.
+	SetSystemDatabaseDescriptorVersion
 )


### PR DESCRIPTION
This change is needed in order to convert system database tables to
regional by row.

This PR removes some logic which prevented the system database from being
properly modified. It also adds a test which ensures that the changes happen
as expected.

Epic: CRDB-18596

Release note: None