### PR TITLE
release-22.1: server: correctly query index usage stats for db/table names with quotation marks

### DIFF
--- a/pkg/server/index_usage_stats.go
+++ b/pkg/server/index_usage_stats.go
@@ -335,7 +335,10 @@ func getTableIDFromDatabaseAndTableName(
 		return 0, err
 	}
 	names := strings.Split(fqtName, ".")
-
+	// Strip quotations marks from db and table names.
+	for idx := range names {
+		names[idx] = strings.Trim(names[idx], "\"")
+	}
 	q := makeSQLQuery()
 	q.Append(`SELECT table_id FROM crdb_internal.tables WHERE database_name = $ `, names[0])
 


### PR DESCRIPTION
Backport 1/1 commits from #77642.

/cc @cockroachdb/release

---

server: correctly query index usage stats for db/table names with
quotation marks

Resolves: https://github.com/cockroachlabs/support/issues/1909

**This PR backports a small bugfix from the original PR.** 

This change strips quotation marks from database and table names when
querying for index usages statistics.

Release note (bug fix): Strip quotation marks from database and table
names to correctly query for index usage statistics.

Release justification: Category 2: Bug fixes and low-risk updates to new functionality
