### PR TITLE
roachtest: get more ranges when restoring TPCH

### DIFF
--- a/pkg/cmd/roachtest/tests/tpc_utils.go
+++ b/pkg/cmd/roachtest/tests/tpc_utils.go
@@ -97,6 +97,12 @@ func loadTPCHDataset(
 	}
 
 	t.L().Printf("restoring tpch scale factor %d\n", sf)
+	// Lower the target size for the restore spans so that we get more ranges.
+	// This is useful to exercise the parallelism across ranges within a single
+	// query.
+	if _, err := db.ExecContext(ctx, "SET CLUSTER SETTING backup.restore_span.target_size = '64MiB';"); err != nil {
+		return err
+	}
 	tpchURL := fmt.Sprintf("gs://cockroach-fixtures/workload/tpch/scalefactor=%d/backup?AUTH=implicit", sf)
 	if _, err := db.ExecContext(ctx, `CREATE DATABASE IF NOT EXISTS tpch;`); err != nil {
 		return err


### PR DESCRIPTION
This commit makes it so that we reduce `backup.restore_span.target_size` cluster setting so that more ranges are created when restoring the TPCH dataset. As a concrete example, the lineitem can now have 9 ranges in comparison to 2 that we get by default. This setup is useful to exercise the parallelism across ranges within a single query (think streamer) but also better resembles what we had before the changes to splitting logic of the restore merged.

Epic: None

Release note: None