### PR TITLE
release-22.1: roachtest: Update liquibase blocklist

### DIFF
--- a/pkg/cmd/roachtest/tests/liquibase.go
+++ b/pkg/cmd/roachtest/tests/liquibase.go
@@ -101,10 +101,9 @@ func registerLiquibase(r registry.Registry) {
 		}
 
 		t.Status("running liquibase test harness")
-		blocklistName, expectedFailures, _, ignoreList := liquibaseBlocklists.getLists(version)
-		if expectedFailures == nil {
-			t.Fatalf("No hibernate blocklist defined for cockroach version %s", version)
-		}
+		const blocklistName = "liquibaseBlocklist"
+		expectedFailures := liquibaseBlocklist
+		ignoreList := liquibaseIgnorelist
 
 		const (
 			repoDir     = "/mnt/data1/liquibase-test-harness"

--- a/pkg/cmd/roachtest/tests/liquibase_blocklist.go
+++ b/pkg/cmd/roachtest/tests/liquibase_blocklist.go
@@ -10,31 +10,16 @@
 
 package tests
 
-var liquibaseBlocklists = blocklistsForVersion{
-	{"v20.2", "liquibaseBlocklist20_2", liquibaseBlocklist20_2, "liquibaseIgnorelist20_2", liquibaseIgnorelist20_2},
-	{"v21.1", "liquibaseBlocklist21_1", liquibaseBlocklist21_1, "liquibaseIgnorelist21_1", liquibaseIgnorelist21_1},
-	{"v21.2", "liquibaseBlocklist21_2", liquibaseBlocklist21_2, "liquibaseIgnorelist21_2", liquibaseIgnorelist21_2},
-	{"v22.1", "liquibaseBlocklist22_1", liquibaseBlocklist22_1, "liquibaseIgnorelist21_2", liquibaseIgnorelist22_1},
+var liquibaseBlocklist = blocklist{
+	"liquibase.harness.change.ChangeObjectTests.apply addAutoIncrement against cockroachdb 20.2":            "unknown",
+	"liquibase.harness.change.ChangeObjectTests.apply addCheckConstraint against cockroachdb 20.2":          "unknown",
+	"liquibase.harness.change.ChangeObjectTests.apply addDefaultValueSequenceNext against cockroachdb 20.2": "unknown",
+	"liquibase.harness.change.ChangeObjectTests.apply alterSequence against cockroachdb 20.2":               "unknown",
+	"liquibase.harness.change.ChangeObjectTests.apply createPackage against cockroachdb 20.2":               "unknown",
+	"liquibase.harness.change.ChangeObjectTests.apply createSequence against cockroachdb 20.2":              "unknown",
+	"liquibase.harness.change.ChangeObjectTests.apply dropCheckConstraint against cockroachdb 20.2":         "unknown",
+	"liquibase.harness.change.ChangeObjectTests.apply dropSequence against cockroachdb 20.2":                "unknown",
+	"liquibase.harness.change.ChangeObjectTests.apply renameSequence against cockroachdb 20.2":              "unknown",
 }
 
-var liquibaseBlocklist22_1 = blocklist{
-	"liquibase.harness.change.ChangeObjectTests.apply addCheckConstraint against cockroachdb 20.2":  "unknown",
-	"liquibase.harness.change.ChangeObjectTests.apply createPackage against cockroachdb 20.2":       "unknown",
-	"liquibase.harness.change.ChangeObjectTests.apply dropCheckConstraint against cockroachdb 20.2": "unknown",
-}
-
-var liquibaseBlocklist21_2 = blocklist{
-	"liquibase.harness.change.ChangeObjectTests.apply addDefaultValueSequenceNext against cockroachdb 20.2; verify generated SQL and DB snapshot": "",
-}
-
-var liquibaseBlocklist21_1 = liquibaseBlocklist20_2
-
-var liquibaseBlocklist20_2 = blocklist{}
-
-var liquibaseIgnorelist22_1 = liquibaseIgnorelist21_2
-
-var liquibaseIgnorelist21_2 = liquibaseIgnorelist21_1
-
-var liquibaseIgnorelist21_1 = liquibaseIgnorelist20_2
-
-var liquibaseIgnorelist20_2 = blocklist{}
+var liquibaseIgnorelist = blocklist{}


### PR DESCRIPTION
Backport 1/1 commits from #92288.

/cc @cockroachdb/release

---

fixes: #83050

Release note: None
Release Justification: Non-production code changes