### PR TITLE
storage: fix a bug with reverse scans, multiple column families, and max keys

### DIFF
--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -96,7 +96,7 @@ var (
 // put            [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key> v=<string> [raw]
 // put_rangekey   ts=<int>[,<int>] [localTs=<int>[,<int>]] k=<key> end=<key>
 // get            [t=<name>] [ts=<int>[,<int>]]                         [resolve [status=<txnstatus>]] k=<key> [inconsistent] [skipLocked] [tombstones] [failOnMoreRecent] [localUncertaintyLimit=<int>[,<int>]] [globalUncertaintyLimit=<int>[,<int>]]
-// scan           [t=<name>] [ts=<int>[,<int>]]                         [resolve [status=<txnstatus>]] k=<key> [end=<key>] [inconsistent] [skipLocked] [tombstones] [reverse] [failOnMoreRecent] [localUncertaintyLimit=<int>[,<int>]] [globalUncertaintyLimit=<int>[,<int>]] [max=<max>] [targetbytes=<target>] [allowEmpty]
+// scan           [t=<name>] [ts=<int>[,<int>]]                         [resolve [status=<txnstatus>]] k=<key> [end=<key>] [inconsistent] [skipLocked] [tombstones] [reverse] [failOnMoreRecent] [localUncertaintyLimit=<int>[,<int>]] [globalUncertaintyLimit=<int>[,<int>]] [max=<max>] [targetbytes=<target>] [wholeRows[=<int>]] [allowEmpty]
 // export         [k=<key>] [end=<key>] [ts=<int>[,<int>]] [kTs=<int>[,<int>]] [startTs=<int>[,<int>]] [maxIntents=<int>] [allRevisions] [targetSize=<int>] [maxSize=<int>] [stopMidKey] [fingerprint]
 //
 // iter_new       [k=<key>] [end=<key>] [prefix] [kind=key|keyAndIntents] [types=pointsOnly|pointsWithRanges|pointsAndRanges|rangesOnly] [pointSynthesis] [maskBelow=<int>[,<int>]]
@@ -1482,7 +1482,26 @@ func cmdScan(e *evalCtx) error {
 		opts.AllowEmpty = true
 	}
 	if e.hasArg("wholeRows") {
-		opts.WholeRowsOfSize = 10 // arbitrary, must be greater than largest column family in tests
+		for _, c := range e.td.CmdArgs {
+			if c.Key == "wholeRows" {
+				// If we have a custom value for wholeRows key, then use it,
+				// otherwise, pick an arbitrary value greater than the largest
+				// column family in tests.
+				if len(c.Vals) > 0 {
+					wholeRowsOfSize, err := strconv.ParseInt(c.Vals[0], 10, 64)
+					if err != nil {
+						return err
+					}
+					if wholeRowsOfSize < 2 {
+						return errors.Newf("wholeRowOfSize value must be at least 2, got %d", wholeRowsOfSize)
+					}
+					opts.WholeRowsOfSize = int32(wholeRowsOfSize)
+				} else {
+					opts.WholeRowsOfSize = 10
+				}
+				break
+			}
+		}
 	}
 	return e.withReader(func(r storage.Reader) error {
 		res, err := storage.MVCCScan(e.ctx, r, key, endKey, ts, opts)

--- a/pkg/storage/testdata/mvcc_histories/max_keys
+++ b/pkg/storage/testdata/mvcc_histories/max_keys
@@ -12,7 +12,7 @@ with ts=1,0
   put      k=/row1/4 v=r1e # column family 2-3 omitted (e.g. if all NULLs)
   put      k=/row2   v=r2a
   put      k=/row3   v=r3a
-  put      k=/row3/1 v=r3b
+  put      k=/row3/4 v=r3e # column family 1-3 omitted (e.g. if all NULLs)
 del        k=aa ts=2,0
 ----
 del: "aa": found key true
@@ -27,7 +27,7 @@ data: /Table/1/1/"row1"/1/1/1.000000000,0 -> /BYTES/r1b
 data: /Table/1/1/"row1"/4/1/1.000000000,0 -> /BYTES/r1e
 data: /Table/1/1/"row2"/0/1.000000000,0 -> /BYTES/r2a
 data: /Table/1/1/"row3"/0/1.000000000,0 -> /BYTES/r3a
-data: /Table/1/1/"row3"/1/1/1.000000000,0 -> /BYTES/r3b
+data: /Table/1/1/"row3"/4/1/1.000000000,0 -> /BYTES/r3e
 
 # Limit 1 works.
 run ok
@@ -153,7 +153,7 @@ data: /Table/1/1/"row1"/1/1/1.000000000,0 -> /BYTES/r1b
 data: /Table/1/1/"row1"/4/1/1.000000000,0 -> /BYTES/r1e
 data: /Table/1/1/"row2"/0/1.000000000,0 -> /BYTES/r2a
 data: /Table/1/1/"row3"/0/1.000000000,0 -> /BYTES/r3a
-data: /Table/1/1/"row3"/1/1/1.000000000,0 -> /BYTES/r3b
+data: /Table/1/1/"row3"/4/1/1.000000000,0 -> /BYTES/r3e
 
 run ok
 with t=A ts=11,0 max=3
@@ -179,7 +179,7 @@ data: /Table/1/1/"row1"/1/1/1.000000000,0 -> /BYTES/r1b
 data: /Table/1/1/"row1"/4/1/1.000000000,0 -> /BYTES/r1e
 data: /Table/1/1/"row2"/0/1.000000000,0 -> /BYTES/r2a
 data: /Table/1/1/"row3"/0/1.000000000,0 -> /BYTES/r3a
-data: /Table/1/1/"row3"/1/1/1.000000000,0 -> /BYTES/r3b
+data: /Table/1/1/"row3"/4/1/1.000000000,0 -> /BYTES/r3e
 
 # Same case as above, except with a committed value at the key after MaxKeys.
 
@@ -227,15 +227,19 @@ data: /Table/1/1/"row1"/1/1/1.000000000,0 -> /BYTES/r1b
 data: /Table/1/1/"row1"/4/1/1.000000000,0 -> /BYTES/r1e
 data: /Table/1/1/"row2"/0/1.000000000,0 -> /BYTES/r2a
 data: /Table/1/1/"row3"/0/1.000000000,0 -> /BYTES/r3a
-data: /Table/1/1/"row3"/1/1/1.000000000,0 -> /BYTES/r3b
+data: /Table/1/1/"row3"/4/1/1.000000000,0 -> /BYTES/r3e
 
 # Whole SQL rows.
 run ok
 with ts=12,0
   scan k=/ end=/z max=2
+  scan k=/ end=/z max=2 wholeRows=2 # we should not scan '/row1/4' key
   scan k=/ end=/z max=2 wholeRows
   scan k=/ end=/z max=2 wholeRows allowEmpty
 ----
+scan: /Table/1/1/"row1"/0 -> /BYTES/r1a @1.000000000,0
+scan: /Table/1/1/"row1"/1/1 -> /BYTES/r1b @1.000000000,0
+scan: resume span [/Table/1/1/"row1"/4/1,/Table/1/1/"z"/0) RESUME_KEY_LIMIT nextBytes=0
 scan: /Table/1/1/"row1"/0 -> /BYTES/r1a @1.000000000,0
 scan: /Table/1/1/"row1"/1/1 -> /BYTES/r1b @1.000000000,0
 scan: resume span [/Table/1/1/"row1"/4/1,/Table/1/1/"z"/0) RESUME_KEY_LIMIT nextBytes=0
@@ -278,21 +282,21 @@ scan: /Table/1/1/"row1"/1/1 -> /BYTES/r1b @1.000000000,0
 scan: /Table/1/1/"row1"/4/1 -> /BYTES/r1e @1.000000000,0
 scan: /Table/1/1/"row2"/0 -> /BYTES/r2a @1.000000000,0
 scan: /Table/1/1/"row3"/0 -> /BYTES/r3a @1.000000000,0
-scan: /Table/1/1/"row3"/1/1 -> /BYTES/r3b @1.000000000,0
+scan: /Table/1/1/"row3"/4/1 -> /BYTES/r3e @1.000000000,0
 
 # Whole SQL rows in reverse.
 run ok
 with ts=12,0
   scan k=/ end=/z max=1 reverse
-  scan k=/ end=/z max=1 reverse wholeRows
+  scan k=/ end=/z max=1 reverse wholeRows=5
   scan k=/ end=/z max=1 reverse wholeRows allowEmpty
 ----
-scan: /Table/1/1/"row3"/1/1 -> /BYTES/r3b @1.000000000,0
+scan: /Table/1/1/"row3"/4/1 -> /BYTES/r3e @1.000000000,0
 scan: resume span [/Table/1/1/""/0,/Table/1/1/"row3"/0/NULL) RESUME_KEY_LIMIT nextBytes=0
-scan: /Table/1/1/"row3"/1/1 -> /BYTES/r3b @1.000000000,0
+scan: /Table/1/1/"row3"/4/1 -> /BYTES/r3e @1.000000000,0
 scan: /Table/1/1/"row3"/0 -> /BYTES/r3a @1.000000000,0
 scan: resume span [/Table/1/1/""/0,/Table/1/1/"row2"/0/NULL) RESUME_KEY_LIMIT nextBytes=0
-scan: resume span [/Table/1/1/""/0,/Table/1/1/"row3"/1/1/NULL) RESUME_KEY_LIMIT nextBytes=0
+scan: resume span [/Table/1/1/""/0,/Table/1/1/"row3"/4/1/NULL) RESUME_KEY_LIMIT nextBytes=0
 scan: /Table/1/1/""/0-/Table/1/1/"z"/0 -> <no data>
 
 run ok
@@ -304,24 +308,24 @@ with ts=12,0
   scan k=/ end=/z max=5 reverse wholeRows allowEmpty
   scan k=/ end=/z max=6 reverse wholeRows allowEmpty
 ----
-scan: resume span [/Table/1/1/""/0,/Table/1/1/"row3"/1/1/NULL) RESUME_KEY_LIMIT nextBytes=0
+scan: resume span [/Table/1/1/""/0,/Table/1/1/"row3"/4/1/NULL) RESUME_KEY_LIMIT nextBytes=0
 scan: /Table/1/1/""/0-/Table/1/1/"z"/0 -> <no data>
-scan: /Table/1/1/"row3"/1/1 -> /BYTES/r3b @1.000000000,0
+scan: /Table/1/1/"row3"/4/1 -> /BYTES/r3e @1.000000000,0
 scan: /Table/1/1/"row3"/0 -> /BYTES/r3a @1.000000000,0
 scan: resume span [/Table/1/1/""/0,/Table/1/1/"row2"/0/NULL) RESUME_KEY_LIMIT nextBytes=0
-scan: /Table/1/1/"row3"/1/1 -> /BYTES/r3b @1.000000000,0
+scan: /Table/1/1/"row3"/4/1 -> /BYTES/r3e @1.000000000,0
 scan: /Table/1/1/"row3"/0 -> /BYTES/r3a @1.000000000,0
 scan: /Table/1/1/"row2"/0 -> /BYTES/r2a @1.000000000,0
 scan: resume span [/Table/1/1/""/0,/Table/1/1/"row1"/4/1/NULL) RESUME_KEY_LIMIT nextBytes=0
-scan: /Table/1/1/"row3"/1/1 -> /BYTES/r3b @1.000000000,0
+scan: /Table/1/1/"row3"/4/1 -> /BYTES/r3e @1.000000000,0
 scan: /Table/1/1/"row3"/0 -> /BYTES/r3a @1.000000000,0
 scan: /Table/1/1/"row2"/0 -> /BYTES/r2a @1.000000000,0
 scan: resume span [/Table/1/1/""/0,/Table/1/1/"row1"/4/1/NULL) RESUME_KEY_LIMIT nextBytes=0
-scan: /Table/1/1/"row3"/1/1 -> /BYTES/r3b @1.000000000,0
+scan: /Table/1/1/"row3"/4/1 -> /BYTES/r3e @1.000000000,0
 scan: /Table/1/1/"row3"/0 -> /BYTES/r3a @1.000000000,0
 scan: /Table/1/1/"row2"/0 -> /BYTES/r2a @1.000000000,0
 scan: resume span [/Table/1/1/""/0,/Table/1/1/"row1"/4/1/NULL) RESUME_KEY_LIMIT nextBytes=0
-scan: /Table/1/1/"row3"/1/1 -> /BYTES/r3b @1.000000000,0
+scan: /Table/1/1/"row3"/4/1 -> /BYTES/r3e @1.000000000,0
 scan: /Table/1/1/"row3"/0 -> /BYTES/r3a @1.000000000,0
 scan: /Table/1/1/"row2"/0 -> /BYTES/r2a @1.000000000,0
 scan: /Table/1/1/"row1"/4/1 -> /BYTES/r1e @1.000000000,0


### PR DESCRIPTION
This commit fixes a bug with how we're checking whether the last row has final column family when performing a reverse scan. Previously, we'd incorrectly treat the largest column ID as the "last" one, but with the reverse iteration actually the zeroth column family is the "last" one. As a result, we could return an incomplete row to SQL.

However, there is no production impact to this bug because no user at the SQL layer currently satisfies all the conditions:
- `WholeRowsOfSize` option must be used. Currently, it is only used by the streamer;
- the reverse scan must be requested and `MaxSpanRequestKeys` must be set - neither is currently done by the streamer.

Epic: None

Release note: None