### PR TITLE
backupccl: unskip TestBackupExportRequestTimeout

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -7226,8 +7226,6 @@ func TestBackupExportRequestTimeout(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.WithIssue(t, 90646)
-
 	allowRequest := make(chan struct{})
 	defer close(allowRequest)
 
@@ -7262,7 +7260,7 @@ func TestBackupExportRequestTimeout(t *testing.T) {
 	// should hang. The timeout should save us in this case.
 	_, err := sqlSessions[1].DB.ExecContext(ctx, "BACKUP data.bank TO 'nodelocal://0/timeout'")
 	require.Regexp(t,
-		`timeout: operation "ExportRequest for span .*/Table/\d+/.*\" timed out after \S+ \(given timeout 3s\)`,
+		`exporting .*/Table/\d+/.*\: context deadline exceeded`,
 		err.Error())
 }
 


### PR DESCRIPTION
The root cause is not a 100% clear to me but under stress sometimes the context that we run the backup processor workers in will exceed its deadline but continue to have `ctx.Err()` returning nil. The comment in `context/context.go` suggests that `Done` is closed asynchronously after the cancel function which means that `ctx.Err()` could return nil even after the context has been cancelled, until `Done` is closed. A side effect of that is we fail to decorate the context deadline exceeded error over here https://github.com/cockroachdb/cockroach/blob/bd6096fb7837b051b1c0f52bd634dfd063ac8e3a/pkg/util/contextutil/context.go#L92 causing our test to fail.

Release note: None

Fixes: #90646