### PR TITLE
logictest: avoid a lint failure

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1233,6 +1233,10 @@ func getFreePort() (int, error) {
 	return port, err
 }
 
+// Prevent a lint failure "this value is never used" in
+// `(*logicTest).setup` when bazel.BuiltWithBazel returns false.
+var _ = ((*logicTest)(nil)).newTestServerCluster
+
 // newTestServerCluster creates a 3-node cluster using the cockroach-go library.
 // bootstrapBinaryPath is given by the config's CockroachGoBootstrapVersion.
 // upgradeBinaryPath is given by the config's CockroachGoUpgradeVersion, or
@@ -1823,6 +1827,11 @@ func (t *logicTest) setup(
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		// Prevent a lint failure "this value is never used" when
+		// bazel.BuiltWithBazel returns false above.
+		_ = bootstrapBinaryPath
+
 		localBinaryPath, found := bazel.FindBinary("pkg/cmd/cockroach-short/cockroach-short_/", "cockroach-short")
 		if !found {
 			t.Fatal(errors.New("cockroach binary not found"))


### PR DESCRIPTION
Fixes #92592

The go compiler treats calls to `bazel.BuiltWithBazel()` as a
compile-time constant. Therefore,

```go
if !bazel.BuiltWithBazel() {
   skip.XXX()
}
```

is considered to always terminate execution (because `skip` does its
job by raising a panic), and any code coming after that is treated as
dead/unreachable.