### PR TITLE
opt: prevent null-rejection cycle with RightJoin

### DIFF
--- a/pkg/sql/opt/norm/reject_nulls_funcs.go
+++ b/pkg/sql/opt/norm/reject_nulls_funcs.go
@@ -171,7 +171,8 @@ func DeriveRejectNullCols(in memo.RelExpr, disabledRules util.FastIntSet) opt.Co
 		relProps.Rule.RejectNullCols.UnionWith(in.Child(1).(memo.RelExpr).Relational().OutputCols)
 
 	case opt.RightJoinOp:
-		if disabledRules.Contains(int(opt.RejectNullsRightJoin)) {
+		if disabledRules.Contains(int(opt.RejectNullsRightJoin)) ||
+			disabledRules.Contains(int(opt.CommuteRightJoin)) {
 			// Avoid rule cycles.
 			break
 		}


### PR DESCRIPTION
The null-rejection rules that simplify outer joins ignore RightJoin expressions because the `CommuteRightJoin` rule normally converts RightJoins to LeftJoins. However, in the case when `CommuteRightJoin` is disabled, we can hit a case where an `IS NOT NULL` filter gets pushed down but then gets pulled back up by decorrelation rules when it can't simplify the RightJoin, causing a cycle. This patch fixes the problem by preventing RightJoins from requesting null-rejection when `CommuteRightJoin` is disabled.

Fixes #91917

Release note: None