### PR TITLE
testcluster: don't swallow node start error

### DIFF
--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -519,8 +519,7 @@ func (tc *TestCluster) AddAndStartServerE(serverArgs base.TestServerArgs) error 
 	if serverArgs.JoinAddr == "" && len(tc.Servers) > 0 {
 		serverArgs.JoinAddr = tc.Servers[0].ServingRPCAddr()
 	}
-	_, err := tc.AddServer(serverArgs)
-	if err != nil {
+	if _, err := tc.AddServer(serverArgs); err != nil {
 		return err
 	}
 
@@ -529,8 +528,9 @@ func (tc *TestCluster) AddAndStartServerE(serverArgs base.TestServerArgs) error 
 			tc.Stopper().Stop(context.TODO())
 			skip.IgnoreLint(tc.t, serverutils.TenantSkipCCLBinaryMessage)
 		}
+		return err
 	}
-	return err
+	return nil
 }
 
 // AddServer is like AddAndStartServer, except it does not start it.


### PR DESCRIPTION
The buggy code path had the structure:
```
func bug() {
  var err error
  if err := foo(); err != nil {
    if cond {
      goexit
    }
  }
  return err
}
```
This inadvertently swallws foo()'s error when `!cond`, because foo's error has a smaller scope than the error that ends up being returned.

Release note: None
Epic: None