### PR TITLE
authccl: remove useless noise from test

### DIFF
--- a/pkg/ccl/testccl/authccl/auth_test.go
+++ b/pkg/ccl/testccl/authccl/auth_test.go
@@ -184,13 +184,7 @@ func jwtRunTest(t *testing.T, insecure bool) {
 			base.TestServerArgs{Insecure: insecure, SocketFile: maybeSocketFile})
 		defer s.Stopper().Stop(context.Background())
 
-		// Enable conn/auth logging.
-		// We can't use the cluster settings to do this, because
-		// cluster settings propagate asynchronously.
 		testServer := s.(*server.TestServer)
-		pgServer := s.(*server.TestServer).PGServer().(*pgwire.Server)
-		pgServer.TestingEnableConnLogging()
-		pgServer.TestingEnableAuthLogging()
 
 		if _, err := conn.ExecContext(context.Background(), fmt.Sprintf(`CREATE USER %s`, username.TestUser)); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
This test was enabling some logging, without that actually mattering for the test. Besides being more or less useless, this code is about to become confusing; I'm separately making the test work in multi-tenant mode, and there the logging would need to be enabled on a different server for it to still make any sense. This patch removes it instead.

Release note: None
Epic: None