### PR TITLE
release-22.2: roachtest: new passing test in pgjdbc test suite

### DIFF
--- a/pkg/cmd/roachtest/tests/pgjdbc_blocklist.go
+++ b/pkg/cmd/roachtest/tests/pgjdbc_blocklist.go
@@ -481,7 +481,6 @@ var pgjdbcBlockList = blocklist{
 	"org.postgresql.test.jdbc2.ServerErrorTest.testPrimaryKey":                                                                                                                 "27796",
 	"org.postgresql.test.jdbc2.StatementTest.testCloseInProgressStatement":                                                                                                     "17511",
 	"org.postgresql.test.jdbc2.StatementTest.testConcurrentWarningReadAndClear":                                                                                                "17511",
-	"org.postgresql.test.jdbc2.StatementTest.testDateFunctions":                                                                                                                "17511",
 	"org.postgresql.test.jdbc2.StatementTest.testFastCloses":                                                                                                                   "17511",
 	"org.postgresql.test.jdbc2.StatementTest.testParsingSemiColons":                                                                                                            "17511",
 	"org.postgresql.test.jdbc2.StatementTest.testUpdateCount":                                                                                                                  "17511",


### PR DESCRIPTION
Backport 1/1 commits from #91843.

/cc @cockroachdb/release

Release justification: test only change

---

fixes https://github.com/cockroachdb/cockroach/issues/91506
backport fixes https://github.com/cockroachdb/cockroach/issues/91500

Epic: None

Release note: None
