### PR TITLE
ui: add time picker to insights pages

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/detailsPanels/waitTimeInsightsPanel.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/detailsPanels/waitTimeInsightsPanel.tsx
@@ -16,7 +16,7 @@ import React from "react";
 import { SummaryCard, SummaryCardItem } from "src/summaryCard";
 
 import { ContendedExecution, ExecutionType } from "src/recentExecutions";
-import { capitalize, Duration } from "../util";
+import { capitalize, Duration, NO_SAMPLES_FOUND } from "../util";
 
 import { Heading } from "@cockroachlabs/ui-components";
 import { ExecutionContentionTable } from "../recentExecutions/recentTransactionsTable/execContentionTable";
@@ -89,7 +89,7 @@ export const WaitTimeInsightsPanel: React.FC<WaitTimeInsightsPanelProps> = ({
                     value={
                       waitTime
                         ? Duration(waitTime.asMilliseconds() * 1e6)
-                        : "no samples"
+                        : NO_SAMPLES_FOUND
                     }
                   />
                   {schemaName && (

--- a/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
@@ -9,7 +9,10 @@
 // licenses/APL.txt.
 
 import { limitStringArray, unset } from "src/util";
-import { FlattenedStmtInsights } from "src/api/insightsApi";
+import {
+  ExecutionInsightsRequest,
+  FlattenedStmtInsights,
+} from "src/api/insightsApi";
 import {
   ExecutionDetails,
   FlattenedStmtInsightEvent,
@@ -28,6 +31,7 @@ import {
   TxnInsightEvent,
   WorkloadInsightEventFilters,
 } from "./types";
+import { TimeScale, toDateRange } from "../timeScaleDropdown";
 
 export const filterTransactionInsights = (
   transactions: MergedTxnInsightEvent[] | null,
@@ -275,7 +279,7 @@ export function getInsightsFromProblemsAndCauses(
 
 /**
  * flattenTxnInsightsToStmts flattens the txn insights array
- * into its stmt insights, including the txn level ifnormation.
+ * into its stmt insights, including the txn level information.
  * Only stmts with non-empty insights array will be included.
  * @param txnInsights array of transaction insights
  * @returns An array of FlattenedStmtInsightEvent where each elem
@@ -287,11 +291,18 @@ export function flattenTxnInsightsToStmts(
 ): FlattenedStmtInsightEvent[] {
   if (!txnInsights?.length) return [];
   const stmtInsights: FlattenedStmtInsightEvent[] = [];
+  const seenExecutions = new Set<string>();
   txnInsights.forEach(txnInsight => {
     const { statementInsights, ...txnInfo } = txnInsight;
     statementInsights?.forEach(stmt => {
-      if (!stmt.insights?.length) return;
+      if (
+        !stmt.insights?.length ||
+        seenExecutions.has(stmt.statementExecutionID)
+      ) {
+        return;
+      }
       stmtInsights.push({ ...txnInfo, ...stmt, query: stmt.query });
+      seenExecutions.add(stmt.statementExecutionID);
     });
   });
   return stmtInsights;
@@ -509,4 +520,15 @@ export function dedupInsights(insights: Insight[]): Insight[] {
     deduped.push(i);
     return deduped;
   }, []);
+}
+
+export function executionInsightsRequestFromTimeScale(
+  ts: TimeScale,
+): ExecutionInsightsRequest {
+  if (ts === null) return {};
+  const [startTime, endTime] = toDateRange(ts);
+  return {
+    start: startTime,
+    end: endTime,
+  };
 }

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
@@ -21,14 +21,15 @@ import { SqlBox, SqlBoxSize } from "src/sql";
 import { getMatchParamByName, idAttr } from "src/util";
 import { FlattenedStmtInsightEvent } from "../types";
 import { InsightsError } from "../insightsErrorComponent";
-import classNames from "classnames/bind";
-
-import { commonStyles } from "src/common";
 import { getExplainPlanFromGist } from "src/api/decodePlanGistApi";
 import { StatementInsightDetailsOverviewTab } from "./statementInsightDetailsOverviewTab";
+import { ExecutionInsightsRequest } from "../../api";
+import { executionInsightsRequestFromTimeScale } from "../utils";
 import { TimeScale } from "../../timeScaleDropdown";
 
 // Styles
+import classNames from "classnames/bind";
+import { commonStyles } from "src/common";
 import insightsDetailsStyles from "src/insights/workloadInsightDetails/insightsDetails.module.scss";
 import LoadingError from "../../sqlActivity/errorComponent";
 
@@ -42,11 +43,12 @@ export interface StatementInsightDetailsStateProps {
   insightEventDetails: FlattenedStmtInsightEvent;
   insightError: Error | null;
   isTenant?: boolean;
+  timeScale?: TimeScale;
 }
 
 export interface StatementInsightDetailsDispatchProps {
+  refreshStatementInsights: (req: ExecutionInsightsRequest) => void;
   setTimeScale: (ts: TimeScale) => void;
-  refreshStatementInsights: () => void;
 }
 
 export type StatementInsightDetailsProps = StatementInsightDetailsStateProps &
@@ -67,6 +69,7 @@ export const StatementInsightDetails: React.FC<
   insightError,
   match,
   isTenant,
+  timeScale,
   setTimeScale,
   refreshStatementInsights,
 }) => {
@@ -101,10 +104,11 @@ export const StatementInsightDetails: React.FC<
   const executionID = getMatchParamByName(match, idAttr);
 
   useEffect(() => {
-    if (insightEventDetails == null) {
-      refreshStatementInsights();
+    if (!insightEventDetails || insightEventDetails === null) {
+      const req = executionInsightsRequestFromTimeScale(timeScale);
+      refreshStatementInsights(req);
     }
-  }, [insightEventDetails, refreshStatementInsights]);
+  }, [insightEventDetails, timeScale, refreshStatementInsights]);
 
   return (
     <div>
@@ -124,8 +128,8 @@ export const StatementInsightDetails: React.FC<
       </h3>
       <div>
         <Loading
-          loading={insightEventDetails == null}
-          page={"Transaction Insight details"}
+          loading={insightEventDetails === null}
+          page={"Statement Insight details"}
           error={insightError}
           renderError={() => InsightsError()}
         >

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsConnected.tsx
@@ -19,30 +19,33 @@ import { AppState } from "src/store";
 import {
   actions as statementInsights,
   selectStatementInsightDetails,
-  selectStatementInsightsError,
+  selectExecutionInsightsError,
 } from "src/store/insights/statementInsights";
 import { selectIsTenant } from "src/store/uiConfig";
 import { TimeScale } from "../../timeScaleDropdown";
 import { actions as sqlStatsActions } from "../../store/sqlStats";
+import { selectTimeScale } from "../../store/utils/selectors";
+import { ExecutionInsightsRequest } from "../../api";
 
 const mapStateToProps = (
   state: AppState,
   props: RouteComponentProps,
 ): StatementInsightDetailsStateProps => {
   const insightStatements = selectStatementInsightDetails(state, props);
-  const insightError = selectStatementInsightsError(state);
+  const insightError = selectExecutionInsightsError(state);
   return {
     insightEventDetails: insightStatements,
     insightError: insightError,
     isTenant: selectIsTenant(state),
+    timeScale: selectTimeScale(state),
   };
 };
 
 const mapDispatchToProps = (
   dispatch: Dispatch,
 ): StatementInsightDetailsDispatchProps => ({
-  refreshStatementInsights: () => {
-    dispatch(statementInsights.refresh());
+  refreshStatementInsights: (req: ExecutionInsightsRequest) => {
+    dispatch(statementInsights.refresh(req));
   },
   setTimeScale: (ts: TimeScale) => {
     dispatch(

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
@@ -67,7 +67,7 @@ export const StatementInsightDetailsOverviewTab: React.FC<
     columnTitle: "duration",
   });
   let contentionTable: JSX.Element = null;
-  if (insightDetails.contentionEvents != null) {
+  if (insightDetails?.contentionEvents !== null) {
     contentionTable = (
       <Row gutter={24} className={tableCx("margin-bottom")}>
         <Col className="gutter-row">

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
@@ -28,9 +28,11 @@ import { TransactionInsightDetailsOverviewTab } from "./transactionInsightDetail
 import { TransactionInsightsDetailsStmtsTab } from "./transactionInsightDetailsStmtsTab";
 
 import "antd/lib/tabs/style";
+import { executionInsightsRequestFromTimeScale } from "../utils";
 export interface TransactionInsightDetailsStateProps {
   insightDetails: TxnInsightDetails;
   insightError: Error | null;
+  timeScale?: TimeScale;
 }
 
 export interface TransactionInsightDetailsDispatchProps {
@@ -58,18 +60,22 @@ export const TransactionInsightDetails: React.FC<
   history,
   insightDetails,
   insightError,
+  timeScale,
   match,
 }) => {
   const executionID = getMatchParamByName(match, idAttr);
   const noInsights = !insightDetails;
   useEffect(() => {
+    const execReq = executionInsightsRequestFromTimeScale(timeScale);
     if (noInsights) {
       // Only refresh if we have no data (e.g. refresh the page)
       refreshTransactionInsightDetails({
         id: executionID,
+        start: execReq.start,
+        end: execReq.end,
       });
     }
-  }, [executionID, refreshTransactionInsightDetails, noInsights]);
+  }, [executionID, refreshTransactionInsightDetails, noInsights, timeScale]);
 
   const prevPage = (): void => history.goBack();
 
@@ -95,7 +101,7 @@ export const TransactionInsightDetails: React.FC<
       </div>
       <section>
         <Loading
-          loading={insightDetails == null}
+          loading={!insightDetails || insightDetails === null}
           page={"Transaction Insight details"}
           error={insightError}
           renderError={() => InsightsError()}

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsConnected.tsx
@@ -24,6 +24,7 @@ import { TimeScale } from "../../timeScaleDropdown";
 import { actions as sqlStatsActions } from "../../store/sqlStats";
 import { Dispatch } from "redux";
 import { TxnContentionInsightDetailsRequest } from "src/api";
+import { selectTimeScale } from "../../store/utils/selectors";
 
 const mapStateToProps = (
   state: AppState,
@@ -34,6 +35,7 @@ const mapStateToProps = (
   return {
     insightDetails: insightDetails,
     insightError: insightError,
+    timeScale: selectTimeScale(state),
   };
 };
 

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsOverviewTab.tsx
@@ -18,6 +18,7 @@ import { SummaryCard, SummaryCardItem } from "src/summaryCard";
 import { DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT_24_UTC } from "src/util/format";
 import { WaitTimeInsightsLabels } from "src/detailsPanels/waitTimeInsightsPanel";
 import { TxnContentionInsightDetailsRequest } from "src/api";
+import { NO_SAMPLES_FOUND } from "src/util";
 import {
   InsightsSortedTable,
   makeInsightsColumns,
@@ -44,9 +45,6 @@ export interface TransactionInsightDetailsStateProps {
 }
 
 export interface TransactionInsightDetailsDispatchProps {
-  refreshTransactionInsightDetails: (
-    req: TxnContentionInsightDetailsRequest,
-  ) => void;
   setTimeScale: (ts: TimeScale) => void;
 }
 
@@ -102,10 +100,10 @@ export const TransactionInsightDetailsOverviewTab: React.FC<Props> = ({
 
   const rowsRead =
     stmtInsights?.reduce((count, stmt) => (count += stmt.rowsRead), 0) ??
-    "no samples";
+    NO_SAMPLES_FOUND;
   const rowsWritten =
     stmtInsights?.reduce((count, stmt) => (count += stmt.rowsWritten), 0) ??
-    "no samples";
+    NO_SAMPLES_FOUND;
 
   return (
     <div>
@@ -125,21 +123,21 @@ export const TransactionInsightDetailsOverviewTab: React.FC<Props> = ({
                     value={
                       insightDetails.startTime?.format(
                         DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT_24_UTC,
-                      ) ?? "no samples"
+                      ) ?? NO_SAMPLES_FOUND
                     }
                   />
                   <SummaryCardItem label="Rows Read" value={rowsRead} />
                   <SummaryCardItem label="Rows Written" value={rowsWritten} />
                   <SummaryCardItem
                     label="Priority"
-                    value={insightDetails.priority ?? "no samples"}
+                    value={insightDetails.priority ?? NO_SAMPLES_FOUND}
                   />
                   <SummaryCardItem
                     label="Full Scan"
                     value={
                       insightDetails.statementInsights
                         ?.some(stmt => stmt.isFullScan)
-                        ?.toString() ?? "no samples"
+                        ?.toString() ?? NO_SAMPLES_FOUND
                     }
                   />
                 </SummaryCard>
@@ -148,7 +146,7 @@ export const TransactionInsightDetailsOverviewTab: React.FC<Props> = ({
                 <SummaryCard>
                   <SummaryCardItem
                     label="Number of Retries"
-                    value={insightDetails.retries ?? "no samples"}
+                    value={insightDetails.retries ?? NO_SAMPLES_FOUND}
                   />
                   {insightDetails.lastRetryReason && (
                     <SummaryCardItem
@@ -158,7 +156,7 @@ export const TransactionInsightDetailsOverviewTab: React.FC<Props> = ({
                   )}
                   <SummaryCardItem
                     label="Session ID"
-                    value={insightDetails.sessionID ?? "no samples"}
+                    value={insightDetails.sessionID ?? NO_SAMPLES_FOUND}
                   />
                   <SummaryCardItem
                     label="Application"

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsTable.tsx
@@ -20,6 +20,7 @@ import {
   DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT,
   Duration,
   limitText,
+  NO_SAMPLES_FOUND,
 } from "src/util";
 import { InsightExecEnum, FlattenedStmtInsightEvent } from "src/insights";
 import {
@@ -143,7 +144,7 @@ export function makeStatementInsightsColumns(
       title: insightsTableTitles.contention(execType),
       cell: (item: FlattenedStmtInsightEvent) =>
         !item.totalContentionTime
-          ? "no samples"
+          ? NO_SAMPLES_FOUND
           : Duration(item.totalContentionTime.asMilliseconds() * 1e6),
       sort: (item: FlattenedStmtInsightEvent) =>
         item.totalContentionTime?.asMilliseconds() ?? -1,

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
@@ -30,8 +30,12 @@ import { getTableSortFromURL } from "src/sortedtable/getTableSortFromURL";
 import { TableStatistics } from "src/tableStatistics";
 import { isSelectedColumn } from "src/columnsSelector/utils";
 
-import { FlattenedStmtInsights } from "src/api/insightsApi";
 import {
+  ExecutionInsightsRequest,
+  FlattenedStmtInsights,
+} from "src/api/insightsApi";
+import {
+  executionInsightsRequestFromTimeScale,
   filterStatementInsights,
   getAppsFromStatementInsights,
   makeStatementInsightsColumns,
@@ -40,12 +44,17 @@ import {
 import { EmptyInsightsTablePlaceholder } from "../util";
 import { StatementInsightsTable } from "./statementInsightsTable";
 import { InsightsError } from "../../insightsErrorComponent";
+import ColumnsSelector from "../../../columnsSelector/columnsSelector";
+import { SelectOption } from "../../../multiSelectCheckbox/multiSelectCheckbox";
+import {
+  defaultTimeScaleOptions,
+  TimeScale,
+  TimeScaleDropdown,
+} from "../../../timeScaleDropdown";
 
 import styles from "src/statementsPage/statementsPage.module.scss";
 import sortableTableStyles from "src/sortedtable/sortedtable.module.scss";
-import ColumnsSelector from "../../../columnsSelector/columnsSelector";
-import { SelectOption } from "../../../multiSelectCheckbox/multiSelectCheckbox";
-import { TimeScale } from "../../../timeScaleDropdown";
+import { commonStyles } from "../../../common";
 
 const cx = classNames.bind(styles);
 const sortableTableCx = classNames.bind(sortableTableStyles);
@@ -56,13 +65,15 @@ export type StatementInsightsViewStateProps = {
   filters: WorkloadInsightEventFilters;
   sortSetting: SortSetting;
   selectedColumnNames: string[];
+  isLoading?: boolean;
   dropDownSelect?: React.ReactElement;
+  timeScale?: TimeScale;
 };
 
 export type StatementInsightsViewDispatchProps = {
   onFiltersChange: (filters: WorkloadInsightEventFilters) => void;
   onSortChange: (ss: SortSetting) => void;
-  refreshStatementInsights: () => void;
+  refreshStatementInsights: (req: ExecutionInsightsRequest) => void;
   onColumnsChange: (selectedColumns: string[]) => void;
   setTimeScale: (ts: TimeScale) => void;
 };
@@ -81,6 +92,8 @@ export const StatementInsightsView: React.FC<StatementInsightsViewProps> = (
     statements,
     statementsError,
     filters,
+    timeScale,
+    isLoading,
     refreshStatementInsights,
     onFiltersChange,
     onSortChange,
@@ -100,13 +113,23 @@ export const StatementInsightsView: React.FC<StatementInsightsViewProps> = (
   );
 
   useEffect(() => {
-    // Refresh every 10 seconds.
-    refreshStatementInsights();
-    const interval = setInterval(refreshStatementInsights, 10 * 1000);
-    return () => {
-      clearInterval(interval);
-    };
-  }, [refreshStatementInsights]);
+    if (timeScale.key !== "Custom") {
+      const req = executionInsightsRequestFromTimeScale(timeScale);
+      refreshStatementInsights(req);
+      // Refresh every 10 seconds except when on custom timeScale.
+      const interval = setInterval(refreshStatementInsights, 10 * 1000, req);
+      return () => {
+        clearInterval(interval);
+      };
+    }
+  }, [timeScale, refreshStatementInsights]);
+
+  useEffect(() => {
+    if (statements === null || statements.length < 1) {
+      const req = executionInsightsRequestFromTimeScale(timeScale);
+      refreshStatementInsights(req);
+    }
+  }, [statements, timeScale, refreshStatementInsights]);
 
   useEffect(() => {
     // We use this effect to sync settings defined on the URL (sort, filters),
@@ -232,10 +255,17 @@ export const StatementInsightsView: React.FC<StatementInsightsViewProps> = (
             filters={filters}
           />
         </PageConfigItem>
+        <PageConfigItem className={commonStyles("separator")}>
+          <TimeScaleDropdown
+            options={defaultTimeScaleOptions}
+            currentScale={timeScale}
+            setTimeScale={setTimeScale}
+          />
+        </PageConfigItem>
       </PageConfig>
       <div className={cx("table-area")}>
         <Loading
-          loading={statements === null}
+          loading={statements === null || isLoading}
           page="statement insights"
           error={statementsError}
           renderError={() => InsightsError()}

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsView.tsx
@@ -34,14 +34,21 @@ import {
   getAppsFromTransactionInsights,
   WorkloadInsightEventFilters,
   MergedTxnInsightEvent,
+  executionInsightsRequestFromTimeScale,
 } from "src/insights";
 import { EmptyInsightsTablePlaceholder } from "../util";
 import { TransactionInsightsTable } from "./transactionInsightsTable";
 import { InsightsError } from "../../insightsErrorComponent";
+import {
+  TimeScale,
+  defaultTimeScaleOptions,
+  TimeScaleDropdown,
+} from "../../../timeScaleDropdown";
+import { ExecutionInsightsRequest } from "src/api";
 
 import styles from "src/statementsPage/statementsPage.module.scss";
 import sortableTableStyles from "src/sortedtable/sortedtable.module.scss";
-import { TimeScale } from "../../../timeScaleDropdown";
+import { commonStyles } from "../../../common";
 
 const cx = classNames.bind(styles);
 const sortableTableCx = classNames.bind(sortableTableStyles);
@@ -51,13 +58,15 @@ export type TransactionInsightsViewStateProps = {
   transactionsError: Error | null;
   filters: WorkloadInsightEventFilters;
   sortSetting: SortSetting;
+  isLoading?: boolean;
   dropDownSelect?: React.ReactElement;
+  timeScale?: TimeScale;
 };
 
 export type TransactionInsightsViewDispatchProps = {
   onFiltersChange: (filters: WorkloadInsightEventFilters) => void;
   onSortChange: (ss: SortSetting) => void;
-  refreshTransactionInsights: () => void;
+  refreshTransactionInsights: (req: ExecutionInsightsRequest) => void;
   setTimeScale: (ts: TimeScale) => void;
 };
 
@@ -75,6 +84,8 @@ export const TransactionInsightsView: React.FC<TransactionInsightsViewProps> = (
     transactions,
     transactionsError,
     filters,
+    timeScale,
+    isLoading,
     refreshTransactionInsights,
     onFiltersChange,
     onSortChange,
@@ -92,13 +103,23 @@ export const TransactionInsightsView: React.FC<TransactionInsightsViewProps> = (
   );
 
   useEffect(() => {
-    // Refresh every 20 seconds.
-    refreshTransactionInsights();
-    const interval = setInterval(refreshTransactionInsights, 20 * 1000);
-    return () => {
-      clearInterval(interval);
-    };
-  }, [refreshTransactionInsights]);
+    if (timeScale.key !== "Custom") {
+      const req = executionInsightsRequestFromTimeScale(timeScale);
+      refreshTransactionInsights(req);
+      // Refresh every 10 seconds.
+      const interval = setInterval(refreshTransactionInsights, 10 * 1000, req);
+      return () => {
+        clearInterval(interval);
+      };
+    }
+  }, [timeScale, refreshTransactionInsights]);
+
+  useEffect(() => {
+    if (transactions === null || transactions.length < 1) {
+      const req = executionInsightsRequestFromTimeScale(timeScale);
+      refreshTransactionInsights(req);
+    }
+  }, [transactions, timeScale, refreshTransactionInsights]);
 
   useEffect(() => {
     // We use this effect to sync settings defined on the URL (sort, filters),
@@ -209,10 +230,17 @@ export const TransactionInsightsView: React.FC<TransactionInsightsViewProps> = (
             filters={filters}
           />
         </PageConfigItem>
+        <PageConfigItem className={commonStyles("separator")}>
+          <TimeScaleDropdown
+            options={defaultTimeScaleOptions}
+            currentScale={timeScale}
+            setTimeScale={setTimeScale}
+          />
+        </PageConfigItem>
       </PageConfig>
       <div className={cx("table-area")}>
         <Loading
-          loading={transactions === null}
+          loading={transactions === null || isLoading}
           page="transaction insights"
           error={transactionsError}
           renderError={() => InsightsError()}

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/workloadInsightsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/workloadInsightsPageConnected.tsx
@@ -29,8 +29,9 @@ import { SortSetting } from "src/sortedtable";
 import {
   actions as statementInsights,
   selectColumns,
-  selectStatementInsights,
-  selectStatementInsightsError,
+  selectExecutionInsights,
+  selectExecutionInsightsError,
+  selectExecutionInsightsLoading,
 } from "src/store/insights/statementInsights";
 import {
   actions as transactionInsights,
@@ -38,10 +39,12 @@ import {
   selectTransactionInsightsError,
   selectFilters,
   selectSortSetting,
+  selectTransactionInsightsLoading,
 } from "src/store/insights/transactionInsights";
 import { Dispatch } from "redux";
 import { TimeScale } from "../../timeScaleDropdown";
-import { actions as sqlStatsActions } from "../../store/sqlStats";
+import { ExecutionInsightsRequest } from "../../api";
+import { selectTimeScale } from "../../store/utils/selectors";
 
 const transactionMapStateToProps = (
   state: AppState,
@@ -51,17 +54,21 @@ const transactionMapStateToProps = (
   transactionsError: selectTransactionInsightsError(state),
   filters: selectFilters(state),
   sortSetting: selectSortSetting(state),
+  timeScale: selectTimeScale(state),
+  isLoading: selectTransactionInsightsLoading(state),
 });
 
 const statementMapStateToProps = (
   state: AppState,
   _props: RouteComponentProps,
 ): StatementInsightsViewStateProps => ({
-  statements: selectStatementInsights(state),
-  statementsError: selectStatementInsightsError(state),
+  statements: selectExecutionInsights(state),
+  statementsError: selectExecutionInsightsError(state),
   filters: selectFilters(state),
   sortSetting: selectSortSetting(state),
   selectedColumnNames: selectColumns(state),
+  timeScale: selectTimeScale(state),
+  isLoading: selectExecutionInsightsLoading(state),
 });
 
 const TransactionDispatchProps = (
@@ -83,13 +90,13 @@ const TransactionDispatchProps = (
     ),
   setTimeScale: (ts: TimeScale) => {
     dispatch(
-      sqlStatsActions.updateTimeScale({
+      transactionInsights.updateTimeScale({
         ts: ts,
       }),
     );
   },
-  refreshTransactionInsights: () => {
-    dispatch(transactionInsights.refresh());
+  refreshTransactionInsights: (req: ExecutionInsightsRequest) => {
+    dispatch(transactionInsights.refresh(req));
   },
 });
 
@@ -123,13 +130,13 @@ const StatementDispatchProps = (
     ),
   setTimeScale: (ts: TimeScale) => {
     dispatch(
-      sqlStatsActions.updateTimeScale({
+      statementInsights.updateTimeScale({
         ts: ts,
       }),
     );
   },
-  refreshStatementInsights: () => {
-    dispatch(statementInsights.refresh());
+  refreshStatementInsights: (req: ExecutionInsightsRequest) => {
+    dispatch(statementInsights.refresh(req));
   },
 });
 

--- a/pkg/ui/workspaces/cluster-ui/src/selectors/insightsCommon.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/selectors/insightsCommon.selectors.ts
@@ -35,7 +35,7 @@ export const selectStatementInsightDetailsCombiner = (
   statementInsights: FlattenedStmtInsights,
   executionID: string,
 ): FlattenedStmtInsightEvent | null => {
-  if (!statementInsights) {
+  if (!statementInsights || statementInsights?.length < 1 || !executionID) {
     return null;
   }
 

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.selectors.ts
@@ -21,7 +21,7 @@ import {
 } from "../util";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { TimeScale, toRoundedDateRange } from "../timeScaleDropdown";
-import { selectTimeScale } from "../statementsPage/statementsPage.selectors";
+import { selectTimeScale } from "../store/utils/selectors";
 import moment from "moment";
 
 type StatementDetailsResponseMessage =

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetailsConnected.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetailsConnected.ts
@@ -36,7 +36,7 @@ import { actions as analyticsActions } from "src/store/analytics";
 import { actions as localStorageActions } from "src/store/localStorage";
 import { actions as nodesActions } from "../store/nodes";
 import { actions as nodeLivenessActions } from "../store/liveness";
-import { selectTimeScale } from "../statementsPage/statementsPage.selectors";
+import { selectTimeScale } from "../store/utils/selectors";
 import {
   InsertStmtDiagnosticRequest,
   StatementDetailsRequest,

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
@@ -222,11 +222,6 @@ export const selectColumns = createSelector(
       : null,
 );
 
-export const selectTimeScale = createSelector(
-  localStorageSelector,
-  localStorage => localStorage["timeScale/SQLActivity"],
-);
-
 export const selectSortSetting = createSelector(
   localStorageSelector,
   localStorage => localStorage["sortSetting/StatementsPage"],

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
@@ -31,12 +31,12 @@ import {
   selectStatementsLastError,
   selectTotalFingerprints,
   selectColumns,
-  selectTimeScale,
   selectSortSetting,
   selectFilters,
   selectSearch,
   selectStatementsLastUpdated,
 } from "./statementsPage.selectors";
+import { selectTimeScale } from "../store/utils/selectors";
 import {
   selectIsTenant,
   selectHasViewActivityRedactedRole,

--- a/pkg/ui/workspaces/cluster-ui/src/store/insightDetails/transactionInsightDetails/transactionInsightDetails.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insightDetails/transactionInsightDetails/transactionInsightDetails.reducer.ts
@@ -30,11 +30,13 @@ const txnInitialState: TransactionInsightDetailsState = {
 };
 
 export type TransactionInsightDetailsCachedState = {
-  cachedData: Map<string, TransactionInsightDetailsState>;
+  cachedData: {
+    [id: string]: TransactionInsightDetailsState;
+  };
 };
 
 const initialState: TransactionInsightDetailsCachedState = {
-  cachedData: new Map(),
+  cachedData: {},
 };
 
 const transactionInsightDetailsSlice = createSlice({
@@ -42,22 +44,25 @@ const transactionInsightDetailsSlice = createSlice({
   initialState,
   reducers: {
     received: (state, action: PayloadAction<TxnContentionInsightDetails>) => {
-      state.cachedData.set(action.payload.transactionExecutionID, {
-        data: action.payload,
-        valid: true,
-        lastError: null,
-        lastUpdated: moment.utc(),
-      });
+      if (action?.payload?.transactionExecutionID) {
+        state.cachedData[action.payload.transactionExecutionID] = {
+          data: action.payload,
+          valid: true,
+          lastError: null,
+          lastUpdated: moment.utc(),
+        };
+      }
     },
     failed: (state, action: PayloadAction<ErrorWithKey>) => {
-      const txnInsight =
-        state.cachedData.get(action.payload.key) ?? txnInitialState;
-      txnInsight.valid = false;
-      txnInsight.lastError = action.payload.err;
-      state.cachedData.set(action.payload.key, txnInsight);
+      state.cachedData[action.payload.key] = {
+        data: null,
+        valid: false,
+        lastError: action?.payload?.err,
+        lastUpdated: null,
+      };
     },
     invalidated: (state, action: PayloadAction<{ key: string }>) => {
-      state.cachedData.delete(action.payload.key);
+      delete state.cachedData[action.payload.key];
     },
     refresh: (
       _,

--- a/pkg/ui/workspaces/cluster-ui/src/store/insightDetails/transactionInsightDetails/transactionInsightDetails.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insightDetails/transactionInsightDetails/transactionInsightDetails.sagas.ts
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { all, call, put, takeLatest } from "redux-saga/effects";
+import { all, call, put, takeLatest, takeEvery } from "redux-saga/effects";
 
 import { actions } from "./transactionInsightDetails.reducer";
 import {
@@ -18,11 +18,18 @@ import {
 import { TxnContentionInsightDetails } from "src/insights";
 import { PayloadAction } from "@reduxjs/toolkit";
 import { ErrorWithKey } from "src/api";
+import { actions as stmtInsightActions } from "../../insights/statementInsights";
 
 export function* refreshTransactionInsightDetailsSaga(
   action: PayloadAction<TxnContentionInsightDetailsRequest>,
 ) {
   yield put(actions.request(action.payload));
+  yield put(
+    stmtInsightActions.request({
+      start: action.payload.start,
+      end: action.payload.end,
+    }),
+  );
 }
 
 export function* requestTransactionInsightDetailsSaga(
@@ -50,18 +57,21 @@ const timeoutsByExecID = new Map<string, NodeJS.Timeout>();
 export function receivedTxnInsightsDetailsSaga(
   action: PayloadAction<TxnContentionInsightDetails>,
 ) {
-  const execID = action.payload.transactionExecutionID;
-  clearTimeout(timeoutsByExecID.get(execID));
-  const id = setTimeout(() => {
-    actions.invalidated({ key: execID });
-    timeoutsByExecID.delete(execID);
-  }, CACHE_INVALIDATION_PERIOD);
-  timeoutsByExecID.set(execID, id);
+  if (action?.payload?.transactionExecutionID) {
+    const execID = action.payload.transactionExecutionID;
+    clearTimeout(timeoutsByExecID.get(execID));
+    const id = setTimeout(() => {
+      actions.invalidated({ key: execID });
+      stmtInsightActions.invalidated();
+      timeoutsByExecID.delete(execID);
+    }, CACHE_INVALIDATION_PERIOD);
+    timeoutsByExecID.set(execID, id);
+  }
 }
 
 export function* transactionInsightDetailsSaga() {
   yield all([
-    takeLatest(actions.refresh, refreshTransactionInsightDetailsSaga),
+    takeEvery(actions.refresh, refreshTransactionInsightDetailsSaga),
     takeLatest(actions.request, requestTransactionInsightDetailsSaga),
     takeLatest(actions.received, receivedTxnInsightsDetailsSaga),
   ]);

--- a/pkg/ui/workspaces/cluster-ui/src/store/insightDetails/transactionInsightDetails/transactionInsightDetails.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insightDetails/transactionInsightDetails/transactionInsightDetails.selectors.ts
@@ -18,7 +18,7 @@ const selectTxnContentionInsightsDetails = createSelector(
   (state: AppState) => state.adminUI.transactionInsightDetails.cachedData,
   selectID,
   (cachedTxnInsightDetails, execId) => {
-    return cachedTxnInsightDetails.get(execId);
+    return cachedTxnInsightDetails[execId];
   },
 );
 
@@ -26,7 +26,7 @@ const selectTxnInsightFromExecInsight = createSelector(
   (state: AppState) => state.adminUI.executionInsights?.data,
   selectID,
   (execInsights, execID): TxnInsightEvent => {
-    return execInsights.find(txn => txn.transactionExecutionID === execID);
+    return execInsights?.find(txn => txn.transactionExecutionID === execID);
   },
 );
 

--- a/pkg/ui/workspaces/cluster-ui/src/store/insights/statementInsights/statementInsights.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insights/statementInsights/statementInsights.sagas.ts
@@ -11,24 +11,60 @@
 import { all, call, put, takeLatest } from "redux-saga/effects";
 
 import { actions } from "./statementInsights.reducer";
-import { getClusterInsightsApi } from "src/api/insightsApi";
+import { actions as txnInsightActions } from "../transactionInsights";
+import {
+  ExecutionInsightsRequest,
+  getClusterInsightsApi,
+} from "src/api/insightsApi";
+import { PayloadAction } from "@reduxjs/toolkit";
+import {
+  UpdateTimeScalePayload,
+  actions as sqlStatsActions,
+} from "../../sqlStats";
+import { actions as localStorageActions } from "../../localStorage";
+import { executionInsightsRequestFromTimeScale } from "../../../insights";
 
-export function* refreshStatementInsightsSaga() {
-  yield put(actions.request());
+export function* refreshStatementInsightsSaga(
+  action?: PayloadAction<ExecutionInsightsRequest>,
+) {
+  yield put(actions.request(action?.payload));
 }
 
-export function* requestStatementInsightsSaga(): any {
+export function* requestStatementInsightsSaga(
+  action?: PayloadAction<ExecutionInsightsRequest>,
+): any {
   try {
-    const result = yield call(getClusterInsightsApi);
+    const result = yield call(getClusterInsightsApi, action?.payload);
     yield put(actions.received(result));
   } catch (e) {
     yield put(actions.failed(e));
   }
 }
 
+export function* updateSQLStatsTimeScaleSaga(
+  action: PayloadAction<UpdateTimeScalePayload>,
+) {
+  const { ts } = action.payload;
+  yield put(
+    localStorageActions.update({
+      key: "timeScale/SQLActivity",
+      value: ts,
+    }),
+  );
+  const req = executionInsightsRequestFromTimeScale(ts);
+  yield put(actions.invalidated());
+  yield put(txnInsightActions.invalidated());
+  yield put(sqlStatsActions.invalidated());
+  yield put(actions.refresh(req));
+}
+
 export function* statementInsightsSaga() {
   yield all([
     takeLatest(actions.refresh, refreshStatementInsightsSaga),
     takeLatest(actions.request, requestStatementInsightsSaga),
+    takeLatest(
+      [actions.updateTimeScale, txnInsightActions.updateTimeScale],
+      updateSQLStatsTimeScaleSaga,
+    ),
   ]);
 }

--- a/pkg/ui/workspaces/cluster-ui/src/store/insights/statementInsights/statementInsights.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insights/statementInsights/statementInsights.selectors.ts
@@ -17,16 +17,17 @@ import {
   selectStatementInsightDetailsCombiner,
 } from "src/selectors/insightsCommon.selectors";
 import { selectID } from "src/selectors/common";
-export const selectStatementInsights = createSelector(
+
+export const selectExecutionInsights = createSelector(
   (state: AppState) => state.adminUI.executionInsights?.data,
   selectFlattenedStmtInsightsCombiner,
 );
 
-export const selectStatementInsightsError = (state: AppState) =>
+export const selectExecutionInsightsError = (state: AppState) =>
   state.adminUI.executionInsights?.lastError;
 
 export const selectStatementInsightDetails = createSelector(
-  selectStatementInsights,
+  selectExecutionInsights,
   selectID,
   selectStatementInsightDetailsCombiner,
 );
@@ -38,3 +39,7 @@ export const selectColumns = createSelector(
       ? localStorage["showColumns/StatementInsightsPage"].split(",")
       : null,
 );
+
+export const selectExecutionInsightsLoading = (state: AppState) =>
+  !state.adminUI.executionInsights?.valid ||
+  state.adminUI.executionInsights?.inFlight;

--- a/pkg/ui/workspaces/cluster-ui/src/store/insights/transactionInsights/transactionInsights.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insights/transactionInsights/transactionInsights.reducer.ts
@@ -9,22 +9,24 @@
 // licenses/APL.txt.
 
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
-import { DOMAIN_NAME, noopReducer } from "src/store/utils";
+import { DOMAIN_NAME } from "src/store/utils";
 import moment, { Moment } from "moment";
 import { TxnContentionInsightEvent } from "src/insights";
+import { ExecutionInsightsRequest } from "../../../api";
+import { UpdateTimeScalePayload } from "../../sqlStats";
 
 export type TransactionInsightsState = {
   data: TxnContentionInsightEvent[];
-  lastUpdated: Moment;
   lastError: Error;
   valid: boolean;
+  inFlight: boolean;
 };
 
 const initialState: TransactionInsightsState = {
   data: null,
-  lastUpdated: null,
   lastError: null,
-  valid: true,
+  valid: false,
+  inFlight: false,
 };
 
 const transactionInsightsSlice = createSlice({
@@ -35,17 +37,24 @@ const transactionInsightsSlice = createSlice({
       state.data = action.payload;
       state.valid = true;
       state.lastError = null;
-      state.lastUpdated = moment.utc();
+      state.inFlight = false;
     },
     failed: (state, action: PayloadAction<Error>) => {
       state.valid = false;
       state.lastError = action.payload;
+      state.inFlight = false;
     },
     invalidated: state => {
       state.valid = false;
     },
-    refresh: noopReducer,
-    request: noopReducer,
+    refresh: (_, _action: PayloadAction<ExecutionInsightsRequest>) => {},
+    request: (_, _action: PayloadAction<ExecutionInsightsRequest>) => {},
+    updateTimeScale: (
+      state,
+      _action: PayloadAction<UpdateTimeScalePayload>,
+    ) => {
+      state.inFlight = true;
+    },
   },
 });
 

--- a/pkg/ui/workspaces/cluster-ui/src/store/insights/transactionInsights/transactionInsights.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insights/transactionInsights/transactionInsights.sagas.ts
@@ -8,29 +8,64 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { all, call, put, takeEvery } from "redux-saga/effects";
+import { all, call, put, takeLatest } from "redux-saga/effects";
 
 import { actions } from "./transactionInsights.reducer";
-import { actions as stmtActions } from "../statementInsights/statementInsights.reducer";
-import { getTxnInsightEvents } from "src/api/insightsApi";
+import { actions as stmtInsightActions } from "../statementInsights";
+import {
+  ExecutionInsightsRequest,
+  getTxnInsightEvents,
+} from "src/api/insightsApi";
+import { PayloadAction } from "@reduxjs/toolkit";
+import {
+  UpdateTimeScalePayload,
+  actions as sqlStatsActions,
+} from "../../sqlStats";
+import { actions as localStorageActions } from "../../localStorage";
+import { executionInsightsRequestFromTimeScale } from "../../../insights";
 
-export function* refreshTransactionInsightsSaga() {
-  yield put(actions.request());
-  yield put(stmtActions.request());
+export function* refreshTransactionInsightsSaga(
+  action?: PayloadAction<ExecutionInsightsRequest>,
+) {
+  yield put(actions.request(action?.payload));
+  yield put(stmtInsightActions.request(action.payload));
 }
 
-export function* requestTransactionInsightsSaga(): any {
+export function* requestTransactionInsightsSaga(
+  action?: PayloadAction<ExecutionInsightsRequest>,
+): any {
   try {
-    const result = yield call(getTxnInsightEvents);
+    const result = yield call(getTxnInsightEvents, action?.payload);
     yield put(actions.received(result));
   } catch (e) {
     yield put(actions.failed(e));
   }
 }
 
+export function* updateSQLStatsTimeScaleSaga(
+  action: PayloadAction<UpdateTimeScalePayload>,
+) {
+  const { ts } = action.payload;
+  yield put(
+    localStorageActions.update({
+      key: "timeScale/SQLActivity",
+      value: ts,
+    }),
+  );
+  const req = executionInsightsRequestFromTimeScale(ts);
+  yield put(actions.invalidated());
+  yield put(stmtInsightActions.invalidated());
+  yield put(sqlStatsActions.invalidated());
+  yield put(actions.refresh(req));
+}
+
 export function* transactionInsightsSaga() {
   yield all([
-    takeEvery(actions.refresh, refreshTransactionInsightsSaga),
-    takeEvery(actions.request, requestTransactionInsightsSaga),
+    takeLatest(actions.refresh, refreshTransactionInsightsSaga),
+    takeLatest(actions.request, requestTransactionInsightsSaga),
+    takeLatest(
+      [actions.updateTimeScale, stmtInsightActions.updateTimeScale],
+      updateSQLStatsTimeScaleSaga,
+    ),
   ]);
 }

--- a/pkg/ui/workspaces/cluster-ui/src/store/insights/transactionInsights/transactionInsights.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insights/transactionInsights/transactionInsights.selectors.ts
@@ -14,10 +14,10 @@ import { selectTxnInsightsCombiner } from "src/selectors/insightsCommon.selector
 import { localStorageSelector } from "src/store/utils/selectors";
 
 const selectTransactionInsightsData = (state: AppState) =>
-  state.adminUI.transactionInsights.data;
+  state.adminUI.transactionInsights?.data;
 
 export const selectTransactionInsights = createSelector(
-  (state: AppState) => state.adminUI.executionInsights.data,
+  (state: AppState) => state.adminUI.executionInsights?.data,
   selectTransactionInsightsData,
   selectTxnInsightsCombiner,
 );
@@ -34,3 +34,7 @@ export const selectFilters = createSelector(
   localStorageSelector,
   localStorage => localStorage["filters/InsightsPage"],
 );
+
+export const selectTransactionInsightsLoading = (state: AppState) =>
+  !state.adminUI.transactionInsights?.valid ||
+  state.adminUI.transactionInsights?.inFlight;

--- a/pkg/ui/workspaces/cluster-ui/src/store/sqlStats/sqlStats.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sqlStats/sqlStats.sagas.ts
@@ -24,6 +24,8 @@ import {
 } from "./sqlStats.reducer";
 import { actions as sqlDetailsStatsActions } from "../statementDetails/statementDetails.reducer";
 import { toRoundedDateRange } from "../../timeScaleDropdown";
+import { actions as stmtInsightActions } from "../insights/statementInsights";
+import { actions as txnInsightActions } from "../insights/transactionInsights";
 
 export function* refreshSQLStatsSaga(action: PayloadAction<StatementsRequest>) {
   yield put(sqlStatsActions.request(action.payload));
@@ -57,6 +59,8 @@ export function* updateSQLStatsTimeScaleSaga(
     end: Long.fromNumber(end.unix()),
   });
   yield put(sqlStatsActions.invalidated());
+  yield put(stmtInsightActions.invalidated());
+  yield put(txnInsightActions.invalidated());
   yield put(sqlStatsActions.refresh(req));
 }
 

--- a/pkg/ui/workspaces/cluster-ui/src/store/utils/selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/utils/selectors.ts
@@ -20,3 +20,8 @@ export const localStorageSelector = createSelector(
   adminUISelector,
   adminUiState => adminUiState.localStorage,
 );
+
+export const selectTimeScale = createSelector(
+  localStorageSelector,
+  localStorage => localStorage["timeScale/SQLActivity"],
+);

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetailsConnected.tsx
@@ -31,7 +31,7 @@ import {
   selectHasViewActivityRedactedRole,
 } from "../store/uiConfig";
 import { nodeRegionsByIDSelector } from "../store/nodes";
-import { selectTimeScale } from "src/statementsPage/statementsPage.selectors";
+import { selectTimeScale } from "../store/utils/selectors";
 import { StatementsRequest } from "src/api/statementsApi";
 import { txnFingerprintIdAttr, getMatchParamByName } from "../util";
 import { TimeScale } from "../timeScaleDropdown";

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
@@ -29,10 +29,8 @@ import {
 } from "./transactionsPage.selectors";
 import { selectIsTenant } from "../store/uiConfig";
 import { nodeRegionsByIDSelector } from "../store/nodes";
-import {
-  selectTimeScale,
-  selectStatementsLastUpdated,
-} from "src/statementsPage/statementsPage.selectors";
+import { selectStatementsLastUpdated } from "src/statementsPage/statementsPage.selectors";
+import { selectTimeScale } from "../store/utils/selectors";
 import { StatementsRequest } from "src/api/statementsApi";
 import { actions as localStorageActions } from "../store/localStorage";
 import { Filters } from "../queryFilter";

--- a/pkg/ui/workspaces/cluster-ui/src/util/constants.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/constants.ts
@@ -44,3 +44,5 @@ export const serverToClientErrorMessageMap = new Map([
     REMOTE_DEBUGGING_ERROR_TEXT,
   ],
 ]);
+
+export const NO_SAMPLES_FOUND = "no samples";

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -420,17 +420,16 @@ const transactionInsightsReducerObj = new CachedDataReducer(
 export const refreshTxnContentionInsights =
   transactionInsightsReducerObj.refresh;
 
-export const refreshTransactionInsights = (): ThunkAction<
-  any,
-  any,
-  any,
-  Action
-> => {
+export const refreshTransactionInsights = (
+  req?: clusterUiApi.ExecutionInsightsRequest,
+): ThunkAction<any, any, any, Action> => {
   return (dispatch: ThunkDispatch<unknown, unknown, Action>) => {
-    dispatch(refreshTxnContentionInsights());
-    dispatch(refreshExecutionInsights());
+    dispatch(refreshTxnContentionInsights(req));
+    dispatch(refreshExecutionInsights(req));
   };
 };
+export const invalidateTransactionInsights =
+  transactionInsightsReducerObj.invalidateData;
 
 const executionInsightsReducerObj = new CachedDataReducer(
   clusterUiApi.getClusterInsightsApi,
@@ -439,6 +438,8 @@ const executionInsightsReducerObj = new CachedDataReducer(
   moment.duration(5, "m"),
 );
 export const refreshExecutionInsights = executionInsightsReducerObj.refresh;
+export const invalidateExecutionInsights =
+  executionInsightsReducerObj.invalidateData;
 
 export const transactionInsightRequestKey = (
   req: clusterUiApi.TxnContentionInsightDetailsRequest,
@@ -460,7 +461,7 @@ export const refreshTransactionInsightDetails = (
 ): ThunkAction<any, any, any, Action> => {
   return (dispatch: ThunkDispatch<unknown, unknown, Action>) => {
     dispatch(refreshTxnContentionInsightDetails(req));
-    dispatch(refreshExecutionInsights());
+    dispatch(refreshExecutionInsights({ start: req.start, end: req.end }));
   };
 };
 

--- a/pkg/ui/workspaces/db-console/src/redux/statements/statementsSagas.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/statements/statementsSagas.ts
@@ -27,6 +27,8 @@ import {
   refreshStatementDiagnosticsRequests,
   invalidateStatements,
   refreshStatements,
+  invalidateExecutionInsights,
+  invalidateTransactionInsights,
 } from "src/redux/apiReducers";
 import {
   createStatementDiagnosticsAlertLocalSetting,
@@ -133,6 +135,8 @@ export function* setCombinedStatementsTimeScaleSaga(
     end: Long.fromNumber(end.unix()),
   });
   yield put(invalidateStatements());
+  yield put(invalidateExecutionInsights());
+  yield put(invalidateTransactionInsights());
   yield put(refreshStatements(req) as any);
 }
 

--- a/pkg/ui/workspaces/db-console/src/views/insights/insightsSelectors.ts
+++ b/pkg/ui/workspaces/db-console/src/views/insights/insightsSelectors.ts
@@ -41,17 +41,29 @@ export const sortSettingLocalSetting = new LocalSetting<
 });
 
 export const selectTransactionInsights = createSelector(
-  (state: AdminUIState) => state.cachedData.executionInsights?.data,
-  (state: AdminUIState) => state.cachedData.transactionInsights?.data,
+  (state: AdminUIState) => {
+    if (state.cachedData.executionInsights?.valid) {
+      return state.cachedData.executionInsights?.data;
+    } else return null;
+  },
+  (state: AdminUIState) => {
+    if (state.cachedData.transactionInsights?.valid) {
+      return state.cachedData.transactionInsights?.data;
+    } else return null;
+  },
   selectTxnInsightsCombiner,
 );
+
+export const selectTransactionInsightsLoading = (state: AdminUIState) =>
+  !state.cachedData.transactionInsights?.valid &&
+  state.cachedData.transactionInsights?.inFlight;
 
 const selectTxnContentionInsightDetails = createSelector(
   [
     (state: AdminUIState) => state.cachedData.transactionInsightDetails,
     selectID,
   ],
-  (insight, insightId): TxnContentionInsightDetails => {
+  (insight, insightId: string): TxnContentionInsightDetails => {
     if (!insight) {
       return null;
     }
@@ -84,13 +96,18 @@ export const selectTransactionInsightDetailsError = createSelector(
   },
 );
 
-export const selectStatementInsights = createSelector(
-  (state: AdminUIState) => state.cachedData.executionInsights?.data,
-  selectFlattenedStmtInsightsCombiner,
-);
+export const selectExecutionInsightsLoading = (state: AdminUIState) =>
+  !state.cachedData.executionInsights?.valid &&
+  state.cachedData.executionInsights?.inFlight;
+
+export const selectExecutionInsights = createSelector((state: AdminUIState) => {
+  if (state.cachedData?.executionInsights?.valid) {
+    return state.cachedData?.executionInsights?.data;
+  } else return null;
+}, selectFlattenedStmtInsightsCombiner);
 
 export const selectStatementInsightDetails = createSelector(
-  selectStatementInsights,
+  selectExecutionInsights,
   selectID,
   selectStatementInsightDetailsCombiner,
 );

--- a/pkg/ui/workspaces/db-console/src/views/insights/statementInsightDetailsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/insights/statementInsightDetailsPage.tsx
@@ -18,22 +18,22 @@ import { AdminUIState } from "src/redux/state";
 import { refreshExecutionInsights } from "src/redux/apiReducers";
 import { selectStatementInsightDetails } from "src/views/insights/insightsSelectors";
 import { setGlobalTimeScaleAction } from "src/redux/statements";
+import { selectTimeScale } from "src/redux/timeScale";
 
 const mapStateToProps = (
   state: AdminUIState,
   props: RouteComponentProps,
 ): StatementInsightDetailsStateProps => {
-  const insightStatements = selectStatementInsightDetails(state, props);
-  const insightError = state.cachedData?.executionInsights?.lastError;
   return {
-    insightEventDetails: insightStatements,
-    insightError,
+    insightEventDetails: selectStatementInsightDetails(state, props),
+    insightError: state.cachedData?.executionInsights?.lastError,
+    timeScale: selectTimeScale(state),
   };
 };
 
 const mapDispatchToProps: StatementInsightDetailsDispatchProps = {
-  setTimeScale: setGlobalTimeScaleAction,
   refreshStatementInsights: refreshExecutionInsights,
+  setTimeScale: setGlobalTimeScaleAction,
 };
 
 const StatementInsightDetailsPage = withRouter(

--- a/pkg/ui/workspaces/db-console/src/views/insights/transactionInsightDetailsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/insights/transactionInsightDetailsPage.tsx
@@ -21,6 +21,7 @@ import {
   selectTransactionInsightDetailsError,
 } from "src/views/insights/insightsSelectors";
 import { setGlobalTimeScaleAction } from "src/redux/statements";
+import { selectTimeScale } from "src/redux/timeScale";
 
 const mapStateToProps = (
   state: AdminUIState,
@@ -29,11 +30,12 @@ const mapStateToProps = (
   return {
     insightDetails: selectTxnInsightDetails(state, props),
     insightError: selectTransactionInsightDetailsError(state, props),
+    timeScale: selectTimeScale(state),
   };
 };
 
 const mapDispatchToProps: TransactionInsightDetailsDispatchProps = {
-  refreshTransactionInsightDetails,
+  refreshTransactionInsightDetails: refreshTransactionInsightDetails,
   setTimeScale: setGlobalTimeScaleAction,
 };
 

--- a/pkg/ui/workspaces/db-console/src/views/insights/workloadInsightsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/insights/workloadInsightsPage.tsx
@@ -27,13 +27,16 @@ import {
 } from "@cockroachlabs/cluster-ui";
 import {
   filtersLocalSetting,
-  selectStatementInsights,
+  selectExecutionInsights,
   sortSettingLocalSetting,
   selectTransactionInsights,
+  selectExecutionInsightsLoading,
+  selectTransactionInsightsLoading,
 } from "src/views/insights/insightsSelectors";
 import { bindActionCreators } from "redux";
 import { LocalSetting } from "src/redux/localsettings";
 import { setGlobalTimeScaleAction } from "src/redux/statements";
+import { selectTimeScale } from "src/redux/timeScale";
 
 export const insightStatementColumnsLocalSetting = new LocalSetting<
   AdminUIState,
@@ -52,18 +55,22 @@ const transactionMapStateToProps = (
   transactionsError: state.cachedData?.transactionInsights?.lastError,
   filters: filtersLocalSetting.selector(state),
   sortSetting: sortSettingLocalSetting.selector(state),
+  timeScale: selectTimeScale(state),
+  isLoading: selectTransactionInsightsLoading(state),
 });
 
 const statementMapStateToProps = (
   state: AdminUIState,
   _props: RouteComponentProps,
 ): StatementInsightsViewStateProps => ({
-  statements: selectStatementInsights(state),
+  statements: selectExecutionInsights(state),
   statementsError: state.cachedData?.executionInsights?.lastError,
   filters: filtersLocalSetting.selector(state),
   sortSetting: sortSettingLocalSetting.selector(state),
   selectedColumnNames:
     insightStatementColumnsLocalSetting.selectorToArray(state),
+  timeScale: selectTimeScale(state),
+  isLoading: selectExecutionInsightsLoading(state),
 });
 
 const TransactionDispatchProps = {


### PR DESCRIPTION
This commit adds a time picker to the workload insights overview pages.

Loom (CC Console): https://www.loom.com/share/379aa57e40934bdb92e9c212f4c31735

Loom (DB Console): https://www.loom.com/share/1a54e02644e84941af0a54e4cb88cff2

Fixes https://github.com/cockroachdb/cockroach/issues/94761.
Fixes https://github.com/cockroachdb/cockroach/issues/94380.

Part of https://github.com/cockroachdb/cockroach/issues/83780.

Release note (ui change): Added a time picker to the Workload Insights Overview pages in the DB Console.