### PR TITLE
sqlstats: avoid mutex deadlock in Container.SaveToLog

### DIFF
--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
@@ -615,7 +615,7 @@ func (s *Container) SaveToLog(ctx context.Context, appName string) {
 	for key, stats := range s.mu.stmts {
 		stats.mu.Lock()
 		json, err := json.Marshal(stats.mu.data)
-		s.mu.Unlock()
+		stats.mu.Unlock()
 		if err != nil {
 			log.Errorf(ctx, "error while marshaling stats for %q // %q: %v", appName, key.String(), err)
 			continue


### PR DESCRIPTION
This commit fixes the locking in `ssmemstorage.Container.SaveToLog` to avoid a deadlock. Since 06f6874, we've been unlocking the incorrect mutex in the method. Luckily, it doesn't look like this code is called by default, because `sql.metrics.statement_details.dump_to_logs` defaults to false. If a user was to change that to true, they would have a bad time.

This code could use a test. I don't plan to add one here because I don't know the code well and only stumbled upon this during an unrelated support escalation, but I encourage others to consider extending the testing.

Release note (bug fix): When configured to true, the `sql.metrics.statement_details.dump_to_logs` cluster setting no longer causes a mutex deadlock.

Epic: None