### PR TITLE
release-22.1: roachtest: use nodejs 16 for JS tests

### DIFF
--- a/pkg/cmd/roachtest/tests/nodejs_postgres.go
+++ b/pkg/cmd/roachtest/tests/nodejs_postgres.go
@@ -72,7 +72,7 @@ func registerNodeJSPostgres(r registry.Registry) {
 			c,
 			node,
 			"add nodesource repository",
-			`sudo apt install ca-certificates && curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -`,
+			`sudo apt install ca-certificates && curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash -`,
 		)
 		require.NoError(t, err)
 

--- a/pkg/cmd/roachtest/tests/sequelize.go
+++ b/pkg/cmd/roachtest/tests/sequelize.go
@@ -99,7 +99,7 @@ func registerSequelize(r registry.Registry) {
 			c,
 			node,
 			"add nodesource repository",
-			`sudo apt install ca-certificates && curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -`,
+			`sudo apt install ca-certificates && curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash -`,
 		); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cmd/roachtest/tests/typeorm.go
+++ b/pkg/cmd/roachtest/tests/typeorm.go
@@ -89,7 +89,7 @@ func registerTypeORM(r registry.Registry) {
 			c,
 			node,
 			"add nodesource repository",
-			`sudo apt install ca-certificates && curl -fsSL https://deb.nodesource.com/setup_14.x | sudo -E bash -`,
+			`sudo apt install ca-certificates && curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -`,
 		); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Backport 1/1 commits from #91847.

/cc @cockroachdb/release

---

Node 12 is EOL, so the tests can't use it.

fixes https://github.com/cockroachdb/cockroach/issues/91667
fixes https://github.com/cockroachdb/cockroach/issues/91664

backports fix:
- https://github.com/cockroachdb/cockroach/issues/91673
- https://github.com/cockroachdb/cockroach/issues/91672
- https://github.com/cockroachdb/cockroach/issues/91661
- https://github.com/cockroachdb/cockroach/issues/91658

Epic: None

Release note: None
Release justification: only test related changes
