### PR TITLE
sql: clearer error from SHOW TENANT in guest tenant

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant-multiregion/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/3node-tenant-multiregion/BUILD.bazel
@@ -11,7 +11,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
-    shard_count = 3,
+    shard_count = 4,
     tags = ["cpu:2"],
     deps = [
         "//pkg/build/bazel",

--- a/pkg/ccl/logictestccl/tests/3node-tenant-multiregion/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant-multiregion/generated_test.go
@@ -110,6 +110,13 @@ func TestTenantLogic_distsql_tenant_locality(
 	runLogicTest(t, "distsql_tenant_locality")
 }
 
+func TestTenantLogic_tenant_from_tenant(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "tenant_from_tenant")
+}
+
 func TestTenantExecBuild_distsql_tenant_locality(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -1855,6 +1855,13 @@ func TestTenantLogic_temp_table_txn(
 	runLogicTest(t, "temp_table_txn")
 }
 
+func TestTenantLogic_tenant_from_tenant(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "tenant_from_tenant")
+}
+
 func TestTenantLogic_tenant_slow_repro(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/testdata/logic_test/tenant_from_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/tenant_from_tenant
@@ -1,0 +1,10 @@
+# LogicTest: 3node-tenant-default-configs
+
+statement error only the system tenant can create other tenants
+CREATE TENANT nope
+
+statement error only the system tenant can show other tenants
+SHOW TENANT nope
+
+statement error only the system tenant can destroy other tenants
+DROP TENANT nope

--- a/pkg/sql/tenant.go
+++ b/pkg/sql/tenant.go
@@ -320,7 +320,7 @@ func (p *planner) CreateTenant(
 	if err := p.RequireAdminRole(ctx, op); err != nil {
 		return roachpb.TenantID{}, err
 	}
-	if err := rejectIfCantCoordinateMultiTenancy(p.execCfg.Codec, op); err != nil {
+	if err := rejectIfCantCoordinateMultiTenancy(p.execCfg.Codec, "create"); err != nil {
 		return roachpb.TenantID{}, err
 	}
 
@@ -824,7 +824,11 @@ WHERE id = $1`, tenantID, tenantName); err != nil {
 func (p *planner) GetTenantInfo(
 	ctx context.Context, tenantName roachpb.TenantName,
 ) (*descpb.TenantInfo, error) {
-	if err := p.RequireAdminRole(ctx, "get tenant"); err != nil {
+	if err := p.RequireAdminRole(ctx, "show tenant"); err != nil {
+		return nil, err
+	}
+
+	if err := rejectIfCantCoordinateMultiTenancy(p.execCfg.Codec, "show"); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Previously, SHOW TENANT would fail with an error about a missing system.tenants table.

Epic: CRDB-18749

Release note: None