### PR TITLE
rowcontainer: add cancel-checking to the DiskRowContainer

### DIFF
--- a/pkg/sql/rowcontainer/hash_row_container.go
+++ b/pkg/sql/rowcontainer/hash_row_container.go
@@ -509,7 +509,7 @@ func MakeHashDiskRowContainer(
 
 // Init implements the HashRowContainer interface.
 func (h *HashDiskRowContainer) Init(
-	_ context.Context, shouldMark bool, typs []*types.T, storedEqCols columns, encodeNull bool,
+	ctx context.Context, shouldMark bool, typs []*types.T, storedEqCols columns, encodeNull bool,
 ) error {
 	h.columnEncoder.init(typs, storedEqCols, encodeNull)
 	h.shouldMark = shouldMark
@@ -529,7 +529,7 @@ func (h *HashDiskRowContainer) Init(
 		)
 	}
 
-	h.DiskRowContainer = MakeDiskRowContainer(h.diskMonitor, storedTypes, storedEqColsToOrdering(storedEqCols), h.engine)
+	h.DiskRowContainer = MakeDiskRowContainer(ctx, h.diskMonitor, storedTypes, storedEqColsToOrdering(storedEqCols), h.engine)
 	return nil
 }
 

--- a/pkg/sql/rowcontainer/kvstreamer_result_disk_buffer.go
+++ b/pkg/sql/rowcontainer/kvstreamer_result_disk_buffer.go
@@ -66,6 +66,7 @@ func (b *kvStreamerResultDiskBuffer) Serialize(
 ) (resultID int, _ error) {
 	if !b.initialized {
 		b.container = MakeDiskRowContainer(
+			ctx,
 			b.monitor,
 			inOrderResultsBufferSpillTypeSchema,
 			colinfo.ColumnOrdering{},

--- a/pkg/sql/rowcontainer/row_container.go
+++ b/pkg/sql/rowcontainer/row_container.go
@@ -591,7 +591,7 @@ func (f *DiskBackedRowContainer) SpillToDisk(ctx context.Context) error {
 	if f.UsingDisk() {
 		return errors.New("already using disk")
 	}
-	drc := MakeDiskRowContainer(f.diskMonitor, f.mrc.types, f.mrc.ordering, f.engine)
+	drc := MakeDiskRowContainer(ctx, f.diskMonitor, f.mrc.types, f.mrc.ordering, f.engine)
 	f.src = &drc
 	f.drc = &drc
 	if f.deDuplicate {


### PR DESCRIPTION
This patch adds cancel checks to the `DiskRowContainer` to ensure queries can be promptly canceled. This will prevent timeouts during randomized testing.

Fixes #91807

Release note: None