### PR TITLE
ui: use MAX downsampler as default for metric graphs

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/shared/containers/metricDataProvider/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/containers/metricDataProvider/index.tsx
@@ -49,7 +49,7 @@ function queryFromProps(
 ): protos.cockroach.ts.tspb.IQuery {
   let derivative = protos.cockroach.ts.tspb.TimeSeriesQueryDerivative.NONE;
   let sourceAggregator = protos.cockroach.ts.tspb.TimeSeriesQueryAggregator.SUM;
-  let downsampler = protos.cockroach.ts.tspb.TimeSeriesQueryAggregator.AVG;
+  let downsampler = protos.cockroach.ts.tspb.TimeSeriesQueryAggregator.MAX;
 
   // Compute derivative function.
   if (!_.isNil(metricProps.derivative)) {

--- a/pkg/ui/workspaces/db-console/src/views/shared/containers/metricDataProvider/metricDataProvider.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/containers/metricDataProvider/metricDataProvider.spec.tsx
@@ -74,7 +74,7 @@ function makeMetricsRequest(timeInfo: QueryTimeInfo, sources?: string[]) {
       {
         name: "test.metric.1",
         sources: sources,
-        downsampler: protos.cockroach.ts.tspb.TimeSeriesQueryAggregator.AVG,
+        downsampler: protos.cockroach.ts.tspb.TimeSeriesQueryAggregator.MAX,
         source_aggregator:
           protos.cockroach.ts.tspb.TimeSeriesQueryAggregator.SUM,
         derivative: protos.cockroach.ts.tspb.TimeSeriesQueryDerivative.NONE,
@@ -82,7 +82,7 @@ function makeMetricsRequest(timeInfo: QueryTimeInfo, sources?: string[]) {
       {
         name: "test.metric.2",
         sources: sources,
-        downsampler: protos.cockroach.ts.tspb.TimeSeriesQueryAggregator.AVG,
+        downsampler: protos.cockroach.ts.tspb.TimeSeriesQueryAggregator.MAX,
         source_aggregator:
           protos.cockroach.ts.tspb.TimeSeriesQueryAggregator.SUM,
         derivative: protos.cockroach.ts.tspb.TimeSeriesQueryDerivative.NONE,
@@ -90,7 +90,7 @@ function makeMetricsRequest(timeInfo: QueryTimeInfo, sources?: string[]) {
       {
         name: "test.metric.3",
         sources: sources,
-        downsampler: protos.cockroach.ts.tspb.TimeSeriesQueryAggregator.AVG,
+        downsampler: protos.cockroach.ts.tspb.TimeSeriesQueryAggregator.MAX,
         source_aggregator:
           protos.cockroach.ts.tspb.TimeSeriesQueryAggregator.SUM,
         derivative: protos.cockroach.ts.tspb.TimeSeriesQueryDerivative.NONE,


### PR DESCRIPTION
Previously, we were using AVG as the default downsampler for all metric graphs. The problem with this was that it would hide spikes since the AVG downsampler would by design smooth out the curve for a given interval when zoomed out.

The MAX downsampler fixes this by reporting any spikes for a time period even when rolled up. This is more desirable for most metrics and makes sense to be the default downsampler.

fixes #91945

Release note (ui change): Graphs on Metrics page now downsample using max value instead of avg. Previously, zooming out on a graph would cause any spikes in the graph to smoothen out, potentially hiding anomalies. By using max, these anomalies are visible even when looking at a zoomed out interval.