### PR TITLE
ci: use GCS instead of S3 to download binaries

### DIFF
--- a/build/teamcity/internal/release/process/make-and-publish-build-artifacts.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-artifacts.sh
@@ -33,6 +33,7 @@ else
   # export the variable to avoid shell escaping
   export gcs_credentials="$GCS_CREDENTIALS_DEV"
 fi
+download_prefix="https://storage.googleapis.com/$gcs_bucket"
 
 cat << EOF
 
@@ -88,7 +89,7 @@ for platform_name in "${platform_names[@]}"; do
     --silent \
     --show-error \
     --output /dev/stdout \
-    --url "https://${bucket}.s3.amazonaws.com/cockroach-${build_name}.${linux_platform}-${tarball_arch}.tgz" \
+    --url "${download_prefix}/cockroach-${build_name}.${linux_platform}-${tarball_arch}.tgz" \
     | tar \
     --directory="build/deploy-${docker_arch}" \
     --extract \

--- a/build/teamcity/internal/release/process/publish-cockroach-release.sh
+++ b/build/teamcity/internal/release/process/publish-cockroach-release.sh
@@ -37,7 +37,6 @@ if [[ -z "${DRY_RUN}" ]] ; then
   gcr_repository="us-docker.pkg.dev/cockroach-cloud-images/cockroachdb/cockroach"
   # Used for docker login for gcloud
   gcr_hostname="us-docker.pkg.dev"
-  s3_download_hostname="${bucket}"
   git_repo_for_tag="cockroachdb/cockroach"
 else
   bucket="cockroach-builds-test"
@@ -48,7 +47,6 @@ else
   dockerhub_repository="docker.io/cockroachdb/cockroach-misc"
   gcr_repository="us.gcr.io/cockroach-release/cockroach-test"
   gcr_hostname="us.gcr.io"
-  s3_download_hostname="${bucket}.s3.amazonaws.com"
   git_repo_for_tag="cockroachlabs/release-staging"
   if [[ -z "$(echo ${build_name} | grep -E -o '^v[0-9]+\.[0-9]+\.[0-9]+$')" ]] ; then
     # Using `.` to match how we usually format the pre-release portion of the
@@ -62,6 +60,7 @@ else
   fi
 fi
 
+download_prefix="https://storage.googleapis.com/$gcs_bucket"
 tc_end_block "Variable Setup"
 
 
@@ -119,7 +118,7 @@ for platform_name in "${platform_names[@]}"; do
     --silent \
     --show-error \
     --output /dev/stdout \
-    --url "https://${s3_download_hostname}/cockroach-${build_name}.${linux_platform}-${tarball_arch}.tgz" \
+    --url "${download_prefix}/cockroach-${build_name}.${linux_platform}-${tarball_arch}.tgz" \
     | tar \
     --directory="build/deploy-${docker_arch}" \
     --extract \

--- a/build/teamcity/internal/release/process/roachtest-release-qualification.sh
+++ b/build/teamcity/internal/release/process/roachtest-release-qualification.sh
@@ -24,10 +24,8 @@ fi
 artifacts=$PWD/artifacts/$(date +"%%Y%%m%%d")-${TC_BUILD_ID}
 mkdir -p "$artifacts"
 
-bucket="${BUCKET-cockroach-builds}"
-
 release_version=$(echo $TC_BUILD_BRANCH | sed -e 's/provisional_[[:digit:]]*_//')
-curl -f -s -S -o- "https://${bucket}.s3.amazonaws.com/cockroach-${release_version}.linux-amd64.tgz" | tar ixfz - --strip-components 1
+curl -f -s -S -o- "https://storage.googleapis.com/cockroach-builds-artifacts-prod/cockroach-${release_version}.linux-amd64.tgz" | tar ixfz - --strip-components 1
 chmod +x cockroach
 
 run_bazel <<'EOF'

--- a/pkg/cmd/release/sentry.go
+++ b/pkg/cmd/release/sentry.go
@@ -21,7 +21,7 @@ func generatePanic(tag string) error {
 	// the call usually exits non-zero on panic, but we don't need to fail in that case, thus "|| true"
 	// TODO: do not hardcode the URL
 	script := fmt.Sprintf(`
-curl https://cockroach-builds.s3.amazonaws.com/cockroach-%s.linux-amd64.tgz | tar -xz
+curl https://binaries.cockroachdb.com/cockroach-%s.linux-amd64.tgz | tar -xz
 ./cockroach-%s.linux-amd64/cockroach demo --insecure -e "select crdb_internal.force_panic('testing')" || true
 `, tag, tag)
 	cmd := exec.Command("bash", "-c", script)


### PR DESCRIPTION
Previously, CI used S3 to download the binaries. Now that we are moving the primary location to GCS and will stop uploading to s3 at some point, it's time to start using GCS for this operation.

Part of RE-342
Release note: None