### PR TITLE
pgwire: unexport ServerMetrics, rename to tenantSpecificMetrics

### DIFF
--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -64,7 +64,7 @@ type conn struct {
 	conn net.Conn
 
 	sessionArgs sql.SessionArgs
-	metrics     *ServerMetrics
+	metrics     *tenantSpecificMetrics
 
 	// startTime is the time when the connection attempt was first received
 	// by the server.
@@ -164,7 +164,7 @@ func (s *Server) serveConn(
 		log.Infof(ctx, "new connection with options: %+v", sArgs)
 	}
 
-	c := newConn(netConn, sArgs, &s.metrics, connStart, &s.execCfg.Settings.SV)
+	c := newConn(netConn, sArgs, &s.tenantMetrics, connStart, &s.execCfg.Settings.SV)
 	c.alwaysLogAuthActivity = alwaysLogAuthActivity || atomic.LoadInt32(&s.testingAuthLogEnabled) > 0
 	if s.execCfg.PGWireTestingKnobs != nil {
 		c.afterReadMsgTestingKnob = s.execCfg.PGWireTestingKnobs.AfterReadMsgTestingKnob
@@ -184,7 +184,7 @@ var alwaysLogAuthActivity = envutil.EnvOrDefaultBool("COCKROACH_ALWAYS_LOG_AUTHN
 func newConn(
 	netConn net.Conn,
 	sArgs sql.SessionArgs,
-	metrics *ServerMetrics,
+	metrics *tenantSpecificMetrics,
 	connStart time.Time,
 	sv *settings.Values,
 ) *conn {

--- a/pkg/sql/pgwire/conn_test.go
+++ b/pkg/sql/pgwire/conn_test.go
@@ -541,7 +541,7 @@ func waitForClientConn(ln net.Listener) (*conn, error) {
 		return nil, err
 	}
 
-	metrics := makeServerMetrics(sql.MemoryMetrics{} /* sqlMemMetrics */, metric.TestSampleInterval)
+	metrics := makeTenantSpecificMetrics(sql.MemoryMetrics{} /* sqlMemMetrics */, metric.TestSampleInterval)
 	pgwireConn := newConn(conn, sql.SessionArgs{ConnResultsBufferSize: 16 << 10}, &metrics, timeutil.Now(), nil)
 	return pgwireConn, nil
 }
@@ -1070,7 +1070,7 @@ func TestMaliciousInputs(t *testing.T) {
 			}(tc)
 
 			sqlMetrics := sql.MakeMemMetrics("test" /* endpoint */, time.Second /* histogramWindow */)
-			metrics := makeServerMetrics(sqlMetrics, time.Second /* histogramWindow */)
+			metrics := makeTenantSpecificMetrics(sqlMetrics, time.Second /* histogramWindow */)
 
 			conn := newConn(
 				r,

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -119,25 +119,25 @@ const (
 var (
 	MetaConns = metric.Metadata{
 		Name:        "sql.conns",
-		Help:        "Number of active sql connections",
+		Help:        "Number of active SQL connections",
 		Measurement: "Connections",
 		Unit:        metric.Unit_COUNT,
 	}
 	MetaNewConns = metric.Metadata{
 		Name:        "sql.new_conns",
-		Help:        "Counter of the number of sql connections created",
+		Help:        "Counter of the number of SQL connections created",
 		Measurement: "Connections",
 		Unit:        metric.Unit_COUNT,
 	}
 	MetaBytesIn = metric.Metadata{
 		Name:        "sql.bytesin",
-		Help:        "Number of sql bytes received",
+		Help:        "Number of SQL bytes received",
 		Measurement: "SQL Bytes",
 		Unit:        metric.Unit_BYTES,
 	}
 	MetaBytesOut = metric.Metadata{
 		Name:        "sql.bytesout",
-		Help:        "Number of sql bytes sent",
+		Help:        "Number of SQL bytes sent",
 		Measurement: "SQL Bytes",
 		Unit:        metric.Unit_BYTES,
 	}
@@ -149,7 +149,7 @@ var (
 	}
 	MetaConnFailures = metric.Metadata{
 		Name:        "sql.conn.failures",
-		Help:        "Number of sql conection failures",
+		Help:        "Number of SQL connection failures",
 		Measurement: "Connections",
 		Unit:        metric.Unit_COUNT,
 	}


### PR DESCRIPTION
Parent PRs:
- [x] https://github.com/cockroachdb/cockroach/pull/84608
- [x] https://github.com/cockroachdb/cockroach/pull/91739
- [x] https://github.com/cockroachdb/cockroach/pull/91744

Epic: CRDB-14537