### PR TITLE
tree: fix internal error comparing tuple type with non-tuple type

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/datetime
+++ b/pkg/sql/logictest/testdata/logic_test/datetime
@@ -2000,3 +2000,13 @@ ORDER BY a.attnum
 ----
 interval_col  interval  'P3Y'::INTERVAL
 rowid         bigint    unique_rowid()
+
+statement error pq: unsupported comparison operator: <tuple> < <string>
+SELECT * FROM ex WHERE () < '1970-01-02 00:00:01.000001-04';
+
+statement error pq: could not parse \"1970-01-02 00:00:01.000001-04\" as type tuple{timestamptz}: record must be enclosed in \( and \)
+SELECT * FROM ex WHERE ROW('1970-01-02 00:00:01.000001-04'::TIMESTAMPTZ) < '1970-01-02 00:00:01.000001-04';
+
+query TTTTT
+SELECT * FROM ex WHERE ROW('1970-01-03 00:00:01.000001-04'::TIMESTAMPTZ) < ROW('1970-01-02 00:00:01.000001-04');
+----

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -2161,6 +2161,7 @@ func typeCheckComparisonOp(
 	rightTuple, rightIsTuple := foldedRight.(*Tuple)
 
 	_, rightIsSubquery := foldedRight.(SubqueryExpr)
+	handleTupleTypeMismatch := false
 	switch {
 	case foldedOp.Symbol == treecmp.In && rightIsTuple:
 		sameTypeExprs := make([]Expr, len(rightTuple.Exprs)+1)
@@ -2238,6 +2239,18 @@ func typeCheckComparisonOp(
 			return nil, nil, nil, false, err
 		}
 		return typedLeft, typedRight, fn, false, nil
+
+	case leftIsTuple || rightIsTuple:
+		// Tuple must compare with a tuple type, as handled above.
+		typedLeft, errLeft := foldedLeft.TypeCheck(ctx, semaCtx, types.Any)
+		typedRight, errRight := foldedRight.TypeCheck(ctx, semaCtx, types.Any)
+		if errLeft == nil && errRight == nil &&
+			((typedLeft.ResolvedType().Family() == types.TupleFamily &&
+				typedRight.ResolvedType().Family() != types.TupleFamily) ||
+				(typedRight.ResolvedType().Family() == types.TupleFamily &&
+					typedLeft.ResolvedType().Family() != types.TupleFamily)) {
+			handleTupleTypeMismatch = true
+		}
 	}
 
 	// For comparisons, we do not stimulate the typing of untyped NULL with the
@@ -2286,7 +2299,7 @@ func typeCheckComparisonOp(
 	genericComparison := leftIsGeneric && rightIsGeneric
 
 	typeMismatch := false
-	if genericComparison && !nullComparison {
+	if (genericComparison || handleTupleTypeMismatch) && !nullComparison {
 		// A generic comparison (one between two generic types, like arrays) is not
 		// well-typed if the two input types are not equivalent, unless one of the
 		// sides is NULL.

--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -337,6 +337,8 @@ func TestTypeCheckError(t *testing.T) {
 			`1 + 2::d.s.typ`,
 			`type "d.s.typ" does not exist`,
 		},
+		{`() = '03:00:00'`, `unsupported comparison operator: <tuple> = <string>`},
+		{`'03:00:00' > ROW()`, `unsupported comparison operator: <string> > <tuple>`},
 	}
 	ctx := context.Background()
 	for _, d := range testData {


### PR DESCRIPTION
Fixes #91532

This fixes comparison of an empty tuple expression, ROW() or (), or
a non-empty tuple expression with a non-tuple type by returning
an error message instead of an internal error.

Release note (bug fix): This fixes an internal error when comparing
a tuple type with a non-tuple type.