### PR TITLE
server: reduce logging noise in tests

### DIFF
--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -2416,6 +2416,7 @@ func TestStatsforSpanOnLocalMax(t *testing.T) {
 // `Status` requests.
 func TestEndpointTelemetryBasic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
 		// Disable the default test tenant for now as this tests fails

--- a/pkg/server/api_v2_sql_test.go
+++ b/pkg/server/api_v2_sql_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/datadriven"
 	"github.com/stretchr/testify/require"
@@ -29,6 +30,8 @@ import (
 
 func TestExecSQL(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
 	SQLAPIClock = timeutil.NewManualTime(timeutil.FromUnixMicros(0))
 	defer func() {
 		SQLAPIClock = timeutil.DefaultTimeSource{}

--- a/pkg/server/auto_tls_init_test.go
+++ b/pkg/server/auto_tls_init_test.go
@@ -22,11 +22,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/certnames"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 // TestInitializeFromConfig is a placeholder for actual testing functions.
 func TestInitializeFromConfig(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	// Create a temp dir for all certificate tests.
 	tempDir := t.TempDir()
@@ -207,6 +209,7 @@ func compareBundleServiceCerts(
 // TODO(aaron-crl): [tests] write unit tests.
 func TestDummyInitializeNodeFromBundle(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	// Create a temp dir for all certificate tests.
 	tempDir := t.TempDir()
@@ -274,6 +277,7 @@ func TestRotationOnUnintializedNode(t *testing.T) {
 
 func TestRotationOnIntializedNode(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	// Create a temp dir for all certificate tests.
 	tempDir := t.TempDir()
@@ -307,6 +311,7 @@ func TestRotationOnIntializedNode(t *testing.T) {
 
 func TestRotationOnPartialIntializedNode(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	// Create a temp dir for all certificate tests.
 	tempDir := t.TempDir()
@@ -363,6 +368,7 @@ func TestRotationOnPartialIntializedNode(t *testing.T) {
 // TestRotationOnBrokenIntializedNode in the partially provisioned case (remove the Client and UI CAs).
 func TestRotationOnBrokenIntializedNode(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	// Create a temp dir for all certificate tests.
 	tempDir := t.TempDir()

--- a/pkg/server/migration_test.go
+++ b/pkg/server/migration_test.go
@@ -27,11 +27,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/upgrade/upgradebase"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
 )
 
 func TestValidateTargetClusterVersion(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	v := func(major, minor int32) roachpb.Version {
 		return roachpb.Version{Major: major, Minor: minor}
@@ -108,6 +110,7 @@ func TestValidateTargetClusterVersion(t *testing.T) {
 // version.
 func TestBumpClusterVersion(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	v := func(major, minor int32) roachpb.Version {
 		return roachpb.Version{Major: major, Minor: minor}
@@ -204,6 +207,7 @@ func TestBumpClusterVersion(t *testing.T) {
 
 func TestMigrationPurgeOutdatedReplicas(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	const numStores = 3
 	var storeSpecs []base.StoreSpec
@@ -241,6 +245,7 @@ func TestMigrationPurgeOutdatedReplicas(t *testing.T) {
 // version.
 func TestUpgradeHappensAfterMigrations(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettingsWithVersions(


### PR DESCRIPTION
The excess logging was making test failures unwieldy during investigations. This commit fixes that.

Release note: None