### PR TITLE
roachtest: This commit guards against a nil dereference

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2006,7 +2006,10 @@ func (c *clusterImpl) RunWithDetails(
 	if err != nil {
 		return nil, err
 	}
-	physicalFileName := l.File.Name()
+	physicalFileName := ""
+	if l.File != nil {
+		physicalFileName = l.File.Name()
+	}
 
 	if err := ctx.Err(); err != nil {
 		l.Printf("(note: incoming context was canceled: %s", err)
@@ -2019,7 +2022,7 @@ func (c *clusterImpl) RunWithDetails(
 	}
 
 	results, err := roachprod.RunWithDetails(ctx, l, c.MakeNodes(nodes), "" /* SSHOptions */, "" /* processTag */, false /* secure */, args)
-	if err != nil {
+	if err != nil && len(physicalFileName) > 0 {
 		l.Printf("> result: %+v", err)
 		createFailedFile(physicalFileName)
 		return results, err


### PR DESCRIPTION
of a fileless child logger's file name, which can happen due to a race condition in which we attempt to log whilst the test is being torn down.

See also: https://github.com/cockroachdb/cockroach/pull/81779

Release note: None
Epic: None