### PR TITLE
bors: update required status after renaming TC project

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -2,7 +2,7 @@
 
 # List of commit statuses that must pass on the merge commit before it is
 # pushed to master.
-status = ["Bazel Essential CI (Cockroach)"]
+status = ["Bazel Essential CI (Cockroach - Public/External)"]
 
 # List of commit statuses that must not be failing on the PR commit when it is
 # r+-ed. If it's still in progress (for e.g. if CI is still running), bors will


### PR DESCRIPTION
Following renaming `Cockroach` project in TeamCity to `Cockroach - Public/External`, we need to update bors's required status to reflect this change.

Part of: DEVINF-539
Release note: None