### PR TITLE
leaktest: don't recover from panics

### DIFF
--- a/pkg/util/leaktest/leaktest.go
+++ b/pkg/util/leaktest/leaktest.go
@@ -23,7 +23,6 @@ package leaktest
 import (
 	"fmt"
 	"runtime"
-	"runtime/debug"
 	"sort"
 	"strings"
 	"sync/atomic"
@@ -94,6 +93,10 @@ var PrintLeakedStoppers = func(t testing.TB) {}
 // function to be run at the end of tests to see whether any
 // goroutines leaked.
 func AfterTest(t testing.TB) func() {
+	if atomic.LoadUint32(&leakDetectorDisabled) != 0 {
+		return func() {}
+	}
+
 	// Try a best effort GC to help the race tests move along.
 	runtime.GC()
 	orig := interestingGoroutines()
@@ -101,18 +104,13 @@ func AfterTest(t testing.TB) func() {
 		t.Helper()
 		// If there was a panic, "leaked" goroutines are expected.
 		if r := recover(); r != nil {
+			// Inhibit the leak detector for future tests, in case someone (insanely?)
+			// recovers our re-panic below and continues running other tests. We're
+			// likely leaving goroutines around, which may spawn more goroutines in
+			// the middle of another test's execution and trip the leak detector for
+			// that innocent test.
 			atomic.StoreUint32(&leakDetectorDisabled, 1)
-			// NB: we don't want to re-panic here, for the Go test
-			// harness will not recover that for us. Instead, it will
-			// stop running the tests, but we are deciding here to fail
-			// only that one test but keep going otherwise.
-			// We need to explicitly print the stack trace though.
-			t.Fatalf("%v\n%s", r, debug.Stack())
-			return
-		}
-
-		if atomic.LoadUint32(&leakDetectorDisabled) != 0 {
-			return
+			panic(r)
 		}
 
 		// If the test already failed, we don't pile on any more errors but we check

--- a/pkg/util/leaktest/leaktest.go
+++ b/pkg/util/leaktest/leaktest.go
@@ -110,6 +110,8 @@ func AfterTest(t testing.TB) func() {
 			// the middle of another test's execution and trip the leak detector for
 			// that innocent test.
 			atomic.StoreUint32(&leakDetectorDisabled, 1)
+			t.Log(fmt.Sprintf("panic: %s", r)) // !!!
+			//t.Fatal(fmt.Sprintf("panic: %s", r)) // !!!
 			panic(r)
 		}
 

--- a/pkg/util/tracing/span_test.go
+++ b/pkg/util/tracing/span_test.go
@@ -49,6 +49,7 @@ func TestStartSpan(t *testing.T) {
 }
 
 func TestRecordingString(t *testing.T) {
+	panic("!!!")
 	tr := NewTracer()
 	tr2 := NewTracer()
 

--- a/pkg/util/tracing/span_test.go
+++ b/pkg/util/tracing/span_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
@@ -49,6 +50,7 @@ func TestStartSpan(t *testing.T) {
 }
 
 func TestRecordingString(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	panic("!!!")
 	tr := NewTracer()
 	tr2 := NewTracer()


### PR DESCRIPTION
This patch effectively reverts #45983. The leaktest will now re-panic
when invoked on a panic unwind, instead of failing the test but
otherwise swallowing the panic and letting further tests run. Recovering
from panics is generally not a Go thing to do. The leaktest can only
recover from panics on the test's main goroutine (panics on other
goroutines, for example panics in a TestServer/TestCluster still crash
the binary), so the leaktest's behavior is inconsistent at best. The
panic-swallowing behavior is also surprising and magical - tests using
leaktest get it, tests not using leaktests don't get it, and figuring
out this difference is hard. Additionally, having the leaktest recover
panics is contageous - it puts pressure on other random code to be
mindful of its behavior under panic unwind. For example, the Stopper has
complex logic for recovering panics and doing best-effort cleanup,
recovering more panics from confused cleanup code, so that ultimately
future tests can run in a more or less sane environment.

I don't think the magic is worth it. Let's try again without it.

I believe that, at the time the leaktest magic was added, panics in go
tests were not resulting in a very clean experience in CI - it wasn't
trivial to see what test failed. I don't know if that's still the case.

Release note: None
Epic: None