### PR TITLE
release-22.1: distsql: add flow ID tag earlier

### DIFF
--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -406,17 +406,18 @@ func (ds *ServerImpl) setupFlow(
 		opt = flowinfra.FuseAggressively
 	}
 
+	if !f.IsLocal() {
+		flowCtx.AmbientContext.AddLogTag("f", f.GetFlowCtx().ID.Short())
+		ctx = flowCtx.AmbientContext.AnnotateCtx(ctx)
+		telemetry.Inc(sqltelemetry.DistSQLExecCounter)
+	}
+
 	var opChains execinfra.OpChains
 	var err error
 	ctx, opChains, err = f.Setup(ctx, &req.Flow, opt)
 	if err != nil {
 		log.Errorf(ctx, "error setting up flow: %s", err)
 		return ctx, nil, nil, err
-	}
-	if !f.IsLocal() {
-		flowCtx.AmbientContext.AddLogTag("f", f.GetFlowCtx().ID.Short())
-		ctx = flowCtx.AmbientContext.AnnotateCtx(ctx)
-		telemetry.Inc(sqltelemetry.DistSQLExecCounter)
 	}
 	if f.IsVectorized() {
 		telemetry.Inc(sqltelemetry.VecExecCounter)


### PR DESCRIPTION
Backport 1/1 commits from #91967.

/cc @cockroachdb/release

---

This allows the tag to be correctly picked up by the asynchronous components (e.g. outboxes) that are created in the `Setup` method.

Epic: None

Release note: None

Release justification: low-risk debugging improvement.