### PR TITLE
nightlies: pass GOTRACEBACK=all

### DIFF
--- a/build/teamcity/cockroach/nightlies/stress_impl.sh
+++ b/build/teamcity/cockroach/nightlies/stress_impl.sh
@@ -29,6 +29,7 @@ fi
 GOTESTTIMEOUTSECS=$(($TESTTIMEOUTSECS - 5))
 $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- test --config=ci "$TARGET" \
                                         --test_env=COCKROACH_NIGHTLY_STRESS=true \
+                                        --test_env=GOTRACEBACK=all \
                                         --test_timeout="$TESTTIMEOUTSECS" \
                                         --test_arg=-test.timeout="${GOTESTTIMEOUTSECS}s" \
                                         --run_under "@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts 'XML_OUTPUT_FILE=$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci merge-test-xmls' $STRESSFLAGS" \


### PR DESCRIPTION
While `./dev test` does this, we're not going through `./dev test` here.
We need to set the env var explicitly.

Found in https://github.com/cockroachdb/cockroach/issues/92113.

Epic: none
Release note: None
