### PR TITLE
ui: fix sort setting on stmt/txn insights details

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/insightDetailsTables.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/insightDetailsTables.tsx
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import React from "react";
+import React, { useState } from "react";
 import { ColumnDescriptor, SortedTable, SortSetting } from "src/sortedtable";
 import { DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT, Duration } from "src/util";
 import {
@@ -101,8 +101,18 @@ export const WaitTimeDetailsTable: React.FC<
   InsightDetailsTableProps
 > = props => {
   const columns = makeInsightDetailsColumns(props.execType, props.setTimeScale);
+  const [sortSetting, setSortSetting] = useState<SortSetting>({
+    ascending: false,
+    columnTitle: "contention",
+  });
   return (
-    <SortedTable className="statements-table" columns={columns} {...props} />
+    <SortedTable
+      className="statements-table"
+      columns={columns}
+      sortSetting={sortSetting}
+      onChangeSortSetting={setSortSetting}
+      {...props}
+    />
   );
 };
 

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
@@ -89,7 +89,7 @@ export const StatementInsightDetailsOverviewTab: React.FC<
 
   const [insightsSortSetting, setInsightsSortSetting] = useState<SortSetting>({
     ascending: false,
-    columnTitle: "Insights",
+    columnTitle: "insights",
   });
 
   return (

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsOverviewTab.tsx
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
 import { Heading } from "@cockroachlabs/ui-components";
 import { Col, Row } from "antd";
 import "antd/lib/col/style";
@@ -30,6 +30,7 @@ import { CockroachCloudContext } from "../../contexts";
 import { TransactionDetailsLink } from "../workloadInsights/util";
 import { TimeScale } from "../../timeScaleDropdown";
 import { getTxnInsightRecommendations } from "../utils";
+import { SortSetting } from "../../sortedtable";
 
 import insightTableStyles from "src/insightsTable/insightsTable.module.scss";
 import insightsDetailsStyles from "src/insights/workloadInsightDetails/insightsDetails.module.scss";
@@ -58,6 +59,10 @@ export const TransactionInsightDetailsOverviewTab: React.FC<Props> = ({
   insightDetails,
   setTimeScale,
 }) => {
+  const [insightsSortSetting, setInsightsSortSetting] = useState<SortSetting>({
+    ascending: false,
+    columnTitle: "insights",
+  });
   const isCockroachCloud = useContext(CockroachCloudContext);
 
   const insightQueries =
@@ -175,6 +180,8 @@ export const TransactionInsightDetailsOverviewTab: React.FC<Props> = ({
                 <InsightsSortedTable
                   columns={insightsColumns}
                   data={insightRecs}
+                  sortSetting={insightsSortSetting}
+                  onChangeSortSetting={setInsightsSortSetting}
                 />
               </Col>
             </Row>


### PR DESCRIPTION
Previously, the transaction insight details page had no sorting on the tables, and the statement insights details had the wrong column name as the default.
This commit fixes both issues.

Fixes #86534

https://www.loom.com/share/93c3be6312344da8be23bf1c116169bc

Release note (bug fix): Add sort setting to tables on Transaction and Statement Insights Details pages.