### PR TITLE
sql: Fix syntax error when inserting into system.table_statistics

### DIFF
--- a/pkg/sql/stats/new_stat.go
+++ b/pkg/sql/stats/new_stat.go
@@ -103,7 +103,7 @@ func InsertNewStat(
 					"distinctCount",
 					"nullCount",
 					"avgSize",
-					histogram,
+					histogram
 				) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
 			tableID,
 			nameVal,


### PR DESCRIPTION
Previously, code that was run if the clusterversion `V23_1AddPartialStatisticsPredicateCol` was not active would return a syntax error due to a superfluous comma in an INSERT SQL statement in a roachtest.

Release note: None

Resolves: #92412