### PR TITLE
sql: add TenantStatusServer.NodeLocality to support crdb_internal.ranges{_no_leases} for secondary tenants

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -208,6 +208,60 @@ RegionsResponse describes the available regions.
 
 
 
+## NodeLocality
+
+
+
+NodeLocality retrieves the locality of the node with the given ID.
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+
+
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_localities | [NodeLocalityResponse.NodeLocalitiesEntry](#cockroach.server.serverpb.NodeLocalityResponse-cockroach.server.serverpb.NodeLocalityResponse.NodeLocalitiesEntry) | repeated |  | [reserved](#support-status) |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.NodeLocalityResponse-cockroach.server.serverpb.NodeLocalityResponse.NodeLocalitiesEntry"></a>
+#### NodeLocalityResponse.NodeLocalitiesEntry
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [int32](#cockroach.server.serverpb.NodeLocalityResponse-int32) |  |  |  |
+| value | [cockroach.roachpb.Locality](#cockroach.server.serverpb.NodeLocalityResponse-cockroach.roachpb.Locality) |  |  |  |
+
+
+
+
+
+
 ## NodesList
 
 

--- a/pkg/ccl/kvccl/kvtenantccl/connector.go
+++ b/pkg/ccl/kvccl/kvtenantccl/connector.go
@@ -410,34 +410,37 @@ func (c *Connector) RangeLookup(
 	return nil, nil, ctx.Err()
 }
 
-// Regions implements the serverpb.TenantStatusServer interface.
+// Regions implements the serverpb.TenantStatusServer interface
 func (c *Connector) Regions(
 	ctx context.Context, req *serverpb.RegionsRequest,
-) (resp *serverpb.RegionsResponse, _ error) {
-	if err := c.withClient(ctx, func(ctx context.Context, c *client) error {
-		var err error
-		resp, err = c.Regions(ctx, req)
-		return err
-	}); err != nil {
-		return nil, err
-	}
+) (resp *serverpb.RegionsResponse, retErr error) {
+	retErr = c.withClient(ctx, func(ctx context.Context, client *client) (err error) {
+		resp, err = client.Regions(ctx, req)
+		return
+	})
+	return
+}
 
-	return resp, nil
+// NodeLocality implements the serverpb.TenantStatusServer interface
+func (c *Connector) NodeLocality(
+	ctx context.Context, req *serverpb.NodeLocalityRequest,
+) (resp *serverpb.NodeLocalityResponse, retErr error) {
+	retErr = c.withClient(ctx, func(ctx context.Context, client *client) (err error) {
+		resp, err = client.NodeLocality(ctx, req)
+		return
+	})
+	return
 }
 
 // TenantRanges implements the serverpb.TenantStatusServer interface
 func (c *Connector) TenantRanges(
 	ctx context.Context, req *serverpb.TenantRangesRequest,
-) (resp *serverpb.TenantRangesResponse, _ error) {
-	if err := c.withClient(ctx, func(ctx context.Context, c *client) error {
-		var err error
-		resp, err = c.TenantRanges(ctx, req)
-		return err
-	}); err != nil {
-		return nil, err
-	}
-
-	return resp, nil
+) (resp *serverpb.TenantRangesResponse, retErr error) {
+	retErr = c.withClient(ctx, func(ctx context.Context, client *client) (err error) {
+		resp, err = client.TenantRanges(ctx, req)
+		return
+	})
+	return
 }
 
 // FirstRange implements the kvcoord.RangeDescriptorDB interface.

--- a/pkg/rpc/auth_tenant.go
+++ b/pkg/rpc/auth_tenant.go
@@ -70,6 +70,9 @@ func (a tenantAuthorizer) authorize(
 	case "/cockroach.server.serverpb.Status/Regions":
 		return nil // no restriction to usage of this endpoint by tenants
 
+	case "/cockroach.server.serverpb.Status/NodeLocality":
+		return nil // no restriction to usage of this endpoint by tenants
+
 	case "/cockroach.server.serverpb.Status/Statements":
 		return a.authTenant(tenID)
 
@@ -174,7 +177,9 @@ func reqAllowed(r roachpb.Request, tenID roachpb.TenantID) bool {
 		*roachpb.AddSSTableRequest,
 		*roachpb.RefreshRequest,
 		*roachpb.RefreshRangeRequest,
-		*roachpb.IsSpanEmptyRequest:
+		*roachpb.IsSpanEmptyRequest,
+		*roachpb.LeaseInfoRequest,
+		*roachpb.RangeStatsRequest:
 		return true
 	case *roachpb.AdminScatterRequest:
 		return t.Class != roachpb.AdminScatterRequest_ARBITRARY || tenID.IsSystem()

--- a/pkg/server/serverpb/status.go
+++ b/pkg/server/serverpb/status.go
@@ -11,7 +11,7 @@
 package serverpb
 
 import (
-	context "context"
+	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 )
@@ -79,6 +79,7 @@ type NodesStatusServer interface {
 type TenantStatusServer interface {
 	TenantRanges(context.Context, *TenantRangesRequest) (*TenantRangesResponse, error)
 	Regions(context.Context, *RegionsRequest) (*RegionsResponse, error)
+	NodeLocality(context.Context, *NodeLocalityRequest) (*NodeLocalityResponse, error)
 }
 
 // OptionalNodesStatusServer returns the wrapped NodesStatusServer, if it is

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -308,6 +308,14 @@ message RegionsResponse {
   map<string, Region> regions = 1;
 }
 
+message NodeLocalityRequest{}
+
+message NodeLocalityResponse{
+  map<int32, roachpb.Locality> node_localities = 1 [
+    (gogoproto.castkey) = "github.com/cockroachdb/cockroach/pkg/roachpb.NodeID"
+  ];
+}
+
 // NodesListRequest requests list of all nodes.
 // The nodes are KV nodes when the cluster is a single
 // tenant cluster or the host cluster in case of multi-tenant
@@ -1899,6 +1907,9 @@ service Status {
 
   // RegionsRequest retrieves all available regions.
   rpc Regions(RegionsRequest) returns (RegionsResponse) {}
+
+  // NodeLocality retrieves the locality of the node with the given ID.
+  rpc NodeLocality(NodeLocalityRequest) returns (NodeLocalityResponse) {}
 
   // NodesList returns all available nodes with their addresses.
   rpc NodesList(NodesListRequest) returns (NodesListResponse) {}

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1385,6 +1385,23 @@ func (s *statusServer) Regions(
 	return regionsResponseFromNodesResponse(resp), nil
 }
 
+// NodeLocality implements the serverpb.StatusServer interface.
+func (s *statusServer) NodeLocality(
+	ctx context.Context, req *serverpb.NodeLocalityRequest,
+) (*serverpb.NodeLocalityResponse, error) {
+	resp, _, err := s.nodesHelper(ctx, 0 /* limit */, 0 /* offset */)
+	if err != nil {
+		return nil, serverError(ctx, err)
+	}
+	nodes := resp.Nodes
+	res := make(map[roachpb.NodeID]*roachpb.Locality, len(nodes))
+	for _, node := range nodes {
+		desc := node.Desc
+		res[desc.NodeID] = &desc.Locality
+	}
+	return &serverpb.NodeLocalityResponse{NodeLocalities: res}, nil
+}
+
 func regionsResponseFromNodesResponse(nr *serverpb.NodesResponse) *serverpb.RegionsResponse {
 	regionsToZones := make(map[string]map[string]struct{})
 	for _, node := range nr.Nodes {

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -3662,15 +3662,11 @@ CREATE TABLE crdb_internal.ranges_no_leases (
 			return nil, nil, err
 		}
 
-		// Map node descriptors to localities
-		descriptors, err := getAllNodeDescriptors(p)
+		resp, err := p.ExecCfg().TenantStatusServer.NodeLocality(ctx, &serverpb.NodeLocalityRequest{})
 		if err != nil {
 			return nil, nil, err
 		}
-		nodeIDToLocality := make(map[roachpb.NodeID]roachpb.Locality)
-		for _, desc := range descriptors {
-			nodeIDToLocality[desc.NodeID] = desc.Locality
-		}
+		nodeIDToLocality := resp.NodeLocalities
 
 		var desc roachpb.RangeDescriptor
 


### PR DESCRIPTION
This PR adds a new node locality lookup KV admin function which is
used by crdb_internal.ranges{_no_leases} and SHOW RANGES to
work for secondary tenants.

Release note: None

Epic: CRDB-14522