### PR TITLE
release-22.2.0: ci: fix regression in stress_impl

### DIFF
--- a/build/teamcity/cockroach/nightlies/stress_impl.sh
+++ b/build/teamcity/cockroach/nightlies/stress_impl.sh
@@ -33,8 +33,7 @@ do
         continue
     fi
     exit_status=0
-    GO_TEST_JSON_OUTPUT_FILE=$ARTIFACTS_DIR/$(echo "$test" | cut -d: -f2).test.json.txt
-    $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- --config=ci test "$test" \
+    $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- test --config=ci "$test" \
                                           --test_env=COCKROACH_NIGHTLY_STRESS=true \
                                           --test_env=GO_TEST_JSON_OUTPUT_FILE=$GO_TEST_JSON_OUTPUT_FILE \
                                           --test_timeout="$TESTTIMEOUTSECS" \


### PR DESCRIPTION
Backport 1/1 commits from #91962.

/cc @cockroachdb/release

---

Fixes a regression introduced in [1] which broke nightly Stress tests. bazci is _sensitive_ to the order of command-line arguments. Specifically, --config cannot be in the first position.

[1] https://github.com/cockroachdb/cockroach/commit/7122bac7602a7f2ba564017d764e2bb76ecc7482

Release note: None
Release justification: fix 1K+ nightly stress test failures in CI
Epic: None
