### PR TITLE
admission: export elastic CPU utilization % as a metric, natively

### DIFF
--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -3656,8 +3656,9 @@ var charts = []sectionDescription{
 				},
 			},
 			{
-				Title: "Elastic CPU Utilization Limit",
+				Title: "Elastic CPU Utilization",
 				Metrics: []string{
+					"admission.elastic_cpu.utilization",
 					"admission.elastic_cpu.utilization_limit",
 				},
 			},

--- a/pkg/util/admission/BUILD.bazel
+++ b/pkg/util/admission/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/settings/cluster",
+        "//pkg/util",
         "//pkg/util/admission/admissionpb",
         "//pkg/util/buildutil",
         "//pkg/util/grunning",

--- a/pkg/util/admission/admission.go
+++ b/pkg/util/admission/admission.go
@@ -331,6 +331,7 @@ type elasticCPULimiter interface {
 	getUtilizationLimit() float64
 	setUtilizationLimit(limit float64)
 	hasWaitingRequests() bool
+	computeUtilizationMetric()
 }
 
 // SchedulerLatencyListener listens to the latest scheduler latency data. We

--- a/pkg/util/admission/scheduler_latency_listener.go
+++ b/pkg/util/admission/scheduler_latency_listener.go
@@ -145,6 +145,7 @@ func (e *schedulerLatencyListener) SchedulerLatency(p99, period time.Duration) {
 	}
 
 	e.elasticCPULimiter.setUtilizationLimit(newUtilizationLimit)
+	e.elasticCPULimiter.computeUtilizationMetric()
 	if e.coord != nil { // only nil in tests
 		// TODO(irfansharif): Right now this is the only ticking mechanism for
 		// elastic CPU grants; consider some form of explicit ticking instead.

--- a/pkg/util/admission/scheduler_latency_listener_test.go
+++ b/pkg/util/admission/scheduler_latency_listener_test.go
@@ -364,6 +364,8 @@ func (t *testElasticCPUUtilizationLimiter) setHasWaitingRequests(hasWaitingReque
 	t.hasWaitingRequestsVal = hasWaitingRequestsVal
 }
 
+func (t *testElasticCPUUtilizationLimiter) computeUtilizationMetric() {}
+
 func (p schedulerLatencyListenerParams) String() string {
 	inactiveUtilizationLimit := p.minUtilization +
 		p.inactivePoint*(p.maxUtilization-p.minUtilization)


### PR DESCRIPTION
Fixes #89814. With the elastic CPU limiter (#86638) closely tracking acquired/returned CPU nanoseconds, it's possible to compute what % CPU utilization it's nominally overseeing. In experimentation we've been using prometheus where this CPU % is being computed using:

    (
      rate(admission_elastic_cpu_acquired_nanos[$__rate_interval]) -
      rate(admission_elastic_cpu_acquired_nanos[$__rate_interval])
    ) / admission_elastic_cpu_max_available_nanos

This timeseries math is not possible in CRDB natively, but it's a useful one to have to observe the CPU limiter in action. This PR computes this number within CRDB and exports it as a metric. Below we see the two different forms of this metric, one computed as described above (smoother) and the version introduced in this PR.

<img width="800" alt="image" src="https://user-images.githubusercontent.com/10536690/203867144-465e7373-8e40-4090-9772-32109eb70c7c.png">


Release note: None