### PR TITLE
Revert "roachtest: update jepsen core to 0.1.19"

### DIFF
--- a/pkg/cmd/roachtest/tests/jepsen.go
+++ b/pkg/cmd/roachtest/tests/jepsen.go
@@ -81,7 +81,7 @@ const jepsenRepo = "https://github.com/cockroachdb/jepsen"
 const repoBranch = "tc-nightly"
 
 const gcpPath = "https://storage.googleapis.com/cockroach-jepsen"
-const binaryVersion = "0.2.0-1150b38f-standalone"
+const binaryVersion = "0.1.0-3d7c345d-standalone"
 
 var jepsenNemeses = []struct {
 	name, config string


### PR DESCRIPTION
This reverts commit 4d1b9fc0166e1d97c4d86ecb760777386fb6db5c.

See https://github.com/cockroachdb/cockroach/issues/92743