### PR TITLE
changefeedccl: sqlsmith test

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -213,6 +213,7 @@ go_test(
         "//pkg/cloud/impl:cloudimpl",
         "//pkg/clusterversion",
         "//pkg/gossip",
+        "//pkg/internal/sqlsmith",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/jobs/jobstest",

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -190,7 +190,7 @@ func assertPayloadsBase(
 
 	require.NoError(t,
 		withTimeout(f, timeout,
-			func(ctx context.Context) error {
+			func(ctx context.Context) (err error) {
 				return assertPayloadsBaseErr(ctx, f, expected, stripTs, perKeyOrdered)
 			},
 		))
@@ -694,6 +694,18 @@ func closeFeed(t testing.TB, f cdctest.TestFeed) {
 	t.Helper()
 	if err := f.Close(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func closeFeedIgnoreError(t testing.TB, f cdctest.TestFeed) {
+	defer func() {
+		if e := recover(); e != nil {
+			t.Log(e)
+		}
+	}()
+	t.Helper()
+	if err := f.Close(); err != nil {
+		t.Log(err)
 	}
 }
 

--- a/pkg/internal/sqlsmith/relational.go
+++ b/pkg/internal/sqlsmith/relational.go
@@ -185,7 +185,6 @@ func makeJoinExpr(s *Smither, refs colRefs, forJoin bool) (tree.TableExpr, colRe
 	if !ok {
 		return nil, nil, false
 	}
-
 	maxJoinType := len(joinTypes)
 	if s.disableCrossJoins {
 		maxJoinType = len(joinTypes) - 1
@@ -650,7 +649,11 @@ func (s *Smither) makeSelectClause(
 		}
 		clause.From.Tables = append(clause.From.Tables, from)
 		// Restrict so that we don't have a crazy amount of rows due to many joins.
-		if len(clause.From.Tables) >= 4 {
+		tableLimit := 4
+		if s.disableJoins {
+			tableLimit = 1
+		}
+		if len(clause.From.Tables) >= tableLimit {
 			break
 		}
 	}

--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -96,6 +96,7 @@ type Smither struct {
 	unlikelyConstantPredicate  bool
 	favorCommonData            bool
 	unlikelyRandomNulls        bool
+	disableJoins               bool
 	disableCrossJoins          bool
 	disableIndexHints          bool
 	lowProbWhereWithJoinTables bool
@@ -432,6 +433,11 @@ var FavorCommonData = simpleOption("favor common data", func(s *Smither) {
 // values much less likely than generation of random non-null data.
 var UnlikelyRandomNulls = simpleOption("unlikely random nulls", func(s *Smither) {
 	s.unlikelyRandomNulls = true
+})
+
+// DisableJoins causes the Smither to disable joins.
+var DisableJoins = simpleOption("disable joins", func(s *Smither) {
+	s.disableJoins = true
 })
 
 // DisableCrossJoins causes the Smither to disable cross joins.

--- a/pkg/sql/randgen/schema.go
+++ b/pkg/sql/randgen/schema.go
@@ -331,7 +331,10 @@ func PopulateTableWithRandData(
 				// them to the list of columns to insert data into.
 				continue
 			}
-			colTypes = append(colTypes, tree.MustBeStaticallyKnownType(col.Type.(*types.T)))
+			if _, ok := col.Type.(*types.T); !ok {
+				return 0, errors.Newf("No type for %v", col)
+			}
+			colTypes = append(colTypes, tree.MustBeStaticallyKnownType(col.Type))
 			nullable = append(nullable, col.Nullable.Nullability == tree.Null)
 
 			colNameBuilder.WriteString(comma)


### PR DESCRIPTION
Informs https://github.com/cockroachdb/cockroach/issues/83591

Adds a test generating random predicates and
verifies that (except for a few known issues)
if a changefeed runs successfully it will output
the same rows as a regular query.

Release note: None