### PR TITLE
testccl/workload/schemachange: shorten test

### DIFF
--- a/pkg/ccl/testccl/workload/schemachange/schema_change_external_test.go
+++ b/pkg/ccl/testccl/workload/schemachange/schema_change_external_test.go
@@ -89,7 +89,7 @@ func TestWorkload(t *testing.T) {
 	ql, err := wl.Ops(ctx, []string{pgURL.String()}, reg)
 	require.NoError(t, err)
 
-	const N = 800
+	const N = 100
 	workerFn := func(ctx context.Context, fn func(ctx context.Context) error) func() error {
 		return func() error {
 			for i := 0; i < N; i++ {


### PR DESCRIPTION
When it runs with 800, it gets more likely that it's going to run into backoffs and it takes non-linearly longer.

Fixes #92187

Release note: None