### PR TITLE
release-22.2: cluster-ui: insights cleanup

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/insightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/insightsApi.ts
@@ -96,7 +96,7 @@ type TransactionContentionResponseColumns = {
 function transactionContentionResultsToEventState(
   response: SqlExecutionResponse<TransactionContentionResponseColumns>,
 ): TransactionContentionEventsResponse {
-  if (!response.execution.txn_results[0].rows) {
+  if (sqlResultsAreEmpty(response)) {
     // No transaction contention events.
     return [];
   }
@@ -123,24 +123,26 @@ export type TxnStmtFingerprintEventsResponse = TxnStmtFingerprintEventState[];
 
 type TxnStmtFingerprintsResponseColumns = {
   transaction_fingerprint_id: string;
-  query_ids: string[];
+  query_ids: string[]; // Statement Fingerprint IDs.
   app_name: string;
 };
 
 // txnStmtFingerprintsQuery selects all statement fingerprints for each recorded transaction fingerprint.
-const txnStmtFingerprintsQuery = (txn_fingerprint_ids: string[] | string) => `
+const txnStmtFingerprintsQuery = (txn_fingerprint_ids: string[]) => `
 SELECT
   DISTINCT ON (fingerprint_id) encode(fingerprint_id, 'hex') AS transaction_fingerprint_id,
   app_name,
   ARRAY( SELECT jsonb_array_elements_text(metadata -> 'stmtFingerprintIDs' )) AS query_ids
 FROM crdb_internal.transaction_statistics
 WHERE app_name != '${INTERNAL_SQL_API_APP}'
-  AND encode(fingerprint_id, 'hex') = ANY (string_to_array('${txn_fingerprint_ids}', ','))`;
+  AND encode(fingerprint_id, 'hex') = ANY ARRAY[ ${txn_fingerprint_ids
+    .map(id => `'${id}'`)
+    .join(",")} ]`;
 
 function txnStmtFingerprintsResultsToEventState(
   response: SqlExecutionResponse<TxnStmtFingerprintsResponseColumns>,
 ): TxnStmtFingerprintEventsResponse {
-  if (!response.execution.txn_results[0].rows) {
+  if (sqlResultsAreEmpty(response)) {
     // No transaction fingerprint results.
     return [];
   }
@@ -152,12 +154,10 @@ function txnStmtFingerprintsResultsToEventState(
   }));
 }
 
-type FingerprintStmtsEventState = {
-  query: string;
-  stmtFingerprintID: string;
-};
-
-type FingerprintStmtsEventsResponse = FingerprintStmtsEventState[];
+type StmtFingerprintToQueryRecord = Map<
+  string, // Key = Stmt fingerprint ID
+  string // Value = query string
+>;
 
 type FingerprintStmtsResponseColumns = {
   statement_fingerprint_id: string;
@@ -165,125 +165,126 @@ type FingerprintStmtsResponseColumns = {
 };
 
 // fingerprintStmtsQuery selects all statement queries for each recorded statement fingerprint.
-const fingerprintStmtsQuery = (stmt_fingerprint_ids: string[]) => `
+const fingerprintStmtsQuery = (stmt_fingerprint_ids: string[]): string => `
 SELECT
   DISTINCT ON (fingerprint_id) encode(fingerprint_id, 'hex') AS statement_fingerprint_id,
   prettify_statement(metadata ->> 'query', 108, 1, 1) AS query
 FROM crdb_internal.statement_statistics
-WHERE encode(fingerprint_id, 'hex') = ANY (string_to_array('${stmt_fingerprint_ids}', ','))`;
+WHERE encode(fingerprint_id, 'hex') = ANY ARRAY[ ${stmt_fingerprint_ids
+  .map(id => `'${id}'`)
+  .join(",")} ]`;
 
 function fingerprintStmtsResultsToEventState(
   response: SqlExecutionResponse<FingerprintStmtsResponseColumns>,
-): FingerprintStmtsEventsResponse {
-  if (!response.execution.txn_results[0].rows) {
+): StmtFingerprintToQueryRecord {
+  const idToQuery: Map<string, string> = new Map();
+  if (sqlResultsAreEmpty(response)) {
     // No statement fingerprint results.
-    return [];
+    return idToQuery;
   }
-  return response.execution.txn_results[0].rows.map(row => ({
-    stmtFingerprintID: FixFingerprintHexValue(row.statement_fingerprint_id),
-    query: row.query,
-  }));
+  response.execution.txn_results[0].rows.forEach(row => {
+    idToQuery.set(
+      FixFingerprintHexValue(row.statement_fingerprint_id),
+      row.query,
+    );
+  });
+
+  return idToQuery;
 }
 
+const makeInsightsSqlRequest = (queries: string[]): SqlExecutionRequest => ({
+  statements: queries.map(query => ({ sql: query })),
+  execute: true,
+  max_result_size: LARGE_RESULT_SIZE,
+  timeout: LONG_TIMEOUT,
+});
+
 // getTransactionInsightEventState is the API function that executes the queries and returns the results.
-export function getTransactionInsightEventState(): Promise<TransactionInsightEventsResponse> {
-  const txnContentionRequest: SqlExecutionRequest = {
-    statements: [
-      {
-        sql: `${txnContentionQuery}`,
-      },
-    ],
-    execute: true,
-    max_result_size: LARGE_RESULT_SIZE,
-    timeout: LONG_TIMEOUT,
-  };
-  return executeInternalSql<TransactionContentionResponseColumns>(
-    txnContentionRequest,
-  ).then(contentionResults => {
-    if (sqlResultsAreEmpty(contentionResults)) {
-      return;
-    }
-    const res = contentionResults.execution.txn_results[0].rows;
-    const txnFingerprintIDs = res.map(row =>
-      FixFingerprintHexValue(row.waiting_txn_fingerprint_id),
+export async function getTransactionInsightEventState(): Promise<TransactionInsightEventsResponse> {
+  // Note that any errors encountered fetching these results are caught
+  // earlier in the call stack.
+
+  // Step 1: Get transaction contention events that are over the insights
+  // latency threshold.
+  const contentionResults =
+    await executeInternalSql<TransactionContentionResponseColumns>(
+      makeInsightsSqlRequest([txnContentionQuery]),
     );
-    const txnFingerprintRequest: SqlExecutionRequest = {
-      statements: [
-        {
-          sql: `${txnStmtFingerprintsQuery(txnFingerprintIDs)}`,
-        },
-      ],
-      execute: true,
-      max_result_size: LARGE_RESULT_SIZE,
-      timeout: LONG_TIMEOUT,
-    };
-    return executeInternalSql<TxnStmtFingerprintsResponseColumns>(
-      txnFingerprintRequest,
-    ).then(txnStmtFingerprintResults => {
-      if (sqlResultsAreEmpty(txnStmtFingerprintResults)) {
-        return;
-      }
-      const txnStmtRes =
-        txnStmtFingerprintResults.execution.txn_results[0].rows;
-      const stmtFingerprintIDs = txnStmtRes.map(row => row.query_ids);
-      const fingerprintStmtsRequest: SqlExecutionRequest = {
-        statements: [
-          {
-            sql: `${fingerprintStmtsQuery(
-              [].concat([], ...stmtFingerprintIDs),
-            )}`,
-          },
-        ],
-        execute: true,
-        max_result_size: LARGE_RESULT_SIZE,
-        timeout: LONG_TIMEOUT,
-      };
-      return executeInternalSql<FingerprintStmtsResponseColumns>(
-        fingerprintStmtsRequest,
-      ).then(fingerprintStmtResults => {
-        return combineTransactionInsightEventState(
-          transactionContentionResultsToEventState(contentionResults),
-          txnStmtFingerprintsResultsToEventState(txnStmtFingerprintResults),
-          fingerprintStmtsResultsToEventState(fingerprintStmtResults),
-        );
-      });
-    });
+  if (sqlResultsAreEmpty(contentionResults)) {
+    return [];
+  }
+
+  // Step 2: Fetch the stmt fingerprints in the contended transactions.
+  const txnFingerprintIDs = new Set<string>();
+  contentionResults.execution.txn_results[0].rows.forEach(row =>
+    txnFingerprintIDs.add(
+      FixFingerprintHexValue(row.waiting_txn_fingerprint_id),
+    ),
+  );
+
+  const txnStmtFingerprintResults =
+    await executeInternalSql<TxnStmtFingerprintsResponseColumns>(
+      makeInsightsSqlRequest([
+        txnStmtFingerprintsQuery(Array.from(txnFingerprintIDs)),
+      ]),
+    );
+  if (sqlResultsAreEmpty(txnStmtFingerprintResults)) {
+    return [];
+  }
+
+  // Step 3: Get all query strings for statement fingerprints.
+  const stmtFingerprintIDs = new Set<string>();
+  txnStmtFingerprintResults.execution.txn_results[0].rows.forEach(row => {
+    row.query_ids.forEach(id => stmtFingerprintIDs.add(id));
   });
+  const fingerprintStmtsRequest = makeInsightsSqlRequest([
+    fingerprintStmtsQuery(Array.from(stmtFingerprintIDs)),
+  ]);
+  const fingerprintStmtResults =
+    await executeInternalSql<FingerprintStmtsResponseColumns>(
+      fingerprintStmtsRequest,
+    );
+
+  return combineTransactionInsightEventState(
+    transactionContentionResultsToEventState(contentionResults),
+    txnStmtFingerprintsResultsToEventState(txnStmtFingerprintResults),
+    fingerprintStmtsResultsToEventState(fingerprintStmtResults),
+  );
 }
 
 export function combineTransactionInsightEventState(
   txnContentionState: TransactionContentionEventsResponse,
   txnFingerprintState: TxnStmtFingerprintEventsResponse,
-  fingerprintStmtState: FingerprintStmtsEventsResponse,
+  fingerprintToQuery: StmtFingerprintToQueryRecord,
 ): TransactionInsightEventState[] {
-  let res: TransactionInsightEventState[];
-  if (txnContentionState && txnFingerprintState && fingerprintStmtState) {
-    const queries = txnFingerprintState.map(txnRow => ({
-      fingerprintID: txnRow.fingerprintID,
-      app_name: txnRow.application,
-      queries: txnRow.queryIDs.map(
-        stmtID =>
-          fingerprintStmtState.find(row => row.stmtFingerprintID === stmtID)
-            ?.query,
-      ),
-    }));
-    if (queries) {
-      res = txnContentionState.map(row => {
-        const qa = queries.find(
-          query => query.fingerprintID === row.fingerprintID,
-        );
-        if (qa) {
-          return {
-            ...row,
-            queries: qa.queries,
-            application: qa.app_name,
-            insightName: InsightNameEnum.highContention,
-            execType: InsightExecEnum.TRANSACTION,
-          };
-        }
-      });
-    }
+  if (
+    !txnContentionState.length ||
+    !txnFingerprintState.length ||
+    !fingerprintToQuery.size
+  ) {
+    return [];
   }
+  const txnsWithStmtQueries = txnFingerprintState.map(txnRow => ({
+    fingerprintID: txnRow.fingerprintID,
+    appName: txnRow.application,
+    queries: txnRow.queryIDs.map(stmtID => fingerprintToQuery.get(stmtID)),
+  }));
+
+  const res = txnContentionState.map(row => {
+    const qa = txnsWithStmtQueries.find(
+      query => query.fingerprintID === row.fingerprintID,
+    );
+    if (qa) {
+      return {
+        ...row,
+        queries: qa.queries,
+        application: qa.appName,
+        insightName: InsightNameEnum.highContention,
+        execType: InsightExecEnum.TRANSACTION,
+      };
+    }
+  });
+
   return res;
 }
 
@@ -303,6 +304,7 @@ export type TransactionInsightEventDetailsState = Omit<
 };
 export type TransactionInsightEventDetailsResponse =
   TransactionInsightEventDetailsState;
+
 export type TransactionInsightEventDetailsRequest = { id: string };
 
 // Query 1 types, functions.
@@ -407,168 +409,110 @@ function transactionContentionDetailsResultsToEventState(
 }
 
 // getTransactionInsightEventState is the API function that executes the queries and returns the results.
-export function getTransactionInsightEventDetailsState(
+export async function getTransactionInsightEventDetailsState(
   req: TransactionInsightEventDetailsRequest,
 ): Promise<TransactionInsightEventDetailsResponse> {
-  const txnContentionDetailsRequest: SqlExecutionRequest = {
-    statements: [
-      {
-        sql: `${txnContentionDetailsQuery(req.id)}`,
-      },
-    ],
-    execute: true,
-    max_result_size: LARGE_RESULT_SIZE,
-    timeout: LONG_TIMEOUT,
-  };
-  return executeInternalSql<TxnContentionDetailsResponseColumns>(
-    txnContentionDetailsRequest,
-  ).then(contentionResults => {
-    if (sqlResultsAreEmpty(contentionResults)) {
-      return;
-    }
-    const res = contentionResults.execution.txn_results[0].rows;
-    const waitingTxnFingerprintId = FixFingerprintHexValue(
-      res[0].waiting_txn_fingerprint_id,
+  // Note that any errors encountered fetching these results are caught // earlier in the call stack.
+  //
+  // There are 3 api requests/queries in this process.
+  // 1. Get contention insight for the requested transaction.
+  // 2. Get the stmt fingerprints for ALL transactions involved in the contention.
+  // 3. Get the query strings for ALL statements involved in the transaction.
+
+  // Get contention results for requested transaction.
+  const txnContentionDetailsRequest = makeInsightsSqlRequest([
+    txnContentionDetailsQuery(req.id),
+  ]);
+  const contentionResults =
+    await executeInternalSql<TxnContentionDetailsResponseColumns>(
+      txnContentionDetailsRequest,
     );
-    const waitingTxnFingerprintRequest: SqlExecutionRequest = {
-      statements: [
-        {
-          sql: `${txnStmtFingerprintsQuery(waitingTxnFingerprintId)}`,
-        },
-      ],
-      execute: true,
-      max_result_size: LARGE_RESULT_SIZE,
-      timeout: LONG_TIMEOUT,
-    };
-    return executeInternalSql<TxnStmtFingerprintsResponseColumns>(
-      waitingTxnFingerprintRequest,
-    ).then(waitingTxnStmtFingerprintIDs => {
-      const waitingStmtFingerprintIDs =
-        waitingTxnStmtFingerprintIDs.execution.txn_results[0].rows[0].query_ids;
-      const waitingFingerprintStmtsRequest: SqlExecutionRequest = {
-        statements: [
-          {
-            sql: `${fingerprintStmtsQuery(waitingStmtFingerprintIDs)}`,
-          },
-        ],
-        execute: true,
-        max_result_size: LARGE_RESULT_SIZE,
-        timeout: LONG_TIMEOUT,
-      };
-      return executeInternalSql<FingerprintStmtsResponseColumns>(
-        waitingFingerprintStmtsRequest,
-      ).then(waitingTxnStmtQueries => {
-        let blockingTxnFingerprintId: string[] = [];
-        contentionResults.execution.txn_results.forEach(txnResult => {
-          blockingTxnFingerprintId = blockingTxnFingerprintId.concat(
-            txnResult.rows.map(x =>
-              FixFingerprintHexValue(x.blocking_txn_fingerprint_id),
-            ),
-          );
-        });
+  if (sqlResultsAreEmpty(contentionResults)) {
+    return;
+  }
 
-        const blockingTxnFingerprintRequest: SqlExecutionRequest = {
-          statements: [
-            {
-              sql: `${txnStmtFingerprintsQuery(blockingTxnFingerprintId)}`,
-            },
-          ],
-          execute: true,
-          max_result_size: LARGE_RESULT_SIZE,
-          timeout: LONG_TIMEOUT,
-        };
-        return executeInternalSql<TxnStmtFingerprintsResponseColumns>(
-          blockingTxnFingerprintRequest,
-        ).then(blockingTxnStmtFingerprintIDs => {
-          let blockingStmtFingerprintIDs: string[] = [];
-          blockingTxnStmtFingerprintIDs.execution.txn_results[0].rows.map(
-            row => {
-              if (row.query_ids && row.query_ids.length > 0) {
-                blockingStmtFingerprintIDs = blockingStmtFingerprintIDs.concat(
-                  row.query_ids,
-                );
-              }
-            },
-          );
+  // Collect all txn fingerprints involved.
+  const txnFingerprintIDs: string[] = [];
+  contentionResults.execution.txn_results.forEach(txnResult =>
+    txnResult.rows.forEach(x =>
+      txnFingerprintIDs.push(
+        FixFingerprintHexValue(x.blocking_txn_fingerprint_id),
+      ),
+    ),
+  );
+  // Add the waiting txn fingerprint ID.
+  txnFingerprintIDs.push(
+    FixFingerprintHexValue(
+      contentionResults.execution.txn_results[0].rows[0]
+        .waiting_txn_fingerprint_id,
+    ),
+  );
 
-          const blockingFingerprintStmtsRequest: SqlExecutionRequest = {
-            statements: [
-              {
-                sql: `${fingerprintStmtsQuery(blockingStmtFingerprintIDs)}`,
-              },
-            ],
-            execute: true,
-            max_result_size: LARGE_RESULT_SIZE,
-            timeout: LONG_TIMEOUT,
-          };
-          return executeInternalSql<FingerprintStmtsResponseColumns>(
-            blockingFingerprintStmtsRequest,
-          ).then(blockingTxnStmtQueries => {
-            return combineTransactionInsightEventDetailsState(
-              transactionContentionDetailsResultsToEventState(
-                contentionResults,
-              ),
-              txnStmtFingerprintsResultsToEventState(
-                waitingTxnStmtFingerprintIDs,
-              ),
-              txnStmtFingerprintsResultsToEventState(
-                blockingTxnStmtFingerprintIDs,
-              ),
-              fingerprintStmtsResultsToEventState(waitingTxnStmtQueries),
-              fingerprintStmtsResultsToEventState(blockingTxnStmtQueries),
-            );
-          });
-        });
-      });
-    });
-  });
+  // Collect all stmt fingerprint ids involved.
+  const getStmtFingerprintsResponse =
+    await executeInternalSql<TxnStmtFingerprintsResponseColumns>(
+      makeInsightsSqlRequest([txnStmtFingerprintsQuery(txnFingerprintIDs)]),
+    );
+
+  const stmtFingerprintIDs = new Set<string>();
+  getStmtFingerprintsResponse.execution.txn_results[0].rows.forEach(
+    txnFingerprint =>
+      txnFingerprint.query_ids.forEach(id => stmtFingerprintIDs.add(id)),
+  );
+  console.log("ok");
+  console.log(txnFingerprintIDs);
+  console.log(stmtFingerprintIDs);
+  const stmtQueriesResponse =
+    await executeInternalSql<FingerprintStmtsResponseColumns>(
+      makeInsightsSqlRequest([
+        fingerprintStmtsQuery(Array.from(stmtFingerprintIDs)),
+      ]),
+    );
+
+  return combineTransactionInsightEventDetailsState(
+    transactionContentionDetailsResultsToEventState(contentionResults),
+    txnStmtFingerprintsResultsToEventState(getStmtFingerprintsResponse),
+    fingerprintStmtsResultsToEventState(stmtQueriesResponse),
+  );
 }
 
 export function combineTransactionInsightEventDetailsState(
   txnContentionDetailsState: TransactionContentionEventDetailsResponse,
-  waitingTxnFingerprintState: TxnStmtFingerprintEventsResponse,
-  blockingTxnFingerprintState: TxnStmtFingerprintEventsResponse,
-  waitingFingerprintStmtState: FingerprintStmtsEventsResponse,
-  blockingFingerprintStmtState: FingerprintStmtsEventsResponse,
+  txnsWithStmtFingerprints: TxnStmtFingerprintEventsResponse,
+  stmtFingerprintToQuery: StmtFingerprintToQueryRecord,
 ): TransactionInsightEventDetailsState {
-  let res: TransactionInsightEventDetailsState;
   if (
-    txnContentionDetailsState &&
-    waitingTxnFingerprintState &&
-    blockingTxnFingerprintState &&
-    waitingFingerprintStmtState &&
-    blockingFingerprintStmtState
+    !txnContentionDetailsState &&
+    !txnsWithStmtFingerprints.length &&
+    !stmtFingerprintToQuery.size
   ) {
-    txnContentionDetailsState.blockingContentionDetails.forEach(blockedRow => {
-      const currBlockedFingerprintStmts = blockingTxnFingerprintState.filter(
-        x => x.fingerprintID === blockedRow.blockingFingerprintID,
-      );
-      if (
-        !currBlockedFingerprintStmts ||
-        currBlockedFingerprintStmts.length != 1
-      ) {
-        return;
-      }
-
-      blockedRow.blockingQueries = currBlockedFingerprintStmts[0].queryIDs.map(
-        id =>
-          blockingFingerprintStmtState.find(
-            stmt => stmt.stmtFingerprintID === id,
-          )?.query,
-      );
-    });
-
-    res = {
-      ...txnContentionDetailsState,
-      application: waitingTxnFingerprintState[0].application,
-      queries: waitingTxnFingerprintState[0].queryIDs.map(
-        id =>
-          waitingFingerprintStmtState.find(
-            stmt => stmt.stmtFingerprintID === id,
-          )?.query,
-      ),
-    };
+    return null;
   }
+
+  txnContentionDetailsState.blockingContentionDetails.forEach(blockedRow => {
+    const currBlockedFingerprintStmts = txnsWithStmtFingerprints.find(
+      txn => txn.fingerprintID === blockedRow.blockingFingerprintID,
+    );
+
+    if (!currBlockedFingerprintStmts) {
+      return;
+    }
+
+    blockedRow.blockingQueries = currBlockedFingerprintStmts.queryIDs.map(
+      id => stmtFingerprintToQuery.get(id) ?? "",
+    );
+  });
+
+  const waitingTxn = txnsWithStmtFingerprints.find(
+    txn => txn.fingerprintID === txnContentionDetailsState.fingerprintID,
+  );
+
+  const res = {
+    ...txnContentionDetailsState,
+    application: waitingTxn.application,
+    queries: waitingTxn.queryIDs.map(id => stmtFingerprintToQuery.get(id)),
+  };
+
   return res;
 }
 
@@ -696,7 +640,7 @@ export function getStatementInsightsApi(): Promise<StatementInsights> {
   const request: SqlExecutionRequest = {
     statements: [
       {
-        sql: `${statementInsightsQuery.query}`,
+        sql: statementInsightsQuery.query,
       },
     ],
     execute: true,

--- a/pkg/ui/workspaces/cluster-ui/src/api/insightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/insightsApi.ts
@@ -56,30 +56,34 @@ export type TransactionContentionEventsResponse =
   TransactionContentionEventState[];
 
 // txnContentionQuery selects all relevant transaction contention events.
-const txnContentionQuery = `SELECT *
-                            FROM (SELECT waiting_txn_id,
-                                         encode(
-                                           waiting_txn_fingerprint_id, 'hex'
-                                           )                       AS waiting_txn_fingerprint_id,
-                                         collection_ts,
-                                         total_contention_duration AS contention_duration,
-                                         row_number()                 over (
-                 PARTITION BY waiting_txn_fingerprint_id
-                 ORDER BY
-                     collection_ts DESC
-                 ) AS rank, threshold
-                                  FROM (SELECT "sql.insights.latency_threshold" :: INTERVAL AS threshold
-                                        FROM
-                                          [SHOW CLUSTER SETTING sql.insights.latency_threshold]),
-                                       (SELECT waiting_txn_id,
-                                               waiting_txn_fingerprint_id,
-                                               max(collection_ts)       AS collection_ts,
-                                               sum(contention_duration) AS total_contention_duration
-                                        FROM crdb_internal.transaction_contention_events
-                                        WHERE encode(waiting_txn_fingerprint_id, 'hex') != '0000000000000000'
-                                        GROUP BY waiting_txn_id, waiting_txn_fingerprint_id)
-                                  WHERE total_contention_duration > threshold)
-                            WHERE rank = 1`;
+const txnContentionQuery = `
+SELECT * FROM
+(
+  SELECT
+    waiting_txn_id,
+    encode( waiting_txn_fingerprint_id, 'hex' ) AS waiting_txn_fingerprint_id,
+    collection_ts,
+    total_contention_duration AS contention_duration,
+    row_number() OVER ( PARTITION BY waiting_txn_fingerprint_id ORDER BY collection_ts DESC ) AS rank,
+    threshold
+  FROM
+    (
+      SELECT "sql.insights.latency_threshold"::INTERVAL AS threshold
+      FROM [SHOW CLUSTER SETTING sql.insights.latency_threshold]
+    ),
+    (
+      SELECT
+        waiting_txn_id,
+        waiting_txn_fingerprint_id,
+        max(collection_ts) AS collection_ts,
+        sum(contention_duration) AS total_contention_duration
+      FROM crdb_internal.transaction_contention_events
+      WHERE encode(waiting_txn_fingerprint_id, 'hex') != '0000000000000000'
+      GROUP BY waiting_txn_id, waiting_txn_fingerprint_id
+    )
+  WHERE total_contention_duration > threshold
+)
+WHERE rank = 1`;
 
 type TransactionContentionResponseColumns = {
   waiting_txn_id: string;
@@ -124,17 +128,14 @@ type TxnStmtFingerprintsResponseColumns = {
 };
 
 // txnStmtFingerprintsQuery selects all statement fingerprints for each recorded transaction fingerprint.
-const txnStmtFingerprintsQuery = (
-  txn_fingerprint_ids: string[] | string,
-) => `SELECT DISTINCT ON (fingerprint_id) encode(fingerprint_id, 'hex') AS transaction_fingerprint_id,
-                                          app_name,
-                                          ARRAY(
-                                            SELECT jsonb_array_elements_text(metadata -> 'stmtFingerprintIDs')
-                                            ) AS query_ids
-      FROM crdb_internal.transaction_statistics
-      WHERE app_name != '${INTERNAL_SQL_API_APP}'
-        AND encode(fingerprint_id, 'hex') = ANY (string_to_array('${txn_fingerprint_ids}'
-        , ','))`;
+const txnStmtFingerprintsQuery = (txn_fingerprint_ids: string[] | string) => `
+SELECT
+  DISTINCT ON (fingerprint_id) encode(fingerprint_id, 'hex') AS transaction_fingerprint_id,
+  app_name,
+  ARRAY( SELECT jsonb_array_elements_text(metadata -> 'stmtFingerprintIDs' )) AS query_ids
+FROM crdb_internal.transaction_statistics
+WHERE app_name != '${INTERNAL_SQL_API_APP}'
+  AND encode(fingerprint_id, 'hex') = ANY (string_to_array('${txn_fingerprint_ids}', ','))`;
 
 function txnStmtFingerprintsResultsToEventState(
   response: SqlExecutionResponse<TxnStmtFingerprintsResponseColumns>,
@@ -164,13 +165,12 @@ type FingerprintStmtsResponseColumns = {
 };
 
 // fingerprintStmtsQuery selects all statement queries for each recorded statement fingerprint.
-const fingerprintStmtsQuery = (
-  stmt_fingerprint_ids: string[],
-) => `SELECT DISTINCT ON (fingerprint_id) encode(fingerprint_id, 'hex') AS statement_fingerprint_id,
-                                          prettify_statement(metadata ->> 'query', 108, 1, 1) AS query
-      FROM crdb_internal.statement_statistics
-      WHERE encode(fingerprint_id, 'hex') = ANY (string_to_array('${stmt_fingerprint_ids}'
-        , ','))`;
+const fingerprintStmtsQuery = (stmt_fingerprint_ids: string[]) => `
+SELECT
+  DISTINCT ON (fingerprint_id) encode(fingerprint_id, 'hex') AS statement_fingerprint_id,
+  prettify_statement(metadata ->> 'query', 108, 1, 1) AS query
+FROM crdb_internal.statement_statistics
+WHERE encode(fingerprint_id, 'hex') = ANY (string_to_array('${stmt_fingerprint_ids}', ','))`;
 
 function fingerprintStmtsResultsToEventState(
   response: SqlExecutionResponse<FingerprintStmtsResponseColumns>,
@@ -315,30 +315,29 @@ export type TransactionContentionEventDetailsResponse =
   TransactionContentionEventDetailsState;
 
 // txnContentionDetailsQuery selects information about a specific transaction contention event.
-const txnContentionDetailsQuery = (id: string) => `SELECT collection_ts,
-                                                          blocking_txn_id,
-                                                          encode(
-                                                            blocking_txn_fingerprint_id, 'hex'
-                                                            ) AS blocking_txn_fingerprint_id,
-                                                          waiting_txn_id,
-                                                          encode(
-                                                            waiting_txn_fingerprint_id, 'hex'
-                                                            ) AS waiting_txn_fingerprint_id,
-                                                          contention_duration,
-                                                          crdb_internal.pretty_key(contending_key, 0) AS key,
-                                                          database_name,
-                                                          schema_name,
-                                                          table_name,
-                                                          index_name,
-                                                          threshold
-                                                   FROM (SELECT "sql.insights.latency_threshold" :: INTERVAL AS threshold
-                                                         FROM
-                                                           [SHOW CLUSTER SETTING sql.insights.latency_threshold]),
-                                                        crdb_internal.transaction_contention_events AS tce
-                                                          LEFT OUTER JOIN crdb_internal.ranges AS ranges
-                                                                          ON tce.contending_key BETWEEN ranges.start_key
-                                                                            AND ranges.end_key
-                                                   WHERE waiting_txn_id = '${id}'
+const txnContentionDetailsQuery = (id: string) => `
+SELECT
+  collection_ts,
+  blocking_txn_id,
+  encode( blocking_txn_fingerprint_id, 'hex' ) AS blocking_txn_fingerprint_id,
+  waiting_txn_id,
+  encode( waiting_txn_fingerprint_id, 'hex' ) AS waiting_txn_fingerprint_id,
+  contention_duration,
+  crdb_internal.pretty_key(contending_key, 0) AS key,
+  database_name,
+  schema_name,
+  table_name,
+  index_name,
+  threshold
+FROM
+  (
+    SELECT "sql.insights.latency_threshold"::INTERVAL AS threshold
+    FROM [SHOW CLUSTER SETTING sql.insights.latency_threshold]
+  ),
+  crdb_internal.transaction_contention_events AS tce
+  LEFT OUTER JOIN crdb_internal.ranges AS ranges
+    ON tce.contending_key BETWEEN ranges.start_key AND ranges.end_key
+  WHERE waiting_txn_id = '${id}'
 `;
 
 type TxnContentionDetailsResponseColumns = {
@@ -682,7 +681,7 @@ const statementInsightsQuery: InsightQuery<
       problem,
       causes,
       plan_gist,
-      row_number()                          OVER (
+      row_number()    OVER (
         PARTITION BY txn_fingerprint_id
         ORDER BY end_time DESC
       ) AS rank

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
@@ -18,7 +18,7 @@ import "antd/lib/row/style";
 import { Button } from "src/button";
 import { Loading } from "src/loading";
 import { SqlBox, SqlBoxSize } from "src/sql";
-import { getMatchParamByName } from "src/util/query";
+import { getMatchParamByName, executionIdAttr } from "src/util";
 import { StatementInsightEvent } from "../types";
 import { InsightsError } from "../insightsErrorComponent";
 import classNames from "classnames/bind";
@@ -98,7 +98,7 @@ export const StatementInsightDetails: React.FC<
     }
   };
 
-  const executionID = getMatchParamByName(match, "id");
+  const executionID = getMatchParamByName(match, executionIdAttr);
 
   useEffect(() => {
     if (insightEventDetails == null) {

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
@@ -22,7 +22,6 @@ import {
   InsightRecommendation,
   StatementInsightEvent,
 } from "../types";
-import { populateStatementInsightsFromProblemAndCauses } from "../utils";
 import classNames from "classnames/bind";
 import { CockroachCloudContext } from "../../contexts";
 
@@ -47,73 +46,69 @@ const insightsTableData = (
 ): InsightRecommendation[] => {
   if (!insightDetails) return [];
 
-  const recs: InsightRecommendation[] = [];
-  let rec: InsightRecommendation;
   const execDetails: executionDetails = {
     statement: insightDetails.query,
     fingerprintID: insightDetails.statementFingerprintID,
     retries: insightDetails.retries,
   };
-  insightDetails.insights.forEach(insight => {
-    switch (insight.name) {
-      case InsightNameEnum.highContention:
-        rec = {
-          type: "HighContention",
-          execution: execDetails,
-          details: {
-            duration: insightDetails.elapsedTimeMillis,
-            description: insight.description,
-          },
-        };
-        break;
-      case InsightNameEnum.failedExecution:
-        rec = {
-          type: "FailedExecution",
-        };
-        break;
-      case InsightNameEnum.highRetryCount:
-        rec = {
-          type: "HighRetryCount",
-          execution: execDetails,
-          details: {
-            description: insight.description,
-          },
-        };
-        break;
-      case InsightNameEnum.planRegression:
-        rec = {
-          type: "PlanRegression",
-          execution: execDetails,
-          details: {
-            description: insight.description,
-          },
-        };
-        break;
-      case InsightNameEnum.suboptimalPlan:
-        rec = {
-          type: "SuboptimalPlan",
-          database: insightDetails.databaseName,
-          execution: {
-            ...execDetails,
-            indexRecommendations: insightDetails.indexRecommendations,
-          },
-          details: {
-            description: insight.description,
-          },
-        };
-        break;
-      default:
-        rec = {
-          type: "Unknown",
-          details: {
-            duration: insightDetails.elapsedTimeMillis,
-            description: insight.description,
-          },
-        };
-        break;
-    }
-    recs.push(rec);
-  });
+
+  const recs: InsightRecommendation[] = insightDetails.insights?.map(
+    insight => {
+      switch (insight.name) {
+        case InsightNameEnum.highContention:
+          return {
+            type: "HighContention",
+            execution: execDetails,
+            details: {
+              duration: insightDetails.elapsedTimeMillis,
+              description: insight.description,
+            },
+          };
+        case InsightNameEnum.failedExecution:
+          return {
+            type: "FailedExecution",
+          };
+        case InsightNameEnum.highRetryCount:
+          return {
+            type: "HighRetryCount",
+            execution: execDetails,
+            details: {
+              description: insight.description,
+            },
+          };
+          break;
+        case InsightNameEnum.planRegression:
+          return {
+            type: "PlanRegression",
+            execution: execDetails,
+            details: {
+              description: insight.description,
+            },
+          };
+        case InsightNameEnum.suboptimalPlan:
+          return {
+            type: "SuboptimalPlan",
+            database: insightDetails.databaseName,
+            execution: {
+              ...execDetails,
+              indexRecommendations: insightDetails.indexRecommendations,
+            },
+            details: {
+              description: insight.description,
+            },
+          };
+        default:
+          return {
+            type: "Unknown",
+            details: {
+              duration: insightDetails.elapsedTimeMillis,
+              description: insight.description,
+            },
+          };
+      }
+    },
+  );
+
   return recs;
 };
 
@@ -132,11 +127,7 @@ export const StatementInsightDetailsOverviewTab: React.FC<
     [isCockroachCloud],
   );
 
-  const insightDetailsArr = useMemo(
-    () => populateStatementInsightsFromProblemAndCauses([insightEventDetails]),
-    [insightEventDetails],
-  );
-  const insightDetails = insightDetailsArr.length ? insightDetailsArr[0] : null;
+  const insightDetails = insightEventDetails;
   const tableData = insightsTableData(insightDetails);
 
   return (

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
-import React, { useContext } from "react";
+import React, { useContext, useEffect } from "react";
 import Helmet from "react-helmet";
 import { RouteComponentProps } from "react-router-dom";
 import { ArrowLeft } from "@cockroachlabs/icons";
@@ -36,6 +36,7 @@ import {
   EventExecution,
   InsightNameEnum,
   InsightRecommendation,
+  TransactionInsightEventDetails,
 } from "../types";
 
 import classNames from "classnames/bind";
@@ -45,8 +46,28 @@ import { CockroachCloudContext } from "../../contexts";
 import { InsightsError } from "../insightsErrorComponent";
 import { TransactionDetailsLink } from "../workloadInsights/util";
 import { TimeScale } from "../../timeScaleDropdown";
+import { executionIdAttr } from "src/util";
 
 const tableCx = classNames.bind(insightTableStyles);
+
+function insightsTableData(
+  insightDetails: TransactionInsightEventDetails,
+): InsightRecommendation[] {
+  if (!insightDetails?.insights) {
+    return [];
+  }
+  return insightDetails.insights
+    .filter(insight => insight.name === InsightNameEnum.highContention)
+    .map(insight => {
+      return {
+        type: "HighContention",
+        details: {
+          duration: insightDetails.totalContentionTime,
+          description: insight.description,
+        },
+      };
+    });
+}
 
 export interface TransactionInsightDetailsStateProps {
   insightEventDetails: TransactionInsightEventDetailsResponse;
@@ -65,162 +86,148 @@ export type TransactionInsightDetailsProps =
     TransactionInsightDetailsDispatchProps &
     RouteComponentProps<unknown>;
 
-export class TransactionInsightDetails extends React.Component<TransactionInsightDetailsProps> {
-  constructor(props: TransactionInsightDetailsProps) {
-    super(props);
-  }
+export const TransactionInsightDetails: React.FC<
+  TransactionInsightDetailsProps
+> = ({
+  refreshTransactionInsightDetails,
+  setTimeScale,
+  history,
+  insightEventDetails,
+  insightError,
+  match,
+}) => {
+  const isCockroachCloud = useContext(CockroachCloudContext);
+  const executionID = getMatchParamByName(match, executionIdAttr);
+  const noInsights = !insightEventDetails;
+  useEffect(() => {
+    if (noInsights) {
+      refreshTransactionInsightDetails({
+        id: executionID,
+      });
+    }
+  }, [executionID, refreshTransactionInsightDetails, noInsights]);
 
-  private refresh(): void {
-    this.props.refreshTransactionInsightDetails({
-      id: getMatchParamByName(this.props.match, "id"),
+  const prevPage = (): void => history.goBack();
+
+  const insightDetails =
+    getTransactionInsightEventDetailsFromState(insightEventDetails);
+
+  const insightQueries =
+    insightDetails?.queries.join("") || "Insight not found.";
+  const insightsColumns = makeInsightsColumns(isCockroachCloud);
+
+  const blockingExecutions: EventExecution[] =
+    insightDetails?.blockingContentionDetails.map(x => {
+      return {
+        executionID: x.blockingExecutionID,
+        fingerprintID: x.blockingFingerprintID,
+        queries: x.blockingQueries,
+        startTime: x.collectionTimeStamp,
+        contentionTimeMs: x.contentionTimeMs,
+        execType: insightDetails.execType,
+        schemaName: x.schemaName,
+        databaseName: x.databaseName,
+        tableName: x.tableName,
+        indexName: x.indexName,
+      };
     });
-  }
 
-  componentDidMount(): void {
-    this.refresh();
-  }
+  const tableData = insightsTableData(insightDetails);
 
-  prevPage = (): void => this.props.history.goBack();
-
-  renderContent = (): React.ReactElement => {
-    const insightDetails = getTransactionInsightEventDetailsFromState(
-      this.props.insightEventDetails,
-    );
-    if (!insightDetails) {
-      return null;
-    }
-    const insightQueries = insightDetails.queries.join("");
-    const isCockroachCloud = useContext(CockroachCloudContext);
-    const insightsColumns = makeInsightsColumns(isCockroachCloud);
-
-    function insightsTableData(): InsightRecommendation[] {
-      const recs: InsightRecommendation[] = [];
-      let rec: InsightRecommendation;
-      insightDetails.insights.forEach(insight => {
-        switch (insight.name) {
-          case InsightNameEnum.highContention:
-            rec = {
-              type: "HighContention",
-              details: {
-                duration: insightDetails.totalContentionTime,
-                description: insight.description,
-              },
-            };
-            break;
-        }
-      });
-      recs.push(rec);
-      return recs;
-    }
-
-    const tableData = insightsTableData();
-    const blockingExecutions: EventExecution[] =
-      insightDetails.blockingContentionDetails.map(x => {
-        return {
-          executionID: x.blockingExecutionID,
-          fingerprintID: x.blockingFingerprintID,
-          queries: x.blockingQueries,
-          startTime: x.collectionTimeStamp,
-          contentionTimeMs: x.contentionTimeMs,
-          execType: insightDetails.execType,
-          schemaName: x.schemaName,
-          databaseName: x.databaseName,
-          tableName: x.tableName,
-          indexName: x.indexName,
-        };
-      });
-
-    return (
-      <>
-        <section className={tableCx("section")}>
-          <Row gutter={24}>
-            <Col className="gutter-row" span={24}>
-              <SqlBox value={insightQueries} size={SqlBoxSize.custom} />
-            </Col>
-          </Row>
-          <Row gutter={24}>
-            <Col className="gutter-row" span={12}>
-              <SummaryCard>
-                <SummaryCardItem
-                  label="Start Time"
-                  value={insightDetails.startTime.format(DATE_FORMAT_24_UTC)}
-                />
-              </SummaryCard>
-            </Col>
-            <Col className="gutter-row" span={12}>
-              <SummaryCard>
-                <SummaryCardItem
-                  label="Transaction Fingerprint ID"
-                  value={TransactionDetailsLink(
-                    insightDetails.fingerprintID,
-                    insightDetails.startTime,
-                    this.props.setTimeScale,
-                  )}
-                />
-              </SummaryCard>
-            </Col>
-          </Row>
-          <Row gutter={24} className={tableCx("margin-bottom")}>
-            {/* TO DO (ericharmeling): We might want this table to span the entire page when other types of insights
-            are added*/}
-            <Col className="gutter-row" span={12}>
-              <InsightsSortedTable columns={insightsColumns} data={tableData} />
-            </Col>
-          </Row>
-        </section>
-        <section className={tableCx("section")}>
-          <Row gutter={24}>
-            <Col className="gutter-row">
-              <Heading type="h5">
-                {WaitTimeInsightsLabels.BLOCKED_TXNS_TABLE_TITLE(
-                  insightDetails.executionID,
-                  insightDetails.execType,
-                )}
-              </Heading>
-              <div className={tableCx("table-area")}>
-                <WaitTimeDetailsTable
-                  data={blockingExecutions}
-                  execType={insightDetails.execType}
-                />
-              </div>
-            </Col>
-          </Row>
-        </section>
-      </>
-    );
-  };
-
-  render(): React.ReactElement {
-    return (
+  return (
+    <div>
+      <Helmet title={"Details | Insight"} />
       <div>
-        <Helmet title={"Details | Insight"} />
-        <div>
-          <Button
-            onClick={this.prevPage}
-            type="unstyled-link"
-            size="small"
-            icon={<ArrowLeft fontSize={"10px"} />}
-            iconPosition="left"
-            className={commonStyles("small-margin")}
-          >
-            Insights
-          </Button>
-          <h3
-            className={commonStyles("base-heading", "no-margin-bottom")}
-          >{`Transaction Execution ID: ${String(
-            getMatchParamByName(this.props.match, "id"),
-          )}`}</h3>
-        </div>
-        <section>
-          <Loading
-            loading={this.props.insightEventDetails == null}
-            page={"Transaction Insight details"}
-            error={this.props.insightError}
-            render={this.renderContent}
-            renderError={() => InsightsError()}
-          />
-        </section>
+        <Button
+          onClick={prevPage}
+          type="unstyled-link"
+          size="small"
+          icon={<ArrowLeft fontSize={"10px"} />}
+          iconPosition="left"
+          className={commonStyles("small-margin")}
+        >
+          Insights
+        </Button>
+        <h3
+          className={commonStyles("base-heading", "no-margin-bottom")}
+        >{`Transaction Execution ID: ${String(
+          getMatchParamByName(match, executionIdAttr),
+        )}`}</h3>
       </div>
-    );
-  }
-}
+      <section>
+        <Loading
+          loading={insightEventDetails == null}
+          page={"Transaction Insight details"}
+          error={insightError}
+          renderError={() => InsightsError()}
+        >
+          <section className={tableCx("section")}>
+            <Row gutter={24}>
+              <Col className="gutter-row" span={24}>
+                <SqlBox value={insightQueries} size={SqlBoxSize.custom} />
+              </Col>
+            </Row>
+            {insightDetails && (
+              <>
+                <Row gutter={24}>
+                  <Col className="gutter-row" span={12}>
+                    <SummaryCard>
+                      <SummaryCardItem
+                        label="Start Time"
+                        value={insightDetails.startTime.format(
+                          DATE_FORMAT_24_UTC,
+                        )}
+                      />
+                    </SummaryCard>
+                  </Col>
+                  <Col className="gutter-row" span={12}>
+                    <SummaryCard>
+                      <SummaryCardItem
+                        label="Transaction Fingerprint ID"
+                        value={TransactionDetailsLink(
+                          insightDetails.fingerprintID,
+                          insightDetails.startTime,
+                          setTimeScale,
+                        )}
+                      />
+                    </SummaryCard>
+                  </Col>
+                </Row>
+                <Row gutter={24} className={tableCx("margin-bottom")}>
+                  {/* TO DO (ericharmeling): We might want this table to span the entire page when other types of insights
+            are added*/}
+                  <Col className="gutter-row" span={12}>
+                    <InsightsSortedTable
+                      columns={insightsColumns}
+                      data={tableData}
+                    />
+                  </Col>
+                </Row>
+              </>
+            )}
+          </section>
+          {blockingExecutions?.length && insightDetails && (
+            <section className={tableCx("section")}>
+              <Row gutter={24}>
+                <Col className="gutter-row">
+                  <Heading type="h5">
+                    {WaitTimeInsightsLabels.BLOCKED_TXNS_TABLE_TITLE(
+                      insightDetails.executionID,
+                      insightDetails.execType,
+                    )}
+                  </Heading>
+                  <div className={tableCx("table-area")}>
+                    <WaitTimeDetailsTable
+                      data={blockingExecutions}
+                      execType={insightDetails.execType}
+                    />
+                  </div>
+                </Col>
+              </Row>
+            </section>
+          )}
+        </Loading>
+      </section>
+    </div>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsConnected.tsx
@@ -27,10 +27,10 @@ import { TransactionInsightEventDetailsRequest } from "src/api";
 
 const mapStateToProps = (
   state: AppState,
-  _props: RouteComponentProps,
+  props: RouteComponentProps,
 ): TransactionInsightDetailsStateProps => {
-  const insightDetails = selectTransactionInsightDetails(state);
-  const insightError = selectTransactionInsightDetailsError(state);
+  const insightDetails = selectTransactionInsightDetails(state, props);
+  const insightError = selectTransactionInsightDetailsError(state, props);
   return {
     insightEventDetails: insightDetails,
     insightError: insightError,

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsTable.tsx
@@ -22,7 +22,7 @@ import {
   insightsTableTitles,
   StatementDetailsLink,
 } from "../util";
-import { StatementInsights } from "../../../api";
+import { StatementInsights } from "src/api";
 import { Tooltip } from "@cockroachlabs/ui-components";
 import { Link } from "react-router-dom";
 import classNames from "classnames/bind";

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
@@ -36,7 +36,6 @@ import {
   getAppsFromStatementInsights,
   makeStatementInsightsColumns,
   WorkloadInsightEventFilters,
-  populateStatementInsightsFromProblemAndCauses,
 } from "src/insights";
 import { EmptyInsightsTablePlaceholder } from "../util";
 import { StatementInsightsTable } from "./statementInsightsTable";
@@ -203,8 +202,10 @@ export const StatementInsightsView: React.FC<StatementInsightsViewProps> = (
     search,
   );
 
-  const statementInsights =
-    populateStatementInsightsFromProblemAndCauses(filteredStatements);
+  // const statementInsights =
+  //   populateStatementInsightsFromProblemAndCauses(filteredStatements);
+  const statementInsights = filteredStatements;
+
   const tableColumns = defaultColumns
     .filter(c => !c.alwaysShow)
     .map(

--- a/pkg/ui/workspaces/cluster-ui/src/selectors/activeExecutions.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/selectors/activeExecutions.selectors.ts
@@ -11,10 +11,9 @@
 import { createSelector } from "reselect";
 import { ActiveExecutions } from "src/activeExecutions/types";
 import { AppState } from "src/store";
-import {
-  selectActiveExecutionsCombiner,
-  selectExecutionID,
-} from "./activeExecutionsCommon.selectors";
+import { selectActiveExecutionsCombiner } from "src/selectors/activeExecutionsCommon.selectors";
+import { selectExecutionID } from "src/selectors/common";
+
 import {
   getActiveTransaction,
   getContentionDetailsFromLocksAndTxns,

--- a/pkg/ui/workspaces/cluster-ui/src/selectors/activeExecutionsCommon.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/selectors/activeExecutionsCommon.selectors.ts
@@ -8,10 +8,8 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { RouteComponentProps } from "react-router";
 import { ActiveExecutions, SessionsResponse } from "src/activeExecutions/types";
 import { ClusterLocksResponse } from "src/api";
-import { executionIdAttr, getMatchParamByName } from "src/util";
 import {
   getActiveExecutionsFromSessions,
   getWaitTimeByTxnIDFromLocks,
@@ -20,11 +18,6 @@ import {
 // The functions in this file are agnostic to the different shape of each
 // state in db-console and cluster-ui. This file contains selector functions
 // and combiners that can be reused across both packages.
-
-export const selectExecutionID = (
-  _state: unknown,
-  props: RouteComponentProps,
-): string | null => getMatchParamByName(props.match, executionIdAttr);
 
 export const selectActiveExecutionsCombiner = (
   sessions: SessionsResponse | null,

--- a/pkg/ui/workspaces/cluster-ui/src/selectors/common.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/selectors/common.ts
@@ -1,0 +1,23 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { RouteComponentProps } from "react-router";
+import { getMatchParamByName, executionIdAttr } from "src/util";
+
+// The functions in this file are agnostic to the different shape of each
+// state in db-console and cluster-ui. This file contains selector functions
+// and combiners that can be reused across both packages.
+// This is to avoid unnecessary repeated logic in the creation of selectors
+// between db-console and cluster-ui.
+
+export const selectExecutionID = (
+  _state: unknown,
+  props: RouteComponentProps,
+): string | null => getMatchParamByName(props.match, executionIdAttr);

--- a/pkg/ui/workspaces/cluster-ui/src/selectors/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/selectors/index.ts
@@ -8,4 +8,48 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+// Only export functions here which are used in both db-console
+// and cluster-ui. The purpose of these functions should be to
+// reduce the amount of repeated logic in selector bodies throughout
+// cluster-ui and db-console.
+//
+// Example:
+// Suppose we have an api response, responseData.
+// In both cluster-ui and db-console, responseData is stored in redux.
+// We would like to convert responseData -> componentData, and so we
+// create two distinct selectors in cluster-ui and db-console that both look
+// something like this:
+//
+// const selector = createSelector(
+//     functionToGetApiResponseFromReduxStore,
+//     ...otherSelectors,
+//     (apiResponse, ...otherStuff) => {
+//         /* some logic that converts apiResponse -> componentData format */
+//     }
+// );
+//
+// We need these distinct selectors because the shape of redux is different
+// in both packages. For some cases, the logic in the combiner function
+// body to convert the redux data to the expected format can be quite
+// lengthy (e.g. statement sql stats) and when we make changes / fixes to them
+// we need to change both selector functions (essentially maintaining a copy in
+// each repo).
+// To reduce this, we can use the same combiner functions so long as we are able
+// to provide the same parameters to the function.  Thus, we can export something
+// like the below in the cluster-ui package to reuse across both:
+//
+// Exported function:
+// export const combinerFunc = (resultA, resultB) => {
+//     /* convert to expected format */
+// }
+//
+// Usage:
+// const mySelector = createSelector(
+//     selectA,
+//     selectB,
+//     combinerFunc, <-- all the important logic
+// )
+
+export * from "./common";
 export * from "./activeExecutionsCommon.selectors";
+export * from "./insightsCommon.selectors";

--- a/pkg/ui/workspaces/cluster-ui/src/selectors/insightsCommon.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/selectors/insightsCommon.selectors.ts
@@ -1,0 +1,47 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import {
+  StatementInsights,
+  TransactionInsightEventsResponse,
+} from "src/api/insightsApi";
+import {
+  StatementInsightEvent,
+  populateStatementInsightsFromProblemAndCauses,
+} from "src/insights";
+
+// The functions in this file are agnostic to the different shape of each
+// state in db-console and cluster-ui. This file contains selector functions
+// and combiners that can be reused across both packages.
+
+export const selectStatementInsightsCombiner = (
+  statementInsights: StatementInsights,
+): StatementInsights => {
+  if (!statementInsights) return [];
+  return populateStatementInsightsFromProblemAndCauses(statementInsights);
+};
+
+export const selectStatementInsightDetailsCombiner = (
+  statementInsights: StatementInsights,
+  executionID: string,
+): StatementInsightEvent | null => {
+  if (!statementInsights) {
+    return null;
+  }
+
+  return statementInsights.find(insight => insight.statementID === executionID);
+};
+
+export const selectTxnInsightsCombiner = (
+  txnInsights: TransactionInsightEventsResponse,
+): TransactionInsightEventsResponse => {
+  if (!txnInsights) return [];
+  return txnInsights;
+};

--- a/pkg/ui/workspaces/cluster-ui/src/store/insightDetails/transactionInsightDetails/transactionInsightDetails.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insightDetails/transactionInsightDetails/transactionInsightDetails.selectors.ts
@@ -9,28 +9,23 @@
 // licenses/APL.txt.
 
 import { createSelector } from "reselect";
-import { adminUISelector } from "src/store/utils/selectors";
+import { AppState } from "src/store/reducers";
+import { selectExecutionID } from "src/selectors/common";
 
 const selectTransactionInsightDetailsState = createSelector(
-  adminUISelector,
-  adminUiState => {
-    if (!adminUiState.transactionInsightDetails) return null;
-    return adminUiState.transactionInsightDetails;
+  (state: AppState) => state.adminUI.transactionInsightDetails.cachedData,
+  selectExecutionID,
+  (cachedTxnInsightDetails, execId) => {
+    return cachedTxnInsightDetails.get(execId);
   },
 );
 
 export const selectTransactionInsightDetails = createSelector(
   selectTransactionInsightDetailsState,
-  txnInsightDetailsState => {
-    if (!txnInsightDetailsState) return null;
-    return txnInsightDetailsState.data;
-  },
+  state => state.data,
 );
 
 export const selectTransactionInsightDetailsError = createSelector(
   selectTransactionInsightDetailsState,
-  txnInsightDetailsState => {
-    if (!txnInsightDetailsState) return null;
-    return txnInsightDetailsState.lastError;
-  },
+  state => state.lastError,
 );

--- a/pkg/ui/workspaces/cluster-ui/src/store/insights/statementInsights/statementInsights.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insights/statementInsights/statementInsights.selectors.ts
@@ -9,50 +9,26 @@
 // licenses/APL.txt.
 
 import { createSelector } from "reselect";
+import { localStorageSelector } from "src/store/utils/selectors";
+import { AppState } from "src/store/reducers";
+
 import {
-  adminUISelector,
-  localStorageSelector,
-} from "src/store/utils/selectors";
-import { getMatchParamByName } from "../../../util";
-import { RouteComponentProps } from "react-router";
-import { StatementInsightEvent } from "../../../insights";
-import { AppState } from "../../reducers";
-
-const selectStatementInsightsState = createSelector(
-  adminUISelector,
-  adminUiState => {
-    if (!adminUiState.statementInsights) return null;
-    return adminUiState.statementInsights;
-  },
-);
-
+  selectStatementInsightsCombiner,
+  selectStatementInsightDetailsCombiner,
+} from "src/selectors/insightsCommon.selectors";
+import { selectExecutionID } from "src/selectors/common";
 export const selectStatementInsights = createSelector(
-  selectStatementInsightsState,
-  stmtInsightsState => {
-    if (!stmtInsightsState) return [];
-    return stmtInsightsState.data;
-  },
+  (state: AppState) => state.adminUI.statementInsights?.data,
+  selectStatementInsightsCombiner,
 );
 
-export const selectStatementInsightsError = createSelector(
-  selectStatementInsightsState,
-  stmtInsightsState => {
-    if (!stmtInsightsState) return null;
-    return stmtInsightsState.lastError;
-  },
-);
+export const selectStatementInsightsError = (state: AppState) =>
+  state.adminUI.statementInsights?.lastError;
 
 export const selectStatementInsightDetails = createSelector(
-  selectStatementInsightsState,
-  (_state: AppState, props: RouteComponentProps) => props,
-  (statementInsights, props): StatementInsightEvent => {
-    if (!statementInsights) return null;
-
-    const insightId = getMatchParamByName(props.match, "id");
-    return statementInsights.data?.find(
-      statementInsight => statementInsight.statementID === insightId,
-    );
-  },
+  selectStatementInsights,
+  selectExecutionID,
+  selectStatementInsightDetailsCombiner,
 );
 
 export const selectColumns = createSelector(

--- a/pkg/ui/workspaces/cluster-ui/src/store/insights/transactionInsights/transactionInsights.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insights/transactionInsights/transactionInsights.selectors.ts
@@ -9,34 +9,20 @@
 // licenses/APL.txt.
 
 import { createSelector } from "reselect";
-import {
-  adminUISelector,
-  localStorageSelector,
-} from "src/store/utils/selectors";
+import { AppState } from "src/store/reducers";
+import { selectTxnInsightsCombiner } from "src/selectors/insightsCommon.selectors";
+import { localStorageSelector } from "src/store/utils/selectors";
 
-const selectTransactionInsightsState = createSelector(
-  adminUISelector,
-  adminUiState => {
-    if (!adminUiState.transactionInsights) return null;
-    return adminUiState.transactionInsights;
-  },
-);
+const selectTransactionInsightsData = (state: AppState) =>
+  state.adminUI.transactionInsights.data;
 
 export const selectTransactionInsights = createSelector(
-  selectTransactionInsightsState,
-  txnInsightsState => {
-    if (!txnInsightsState) return [];
-    return txnInsightsState.data;
-  },
+  selectTransactionInsightsData,
+  selectTxnInsightsCombiner,
 );
 
-export const selectTransactionInsightsError = createSelector(
-  selectTransactionInsightsState,
-  txnInsightsState => {
-    if (!txnInsightsState) return null;
-    return txnInsightsState.lastError;
-  },
-);
+export const selectTransactionInsightsError = (state: AppState) =>
+  state.adminUI.transactionInsights?.lastError;
 
 export const selectSortSetting = createSelector(
   localStorageSelector,

--- a/pkg/ui/workspaces/cluster-ui/src/store/reducers.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/reducers.ts
@@ -52,8 +52,8 @@ import {
   reducer as schemaInsights,
 } from "./schemaInsights";
 import {
-  TransactionInsightDetailsState,
   reducer as transactionInsightDetails,
+  TransactionInsightDetailsCachedState,
 } from "./insightDetails/transactionInsightDetails";
 
 export type AdminUiState = {
@@ -71,7 +71,7 @@ export type AdminUiState = {
   job: JobState;
   clusterLocks: ClusterLocksReqState;
   transactionInsights: TransactionInsightsState;
-  transactionInsightDetails: TransactionInsightDetailsState;
+  transactionInsightDetails: TransactionInsightDetailsCachedState;
   statementInsights: StatementInsightsState;
   schemaInsights: SchemaInsightsState;
 };

--- a/pkg/ui/workspaces/db-console/src/app.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.tsx
@@ -311,11 +311,11 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
                     component={InsightsOverviewPage}
                   />
                   <Route
-                    path={"/insights/transaction/:id"}
+                    path={`/insights/transaction/:${executionIdAttr}`}
                     component={TransactionInsightDetailsPage}
                   />
                   <Route
-                    path={"/insights/statement/:id"}
+                    path={`/insights/statement/:${executionIdAttr}`}
                     component={StatementInsightDetailsPage}
                   />
 

--- a/pkg/ui/workspaces/db-console/src/views/insights/insightsSelectors.ts
+++ b/pkg/ui/workspaces/db-console/src/views/insights/insightsSelectors.ts
@@ -18,11 +18,11 @@ import {
   insightType,
   SchemaInsightEventFilters,
   SortSetting,
-  StatementInsightEvent,
+  selectStatementInsightsCombiner,
+  selectExecutionID,
+  selectStatementInsightDetailsCombiner,
+  selectTxnInsightsCombiner,
 } from "@cockroachlabs/cluster-ui";
-import { RouteComponentProps } from "react-router-dom";
-import { CachedDataReducerState } from "src/redux/cachedDataReducer";
-import { getMatchParamByName } from "src/util/query";
 
 export const filtersLocalSetting = new LocalSetting<
   AdminUIState,
@@ -40,50 +40,43 @@ export const sortSettingLocalSetting = new LocalSetting<
 });
 
 export const selectTransactionInsights = createSelector(
-  (state: AdminUIState) => state.cachedData,
-  adminUiState => {
-    if (!adminUiState.transactionInsights) return [];
-    return adminUiState.transactionInsights.data;
-  },
+  (state: AdminUIState) => state.cachedData.transactionInsights?.data,
+  selectTxnInsightsCombiner,
 );
 
 export const selectTransactionInsightDetails = createSelector(
   [
     (state: AdminUIState) => state.cachedData.transactionInsightDetails,
-    (_state: AdminUIState, props: RouteComponentProps) => props,
+    selectExecutionID,
   ],
-  (
-    insight,
-    props,
-  ): CachedDataReducerState<api.TransactionInsightEventDetailsResponse> => {
+  (insight, insightId): api.TransactionInsightEventDetailsResponse => {
     if (!insight) {
       return null;
     }
-    const insightId = getMatchParamByName(props.match, "id");
-    return insight[insightId];
+    return insight[insightId]?.data;
+  },
+);
+
+export const selectTransactionInsightDetailsError = createSelector(
+  (state: AdminUIState) => state.cachedData.transactionInsightDetails,
+  selectExecutionID,
+  (insight, insightId): Error | null => {
+    if (!insight) {
+      return null;
+    }
+    return insight[insightId]?.lastError;
   },
 );
 
 export const selectStatementInsights = createSelector(
-  (state: AdminUIState) => state.cachedData,
-  adminUiState => {
-    if (!adminUiState.statementInsights) return [];
-    return adminUiState.statementInsights.data;
-  },
+  (state: AdminUIState) => state.cachedData.statementInsights?.data,
+  selectStatementInsightsCombiner,
 );
 
 export const selectStatementInsightDetails = createSelector(
-  [
-    (state: AdminUIState) => state.cachedData.statementInsights,
-    (_state: AdminUIState, props: RouteComponentProps) => props,
-  ],
-  (insights, props): StatementInsightEvent => {
-    if (!insights) {
-      return null;
-    }
-    const insightId = getMatchParamByName(props.match, "id");
-    return insights.data?.find(insight => insight.statementID === insightId);
-  },
+  selectStatementInsights,
+  selectExecutionID,
+  selectStatementInsightDetailsCombiner,
 );
 
 export const schemaInsightsFiltersLocalSetting = new LocalSetting<

--- a/pkg/ui/workspaces/db-console/src/views/insights/transactionInsightDetailsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/insights/transactionInsightDetailsPage.tsx
@@ -11,31 +11,29 @@ import {
   TransactionInsightDetails,
   TransactionInsightDetailsStateProps,
   TransactionInsightDetailsDispatchProps,
-  api,
 } from "@cockroachlabs/cluster-ui";
 import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { refreshTransactionInsightDetails } from "src/redux/apiReducers";
 import { AdminUIState } from "src/redux/state";
-import { selectTransactionInsightDetails } from "src/views/insights/insightsSelectors";
+import {
+  selectTransactionInsightDetails,
+  selectTransactionInsightDetailsError,
+} from "src/views/insights/insightsSelectors";
 import { setGlobalTimeScaleAction } from "src/redux/statements";
 
 const mapStateToProps = (
   state: AdminUIState,
   props: RouteComponentProps,
 ): TransactionInsightDetailsStateProps => {
-  const insightDetailsState = selectTransactionInsightDetails(state, props);
-  const insight: api.TransactionInsightEventDetailsResponse =
-    insightDetailsState?.data;
-  const insightError = insightDetailsState?.lastError;
   return {
-    insightEventDetails: insight,
-    insightError: insightError,
+    insightEventDetails: selectTransactionInsightDetails(state, props),
+    insightError: selectTransactionInsightDetailsError(state, props),
   };
 };
 
 const mapDispatchToProps: TransactionInsightDetailsDispatchProps = {
-  refreshTransactionInsightDetails: refreshTransactionInsightDetails,
+  refreshTransactionInsightDetails,
   setTimeScale: setGlobalTimeScaleAction,
 };
 


### PR DESCRIPTION
Backport 2 commits from #91698:

[- cluster-ui: format insights queries](https://github.com/cockroachdb/cockroach/commit/381836e7a482e334332d799bd57320da7ef066ea)
[- cluster-ui: insights cleanup](https://github.com/cockroachdb/cockroach/commit/08ee402edfd7e5746df5f9a4722d2004126b9f77)


Release note: None

Release justification: non production code changes. These will make future backports easier.