### PR TITLE
envutil: add GOMEMLIMIT to safeVarRegistry

### DIFF
--- a/pkg/util/envutil/env.go
+++ b/pkg/util/envutil/env.go
@@ -186,10 +186,12 @@ func GetEnvVarsUsed() (result []redact.RedactableString) {
 // the name and the value safely: the value is known to never contain
 // sensitive information.
 var safeVarRegistry = map[redact.SafeString]struct{}{
+	// Go runtime.
 	"GOGC":        {},
 	"GODEBUG":     {},
 	"GOMAXPROCS":  {},
 	"GOTRACEBACK": {},
+	"GOMEMLIMIT":  {},
 	// gRPC.
 	"GRPC_GO_LOG_SEVERITY_LEVEL":  {},
 	"GRPC_GO_LOG_VERBOSITY_LEVEL": {},


### PR DESCRIPTION
This commit adds the GOMEMLIMIT environment variable to the list of go runtime env vars that Cockroach will report about on the Node Diagnostics page. The original set was added in f6e2313. Since then, this is the only env var added to the go runtime.

Release note: None

Epic: None