### PR TITLE
copy: optimize date parsing memory usage

### DIFF
--- a/pkg/sql/colexec/colexecbase/cast.eg.go
+++ b/pkg/sql/colexec/colexecbase/cast.eg.go
@@ -9427,7 +9427,8 @@ func (c *castStringDateOp) Next() coldata.Batch {
 
 							_now := evalCtx.GetRelativeParseTime()
 							_dateStyle := evalCtx.GetDateStyle()
-							_d, _, err := pgdate.ParseDate(_now, _dateStyle, string(v))
+							_ph := &evalCtx.ParseHelper
+							_d, _, err := pgdate.ParseDate(_now, _dateStyle, string(v), _ph)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -9457,7 +9458,8 @@ func (c *castStringDateOp) Next() coldata.Batch {
 
 							_now := evalCtx.GetRelativeParseTime()
 							_dateStyle := evalCtx.GetDateStyle()
-							_d, _, err := pgdate.ParseDate(_now, _dateStyle, string(v))
+							_ph := &evalCtx.ParseHelper
+							_d, _, err := pgdate.ParseDate(_now, _dateStyle, string(v), _ph)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -9489,7 +9491,8 @@ func (c *castStringDateOp) Next() coldata.Batch {
 
 							_now := evalCtx.GetRelativeParseTime()
 							_dateStyle := evalCtx.GetDateStyle()
-							_d, _, err := pgdate.ParseDate(_now, _dateStyle, string(v))
+							_ph := &evalCtx.ParseHelper
+							_d, _, err := pgdate.ParseDate(_now, _dateStyle, string(v), _ph)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -9519,7 +9522,8 @@ func (c *castStringDateOp) Next() coldata.Batch {
 
 							_now := evalCtx.GetRelativeParseTime()
 							_dateStyle := evalCtx.GetDateStyle()
-							_d, _, err := pgdate.ParseDate(_now, _dateStyle, string(v))
+							_ph := &evalCtx.ParseHelper
+							_d, _, err := pgdate.ParseDate(_now, _dateStyle, string(v), _ph)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}

--- a/pkg/sql/colexec/execgen/cmd/execgen/cast_gen_util.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/cast_gen_util.go
@@ -395,7 +395,8 @@ func stringToDate(to, from, evalCtx, _, _ string) string {
 	convStr := `
 		_now := %[3]s.GetRelativeParseTime()
 		_dateStyle := %[3]s.GetDateStyle()
-		_d, _, err := pgdate.ParseDate(_now, _dateStyle, string(%[2]s))
+		_ph := &%[3]s.ParseHelper
+		_d, _, err := pgdate.ParseDate(_now, _dateStyle, string(%[2]s), _ph)
 		if err != nil {
 			colexecerror.ExpectedError(err)
 		}

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -244,6 +244,9 @@ type Context struct {
 
 	// ChangefeedState stores the state (progress) of core changefeeds.
 	ChangefeedState ChangefeedState
+
+	// ParseHelper makes date parsing more efficient.
+	ParseHelper pgdate.ParseHelper
 }
 
 // DescIDGenerator generates unique descriptor IDs.
@@ -562,6 +565,11 @@ func (ec *Context) GetRelativeParseTime() time.Time {
 		ret = timeutil.Now()
 	}
 	return ret.In(ec.GetLocation())
+}
+
+// GetDateHelper implements ParseTimeContext.
+func (ec *Context) GetDateHelper() *pgdate.ParseHelper {
+	return &ec.ParseHelper
 }
 
 // GetTxnTimestamp retrieves the current transaction timestamp as per

--- a/pkg/util/timeutil/pgdate/field_extract_test.go
+++ b/pkg/util/timeutil/pgdate/field_extract_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestExtractRelative(t *testing.T) {
+	var parseHelper ParseHelper
 	tests := []struct {
 		s   string
 		rel int
@@ -42,20 +43,22 @@ func TestExtractRelative(t *testing.T) {
 	now := time.Date(2018, 10, 17, 0, 0, 0, 0, time.UTC)
 	for _, tc := range tests {
 		t.Run(tc.s, func(t *testing.T) {
-			d, depOnCtx, err := ParseDate(now, DateStyle{Order: Order_YMD}, tc.s)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if !depOnCtx {
-				t.Fatalf("relative dates should depend on context")
-			}
-			ts, err := d.ToTime()
-			if err != nil {
-				t.Fatal(err)
-			}
-			exp := now.AddDate(0, 0, tc.rel)
-			if ts != exp {
-				t.Fatalf("expected %v, got %v", exp, ts)
+			for _, ph := range []*ParseHelper{nil, &parseHelper} {
+				d, depOnCtx, err := ParseDate(now, DateStyle{Order: Order_YMD}, tc.s, ph)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !depOnCtx {
+					t.Fatalf("relative dates should depend on context")
+				}
+				ts, err := d.ToTime()
+				if err != nil {
+					t.Fatal(err)
+				}
+				exp := now.AddDate(0, 0, tc.rel)
+				if ts != exp {
+					t.Fatalf("expected %v, got %v", exp, ts)
+				}
 			}
 		})
 	}

--- a/pkg/util/timeutil/pgdate/parsing_test.go
+++ b/pkg/util/timeutil/pgdate/parsing_test.go
@@ -116,10 +116,12 @@ func (td timeData) expected(order pgdate.Order) (time.Time, bool) {
 	return td.exp, td.err
 }
 
-func (td timeData) testParseDate(t *testing.T, info string, order pgdate.Order) {
+func (td timeData) testParseDate(
+	t *testing.T, info string, order pgdate.Order, ph *pgdate.ParseHelper,
+) {
 	info = fmt.Sprintf("%s ParseDate", info)
 	exp, expErr := td.expected(order)
-	dt, _, err := pgdate.ParseDate(time.Time{}, pgdate.DateStyle{Order: order}, td.s)
+	dt, _, err := pgdate.ParseDate(time.Time{}, pgdate.DateStyle{Order: order}, td.s, ph)
 	res, _ := dt.ToTime()
 
 	// HACK: This is a format that parses as a date and timestamp,
@@ -138,15 +140,17 @@ func (td timeData) testParseDate(t *testing.T, info string, order pgdate.Order) 
 	td.crossCheck(t, info, "date", td.s, order, exp, expErr)
 }
 
-func (td timeData) testParseTime(t *testing.T, info string, order pgdate.Order) {
+func (td timeData) testParseTime(
+	t *testing.T, info string, order pgdate.Order, ph *pgdate.ParseHelper,
+) {
 	info = fmt.Sprintf("%s ParseTime", info)
 	exp, expErr := td.expected(order)
-	res, _, err := pgdate.ParseTime(time.Time{}, pgdate.DateStyle{Order: order}, td.s)
+	res, _, err := pgdate.ParseTime(time.Time{}, pgdate.DateStyle{Order: order}, td.s, ph)
 
 	// Weird times like 24:00:00 or 23:59:60 aren't allowed,
 	// unless there's also a date.
 	if td.isRolloverTime {
-		_, _, err := pgdate.ParseDate(time.Time{}, pgdate.DateStyle{Order: order}, td.s)
+		_, _, err := pgdate.ParseDate(time.Time{}, pgdate.DateStyle{Order: order}, td.s, ph)
 		expErr = err != nil
 	}
 
@@ -761,6 +765,7 @@ func TestMain(m *testing.M) {
 // * Pick an example time input:
 //   - Test ParseTime()
 func TestParse(t *testing.T) {
+	var ph pgdate.ParseHelper
 	for _, order := range []pgdate.Order{
 		pgdate.Order_YMD,
 		pgdate.Order_DMY,
@@ -768,14 +773,17 @@ func TestParse(t *testing.T) {
 	} {
 		t.Run(order.String(), func(t *testing.T) {
 			for _, dtc := range dateTestData {
-				dtc.testParseDate(t, dtc.s, order)
+				dtc.testParseDate(t, dtc.s, order, nil)
+				dtc.testParseDate(t, dtc.s, order, &ph)
 
 				// Combine times with dates to create timestamps.
 				for _, ttc := range timeTestData {
 					info := fmt.Sprintf("%s %s", dtc.s, ttc.s)
 					tstc := dtc.concatTime(ttc)
-					tstc.testParseDate(t, info, order)
-					tstc.testParseTime(t, info, order)
+					tstc.testParseDate(t, info, order, nil)
+					tstc.testParseDate(t, info, order, &ph)
+					tstc.testParseTime(t, info, order, nil)
+					tstc.testParseTime(t, info, order, &ph)
 					tstc.testParseTimestamp(t, info, order)
 					tstc.testParseTimestampWithoutTimezone(t, info, order)
 				}
@@ -784,14 +792,16 @@ func TestParse(t *testing.T) {
 			// Test some other timestamps formats we can't create
 			// by just concatenating a date + time string.
 			for _, ttc := range timestampTestData {
-				ttc.testParseTime(t, ttc.s, order)
+				ttc.testParseTime(t, ttc.s, order, nil)
+				ttc.testParseTime(t, ttc.s, order, &ph)
 			}
 		})
 	}
 
 	t.Run("ParseTime", func(t *testing.T) {
 		for _, ttc := range timeTestData {
-			ttc.testParseTime(t, ttc.s, 0 /* order */)
+			ttc.testParseTime(t, ttc.s, 0 /* order */, nil)
+			ttc.testParseTime(t, ttc.s, 0 /* order */, &ph)
 		}
 	})
 }
@@ -1040,6 +1050,7 @@ func TestDependsOnContext(t *testing.T) {
 
 	now := time.Date(2001, time.February, 3, 4, 5, 6, 1000, time.FixedZone("foo", 18000))
 	order := pgdate.Order_YMD
+	var ph pgdate.ParseHelper
 	for _, tc := range testCases {
 		t.Run(tc.s, func(t *testing.T) {
 			toStr := func(result interface{}, depOnCtx bool, err error) string {
@@ -1058,8 +1069,10 @@ func TestDependsOnContext(t *testing.T) {
 					t.Errorf("%s: expected '%s', got '%s'", what, expected, actual)
 				}
 			}
-			check("ParseDate", tc.date, toStr(pgdate.ParseDate(now, pgdate.DateStyle{Order: order}, tc.s)))
-			check("ParseTime", tc.time, toStr(pgdate.ParseTime(now, pgdate.DateStyle{Order: order}, tc.s)))
+			check("ParseDate", tc.date, toStr(pgdate.ParseDate(now, pgdate.DateStyle{Order: order}, tc.s, nil)))
+			check("ParseDate", tc.date, toStr(pgdate.ParseDate(now, pgdate.DateStyle{Order: order}, tc.s, &ph)))
+			check("ParseTime", tc.time, toStr(pgdate.ParseTime(now, pgdate.DateStyle{Order: order}, tc.s, nil)))
+			check("ParseTime", tc.time, toStr(pgdate.ParseTime(now, pgdate.DateStyle{Order: order}, tc.s, &ph)))
 			check(
 				"ParseTimeWithoutTimezone", tc.timeNoTZ,
 				toStr(pgdate.ParseTimeWithoutTimezone(now, pgdate.DateStyle{Order: order}, tc.s)),
@@ -1084,11 +1097,12 @@ var benchDates = [...]string{
 }
 
 func BenchmarkParseDate(b *testing.B) {
+	var ph pgdate.ParseHelper
 	now := timeutil.Now()
 	ds := pgdate.DefaultDateStyle()
 	for i := 0; i < b.N; i++ {
 		for _, str := range benchDates {
-			_, _, err := pgdate.ParseDate(now, ds, str)
+			_, _, err := pgdate.ParseDate(now, ds, str, &ph)
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/pkg/util/timeutil/pgdate/parsing_test.go
+++ b/pkg/util/timeutil/pgdate/parsing_test.go
@@ -1071,3 +1071,27 @@ func TestDependsOnContext(t *testing.T) {
 		})
 	}
 }
+
+var benchDates = [...]string{
+	"1993-05-23",
+	"1993-04-03",
+	"1993-07-28",
+	"1993-04-19",
+	"1993-06-15",
+	"1998-10-22",
+	"1998-07-11",
+	"1998-07-31",
+}
+
+func BenchmarkParseDate(b *testing.B) {
+	now := timeutil.Now()
+	ds := pgdate.DefaultDateStyle()
+	for i := 0; i < b.N; i++ {
+		for _, str := range benchDates {
+			_, _, err := pgdate.ParseDate(now, ds, str)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+}

--- a/pkg/util/timeutil/pgdate/pgdate_test.go
+++ b/pkg/util/timeutil/pgdate/pgdate_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestParseDate(t *testing.T) {
+	var parseHelper ParseHelper
 	for _, tc := range []struct {
 		s      string
 		err    string
@@ -72,23 +73,25 @@ func TestParseDate(t *testing.T) {
 		},
 	} {
 		t.Run(tc.s, func(t *testing.T) {
-			d, depOnCtx, err := ParseDate(time.Time{}, DateStyle{Order: Order_YMD}, tc.s)
-			if tc.err != "" {
-				if err == nil || !strings.Contains(err.Error(), tc.err) {
-					t.Fatalf("got %v, expected %v", err, tc.err)
+			for _, ph := range []*ParseHelper{nil, &parseHelper} {
+				d, depOnCtx, err := ParseDate(time.Time{}, DateStyle{Order: Order_YMD}, tc.s, ph)
+				if tc.err != "" {
+					if err == nil || !strings.Contains(err.Error(), tc.err) {
+						t.Fatalf("got %v, expected %v", err, tc.err)
+					}
+					return
 				}
-				return
-			}
-			if depOnCtx {
-				t.Fatalf("should not depend on context")
-			}
-			pg := d.PGEpochDays()
-			if pg != tc.pgdays {
-				t.Fatalf("%d != %d", pg, tc.pgdays)
-			}
-			s := d.String()
-			if s != tc.s {
-				t.Fatalf("%s != %s", s, tc.s)
+				if depOnCtx {
+					t.Fatalf("should not depend on context")
+				}
+				pg := d.PGEpochDays()
+				if pg != tc.pgdays {
+					t.Fatalf("%d != %d", pg, tc.pgdays)
+				}
+				s := d.String()
+				if s != tc.s {
+					t.Fatalf("%s != %s", s, tc.s)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
- pgdate: benchmark ParseDate
- pgdate: optimize bulk date parsing
- sql: wire up pgdate optimization to ParseAndRequireString and colexec.

Fixes: #91834

I'll squash the last two commits but thought for review purposes they'd be better separate.

Epic: CRDB-18892
