### PR TITLE
acceptance: fix TestComposeGSS

### DIFF
--- a/pkg/acceptance/compose/gss/psql/Dockerfile
+++ b/pkg/acceptance/compose/gss/psql/Dockerfile
@@ -5,7 +5,7 @@ COPY . .
 RUN go test -v -c -tags gss_compose -o gss.test
 
 # Copy the test binary to an image with psql and krb installed.
-FROM postgres:11
+FROM postgres:15
 
 RUN apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \

--- a/pkg/acceptance/compose_test.go
+++ b/pkg/acceptance/compose_test.go
@@ -21,13 +21,11 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/acceptance/cluster"
 	"github.com/cockroachdb/cockroach/pkg/build/bazel"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 )
 
 const composeDir = "compose"
 
 func TestComposeGSS(t *testing.T) {
-	skip.WithIssue(t, 91420)
 	testCompose(t, filepath.Join("gss", "docker-compose.yml"), "psql")
 }
 


### PR DESCRIPTION
Previously, the TestComposeGSS was broken, because the base docker image (`postgres:11`) used APT repos, that had been moved to a different location.

This PR changes the base image to `postgres:15`. The upgrade should be relatively safe.

Fixes #91420
Epic: None
Release note: None