### PR TITLE
ci: fix stress by passing TARGET env var

### DIFF
--- a/build/teamcity/cockroach/nightlies/stress.sh
+++ b/build/teamcity/cockroach/nightlies/stress.sh
@@ -8,6 +8,6 @@ source "$dir/teamcity-support.sh"  # For $root
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
 tc_start_block "Run stress"
-BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e BUILD_TAG -e BUILD_VCS_NUMBER -e GITHUB_API_TOKEN -e GITHUB_ORG -e GITHUB_REPO -e TC_BUILDTYPE_ID -e TC_BUILD_BRANCH -e TC_BUILD_ID -e TC_SERVER_URL -e PKG -e TAGS -e STRESSFLAGS -e TESTTIMEOUTSECS -e EXTRA_BAZEL_FLAGS" \
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e BUILD_TAG -e BUILD_VCS_NUMBER -e GITHUB_API_TOKEN -e GITHUB_ORG -e GITHUB_REPO -e TC_BUILDTYPE_ID -e TC_BUILD_BRANCH -e TC_BUILD_ID -e TC_SERVER_URL -e TARGET -e TAGS -e STRESSFLAGS -e TESTTIMEOUTSECS -e EXTRA_BAZEL_FLAGS" \
   run_bazel build/teamcity/cockroach/nightlies/stress_impl.sh
 tc_end_block "Run stress"


### PR DESCRIPTION
We used to pass packages but with the recent changes in https://github.com/cockroachdb/cockroach/pull/92476 we
now pass targets. I added a new env var in the build config
but forgot to pass it here. This fixes the issue that caused
all stress runs to fail in the last nightly.

Epic: None
Release note: None