### PR TITLE
backupccl: extend backupccl test timeout to 2 hours

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -180,7 +180,7 @@ go_test(
         "system_schema_test.go",
         "utils_test.go",
     ],
-    args = ["-test.timeout=3595s"],
+    args = ["-test.timeout=7195s"],
     data = glob(["testdata/**"]) + ["//c-deps:libgeos"],
     embed = [":backupccl"],
     shard_count = 16,

--- a/pkg/cmd/generate-bazel-extra/main.go
+++ b/pkg/cmd/generate-bazel-extra/main.go
@@ -284,14 +284,15 @@ unused_checker(srcs = GET_X_DATA_TARGETS)`)
 	}
 }
 
-// excludeSqliteLogicTests removes the sqlite logic tests targets from the
-// given list of targets and returns the updated list.
-func excludeSqliteLogicTests(targets []string) []string {
+// excludeReallyEnormousTargets removes the really enormous test targets
+// from the given list of targets and returns the updated list.
+func excludeReallyEnormousTargets(targets []string) []string {
 	for i := 0; i < len(targets); i++ {
 		var excluded bool
 		for _, toExclude := range []string{
 			"//pkg/ccl/sqlitelogictestccl",
 			"//pkg/sql/sqlitelogictest",
+			"//pkg/ccl/backupccl",
 		} {
 			if strings.HasPrefix(targets[i], toExclude) {
 				excluded = true
@@ -315,9 +316,9 @@ func generateTestsTimeouts() {
 	}
 	for size, timeout := range testSizeToDefaultTimeout {
 		if size == "enormous" {
-			// Exclude sqlite logic tests since they have a custom timeout that
+			// Exclude really enormous targets since they have a custom timeout that
 			// exceeds the default 1h.
-			targets[size] = excludeSqliteLogicTests(targets[size])
+			targets[size] = excludeReallyEnormousTargets(targets[size])
 		}
 		// Let the `go test` process timeout 5 seconds before bazel attempts to kill it.
 		// Note that if this causes issues such as not having enough time to run normally

--- a/pkg/cmd/generate-bazel-extra/main_test.go
+++ b/pkg/cmd/generate-bazel-extra/main_test.go
@@ -47,7 +47,7 @@ func TestParseQueryXML(t *testing.T) {
 	}
 }
 
-func TestExcludeSqliteLogicTests(t *testing.T) {
+func TestExcludeReallyEnormousTests(t *testing.T) {
 	for _, tc := range []struct {
 		in  []string
 		out []string
@@ -55,6 +55,7 @@ func TestExcludeSqliteLogicTests(t *testing.T) {
 		{
 			in: []string{
 				"//pkg/jobs:jobs_test",
+				"//pkg/ccl/backupccl:backupccl_test",
 				"//pkg/sql/sem/eval:eval_test",
 				"//pkg/sql/sqlitelogictest:sqlitelogictest_test",
 			},
@@ -83,6 +84,7 @@ func TestExcludeSqliteLogicTests(t *testing.T) {
 		{
 			in: []string{
 				"//pkg/ccl/sqlitelogictestccl:sqlitelogictestccl_test",
+				"//pkg/ccl/backupccl:backupccl_test",
 				"//pkg/jobs:jobs_test",
 				"//pkg/sql/colexec:colexec_test",
 				"//pkg/sql/sem/eval:eval_test",
@@ -95,6 +97,6 @@ func TestExcludeSqliteLogicTests(t *testing.T) {
 			},
 		},
 	} {
-		require.Equal(t, tc.out, excludeSqliteLogicTests(tc.in))
+		require.Equal(t, tc.out, excludeReallyEnormousTargets(tc.in))
 	}
 }


### PR DESCRIPTION
This patch doubles the backupccl test timeout from 1hr to 2 hrs, to prevent the
 nightly stress job from timing out every night. The expected backupccl test
runtime is currently 1h and 17 mins, so this timeout extension should prevent 
the stress job from flaking due to timeout.

Fixes #92040, #92236

Release note: None