### PR TITLE
ui: add 99.9th and 99.99th SQL latency charts

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -211,6 +211,58 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
+      title="Service Latency: SQL Statements, 99.99th percentile"
+      tooltip={
+        <div>
+          Over the last minute, this node executed 99.99% of SQL statements
+          within this time.&nbsp;
+          <em>
+            This time only includes SELECT, INSERT, UPDATE and DELETE statements
+            and does not include network latency between the node and client.
+          </em>
+        </div>
+      }
+    >
+      <Axis units={AxisUnits.Duration} label="latency">
+        {_.map(nodeIDs, node => (
+          <Metric
+            key={node}
+            name="cr.node.sql.service.latency-p99.99"
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
+            sources={[node]}
+            downsampleMax
+          />
+        ))}
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
+      title="Service Latency: SQL Statements, 99.9th percentile"
+      tooltip={
+        <div>
+          Over the last minute, this node executed 99.9% of SQL statements
+          within this time.&nbsp;
+          <em>
+            This time only includes SELECT, INSERT, UPDATE and DELETE statements
+            and does not include network latency between the node and client.
+          </em>
+        </div>
+      }
+    >
+      <Axis units={AxisUnits.Duration} label="latency">
+        {_.map(nodeIDs, node => (
+          <Metric
+            key={node}
+            name="cr.node.sql.service.latency-p99.9"
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
+            sources={[node]}
+            downsampleMax
+          />
+        ))}
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
       title="Service Latency: SQL Statements, 99th percentile"
       tooltip={
         <div>


### PR DESCRIPTION
This commit introduces the charts for:
`Service Latency: SQL Statements, 99.99th percentile` and
`Service Latency: SQL Statements, 99.9th percentile` on Metrics page under SQL view.

Fixes #74247

<img width="806" alt="Screen Shot 2022-11-28 at 12 23 56 PM" src="https://user-images.githubusercontent.com/1017486/204342077-b5509f51-f94e-44be-a2e8-8bd185d12ce6.png">



Release note (ui change): Added charts
`Service Latency: SQL Statements, 99.9th percentile` and `Service Latency: SQL Statements, 99.99th percentile` to Metrics page, under SQL view.