### PR TITLE
release-22.1: roachtest: reassign tests to replication team

### DIFF
--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -39,6 +39,10 @@ cockroachdb/kv:
     cockroachdb/kv-triage: roachtest
     cockroachdb/kv-prs: other
   triage_column_id: 14242655
+cockroachdb/replication:
+  aliases:
+    cockroachdb/repl-prs: other
+  label: T-kv-replication
 cockroachdb/geospatial:
   triage_column_id: 9487269
 cockroachdb/dev-inf:

--- a/pkg/cmd/roachtest/registry/owners.go
+++ b/pkg/cmd/roachtest/registry/owners.go
@@ -20,6 +20,7 @@ const (
 	OwnerDisasterRecovery Owner = `disaster-recovery`
 	OwnerCDC              Owner = `cdc`
 	OwnerKV               Owner = `kv`
+	OwnerReplication      Owner = `replication`
 	OwnerMultiRegion      Owner = `multiregion`
 	OwnerObsInf           Owner = `obs-inf-prs`
 	OwnerServer           Owner = `server`

--- a/pkg/cmd/roachtest/tests/inconsistency.go
+++ b/pkg/cmd/roachtest/tests/inconsistency.go
@@ -25,7 +25,7 @@ import (
 func registerInconsistency(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:    "inconsistency",
-		Owner:   registry.OwnerKV,
+		Owner:   registry.OwnerReplication,
 		Cluster: r.MakeClusterSpec(3),
 		Run:     runInconsistency,
 	})

--- a/pkg/cmd/roachtest/tests/replicagc.go
+++ b/pkg/cmd/roachtest/tests/replicagc.go
@@ -31,7 +31,7 @@ func registerReplicaGC(r registry.Registry) {
 	for _, restart := range []bool{true, false} {
 		r.Add(registry.TestSpec{
 			Name:    fmt.Sprintf("replicagc-changed-peers/restart=%t", restart),
-			Owner:   registry.OwnerKV,
+			Owner:   registry.OwnerReplication,
 			Cluster: r.MakeClusterSpec(6),
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runReplicaGCChangedPeers(ctx, t, c, restart)

--- a/pkg/internal/team/team.go
+++ b/pkg/internal/team/team.go
@@ -37,6 +37,8 @@ type Team struct {
 	// CODEOWNERS, code reviews for the @cockroachdb/kv team). This map
 	// does not contain TeamName.
 	Aliases map[Alias]Purpose `yaml:"aliases"`
+	// GitHub label will be added to issues posted for this team.
+	Label string `yaml:"label"`
 	// TriageColumnID is the GitHub Column ID to assign issues to.
 	TriageColumnID int `yaml:"triage_column_id"`
 	// Email is the email address for this team.


### PR DESCRIPTION
Backport 3/3 commits from #91901.

Unclean backport due to code reorganization in roachtest. No test coverage, since the test that was adjusted does not exist in 22.1.

Release justification: roachtest reassignment.

/cc @cockroachdb/release

---

**internal/team: add support for team labels**

Previously, roachtest issues were assigned to a GitHub project board,
and Blathers would assign a team label based on that. However, some
teams don't use GitHub project boards.

This patch adds an explicit team label, and makes roachtest set it when
posting issues.

Release note: None
  
**TEAMS: add replication**

Release note: None
  
**roachtest: reassign tests to replication team**

Resolves #90125.

Release note: None
