### PR TITLE
dev-inf: Add T-multitenant label to multi-tenant

### DIFF
--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -79,7 +79,7 @@ cockroachdb/cluster-ui:
 cockroachdb/obs-inf-prs:
   triage_column_id: 14196277
 cockroachdb/multi-tenant:
-  triage_column_id: 16575985
+  label: T-multitenant
 cockroachdb/jobs:
   aliases:
     cockroachdb/jobs-prs: other


### PR DESCRIPTION
Added the t-multitenant lable to the multi-tenant section of TEAMS.yaml

Release note: None

Epic: None