### PR TITLE
sql: fix left semi and left anti virtual lookup joins

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4674,3 +4674,39 @@ order by attnum;
 attnum  attname
 1       x
 2       y
+
+# Regression test for not projecting away looked up columns by the left semi
+# virtual lookup join (#91012).
+statement ok
+CREATE TABLE t91012 (id INT, a_id INT);
+
+query I
+SELECT
+	count(*)
+FROM
+	pg_class AS t INNER JOIN pg_attribute AS a ON t.oid = a.attrelid
+WHERE
+	a.attnotnull = 'f'
+	AND a.attname = 'a_id'
+	AND t.relname = 't91012'
+	AND a.atttypid
+		IN (SELECT oid FROM pg_type WHERE typname = ANY (ARRAY['int8']));
+----
+1
+
+# Regression test for incorrectly handling left anti virtual lookup joins
+# (#88096).
+statement ok
+CREATE TYPE mytype AS enum('hello')
+
+query I
+SELECT
+	count(*)
+FROM
+	pg_type AS t
+WHERE
+	t.typrelid = 0
+	AND NOT EXISTS(SELECT 1 FROM pg_type AS el WHERE el.oid = t.typelem AND el.typarray = t.oid)
+	AND t.typname LIKE 'myt%'
+----
+1

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -292,6 +292,7 @@ func (c *CustomFuncs) GenerateLookupJoins(
 //
 // It should be possible to support semi- and anti- joins. Left joins may be
 // possible with additional complexity.
+// TODO(mgartner): update this comment.
 //
 // It should also be possible to support cases where all the virtual columns are
 // not covered by a single index by wrapping the lookup join in a Project that


### PR DESCRIPTION
Epic: CRDB-23454

This commit fixes the execution of the left semi and left anti virtual
lookup joins. The bug was that we forgot to project away the looked up
columns (coming from the "right" side) which could then lead to wrong
columns being used higher up the tree. The bug was introduced during
22.1 release cycle where we added the optimizer support for generating
plans that could contain left semi and left anti virtual lookup joins.
This commit fixes that issue as well as the output columns of such joins
(I'm not sure whether there is a user facing impact of having incorrect
"output columns").

Additionally, this commit fixes the execution of these virtual lookup
joins to correctly return the input row only once. Previously, for left
anti joins we'd be producing an output row if there was a match (which
is wrong), and for both left semi and left anti we would emit an output
row every time there was a match (but this should be done only once).
(Although I'm not sure whether it is possible for virtual indexes to
result in multiple looked up rows.)

Also, as a minor simplification this commit makes it so that the output
rows are not added into the row container for left semi and left anti
and the container is not instantiated at all.

Fixes: #91012.
Fixes: #88096.

Release note (bug fix): CockroachDB previously could incorrectly
evaluate queries that performed left semi and left anti "virtual lookup"
joins on tables in `pg_catalog` or `information_schema`. These join types
can be planned when a subquery is used inside of a filter condition. The
bug was introduced in 20.2.0 and is now fixed.