### PR TITLE
release-22.2: ui: change selection order of workload insights

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
@@ -242,8 +242,8 @@ export const getInsightFromProblem = (
 };
 
 export const InsightExecOptions = new Map<string, string>([
-  [InsightExecEnum.TRANSACTION.toString(), "Transaction Executions"],
   [InsightExecEnum.STATEMENT.toString(), "Statement Executions"],
+  [InsightExecEnum.TRANSACTION.toString(), "Transaction Executions"],
 ]);
 
 export type WorkloadInsightEventFilters = Pick<Filters, "app">;

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/workloadInsightRootControl.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/workloadInsightRootControl.tsx
@@ -36,12 +36,11 @@ export const WorkloadInsightsRootControl = ({
 }: WorkloadInsightsViewProps): React.ReactElement => {
   const location = useLocation();
   const history = useHistory();
-  let viewValue =
-    queryByName(location, viewAttr) || InsightExecEnum.TRANSACTION;
-  // Use the default Transaction page if an
+  let viewValue = queryByName(location, viewAttr) || InsightExecEnum.STATEMENT;
+  // Use the default Statement page if an
   // unrecognized string was passed in from the URL
   if (!InsightExecOptions.has(viewValue)) {
-    viewValue = InsightExecEnum.TRANSACTION;
+    viewValue = InsightExecEnum.STATEMENT;
   }
 
   const [selectedInsightView, setSelectedInsightView] = useState(viewValue);


### PR DESCRIPTION
Previously, the Workload Insights view were first
Transaction and then Statements. Since 22.2 has more information on a 
Statement level, this commit changes the order of views, so Statement is first 
and Transactions is second.

Fixes #92931

Before
<img width="247" alt="Screen Shot 2022-12-02 at 1 06 55 PM" src="https://user-images.githubusercontent.com/1017486/205358206-6a89c98b-981f-471c-b095-c42329eb1a06.png">

After
<img width="379" alt="Screen Shot 2022-12-02 at 1 03 54 PM" src="https://user-images.githubusercontent.com/1017486/205358234-4effb877-8715-4266-9286-4575b97d49ad.png">


Release note (ui change): Switch order of Transaction and Statement 
views on Workload Insights.

---
Release Justification: small ui change