### PR TITLE
cmd: increase logictestccl stress timeout to 2h

### DIFF
--- a/pkg/cmd/teamcity-trigger/main.go
+++ b/pkg/cmd/teamcity-trigger/main.go
@@ -109,7 +109,8 @@ func runTC(queueBuild func(string, map[string]string)) {
 			} else {
 				opts["env.COCKROACH_KVNEMESIS_STEPS"] = "10000"
 			}
-		case baseImportPath + "sql/logictest", baseImportPath + "kv/kvserver":
+		case baseImportPath + "sql/logictest", baseImportPath + "kv/kvserver",
+			baseImportPath + "ccl/logictestccl":
 			// Stress heavy with reduced parallelism (to avoid overloading the
 			// machine, see https://github.com/cockroachdb/cockroach/pull/10966).
 			parallelism /= 2


### PR DESCRIPTION
The default timeout of 1h is not enough. Increase it to 2h to match the regular logictests.

Fixes #92108

Release note: None