### PR TITLE
sql/opt: Support regtype in foldOIDFamilyCast 

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -1055,6 +1055,46 @@ vectorized: true
   table: pg_class@pg_class_oid_idx
   spans: [/101 - /101]
 
+statement ok
+CREATE TYPE status AS ENUM ('open', 'closed', 'inactive');
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM pg_type WHERE oid = 'status'::regtype
+----
+distribution: local
+vectorized: true
+·
+• virtual table
+  columns: (oid, typname, typnamespace, typowner, typlen, typbyval, typtype, typcategory, typispreferred, typisdefined, typdelim, typrelid, typelem, typarray, typinput, typoutput, typreceive, typsend, typmodin, typmodout, typanalyze, typalign, typstorage, typnotnull, typbasetype, typtypmod, typndims, typcollation, typdefaultbin, typdefault, typacl)
+  estimated row count: 10 (missing stats)
+  table: pg_type@pg_type_oid_idx
+  spans: [/status - /status]
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM pg_type WHERE oid = 'bool'::regtype
+----
+distribution: local
+vectorized: true
+·
+• virtual table
+  columns: (oid, typname, typnamespace, typowner, typlen, typbyval, typtype, typcategory, typispreferred, typisdefined, typdelim, typrelid, typelem, typarray, typinput, typoutput, typreceive, typsend, typmodin, typmodout, typanalyze, typalign, typstorage, typnotnull, typbasetype, typtypmod, typndims, typcollation, typdefaultbin, typdefault, typacl)
+  estimated row count: 10 (missing stats)
+  table: pg_type@pg_type_oid_idx
+  spans: [/boolean - /boolean]
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM pg_type WHERE oid = 'bool[]'::regtype
+----
+distribution: local
+vectorized: true
+·
+• virtual table
+  columns: (oid, typname, typnamespace, typowner, typlen, typbyval, typtype, typcategory, typispreferred, typisdefined, typdelim, typrelid, typelem, typarray, typinput, typoutput, typreceive, typsend, typmodin, typmodout, typanalyze, typalign, typstorage, typnotnull, typbasetype, typtypmod, typndims, typcollation, typdefaultbin, typdefault, typacl)
+  estimated row count: 10 (missing stats)
+  table: pg_type@pg_type_oid_idx
+  spans: [/boolean[] - /boolean[]]
+
+
 query T
 EXPLAIN (VERBOSE) SELECT CASE WHEN current_database() = 'test' THEN 42 ELSE 1/3 END
 ----

--- a/pkg/sql/opt/norm/fold_constants_funcs.go
+++ b/pkg/sql/opt/norm/fold_constants_funcs.go
@@ -352,7 +352,6 @@ func (c *CustomFuncs) foldOIDFamilyCast(
 		default:
 			return nil, false, nil
 		}
-
 	case oid.T_regclass:
 		switch inputFamily {
 		case types.StringFamily:
@@ -369,6 +368,43 @@ func (c *CustomFuncs) foldOIDFamilyCast(
 
 			c.mem.Metadata().AddDependency(opt.DepByName(&resName), ds, privilege.SELECT)
 			dOid = tree.NewDOidWithName(oid.Oid(ds.PostgresDescriptorID()), types.RegClass, string(tn.ObjectName))
+		default:
+			return nil, false, nil
+		}
+	case oid.T_regtype:
+		switch inputFamily {
+		case types.StringFamily:
+			s := tree.MustBeDString(datum)
+			typRef, err := parser.GetTypeFromValidSQLSyntax(string(s))
+			if err != nil {
+				return nil, true, err
+			}
+
+			var resolvedTyp *types.T
+			var isArray bool
+			switch t := typRef.(type) {
+			case *tree.ArrayTypeReference:
+				resolvedTyp, err = c.f.catalog.ResolveType(c.f.ctx, t.ElementType.(*tree.UnresolvedObjectName))
+				if err != nil {
+					return nil, true, err
+				}
+				isArray = true
+			case *tree.UnresolvedObjectName:
+				resolvedTyp, err = c.f.catalog.ResolveType(c.f.ctx, t)
+				if err != nil {
+					return nil, true, err
+				}
+			case *types.T:
+				resolvedTyp = t
+			default:
+				return nil, false, nil
+			}
+
+			if isArray {
+				resolvedTyp = types.MakeArray(resolvedTyp)
+			}
+			dOid = tree.NewDOidWithTypeAndName(resolvedTyp.Oid(), types.RegType, resolvedTyp.SQLStandardName())
+
 		default:
 			return nil, false, nil
 		}


### PR DESCRIPTION
Informs: #91022

Type cast to regtype can now use the index on pgtype(oid).

Release note: None