### PR TITLE
backupccl: improve restore checkpointing with span frontier

### DIFF
--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backuppb"
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
@@ -414,32 +413,7 @@ func (rd *restoreDataProcessor) processRestoreSpanEntry(
 			log.Warningf(ctx, "restoring span %s at its original timestamps because it is a tenant span", entry.Span)
 			writeAtBatchTS = false
 		}
-
-		// disallowShadowingBelow is set to an empty hlc.Timestamp in release builds
-		// i.e. allow all shadowing without AddSSTable having to check for overlapping
-		// keys. This is because RESTORE is expected to ingest into an empty keyspace.
-		// If a restore job is resumed, the un-checkpointed spans that are re-ingested
-		// will shadow (equal key, value; different ts) the already ingested keys.
-		//
-		// NB: disallowShadowingBelow used to be unconditionally set to logical=1.
-		// This permissive value would allow shadowing in case the RESTORE has to
-		// retry ingestions but served to force evaluation of AddSSTable to check for
-		// overlapping keys. It was believed that even across resumptions of a restore
-		// job, `checkForKeyCollisions` would be inexpensive because of our frequent
-		// job checkpointing. Further investigation in
-		// https://github.com/cockroachdb/cockroach/issues/81116 revealed that our
-		// progress checkpointing could significantly lag behind the spans we have
-		// ingested, making a resumed restore spend a lot of time in
-		// `checkForKeyCollisions` leading to severely degraded performance. We have
-		// *never* seen a restore fail because of the invariant enforced by setting
-		// `disallowShadowingBelow` to a non-empty value, and so we feel comfortable
-		// disabling this check entirely. A future release will work on fixing our
-		// progress checkpointing so that we do not have a buildup of un-checkpointed
-		// work, at which point we can reassess reverting to logical=1.
-		disallowShadowingBelow := hlc.Timestamp{}
-		if !build.IsRelease() {
-			disallowShadowingBelow = hlc.Timestamp{Logical: 1}
-		}
+		disallowShadowingBelow := hlc.Timestamp{Logical: 1}
 
 		var err error
 		batcher, err = bulk.MakeSSTBatcher(ctx,

--- a/pkg/ccl/backupccl/restore_span_covering.go
+++ b/pkg/ccl/backupccl/restore_span_covering.go
@@ -87,6 +87,7 @@ func makeSimpleImportSpans(
 	backups []backuppb.BackupManifest,
 	backupLocalityMap map[int]storeByLocalityKV,
 	introducedSpanFrontier *spanUtils.Frontier,
+	// TODO(mb): Remove lowWaterMark argument in 23.1.
 	lowWaterMark roachpb.Key,
 	targetSize int64,
 ) []execinfrapb.RestoreSpanEntry {

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -451,7 +451,14 @@ message RestoreDetails {
 
 
 message RestoreProgress {
+  message RestoreProgressFrontierEntry {
+    roachpb.Span entry = 1 [(gogoproto.nullable) = false];
+    util.hlc.Timestamp timestamp = 2 [(gogoproto.nullable) = false];
+  }
+
   bytes high_water = 1;
+  // CompletedSpans tracks the completed spans in a RESTORE operation.
+  repeated RestoreProgressFrontierEntry completed_spans = 2 [(gogoproto.nullable) = false];
 }
 
 message ImportDetails {


### PR DESCRIPTION
Fixes: #81116, #87843

Release note (performance improvement): Previously, whenever a user resumed a paused `RESTORE` job the checkpointing mechanism would potentially not account for completed work. This change allows completed spans to be skipped over when restoring.