### PR TITLE
logictest: disable small-engine-blocks randomization for sqlite

### DIFF
--- a/pkg/ccl/sqlitelogictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/sqlitelogictestccl/tests/3node-tenant/generated_test.go
@@ -71,10 +71,12 @@ func runSqliteLogicTest(t *testing.T, file string) {
 	// SQLLite logic tests can be very memory intensive, so we give them larger
 	// limit than other logic tests get. Also some of the 'delete' files become
 	// extremely slow when MVCC range tombstones are enabled for point deletes,
-	// so we disable that.
+	// so we disable that. Similarly, some of the 'view' files are too slow
+	// when small engine blocks are enabled.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
 		DisableUseMVCCRangeTombstonesForPointDeletes: true,
+		DisableSmallEngineBlocks:                     true,
 	}
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(sqliteLogicTestDir, file))
 }

--- a/pkg/cmd/generate-logictest/templates.go
+++ b/pkg/cmd/generate-logictest/templates.go
@@ -90,10 +90,12 @@ func runSqliteLogicTest(t *testing.T, file string) {
 	// SQLLite logic tests can be very memory intensive, so we give them larger
 	// limit than other logic tests get. Also some of the 'delete' files become
 	// extremely slow when MVCC range tombstones are enabled for point deletes,
-	// so we disable that.
+	// so we disable that. Similarly, some of the 'view' files are too slow
+	// when small engine blocks are enabled.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
 		DisableUseMVCCRangeTombstonesForPointDeletes: true,
+		DisableSmallEngineBlocks:                     true,
 	}
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(sqliteLogicTestDir, file))
 }

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1231,6 +1231,7 @@ func (t *logicTest) newCluster(
 	shouldUseMVCCRangeTombstonesForPointDeletes := useMVCCRangeTombstonesForPointDeletes && !serverArgs.DisableUseMVCCRangeTombstonesForPointDeletes
 	ignoreMVCCRangeTombstoneErrors := supportsMVCCRangeTombstones &&
 		(globalMVCCRangeTombstone || shouldUseMVCCRangeTombstonesForPointDeletes)
+	useSmallEngineBlocks := smallEngineBlocks && !serverArgs.DisableSmallEngineBlocks
 
 	params := base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
@@ -1249,7 +1250,7 @@ func (t *logicTest) newCluster(
 						UseRangeTombstonesForPointDeletes: supportsMVCCRangeTombstones &&
 							shouldUseMVCCRangeTombstonesForPointDeletes,
 					},
-					SmallEngineBlocks: smallEngineBlocks,
+					SmallEngineBlocks: useSmallEngineBlocks,
 				},
 				SQLEvalContext: &eval.TestingKnobs{
 					AssertBinaryExprReturnTypes:     true,
@@ -3847,6 +3848,9 @@ type TestServerArgs struct {
 	// If set, then we will disable the metamorphic randomization of
 	// useMVCCRangeTombstonesForPointDeletes variable.
 	DisableUseMVCCRangeTombstonesForPointDeletes bool
+	// If set, then we will disable the metamorphic randomization of
+	// smallEngineBlocks variable.
+	DisableSmallEngineBlocks bool
 }
 
 // RunLogicTests runs logic tests for all files matching the given glob.

--- a/pkg/sql/sqlitelogictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/sqlitelogictest/tests/fakedist-disk/generated_test.go
@@ -70,10 +70,12 @@ func runSqliteLogicTest(t *testing.T, file string) {
 	// SQLLite logic tests can be very memory intensive, so we give them larger
 	// limit than other logic tests get. Also some of the 'delete' files become
 	// extremely slow when MVCC range tombstones are enabled for point deletes,
-	// so we disable that.
+	// so we disable that. Similarly, some of the 'view' files are too slow
+	// when small engine blocks are enabled.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
 		DisableUseMVCCRangeTombstonesForPointDeletes: true,
+		DisableSmallEngineBlocks:                     true,
 	}
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(sqliteLogicTestDir, file))
 }

