### PR TITLE
cli: remove useless test skip

### DIFF
--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -182,7 +182,6 @@ go_library(
         "//pkg/storage/enginepb",
         "//pkg/storage/fs",
         "//pkg/testutils/serverutils",
-        "//pkg/testutils/skip",
         "//pkg/ts",
         "//pkg/ts/tspb",
         "//pkg/util",

--- a/pkg/cli/testutils.go
+++ b/pkg/cli/testutils.go
@@ -36,7 +36,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 	"github.com/kr/pretty"
@@ -104,12 +103,6 @@ const testUserfileUploadTempDirPrefix = "test-userfile-upload-temp-dir-"
 func (c *TestCLI) fail(err error) {
 	if c.t != nil {
 		defer c.logScope.Close(c.t)
-		if strings.Contains(err.Error(), serverutils.RequiresCCLBinaryMessage) {
-			if c.TestServer != nil {
-				c.TestServer.Stopper().Stop(context.Background())
-			}
-			skip.IgnoreLint(c.t, serverutils.TenantSkipCCLBinaryMessage)
-		}
 		c.t.Fatal(err)
 	} else {
 		panic(err)


### PR DESCRIPTION
We had code protecting us against a cli test attempting to start a tenant but discovering that the binary does not have enough ccl code linked in to do that. The code was silently skipping the test in this case. This code is no longer necessary because no test hits it. When it was introduced, I think there was a ccl test hitting it, but I believe that went away in #88338. This patch removes the protection.

This patch is part of a larger effort to remove such silent skipping.

Release note: None
Epic: None