### PR TITLE
nightlies/stress: skip integration tests and `broken_in_bazel` tests

### DIFF
--- a/build/teamcity/cockroach/nightlies/stress_impl.sh
+++ b/build/teamcity/cockroach/nightlies/stress_impl.sh
@@ -16,6 +16,17 @@ bazel build //pkg/cmd/bazci //pkg/cmd/github-post //pkg/cmd/testfilter --config=
 BAZEL_BIN=$(bazel info bazel-bin --config=ci)
 ARTIFACTS_DIR=/artifacts
 
+if [[ ! -z $(bazel query "attr(tags, \"broken_in_bazel\", $TARGET)") ]]
+then
+    echo "Skipping test $TARGET as it is broken in bazel"
+    exit 0
+fi
+if [[ ! -z $(bazel query "attr(tags, \"integration\", $TARGET)") ]]
+then
+    echo "Skipping test $TARGET as it is an integration test"
+    exit 0
+fi
+
 GOTESTTIMEOUTSECS=$(($TESTTIMEOUTSECS - 5))
 GO_TEST_JSON_OUTPUT_FILE=$ARTIFACTS_DIR/$(echo "$TARGET" | cut -d: -f2).test.json.txt
 exit_status=0


### PR DESCRIPTION
Just copy-pasting code from `master` that's useful for skipping broken tests.

Closes #92794.
Closes #92813.
Closes #92815.
Closes #92820.

Release note: None
Epic: None