### PR TITLE
cluster-ui: align card height in  details pages

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/insightsDetails.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/insightsDetails.module.scss
@@ -1,3 +1,6 @@
 .section {
   padding: 12px 24px 12px 0px;
+  display: flex;
+  flex-direction: column;
+  row-gap: 24px;
 }

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
@@ -94,7 +94,7 @@ export const StatementInsightDetailsOverviewTab: React.FC<
 
   return (
     <section className={cx("section")}>
-      <Row gutter={24}>
+      <Row gutter={24} type="flex">
         <Col span={12}>
           <SummaryCard>
             <SummaryCardItem

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsOverviewTab.tsx
@@ -26,12 +26,15 @@ import { WaitTimeDetailsTable } from "./insightDetailsTables";
 import { ContentionEvent, TxnInsightDetails } from "../types";
 
 import classNames from "classnames/bind";
-import insightTableStyles from "src/insightsTable/insightsTable.module.scss";
 import { CockroachCloudContext } from "../../contexts";
 import { TransactionDetailsLink } from "../workloadInsights/util";
 import { TimeScale } from "../../timeScaleDropdown";
 import { getTxnInsightRecommendations } from "../utils";
 
+import insightTableStyles from "src/insightsTable/insightsTable.module.scss";
+import insightsDetailsStyles from "src/insights/workloadInsightDetails/insightsDetails.module.scss";
+
+const cx = classNames.bind(insightsDetailsStyles);
 const tableCx = classNames.bind(insightTableStyles);
 
 export interface TransactionInsightDetailsStateProps {
@@ -101,16 +104,16 @@ export const TransactionInsightDetailsOverviewTab: React.FC<Props> = ({
 
   return (
     <div>
-      <section className={tableCx("section")}>
+      <section className={cx("section")}>
         <Row gutter={24}>
-          <Col className="gutter-row" span={24}>
+          <Col span={24}>
             <SqlBox value={insightQueries} size={SqlBoxSize.custom} />
           </Col>
         </Row>
         {insightDetails && (
           <>
-            <Row gutter={24}>
-              <Col className="gutter-row" span={12}>
+            <Row gutter={24} type="flex">
+              <Col span={12}>
                 <SummaryCard>
                   <SummaryCardItem
                     label="Start Time"
@@ -135,7 +138,7 @@ export const TransactionInsightDetailsOverviewTab: React.FC<Props> = ({
                   />
                 </SummaryCard>
               </Col>
-              <Col className="gutter-row" span={12}>
+              <Col span={12}>
                 <SummaryCard>
                   <SummaryCardItem
                     label="Number of Retries"
@@ -167,7 +170,7 @@ export const TransactionInsightDetailsOverviewTab: React.FC<Props> = ({
               </Col>
             </Row>
             <Row gutter={24} className={tableCx("margin-bottom")}>
-              <Col className="gutter-row" span={24}>
+              <Col span={24}>
                 <InsightsSortedTable
                   columns={insightsColumns}
                   data={insightRecs}
@@ -180,7 +183,7 @@ export const TransactionInsightDetailsOverviewTab: React.FC<Props> = ({
       {blockingExecutions?.length && insightDetails && (
         <section className={tableCx("section")}>
           <Row gutter={24}>
-            <Col className="gutter-row">
+            <Col>
               <Heading type="h5">
                 {WaitTimeInsightsLabels.BLOCKED_TXNS_TABLE_TITLE(
                   insightDetails.transactionExecutionID,

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/recentStatementDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/recentStatementDetailsOverviewTab.tsx
@@ -44,36 +44,30 @@ export const RecentStatementDetailsOverviewTab = ({
   return (
     <>
       <section className={cx("section", "section--container")}>
-        <Row gutter={24}>
+        <Row gutter={24} type="flex">
           <Col className="gutter-row" span={12}>
             <SummaryCard className={cx("summary-card")}>
-              <Row>
-                <Col>
-                  <SummaryCardItem
-                    label="Start Time (UTC)"
-                    value={statement.start.format(DATE_FORMAT_24_UTC)}
-                  />
-                  <SummaryCardItem
-                    label="Elapsed Time"
-                    value={Duration(
-                      statement.elapsedTime.asMilliseconds() * 1e6,
-                    )}
-                  />
-                  <SummaryCardItem
-                    label="Status"
-                    value={
-                      <>
-                        <StatusIcon status={statement.status} />
-                        {statement.status}
-                      </>
-                    }
-                  />
-                  <SummaryCardItem
-                    label="Full Scan"
-                    value={statement.isFullScan.toString()}
-                  />
-                </Col>
-              </Row>
+              <SummaryCardItem
+                label="Start Time (UTC)"
+                value={statement.start.format(DATE_FORMAT_24_UTC)}
+              />
+              <SummaryCardItem
+                label="Elapsed Time"
+                value={Duration(statement.elapsedTime.asMilliseconds() * 1e6)}
+              />
+              <SummaryCardItem
+                label="Status"
+                value={
+                  <>
+                    <StatusIcon status={statement.status} />
+                    {statement.status}
+                  </>
+                }
+              />
+              <SummaryCardItem
+                label="Full Scan"
+                value={statement.isFullScan.toString()}
+              />
             </SummaryCard>
           </Col>
           <Col className="gutter-row" span={12}>

--- a/pkg/ui/workspaces/cluster-ui/src/summaryCard/summaryCard.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/summaryCard/summaryCard.module.scss
@@ -1,11 +1,14 @@
 @import "../core/index.module";
 
 .summary--card {
+  display: flex;
+  flex-direction: column;
+  row-gap: 10px;
+  height: 100%;
   border-radius: 3px;
   box-shadow: 0 0 1px 0 rgba(67, 90, 111, 0.41);
   background-color: $adminui-white;
   padding: 24px;
-  margin-bottom: 15px;
   font-family: $font-family--base;
   font-size: $font-size--medium;
   h4 {
@@ -54,7 +57,6 @@
   &__item {
     display: flex;
     justify-content: space-between;
-    margin-bottom: 10px;
     &--label {
       font-family: $font-family--base;
       font-size: 14px;

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/recentTransactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/recentTransactionDetails.tsx
@@ -28,7 +28,7 @@ import {
 import { StatusIcon } from "src/recentExecutions/statusIcon";
 import summaryCardStyles from "src/summaryCard/summaryCard.module.scss";
 import { getMatchParamByName } from "src/util/query";
-import { executionIdAttr } from "../util";
+import { executionIdAttr, DATE_FORMAT_24_UTC } from "src/util";
 
 import styles from "../statementDetails/statementDetails.module.scss";
 import { WaitTimeInsightsPanel } from "src/detailsPanels/waitTimeInsightsPanel";
@@ -114,38 +114,32 @@ export const RecentTransactionDetails: React.FC<
           </Col>
         </Row>
         {transaction && (
-          <Row gutter={24}>
+          <Row gutter={24} type="flex">
             <Col className="gutter-row" span={12}>
               <SummaryCard className={cx("summary-card")}>
-                <Row>
-                  <Col>
-                    <SummaryCardItem
-                      label={RecentTxnInsightsLabels.START_TIME}
-                      value={transaction.start.format(
-                        "MMM D, YYYY [at] H:mm (UTC)",
-                      )}
-                    />
-                    <SummaryCardItem
-                      label={RecentTxnInsightsLabels.ELAPSED_TIME}
-                      value={Duration(
-                        transaction.elapsedTime.asMilliseconds() * 1e6,
-                      )}
-                    />
-                    <SummaryCardItem
-                      label={RecentTxnInsightsLabels.STATUS}
-                      value={
-                        <>
-                          <StatusIcon status={transaction.status} />
-                          {transaction.status}
-                        </>
-                      }
-                    />
-                    <SummaryCardItem
-                      label={RecentTxnInsightsLabels.PRIORITY}
-                      value={capitalize(transaction.priority)}
-                    />
-                  </Col>
-                </Row>
+                <SummaryCardItem
+                  label={RecentTxnInsightsLabels.START_TIME}
+                  value={transaction.start.format(DATE_FORMAT_24_UTC)}
+                />
+                <SummaryCardItem
+                  label={RecentTxnInsightsLabels.ELAPSED_TIME}
+                  value={Duration(
+                    transaction.elapsedTime.asMilliseconds() * 1e6,
+                  )}
+                />
+                <SummaryCardItem
+                  label={RecentTxnInsightsLabels.STATUS}
+                  value={
+                    <>
+                      <StatusIcon status={transaction.status} />
+                      {transaction.status}
+                    </>
+                  }
+                />
+                <SummaryCardItem
+                  label={RecentTxnInsightsLabels.PRIORITY}
+                  value={capitalize(transaction.priority)}
+                />
               </SummaryCard>
             </Col>
             <Col className="gutter-row" span={12}>


### PR DESCRIPTION
Fixes #87637

Previously, the cards in the active execution details pages were different heights due to the difference in the amount of content. This commit ensures all cards in the active executions and insights pages that are in the same row have the same height.

Release note: None


-----------------------------------------------

Txn insights:
![image](https://user-images.githubusercontent.com/20136951/204358350-96a7aa22-dc00-4651-b56b-31877d0516e0.png)

stmt details:
<img width="1912" alt="image" src="https://user-images.githubusercontent.com/20136951/204350990-e15834ce-21da-4369-b802-bb29ff73b922.png">

active stmts:
<img width="1910" alt="image" src="https://user-images.githubusercontent.com/20136951/204351086-6d7e0e55-b84b-444b-a0e0-9416fa9894ee.png">

active txns:
<img width="1737" alt="image" src="https://user-images.githubusercontent.com/20136951/204357955-4eed9f89-1b7a-4a85-995e-79178710bced.png">