### PR TITLE
logictest: add couple more virtual lookup join tests

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4682,15 +4682,28 @@ CREATE TABLE t91012 (id INT, a_id INT);
 
 query I
 SELECT
-	count(*)
+    count(*)
 FROM
-	pg_class AS t INNER JOIN pg_attribute AS a ON t.oid = a.attrelid
+    pg_class AS t INNER JOIN pg_attribute AS a ON t.oid = a.attrelid
 WHERE
-	a.attnotnull = 'f'
-	AND a.attname = 'a_id'
-	AND t.relname = 't91012'
-	AND a.atttypid
-		IN (SELECT oid FROM pg_type WHERE typname = ANY (ARRAY['int8']));
+    a.attnotnull = 'f'
+    AND a.attname = 'a_id'
+    AND t.relname = 't91012'
+    AND a.atttypid IN (SELECT oid FROM pg_type WHERE typname = ANY (ARRAY['int8']));
+----
+1
+
+# Same query, but with left anti join instead.
+query I
+SELECT
+    count(*)
+FROM
+    pg_class AS t INNER JOIN pg_attribute AS a ON t.oid = a.attrelid
+WHERE
+    a.attnotnull = 'f'
+    AND a.attname = 'a_id'
+    AND t.relname = 't91012'
+    AND NOT EXISTS(SELECT 1 FROM pg_type WHERE typname = ANY (ARRAY['typefoo']) AND a.atttypid = oid);
 ----
 1
 
@@ -4701,12 +4714,25 @@ CREATE TYPE mytype AS enum('hello')
 
 query I
 SELECT
-	count(*)
+    count(*)
 FROM
-	pg_type AS t
+    pg_type AS t
 WHERE
-	t.typrelid = 0
-	AND NOT EXISTS(SELECT 1 FROM pg_type AS el WHERE el.oid = t.typelem AND el.typarray = t.oid)
-	AND t.typname LIKE 'myt%'
+    t.typrelid = 0
+    AND NOT EXISTS(SELECT 1 FROM pg_type AS el WHERE el.oid = t.typelem AND el.typarray = t.oid)
+    AND t.typname LIKE 'myt%';
 ----
 1
+
+# Same query, but with left semi join instead.
+query I
+SELECT
+    count(*)
+FROM
+    pg_type AS t
+WHERE
+    t.typrelid = 0
+    AND EXISTS(SELECT 1 FROM pg_type AS el WHERE el.oid = t.typelem AND el.typarray = t.oid)
+    AND t.typname LIKE 'myt%';
+----
+0

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual
@@ -274,3 +274,123 @@ SELECT info FROM [EXPLAIN SELECT count(*) FROM crdb_internal.jobs WHERE status =
     └── • virtual table
           table: jobs@jobs_status_idx
           spans: [/'paused' - /'paused']
+
+# Regression test for not projecting away looked up columns by the left semi
+# virtual lookup join (#91012).
+statement ok
+CREATE TABLE t91012 (id INT, a_id INT);
+
+query T
+EXPLAIN SELECT
+    *
+FROM
+    pg_class AS t INNER JOIN pg_attribute AS a ON t.oid = a.attrelid
+WHERE
+    a.attnotnull = 'f'
+    AND a.attname = 'a_id'
+    AND t.relname = 't91012'
+    AND a.atttypid IN (SELECT oid FROM pg_type WHERE typname = ANY (ARRAY['int8']));
+----
+distribution: local
+vectorized: true
+·
+• virtual table lookup join
+│ table: pg_class@pg_class_oid_idx
+│ equality: (attrelid) = (oid)
+│ pred: relname = 't91012'
+│
+└── • virtual table lookup join (semi)
+    │ table: pg_type@pg_type_oid_idx
+    │ equality: (atttypid) = (oid)
+    │ pred: typname = 'int8'
+    │
+    └── • filter
+        │ filter: (NOT attnotnull) AND (attname = 'a_id')
+        │
+        └── • virtual table
+              table: pg_attribute@primary
+
+# Same query, but with left anti join instead.
+query T
+EXPLAIN SELECT
+    *
+FROM
+    pg_class AS t INNER JOIN pg_attribute AS a ON t.oid = a.attrelid
+WHERE
+    a.attnotnull = 'f'
+    AND a.attname = 'a_id'
+    AND t.relname = 't91012'
+    AND NOT EXISTS(SELECT 1 FROM pg_type WHERE typname = ANY (ARRAY['typefoo']) AND a.atttypid = oid);
+----
+distribution: local
+vectorized: true
+·
+• virtual table lookup join
+│ table: pg_class@pg_class_oid_idx
+│ equality: (attrelid) = (oid)
+│ pred: relname = 't91012'
+│
+└── • virtual table lookup join (anti)
+    │ table: pg_type@pg_type_oid_idx
+    │ equality: (atttypid) = (oid)
+    │ pred: typname = 'typefoo'
+    │
+    └── • filter
+        │ filter: (NOT attnotnull) AND (attname = 'a_id')
+        │
+        └── • virtual table
+              table: pg_attribute@primary
+
+# Regression test for incorrectly handling left anti virtual lookup joins
+# (#88096).
+statement ok
+CREATE TYPE mytype AS enum('hello')
+
+query T
+EXPLAIN SELECT
+    *
+FROM
+    pg_type AS t
+WHERE
+    t.typrelid = 0
+    AND NOT EXISTS(SELECT 1 FROM pg_type AS el WHERE el.oid = t.typelem AND el.typarray = t.oid)
+    AND t.typname LIKE 'myt%';
+----
+distribution: local
+vectorized: true
+·
+• virtual table lookup join (anti)
+│ table: pg_type@pg_type_oid_idx
+│ equality: (typelem) = (oid)
+│ pred: typarray = oid
+│
+└── • filter
+    │ filter: (typrelid = 0) AND (typname LIKE 'myt%')
+    │
+    └── • virtual table
+          table: pg_type@primary
+
+# Same query, but with left semi join instead.
+query T
+EXPLAIN SELECT
+    *
+FROM
+    pg_type AS t
+WHERE
+    t.typrelid = 0
+    AND EXISTS(SELECT 1 FROM pg_type AS el WHERE el.oid = t.typelem AND el.typarray = t.oid)
+    AND t.typname LIKE 'myt%';
+----
+distribution: local
+vectorized: true
+·
+• virtual table lookup join (semi)
+│ table: pg_type@pg_type_oid_idx
+│ equality: (typelem) = (oid)
+│ pred: typarray = oid
+│
+└── • filter
+    │ filter: (typrelid = 0) AND (typname LIKE 'myt%')
+    │
+    └── • virtual table
+          table: pg_type@primary


### PR DESCRIPTION
This commit adds a couple more queries that use left semi and left anti virtual lookup joins as well as the execbuilder ones. Additionally, it replaces tabs with spaces in the tests added in the previous commit.

Epic: None

Release note: None