### PR TITLE
logictestccl: extend 3node-tenant test timeout to 2 hours

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/BUILD.bazel
@@ -5,7 +5,7 @@ go_test(
     name = "3node-tenant_test",
     size = "enormous",
     srcs = ["generated_test.go"],
-    args = ["-test.timeout=3595s"],
+    args = ["-test.timeout=7195s"],
     data = [
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep

--- a/pkg/cmd/generate-bazel-extra/main.go
+++ b/pkg/cmd/generate-bazel-extra/main.go
@@ -293,6 +293,7 @@ func excludeReallyEnormousTargets(targets []string) []string {
 			"//pkg/ccl/sqlitelogictestccl",
 			"//pkg/sql/sqlitelogictest",
 			"//pkg/ccl/backupccl",
+			"//pkg/ccl/logictestccl",
 		} {
 			if strings.HasPrefix(targets[i], toExclude) {
 				excluded = true

--- a/pkg/cmd/generate-bazel-extra/main_test.go
+++ b/pkg/cmd/generate-bazel-extra/main_test.go
@@ -56,6 +56,7 @@ func TestExcludeReallyEnormousTests(t *testing.T) {
 			in: []string{
 				"//pkg/jobs:jobs_test",
 				"//pkg/ccl/backupccl:backupccl_test",
+				"//pkg/ccl/logictestccl/tests/3node-tenant:3node-tenant_test",
 				"//pkg/sql/sem/eval:eval_test",
 				"//pkg/sql/sqlitelogictest:sqlitelogictest_test",
 			},
@@ -85,6 +86,7 @@ func TestExcludeReallyEnormousTests(t *testing.T) {
 			in: []string{
 				"//pkg/ccl/sqlitelogictestccl:sqlitelogictestccl_test",
 				"//pkg/ccl/backupccl:backupccl_test",
+				"//pkg/ccl/logictestccl/tests/3node-tenant:3node-tenant_test",
 				"//pkg/jobs:jobs_test",
 				"//pkg/sql/colexec:colexec_test",
 				"//pkg/sql/sem/eval:eval_test",


### PR DESCRIPTION
This patch increases the timeout for the 3node-tenant logictestccl test from 1 to 2 hours to prevent the nightly stress testing job from timing out. Any future timeout changes for logictestccl tests should only require changes in the `BUILD.bazel` file for that test.

Informs #92052

Release note: None