### PR TITLE
ui: update sql error tooltip

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -116,7 +116,7 @@ export default function (props: GraphDashboardProps) {
       title="SQL Statement Errors"
       sources={nodeSources}
       tooltip={
-        "The number of statements which returned a planning or runtime error."
+        "The number of statements which returned a planning, runtime, or client-side retry error."
       }
     >
       <Axis label="errors">


### PR DESCRIPTION
Update tooltip on `SQL Statement Errors` chart on
Metrics page, to align with the description from our documentation.

Fixes #91094

Release note (ui change): Update tooltip on `SQL Statement Errors` chart on Metrics page.