### PR TITLE
server,rpc: use an in-memory loopback connection for self-dials

### DIFF
--- a/pkg/acceptance/localcluster/cluster.go
+++ b/pkg/acceptance/localcluster/cluster.go
@@ -276,6 +276,8 @@ func (c *Cluster) makeNode(ctx context.Context, nodeIdx int, cfg NodeConfig) (*N
 		MaxOffset: 0,
 		Stopper:   c.stopper,
 		Settings:  cluster.MakeTestingClusterSettings(),
+
+		ClientOnly: true,
 	})
 
 	n := &Node{

--- a/pkg/ccl/oidcccl/authentication_oidc_test.go
+++ b/pkg/ccl/oidcccl/authentication_oidc_test.go
@@ -58,6 +58,8 @@ func TestOIDCBadRequestIfDisabled(t *testing.T) {
 				MaxOffset: 1,
 				Stopper:   s.Stopper(),
 				Settings:  s.ClusterSettings(),
+
+				ClientOnly: true,
 			})
 	}
 
@@ -94,6 +96,8 @@ func TestOIDCEnabled(t *testing.T) {
 			MaxOffset: 1,
 			Stopper:   s.Stopper(),
 			Settings:  s.ClusterSettings(),
+
+			ClientOnly: true,
 		})
 	}
 

--- a/pkg/gossip/simulation/network.go
+++ b/pkg/gossip/simulation/network.go
@@ -78,6 +78,10 @@ func NewNetwork(
 			MaxOffset: 0,
 			Stopper:   n.Stopper,
 			Settings:  cluster.MakeTestingClusterSettings(),
+
+			Knobs: rpc.ContextTestingKnobs{
+				NoLoopbackDialer: true,
+			},
 		})
 	var err error
 	n.tlsConfig, err = n.RPCContext.GetServerTLSConfig()

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -1376,20 +1376,8 @@ func (rpcCtx *Context) ConnHealth(
 }
 
 // GRPCDialOptions returns the minimal `grpc.DialOption`s necessary to connect
