### PR TITLE
upgrades: make a couple of permanent upgrades idempotent

### DIFF
--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -293,12 +293,12 @@ var (
 	RangeIDGenerator = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("range-idgen")))
 	// StoreIDGenerator is the global store ID generator sequence.
 	StoreIDGenerator = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("store-idgen")))
-	//
 	// StatusPrefix specifies the key prefix to store all status details.
 	StatusPrefix = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("status-")))
 	// StatusNodePrefix stores all status info for nodes.
 	StatusNodePrefix = roachpb.Key(makeKey(StatusPrefix, roachpb.RKey("node-")))
-	//
+	// StartupMigrationPrefix specifies the key prefix to store all migration details.
+	StartupMigrationPrefix = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("system-version/")))
 	// TimeseriesPrefix is the key prefix for all timeseries data.
 	TimeseriesPrefix = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("tsd")))
 	// TimeseriesKeyMax is the maximum value for any timeseries data.

--- a/pkg/keys/doc.go
+++ b/pkg/keys/doc.go
@@ -242,15 +242,15 @@ var _ = [...]interface{}{
 	// 	2. System keys: This is where we store global, system data which is
 	// 	replicated across the cluster.
 	SystemPrefix,
-	NodeLivenessPrefix,    // "\x00liveness-"
-	BootstrapVersionKey,   // "bootstrap-version"
-	LegacyDescIDGenerator, // "desc-idgen"
-	NodeIDGenerator,       // "node-idgen"
-	RangeIDGenerator,      // "range-idgen"
-	StatusPrefix,          // "status-"
-	StatusNodePrefix,      // "status-node-"
-	StoreIDGenerator,      // "store-idgen"
-	// StartupMigrationPrefix, // "system-version/" - removed in 23.1
+	NodeLivenessPrefix,     // "\x00liveness-"
+	BootstrapVersionKey,    // "bootstrap-version"
+	LegacyDescIDGenerator,  // "desc-idgen"
+	NodeIDGenerator,        // "node-idgen"
+	RangeIDGenerator,       // "range-idgen"
+	StatusPrefix,           // "status-"
+	StatusNodePrefix,       // "status-node-"
+	StoreIDGenerator,       // "store-idgen"
+	StartupMigrationPrefix, // "system-version/"
 	// StartupMigrationLease,  // "system-version/lease" - removed in 23.1
 	TimeseriesPrefix,       // "tsd"
 	SystemSpanConfigPrefix, // "xffsys-scfg"

--- a/pkg/keys/sql.go
+++ b/pkg/keys/sql.go
@@ -163,6 +163,12 @@ func (e sqlEncoder) SequenceKey(tableID uint32) roachpb.Key {
 	return k
 }
 
+// StartupMigrationKeyPrefix returns the key prefix to store all startup
+// migration details.
+func (e sqlEncoder) StartupMigrationKeyPrefix() roachpb.Key {
+	return append(e.TenantPrefix(), StartupMigrationPrefix...)
+}
+
 // unexpected to avoid colliding with sqlEncoder.tenantPrefix.
 func (d sqlDecoder) tenantPrefix() roachpb.Key {
 	return *d.buf

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -1055,10 +1055,10 @@ func TestAdminAPIEvents(t *testing.T) {
 		{"create_database", false, 0, false, 3},
 		{"drop_table", false, 0, false, 2},
 		{"create_table", false, 0, false, 3},
-		{"set_cluster_setting", false, 0, false, 3},
+		{"set_cluster_setting", false, 0, false, 2},
 		// We use limit=true with no limit here because otherwise the
 		// expCount will mess up the expected total count below.
-		{"set_cluster_setting", true, 0, true, 3},
+		{"set_cluster_setting", true, 0, true, 2},
 		{"create_table", true, 0, false, 3},
 		{"create_table", true, -1, false, 3},
 		{"create_table", true, 2, false, 2},

--- a/pkg/upgrade/upgrades/permanent_upgrades.go
+++ b/pkg/upgrade/upgrades/permanent_upgrades.go
@@ -67,6 +67,25 @@ func optInToDiagnosticsStatReporting(
 	if cluster.TelemetryOptOut() {
 		return nil
 	}
+
+	// Check whether this is a cluster upgraded from a pre-23.1 version and the
+	// old startupmigration dealing with enabling diagnostics has already run. If
+	// it did, there's nothing for us to do - in particular, we don't want to
+	// enable diagnostics if the cluster was created with the TelemetryOptOut()
+	// env var.
+	{
+		codec := deps.Codec
+		oldMigrationName := "enable diagnostics reporting"
+		migrationKey := append(codec.StartupMigrationKeyPrefix(), roachpb.RKey(oldMigrationName)...)
+		kv, err := deps.DB.Get(ctx, migrationKey)
+		if err != nil {
+			return err
+		}
+		if kv.Exists() {
+			return nil
+		}
+	}
+
 	_, err := deps.InternalExecutor.Exec(
 		ctx, "optInToDiagnosticsStatReporting", nil, /* txn */
 		`SET CLUSTER SETTING diagnostics.reporting.enabled = true`)
@@ -126,7 +145,7 @@ func initializeClusterSecret(
 ) error {
 	_, err := deps.InternalExecutor.Exec(
 		ctx, "initializeClusterSecret", nil, /* txn */
-		`SET CLUSTER SETTING cluster.secret = gen_random_uuid()::STRING`,
+		`INSERT INTO system.settings (name, value, "lastUpdated", "valueType") VALUES ('cluster.secret', gen_random_uuid()::STRING, now(), 's') ON CONFLICT(name) DO NOTHING`,
 	)
 	return err
 }


### PR DESCRIPTION
Some of the permanent upgrades (opting into telemetry and initializing the cluster secret) were not idempotent; this patch makes them be. In particular, this is important since these upgrades will run on 23.1 cluster that are being upgraded from 22.2 as they've been turned from startupmigrations to upgrades in #91627. For the telemetry one, there's no "natural" way to make it idempotent, so I've added a check for the old startupmigration key.

Release note: None
Epic: None