### PR TITLE
streamclient: replace usage of deprecated ioutil.ReadFile function

### DIFF
--- a/pkg/ccl/streamingccl/streamclient/partitioned_stream_client_test.go
+++ b/pkg/ccl/streamingccl/streamclient/partitioned_stream_client_test.go
@@ -11,8 +11,8 @@ package streamclient
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -107,7 +107,7 @@ INSERT INTO d.t2 VALUES (2);
 		v := ret.Query()
 		for _, opt := range []string{"sslcert", "sslkey", "sslrootcert"} {
 			path := v.Get(opt)
-			content, err := ioutil.ReadFile(path)
+			content, err := os.ReadFile(path)
 			require.NoError(t, err)
 			v.Set(opt, string(content))
 


### PR DESCRIPTION
This patch fixes a lint error resulting from a usage of the
deprecated ioutil.ReadFile function.

Fixes #92761 

Release note: None