### PR TITLE
kvserver,raftlog: dedup Raft log iteration

### DIFF
--- a/pkg/kv/kvserver/loqrecovery/BUILD.bazel
+++ b/pkg/kv/kvserver/loqrecovery/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//pkg/util/timeutil",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
+        "@io_etcd_go_etcd_raft_v3//raftpb",
     ],
 )
 

--- a/pkg/kv/kvserver/loqrecovery/collect.go
+++ b/pkg/kv/kvserver/loqrecovery/collect.go
@@ -82,7 +82,7 @@ func GetDescriptorChangesFromRaftLog(
 	rangeID roachpb.RangeID, lo, hi uint64, reader storage.Reader,
 ) ([]loqrecoverypb.DescriptorChangeInfo, error) {
 	var changes []loqrecoverypb.DescriptorChangeInfo
-	if err := raftlog.Visit(context.Background(), rangeID, reader, lo, hi, func(ctx context.Context, e *raftlog.Entry) error {
+	if err := raftlog.Visit(rangeID, reader, lo, hi, func(e *raftlog.Entry) error {
 		raftCmd := e.Cmd
 		switch {
 		case raftCmd.ReplicatedEvalResult.Split != nil:

--- a/pkg/kv/kvserver/loqrecovery/collect.go
+++ b/pkg/kv/kvserver/loqrecovery/collect.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/errors"
+	"go.etcd.io/etcd/raft/v3/raftpb"
 )
 
 // CollectReplicaInfo captures states of all replicas in all stores for the sake of quorum recovery.
@@ -82,7 +83,11 @@ func GetDescriptorChangesFromRaftLog(
 	rangeID roachpb.RangeID, lo, hi uint64, reader storage.Reader,
 ) ([]loqrecoverypb.DescriptorChangeInfo, error) {
 	var changes []loqrecoverypb.DescriptorChangeInfo
-	if err := raftlog.Visit(rangeID, reader, lo, hi, func(e *raftlog.Entry) error {
+	if err := raftlog.Visit(reader, rangeID, lo, hi, func(ent raftpb.Entry) error {
+		e, err := raftlog.NewEntry(ent)
+		if err != nil {
+			return err
+		}
 		raftCmd := e.Cmd
 		switch {
 		case raftCmd.ReplicatedEvalResult.Split != nil:

--- a/pkg/kv/kvserver/raftlog/iter_bench_test.go
+++ b/pkg/kv/kvserver/raftlog/iter_bench_test.go
@@ -166,16 +166,6 @@ func BenchmarkIterator(b *testing.B) {
 	b.Run("SeekGE", func(b *testing.B) {
 		benchForOp(b, (*Iterator).Next)
 	})
-
-	b.Run("NextPooled", func(b *testing.B) {
-		benchForOp(b, func(it *Iterator) (bool, error) {
-			if ok, err := it.Next(); err != nil || !ok {
-				return false, err
-			}
-			_ = it.Entry()
-			return true, nil
-		})
-	})
 }
 
 // Visit benchmarks Visit on a pebble engine, i.e. the results will measure

--- a/pkg/kv/kvserver/raftlog/iter_bench_test.go
+++ b/pkg/kv/kvserver/raftlog/iter_bench_test.go
@@ -172,8 +172,7 @@ func BenchmarkIterator(b *testing.B) {
 			if ok, err := it.Next(); err != nil || !ok {
 				return false, err
 			}
-			ent := it.Entry()
-			ent.Release()
+			_ = it.Entry()
 			return true, nil
 		})
 	})
@@ -191,8 +190,7 @@ func BenchmarkVisit(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if err := Visit(rangeID, eng, 0, math.MaxUint64, func(entry *Entry) error {
-			entry.Release()
+		if err := Visit(eng, rangeID, 0, math.MaxUint64, func(entry raftpb.Entry) error {
 			return nil
 		}); err != nil {
 			b.Fatal(err)

--- a/pkg/kv/kvserver/raftlog/iter_test.go
+++ b/pkg/kv/kvserver/raftlog/iter_test.go
@@ -101,9 +101,9 @@ type modelIter struct {
 	hi   uint64
 }
 
-func (it *modelIter) load() (*Entry, error) {
+func (it *modelIter) load() (raftpb.Entry, error) {
 	// Only called when on valid position.
-	return NewEntry(it.ents[it.idx])
+	return it.ents[it.idx], nil
 }
 
 func (it *modelIter) check() error {
@@ -139,7 +139,7 @@ func (it *modelIter) Next() (bool, error) {
 	return err == nil, err
 }
 
-func (it *modelIter) Entry() *Entry {
+func (it *modelIter) Entry() raftpb.Entry {
 	e, err := it.load()
 	if err != nil {
 		panic(err) // bug in modelIter
@@ -275,7 +275,7 @@ func TestIterator(t *testing.T) {
 type iter interface {
 	SeekGE(idx uint64) (bool, error)
 	Next() (bool, error)
-	Entry() *Entry
+	Entry() raftpb.Entry
 }
 
 func consumeIter(it iter, lo uint64) ([]uint64, error) {

--- a/pkg/kv/kvserver/raftlog/iterator.go
+++ b/pkg/kv/kvserver/raftlog/iterator.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
+	"go.etcd.io/etcd/raft/v3/raftpb"
 )
 
 type storageIter interface {
@@ -52,12 +53,12 @@ type Iterator struct {
 	// TODO(tbg): we're not reusing memory here. Since all of our allocs come
 	// from protobuf marshaling, this is hard to avoid but we can do a little
 	// better and at least avoid a few allocations.
-	entry *Entry
+	entry raftpb.Entry
 }
 
 // IterOptions are options to NewIterator.
 type IterOptions struct {
-	// Hi ensures the Iterator never seeks to any Entry with index >= Hi. This is
+	// Hi ensures the Iterator never seeks to any entry with index >= Hi. This is
 	// useful when the caller is interested in a slice [Lo, Hi) of the raft log.
 	Hi uint64
 }
@@ -90,44 +91,36 @@ func (it *Iterator) Close() {
 }
 
 func (it *Iterator) load() (bool, error) {
-	ok, err := it.iter.Valid()
-	if err != nil || !ok {
+	if ok, err := it.iter.Valid(); err != nil || !ok {
 		return false, err
 	}
-
-	it.entry, err = NewEntryFromRawValue(it.iter.UnsafeValue())
-	if err != nil {
+	var err error
+	if it.entry, err = raftEntryFromRawValue(it.iter.UnsafeValue()); err != nil {
 		return false, err
 	}
-
 	return true, nil
 }
 
 // SeekGE positions the Iterator at the first raft log with index greater than
 // or equal to idx. Returns (true, nil) on success, (false, nil) if no such
-// Entry exists.
+// entry exists.
 func (it *Iterator) SeekGE(idx uint64) (bool, error) {
 	it.iter.SeekGE(storage.MakeMVCCMetadataKey(it.prefixBuf.RaftLogKey(idx)))
 	return it.load()
 }
 
 // Next returns (true, nil) when the (in ascending index order) next entry is
-// available via Entry. It returns (false, nil) if there are no more
-// entries.
+// available via Entry(). It returns (false, nil) if there are no more entries.
 //
-// Note that a valid raft log has no gaps, and that the Iterator does not
-// validate that.
+// NB: a valid raft log has no gaps, but the Iterator does not validate that.
 func (it *Iterator) Next() (bool, error) {
 	it.iter.Next()
 	return it.load()
 }
 
-// Entry returns the Entry the iterator is currently positioned at. This
+// Entry returns the raft entry the iterator is currently positioned at. This
 // must only be called after a prior successful call to SeekGE or Next.
-//
-// The caller may invoke `(*Entry).Release` if it no longer wishes to access the
-// current Entry.
-func (it *Iterator) Entry() *Entry {
+func (it *Iterator) Entry() raftpb.Entry {
 	return it.entry
 }
 
@@ -138,10 +131,7 @@ func (it *Iterator) Entry() *Entry {
 //
 // The closure may return iterutil.StopIteration(), which will stop iteration
 // without returning an error.
-//
-// The closure may invoke `(*Entry).Release` if it is no longer going to access
-// any memory in the current Entry.
-func Visit(rangeID roachpb.RangeID, eng Reader, lo, hi uint64, fn func(*Entry) error) error {
+func Visit(eng Reader, rangeID roachpb.RangeID, lo, hi uint64, fn func(raftpb.Entry) error) error {
 	it := NewIterator(rangeID, eng, IterOptions{Hi: hi})
 	defer it.Close()
 	ok, err := it.SeekGE(lo)


### PR DESCRIPTION
The log storage in `Replica` iterates over raw `raftpb.Entry` (see `iterateEntries`). There is also a `raftlog.Iterator/Visit` which does the same thing, but wraps the entry into `raftlog.Entry`.

This PR makes `raftlog.Iterator` return `raftpb.Entry` instead of the wrapped entry. This enables `Replica` to use it too, and benefit from the fact that it's unit-tested.

Part of #91979
Release note: None