### PR TITLE
clisqlshell: fix a panic on tab key

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -5163,10 +5163,10 @@ def go_deps():
         name = "com_github_knz_bubbline",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/knz/bubbline",
-        sha256 = "cbb483551afc4af0ab2a490936cc4136fc70eeed69303162de59de6adfc2615c",
-        strip_prefix = "github.com/knz/bubbline@v0.0.0-20221124133514-7e375ec1ee20",
+        sha256 = "176f2b58f6206410c6118965e6cbdfcb2e626830587d94595c0026a31c70432c",
+        strip_prefix = "github.com/knz/bubbline@v0.0.0-20221202175954-247a3055d876",
         urls = [
-            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/knz/bubbline/com_github_knz_bubbline-v0.0.0-20221124133514-7e375ec1ee20.zip",
+            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/knz/bubbline/com_github_knz_bubbline-v0.0.0-20221202175954-247a3055d876.zip",
         ],
     )
     go_repository(

--- a/build/bazelutil/distdir_files.bzl
+++ b/build/bazelutil/distdir_files.bzl
@@ -551,7 +551,7 @@ DISTDIR_FILES = {
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/klauspost/cpuid/v2/com_github_klauspost_cpuid_v2-v2.0.9.zip": "52c716413296dce2b1698c6cdbc4c53927ce4aee2a60980daf9672e6b6a3b4cb",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/klauspost/crc32/com_github_klauspost_crc32-v0.0.0-20161016154125-cb6bfca970f6.zip": "6b632853a19f039138f251f94dbbdfdb72809adc3a02da08e4301d3d48275b06",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/klauspost/pgzip/com_github_klauspost_pgzip-v1.2.5.zip": "1143b6417d4bb46d26dc8e6223407b84b6cd5f32e5d705cd4a9fb142220ce4ba",
-    "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/knz/bubbline/com_github_knz_bubbline-v0.0.0-20221124133514-7e375ec1ee20.zip": "cbb483551afc4af0ab2a490936cc4136fc70eeed69303162de59de6adfc2615c",
+    "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/knz/bubbline/com_github_knz_bubbline-v0.0.0-20221202175954-247a3055d876.zip": "176f2b58f6206410c6118965e6cbdfcb2e626830587d94595c0026a31c70432c",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/knz/catwalk/com_github_knz_catwalk-v0.1.2.zip": "7b44ddd491c68b186426e5f98fcb9410c4d26a5c4fa82205b3ff2797ffc3b51b",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/knz/lipgloss-convert/com_github_knz_lipgloss_convert-v0.1.0.zip": "f9f9ffa12e7df4007cc60c87327d47ad42d1f71a80e360af4014674138de8bef",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/knz/strtime/com_github_knz_strtime-v0.0.0-20200318182718-be999391ffa9.zip": "c1e1b06c339798387413af1444f06f31a483d4f5278ab3a91b6cd5d7cd8d91a1",

--- a/go.mod
+++ b/go.mod
@@ -158,7 +158,7 @@ require (
 	github.com/kisielk/gotool v1.0.0
 	github.com/klauspost/compress v1.15.11
 	github.com/klauspost/pgzip v1.2.5
-	github.com/knz/bubbline v0.0.0-20221124133514-7e375ec1ee20
+	github.com/knz/bubbline v0.0.0-20221202175954-247a3055d876
 	github.com/knz/go-libedit v1.10.1
 	github.com/knz/strtime v0.0.0-20200318182718-be999391ffa9
 	github.com/kr/pretty v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -1483,8 +1483,8 @@ github.com/klauspost/pgzip v1.0.2-0.20170402124221-0bf5dcad4ada/go.mod h1:Ch1tH6
 github.com/klauspost/pgzip v1.2.4/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/pgzip v1.2.5 h1:qnWYvvKqedOF2ulHpMG72XQol4ILEJ8k2wwRl/Km8oE=
 github.com/klauspost/pgzip v1.2.5/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
-github.com/knz/bubbline v0.0.0-20221124133514-7e375ec1ee20 h1:+0fTqUp3/g+FybcL8jbpmg3btb/6ENUjK87U/ry1QWE=
-github.com/knz/bubbline v0.0.0-20221124133514-7e375ec1ee20/go.mod h1:ncR/xqKMlcer+tzvUfzTTF2LeAMAenWcWm21b8cy8LI=
+github.com/knz/bubbline v0.0.0-20221202175954-247a3055d876 h1:0Cqd+JGFEM7xxBPNeVpe5EHdWSX1Rj0XxYtrBP5twe8=
+github.com/knz/bubbline v0.0.0-20221202175954-247a3055d876/go.mod h1:ncR/xqKMlcer+tzvUfzTTF2LeAMAenWcWm21b8cy8LI=
 github.com/knz/catwalk v0.1.2 h1:sNLvF6WOXdvedeiCpqkpsHSGavOYxZwDsgdbKiu1IOc=
 github.com/knz/catwalk v0.1.2/go.mod h1:Q+Yj4ny4AXgrOOyWyDGY/HJzmbGH8MFnsUqvCAiUT5s=
 github.com/knz/lipgloss-convert v0.1.0 h1:qUPUt6r8mqvi9DIV3nBPu3kEmFyHrZtXzv0BlPBPLNQ=

--- a/pkg/cli/clisqlshell/complete.go
+++ b/pkg/cli/clisqlshell/complete.go
@@ -61,8 +61,13 @@ func (b *bubblineReader) getCompletions(
 	for _, row := range rows {
 		candidates = append(candidates, row[0])
 	}
-	_, wstart, wend := computil.FindWord(v, line, col)
-	return msg, editline.SimpleWordsCompletion(candidates, "keywords", col, wstart, wend)
+
+	if len(candidates) > 0 {
+		_, wstart, wend := computil.FindWord(v, line, col)
+		comps = editline.SimpleWordsCompletion(candidates, "keywords", col, wstart, wend)
+	}
+
+	return msg, comps
 }
 
 // runeOffset converts the 2D rune cursor to a 1D offset from the


### PR DESCRIPTION
Fixes  #92935.
Epic: CRDB-22182
This patch ensures that there's no visible panic if the user presses "tab" and there's no completion available.

NB: no unit tests here - the test coverage will be delivered by #87606.