### PR TITLE
sqlstats: record idle latency for transactions

### DIFF
--- a/pkg/roachpb/app_stats.go
+++ b/pkg/roachpb/app_stats.go
@@ -124,6 +124,7 @@ func (t *TransactionStatistics) Add(other *TransactionStatistics) {
 		t.MaxRetries = other.MaxRetries
 	}
 
+	t.IdleLat.Add(other.IdleLat, t.Count, other.Count)
 	t.CommitLat.Add(other.CommitLat, t.Count, other.Count)
 	t.RetryLat.Add(other.RetryLat, t.Count, other.Count)
 	t.ServiceLat.Add(other.ServiceLat, t.Count, other.Count)

--- a/pkg/roachpb/app_stats.proto
+++ b/pkg/roachpb/app_stats.proto
@@ -149,6 +149,10 @@ message TransactionStatistics {
   // all statement operations have been applied.
   optional NumericStat commit_lat = 6 [(gogoproto.nullable) = false];
 
+  // IdleLat is the cumulative amount of time spent in seconds waiting for
+  // the client to send statements while holding the transaction open.
+  optional NumericStat idle_lat = 11 [(gogoproto.nullable) = false];
+
   // BytesRead collects the number of bytes read from disk.
   optional NumericStat bytes_read = 7 [(gogoproto.nullable) = false];
 

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1398,6 +1398,11 @@ type connExecutor struct {
 		shouldCollectTxnExecutionStats bool
 		// accumulatedStats are the accumulated stats of all statements.
 		accumulatedStats execstats.QueryLevelStats
+
+		// idleLatency is the cumulative amount of time spent waiting for the
+		// client to send statements while holding the transaction open.
+		idleLatency time.Duration
+
 		// rowsRead and bytesRead are separate from QueryLevelStats because they are
 		// accumulated independently since they are always collected, as opposed to
 		// QueryLevelStats which are sampled.

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -252,6 +252,7 @@ func (ex *connExecutor) recordStatementSummary(
 		ex.extraTxnState.transactionStatementsHash.Add(uint64(stmtFingerprintID))
 	}
 	ex.extraTxnState.numRows += rowsAffected
+	ex.extraTxnState.idleLatency += idleLatRaw
 
 	if log.V(2) {
 		// ages since significant epochs

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding.go
@@ -218,6 +218,7 @@ func BuildTxnMetadataJSON(statistics *roachpb.CollectedTransactionStatistics) (j
 //	        "svcLat":     { "$ref": "#/definitions/numeric_stats" },
 //	        "retryLat":   { "$ref": "#/definitions/numeric_stats" },
 //	        "commitLat":  { "$ref": "#/definitions/numeric_stats" },
+//	        "idleLat":    { "$ref": "#/definitions/numeric_stats" },
 //	        "bytesRead":  { "$ref": "#/definitions/numeric_stats" },
 //	        "rowsRead":   { "$ref": "#/definitions/numeric_stats" }
 //	      },
@@ -227,6 +228,7 @@ func BuildTxnMetadataJSON(statistics *roachpb.CollectedTransactionStatistics) (j
 //	        "svcLat",
 //	        "retryLat",
 //	        "commitLat",
+//	        "idleLat",
 //	        "bytesRead",
 //	        "rowsRead",
 //	      ]

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
@@ -318,6 +318,10 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
       "mean": {{.Float}},
       "sqDiff": {{.Float}}
     },
+    "idleLat": {
+      "mean": {{.Float}},
+      "sqDiff": {{.Float}}
+    },
     "bytesRead": {
       "mean": {{.Float}},
       "sqDiff": {{.Float}}

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
@@ -303,6 +303,7 @@ func (t *innerTxnStats) jsonFields() jsonFields {
 		{"svcLat", (*numericStats)(&t.ServiceLat)},
 		{"retryLat", (*numericStats)(&t.RetryLat)},
 		{"commitLat", (*numericStats)(&t.CommitLat)},
+		{"idleLat", (*numericStats)(&t.IdleLat)},
 		{"bytesRead", (*numericStats)(&t.BytesRead)},
 		{"rowsRead", (*numericStats)(&t.RowsRead)},
 		{"rowsWritten", (*numericStats)(&t.RowsWritten)},

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
@@ -301,6 +301,7 @@ func (s *Container) RecordTransaction(
 	stats.mu.data.ServiceLat.Record(stats.mu.data.Count, value.ServiceLatency.Seconds())
 	stats.mu.data.RetryLat.Record(stats.mu.data.Count, value.RetryLatency.Seconds())
 	stats.mu.data.CommitLat.Record(stats.mu.data.Count, value.CommitLatency.Seconds())
+	stats.mu.data.IdleLat.Record(stats.mu.data.Count, value.IdleLatency.Seconds())
 	if value.RetryCount > stats.mu.data.MaxRetries {
 		stats.mu.data.MaxRetries = value.RetryCount
 	}

--- a/pkg/sql/sqlstats/ssprovider.go
+++ b/pkg/sql/sqlstats/ssprovider.go
@@ -234,6 +234,7 @@ type RecordedTxnStats struct {
 	ServiceLatency          time.Duration
 	RetryLatency            time.Duration
 	CommitLatency           time.Duration
+	IdleLatency             time.Duration
 	RowsAffected            int
 	CollectedExecStats      bool
 	ExecStats               execstats.QueryLevelStats

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
@@ -340,6 +340,7 @@ function addTransactionStats(
       countA,
       countB,
     ),
+    idle_lat: aggregateNumericStats(a.idle_lat, b.idle_lat, countA, countB),
     rows_read: aggregateNumericStats(a.rows_read, b.rows_read, countA, countB),
     rows_written: aggregateNumericStats(
       a.rows_written,


### PR DESCRIPTION
Part of #86667
Follows #91098

Release note (sql change): A new NumericStat, idleLat, was introduced to the statistics column of crdb_internal.transaction_statistics, reporting the time spent waiting for the client to send statements while holding a transaction open.