### PR TITLE
physicalplan: make fakeSpanResolver deterministic

### DIFF
--- a/pkg/sql/physicalplan/BUILD.bazel
+++ b/pkg/sql/physicalplan/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//pkg/util",
         "//pkg/util/hlc",
         "//pkg/util/log",
+        "//pkg/util/randutil",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
     ],


### PR DESCRIPTION
This commit fixes an omission of not using `NewTestRand()` for the fake span resolver which makes the placement of "ranges" in `fakedist*` logic test configs deterministic with the fixed seed.

Epic: None

Release note: None