### PR TITLE
kvserver: TestReplicaStateMachineChangeReplicas

### DIFF
--- a/pkg/kv/kvserver/replica_application_state_machine_test.go
+++ b/pkg/kv/kvserver/replica_application_state_machine_test.go
@@ -145,6 +145,14 @@ func TestReplicaStateMachineChangeReplicas(t *testing.T) {
 			require.Error(t, err)
 			require.IsType(t, &roachpb.RangeNotFoundError{}, err)
 		}
+		// Set a destroyStatus to make sure there won't be any raft processing once
+		// we release raftMu. We applied a command but not one from the raft log, so
+		// should there be a command in the raft log (i.e. some errant lease request
+		// or whatnot) this will fire assertions because it will conflict with the
+		// log index that we pulled out of thin air above.
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		r.mu.destroyStatus.Set(errors.New("test done"), destroyReasonRemoved)
 	})
 }
 

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -162,6 +162,7 @@ func (tc *testContext) Start(ctx context.Context, t testing.TB, stopper *stop.St
 	// testContext tests like to move the manual clock around and assume that they can write at past
 	// timestamps.
 	cfg.TestingKnobs.DontCloseTimestamps = true
+	cfg.TestingKnobs.DisableMergeWaitForReplicasInit = true
 	tc.StartWithStoreConfig(ctx, t, stopper, cfg)
 }
 
@@ -14008,7 +14009,7 @@ func TestStoreTenantMetricsAndRateLimiterRefcount(t *testing.T) {
 			Key: leftRepl.Desc().StartKey.AsRawKey(),
 		},
 	}, "testing")
-	require.Nil(t, pErr)
+	require.NoError(t, pErr.GoError())
 
 	// The store metrics no longer track tenant 123.
 	require.Equal(t,

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -207,7 +207,15 @@ func createTestStoreWithoutStart(
 	eng := storage.NewDefaultInMemForTesting()
 	stopper.AddCloser(eng)
 	require.Nil(t, cfg.Transport)
-	cfg.Transport = NewDummyRaftTransport(cfg.Settings, cfg.AmbientCtx.Tracer)
+
+	require.NotNil(t, cfg.Gossip) // was set above already
+	// Even though testContext is fundamentally a single-store test, some tests
+	// will try config changes, etc, so we will see some use of the transport
+	// and it's important that this doesn't cause crashes. Just set up the
+	// "real thing" since it's straightforward enough.
+	cfg.NodeDialer = nodedialer.New(rpcContext, gossip.AddressResolver(cfg.Gossip))
+	cfg.Transport = NewRaftTransport(cfg.AmbientCtx, cfg.Settings, cfg.Tracer(), cfg.NodeDialer, server, stopper)
+
 	stores := NewStores(cfg.AmbientCtx, cfg.Clock)
 	nodeDesc := &roachpb.NodeDescriptor{NodeID: 1}
 

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -473,6 +473,10 @@ type StoreTestingKnobs struct {
 	// Replica.executeReadOnlyBatch after checks have successfully determined
 	// execution can proceed but a storage snapshot has not been acquired.
 	PreStorageSnapshotButChecksCompleteInterceptor func(replica *Replica)
+
+	// DisableMergeWaitForReplicasInit skips the waitForReplicasInit calls
+	// during merges. Useful for testContext tests that want to use merges.
+	DisableMergeWaitForReplicasInit bool
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
- kvserver: give testContext a real raft transport
- kvserver: deflake TestReplicaStateMachineChangeReplicas

Flaked instantly before, now stable for 10+ min.

Fixes #92242.

Epic: none
Release note: None
