### PR TITLE
changefeedccl: enable webhook roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -172,7 +172,6 @@ go_library(
         "//pkg/base",
         "//pkg/ccl/changefeedccl",
         "//pkg/ccl/changefeedccl/cdctest",
-        "//pkg/ccl/changefeedccl/changefeedbase",
         "//pkg/cli",
         "//pkg/cli/clisqlclient",
         "//pkg/cloud",


### PR DESCRIPTION
The existing webhook sink roachtest code was set up to only function locally.  This change mirrors the cdc-webhook-sink-test-server code to set up a server that other roachtest nodes can connect to.

Release note: None