### PR TITLE
sqlproxycc: allow routing with composite db names

### DIFF
--- a/pkg/ccl/sqlproxyccl/proxy_handler.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler.go
@@ -768,7 +768,7 @@ func parseDatabaseParam(databaseParam string) (clusterIdentifier, databaseName s
 		return "", "", nil
 	}
 
-	parts := strings.Split(databaseParam, ".")
+	parts := strings.SplitN(databaseParam, ".", 2)
 
 	// Database param provided without cluster name.
 	if len(parts) <= 1 {
@@ -778,7 +778,7 @@ func parseDatabaseParam(databaseParam string) (clusterIdentifier, databaseName s
 	clusterIdentifier, databaseName = parts[0], parts[1]
 
 	// Ensure that the param is in the right format if the delimiter is provided.
-	if len(parts) > 2 || clusterIdentifier == "" || databaseName == "" {
+	if clusterIdentifier == "" || databaseName == "" {
 		return "", "", errors.New("invalid database param")
 	}
 

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -1812,6 +1812,15 @@ func TestClusterNameAndTenantFromParams(t *testing.T) {
 				clusterIdentifierHint,
 		},
 		{
+			name: "composite db name",
+			params: map[string]string{
+				"database": "happy-koala-7.my.db",
+			},
+			expectedClusterName: "happy-koala",
+			expectedTenantID:    7,
+			expectedParams:      map[string]string{"database": "my.db"},
+		},
+		{
 			name: "invalid cluster identifier in database param",
 			params: map[string]string{
 				// Cluster names need to be between 6 to 100 alphanumeric characters.


### PR DESCRIPTION
Fixes #92526.
Epic: CRDB-22385

Release note (bug fix): It is now possible to connect a SQL client to a database whose name contains a period (`.`) in CockroachCloud Serverless.