### PR TITLE
codeowners: sql-observability owns scheduledlogging

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,6 +51,7 @@
 /pkg/sql/delegate/*job*.go   @cockroachdb/jobs-prs
 
 /pkg/sql/execstats/          @cockroachdb/sql-observability
+/pkg/sql/scheduledlogging/   @cockroachdb/sql-observability
 
 /pkg/sql/sem/tree/           @cockroachdb/sql-syntax-prs
 /pkg/sql/parser/             @cockroachdb/sql-syntax-prs


### PR DESCRIPTION
Epic: None

Release note: None