### PR TITLE
kvcoord: return error on failed scan response checksum

### DIFF
--- a/pkg/kv/kvclient/kvcoord/transport.go
+++ b/pkg/kv/kvclient/kvcoord/transport.go
@@ -210,12 +210,18 @@ func (gt *grpcTransport) sendBatch(
 	// If we queried a remote node, perform extra validation and
 	// import trace spans.
 	if reply != nil && !rpc.IsLocal(iface) {
-		for i := range reply.Responses {
-			if err := reply.Responses[i].GetInner().Verify(ba.Requests[i].GetInner()); err != nil {
-				log.Errorf(ctx, "%v", err)
+		if err == nil {
+			for i := range reply.Responses {
+				err = reply.Responses[i].GetInner().Verify(ba.Requests[i].GetInner())
+				if err != nil {
+					log.Errorf(ctx, "verification of response for %s failed: %v", ba.Requests[i].GetInner(), err)
+					break
+				}
 			}
 		}
-		// Import the remotely collected spans, if any.
+
+		// Import the remotely collected spans, if any. Do this on error too,
+		// to get traces in that case as well (or to at least have a chance).
 		if len(reply.CollectedSpans) != 0 {
 			span := tracing.SpanFromContext(ctx)
 			if span == nil {


### PR DESCRIPTION
Found in #89477.

Epic: none
Release note: None
