### PR TITLE
sql: show notice when revoking from owner

### DIFF
--- a/pkg/sql/grant_revoke.go
+++ b/pkg/sql/grant_revoke.go
@@ -281,6 +281,16 @@ func (n *changeDescriptorBackedPrivilegesNode) startExec(params runParams) error
 			for _, grantee := range n.grantees {
 				changed := n.changePrivilege(privileges, n.desiredprivs, grantee)
 				descPrivsChanged = descPrivsChanged || changed
+				if !n.isGrant && grantee == privileges.Owner() {
+					params.p.BufferClientNotice(
+						ctx,
+						pgnotice.Newf(
+							"%s is the owner of %s and still has all privileges implicitly",
+							privileges.Owner(),
+							descriptor.GetName(),
+						),
+					)
+				}
 			}
 
 			if len(sequencePrivilegesNoOp) > 0 {

--- a/pkg/sql/logictest/testdata/logic_test/grant_revoke_with_grant_option
+++ b/pkg/sql/logictest/testdata/logic_test/grant_revoke_with_grant_option
@@ -517,8 +517,11 @@ test           public       t1          testuser  ALL             true
 statement ok
 GRANT SELECT ON TABLE t1 TO testuser2
 
-statement ok
+# Show a notice when revoking privileges from the owner.
+query T noticetrace
 REVOKE ALL PRIVILEGES ON TABLE t1 FROM testuser
+----
+NOTICE: testuser is the owner of t1 and still has all privileges implicitly
 
 query TTTTTB colnames
 SHOW GRANTS ON TABLE t1;


### PR DESCRIPTION
The owner always has privileges implicitly, so REVOKE may not have the intended effect.

fixes https://github.com/cockroachdb/cockroach/issues/92298

Release note: None