### PR TITLE
sqlinstance: make Start async, use in-memory copy of self to bootstrap

### DIFF
--- a/pkg/sql/sqlinstance/BUILD.bazel
+++ b/pkg/sql/sqlinstance/BUILD.bazel
@@ -11,6 +11,8 @@ go_library(
         "//pkg/roachpb",
         "//pkg/sql/sqlliveness",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
+        "@com_github_cockroachdb_redact//interfaces",
     ],
 )
 


### PR DESCRIPTION
This solves bullet 4 of https://github.com/cockroachdb/cockroach/issues/85737. This commit makes sqlinstance.Start async, and
not block until the rangefeed gets started.

Epic: [CRDB-18596](https://cockroachlabs.atlassian.net/browse/CRDB-18596)

Release note: None
