### PR TITLE
test: update time on test

### DIFF
--- a/pkg/sql/scheduledlogging/captured_index_usage_stats_test.go
+++ b/pkg/sql/scheduledlogging/captured_index_usage_stats_test.go
@@ -79,7 +79,7 @@ func TestCaptureIndexUsageStats(t *testing.T) {
 	stubLoggingDelay := 0 * time.Second
 
 	// timeBuffer is a short time buffer to account for non-determinism in the logging timings.
-	const timeBuffer = 2 * time.Second
+	const timeBuffer = 3 * time.Second
 
 	settings := cluster.MakeTestingClusterSettings()
 	// Configure capture index usage statistics to be disabled. This is to test


### PR DESCRIPTION
The test `pkg/sql/scheduledlogging/TestCaptureIndexUsageStats` was flaky on CI, even though it was passing (including on stress) locally.
This commit increases the time buffer used to account for non-determinism in the logging timings.

Fixes #92006

Release note: None