### PR TITLE
release-22.2: roachtest: reassign tests to replication team

### DIFF
--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -39,6 +39,10 @@ cockroachdb/kv:
     cockroachdb/kv-triage: roachtest
     cockroachdb/kv-prs: other
   triage_column_id: 14242655
+cockroachdb/replication:
+  aliases:
+    cockroachdb/repl-prs: other
+  label: T-kv-replication
 cockroachdb/geospatial:
   triage_column_id: 9487269
 cockroachdb/dev-inf:

--- a/pkg/cmd/roachtest/github.go
+++ b/pkg/cmd/roachtest/github.go
@@ -63,6 +63,15 @@ func (g *githubIssues) createPostRequest(t test.Test, message string) issues.Pos
 	var mention []string
 	var projColID int
 
+	// Issues posted from roachtest are identifiable as such and
+	// they are also release blockers (this label may be removed
+	// by a human upon closer investigation).
+	spec := t.Spec().(*registry.TestSpec)
+	labels := []string{"O-roachtest"}
+	if !spec.NonReleaseBlocker {
+		labels = append(labels, "release-blocker")
+	}
+
 	teams, err := g.teamLoader()
 	if err != nil {
 		t.Fatalf("could not load teams: %v", err)
@@ -71,6 +80,9 @@ func (g *githubIssues) createPostRequest(t test.Test, message string) issues.Pos
 	if sl, ok := teams.GetAliasesForPurpose(ownerToAlias(t.Spec().(*registry.TestSpec).Owner), team.PurposeRoachtest); ok {
 		for _, alias := range sl {
 			mention = append(mention, "@"+string(alias))
+			if label := teams[alias].Label; label != "" {
+				labels = append(labels, label)
+			}
 		}
 		projColID = teams[sl[0]].TriageColumnID
 	}
@@ -81,15 +93,6 @@ func (g *githubIssues) createPostRequest(t test.Test, message string) issues.Pos
 	}
 
 	artifacts := fmt.Sprintf("/%s", t.Name())
-
-	// Issues posted from roachtest are identifiable as such and
-	// they are also release blockers (this label may be removed
-	// by a human upon closer investigation).
-	spec := t.Spec().(*registry.TestSpec)
-	labels := []string{"O-roachtest"}
-	if !spec.NonReleaseBlocker {
-		labels = append(labels, "release-blocker")
-	}
 
 	clusterParams := map[string]string{
 		roachtestPrefix("cloud"): spec.Cluster.Cloud,

--- a/pkg/cmd/roachtest/github_test.go
+++ b/pkg/cmd/roachtest/github_test.go
@@ -29,7 +29,8 @@ var (
 	teamsYaml = `cockroachdb/unowned:
   aliases:
     cockroachdb/rfc-prs: other
-  triage_column_id: 0`
+  triage_column_id: 0
+  label: T-testeng`
 
 	validTeamsFn   = func() (team.Map, error) { return loadYamlTeams(teamsYaml) }
 	invalidTeamsFn = func() (team.Map, error) { return loadYamlTeams("invalid yaml") }
@@ -196,6 +197,7 @@ func TestCreatePostRequest(t *testing.T) {
 			if !c.nonReleaseBlocker {
 				require.True(t, contains(req.ExtraLabels, nil, "release-blocker"))
 			}
+			require.Contains(t, req.ExtraLabels, "T-testeng")
 		}
 	}
 }

--- a/pkg/cmd/roachtest/registry/owners.go
+++ b/pkg/cmd/roachtest/registry/owners.go
@@ -20,6 +20,7 @@ const (
 	OwnerDisasterRecovery Owner = `disaster-recovery`
 	OwnerCDC              Owner = `cdc`
 	OwnerKV               Owner = `kv`
+	OwnerReplication      Owner = `replication`
 	OwnerMultiRegion      Owner = `multiregion`
 	OwnerObsInf           Owner = `obs-inf-prs`
 	OwnerServer           Owner = `server` // not currently staffed

--- a/pkg/cmd/roachtest/tests/inconsistency.go
+++ b/pkg/cmd/roachtest/tests/inconsistency.go
@@ -25,7 +25,7 @@ import (
 func registerInconsistency(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:    "inconsistency",
-		Owner:   registry.OwnerKV,
+		Owner:   registry.OwnerReplication,
 		Cluster: r.MakeClusterSpec(3),
 		Run:     runInconsistency,
 	})

--- a/pkg/cmd/roachtest/tests/loss_of_quorum_recovery.go
+++ b/pkg/cmd/roachtest/tests/loss_of_quorum_recovery.go
@@ -62,7 +62,7 @@ func registerLOQRecovery(r registry.Registry) {
 		testSpec := s
 		r.Add(registry.TestSpec{
 			Name:              s.String(),
-			Owner:             registry.OwnerKV,
+			Owner:             registry.OwnerReplication,
 			Tags:              []string{`default`},
 			Cluster:           spec,
 			NonReleaseBlocker: true,

--- a/pkg/cmd/roachtest/tests/replicagc.go
+++ b/pkg/cmd/roachtest/tests/replicagc.go
@@ -31,7 +31,7 @@ func registerReplicaGC(r registry.Registry) {
 	for _, restart := range []bool{true, false} {
 		r.Add(registry.TestSpec{
 			Name:    fmt.Sprintf("replicagc-changed-peers/restart=%t", restart),
-			Owner:   registry.OwnerKV,
+			Owner:   registry.OwnerReplication,
 			Cluster: r.MakeClusterSpec(6),
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runReplicaGCChangedPeers(ctx, t, c, restart)

--- a/pkg/internal/team/team.go
+++ b/pkg/internal/team/team.go
@@ -36,6 +36,8 @@ type Team struct {
 	// CODEOWNERS, code reviews for the @cockroachdb/kv team). This map
 	// does not contain TeamName.
 	Aliases map[Alias]Purpose `yaml:"aliases"`
+	// GitHub label will be added to issues posted for this team.
+	Label string `yaml:"label"`
 	// TriageColumnID is the GitHub Column ID to assign issues to.
 	TriageColumnID int `yaml:"triage_column_id"`
 	// Email is the email address for this team.


### PR DESCRIPTION
Backport 3/3 commits from #91901.

Release justification: roachtest reassignment.

/cc @cockroachdb/release

---

**internal/team: add support for team labels**

Previously, roachtest issues were assigned to a GitHub project board,
and Blathers would assign a team label based on that. However, some
teams don't use GitHub project boards.

This patch adds an explicit team label, and makes roachtest set it when
posting issues.

Release note: None
  
**TEAMS: add replication**

Release note: None
  
**roachtest: reassign tests to replication team**

Resolves #90125.

Release note: None