--- a/pkg/sql/sqlitelogictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/sqlitelogictest/tests/fakedist-vec-off/generated_test.go
@@ -70,10 +70,12 @@ func runSqliteLogicTest(t *testing.T, file string) {
 	// SQLLite logic tests can be very memory intensive, so we give them larger
 	// limit than other logic tests get. Also some of the 'delete' files become
 	// extremely slow when MVCC range tombstones are enabled for point deletes,
-	// so we disable that.
+	// so we disable that. Similarly, some of the 'view' files are too slow
+	// when small engine blocks are enabled.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
 		DisableUseMVCCRangeTombstonesForPointDeletes: true,
+		DisableSmallEngineBlocks:                     true,
 	}
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(sqliteLogicTestDir, file))
 }

--- a/pkg/sql/sqlitelogictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/sqlitelogictest/tests/fakedist/generated_test.go
@@ -70,10 +70,12 @@ func runSqliteLogicTest(t *testing.T, file string) {
 	// SQLLite logic tests can be very memory intensive, so we give them larger
 	// limit than other logic tests get. Also some of the 'delete' files become
 	// extremely slow when MVCC range tombstones are enabled for point deletes,
-	// so we disable that.
+	// so we disable that. Similarly, some of the 'view' files are too slow
+	// when small engine blocks are enabled.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
 		DisableUseMVCCRangeTombstonesForPointDeletes: true,
+		DisableSmallEngineBlocks:                     true,
 	}
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(sqliteLogicTestDir, file))
 }

--- a/pkg/sql/sqlitelogictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/sqlitelogictest/tests/local-legacy-schema-changer/generated_test.go
@@ -70,10 +70,12 @@ func runSqliteLogicTest(t *testing.T, file string) {
 	// SQLLite logic tests can be very memory intensive, so we give them larger
 	// limit than other logic tests get. Also some of the 'delete' files become
 	// extremely slow when MVCC range tombstones are enabled for point deletes,
-	// so we disable that.
+	// so we disable that. Similarly, some of the 'view' files are too slow
+	// when small engine blocks are enabled.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
 		DisableUseMVCCRangeTombstonesForPointDeletes: true,
+		DisableSmallEngineBlocks:                     true,
 	}
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(sqliteLogicTestDir, file))
 }

--- a/pkg/sql/sqlitelogictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/sqlitelogictest/tests/local-vec-off/generated_test.go
@@ -70,10 +70,12 @@ func runSqliteLogicTest(t *testing.T, file string) {
 	// SQLLite logic tests can be very memory intensive, so we give them larger
 	// limit than other logic tests get. Also some of the 'delete' files become
 	// extremely slow when MVCC range tombstones are enabled for point deletes,
-	// so we disable that.
+	// so we disable that. Similarly, some of the 'view' files are too slow
+	// when small engine blocks are enabled.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
 		DisableUseMVCCRangeTombstonesForPointDeletes: true,
+		DisableSmallEngineBlocks:                     true,
 	}
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(sqliteLogicTestDir, file))
 }

--- a/pkg/sql/sqlitelogictest/tests/local/generated_test.go
+++ b/pkg/sql/sqlitelogictest/tests/local/generated_test.go
@@ -70,10 +70,12 @@ func runSqliteLogicTest(t *testing.T, file string) {
 	// SQLLite logic tests can be very memory intensive, so we give them larger
 	// limit than other logic tests get. Also some of the 'delete' files become
 	// extremely slow when MVCC range tombstones are enabled for point deletes,
-	// so we disable that.
+	// so we disable that. Similarly, some of the 'view' files are too slow
+	// when small engine blocks are enabled.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
 		DisableUseMVCCRangeTombstonesForPointDeletes: true,
+		DisableSmallEngineBlocks:                     true,
 	}
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(sqliteLogicTestDir, file))
 }


### PR DESCRIPTION
With the small engine blocks enabled, some of the "view" sqlite test files become too slow (in one example the time increased from six minutes to like an hour).

Fixes: #92058.

Release note: None