### PR TITLE
row: clean up fetchers

### DIFF
--- a/pkg/ccl/changefeedccl/cdcevent/event.go
+++ b/pkg/ccl/changefeedccl/cdcevent/event.go
@@ -367,8 +367,8 @@ type eventDecoder struct {
 	// Cached allocations for *row.Fetcher
 	rfCache *rowFetcherCache
 
-	// kvFetcher used to decode datums.
-	kvFetcher row.SpanKVFetcher
+	// kvProvider used to feed KVs into fetcher to decode them into datums.
+	kvProvider row.KVProvider
 
 	// factory for constructing event descriptors.
 	getEventDescriptor eventDescriptorFactory
@@ -451,9 +451,9 @@ func (d *eventDecoder) DecodeKV(
 		return Row{}, err
 	}
 
-	d.kvFetcher.KVs = d.kvFetcher.KVs[:0]
-	d.kvFetcher.KVs = append(d.kvFetcher.KVs, kv)
-	if err := d.fetcher.StartScanFrom(ctx, &d.kvFetcher); err != nil {
+	d.kvProvider.KVs = d.kvProvider.KVs[:0]
+	d.kvProvider.KVs = append(d.kvProvider.KVs, kv)
+	if err := d.fetcher.ConsumeKVProvider(ctx, &d.kvProvider); err != nil {
 		return Row{}, err
 	}
 

--- a/pkg/ccl/changefeedccl/cdcevent/rowfetcher_cache.go
+++ b/pkg/ccl/changefeedccl/cdcevent/rowfetcher_cache.go
@@ -28,11 +28,11 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// rowFetcherCache maintains a cache of single table RowFetchers. Given a key
+// rowFetcherCache maintains a cache of single table row.Fetchers. Given a key
 // with an mvcc timestamp, it retrieves the correct TableDescriptor for that key
-// and returns a Fetcher initialized with that table. This Fetcher's
-// StartScanFrom can be used to turn that key (or all the keys making up the
-// column families of one row) into a row.
+// and returns a row.Fetcher initialized with that table. This Fetcher's
+// ConsumeKVProvider() can be used to turn that key (or all the keys making up
+// the column families of one row) into a row.
 type rowFetcherCache struct {
 	codec           keys.SQLCodec
 	leaseMgr        *lease.Manager
@@ -237,9 +237,9 @@ func (c *rowFetcherCache) RowFetcherForColumnFamily(
 	if err := rf.Init(
 		context.TODO(),
 		row.FetcherInitArgs{
-			WillUseCustomKVBatchFetcher: true,
-			Alloc:                       &c.a,
-			Spec:                        &spec,
+			WillUseKVProvider: true,
+			Alloc:             &c.a,
+			Spec:              &spec,
 		},
 	); err != nil {
 		return nil, nil, err

--- a/pkg/sql/delete_range.go
+++ b/pkg/sql/delete_range.go
@@ -101,9 +101,9 @@ func (d *deleteRangeNode) startExec(params runParams) error {
 	if err := d.fetcher.Init(
 		params.ctx,
 		row.FetcherInitArgs{
-			WillUseCustomKVBatchFetcher: true,
-			Alloc:                       &tree.DatumAlloc{},
-			Spec:                        &spec,
+			WillUseKVProvider: true,
+			Alloc:             &tree.DatumAlloc{},
+			Spec:              &spec,
 		},
 	); err != nil {
 		return err

--- a/pkg/sql/row/BUILD.bazel
+++ b/pkg/sql/row/BUILD.bazel
@@ -62,7 +62,6 @@ go_library(
         "//pkg/sql/span",
         "//pkg/sql/sqlerrors",
         "//pkg/sql/types",
-        "//pkg/storage",
         "//pkg/storage/enginepb",
         "//pkg/util",
         "//pkg/util/admission",

--- a/pkg/sql/row/fetcher_mvcc_test.go
+++ b/pkg/sql/row/fetcher_mvcc_test.go
@@ -97,9 +97,9 @@ func TestRowFetcherMVCCMetadata(t *testing.T) {
 	if err := rf.Init(
 		ctx,
 		row.FetcherInitArgs{
-			WillUseCustomKVBatchFetcher: true,
-			Alloc:                       &tree.DatumAlloc{},
-			Spec:                        &spec,
+			WillUseKVProvider: true,
+			Alloc:             &tree.DatumAlloc{},
+			Spec:              &spec,
 		},
 	); err != nil {
 		t.Fatal(err)
@@ -115,7 +115,7 @@ func TestRowFetcherMVCCMetadata(t *testing.T) {
 			log.Infof(ctx, "%v %v %v", kv.Key, kv.Value.Timestamp, kv.Value.PrettyPrint())
 		}
 
-		if err := rf.StartScanFrom(ctx, &row.SpanKVFetcher{KVs: kvs}); err != nil {
+		if err := rf.ConsumeKVProvider(ctx, &row.KVProvider{KVs: kvs}); err != nil {
 			t.Fatal(err)
 		}
 		var rows []rowWithMVCCMetadata

--- a/pkg/sql/row/kv_fetcher.go
+++ b/pkg/sql/row/kv_fetcher.go
@@ -22,12 +22,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowinfra"
-	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
-	"github.com/cockroachdb/errors"
 )
 
 // KVFetcher wraps KVBatchFetcher, providing a NextKV interface that returns the
@@ -301,15 +299,15 @@ func (f *KVFetcher) Close(ctx context.Context) {
 	f.KVBatchFetcher.close(ctx)
 }
 
-// SpanKVFetcher is a KVBatchFetcher that returns a set slice of kvs.
-type SpanKVFetcher struct {
+// KVProvider is a KVBatchFetcher that returns a set slice of kvs.
+type KVProvider struct {
 	KVs []roachpb.KeyValue
 }
 
-var _ KVBatchFetcher = &SpanKVFetcher{}
+var _ KVBatchFetcher = &KVProvider{}
 
 // nextBatch implements the KVBatchFetcher interface.
-func (f *SpanKVFetcher) nextBatch(ctx context.Context) (kvBatchFetcherResponse, error) {
+func (f *KVProvider) nextBatch(ctx context.Context) (kvBatchFetcherResponse, error) {
 	if len(f.KVs) == 0 {
 		return kvBatchFetcherResponse{moreKVs: false}, nil
 	}
@@ -322,122 +320,10 @@ func (f *SpanKVFetcher) nextBatch(ctx context.Context) (kvBatchFetcherResponse, 
 }
 
 // SetupNextFetch implements the KVBatchFetcher interface.
-func (f *SpanKVFetcher) SetupNextFetch(
+func (f *KVProvider) SetupNextFetch(
 	context.Context, roachpb.Spans, []int, rowinfra.BytesLimit, rowinfra.KeyLimit,
 ) error {
 	return nil
 }
 
-func (f *SpanKVFetcher) close(context.Context) {}
-
-// BackupSSTKVFetcher is a KVBatchFetcher that wraps storage.SimpleMVCCIterator
-// and returns a batch of kv from backupSST.
-type BackupSSTKVFetcher struct {
-	iter          storage.SimpleMVCCIterator
-	endKeyMVCC    storage.MVCCKey
-	startTime     hlc.Timestamp
-	endTime       hlc.Timestamp
-	withRevisions bool
-}
-
-var _ KVBatchFetcher = &BackupSSTKVFetcher{}
-
-// MakeBackupSSTKVFetcher creates a BackupSSTKVFetcher and
-// advances the iter to the first key >= startKeyMVCC
-func MakeBackupSSTKVFetcher(
-	startKeyMVCC, endKeyMVCC storage.MVCCKey,
-	iter storage.SimpleMVCCIterator,
-	startTime hlc.Timestamp,
-	endTime hlc.Timestamp,
-	withRev bool,
-) BackupSSTKVFetcher {
-	res := BackupSSTKVFetcher{
-		iter,
-		endKeyMVCC,
-		startTime,
-		endTime,
-		withRev,
-	}
-	res.iter.SeekGE(startKeyMVCC)
-	return res
-}
-
-func (f *BackupSSTKVFetcher) nextBatch(ctx context.Context) (kvBatchFetcherResponse, error) {
-	res := make([]roachpb.KeyValue, 0)
-
-	copyKV := func(mvccKey storage.MVCCKey, value []byte) roachpb.KeyValue {
-		keyCopy := make([]byte, len(mvccKey.Key))
-		copy(keyCopy, mvccKey.Key)
-		valueCopy := make([]byte, len(value))
-		copy(valueCopy, value)
-		return roachpb.KeyValue{
-			Key:   keyCopy,
-			Value: roachpb.Value{RawBytes: valueCopy, Timestamp: mvccKey.Timestamp},
-		}
-	}
-
-	for {
-		valid, err := f.iter.Valid()
-		if err != nil {
-			err = errors.Wrapf(err, "iter key value of table data")
-			return kvBatchFetcherResponse{}, err
-		}
-
-		if !valid || !f.iter.UnsafeKey().Less(f.endKeyMVCC) {
-			break
-		}
-
-		if !f.endTime.IsEmpty() {
-			if f.endTime.Less(f.iter.UnsafeKey().Timestamp) {
-				f.iter.Next()
-				continue
-			}
-		}
-
-		if f.withRevisions {
-			if f.iter.UnsafeKey().Timestamp.Less(f.startTime) {
-				f.iter.NextKey()
-				continue
-			}
-		} else {
-			if len(f.iter.UnsafeValue()) == 0 {
-				if f.endTime.IsEmpty() || f.iter.UnsafeKey().Timestamp.Less(f.endTime) {
-					// Value is deleted at endTime.
-					f.iter.NextKey()
-					continue
-				} else {
-					// Otherwise we call Next to trace back the correct revision.
-					f.iter.Next()
-					continue
-				}
-			}
-		}
-
-		res = append(res, copyKV(f.iter.UnsafeKey(), f.iter.UnsafeValue()))
-
-		if f.withRevisions {
-			f.iter.Next()
-		} else {
-			f.iter.NextKey()
-		}
-
-	}
-	if len(res) == 0 {
-		return kvBatchFetcherResponse{moreKVs: false}, nil
-	}
-	return kvBatchFetcherResponse{
-		moreKVs: true,
-		kvs:     res,
-	}, nil
-}
-
-// SetupNextFetch implements the KVBatchFetcher interface.
-func (f *BackupSSTKVFetcher) SetupNextFetch(
-	context.Context, roachpb.Spans, []int, rowinfra.BytesLimit, rowinfra.KeyLimit,
-) error {
-	return nil
-}
-
-func (f *BackupSSTKVFetcher) close(context.Context) {
-	f.iter.Close()
-}
+func (f *KVProvider) close(context.Context) {}

--- a/pkg/sql/rowexec/rowfetcher.go
+++ b/pkg/sql/rowexec/rowfetcher.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
-	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
@@ -31,7 +30,6 @@ type rowFetcher interface {
 		_ context.Context, _ roachpb.Spans, spanIDs []int,
 		batchBytesLimit rowinfra.BytesLimit, rowLimitHint rowinfra.RowLimit,
 	) error
-	StartScanFrom(_ context.Context, _ row.KVBatchFetcher) error
 	StartInconsistentScan(
 		_ context.Context,
 		_ *kv.DB,


### PR DESCRIPTION
This commit performs a bunch of miscellaneous cleanups around the different fetcher objects in the `row` package. The following changes are made:
- `SpanKVFetcher` has been renamed into `KVProvider` to better indicate its purpose (of supplying a given set of KVs to the fetcher machinery).
- relatedly, `StartScanFrom` method has been renamed to `ConsumeKVProvider` since the former is only used with the `KVProvider` as an argument (with the corresponding change to the signature too).
- we no longer track the "number of batch requests issued" when using the `KVProvider` since there aren't any and the callers don't actually need this info. Still, to be safe this commit adds an additional check to `row.Fetcher.GetBatchRequestsIssued`.
- `singleKVFetcher` previously used for decoding a single KV for error messages has been removed and its usage replaced with the `KVProvider`.
- `BackupSSTKVFetcher` is deleted entirely. This hasn't been used as of 3caed9e4b37a06333b0fcc8ad216e8f01cc9d48b.
- `StartScanFrom` method has been removed from `rowFetcher` interface since the processors don't need it.
- `rowFetcherStatCollector` now directly embeds `row.Fetcher` allowing it to just "inherit" different methods that don't require any instrumentation.

Epic: None

Release note: None