### PR TITLE
rttanalysis: skip test which doesn't work due to tracing limitations

### DIFF
--- a/pkg/bench/rttanalysis/orm_queries_bench_test.go
+++ b/pkg/bench/rttanalysis/orm_queries_bench_test.go
@@ -287,8 +287,9 @@ ORDER BY relname DESC, input`,
 		},
 
 		{
-			Name:  "hasura column descriptions",
-			Setup: "CREATE TABLE t(a INT PRIMARY KEY)",
+			Name:      "hasura column descriptions",
+			SkipIssue: 88885,
+			Setup:     "CREATE TABLE t(a INT PRIMARY KEY)",
 			Stmt: `WITH
   "tabletable" as ( SELECT "table".oid,
            "table".relkind,


### PR DESCRIPTION
This test ends up not seeing all the round trips because the trace is way too large. Given that, we get flakes sometimes. See the referenced issue (#88885).

Fixes #92770

Release note: None