### PR TITLE
kvserver,logstore: move term and entry loading to logstore

### DIFF
--- a/pkg/kv/kvserver/logstore/BUILD.bazel
+++ b/pkg/kv/kvserver/logstore/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/storage/enginepb",
         "//pkg/storage/fs",
         "//pkg/util/hlc",
+        "//pkg/util/iterutil",
         "//pkg/util/log",
         "//pkg/util/metric",
         "//pkg/util/protoutil",

--- a/pkg/kv/kvserver/logstore/BUILD.bazel
+++ b/pkg/kv/kvserver/logstore/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/kvserverpb",
         "//pkg/kv/kvserver/raftentry",
+        "//pkg/kv/kvserver/raftlog",
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/settings/cluster",

--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -334,4 +335,119 @@ func LoadTerm(
 		return 0, errors.Errorf("there is a gap at index %d", index)
 	}
 	return 0, raft.ErrCompacted
+}
+
+// LoadEntries retrieves entries from the engine. It inlines the sideloaded
+// entries, and caches all the loaded entries. The size of the returned entries
+// does not exceed maxSize, unless only one entry is returned.
+//
+// TODO(pavelkalinnikov): return all entries we've read, consider maxSize a
+// target size. Currently we may read one extra entry and drop it.
+func LoadEntries(
+	ctx context.Context,
+	rsl StateLoader,
+	eng storage.Engine,
+	rangeID roachpb.RangeID,
+	eCache *raftentry.Cache,
+	sideloaded SideloadStorage,
+	lo, hi, maxBytes uint64,
+) ([]raftpb.Entry, error) {
+	if lo > hi {
+		return nil, errors.Errorf("lo:%d is greater than hi:%d", lo, hi)
+	}
+
+	n := hi - lo
+	if n > 100 {
+		n = 100
+	}
+	ents := make([]raftpb.Entry, 0, n)
+
+	ents, size, hitIndex, exceededMaxBytes := eCache.Scan(ents, rangeID, lo, hi, maxBytes)
+
+	// Return results if the correct number of results came back or if
+	// we ran into the max bytes limit.
+	if uint64(len(ents)) == hi-lo || exceededMaxBytes {
+		return ents, nil
+	}
+
+	// Scan over the log to find the requested entries in the range [lo, hi),
+	// stopping once we have enough.
+	expectedIndex := hitIndex
+
+	scanFunc := func(ent raftpb.Entry) error {
+		// Exit early if we have any gaps or it has been compacted.
+		if ent.Index != expectedIndex {
+			return iterutil.StopIteration()
+		}
+		expectedIndex++
+
+		if SniffSideloadedRaftCommand(ent.Data) {
+			newEnt, err := MaybeInlineSideloadedRaftCommand(
+				ctx, rangeID, ent, sideloaded, eCache,
+			)
+			if err != nil {
+				return err
+			}
+			if newEnt != nil {
+				ent = *newEnt
+			}
+		}
+
+		// Note that we track the size of proposals with payloads inlined.
+		size += uint64(ent.Size())
+		if size > maxBytes {
+			exceededMaxBytes = true
+			if len(ents) == 0 { // make sure to return at least one entry
+				ents = append(ents, ent)
+			}
+			return iterutil.StopIteration()
+		}
+
+		ents = append(ents, ent)
+		return nil
+	}
+
+	reader := eng.NewReadOnly(storage.StandardDurability)
+	defer reader.Close()
+	if err := raftlog.Visit(reader, rangeID, expectedIndex, hi, scanFunc); err != nil {
+		return nil, err
+	}
+	eCache.Add(rangeID, ents, false /* truncate */)
+
+	// Did the correct number of results come back? If so, we're all good.
+	if uint64(len(ents)) == hi-lo {
+		return ents, nil
+	}
+
+	// Did we hit the size limit? If so, return what we have.
+	if exceededMaxBytes {
+		return ents, nil
+	}
+
+	// Did we get any results at all? Because something went wrong.
+	if len(ents) > 0 {
+		// Was the missing index after the last index?
+		lastIndex, err := rsl.LoadLastIndex(ctx, reader)
+		if err != nil {
+			return nil, err
+		}
+		if lastIndex <= expectedIndex {
+			return nil, raft.ErrUnavailable
+		}
+
+		// We have a gap in the record, if so, return a nasty error.
+		return nil, errors.Errorf("there is a gap in the index record between lo:%d and hi:%d at index:%d", lo, hi, expectedIndex)
+	}
+
+	// No results, was it due to unavailability or truncation?
+	ts, err := rsl.LoadRaftTruncatedState(ctx, reader)
+	if err != nil {
+		return nil, err
+	}
+	if ts.Index >= lo {
+		// The requested lo index has already been truncated.
+		return nil, raft.ErrCompacted
+	}
+	// The requested lo index does not yet exist.
+	return nil, raft.ErrUnavailable
 }

