### PR TITLE
[WIP] catalog,tabledesc: add & adopt Constraint subtypes

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -295,8 +295,11 @@ func (sc *SchemaChanger) runBackfill(ctx context.Context) error {
 					addedIndexSpans = append(addedIndexSpans, tableDesc.IndexSpan(sc.execCfg.Codec, idx.GetID()))
 					addedIndexes = append(addedIndexes, idx.GetID())
 				}
-			} else if c := m.AsConstraint(); c != nil {
-				isValidating := c.GetConstraintValidity() == descpb.ConstraintValidity_Validating || c.NotNullColumnID() != 0
+			} else if c := m.AsConstraintWithoutIndex(); c != nil {
+				isValidating := c.GetConstraintValidity() == descpb.ConstraintValidity_Validating
+				if ck := c.AsCheck(); ck != nil && !isValidating {
+					isValidating = ck.IsNotNullColumnConstraint()
+				}
 				isSkippingValidation, err := shouldSkipConstraintValidation(tableDesc, c)
 				if err != nil {
 					return err
@@ -321,7 +324,7 @@ func (sc *SchemaChanger) runBackfill(ctx context.Context) error {
 				needColumnBackfill = needColumnBackfill || catalog.ColumnNeedsBackfill(col)
 			} else if idx := m.AsIndex(); idx != nil {
 				// no-op. Handled in (*schemaChanger).done by queueing an index gc job.
-			} else if c := m.AsConstraint(); c != nil {
+			} else if c := m.AsConstraintWithoutIndex(); c != nil {
 				constraintsToDrop = append(constraintsToDrop, c)
 			} else if m.AsPrimaryKeySwap() != nil || m.AsComputedColumnSwap() != nil || m.AsMaterializedViewRefresh() != nil || m.AsModifyRowLevelTTL() != nil {
 				// The backfiller doesn't need to do anything here.
@@ -410,11 +413,11 @@ func shouldSkipConstraintValidation(
 	}
 
 	// The check constraint on shard column is always on the shard column itself.
-	if len(check.ColumnIDs) != 1 {
+	if check.NumReferencedColumns() != 1 {
 		return false, nil
 	}
 
-	checkCol, err := tableDesc.FindColumnWithID(check.ColumnIDs[0])
+	checkCol, err := tableDesc.FindColumnWithID(check.GetReferencedColumnID(0))
 	if err != nil {
 		return false, err
 	}
@@ -438,7 +441,7 @@ func (sc *SchemaChanger) dropConstraints(
 	fksByBackrefTable := make(map[descpb.ID][]catalog.Constraint)
 	for _, c := range constraints {
 		if fk := c.AsForeignKey(); fk != nil {
-			id := fk.ReferencedTableID
+			id := fk.GetReferencedTableID()
 			if id != sc.descID {
 				fksByBackrefTable[id] = append(fksByBackrefTable[id], c)
 			}
@@ -477,7 +480,7 @@ func (sc *SchemaChanger) dropConstraints(
 					if def.Name != constraint.GetName() {
 						continue
 					}
-					backrefTable, err := descsCol.GetMutableTableVersionByID(ctx, fk.ReferencedTableID, txn)
+					backrefTable, err := descsCol.GetMutableTableVersionByID(ctx, fk.GetReferencedTableID(), txn)
 					if err != nil {
 						return err
 					}
@@ -580,7 +583,7 @@ func (sc *SchemaChanger) addConstraints(
 	fksByBackrefTable := make(map[descpb.ID][]catalog.Constraint)
 	for _, c := range constraints {
 		if fk := c.AsForeignKey(); fk != nil {
-			id := fk.ReferencedTableID
+			id := fk.GetReferencedTableID()
 			if id != sc.descID {
 				fksByBackrefTable[id] = append(fksByBackrefTable[id], c)
 			}
@@ -616,7 +619,7 @@ func (sc *SchemaChanger) addConstraints(
 					}
 				}
 				if !found {
-					scTable.Checks = append(scTable.Checks, ck)
+					scTable.Checks = append(scTable.Checks, ck.CheckDesc())
 				}
 			} else if fk := constraint.AsForeignKey(); fk != nil {
 				var foundExisting bool
@@ -639,8 +642,8 @@ func (sc *SchemaChanger) addConstraints(
 					}
 				}
 				if !foundExisting {
-					scTable.OutboundFKs = append(scTable.OutboundFKs, *fk)
-					backrefTable, err := descsCol.GetMutableTableVersionByID(ctx, fk.ReferencedTableID, txn)
+					scTable.OutboundFKs = append(scTable.OutboundFKs, *fk.ForeignKeyDesc())
+					backrefTable, err := descsCol.GetMutableTableVersionByID(ctx, fk.GetReferencedTableID(), txn)
 					if err != nil {
 						return err
 					}
@@ -653,11 +656,11 @@ func (sc *SchemaChanger) addConstraints(
 					// referenced table. It's possible for the unique index found during
 					// planning to have been dropped in the meantime, since only the
 					// presence of the backreference prevents it.
-					_, err = tabledesc.FindFKReferencedUniqueConstraint(backrefTable, fk.ReferencedColumnIDs)
+					_, err = tabledesc.FindFKReferencedUniqueConstraint(backrefTable, fk.ForeignKeyDesc().ReferencedColumnIDs)
 					if err != nil {
 						return err
 					}
-					backrefTable.InboundFKs = append(backrefTable.InboundFKs, *fk)
+					backrefTable.InboundFKs = append(backrefTable.InboundFKs, *fk.ForeignKeyDesc())
 
 					// Note that this code may add the same descriptor to the batch
 					// multiple times if it is referenced multiple times. That's fine as
@@ -689,7 +692,8 @@ func (sc *SchemaChanger) addConstraints(
 					}
 				}
 				if !found {
-					scTable.UniqueWithoutIndexConstraints = append(scTable.UniqueWithoutIndexConstraints, *uwi)
+					scTable.UniqueWithoutIndexConstraints =
+						append(scTable.UniqueWithoutIndexConstraints, *uwi.UniqueWithoutIndexDesc())
 				}
 			}
 		}
@@ -780,9 +784,9 @@ func (sc *SchemaChanger) validateConstraints(
 				defer func() { collection.ReleaseAll(ctx) }()
 				if ck := c.AsCheck(); ck != nil {
 					if err := validateCheckInTxn(
-						ctx, &semaCtx, evalCtx.SessionData(), desc, txn, ie, ck.Expr,
+						ctx, &semaCtx, evalCtx.SessionData(), desc, txn, ie, ck.Expr(),
 					); err != nil {
-						if c.NotNullColumnID() != 0 {
+						if ck.IsNotNullColumnConstraint() {
 							// TODO (lucy): This should distinguish between constraint
 							// validation errors and other types of unexpected errors, and
 							// return a different error code in the former case
@@ -1518,15 +1522,11 @@ func (e InvalidIndexesError) Error() string {
 func ValidateCheckConstraint(
 	ctx context.Context,
 	tableDesc catalog.TableDescriptor,
-	constraint catalog.Constraint,
+	checkConstraint catalog.CheckConstraint,
 	sessionData *sessiondata.SessionData,
 	runHistoricalTxn descs.HistoricalInternalExecTxnRunner,
 	execOverride sessiondata.InternalExecutorOverride,
 ) (err error) {
-	ck := constraint.AsCheck()
-	if ck == nil {
-		return errors.AssertionFailedf("%v is not a check constraint", constraint.GetName())
-	}
 
 	tableDesc, err = tableDesc.MakeFirstMutationPublic(catalog.IgnoreConstraints)
 	if err != nil {
@@ -1544,7 +1544,7 @@ func ValidateCheckConstraint(
 		defer func() { descriptors.ReleaseAll(ctx) }()
 
 		return ie.WithSyntheticDescriptors([]catalog.Descriptor{tableDesc}, func() error {
-			return validateCheckExpr(ctx, &semaCtx, txn, sessionData, ck.Expr,
+			return validateCheckExpr(ctx, &semaCtx, txn, sessionData, checkConstraint.Expr(),
 				tableDesc.(*tabledesc.Mutable), ie)
 		})
 	})
@@ -2385,7 +2385,7 @@ func runSchemaChangesInTxn(
 				if err := indexBackfillInTxn(ctx, planner.Txn(), planner.EvalContext(), planner.SemaCtx(), immutDesc, traceKV); err != nil {
 					return err
 				}
-			} else if c := m.AsConstraint(); c != nil {
+			} else if c := m.AsConstraintWithoutIndex(); c != nil {
 				// This is processed later. Do not proceed to MakeMutationComplete.
 				constraintAdditionMutations = append(constraintAdditionMutations, c)
 				continue
@@ -2410,7 +2410,7 @@ func runSchemaChangesInTxn(
 				); err != nil {
 					return err
 				}
-			} else if c := m.AsConstraint(); c != nil {
+			} else if c := m.AsConstraintWithoutIndex(); c != nil {
 				if c.AsCheck() != nil {
 					for i := range tableDesc.Checks {
 						if tableDesc.Checks[i].Name == c.GetName() {
@@ -2457,17 +2457,17 @@ func runSchemaChangesInTxn(
 		}
 		if ck := c.AsCheck(); ck != nil {
 			ctu.ConstraintType = descpb.ConstraintToUpdate_CHECK
-			ctu.Check = *ck
-			if c.NotNullColumnID() != 0 {
+			ctu.Check = *ck.CheckDesc()
+			if ck.IsNotNullColumnConstraint() {
 				ctu.ConstraintType = descpb.ConstraintToUpdate_NOT_NULL
-				ctu.NotNullColumn = c.NotNullColumnID()
+				ctu.NotNullColumn = ck.GetReferencedColumnID(0)
 			}
 		} else if fk := c.AsForeignKey(); fk != nil {
 			ctu.ConstraintType = descpb.ConstraintToUpdate_FOREIGN_KEY
-			ctu.ForeignKey = *fk
+			ctu.ForeignKey = *fk.ForeignKeyDesc()
 		} else if uwi := c.AsUniqueWithoutIndex(); uwi != nil {
 			ctu.ConstraintType = descpb.ConstraintToUpdate_UNIQUE_WITHOUT_INDEX
-			ctu.UniqueWithoutIndexConstraint = *uwi
+			ctu.UniqueWithoutIndexConstraint = *uwi.UniqueWithoutIndexDesc()
 		} else {
 			return errors.AssertionFailedf("unknown constraint type: %s", c)
 		}
@@ -2487,13 +2487,13 @@ func runSchemaChangesInTxn(
 	// mutations applied, it can be used for validating check/FK constraints.
 	for _, c := range constraintAdditionMutations {
 		if check := c.AsCheck(); check != nil {
-			if check.Validity == descpb.ConstraintValidity_Validating {
+			if check.GetConstraintValidity() == descpb.ConstraintValidity_Validating {
 				if err := planner.WithInternalExecutor(ctx, func(ctx context.Context, txn *kv.Txn, ie sqlutil.InternalExecutor) error {
-					return validateCheckInTxn(ctx, &planner.semaCtx, planner.SessionData(), tableDesc, txn, ie, check.Expr)
+					return validateCheckInTxn(ctx, &planner.semaCtx, planner.SessionData(), tableDesc, txn, ie, check.Expr())
 				}); err != nil {
 					return err
 				}
-				check.Validity = descpb.ConstraintValidity_Validated
+				check.CheckDesc().Validity = descpb.ConstraintValidity_Validated
 			}
 		} else if fk := c.AsForeignKey(); fk != nil {
 			// We can't support adding a validated foreign key constraint in the same
@@ -2508,9 +2508,9 @@ func runSchemaChangesInTxn(
 			// schema change framework eventually.
 			//
 			// For now, just always add the FK as unvalidated.
-			fk.Validity = descpb.ConstraintValidity_Unvalidated
+			fk.ForeignKeyDesc().Validity = descpb.ConstraintValidity_Unvalidated
 		} else if uwi := c.AsUniqueWithoutIndex(); uwi != nil {
-			if uwi.Validity == descpb.ConstraintValidity_Validating {
+			if uwi.GetConstraintValidity() == descpb.ConstraintValidity_Validating {
 				if err := planner.WithInternalExecutor(ctx, func(ctx context.Context, txn *kv.Txn, ie sqlutil.InternalExecutor) error {
 					return validateUniqueWithoutIndexConstraintInTxn(
 						ctx,
@@ -2523,7 +2523,7 @@ func runSchemaChangesInTxn(
 				}); err != nil {
 					return err
 				}
-				uwi.Validity = descpb.ConstraintValidity_Validated
+				uwi.UniqueWithoutIndexDesc().Validity = descpb.ConstraintValidity_Validated
 			}
 		} else {
 			return errors.AssertionFailedf("unsupported constraint type: %s", c)
@@ -2536,22 +2536,22 @@ func runSchemaChangesInTxn(
 	// update the table descriptor directly.
 	for _, c := range constraintAdditionMutations {
 		if ck := c.AsCheck(); ck != nil {
-			tableDesc.Checks = append(tableDesc.Checks, ck)
+			tableDesc.Checks = append(tableDesc.Checks, ck.CheckDesc())
 		} else if fk := c.AsForeignKey(); fk != nil {
 			var referencedTableDesc *tabledesc.Mutable
 			// We don't want to lookup/edit a second copy of the same table.
-			selfReference := tableDesc.ID == fk.ReferencedTableID
+			selfReference := tableDesc.ID == fk.GetReferencedTableID()
 			if selfReference {
 				referencedTableDesc = tableDesc
 			} else {
-				lookup, err := planner.Descriptors().GetMutableTableVersionByID(ctx, fk.ReferencedTableID, planner.Txn())
+				lookup, err := planner.Descriptors().GetMutableTableVersionByID(ctx, fk.GetReferencedTableID(), planner.Txn())
 				if err != nil {
-					return errors.Wrapf(err, "error resolving referenced table ID %d", fk.ReferencedTableID)
+					return errors.Wrapf(err, "error resolving referenced table ID %d", fk.GetReferencedTableID())
 				}
 				referencedTableDesc = lookup
 			}
-			referencedTableDesc.InboundFKs = append(referencedTableDesc.InboundFKs, *fk)
-			tableDesc.OutboundFKs = append(tableDesc.OutboundFKs, *fk)
+			referencedTableDesc.InboundFKs = append(referencedTableDesc.InboundFKs, *fk.ForeignKeyDesc())
+			tableDesc.OutboundFKs = append(tableDesc.OutboundFKs, *fk.ForeignKeyDesc())
 
 			// Write the other table descriptor here if it's not the current table
 			// we're already modifying.
@@ -2565,7 +2565,7 @@ func runSchemaChangesInTxn(
 				}
 			}
 		} else if uwi := c.AsUniqueWithoutIndex(); uwi != nil {
-			tableDesc.UniqueWithoutIndexConstraints = append(tableDesc.UniqueWithoutIndexConstraints, *uwi)
+			tableDesc.UniqueWithoutIndexConstraints = append(tableDesc.UniqueWithoutIndexConstraints, *uwi.UniqueWithoutIndexDesc())
 		} else {
 			return errors.AssertionFailedf("unsupported constraint type: %s", c)
 		}

--- a/pkg/sql/backfill_test.go
+++ b/pkg/sql/backfill_test.go
@@ -29,9 +29,39 @@ type constraintToUpdateForTest struct {
 	desc *descpb.ConstraintToUpdate
 }
 
-// Check returns the underlying check constraint, if there is one.
-func (c constraintToUpdateForTest) AsCheck() *descpb.TableDescriptor_CheckConstraint {
+var _ catalog.CheckConstraint = (*constraintToUpdateForTest)(nil)
+
+// AsCheck implements the catalog.Constraint interface.
+func (c constraintToUpdateForTest) AsCheck() catalog.CheckConstraint {
+	if c.desc.ConstraintType != descpb.ConstraintToUpdate_CHECK {
+		return nil
+	}
+	return c
+}
+
+// CheckDesc implements the catalog.CheckConstraint interface.
+func (c constraintToUpdateForTest) CheckDesc() *descpb.TableDescriptor_CheckConstraint {
 	return &c.desc.Check
+}
+
+// Expr implements the catalog.CheckConstraint interface.
+func (c constraintToUpdateForTest) Expr() string {
+	return c.desc.Check.Expr
+}
+
+// NumReferencedColumns implements the catalog.CheckConstraint interface.
+func (c constraintToUpdateForTest) NumReferencedColumns() int {
+	return len(c.desc.Check.ColumnIDs)
+}
+
+// GetReferencedColumnID implements the catalog.CheckConstraint interface.
+func (c constraintToUpdateForTest) GetReferencedColumnID(columnOrdinal int) descpb.ColumnID {
+	return c.desc.Check.ColumnIDs[columnOrdinal]
+}
+
+// IsNotNullColumnConstraint implements the catalog.CheckConstraint interface.
+func (c constraintToUpdateForTest) IsNotNullColumnConstraint() bool {
+	return c.desc.NotNullColumn != 0
 }
 
 func TestShouldSkipConstraintValidation(t *testing.T) {

--- a/pkg/sql/catalog/tabledesc/constraint_test.go
+++ b/pkg/sql/catalog/tabledesc/constraint_test.go
@@ -189,9 +189,6 @@ func checkIndexBackedConstraint(
 	require.Equal(t, expectedID, c.GetConstraintID())
 	require.Equal(t, expectedValidity, c.GetConstraintValidity())
 	idx := c.AsUnique()
-	if idx != nil {
-		idx = c.AsPrimaryKey()
-	}
 	require.NotNil(t, idx)
 	require.Equal(t, expectedEncodingType, idx.IndexDesc().EncodingType)
 	if expectedEncodingType == descpb.SecondaryIndexEncoding {
@@ -213,22 +210,20 @@ func checkNonIndexBackedConstraint(
 	switch expectedType {
 	case descpb.ConstraintToUpdate_CHECK:
 		require.NotNil(t, c.AsCheck())
-		require.Zero(t, c.NotNullColumnID())
+		require.False(t, c.AsCheck().IsNotNullColumnConstraint())
 		require.Nil(t, c.AsForeignKey())
 		require.Nil(t, c.AsUniqueWithoutIndex())
 	case descpb.ConstraintToUpdate_NOT_NULL:
 		require.NotNil(t, c.AsCheck())
-		require.NotZero(t, c.NotNullColumnID())
+		require.True(t, c.AsCheck().IsNotNullColumnConstraint())
 		require.Nil(t, c.AsForeignKey())
 		require.Nil(t, c.AsUniqueWithoutIndex())
 	case descpb.ConstraintToUpdate_FOREIGN_KEY:
 		require.Nil(t, c.AsCheck())
-		require.Zero(t, c.NotNullColumnID())
 		require.NotNil(t, c.AsForeignKey())
 		require.Nil(t, c.AsUniqueWithoutIndex())
 	case descpb.ConstraintToUpdate_UNIQUE_WITHOUT_INDEX:
 		require.Nil(t, c.AsCheck())
-		require.Zero(t, c.NotNullColumnID())
 		require.Nil(t, c.AsForeignKey())
 		require.NotNil(t, c.AsUniqueWithoutIndex())
 	default:

--- a/pkg/sql/catalog/tabledesc/index.go
+++ b/pkg/sql/catalog/tabledesc/index.go
@@ -27,7 +27,7 @@ import (
 )
 
 var _ catalog.Index = (*index)(nil)
-var _ catalog.Constraint = (*index)(nil)
+var _ catalog.UniqueWithIndexConstraint = (*index)(nil)
 
 // index implements the catalog.Index interface by wrapping the protobuf index
 // descriptor along with some metadata from its parent table descriptor.
@@ -425,37 +425,24 @@ func (w index) IsTemporaryIndexForBackfill() bool {
 	return w.desc.UseDeletePreservingEncoding
 }
 
-// NotNullColumnID implements the catalog.Constraint interface.
-func (w index) NotNullColumnID() descpb.ColumnID {
-	return 0
-}
-
 // AsCheck implements the catalog.Constraint interface.
-func (w index) AsCheck() *descpb.TableDescriptor_CheckConstraint {
+func (w index) AsCheck() catalog.CheckConstraint {
 	return nil
 }
 
 // AsForeignKey implements the catalog.Constraint interface.
-func (w index) AsForeignKey() *descpb.ForeignKeyConstraint {
+func (w index) AsForeignKey() catalog.ForeignKeyConstraint {
 	return nil
 }
 
 // AsUniqueWithoutIndex implements the catalog.Constraint interface.
-func (w index) AsUniqueWithoutIndex() *descpb.UniqueWithoutIndexConstraint {
+func (w index) AsUniqueWithoutIndex() catalog.UniqueWithoutIndexConstraint {
 	return nil
 }
 
-// AsPrimaryKey implements the catalog.Constraint interface.
-func (w index) AsPrimaryKey() catalog.Index {
-	if w.GetEncodingType() != descpb.PrimaryIndexEncoding {
-		return nil
-	}
-	return w
-}
-
 // AsUnique implements the catalog.Constraint interface.
-func (w index) AsUnique() catalog.Index {
-	if !w.desc.Unique {
+func (w index) AsUnique() catalog.UniqueWithIndexConstraint {
+	if !w.desc.Unique && w.desc.EncodingType != descpb.PrimaryIndexEncoding {
 		return nil
 	}
 	return w

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1428,14 +1428,14 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 					}
 				}
 			}
-			if constraint := m.AsConstraint(); constraint != nil && constraint.Adding() {
-				if fk := constraint.AsForeignKey(); fk != nil && fk.Validity == descpb.ConstraintValidity_Unvalidated {
+			if constraint := m.AsConstraintWithoutIndex(); constraint != nil && constraint.Adding() {
+				if fk := constraint.AsForeignKey(); fk != nil && fk.GetConstraintValidity() == descpb.ConstraintValidity_Unvalidated {
 					// Add backreference on the referenced table (which could be the same table)
-					backrefTable, err := descsCol.GetMutableTableVersionByID(ctx, fk.ReferencedTableID, txn)
+					backrefTable, err := descsCol.GetMutableTableVersionByID(ctx, fk.GetReferencedTableID(), txn)
 					if err != nil {
 						return err
 					}
-					backrefTable.InboundFKs = append(backrefTable.InboundFKs, *fk)
+					backrefTable.InboundFKs = append(backrefTable.InboundFKs, *fk.ForeignKeyDesc())
 					if backrefTable != scTable {
 						if err := descsCol.WriteDescToBatch(ctx, kvTrace, backrefTable, b); err != nil {
 							return err
@@ -2002,14 +2002,14 @@ func (sc *SchemaChanger) maybeReverseMutations(ctx context.Context, causingError
 
 			// If the mutation is for validating a constraint that is being added,
 			// drop the constraint because validation has failed.
-			if constraint := m.AsConstraint(); constraint != nil && constraint.Adding() {
+			if constraint := m.AsConstraintWithoutIndex(); constraint != nil && constraint.Adding() {
 				log.Warningf(ctx, "dropping constraint %s", constraint)
 				if err := sc.maybeDropValidatingConstraint(ctx, scTable, constraint); err != nil {
 					return err
 				}
 				// Get the foreign key backreferences to remove.
 				if fk := constraint.AsForeignKey(); fk != nil {
-					backrefTable, err := descsCol.GetMutableTableVersionByID(ctx, fk.ReferencedTableID, txn)
+					backrefTable, err := descsCol.GetMutableTableVersionByID(ctx, fk.GetReferencedTableID(), txn)
 					if err != nil {
 						return err
 					}
@@ -3222,11 +3222,11 @@ func isCurrentMutationDiscarded(
 	colToCheck := make([]descpb.ColumnID, 0, 1)
 	// Both NOT NULL related updates and check constraint updates
 	// involving this column will get canceled out by a drop column.
-	if constraint := currentMutation.AsConstraint(); constraint != nil {
-		if colID := constraint.NotNullColumnID(); colID != 0 {
-			colToCheck = append(colToCheck, colID)
-		} else if ck := constraint.AsCheck(); ck != nil {
-			colToCheck = ck.ColumnIDs
+	if constraint := currentMutation.AsConstraintWithoutIndex(); constraint != nil {
+		if ck := constraint.AsCheck(); ck != nil {
+			for i, n := 0, ck.NumReferencedColumns(); i < n; i++ {
+				colToCheck = append(colToCheck, ck.GetReferencedColumnID(i))
+			}
 		}
 	}
 

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -986,7 +986,7 @@ func (s *TestState) Validator() scexec.Validator {
 func (s *TestState) ValidateCheckConstraint(
 	ctx context.Context,
 	tbl catalog.TableDescriptor,
-	constraint catalog.Constraint,
+	constraint catalog.CheckConstraint,
 	override sessiondata.InternalExecutorOverride,
 ) error {
 	s.LogSideEffectf("validate check constraint %v in table #%d", constraint.GetName(), tbl.GetID())

--- a/pkg/sql/schemachanger/scdeps/validator.go
+++ b/pkg/sql/schemachanger/scdeps/validator.go
@@ -56,7 +56,7 @@ type ValidateInvertedIndexesFn func(
 type ValidateCheckConstraintFn func(
 	ctx context.Context,
 	tbl catalog.TableDescriptor,
-	constraint catalog.Constraint,
+	constraint catalog.CheckConstraint,
 	sessionData *sessiondata.SessionData,
 	runHistoricalTxn descs.HistoricalInternalExecTxnRunner,
 	execOverride sessiondata.InternalExecutorOverride,
@@ -114,7 +114,7 @@ func (vd validator) ValidateInvertedIndexes(
 func (vd validator) ValidateCheckConstraint(
 	ctx context.Context,
 	tbl catalog.TableDescriptor,
-	constraint catalog.Constraint,
+	constraint catalog.CheckConstraint,
 	override sessiondata.InternalExecutorOverride,
 ) error {
 	return vd.validateCheckConstraint(ctx, tbl, constraint, vd.newFakeSessionData(&vd.settings.SV),

--- a/pkg/sql/schemachanger/scexec/dependencies.go
+++ b/pkg/sql/schemachanger/scexec/dependencies.go
@@ -224,7 +224,7 @@ type Validator interface {
 	ValidateCheckConstraint(
 		ctx context.Context,
 		tbl catalog.TableDescriptor,
-		constraint catalog.Constraint,
+		constraint catalog.CheckConstraint,
 		override sessiondata.InternalExecutorOverride,
 	) error
 }

--- a/pkg/sql/schemachanger/scexec/exec_validation.go
+++ b/pkg/sql/schemachanger/scexec/exec_validation.go
@@ -69,7 +69,8 @@ func executeValidateCheckConstraint(
 	if err != nil {
 		return err
 	}
-	if constraint.AsCheck() == nil {
+	check := constraint.AsCheck()
+	if check == nil {
 		return errors.Newf("constraint ID %v does not identify a check constraint in table %v.",
 			op.ConstraintID, op.TableID)
 	}
@@ -78,7 +79,7 @@ func executeValidateCheckConstraint(
 	execOverride := sessiondata.InternalExecutorOverride{
 		User: username.RootUserName(),
 	}
-	err = deps.Validator().ValidateCheckConstraint(ctx, table, constraint, execOverride)
+	err = deps.Validator().ValidateCheckConstraint(ctx, table, check, execOverride)
 	if err != nil {
 		return scerrors.SchemaChangerUserError(err)
 	}

--- a/pkg/sql/schemachanger/scexec/executor_external_test.go
+++ b/pkg/sql/schemachanger/scexec/executor_external_test.go
@@ -488,7 +488,7 @@ func (noopValidator) ValidateInvertedIndexes(
 func (noopValidator) ValidateCheckConstraint(
 	ctx context.Context,
 	tbl catalog.TableDescriptor,
-	constraint catalog.Constraint,
+	constraint catalog.CheckConstraint,
 	override sessiondata.InternalExecutorOverride,
 ) error {
 	return nil

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -354,11 +354,11 @@ func checkTableForDisallowedMutationsWithTruncate(desc *tabledesc.Mutable) error
 					"cannot perform TRUNCATE on %q which has a column (%q) being "+
 						"dropped which depends on another object", desc.GetName(), col.GetName())
 			}
-		} else if c := m.AsConstraint(); c != nil {
+		} else if c := m.AsConstraintWithoutIndex(); c != nil {
 			var constraintType descpb.ConstraintToUpdate_ConstraintType
 			if ck := c.AsCheck(); ck != nil {
 				constraintType = descpb.ConstraintToUpdate_CHECK
-				if c.NotNullColumnID() != 0 {
+				if ck.IsNotNullColumnConstraint() {
 					constraintType = descpb.ConstraintToUpdate_NOT_NULL
 				}
 			} else if c.AsForeignKey() != nil {

--- a/pkg/upgrade/upgrades/fix_userfile_descriptor_corruption.go
+++ b/pkg/upgrade/upgrades/fix_userfile_descriptor_corruption.go
@@ -139,14 +139,19 @@ func mutationsLookLikeuserfilePayloadCorruption(
 	}
 	mutation := tableDesc.AllMutations()[0]
 	if mutation.Adding() && mutation.DeleteOnly() {
-		if constraintMutation := mutation.AsConstraint(); constraintMutation != nil {
+		if constraintMutation := mutation.AsConstraintWithoutIndex(); constraintMutation != nil {
 			if fkConstraint := constraintMutation.AsForeignKey(); fkConstraint != nil {
-				targetTableDesc, err := descriptors.GetImmutableTableByID(ctx, txn, fkConstraint.ReferencedTableID, tree.ObjectLookupFlags{
-					CommonLookupFlags: tree.CommonLookupFlags{
-						IncludeOffline: true,
-						IncludeDropped: true,
+				targetTableDesc, err := descriptors.GetImmutableTableByID(
+					ctx,
+					txn,
+					fkConstraint.GetReferencedTableID(),
+					tree.ObjectLookupFlags{
+						CommonLookupFlags: tree.CommonLookupFlags{
+							IncludeOffline: true,
+							IncludeDropped: true,
+						},
 					},
-				})
+				)
 				if err != nil {
 					return false
 				}


### PR DESCRIPTION
These new interfaces help encapsulate the descriptor protobufs for table
constraints.

Informs #91918.

Release note: None

