### PR TITLE
upgrademanager: clarify job running code

### DIFF
--- a/pkg/jobs/wait.go
+++ b/pkg/jobs/wait.go
@@ -36,11 +36,11 @@ func (r *Registry) NotifyToAdoptJobs() {
 	}
 }
 
-// NotifyToResume is used to notify the registry that it should attempt
-// to resume the specified jobs. The assumption is that these jobs were
-// created by this registry and thus are pre-claimed by it. This bypasses
-// the loop to discover jobs already claimed by this registry. If the jobs
-// turn out to not be claimed by this registry, it's not a problem.
+// NotifyToResume is used to notify the registry that it should attempt to
+// resume the specified jobs. The assumption is that these jobs were created by
+// this registry and thus are pre-claimed by it. This bypasses the loop to
+// discover jobs already claimed by this registry. Jobs that are not claimed by
+// this registry are silently ignored.
 func (r *Registry) NotifyToResume(ctx context.Context, jobs ...jobspb.JobID) {
 	m := newJobIDSet(jobs...)
 	_ = r.stopper.RunAsyncTask(ctx, "resume-jobs", func(ctx context.Context) {


### PR DESCRIPTION
This patch makes the code clearer around running upgrade in jobs. Before this patch, the upgrade manager was looking for existing jobs corresponding to upgrades and, if it found them, it called jobsRegistry.Run() on them - just like it did for newly-created jobs. The behavior of Run() for jobs that are not already claimed by the registry is a bit under-specified. I believe it ended up printing an error [1] and then correctly waiting for the job to finish.

This patch no longer calls Run() for existing jobs; instead, it calls WaitForJobs(), which is more suggestive.

[1] https://github.com/cockroachdb/cockroach/blob/b2a6b80920324bd6b31cba9a6f622961979de600/pkg/jobs/adopt.go#L255

Release note: None
Epic: None