### PR TITLE
leaktest: remove forced GC

### DIFF
--- a/pkg/util/leaktest/leaktest.go
+++ b/pkg/util/leaktest/leaktest.go
@@ -97,8 +97,6 @@ func AfterTest(t testing.TB) func() {
 		return func() {}
 	}
 
-	// Try a best effort GC to help the race tests move along.
-	runtime.GC()
 	orig := interestingGoroutines()
 	return func() {
 		t.Helper()


### PR DESCRIPTION
The leaktest was forcing a GC, which is bizarre. Folklore has it that it was done for #61120, which in the meantime has been solved in other ways. This patch removes the unusual GC and hopes for the best.

Release note: None
Epic: None