### PR TITLE
release 22-1: backupccl: fix restoreTPCE10TB test infra flake

### DIFF
--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -501,7 +501,7 @@ func checkDetachedRestore(
 				var status string
 				var payloadBytes []byte
 				if err = conn.QueryRowContext(ctx,
-					`SELECT status, payload FROM [SHOW JOBS] WHERE job_id = $1`,
+					`SELECT status, payload FROM system.jobs WHERE id = $1`,
 					jobID).Scan(&status, &payloadBytes); err != nil {
 					return false, errors.Wrapf(err, "failed to check restore job status")
 				}


### PR DESCRIPTION
The query to check the job status is incorrect. Instead of getting the payload from SHOW JOBS, it should query system.jobs.

Fixes #92735

Release note: None

Release justification: test only change