### PR TITLE
release-22.2: ui: fix sort setting on stmt/txn insights details

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/insightDetailsTables.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/insightDetailsTables.tsx
@@ -8,8 +8,8 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import React from "react";
-import { ColumnDescriptor, SortedTable } from "src/sortedtable";
+import React, { useState } from "react";
+import { ColumnDescriptor, SortedTable, SortSetting } from "src/sortedtable";
 import { DATE_FORMAT, Duration } from "src/util";
 import { EventExecution, InsightExecEnum } from "../types";
 import { insightsTableTitles, QueriesCell } from "../workloadInsights/util";
@@ -84,7 +84,17 @@ export const WaitTimeDetailsTable: React.FC<
   InsightDetailsTableProps
 > = props => {
   const columns = makeInsightDetailsColumns(props.execType);
+  const [sortSetting, setSortSetting] = useState<SortSetting>({
+    ascending: false,
+    columnTitle: "contention",
+  });
   return (
-    <SortedTable className="statements-table" columns={columns} {...props} />
+    <SortedTable
+      className="statements-table"
+      columns={columns}
+      sortSetting={sortSetting}
+      onChangeSortSetting={setSortSetting}
+      {...props}
+    />
   );
 };

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
-import React, { useContext, useMemo } from "react";
+import React, { useContext, useMemo, useState } from "react";
 import { Col, Row } from "antd";
 import {
   InsightsSortedTable,
@@ -22,6 +22,7 @@ import {
   InsightRecommendation,
   StatementInsightEvent,
 } from "../types";
+import { SortSetting } from "../../sortedtable";
 import classNames from "classnames/bind";
 import { CockroachCloudContext } from "../../contexts";
 
@@ -76,7 +77,6 @@ const insightsTableData = (
               description: insight.description,
             },
           };
-          break;
         case InsightNameEnum.planRegression:
           return {
             type: "PlanRegression",
@@ -129,6 +129,10 @@ export const StatementInsightDetailsOverviewTab: React.FC<
 
   const insightDetails = insightEventDetails;
   const tableData = insightsTableData(insightDetails);
+  const [insightsSortSetting, setInsightsSortSetting] = useState<SortSetting>({
+    ascending: false,
+    columnTitle: "insights",
+  });
 
   return (
     <section className={cx("section")}>
@@ -203,7 +207,12 @@ export const StatementInsightDetailsOverviewTab: React.FC<
       </Row>
       <Row gutter={24} className={tableCx("margin-bottom")}>
         <Col>
-          <InsightsSortedTable columns={insightsColumns} data={tableData} />
+          <InsightsSortedTable
+            sortSetting={insightsSortSetting}
+            onChangeSortSetting={setInsightsSortSetting}
+            columns={insightsColumns}
+            data={tableData}
+          />
         </Col>
       </Row>
     </section>

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
-import React, { useContext, useEffect } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import Helmet from "react-helmet";
 import { RouteComponentProps } from "react-router-dom";
 import { ArrowLeft } from "@cockroachlabs/icons";
@@ -38,6 +38,7 @@ import {
   InsightRecommendation,
   TransactionInsightEventDetails,
 } from "../types";
+import { SortSetting } from "../../sortedtable";
 
 import classNames from "classnames/bind";
 import { commonStyles } from "src/common";
@@ -96,6 +97,10 @@ export const TransactionInsightDetails: React.FC<
   insightError,
   match,
 }) => {
+  const [insightsSortSetting, setInsightsSortSetting] = useState<SortSetting>({
+    ascending: false,
+    columnTitle: "insights",
+  });
   const isCockroachCloud = useContext(CockroachCloudContext);
   const executionID = getMatchParamByName(match, executionIdAttr);
   const noInsights = !insightEventDetails;
@@ -200,6 +205,8 @@ export const TransactionInsightDetails: React.FC<
                     <InsightsSortedTable
                       columns={insightsColumns}
                       data={tableData}
+                      sortSetting={insightsSortSetting}
+                      onChangeSortSetting={setInsightsSortSetting}
                     />
                   </Col>
                 </Row>


### PR DESCRIPTION
Backport 1/1 commits from #92573.

/cc @cockroachdb/release

---

Previously, the transaction insight details page had no sorting on the tables, and the statement insights details had the wrong column name as the default.
This commit fixes both issues.

Fixes #86534

https://www.loom.com/share/93c3be6312344da8be23bf1c116169bc

Release note (bug fix): Add sort setting to tables on Transaction and Statement Insights Details pages.

---

Release justification: bug fix
