### PR TITLE
server: split apiV2 into a system version

### DIFF
--- a/pkg/server/api_v2_ranges.go
+++ b/pkg/server/api_v2_ranges.go
@@ -103,12 +103,12 @@ type nodesResponse struct {
 //	  description: List nodes response.
 //	  schema:
 //	    "$ref": "#/definitions/nodesResponse"
-func (a *apiV2Server) listNodes(w http.ResponseWriter, r *http.Request) {
+func (a *apiV2SystemServer) listNodes(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	limit, offset := getSimplePaginationValues(r)
 	ctx = apiToOutgoingGatewayCtx(ctx, r)
 
-	nodes, next, err := a.status.nodesHelper(ctx, limit, offset)
+	nodes, next, err := a.systemStatus.nodesHelper(ctx, limit, offset)
 	if err != nil {
 		apiV2InternalError(ctx, err, w)
 		return
@@ -134,6 +134,10 @@ func (a *apiV2Server) listNodes(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 	writeJSONResponse(ctx, w, 200, resp)
+}
+
+func (a *apiV2Server) listNodes(w http.ResponseWriter, r *http.Request) {
+	writeJSONResponse(r.Context(), w, http.StatusNotImplemented, nil)
 }
 
 func parseRangeIDs(input string, w http.ResponseWriter) (ranges []roachpb.RangeID, ok bool) {
@@ -372,7 +376,7 @@ type nodeRangesResponse struct {
 //	  description: Node ranges response.
 //	  schema:
 //	    "$ref": "#/definitions/nodeRangesResponse"
-func (a *apiV2Server) listNodeRanges(w http.ResponseWriter, r *http.Request) {
+func (a *apiV2SystemServer) listNodeRanges(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	ctx = apiToOutgoingGatewayCtx(ctx, r)
 	vars := mux.Vars(r)
@@ -394,7 +398,7 @@ func (a *apiV2Server) listNodeRanges(w http.ResponseWriter, r *http.Request) {
 		RangeIDs: ranges,
 	}
 	limit, offset := getSimplePaginationValues(r)
-	statusResp, next, err := a.status.rangesHelper(ctx, req, limit, offset)
+	statusResp, next, err := a.systemStatus.rangesHelper(ctx, req, limit, offset)
 	if err != nil {
 		apiV2InternalError(ctx, err, w)
 		return
@@ -409,6 +413,10 @@ func (a *apiV2Server) listNodeRanges(w http.ResponseWriter, r *http.Request) {
 		resp.Ranges = append(resp.Ranges, ri)
 	}
 	writeJSONResponse(ctx, w, 200, resp)
+}
+
+func (a *apiV2Server) listNodeRanges(w http.ResponseWriter, r *http.Request) {
+	writeJSONResponse(r.Context(), w, http.StatusNotImplemented, nil)
 }
 
 type responseError struct {

--- a/pkg/server/server_http.go
+++ b/pkg/server/server_http.go
@@ -93,7 +93,7 @@ func (s *httpServer) setupRoutes(
 	runtimeStatSampler *status.RuntimeStatSampler,
 	handleRequestsUnauthenticated http.Handler,
 	handleDebugUnauthenticated http.Handler,
-	apiServer *apiV2Server,
+	apiServer http.Handler,
 ) error {
 	// OIDC Configuration must happen prior to the UI Handler being defined below so that we have
 	// the system settings initialized for it to pick up from the oidcAuthenticationServer.

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -237,7 +237,8 @@ type sqlServerOptionalKVArgs struct {
 // sqlServerOptionalTenantArgs are the arguments supplied to newSQLServer which
 // are only available if the SQL server runs as part of a standalone SQL node.
 type sqlServerOptionalTenantArgs struct {
-	tenantConnect kvtenant.Connector
+	tenantConnect    kvtenant.Connector
+	promRuleExporter *metric.PrometheusRuleExporter
 }
 
 type sqlServerArgs struct {


### PR DESCRIPTION
Previously, our apiV2 server embedded pointers to the status and admin servers.
This made it challenging to use this server from app tenants.

This change embeds the non-system status and admin servers and creates a
separate systemApiV2Server that contains implementations for endpoints that
only the system tenant can handle.

Epic: [CRDB-17356](https://cockroachlabs.atlassian.net/browse/CRDB-17356)

Release note: None