### PR TITLE
docs/RFCS: redact statement diagnostics bundles

### DIFF
--- a/docs/RFCS/20221017_redact_statement_bundles.md
+++ b/docs/RFCS/20221017_redact_statement_bundles.md
@@ -1,0 +1,161 @@
+- Feature Name: Redact Statement Diagnostics Bundles
+- Status: draft
+- Start Date: 2022-10-17
+- Authors: Michael Erickson
+- RFC PR: (PR # after acceptance of initial draft)
+- Cockroach Issue: (one or more # from the issue tracker)
+
+# Summary
+
+This RFC proposes options to redact PII from statement diagnostics bundles in
+order to comply with PCI DSS and other security audits, without unduly hampering
+customer support investigations.
+
+The options are divided into three sets:
+1. Options to _redact_ statement diagnostics bundles.
+2. Options to _unredact_ statement diagnostics bundles.
+3. Options to _obfuscate_ statement diagnostics bundles.
+
+The first set of options are currently being prototyped, and must be finished by
+the end of the year for an upcoming audit. The second and third sets of options
+are speculative, and are included here to solicit comments.
+
+# Motivation
+
+
+
+# Technical design
+
+
+
+## Background
+
+Statement diagnostics bundles are zip archives containing information about the
+execution of individual SQL statements. They are used to troubleshoot SQL
+execution during customer support investigations. The primary users of statement
+diagnostics bundles are Cockroach Labs TSEs, SREs, SEs, and Engineering.
+
+### Collection
+
+Collection of statement diagnostics bundles can be triggered via several
+methods:
+1. By executing the SQL statement prepended with `EXPLAIN ANALYZE (DEBUG)`.
+2. By calling the built-in SQL function `crdb_internal.request_statement_bundle`
+   with the fingerprint of the SQL statement.
+3. By POSTing a `CreateStatementDiagnosticsReportRequest` message to the
+   `/_status/stmtdiagreports` gRPC endpoint with the fingerprint of the SQL
+   statement.
+4. By clicking "Activate statement diagnostics" on the Diagnostics tab of the
+   Statement Fingerprint page for the statement in the DB Console.
+
+Method 1 immediately executes the statement with verbose tracing, creates a
+bundle after execution finishes, inserts the bundle and bundle metadata into
+`system.statement_bundle_chunks` and `system.statement_diagnostics`, and then
+either updates or inserts a completed row into
+`system.statement_diagnostics_requests`. After this, instead of normal query
+results a message with bundle download instructions is returned to the client.
+
+Method 2 inserts a row into `system.statement_diagnostics_requests` and also
+adds the request to the local statement diagnostics registry. Other nodes poll
+`system.statement_diagnostics_requests` and add any new requests to their local
+registries. When executing a statement, each node checks with its local registry
+whether the statement matches a diagnostics request fingerprint, and if so
+proceeds with method 1 (except returning normal query results instead of
+download instructions).
+
+Method 3 uses a gRPC message to trigger the insert into
+`system.statement_diagnostics_requests` instead of a SQL function, but otherwise
+follows the same steps as method 2.
+
+Method 4 POSTs a SQL statement inserting into
+`system.statement_diagnostics_requests` to `/api/v2/sql/` instead of using a
+gRPC message or a SQL function, but otherwise follows the same steps as method
+2.
+
+All four methods require either the `ADMIN` role option, or the `VIEWACTIVITY`
+role option and absence of the `VIEWACTIVITYREDACTED` role option.
+
+### Contents
+
+The contents of statement diagnostics bundles are various files recording
+information about the execution of the statement. These files are currently
+mostly unredacted*, and may include potential PII.
+
+(*Redaction of the KV portion of traces was added for multi-tenant clusters in
+PR #70562.)
+
+| File(s) | Description | Customer Information | Sensitive Customer Information |
+|-|-|-|-|
+| `distsql.html` | DistSQL plan diagram (output of `EXPLAIN (DISTSQL)`) | (see statement.txt) | (see statement.txt) |
+| `env.sql` | cluster and session settings | some cluster settings (e.g. `cluster.organization`) | values of all string-typed settings |
+| `opt*.txt` | optimizer plan (output of variants of `EXPLAIN (OPT)`) | (see statement.txt and stats*.sql) | (see statement.txt and stats*.sql) |
+| `plan.txt` | plan annotated with execution stats (output of `EXPLAIN ANALYZE`) | (see statement.txt) | (see statement.txt) |
+| `schema.sql` | `CREATE` statements for all referenced schemas, tables, views, and sequences | table and column names, view definitions, default values, constraints, partition keys, table comments | constants |
+| `statement.txt` | the statement, formatted | table and column names, constants, placeholder values | constants, placeholder values |
+| `stats*.sql` | stats for all referenced tables (output of `SHOW STATISTICS USING JSON`) | table and column names, constants in histograms | constants |
+| `trace*` | execution trace of the statement in various formats | range keys, key spans, row data, table and column names, user name, constants | constants and other row data |
+| `vec*.txt` | vectorized execution plan (output of variants of `EXPLAIN (VEC)`) | none | none |
+
+## Redaction
+
+Initially we will add two options controlling redaction of statement diagnostics bundles:
+1. `REDACT` will completely remove all sensitive customer information, replacing
+   it with `‹×›` (analogous to the `redact` logging configuration).
+2. `REDACTABLE` will surround sensitive customer information with redaction
+   markers `‹` and `›`, but will not remove it (analogous to the `redactable`
+   logging configuration).
+
+If both options are used, `REDACT` will take precedence (as it does currently in
+logging configurations).
+
+These options will be available for all methods used to trigger collection of
+bundles:
+1. As additional options in `EXPLAIN`, e.g. `EXPLAIN ANALYZE (DEBUG, REDACT)`.
+2. As a string of comma-separated options in another overload of built-in SQL
+   function `crdb_internal.request_statement_bundle`, e.g.
+   ```sql
+   SELECT crdb_internal.request_statement_bundle('SELECT _', 1.0, '1 ms', '1 day', 'REDACT');
+   ```
+3.
+4.
+
+Furthermore, collecting statement diagnostics bundles with the
+`VIEWACTIVITYREDACTED` role option will now be allowed, in which case the
+`REDACT` option will automatically be applied.
+
+## Unredaction
+
+During an investigation it can be surprisingly difficult to collect a "smoking
+gun" statement diagnostics bundle actually showing the phenomenon of
+interest. Sometimes it is not clear which specific statement should be
+investigated, and so bundles are collected for multiple statements. Even when
+the specific statement is known, different executions of the same statement may
+use different query plans, visit different nodes, or read different data. Often
+multiple bundles must be collected to find one that shows the problem.
+
+Furthermore, reproduction steps must often be taken before collecting the
+bundle, such as changing cluster settings, adding or removing indexes, turning
+application load on or off, etc.
+
+Redaction of statement diagnostics bundles will make this process more
+onerous. Suppose that after a long series of steps to reproduce a problem, a few
+bundles are collected, and one of these seems to show the problem. If the bundle
+is redacted, after a few rounds of emails, engineering may ask for an unredacted
+bundle to investigate further. Now the customer must go through the same long
+series of steps (perhaps days or weeks later) to try and obtain another bundle
+showing the problem again, this time unredacted.
+
+The `REDACTABLE` option could be used to make this less painful. The customer
+would collect a redactable bundle, use a tool to create a redacted copy, and
+would initially share this redacted copy with Support. If the unredacted bundle
+were needed the customer could provide the original. But this would require the
+customer to do additional work, and to hold on to the original bundle until the
+investigation was over.
+
+To make this process easier for the customer, we propose a new option:
+- `UNREDACTABLE` will include an encrypted copy of the original unredacted
+  bundle in the redacted bundle. Instead of keeping the original bundle, the
+  customer only has to keep the key that will decrypt the unredacted bundle, and
+  can easily provide this if an unredacted bundle is needed.
+
+## Obfuscation

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -55,6 +55,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"github.com/cockroachdb/redact"
@@ -240,6 +241,10 @@ func (f *vectorizedFlow) Setup(
 		return ctx, nil, err
 	}
 	log.VEvent(ctx, 2, "setting up vectorized flow")
+	if sp := tracing.SpanFromContext(ctx); sp != nil {
+		log.VEventf(ctx, 2, "redactable: %v", sp.Redactable())
+	}
+	log.VEventf(ctx, 2, "should this be redacted? %s", redact.Unsafe("foo"))
 	recordingStats := false
 	if execstats.ShouldCollectStats(ctx, f.FlowCtx.CollectStats) {
 		recordingStats = true

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -398,7 +398,8 @@ func (ex *connExecutor) execStmtInOpenState(
 		switch e.Mode {
 		case tree.ExplainDebug:
 			telemetry.Inc(sqltelemetry.ExplainAnalyzeDebugUseCounter)
-			ih.SetOutputMode(explainAnalyzeDebugOutput, explain.Flags{})
+			flags := explain.MakeFlags(&e.ExplainOptions)
+			ih.SetOutputMode(explainAnalyzeDebugOutput, flags)
 
 		case tree.ExplainPlan:
 			telemetry.Inc(sqltelemetry.ExplainAnalyzeUseCounter)

--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -346,7 +346,13 @@ func (b *stmtBundleBuilder) addTrace(flags explain.RedactFlags) {
 	}
 
 	// The JSON is not very human-readable, so we include another format too.
-	b.z.AddFile("trace.txt", fmt.Sprintf("%s\n\n\n\n%s", stmt, b.trace.String()))
+	var text string
+	if flags.Has(explain.RedactPII) {
+		text = b.trace.RedactedString()
+	} else {
+		text = b.trace.String()
+	}
+	b.z.AddFile("trace.txt", fmt.Sprintf("%s\n\n\n\n%s", stmt, text))
 
 	// Note that we're going to include the non-anonymized statement in the trace.
 	// But then again, nothing in the trace is anonymized.

--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -451,7 +451,8 @@ func (b *stmtBundleBuilder) addEnv(ctx context.Context, flags explain.RedactFlag
 	b.z.AddFile("schema.sql", buf.String())
 	for i := range tables {
 		buf.Reset()
-		if err := c.PrintTableStats(&buf, &tables[i], false /* hideHistograms */); err != nil {
+		hideHistograms := flags.Has(explain.RedactPII)
+		if err := c.PrintTableStats(&buf, &tables[i], hideHistograms); err != nil {
 			fmt.Fprintf(&buf, "-- error getting statistics for table %s: %v\n", tables[i].String(), err)
 		}
 		b.z.AddFile(fmt.Sprintf("stats-%s.sql", tables[i].String()), buf.String())

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -398,13 +398,18 @@ func (ih *instrumentationHelper) Finish(
 		if ih.stmtDiagnosticsRecorder.IsConditionSatisfied(ih.diagRequest, execLatency) {
 			placeholders := p.extendedEvalCtx.Placeholders
 			ob := ih.emitExplainAnalyzePlanToOutputBuilder(
-				explain.Flags{Verbose: true, ShowTypes: true},
+				explain.Flags{
+					Verbose:   true,
+					ShowTypes: true,
+					Redact:    ih.explainFlags.Redact & explain.RedactPII,
+				},
 				phaseTimes,
 				queryLevelStats,
 			)
 			warnings = ob.GetWarnings()
 			bundle = buildStatementBundle(
 				ctx, cfg.DB, ie.(*InternalExecutor), &p.curPlan, ob.BuildString(), trace, placeholders,
+				ih.explainFlags.Redact,
 			)
 			bundle.insert(ctx, ih.fingerprint, ast, cfg.StmtDiagnosticsRecorder, ih.diagRequestID, ih.diagRequest)
 			telemetry.Inc(sqltelemetry.StatementDiagnosticsCollectedCounter)

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -345,11 +345,15 @@ func (ih *instrumentationHelper) Setup(
 		// testing callback.
 		recType = tracingpb.RecordingVerbose
 	}
+	//if ih.explainFlags.Redact&explain.RedactPII != 0 {
+	//ih.previousRedactable = cfg.AmbientCtx.Tracer.Redactable()
+	//cfg.AmbientCtx.Tracer.SetRedactable(true)
+	//}
 	if ih.explainFlags.Redact&explain.RedactPII != 0 {
-		ih.previousRedactable = cfg.AmbientCtx.Tracer.Redactable()
-		cfg.AmbientCtx.Tracer.SetRedactable(true)
+		newCtx, ih.sp = tracing.EnsureChildSpan(ctx, cfg.AmbientCtx.Tracer, "traced statement", tracing.WithRecording(recType), tracing.WithRedactable())
+	} else {
+		newCtx, ih.sp = tracing.EnsureChildSpan(ctx, cfg.AmbientCtx.Tracer, "traced statement", tracing.WithRecording(recType))
 	}
-	newCtx, ih.sp = tracing.EnsureChildSpan(ctx, cfg.AmbientCtx.Tracer, "traced statement", tracing.WithRecording(recType))
 	ih.shouldFinishSpan = true
 	return newCtx, true
 }

--- a/pkg/sql/opt/exec/explain/flags.go
+++ b/pkg/sql/opt/exec/explain/flags.go
@@ -30,12 +30,12 @@ type Flags struct {
 	// debug tool.
 	OnlyShape bool
 
-	// Redaction control (for testing purposes).
+	// Redaction control. This is used both for testing purposes (to make EXPLAIN
+	// output deterministic) and for redaction of PII.
 	Redact RedactFlags
 }
 
-// RedactFlags control the redacting of various field values. They are used to
-// guarantee deterministic results for testing purposes.
+// RedactFlags control the redacting of various field values.
 type RedactFlags uint8
 
 const (
@@ -52,6 +52,8 @@ const (
 	// other, even without changes to the configuration or data distribution (e.g.
 	// timings).
 	RedactVolatile
+
+	RedactPII
 )
 
 const (
@@ -78,6 +80,9 @@ func MakeFlags(options *tree.ExplainOptions) Flags {
 		f.HideValues = true
 		f.OnlyShape = true
 		f.Redact = RedactAll
+	}
+	if options.Flags[tree.ExplainFlagRedact] {
+		f.Redact = RedactPII
 	}
 	return f
 }

--- a/pkg/sql/sem/tree/explain.go
+++ b/pkg/sql/sem/tree/explain.go
@@ -116,6 +116,7 @@ const (
 	ExplainFlagMemo
 	ExplainFlagShape
 	ExplainFlagViz
+	ExplainFlagRedact
 	numExplainFlags = iota
 )
 
@@ -128,6 +129,7 @@ var explainFlagStrings = [...]string{
 	ExplainFlagMemo:    "MEMO",
 	ExplainFlagShape:   "SHAPE",
 	ExplainFlagViz:     "VIZ",
+	ExplainFlagRedact:  "REDACT",
 }
 
 var explainFlagStringMap = func() map[string]ExplainFlag {
@@ -258,6 +260,12 @@ func MakeExplain(options []string, stmt Statement) (Statement, error) {
 		}
 		if analyze {
 			return nil, pgerror.Newf(pgcode.Syntax, "the JSON flag cannot be used with ANALYZE")
+		}
+	}
+
+	if opts.Flags[ExplainFlagRedact] {
+		if !analyze || opts.Mode != ExplainDebug {
+			return nil, pgerror.Newf(pgcode.Syntax, "the REDACT flag can only be used with EXPLAIN ANALYZE (DEBUG)")
 		}
 	}
 

--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -1149,7 +1149,7 @@ func (s *crdbSpan) getRecordingNoChildrenLocked(
 		if s.recordingType() == tracingpb.RecordingVerbose {
 			rs.EnsureTagGroup(tracingpb.AnonymousTagGroupName).AddTag("_verbose", "1")
 		}
-		if s.tracer.Redactable() {
+		if s.sp.i.redactable {
 			rs.EnsureTagGroup(tracingpb.AnonymousTagGroupName).AddTag("_redactable", "1")
 		}
 		if s.mu.recording.droppedLogs {

--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -1149,6 +1149,9 @@ func (s *crdbSpan) getRecordingNoChildrenLocked(
 		if s.recordingType() == tracingpb.RecordingVerbose {
 			rs.EnsureTagGroup(tracingpb.AnonymousTagGroupName).AddTag("_verbose", "1")
 		}
+		if s.tracer.Redactable() {
+			rs.EnsureTagGroup(tracingpb.AnonymousTagGroupName).AddTag("_redactable", "1")
+		}
 		if s.mu.recording.droppedLogs {
 			rs.EnsureTagGroup(tracingpb.AnonymousTagGroupName).AddTag("_dropped_logs", "")
 		}

--- a/pkg/util/tracing/span_options.go
+++ b/pkg/util/tracing/span_options.go
@@ -75,6 +75,7 @@ type spanOptions struct {
 	ForceRealSpan                 bool                   // see WithForceRealSpan
 	SpanKind                      oteltrace.SpanKind     // see WithSpanKind
 	Sterile                       bool                   // see WithSterile
+	Redactable                    bool                   // see WithRedactable
 	EventListeners                []EventListener        // see WithEventListeners
 
 	// recordingTypeExplicit is set if the WithRecording() option was used. In
@@ -439,6 +440,17 @@ func WithSterile() SpanOption {
 
 func (w withSterileOption) apply(opts spanOptions) spanOptions {
 	opts.Sterile = true
+	return opts
+}
+
+type withRedactableOption struct{}
+
+func WithRedactable() SpanOption {
+	return withRedactableOption{}
+}
+
+func (w withRedactableOption) apply(opts spanOptions) spanOptions {
+	opts.Redactable = true
 	return opts
 }
 

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -979,6 +979,7 @@ func (t *Tracer) newSpan(
 	otelSpan oteltrace.Span,
 	netTr trace.Trace,
 	sterile bool,
+	redactable bool,
 ) *Span {
 	if t.testing.MaintainAllocationCounters {
 		atomic.AddInt32(&t.spansCreated, 1)
@@ -987,7 +988,7 @@ func (t *Tracer) newSpan(
 	h.span.reset(
 		traceID, spanID, operation, goroutineID,
 		startTime, logTags, eventListeners, kind,
-		otelSpan, netTr, sterile)
+		otelSpan, netTr, sterile, redactable)
 	return &h.span
 }
 
@@ -1187,10 +1188,14 @@ child operation: %s, tracer created at:
 	}
 	spanID := tracingpb.SpanID(randutil.FastInt63())
 
+	if !opts.Parent.empty() && opts.Parent.i.redactable {
+		opts.Redactable = true
+	}
+
 	s := t.newSpan(
 		traceID, spanID, opName, uint64(goid.Get()),
 		startTime, opts.LogTags, opts.EventListeners, opts.SpanKind,
-		otelSpan, netTr, opts.Sterile)
+		otelSpan, netTr, opts.Sterile, opts.Redactable)
 
 	s.i.crdb.SetRecordingType(opts.recordingType())
 	s.i.crdb.parentSpanID = opts.parentSpanID()

--- a/pkg/util/tracing/tracingpb/tracing.proto
+++ b/pkg/util/tracing/tracingpb/tracing.proto
@@ -43,5 +43,6 @@ message TraceInfo {
   }
 
   OtelInfo otel = 4;
-}
 
+  bool redactable = 5;
+}


### PR DESCRIPTION
**docs/RFCS: redact statement diagnostics bundles**

Epic: CRDB-19756

Release note: None

---

**sql: add REDACT flag to EXPLAIN ANALYZE (DEBUG)**

And also use it to hide constants in the statements in statement.txt
and trace.txt.

Release note: None

Epic: CRDB-19756