### PR TITLE
kvserver: break up replicaAppBatch via appBatch and  appHandler

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "raft_truncator_replica.go",
         "range_log.go",
         "replica.go",
+        "replica_application_app_batch.go",
         "replica_application_cmd.go",
         "replica_application_cmd_buf.go",
         "replica_application_decoder.go",

--- a/pkg/kv/kvserver/replica_application_app_batch.go
+++ b/pkg/kv/kvserver/replica_application_app_batch.go
@@ -1,0 +1,108 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kvserver
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/apply"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftlog"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+)
+
+// appBatchNoMethods is the struct on which an implementation of appHandler is
+// be provided for use with stand-alone log application (#75729).
+//
+// The desire to provide both stand-alone and "regular" log application without
+// code duplication has led to there being three identical structs:
+//
+//   - appBatchNoMethods is a pure struct, with no methods attached. This is embedded
+//     into replicaAppBatch for convenience, without having to worry about accidentally
+//     adopting methods.
+//   - appBatchConcrete implements a variant of appHandler but using concrete types
+//     (i.e. no interfaces) in the parameters. This is the type used when
+//     replicaAppBatch calls through to appBatch to avoid duplicated logic,
+//     and avoids repeatedly type asserting.
+//   - appBatchHandler implements appHandler. It contains no logic but simply type
+//     asserts and calls through to appBatchConcrete. This is currently unused but
+//     will be used as replicaAppBatch.h in standalone log application.
+type appBatchNoMethods struct {
+	// batch accumulates writes implied by the raft entries in this batch.
+	batch storage.Batch
+	// state is this batch's view of the replica's state. It may be updated
+	// as commands are staged into this batch.
+	state kvserverpb.ReplicaState
+	// changeRemovesReplica tracks whether the command in the batch (there must
+	// be only one) removes this replica from the range. If this is the case,
+	// the command that does so effectively removes the replica.
+	changeRemovesReplica bool
+}
+
+// appBatchConcrete implements a variant of apply.Batch, but using concrete
+// paremeter types. See appBatchNoMethods for rationale.
+type appBatchConcrete appBatchNoMethods
+
+// CheckForcedErr is part of a concrete implementation of appHandler. It passes
+// through to kvserverbase.CheckForcedErr.
+func (h *appBatchConcrete) CheckForcedErr(
+	ctx context.Context,
+	idKey kvserverbase.CmdIDKey,
+	raftCmd *kvserverpb.RaftCommand,
+	isLocal bool,
+	state *kvserverpb.ReplicaState,
+) (leaseIndex uint64, _ kvserverbase.ProposalRejectionType, _ *roachpb.Error) {
+	return kvserverbase.CheckForcedErr(ctx, idKey, raftCmd, isLocal, state)
+}
+
+// AssertCheckedCommand is part of a concrete implementation of appHandler. It
+// checks that the raft log index is set and equals the previously applied entry
+// plus one, i.e. asserts that no entries were skipped.
+func (h *appBatchConcrete) AssertCheckedCommand(
+	ctx context.Context, cmd *raftlog.ReplicatedCmd,
+) error {
+	if cmd.Index() == 0 {
+		return kvserverbase.NonDeterministicErrorf("processRaftCommand requires a non-zero index")
+	}
+	if idx, applied := cmd.Index(), h.state.RaftAppliedIndex; idx != applied+1 {
+		// If we have an out-of-order index, there's corruption. No sense in
+		// trying to update anything or running the command. Simply return.
+		return kvserverbase.NonDeterministicErrorf("applied index jumped from %d to %d", applied, idx)
+	}
+
+	// TODO(sep-raft-log): move the remainder of (*replicaAppBatchHandler).AssertCheckedCommand here; this
+	// just needs a bit more untangling.
+	return nil
+}
+
+// appBatchHandler implements appHandler, by calling the corresponding concrete
+// methods on appBatchConcrete. See appBatchNoMethods for rationale.
+type appBatchHandler appBatchNoMethods
+
+var _ appHandler = (*appBatchHandler)(nil)
+
+// CheckForcedErr implements appHandler. See the corresponding method on appBatchConcrete.
+func (h *appBatchHandler) CheckForcedErr(
+	ctx context.Context, cmdI apply.Command,
+) (leaseIndex uint64, _ kvserverbase.ProposalRejectionType, _ *roachpb.Error) {
+	cmd := cmdI.(*raftlog.ReplicatedCmd)
+	const isLocal = false // standalone application is never local
+	return (*appBatchConcrete)(h).CheckForcedErr(ctx, cmd.ID, &cmd.Cmd, isLocal, &h.state)
+}
+
+// AssertCheckedCommand implements appHandler. See the corresponding method on appBatchConcrete.
+func (h *appBatchHandler) AssertCheckedCommand(
+	ctx context.Context, cmdI apply.CheckedCommand,
+) error {
+	return (*appBatchConcrete)(h).AssertCheckedCommand(ctx, cmdI.(*raftlog.ReplicatedCmd))
+}


### PR DESCRIPTION
`(*replicaAppBatch).Stage` roughly

1. checks whether to apply the `Command` as a no-op
2. runs a bunch of triggers (touching `*Replica` a lot)
3. stages the command into a `storage.Batch`
4. runs a bunch of triggers (touching `*Replica` a lot)
5. returns the cmd as a `CheckedCommand`

Standalone log application needs to do 1, 3, 5 but it only needs to do
parts of 2 and 4.

We're trying to morph `replicaAppBatch` into something that can apply
log entries both in regular and standalone mode, where all of the
interactions with the surrounding *Replica (if any) are pushed into an
interface handed to `replicaAppBatch`. The implementation of the
interface is either a standalone-specific handler, or a
*Replica-specific one (that relies heavily on the standalone handler to
avoid logic duplication).

This will take many commits to achieve but the goal is something like
this:

```go
// appBatch implements apply.Batch and Handler (for standalone
// application).
type appBatch struct {
  // All the fields that we need during standalone application.
  state ReplicaState
  batch storage.Batch
}

// Handler is used by replicaAppBatch to execute side effects of entry
// application. The implementation depends on regular vs standalone mode.
type Handler interface { // methods are called from Stage
  PreHandler // addSSTPreApply, maybeAcquireSplitLock, etc
curre
  PostHandler // runPreApplyTriggersAfterStagingWriteBatch, itemized
}

// replicaAppBatch implements apply.Batch. It also implements Handler,
// by first calling appBatch's Handler implementation and augmenting it
// with additional actions that don't apply in a standalone context.
type replicaAppBatch struct {
  appBatch
  r *Replica
  // More fields only required in *Replica context, like
  // `followerStoreWriteBytes` which is used for admission control
}
```

That exact plan is unlikely to entirely survive contact with reality but
something along those lines ought to work out.

Other than paving a particularly bumpy part of the road to stand-alone
log application, I expect this to also make the code more accessible, as
it is currently somewhat ad-hoc.

This first commit moves the lease applied index checks and the closed
timestamp assertions[^1] to this new scheme. Follow-up commits will do the
same for the other references to `*Replica` in `Stage` until `*Replica`
is only referenced from `*replicaAppBatchHandler`. At that point, we
can move `*Replica` from `replicaAppBatch` to `replicaAppBatchHandler`
and can declare victory.

This PR tries to minimize code movement. I left TODOs on everything that
I think should move in a future commit.

Touches #75729.

[^1]: these assertions are currently only run in "regular" mode but
sould also be ported to standalone mode in the future. For now it's
convenient to have them out of the way; better to have a standalone mode
with a few assertions missing earlier.

Epic: CRDB-220

Release note: None
