### PR TITLE
jobs: add pause-point to pause on any error

### DIFF
--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -1524,6 +1524,10 @@ func (r *Registry) stepThroughStateMachine(
 			return errors.Errorf("job %d: node liveness error: restarting in background", job.ID())
 		}
 
+		if pauseOnErrErr := r.CheckPausepoint("after_exec_error"); pauseOnErrErr != nil {
+			err = errors.WithSecondaryError(pauseOnErrErr, err)
+		}
+
 		if errors.Is(err, errPauseSelfSentinel) {
 			if err := r.PauseRequested(ctx, nil, job.ID(), err.Error()); err != nil {
 				return err


### PR DESCRIPTION
Release note (sql change): the new 'error' pause-point can be enabled via the jobs.debug.pausepoints setting to pause, rather than fail, when a job execution returns an error to the job execution system.

Epic: none.