### PR TITLE
sql/stats: guard against nil HistogramData.ColumnType when forecasting

### DIFF
--- a/pkg/sql/stats/quantile.go
+++ b/pkg/sql/stats/quantile.go
@@ -116,7 +116,7 @@ func canMakeQuantile(version HistogramVersion, colType *types.T) bool {
 		return false
 	}
 
-	if colType.UserDefined() {
+	if colType == nil || colType.UserDefined() {
 		return false
 	}
 	switch colType.Family() {


### PR DESCRIPTION
Sometimes HistogramData.ColumnType can be nil. We check for this in a few places, but were not in statistics forecasting. If we run into these histograms we will consider them "missing" histograms (as if `sql.stats.histogram_collection.enabled` were false) and skip over them when predicting histograms.

Fixes: #92489

Release note (bug fix): Fix a rare panic only present in v22.2.0 that
occurs when using particular forms of old statistics in table statistics
forecasting.

This panic can also be mitigated by deleting old statistics, or by
disabling forecasting with either:

```
SET CLUSTER SETTING sql.stats.forecasts.enabled = false;
```

or, if the specific table with the problematic statistics is known:

```
ALTER TABLE t SET (sql_stats_forecasts_enabled = false);
```