### PR TITLE
colflow: fix EXPLAIN (VEC) in the bundle

### DIFF
--- a/pkg/sql/colflow/stats.go
+++ b/pkg/sql/colflow/stats.go
@@ -36,11 +36,11 @@ type childStatsCollector interface {
 
 // batchInfoCollector is a helper used by collector implementations.
 //
-// It wraps an Operator and keeps track of how much time was spent while calling
-// Next on the underlying Operator and how many batches and tuples were
-// returned.
+// It wraps a colexecop.Operator (inside of the colexecop.OneInputNode) and
+// keeps track of how much time was spent while calling Next on the underlying
+// Operator and how many batches and tuples were returned.
 type batchInfoCollector struct {
-	colexecop.Operator
+	colexecop.OneInputNode
 	colexecop.NonExplainable
 	componentID execinfrapb.ComponentID
 
@@ -81,7 +81,7 @@ func makeBatchInfoCollector(
 		colexecerror.InternalError(errors.AssertionFailedf("input watch is nil"))
 	}
 	return batchInfoCollector{
-		Operator:             op,
+		OneInputNode:         colexecop.NewOneInputNode(op),
 		componentID:          id,
 		stopwatch:            inputWatch,
 		childStatsCollectors: childStatsCollectors,
@@ -89,7 +89,7 @@ func makeBatchInfoCollector(
 }
 
 func (bic *batchInfoCollector) init() {
-	bic.Operator.Init(bic.ctx)
+	bic.Input.Init(bic.ctx)
 }
 
 // Init is part of the colexecop.Operator interface.
@@ -113,7 +113,7 @@ func (bic *batchInfoCollector) Init(ctx context.Context) {
 }
 
 func (bic *batchInfoCollector) next() {
-	bic.batch = bic.Operator.Next()
+	bic.batch = bic.Input.Next()
 }
 
 // Next is part of the colexecop.Operator interface.


### PR DESCRIPTION
This commit makes it so that all operators in the vectorized tree are considered when printing out `EXPLAIN (VEC)` when the execution stats collection is enabled. Previously, due to how we structured the vectorized stats collector (namely, `batchInfoCollector` simply wrapped the input `Operator`) we would omit the name of that operator in the EXPLAIN output (because `batchInfoCollector.Child` was the `Child` method of the wrapped operator - i.e. we'd effectively skip the wrapped operator). This commit fixes that issue. I believe the impact is very minor, and probably only the stmt bundles are affected, but it still could cause the confusion.

There is no unit test since it's quite annoying to write (we need to inspect the contents of a file in a stmt bundle), and since this is mostly a debugging tool for our team, the manual QA seems sufficient.

Epic: CRDB-14510

Release note: None