### PR TITLE
release-22.2: parser: normalize docs link in TestParseDatadriven

### DIFF
--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"go/constant"
 	"reflect"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -31,6 +32,8 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 )
+
+var issueLinkRE = regexp.MustCompile("https://go.crdb.dev/issue-v/([0-9]+)/.*")
 
 // TestParseDataDriven verifies that we can parse the supplied SQL and regenerate the SQL
 // string from the syntax tree.
@@ -98,6 +101,7 @@ func TestParseDatadriven(t *testing.T) {
 				if pgerr.Hint != "" {
 					msg += "\nHINT: " + pgerr.Hint
 				}
+				msg = issueLinkRE.ReplaceAllString(msg, "https://go.crdb.dev/issue-v/$1/")
 				return msg
 			}
 			d.Fatalf(t, "unsupported command: %s", d.Cmd)

--- a/pkg/sql/parser/testdata/create_function
+++ b/pkg/sql/parser/testdata/create_function
@@ -263,7 +263,7 @@ DETAIL: source SQL:
 CREATE OR REPLACE FUNCTION f(VARIADIC a int = 7) RETURNS INT AS 'SELECT 1' LANGUAGE SQL
                              ^
 HINT: You have attempted to use a feature that is not yet implemented.
-See: https://go.crdb.dev/issue-v/88947/v22.2
+See: https://go.crdb.dev/issue-v/88947/
 
 error
 CREATE OR REPLACE FUNCTION f(a int = 7) RETURNS INT TRANSFORM AS 'SELECT 1' LANGUAGE SQL


### PR DESCRIPTION
Backport 1/1 commits from #92270.

/cc @cockroachdb/release

---

fixes https://github.com/cockroachdb/cockroach/issues/92201

Release note: None

Release justification: low risk test fix.