### PR TITLE
cloud: add azure-blob as scheme

### DIFF
--- a/pkg/cloud/azure/azure_connection.go
+++ b/pkg/cloud/azure/azure_connection.go
@@ -41,7 +41,12 @@ func parseAndValidateAzureConnectionURI(
 
 func init() {
 	externalconn.RegisterConnectionDetailsFromURIFactory(
-		externalConnectionScheme,
+		scheme,
+		parseAndValidateAzureConnectionURI,
+	)
+
+	externalconn.RegisterConnectionDetailsFromURIFactory(
+		deprecatedExternalConnectionScheme,
 		parseAndValidateAzureConnectionURI,
 	)
 }

--- a/pkg/cloud/azure/azure_storage.go
+++ b/pkg/cloud/azure/azure_storage.go
@@ -49,8 +49,10 @@ const (
 	// AzureEnvironmentKeyParam is the query parameter for the environment name in an azure URI.
 	AzureEnvironmentKeyParam = "AZURE_ENVIRONMENT"
 
-	scheme                   = "azure"
-	externalConnectionScheme = "azure-storage"
+	scheme = "azure-blob"
+
+	deprecatedScheme                   = "azure"
+	deprecatedExternalConnectionScheme = "azure-storage"
 )
 
 func parseAzureURL(
@@ -275,5 +277,5 @@ func (s *azureStorage) Close() error {
 
 func init() {
 	cloud.RegisterExternalStorageProvider(cloudpb.ExternalStorageProvider_azure,
-		parseAzureURL, makeAzureStorage, cloud.RedactedParams(AzureAccountKeyParam), scheme, externalConnectionScheme)
+		parseAzureURL, makeAzureStorage, cloud.RedactedParams(AzureAccountKeyParam), scheme, deprecatedScheme, deprecatedExternalConnectionScheme)
 }

--- a/pkg/cloud/userfile/BUILD.bazel
+++ b/pkg/cloud/userfile/BUILD.bazel
@@ -52,6 +52,7 @@ go_test(
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/util/leaktest",
+        "//pkg/util/log",
         "//pkg/util/randutil",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/cloud/userfile/file_table_storage_test.go
+++ b/pkg/cloud/userfile/file_table_storage_test.go
@@ -29,11 +29,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
 )
 
 func TestPutUserFileTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	qualifiedTableName := "defaultdb.public.user_file_table_test"
 	filename := "path/to/file"
@@ -97,6 +99,7 @@ func createUserGrantAllPrivieleges(
 
 func TestUserScoping(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	qualifiedTableName := "defaultdb.public.user_file_table_test"
 	filename := "path/to/file"

--- a/pkg/cloud/userfile/filetable/filetabletest/BUILD.bazel
+++ b/pkg/cloud/userfile/filetable/filetabletest/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
         "//pkg/testutils/serverutils",
         "//pkg/util/ioctx",
         "//pkg/util/leaktest",
+        "//pkg/util/log",
         "//pkg/util/randutil",
         "@com_github_cockroachdb_errors//oserror",
         "@com_github_stretchr_testify//require",

--- a/pkg/cloud/userfile/filetable/filetabletest/file_table_read_writer_test.go
+++ b/pkg/cloud/userfile/filetable/filetabletest/file_table_read_writer_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/ioctx"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/errors/oserror"
 	"github.com/stretchr/testify/require"
@@ -101,6 +102,7 @@ func checkMetadataEntryExists(
 
 func TestListAndDeleteFiles(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	params, _ := tests.CreateTestServerParams()
@@ -155,6 +157,7 @@ func TestListAndDeleteFiles(t *testing.T) {
 
 func TestReadWriteFile(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	params, _ := tests.CreateTestServerParams()
@@ -331,6 +334,7 @@ func TestReadWriteFile(t *testing.T) {
 // file and payload tables.
 func TestUserGrants(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	params, _ := tests.CreateTestServerParams()
@@ -412,6 +416,7 @@ func getTableGrantees(ctx context.Context, tablename string, conn *gosql.Conn) (
 // tables once they have been created/written to.
 func TestDifferentUserDisallowed(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	params, _ := tests.CreateTestServerParams()
@@ -467,6 +472,7 @@ func TestDifferentUserDisallowed(t *testing.T) {
 // access the tables once they have been created/written to.
 func TestDifferentRoleDisallowed(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	params, _ := tests.CreateTestServerParams()
@@ -527,6 +533,7 @@ func TestDifferentRoleDisallowed(t *testing.T) {
 // internal queries wrt the database it is given.
 func TestDatabaseScope(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	params, _ := tests.CreateTestServerParams()


### PR DESCRIPTION
We previously added azure-storage as a new scheme for storage since we anticipate future integration with other Azure features. However, it seems that azure-storage may also not be specific enough.

This adds azure-blob as another alternative.

Epic: None

Release note: None