### PR TITLE
backupccl, changefeedccl, importer: log (sanitized) destination URIs

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -54,6 +54,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 	pbtypes "github.com/gogo/protobuf/types"
 )
 
@@ -618,6 +619,9 @@ func backupPlanHook(
 			return nil, nil, nil, false, err
 		}
 		encryptionParams.Mode = jobspb.EncryptionMode_KMS
+		if err = logAndSanitizeKmsURIs(ctx, kms...); err != nil {
+			return nil, nil, nil, false, err
+		}
 	}
 
 	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
@@ -757,6 +761,10 @@ func backupPlanHook(
 
 		jobID := p.ExecCfg().JobRegistry.MakeJobID()
 
+		if err := logAndSanitizeBackupDestinations(ctx, append(to, incrementalFrom...)...); err != nil {
+			return errors.Wrap(err, "logging backup destinations")
+		}
+
 		description, err := backupJobDescription(p,
 			backupStmt.Backup, to, incrementalFrom,
 			encryptionParams.RawKmsUris,
@@ -826,6 +834,28 @@ func backupPlanHook(
 		return fn, jobs.DetachedJobExecutionResultHeader, nil, false, nil
 	}
 	return fn, jobs.BulkJobExecutionResultHeader, nil, false, nil
+}
+
+func logAndSanitizeKmsURIs(ctx context.Context, kmsURIs ...string) error {
+	for _, dest := range kmsURIs {
+		clean, err := cloud.RedactKMSURI(dest)
+		if err != nil {
+			return err
+		}
+		log.Ops.Infof(ctx, "backup planning to connect to KMS destination %v", redact.Safe(clean))
+	}
+	return nil
+}
+
+func logAndSanitizeBackupDestinations(ctx context.Context, backupDestinations ...string) error {
+	for _, dest := range backupDestinations {
+		clean, err := cloud.SanitizeExternalStorageURI(dest, nil)
+		if err != nil {
+			return err
+		}
+		log.Ops.Infof(ctx, "backup planning to connect to destination %v", redact.Safe(clean))
+	}
+	return nil
 }
 
 func collectTelemetry(

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -65,6 +65,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 const (
@@ -834,7 +835,12 @@ func maybeUpgradeDescriptorsInBackupManifests(
 // them to be suitable for displaying in the jobs' description.
 // This includes redacting secrets from external storage URIs.
 func resolveOptionsForRestoreJobDescription(
-	opts tree.RestoreOptions, intoDB string, newDBName string, kmsURIs []string, incFrom []string,
+	ctx context.Context,
+	opts tree.RestoreOptions,
+	intoDB string,
+	newDBName string,
+	kmsURIs []string,
+	incFrom []string,
 ) (tree.RestoreOptions, error) {
 	if opts.IsDefault() {
 		return opts, nil
@@ -868,11 +874,15 @@ func resolveOptionsForRestoreJobDescription(
 			return tree.RestoreOptions{}, err
 		}
 		newOpts.DecryptionKMSURI = append(newOpts.DecryptionKMSURI, tree.NewDString(redactedURI))
+		logSanitizedKmsURI(ctx, redactedURI)
 	}
 
 	if opts.IncrementalStorage != nil {
 		var err error
 		newOpts.IncrementalStorage, err = sanitizeURIList(incFrom)
+		for _, uri := range newOpts.IncrementalStorage {
+			logSanitizedRestoreDestination(ctx, uri.String())
+		}
 		if err != nil {
 			return tree.RestoreOptions{}, err
 		}
@@ -882,6 +892,7 @@ func resolveOptionsForRestoreJobDescription(
 }
 
 func restoreJobDescription(
+	ctx context.Context,
 	p sql.PlanHookState,
 	restore *tree.Restore,
 	from [][]string,
@@ -900,7 +911,7 @@ func restoreJobDescription(
 
 	var options tree.RestoreOptions
 	var err error
-	if options, err = resolveOptionsForRestoreJobDescription(opts, intoDB, newDBName,
+	if options, err = resolveOptionsForRestoreJobDescription(ctx, opts, intoDB, newDBName,
 		kmsURIs, incFrom); err != nil {
 		return "", err
 	}
@@ -909,6 +920,9 @@ func restoreJobDescription(
 	for i, backup := range from {
 		r.From[i] = make(tree.StringOrPlaceholderOptList, len(backup))
 		r.From[i], err = sanitizeURIList(backup)
+		for _, uri := range r.From[i] {
+			logSanitizedRestoreDestination(ctx, uri.String())
+		}
 		if err != nil {
 			return "", err
 		}
@@ -949,6 +963,14 @@ func restoreTypeCheck(
 		header = jobs.BulkJobExecutionResultHeader
 	}
 	return true, header, nil
+}
+
+func logSanitizedKmsURI(ctx context.Context, kmsDestination string) {
+	log.Ops.Infof(ctx, "restore planning to connect to KMS destination %v", redact.Safe(kmsDestination))
+}
+
+func logSanitizedRestoreDestination(ctx context.Context, restoreDestinations string) {
+	log.Ops.Infof(ctx, "restore planning to connect to destination %v", redact.Safe(restoreDestinations))
 }
 
 // restorePlanHook implements sql.PlanHookFn.
@@ -1749,6 +1771,7 @@ func doRestorePlan(
 		fromDescription = from
 	}
 	description, err := restoreJobDescription(
+		ctx,
 		p,
 		restoreStmt,
 		fromDescription,

--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -115,6 +115,7 @@ go_library(
         "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_fraugster_parquet_go//:parquet-go",
         "@com_github_fraugster_parquet_go//parquet",
         "@com_github_fraugster_parquet_go//parquetschema",

--- a/pkg/sql/importer/exportcsv_test.go
+++ b/pkg/sql/importer/exportcsv_test.go
@@ -451,11 +451,11 @@ func TestExportFeatureFlag(t *testing.T) {
 	sqlDB.Exec(t, `SET CLUSTER SETTING feature.export.enabled = FALSE`)
 	sqlDB.Exec(t, `CREATE TABLE feature_flags (a INT PRIMARY KEY)`)
 	sqlDB.ExpectErr(t, `feature EXPORT was disabled by the database administrator`,
-		`EXPORT INTO CSV 'nodelocal://0/%s/' FROM TABLE feature_flags`)
+		`EXPORT INTO CSV 'nodelocal://0/foo/' FROM TABLE feature_flags`)
 
 	// Feature flag is on — test that EXPORT does not error.
 	sqlDB.Exec(t, `SET CLUSTER SETTING feature.export.enabled = TRUE`)
-	sqlDB.Exec(t, `EXPORT INTO CSV 'nodelocal://0/%s/' FROM TABLE feature_flags`)
+	sqlDB.Exec(t, `EXPORT INTO CSV 'nodelocal://0/foo/' FROM TABLE feature_flags`)
 }
 
 func TestExportPrivileges(t *testing.T) {

--- a/pkg/sql/importer/import_planning.go
+++ b/pkg/sql/importer/import_planning.go
@@ -55,6 +55,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 const (
@@ -223,7 +224,11 @@ func validateFormatOptions(
 }
 
 func importJobDescription(
-	p sql.PlanHookState, orig *tree.Import, files []string, opts map[string]string,
+	ctx context.Context,
+	p sql.PlanHookState,
+	orig *tree.Import,
+	files []string,
+	opts map[string]string,
 ) (string, error) {
 	stmt := *orig
 	stmt.Files = nil
@@ -232,6 +237,7 @@ func importJobDescription(
 		if err != nil {
 			return "", err
 		}
+		logSanitizedImportDestination(ctx, clean)
 		stmt.Files = append(stmt.Files, tree.NewDString(clean))
 	}
 	stmt.Options = nil
@@ -247,6 +253,10 @@ func importJobDescription(
 	sort.Slice(stmt.Options, func(i, j int) bool { return stmt.Options[i].Key < stmt.Options[j].Key })
 	ann := p.ExtendedEvalContext().Annotations
 	return tree.AsStringWithFQNames(&stmt, ann), nil
+}
+
+func logSanitizedImportDestination(ctx context.Context, destination string) {
+	log.Ops.Infof(ctx, "import planning to connect to destination %v", redact.Safe(destination))
 }
 
 func ensureRequiredPrivileges(
@@ -794,7 +804,7 @@ func importPlanHook(
 
 		var tableDetails []jobspb.ImportDetails_Table
 		var typeDetails []jobspb.ImportDetails_Type
-		jobDesc, err := importJobDescription(p, importStmt, filenamePatterns, opts)
+		jobDesc, err := importJobDescription(ctx, p, importStmt, filenamePatterns, opts)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Previously, there were no logs that indicated the destinations CRDB was attempting to connect to during egress enabled jobs (BACKUP,IMPORT, CHANGEFEED, RESTORE).

This needed to change because security teams want the ability to analyze egress traffic coming out of a CRDB cluster. These logs allow them to determine which traffic is actually user initiated (network egress logs align with CRDB logs). And furthermore, if that traffic is initiated by a malicious user (comparing with historical logs indicating unexpected destinations).

To address this, jobs that leverage egress have been modified to include additional logging. Note that we mark the logged destinations as redact safe since we ensure to log only sanitized URIs.
While there may be other ways to manipulate CRDB to make egress calls, these jobs (BACKUP, IMPORT, CHANGEFEED, RESTORE) are the most likely targets for egress manipulation.

Release note (general change): Bulk operations now log the (sanitized) destinations they are connecting to. For example "backup planning to connect to destination
gs://test/backupadhoc?AUTH=specified&CREDENTIALS=redacted"