### PR TITLE
kv: default kv.raft_log.disable_synchronization_unsafe to env var

### DIFF
--- a/pkg/kv/kvserver/logstore/BUILD.bazel
+++ b/pkg/kv/kvserver/logstore/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/storage",
         "//pkg/storage/enginepb",
         "//pkg/storage/fs",
+        "//pkg/util/envutil",
         "//pkg/util/hlc",
         "//pkg/util/iterutil",
         "//pkg/util/log",

--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
@@ -39,7 +40,7 @@ var disableSyncRaftLog = settings.RegisterBoolSetting(
 	"set to true to disable synchronization on Raft log writes to persistent storage. "+
 		"Setting to true risks data loss or data corruption on server crashes. "+
 		"The setting is meant for internal testing only and SHOULD NOT be used in production.",
-	false,
+	envutil.EnvOrDefaultBool("COCKROACH_DISABLE_RAFT_LOG_SYNCHRONIZATION_UNSAFE", false),
 )
 
 // Ready contains the log entries and state to be saved to stable storage. This


### PR DESCRIPTION
This commit introduces a new environment variable called `COCKROACH_DISABLE_RAFT_LOG_SYNCHRONIZATION_UNSAFE` which controls the default value of the `kv.raft_log.disable_synchronization_unsafe` cluster setting.

This is useful for operators that want to disable Raft log syncs ahead of cluster bootstrapping.

Release note: None.
Epic: None.