### PR TITLE
server, ui: add used index to statement details

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/plansTable.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/plansTable.module.scss
@@ -1,0 +1,15 @@
+@import "src/core/index.module";
+
+.bold-link {
+  font-weight: $font-weight--bold;
+
+  &:hover {
+    color: $colors--link;
+    text-decoration: underline;
+  }
+}
+
+.regular-link:hover {
+  color: $colors--link;
+  text-decoration: underline;
+}


### PR DESCRIPTION
This commit convert from table id and index id on
the statement details endpoint, and adds the index used information to the Explain Plan tab on Statement Details.

The elements of the list are links that redirect to the table or index details page.

Fixes #82615

https://www.loom.com/share/530bf4e795d648bb854c18d60b074e4c

<img width="1483" alt="Screen Shot 2022-11-24 at 11 11 54 AM" src="https://user-images.githubusercontent.com/1017486/203828306-0a6fb905-cae1-4217-8ea3-b4e323cf3a72.png">



Release note (ui change): Add a list of used index per explain plan, under the Explain Plan tab on Statement Details page, with links to the table or index details pages.