### PR TITLE
sql: support crdb_internal.ranges{_no_leases} for secondary tenants

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -208,6 +208,60 @@ RegionsResponse describes the available regions.
 
 
 
+## NodeLocality
+
+
+
+NodeLocality retrieves the locality of the node with the given ID.
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+
+
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_localities | [NodeLocalityResponse.NodeLocalitiesEntry](#cockroach.server.serverpb.NodeLocalityResponse-cockroach.server.serverpb.NodeLocalityResponse.NodeLocalitiesEntry) | repeated |  | [reserved](#support-status) |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.NodeLocalityResponse-cockroach.server.serverpb.NodeLocalityResponse.NodeLocalitiesEntry"></a>
+#### NodeLocalityResponse.NodeLocalitiesEntry
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#cockroach.server.serverpb.NodeLocalityResponse-int32) |  |  |  |
+| value | [cockroach.roachpb.Locality](#cockroach.server.serverpb.NodeLocalityResponse-cockroach.roachpb.Locality) |  |  |  |
+
+
+
+
+
+
 ## NodesList
 
 

--- a/pkg/ccl/kvccl/kvtenantccl/connector.go
+++ b/pkg/ccl/kvccl/kvtenantccl/connector.go
@@ -121,6 +121,10 @@ var _ config.SystemConfigProvider = (*Connector)(nil)
 // multi-region primitives.
 var _ serverpb.RegionsServer = (*Connector)(nil)
 
+// Connector is capable of providing locality information on each of the KV
+// nodes in the cluster.
+var _ serverpb.NodeLocalityServer = (*Connector)(nil)
+
 // Connector is capable of finding debug information about the current
 // tenant within the cluster. This is necessary for things such as
 // debug zip and range reports.
@@ -426,6 +430,21 @@ func (c *Connector) Regions(
 	if err := c.withClient(ctx, func(ctx context.Context, c *client) error {
 		var err error
 		resp, err = c.Regions(ctx, req)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// NodeLocality implements the serverpb.NodeLocalityServer interface.
+func (c *Connector) NodeLocality(
+	ctx context.Context, req *serverpb.NodeLocalityRequest,
+) (resp *serverpb.NodeLocalityResponse, err error) {
+	if err := c.withClient(ctx, func(ctx context.Context, c *client) error {
+		var err error
+		resp, err = c.NodeLocality(ctx, req)
 		return err
 	}); err != nil {
 		return nil, err

--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
@@ -301,11 +301,15 @@ SELECT * FROM crdb_internal.node_inflight_trace_spans WHERE span_id < 0
 ----
 trace_id  parent_span_id  span_id  goroutine_id  finished  start_time  duration  operation
 
-statement error not fully contained in tenant keyspace
-SELECT * FROM crdb_internal.ranges WHERE range_id < 0
+query ITTI
+SELECT range_id, start_pretty, end_pretty, lease_holder FROM crdb_internal.ranges
+----
+54  /Tenant/10  /Max  1
 
-statement error not fully contained in tenant keyspace
-SELECT * FROM crdb_internal.ranges_no_leases WHERE range_id < 0
+query ITT
+SELECT range_id, start_pretty, end_pretty FROM crdb_internal.ranges_no_leases
+----
+54  /Tenant/10  /Max
 
 query IT
 SELECT zone_id, target FROM crdb_internal.zones ORDER BY 1

--- a/pkg/kv/kvclient/kvtenant/connector.go
+++ b/pkg/kv/kvclient/kvtenant/connector.go
@@ -63,6 +63,9 @@ type Connector interface {
 	// primitives.
 	serverpb.RegionsServer
 
+	// NodeLocalityServer provides access to a node's locality information.
+	serverpb.NodeLocalityServer
+
 	// TenantStatusServer is the subset of the serverpb.StatusInterface that is
 	// used by the SQL system to query for debug information, such as tenant-specific
 	// range reports.

--- a/pkg/rpc/auth_tenant.go
+++ b/pkg/rpc/auth_tenant.go
@@ -174,7 +174,8 @@ func reqAllowed(r roachpb.Request, tenID roachpb.TenantID) bool {
 		*roachpb.AddSSTableRequest,
 		*roachpb.RefreshRequest,
 		*roachpb.RefreshRangeRequest,
-		*roachpb.IsSpanEmptyRequest:
+		*roachpb.IsSpanEmptyRequest,
+		*roachpb.LeaseInfoRequest, *roachpb.RangeStatsRequest:
 		return true
 	case *roachpb.AdminScatterRequest:
 		return t.Class != roachpb.AdminScatterRequest_ARBITRARY || tenID.IsSystem()

--- a/pkg/rpc/auth_tenant.go
+++ b/pkg/rpc/auth_tenant.go
@@ -70,6 +70,9 @@ func (a tenantAuthorizer) authorize(
 	case "/cockroach.server.serverpb.Status/Regions":
 		return nil // no restriction to usage of this endpoint by tenants
 
+	case "/cockroach.server.serverpb.Status/NodeLocality":
+		return nil // no restriction to usage of this endpoint by tenants
+
 	case "/cockroach.server.serverpb.Status/Statements":
 		return a.authTenant(tenID)
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -875,6 +875,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		rangeFeedFactory:         rangeFeedFactory,
 		sqlStatusServer:          sStatus,
 		regionsServer:            sStatus,
+		nodeLocalityServer:       sStatus,
 		tenantStatusServer:       sStatus,
 		tenantUsageServer:        tenantUsage,
 		monitorAndMetrics:        sqlMonitorAndMetrics,

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -340,6 +340,9 @@ type sqlServerArgs struct {
 	// Used to query valid regions on the server.
 	regionsServer serverpb.RegionsServer
 
+	// Used to query node locality information.
+	nodeLocalityServer serverpb.NodeLocalityServer
+
 	// Used to query status information useful for debugging on the server.
 	tenantStatusServer serverpb.TenantStatusServer
 
@@ -844,6 +847,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		NodesStatusServer:         cfg.nodesStatusServer,
 		SQLStatusServer:           cfg.sqlStatusServer,
 		RegionsServer:             cfg.regionsServer,
+		NodeLocalityServer:        cfg.nodeLocalityServer,
 		SessionRegistry:           cfg.sessionRegistry,
 		ClosedSessionCache:        cfg.closedSessionCache,
 		ContentionRegistry:        contentionRegistry,

--- a/pkg/server/serverpb/status.go
+++ b/pkg/server/serverpb/status.go
@@ -11,7 +11,7 @@
 package serverpb
 
 import (
-	context "context"
+	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 )
@@ -73,6 +73,13 @@ type NodesStatusServer interface {
 // It is available for tenants.
 type RegionsServer interface {
 	Regions(context.Context, *RegionsRequest) (*RegionsResponse, error)
+}
+
+// NodeLocalityServer is the subset of serverpb.StatusInterface that is used by
+// the SQL system to query for the node locality of a given node ID.
+// It is available for tenants.
+type NodeLocalityServer interface {
+	NodeLocality(ctx context.Context, req *NodeLocalityRequest) (*NodeLocalityResponse, error)
 }
 
 // TenantStatusServer is the subset of the serverpb.StatusInterface that is

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -307,6 +307,14 @@ message RegionsResponse {
   map<string, Region> regions = 1;
 }
 
+message NodeLocalityRequest{}
+
+message NodeLocalityResponse{
+  map<int32, roachpb.Locality> node_localities = 1 [
+    (gogoproto.castkey) = "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID"
+  ];
+}
+
 // NodesListRequest requests list of all nodes.
 // The nodes are KV nodes when the cluster is a single
 // tenant cluster or the host cluster in case of multi-tenant
@@ -1898,6 +1906,9 @@ service Status {
 
   // RegionsRequest retrieves all available regions.
   rpc Regions(RegionsRequest) returns (RegionsResponse) {}
+
+  // NodeLocality retrieves the locality of the node with the given ID.
+  rpc NodeLocality(NodeLocalityRequest) returns (NodeLocalityResponse) {}
 
   // NodesList returns all available nodes with their addresses.
   rpc NodesList(NodesListRequest) returns (NodesListResponse) {}

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1381,6 +1381,21 @@ func (s *statusServer) Regions(
 	return regionsResponseFromNodesResponse(resp), nil
 }
 
+// NodeLocality implements the serverpb.Status interface
+func (s *statusServer) NodeLocality(
+	ctx context.Context, req *serverpb.NodeLocalityRequest,
+) (*serverpb.NodeLocalityResponse, error) {
+	resp, _, err := s.nodesHelper(ctx, 0 /* limit */, 0 /* offset */)
+	if err != nil {
+		return nil, serverError(ctx, err)
+	}
+	res := make(map[roachpb.NodeID]*roachpb.Locality, len(resp.Nodes))
+	for _, node := range resp.Nodes {
+		res[node.Desc.NodeID] = &node.Desc.Locality
+	}
+	return &serverpb.NodeLocalityResponse{NodeLocalities: res}, nil
+}
+
 func regionsResponseFromNodesResponse(nr *serverpb.NodesResponse) *serverpb.RegionsResponse {
 	regionsToZones := make(map[string]map[string]struct{})
 	for _, node := range nr.Nodes {

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -917,6 +917,7 @@ func makeTenantSQLServerArgs(
 		protectedtsProvider:      protectedTSProvider,
 		rangeFeedFactory:         rangeFeedFactory,
 		regionsServer:            tenantConnect,
+		nodeLocalityServer:       tenantConnect,
 		tenantStatusServer:       tenantConnect,
 		costController:           costController,
 		monitorAndMetrics:        monitorAndMetrics,

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvclient"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
@@ -3648,40 +3647,29 @@ CREATE TABLE crdb_internal.ranges_no_leases (
 		if !hasPermission {
 			return nil, nil, pgerror.Newf(pgcode.InsufficientPrivilege, "only users with the ZONECONFIG privilege or the admin role can read crdb_internal.ranges_no_leases")
 		}
-		ranges, err := kvclient.ScanMetaKVs(ctx, p.txn, roachpb.Span{
-			Key:    keys.MinKey,
-			EndKey: keys.MaxKey,
-		})
+
+		ri := kvcoord.MakeRangeIterator(p.execCfg.DistSender)
+		ri.Seek(ctx, roachpb.RKey(p.EvalContext().Codec.TenantPrefix()), kvcoord.Ascending)
+		if !ri.Valid() {
+			return nil, nil, ri.Error()
+		}
+
+		resp, err := p.ExecCfg().NodeLocalityServer.NodeLocality(ctx, &serverpb.NodeLocalityRequest{})
 		if err != nil {
 			return nil, nil, err
 		}
+		nodeIDToLocality := resp.NodeLocalities
+		var desc *roachpb.RangeDescriptor
 
-		// Map node descriptors to localities
-		descriptors, err := getAllNodeDescriptors(p)
-		if err != nil {
-			return nil, nil, err
-		}
-		nodeIDToLocality := make(map[roachpb.NodeID]roachpb.Locality)
-		for _, desc := range descriptors {
-			nodeIDToLocality[desc.NodeID] = desc.Locality
-		}
-
-		var desc roachpb.RangeDescriptor
-
-		i := 0
-
+		// At each stage of the iteration, we check if the RangeIterator is valid.
+		// If so, we emit a result for the range the iterator is currently on and
+		// move it forward.
 		return func() (tree.Datums, error) {
-			if i >= len(ranges) {
+			if !ri.Valid() {
 				return nil, nil
 			}
-
-			r := ranges[i]
-			i++
-
-			if err := r.ValueProto(&desc); err != nil {
-				return nil, err
-			}
-
+			defer ri.Next(ctx)
+			desc = ri.Desc()
 			votersAndNonVoters := append([]roachpb.ReplicaDescriptor(nil),
 				desc.Replicas().VoterAndNonVoterDescriptors()...)
 			var learnerReplicaStoreIDs []int

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1177,6 +1177,7 @@ type ExecutorConfig struct {
 	SQLStatusServer    serverpb.SQLStatusServer
 	TenantStatusServer serverpb.TenantStatusServer
 	RegionsServer      serverpb.RegionsServer
+	NodeLocalityServer serverpb.NodeLocalityServer
 	MetricsRecorder    nodeStatusGenerator
 	SessionRegistry    *SessionRegistry
 	ClosedSessionCache *ClosedSessionCache

--- a/pkg/workload/workloadsql/BUILD.bazel
+++ b/pkg/workload/workloadsql/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
     deps = [
         "//pkg/sql/lexbase",
         "//pkg/util/ctxgroup",
-        "//pkg/util/errorutil",
         "//pkg/util/log",
         "//pkg/util/timeutil",
         "//pkg/util/version",


### PR DESCRIPTION
This PR makes `crdb_internal.ranges{_no_leases}` and `SHOW RANGES`
work for secondary tenants. It achieves this by leveraging the
`DistSender` on the secondary tenant to perform privileged meta2
lookups over the tenant `Connector` boundary.

Release note (sql change): `crdb_internal.ranges{_no_leases}` and 
`SHOW RANGES` statements now work on secondary tenants.

Epic: https://cockroachlabs.atlassian.net/browse/CRDB-14522