### PR TITLE
storage: never elide resume key in MVCCExportToSST

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_export.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export.go
@@ -218,11 +218,21 @@ func evalExport(
 		}
 		data := destFile.Data()
 
-		// NB: This should only happen on the first page of results. If there were
-		// more data to be read that lead to pagination then we'd see it in this
-		// page. Break out of the loop because there must be no data to export.
+		// NB: This should only happen in two cases:
+		//
+		// 1. There was nothing to export for this span.
+		//
+		// 2. We hit a resource constraint that led to an
+		//    early exit and thus have a resume key despite
+		//    not having data.
 		if summary.DataSize == 0 {
-			break
+			if resume.Key != nil {
+				start = resume.Key
+				resumeKeyTS = resume.Timestamp
+				continue
+			} else {
+				break
+			}
 		}
 
 		span := roachpb.Span{Key: start}

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -5904,9 +5904,9 @@ func MVCCExportToSST(
 	}
 
 	if summary.DataSize == 0 {
-		// If no records were added to the sstable, skip completing it and return a
-		// nil slice – the export code will discard it anyway (based on 0 DataSize).
-		return roachpb.BulkOpSummary{}, MVCCKey{}, nil
+		// If no records were added to the sstable, skip
+		// completing it and return an empty summary.
+		return roachpb.BulkOpSummary{}, resumeKey, nil
 	}
 
 	return summary, resumeKey, sstWriter.Finish()

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -5995,15 +5995,33 @@ func mvccExportToWriter(
 	defer iter.Close()
 
 	paginated := opts.TargetSize > 0
-
 	hasElasticCPULimiter := elasticCPUHandle != nil
 	hasTimeBasedResourceLimiter := opts.ResourceLimiter != nil
-	trackKeyBoundary := paginated || hasTimeBasedResourceLimiter || hasElasticCPULimiter
+
+	// trackKeyBoundary is true if we need to know whether the
+	// iteration has proceeded to a new key.
+	//
+	// If opts.ExportAllRevisions is false, then our iteration loop
+	// will use NextKey() and thus will always be on a new key.
+	//
+	// If opts.ExportAllRevisions is true, we only need to track
+	// key boundaries if we may return from our iteration before
+	// the EndKey. This can happen if the user has requested
+	// paginated results, or if we hit a resource limit.
+	trackKeyBoundary := opts.ExportAllRevisions && (paginated || hasTimeBasedResourceLimiter || hasElasticCPULimiter)
+
 	firstIteration := true
+	// skipTombstones controls whether we include tombstones.
+	//
+	// We want tombstones if we are exporting all reivions or if
+	// we have a StartTS. A non-empty StartTS is used by
+	// incremental backups and thus needs to see tombstones if
+	// that happens to be the latest value.
 	skipTombstones := !opts.ExportAllRevisions && opts.StartTS.IsEmpty()
 
 	var rows RowCounter
-	var curKey roachpb.Key // only used if exportAllRevisions
+	// Only used if trackKeyBoundary is true.
+	var curKey roachpb.Key
 	var resumeKey MVCCKey
 	var rangeKeys MVCCRangeKeyStack
 	var rangeKeysSize int64
@@ -6052,8 +6070,12 @@ func mvccExportToWriter(
 
 		unsafeKey := iter.UnsafeKey()
 
-		isNewKey := !opts.ExportAllRevisions || !unsafeKey.Key.Equal(curKey)
-		if trackKeyBoundary && opts.ExportAllRevisions && isNewKey {
+		// isNewKey is true when we aren't tracking key
+		// boundaries because either we are not exporting all
+		// revisions or because we know we won't stop before a
+		// key boundary anyway.
+		isNewKey := !trackKeyBoundary || !unsafeKey.Key.Equal(curKey)
+		if trackKeyBoundary && isNewKey {
 			curKey = append(curKey[:0], unsafeKey.Key...)
 		}
 
@@ -6093,7 +6115,9 @@ func mvccExportToWriter(
 			stopAllowed := isNewKey || opts.StopMidKey
 			if overLimit, _ := elasticCPUHandle.OverLimit(); overLimit && stopAllowed {
 				resumeKey = unsafeKey.Clone()
-				resumeKey.Timestamp = hlc.Timestamp{}
+				if isNewKey {
+					resumeKey.Timestamp = hlc.Timestamp{}
+				}
 				break
 			}
 		}
@@ -6315,9 +6339,8 @@ type MVCCExportOptions struct {
 	ExportAllRevisions bool
 	// If TargetSize is positive, it indicates that the export should produce SSTs
 	// which are roughly target size. Specifically, it will return an SST such that
-	// the last key is responsible for meeting or exceeding the targetSize. If the
-	// resumeKey is non-nil then the data size of the returned sst will be greater
-	// than or equal to the targetSize.
+	// the last key is responsible for meeting or exceeding the targetSize, unless the
+	// iteration has been stopped because of resource limitations.
 	TargetSize uint64
 	// If MaxSize is positive, it is an absolute maximum on byte size for the
 	// returned sst. If it is the case that the versions of the last key will lead

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -5971,8 +5971,8 @@ func TestMVCCExportToSSTResourceLimits(t *testing.T) {
 
 // TestMVCCExportToSSTExhaustedAtStart is a regression test for a bug
 // in which mis-handling of resume spans would cause MVCCExportToSST
-// would return an empty resume key in cases where out various
-// resource limiters caused an early return of a resume span.
+// to return an empty resume key in cases where the resource limiters
+// caused an early return of a resume span.
 func TestMVCCExportToSSTExhaustedAtStart(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -6046,6 +6046,108 @@ func TestMVCCExportToSSTExhaustedAtStart(t *testing.T) {
 				EndTS:              limits.maxTimestamp,
 				ExportAllRevisions: true,
 			})
+		})
+	t.Run("elastic CPU limit always exhausted",
+		func(t *testing.T) {
+			engine := createTestPebbleEngine()
+			defer engine.Close()
+
+			limits := dataLimits{
+				minKey:          minKey,
+				maxKey:          maxKey,
+				minTimestamp:    minTimestamp,
+				maxTimestamp:    maxTimestamp,
+				tombstoneChance: 0.01,
+			}
+			generateData(t, engine, limits, (limits.maxKey-limits.minKey)*10)
+			data := exportAllData(t, engine, queryLimits{
+				minKey:       minKey,
+				maxKey:       maxKey,
+				minTimestamp: minTimestamp,
+				maxTimestamp: maxTimestamp,
+				latest:       false,
+			})
+
+			// Our ElasticCPUWorkHandle will always
+			// fail. But, we should still make progress,
+			// one key at a time.
+			ctx := admission.ContextWithElasticCPUWorkHandle(context.Background(), admission.TestingNewElasticCPUHandleWithCallback(func() (bool, time.Duration) {
+				return false, 0
+			}))
+			assertExportEqualWithOptions(t, ctx, engine, data, MVCCExportOptions{
+				StartKey:           MVCCKey{Key: testKey(limits.minKey), Timestamp: limits.minTimestamp},
+				EndKey:             testKey(limits.maxKey),
+				StartTS:            limits.minTimestamp,
+				EndTS:              limits.maxTimestamp,
+				ExportAllRevisions: true,
+			})
+		})
+	t.Run("elastic CPU limit exhausted respects StopMidKey",
+		func(t *testing.T) {
+			engine := createTestPebbleEngine()
+			defer engine.Close()
+
+			// Construct a data set that contains 6
+			// revisions of the same key.
+			//
+			// We expect that MVCCExportToSST with
+			// ExportAllRevisions set to true but with
+			// StopMidKey set to false to always return
+			// all or none of this key.
+			revisionCount := 6
+			rng := rand.New(rand.NewSource(timeutil.Now().Unix()))
+			key := testKey(6)
+			start := minTimestamp.Add(1, 0)
+			nextKey := func(i int64) MVCCKey { return MVCCKey{Key: key, Timestamp: start.Add(i, 0)} }
+			nextValue := func() MVCCValue { return MVCCValue{Value: roachpb.MakeValueFromBytes(randutil.RandBytes(rng, 256))} }
+			for i := 0; i < revisionCount; i++ {
+				require.NoError(t, engine.PutMVCC(nextKey(int64(i)), nextValue()), "write data to test storage")
+			}
+			require.NoError(t, engine.Flush(), "Flush engine data")
+
+			sstFile := &MemFile{}
+			opts := MVCCExportOptions{
+				StartKey:           MVCCKey{Key: testKey(minKey), Timestamp: minTimestamp},
+				EndKey:             testKey(maxKey),
+				StartTS:            minTimestamp,
+				EndTS:              maxTimestamp,
+				ExportAllRevisions: true,
+				ResourceLimiter:    nil,
+				StopMidKey:         false,
+			}
+
+			// Create an ElasticCPUWorkHandler that will
+			// simulate a resource constraint failure
+			// after some number of loop iterations.
+			ctx := context.Background()
+			callsBeforeFailure := 2
+			ctx = admission.ContextWithElasticCPUWorkHandle(ctx, admission.TestingNewElasticCPUHandleWithCallback(func() (bool, time.Duration) {
+				if callsBeforeFailure > 0 {
+					callsBeforeFailure--
+					return false, 0
+				}
+				return true, 0
+			}))
+
+			// With StopMidKey=false, we expect 6
+			// revisions or 0 revisions.
+			_, _, err := MVCCExportToSST(ctx, st, engine, opts, sstFile)
+			require.NoError(t, err)
+			chunk := sstToKeys(t, sstFile.Data())
+			require.Equal(t, 6, len(chunk))
+
+			// With StopMidKey=true, we can stop in the
+			// middle of iteration.
+			callsBeforeFailure = 2
+			sstFile = &MemFile{}
+			opts.StopMidKey = true
+			_, _, err = MVCCExportToSST(ctx, st, engine, opts, sstFile)
+			require.NoError(t, err)
+			chunk = sstToKeys(t, sstFile.Data())
+			// We expect 3 here rather than 2 because the
+			// first iteration never calls the handler.
+			require.Equal(t, 3, len(chunk))
+
 		})
 	t.Run("resource limit exhausted",
 		func(t *testing.T) {

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -6046,6 +6046,7 @@ func TestMVCCExportToSSTExhaustedAtStart(t *testing.T) {
 				EndTS:              limits.maxTimestamp,
 				ExportAllRevisions: true,
 			})
+			require.False(t, firstCall)
 		})
 	t.Run("elastic CPU limit always exhausted",
 		func(t *testing.T) {

--- a/pkg/storage/testdata/mvcc_histories/export
+++ b/pkg/storage/testdata/mvcc_histories/export
@@ -557,10 +557,10 @@ error: (*storage.ExceedMaxSizeError:) export size (12 bytes) exceeds max size (1
 
 # MaxSize with TargetSize will bail out before exceeding MaxSize, but it
 # depends on StopMidKey.
-run ok
+run error
 export k=a end=z ts=6 allRevisions targetSize=1 maxSize=1
 ----
-export: 
+error: (*storage.ExceedMaxSizeError:) export size (3 bytes) exceeds max size (1 bytes)
 
 run error
 export k=a end=z ts=6 allRevisions targetSize=10 maxSize=10

--- a/pkg/storage/testdata/mvcc_histories/export_fingerprint
+++ b/pkg/storage/testdata/mvcc_histories/export_fingerprint
@@ -366,11 +366,11 @@ error: (*storage.ExceedMaxSizeError:) export size (12 bytes) exceeds max size (1
 
 # MaxSize with TargetSize will bail out before exceeding MaxSize, but it
 # depends on StopMidKey.
-run ok
+run error
 export fingerprint k=a end=z ts=6 allRevisions targetSize=1 maxSize=1
 ----
-export:  fingerprint=true resume="a"/0,0
-fingerprint: 0
+error: (*storage.ExceedMaxSizeError:) export size (3 bytes) exceeds max size (1 bytes)
+
 
 run error
 export fingerprint k=a end=z ts=6 allRevisions targetSize=10 maxSize=10

--- a/pkg/util/admission/elastic_cpu_work_handle.go
+++ b/pkg/util/admission/elastic_cpu_work_handle.go
@@ -73,14 +73,6 @@ func (h *ElasticCPUWorkHandle) OverLimit() (overLimit bool, difference time.Dura
 		return false, time.Duration(0)
 	}
 
-	// TODO(ssd): It would be nice to get this in some zero-cost
-	// way. We could make ElasticCPUWorkHandle an interface and
-	// then allow for testing implementations. Not sure if the
-	// indirect call is better or worse than the conditional.
-	if h.testingOverrideOverLimit != nil {
-		return h.testingOverrideOverLimit()
-	}
-
 	// What we're effectively doing is just:
 	//
 	// 		runningTime := h.runningTime()
@@ -102,6 +94,10 @@ func (h *ElasticCPUWorkHandle) OverLimit() (overLimit bool, difference time.Dura
 }
 
 func (h *ElasticCPUWorkHandle) overLimitInner() (overLimit bool, difference time.Duration) {
+	if h.testingOverrideOverLimit != nil {
+		return h.testingOverrideOverLimit()
+	}
+
 	runningTime := h.runningTime()
 	if runningTime >= h.allotted {
 		return true, grunning.Difference(runningTime, h.allotted)

--- a/pkg/util/admission/elastic_cpu_work_handle.go
+++ b/pkg/util/admission/elastic_cpu_work_handle.go
@@ -43,6 +43,8 @@ type ElasticCPUWorkHandle struct {
 	runningTimeAtLastCheck, differenceWithAllottedAtLastCheck time.Duration
 
 	testingOverrideRunningTime func() time.Duration
+
+	testingOverrideOverLimit func() (bool, time.Duration)
 }
 
 func newElasticCPUWorkHandle(allotted time.Duration) *ElasticCPUWorkHandle {
@@ -69,6 +71,14 @@ func (h *ElasticCPUWorkHandle) runningTime() time.Duration {
 func (h *ElasticCPUWorkHandle) OverLimit() (overLimit bool, difference time.Duration) {
 	if h == nil { // not applicable
 		return false, time.Duration(0)
+	}
+
+	// TODO(ssd): It would be nice to get this in some zero-cost
+	// way. We could make ElasticCPUWorkHandle an interface and
+	// then allow for testing implementations. Not sure if the
+	// indirect call is better or worse than the conditional.
+	if h.testingOverrideOverLimit != nil {
+		return h.testingOverrideOverLimit()
 	}
 
 	// What we're effectively doing is just:
@@ -137,4 +147,13 @@ func ElasticCPUWorkHandleFromContext(ctx context.Context) *ElasticCPUWorkHandle 
 // testing purposes.
 func TestingNewElasticCPUHandle() *ElasticCPUWorkHandle {
 	return newElasticCPUWorkHandle(420 * time.Hour) // use a very high allotment
+}
+
+// TestingNewElasticCPUWithCallback constructs an
+// ElascticCPUWorkHandle with a testing override for the behaviour of
+// OverLimit().
+func TestingNewElasticCPUHandleWithCallback(cb func() (bool, time.Duration)) *ElasticCPUWorkHandle {
+	h := TestingNewElasticCPUHandle()
+	h.testingOverrideOverLimit = cb
+	return h
 }


### PR DESCRIPTION
MVCCExportToSST checks if no data has been written to the SST and avoids calling Finish() on the writer in that case. However, it was previously also returning an empty resume key in that case, regardless of the resume key's previous value.

Returning an empty resume key was OK since it was assumed that if the SST had no data, then there couldn't possibly be anything to resume.

However, when this method was extended to support cooperative resource management, it now has two cases in which the main iteration loop of the export may return a resume key despite not having written any data.

First, the Elastic CPU work handler is called unconditionally. If the CPU work handler was already over the limit on the first call, then we return immediately and with no data and a resume key set.

Second, the time-based resource limiter is called after the first iteration of the loop. While typically allowing one iteration will result in data being written to the SST before the exhaustion condition can be hit; if there is a long string of deletion tombstones that are not being added to our response, then it is possible that we've completed iterations of the loop without any data being written.

As a result of dropping this resume key, users of ExportRequest such as backup would then assume that their work was done. As a result, a backup may not contain all of the expected data.

Elastic CPU limiting and the time-based resource limiter are disabled by default in previous releases.

Elastic CPU limiting is enabled by default on master.

Epic: None

Release note (bug fix): Fix a bug that would result in incomplete backups when non-default, non-public resource limiting settings (kv.bulk_sst.max_request_time or
admission.elastic_cpu.enabled) were enabled.