### PR TITLE
multitenant: Remove permissions from add-mt-to-project

### DIFF
--- a/.github/workflows/add-mt-issues-to-project.yml
+++ b/.github/workflows/add-mt-issues-to-project.yml
@@ -8,9 +8,6 @@ jobs:
   add-to-project:
     name: Add issue to project
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      repository-projects: write
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:


### PR DESCRIPTION
The multitenant add-to-project job is failing with an authorization issue.  Removing the permissions restrictions to see if that resolves things.

Epic: none