### PR TITLE
cluster-ui: insights bug fixes

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/insightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/insightsApi.ts
@@ -694,7 +694,7 @@ FROM
   (
     SELECT
      txn_id,
-     row_number() OVER ( PARTITION BY txn_fingerprint_id ORDER BY end_time  ) as rank
+     row_number() OVER ( PARTITION BY txn_fingerprint_id ORDER BY end_time DESC ) as rank
     FROM crdb_internal.cluster_execution_insights
   ) as latestTxns
 JOIN crdb_internal.cluster_execution_insights AS insights


### PR DESCRIPTION
Previously, when the insights statement was refactored to include all stmts for txn insights, the sorting by most recent txn was missed, causing the first execution to be surfaced instead of the most recent. This commit reverses the sorting s.t. we surface the most recent execution of a txn in the insights pages.

Epic: None

Release note: None