### PR TITLE
lease: revive TestLeaseAcquireAndReleaseConcurrencly

### DIFF
--- a/pkg/sql/catalog/lease/descriptor_state.go
+++ b/pkg/sql/catalog/lease/descriptor_state.go
@@ -305,7 +305,7 @@ func (t *descriptorState) startLeaseRenewal(
 	log.VEventf(ctx, 1,
 		"background lease renewal beginning for id=%d name=%q",
 		id, name)
-	if _, err := acquireNodeLease(ctx, m, id); err != nil {
+	if _, err := acquireNodeLease(ctx, m, id, AcquireBackground); err != nil {
 		log.Errorf(ctx,
 			"background lease renewal for id=%d name=%q failed: %s",
 			id, name, err)

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -1334,8 +1334,8 @@ func TestLeaseRenewedAutomatically(testingT *testing.T) {
 						atomic.AddInt32(&testAcquiredCount, 1)
 					}
 				},
-				LeaseAcquireResultBlockEvent: func(_ lease.AcquireBlockType, id descpb.ID) {
-					if uint32(id) < bootstrap.TestingMinUserDescID() {
+				LeaseAcquireResultBlockEvent: func(typ lease.AcquireType, id descpb.ID) {
+					if uint32(id) < bootstrap.TestingMinUserDescID() || typ == lease.AcquireBackground {
 						return
 					}
 					atomic.AddInt32(&testAcquisitionBlockCount, 1)
@@ -1798,8 +1798,8 @@ func TestLeaseRenewedPeriodically(testingT *testing.T) {
 					defer mu.Unlock()
 					releasedIDs[id] = struct{}{}
 				},
-				LeaseAcquireResultBlockEvent: func(_ lease.AcquireBlockType, id descpb.ID) {
-					if uint32(id) < bootstrap.TestingMinUserDescID() {
+				LeaseAcquireResultBlockEvent: func(typ lease.AcquireType, id descpb.ID) {
+					if uint32(id) < bootstrap.TestingMinUserDescID() || typ == lease.AcquireBackground {
 						return
 					}
 					atomic.AddInt32(&testAcquisitionBlockCount, 1)

--- a/pkg/sql/catalog/lease/testutils.go
+++ b/pkg/sql/catalog/lease/testutils.go
@@ -29,8 +29,8 @@ type StorageTestingKnobs struct {
 	// Called after a lease is acquired, with any operation error.
 	LeaseAcquiredEvent func(desc catalog.Descriptor, err error)
 	// Called before waiting on a results from a DoChan call of acquireNodeLease
-	// in descriptorState.acquire() and descriptorState.acquireFreshestFromStore().
-	LeaseAcquireResultBlockEvent func(leaseBlockType AcquireBlockType, id descpb.ID)
+	// in Acquire and AcquireFreshestFromStore.
+	LeaseAcquireResultBlockEvent func(leaseBlockType AcquireType, id descpb.ID)
 	// RemoveOnceDereferenced forces leases to be removed
 	// as soon as they are dereferenced.
 	RemoveOnceDereferenced bool


### PR DESCRIPTION
This test relied on an old placement of a testing knob (it's been moved back), and it relied on the leasing subsystem interacting with the lease table itself in interesting ways. We sidestep this latter bit by making the test use a new table. Lastly, we allow other concurrent leasing activity to not disturb the test.

Fixes #51798

Release note: None