### PR TITLE
sql: Fix create partial stats test cases

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -1301,6 +1301,11 @@ func insertJSONStatistic(
 	}
 
 	if !settings.Version.IsActive(ctx, clusterversion.V23_1AddPartialStatisticsPredicateCol) {
+
+		if s.PartialPredicate != "" {
+			return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState, "statistic for columns %v with collection time %s to insert is partial but cluster version is below 23.1", s.Columns, s.CreatedAt)
+		}
+
 		_ /* rows */, err := ie.Exec(
 			ctx,
 			"insert-stats",
@@ -1327,6 +1332,12 @@ func insertJSONStatistic(
 			histogram)
 		return err
 	}
+
+	var predicateValue interface{}
+	if s.PartialPredicate != "" {
+		predicateValue = s.PartialPredicate
+	}
+
 	_ /* rows */, err := ie.Exec(
 		ctx,
 		"insert-stats",
@@ -1352,7 +1363,7 @@ func insertJSONStatistic(
 		s.NullCount,
 		s.AvgSize,
 		histogram,
-		s.PartialPredicate,
+		predicateValue,
 	)
 	return err
 }

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -1958,11 +1958,6 @@ SELECT * FROM indexed_arr WHERE a @> ARRAY[100]
 
 # Test single column partial statistics creation.
 
-# Disable auto stats collection to avoid new full stats collection
-# when inserting values into the extremes in the table.
-statement ok
-SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false;
-
 statement ok
 CREATE TABLE abcd (a INT PRIMARY KEY, b INT, c INT, d INT, INDEX (c, d));
 
@@ -2085,6 +2080,16 @@ INSERT INTO a_null VALUES (NULL), (1), (2);
 statement ok
 CREATE STATISTICS a_null_stat ON a FROM a_null;
 
+let $a_null_stats
+SHOW STATISTICS USING JSON FOR TABLE a_null
+
+# Inject statistics so that the current stats
+# cache is invalidated and creating partial
+# statistics has access to the latest full
+# statistic.
+statement ok
+ALTER TABLE a_null INJECT STATISTICS '$a_null_stats'
+
 statement ok
 INSERT INTO a_null VALUES (NULL), (NULL), (NULL);
 
@@ -2116,6 +2121,16 @@ INSERT INTO d_desc VALUES (1, 10), (2, 20), (3, 30), (4, 40);
 statement ok
 CREATE STATISTICS sd ON a FROM d_desc;
 
+let $d_desc_stats
+SHOW STATISTICS USING JSON FOR TABLE d_desc;
+
+# Inject statistics so that the current stats
+# cache is invalidated and creating partial
+# statistics has access to the latest full
+# statistic.
+statement ok
+ALTER TABLE d_desc INJECT STATISTICS '$d_desc_stats'
+
 statement ok
 INSERT INTO d_desc VALUES (0, 0), (5, 50);
 
@@ -2145,6 +2160,16 @@ INSERT INTO d_desc VALUES (NULL, NULL), (NULL, 2);
 
 statement ok
 CREATE STATISTICS sdn ON a FROM d_desc;
+
+let $d_desc_null_stats
+SHOW STATISTICS USING JSON FOR TABLE d_desc;
+
+# Inject statistics so that the current stats
+# cache is invalidated and creating partial
+# statistics has access to the latest full
+# statistic.
+statement ok
+ALTER TABLE d_desc INJECT STATISTICS '$d_desc_null_stats'
 
 statement ok
 CREATE STATISTICS sdnp ON a FROM d_desc USING EXTREMES;
@@ -2176,13 +2201,26 @@ statement error pq: table xy does not contain a non-partial forward index with y
 CREATE STATISTICS xy_y_partial ON y FROM xy USING EXTREMES;
 
 statement ok
-DELETE FROM a_null WHERE a IS NOT NULL;
+CREATE TABLE only_null (a INT, INDEX (a));
 
 statement ok
-CREATE STATISTICS a_null_stat ON a FROM a_null;
+INSERT INTO only_null VALUES (NULL), (NULL), (NULL);
+
+statement ok
+CREATE STATISTICS only_null_stat ON a FROM only_null;
+
+let $only_null_stat
+SHOW STATISTICS USING JSON FOR TABLE only_null;
+
+# Inject statistics so that the current stats
+# cache is invalidated and creating partial
+# statistics has access to the latest full
+# statistic.
+statement ok
+ALTER TABLE only_null INJECT STATISTICS '$only_null_stat';
 
 statement error pq: only NULL values exist in the index, so partial stats cannot be collected
-CREATE STATISTICS only_null_partial ON a FROM a_null USING EXTREMES;
+CREATE STATISTICS only_null_partial ON a FROM only_null USING EXTREMES;
 
 statement ok
 CREATE INDEX ON xy (y) WHERE y > 5;


### PR DESCRIPTION
This commit modifies the create partial statistics test cases to ensure that the full table statistics that are to be used to create a partial statistic exist in the cache. Previously, this was not the case so certain tests had non-deterministic outputs causing failures in stress tests.

Resolves: #92495 and #92559

Epic: CRDB-19449

Release note: None