### PR TITLE
release-22.2.0: ci: fix regression in stress_impl

### DIFF
--- a/build/teamcity/cockroach/nightlies/stress_impl.sh
+++ b/build/teamcity/cockroach/nightlies/stress_impl.sh
@@ -34,7 +34,7 @@ do
     fi
     exit_status=0
     GO_TEST_JSON_OUTPUT_FILE=$ARTIFACTS_DIR/$(echo "$test" | cut -d: -f2).test.json.txt
-    $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- --config=ci test "$test" \
+    $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- test --config=ci "$test" \
                                           --test_env=COCKROACH_NIGHTLY_STRESS=true \
                                           --test_env=GO_TEST_JSON_OUTPUT_FILE=$GO_TEST_JSON_OUTPUT_FILE \
                                           --test_timeout="$TESTTIMEOUTSECS" \


### PR DESCRIPTION
Fixes previous backport which removed GO_TEST_JSON_OUTPUT_FILE by mistake during git conflict resolution.

Release note: None
Release justification: ci fix for nightly stress tests