### PR TITLE
jobsprotectedtsccl: unskip TestJobsProtectedTimestamp

### DIFF
--- a/pkg/ccl/jobsccl/jobsprotectedtsccl/BUILD.bazel
+++ b/pkg/ccl/jobsccl/jobsprotectedtsccl/BUILD.bazel
@@ -29,7 +29,6 @@ go_test(
         "//pkg/sql/catalog/descpb",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
-        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/hlc",

--- a/pkg/ccl/jobsccl/jobsprotectedtsccl/jobs_protected_ts_test.go
+++ b/pkg/ccl/jobsccl/jobsprotectedtsccl/jobs_protected_ts_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -132,8 +131,6 @@ WHERE
 // reconciliation for jobs.
 func TestJobsProtectedTimestamp(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-
-	skip.WithIssue(t, 91865) // flaky test
 
 	ctx := context.Background()
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{


### PR DESCRIPTION
It was fixed by #92692.

Fixes #91865.

Release note: None