### PR TITLE
nogo: detect deprecated go standard library packages

### DIFF
--- a/build/bazelutil/nogo_config.json
+++ b/build/bazelutil/nogo_config.json
@@ -739,7 +739,14 @@
             "pkg/sql/execinfra/processorsbase.go$": "temporary exclusion until deprecatedContext is removed from eval.Context",
             "pkg/sql/importer/import_table_creation.go$": "temporary exclusion until deprecatedContext is removed from eval.Context",
             "pkg/sql/row/expr_walker_test.go$": "temporary exclusion until deprecatedContext is removed from eval.Context",
-            "pkg/sql/schemachanger/scbuild/tree_context_builder.go$": "temporary exclusion until deprecatedContext is removed from eval.Context"
+            "pkg/sql/schemachanger/scbuild/tree_context_builder.go$": "temporary exclusion until deprecatedContext is removed from eval.Context",
+            "pkg/security/securityassets/security_assets.go$": "excluded until all uses of io/ioutil are replaced",
+            "pkg/roachprod/install/cluster_synced.go$": "excluded until all uses of io/ioutil are replaced",
+            "pkg/security/securitytest/securitytest.go$": "excluded until all uses of io/ioutil are replaced",
+            "pkg/server/dumpstore/dumpstore.go$": "excluded until all uses of io/ioutil are replaced",
+            "pkg/server/dumpstore/dumpstore_test.go$": "excluded until all uses of io/ioutil are replaced",
+            "pkg/server/heapprofiler/profilestore_test.go$": "excluded until all uses of io/ioutil are replaced",
+            "pkg/util/log/file_api.go$": "excluded until all uses of io/ioutil are replaced"
         },
         "only_files": {
             "cockroach/pkg/.*$": "first-party code"

--- a/build/patches/co_honnef_go_tools.patch
+++ b/build/patches/co_honnef_go_tools.patch
@@ -1,5 +1,5 @@
 diff --git a/staticcheck/lint.go b/staticcheck/lint.go
-index 85bcb21..e91e81c 100644
+index 85bcb21..9fb4cc0 100644
 --- a/staticcheck/lint.go
 +++ b/staticcheck/lint.go
 @@ -3080,6 +3080,9 @@ func CheckDeprecated(pass *analysis.Pass) (interface{}, error) {
@@ -44,3 +44,12 @@ index 85bcb21..e91e81c 100644
  		}
  		return true
  	}
+@@ -3209,6 +3214,8 @@ func CheckDeprecated(pass *analysis.Pass) (interface{}, error) {
+ 			}
+ 
+ 			handleDeprecation(depr, spec.Path, path, path, nil)
++		} else if _, ok := knowledge.StdlibDeprecations[path]; ok {
++			handleDeprecation(nil, spec.Path, path, path, nil)
+ 		}
+ 	}
+ 	pass.ResultOf[inspect.Analyzer].(*inspector.Inspector).Nodes(nil, fn)


### PR DESCRIPTION
In #87327, we patched `staticcheck` to detect deprecated "objects" from the standard library. This patch ensures that we also detect deprecated "packages".

Closes #84877

Release note: None