### PR TITLE
kvcoord: default closed timestamp policy to LEAD_FOR_GLOBAL_READS

### DIFF
--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -198,6 +198,7 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/metric",
         "//pkg/util/netutil",
+        "//pkg/util/protoutil",
         "//pkg/util/randutil",
         "//pkg/util/retry",
         "//pkg/util/shuffle",

--- a/pkg/kv/kvclient/kvcoord/range_iter.go
+++ b/pkg/kv/kvclient/kvcoord/range_iter.go
@@ -103,7 +103,12 @@ func (ri *RangeIterator) ClosedTimestampPolicy() roachpb.RangeClosedTimestampPol
 	if !ri.Valid() {
 		panic(ri.Error())
 	}
-	return ri.token.ClosedTimestampPolicy()
+	// TODO(ajwerner): We default the closed timestamp policy here to
+	// LAG_BY_CLUSTER_SETTING, which is pessimistic. When sending batch requests,
+	// we default the policy to LEAD_FOR_GLOBAL_READS. The reasoning for this
+	// difference is not deeply principled. Consider unifying them.
+	const defaultPolicy = roachpb.LAG_BY_CLUSTER_SETTING
+	return ri.token.ClosedTimestampPolicy(defaultPolicy)
 }
 
 // Token returns the eviction token corresponding to the range

--- a/pkg/kv/kvclient/rangecache/range_cache.go
+++ b/pkg/kv/kvclient/rangecache/range_cache.go
@@ -86,6 +86,11 @@ const (
 	ReadFromLeaseholder = roachpb.READ_UNCOMMITTED
 )
 
+// UnknownClosedTimestampPolicy is used to mark on a CacheEntry that the closed
+// timestamp policy is not known. This value is never serialized into
+// RangeInfo or any other message which uses the type.
+const UnknownClosedTimestampPolicy roachpb.RangeClosedTimestampPolicy = -1
+
 // RangeDescriptorDB is a type which can query range descriptors from an
 // underlying datastore. This interface is used by RangeCache to
 // initially retrieve information which will be cached.
@@ -376,11 +381,16 @@ func (et EvictionToken) LeaseSeq() roachpb.LeaseSequence {
 }
 
 // ClosedTimestampPolicy returns the cache's current understanding of the
