### PR TITLE
ui: Aggregate grants for each user on the Database Tables Page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.stories.tsx
@@ -10,6 +10,7 @@
 
 import React from "react";
 import { storiesOf } from "@storybook/react";
+import _ from "lodash";
 
 import { withBackground, withRouterProvider } from "src/storybook/decorators";
 import {
@@ -94,7 +95,9 @@ const withData: DatabaseTablePageProps = {
     grants: [
       {
         user: randomRole(),
-        privilege: randomTablePrivilege(),
+        privileges: _.uniq(
+          new Array(_.random(1, 5)).map(() => randomTablePrivilege()),
+        ),
       },
     ],
     statsLastUpdated: moment("0001-01-01T00:00:00Z"),

--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
@@ -147,7 +147,7 @@ interface IndexRecommendation {
 
 interface Grant {
   user: string;
-  privilege: string;
+  privileges: string[];
 }
 
 export interface DatabaseTablePageDataStats {
@@ -470,8 +470,8 @@ export class DatabaseTablePage extends React.Component<
           Grants
         </Tooltip>
       ),
-      cell: grant => grant.privilege,
-      sort: grant => grant.privilege,
+      cell: grant => grant.privileges.join(", "),
+      sort: grant => grant.privileges.join(", "),
     },
   ];
 

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.ts
@@ -33,7 +33,7 @@ import {
   nodeRegionsByIDSelector,
   selectIsMoreThanOneNode,
 } from "src/redux/nodes";
-import { getNodesByRegionString } from "../utils";
+import { getNodesByRegionString, normalizePrivileges } from "../utils";
 
 const { DatabaseDetailsRequest, TableDetailsRequest, TableStatsRequest } =
   cockroach.server.serverpb;
@@ -51,24 +51,6 @@ function normalizeRoles(raw: string[]): string[] {
   const alphabetizedRoles = _.sortBy(_.uniq(_.filter(raw)));
 
   return _.sortBy(alphabetizedRoles, role => rolePrecedence[role] || 100);
-}
-
-function normalizePrivileges(raw: string[]): string[] {
-  const privilegePrecedence: Record<string, number> = {
-    ALL: 1,
-    CREATE: 2,
-    DROP: 3,
-    GRANT: 4,
-    SELECT: 5,
-    INSERT: 6,
-    UPDATE: 7,
-    DELETE: 8,
-  };
-
-  return _.sortBy(
-    _.uniq(_.map(_.filter(raw), _.toUpper)),
-    privilege => privilegePrecedence[privilege] || 100,
-  );
 }
 
 const sortSettingTablesLocalSetting = new LocalSetting(

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseTablePage/redux.spec.ts
@@ -231,9 +231,8 @@ describe("Database Table Page", function () {
       replicaCount: 5,
       indexNames: ["primary", "another_index"],
       grants: [
-        { user: "admin", privilege: "CREATE" },
-        { user: "admin", privilege: "DROP" },
-        { user: "public", privilege: "SELECT" },
+        { user: "admin", privileges: ["CREATE", "DROP"] },
+        { user: "public", privileges: ["SELECT"] },
       ],
       statsLastUpdated: util.TimestampToMoment(
         makeTimestamp("0001-01-01T00:00:00Z"),

--- a/pkg/ui/workspaces/db-console/src/views/databases/utils.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/utils.ts
@@ -12,6 +12,7 @@
 // based on the nodes list provided and nodeRegions, which is a full
 // list of node id to the region it resides.
 import * as protos from "src/js/protos";
+import _ from "lodash";
 import Long from "long";
 
 type Timestamp = protos.google.protobuf.ITimestamp;
@@ -69,4 +70,23 @@ export function makeTimestamp(date: string): Timestamp {
   return new protos.google.protobuf.Timestamp({
     seconds: new Long(new Date(date).getUTCSeconds()),
   });
+}
+
+// normalizePrivileges sorts priveleges by privelege precedence.
+export function normalizePrivileges(raw: string[]): string[] {
+  const privilegePrecedence: Record<string, number> = {
+    ALL: 1,
+    CREATE: 2,
+    DROP: 3,
+    GRANT: 4,
+    SELECT: 5,
+    INSERT: 6,
+    UPDATE: 7,
+    DELETE: 8,
+  };
+
+  return _.sortBy(
+    _.uniq(_.map(_.filter(raw), _.toUpper)),
+    privilege => privilegePrecedence[privilege] || 100,
+  );
 }


### PR DESCRIPTION
Fixes: https://github.com/cockroachdb/cockroach/issues/92872.

Previously, the database tables page displayed the grants for each user
on a separate row; one user and grant pair per row. This commit
aggregates all the grants into a single string value; one user and all
their grants per row.

Before:
<img width="336" alt="Screen Shot 2022-12-01 at 6 00 02 PM" src="https://user-images.githubusercontent.com/35943354/205177986-5bffc2f9-d65e-435b-906f-2686a83fd03d.png">

After:
<img width="446" alt="Screen Shot 2022-12-01 at 5 57 00 PM" src="https://user-images.githubusercontent.com/35943354/205178028-097629eb-461e-45b0-81de-e7284e3891eb.png">

Release note (ui change): the databases table page now displays all the
grants in a single row per user.
