### PR TITLE
server: extract tenant-independent logic out of `SQLServer`

### DIFF
--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -239,8 +239,8 @@ func TestProxyAgainstSecureCRDB(t *testing.T) {
 		DisableDefaultTestTenant: true,
 	},
 	)
+	sql.(*server.TestServer).PGPreServer().TestingSetTrustClientProvidedRemoteAddr(true)
 	pgs := sql.(*server.TestServer).PGServer().(*pgwire.Server)
-	pgs.TestingSetTrustClientProvidedRemoteAddr(true)
 	pgs.TestingEnableAuthLogging()
 	defer sql.Stopper().Stop(ctx)
 
@@ -402,8 +402,8 @@ func TestProxyTLSClose(t *testing.T) {
 			DisableDefaultTestTenant: true,
 		},
 	)
+	sql.(*server.TestServer).PGPreServer().TestingSetTrustClientProvidedRemoteAddr(true)
 	pgs := sql.(*server.TestServer).PGServer().(*pgwire.Server)
-	pgs.TestingSetTrustClientProvidedRemoteAddr(true)
 	pgs.TestingEnableAuthLogging()
 	defer sql.Stopper().Stop(ctx)
 
@@ -458,8 +458,8 @@ func TestProxyModifyRequestParams(t *testing.T) {
 			DisableDefaultTestTenant: true,
 		},
 	)
+	sql.(*server.TestServer).PGPreServer().TestingSetTrustClientProvidedRemoteAddr(true)
 	pgs := sql.(*server.TestServer).PGServer().(*pgwire.Server)
-	pgs.TestingSetTrustClientProvidedRemoteAddr(true)
 	pgs.TestingEnableAuthLogging()
 	defer sql.Stopper().Stop(ctx)
 
@@ -523,8 +523,8 @@ func TestInsecureProxy(t *testing.T) {
 			Insecure:                 false,
 		},
 	)
+	sql.(*server.TestServer).PGPreServer().TestingSetTrustClientProvidedRemoteAddr(true)
 	pgs := sql.(*server.TestServer).PGServer().(*pgwire.Server)
-	pgs.TestingSetTrustClientProvidedRemoteAddr(true)
 	pgs.TestingEnableAuthLogging()
 	defer sql.Stopper().Stop(ctx)
 
@@ -677,7 +677,7 @@ func TestDenylistUpdate(t *testing.T) {
 			DisableDefaultTestTenant: true,
 		},
 	)
-	sql.(*server.TestServer).PGServer().(*pgwire.Server).TestingSetTrustClientProvidedRemoteAddr(true)
+	sql.(*server.TestServer).PGPreServer().TestingSetTrustClientProvidedRemoteAddr(true)
 	defer sql.Stopper().Stop(ctx)
 
 	// Create some user with password authn.
@@ -758,7 +758,7 @@ func TestDirectoryConnect(t *testing.T) {
 			DisableDefaultTestTenant: true,
 		},
 	)
-	srv.(*server.TestServer).PGServer().(*pgwire.Server).TestingSetTrustClientProvidedRemoteAddr(true)
+	srv.(*server.TestServer).PGPreServer().TestingSetTrustClientProvidedRemoteAddr(true)
 	defer srv.Stopper().Stop(ctx)
 
 	// Create tenant 28.
