### PR TITLE
ui: show regions in SQL Activity for tenants

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -635,20 +635,18 @@ export class StatementDetails extends React.Component<
             <Col className="gutter-row" span={12}>
               <SummaryCard id="first-card" className={cx("summary-card")}>
                 {!isTenant && (
-                  <>
-                    <SummaryCardItem
-                      label="Nodes"
-                      value={intersperse<ReactNode>(
-                        nodes.map(n => <NodeLink node={n} key={n} />),
-                        ", ",
-                      )}
-                    />
-                    <SummaryCardItem
-                      label="Regions"
-                      value={intersperse<ReactNode>(regions, ", ")}
-                    />
-                  </>
+                  <SummaryCardItem
+                    label="Nodes"
+                    value={intersperse<ReactNode>(
+                      nodes.map(n => <NodeLink node={n} key={n} />),
+                      ", ",
+                    )}
+                  />
                 )}
+                <SummaryCardItem
+                  label="Regions"
+                  value={intersperse<ReactNode>(regions, ", ")}
+                />
                 <SummaryCardItem label="Database" value={db} />
                 <SummaryCardItem
                   label="Application Name"

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetailsConnected.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetailsConnected.ts
@@ -62,8 +62,9 @@ const mapStateToProps = (state: AppState, props: RouteComponentProps) => {
     isLoading: isLoading,
     statementsError: lastError,
     timeScale: selectTimeScale(state),
+    // TODO(todd): Remove this unused property!
     nodeNames: selectIsTenant(state) ? {} : nodeDisplayNameByIDSelector(state),
-    nodeRegions: selectIsTenant(state) ? {} : nodeRegionsByIDSelector(state),
+    nodeRegions: nodeRegionsByIDSelector(state),
     diagnosticsReports:
       selectIsTenant(state) || selectHasViewActivityRedactedRole(state)
         ? []

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -525,10 +525,7 @@ export class StatementsPage extends React.Component<
       .filter(
         // The statement must contain at least one value from the selected regions
         // list if the list is not empty.
-        // If the cluster is a tenant cluster we don't care
-        // about regions.
         statement =>
-          isTenant ||
           regions.length == 0 ||
           (statement.stats.nodes &&
             containAny(
@@ -578,7 +575,7 @@ export class StatementsPage extends React.Component<
     const isEmptySearchResults = statements?.length > 0 && search?.length > 0;
     // If the cluster is a tenant cluster we don't show info
     // about nodes/regions.
-    populateRegionNodeForStatements(statements, nodeRegions, isTenant);
+    populateRegionNodeForStatements(statements, nodeRegions);
 
     // Creates a list of all possible columns,
     // hiding nodeRegions if is not multi-region and
@@ -595,6 +592,7 @@ export class StatementsPage extends React.Component<
       onSelectDiagnosticsReportDropdownOption,
       onStatementClick,
     )
+      .filter(c => !(c.name === "regions" && regions.length < 2))
       .filter(c => !(c.name === "regionNodes" && regions.length < 2))
       .filter(c => !(isTenant && c.hideIfTenant));
 
@@ -673,14 +671,14 @@ export class StatementsPage extends React.Component<
       nodeRegions,
     } = this.props;
 
-    const nodes = isTenant
-      ? []
-      : Object.keys(nodeRegions)
-          .map(n => Number(n))
-          .sort();
-    const regions = isTenant
-      ? []
-      : unique(nodes.map(node => nodeRegions[node.toString()])).sort();
+    const nodes = Object.keys(nodeRegions)
+      .map(n => Number(n))
+      .sort();
+
+    const regions = unique(
+      nodes.map(node => nodeRegions[node.toString()]),
+    ).sort();
+
     const { filters, activeFilters } = this.state;
 
     const longLoadingMessage = isNil(this.props.statements) &&
@@ -716,7 +714,7 @@ export class StatementsPage extends React.Component<
               showSqlType={true}
               showScan={true}
               showRegions={regions.length > 1}
-              showNodes={nodes.length > 1}
+              showNodes={!isTenant && nodes.length > 1}
             />
           </PageConfigItem>
           <PageConfigItem className={commonStyles("separator")}>

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
@@ -88,9 +88,7 @@ export const ConnectedStatementsPage = withRouter(
         isTenant: selectIsTenant(state),
         hasViewActivityRedactedRole: selectHasViewActivityRedactedRole(state),
         lastReset: selectLastReset(state),
-        nodeRegions: selectIsTenant(state)
-          ? {}
-          : nodeRegionsByIDSelector(state),
+        nodeRegions: nodeRegionsByIDSelector(state),
         search: selectSearch(state),
         sortSetting: selectSortSetting(state),
         statements: selectStatements(state, props),

--- a/pkg/ui/workspaces/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
@@ -51,6 +51,7 @@ export const statisticsColumnLabels = {
   executionCount: "Execution Count",
   maxMemUsage: "Max Memory",
   networkBytes: "Network",
+  regions: "Regions",
   regionNodes: "Regions/Nodes",
   retries: "Retries",
   rowsProcessed: "Rows Processed",
@@ -779,6 +780,27 @@ export const statisticsTableTitles: StatisticTableTitleType = {
         }
       >
         {getLabel("workloadPct")}
+      </Tooltip>
+    );
+  },
+  regions: (statType: StatisticType) => {
+    let contentModifier = "";
+    switch (statType) {
+      case "transaction":
+        contentModifier = contentModifiers.transaction;
+        break;
+      case "statement":
+        contentModifier = contentModifiers.statement;
+        break;
+    }
+
+    return (
+      <Tooltip
+        placement="bottom"
+        style="tableTitle"
+        content={<p>Regions in which the {contentModifier} was executed.</p>}
+      >
+        {getLabel("regions")}
       </Tooltip>
     );
   },

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -319,11 +319,7 @@ export class TransactionDetails extends React.Component<
             const aggregatedStatements = aggregateStatements(
               statementsForTransaction,
             );
-            populateRegionNodeForStatements(
-              aggregatedStatements,
-              nodeRegions,
-              isTenant,
-            );
+            populateRegionNodeForStatements(aggregatedStatements, nodeRegions);
             const duration = (v: number) => Duration(v * 1e9);
 
             const transactionSampled =

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsTable.tsx
@@ -61,6 +61,7 @@ interface TransactionsTable {
 }
 
 export interface TransactionInfo extends Transaction {
+  regions: string[];
   regionNodes: string[];
 }
 
@@ -228,16 +229,7 @@ export function makeTransactionsColumns(
       sort: (item: TransactionInfo) =>
         longToInt(Number(item.stats_data.stats.max_retries)),
     },
-    {
-      name: "regionNodes",
-      title: statisticsTableTitles.regionNodes(statType),
-      className: cx("statements-table__col-regions"),
-      cell: (item: TransactionInfo) => {
-        return longListWithTooltip(item.regionNodes.sort().join(", "), 50);
-      },
-      sort: (item: TransactionInfo) => item.regionNodes.sort().join(", "),
-      hideIfTenant: true,
-    },
+    makeRegionsColumn(isTenant),
     {
       name: "statementsCount",
       title: statisticsTableTitles.statementsCount(statType),
@@ -257,7 +249,33 @@ export function makeTransactionsColumns(
         item.stats_data?.transaction_fingerprint_id.toString(16),
       showByDefault: false,
     },
-  ].filter(c => !(isTenant && c.hideIfTenant));
+  ];
+}
+
+function makeRegionsColumn(
+  isTenant: boolean,
+): ColumnDescriptor<TransactionInfo> {
+  if (isTenant) {
+    return {
+      name: "regions",
+      title: statisticsTableTitles.regions("transaction"),
+      className: cx("statements-table__col-regions"),
+      cell: (item: TransactionInfo) => {
+        return longListWithTooltip(item.regions.sort().join(", "), 50);
+      },
+      sort: (item: TransactionInfo) => item.regions.sort().join(", "),
+    };
+  } else {
+    return {
+      name: "regionNodes",
+      title: statisticsTableTitles.regionNodes("transaction"),
+      className: cx("statements-table__col-regions"),
+      cell: (item: TransactionInfo) => {
+        return longListWithTooltip(item.regionNodes.sort().join(", "), 50);
+      },
+      sort: (item: TransactionInfo) => item.regionNodes.sort().join(", "),
+    };
+  }
 }
 
 export const TransactionsTable: React.FC<TransactionsTable> = props => {


### PR DESCRIPTION
Fixes #89949.

### Statements
| Regions Column | Regions Filter | Regions Field in Details |
|--|--|--|
|<img width="1628" alt="Screen Shot 2022-12-14 at 10 40 03 AM" src="https://user-images.githubusercontent.com/5261/207641874-ce92079b-0e98-4772-8a78-fb4f3ed1ea0f.png">|<img width="1628" alt="Screen Shot 2022-12-14 at 10 40 22 AM" src="https://user-images.githubusercontent.com/5261/207641883-0e5675ca-3959-4844-943c-a37943a32f2c.png">|<img width="1628" alt="Screen Shot 2022-12-14 at 10 40 43 AM" src="https://user-images.githubusercontent.com/5261/207641900-2a04bef4-398e-4b0b-a703-218778e2ad62.png">|

### Transactions
| Regions Column | Regions Filter | Regions Column in Details |
|--|--|--|
|<img width="1628" alt="Screen Shot 2022-12-14 at 10 41 10 AM" src="https://user-images.githubusercontent.com/5261/207641909-eddda97e-faa3-4695-8371-924f80c0f114.png">|<img width="1628" alt="Screen Shot 2022-12-14 at 10 41 21 AM" src="https://user-images.githubusercontent.com/5261/207641924-8543dada-a6eb-413e-bc2c-de58b737b86e.png">|<img width="1628" alt="Screen Shot 2022-12-14 at 10 41 56 AM" src="https://user-images.githubusercontent.com/5261/207641941-4d72b31f-99ab-4ab5-89b2-1d20baa9f8cb.png">|

Release note (ui change): The console statement and transaction pages for tenant clusters gained region columns and filters for multiregion tenants.