### PR TITLE
nightlies: skip integration-style tests in nightly stress

### DIFF
--- a/build/teamcity/cockroach/nightlies/stress_impl.sh
+++ b/build/teamcity/cockroach/nightlies/stress_impl.sh
@@ -31,6 +31,11 @@ do
         echo "Skipping test $test as it is broken in bazel"
         continue
     fi
+    if [[ ! -z $(bazel query "attr(tags, \"integration\", $test)") ]]
+    then
+        echo "Skipping test $test as it is an integration test"
+        continue
+    fi
     exit_status=0
     $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- test --config=ci "$test" \
                                           --test_env=COCKROACH_NIGHTLY_STRESS=true \


### PR DESCRIPTION
This mirrors what we do in the CI `maybe_stress`.

Closes #92059.
Closes #92057.

Release note: None
Epic: None