### PR TITLE
server, ui:  add multitenant login/logout and tenant dropdown

### DIFF
--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -54,6 +54,7 @@ go_library(
         "server_http.go",
         "server_sql.go",
         "server_systemlog_gc.go",
+        "session_writer.go",
         "settings_cache.go",
         "sql_stats.go",
         "start_listen.go",

--- a/pkg/server/authentication_test.go
+++ b/pkg/server/authentication_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/lib/pq"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/bcrypt"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -524,8 +525,7 @@ func TestAuthenticationAPIUserLogin(t *testing.T) {
 	if len(cookies) == 0 {
 		t.Fatalf("good login got no cookies: %v", response)
 	}
-
-	sessionCookie, err := decodeSessionCookie(cookies[0])
+	sessionCookie, err := findAndDecodeSessionCookie(context.Background(), cookies)
 	if err != nil {
 		t.Fatalf("failed to decode session cookie: %s", err)
 	}
@@ -835,6 +835,100 @@ func TestGRPCAuthentication(t *testing.T) {
 			if exp := `client certificate CN=testuser,O=Cockroach cannot be used to perform RPC on tenant {1}`; !testutils.IsError(err, exp) {
 				t.Errorf("expected %q error, but got %v", exp, err)
 			}
+		})
+	}
+}
+
+func TestCreateAggregatedSessionCookieValue(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	tests := []struct {
+		name        string
+		mapArg      []sessionCookieValue
+		resExpected string
+	}{
+		{"standard arg", []sessionCookieValue{
+			{name: "system", setCookie: "session=abcd1234"},
+			{name: "app", setCookie: "session=efgh5678"}},
+			"abcd1234,system,efgh5678,app",
+		},
+		{"empty arg", []sessionCookieValue{}, ""},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("create-session-cookie/%s", test.name), func(t *testing.T) {
+			res := createAggregatedSessionCookieValue(test.mapArg)
+			require.Equal(t, test.resExpected, res)
+		})
+	}
+}
+
+func TestFindSessionCookieValue(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	normalSessionStr := "abcd1234,system,efgh5678,app"
+	tests := []struct {
+		name          string
+		cookieArg     []*http.Cookie
+		resExpected   string
+		errorExpected bool
+	}{
+		{"standard args", []*http.Cookie{
+			{
+				Name:  MultitenantSessionCookieName,
+				Value: normalSessionStr,
+				Path:  "/",
+			},
+			{
+				Name:  TenantSelectCookieName,
+				Value: "system",
+				Path:  "/",
+			},
+		}, "abcd1234", false},
+		{"no multitenant session cookie", []*http.Cookie{
+			{
+				Name:  TenantSelectCookieName,
+				Value: "system",
+				Path:  "/",
+			},
+		}, "", false},
+		{"no tenant cookie", []*http.Cookie{
+			{
+				Name:  MultitenantSessionCookieName,
+				Value: normalSessionStr,
+				Path:  "/",
+			},
+		}, "abcd1234", false},
+		{"empty string tenant cookie", []*http.Cookie{
+			{
+				Name:  MultitenantSessionCookieName,
+				Value: normalSessionStr,
+				Path:  "/",
+			},
+			{
+				Name:  TenantSelectCookieName,
+				Value: "",
+				Path:  "/",
+			},
+		}, "abcd1234", false},
+		{"no tenant name match", []*http.Cookie{
+			{
+				Name:  MultitenantSessionCookieName,
+				Value: normalSessionStr,
+				Path:  "/",
+			},
+			{
+				Name:  TenantSelectCookieName,
+				Value: "app2",
+				Path:  "/",
+			},
+		}, "", true},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("find-session-cookie/%s", test.name), func(t *testing.T) {
+			res, err := findSessionCookieValue(test.cookieArg)
+			require.Equal(t, test.resExpected, res)
+			require.Equal(t, test.errorExpected, err != nil)
 		})
 	}
 }

--- a/pkg/server/session_writer.go
+++ b/pkg/server/session_writer.go
@@ -1,0 +1,39 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package server
+
+import (
+	"bytes"
+	"net/http"
+)
+
+// sessionWriter implements http.ResponseWriter. It is used
+// to extract cookies written to the header when passed in to
+// a ServeHTTP function.
+type sessionWriter struct {
+	header http.Header
+	buf    bytes.Buffer
+	code   int
+}
+
+var _ http.ResponseWriter = &sessionWriter{}
+
+func (sw *sessionWriter) Header() http.Header {
+	return sw.header
+}
+
+func (sw *sessionWriter) WriteHeader(statusCode int) {
+	sw.code = statusCode
+}
+
+func (sw *sessionWriter) Write(data []byte) (int, error) {
+	return sw.buf.Write(data)
+}

