### PR TITLE
release-22.2: backupccl: extend backupccl test timeout to 2 hours

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -179,7 +179,7 @@ go_test(
         "system_schema_test.go",
         "utils_test.go",
     ],
-    args = ["-test.timeout=3595s"],
+    args = ["-test.timeout=7195s"],
     data = glob(["testdata/**"]) + ["//c-deps:libgeos"],
     embed = [":backupccl"],
     shard_count = 16,

--- a/pkg/cmd/generate-bazel-extra/main.go
+++ b/pkg/cmd/generate-bazel-extra/main.go
@@ -244,14 +244,15 @@ unused_checker(srcs = GET_X_DATA_TARGETS)`)
 	}
 }
 
-// excludeSqliteLogicTests removes the sqlite logic tests targets from the
-// given list of targets and returns the updated list.
-func excludeSqliteLogicTests(targets []string) []string {
+// excludeReallyEnormousTargets removes the really enormous test targets
+// from the given list of targets and returns the updated list.
+func excludeReallyEnormousTargets(targets []string) []string {
 	for i := 0; i < len(targets); i++ {
 		var excluded bool
 		for _, toExclude := range []string{
 			"//pkg/ccl/sqlitelogictestccl",
 			"//pkg/sql/sqlitelogictest",
+			"//pkg/ccl/backupccl",
 		} {
 			if strings.HasPrefix(targets[i], toExclude) {
 				excluded = true
@@ -275,9 +276,9 @@ func generateTestsTimeouts() {
 			log.Fatal(err)
 		}
 		if size == "enormous" {
-			// Exclude sqlite logic tests since they have a custom timeout that
+			// Exclude really enormous targets since they have a custom timeout that
 			// exceeds the default 1h.
-			targets = excludeSqliteLogicTests(targets)
+			targets = excludeReallyEnormousTargets(targets)
 		}
 		// Let the `go test` process timeout 5 seconds before bazel attempts to kill it.
 		// Note that if this causes issues such as not having enough time to run normally

--- a/pkg/cmd/generate-bazel-extra/main_test.go
+++ b/pkg/cmd/generate-bazel-extra/main_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestExcludeSqliteLogicTests(t *testing.T) {
+func TestExcludeReallyEnormousTests(t *testing.T) {
 	for _, tc := range []struct {
 		in  []string
 		out []string
@@ -24,6 +24,7 @@ func TestExcludeSqliteLogicTests(t *testing.T) {
 		{
 			in: []string{
 				"//pkg/jobs:jobs_test",
+				"//pkg/ccl/backupccl:backupccl_test",
 				"//pkg/sql/sem/eval:eval_test",
 				"//pkg/sql/sqlitelogictest:sqlitelogictest_test",
 			},
@@ -52,6 +53,7 @@ func TestExcludeSqliteLogicTests(t *testing.T) {
 		{
 			in: []string{
 				"//pkg/ccl/sqlitelogictestccl:sqlitelogictestccl_test",
+				"//pkg/ccl/backupccl:backupccl_test",
 				"//pkg/jobs:jobs_test",
 				"//pkg/sql/colexec:colexec_test",
 				"//pkg/sql/sem/eval:eval_test",
@@ -64,6 +66,6 @@ func TestExcludeSqliteLogicTests(t *testing.T) {
 			},
 		},
 	} {
-		require.Equal(t, tc.out, excludeSqliteLogicTests(tc.in))
+		require.Equal(t, tc.out, excludeReallyEnormousTargets(tc.in))
 	}
 }


### PR DESCRIPTION
Backport 1/1 commits from #92346.

/cc @cockroachdb/release

---

This patch doubles the backupccl test timeout from 1hr to 2 hrs, to prevent the
 nightly stress job from timing out every night. The expected backupccl test
runtime is currently 1h and 17 mins, so this timeout extension should prevent 
the stress job from flaking due to timeout.

Fixes #92040, #92236

Release note: None

Release justification: increases test timeout for persistently flakey test.