### PR TITLE
scripts: improve pprof-loop.sh

### DIFF
--- a/scripts/pprof-loop.sh
+++ b/scripts/pprof-loop.sh
@@ -1,14 +1,46 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -eu
 
 if [ "$#" -ne 1 ]; then
-	echo "Usage: $0 'http://<foo>:8080/debug/pprof/profile?labels=true&seconds=5'"
+	cat <<EOF
+Takes profiles or runtime traces in a loop. For endpoints that don't
+block, fetches at 1s intervals.
+
+See https://pkg.go.dev/runtime/pprof for details.
+
+Usage:
+
+$0 'http://localhost:8080/debug/pprof/allocs'
+$0 'http://localhost:8080/debug/pprof/heap'
+$0 'http://localhost:8080/debug/pprof/mutex'
+$0 'http://localhost:8080/debug/pprof/goroutine'
+
+# not sampled by default; need COCKROACH_BLOCK_PROFILE_RATE
+$0 'http://localhost:8080/debug/pprof/block'
+
+# 3s runtime traces
+$0 'http://localhost:8080/debug/pprof/trace?seconds=3'
+
+# 3s CPU profiles
+$0 'http://localhost:8080/debug/pprof/profile?seconds=3'
+EOF
 	exit 1
 fi
 
 first=1
+extra_sleep=0
 while true; do
 	f="pprof_$(date -u '+%Y%m%d_%H%M%S').pb.gz"
+	if [ -f "${f}" ]; then
+		# If we ever see ourselves overwriting the
+		# same file, we got through the loop twice
+		# in one second. Add an extra one second sleep
+		# for all remaining loops.
+		#
+		# This makes this script "just work" with
+		# non-blocking profiles such as heap and mutex.
+		extra_sleep=1
+	fi
 	set +e
 	# Be resilient to spurious pprof failures but make sure
 	# to bail eagerly on first time since probably the URL
@@ -24,9 +56,10 @@ while true; do
 	fi
 	set -e
 	echo "${f}"
-	if [ -n "$(which go)" ]; then
+	if [[ -n "$(which go)" && "${1}" != *"/trace"* ]]; then
 		go tool pprof -nodefraction 0.3 -top "${f}" | head -n 15
 	fi
 	first=0
+	sleep "${extra_sleep}"
 done
 


### PR DESCRIPTION
Now it also works with the runtime trace endpoint (worked before but
printed concerning-looking errors) and with non-blocking endpoints
(cumulative profiles such as heap or mutex), for which it previously
busy-looped.

Epic: None
Release note: None