-// range's closed timestamp policy. If no policy is known, the default policy of
-// LAG_BY_CLUSTER_SETTING is returned.
-func (et EvictionToken) ClosedTimestampPolicy() roachpb.RangeClosedTimestampPolicy {
+// range's closed timestamp policy. If no policy is known, the _default
+// is returned.
+func (et EvictionToken) ClosedTimestampPolicy(
+	_default roachpb.RangeClosedTimestampPolicy,
+) roachpb.RangeClosedTimestampPolicy {
 	if !et.Valid() {
 		panic("invalid ClosedTimestampPolicy() call on empty EvictionToken")
+	}
+	if et.closedts == UnknownClosedTimestampPolicy {
+		return _default
 	}
 	return et.closedts
 }
@@ -969,10 +979,10 @@ func tryLookupImpl(
 		// We don't have any lease information.
 		lease: roachpb.Lease{},
 		// We don't know the closed timestamp policy.
-		closedts: roachpb.LAG_BY_CLUSTER_SETTING,
+		closedts: UnknownClosedTimestampPolicy,
 	}
 	for i, preR := range preRs {
-		newEntries[i+1] = &CacheEntry{desc: preR}
+		newEntries[i+1] = &CacheEntry{desc: preR, closedts: UnknownClosedTimestampPolicy}
 	}
 	insertedEntries := rc.insertLockedInner(ctx, newEntries)
 	// entry corresponds to rs[0], which is the descriptor covering the key
@@ -1007,7 +1017,7 @@ func tryLookupImpl(
 		entry = &CacheEntry{
 			desc:     rs[0],
 			lease:    roachpb.Lease{},
-			closedts: roachpb.LAG_BY_CLUSTER_SETTING,
+			closedts: UnknownClosedTimestampPolicy,
 		}
 	}
 	if len(rs) == 1 {

--- a/pkg/kv/kvclient/rangecache/range_cache_test.go
+++ b/pkg/kv/kvclient/rangecache/range_cache_test.go
@@ -382,6 +382,19 @@ func TestRangeCacheAssumptions(t *testing.T) {
 	}
 }
 
+// requireTokenDoesNotHaveClosedTimestampPolicy is a helper to assert that the
+// ClosedTimestampPolicy method on the EvictionToken is going to return its
+// argument.
+func requireTokenDoesNotHaveClosedTimestampPolicy(t *testing.T, et EvictionToken) {
+	t.Helper()
+	for _, _default := range []roachpb.RangeClosedTimestampPolicy{
+		roachpb.LAG_BY_CLUSTER_SETTING,
+		roachpb.LEAD_FOR_GLOBAL_READS,
+	} {
+		require.Equal(t, _default, et.ClosedTimestampPolicy(_default))
+	}
+}
+
 // TestRangeCache is a simple test which verifies that metadata ranges
 // are being cached and retrieved properly. It sets up a fake backing
 // store for the cache, and measures how often that backing store is
@@ -396,7 +409,9 @@ func TestRangeCache(t *testing.T) {
 	// Totally uncached range.
 	//  Retrieves [meta(min),meta(g)) and [a,b).
 	//  Prefetches [meta(g),meta(m)), [meta(m),meta(s)), [b,c), and [c,d).
-	doLookup(ctx, db.cache, "aa")
+	_, token := doLookup(ctx, db.cache, "aa")
+	// Assert that the token does not have a closed timestamp policy.
+	requireTokenDoesNotHaveClosedTimestampPolicy(t, token)
 	db.assertLookupCountEq(t, 2, "aa")
 
 	// Descriptors for the following ranges should be cached.
@@ -1487,25 +1502,30 @@ func TestRangeCacheEvictAndReplace(t *testing.T) {
 	defer stopper.Stop(ctx)
 	cache := NewRangeCache(st, nil, staticSize(2<<10), stopper, tr)
 
-	ri := roachpb.RangeInfo{Desc: desc1}
+	ri := roachpb.RangeInfo{
+		Desc:                  desc1,
+		ClosedTimestampPolicy: UnknownClosedTimestampPolicy,
+	}
 	cache.Insert(ctx, ri)
-
+	const lag, lead = roachpb.LAG_BY_CLUSTER_SETTING, roachpb.LEAD_FOR_GLOBAL_READS
 	// Check that initially the cache has an empty lease and a default
 	// closed timestamp policy.
 	tok, err := cache.LookupWithEvictionToken(ctx, startKey, EvictionToken{}, false /* useReverseScan */)
 	require.NoError(t, err)
 	require.Equal(t, desc1, *tok.Desc())
 	require.Nil(t, tok.Leaseholder())
-	require.Equal(t, roachpb.LAG_BY_CLUSTER_SETTING, tok.ClosedTimestampPolicy())
+	requireTokenDoesNotHaveClosedTimestampPolicy(t, tok)
 
 	// EvictAndReplace() with a new descriptor.
 	ri.Desc = desc2
+	ri.ClosedTimestampPolicy = 0
 	tok.EvictAndReplace(ctx, ri)
 	tok, err = cache.LookupWithEvictionToken(ctx, startKey, tok, false /* useReverseScan */)
 	require.NoError(t, err)
 	require.Equal(t, desc2, *tok.Desc())
 	require.Nil(t, tok.Leaseholder())
-	require.Equal(t, roachpb.LAG_BY_CLUSTER_SETTING, tok.ClosedTimestampPolicy())
+	// Note that we now have a definitive closed timestamp policy.
+	require.Equal(t, lag, tok.ClosedTimestampPolicy(lead))
 
 	// EvictAndReplace() with a new lease.
 	ri.Lease = roachpb.Lease{
@@ -1519,10 +1539,10 @@ func TestRangeCacheEvictAndReplace(t *testing.T) {
 	require.NotNil(t, tok.Leaseholder())
 	require.Equal(t, rep1, *tok.Leaseholder())
 	require.Equal(t, roachpb.LeaseSequence(1), tok.LeaseSeq())
-	require.Equal(t, roachpb.LAG_BY_CLUSTER_SETTING, tok.ClosedTimestampPolicy())
+	require.Equal(t, lag, tok.ClosedTimestampPolicy(lead))
 
 	// EvictAndReplace() with a new closed timestamp policy.
-	ri.ClosedTimestampPolicy = roachpb.LEAD_FOR_GLOBAL_READS
+	ri.ClosedTimestampPolicy = lead
 	tok.EvictAndReplace(ctx, ri)
 	tok, err = cache.LookupWithEvictionToken(ctx, startKey, tok, false /* useReverseScan */)
 	require.NoError(t, err)
@@ -1530,7 +1550,7 @@ func TestRangeCacheEvictAndReplace(t *testing.T) {
 	require.NotNil(t, tok.Leaseholder())
 	require.Equal(t, rep1, *tok.Leaseholder())
 	require.Equal(t, roachpb.LeaseSequence(1), tok.LeaseSeq())
-	require.Equal(t, roachpb.LEAD_FOR_GLOBAL_READS, tok.ClosedTimestampPolicy())
+	require.Equal(t, lead, tok.ClosedTimestampPolicy(lag))
 
 	// EvictAndReplace() with a speculative descriptor. Should update decriptor,
 	// remove lease, and retain closed timestamp policy.
@@ -1540,7 +1560,7 @@ func TestRangeCacheEvictAndReplace(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, desc3, *tok.Desc())
 	require.Nil(t, tok.Leaseholder())
-	require.Equal(t, roachpb.LEAD_FOR_GLOBAL_READS, tok.ClosedTimestampPolicy())
+	require.Equal(t, lead, tok.ClosedTimestampPolicy(lag))
 }
 
 // TestRangeCacheSyncTokenAndMaybeUpdateCache tests
@@ -1618,7 +1638,7 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 	cache := NewRangeCache(st, nil, staticSize(2<<10), stopper, tr)
-
+	const lag, lead = roachpb.LAG_BY_CLUSTER_SETTING, roachpb.LEAD_FOR_GLOBAL_READS
 	testCases := []struct {
 		name   string
 		testFn func(*testing.T, *RangeCache)
@@ -1629,7 +1649,7 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 				cache.Insert(ctx, roachpb.RangeInfo{
 					Desc:                  desc1,
 					Lease:                 roachpb.Lease{},
-					ClosedTimestampPolicy: roachpb.LEAD_FOR_GLOBAL_READS,
+					ClosedTimestampPolicy: lead,
 				})
 
 				// Check that initially the cache has an empty lease. Then, we'll
@@ -1639,7 +1659,7 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, desc1, *tok.Desc())
 				require.Nil(t, tok.Leaseholder())
-				require.Equal(t, roachpb.LEAD_FOR_GLOBAL_READS, tok.ClosedTimestampPolicy())
+				require.Equal(t, lead, tok.ClosedTimestampPolicy(lead))
 
 				l := &roachpb.Lease{
 					Replica:  rep1,
@@ -1650,12 +1670,12 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 				require.True(t, updatedLeaseholder)
 				require.Equal(t, oldTok.Desc(), tok.Desc())
 				require.Equal(t, &l.Replica, tok.Leaseholder())
-				require.Equal(t, oldTok.ClosedTimestampPolicy(), tok.ClosedTimestampPolicy())
+				require.Equal(t, oldTok.ClosedTimestampPolicy(lag), tok.ClosedTimestampPolicy(lag))
 				ri := cache.GetCached(ctx, startKey, false /* inverted */)
 				require.NotNil(t, ri)
 				require.Equal(t, desc1, *ri.Desc())
 				require.Equal(t, rep1, ri.Lease().Replica)
-				require.Equal(t, roachpb.LEAD_FOR_GLOBAL_READS, ri.ClosedTimestampPolicy())
+				require.Equal(t, lead, ri.ClosedTimestampPolicy())
 
 				// Ensure evicting the lease doesn't remove the closed timestamp
 				// policy/desc.
@@ -1663,12 +1683,12 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 				tok.EvictLease(ctx)
 				require.Equal(t, oldTok.Desc(), tok.Desc())
 				require.Nil(t, tok.Leaseholder())
-				require.Equal(t, oldTok.ClosedTimestampPolicy(), tok.ClosedTimestampPolicy())
+				require.Equal(t, oldTok.ClosedTimestampPolicy(lag), tok.ClosedTimestampPolicy(lag))
 				ri = cache.GetCached(ctx, startKey, false /* inverted */)
 				require.NotNil(t, ri)
 				require.Equal(t, desc1, *ri.Desc())
 				require.True(t, ri.lease.Empty())
-				require.Equal(t, roachpb.LEAD_FOR_GLOBAL_READS, ri.ClosedTimestampPolicy())
+				require.Equal(t, lead, ri.ClosedTimestampPolicy())
 			},
 		},
 		{
@@ -1680,7 +1700,7 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 				cache.Insert(ctx, roachpb.RangeInfo{
 					Desc:                  desc1,
 					Lease:                 roachpb.Lease{},
-					ClosedTimestampPolicy: roachpb.LEAD_FOR_GLOBAL_READS,
+					ClosedTimestampPolicy: lead,
 				})
 				tok, err := cache.LookupWithEvictionToken(
 					ctx, startKey, EvictionToken{}, false /* useReverseScan */)
@@ -1699,7 +1719,7 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 				require.Equal(t, &desc2, tok.Desc())
 				require.Equal(t, &rep2, tok.Leaseholder())
 				require.Equal(t, tok.lease.Replica, rep2)
-				require.Equal(t, roachpb.LEAD_FOR_GLOBAL_READS, tok.ClosedTimestampPolicy())
+				require.Equal(t, lead, tok.ClosedTimestampPolicy(lag))
 			},
 		},
 		{
@@ -1712,7 +1732,7 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 				cache.Insert(ctx, roachpb.RangeInfo{
 					Desc:                  desc1,
 					Lease:                 roachpb.Lease{},
-					ClosedTimestampPolicy: roachpb.LEAD_FOR_GLOBAL_READS,
+					ClosedTimestampPolicy: lead,
 				})
 				tok, err := cache.LookupWithEvictionToken(
 					ctx, startKey, EvictionToken{}, false /* useReverseScan */)
@@ -1726,7 +1746,7 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 				cache.Insert(ctx, roachpb.RangeInfo{
 					Desc:                  desc3,
 					Lease:                 l,
-					ClosedTimestampPolicy: roachpb.LEAD_FOR_GLOBAL_READS,
+					ClosedTimestampPolicy: lead,
 				})
 				updatedLeaseholder := tok.SyncTokenAndMaybeUpdateCache(ctx, &l, &desc2)
 				require.False(t, updatedLeaseholder)
@@ -1734,7 +1754,7 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 				require.Equal(t, &desc3, tok.Desc())
 				require.Equal(t, &rep2, tok.Leaseholder())
 				require.Equal(t, tok.lease.Replica, rep2)
-				require.Equal(t, roachpb.LEAD_FOR_GLOBAL_READS, tok.ClosedTimestampPolicy())
+				require.Equal(t, lead, tok.ClosedTimestampPolicy(lag))
 			},
 		},
 		{
@@ -1748,7 +1768,7 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 						Replica:  rep3,
 						Sequence: 4,
 					},
-					ClosedTimestampPolicy: roachpb.LEAD_FOR_GLOBAL_READS,
+					ClosedTimestampPolicy: lead,
 				})
 				tok, err := cache.LookupWithEvictionToken(
 					ctx, startKey, EvictionToken{}, false, /* useReverseScan */
@@ -1763,7 +1783,7 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 				require.Equal(t, &desc2, tok.Desc())
 				require.Equal(t, &rep3, tok.Leaseholder())
 				require.Equal(t, tok.lease.Replica, rep3)
-				require.Equal(t, roachpb.LEAD_FOR_GLOBAL_READS, tok.ClosedTimestampPolicy())
+				require.Equal(t, lead, tok.ClosedTimestampPolicy(lag))
 			},
 		},
 		{
@@ -1777,7 +1797,7 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 						Replica:  rep3,
 						Sequence: 4,
 					},
