### PR TITLE
bazel: Add s390x support for libkrb5 cross-compilation

### DIFF
--- a/build/toolchains/BUILD.bazel
+++ b/build/toolchains/BUILD.bazel
@@ -213,7 +213,7 @@ toolchain(
     name = "cross_arm64_s390x_toolchain",
     exec_compatible_with = [
         "@platforms//os:linux",
-        "@platforms//cpu:x86_64",
+        "@platforms//cpu:arm64",
     ],
     target_compatible_with = [
         "@platforms//os:linux",

--- a/c-deps/BUILD.bazel
+++ b/c-deps/BUILD.bazel
@@ -218,6 +218,7 @@ configure_make(
     ] + select({
         "@io_bazel_rules_go//go/platform:linux_amd64": ["--host=x86_64-unknown-linux-gnu"],
         "@io_bazel_rules_go//go/platform:linux_arm64": ["--host=aarch64-unknown-linux-gnu"],
+        "@io_bazel_rules_go//go/platform:linux_s390x": ["--host=s390x-unknown-linux-gnu"],
         "//conditions:default": [],
     }),
     copts = select({


### PR DESCRIPTION
This PR is in reference to https://github.com/cockroachdb/cockroach/issues/58676

This change will allow cross-compiling s390x binary on Intel 64bit.  I was able to run `bazel build pkg/cmd/cockroach --config with_ui --config crosslinuxs390x //pkg/cmd/cockroach-short //pkg/cmd/cockroach //pkg/cmd/cockroach-sql //pkg/cmd/cockroach-oss //c-deps:libgeos //pkg/cmd/roachprod` and got the `Build completed successfully` message.

Will CockroachDB consider adding s390x to CI and publishing experimental binaries for s390x?   

Thanks.