### PR TITLE
jobs: increase the test timeout

### DIFF
--- a/pkg/jobs/BUILD.bazel
+++ b/pkg/jobs/BUILD.bazel
@@ -78,7 +78,7 @@ go_library(
 
 go_test(
     name = "jobs_test",
-    size = "medium",
+    size = "large",
     srcs = [
         "delegate_control_test.go",
         "executor_impl_test.go",
@@ -93,7 +93,7 @@ go_test(
         "scheduled_job_test.go",
         "testutils_test.go",
     ],
-    args = ["-test.timeout=295s"],
+    args = ["-test.timeout=895s"],
     embed = [":jobs"],
     shard_count = 16,
     deps = [


### PR DESCRIPTION
This package seems to timeout every night in our stress build, both under race and without it. Under test, without stress, it took 200s for me on a fast machine. The current timeout is 300s - which seems too tight. This patch increases it to 900.
Without race and without stress, the pkg runs in about 30s for me. But I'm not sure I'm running it with the `deadlock` build tag, like CI is. Some of the failures below are from no-race stress builds.

Closes #92188
Closes #92191
Closes #92110
Closes #92111
Closes #92046

Release note: None
Epic: None