### PR TITLE
release-22.1: sql: audit all processors to make their closure bullet-proof

### DIFF
--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -227,7 +227,7 @@ func (bp *backupDataProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.Producer
 func (bp *backupDataProcessor) close() {
 	bp.cancelAndWaitForWorker()
 	if bp.InternalClose() {
-		bp.memAcc.Close(bp.Ctx)
+		bp.memAcc.Close(bp.Ctx())
 	}
 }
 

--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -568,8 +568,8 @@ func (rd *restoreDataProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.Produce
 		prog.ProgressDetails = *details
 	case meta := <-rd.metaCh:
 		return nil, meta
-	case <-rd.Ctx.Done():
-		rd.MoveToDraining(rd.Ctx.Err())
+	case <-rd.Ctx().Done():
+		rd.MoveToDraining(rd.Ctx().Err())
 		return nil, rd.DrainHelper()
 	}
 

--- a/pkg/ccl/backupccl/restore_data_processor_test.go
+++ b/pkg/ccl/backupccl/restore_data_processor_test.go
@@ -374,8 +374,7 @@ func runTestIngest(t *testing.T, init func(*cluster.Settings)) {
 			}
 			expectedKVs := slurpSSTablesLatestKey(t, filepath.Join(dir, "foo"), slurp, srcPrefix, newPrefix)
 
-			mockRestoreDataProcessor, err := newTestingRestoreDataProcessor(ctx, &evalCtx, &flowCtx,
-				mockRestoreDataSpec)
+			mockRestoreDataProcessor, err := newTestingRestoreDataProcessor(&evalCtx, &flowCtx, mockRestoreDataSpec)
 			require.NoError(t, err)
 			ssts := make(chan mergedSST, 1)
 			require.NoError(t, mockRestoreDataProcessor.openSSTs(ctx, restoreSpanEntry, ssts))
@@ -417,15 +416,11 @@ func runTestIngest(t *testing.T, init func(*cluster.Settings)) {
 }
 
 func newTestingRestoreDataProcessor(
-	ctx context.Context,
-	evalCtx *tree.EvalContext,
-	flowCtx *execinfra.FlowCtx,
-	spec execinfrapb.RestoreDataSpec,
+	evalCtx *tree.EvalContext, flowCtx *execinfra.FlowCtx, spec execinfrapb.RestoreDataSpec,
 ) (*restoreDataProcessor, error) {
 	rd := &restoreDataProcessor{
 		ProcessorBase: execinfra.ProcessorBase{
 			ProcessorBaseNoHelper: execinfra.ProcessorBaseNoHelper{
-				Ctx:     ctx,
 				EvalCtx: evalCtx,
 			},
 		},

--- a/pkg/sql/colexec/materializer.go
+++ b/pkg/sql/colexec/materializer.go
@@ -311,15 +311,7 @@ func (m *Materializer) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata
 
 func (m *Materializer) close() {
 	if m.InternalClose() {
-		if m.Ctx == nil {
-			// In some edge cases (like when Init of an operator above this
-			// materializer encounters a panic), the materializer might never be
-			// started, yet it still will attempt to close its Closers. This
-			// context is only used for logging purposes, so it is ok to grab
-			// the background context in order to prevent a NPE below.
-			m.Ctx = context.Background()
-		}
-		m.closers.CloseAndLogOnErr(m.Ctx, "materializer")
+		m.closers.CloseAndLogOnErr(m.Ctx(), "materializer")
 	}
 }
 

--- a/pkg/sql/execinfra/metadata_test_receiver.go
+++ b/pkg/sql/execinfra/metadata_test_receiver.go
@@ -212,7 +212,7 @@ func (mtr *MetadataTestReceiver) Next() (rowenc.EncDatumRow, *execinfrapb.Produc
 		// We don't use ProcessorBase.ProcessRowHelper() here because we need
 		// special handling for errors: this proc never starts draining in order for
 		// it to be as unintrusive as possible.
-		outRow, ok, err := mtr.OutputHelper.ProcessRow(mtr.Ctx, row)
+		outRow, ok, err := mtr.OutputHelper.ProcessRow(mtr.Ctx(), row)
 		if err != nil {
 			mtr.trailingMeta = append(mtr.trailingMeta, execinfrapb.ProducerMetadata{Err: err})
 			continue

--- a/pkg/sql/rowexec/countrows.go
+++ b/pkg/sql/rowexec/countrows.go
@@ -85,7 +85,7 @@ func (ag *countAggregator) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMeta
 		if row == nil {
 			ret := make(rowenc.EncDatumRow, 1)
 			ret[0] = rowenc.EncDatum{Datum: tree.NewDInt(tree.DInt(ag.count))}
-			rendered, _, err := ag.OutputHelper.ProcessRow(ag.Ctx, ret)
+			rendered, _, err := ag.OutputHelper.ProcessRow(ag.Ctx(), ret)
 			// We're done as soon as we process our one output row, so we
 			// transition into draining state. We will, however, return non-nil
 			// error (if such occurs during rendering) separately below.

--- a/pkg/sql/rowexec/distinct.go
+++ b/pkg/sql/rowexec/distinct.go
@@ -187,7 +187,7 @@ func (d *distinct) encode(appendTo []byte, row rowenc.EncDatumRow) ([]byte, erro
 		// the references to the row (and to the newly allocated datums)
 		// shortly, it'll likely take some time before GC reclaims that memory,
 		// so we choose the over-accounting route to be safe.
-		appendTo, err = datum.Fingerprint(d.Ctx, d.types[colIdx], &d.datumAlloc, appendTo, &d.memAcc)
+		appendTo, err = datum.Fingerprint(d.Ctx(), d.types[colIdx], &d.datumAlloc, appendTo, &d.memAcc)
 		if err != nil {
 			return nil, err
 		}
@@ -210,8 +210,8 @@ func (d *distinct) encode(appendTo []byte, row rowenc.EncDatumRow) ([]byte, erro
 
 func (d *distinct) close() {
 	if d.InternalClose() {
-		d.memAcc.Close(d.Ctx)
-		d.MemMonitor.Stop(d.Ctx)
+		d.memAcc.Close(d.Ctx())
+		d.MemMonitor.Stop(d.Ctx())
 	}
 }
 
@@ -256,7 +256,7 @@ func (d *distinct) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata) {
 			// allocated on it, which implies that UnsafeReset() is safe to call here.
 			copy(d.lastGroupKey, row)
 			d.haveLastGroupKey = true
-			if err := d.arena.UnsafeReset(d.Ctx); err != nil {
+			if err := d.arena.UnsafeReset(d.Ctx()); err != nil {
 				d.MoveToDraining(err)
 				break
 			}
@@ -280,7 +280,7 @@ func (d *distinct) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata) {
 			}
 			continue
 		}
-		s, err := d.arena.AllocBytes(d.Ctx, encoding)
+		s, err := d.arena.AllocBytes(d.Ctx(), encoding)
 		if err != nil {
 			d.MoveToDraining(err)
 			break

--- a/pkg/sql/rowexec/inverted_filterer.go
+++ b/pkg/sql/rowexec/inverted_filterer.go
@@ -167,7 +167,7 @@ func (ifr *invertedFilterer) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMe
 		case ifrEmittingRows:
 			ifr.runningState, row, meta = ifr.emitRow()
 		default:
-			log.Fatalf(ifr.Ctx, "unsupported state: %d", ifr.runningState)
+			log.Fatalf(ifr.Ctx(), "unsupported state: %d", ifr.runningState)
 		}
 		if row == nil && meta == nil {
 			continue
@@ -192,9 +192,9 @@ func (ifr *invertedFilterer) readInput() (invertedFiltererState, *execinfrapb.Pr
 		return ifrReadingInput, meta
 	}
 	if row == nil {
-		log.VEventf(ifr.Ctx, 1, "no more input rows")
+		log.VEventf(ifr.Ctx(), 1, "no more input rows")
 		evalResult := ifr.invertedEval.evaluate()
-		ifr.rc.SetupForRead(ifr.Ctx, evalResult)
+		ifr.rc.SetupForRead(ifr.Ctx(), evalResult)
 		// invertedEval had a single expression in the batch, and the results
 		// for that expression are in evalResult[0].
 		ifr.evalResult = evalResult[0]
@@ -243,7 +243,7 @@ func (ifr *invertedFilterer) readInput() (invertedFiltererState, *execinfrapb.Pr
 		// evaluator.
 		copy(ifr.keyRow, row[:ifr.invertedColIdx])
 		copy(ifr.keyRow[ifr.invertedColIdx:], row[ifr.invertedColIdx+1:])
-		keyIndex, err := ifr.rc.AddRow(ifr.Ctx, ifr.keyRow)
+		keyIndex, err := ifr.rc.AddRow(ifr.Ctx(), ifr.keyRow)
 		if err != nil {
 			ifr.MoveToDraining(err)
 			return ifrStateUnknown, ifr.DrainHelper()
@@ -271,11 +271,11 @@ func (ifr *invertedFilterer) emitRow() (
 	}
 	if ifr.resultIdx >= len(ifr.evalResult) {
 		// We are done emitting all rows.
-		return drainFunc(ifr.rc.UnsafeReset(ifr.Ctx))
+		return drainFunc(ifr.rc.UnsafeReset(ifr.Ctx()))
 	}
 	curRowIdx := ifr.resultIdx
 	ifr.resultIdx++
-	keyRow, err := ifr.rc.GetRow(ifr.Ctx, ifr.evalResult[curRowIdx], false /* skip */)
+	keyRow, err := ifr.rc.GetRow(ifr.Ctx(), ifr.evalResult[curRowIdx], false /* skip */)
 	if err != nil {
 		return drainFunc(err)
 	}
@@ -299,12 +299,12 @@ func (ifr *invertedFilterer) ConsumerClosed() {
 
 func (ifr *invertedFilterer) close() {
 	if ifr.InternalClose() {
-		ifr.rc.Close(ifr.Ctx)
+		ifr.rc.Close(ifr.Ctx())
 		if ifr.MemMonitor != nil {
-			ifr.MemMonitor.Stop(ifr.Ctx)
+			ifr.MemMonitor.Stop(ifr.Ctx())
 		}
 		if ifr.diskMonitor != nil {
-			ifr.diskMonitor.Stop(ifr.Ctx)
+			ifr.diskMonitor.Stop(ifr.Ctx())
 		}
 	}
 }

--- a/pkg/sql/rowexec/mergejoiner.go
+++ b/pkg/sql/rowexec/mergejoiner.go
@@ -230,7 +230,7 @@ func (m *mergeJoiner) nextRow() (rowenc.EncDatumRow, *execinfrapb.ProducerMetada
 		// TODO(paul): Investigate (with benchmarks) whether or not it's
 		// worthwhile to only buffer one row from the right stream per batch
 		// for semi-joins.
-		m.leftRows, m.rightRows, meta = m.streamMerger.NextBatch(m.Ctx, m.EvalCtx)
+		m.leftRows, m.rightRows, meta = m.streamMerger.NextBatch(m.Ctx(), m.EvalCtx)
 		if meta != nil {
 			return nil, meta
 		}
@@ -249,8 +249,8 @@ func (m *mergeJoiner) nextRow() (rowenc.EncDatumRow, *execinfrapb.ProducerMetada
 
 func (m *mergeJoiner) close() {
 	if m.InternalClose() {
-		m.streamMerger.close(m.Ctx)
-		m.MemMonitor.Stop(m.Ctx)
+		m.streamMerger.close(m.Ctx())
+		m.MemMonitor.Stop(m.Ctx())
 	}
 }
 

--- a/pkg/sql/rowexec/processors_test.go
+++ b/pkg/sql/rowexec/processors_test.go
@@ -342,7 +342,8 @@ func TestAggregatorSpecAggregationEquals(t *testing.T) {
 func TestProcessorBaseContext(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	ctx := context.Background()
+	// Use a custom context to distinguish it from the background one.
+	ctx := context.WithValue(context.Background(), struct{}{}, struct{}{})
 	st := cluster.MakeTestingClusterSettings()
 
 	runTest := func(t *testing.T, f func(noop *noopProcessor)) {
@@ -358,18 +359,22 @@ func TestProcessorBaseContext(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		// Before Start we should get the background context.
+		if noop.Ctx() != context.Background() {
+			t.Fatalf("ProcessorBase.Ctx() didn't return the background context before Start")
+		}
 		noop.Start(ctx)
-		origCtx := noop.Ctx
+		origCtx := noop.Ctx()
 
 		// The context should be valid after Start but before Next is called in case
 		// ConsumerDone or ConsumerClosed are called without calling Next.
-		if noop.Ctx == nil {
+		if noop.Ctx() == context.Background() {
 			t.Fatalf("ProcessorBase.ctx not initialized")
 		}
 		f(noop)
 		// The context should be reset after ConsumerClosed is called so that any
 		// subsequent logging calls will not operate on closed spans.
-		if noop.Ctx != origCtx {
+		if noop.Ctx() != origCtx {
 			t.Fatalf("ProcessorBase.ctx not reset on close")
 		}
 	}

--- a/pkg/sql/rowexec/project_set.go
+++ b/pkg/sql/rowexec/project_set.go
@@ -147,7 +147,7 @@ func (ps *projectSetProcessor) nextInputRow() (
 			// First, make sure to close its ValueGenerator from the previous
 			// input row (if it exists).
 			if ps.gens[i] != nil {
-				ps.gens[i].Close(ps.Ctx)
+				ps.gens[i].Close(ps.Ctx())
 				ps.gens[i] = nil
 			}
 
@@ -165,7 +165,7 @@ func (ps *projectSetProcessor) nextInputRow() (
 			// Store the generator before Start so that it'll be closed even if
 			// Start returns an error.
 			ps.gens[i] = gen
-			if err := gen.Start(ps.Ctx, ps.FlowCtx.Txn); err != nil {
+			if err := gen.Start(ps.Ctx(), ps.FlowCtx.Txn); err != nil {
 				return nil, nil, err
 			}
 		}
@@ -186,7 +186,7 @@ func (ps *projectSetProcessor) nextGeneratorValues() (newValAvail bool, err erro
 			numCols := int(ps.spec.NumColsPerGen[i])
 			if !ps.done[i] {
 				// Yes; check whether this source still has some values available.
-				hasVals, err := gen.Next(ps.Ctx)
+				hasVals, err := gen.Next(ps.Ctx())
 				if err != nil {
 					return false, err
 				}
@@ -297,7 +297,7 @@ func (ps *projectSetProcessor) close() {
 	ps.InternalCloseEx(func() {
 		for _, gen := range ps.gens {
 			if gen != nil {
-				gen.Close(ps.Ctx)
+				gen.Close(ps.Ctx())
 			}
 		}
 	})

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -203,9 +203,9 @@ func (s *sampleAggregator) Run(ctx context.Context) {
 
 func (s *sampleAggregator) close() {
 	if s.InternalClose() {
-		s.memAcc.Close(s.Ctx)
-		s.tempMemAcc.Close(s.Ctx)
-		s.MemMonitor.Stop(s.Ctx)
+		s.memAcc.Close(s.Ctx())
+		s.tempMemAcc.Close(s.Ctx())
+		s.MemMonitor.Stop(s.Ctx())
 	}
 }
 

--- a/pkg/sql/rowexec/sampler.go
+++ b/pkg/sql/rowexec/sampler.go
@@ -478,8 +478,8 @@ func (s *samplerProcessor) sampleRow(
 
 func (s *samplerProcessor) close() {
 	if s.InternalClose() {
-		s.memAcc.Close(s.Ctx)
-		s.MemMonitor.Stop(s.Ctx)
+		s.memAcc.Close(s.Ctx())
+		s.MemMonitor.Stop(s.Ctx())
 	}
 }
 

--- a/pkg/sql/rowexec/sorter.go
+++ b/pkg/sql/rowexec/sorter.go
@@ -116,10 +116,10 @@ func (s *sorterBase) close() {
 		if s.i != nil {
 			s.i.Close()
 		}
-		s.rows.Close(s.Ctx)
-		s.MemMonitor.Stop(s.Ctx)
+		s.rows.Close(s.Ctx())
+		s.MemMonitor.Stop(s.Ctx())
 		if s.diskMonitor != nil {
-			s.diskMonitor.Stop(s.Ctx)
+			s.diskMonitor.Stop(s.Ctx())
 		}
 	}
 }
@@ -422,7 +422,7 @@ func newSortChunksProcessor(
 	); err != nil {
 		return nil, err
 	}
-	proc.i = proc.rows.NewFinalIterator(proc.Ctx)
+	proc.i = proc.rows.NewFinalIterator(proc.Ctx())
 	return proc, nil
 }
 
@@ -449,7 +449,7 @@ func (s *sortChunksProcessor) chunkCompleted(
 // if a metadata record was encountered). The caller is expected to drain when
 // this returns false.
 func (s *sortChunksProcessor) fill() (bool, error) {
-	ctx := s.Ctx
+	ctx := s.Ctx()
 
 	var meta *execinfrapb.ProducerMetadata
 
@@ -519,7 +519,7 @@ func (s *sortChunksProcessor) Start(ctx context.Context) {
 
 // Next is part of the RowSource interface.
 func (s *sortChunksProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata) {
-	ctx := s.Ctx
+	ctx := s.Ctx()
 	for s.State == execinfra.StateRunning {
 		ok, err := s.i.Valid()
 		if err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #91969.

/cc @cockroachdb/release

---

This commit replaces all usages of `ProcessorBaseNoHelper.Ctx` field
with a call to the newly-introduced `Ctx()` method which returns
a background context if the processor hasn't been started. This change
makes it so that all processors now respect the contract of
`colexecop.Closer` interface which says that `Close` must be safe to
call even if `Init` hasn't been performed (in the context of processors
this means that `Columnarizer.Init` wasn't called meaning that
`Processor.Start` wasn't either).

Initially, I attempted to fix this in #91446 by putting the protection
into the columnarizer, but that led to broken assumptions since we
wouldn't close all closers that we expected to (in particular, the
materializer that is the input to the wrapped row-by-row processor
wouldn't be closed). This commit takes a different approach and should
fix the issue for good without introducing any flakiness.

As a result, this commit fixes a rarely hit issue when the aggregator
and the zigzag joiner attempt to log when they are closed if they
haven't been started (that we see occasionally from sentry). The issue
is quite rare though, so no release note seems appropriate.

Fixes: #84902.
Fixes: #91845.

Release note: None

Release justification: low-risk bug fix.