### PR TITLE
release-22.1: sql: fix implicit txn flag in console

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1105,7 +1105,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 	// defer is a catch-all in case some other return path is taken.
 	defer planner.curPlan.close(ctx)
 
-	if planner.autoCommit {
+	if planner.extendedEvalCtx.TxnImplicit {
 		planner.curPlan.flags.Set(planFlagImplicitTxn)
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/statement_statistics
+++ b/pkg/sql/logictest/testdata/logic_test/statement_statistics
@@ -64,13 +64,13 @@ select 1, 2; select 1, 2, 3; select 'ok'
 statement ok
 SET application_name = ''
 
-query T
-SELECT txn_fingerprint_id FROM crdb_internal.node_statement_statistics WHERE application_name = 'multi_stmts_test' ORDER BY txn_fingerprint_id
+query TTB
+SELECT txn_fingerprint_id, key, implicit_txn FROM crdb_internal.node_statement_statistics WHERE application_name = 'multi_stmts_test' ORDER BY txn_fingerprint_id
 ----
-10413021493801724718
-10413021493801724718
-10413021493801724718
-17854018046052698166
+10659166962890673102  SELECT '_'                  true
+10659166962890673102  SELECT _, _                 true
+10659166962890673102  SELECT _, _, _              true
+17854018046052698166  SET application_name = '_'  true
 
 statement ok
 CREATE TABLE test(x INT, y INT, z INT); INSERT INTO test(x, y, z) VALUES (0,0,0);
@@ -258,6 +258,7 @@ SELECT key, implicit_txn
 ----
 key                             implicit_txn
 SELECT _                        false
+SELECT _                        true
 SELECT x FROM test WHERE y = _  false
 SELECT x FROM test WHERE y = _  false
 SELECT x FROM test WHERE y = _  true


### PR DESCRIPTION
Backport 1/1 commits from #92408.

/cc @cockroachdb/release

Release justification: low risk bug fix

---

See: https://cockroachlabs.slack.com/archives/CPD3ANLMB/p1669224473591659
Epic: none

Release note (bug fix): Fixed the statement activity page so that it no longer shows multi-statement implicit transactions as "explicit."
