### PR TITLE
backupccl: add restore corrupt descriptor validation test

### DIFF
--- a/pkg/ccl/backupccl/datadriven_test.go
+++ b/pkg/ccl/backupccl/datadriven_test.go
@@ -754,6 +754,8 @@ func TestDataDriven(t *testing.T) {
 						jobutils.WaitForJobToPause(t, runner, jobID)
 					case "failed":
 						jobutils.WaitForJobToFail(t, runner, jobID)
+					case "reverting":
+						jobutils.WaitForJobReverting(t, runner, jobID)
 					default:
 						t.Fatalf("unknown state %s", state)
 					}

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-check-descriptors
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-check-descriptors
@@ -1,0 +1,62 @@
+# This test checks that restore automatically detects a corrupt restoring
+# descriptor and enters the reverting state (i.e. an infinite OnFailOrCancel
+# loop with exponential back off, as Restore's OnFailOrCancel implementation
+# cannot fix this specific corrupt descriptor problem automatically) and does
+# not publish restoring database with the corrupt descriptor.
+
+new-server name=s1
+----
+
+exec-sql
+CREATE DATABASE testdb;
+CREATE TABLE testdb.parent (k INT PRIMARY KEY, v STRING);
+INSERT INTO testdb.parent (k, v) VALUES (1, 'a');
+CREATE TABLE testdb.child (k INT NOT NULL, FOREIGN KEY (k) REFERENCES testdb.parent (k))
+----
+
+exec-sql
+BACKUP INTO 'nodelocal://1/full_cluster_backup/';
+----
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = 'restore.before_publishing_descriptors';
+----
+
+# Rename the original testdb.child table to make it easier to invalidate the restoring child table.
+exec-sql
+ALTER TABLE testdb.child RENAME TO cool_cousin;
+----
+
+restore expect-pausepoint tag=a
+RESTORE DATABASE testdb FROM LATEST IN 'nodelocal://1/full_cluster_backup/' with new_db_name='d2'
+----
+job paused at pausepoint
+
+# Corrupt the child, the restoring table descriptor that has been written but not published
+exec-sql
+SELECT crdb_internal.unsafe_delete_descriptor(id) FROM system.namespace WHERE name = 'child'
+----
+
+exec-sql
+SELECT crdb_internal.unsafe_delete_namespace_entry("parentID", "parentSchemaID", name, id) FROM system.namespace WHERE name = 'child'
+----
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = '';
+----
+
+
+job resume=a
+----
+
+job tag=a wait-for-state=reverting
+----
+
+query-sql regex=(prefetch descriptors: referenced descriptor ID .*: descriptor not found)
+SELECT error FROM crdb_internal.jobs WHERE job_type = 'RESTORE';
+----
+true
+
+query-sql
+SELECT * FROM [SHOW DATABASES] WHERE database_name='d2';
+----

--- a/pkg/testutils/jobutils/jobs_verification.go
+++ b/pkg/testutils/jobutils/jobs_verification.go
@@ -62,6 +62,12 @@ func WaitForJobToFail(t testing.TB, db *sqlutils.SQLRunner, jobID jobspb.JobID) 
 	waitForJobToHaveStatus(t, db, jobID, jobs.StatusFailed)
 }
 
+// WaitForJobReverting waits for the specified job ID to be in a reverting state.
+func WaitForJobReverting(t testing.TB, db *sqlutils.SQLRunner, jobID jobspb.JobID) {
+	t.Helper()
+	waitForJobToHaveStatus(t, db, jobID, jobs.StatusReverting)
+}
+
 func waitForJobToHaveStatus(
 	t testing.TB, db *sqlutils.SQLRunner, jobID jobspb.JobID, expectedStatus jobs.Status,
 ) {


### PR DESCRIPTION
This patch adds a test that ensures that restore automatically detects corrupt restoring descriptors via the sql descriptor collection read/write machinery.

Fixes #84757

Release note: None