### PR TITLE
roachtest: update jepsen core to 0.1.19

### DIFF
--- a/pkg/cmd/roachtest/tests/jepsen.go
+++ b/pkg/cmd/roachtest/tests/jepsen.go
@@ -81,7 +81,7 @@ const jepsenRepo = "https://github.com/cockroachdb/jepsen"
 const repoBranch = "tc-nightly"
 
 const gcpPath = "https://storage.googleapis.com/cockroach-jepsen"
-const binaryVersion = "0.1.0-3d7c345d-standalone"
+const binaryVersion = "0.2.0-1150b38f-standalone"
 
 var jepsenNemeses = []struct {
 	name, config string


### PR DESCRIPTION
This commit bumps jepsen dependency:
 jepsen core to 0.1.19
 cockroachdb to 0.2.0 (updates to make it compatible with core)

The goal is to improve test stability and use updated library dependencies so that disabled tests could be run again.

Release note: None

Fixes #74400