### PR TITLE
sql: introduce DROP TENANT

### DIFF
--- a/docs/generated/sql/bnf/BUILD.bazel
+++ b/docs/generated/sql/bnf/BUILD.bazel
@@ -123,6 +123,7 @@ FILES = [
     "drop_sequence_stmt",
     "drop_stmt",
     "drop_table",
+    "drop_tenant_stmt",
     "drop_type",
     "drop_view",
     "execute_stmt",

--- a/docs/generated/sql/bnf/drop_stmt.bnf
+++ b/docs/generated/sql/bnf/drop_stmt.bnf
@@ -10,3 +10,4 @@ drop_stmt ::=
 	| drop_role_stmt
 	| drop_schedule_stmt
 	| drop_external_connection_stmt
+	| drop_tenant_stmt

--- a/docs/generated/sql/bnf/drop_tenant_stmt.bnf
+++ b/docs/generated/sql/bnf/drop_tenant_stmt.bnf
@@ -1,0 +1,3 @@
+drop_tenant_stmt ::=
+	'DROP' 'TENANT' name
+	| 'DROP' 'TENANT' 'IF' 'EXISTS' name

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -201,6 +201,7 @@ drop_stmt ::=
 	| drop_role_stmt
 	| drop_schedule_stmt
 	| drop_external_connection_stmt
+	| drop_tenant_stmt
 
 explain_stmt ::=
 	'EXPLAIN' explainable_stmt
@@ -638,6 +639,10 @@ drop_schedule_stmt ::=
 
 drop_external_connection_stmt ::=
 	'DROP' 'EXTERNAL' 'CONNECTION' string_or_placeholder
+
+drop_tenant_stmt ::=
+	'DROP' 'TENANT' name
+	| 'DROP' 'TENANT' 'IF' 'EXISTS' name
 
 explainable_stmt ::=
 	preparable_stmt

--- a/pkg/gen/bnf.bzl
+++ b/pkg/gen/bnf.bzl
@@ -123,6 +123,7 @@ BNF_SRCS = [
   "//docs/generated/sql/bnf:drop_sequence_stmt.bnf",
   "//docs/generated/sql/bnf:drop_stmt.bnf",
   "//docs/generated/sql/bnf:drop_table.bnf",
+  "//docs/generated/sql/bnf:drop_tenant_stmt.bnf",
   "//docs/generated/sql/bnf:drop_type.bnf",
   "//docs/generated/sql/bnf:drop_view.bnf",
   "//docs/generated/sql/bnf:execute_stmt.bnf",

--- a/pkg/gen/diagrams.bzl
+++ b/pkg/gen/diagrams.bzl
@@ -122,6 +122,7 @@ DIAGRAMS_SRCS = [
   "//docs/generated/sql/bnf:drop_schema.html",
   "//docs/generated/sql/bnf:drop_sequence.html",
   "//docs/generated/sql/bnf:drop_table.html",
+  "//docs/generated/sql/bnf:drop_tenant.html",
   "//docs/generated/sql/bnf:drop_type.html",
   "//docs/generated/sql/bnf:drop_view.html",
   "//docs/generated/sql/bnf:execute.html",

--- a/pkg/gen/docs.bzl
+++ b/pkg/gen/docs.bzl
@@ -135,6 +135,7 @@ DOCS_SRCS = [
   "//docs/generated/sql/bnf:drop_sequence_stmt.bnf",
   "//docs/generated/sql/bnf:drop_stmt.bnf",
   "//docs/generated/sql/bnf:drop_table.bnf",
+  "//docs/generated/sql/bnf:drop_tenant_stmt.bnf",
   "//docs/generated/sql/bnf:drop_type.bnf",
   "//docs/generated/sql/bnf:drop_view.bnf",
   "//docs/generated/sql/bnf:execute_stmt.bnf",

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -97,6 +97,7 @@ go_library(
         "drop_schema.go",
         "drop_sequence.go",
         "drop_table.go",
+        "drop_tenant.go",
         "drop_type.go",
         "drop_view.go",
         "error_if_rows.go",

--- a/pkg/sql/drop_tenant.go
+++ b/pkg/sql/drop_tenant.go
@@ -1,0 +1,47 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+type dropTenantNode struct {
+	name     roachpb.TenantName
+	ifExists bool
+}
+
+func (p *planner) DropTenant(_ context.Context, n *tree.DropTenant) (planNode, error) {
+	return &dropTenantNode{
+		name:     roachpb.TenantName(n.Name.String()),
+		ifExists: n.IfExists,
+	}, nil
+}
+
+func (n *dropTenantNode) startExec(params runParams) error {
+	err := params.p.DestroyTenant(params.ctx, n.name, false)
+	if err != nil {
+		if pgerror.GetPGCode(err) == pgcode.UndefinedObject && n.ifExists {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func (n *dropTenantNode) Next(_ runParams) (bool, error) { return false, nil }
+func (n *dropTenantNode) Values() tree.Datums            { return tree.Datums{} }
+func (n *dropTenantNode) Close(_ context.Context)        {}

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -583,6 +583,13 @@ func (c *DummyTenantOperator) RenameTenant(
 
 // DestroyTenant is part of the tree.TenantOperator interface.
 func (c *DummyTenantOperator) DestroyTenant(
+	ctx context.Context, tenantName roachpb.TenantName, synchronous bool,
+) error {
+	return errors.WithStack(errEvalTenant)
+}
+
+// DestroyTenantByID is part of the tree.TenantOperator interface.
+func (c *DummyTenantOperator) DestroyTenantByID(
 	ctx context.Context, tenantID uint64, synchronous bool,
 ) error {
 	return errors.WithStack(errEvalTenant)

--- a/pkg/sql/logictest/testdata/logic_test/tenant
+++ b/pkg/sql/logictest/testdata/logic_test/tenant
@@ -45,3 +45,54 @@ user testuser
 
 statement error only users with the admin role are allowed to create tenant
 CREATE TENANT "not-allowed"
+
+subtest drop_tenant
+user root
+
+statement error destroying tenant: tenant "dne" does not exist
+DROP TENANT dne
+
+statement ok
+DROP TENANT IF EXISTS dne
+
+statement ok
+CREATE TENANT four
+
+query IBTT colnames
+SELECT id, active, name, crdb_internal.pb_to_json('cockroach.sql.sqlbase.TenantInfo', info, true)
+FROM system.tenants WHERE name = 'four'
+ORDER BY id
+----
+id  active  name          crdb_internal.pb_to_json
+5   true    four         {"id": "5", "name": "four", "state": "ACTIVE"}
+
+statement ok
+DROP TENANT four
+
+query IBTT colnames
+SELECT id, active, name, crdb_internal.pb_to_json('cockroach.sql.sqlbase.TenantInfo', info, true)
+FROM system.tenants WHERE name = 'four'
+ORDER BY id
+----
+id  active  name          crdb_internal.pb_to_json
+5   false    four         {"id": "5", "name": "four", "state": "DROP"}
+
+statement ok
+CREATE TENANT "five-requiring-quotes"
+
+statement ok
+DROP TENANT "five-requiring-quotes"
+
+statement ok
+set default_transaction_read_only = on;
+
+statement error cannot execute DROP TENANT in a read-only transaction
+DROP TENANT four;
+
+statement ok
+set default_transaction_read_only = off;
+
+user testuser
+
+statement error only users with the admin role are allowed to destroy tenant
+DROP TENANT "not-allowed"

--- a/pkg/sql/opaque.go
+++ b/pkg/sql/opaque.go
@@ -194,6 +194,8 @@ func planOpaque(ctx context.Context, p *planner, stmt tree.Statement) (planNode,
 		return p.DropSequence(ctx, n)
 	case *tree.DropTable:
 		return p.DropTable(ctx, n)
+	case *tree.DropTenant:
+		return p.DropTenant(ctx, n)
 	case *tree.DropType:
 		return p.DropType(ctx, n)
 	case *tree.DropView:
@@ -339,6 +341,7 @@ func init() {
 		&tree.DropSchema{},
 		&tree.DropSequence{},
 		&tree.DropTable{},
+		&tree.DropTenant{},
 		&tree.DropType{},
 		&tree.DropView{},
 		&tree.FetchCursor{},

--- a/pkg/sql/parser/help_test.go
+++ b/pkg/sql/parser/help_test.go
@@ -213,6 +213,10 @@ func TestContextualHelp(t *testing.T) {
 
 		{`DROP SCHEMA ??`, `DROP SCHEMA`},
 
+		{`DROP TENANT ??`, `DROP TENANT`},
+		{`DROP TENANT IF ??`, `DROP TENANT`},
+		{`DROP TENANT IF EXISTS ??`, `DROP TENANT`},
+
 		{`EXPLAIN (??`, `EXPLAIN`},
 		{`EXPLAIN SELECT 1 ??`, `SELECT`},
 		{`EXPLAIN INSERT INTO xx (SELECT 1) ??`, `INSERT`},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1139,6 +1139,7 @@ func (u *sqlSymUnion) functionObjs() tree.FuncObjs {
 %type <tree.Statement> drop_view_stmt
 %type <tree.Statement> drop_sequence_stmt
 %type <tree.Statement> drop_func_stmt
+%type <tree.Statement> drop_tenant_stmt
 
 %type <tree.Statement> analyze_stmt
 %type <tree.Statement> explain_stmt
@@ -4909,6 +4910,7 @@ drop_stmt:
 | drop_role_stmt     // EXTEND WITH HELP: DROP ROLE
 | drop_schedule_stmt // EXTEND WITH HELP: DROP SCHEDULES
 | drop_external_connection_stmt // EXTEND WITH HELP: DROP EXTERNAL CONNECTION
+| drop_tenant_stmt              // EXTEND WITH HELP: DROP TENANT
 | drop_unsupported   {}
 | DROP error         // SHOW HELP: DROP
 
@@ -5054,6 +5056,26 @@ drop_type_stmt:
     }
   }
 | DROP TYPE error // SHOW HELP: DROP TYPE
+
+// %Help: DROP TENANT - remove a tenant
+// %Category: DDL
+// %Text: DROP TENANT [IF EXISTS] <name>
+drop_tenant_stmt:
+  DROP TENANT name
+  {
+    $$.val = &tree.DropTenant{
+      Name: tree.Name($3),
+      IfExists: false,
+    }
+  }
+| DROP TENANT IF EXISTS name
+  {
+    $$.val = &tree.DropTenant{
+      Name: tree.Name($5),
+      IfExists: true,
+    }
+  }
+| DROP TENANT error // SHOW HELP: DROP TENANT
 
 target_types:
   type_name_list

--- a/pkg/sql/parser/testdata/drop_tenant
+++ b/pkg/sql/parser/testdata/drop_tenant
@@ -1,0 +1,23 @@
+parse
+DROP TENANT foo
+----
+DROP TENANT foo
+DROP TENANT foo -- fully parenthesized
+DROP TENANT foo -- literals removed
+DROP TENANT _ -- identifiers removed
+
+parse
+DROP TENANT "foo-with-hyphen"
+----
+DROP TENANT "foo-with-hyphen"
+DROP TENANT "foo-with-hyphen" -- fully parenthesized
+DROP TENANT "foo-with-hyphen" -- literals removed
+DROP TENANT _ -- identifiers removed
+
+parse
+DROP TENANT IF EXISTS foo
+----
+DROP TENANT IF EXISTS foo
+DROP TENANT IF EXISTS foo -- fully parenthesized
+DROP TENANT IF EXISTS foo -- literals removed
+DROP TENANT IF EXISTS _ -- identifiers removed

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4936,7 +4936,7 @@ value if you rely on the HLC for accuracy.`,
 				if err != nil {
 					return nil, err
 				}
-				if err := evalCtx.Tenant.DestroyTenant(
+				if err := evalCtx.Tenant.DestroyTenantByID(
 					ctx, uint64(sTenID), false, /* synchronous */
 				); err != nil {
 					return nil, err
@@ -4958,7 +4958,7 @@ value if you rely on the HLC for accuracy.`,
 					return nil, err
 				}
 				synchronous := tree.MustBeDBool(args[1])
-				if err := evalCtx.Tenant.DestroyTenant(
+				if err := evalCtx.Tenant.DestroyTenantByID(
 					ctx, uint64(sTenID), bool(synchronous),
 				); err != nil {
 					return nil, err

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -565,10 +565,15 @@ type TenantOperator interface {
 	// the tenant does not exist or the name is already taken.
 	RenameTenant(ctx context.Context, tenantID uint64, tenantName roachpb.TenantName) error
 
+	// DestroyTenantByID attempts to uninstall an existing tenant from the system.
+	// It returns an error if the tenant does not exist. If synchronous is true
+	// the gc job will not wait for a GC ttl.
+	DestroyTenantByID(ctx context.Context, tenantID uint64, synchronous bool) error
+
 	// DestroyTenant attempts to uninstall an existing tenant from the system.
 	// It returns an error if the tenant does not exist. If synchronous is true
 	// the gc job will not wait for a GC ttl.
-	DestroyTenant(ctx context.Context, tenantID uint64, synchronous bool) error
+	DestroyTenant(ctx context.Context, tenantName roachpb.TenantName, synchronous bool) error
 
 	// GCTenant attempts to garbage collect a DROP tenant from the system. Upon
 	// success it also removes the tenant record.

--- a/pkg/sql/sem/tree/drop.go
+++ b/pkg/sql/sem/tree/drop.go
@@ -234,3 +234,20 @@ func (node *DropExternalConnection) Format(ctx *FmtCtx) {
 		ctx.FormatNode(node.ConnectionLabel)
 	}
 }
+
+// DropTenant represents a DROP TENANT command.
+type DropTenant struct {
+	Name     Name
+	IfExists bool
+}
+
+var _ Statement = &DropTenant{}
+
+// Format implements the NodeFormatter interface.
+func (node *DropTenant) Format(ctx *FmtCtx) {
+	ctx.WriteString("DROP TENANT ")
+	if node.IfExists {
+		ctx.WriteString("IF EXISTS ")
+	}
+	ctx.FormatNode(&node.Name)
+}

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -963,6 +963,15 @@ func (*DropSchema) StatementType() StatementType { return TypeDDL }
 func (*DropSchema) StatementTag() string { return "DROP SCHEMA" }
 
 // StatementReturnType implements the Statement interface.
+func (*DropTenant) StatementReturnType() StatementReturnType { return DDL }
+
+// StatementType implements the Statement interface.
+func (*DropTenant) StatementType() StatementType { return TypeDDL }
+
+// StatementTag implements the Statement interface.
+func (*DropTenant) StatementTag() string { return "DROP TENANT" }
+
+// StatementReturnType implements the Statement interface.
 func (*Execute) StatementReturnType() StatementReturnType { return Unknown }
 
 // StatementType implements the Statement interface.
@@ -2088,6 +2097,7 @@ func (n *DropTable) String() string                           { return AsString(
 func (n *DropType) String() string                            { return AsString(n) }
 func (n *DropView) String() string                            { return AsString(n) }
 func (n *DropRole) String() string                            { return AsString(n) }
+func (n *DropTenant) String() string                          { return AsString(n) }
 func (n *Execute) String() string                             { return AsString(n) }
 func (n *Explain) String() string                             { return AsString(n) }
 func (n *ExplainAnalyze) String() string                      { return AsString(n) }

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -403,6 +403,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&dropSequenceNode{}):                        "drop sequence",
 	reflect.TypeOf(&dropSchemaNode{}):                          "drop schema",
 	reflect.TypeOf(&dropTableNode{}):                           "drop table",
+	reflect.TypeOf(&dropTenantNode{}):                          "drop tenant",
 	reflect.TypeOf(&dropTypeNode{}):                            "drop type",
 	reflect.TypeOf(&DropRoleNode{}):                            "drop user/role",
 	reflect.TypeOf(&dropViewNode{}):                            "drop view",


### PR DESCRIPTION
This adds DROP TENANT as a new SQL statement. The statement moves the tenant into the DROP state and create a GC job for the tenant. This currently works the same as `crdb_internal.destroy_tenant(_, false)` but identifies tenants by name rather than by ID.

In the future, this statement will also cancel any running replication stream for the tenant.

NB: It is currently the callers responsibility to ensure that we only call this on tenants that no longer have active SQL pods running.

Informs #91241

Epic: CRDB-18749

Release note: None