### PR TITLE
ui: fix contention time on statement insights

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
@@ -460,6 +460,7 @@ export function getStmtInsightRecommendations(
     indexRecommendations: insightDetails.indexRecommendations,
     databaseName: insightDetails.databaseName,
     elapsedTimeMillis: insightDetails.elapsedTimeMillis,
+    contentionTime: insightDetails.totalContentionTime.asMilliseconds(),
   };
 
   const recs: InsightRecommendation[] = insightDetails.insights?.map(insight =>


### PR DESCRIPTION
Previously, the contention value for statement insights was not being passed on when flattening the values, making the value to show as `NaN` on the UI.
This commit sets the correct value.

Epic: None

Before
<img width="1469" alt="Screen Shot 2022-11-25 at 3 30 02 PM" src="https://user-images.githubusercontent.com/1017486/204056022-7a3d3e91-240e-4704-8a15-aef92b4947a1.png">


After
<img width="817" alt="Screen Shot 2022-11-25 at 4 12 50 PM" src="https://user-images.githubusercontent.com/1017486/204056025-1b41c9a7-7deb-4076-a659-39c9c4948991.png">


Release note: None