### PR TITLE
storage: change pebbleIterator.ValueLen to use LazyValue

### DIFF
--- a/pkg/storage/disk_map.go
+++ b/pkg/storage/disk_map.go
@@ -197,6 +197,9 @@ func (i *pebbleMapIterator) UnsafeKey() []byte {
 
 // UnsafeValue implements the SortedDiskMapIterator interface.
 func (i *pebbleMapIterator) UnsafeValue() []byte {
+	// TODO(sumeer): switch to using ValueAndErr. Since error only happens for
+	// non in-place values, and temp engines only have in-place values, this
+	// change is not critical.
 	return i.iter.Value()
 }
 

--- a/pkg/storage/intent_interleaving_iter_test.go
+++ b/pkg/storage/intent_interleaving_iter_test.go
@@ -149,6 +149,9 @@ func checkAndOutputIter(iter MVCCIterator, b *strings.Builder) {
 		fmt.Fprintf(b, "output: value: %x != %x\n", v1, v2)
 		return
 	}
+	if len(v1) != iter.ValueLen() {
+		fmt.Fprintf(b, "output: value len: %d != %d\n", len(v1), iter.ValueLen())
+	}
 	if k1.Timestamp.IsEmpty() {
 		var meta enginepb.MVCCMetadata
 		if err := protoutil.Unmarshal(v1, &meta); err != nil {


### PR DESCRIPTION
There is also some tweaking of the logic in MVCCValueLenAndIsTombstone to not fetch a value in a value block, and todos for properly handling the error returned by pebble.Iterator.ValueAndErr. Fixing the todo will require changing 100+ callers, so is left for the future.

Informs https://github.com/cockroachdb/pebble/issues/1170

Epic: CRDB-20378

Release note: None