### PR TITLE
[DNM] main: increase teamcity test timeout from 1h to 2h

### DIFF
--- a/pkg/cmd/teamcity-trigger/main.go
+++ b/pkg/cmd/teamcity-trigger/main.go
@@ -72,8 +72,8 @@ func runTC(queueBuild func(string, map[string]string)) {
 		// By default, run each package for up to 100 iterations.
 		maxRuns := 100
 
-		// By default, run each package for up to 1h.
-		maxTime := 1 * time.Hour
+		// By default, run each package for up to 2h.
+		maxTime := 2 * time.Hour
 
 		// By default, fail the stress run on the first test failure.
 		maxFails := 1


### PR DESCRIPTION
Fixes #92052

This increases the teamcity stress test timeout from 1 hour to 2 hours to fix timeouts in TestOpBench.

Release note: None