### PR TITLE
sql,cli: add redacted sql stmts to debug zip

### DIFF
--- a/pkg/cli/zip_table_registry.go
+++ b/pkg/cli/zip_table_registry.go
@@ -126,12 +126,12 @@ var zipInternalTablesPerCluster = DebugZipTableRegistry{
 		},
 	},
 	"crdb_internal.cluster_distsql_flows": {
-		// `stmt` column contains unredacted SQL statement strings.
 		nonSensitiveCols: NonSensitiveColumns{
 			"flow_id",
 			"node_id",
 			"since",
 			"status",
+			"crdb_internal.anonymize_sql_constants(stmt) as stmt",
 		},
 	},
 	"crdb_internal.cluster_execution_insights": {
@@ -183,7 +183,6 @@ var zipInternalTablesPerCluster = DebugZipTableRegistry{
 		},
 	},
 	"crdb_internal.cluster_queries": {
-		// `query` column contains unredacted SQL statement strings.
 		// `client_address` contains unredacted client IP addresses.
 		nonSensitiveCols: NonSensitiveColumns{
 			"query_id",
@@ -196,11 +195,10 @@ var zipInternalTablesPerCluster = DebugZipTableRegistry{
 			"distributed",
 			"phase",
 			"full_scan",
+			"crdb_internal.anonymize_sql_constants(query) as query",
 		},
 	},
 	"crdb_internal.cluster_sessions": {
-		// `active_queries` and `last_active_query` columns contain unredacted
-		// SQL statement strings.
 		// `client_address` contains unredacted client IP addresses.
 		nonSensitiveCols: NonSensitiveColumns{
 			"node_id",
@@ -215,6 +213,8 @@ var zipInternalTablesPerCluster = DebugZipTableRegistry{
 			"max_alloc_bytes",
 			"status",
 			"session_end",
+			"crdb_internal.anonymize_sql_constants(active_queries) as active_queries",
+			"crdb_internal.anonymize_sql_constants(last_active_query) as last_active_query",
 		},
 	},
 	"crdb_internal.cluster_settings": {
@@ -245,14 +245,13 @@ var zipInternalTablesPerCluster = DebugZipTableRegistry{
 		},
 	},
 	`"".crdb_internal.create_function_statements`: {
-		// `create_statement` column contains unredacted CREATE FUNCTION
-		// statements which may contain customer-supplied constants.
 		nonSensitiveCols: NonSensitiveColumns{
 			"database_id",
 			"database_name",
 			"schema_id",
 			"function_id",
 			"function_name",
+			"crdb_internal.anonymize_sql_constants(create_statement) as create_statement",
 		},
 	},
 	// The synthetic SQL CREATE statements for all tables.
@@ -267,8 +266,6 @@ var zipInternalTablesPerCluster = DebugZipTableRegistry{
 		},
 	},
 	`"".crdb_internal.create_statements`: {
-		// `create_statement,` create_nofks`, and `alter_statements` columns
-		// contain unredacted SQL statement strings.
 		nonSensitiveCols: NonSensitiveColumns{
 			"database_id",
 			"database_name",
@@ -281,6 +278,9 @@ var zipInternalTablesPerCluster = DebugZipTableRegistry{
 			"is_multi_region",
 			"is_virtual",
 			"is_temporary",
+			"crdb_internal.anonymize_sql_constants(create_statement) as create_statement",
+			"crdb_internal.anonymize_sql_constants(alter_statements) as alter_statements",
+			"crdb_internal.anonymize_sql_constants(create_nofks) as create_nofks",
 		},
 	},
 	// Ditto, for CREATE TYPE.
@@ -584,6 +584,7 @@ var zipInternalTablesPerNode = DebugZipTableRegistry{
 			"stmt",
 			"since",
 			"status",
+			"crdb_internal.anonymize_sql_constants(stmt) as stmt",
 		},
 	},
 	"crdb_internal.node_execution_insights": {
@@ -633,7 +634,6 @@ var zipInternalTablesPerNode = DebugZipTableRegistry{
 		},
 	},
 	"crdb_internal.node_queries": {
-		// `query` column contains unredacted SQL statement strings.
 		// `client_address` contains unredacted client IP addresses.
 		nonSensitiveCols: NonSensitiveColumns{
 			"query_id",
@@ -646,6 +646,7 @@ var zipInternalTablesPerNode = DebugZipTableRegistry{
 			"distributed",
 			"phase",
 			"full_scan",
+			"crdb_internal.anonymize_sql_constants(query) as query",
 		},
 	},
 	"crdb_internal.node_runtime_info": {
@@ -657,8 +658,6 @@ var zipInternalTablesPerNode = DebugZipTableRegistry{
 		},
 	},
 	"crdb_internal.node_sessions": {
-		// `active_queries` and `last_active_query` columns contain unredacted
-		// SQL statement strings.
 		// `client_address` contains unredacted client IP addresses.
 		nonSensitiveCols: NonSensitiveColumns{
 			"node_id",
@@ -673,6 +672,8 @@ var zipInternalTablesPerNode = DebugZipTableRegistry{
 			"max_alloc_bytes",
 			"status",
 			"session_end",
+			"crdb_internal.anonymize_sql_constants(active_queries) as active_queries",
+			"crdb_internal.anonymize_sql_constants(last_active_query) as last_active_query",
 		},
 	},
 	"crdb_internal.node_statement_statistics": {

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -3681,3 +3681,40 @@ SELECT encode(decompress(compress('Hello World', 'snappy'), 'lz4'), 'escape');
 
 query error pq: compress\(\): only 'gzip', 'lz4', 'snappy', or 'zstd' compression codecs are supported
 SELECT compress('Hello World', 'infiniteCompressionCodec');
+
+subtest crdb_internal.anonymize_sql_constants
+query T
+SELECT crdb_internal.anonymize_sql_constants('select 1, 2, 3')
+----
+SELECT _, _, _
+
+# Passing a redacted sql stmt shouldn't have any effect.
+query T
+SELECT crdb_internal.anonymize_sql_constants('select _, _, _')
+----
+SELECT _, _, _
+
+query T
+SELECT crdb_internal.anonymize_sql_constants(ARRAY('select 1', NULL, 'select ''hello''', ''))
+----
+{"SELECT _",NULL,"SELECT '_'",""}
+
+query T
+SELECT crdb_internal.anonymize_sql_constants('SELECT ''yes'' IN (''no'', ''maybe'', ''yes'')')
+----
+SELECT '_' IN ('_', '_', __more1_10__)
+
+query T
+SELECT crdb_internal.anonymize_sql_constants('')
+----
+·
+
+query T
+SELECT crdb_internal.anonymize_sql_constants(NULL)
+----
+NULL
+
+query T
+SELECT crdb_internal.anonymize_sql_constants(create_statement) from crdb_internal.create_statements where descriptor_name = 'foo'
+----
+CREATE TABLE public.foo (a INT8 NULL, rowid INT8 NOT NULL NOT VISIBLE DEFAULT unique_rowid(), CONSTRAINT foo_pkey PRIMARY KEY (rowid ASC))

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -454,6 +454,8 @@ var builtinOidsBySignature = map[string]oid.Oid{
 	`crdb_internal.range_stats(key: bytes) -> jsonb`:                                          1325,
 	`crdb_internal.read_file(uri: string) -> bytes`:                                           1274,
 	`crdb_internal.redact_descriptor(descriptor: bytes) -> bytes`:                             2038,
+	`crdb_internal.anonymize_sql_constants(val: string) -> string`:                            2055,
+	`crdb_internal.anonymize_sql_constants(val: string[]) -> string[]`:                        2056,
 	`crdb_internal.rename_tenant(id: int, name: string) -> int`:                               2037,
 	`crdb_internal.repair_ttl_table_scheduled_job(oid: oid) -> void`:                          1375,
 	`crdb_internal.replication_stream_progress(stream_id: int, frontier_ts: string) -> bytes`: 1549,


### PR DESCRIPTION
## Commit 1

This commit adds the builtin, `crdb_internal.anonymize_sql_constants`
which takes in a sql string and returns it with  constants redacted.
This will be used to redact columns that are sql stmts in the
redacted debug zip.

Release note: None

## Commit 2
Closes https://github.com/cockroachdb/cockroach/issues/88823

This commit adds the following fields to the redacted
debug zip:

crdb_internal.create_statements:
- create_statement
- - create_nofks
- alter_statements (each elem is redacted)

crdb_internal.create_function_statements:
- create_statement

crdb_internal.{node,cluster}_distsql_flows:
- stmt

crdb_internal.{cluster,node}_sessions:
- last_active
- active_queries

crdb_internal.{cluster,node}_queries:
- query

Release note (cli change):
The following fields have been redacted and added to
the redacted debug zip:
crdb_internal.create_statements:
- create_statement
- create_nofks
- alter_statements (each elem is redacted)

crdb_internal.create_function_statements:
- create_statement
- 
crdb_internal.{node,cluster}_distsql_flows:
- stmt

crdb_internal.{cluster,node}_sessions:
- last_active
- active_queries

crdb_internal.{cluster,node}_queries:
- query



-----------
Running ycsb, tpcc and movr default workloads for 15 minutes and requesting the debug zip on a fresh node in master vs with new changes:
master
<img width="927" alt="Pasted Graphic" src="https://user-images.githubusercontent.com/20136951/203359099-6a035d1c-00fe-4bbb-92c2-d1c2b2a3b706.png">

branch
<img width="978" alt="Pasted Graphic 2" src="https://user-images.githubusercontent.com/20136951/203359158-a8b02ccb-2d82-40b4-a33d-9faf6ddaab70.png">
