### PR TITLE
util: improve allocation of combine functions

### DIFF
--- a/pkg/util/slices.go
+++ b/pkg/util/slices.go
@@ -12,54 +12,66 @@ package util
 
 // CombineUniqueInt64 combines two ordered int64 slices and returns
 // the result without duplicates.
+// This function is used for combine slices where one of the slices is small or
+// has mostly the same elements as the other.
+// If the two slices are large and don't have many duplications, this function should be avoided,
+// because of the usage of `copy` that can increase CPU.
 func CombineUniqueInt64(a []int64, b []int64) []int64 {
-	res := make([]int64, 0, len(a))
+	// We want b to be the smaller slice, so there are fewer elements
+	// to be added.
+	if len(b) > len(a) {
+		b, a = a, b
+	}
 	aIter, bIter := 0, 0
 	for aIter < len(a) && bIter < len(b) {
 		if a[aIter] == b[bIter] {
-			res = append(res, a[aIter])
 			aIter++
 			bIter++
 		} else if a[aIter] < b[bIter] {
-			res = append(res, a[aIter])
 			aIter++
 		} else {
-			res = append(res, b[bIter])
+			a = append(a, 0)
+			copy(a[aIter+1:], a[aIter:])
+			a[aIter] = b[bIter]
+			aIter++
 			bIter++
 		}
 	}
-	if aIter < len(a) {
-		res = append(res, a[aIter:]...)
-	}
 	if bIter < len(b) {
-		res = append(res, b[bIter:]...)
+		a = append(a, b[bIter:]...)
 	}
-	return res
+	return a
 }
 
 // CombineUniqueString combines two ordered string slices and returns
 // the result without duplicates.
+// This function is used for combine slices where one of the slices is small or
+// has mostly the same elements as the other.
+// If the two slices are large and don't have many duplications, this function should be avoided,
+// because of the usage of `copy` that can increase CPU.
 func CombineUniqueString(a []string, b []string) []string {
-	res := make([]string, 0, len(a))
+	// We want b to be the smaller slice, so there are fewer elements
+	// to be added.
+	if len(b) > len(a) {
+		b, a = a, b
+	}
 	aIter, bIter := 0, 0
 	for aIter < len(a) && bIter < len(b) {
 		if a[aIter] == b[bIter] {
-			res = append(res, a[aIter])
 			aIter++
 			bIter++
 		} else if a[aIter] < b[bIter] {
-			res = append(res, a[aIter])
 			aIter++
 		} else {
-			res = append(res, b[bIter])
+			a = append(a, "")
+			copy(a[aIter+1:], a[aIter:])
+			a[aIter] = b[bIter]
+			aIter++
 			bIter++
 		}
 	}
-	if aIter < len(a) {
-		res = append(res, a[aIter:]...)
-	}
 	if bIter < len(b) {
-		res = append(res, b[bIter:]...)
+		a = append(a, b[bIter:]...)
 	}
-	return res
+	return a
 }

--- a/pkg/util/slices_test.go
+++ b/pkg/util/slices_test.go
@@ -43,3 +43,31 @@ func TestCombinesUniqueInt64(t *testing.T) {
 		require.Equal(t, tc.expected, output)
 	}
 }
+
+func TestCombinesUniqueStrings(t *testing.T) {
+	for _, tc := range []struct{ inputA, inputB, expected []string }{
+		{
+			inputA:   []string{"a", "b", "d"},
+			inputB:   []string{"c", "e"},
+			expected: []string{"a", "b", "c", "d", "e"},
+		},
+		{
+			inputA:   []string{"a", "b", "d"},
+			inputB:   []string{"a", "c", "d"},
+			expected: []string{"a", "b", "c", "d"},
+		},
+		{
+			inputA:   []string{"a", "b", "c"},
+			inputB:   []string{"a", "b", "c"},
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			inputA:   []string{},
+			inputB:   []string{"a", "c"},
+			expected: []string{"a", "c"},
+		},
+	} {
+		output := CombineUniqueString(tc.inputA, tc.inputB)
+		require.Equal(t, tc.expected, output)
+	}
+}


### PR DESCRIPTION
Part Of #89918

Previously, the functions `CombineUniqueString` and `CombineUniqueInt64` were always allocating a new object. This change makes improvements on both functions.

Results after running YCSB for a 10 minutes on each implementation:
https://www.loom.com/share/0073101092ae4dffacb254c0363f2132

Before
<img width="1604" alt="Screen Shot 2022-11-23 at 6 17 20 PM" src="https://user-images.githubusercontent.com/1017486/203662183-fcf74b13-a986-45df-b49c-ada82ab7231a.png">

After
<img width="1616" alt="Screen Shot 2022-11-23 at 6 17 01 PM" src="https://user-images.githubusercontent.com/1017486/203662242-744d49a2-234d-47d4-87ee-a304d21c1534.png">


Release note: None