### PR TITLE
ui: show stmt idle time in execution/planning chart

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.fixture.ts
@@ -37,6 +37,7 @@ const statementDetailsNoData: StatementDetailsResponse = {
       max_retries: new Long(0),
       legacy_last_err: "",
       num_rows: { mean: 0, squared_diffs: 0 },
+      idle_lat: { mean: 0, squared_diffs: 0 },
       parse_lat: { mean: 0, squared_diffs: 0 },
       plan_lat: { mean: 0, squared_diffs: 0 },
       run_lat: { mean: 0, squared_diffs: 0 },
@@ -95,6 +96,10 @@ const statementDetailsData: StatementDetailsResponse = {
       num_rows: {
         mean: 6,
         squared_diffs: 0,
+      },
+      idle_lat: {
+        mean: 0.0000876,
+        squared_diffs: 2.35792e-8,
       },
       parse_lat: {
         mean: 0.0000876,
@@ -187,6 +192,10 @@ const statementDetailsData: StatementDetailsResponse = {
         legacy_last_err_redacted: "",
         num_rows: {
           mean: 6,
+          squared_diffs: 0,
+        },
+        idle_lat: {
+          mean: 0.00004,
           squared_diffs: 0,
         },
         parse_lat: {
@@ -285,6 +294,10 @@ const statementDetailsData: StatementDetailsResponse = {
           mean: 6,
           squared_diffs: 0,
         },
+        idle_lat: {
+          mean: 0.000071,
+          squared_diffs: 4.050000000000001e-9,
+        },
         parse_lat: {
           mean: 0.000071,
           squared_diffs: 4.050000000000001e-9,
@@ -381,6 +394,10 @@ const statementDetailsData: StatementDetailsResponse = {
           mean: 6,
           squared_diffs: 0,
         },
+        idle_lat: {
+          mean: 0.000046,
+          squared_diffs: 0,
+        },
         parse_lat: {
           mean: 0.000046,
           squared_diffs: 0,
@@ -475,6 +492,10 @@ const statementDetailsData: StatementDetailsResponse = {
         legacy_last_err_redacted: "",
         num_rows: {
           mean: 6,
+          squared_diffs: 0,
+        },
+        idle_lat: {
+          mean: 0.00021,
           squared_diffs: 0,
         },
         parse_lat: {
@@ -575,6 +596,10 @@ const statementDetailsData: StatementDetailsResponse = {
           mean: 6,
           squared_diffs: 0,
         },
+        idle_lat: {
+          mean: 0.0000876,
+          squared_diffs: 2.35792e-8,
+        },
         parse_lat: {
           mean: 0.0000876,
           squared_diffs: 2.35792e-8,
@@ -668,6 +693,10 @@ const statementDetailsData: StatementDetailsResponse = {
         num_rows: {
           mean: 6,
           squared_diffs: 0,
+        },
+        idle_lat: {
+          mean: 0.0000876,
+          squared_diffs: 2.35792e-8,
         },
         parse_lat: {
           mean: 0.0000876,

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -563,7 +563,12 @@ export class StatementDetails extends React.Component<
       generateExecuteAndPlanningTimeseries(statsPerAggregatedTs);
     const executionAndPlanningOps: Partial<Options> = {
       axes: [{}, { label: "Time Spent" }],
-      series: [{}, { label: "Execution" }, { label: "Planning" }],
+      series: [
+        {},
+        { label: "Execution" },
+        { label: "Planning" },
+        { label: "Idle" },
+      ],
       width: cardWidth,
     };
 

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/timeseriesUtils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/timeseriesUtils.ts
@@ -21,14 +21,16 @@ export function generateExecuteAndPlanningTimeseries(
   const ts: Array<number> = [];
   const execution: Array<number> = [];
   const planning: Array<number> = [];
+  const idle: Array<number> = [];
 
   stats.forEach(function (stat: statementStatisticsPerAggregatedTs) {
     ts.push(TimestampToNumber(stat.aggregated_ts) * 1e3);
     execution.push(stat.stats.run_lat.mean * 1e9);
     planning.push(stat.stats.plan_lat.mean * 1e9);
+    idle.push(stat.stats.idle_lat.mean * 1e9);
   });
 
-  return [ts, execution, planning];
+  return [ts, execution, planning, idle];
 }
 
 export function generateRowsProcessedTimeseries(


### PR DESCRIPTION
Part of #86667.

The example statement fingerprint below comes from me connecting to a local cockroach instance with `psql` (since `cockroach sql` by default runs a few extra queries that confuse the timings) and individually running the following lines to simulate some inter-statement latency:

```sql
BEGIN;
SELECT 1;
COMMIT;
```

| Before | After |
|--|--|
|<img width="1372" alt="Screen Shot 2022-11-21 at 2 35 49 PM" src="https://user-images.githubusercontent.com/5261/203144731-fd5a42fb-7b60-473a-990a-fb5fabf2756a.png">|<img width="1372" alt="Screen Shot 2022-11-21 at 2 35 58 PM" src="https://user-images.githubusercontent.com/5261/203144736-2600c0f9-7811-4b9d-a9e1-dbb8aeea71ee.png">|

Release note (ui change): The "Statement Execution and Planning Time" chart on the statement fingerprint page now includes a third value, "Idle," representing the time spent by the application waiting to execute this statement while holding a transaction open.