### PR TITLE
release-22.2: cluster-ui: align card height in  details pages

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/insightsDetails.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/insightsDetails.module.scss
@@ -1,3 +1,6 @@
 .section {
   padding: 12px 24px 12px 0px;
+  display: flex;
+  flex-direction: column;
+  row-gap: 24px;
 }

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
@@ -132,7 +132,7 @@ export const StatementInsightDetailsOverviewTab: React.FC<
 
   return (
     <section className={cx("section")}>
-      <Row gutter={24}>
+      <Row gutter={24} type="flex">
         <Col span={12}>
           <SummaryCard>
             <SummaryCardItem

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
@@ -169,7 +169,7 @@ export const TransactionInsightDetails: React.FC<
             </Row>
             {insightDetails && (
               <>
-                <Row gutter={24}>
+                <Row gutter={24} type="flex">
                   <Col className="gutter-row" span={12}>
                     <SummaryCard>
                       <SummaryCardItem

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/activeStatementDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/activeStatementDetailsOverviewTab.tsx
@@ -44,36 +44,30 @@ export const ActiveStatementDetailsOverviewTab = ({
   return (
     <>
       <section className={cx("section", "section--container")}>
-        <Row gutter={24}>
+        <Row gutter={24} type="flex">
           <Col className="gutter-row" span={12}>
             <SummaryCard className={cx("summary-card")}>
-              <Row>
-                <Col>
-                  <SummaryCardItem
-                    label="Start Time (UTC)"
-                    value={statement.start.format(DATE_FORMAT_24_UTC)}
-                  />
-                  <SummaryCardItem
-                    label="Elapsed Time"
-                    value={Duration(
-                      statement.elapsedTime.asMilliseconds() * 1e6,
-                    )}
-                  />
-                  <SummaryCardItem
-                    label="Status"
-                    value={
-                      <>
-                        <StatusIcon status={statement.status} />
-                        {statement.status}
-                      </>
-                    }
-                  />
-                  <SummaryCardItem
-                    label="Full Scan"
-                    value={statement.isFullScan.toString()}
-                  />
-                </Col>
-              </Row>
+              <SummaryCardItem
+                label="Start Time (UTC)"
+                value={statement.start.format(DATE_FORMAT_24_UTC)}
+              />
+              <SummaryCardItem
+                label="Elapsed Time"
+                value={Duration(statement.elapsedTime.asMilliseconds() * 1e6)}
+              />
+              <SummaryCardItem
+                label="Status"
+                value={
+                  <>
+                    <StatusIcon status={statement.status} />
+                    {statement.status}
+                  </>
+                }
+              />
+              <SummaryCardItem
+                label="Full Scan"
+                value={statement.isFullScan.toString()}
+              />
             </SummaryCard>
           </Col>
           <Col className="gutter-row" span={12}>

--- a/pkg/ui/workspaces/cluster-ui/src/summaryCard/summaryCard.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/summaryCard/summaryCard.module.scss
@@ -1,11 +1,14 @@
 @import "../core/index.module";
 
 .summary--card {
+  display: flex;
+  flex-direction: column;
+  row-gap: 10px;
+  height: 100%;
   border-radius: 3px;
   box-shadow: 0 0 1px 0 rgba(67, 90, 111, 0.41);
   background-color: $adminui-white;
   padding: 24px;
-  margin-bottom: 15px;
   font-family: $font-family--base;
   font-size: $font-size--medium;
   h4 {
@@ -54,7 +57,6 @@
   &__item {
     display: flex;
     justify-content: space-between;
-    margin-bottom: 10px;
     &--label {
       font-family: $font-family--base;
       font-size: 14px;

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/activeTransactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/activeTransactionDetails.tsx
@@ -28,7 +28,7 @@ import {
 import { StatusIcon } from "src/activeExecutions/statusIcon";
 import summaryCardStyles from "src/summaryCard/summaryCard.module.scss";
 import { getMatchParamByName } from "src/util/query";
-import { executionIdAttr } from "../util";
+import { executionIdAttr, DATE_FORMAT_24_UTC } from "src/util";
 
 import styles from "../statementDetails/statementDetails.module.scss";
 import { WaitTimeInsightsPanel } from "src/detailsPanels/waitTimeInsightsPanel";
@@ -114,38 +114,34 @@ export const ActiveTransactionDetails: React.FC<
           </Col>
         </Row>
         {transaction && (
-          <Row gutter={24}>
+          <Row gutter={24} type="flex">
             <Col className="gutter-row" span={12}>
               <SummaryCard className={cx("summary-card")}>
-                <Row>
-                  <Col>
-                    <SummaryCardItem
-                      label={ActiveTxnInsightsLabels.START_TIME}
-                      value={transaction.start.format(
-                        "MMM D, YYYY [at] H:mm (UTC)",
-                      )}
-                    />
-                    <SummaryCardItem
-                      label={ActiveTxnInsightsLabels.ELAPSED_TIME}
-                      value={Duration(
-                        transaction.elapsedTime.asMilliseconds() * 1e6,
-                      )}
-                    />
-                    <SummaryCardItem
-                      label={ActiveTxnInsightsLabels.STATUS}
-                      value={
-                        <>
-                          <StatusIcon status={transaction.status} />
-                          {transaction.status}
-                        </>
-                      }
-                    />
-                    <SummaryCardItem
-                      label={ActiveTxnInsightsLabels.PRIORITY}
-                      value={capitalize(transaction.priority)}
-                    />
-                  </Col>
-                </Row>
+                <SummaryCardItem
+                  label={ActiveTxnInsightsLabels.START_TIME}
+                  value={transaction.start.format(
+                    "MMM D, YYYY [at] H:mm (UTC)",
+                  )}
+                />
+                <SummaryCardItem
+                  label={ActiveTxnInsightsLabels.ELAPSED_TIME}
+                  value={Duration(
+                    transaction.elapsedTime.asMilliseconds() * 1e6,
+                  )}
+                />
+                <SummaryCardItem
+                  label={ActiveTxnInsightsLabels.STATUS}
+                  value={
+                    <>
+                      <StatusIcon status={transaction.status} />
+                      {transaction.status}
+                    </>
+                  }
+                />
+                <SummaryCardItem
+                  label={ActiveTxnInsightsLabels.PRIORITY}
+                  value={capitalize(transaction.priority)}
+                />
               </SummaryCard>
             </Col>
             <Col className="gutter-row" span={12}>


### PR DESCRIPTION
Backport 1/1 commits from #92595.

/cc @cockroachdb/release

---

Fixes #87637

Previously, the cards in the active execution details pages were different heights due to the difference in the amount of content. This commit ensures all cards in the active executions and insights pages that are in the same row have the same height.

Release note: None

Release justification: low-risk update to existing functionality