### PR TITLE
kvserver: deduplicate replica state used in replicate queue planning

### DIFF
--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -3678,7 +3678,7 @@ func (r *Replica) adminScatter(
 	if args.RandomizeLeases && r.OwnsValidLease(ctx, r.store.Clock().NowAsClockTimestamp()) {
 		desc := r.Desc()
 		potentialLeaseTargets := r.store.allocator.ValidLeaseTargets(
-			ctx, r.SpanConfig(), desc.Replicas().VoterDescriptors(), r, allocator.TransferLeaseOptions{})
+			ctx, r.SpanConfig(), desc.Replicas().VoterDescriptors(), r, desc, allocator.TransferLeaseOptions{})
 		if len(potentialLeaseTargets) > 0 {
 			newLeaseholderIdx := rand.Intn(len(potentialLeaseTargets))
 			targetStoreID := potentialLeaseTargets[newLeaseholderIdx].StoreID

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -663,6 +663,7 @@ func (rq *replicateQueue) shouldQueue(
 			conf,
 			voterReplicas,
 			repl,
+			desc,
 			repl.loadStats.batchRequests.SnapshotRatedSummary(),
 		) {
 		log.KvDistribution.VEventf(ctx, 2, "lease transfer needed, enqueuing")
@@ -1422,7 +1423,6 @@ func (rq *replicateQueue) planAddOrReplaceNonVoters(
 func (rq *replicateQueue) findRemoveVoter(
 	ctx context.Context,
 	repl interface {
-		DescAndSpanConfig() (*roachpb.RangeDescriptor, roachpb.SpanConfig)
 		LastReplicaAdded() (roachpb.ReplicaID, time.Time)
 		RaftStatus() *raft.Status
 	},
@@ -1540,6 +1540,7 @@ func (rq *replicateQueue) maybeTransferLeaseAwayTarget(
 		conf,
 		desc.Replicas().VoterDescriptors(),
 		repl,
+		desc,
 		repl.loadStats.batchRequests.SnapshotRatedSummary(),
 		false, /* forceDecisionWithoutStats */
 		allocator.TransferLeaseOptions{
@@ -1990,6 +1991,7 @@ func (rq *replicateQueue) shedLease(
 		conf,
 		desc.Replicas().VoterDescriptors(),
 		repl,
+		desc,
 		repl.loadStats.batchRequests.SnapshotRatedSummary(),
 		false, /* forceDecisionWithoutStats */
 		opts,

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -672,6 +672,7 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 			conf,
 			candidates,
 			candidateReplica,
+			desc,
 			candidateReplica.Stats(),
 			true, /* forceDecisionWithoutStats */
 			allocator.TransferLeaseOptions{
@@ -867,6 +868,7 @@ func (sr *StoreRebalancer) chooseRangeToRebalance(
 			rebalanceCtx.conf,
 			targetVoterRepls,
 			rebalanceCtx.candidateReplica,
+			rangeDesc,
 			allocator.TransferLeaseOptions{
 				AllowUninitializedCandidates: true,
 			},


### PR DESCRIPTION
Previously throughout the replicate queue planning stage represented by the recently introduced `replicateQueue.PlanOneChange(..)`, the range descriptor and span config was obtained multiple times from a replica, potentially introducing discrepancies and/or staleness as no lock is held on the replica state in the interim. This change modifies the replicate queue planning phase to use a single call to `repl.DescAndSpanConfig()`, the results of which are passed throughout as needed. The change also updates the naming and comments of some replicate queue functions used in the planning phase to indicate that they are intended to be without side effects.

Release note: None