### PR TITLE
cli: avoid generating ballast files for standalone SQL servers

### DIFF
--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -1201,5 +1201,17 @@ func mtStartSQLFlagsInit(cmd *cobra.Command) error {
 		tenantID := fs.Lookup(cliflags.TenantID.Name).Value.String()
 		serverCfg.Stores.Specs[0].Path += "-tenant-" + tenantID
 	}
+
+	// In standalone SQL servers, we do not generate a ballast file,
+	// unless a ballast size was specified explicitly by the user.
+	for i := range serverCfg.Stores.Specs {
+		spec := &serverCfg.Stores.Specs[i]
+		if spec.BallastSize == nil {
+			// Only override if there was no ballast size specified to start
+			// with.
+			zero := base.SizeSpec{InBytes: 0, Percent: 0}
+			spec.BallastSize = &zero
+		}
+	}
 	return nil
 }

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -1349,6 +1349,10 @@ func TestSQLPodStorageDefaults(t *testing.T) {
 			require.NoError(t, f.Parse(td.args))
 			require.NoError(t, mtStartSQLCmd.PersistentPreRunE(mtStartSQLCmd, td.args))
 			assert.Equal(t, td.storePath, serverCfg.Stores.Specs[0].Path)
+			for _, s := range serverCfg.Stores.Specs {
+				assert.Zero(t, s.BallastSize.InBytes)
+				assert.Zero(t, s.BallastSize.Percent)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Fixes #92500.

In a previous PR, we merged the startup code path between `cockroach start` and `cockroach mt start-sql`. Doing so also (mostly) merged the default store config. This was incorrect, as standalone SQL servers should not receive an emergency ballast.

This patch fixes that.

Release note: None