### PR TITLE
sql: skip TestMonotonicInserts under stress

### DIFF
--- a/pkg/sql/tests/monotonic_insert_test.go
+++ b/pkg/sql/tests/monotonic_insert_test.go
@@ -94,6 +94,7 @@ func testMonotonicInserts(t *testing.T, distSQLMode sessiondatapb.DistSQLExecMod
 
 	skip.UnderShort(t)
 	skip.UnderRace(t) // Too slow under race.
+	skip.UnderStressWithIssue(t, 92540, "too much contention under stress")
 
 	ctx := context.Background()
 	tc := testcluster.StartTestCluster(

--- a/pkg/testutils/skip/skip.go
+++ b/pkg/testutils/skip/skip.go
@@ -119,6 +119,17 @@ func UnderStress(t SkippableTest, args ...interface{}) {
 	}
 }
 
+// UnderStressWithIssue skips this test when running under stress, logging the
+// given issue ID as the reason.
+func UnderStressWithIssue(t SkippableTest, githubIssueID int, args ...interface{}) {
+	t.Helper()
+	if Stress() {
+		t.Skip(append([]interface{}{fmt.Sprintf(
+			"disabled under stress. issue: https://github.com/cockroachdb/cockroach/issues/%d", githubIssueID,
+		)}, args...))
+	}
+}
+
 // UnderStressRace skips this test during stressrace runs, which are tests
 // run under stress with the -race flag.
 func UnderStressRace(t SkippableTest, args ...interface{}) {


### PR DESCRIPTION
   `TestMonotonicInserts` can fail with `MaxRetriesExceededError` due to
    contention when run under stress. This was causing failures during the
    nightly stress testing, so this patch skips the test under stress.

   This patch also adds `skip.UnderStressWithIssue`.

   Informs #92540

   Release note: None