### PR TITLE
kvserver: lower replicate queue trace logging verbosity

### DIFF
--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -836,9 +836,9 @@ func (rq *replicateQueue) processOneChangeWithTracing(
 		}
 
 		if err != nil {
-			log.KvDistribution.Infof(ctx, "error processing replica: %v%s", err, traceOutput)
+			log.KvDistribution.VEventf(ctx, 1, "error processing replica: %v%s", err, traceOutput)
 		} else if exceededDuration {
-			log.KvDistribution.Infof(ctx, "processing replica took %s, exceeding threshold of %s%s",
+			log.KvDistribution.VEventf(ctx, 1, "processing replica took %s, exceeding threshold of %s%s",
 				processDuration, loggingThreshold, traceOutput)
 		}
 	}


### PR DESCRIPTION
While we previously logged replicate queue traces on both errors and slow processing at `INFO` level, this lowers the verbosity by logging them at `VEvent` level 1. These messages can be seen in the KV Distribution log channel by enabling `vmodule` setting `replicate_queue=1` (or higher).

Epic: None

Release note: None