### PR TITLE
release-22.1: server: simplify table id query

### DIFF
--- a/pkg/server/index_usage_stats.go
+++ b/pkg/server/index_usage_stats.go
@@ -12,7 +12,6 @@ package server
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -334,38 +333,18 @@ func getTableIDFromDatabaseAndTableName(
 	if err != nil {
 		return 0, err
 	}
-	names := strings.Split(fqtName, ".")
-	// Strip quotations marks from db and table names.
-	for idx := range names {
-		names[idx] = strings.Trim(names[idx], "\"")
-	}
-	q := makeSQLQuery()
-	q.Append(`SELECT table_id FROM crdb_internal.tables WHERE database_name = $ `, names[0])
 
-	if len(names) == 2 {
-		q.Append(`AND name = $`, names[1])
-	} else if len(names) == 3 {
-		q.Append(`AND schema_name = $ AND name = $`, names[1], names[2])
-	} else {
-		return 0, errors.Newf("expected array length 2 or 3, received %d", len(names))
-	}
-	if len(q.Errors()) > 0 {
-		return 0, combineAllErrors(q.Errors())
-	}
-
-	datums, err := ie.QueryRowEx(ctx, "get-table-id", nil,
-		sessiondata.InternalExecutorOverride{
-			User:     userName,
-			Database: database,
-		}, q.String(), q.QueryArguments()...)
-
+	row, err := ie.QueryRowEx(
+		ctx, "get-table-id", nil,
+		sessiondata.InternalExecutorOverride{User: userName, Database: database},
+		"SELECT $1::regclass::oid", table,
+	)
 	if err != nil {
 		return 0, err
 	}
-	if datums == nil {
+	if row == nil {
 		return 0, errors.Newf("expected to find table ID for table %s, but found nothing", fqtName)
 	}
-
-	tableID := int(tree.MustBeDInt(datums[0]))
-	return tableID, nil
+	tableID := tree.MustBeDOid(row[0]).DInt
+	return int(tableID), nil
 }


### PR DESCRIPTION
Backport 1/1 commits from #92339.

/cc @cockroachdb/release

---

Epic: none

This change simplifies the table ID query used when fetching index usage statistics. Previously, we manually parsed the fully qualified table name to create a query which was error-prone. This change simplifies the query such that we no longer need to manually work with the qualified table name, making it less error-prone. This change reflects the existing implementation used in `admin.go` (see `queryTableID`).

Release note: None

Release justification: Category 2: Bug fixes and low-risk updates to new functionality
