### PR TITLE
ci: fix stress script syntax

### DIFF
--- a/build/teamcity/cockroach/nightlies/stress_impl.sh
+++ b/build/teamcity/cockroach/nightlies/stress_impl.sh
@@ -30,9 +30,9 @@ GOTESTTIMEOUTSECS=$(($TESTTIMEOUTSECS - 5))
 $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- test --config=ci "$TARGET" \
                                         --test_env=COCKROACH_NIGHTLY_STRESS=true \
                                         --test_timeout="$TESTTIMEOUTSECS" \
-                                        --test_arg=-test.timeout="${GOTESTTIMEOUTSECS}s"
+                                        --test_arg=-test.timeout="${GOTESTTIMEOUTSECS}s" \
                                         --run_under "@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts 'XML_OUTPUT_FILE=$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci merge-test-xmls' $STRESSFLAGS" \
                                         --define "gotags=$TAGS" \
                                         --nocache_test_results \
                                         --test_output streamed \
-                                        ${EXTRA_BAZEL_FLAGS} \
+                                        ${EXTRA_BAZEL_FLAGS}


### PR DESCRIPTION
Caught more issues with the script. I will only merge this after testing a run :)

Epic: None
Release note: None