### PR TITLE
ui: fixes metrics page contention labels

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
@@ -12,7 +12,7 @@ import React from "react";
 import _ from "lodash";
 
 import { LineGraph } from "src/views/cluster/components/linegraph";
-import { Metric, Axis } from "src/views/shared/components/metricQuery";
+import { Axis, Metric } from "src/views/shared/components/metricQuery";
 
 import {
   GraphDashboardProps,
@@ -36,7 +36,7 @@ export default function (props: GraphDashboardProps) {
     <LineGraph
       title="SQL Statements"
       sources={nodeSources}
-      tooltip={`A ten-second moving average of the # of SELECT, INSERT, UPDATE, and DELETE statements
+      tooltip={`A moving average of the number of SELECT, INSERT, UPDATE, and DELETE statements
         successfully executed per second ${tooltipSelection}.`}
       preCalcGraphSize={true}
     >
@@ -90,14 +90,13 @@ export default function (props: GraphDashboardProps) {
         ))}
       </Axis>
     </LineGraph>,
-
     <LineGraph
       title="SQL Statement Contention"
       sources={nodeSources}
-      tooltip={`The total number of SQL statements that experienced contention ${tooltipSelection}.`}
+      tooltip={`A moving average of the number of SQL statements executed per second that experienced contention ${tooltipSelection}.`}
       preCalcGraphSize={true}
     >
-      <Axis label="queries">
+      <Axis label="Average number of queries per second">
         <Metric
           name="cr.node.sql.distsql.contended_queries.count"
           title="Contention"


### PR DESCRIPTION
The graph actually displays the QPS over
a 30second window. This updates the tooltip
and label to clarify what the graph is displaying.

<img width="1157" alt="Screen Shot 2022-11-29 at 10 52 47 AM" src="https://user-images.githubusercontent.com/8868107/204577693-4650da43-e47f-43d3-9719-d4baa327b4f8.png">


closes: #83971

Release note: none