### PR TITLE
spanconfigreporter: fix up the add-leaktest invocation

### DIFF
--- a/pkg/spanconfig/spanconfigreporter/main_test.go
+++ b/pkg/spanconfig/spanconfigreporter/main_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
-//go:generate ../../../util/leaktest/add-leaktest.sh *_test.go
+//go:generate ../../util/leaktest/add-leaktest.sh *_test.go
 
 func TestMain(m *testing.M) {
 	securityassets.SetLoader(securitytest.EmbeddedAssets)


### PR DESCRIPTION
This was causing an error in CI.

Release note: None