### PR TITLE
sqlstats: include regions in statement_statistics.

### DIFF
--- a/pkg/roachpb/app_stats.go
+++ b/pkg/roachpb/app_stats.go
@@ -155,6 +155,7 @@ func (s *StatementStatistics) Add(other *StatementStatistics) {
 	s.RowsRead.Add(other.RowsRead, s.Count, other.Count)
 	s.RowsWritten.Add(other.RowsWritten, s.Count, other.Count)
 	s.Nodes = util.CombineUniqueInt64(s.Nodes, other.Nodes)
+	s.Regions = util.CombineUniqueString(s.Regions, other.Regions)
 	s.PlanGists = util.CombineUniqueString(s.PlanGists, other.PlanGists)
 	s.IndexRecommendations = other.IndexRecommendations
 

--- a/pkg/roachpb/app_stats.proto
+++ b/pkg/roachpb/app_stats.proto
@@ -108,6 +108,9 @@ message StatementStatistics {
   // Nodes is the ordered list of nodes ids on which the statement was executed.
   repeated int64 nodes = 24;
 
+  // Regions is the ordered list of regions on which the statement was executed.
+  repeated string regions = 29;
+
   // plan_gists is the list of a compressed version of plan that can be converted (lossily)
   // back into a logical plan.
   // Each statement contain only one plan gist, but the same statement fingerprint id

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding.go
@@ -90,6 +90,12 @@ func BuildStmtMetadataJSON(statistics *roachpb.CollectedStatementStatistics) (js
 //	        "type": "int",
 //	      },
 //	    },
+//	    "regions": {
+//	      "type": "array",
+//	      "items": {
+//	        "type": "string",
+//	      },
+//	    },
 //	    "statistics": {
 //	      "type": "object",
 //	      "properties": {
@@ -107,6 +113,7 @@ func BuildStmtMetadataJSON(statistics *roachpb.CollectedStatementStatistics) (js
 //	        "firstExecAt":       { "type": "string" },
 //	        "lastExecAt":        { "type": "string" },
 //	        "nodes":             { "type": "node_ids" },
+//	        "regions":           { "type": "regions" },
 //	      },
 //	      "required": [
 //	        "firstAttemptCnt",
@@ -120,7 +127,8 @@ func BuildStmtMetadataJSON(statistics *roachpb.CollectedStatementStatistics) (js
 //	        "ovhLat",
 //	        "bytesRead",
 //	        "rowsRead",
-//	        "nodes"
+//	        "nodes",
+//	        "regions"
 //	      ]
 //	    },
 //	    "execution_statistics": {

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
@@ -101,6 +101,7 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
            "sqDiff": {{.Float}}
          },
          "nodes": [{{joinInts .IntArray}}],
+         "regions": [{{joinStrings .StringArray}}],
          "planGists": [{{joinStrings .StringArray}}]
        },
        "execution_statistics": {

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
@@ -336,6 +336,7 @@ func (s *innerStmtStats) jsonFields() jsonFields {
 		{"rowsRead", (*numericStats)(&s.RowsRead)},
 		{"rowsWritten", (*numericStats)(&s.RowsWritten)},
 		{"nodes", (*int64Array)(&s.Nodes)},
+		{"regions", (*stringArray)(&s.Regions)},
 		{"planGists", (*stringArray)(&s.PlanGists)},
 	}
 }

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
@@ -135,6 +135,7 @@ func (s *Container) RecordStatement(
 	stats.mu.data.RowsWritten.Record(stats.mu.data.Count, float64(value.RowsWritten))
 	stats.mu.data.LastExecTimestamp = s.getTimeNow()
 	stats.mu.data.Nodes = util.CombineUniqueInt64(stats.mu.data.Nodes, value.Nodes)
+	stats.mu.data.Regions = util.CombineUniqueString(stats.mu.data.Regions, value.Regions)
 	stats.mu.data.PlanGists = util.CombineUniqueString(stats.mu.data.PlanGists, []string{value.PlanGist})
 	stats.mu.data.IndexRecommendations = value.IndexRecommendations
 

--- a/pkg/sql/sqlstats/ssprovider.go
+++ b/pkg/sql/sqlstats/ssprovider.go
@@ -208,6 +208,7 @@ type RecordedStmtStats struct {
 	RowsRead             int64
 	RowsWritten          int64
 	Nodes                []int64
+	Regions              []string
 	StatementType        tree.StatementType
 	Plan                 *roachpb.ExplainTreePlanNode
 	PlanGist             string

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
@@ -53,6 +53,7 @@ const statementStats: Required<IStatementStatistics> = {
   max_retries: Long.fromNumber(10),
   sql_type: "DDL",
   nodes: [Long.fromNumber(1), Long.fromNumber(2)],
+  regions: [],
   num_rows: {
     mean: 1,
     squared_diffs: 0,

--- a/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.spec.ts
@@ -273,6 +273,7 @@ function randomStats(
       nanos: 111613000,
     },
     nodes: [Long.fromInt(1), Long.fromInt(3), Long.fromInt(4)],
+    regions: [],
     plan_gists: ["Ais="],
     index_recommendations: [""],
   };

--- a/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
@@ -196,6 +196,7 @@ export function addStatementStats(
         ? a.last_exec_timestamp
         : b.last_exec_timestamp,
     nodes: uniqueLong([...a.nodes, ...b.nodes]),
+    regions: [],
     plan_gists: planGists,
     index_recommendations: indexRec,
   };

--- a/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
@@ -527,6 +527,7 @@ function makeStats(): Required<StatementStatistics> {
       nanos: 111613000,
     },
     nodes: [Long.fromInt(1), Long.fromInt(2), Long.fromInt(3)],
+    regions: [],
     plan_gists: ["Ais="],
     index_recommendations: [],
   };


### PR DESCRIPTION
Part of #89949.

Before this change, tenants did not have a way to see which regions their statements were executing in: the SQL Activity UI depends on `cockroach.server.serverpb.NodesUI`, which is not available for tenants, and there doesn't seem to be any way to gather the information via SQL.

I am not sure that the approach I've taken here will be the one that makes the most sense architecturally, so I've laid out my thinking and would welcome some advice.

An alternative path would be to implement the `NodesUI` endpoint for tenants, to allow the UI to continue working as is. This work has been suggested in #92065, but I am wondering if we perhaps don't want to be talking about "nodes" for serverless tenants at all?

In the meantime, the concept of regions _is_ still meaningful for serverless tenants.

So, we attach a `regions` array to the `statistics` JSON of `crdb_internal.statement_statistics` bearing the regions of the nodes the statement executed on.

Note that, as of this writing, this change only includes the region of the gateway node. We will want to do more, but an immediate solution was not at hand, so I figured it was worth first validating this direction before pushing further.

Release note (sql change): A `regions` field was added to the statistics column of `crdb_internal.statement_statistics`, reporting the regions of the nodes on which the statement was executed.