-					ClosedTimestampPolicy: roachpb.LEAD_FOR_GLOBAL_READS,
+					ClosedTimestampPolicy: lead,
 				})
 				tok, err := cache.LookupWithEvictionToken(
 					ctx, startKey, EvictionToken{}, false, /* useReverseScan */
@@ -1792,7 +1812,7 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 				require.Equal(t, &desc2, tok.Desc())
 				require.Equal(t, &rep3, tok.Leaseholder())
 				require.Equal(t, tok.lease.Replica, rep3)
-				require.Equal(t, roachpb.LEAD_FOR_GLOBAL_READS, tok.ClosedTimestampPolicy())
+				require.Equal(t, lead, tok.ClosedTimestampPolicy(lag))
 			},
 		},
 		{
@@ -1807,7 +1827,7 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 						Replica:  rep3,
 						Sequence: 4,
 					},
-					ClosedTimestampPolicy: roachpb.LEAD_FOR_GLOBAL_READS,
+					ClosedTimestampPolicy: lead,
 				})
 				tok, err := cache.LookupWithEvictionToken(
 					ctx, startKey, EvictionToken{}, false, /* useReverseScan */
@@ -1821,7 +1841,7 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 				require.NotNil(t, tok)
 				require.Equal(t, &desc3, tok.Desc())
 				require.Nil(t, tok.Leaseholder())
-				require.Equal(t, roachpb.LEAD_FOR_GLOBAL_READS, tok.ClosedTimestampPolicy())
+				require.Equal(t, lead, tok.ClosedTimestampPolicy(lag))
 			},
 		},
 		{
@@ -1838,7 +1858,7 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 						Replica:  rep3,
 						Sequence: 4,
 					},