--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftentry"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftlog"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -266,4 +267,71 @@ func logAppend(
 		LastTerm:  entries[len(entries)-1].Term,
 		ByteSize:  prev.ByteSize + diff.SysBytes,
 	}, nil
+}
+
+// LoadTerm returns the term of the entry at the given index for the specified
+// range. The result is loaded from the storage engine if it's not in the cache.
+func LoadTerm(
+	ctx context.Context,
+	rsl StateLoader,
+	eng storage.Engine,
+	rangeID roachpb.RangeID,
+	eCache *raftentry.Cache,
+	index uint64,
+) (uint64, error) {
+	entry, found := eCache.Get(rangeID, index)
+	if found {
+		return entry.Term, nil
+	}
+
+	reader := eng.NewReadOnly(storage.StandardDurability)
+	defer reader.Close()
+
+	if err := raftlog.Visit(reader, rangeID, index, index+1, func(ent raftpb.Entry) error {
+		if found {
+			return errors.Errorf("found more than one entry in [%d,%d)", index, index+1)
+		}
+		found = true
+		entry = ent
+		return nil
+	}); err != nil {
+		return 0, err
+	}
+
+	if found {
+		// Found an entry. Double-check that it has a correct index.
+		if got, want := entry.Index, index; got != want {
+			return 0, errors.Errorf("there is a gap at index %d, found entry #%d", want, got)
+		}
+		// Cache the entry except if it is sideloaded. We don't load/inline the
+		// sideloaded entries here to keep the term fetching cheap.
+		// TODO(pavelkalinnikov): consider not caching here, after measuring if it
+		// makes any difference.
+		if !SniffSideloadedRaftCommand(entry.Data) {
+			eCache.Add(rangeID, []raftpb.Entry{entry}, false /* truncate */)
+		}
+		return entry.Term, nil
+	}
+	// Otherwise, the entry at the given index is not found. This can happen if
+	// the index is ahead of lastIndex, or it has been compacted away.
+
+	lastIndex, err := rsl.LoadLastIndex(ctx, reader)
+	if err != nil {
+		return 0, err
+	}
+	if index > lastIndex {
+		return 0, raft.ErrUnavailable
+	}
+
+	ts, err := rsl.LoadRaftTruncatedState(ctx, reader)
+	if err != nil {
+		return 0, err
+	}
+	if index == ts.Index {
+		return ts.Term, nil
+	}
+	if index > ts.Index {
+		return 0, errors.Errorf("there is a gap at index %d", index)
+	}
+	return 0, raft.ErrCompacted
 }

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -17,8 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftentry"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftlog"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/readsummary"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
@@ -26,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
-	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -102,128 +99,13 @@ func (r *replicaRaftStorage) Entries(lo, hi, maxBytes uint64) ([]raftpb.Entry, e
 	if r.raftMu.sideloaded == nil {
 		return nil, errors.New("sideloaded storage is uninitialized")
 	}
-	return entries(ctx, r.mu.stateLoader, r.store.Engine(), r.RangeID, r.store.raftEntryCache,
-		r.raftMu.sideloaded, lo, hi, maxBytes)
+	return logstore.LoadEntries(ctx, r.mu.stateLoader.StateLoader, r.store.Engine(), r.RangeID,
+		r.store.raftEntryCache, r.raftMu.sideloaded, lo, hi, maxBytes)
 }
 
 // raftEntriesLocked requires that r.mu is held for writing.
 func (r *Replica) raftEntriesLocked(lo, hi, maxBytes uint64) ([]raftpb.Entry, error) {
 	return (*replicaRaftStorage)(r).Entries(lo, hi, maxBytes)
-}
-
-// entries retrieves entries from the engine. It inlines the sideloaded entries,
-// and caches all the loaded entries. The size of the returned entries does not
-// exceed maxSize, unless only one entry is returned.
-//
-// TODO(pavelkalinnikov): return all entries we've read, consider maxSize a
-// target size. Currently we may read one extra entry and drop it.
-func entries(
-	ctx context.Context,
-	rsl stateloader.StateLoader,
-	eng storage.Engine,
-	rangeID roachpb.RangeID,
-	eCache *raftentry.Cache,
-	sideloaded logstore.SideloadStorage,
-	lo, hi, maxBytes uint64,
-) ([]raftpb.Entry, error) {
-	if lo > hi {
-		return nil, errors.Errorf("lo:%d is greater than hi:%d", lo, hi)
-	}
-
-	n := hi - lo
-	if n > 100 {
-		n = 100
-	}
-	ents := make([]raftpb.Entry, 0, n)
-
-	ents, size, hitIndex, exceededMaxBytes := eCache.Scan(ents, rangeID, lo, hi, maxBytes)
-
-	// Return results if the correct number of results came back or if
-	// we ran into the max bytes limit.
-	if uint64(len(ents)) == hi-lo || exceededMaxBytes {
-		return ents, nil
-	}
-
-	// Scan over the log to find the requested entries in the range [lo, hi),
-	// stopping once we have enough.
-	expectedIndex := hitIndex
-
-	scanFunc := func(ent raftpb.Entry) error {
-		// Exit early if we have any gaps or it has been compacted.
-		if ent.Index != expectedIndex {
-			return iterutil.StopIteration()
-		}
-		expectedIndex++
-
-		if logstore.SniffSideloadedRaftCommand(ent.Data) {
-			newEnt, err := logstore.MaybeInlineSideloadedRaftCommand(
-				ctx, rangeID, ent, sideloaded, eCache,
-			)
-			if err != nil {
-				return err
-			}
-			if newEnt != nil {
-				ent = *newEnt
-			}
-		}
-
-		// Note that we track the size of proposals with payloads inlined.
-		size += uint64(ent.Size())
-		if size > maxBytes {
-			exceededMaxBytes = true
-			if len(ents) == 0 { // make sure to return at least one entry
-				ents = append(ents, ent)
-			}
-			return iterutil.StopIteration()
-		}
-
-		ents = append(ents, ent)
-		return nil
-	}
-
-	reader := eng.NewReadOnly(storage.StandardDurability)
-	defer reader.Close()
-	if err := raftlog.Visit(reader, rangeID, expectedIndex, hi, scanFunc); err != nil {
-		return nil, err
-	}
-	eCache.Add(rangeID, ents, false /* truncate */)
-
-	// Did the correct number of results come back? If so, we're all good.
-	if uint64(len(ents)) == hi-lo {
-		return ents, nil
-	}
-
-	// Did we hit the size limit? If so, return what we have.
-	if exceededMaxBytes {
-		return ents, nil
-	}
-
-	// Did we get any results at all? Because something went wrong.
-	if len(ents) > 0 {
-		// Was the missing index after the last index?
-		lastIndex, err := rsl.LoadLastIndex(ctx, reader)
-		if err != nil {
-			return nil, err
-		}
-		if lastIndex <= expectedIndex {
-			return nil, raft.ErrUnavailable
-		}
-
-		// We have a gap in the record, if so, return a nasty error.
-		return nil, errors.Errorf("there is a gap in the index record between lo:%d and hi:%d at index:%d", lo, hi, expectedIndex)
-	}
-
-	// No results, was it due to unavailability or truncation?
-	ts, err := rsl.LoadRaftTruncatedState(ctx, reader)
-	if err != nil {
-		return nil, err
-	}
-	if ts.Index >= lo {
-		// The requested lo index has already been truncated.
-		return nil, raft.ErrCompacted
-	}
-	// The requested lo index does not yet exist.
-	return nil, raft.ErrUnavailable
 }
 
 // invalidLastTerm is an out-of-band value for r.mu.lastTerm that

--- a/pkg/kv/kvserver/replica_sideload_test.go
+++ b/pkg/kv/kvserver/replica_sideload_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -177,12 +176,12 @@ func TestRaftSSTableSideloading(t *testing.T) {
 	tc.repl.mu.Lock()
 	defer tc.repl.mu.Unlock()
 
-	rsl := stateloader.Make(tc.repl.RangeID)
+	rsl := logstore.NewStateLoader(tc.repl.RangeID)
 	lo := tc.repl.mu.state.TruncatedState.Index + 1
 	hi := tc.repl.mu.lastIndex + 1
 
 	tc.store.raftEntryCache.Clear(tc.repl.RangeID, hi)
-	ents, err := entries(
+	ents, err := logstore.LoadEntries(
 		ctx, rsl, tc.store.Engine(), tc.repl.RangeID, tc.store.raftEntryCache,
 		tc.repl.raftMu.sideloaded, lo, hi, math.MaxUint64,
 	)


### PR DESCRIPTION
This PR moves entry and term fetching to the `logstore` package.

Part of #91979
Release note: None