### PR TITLE
roachtest/cdc: export stats for initial scan test to roachperf

### DIFF
--- a/pkg/cmd/roachtest/clusterstats/exporter.go
+++ b/pkg/cmd/roachtest/clusterstats/exporter.go
@@ -48,6 +48,7 @@ type AggQuery struct {
 	Query    string
 	AggFn    AggregateFn
 	Interval Interval
+	Tag      string
 }
 
 // StatExporter defines an interface to export statistics to roachperf.
@@ -278,6 +279,9 @@ func (cs *clusterStatCollector) getStatSummary(
 		}
 
 		ret.AggTag = summaryQuery.Query
+		if summaryQuery.Tag != "" {
+			ret.AggTag = summaryQuery.Tag
+		}
 		// If there is more than one label name associated with the summary, we
 		// cannot be sure which is the correct label.
 		if len(taggedSummarySeries) != 1 {

--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "canary.go",
         "cancel.go",
         "cdc.go",
+        "cdc_stats.go",
         "chaos.go",
         "clearrange.go",
         "cli.go",

--- a/pkg/cmd/roachtest/tests/cdc_stats.go
+++ b/pkg/cmd/roachtest/tests/cdc_stats.go
@@ -1,0 +1,42 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tests
+
+import "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/clusterstats"
+
+var (
+	// sqlServiceLatency is the sql_service_latency_bucket prometheus metric.
+	sqlServiceLatency = clusterstats.ClusterStat{LabelName: "node", Query: "sql_service_latency_bucket"}
+	// sqlServiceLatencyAgg is the P99 latency of foreground SQL traffic across all nodes measured in ms.
+	sqlServiceLatencyAgg = clusterstats.AggQuery{
+		Stat:  sqlServiceLatency,
+		Query: "histogram_quantile(0.99, sum by(le) (rate(sql_service_latency_bucket[2m]))) / (1000*1000)",
+		Tag:   "P99 Foreground Latency (ms)",
+	}
+
+	// changefeedThroughput is the changefeed_emitted_bytes prometheus metric.
+	changefeedThroughput = clusterstats.ClusterStat{LabelName: "node", Query: "changefeed_emitted_bytes"}
+	// changefeedThroughputAgg is the total rate of bytes being emitted by a cluster measured in MB/s.
+	changefeedThroughputAgg = clusterstats.AggQuery{
+		Stat:  changefeedThroughput,
+		Query: "sum(rate(changefeed_emitted_bytes[1m]) / (1000 * 1000))",
+		Tag:   "Throughput (MBps)",
+	}
+
+	// cpuUsage is the sys_cpu_combined_percent_normalized prometheus metric per mode.
+	cpuUsage = clusterstats.ClusterStat{LabelName: "node", Query: "sys_cpu_combined_percent_normalized"}
+	// cpuUsageAgg is the average CPU usage across all nodes.
+	cpuUsageAgg = clusterstats.AggQuery{
+		Stat:  cpuUsage,
+		Query: "avg(sys_cpu_combined_percent_normalized) * 100",
+		Tag:   "CPU Utilization (%)",
+	}
+)


### PR DESCRIPTION
This change updates the cdc/initial_scan_only test to produce a `stats.json` artifact to be consumed by roachprod. This file contains stats for p99 foreground latency, changefeed throughput, and CPU usage.

Release note: None
Epic: None

<img width="940" alt="image" src="https://user-images.githubusercontent.com/18633281/204564990-740e86e2-5c43-4d45-a715-4932428a5851.png">
