### PR TITLE
config: acquire write lock when overwriting the map

### DIFF
--- a/pkg/config/system.go
+++ b/pkg/config/system.go
@@ -408,8 +408,8 @@ func (s *SystemConfig) GetZoneConfigForObject(
 // requested. Note, this function is only intended to be called during test
 // execution, such as logic tests.
 func (s *SystemConfig) PurgeZoneConfigCache() {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if len(s.mu.zoneCache) != 0 {
 		s.mu.zoneCache = map[ObjectID]zoneEntry{}
 	}


### PR DESCRIPTION
Previously, by mistake we were acquiring a read lock even though we do write operations in `PurgeZoneConfigCache`.

Fixes: #92519.

Release note: None