### PR TITLE
ui: add link on txn insight details fingerprint

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/insightDetailsTables.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/insightDetailsTables.tsx
@@ -16,15 +16,22 @@ import {
   ContentionEvent,
   InsightExecEnum,
 } from "../types";
-import { insightsTableTitles, QueriesCell } from "../workloadInsights/util";
+import {
+  insightsTableTitles,
+  QueriesCell,
+  TransactionDetailsLink,
+} from "../workloadInsights/util";
+import { TimeScale } from "../../timeScaleDropdown";
 
 interface InsightDetailsTableProps {
   data: ContentionEvent[];
   execType: InsightExecEnum;
+  setTimeScale?: (tw: TimeScale) => void;
 }
 
 export function makeInsightDetailsColumns(
   execType: InsightExecEnum,
+  setTimeScale: (tw: TimeScale) => void,
 ): ColumnDescriptor<ContentionEvent>[] {
   return [
     {
@@ -36,7 +43,12 @@ export function makeInsightDetailsColumns(
     {
       name: "fingerprintID",
       title: insightsTableTitles.fingerprintID(execType),
-      cell: (item: ContentionEvent) => String(item.fingerprintID),
+      cell: (item: ContentionEvent) =>
+        TransactionDetailsLink(
+          item.fingerprintID,
+          item.startTime,
+          setTimeScale,
+        ),
       sort: (item: ContentionEvent) => item.fingerprintID,
     },
     {
@@ -87,7 +99,7 @@ export function makeInsightDetailsColumns(
 export const WaitTimeDetailsTable: React.FC<
   InsightDetailsTableProps
 > = props => {
-  const columns = makeInsightDetailsColumns(props.execType);
+  const columns = makeInsightDetailsColumns(props.execType, props.setTimeScale);
   return (
     <SortedTable className="statements-table" columns={columns} {...props} />
   );

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetailsOverviewTab.tsx
@@ -191,6 +191,7 @@ export const TransactionInsightDetailsOverviewTab: React.FC<Props> = ({
                 <WaitTimeDetailsTable
                   data={blockingExecutions}
                   execType={insightDetails.execType}
+                  setTimeScale={setTimeScale}
                 />
               </div>
             </Col>


### PR DESCRIPTION
Previously, the fingerprint id showing on the
contention table inside the transaction insights details didn't have a link to the fingerprint details page. This commit adds the link, including the proper setTimeScale to use the start time of the selected transaction.

Fixes #91291

https://www.loom.com/share/53055cfc6b494e1bb7d11bba54252b22

Release note (ui change): Add link on fingerprint ID on high contention table inside Transaction Insights Details page.