### PR TITLE
tracing/collector: don't import CCL code for no reason

### DIFF
--- a/pkg/util/tracing/collector/BUILD.bazel
+++ b/pkg/util/tracing/collector/BUILD.bazel
@@ -31,7 +31,6 @@ go_test(
     deps = [
         ":collector",
         "//pkg/base",
-        "//pkg/ccl/utilccl",
         "//pkg/kv/kvserver/liveness",
         "//pkg/roachpb",
         "//pkg/rpc/nodedialer",

--- a/pkg/util/tracing/collector/main_test.go
+++ b/pkg/util/tracing/collector/main_test.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -23,7 +22,6 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	defer utilccl.TestingEnableEnterprise()()
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	randutil.SeedForTests()
 	serverutils.InitTestServerFactory(server.TestServerFactory)


### PR DESCRIPTION
The collector test was importing ccl for no apparent reason.

Release note: None
Epic: None