### PR TITLE
kvserver: add average cpu nanos per replica

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -176,6 +176,7 @@ go_library(
         "//pkg/util/envutil",
         "//pkg/util/errorutil",
         "//pkg/util/grpcutil",
+        "//pkg/util/grunning",
         "//pkg/util/hlc",
         "//pkg/util/humanizeutil",
         "//pkg/util/iterutil",

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -354,6 +354,12 @@ var (
 		Measurement: "Bytes/Sec",
 		Unit:        metric.Unit_BYTES,
 	}
+	metaAverageCPUNanosPerSecond = metric.Metadata{
+		Name:        "rebalancing.cpunanospersecond",
+		Help:        "Average CPU nanoseconds spent on processing replica operations in the last 30 minutes.",
+		Measurement: "Nanoseconds/Sec",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
 
 	// Metric for tracking follower reads.
 	metaFollowerReadsCount = metric.Metadata{
@@ -1745,6 +1751,7 @@ type StoreMetrics struct {
 	AverageRequestsPerSecond   *metric.GaugeFloat64
 	AverageWriteBytesPerSecond *metric.GaugeFloat64
 	AverageReadBytesPerSecond  *metric.GaugeFloat64
+	AverageCPUNanosPerSecond   *metric.GaugeFloat64
 	// l0SublevelsWindowedMax doesn't get recorded to metrics itself, it maintains
 	// an ad-hoc history for gosipping information for allocator use.
 	l0SublevelsWindowedMax syncutil.AtomicFloat64
@@ -2286,6 +2293,7 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		AverageReadsPerSecond:      metric.NewGaugeFloat64(metaAverageReadsPerSecond),
 		AverageWriteBytesPerSecond: metric.NewGaugeFloat64(metaAverageWriteBytesPerSecond),
 		AverageReadBytesPerSecond:  metric.NewGaugeFloat64(metaAverageReadBytesPerSecond),
+		AverageCPUNanosPerSecond:   metric.NewGaugeFloat64(metaAverageCPUNanosPerSecond),
 
 		// Follower reads metrics.
 		FollowerReadsCount: metric.NewCounter(metaFollowerReadsCount),

--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
+	"github.com/cockroachdb/cockroach/pkg/util/grunning"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -669,6 +670,10 @@ func (r *replicaGCer) GC(
 func (mgcq *mvccGCQueue) process(
 	ctx context.Context, repl *Replica, _ spanconfig.StoreReader,
 ) (processed bool, err error) {
+	// Record the CPU time processing the request for this replica. This is
+	// recorded regardless of errors that are encountered.
+	defer repl.MeasureReqCPUNanos(grunning.Time())
+
 	// Lookup the descriptor and GC policy for the zone containing this key range.
 	desc, conf := repl.DescAndSpanConfig()
 

--- a/pkg/kv/kvserver/replica_metrics.go
+++ b/pkg/kv/kvserver/replica_metrics.go
@@ -331,6 +331,14 @@ func (r *Replica) ReadBytesPerSecond() float64 {
 	return rbps
 }
 
+// CPUNanosPerSecond tracks the time this replica spent on-processor averaged
+// per second.
+func (r *Replica) CPUNanosPerSecond() float64 {
+	raftCPUNanos, _ := r.loadStats.raftCPUNanos.AverageRatePerSecond()
+	reqCPUNanos, _ := r.loadStats.reqCPUNanos.AverageRatePerSecond()
+	return raftCPUNanos + reqCPUNanos
+}
+
 func (r *Replica) needsSplitBySizeRLocked() bool {
 	exceeded, _ := r.exceedsMultipleOfSplitSizeRLocked(1)
 	return exceeded

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/circuit"
+	"github.com/cockroachdb/cockroach/pkg/util/grunning"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -130,6 +131,10 @@ func (r *Replica) SendWithWriteBytes(
 	}
 	// Add the range log tag.
 	ctx = r.AnnotateCtx(ctx)
+
+	// Record the CPU time processing the request for this replica. This is
+	// recorded regardless of errors that are encountered.
+	defer r.MeasureReqCPUNanos(grunning.Time())
 
 	// Record summary throughput information about the batch request for
 	// accounting.

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3212,6 +3212,7 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 		averageWritesPerSecond        float64
 		averageReadBytesPerSecond     float64
 		averageWriteBytesPerSecond    float64
+		averageCPUNanosPerSecond      float64
 
 		rangeCount                int64
 		unavailableRangeCount     int64
@@ -3309,6 +3310,8 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 		if wbps, dur := rep.loadStats.writeBytes.AverageRatePerSecond(); dur >= replicastats.MinStatsDuration {
 			averageWriteBytesPerSecond += wbps
 		}
+		averageCPUNanosPerSecond += rep.CPUNanosPerSecond()
+
 		locks += metrics.LockTableMetrics.Locks
 		totalLockHoldDurationNanos += metrics.LockTableMetrics.TotalLockHoldDurationNanos
 		locksWithWaitQueues += metrics.LockTableMetrics.LocksWithWaitQueues
@@ -3344,6 +3347,7 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 	s.metrics.AverageReadsPerSecond.Update(averageReadsPerSecond)
 	s.metrics.AverageReadBytesPerSecond.Update(averageReadBytesPerSecond)
 	s.metrics.AverageWriteBytesPerSecond.Update(averageWriteBytesPerSecond)
+	s.metrics.AverageCPUNanosPerSecond.Update(averageCPUNanosPerSecond)
 	s.recordNewPerSecondStats(averageQueriesPerSecond, averageWritesPerSecond)
 
 	s.metrics.RangeCount.Update(rangeCount)
@@ -3547,6 +3551,7 @@ type HotReplicaInfo struct {
 	WriteKeysPerSecond  float64
 	WriteBytesPerSecond float64
 	ReadBytesPerSecond  float64
+	CPUNanosPerSecond   float64
 }
 
 // HottestReplicas returns the hottest replicas on a store, sorted by their

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -693,6 +693,10 @@ var charts = []sectionDescription{
 				Title:   "Bytes Written Per Second",
 				Metrics: []string{"rebalancing.writebytespersecond"},
 			},
+			{
+				Title:   "CPU Nanos Used Per Second",
+				Metrics: []string{"rebalancing.cpunanospersecond"},
+			},
 		},
 	},
 	{


### PR DESCRIPTION
This patch adds partial accounting for the time spent on processing requests, for a specific replica. The time spent is recorded in `ReplicaStats` and allows for observing the aggregate cpu time spent on replicas via an exported metric `rebalancing.cpunanospersecond`.

Release note: None