### PR TITLE
ui: add space for header

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/detailsPanels/waitTimeInsightsPanel.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/detailsPanels/waitTimeInsightsPanel.tsx
@@ -76,7 +76,9 @@ export const WaitTimeInsightsPanel: React.FC<WaitTimeInsightsPanelProps> = ({
     >
       <Row gutter={24}>
         <Col>
-          <Heading type="h5">{WaitTimeInsightsLabels.SECTION_HEADING}</Heading>
+          <Heading type="h5" className={cx("margin-header")}>
+            {WaitTimeInsightsLabels.SECTION_HEADING}
+          </Heading>
           {showWaitTimeInsightsDetails && (
             <Row gutter={24}>
               {" "}
@@ -124,7 +126,7 @@ export const WaitTimeInsightsPanel: React.FC<WaitTimeInsightsPanelProps> = ({
           )}
           {blockingExecutions.length > 0 && (
             <Row>
-              <Heading type="h5">
+              <Heading type="h5" className={cx("margin-header")}>
                 {WaitTimeInsightsLabels.BLOCKING_TXNS_TABLE_TITLE(
                   executionID,
                   execType,
@@ -140,7 +142,7 @@ export const WaitTimeInsightsPanel: React.FC<WaitTimeInsightsPanelProps> = ({
           )}
           {waitingExecutions.length > 0 && (
             <Row>
-              <Heading type="h5">
+              <Heading type="h5" className={cx("margin-header")}>
                 {WaitTimeInsightsLabels.WAITING_TXNS_TABLE_TITLE(
                   executionID,
                   execType,

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.module.scss
@@ -152,3 +152,7 @@
 .margin-right {
   margin-right: 12px !important;
 }
+
+.margin-header {
+  margin-top: 10px;
+}


### PR DESCRIPTION
This commit adds space between header and the top.

Before
<img width="1542" alt="Screen Shot 2022-11-29 at 2 28 19 PM" src="https://user-images.githubusercontent.com/1017486/204645574-8d1b73e0-34a9-44b4-90da-f18fced63076.png">


After
<img width="1537" alt="Screen Shot 2022-11-29 at 3 49 08 PM" src="https://user-images.githubusercontent.com/1017486/204645591-a1b824a0-0253-470e-9e01-d5276ec84243.png">

Epic: None

Release note: None