### PR TITLE
ui: add recent statements to sql activity page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/recentExecutions/executionStatusIcon.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/recentExecutions/executionStatusIcon.module.scss
@@ -14,3 +14,19 @@
 .executing {
   fill: $colors--success;
 }
+
+.timed-out {
+  fill: $colors--warning;
+}
+
+.canceled {
+  fill: $colors--warning;
+}
+
+.failed {
+  fill: $colors--warning;
+}
+
+.completed {
+  fill: $colors--success;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/recentExecutions/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/recentExecutions/index.ts
@@ -10,7 +10,6 @@
 
 export {
   getRecentExecutionsFromSessions,
-  getContendedExecutionsForTxn,
   getWaitTimeByTxnIDFromLocks,
   getRecentTransaction,
   getRecentStatement,

--- a/pkg/ui/workspaces/cluster-ui/src/recentExecutions/recentStatementsSection.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/recentExecutions/recentStatementsSection.tsx
@@ -24,7 +24,7 @@ import {
   ISortedTablePagination,
   SortedTable,
   SortSetting,
-} from "../sortedtable/sortedtable";
+} from "../sortedtable";
 import {
   getColumnOptions,
   makeRecentStatementsColumns,
@@ -32,6 +32,7 @@ import {
 import { StatementViewType } from "src/statementsPage/statementPageTypes";
 import { calculateActiveFilters } from "src/queryFilter/filter";
 import { isSelectedColumn } from "src/columnsSelector/utils";
+import { Pagination } from "../pagination";
 
 const sortableTableCx = classNames.bind(sortableTableStyles);
 
@@ -46,6 +47,7 @@ type RecentStatementsSectionProps = {
   onChangeSortSetting: (sortSetting: SortSetting) => void;
   onClearFilters: () => void;
   onColumnsSelect: (columns: string[]) => void;
+  onChangePagination: (page: number) => void;
 };
 
 export const RecentStatementsSection: React.FC<
@@ -61,6 +63,7 @@ export const RecentStatementsSection: React.FC<
   onClearFilters,
   onChangeSortSetting,
   onColumnsSelect,
+  onChangePagination,
 }) => {
   const columns = useMemo(
     () => makeRecentStatementsColumns(isTenant),
@@ -78,35 +81,43 @@ export const RecentStatementsSection: React.FC<
   const activeFilters = calculateActiveFilters(filters);
 
   return (
-    <section className={sortableTableCx("cl-table-container")}>
-      <div>
-        <ColumnsSelector
-          options={tableColumns}
-          onSubmitColumns={onColumnsSelect}
-        />
-        <TableStatistics
-          pagination={pagination}
-          search={search}
-          totalCount={statements.length}
-          arrayItemName="statements"
-          activeFilters={activeFilters}
-          onClearFilters={onClearFilters}
-        />
-      </div>
-      <SortedTable
-        className="statements-table"
-        data={statements}
-        columns={shownColumns}
-        sortSetting={sortSetting}
-        onChangeSortSetting={onChangeSortSetting}
-        renderNoResult={
-          <EmptyStatementsPlaceholder
-            isEmptySearchResults={search?.length > 0 && statements.length > 0}
-            statementView={StatementViewType.ACTIVE}
+    <div>
+      <section className={sortableTableCx("cl-table-container")}>
+        <div>
+          <ColumnsSelector
+            options={tableColumns}
+            onSubmitColumns={onColumnsSelect}
           />
-        }
-        pagination={pagination}
+          <TableStatistics
+            pagination={pagination}
+            search={search}
+            totalCount={statements.length}
+            arrayItemName="statements"
+            activeFilters={activeFilters}
+            onClearFilters={onClearFilters}
+          />
+        </div>
+        <SortedTable
+          className="statements-table"
+          data={statements}
+          columns={shownColumns}
+          sortSetting={sortSetting}
+          onChangeSortSetting={onChangeSortSetting}
+          renderNoResult={
+            <EmptyStatementsPlaceholder
+              isEmptySearchResults={search?.length > 0 && statements.length > 0}
+              statementView={StatementViewType.ACTIVE}
+            />
+          }
+          pagination={pagination}
+        />
+      </section>
+      <Pagination
+        pageSize={pagination.pageSize}
+        current={pagination.current}
+        total={statements.length}
+        onChange={onChangePagination}
       />
-    </section>
+    </div>
   );
 };

--- a/pkg/ui/workspaces/cluster-ui/src/recentExecutions/statusIcon.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/recentExecutions/statusIcon.tsx
@@ -21,6 +21,8 @@ export type StatusIconProps = {
 };
 
 export const StatusIcon: React.FC<StatusIconProps> = ({ status }) => {
-  const statusClassName = status !== "Waiting" ? "executing" : "waiting";
+  // The className will be an ExecutionStatus with spaces converted to hyphens, and
+  // all letters in lowercase. eg: Timed Out -> timed-out
+  const statusClassName = status.toLowerCase().replace(/\s/g, "-");
   return <CircleFilled className={cx("status-icon", statusClassName)} />;
 };

--- a/pkg/ui/workspaces/cluster-ui/src/recentExecutions/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/recentExecutions/types.ts
@@ -14,9 +14,19 @@ import { Filters } from "src/queryFilter";
 
 export type SessionsResponse =
   protos.cockroach.server.serverpb.ListSessionsResponse;
-export type ActiveStatementResponse =
-  protos.cockroach.server.serverpb.ActiveQuery;
-export type ExecutionStatus = "Waiting" | "Executing" | "Preparing";
+export type ActiveQuery = protos.cockroach.server.serverpb.IActiveQuery;
+export type ActiveQueryPhase =
+  protos.cockroach.server.serverpb.ActiveQuery.Phase;
+export type Session = protos.cockroach.server.serverpb.ISession;
+
+export type ExecutionStatus =
+  | "Waiting"
+  | "Executing"
+  | "Preparing"
+  | "Timed Out"
+  | "Canceled"
+  | "Completed"
+  | "Failed";
 export type ExecutionType = "statement" | "transaction";
 
 export const ActiveStatementPhase =

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/recentStatementsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/recentStatementsView.tsx
@@ -116,6 +116,7 @@ export const RecentStatementsView: React.FC<RecentStatementsViewProps> = ({
       {
         ascending: sortSetting.ascending.toString(),
         columnTitle: sortSetting.columnTitle,
+        page: pagination.current.toString(),
         [RECENT_STATEMENT_SEARCH_PARAM]: search,
         ...getFullFiltersAsStringRecord(filters),
       },
@@ -128,11 +129,19 @@ export const RecentStatementsView: React.FC<RecentStatementsViewProps> = ({
     sortSetting.ascending,
     sortSetting.columnTitle,
     search,
+    pagination,
   ]);
 
   const resetPagination = () => {
     setPagination({
       current: 1,
+      pageSize: 20,
+    });
+  };
+
+  const onPaginationChange = (page: number): void => {
+    setPagination({
+      current: page,
       pageSize: 20,
     });
   };
@@ -206,6 +215,7 @@ export const RecentStatementsView: React.FC<RecentStatementsViewProps> = ({
             onClearFilters={clearFilters}
             onChangeSortSetting={onSortClick}
             onColumnsSelect={onColumnsSelect}
+            onChangePagination={onPaginationChange}
             isTenant={isTenant}
           />
         </Loading>

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageRoot.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageRoot.tsx
@@ -49,13 +49,13 @@ export const StatementsPageRoot = ({
     },
     {
       value: StatementViewType.ACTIVE,
-      label: "Active Executions",
+      label: "Recent Executions",
       description: (
         <span>
-          Active executions represent individual statement executions in
-          progress. Use active statement execution details, such as the
-          application or elapsed time, to understand and tune workload
-          performance.
+          Recent executions represent individual statement executions that are
+          in progress or recently completed, failed, or canceled.
+          Use recent statement execution details, such as the application
+          or elapsed time, to understand and tune workload performance.
           {/* TODO (xinhaoz) #78379 add 'Learn More' link to documentation page*/}
         </span>
       ),


### PR DESCRIPTION
Previously, we only displayed Active Statements on the SQL Activity Page. This change adds Recent Statements to the previous Active Executions table. This change also fixes pagination on that table, and adds four new
possible Execution Statuses: Failed, Timed Out,
Canceled, and Completed, along with a corresponding icon color.

Video with changes: https://www.loom.com/share/06fe2e67bc8f41178f6f7c140e263e9e
The video shows the UI after running several queries via the CLI.

Part of #86955

Release note (ui change): adds Recent Statements to the SQL Activity page