-// to a server created with `NewServer`.
-//
-// At the time of writing, this is being used for making net.Pipe-based
-// connections, so only those options that affect semantics are included. In
-// particular, performance tuning options are omitted. Decompression is
-// necessarily included to support compression-enabled servers, and compression
-// is included for symmetry. These choices are admittedly subjective.
-func (rpcCtx *Context) GRPCDialOptions() ([]grpc.DialOption, error) {
-	return rpcCtx.grpcDialOptions("", DefaultClass)
-}
-
-// grpcDialOptions extends GRPCDialOptions to support a connection class for use
-// with TestingKnobs.
-func (rpcCtx *Context) grpcDialOptions(
+// to a server.
+func (rpcCtx *Context) GRPCDialOptions(
 	target string, class ConnectionClass,
 ) ([]grpc.DialOption, error) {
 	var dialOpts []grpc.DialOption
@@ -1732,7 +1720,7 @@ func (rpcCtx *Context) GRPCDialRaw(target string) (*grpc.ClientConn, error) {
 func (rpcCtx *Context) grpcDialRaw(
 	ctx context.Context, target string, class ConnectionClass,
 ) (*grpc.ClientConn, error) {
-	dialOpts, err := rpcCtx.grpcDialOptions(target, class)
+	dialOpts, err := rpcCtx.GRPCDialOptions(target, class)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -1375,11 +1375,80 @@ func (rpcCtx *Context) ConnHealth(
 	return ErrNoConnection
 }
 
+type transportType bool
+
+const (
+	// loopbackTransport is used for in-memory connections that bypass
+	// the TCP stack entirely, using the loopback listener.
+	loopbackTransport transportType = false
+	// tcpTransport is used when reaching out via TCP.
+	tcpTransport transportType = true
+)
+
 // GRPCDialOptions returns the minimal `grpc.DialOption`s necessary to connect
 // to a server.
 func (rpcCtx *Context) GRPCDialOptions(
-	target string, class ConnectionClass,
+	ctx context.Context, target string, class ConnectionClass,
 ) ([]grpc.DialOption, error) {
+	return rpcCtx.grpcDialOptionsInternal(ctx, target, class, tcpTransport)
+}
+
+// grpcDialOptions produces dial options suitable for connecting to the given target and class.
+func (rpcCtx *Context) grpcDialOptionsInternal(
+	ctx context.Context, target string, class ConnectionClass, transport transportType,
+) ([]grpc.DialOption, error) {
+	dialOpts, err := rpcCtx.dialOptsCommon(class)
+	if err != nil {
+		return nil, err
+	}
+
+	switch transport {
+	case tcpTransport:
+		netOpts, err := rpcCtx.dialOptsNetwork(ctx, target, class)
+		if err != nil {
+			return nil, err
+		}
+		dialOpts = append(dialOpts, netOpts...)
+	case loopbackTransport:
+		localOpts, err := rpcCtx.dialOptsLocal()
+		if err != nil {
+			return nil, err
+		}
+		dialOpts = append(dialOpts, localOpts...)
+	default:
+		// This panic in case the type is ever changed to include more values.
+		panic(errors.AssertionFailedf("unhandled: %v", transport))
+	}
+	return dialOpts, nil
+}
+
+// dialOptsLocal computes options used only for loopback connections.
+func (rpcCtx *Context) dialOptsLocal() ([]grpc.DialOption, error) {
+	// We need to include a TLS overlay even for loopback connections,
+	// because currently a non-insecure server always refuses non-TLS
+	// incoming connections, and inspects the TLS certs to determine the
+	// identity of the client peer.
+	//
+	// We can elide TLS for loopback connections when we add a non-TLS
+	// way to identify peers, i.e. fix these issues:
+	// https://github.com/cockroachdb/cockroach/issues/54007
+	// https://github.com/cockroachdb/cockroach/issues/91996
+	dialOpts, err := rpcCtx.dialOptsNetworkCredentials()
+	if err != nil {
+		return nil, err
+	}
+
+	dialOpts = append(dialOpts, grpc.WithContextDialer(
+		func(ctx context.Context, _ string) (net.Conn, error) {
+			return rpcCtx.loopbackDialFn(ctx)
+		}))
+
+	return dialOpts, err
+}
+
+// dialOptsNetworkCredentials computes options that determines how the
+// RPC client authenticates itself to the remote server.
+func (rpcCtx *Context) dialOptsNetworkCredentials() ([]grpc.DialOption, error) {
 	var dialOpts []grpc.DialOption
 	if rpcCtx.Config.Insecure {
 		dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
@@ -1397,18 +1466,31 @@ func (rpcCtx *Context) GRPCDialOptions(
 		dialOpts = append(dialOpts, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 	}
 
-	// The limiting factor for lowering the max message size is the fact
-	// that a single large kv can be sent over the network in one message.
-	// Our maximum kv size is unlimited, so we need this to be very large.
-	//
-	// TODO(peter,tamird): need tests before lowering.
-	dialOpts = append(dialOpts, grpc.WithDefaultCallOptions(
-		grpc.MaxCallRecvMsgSize(math.MaxInt32),
-		grpc.MaxCallSendMsgSize(math.MaxInt32),
-	))
+	return dialOpts, nil
+}
 
-	// Compression is enabled separately from decompression to allow staged
-	// rollout.
+// dialOptsNetwork compute options used only for over-the-network RPC
+// connections.
+func (rpcCtx *Context) dialOptsNetwork(
+	ctx context.Context, target string, class ConnectionClass,
+) ([]grpc.DialOption, error) {
+	dialOpts, err := rpcCtx.dialOptsNetworkCredentials()
+	if err != nil {
+		return nil, err
+	}
+
+	// Request request compression. Note that it's the client that
+	// decides to opt into compressions; the server accepts either
+	// compressed or decompressed payloads, and the specific codec used
+	// is named in the request (so different clients can use different
+	// compression algorithms.)
+	//
+	// On a related note, this configuration uses our own snappy codec.
+	// We believe it works better than the gzip codec provided natively
+	// by grpc, although the specific reason is now lost to history. It
+	// would be possible to change/simplify this, and since it's for
+	// each client to decide changing this will not require much
+	// cross-version compatibility dance.
 	if rpcCtx.rpcCompression {
 		dialOpts = append(dialOpts, grpc.WithDefaultCallOptions(grpc.UseCompressor((snappyCompressor{}).Name())))
 	}
@@ -1421,41 +1503,100 @@ func (rpcCtx *Context) GRPCDialOptions(
 	// [1]: https://github.com/grpc/grpc-go/blob/c0736608/Documentation/proxy.md
 	dialOpts = append(dialOpts, grpc.WithNoProxy())
 
-	// Append a testing stream interceptor, if so configured. Note that this can
-	// only be done at Dial() time, as opposed to when the rpcCtx is created,
-	// because the testing knob callback wants access to the dial details for this
-	// particular connection.
-	streamInterceptors := rpcCtx.clientStreamInterceptors
+	// Lower the MaxBackoff (which defaults to ~minutes) to something in the
+	// ~second range. Note that we only retry once (see onlyOnceDialer) so we only
+	// hit the first backoff (BaseDelay). Note also that this delay serves as a
+	// sort of circuit breaker, since it will make sure that we're not trying to
+	// dial a down node in a tight loop. This is not a great mechanism but it's
+	// what we have right now. Higher levels have some protection (node dialer
+	// circuit breakers) but not all connection attempts go through that.
+	backoffConfig := backoff.DefaultConfig
+
+	// We need to define a MaxBackoff but it should never be used due to
+	// our setup with onlyOnceDialer below. So note that our choice here is
+	// inconsequential assuming all works as designed.
+	backoff := time.Second
+	if backoff > base.DialTimeout {
+		// This is for testing where we set a small DialTimeout. gRPC will
+		// internally round up the min connection timeout to the max backoff. This
+		// can be unintuitive and so we opt out of it by lowering the max backoff.
+		backoff = base.DialTimeout
+	}
+	backoffConfig.BaseDelay = backoff
+	backoffConfig.MaxDelay = backoff
+	dialOpts = append(dialOpts, grpc.WithConnectParams(grpc.ConnectParams{
+		Backoff:           backoffConfig,
+		MinConnectTimeout: base.DialTimeout}))
+
+	// Ensure the TCP link remains active so that overzealous firewalls
+	// don't shut it down.
+	dialOpts = append(dialOpts, grpc.WithKeepaliveParams(clientKeepalive))
+
+	// Append a testing stream interceptor, if so configured.
+	//
+	// Note that we cannot do this earlier (e.g. in dialOptsNetwork)
+	// because at that time the target address may not be known yet.
 	if rpcCtx.Knobs.StreamClientInterceptor != nil {
 		testingStreamInterceptor := rpcCtx.Knobs.StreamClientInterceptor(target, class)
 		if testingStreamInterceptor != nil {
-			// Make a copy of the interceptors slice and append the knob one.
-			streamInterceptors = append(append([]grpc.StreamClientInterceptor(nil), streamInterceptors...), testingStreamInterceptor)
+			dialOpts = append(dialOpts, grpc.WithChainStreamInterceptor(testingStreamInterceptor))
 		}
 	}
+
+	// Set up the dialer. Like for the stream client interceptor, we cannot
+	// do this earlier because it is sensitive to the actual target address,
+	// which is only definitely provided during dial.
+	dialer := onlyOnceDialer{}
+	dialerFunc := dialer.dial
 	if rpcCtx.Knobs.InjectedLatencyOracle != nil {
-		dialerFunc := func(ctx context.Context, target string) (net.Conn, error) {
-			dialer := net.Dialer{
-				LocalAddr: sourceAddr,
-			}
-			return dialer.DialContext(ctx, "tcp", target)
-		}
 		latency := rpcCtx.Knobs.InjectedLatencyOracle.GetLatency(target)
-		log.VEventf(rpcCtx.MasterCtx, 1, "connecting to node %s with simulated latency %dms", target, latency)
+		log.VEventf(ctx, 1, "connecting with simulated latency %dms",
+			latency)
 		dialer := artificialLatencyDialer{
 			dialerFunc: dialerFunc,
 			latency:    latency,
 			enabled:    rpcCtx.Knobs.InjectedLatencyEnabled,
 		}
 		dialerFunc = dialer.dial
-		dialOpts = append(dialOpts, grpc.WithContextDialer(dialerFunc))
+	}
+	dialOpts = append(dialOpts, grpc.WithContextDialer(dialerFunc))
+
+	return dialOpts, nil
+}
+
+// dialOptsCommon computes options used for both in-memory and
+// over-the-network RPC connections.
+func (rpcCtx *Context) dialOptsCommon(class ConnectionClass) ([]grpc.DialOption, error) {
+	// The limiting factor for lowering the max message size is the fact
+	// that a single large kv can be sent over the network in one message.
+	// Our maximum kv size is unlimited, so we need this to be very large.
+	//
+	// TODO(peter,tamird): need tests before lowering.
+	dialOpts := []grpc.DialOption{grpc.WithDefaultCallOptions(
+		grpc.MaxCallRecvMsgSize(math.MaxInt32),
+		grpc.MaxCallSendMsgSize(math.MaxInt32),
+	)}
+
+	// We throw this one in for good measure, but it only disables the retries
+	// for RPCs that were already pending (which are opt in anyway, and we don't
+	// opt in). It doesn't disable what gRPC calls "transparent retries" (RPC
+	// was not yet put on the wire when the error occurred). So we should
+	// consider this one a no-op, though it can't hurt.
+	dialOpts = append(dialOpts, grpc.WithDisableRetry())
+
+	// Configure the window sizes with optional env var overrides.
+	dialOpts = append(dialOpts, grpc.WithInitialConnWindowSize(initialConnWindowSize))
+	if class == RangefeedClass {
+		dialOpts = append(dialOpts, grpc.WithInitialWindowSize(rangefeedInitialWindowSize))
+	} else {
+		dialOpts = append(dialOpts, grpc.WithInitialWindowSize(initialWindowSize))
 	}
 
 	if len(rpcCtx.clientUnaryInterceptors) > 0 {
 		dialOpts = append(dialOpts, grpc.WithChainUnaryInterceptor(rpcCtx.clientUnaryInterceptors...))
 	}
-	if len(streamInterceptors) > 0 {
-		dialOpts = append(dialOpts, grpc.WithChainStreamInterceptor(streamInterceptors...))
+	if len(rpcCtx.clientStreamInterceptors) > 0 {
+		dialOpts = append(dialOpts, grpc.WithChainStreamInterceptor(rpcCtx.clientStreamInterceptors...))
 	}
 	return dialOpts, nil
 }
@@ -1720,67 +1861,12 @@ func (rpcCtx *Context) GRPCDialRaw(target string) (*grpc.ClientConn, error) {
 func (rpcCtx *Context) grpcDialRaw(
 	ctx context.Context, target string, class ConnectionClass,
 ) (*grpc.ClientConn, error) {
-	dialOpts, err := rpcCtx.GRPCDialOptions(target, class)
+	dialOpts, err := rpcCtx.GRPCDialOptions(ctx, target, class)
 	if err != nil {
 		return nil, err
 	}
 
-	// Lower the MaxBackoff (which defaults to ~minutes) to something in the
-	// ~second range. Note that we only retry once (see onlyOnceDialer) so we only
-	// hit the first backoff (BaseDelay). Note also that this delay serves as a
-	// sort of circuit breaker, since it will make sure that we're not trying to
-	// dial a down node in a tight loop. This is not a great mechanism but it's
-	// what we have right now. Higher levels have some protection (node dialer
-	// circuit breakers) but not all connection attempts go through that.
-	backoffConfig := backoff.DefaultConfig
-
-	// We need to define a MaxBackoff but it should never be used due to
-	// our setup with onlyOnceDialer below. So note that our choice here is
-	// inconsequential assuming all works as designed.
-	backoff := time.Second
-	if backoff > base.DialTimeout {
-		// This is for testing where we set a small DialTimeout. gRPC will
-		// internally round up the min connection timeout to the max backoff. This
-		// can be unintuitive and so we opt out of it by lowering the max backoff.
-		backoff = base.DialTimeout
-	}
-	backoffConfig.BaseDelay = backoff
-	backoffConfig.MaxDelay = backoff
-	dialOpts = append(dialOpts, grpc.WithConnectParams(grpc.ConnectParams{
-		Backoff:           backoffConfig,
-		MinConnectTimeout: base.DialTimeout}))
-	dialOpts = append(dialOpts, grpc.WithKeepaliveParams(clientKeepalive))
-	dialOpts = append(dialOpts, grpc.WithInitialConnWindowSize(initialConnWindowSize))
-	if class == RangefeedClass {
-		dialOpts = append(dialOpts, grpc.WithInitialWindowSize(rangefeedInitialWindowSize))
-	} else {
-		dialOpts = append(dialOpts, grpc.WithInitialWindowSize(initialWindowSize))
-	}
-
-	dialer := onlyOnceDialer{}
-	dialerFunc := dialer.dial
-	if rpcCtx.Knobs.InjectedLatencyOracle != nil {
-		latency := rpcCtx.Knobs.InjectedLatencyOracle.GetLatency(target)
-		log.VEventf(ctx, 1, "connecting with simulated latency %dms",
-			latency)
-		dialer := artificialLatencyDialer{
-			dialerFunc: dialerFunc,
-			latency:    latency,
-			enabled:    rpcCtx.Knobs.InjectedLatencyEnabled,
-		}
-		dialerFunc = dialer.dial
-	}
-	dialOpts = append(dialOpts,
-		grpc.WithContextDialer(dialerFunc),
-		// We throw this one in for good measure, but it only disables the retries
-		// for RPCs that were already pending (which are opt in anyway, and we don't
-		// opt in). It doesn't disable what gRPC calls "transparent retries" (RPC
-		// was not yet put on the wire when the error occurred). So we should
-		// consider this one a no-op, though it can't hurt.
-		grpc.WithDisableRetry(),
-	)
-
-	// add testingDialOpts after our dialer because one of our tests
+	// Add testingDialOpts at the end because one of our tests
 	// uses a custom dialer (this disables the only-one-connection
 	// behavior and redialChan will never be closed).
 	dialOpts = append(dialOpts, rpcCtx.testingDialOpts...)

--- a/pkg/rpc/context_testutils.go
+++ b/pkg/rpc/context_testutils.go
@@ -48,6 +48,13 @@ type ContextTestingKnobs struct {
 	// StorageClusterID initializes the Context's StorageClusterID container to
 	// this value if non-nil at construction time.
 	StorageClusterID *uuid.UUID
+
+	// NoLoopbackDialer, when set, indicates that a test does not care
+	// about the special loopback dial semantics.
+	// If this is left unset, the test is responsible for ensuring
+	// SetLoopbackDialer() has been called on the rpc.Context.
+	// (This is done automatically by server.Server/server.SQLServerWrapper.)
+	NoLoopbackDialer bool
 }
 
 // InjectedLatencyOracle is a testing mechanism used to inject artificial

--- a/pkg/rpc/nodedialer/nodedialer.go
+++ b/pkg/rpc/nodedialer/nodedialer.go
@@ -140,6 +140,9 @@ func (n *Dialer) DialNoBreaker(
 // DialInternalClient is a specialization of DialClass for callers that
 // want a roachpb.InternalClient. This supports an optimization to bypass the
 // network for the local node.
+//
+// For a more contextualized explanation, see the comment that decorates
+// (*rpc.Context).loopbackDialFn.
 func (n *Dialer) DialInternalClient(
 	ctx context.Context, nodeID roachpb.NodeID, class rpc.ConnectionClass,
 ) (rpc.RestrictedInternalClient, error) {

--- a/pkg/rpc/restricted_internal_client.go
+++ b/pkg/rpc/restricted_internal_client.go
@@ -21,6 +21,9 @@ import (
 // interface used by the DistSender. Besides the auto-generated gRPC client,
 // this interface is also implemented by rpc.internalClientAdapter which
 // bypasses gRPC to call into the local Node.
+//
+// For a more contextualized explanation, see the comment that decorates
+// (*rpc.Context).loopbackDialFn.
 type RestrictedInternalClient interface {
 	Batch(ctx context.Context, in *roachpb.BatchRequest, opts ...grpc.CallOption) (*roachpb.BatchResponse, error)
 	RangeFeed(ctx context.Context, in *roachpb.RangeFeedRequest, opts ...grpc.CallOption) (roachpb.Internal_RangeFeedClient, error)

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -37,7 +37,6 @@ go_library(
         "initial_sql.go",
         "listen_and_update_addrs.go",
         "load_endpoint.go",
-        "loopback.go",
         "loss_of_quorum.go",
         "migration.go",
         "node.go",

--- a/pkg/server/connectivity_test.go
+++ b/pkg/server/connectivity_test.go
@@ -196,12 +196,13 @@ func TestClusterConnectivity(t *testing.T) {
 					ctx := context.Background()
 					serv := tc.Server(bootstrapNode)
 
-					dialOpts, err := tc.Server(bootstrapNode).RPCContext().GRPCDialOptions()
+					target := serv.ServingRPCAddr()
+					dialOpts, err := tc.Server(bootstrapNode).RPCContext().GRPCDialOptions(target, rpc.SystemClass)
 					if err != nil {
 						return err
 					}
 
-					conn, err := grpc.DialContext(ctx, serv.ServingRPCAddr(), dialOpts...)
+					conn, err := grpc.DialContext(ctx, target, dialOpts...)
 					if err != nil {
 						return err
 					}

--- a/pkg/server/connectivity_test.go
+++ b/pkg/server/connectivity_test.go
@@ -197,7 +197,7 @@ func TestClusterConnectivity(t *testing.T) {
 					serv := tc.Server(bootstrapNode)
 
 					target := serv.ServingRPCAddr()
-					dialOpts, err := tc.Server(bootstrapNode).RPCContext().GRPCDialOptions(target, rpc.SystemClass)
+					dialOpts, err := tc.Server(bootstrapNode).RPCContext().GRPCDialOptions(ctx, target, rpc.SystemClass)
 					if err != nil {
 						return err
 					}

--- a/pkg/server/grpc_gateway.go
+++ b/pkg/server/grpc_gateway.go
@@ -96,7 +96,7 @@ func configureGRPCGateway(
 
 	// Eschew `(*rpc.Context).GRPCDial` to avoid unnecessary moving parts on the
 	// uniquely in-process connection.
-	dialOpts, err := rpcContext.GRPCDialOptions(GRPCAddr, rpc.DefaultClass)
+	dialOpts, err := rpcContext.GRPCDialOptions(ctx, GRPCAddr, rpc.DefaultClass)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/server/grpc_gateway.go
+++ b/pkg/server/grpc_gateway.go
@@ -80,7 +80,7 @@ func configureGRPCGateway(
 	stopper.AddCloser(stop.CloserFn(gwCancel))
 
 	// loopback handles the HTTP <-> RPC loopback connection.
-	loopback := newLoopbackListener(workersCtx, stopper)
+	loopback := netutil.NewLoopbackListener(workersCtx, stopper)
 
 	waitQuiesce := func(context.Context) {
 		<-stopper.ShouldQuiesce()

--- a/pkg/server/grpc_gateway.go
+++ b/pkg/server/grpc_gateway.go
@@ -13,14 +13,12 @@ package server
 import (
 	"context"
 	"fmt"
-	"net"
 
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/ts"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/netutil"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
@@ -79,21 +77,6 @@ func configureGRPCGateway(
 	gwCtx, gwCancel := context.WithCancel(ambientCtx.AnnotateCtx(context.Background()))
 	stopper.AddCloser(stop.CloserFn(gwCancel))
 
-	// loopback handles the HTTP <-> RPC loopback connection.
-	loopback := netutil.NewLoopbackListener(workersCtx, stopper)
-
-	waitQuiesce := func(context.Context) {
-		<-stopper.ShouldQuiesce()
-		_ = loopback.Close()
-	}
-	if err := stopper.RunAsyncTask(workersCtx, "gw-quiesce", waitQuiesce); err != nil {
-		waitQuiesce(workersCtx)
-	}
-
-	_ = stopper.RunAsyncTask(workersCtx, "serve-loopback", func(context.Context) {
-		netutil.FatalIfUnexpected(grpcSrv.Serve(loopback))
-	})
-
 	// Eschew `(*rpc.Context).GRPCDial` to avoid unnecessary moving parts on the
 	// uniquely in-process connection.
 	dialOpts, err := rpcContext.GRPCDialOptions(ctx, GRPCAddr, rpc.DefaultClass)
@@ -112,12 +95,9 @@ func configureGRPCGateway(
 		telemetry.Inc(getServerEndpointCounter(method))
 		return invoker(ctx, method, req, reply, cc, opts...)
 	}
-	conn, err := grpc.DialContext(ctx, GRPCAddr, append(append(
+	conn, err := grpc.DialContext(ctx, GRPCAddr, append(
 		dialOpts,
-		grpc.WithUnaryInterceptor(callCountInterceptor)),
-		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
-			return loopback.Connect(ctx)
-		}),
+		grpc.WithUnaryInterceptor(callCountInterceptor),
 	)...)
 	if err != nil {
 		return nil, nil, nil, err

--- a/pkg/server/grpc_gateway.go
+++ b/pkg/server/grpc_gateway.go
@@ -96,7 +96,7 @@ func configureGRPCGateway(
 
 	// Eschew `(*rpc.Context).GRPCDial` to avoid unnecessary moving parts on the
 	// uniquely in-process connection.
-	dialOpts, err := rpcContext.GRPCDialOptions()
+	dialOpts, err := rpcContext.GRPCDialOptions(GRPCAddr, rpc.DefaultClass)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -448,7 +448,7 @@ func (s *initServer) startJoinLoop(ctx context.Context, stopper *stop.Stopper) (
 func (s *initServer) attemptJoinTo(
 	ctx context.Context, addr string,
 ) (*roachpb.JoinNodeResponse, error) {
-	dialOpts, err := s.config.getDialOpts(addr, rpc.SystemClass)
+	dialOpts, err := s.config.getDialOpts(ctx, addr, rpc.SystemClass)
 	if err != nil {
 		return nil, err
 	}
@@ -605,7 +605,7 @@ type initServerCfg struct {
 	defaultZoneConfig         zonepb.ZoneConfig
 
 	// getDialOpts retrieves the gRPC dial options to use to issue Join RPCs.
-	getDialOpts func(target string, class rpc.ConnectionClass) ([]grpc.DialOption, error)
+	getDialOpts func(ctx context.Context, target string, class rpc.ConnectionClass) ([]grpc.DialOption, error)
 
 	// bootstrapAddresses is a list of node addresses (populated using --join
 	// addresses) that is used to form a connected graph/network of CRDB servers.
@@ -626,7 +626,7 @@ type initServerCfg struct {
 func newInitServerConfig(
 	ctx context.Context,
 	cfg Config,
-	getDialOpts func(string, rpc.ConnectionClass) ([]grpc.DialOption, error),
+	getDialOpts func(context.Context, string, rpc.ConnectionClass) ([]grpc.DialOption, error),
 ) initServerCfg {
 	binaryVersion := cfg.Settings.Version.BinaryVersion()
 	if knobs := cfg.TestingKnobs.Server; knobs != nil {

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -447,7 +448,11 @@ func (s *initServer) startJoinLoop(ctx context.Context, stopper *stop.Stopper) (
 func (s *initServer) attemptJoinTo(
 	ctx context.Context, addr string,
 ) (*roachpb.JoinNodeResponse, error) {
-	conn, err := grpc.DialContext(ctx, addr, s.config.dialOpts...)
+	dialOpts, err := s.config.getDialOpts(addr, rpc.SystemClass)
+	if err != nil {
+		return nil, err
+	}
+	conn, err := grpc.DialContext(ctx, addr, dialOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -599,8 +604,8 @@ type initServerCfg struct {
 	defaultSystemZoneConfig   zonepb.ZoneConfig
 	defaultZoneConfig         zonepb.ZoneConfig
 
-	// dialOpts holds onto the dial options used when sending out Join RPCs.
-	dialOpts []grpc.DialOption
+	// getDialOpts retrieves the gRPC dial options to use to issue Join RPCs.
+	getDialOpts func(target string, class rpc.ConnectionClass) ([]grpc.DialOption, error)
 
 	// bootstrapAddresses is a list of node addresses (populated using --join
 	// addresses) that is used to form a connected graph/network of CRDB servers.
@@ -619,7 +624,9 @@ type initServerCfg struct {
 }
 
 func newInitServerConfig(
-	ctx context.Context, cfg Config, dialOpts []grpc.DialOption,
+	ctx context.Context,
+	cfg Config,
+	getDialOpts func(string, rpc.ConnectionClass) ([]grpc.DialOption, error),
 ) initServerCfg {
 	binaryVersion := cfg.Settings.Version.BinaryVersion()
 	if knobs := cfg.TestingKnobs.Server; knobs != nil {
@@ -640,7 +647,7 @@ func newInitServerConfig(
 		binaryVersion:             binaryVersion,
 		defaultSystemZoneConfig:   cfg.DefaultSystemZoneConfig,
 		defaultZoneConfig:         cfg.DefaultZoneConfig,
-		dialOpts:                  dialOpts,
+		getDialOpts:               getDialOpts,
 		bootstrapAddresses:        bootstrapAddresses,
 		testingKnobs:              cfg.TestingKnobs,
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1275,10 +1275,13 @@ func (s *Server) PreStart(ctx context.Context) error {
 	// and dispatches the server worker for the RPC.
 	// The SQL listener is returned, to start the SQL server later
 	// below when the server has initialized.
-	pgL, startRPCServer, err := startListenRPCAndSQL(ctx, workersCtx, s.cfg.BaseConfig, s.stopper, s.grpc)
+	pgL, rpcLoopbackDialFn, startRPCServer, err := startListenRPCAndSQL(ctx, workersCtx, s.cfg.BaseConfig, s.stopper, s.grpc)
 	if err != nil {
 		return err
 	}
+
+	// Tell the RPC context how to connect in-memory.
+	s.rpcContext.SetLoopbackDialer(rpcLoopbackDialFn)
 
 	if s.cfg.TestingKnobs.Server != nil {
 		knobs := s.cfg.TestingKnobs.Server.(*TestingKnobs)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1200,12 +1200,8 @@ func (s *Server) PreStart(ctx context.Context) error {
 	// startRPCServer (and for the loopback grpc-gw connection).
 	var initServer *initServer
 	{
-		dialOpts, err := s.rpcContext.GRPCDialOptions()
-		if err != nil {
-			return err
-		}
-
-		initConfig := newInitServerConfig(ctx, s.cfg, dialOpts)
+		getDialOpts := s.rpcContext.GRPCDialOptions
+		initConfig := newInitServerConfig(ctx, s.cfg, getDialOpts)
 		inspectedDiskState, err := inspectEngines(
 			ctx,
 			s.engines,

--- a/pkg/server/settings_cache_test.go
+++ b/pkg/server/settings_cache_test.go
@@ -106,10 +106,9 @@ func TestCachedSettingsServerRestart(t *testing.T) {
 	s := srv.Server
 	var initServer *initServer
 	{
-		dialOpts, err := s.rpcContext.GRPCDialOptions()
-		require.NoError(t, err)
+		getDialOpts := s.rpcContext.GRPCDialOptions
 
-		initConfig := newInitServerConfig(ctx, s.cfg, dialOpts)
+		initConfig := newInitServerConfig(ctx, s.cfg, getDialOpts)
 		inspectState, err := inspectEngines(
 			context.Background(),
 			s.engines,

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -367,6 +367,7 @@ func newRPCTestContext(ctx context.Context, ts *TestServer, cfg *base.Config) *r
 		MaxOffset: ts.Clock().MaxOffset(),
 		Stopper:   ts.Stopper(),
 		Settings:  ts.ClusterSettings(),
+		Knobs:     rpc.ContextTestingKnobs{NoLoopbackDialer: true},
 	})
 	// Ensure that the RPC client context validates the server cluster ID.
 	// This ensures that a test where the server is restarted will not let

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -396,10 +396,13 @@ func (s *SQLServerWrapper) PreStart(ctx context.Context) error {
 	// and dispatches the server worker for the RPC.
 	// The SQL listener is returned, to start the SQL server later
 	// below when the server has initialized.
-	pgL, startRPCServer, err := startListenRPCAndSQL(ctx, workersCtx, *s.sqlServer.cfg, s.stopper, s.grpc)
+	pgL, rpcLoopbackDialFn, startRPCServer, err := startListenRPCAndSQL(ctx, workersCtx, *s.sqlServer.cfg, s.stopper, s.grpc)
 	if err != nil {
 		return err
 	}
+
+	// Tell the RPC context how to connect in-memory.
+	s.rpcContext.SetLoopbackDialer(rpcLoopbackDialFn)
 
 	// NB: This is where (*Server).PreStart() reports the listener readiness
 	// via testing knobs: PauseAfterGettingRPCAddress, SignalAfterGettingRPCAddress.

--- a/pkg/testutils/testcluster/testcluster_test.go
+++ b/pkg/testutils/testcluster/testcluster_test.go
@@ -214,6 +214,8 @@ func TestStopServer(t *testing.T) {
 		MaxOffset: server1.Clock().MaxOffset(),
 		Stopper:   tc.Stopper(),
 		Settings:  server1.ClusterSettings(),
+
+		ClientOnly: true,
 	})
 	conn, err := rpcContext.GRPCDialNode(server1.ServingRPCAddr(), server1.NodeID(),
 		rpc.DefaultClass).Connect(ctx)

--- a/pkg/util/netutil/BUILD.bazel
+++ b/pkg/util/netutil/BUILD.bazel
@@ -4,6 +4,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "netutil",
     srcs = [
+        "loopback.go",
         "net.go",
         "srv.go",
     ],


### PR DESCRIPTION
Fixes  #92054.
Informs #84591.
Needed as prereq for #92524.

This change ensures that a server is always able to perform RPC dials
to itself. It also makes self-dial more lightweight (no compression,
no keepalive, etc).

Note that despite this PR, we still have two separate code paths
for self-dials:

- the distsender works at a higher level and performs dials using
  `(rpc.Dialer).DialInternalClient()`, which returns a
  `rpc.RestrictedInternalClient` (an interface with just the KV
  methods needed by distsender). This uses direct Go function
  calls for the API functions, and eschews data
  serialization/deserialization entirely.

- everything else works at a lower level, using `(rpc.Dialer).Dial()`
  which returns a `grpc.ClientConn`, followed by
  `pkgpb.NewXXXClient(conn)` that defines the gRPC client-side
  implementation of the API. This mandates uses of a network
  pipe, forces data serialization/deserialization, and (currently)
  force use of TLS for authentication.

  This is the path that is simplified with this PR, using
  an in-memory pipe for the network dial instead of a TCP connection.

An alternate approach to this PR would be to convert all uses
of `(rpc.Dialer).Dial` and replace them with a `(rpc.Dial).GetClient`
call, which conditionally bypasses the network dial and returns
an interface able to call the underlying RPC functions directly
(without data serialization/deserialization, etc). However, this would
be a much larger lift - there's currently more than 50 such API
boundaries.

