### PR TITLE
changefeedccl: fix cloudstorage doublecount of emitted messages

### DIFF
--- a/pkg/ccl/changefeedccl/sink_cloudstorage.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage.go
@@ -76,7 +76,6 @@ var _ io.Writer = &cloudStorageSinkFile{}
 
 func (f *cloudStorageSinkFile) Write(p []byte) (int, error) {
 	f.rawSize += len(p)
-	f.numMessages++
 	if f.codec != nil {
 		return f.codec.Write(p)
 	}
@@ -529,6 +528,7 @@ func (s *cloudStorageSink) EmitRow(
 	if _, err := file.Write(s.rowDelimiter); err != nil {
 		return err
 	}
+	file.numMessages++
 
 	if int64(file.buf.Len()) > s.targetMaxFileSize {
 		s.metrics.recordSizeBasedFlush()


### PR DESCRIPTION
Resolves https://github.com/cockroachdb/cockroach/issues/92688

The cloudstorage sink would increase its emitted message count twice per message since there were two calls to Write, one for the message and another for the delimiter.  This change moves the increasing of the count into EmitRow.

Release note (bug fix): Fixed an issue where changefeed.emitted_messages would be increased twice per message for changefeed cloudstorage sinks