### PR TITLE
ccl/sqlproxyccl: fix TestConnectionMigration test flake

### DIFF
--- a/pkg/ccl/sqlproxyccl/conn_migration.go
+++ b/pkg/ccl/sqlproxyccl/conn_migration.go
@@ -111,6 +111,9 @@ func (f *forwarder) tryBeginTransfer() (started bool, cleanupFn func()) {
 	}
 }
 
+// errTransferCannotStart is an error that indicates that the transfer cannot be
+// started (e.g. transfer already in progress, or we're not at a safe transfer
+// point). The caller should retry the transfer again if necessary.
 var errTransferCannotStart = errors.New("transfer cannot be started")
 
 // TransferConnection attempts a best-effort connection migration to an


### PR DESCRIPTION
Fixes #87351.

Previously, some of the TransferConnection attempts have been failing with a "transfer cannot be started" error. That error indicates that the transfer cannot be started because of one of the following:
1. forwarder hasn't been initialized
2. transfer is already in progress
3. we're not in a safe point to transfer

Given that we only invoke TransferConnection in the tests once the forwarder has been initialized, the only possibilities would be (2) and (3). This commit addresses the test flake by retrying whenever we hit any of the last two cases.

Epic: None

Release note: None

Release justification: sqlproxy test only change.