### PR TITLE
sql/sem: add support for "pg_blocking_pids" builtin

### DIFF
--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -1204,6 +1204,7 @@ var builtinOidsBySignature = map[string]oid.Oid{
 	`percentile_disc_impl(arg1: float[], arg2: varbit) -> varbit[]`:                                     302,
 	`pg_advisory_unlock(int: int) -> bool`:                                                              1428,
 	`pg_backend_pid() -> int`:                                                                           1400,
+	`pg_blocking_pids() -> int[]`:                                                                       2045,
 	`pg_client_encoding() -> string`:                                                                    1429,
 	`pg_collation_for(str: anyelement) -> string`:                                                       1418,
 	`pg_column_is_updatable(reloid: oid, attnum: int2, include_triggers: bool) -> bool`:                 1434,

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -1933,6 +1933,18 @@ SELECT description
 		},
 	),
 
+	"pg_blocking_pids": makeBuiltin(defProps(),
+		tree.Overload{
+			Types:      tree.ArgTypes{},
+			ReturnType: tree.FixedReturnType(types.IntArray),
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
+				return tree.NewDArray(types.Int), nil
+			},
+			Info:       notUsableInfo,
+			Volatility: volatility.Stable,
+		},
+	),
+
 	// pg_column_size(any) - number of bytes used to store a particular value
 	// (possibly compressed)
 


### PR DESCRIPTION
added support pg_blocking_pids builtin. Needed for pgadmin.

Closes #91068

Release note (sql change): add support for pg_blocking_pids builtin function. It is hardcoded to return an empty array because CockroachDB has no equivalent concept of PIDs as in Postgres.