### PR TITLE
server: skip TestStatusLogRedaction under race

### DIFF
--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -658,6 +658,7 @@ func TestStatusLocalLogs(t *testing.T) {
 // honor the redaction flags.
 func TestStatusLogRedaction(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.UnderRaceWithIssue(t, 92789, "flaky test")
 
 	testData := []struct {
 		redactableLogs     bool // logging flag


### PR DESCRIPTION
Refs: #92789

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None