### PR TITLE
importer: use 1GiB max-sql-memory in a test

### DIFF
--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -4582,6 +4582,7 @@ func TestImportDefaultWithResume(t *testing.T) {
 					BulkAdderFlushesEveryBatch: true,
 				},
 			},
+			SQLMemoryPoolSize: 1 << 30, // 1 GiB
 		})
 	registry := s.JobRegistry().(*jobs.Registry)
 	ctx := context.Background()


### PR DESCRIPTION
Fixes: #92225.

Release note: None