### PR TITLE
kvserver: use engine only after entry cache

### DIFF
--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -209,11 +209,6 @@ func entries(
 
 	// Did we get any results at all? Because something went wrong.
 	if len(ents) > 0 {
-		// Was the lo already truncated?
-		if ents[0].Index > lo {
-			return nil, raft.ErrCompacted
-		}
-
 		// Was the missing index after the last index?
 		lastIndex, err := rsl.LoadLastIndex(ctx, reader)
 		if err != nil {

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -12,7 +12,6 @@ package kvserver
 
 import (
 	"context"
-	"math"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -114,10 +113,12 @@ func (r *Replica) raftEntriesLocked(lo, hi, maxBytes uint64) ([]raftpb.Entry, er
 	return (*replicaRaftStorage)(r).Entries(lo, hi, maxBytes)
 }
 
-// entries retrieves entries from the engine. To accommodate loading the term,
-// `sideloaded` can be supplied as nil, in which case sideloaded entries will
-// not be inlined, the raft entry cache will not be populated with *any* of the
-// loaded entries, and maxBytes will not be applied to the payloads.
+// entries retrieves entries from the engine. It inlines the sideloaded entries,
+// and caches all the loaded entries. The size of the returned entries does not
+// exceed maxSize, unless only one entry is returned.
+//
+// TODO(pavelkalinnikov): return all entries we've read, consider maxSize a
+// target size. Currently we may read one extra entry and drop it.
 func entries(
 	ctx context.Context,
 	rsl stateloader.StateLoader,
@@ -149,10 +150,6 @@ func entries(
 	// stopping once we have enough.
 	expectedIndex := hitIndex
 
-	// Whether we can populate the Raft entries cache. False if we found a
-	// sideloaded proposal, but the caller didn't give us a sideloaded storage.
-	canCache := true
-
 	scanFunc := func(ent raftpb.Entry) error {
 		// Exit early if we have any gaps or it has been compacted.
 		if ent.Index != expectedIndex {
@@ -161,17 +158,14 @@ func entries(
 		expectedIndex++
 
 		if logstore.SniffSideloadedRaftCommand(ent.Data) {
-			canCache = canCache && sideloaded != nil
-			if sideloaded != nil {
-				newEnt, err := logstore.MaybeInlineSideloadedRaftCommand(
-					ctx, rangeID, ent, sideloaded, eCache,
-				)
-				if err != nil {
-					return err
-				}
-				if newEnt != nil {
-					ent = *newEnt
-				}
+			newEnt, err := logstore.MaybeInlineSideloadedRaftCommand(
+				ctx, rangeID, ent, sideloaded, eCache,
+			)
+			if err != nil {
+				return err
+			}
+			if newEnt != nil {
+				ent = *newEnt
 			}
 		}
 
@@ -192,10 +186,7 @@ func entries(
 	if err := raftlog.Visit(reader, rangeID, expectedIndex, hi, scanFunc); err != nil {
 		return nil, err
 	}
-	// Cache the fetched entries, if we may.
-	if canCache {
-		eCache.Add(rangeID, ents, false /* truncate */)
-	}
+	eCache.Add(rangeID, ents, false /* truncate */)
 
 	// Did the correct number of results come back? If so, we're all good.
 	if uint64(len(ents)) == hi-lo {
@@ -249,10 +240,6 @@ func (r *replicaRaftStorage) Term(i uint64) (uint64, error) {
 	if r.mu.lastIndex == i && r.mu.lastTerm != invalidLastTerm {
 		return r.mu.lastTerm, nil
 	}
-	// Try to retrieve the term for the desired entry from the entry cache.
-	if e, ok := r.store.raftEntryCache.Get(r.RangeID, i); ok {
-		return e.Term, nil
-	}
 	readonly := r.store.Engine().NewReadOnly(storage.StandardDurability)
 	defer readonly.Close()
 	ctx := r.AnnotateCtx(context.TODO())
@@ -278,27 +265,60 @@ func term(
 	reader storage.Reader,
 	rangeID roachpb.RangeID,
 	eCache *raftentry.Cache,
-	i uint64,
+	index uint64,
 ) (uint64, error) {
-	// entries() accepts a `nil` sideloaded storage and will skip inlining of
-	// sideloaded entries. We only need the term, so this is what we do.
-	ents, err := entries(ctx, rsl, reader, rangeID, eCache, nil /* sideloaded */, i, i+1, math.MaxUint64 /* maxBytes */)
-	if errors.Is(err, raft.ErrCompacted) {
-		ts, err := rsl.LoadRaftTruncatedState(ctx, reader)
-		if err != nil {
-			return 0, err
+	entry, found := eCache.Get(rangeID, index)
+	if found {
+		return entry.Term, nil
+	}
+
+	if err := raftlog.Visit(reader, rangeID, index, index+1, func(ent raftpb.Entry) error {
+		if found {
+			return errors.Errorf("found more than one entry in [%d,%d)", index, index+1)
 		}
-		if i == ts.Index {
-			return ts.Term, nil
-		}
-		return 0, raft.ErrCompacted
-	} else if err != nil {
+		found = true
+		entry = ent
+		return nil
+	}); err != nil {
 		return 0, err
 	}
-	if len(ents) == 0 {
-		return 0, nil
+
+	if found {
+		// Found an entry. Double-check that it has a correct index.
+		if got, want := entry.Index, index; got != want {
+			return 0, errors.Errorf("there is a gap at index %d, found entry #%d", want, got)
+		}
+		// Cache the entry except if it is sideloaded. We don't load/inline the
+		// sideloaded entries here to keep the term fetching cheap.
+		// TODO(pavelkalinnikov): consider not caching here, after measuring if it
+		// makes any difference.
+		if !logstore.SniffSideloadedRaftCommand(entry.Data) {
+			eCache.Add(rangeID, []raftpb.Entry{entry}, false /* truncate */)
+		}
+		return entry.Term, nil
 	}
-	return ents[0].Term, nil
+	// Otherwise, the entry at the given index is not found. This can happen if
+	// the index is ahead of lastIndex, or it has been compacted away.
+
+	lastIndex, err := rsl.LoadLastIndex(ctx, reader)
+	if err != nil {
+		return 0, err
+	}
+	if index > lastIndex {
+		return 0, raft.ErrUnavailable
+	}
+
+	ts, err := rsl.LoadRaftTruncatedState(ctx, reader)
+	if err != nil {
+		return 0, err
+	}
+	if index == ts.Index {
+		return ts.Term, nil
+	}
+	if index > ts.Index {
+		return 0, errors.Errorf("there is a gap at index %d", index)
+	}
+	return 0, raft.ErrCompacted
 }
 
 // raftLastIndexRLocked requires that r.mu is held for reading.

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -179,17 +179,13 @@ func entries(
 		size += uint64(ent.Size())
 		if size > maxBytes {
 			exceededMaxBytes = true
-			if len(ents) > 0 {
-				if exceededMaxBytes {
-					return iterutil.StopIteration()
-				}
-				return nil
+			if len(ents) == 0 { // make sure to return at least one entry
+				ents = append(ents, ent)
 			}
-		}
-		ents = append(ents, ent)
-		if exceededMaxBytes {
 			return iterutil.StopIteration()
 		}
+
+		ents = append(ents, ent)
 		return nil
 	}
 

--- a/pkg/kv/kvserver/replica_sideload_test.go
+++ b/pkg/kv/kvserver/replica_sideload_test.go
@@ -170,60 +170,46 @@ func TestRaftSSTableSideloading(t *testing.T) {
 		}
 	}
 
-	// Check the `entries()` method which has special handling to accommodate
-	// `term()`: when an empty sideload storage is passed in, `entries()` should
-	// not inline, and in turn also not populate the entries cache (since its
-	// contents must always be fully inlined).
+	// Check that the `entries()` call caches the loaded entries and inlines the
+	// sideloaded ones.
 	tc.repl.raftMu.Lock()
 	defer tc.repl.raftMu.Unlock()
 	tc.repl.mu.Lock()
 	defer tc.repl.mu.Unlock()
-	testutils.RunTrueAndFalse(t, "withSS", func(t *testing.T, withSS bool) {
-		rsl := stateloader.Make(tc.repl.RangeID)
-		lo := tc.repl.mu.state.TruncatedState.Index + 1
-		hi := tc.repl.mu.lastIndex + 1
 
-		var ss logstore.SideloadStorage
-		if withSS {
-			ss = tc.repl.raftMu.sideloaded
+	rsl := stateloader.Make(tc.repl.RangeID)
+	lo := tc.repl.mu.state.TruncatedState.Index + 1
+	hi := tc.repl.mu.lastIndex + 1
+
+	tc.store.raftEntryCache.Clear(tc.repl.RangeID, hi)
+	ents, err := entries(
+		ctx, rsl, tc.store.Engine(), tc.repl.RangeID, tc.store.raftEntryCache,
+		tc.repl.raftMu.sideloaded, lo, hi, math.MaxUint64,
+	)
+	require.NoError(t, err)
+	require.Len(t, ents, int(hi-lo))
+
+	// Check that the Raft entry cache was populated.
+	_, okLo := tc.store.raftEntryCache.Get(tc.repl.RangeID, lo)
+	_, okHi := tc.store.raftEntryCache.Get(tc.repl.RangeID, hi-1)
+	require.True(t, okLo)
+	require.True(t, okHi)
+
+	// Check that the sideloaded entries were inlined.
+	var idx int
+	for idx = 0; idx < len(ents); idx++ {
+		// Get the SST back from the raft log.
+		if !logstore.SniffSideloadedRaftCommand(ents[idx].Data) {
+			continue
 		}
-
-		tc.store.raftEntryCache.Clear(tc.repl.RangeID, hi)
-		ents, err := entries(
-			ctx, rsl, tc.store.Engine(), tc.repl.RangeID, tc.store.raftEntryCache,
-			ss, lo, hi, math.MaxUint64,
-		)
+		ent, err := logstore.MaybeInlineSideloadedRaftCommand(ctx, tc.repl.RangeID, ents[idx], tc.repl.raftMu.sideloaded, tc.store.raftEntryCache)
 		require.NoError(t, err)
-		require.Len(t, ents, int(hi-lo))
-
-		// Raft entry cache only gets populated when sideloaded storage provided.
-		_, okLo := tc.store.raftEntryCache.Get(tc.repl.RangeID, lo)
-		_, okHi := tc.store.raftEntryCache.Get(tc.repl.RangeID, hi-1)
-		if withSS {
-			require.True(t, okLo)
-			require.True(t, okHi)
-		} else {
-			require.False(t, okLo)
-			require.False(t, okHi)
-		}
-
-		// The rest of the test is the same in both cases. We find the sideloaded entry
-		// and check the sideloaded storage for the payload.
-		var idx int
-		for idx = 0; idx < len(ents); idx++ {
-			// Get the SST back from the raft log.
-			if !logstore.SniffSideloadedRaftCommand(ents[idx].Data) {
-				continue
-			}
-			ent, err := logstore.MaybeInlineSideloadedRaftCommand(ctx, tc.repl.RangeID, ents[idx], tc.repl.raftMu.sideloaded, tc.store.raftEntryCache)
-			require.NoError(t, err)
-			sst, err := tc.repl.raftMu.sideloaded.Get(ctx, ent.Index, ent.Term)
-			require.NoError(t, err)
-			require.Equal(t, origSSTData, sst)
-			break
-		}
-		require.Less(t, idx, len(ents)) // there was an SST
-	})
+		sst, err := tc.repl.raftMu.sideloaded.Get(ctx, ent.Index, ent.Term)
+		require.NoError(t, err)
+		require.Equal(t, origSSTData, sst)
+		break
+	}
+	require.Less(t, idx, len(ents)) // there was an SST
 }
 
 func TestRaftSSTableSideloadingTruncation(t *testing.T) {


### PR DESCRIPTION
Raft entries are often in the entries cache. This PR decouples `term` and `entries` fetching to prepare for the refactoring, and moves constructing a storage Reader strictly after checking the cache, to reduce the overhead.

Fixes #92274
Release note: None