### PR TITLE
sql, ui: add index used by statement

### DIFF
--- a/pkg/roachpb/app_stats.go
+++ b/pkg/roachpb/app_stats.go
@@ -157,6 +157,7 @@ func (s *StatementStatistics) Add(other *StatementStatistics) {
 	s.Nodes = util.CombineUniqueInt64(s.Nodes, other.Nodes)
 	s.PlanGists = util.CombineUniqueString(s.PlanGists, other.PlanGists)
 	s.IndexRecommendations = other.IndexRecommendations
+	s.Indexes = util.CombineUniqueString(s.Indexes, other.Indexes)
 
 	s.ExecStats.Add(other.ExecStats)
 

--- a/pkg/roachpb/app_stats.proto
+++ b/pkg/roachpb/app_stats.proto
@@ -117,6 +117,9 @@ message StatementStatistics {
   // index_recommendations is the list of index recommendations generated for the statement fingerprint.
   repeated string index_recommendations = 27;
 
+  // indexes is the list of indexes used by the particular plan when executing the statement.
+  repeated string indexes = 30;
+
   // Note: be sure to update `sql/app_stats.go` when adding/removing fields here!
 
   reserved 13, 14, 17, 18, 19, 20;

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -210,6 +210,7 @@ func (ex *connExecutor) recordStatementSummary(
 		FullScan:             fullScan,
 		SessionData:          planner.SessionData(),
 		ExecStats:            queryLevelStats,
+		Indexes:              planner.instrumentation.indexesUsed,
 	}
 
 	stmtFingerprintID, err :=

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -191,6 +191,9 @@ type instrumentationHelper struct {
 
 	// scanCounts records the number of times scans were used in the query.
 	scanCounts [exec.NumScanCountTypes]int
+
+	// indexesUsed list the indexes used in the query with format tableID@indexID.
+	indexesUsed []string
 }
 
 // outputMode indicates how the statement output needs to be populated (for

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -186,6 +186,9 @@ type Builder struct {
 	// 4 DML statements, SELECT, UPDATE, INSERT, DELETE, or an EXPLAIN of one of
 	// these statements.
 	IsANSIDML bool
+
+	// IndexesUsed list the indexes used in query with the format tableID@indexID.
+	IndexesUsed []string
 }
 
 // New constructs an instance of the execution node builder using the

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -730,6 +730,7 @@ func (b *Builder) buildScan(scan *memo.ScanExpr) (execPlan, error) {
 		return execPlan{},
 			errors.AssertionFailedf("expected inverted index scan to have an inverted constraint")
 	}
+	b.IndexesUsed = util.CombineUniqueString(b.IndexesUsed, []string{fmt.Sprintf("%d@%d", tab.ID(), idx.ID())})
 
 	// Save if we planned a full table/index scan on the builder so that the
 	// planner can be made aware later. We only do this for non-virtual tables.
@@ -1987,6 +1988,7 @@ func (b *Builder) buildIndexJoin(join *memo.IndexJoinExpr) (execPlan, error) {
 	// TODO(radu): the distsql implementation of index join assumes that the input
 	// starts with the PK columns in order (#40749).
 	pri := tab.Index(cat.PrimaryIndex)
+	b.IndexesUsed = util.CombineUniqueString(b.IndexesUsed, []string{fmt.Sprintf("%d@%d", tab.ID(), pri.ID())})
 	keyCols := make([]exec.NodeColumnOrdinal, pri.KeyColumnCount())
 	for i := range keyCols {
 		keyCols[i] = input.getNodeColumnOrdinal(join.Table.ColumnID(pri.Column(i).Ordinal()))
@@ -2281,6 +2283,7 @@ func (b *Builder) buildLookupJoin(join *memo.LookupJoinExpr) (execPlan, error) {
 
 	tab := md.Table(join.Table)
 	idx := tab.Index(join.Index)
+	b.IndexesUsed = util.CombineUniqueString(b.IndexesUsed, []string{fmt.Sprintf("%d@%d", tab.ID(), idx.ID())})
 
 	locking := join.Locking
 	if b.forceForUpdateLocking {
@@ -2442,6 +2445,7 @@ func (b *Builder) buildInvertedJoin(join *memo.InvertedJoinExpr) (execPlan, erro
 	md := b.mem.Metadata()
 	tab := md.Table(join.Table)
 	idx := tab.Index(join.Index)
+	b.IndexesUsed = util.CombineUniqueString(b.IndexesUsed, []string{fmt.Sprintf("%d@%d", tab.ID(), idx.ID())})
 
 	prefixEqCols := make([]exec.NodeColumnOrdinal, len(join.PrefixKeyCols))
 	for i, c := range join.PrefixKeyCols {
@@ -2543,6 +2547,10 @@ func (b *Builder) buildZigzagJoin(join *memo.ZigzagJoinExpr) (execPlan, error) {
 	rightTable := md.Table(join.RightTable)
 	leftIndex := leftTable.Index(join.LeftIndex)
 	rightIndex := rightTable.Index(join.RightIndex)
+	b.IndexesUsed = util.CombineUniqueString(b.IndexesUsed,
+		[]string{fmt.Sprintf("%d@%d", leftTable.ID(), leftIndex.ID())})
+	b.IndexesUsed = util.CombineUniqueString(b.IndexesUsed,
+		[]string{fmt.Sprintf("%d@%d", rightTable.ID(), rightIndex.ID())})
 
 	leftEqCols := make([]exec.TableColumnOrdinal, len(join.LeftEqCols))
 	rightEqCols := make([]exec.TableColumnOrdinal, len(join.RightEqCols))

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -645,6 +645,7 @@ func (opc *optPlanningCtx) runExecBuilder(
 	planTop.instrumentation.joinTypeCounts = bld.JoinTypeCounts
 	planTop.instrumentation.joinAlgorithmCounts = bld.JoinAlgorithmCounts
 	planTop.instrumentation.scanCounts = bld.ScanCounts
+	planTop.instrumentation.indexesUsed = bld.IndexesUsed
 
 	if gf != nil {
 		planTop.instrumentation.planGist = gf.PlanGist()

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding.go
@@ -84,6 +84,12 @@ func BuildStmtMetadataJSON(statistics *roachpb.CollectedStatementStatistics) (js
 //	      },
 //	      "required": ["mean", "sqDiff"]
 //	    },
+//	    "indexes": {
+//	      "type": "array",
+//	      "items": {
+//	        "type": "string",
+//	      },
+//	    },
 //	    "node_ids": {
 //	      "type": "array",
 //	      "items": {
@@ -103,10 +109,11 @@ func BuildStmtMetadataJSON(statistics *roachpb.CollectedStatementStatistics) (js
 //	        "svcLat":            { "$ref": "#/definitions/numeric_stats" },
 //	        "ovhLat":            { "$ref": "#/definitions/numeric_stats" },
 //	        "bytesRead":         { "$ref": "#/definitions/numeric_stats" },
-//	        "rowsRead":          { "$ref": "#/definitions/numeric_stats" }
+//	        "rowsRead":          { "$ref": "#/definitions/numeric_stats" },
 //	        "firstExecAt":       { "type": "string" },
 //	        "lastExecAt":        { "type": "string" },
 //	        "nodes":             { "type": "node_ids" },
+//	        "indexes":           { "type": "indexes" },
 //	      },
 //	      "required": [
 //	        "firstAttemptCnt",
@@ -120,7 +127,8 @@ func BuildStmtMetadataJSON(statistics *roachpb.CollectedStatementStatistics) (js
 //	        "ovhLat",
 //	        "bytesRead",
 //	        "rowsRead",
-//	        "nodes"
+//	        "nodes",
+//	        "indexes
 //	      ]
 //	    },
 //	    "execution_statistics": {

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
@@ -101,7 +101,8 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
            "sqDiff": {{.Float}}
          },
          "nodes": [{{joinInts .IntArray}}],
-         "planGists": [{{joinStrings .StringArray}}]
+         "planGists": [{{joinStrings .StringArray}}],
+         "indexes": [{{joinStrings .StringArray}}]
        },
        "execution_statistics": {
          "cnt": {{.Int64}},

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
@@ -337,6 +337,7 @@ func (s *innerStmtStats) jsonFields() jsonFields {
 		{"rowsWritten", (*numericStats)(&s.RowsWritten)},
 		{"nodes", (*int64Array)(&s.Nodes)},
 		{"planGists", (*stringArray)(&s.PlanGists)},
+		{"indexes", (*stringArray)(&s.Indexes)},
 	}
 }
 

--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -13,8 +13,11 @@ package sslocal_test
 import (
 	"context"
 	gosql "database/sql"
+	"encoding/json"
 	"math"
 	"net/url"
+	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -1291,4 +1294,117 @@ func TestSQLStatsIdleLatencies(t *testing.T) {
 				"expected: %v\nactual: %v", tc.lats, actual)
 		})
 	}
+}
+
+type indexInfo struct {
+	name  string
+	table string
+}
+
+func TestSQLStatsIndexesUsed(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	params, _ := tests.CreateTestServerParams()
+	testServer, sqlConn, _ := serverutils.StartServer(t, params)
+	defer func() {
+		require.NoError(t, sqlConn.Close())
+		testServer.Stopper().Stop(ctx)
+	}()
+	testConn := sqlutils.MakeSQLRunner(sqlConn)
+	appName := "indexes-usage"
+	testConn.Exec(t, "SET application_name = $1", appName)
+
+	testCases := []struct {
+		name          string
+		tableCreation string
+		statement     string
+		fingerprint   string
+		indexes       []indexInfo
+	}{
+		{
+			name:          "buildScan",
+			tableCreation: "CREATE TABLE t1 (k INT)",
+			statement:     "SELECT * FROM t1",
+			fingerprint:   "SELECT * FROM t1",
+			indexes:       []indexInfo{{name: "t1_pkey", table: "t1"}},
+		},
+		{
+			name:          "buildIndexJoin",
+			tableCreation: "CREATE TABLE t2 (x INT, y INT, INDEX x_idx (x))",
+			statement:     "SELECT * FROM t2@x_idx",
+			fingerprint:   "SELECT * FROM t2@x_idx",
+			indexes: []indexInfo{
+				{name: "t2_pkey", table: "t2"},
+				{name: "x_idx", table: "t2"}},
+		},
+		{
+			name:          "buildLookupJoin",
+			tableCreation: "CREATE TABLE t3 (x INT, y INT, INDEX x_idx (x)); CREATE TABLE t4 (u INT, v INT)",
+			statement:     "SELECT * FROM t4 INNER LOOKUP JOIN t3 ON u = x",
+			fingerprint:   "SELECT * FROM t4 INNER LOOKUP JOIN t3 ON u = x",
+			indexes: []indexInfo{
+				{name: "t3_pkey", table: "t3"},
+				{name: "t4_pkey", table: "t4"},
+				{name: "x_idx", table: "t3"}},
+		},
+		{
+			name:          "buildZigZag",
+			tableCreation: "CREATE TABLE t5 (a INT, b INT, INDEX a_idx(a), INDEX b_idx(b))",
+			statement:     "SELECT * FROM t5@{FORCE_ZIGZAG} WHERE a = 1 AND b = 1",
+			fingerprint:   "SELECT * FROM t5@{FORCE_ZIGZAG} WHERE (a = _) AND (b = _)",
+			indexes: []indexInfo{
+				{name: "a_idx", table: "t5"},
+				{name: "b_idx", table: "t5"}},
+		},
+		{
+			name:          "buildInvertedJoin",
+			tableCreation: "CREATE TABLE t6 (k INT, j JSON, INVERTED INDEX j_idx (j))",
+			statement:     "SELECT * FROM t6 INNER INVERTED JOIN t6 AS t6_2 ON t6.j @> t6_2.j",
+			fingerprint:   "SELECT * FROM t6 INNER INVERTED JOIN t6 AS t6_2 ON t6.j @> t6_2.j",
+			indexes: []indexInfo{
+				{name: "j_idx", table: "t6"},
+				{name: "t6_pkey", table: "t6"}},
+		},
+	}
+
+	var indexesString string
+	var indexes []string
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testConn.Exec(t, tc.tableCreation)
+			testConn.Exec(t, tc.statement)
+
+			rows := testConn.QueryRow(t, "SELECT statistics -> 'statistics' ->> 'indexes' "+
+				"FROM CRDB_INTERNAL.STATEMENT_STATISTICS WHERE app_name = $1 "+
+				"AND metadata ->> 'query'=$2", appName, tc.fingerprint)
+			rows.Scan(&indexesString)
+
+			err := json.Unmarshal([]byte(indexesString), &indexes)
+			require.NoError(t, err)
+			require.Equal(t, len(tc.indexes), len(indexes))
+			require.Equal(t, tc.indexes, convertIDsToNames(t, testConn, indexes))
+		})
+	}
+}
+
+func convertIDsToNames(t *testing.T, testConn *sqlutils.SQLRunner, indexes []string) []indexInfo {
+	var indexesInfo []indexInfo
+	var tableName string
+	var indexName string
+	for _, idx := range indexes {
+		tableID := strings.Split(idx, "@")[0]
+		idxID := strings.Split(idx, "@")[1]
+
+		rows := testConn.QueryRow(t, "SELECT descriptor_name, index_name FROM "+
+			"crdb_internal.table_indexes WHERE descriptor_id =$1 AND index_id=$2", tableID, idxID)
+		rows.Scan(&tableName, &indexName)
+		indexesInfo = append(indexesInfo, indexInfo{name: indexName, table: tableName})
+	}
+
+	sort.Slice(indexesInfo, func(i, j int) bool {
+		return indexesInfo[i].name < indexesInfo[j].name
+	})
+	return indexesInfo
 }

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
@@ -137,6 +137,7 @@ func (s *Container) RecordStatement(
 	stats.mu.data.Nodes = util.CombineUniqueInt64(stats.mu.data.Nodes, value.Nodes)
 	stats.mu.data.PlanGists = util.CombineUniqueString(stats.mu.data.PlanGists, []string{value.PlanGist})
 	stats.mu.data.IndexRecommendations = value.IndexRecommendations
+	stats.mu.data.Indexes = util.CombineUniqueString(stats.mu.data.Indexes, value.Indexes)
 
 	// Note that some fields derived from tracing statements (such as
 	// BytesSentOverNetwork) are not updated here because they are collected

--- a/pkg/sql/sqlstats/ssprovider.go
+++ b/pkg/sql/sqlstats/ssprovider.go
@@ -219,6 +219,7 @@ type RecordedStmtStats struct {
 	FullScan             bool
 	SessionData          *sessiondata.SessionData
 	ExecStats            *execstats.QueryLevelStats
+	Indexes              []string
 }
 
 // RecordedTxnStats stores the statistics of a transaction to be recorded.

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
@@ -97,6 +97,7 @@ const statementStats: Required<IStatementStatistics> = {
   },
   plan_gists: ["Ais="],
   index_recommendations: [""],
+  indexes: ["123@456"],
   exec_stats: execStats,
   last_exec_timestamp: {
     seconds: Long.fromInt(1599670292),

--- a/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.spec.ts
@@ -275,6 +275,7 @@ function randomStats(
     nodes: [Long.fromInt(1), Long.fromInt(3), Long.fromInt(4)],
     plan_gists: ["Ais="],
     index_recommendations: [""],
+    indexes: ["123@456"],
   };
 }
 

--- a/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
@@ -148,6 +148,15 @@ export function addStatementStats(
     indexRec = b.index_recommendations;
   }
 
+  let indexes: string[] = [];
+  if (a.indexes && b.indexes) {
+    indexes = unique(a.indexes.concat(b.indexes));
+  } else if (a.indexes) {
+    indexes = a.indexes;
+  } else if (b.indexes) {
+    indexes = b.indexes;
+  }
+
   return {
     count: a.count.add(b.count),
     first_attempt_count: a.first_attempt_count.add(b.first_attempt_count),
@@ -198,6 +207,7 @@ export function addStatementStats(
     nodes: uniqueLong([...a.nodes, ...b.nodes]),
     plan_gists: planGists,
     index_recommendations: indexRec,
+    indexes: indexes,
   };
 }
 

--- a/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
@@ -529,6 +529,7 @@ function makeStats(): Required<StatementStatistics> {
     nodes: [Long.fromInt(1), Long.fromInt(2), Long.fromInt(3)],
     plan_gists: ["Ais="],
     index_recommendations: [],
+    indexes: ["123@456"],
   };
 }
 


### PR DESCRIPTION
Part Of #82615

This commits collects the list of indexes used by the statement execution and and saves on `system.statement_statistics` and `crdb_internal.statement_statistics` under the statistics columns, inside the statistics key.
To get the information
```
SELECT statistics -> 'statistics' ->> 'indexes' from
crdb_internal.statement_statistics
```

The value is saved as an array of string with format `tableId@indexId`.

Release note (sql change): Add list of indexes used by the query on the statistics column on system.statement_statistics and crdb_internal.statement_statistics tables. The format is `tableID@indexID`.