-					ClosedTimestampPolicy: roachpb.LEAD_FOR_GLOBAL_READS,
+					ClosedTimestampPolicy: lead,
 				})
 				tok, err := cache.LookupWithEvictionToken(
 					ctx, startKey, EvictionToken{}, false, /* useReverseScan */
@@ -1874,7 +1894,7 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 				cache.Insert(ctx, roachpb.RangeInfo{
 					Desc:                  desc2,
 					Lease:                 l,
-					ClosedTimestampPolicy: roachpb.LEAD_FOR_GLOBAL_READS,
+					ClosedTimestampPolicy: lead,
 				})
 				tok, err := cache.LookupWithEvictionToken(
 					ctx, startKey, EvictionToken{}, false, /* useReverseScan */
@@ -1907,7 +1927,7 @@ func TestRangeCacheSyncTokenAndMaybeUpdateCache(t *testing.T) {
 						Replica:  rep3,
 						Sequence: 2,
 					},
-					ClosedTimestampPolicy: roachpb.LEAD_FOR_GLOBAL_READS,
+					ClosedTimestampPolicy: lead,
 				})
 				tok, err := cache.LookupWithEvictionToken(
 					ctx, startKey, EvictionToken{}, false, /* useReverseScan */


### PR DESCRIPTION
Today if we do not know about the ClosedTimestampPolicy we'll route the
request to the nearest *voting* replica. This replica may be in a remote
region. Not knowing these things is the common case when starting up a
server.

Epic: CRDB-18596

Release note: None