### PR TITLE
multitenant: replace EXPERIMENTAL_RELOCATE StoreID to NodeID lookup

### DIFF
--- a/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
@@ -482,6 +482,10 @@ func (s mockNodeStore) GetNodeDescriptor(id roachpb.NodeID) (*roachpb.NodeDescri
 	return nil, errors.Errorf("unable to look up descriptor for n%d", id)
 }
 
+func (s mockNodeStore) GetStoreDescriptor(id roachpb.StoreID) (*roachpb.StoreDescriptor, error) {
+	return nil, errors.Errorf("unable to look up descriptor for store ID %d", id)
+}
+
 // TestOracle tests the Oracle exposed by this package.
 func TestOracle(t *testing.T) {
 	defer leaktest.AfterTest(t)()

--- a/pkg/ccl/kvccl/kvtenantccl/connector_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/connector_test.go
@@ -157,6 +157,18 @@ func gossipEventForNodeDesc(desc *roachpb.NodeDescriptor) *roachpb.GossipSubscri
 	}
 }
 
+func gossipEventForStoreDesc(desc *roachpb.StoreDescriptor) *roachpb.GossipSubscriptionEvent {
+	val, err := protoutil.Marshal(desc)
+	if err != nil {
+		panic(err)
+	}
+	return &roachpb.GossipSubscriptionEvent{
+		Key:            gossip.MakeStoreDescKey(desc.StoreID),
+		Content:        roachpb.MakeValueFromBytesAndTimestamp(val, hlc.Timestamp{}),
+		PatternMatched: gossip.MakePrefixPattern(gossip.KeyStoreDescPrefix),
+	}
+}
+
 func gossipEventForSystemConfig(cfg *config.SystemConfigEntries) *roachpb.GossipSubscriptionEvent {
 	val, err := protoutil.Marshal(cfg)
 	if err != nil {
@@ -173,6 +185,14 @@ func waitForNodeDesc(t *testing.T, c *Connector, nodeID roachpb.NodeID) {
 	t.Helper()
 	testutils.SucceedsSoon(t, func() error {
 		_, err := c.GetNodeDescriptor(nodeID)
+		return err
+	})
+}
+
+func waitForStoreDesc(t *testing.T, c *Connector, storeID roachpb.StoreID) {
+	t.Helper()
+	testutils.SucceedsSoon(t, func() error {
+		_, err := c.GetStoreDescriptor(storeID)
 		return err
 	})
 }
@@ -197,10 +217,11 @@ func TestConnectorGossipSubscription(t *testing.T) {
 	gossipSubC := make(chan *roachpb.GossipSubscriptionEvent)
 	defer close(gossipSubC)
 	gossipSubFn := func(req *roachpb.GossipSubscriptionRequest, stream roachpb.Internal_GossipSubscriptionServer) error {
-		assert.Len(t, req.Patterns, 3)
+		assert.Len(t, req.Patterns, 4)
 		assert.Equal(t, "cluster-id", req.Patterns[0])
 		assert.Equal(t, "node:.*", req.Patterns[1])
-		assert.Equal(t, "system-db", req.Patterns[2])
+		assert.Equal(t, "store:.*", req.Patterns[2])
+		assert.Equal(t, "system-db", req.Patterns[3])
 		for gossipSub := range gossipSubC {
 			if err := stream.Send(gossipSub); err != nil {
 				return err
@@ -253,6 +274,25 @@ func TestConnectorGossipSubscription(t *testing.T) {
 	desc, err = c.GetNodeDescriptor(3)
 	require.Nil(t, desc)
 	require.Regexp(t, "unable to look up descriptor for n3", err)
+
+	// Test GetStoreDescriptor.
+	storeID1 := roachpb.StoreID(1)
+	store1 := &roachpb.StoreDescriptor{StoreID: storeID1, Node: *node1}
+	storeID2 := roachpb.StoreID(2)
+	store2 := &roachpb.StoreDescriptor{StoreID: storeID2, Node: *node2}
+	gossipSubC <- gossipEventForStoreDesc(store1)
+	gossipSubC <- gossipEventForStoreDesc(store2)
+	waitForStoreDesc(t, c, storeID1)
+	storeDesc, err := c.GetStoreDescriptor(storeID1)
+	require.NoError(t, err)
+	require.Equal(t, store1, storeDesc)
+	waitForStoreDesc(t, c, storeID2)
+	storeDesc, err = c.GetStoreDescriptor(storeID2)
+	require.NoError(t, err)
+	require.Equal(t, store2, storeDesc)
+	storeDesc, err = c.GetStoreDescriptor(3)
+	require.Nil(t, storeDesc)
+	require.Regexp(t, "unable to look up descriptor for store ID 3", err)
 
 	// Return updated GossipSubscription response.
 	node1Up := &roachpb.NodeDescriptor{NodeID: 1, Address: util.MakeUnresolvedAddr("tcp", "1.2.3.4")}
@@ -414,10 +454,11 @@ func TestConnectorRetriesUnreachable(t *testing.T) {
 		gossipEventForNodeDesc(node2),
 	}
 	gossipSubFn := func(req *roachpb.GossipSubscriptionRequest, stream roachpb.Internal_GossipSubscriptionServer) error {
-		assert.Len(t, req.Patterns, 3)
+		assert.Len(t, req.Patterns, 4)
 		assert.Equal(t, "cluster-id", req.Patterns[0])
 		assert.Equal(t, "node:.*", req.Patterns[1])
-		assert.Equal(t, "system-db", req.Patterns[2])
+		assert.Equal(t, "store:.*", req.Patterns[2])
+		assert.Equal(t, "system-db", req.Patterns[3])
 		for _, event := range gossipSubEvents {
 			if err := stream.Send(event); err != nil {
 				return err

--- a/pkg/kv/kvclient/kvcoord/node_store.go
+++ b/pkg/kv/kvclient/kvcoord/node_store.go
@@ -12,11 +12,14 @@ package kvcoord
 
 import "github.com/cockroachdb/cockroach/pkg/roachpb"
 
-// NodeDescStore stores a collection of NodeDescriptors.
+// NodeDescStore stores a collection of NodeDescriptors and StoreDescriptors.
 //
 // Implementations of the interface are expected to be threadsafe.
 type NodeDescStore interface {
-	// GetNodeDescriptor looks up the descriptor of the node by ID.
-	// It returns an error if the node is not known by the store.
+	// GetNodeDescriptor looks up the node descriptor by node ID.
+	// It returns an error if the node is not known by the cache.
 	GetNodeDescriptor(roachpb.NodeID) (*roachpb.NodeDescriptor, error)
+	// GetStoreDescriptor looks up the store descriptor by store ID.
+	// It returns an error if the store is not known by the cache.
+	GetStoreDescriptor(roachpb.StoreID) (*roachpb.StoreDescriptor, error)
 }

--- a/pkg/kv/kvclient/kvcoord/replica_slice_test.go
+++ b/pkg/kv/kvclient/kvcoord/replica_slice_test.go
@@ -33,7 +33,7 @@ type mockNodeStore struct {
 
 var _ NodeDescStore = &mockNodeStore{}
 
-// GetNodeDesc is part of the NodeDescStore interface.
+// GetNodeDescriptor is part of the NodeDescStore interface.
 func (ns *mockNodeStore) GetNodeDescriptor(nodeID roachpb.NodeID) (*roachpb.NodeDescriptor, error) {
 	for _, nd := range ns.nodes {
 		if nd.NodeID == nodeID {
@@ -41,6 +41,13 @@ func (ns *mockNodeStore) GetNodeDescriptor(nodeID roachpb.NodeID) (*roachpb.Node
 		}
 	}
 	return nil, errors.Errorf("unable to look up descriptor for n%d", nodeID)
+}
+
+// GetStoreDescriptor is part of the NodeDescStore interface.
+func (ns *mockNodeStore) GetStoreDescriptor(
+	storeID roachpb.StoreID,
+) (*roachpb.StoreDescriptor, error) {
+	return nil, errors.Errorf("unable to look up descriptor for store ID %d", storeID)
 }
 
 func TestNewReplicaSlice(t *testing.T) {

--- a/pkg/kv/kvclient/kvtenant/connector.go
+++ b/pkg/kv/kvclient/kvtenant/connector.go
@@ -47,8 +47,9 @@ type Connector interface {
 	Start(context.Context) error
 
 	// NodeDescStore provides information on each of the KV nodes in the cluster
-	// in the form of NodeDescriptors. This obviates the need for SQL-only
-	// tenant processes to join the cluster-wide gossip network.
+	// in the form of NodeDescriptors and StoreDescriptors. This obviates the
+	// need for SQL-only tenant processes to join the cluster-wide gossip
+	// network.
 	kvcoord.NodeDescStore
 
 	// RangeDescriptorDB provides range addressing information in the form of

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -140,6 +140,10 @@ func (m mockNodeStore) GetNodeDescriptor(id roachpb.NodeID) (*roachpb.NodeDescri
 	return m.desc, nil
 }
 
+func (m mockNodeStore) GetStoreDescriptor(id roachpb.StoreID) (*roachpb.StoreDescriptor, error) {
+	return nil, errors.Errorf("unable to look up descriptor for store ID %d", id)
+}
+
 type dummyFirstRangeProvider struct {
 	store *Store
 }

--- a/pkg/rpc/auth_tenant.go
+++ b/pkg/rpc/auth_tenant.go
@@ -265,6 +265,7 @@ func (a tenantAuthorizer) authTenant(id roachpb.TenantID) error {
 var gossipSubscriptionPatternAllowlist = []string{
 	"cluster-id",
 	"node:.*",
+	"store:.*",
 	"system-db",
 }
 

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1342,7 +1342,7 @@ type ExecutorConfig struct {
 	// EventsExporter is the client for the Observability Service.
 	EventsExporter obs.EventsExporter
 
-	// NodeDescs stores node descriptors in an in-memory cache.
+	// NodeDescs stores {Store,Node}Descriptors in an in-memory cache.
 	NodeDescs kvcoord.NodeDescStore
 }
 

--- a/pkg/sql/multitenant_admin_function_test.go
+++ b/pkg/sql/multitenant_admin_function_test.go
@@ -131,6 +131,12 @@ func TestMultiTenantAdminFunction(t *testing.T) {
 			query: "ALTER TABLE t EXPERIMENTAL_RELOCATE VOTERS SELECT ARRAY[1], 1;",
 		},
 		{
+			desc:                     "ALTER TABLE x EXPERIMENTAL_RELOCATE VOTERS SkipSQLSystemTenantCheck",
+			query:                    "ALTER TABLE t EXPERIMENTAL_RELOCATE VOTERS SELECT ARRAY[1], 1;",
+			errorMessage:             rangeErrorMessage,
+			skipSQLSystemTenantCheck: true,
+		},
+		{
 			desc:         "ALTER TABLE x SPLIT AT",
 			query:        "ALTER TABLE t SPLIT AT VALUES (1);",
 			errorMessage: "request [1 AdmSplit] not permitted",

--- a/pkg/sql/relocate.go
+++ b/pkg/sql/relocate.go
@@ -13,7 +13,6 @@ package sql
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -40,14 +39,9 @@ type relocateNode struct {
 // relocateNode during local execution.
 type relocateRun struct {
 	lastRangeStartKey []byte
-
-	// storeMap caches information about stores seen in relocation strings (to
-	// avoid looking them up for every row).
-	storeMap map[roachpb.StoreID]roachpb.NodeID
 }
 
 func (n *relocateNode) startExec(runParams) error {
-	n.run.storeMap = make(map[roachpb.StoreID]roachpb.NodeID)
 	return nil
 }
 
@@ -65,6 +59,7 @@ func (n *relocateNode) Next(params runParams) (bool, error) {
 
 	var relocationTargets []roachpb.ReplicationTarget
 	var leaseStoreID roachpb.StoreID
+	execCfg := params.ExecCfg()
 	if n.subjectReplicas == tree.RelocateLease {
 		if !data[0].ResolvedType().Equivalent(types.Int) {
 			return false, errors.Errorf(
@@ -96,17 +91,11 @@ func (n *relocateNode) Next(params runParams) (bool, error) {
 				return false, errors.Errorf("NULL value in relocation array for EXPERIMENTAL_RELOCATE")
 			}
 			storeID := roachpb.StoreID(*d.(*tree.DInt))
-			nodeID, ok := n.run.storeMap[storeID]
-			if !ok {
-				// Lookup the store in gossip.
-				storeDesc, err := lookupStoreDesc(storeID, params)
-				if err != nil {
-					return false, err
-				}
-				nodeID = storeDesc.Node.NodeID
-				n.run.storeMap[storeID] = nodeID
+			storeDesc, err := execCfg.NodeDescs.GetStoreDescriptor(storeID)
+			if err != nil {
+				return false, err
 			}
-			relocationTargets[i] = roachpb.ReplicationTarget{NodeID: nodeID, StoreID: storeID}
+			relocationTargets[i] = roachpb.ReplicationTarget{NodeID: storeDesc.Node.NodeID, StoreID: storeID}
 		}
 	}
 
@@ -116,13 +105,13 @@ func (n *relocateNode) Next(params runParams) (bool, error) {
 	// TODO(a-robinson): Get the lastRangeStartKey via the ReturnRangeInfo option
 	// on the BatchRequest Header. We can't do this until v2.2 because admin
 	// requests don't respect the option on versions earlier than v2.1.
-	rowKey, err := getRowKey(params.ExecCfg().Codec, n.tableDesc, n.index, data[1:])
+	rowKey, err := getRowKey(execCfg.Codec, n.tableDesc, n.index, data[1:])
 	if err != nil {
 		return false, err
 	}
 	rowKey = keys.MakeFamilyKey(rowKey, 0)
 
-	rangeDesc, err := lookupRangeDescriptor(params.ctx, params.extendedEvalCtx.ExecCfg.DB, rowKey)
+	rangeDesc, err := lookupRangeDescriptor(params.ctx, execCfg.DB, rowKey)
 	if err != nil {
 		return false, errors.Wrapf(err, "error looking up range descriptor")
 	}
@@ -132,11 +121,11 @@ func (n *relocateNode) Next(params runParams) (bool, error) {
 	existingNonVoters := rangeDesc.Replicas().NonVoters().ReplicationTargets()
 	switch n.subjectReplicas {
 	case tree.RelocateLease:
-		if err = params.p.ExecCfg().DB.AdminTransferLease(params.ctx, rowKey, leaseStoreID); err != nil {
+		if err = execCfg.DB.AdminTransferLease(params.ctx, rowKey, leaseStoreID); err != nil {
 			return false, err
 		}
 	case tree.RelocateNonVoters:
-		err = params.p.ExecCfg().DB.AdminRelocateRange(
+		err = execCfg.DB.AdminRelocateRange(
 			params.ctx,
 			rowKey,
 			existingVoters,
@@ -144,7 +133,7 @@ func (n *relocateNode) Next(params runParams) (bool, error) {
 			true, /* transferLeaseToFirstVoter */
 		)
 	case tree.RelocateVoters:
-		err = params.p.ExecCfg().DB.AdminRelocateRange(
+		err = execCfg.DB.AdminRelocateRange(
 			params.ctx,
 			rowKey,
 			relocationTargets,
@@ -173,21 +162,6 @@ func (n *relocateNode) Values() tree.Datums {
 
 func (n *relocateNode) Close(ctx context.Context) {
 	n.rows.Close(ctx)
-}
-
-func lookupStoreDesc(storeID roachpb.StoreID, params runParams) (*roachpb.StoreDescriptor, error) {
-	var storeDesc roachpb.StoreDescriptor
-	gossipStoreKey := gossip.MakeStoreDescKey(storeID)
-	g, err := params.extendedEvalCtx.ExecCfg.Gossip.OptionalErr(54250)
-	if err != nil {
-		return nil, err
-	}
-	if err := g.GetInfoProto(
-		gossipStoreKey, &storeDesc,
-	); err != nil {
-		return nil, errors.Wrapf(err, "error looking up store %d", storeID)
-	}
-	return &storeDesc, nil
 }
 
 func lookupRangeDescriptor(


### PR DESCRIPTION
Fixes #91628

Replace EXPERIMENTAL_RELOCATE's StoreID -> NodeID lookup's gossip impl with an in-memory cache.

Release note: None