### PR TITLE
sql: prevent error with ALTER DEFAULT PRIV on system db

### DIFF
--- a/pkg/sql/alter_default_privileges.go
+++ b/pkg/sql/alter_default_privileges.go
@@ -13,6 +13,7 @@ package sql
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
@@ -61,6 +62,9 @@ func (p *planner) alterDefaultPrivileges(
 		tree.DatabaseLookupFlags{Required: true})
 	if err != nil {
 		return nil, err
+	}
+	if dbDesc.GetID() == keys.SystemDatabaseID {
+		return nil, pgerror.Newf(pgcode.InvalidParameterValue, "cannot alter system database")
 	}
 
 	objectType := n.Grant.Target

--- a/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_table
@@ -15,6 +15,16 @@ ALTER DEFAULT PRIVILEGES FOR ROLE testuser GRANT SELECT ON TABLES to testuser, w
 statement error pq: invalid privilege type USAGE for table
 ALTER DEFAULT PRIVILEGES GRANT USAGE ON TABLES to testuser
 
+# Should not be able to alter system database.
+statement ok
+USE system
+
+statement error cannot alter system database
+ALTER DEFAULT PRIVILEGES FOR ROLE testuser REVOKE ALL ON TABLES FROM testuser
+
+statement ok
+RESET database
+
 # For Tables.
 statement ok
 CREATE DATABASE d;


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/89764

Release note (bug fix): Fixed an unhandled error that could happen if ALTER DEFAULT PRIVILEGES was run on the system database.