### PR TITLE
release-21.2: release-22.1: acceptance: fix TestComposeGSS

### DIFF
--- a/pkg/acceptance/compose/gss/psql/Dockerfile
+++ b/pkg/acceptance/compose/gss/psql/Dockerfile
@@ -7,7 +7,7 @@ RUN GO111MODULE=off go get -d -t -tags gss_compose
 RUN GO111MODULE=off go test -v -c -tags gss_compose -o gss.test
 
 # Copy the test binary to an image with psql and krb installed.
-FROM postgres:11
+FROM postgres:15
 
 RUN apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \


### PR DESCRIPTION
Backport 1/1 commits from #92849.

/cc @cockroachdb/release

---

Backport 1/1 commits from #92837 on behalf of @rail.

/cc @cockroachdb/release

----

Previously, the TestComposeGSS was broken, because the base docker image (`postgres:11`) used APT repos, that had been moved to a different location.

This PR changes the base image to `postgres:15`. The upgrade should be relatively safe.

Fixes #91420
Epic: None
Release note: None

----

Release justification: re-enabling TestComposeGSS should help keep our tests up to date.
