### PR TITLE
actions: use GitHub PAT with project write permissions

### DIFF
--- a/.github/workflows/add-mt-issues-to-project.yml
+++ b/.github/workflows/add-mt-issues-to-project.yml
@@ -14,6 +14,6 @@ jobs:
           # URL of the project to add issues to
           project-url: https://github.com/orgs/cockroachdb/projects/36/
           # A GitHub personal access token with write access to the project
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
           # A comma-separated list of labels to use as a filter for issue to be added
           labeled: T-multitenant


### PR DESCRIPTION
Previously, the default token had no access to write to projects.

This PR changes the action to use the token with proper permissions set.

Release note: None
Epic: None