### PR TITLE
colexec: skip a couple slow tests under stress

### DIFF
--- a/pkg/sql/colexec/mergejoiner_test.go
+++ b/pkg/sql/colexec/mergejoiner_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/colcontainerutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -2005,6 +2006,9 @@ func newBatchesOfRandIntRows(
 func TestMergeJoinerRandomized(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	if coldata.BatchSize() > 1024 {
+		skip.UnderStress(t, "too slow with large coldata.BatchSize()")
+	}
 	ctx := context.Background()
 	evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(ctx)

--- a/pkg/sql/colexec/sorttopk_test.go
+++ b/pkg/sql/colexec/sorttopk_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -124,6 +125,9 @@ func TestTopKSorter(t *testing.T) {
 func TestTopKSortRandomized(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	if coldata.BatchSize() > 1024 {
+		skip.UnderStress(t, "too slow with large coldata.BatchSize()")
+	}
 	ctx := context.Background()
 	rng, _ := randutil.NewTestRand()
 	nTups := coldata.BatchSize()*2 + 1


### PR DESCRIPTION
It appears that some tests are too slow when run under stress if the batch size is randomized to a large value, so this commit skips the tests under stress with batch sizes larger than 1024 (which should happen less than 20% of the time).

Fixes: #92050.
Fixes: #92115.

Release note: None