### PR TITLE
schemachanger/scbuild: import partitionccl in test

### DIFF
--- a/pkg/sql/schemachanger/scbuild/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/BUILD.bazel
@@ -66,6 +66,7 @@ go_test(
     deps = [
         ":scbuild",
         "//pkg/base",
+        "//pkg/ccl/partitionccl",
         "//pkg/ccl/utilccl",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",

--- a/pkg/sql/schemachanger/scbuild/builder_test.go
+++ b/pkg/sql/schemachanger/scbuild/builder_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	_ "github.com/cockroachdb/cockroach/pkg/ccl/partitionccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"

--- a/pkg/sql/schemachanger/scbuild/testdata/create_index
+++ b/pkg/sql/schemachanger/scbuild/testdata/create_index
@@ -74,7 +74,7 @@ CREATE INDEX id3
 - [[IndexName:{DescID: 104, Name: id3, IndexID: 2}, PUBLIC], ABSENT]
   {indexId: 2, name: id3, tableId: 104}
 - [[IndexPartitioning:{DescID: 104, IndexID: 2}, PUBLIC], ABSENT]
-  {indexId: 2, partitioning: {numColumns: 1}, tableId: 104}
+  {indexId: 2, partitioning: {list: [{name: p1, subpartitioning: {}, values: [AwI=]}], numColumns: 1}, tableId: 104}
 - [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT]
   {indexId: 3, isUsingSecondaryEncoding: true, sourceIndexId: 1, tableId: 104}
 - [[IndexData:{DescID: 104, IndexID: 3}, TRANSIENT_ABSENT], ABSENT]
@@ -86,7 +86,7 @@ CREATE INDEX id3
 - [[IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}, PUBLIC], ABSENT]
   {columnId: 3, indexId: 3, kind: STORED, tableId: 104}
 - [[IndexPartitioning:{DescID: 104, IndexID: 3}, PUBLIC], ABSENT]
-  {indexId: 3, partitioning: {numColumns: 1}, tableId: 104}
+  {indexId: 3, partitioning: {list: [{name: p1, subpartitioning: {}, values: [AwI=]}], numColumns: 1}, tableId: 104}
 
 build
 CREATE INDEX id4


### PR DESCRIPTION
This test was importing enough ccl to activate a license and ostensibly perform partitioning operations, but not enough ccl for those partitioning operations to be real. This patch imports the partitionccl pkg and rewrites the affected datadriven test, which now looks like in production.

Release note: None
Epic: None