--- a/pkg/ui/workspaces/db-console/src/redux/cookies.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/cookies.ts
@@ -1,0 +1,58 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+export const MULTITENANT_SESSION_COOKIE_NAME = "multitenant-session";
+
+export const getAllCookies = (): Map<string, string> => {
+  const cookieMap: Map<string, string> = new Map();
+  const cookiesArr = document.cookie.split(";");
+  cookiesArr.map(cookie => {
+    const i = cookie.indexOf("=");
+    const keyValArr = [cookie.slice(0, i), cookie.slice(i + 1)];
+    cookieMap.set(keyValArr[0].trim(), keyValArr[1].trim());
+  });
+  return cookieMap;
+};
+
+export const getCookieValue = (cookieName: string): string => {
+  const cookies = getAllCookies();
+  return cookies.get(cookieName) || null;
+};
+
+// selectTenantsFromMultitenantSessionCookie formats the multitenant-session
+// cookie value and returns only the tenant names.
+export const selectTenantsFromMultitenantSessionCookie = (): string[] => {
+  const cookies = getAllCookies();
+  const sessionsStr = cookies.get(MULTITENANT_SESSION_COOKIE_NAME);
+  return sessionsStr
+    ? sessionsStr
+        .replace(/["]/g, "")
+        .split(/[,]/g)
+        .filter((_, idx) => idx % 2 == 1)
+    : [];
+};
+
+export const setCookie = (
+  key: string,
+  val: string,
+  expires?: string,
+  path?: string,
+) => {
+  let cookieStr = `${key}=${val};`;
+  if (expires) {
+    cookieStr += `expires=${expires};`;
+  }
+  if (path) {
+    cookieStr += `path=${path}`;
+  } else {
+    cookieStr += document.location.pathname;
+  }
+  document.cookie = cookieStr;
+};

--- a/pkg/ui/workspaces/db-console/src/redux/login.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/login.ts
@@ -20,6 +20,10 @@ import { cockroach } from "src/js/protos";
 import { getDataFromServer } from "src/util/dataFromServer";
 
 import UserLoginRequest = cockroach.server.serverpb.UserLoginRequest;
+import {
+  selectTenantsFromMultitenantSessionCookie,
+  setCookie,
+} from "./cookies";
 
 const dataFromServer = getDataFromServer();
 
@@ -234,7 +238,12 @@ export function doLogout(): ThunkAction<
 > {
   return dispatch => {
     dispatch(logoutBeginAction);
-
+    const tenants = selectTenantsFromMultitenantSessionCookie();
+    // If in multi-tenant environment, we need to clear the tenant cookie so that
+    // we can do a multi-tenant logout.
+    if (tenants.length > 1) {
+      setCookie("tenant", "");
+    }
     // Make request to log out, reloading the page whether it succeeds or not.
     // If there was a successful log out but the network dropped the response somehow,
     // you'll get the login page on reload. If The logout actually didn't work, you'll

--- a/pkg/ui/workspaces/db-console/src/views/app/components/tenantDropdown/tenantDropdown.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/components/tenantDropdown/tenantDropdown.spec.tsx
@@ -1,0 +1,45 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+import {
+  selectTenantsFromMultitenantSessionCookie,
+  getCookieValue,
+} from "src/redux/cookies";
+import React from "react";
+import TenantDropdown from "./tenantDropdown";
+import { shallow } from "enzyme";
+
+jest.mock("src/redux/cookies", () => ({
+  selectTenantsFromMultitenantSessionCookie: jest.fn(),
+  getCookieValue: jest.fn(),
+}));
+
+describe("TenantDropdown", () => {
+  it("returns null if there are no tenants in the multitenant-session cookie", () => {
+    (
+      selectTenantsFromMultitenantSessionCookie as jest.MockedFn<
+        typeof selectTenantsFromMultitenantSessionCookie
+      >
+    ).mockReturnValueOnce([]);
+    const wrapper = shallow(<TenantDropdown />);
+    expect(wrapper.isEmptyRender());
+  });
+  it("returns a dropdown list of tenant options if there are tenant in the multitenant-session cookie", () => {
+    (
+      selectTenantsFromMultitenantSessionCookie as jest.MockedFn<
+        typeof selectTenantsFromMultitenantSessionCookie
+      >
+    ).mockReturnValueOnce(["system", "app"]);
+    (
+      getCookieValue as jest.MockedFn<typeof getCookieValue>
+    ).mockReturnValueOnce("system");
+    const wrapper = shallow(<TenantDropdown />);
+    expect(wrapper.find({ children: "Tenant system" }).length).toEqual(1);
+  });
+});

--- a/pkg/ui/workspaces/db-console/src/views/app/components/tenantDropdown/tenantDropdown.styl
+++ b/pkg/ui/workspaces/db-console/src/views/app/components/tenantDropdown/tenantDropdown.styl
@@ -1,4 +1,4 @@
-// Copyright 2019 The Cockroach Authors.
+// Copyright 2022 The Cockroach Authors.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.txt.
@@ -10,19 +10,9 @@
 
 @require '~src/components/core/index.styl'
 
-.page-header
-  height 100%
-  display flex
-  flex-direction row
-  flex-flow wrap
-  align-items center
-  padding $spacing-x-small 0
-  .text
+.tenant-selected
+    color $colors--neutral-7
+    padding-right 6px
+    font-weight 600
+    font-size 14px
     font-family $font-family--semi-bold
-    color $colors--neutral-8
-  :last-child
-    margin-left auto
-
-.page-header > *
-  margin-right $spacing-small
-  margin-bottom 0

--- a/pkg/ui/workspaces/db-console/src/views/app/components/tenantDropdown/tenantDropdown.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/components/tenantDropdown/tenantDropdown.tsx
@@ -1,0 +1,57 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+import {
+  getCookieValue,
+  selectTenantsFromMultitenantSessionCookie,
+  setCookie,
+} from "src/redux/cookies";
+import React from "react";
+import { Dropdown } from "@cockroachlabs/cluster-ui";
+import ErrorBoundary from "../errorMessage/errorBoundary";
+import "./tenantDropdown.styl";
+
+const tenantIDKey = "tenant";
+
+const TenantDropdown = () => {
+  const tenants = selectTenantsFromMultitenantSessionCookie();
+  const currentTenant = getCookieValue(tenantIDKey);
+
+  const createDropdownItems = () => {
+    return (
+      tenants?.map(tenantID => {
+        return { name: "Tenant " + tenantID, value: tenantID };
+      }) || []
+    );
+  };
+
+  const onTenantChange = (tenant: string) => {
+    if (tenant !== currentTenant) {
+      setCookie(tenantIDKey, tenant);
+      location.reload();
+    }
+  };
+
+  if (tenants.length == 0) {
+    return null;
+  }
+
+  return (
+    <ErrorBoundary>
+      <Dropdown
+        items={createDropdownItems()}
+        onChange={tenantID => onTenantChange(tenantID)}
+      >
+        <div className="tenant-selected">{"Tenant " + currentTenant}</div>
+      </Dropdown>
+    </ErrorBoundary>
+  );
+};
+
+export default TenantDropdown;

--- a/pkg/ui/workspaces/db-console/src/views/app/containers/layout/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/containers/layout/index.tsx
@@ -40,6 +40,7 @@ import { Badge } from "@cockroachlabs/cluster-ui";
 import "./layout.styl";
 import "./layoutPanel.styl";
 import { getDataFromServer } from "src/util/dataFromServer";
+import TenantDropdown from "../../components/tenantDropdown/tenantDropdown";
 
 export interface LayoutProps {
   clusterName: string;
@@ -99,6 +100,7 @@ class Layout extends React.Component<LayoutProps & RouteComponentProps> {
                 {clusterName || `Cluster id: ${clusterId || ""}`}
               </Text>
               <Badge text={clusterVersion} />
+              <TenantDropdown />
             </PageHeader>
           </div>
           <div className="layout-panel__body">

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
@@ -28,6 +28,7 @@ import { AdminUIState } from "src/redux/state";
 import { nodeIDsStringifiedSelector } from "src/redux/nodes";
 import { refreshNodes, refreshUserSQLRoles } from "src/redux/apiReducers";
 import { selectHasViewActivityRedactedRole } from "src/redux/user";
+import { getCookieValue, setCookie } from "src/redux/cookies";
 
 const COMMUNITY_URL = "https://www.cockroachlabs.com/community/";
 
@@ -166,28 +167,15 @@ const ProxyToNodeSelector = (props: ProxyToNodeSelectorProps) => {
 
   // currentNodeIDCookie will either be empty or contain two elements
   // with the cookie name and value we're looking for
-  const currentNodeIDCookie: string[] = document.cookie
-    .split(";")
-    .map(cookieString => {
-      return cookieString.split("=").map(kv => {
-        return kv.trim();
-      });
-    })
-    .find(cookie => {
-      return cookie[0] === remoteNodeIDCookieName;
-    });
+  const currentNodeIDCookie: string = getCookieValue(remoteNodeIDCookieName);
   const setNodeIDCookie = (nodeID: string) => {
-    document.cookie = `${remoteNodeIDCookieName}=${nodeID};path=/`;
+    setCookie(remoteNodeIDCookieName, nodeID);
     location.reload();
   };
   let currentNodeID = props.nodeID;
   let proxyEnabled = false;
-  if (
-    currentNodeIDCookie &&
-    currentNodeIDCookie.length == 2 &&
-    currentNodeIDCookie[1] !== ""
-  ) {
-    currentNodeID = currentNodeIDCookie[1];
+  if (currentNodeIDCookie) {
+    currentNodeID = currentNodeIDCookie;
     if (currentNodeID !== "local" && currentNodeID !== "") {
       proxyEnabled = true;
     }


### PR DESCRIPTION
ui, server: add multitenant login/logout and tenant dropdown

This patch enables login/logout for all tenants on the cluster
by fanning out the incoming requests to each tenant server.
Multitenant login introduces a new multitenant session cookie
with the format as <session>,<tenant_name,<session2>,<tenant_name2>
etc. The admin ui displays a dropdown with a list of tenants
the user has successfully logged in to. Selecting a different
tenant sets the tenant cookie to the selected tenant name
and reloads the page. If the cluster is not multitenant, the
dropdown will not display.

Release note (ui change): added a top-level dropdown
on the admin ui which lists tenants the user has logged
in to. If not multitenant, the dropdown is not displayed.

Epic: https://cockroachlabs.atlassian.net/browse/CRDB-14546