### PR TITLE
storage: add a unit test ensuring vfs files implement Fd()

### DIFF
--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -1189,5 +1190,34 @@ func TestPebbleReaderMultipleIterators(t *testing.T) {
 			e2 := r.NewEngineIterator(IterOptions{UpperBound: keys.MaxKey})
 			defer e2.Close()
 		})
+	}
+}
+
+// TestFSOpenFd ensures that an engine opened using the real filesystem
+// correctly implements the Fd() method. The Fd() method is an optional part of
+// the vfs.File interface, that when implemented can be used to perform
+// readahead using prefetch calls.
+func TestFSOpenFd(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	dir := t.TempDir()
+
+	eng, err := Open(context.Background(), Filesystem(dir), ForTesting, MaxSize(1<<20))
+	require.NoError(t, err)
+	defer eng.Close()
+
+	filename := filepath.Join(dir, "foo")
+	require.NoError(t, fs.WriteFile(eng, filename, []byte("hello world")))
+	f, err := eng.Open(filename)
+	require.NoError(t, err)
+	defer f.Close()
+
+	type Fder interface {
+		Fd() uintptr
+	}
+	fder, ok := f.(Fder)
+	require.True(t, ok)
+	if fd := fder.Fd(); fd == 0 {
+		t.Fatalf("Fd() returned %d", fd)
 	}
 }


### PR DESCRIPTION
Pebble expects files to implement a method not declared on the vfs.File interface to provide access to a file's descriptor. This is used for operations such as prefetching for readahead. All  vfs.File middleware is required to preserve the wrapped file's Fd() [see vfs.WithFD].

This commit adds a new unit test to ensure that the vfs.Files created with the default FS middleware and default Pebble configuration correctly exposes a Fd() method.

Release note: None
Epic: None