### PR TITLE
release-22.2: scbuildstmt: remove unknown lint directive

### DIFF
--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
@@ -136,10 +136,8 @@ func errMsgPrefix(b BuildCtx, id catid.DescID) string {
 func dropElementWhenDroppingDescriptor(b BuildCtx, e scpb.Element) {
 	switch t := e.(type) {
 	case *scpb.ColumnType:
-		//lint:ignore SA1019 IsRelationBeingDropped is deprecated
 		t.IsRelationBeingDropped = true
 	case *scpb.SecondaryIndexPartial:
-		//lint:ignore SA1019 IsRelationBeingDropped is deprecated
 		t.IsRelationBeingDropped = true
 	}
 	b.Drop(e)


### PR DESCRIPTION
This was causing make builds on the release branch to fail. No reason for the clickbait.

Fixes #91613

Release justification: fixes testing failure

Release note: None