### PR TITLE
log: fix flakiness in TestStatusLogRedaction

### DIFF
--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -658,7 +658,6 @@ func TestStatusLocalLogs(t *testing.T) {
 // honor the redaction flags.
 func TestStatusLogRedaction(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.UnderRaceWithIssue(t, 92789, "flaky test")
 
 	testData := []struct {
 		redactableLogs     bool // logging flag
@@ -758,7 +757,8 @@ func TestStatusLogRedaction(t *testing.T) {
 						}
 
 						// Retrieve the log entries using the Logs() RPC.
-						logsURL := fmt.Sprintf("logs/local?redact=%v", tc.redact)
+						// Set a high `max` value to ensure we get the log line we're searching for.
+						logsURL := fmt.Sprintf("logs/local?redact=%v&max=5000", tc.redact)
 						var wrapper2 serverpb.LogEntriesResponse
 						if err := getStatusJSONProto(ts, logsURL, &wrapper2); err != nil {
 							t.Fatal(err)


### PR DESCRIPTION
TestStatusLogRedaction was continuously failing when run with `--race`.

The test searches for a specific log line in the results from two separate RPCs - `LogFile()` and `Log()`. The test consistently failed when checking the results from the `Log()` RPC because the endpoint has a default max number of log entries set to 1000. Frequently, the log entry that we're searching for has a line index in the range of [1500, 2000], so the test was failing to find the log entry since it was being filtered out due to the default max number of entries.

This patch simply sets the max to a high enough value where this should no longer happen. With multiple runs I never saw the total # of log lines exceed 2,500, so we set the max to 5,000 to be safe.

Release note: None

Fixes: #92789