### PR TITLE
sql: support crdb_internal.ranges{_no_leases} for secondary tenants

### DIFF
--- a/pkg/ccl/kvccl/kvtenantccl/tenant_scan_range_descriptors_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/tenant_scan_range_descriptors_test.go
@@ -46,7 +46,7 @@ func TestScanRangeDescriptors(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	//Split some ranges within tenant2 that we'll scan over.
+	// Split some ranges within tenant2 that we'll scan over.
 	ten2Codec := keys.MakeSQLCodec(ten2ID)
 	ten2Split1 := append(ten2Codec.TenantPrefix(), 'a')
 	ten2Split2 := append(ten2Codec.TenantPrefix(), 'b')
@@ -57,10 +57,7 @@ func TestScanRangeDescriptors(t *testing.T) {
 	}
 
 	iteratorFactory := tenant2.RangeDescIteratorFactory().(rangedesc.IteratorFactory)
-	iter, err := iteratorFactory.NewIterator(ctx, roachpb.Span{
-		Key:    ten2Codec.TenantPrefix(),
-		EndKey: ten2Codec.TenantPrefix().PrefixEnd(),
-	})
+	iter, err := iteratorFactory.NewIterator(ctx, ten2Codec.TenantSpan())
 	require.NoError(t, err)
 
 	var rangeDescs []roachpb.RangeDescriptor

--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
@@ -301,11 +301,15 @@ SELECT * FROM crdb_internal.node_inflight_trace_spans WHERE span_id < 0
 ----
 trace_id  parent_span_id  span_id  goroutine_id  finished  start_time  duration  operation
 
-statement error not fully contained in tenant keyspace
-SELECT * FROM crdb_internal.ranges WHERE range_id < 0
+query ITTI
+SELECT range_id, start_pretty, end_pretty, lease_holder FROM crdb_internal.ranges
+----
+55  /Tenant/10  /Max  1
 
-statement error not fully contained in tenant keyspace
-SELECT * FROM crdb_internal.ranges_no_leases WHERE range_id < 0
+query ITT
+SELECT range_id, start_pretty, end_pretty FROM crdb_internal.ranges_no_leases
+----
+55  /Tenant/10  /Max
 
 query IT
 SELECT zone_id, target FROM crdb_internal.zones ORDER BY 1

--- a/pkg/keys/sql.go
+++ b/pkg/keys/sql.go
@@ -121,6 +121,12 @@ func (e sqlEncoder) TenantPrefix() roachpb.Key {
 	return *e.buf
 }
 
+// TenantPrefix returns the key prefix used for the tenants's data.
+func (e sqlEncoder) TenantSpan() roachpb.Span {
+	key := *e.buf
+	return roachpb.Span{Key: key, EndKey: key.PrefixEnd()}
+}
+
 // TablePrefix returns the key prefix used for the table's data.
 func (e sqlEncoder) TablePrefix(tableID uint32) roachpb.Key {
 	k := e.TenantPrefix()

--- a/pkg/util/errorutil/tenant.go
+++ b/pkg/util/errorutil/tenant.go
@@ -12,7 +12,7 @@ package errorutil
 
 import "github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 
-// UnsupportedWithMultiTenancyMessage is the message used by UnsupportedWithMultiTenancy error
+// UnsupportedWithMultiTenancyMessage is the message used by UnsupportedWithMultiTenancy error.
 const UnsupportedWithMultiTenancyMessage = "operation is unsupported in multi-tenancy mode"
 
 // UnsupportedWithMultiTenancy returns an error suitable for returning when an


### PR DESCRIPTION
This PR makes crdb_internal.ranges{_no_leases} and SHOW RANGES
work for secondary tenants.
    
Release note (sql change): crdb_internal.ranges{_no_leases} and
SHOW RANGES statements now work on secondary tenants.

Epic: CRDB-14522