### PR TITLE
ui: add seconds, milliseconds to insights timestamps in console

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
@@ -460,7 +460,7 @@ export function getStmtInsightRecommendations(
     indexRecommendations: insightDetails.indexRecommendations,
     databaseName: insightDetails.databaseName,
     elapsedTimeMillis: insightDetails.elapsedTimeMillis,
-    contentionTime: insightDetails.totalContentionTime.asMilliseconds(),
+    contentionTime: insightDetails.totalContentionTime?.asMilliseconds(),
   };
 
   const recs: InsightRecommendation[] = insightDetails.insights?.map(insight =>

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/insightDetailsTables.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/insightDetailsTables.tsx
@@ -10,7 +10,7 @@
 
 import React from "react";
 import { ColumnDescriptor, SortedTable, SortSetting } from "src/sortedtable";
-import { DATE_FORMAT, Duration } from "src/util";
+import { DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT, Duration } from "src/util";
 import {
   BlockedStatementContentionDetails,
   ContentionEvent,
@@ -48,7 +48,8 @@ export function makeInsightDetailsColumns(
     {
       name: "contentionStartTime",
       title: insightsTableTitles.contentionStartTime(execType),
-      cell: (item: ContentionEvent) => item.startTime.format(DATE_FORMAT),
+      cell: (item: ContentionEvent) =>
+        item.startTime?.format(DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT),
       sort: (item: ContentionEvent) => item.startTime.unix(),
     },
     {

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
@@ -15,7 +15,7 @@ import {
 } from "src/insightsTable/insightsTable";
 import { SummaryCard, SummaryCardItem } from "src/summaryCard";
 import { capitalize, Duration } from "src/util";
-import { DATE_FORMAT_24_UTC } from "src/util/format";
+import { DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT_24_UTC } from "src/util/format";
 import { FlattenedStmtInsightEvent } from "../types";
 import classNames from "classnames/bind";
 import { CockroachCloudContext } from "../../contexts";
@@ -99,11 +99,15 @@ export const StatementInsightDetailsOverviewTab: React.FC<
           <SummaryCard>
             <SummaryCardItem
               label="Start Time"
-              value={insightDetails.startTime.format(DATE_FORMAT_24_UTC)}
+              value={insightDetails.startTime.format(
+                DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT_24_UTC,
+              )}
             />
             <SummaryCardItem
               label="End Time"
-              value={insightDetails.endTime.format(DATE_FORMAT_24_UTC)}
+              value={insightDetails.endTime.format(
+                DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT_24_UTC,
+              )}
             />
             <SummaryCardItem
               label="Elapsed Time"

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsOverviewTab.tsx
@@ -15,7 +15,7 @@ import "antd/lib/col/style";
 import "antd/lib/row/style";
 import { SqlBox, SqlBoxSize } from "src/sql";
 import { SummaryCard, SummaryCardItem } from "src/summaryCard";
-import { DATE_FORMAT_24_UTC } from "src/util/format";
+import { DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT_24_UTC } from "src/util/format";
 import { WaitTimeInsightsLabels } from "src/detailsPanels/waitTimeInsightsPanel";
 import { TxnContentionInsightDetailsRequest } from "src/api";
 import {
@@ -118,8 +118,9 @@ export const TransactionInsightDetailsOverviewTab: React.FC<Props> = ({
                   <SummaryCardItem
                     label="Start Time"
                     value={
-                      insightDetails.startTime?.format(DATE_FORMAT_24_UTC) ??
-                      "no samples"
+                      insightDetails.startTime?.format(
+                        DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT_24_UTC,
+                      ) ?? "no samples"
                     }
                   />
                   <SummaryCardItem label="Rows Read" value={rowsRead} />

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsStmtsTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsStmtsTab.tsx
@@ -13,7 +13,11 @@ import { Link } from "react-router-dom";
 import { ColumnDescriptor, SortedTable } from "src/sortedtable";
 import { StatementInsightEvent, TxnInsightDetails } from "../types";
 import { InsightCell } from "../workloadInsights/util/insightCell";
-import { DATE_FORMAT, Duration, limitText } from "src/util";
+import {
+  DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT,
+  Duration,
+  limitText,
+} from "src/util";
 
 const stmtColumns: ColumnDescriptor<StatementInsightEvent>[] = [
   {
@@ -46,14 +50,16 @@ const stmtColumns: ColumnDescriptor<StatementInsightEvent>[] = [
   },
   {
     name: "startTime",
-    title: "Start Time",
-    cell: (item: StatementInsightEvent) => item.startTime.format(DATE_FORMAT),
+    title: "Start Time (UTC)",
+    cell: (item: StatementInsightEvent) =>
+      item.startTime?.format(DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT),
     sort: (item: StatementInsightEvent) => item.startTime.unix(),
   },
   {
     name: "endTime",
-    title: "End Time",
-    cell: (item: StatementInsightEvent) => item.endTime.format(DATE_FORMAT),
+    title: "End Time (UTC)",
+    cell: (item: StatementInsightEvent) =>
+      item.endTime?.format(DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT),
     sort: (item: StatementInsightEvent) => item.endTime.unix(),
   },
   {

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsTable.tsx
@@ -15,7 +15,12 @@ import {
   SortedTable,
   SortSetting,
 } from "src/sortedtable";
-import { Count, DATE_FORMAT, Duration, limitText } from "src/util";
+import {
+  Count,
+  DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT,
+  Duration,
+  limitText,
+} from "src/util";
 import { InsightExecEnum, FlattenedStmtInsightEvent } from "src/insights";
 import {
   InsightCell,
@@ -90,7 +95,7 @@ export function makeStatementInsightsColumns(
       name: "startTime",
       title: insightsTableTitles.startTime(execType),
       cell: (item: FlattenedStmtInsightEvent) =>
-        item.startTime.format(DATE_FORMAT),
+        item.startTime?.format(DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT),
       sort: (item: FlattenedStmtInsightEvent) => item.startTime.unix(),
       showByDefault: true,
     },

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsTable.tsx
@@ -15,7 +15,7 @@ import {
   SortedTable,
   SortSetting,
 } from "src/sortedtable";
-import { DATE_FORMAT, Duration } from "src/util";
+import { DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT, Duration } from "src/util";
 import { InsightExecEnum, MergedTxnInsightEvent } from "src/insights";
 import {
   InsightCell,
@@ -79,7 +79,9 @@ export function makeTransactionInsightsColumns(
     {
       name: "startTime",
       title: insightsTableTitles.startTime(execType),
-      cell: item => item.startTime?.format(DATE_FORMAT) ?? "N/A",
+      cell: item =>
+        item.startTime?.format(DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT) ??
+        "N/A",
       sort: item => item.startTime?.unix() || 0,
     },
     {

--- a/pkg/ui/workspaces/cluster-ui/src/util/format.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/format.ts
@@ -170,12 +170,16 @@ export const DurationFitScale =
   };
 
 export const DATE_FORMAT = "MMM DD, YYYY [at] H:mm";
+export const DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT =
+  "MMM DD, YYYY [at] H:mm:ss:ms";
 
 /**
- * Alternate 24 hour UTC format
+ * Alternate 24 hour UTC formats
  */
 export const DATE_FORMAT_24_UTC = "MMM DD, YYYY [at] H:mm UTC";
 export const DATE_WITH_SECONDS_FORMAT_24_UTC = "MMM DD, YYYY [at] H:mm:ss UTC";
+export const DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT_24_UTC =
+  "MMM DD, YYYY [at] H:mm:ss:ms UTC";
 
 export function RenderCount(yesCount: Long, totalCount: Long): string {
   if (longToInt(yesCount) == 0) {


### PR DESCRIPTION
This commit adds seconds and milliseconds to the timestamp values on the Insights pages in the DB Console.

Fixes #91936.

Loom: https://www.loom.com/share/1aa7e5ca81984b1190f67a1748506aae

Release note (ui change): The Insights pages in the DB Console now show the seconds and milliseconds for all timestamp values.