@@ -1391,7 +1391,7 @@ func TestConnectionMigration(t *testing.T) {
 
 	// Start first SQL pod.
 	tenant1, tenantDB1 := serverutils.StartTenant(t, s, tests.CreateTestTenantParams(tenantID))
-	tenant1.PGServer().(*pgwire.Server).TestingSetTrustClientProvidedRemoteAddr(true)
+	tenant1.(*server.TestTenant).PGPreServer().TestingSetTrustClientProvidedRemoteAddr(true)
 	defer tenant1.Stopper().Stop(ctx)
 	defer tenantDB1.Close()
 
@@ -1399,7 +1399,7 @@ func TestConnectionMigration(t *testing.T) {
 	params2 := tests.CreateTestTenantParams(tenantID)
 	params2.DisableCreateTenant = true
 	tenant2, tenantDB2 := serverutils.StartTenant(t, s, params2)
-	tenant2.PGServer().(*pgwire.Server).TestingSetTrustClientProvidedRemoteAddr(true)
+	tenant2.(*server.TestTenant).PGPreServer().TestingSetTrustClientProvidedRemoteAddr(true)
 	defer tenant2.Stopper().Stop(ctx)
 	defer tenantDB2.Close()
 
@@ -2291,7 +2291,7 @@ func newDirectoryServer(
 		require.NoError(t, err)
 		sqlAddr, err := net.ResolveTCPAddr("tcp", ten.SQLAddr())
 		require.NoError(t, err)
-		ten.PGServer().(*pgwire.Server).TestingSetTrustClientProvidedRemoteAddr(true)
+		ten.(*server.TestTenant).PGPreServer().TestingSetTrustClientProvidedRemoteAddr(true)
 		return &tenantdirsvr.Process{SQL: sqlAddr, Stopper: tenantStopper}, nil
 	}
 
@@ -2354,7 +2354,7 @@ func startTestTenantPods(
 		}
 		params.TestingKnobs = knobs
 		tenant, tenantDB := serverutils.StartTenant(t, ts, params)
-		tenant.PGServer().(*pgwire.Server).TestingSetTrustClientProvidedRemoteAddr(true)
+		tenant.(*server.TestTenant).PGPreServer().TestingSetTrustClientProvidedRemoteAddr(true)
 
 		// Create a test user. We only need to do it once.
 		if i == 0 {

--- a/pkg/ccl/testccl/authccl/auth_test.go
+++ b/pkg/ccl/testccl/authccl/auth_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/jwtauthccl"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -427,10 +428,13 @@ func TestClientAddrOverride(t *testing.T) {
 	// We can't use the cluster settings to do this, because
 	// cluster settings for booleans propagate asynchronously.
 	var pgServer *pgwire.Server
+	var pgPreServer *pgwire.PreServeConnHandler
 	if len(s.TestTenants()) > 0 {
 		pgServer = s.TestTenants()[0].PGServer().(*pgwire.Server)
+		pgPreServer = s.TestTenants()[0].(*server.TestTenant).PGPreServer()
 	} else {
 		pgServer = s.PGServer().(*pgwire.Server)
+		pgPreServer = s.(*server.TestServer).PGPreServer()
 	}
 	pgServer.TestingEnableAuthLogging()
 
@@ -488,7 +492,7 @@ func TestClientAddrOverride(t *testing.T) {
 			t.Run("check-server-reject-override", func(t *testing.T) {
 				// Connect a first time, with trust override disabled. In that case,
 				// the server will complain that the remote override is not supported.
-				_ = pgServer.TestingSetTrustClientProvidedRemoteAddr(false)
+				_ = pgPreServer.TestingSetTrustClientProvidedRemoteAddr(false)
 
 				testDB, err := gosql.Open("postgres", pgURL.String())
 				if err != nil {
@@ -509,7 +513,7 @@ func TestClientAddrOverride(t *testing.T) {
 			t.Run("check-server-hba-uses-override", func(t *testing.T) {
 				// Now recognize the override. Now we're expecting the connection
 				// to hit the HBA rule and fail with an authentication error.
-				_ = pgServer.TestingSetTrustClientProvidedRemoteAddr(true)
+				_ = pgPreServer.TestingSetTrustClientProvidedRemoteAddr(true)
 
 				testDB, err := gosql.Open("postgres", pgURL.String())
 				if err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1827,9 +1827,11 @@ func (s *Server) PreStart(ctx context.Context) error {
 func (s *Server) AcceptClients(ctx context.Context) error {
 	workersCtx := s.AnnotateCtx(context.Background())
 
-	if err := s.sqlServer.startServeSQL(
+	if err := startServeSQL(
 		workersCtx,
 		s.stopper,
+		s.sqlServer.pgPreServer,
+		s.sqlServer.pgServer.ServeConn,
 		s.pgL,
 		&s.cfg.SocketFile,
 	); err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1832,6 +1832,8 @@ func (s *Server) AcceptClients(ctx context.Context) error {
 		return err
 	}
 
+	s.sqlServer.isReady.Set(true)
+
 	log.Event(ctx, "server ready")
 	return nil
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -161,6 +161,10 @@ type Server struct {
 	// pgL is the SQL listener.
 	pgL net.Listener
 
+	// pgPreServer handles SQL connections prior to routing them to a
+	// specific tenant.
+	pgPreServer *pgwire.PreServeConnHandler
+
 	// TODO(knz): pull this down under the serverController.
 	sqlServer *SQLServer
 
@@ -868,6 +872,20 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	settingsWriter := newSettingsCacheWriter(engines[0], stopper)
 	stopTrigger := newStopTrigger()
 
+	// Initialize the pgwire pre-server, which initializes connections,
+	// sets up TLS and reads client status parameters.
+	pgPreServer := pgwire.MakePreServeConnHandler(
+		cfg.AmbientCtx,
+		cfg.Config,
+		cfg.Settings,
+		rpcContext.GetServerTLSConfig,
+		cfg.HistogramWindowInterval(),
+		sqlMonitorAndMetrics.rootSQLMemoryMonitor,
+	)
+	for _, m := range pgPreServer.Metrics() {
+		registry.AddMetricStruct(m)
+	}
+
 	// Instantiate the SQL server proper.
 	sqlServer, err := newSQLServer(ctx, sqlServerArgs{
 		sqlServerOptionalKVArgs: sqlServerOptionalKVArgs{
@@ -1039,6 +1057,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		replicationReporter:    replicationReporter,
 		protectedtsProvider:    protectedtsProvider,
 		spanConfigSubscriber:   spanConfig.subscriber,
+		pgPreServer:            &pgPreServer,
 		sqlServer:              sqlServer,
 		serverController:       sc,
 		externalStorageBuilder: externalStorageBuilder,
@@ -1830,7 +1849,7 @@ func (s *Server) AcceptClients(ctx context.Context) error {
 	if err := startServeSQL(
 		workersCtx,
 		s.stopper,
-		s.sqlServer.pgPreServer,
+		s.pgPreServer,
 		s.sqlServer.pgServer.ServeConn,
 		s.pgL,
 		&s.cfg.SocketFile,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -13,6 +13,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -156,6 +157,9 @@ type Server struct {
 	protectedtsProvider protectedts.Provider
 
 	spanConfigSubscriber spanconfig.KVSubscriber
+
+	// pgL is the SQL listener.
+	pgL net.Listener
 
 	// TODO(knz): pull this down under the serverController.
 	sqlServer *SQLServer
@@ -1280,6 +1284,7 @@ func (s *Server) PreStart(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	s.pgL = pgL
 
 	// Tell the RPC context how to connect in-memory.
 	s.rpcContext.SetLoopbackDialer(rpcLoopbackDialFn)
@@ -1742,7 +1747,6 @@ func (s *Server) PreStart(ctx context.Context) error {
 		workersCtx,
 		s.stopper,
 		s.cfg.TestingKnobs,
-		pgL,
 		orphanedLeasesTimeThresholdNanos,
 	); err != nil {
 		return err
@@ -1826,7 +1830,7 @@ func (s *Server) AcceptClients(ctx context.Context) error {
 	if err := s.sqlServer.startServeSQL(
 		workersCtx,
 		s.stopper,
-		s.sqlServer.pgL,
+		s.pgL,
 		&s.cfg.SocketFile,
 	); err != nil {
 		return err

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -177,9 +177,6 @@ type SQLServer struct {
 
 	isMeta1Leaseholder func(context.Context, hlc.ClockTimestamp) (bool, error)
 
-	// pgL is the shared RPC/SQL listener, opened when RPC was initialized.
-	pgL net.Listener
-
 	// isReady is the health status of the node. When true, the node is healthy;
 	// load balancers and connection management tools treat the node as "ready".
 	// When false, the node is unhealthy or "not ready", with load balancers and
@@ -1343,7 +1340,6 @@ func (s *SQLServer) preStart(
 	ctx context.Context,
 	stopper *stop.Stopper,
 	knobs base.TestingKnobs,
-	pgL net.Listener,
 	orphanedLeasesTimeThresholdNanos int64,
 ) error {
 	// If necessary, start the tenant proxy first, to ensure all other
@@ -1411,7 +1407,6 @@ func (s *SQLServer) preStart(
 		s.sqlInstanceReader.Start(ctx, instance)
 	}
 
-	s.pgL = pgL
 	s.execCfg.GCJobNotifier.Start(ctx)
 	s.temporaryObjectCleaner.Start(ctx, stopper)
 	s.distSQLServer.Start()

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -138,7 +138,6 @@ type SQLServer struct {
 	stopper                 *stop.Stopper
 	stopTrigger             *stopTrigger
 	sqlIDContainer          *base.SQLIDContainer
-	pgPreServer             *pgwire.PreServeConnHandler
 	pgServer                *pgwire.Server
 	distSQLServer           *distsql.ServerImpl
 	execCfg                 *sql.ExecutorConfig
@@ -1034,24 +1033,6 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	// Don't add them to the registry now because it will be added as part of pgServer metrics.
 	sqlMemMetrics := sql.MakeMemMetrics("sql", cfg.HistogramWindowInterval())
 
-	// Initialize the pgwire pre-server, which initializes connections,
-	// sets up TLS and reads client status parameters.
-	//
-	// We are initializing preServeHandler here until the following issue is resolved:
-	// https://github.com/cockroachdb/cockroach/issues/84585
-	pgPreServer := pgwire.MakePreServeConnHandler(
-		cfg.AmbientCtx,
-		cfg.Config,
-		cfg.Settings,
-		cfg.rpcContext.GetServerTLSConfig,
-		cfg.HistogramWindowInterval(),
-		rootSQLMemoryMonitor,
-	)
-
-	for _, m := range pgPreServer.Metrics() {
-		cfg.registry.AddMetricStruct(m)
-	}
-
 	// Initialize the pgwire server which handles connections
 	// established via the pgPreServer.
 	pgServer := pgwire.MakeServer(
@@ -1290,7 +1271,6 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		stopper:                           cfg.stopper,
 		stopTrigger:                       cfg.stopTrigger,
 		sqlIDContainer:                    cfg.nodeIDContainer,
-		pgPreServer:                       &pgPreServer,
 		pgServer:                          pgServer,
 		distSQLServer:                     distSQLServer,
 		execCfg:                           execCfg,

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1656,8 +1656,6 @@ func (s *SQLServer) startServeSQL(
 		}
 	}
 
-	s.isReady.Set(true)
-
 	return nil
 }
 

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1580,7 +1580,7 @@ func (s *SQLServer) startServeSQL(
 		stop.TaskOpts{TaskName: "pgwire-listener", SpanOpt: stop.SterileRootSpan},
 		func(ctx context.Context) {
 			err := connManager.ServeWith(ctx, pgL, func(ctx context.Context, conn net.Conn) {
-				connCtx := s.pgServer.AnnotateCtxForIncomingConn(ctx, conn)
+				connCtx := s.pgPreServer.AnnotateCtxForIncomingConn(ctx, conn)
 				tcpKeepAlive.configure(connCtx, conn)
 
 				conn, status, err := s.pgPreServer.PreServe(connCtx, conn, pgwire.SocketTCP)
@@ -1638,7 +1638,7 @@ func (s *SQLServer) startServeSQL(
 			stop.TaskOpts{TaskName: "unix-listener", SpanOpt: stop.SterileRootSpan},
 			func(ctx context.Context) {
 				err := connManager.ServeWith(ctx, unixLn, func(ctx context.Context, conn net.Conn) {
-					connCtx := s.pgServer.AnnotateCtxForIncomingConn(ctx, conn)
+					connCtx := s.pgPreServer.AnnotateCtxForIncomingConn(ctx, conn)
 
 					conn, status, err := s.pgPreServer.PreServe(connCtx, conn, pgwire.SocketUnix)
 					if err != nil {

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -104,6 +104,10 @@ type SQLServerWrapper struct {
 	// pgL is the SQL listener.
 	pgL net.Listener
 
+	// pgPreServer handles SQL connections prior to routing them to a
+	// specific tenant.
+	pgPreServer *pgwire.PreServeConnHandler
+
 	sqlServer *SQLServer
 	sqlCfg    *SQLConfig
 
@@ -237,6 +241,20 @@ func NewTenantServer(
 	// the eventsServer. This is currently performed in
 	// makeTenantSQLServerArgs().
 
+	// Initialize the pgwire pre-server, which initializes connections,
+	// sets up TLS and reads client status parameters.
+	pgPreServer := pgwire.MakePreServeConnHandler(
+		baseCfg.AmbientCtx,
+		baseCfg.Config,
+		args.Settings,
+		args.rpcContext.GetServerTLSConfig,
+		baseCfg.HistogramWindowInterval(),
+		args.monitorAndMetrics.rootSQLMemoryMonitor,
+	)
+	for _, m := range pgPreServer.Metrics() {
+		args.registry.AddMetricStruct(m)
+	}
+
 	// Instantiate the SQL server proper.
 	sqlServer, err := newSQLServer(ctx, args)
 	if err != nil {
@@ -325,6 +343,8 @@ func NewTenantServer(
 		stopper:         args.stopper,
 
 		debug: debugServer,
+
+		pgPreServer: &pgPreServer,
 
 		sqlServer: sqlServer,
 		sqlCfg:    args.SQLConfig,
@@ -671,7 +691,7 @@ func (s *SQLServerWrapper) AcceptClients(ctx context.Context) error {
 	if err := startServeSQL(
 		workersCtx,
 		s.stopper,
-		s.sqlServer.pgPreServer,
+		s.pgPreServer,
 		s.sqlServer.pgServer.ServeConn,
 		s.pgL,
 		&s.sqlServer.cfg.SocketFile,

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -668,9 +668,11 @@ func (s *SQLServerWrapper) PreStart(ctx context.Context) error {
 func (s *SQLServerWrapper) AcceptClients(ctx context.Context) error {
 	workersCtx := s.AnnotateCtx(context.Background())
 
-	if err := s.sqlServer.startServeSQL(
+	if err := startServeSQL(
 		workersCtx,
 		s.stopper,
+		s.sqlServer.pgPreServer,
+		s.sqlServer.pgServer.ServeConn,
 		s.pgL,
 		&s.sqlServer.cfg.SocketFile,
 	); err != nil {

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -673,6 +673,8 @@ func (s *SQLServerWrapper) AcceptClients(ctx context.Context) error {
 		return err
 	}
 
+	s.sqlServer.isReady.Set(true)
+
 	log.Event(ctx, "server ready")
 	return nil
 }

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -13,6 +13,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -99,6 +100,9 @@ type SQLServerWrapper struct {
 	stopper      *stop.Stopper
 
 	debug *debug.Server
+
+	// pgL is the SQL listener.
+	pgL net.Listener
 
 	sqlServer *SQLServer
 	sqlCfg    *SQLConfig
@@ -400,6 +404,7 @@ func (s *SQLServerWrapper) PreStart(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	s.pgL = pgL
 
 	// Tell the RPC context how to connect in-memory.
 	s.rpcContext.SetLoopbackDialer(rpcLoopbackDialFn)
@@ -603,7 +608,6 @@ func (s *SQLServerWrapper) PreStart(ctx context.Context) error {
 		workersCtx,
 		s.stopper,
 		s.sqlServer.cfg.TestingKnobs,
-		pgL,
 		orphanedLeasesTimeThresholdNanos,
 	); err != nil {
 		return err
@@ -667,7 +671,7 @@ func (s *SQLServerWrapper) AcceptClients(ctx context.Context) error {
 	if err := s.sqlServer.startServeSQL(
 		workersCtx,
 		s.stopper,
-		s.sqlServer.pgL,
+		s.pgL,
 		&s.sqlServer.cfg.SocketFile,
 	); err != nil {
 		return err

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -45,6 +45,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -468,6 +469,15 @@ func (ts *TestServer) PGServer() interface{} {
 	return nil
 }
 
+// PGPreServer exposes the pgwire.PreServeConnHandler instance used by
+// the TestServer.
+func (ts *TestServer) PGPreServer() *pgwire.PreServeConnHandler {
+	if ts != nil {
+		return ts.sqlServer.pgPreServer
+	}
+	return nil
+}
+
 // RaftTransport returns the RaftTransport used by the TestServer.
 func (ts *TestServer) RaftTransport() *kvserver.RaftTransport {
 	if ts != nil {
@@ -647,6 +657,15 @@ func (t *TestTenant) RPCAddr() string {
 // PGServer is part of TestTenantInterface.
 func (t *TestTenant) PGServer() interface{} {
 	return t.pgServer
+}
+
+// PGPreServer exposes the pgwire.PreServeConnHandler instance used by
+// the TestServer.
+func (ts *TestTenant) PGPreServer() *pgwire.PreServeConnHandler {
+	if ts != nil {
+		return ts.pgPreServer
+	}
+	return nil
 }
 
 // DiagnosticsReporter is part of TestTenantInterface.

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -473,7 +473,7 @@ func (ts *TestServer) PGServer() interface{} {
 // the TestServer.
 func (ts *TestServer) PGPreServer() *pgwire.PreServeConnHandler {
 	if ts != nil {
-		return ts.sqlServer.pgPreServer
+		return ts.pgPreServer
 	}
 	return nil
 }
@@ -635,6 +635,10 @@ type TestTenant struct {
 	Cfg *BaseConfig
 	*httpTestServer
 	drain *drainServer
+
+	// pgPreServer handles SQL connections prior to routing them to a
+	// specific tenant.
+	pgPreServer *pgwire.PreServeConnHandler
 }
 
 var _ serverutils.TestTenantInterface = &TestTenant{}
@@ -865,6 +869,7 @@ func (ts *TestServer) StartTenant(
 		return &TestTenant{
 			SQLServer:      sw.server.sqlServer,
 			Cfg:            sw.server.sqlServer.cfg,
+			pgPreServer:    sw.server.pgPreServer,
 			httpTestServer: hts,
 			drain:          sw.server.drainServer,
 		}, err
@@ -1006,6 +1011,7 @@ func (ts *TestServer) StartTenant(
 	return &TestTenant{
 		SQLServer:      sw.sqlServer,
 		Cfg:            &baseCfg,
+		pgPreServer:    sw.pgPreServer,
 		httpTestServer: hts,
 		drain:          sw.drainServer,
 	}, err

--- a/pkg/sql/pgwire/auth_test.go
+++ b/pkg/sql/pgwire/auth_test.go
@@ -605,6 +605,7 @@ func TestClientAddrOverride(t *testing.T) {
 	testServer := s.(*server.TestServer)
 	pgServer := testServer.PGServer().(*pgwire.Server)
 	pgServer.TestingEnableAuthLogging()
+	pgPreServer := testServer.PGPreServer()
 
 	testCases := []struct {
 		specialAddr string
@@ -660,7 +661,7 @@ func TestClientAddrOverride(t *testing.T) {
 			t.Run("check-server-reject-override", func(t *testing.T) {
 				// Connect a first time, with trust override disabled. In that case,
 				// the server will complain that the remote override is not supported.
-				_ = pgServer.TestingSetTrustClientProvidedRemoteAddr(false)
+				_ = pgPreServer.TestingSetTrustClientProvidedRemoteAddr(false)
 
 				testDB, err := gosql.Open("postgres", pgURL.String())
 				if err != nil {
@@ -681,7 +682,7 @@ func TestClientAddrOverride(t *testing.T) {
 			t.Run("check-server-hba-uses-override", func(t *testing.T) {
 				// Now recognize the override. Now we're expecting the connection
 				// to hit the HBA rule and fail with an authentication error.
-				_ = pgServer.TestingSetTrustClientProvidedRemoteAddr(true)
+				_ = pgPreServer.TestingSetTrustClientProvidedRemoteAddr(true)
 
 				testDB, err := gosql.Open("postgres", pgURL.String())
 				if err != nil {

--- a/pkg/sql/pgwire/conn_test.go
+++ b/pkg/sql/pgwire/conn_test.go
@@ -576,11 +576,11 @@ func getSessionArgs(
 		}
 
 		ctx := context.Background()
-		cp, err := parseClientProvidedSessionParameters(ctx, &buf, conn.RemoteAddr())
+		cp, err := parseClientProvidedSessionParameters(ctx, &buf, conn.RemoteAddr(), trustRemoteAddr)
 		if err != nil {
 			return conn, sql.SessionArgs{}, err
 		}
-		args, err := finalizeClientParameters(ctx, cp, nil, trustRemoteAddr)
+		args, err := finalizeClientParameters(ctx, cp, nil)
 		return conn, args, err
 	}
 }

--- a/pkg/sql/pgwire/pre_serve.go
+++ b/pkg/sql/pgwire/pre_serve.go
@@ -29,7 +29,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/logtags"
 )
 
 // Fully-qualified names for metrics.
@@ -90,6 +92,25 @@ type PreServeConnHandler struct {
 	// connection overhead is transferred to the per-tenant
 	// monitor.
 	tenantIndependentConnMonitor *mon.BytesMonitor
+
+	// trustClientProvidedRemoteAddr indicates whether the server should honor
+	// a `crdb:remote_addr` status parameter provided by the client during
+	// session authentication. This status parameter can be set by SQL proxies
+	// to feed the "real" client address, where otherwise the CockroachDB SQL
+	// server would only see the address of the proxy.
+	//
+	// This setting is security-sensitive and should not be enabled
+	// without a SQL proxy that carefully scrubs any client-provided
+	// `crdb:remote_addr` field. In particular, this setting should never
+	// be set when there is no SQL proxy at all. Otherwise, a malicious
+	// client could use this field to pretend being from another address
+	// than its own and defeat the HBA rules.
+	//
+	// TODO(knz,ben): It would be good to have something more specific
+	// than a boolean, i.e. to accept the provided address only from
+	// certain peer IPs, or with certain certificates. (could it be a
+	// special hba.conf directive?)
+	trustClientProvidedRemoteAddr syncutil.AtomicBool
 }
 
 // MakePreServeConnHandler creates a PreServeConnHandler.
@@ -120,7 +141,27 @@ func MakePreServeConnHandler(
 			int64(connReservationBatchSize)*baseSQLMemoryBudget, noteworthyConnMemoryUsageBytes, st),
 	}
 	s.tenantIndependentConnMonitor.StartNoReserved(ctx, parentMemoryMonitor)
+
+	// TODO(knz,ben): Use a cluster setting for this.
+	s.trustClientProvidedRemoteAddr.Set(trustClientProvidedRemoteAddrOverride)
+
 	return s
+}
+
+// AnnotateCtxForIncomingConn annotates the provided context with a
+// tag that reports the peer's address. In the common case, the
+// context is annotated with a "client" tag. When the server is
+// configured to recognize client-specified remote addresses, it is
+// annotated with a "peer" tag and the "client" tag is added later
+// when the session is set up.
+func (s *PreServeConnHandler) AnnotateCtxForIncomingConn(
+	ctx context.Context, conn net.Conn,
+) context.Context {
+	tag := "client"
+	if s.trustClientProvidedRemoteAddr.Get() {
+		tag = "peer"
+	}
+	return logtags.AddTag(ctx, tag, conn.RemoteAddr().String())
 }
 
 // tenantIndependentMetrics is the set of metrics for the
@@ -169,8 +210,7 @@ func (s *PreServeConnHandler) sendErr(ctx context.Context, conn net.Conn, err er
 // configuration adjustements.
 type tenantIndependentClientParameters struct {
 	sql.SessionArgs
-	foundBufferSize          bool
-	clientProvidedRemoteAddr string
+	foundBufferSize bool
 }
 
 // PreServeState describes the state of a connection after PrepareConn,
@@ -321,7 +361,7 @@ func (s *PreServeConnHandler) PreServe(
 	}
 
 	// Load the client-provided session parameters.
-	st.clientParameters, err = parseClientProvidedSessionParameters(ctx, &buf, conn.RemoteAddr())
+	st.clientParameters, err = parseClientProvidedSessionParameters(ctx, &buf, conn.RemoteAddr(), s.trustClientProvidedRemoteAddr.Get())
 	if err != nil {
 		st.Reserved.Close(ctx)
 		return conn, st, s.sendErr(ctx, conn, err)


### PR DESCRIPTION
Parent PRs:
- [x] https://github.com/cockroachdb/cockroach/pull/84608
- [x] https://github.com/cockroachdb/cockroach/pull/91739
- [x] https://github.com/cockroachdb/cockroach/pull/91744
- [x] https://github.com/cockroachdb/cockroach/pull/92574
- [x] https://github.com/cockroachdb/cockroach/pull/92575
- [x] https://github.com/cockroachdb/cockroach/pull/92576
- [x] https://github.com/cockroachdb/cockroach/pull/92577
- [x] https://github.com/cockroachdb/cockroach/pull/92578

This PR extracts the tenant-independent logic in the `server` package out of `SQLServer`.

Epic: CRDB-14537