### PR TITLE
execinfra: fix limit hint computation with offset

### DIFF
--- a/pkg/sql/execinfra/readerbase.go
+++ b/pkg/sql/execinfra/readerbase.go
@@ -36,8 +36,8 @@ const readerOverflowProtection = 1000000000000000 /* 10^15 */
 func LimitHint(specLimitHint int64, post *execinfrapb.PostProcessSpec) (limitHint int64) {
 	// We prioritize the post process's limit since ProcOutputHelper
 	// will tell us to stop once we emit enough rows.
-	if post.Limit != 0 && post.Limit <= readerOverflowProtection {
-		limitHint = int64(post.Limit)
+	if post.Limit != 0 && post.Limit+post.Offset <= readerOverflowProtection && post.Limit+post.Offset > 0 {
+		limitHint = int64(post.Limit + post.Offset)
 	} else if specLimitHint != 0 && specLimitHint <= readerOverflowProtection {
 		limitHint = specLimitHint
 	}

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -573,3 +573,23 @@ vectorized: true
         │ estimated row count: 10
         │
         └── • emptyrow
+
+# Regression test for not incorporating the OFFSET value into the limit hint.
+statement ok
+CREATE TABLE t_offset (k INT PRIMARY KEY);
+
+statement ok
+INSERT INTO t_offset SELECT generate_series(1, 10)
+
+statement ok
+SET tracing = on,kv,results; SELECT * FROM t_offset LIMIT 1 OFFSET 3; SET tracing = off
+
+query T
+SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
+ WHERE message LIKE 'fetched:%'
+ ORDER BY message, ordinality ASC
+----
+fetched: /t_offset/t_offset_pkey/1 -> <undecoded>
+fetched: /t_offset/t_offset_pkey/2 -> <undecoded>
+fetched: /t_offset/t_offset_pkey/3 -> <undecoded>
+fetched: /t_offset/t_offset_pkey/4 -> <undecoded>


### PR DESCRIPTION
Previously, when computing the limit hint for the readers we would ignore the offset. As a result, we could have fetched more rows than necessary because the first limit hint would be insufficient and we grow exponentially on the second and consequent hints.

Epic: None

Release note (performance improvement): CockroachDB in some cases now correctly incorporates the value of the `OFFSET` clause when determining the number of rows that need to be read when the `LIMIT` clause is also present. Note that there was no correctness issue here - only that extra unnecessary rows could be read.