### PR TITLE
release-22.2: ui: add seconds, milliseconds to insights timestamps in console

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/insightDetailsTables.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/insightDetailsTables.tsx
@@ -10,7 +10,7 @@
 
 import React, { useState } from "react";
 import { ColumnDescriptor, SortedTable, SortSetting } from "src/sortedtable";
-import { DATE_FORMAT, Duration } from "src/util";
+import { DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT, Duration } from "src/util";
 import { EventExecution, InsightExecEnum } from "../types";
 import { insightsTableTitles, QueriesCell } from "../workloadInsights/util";
 
@@ -44,7 +44,8 @@ export function makeInsightDetailsColumns(
     {
       name: "contentionStartTime",
       title: insightsTableTitles.contentionStartTime(execType),
-      cell: (item: EventExecution) => item.startTime.format(DATE_FORMAT),
+      cell: (item: EventExecution) =>
+        item.startTime.format(DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT),
       sort: (item: EventExecution) => item.startTime.unix(),
     },
     {

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
@@ -15,7 +15,7 @@ import {
 } from "src/insightsTable/insightsTable";
 import { SummaryCard, SummaryCardItem } from "src/summaryCard";
 import { capitalize, Duration } from "src/util";
-import { DATE_FORMAT_24_UTC } from "src/util/format";
+import { DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT_24_UTC } from "src/util/format";
 import {
   executionDetails,
   InsightNameEnum,
@@ -141,11 +141,11 @@ export const StatementInsightDetailsOverviewTab: React.FC<
           <SummaryCard>
             <SummaryCardItem
               label="Start Time"
-              value={insightDetails.startTime.format(DATE_FORMAT_24_UTC)}
+              value={insightDetails.startTime.format(DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT_24_UTC)}
             />
             <SummaryCardItem
               label="End Time"
-              value={insightDetails.endTime.format(DATE_FORMAT_24_UTC)}
+              value={insightDetails.endTime.format(DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT_24_UTC)}
             />
             <SummaryCardItem
               label="Elapsed Time"

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
@@ -141,11 +141,15 @@ export const StatementInsightDetailsOverviewTab: React.FC<
           <SummaryCard>
             <SummaryCardItem
               label="Start Time"
-              value={insightDetails.startTime.format(DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT_24_UTC)}
+              value={insightDetails.startTime.format(
+                DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT_24_UTC,
+              )}
             />
             <SummaryCardItem
               label="End Time"
-              value={insightDetails.endTime.format(DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT_24_UTC)}
+              value={insightDetails.endTime.format(
+                DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT_24_UTC,
+              )}
             />
             <SummaryCardItem
               label="Elapsed Time"

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
@@ -19,7 +19,7 @@ import { Button } from "src/button";
 import { Loading } from "src/loading";
 import { SqlBox, SqlBoxSize } from "src/sql";
 import { SummaryCard, SummaryCardItem } from "src/summaryCard";
-import { DATE_FORMAT_24_UTC } from "src/util/format";
+import { DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT_24_UTC } from "src/util/format";
 import { getMatchParamByName } from "src/util/query";
 import { WaitTimeInsightsLabels } from "src/detailsPanels/waitTimeInsightsPanel";
 import {
@@ -180,7 +180,7 @@ export const TransactionInsightDetails: React.FC<
                       <SummaryCardItem
                         label="Start Time"
                         value={insightDetails.startTime.format(
-                          DATE_FORMAT_24_UTC,
+                          DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT_24_UTC,
                         )}
                       />
                     </SummaryCard>

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsTable.tsx
@@ -15,7 +15,12 @@ import {
   SortedTable,
   SortSetting,
 } from "src/sortedtable";
-import { Count, DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT, Duration, limitText } from "src/util";
+import {
+  Count,
+  DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT,
+  Duration,
+  limitText,
+} from "src/util";
 import { InsightExecEnum, StatementInsightEvent } from "src/insights";
 import {
   InsightCell,
@@ -89,7 +94,8 @@ export function makeStatementInsightsColumns(
     {
       name: "startTime",
       title: insightsTableTitles.startTime(execType),
-      cell: (item: StatementInsightEvent) => item.startTime.format(DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT),
+      cell: (item: StatementInsightEvent) =>
+        item.startTime.format(DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT),
       sort: (item: StatementInsightEvent) => item.startTime.unix(),
       showByDefault: true,
     },

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsTable.tsx
@@ -15,7 +15,7 @@ import {
   SortedTable,
   SortSetting,
 } from "src/sortedtable";
-import { Count, DATE_FORMAT, Duration, limitText } from "src/util";
+import { Count, DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT, Duration, limitText } from "src/util";
 import { InsightExecEnum, StatementInsightEvent } from "src/insights";
 import {
   InsightCell,
@@ -89,7 +89,7 @@ export function makeStatementInsightsColumns(
     {
       name: "startTime",
       title: insightsTableTitles.startTime(execType),
-      cell: (item: StatementInsightEvent) => item.startTime.format(DATE_FORMAT),
+      cell: (item: StatementInsightEvent) => item.startTime.format(DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT),
       sort: (item: StatementInsightEvent) => item.startTime.unix(),
       showByDefault: true,
     },

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsTable.tsx
@@ -15,7 +15,7 @@ import {
   SortedTable,
   SortSetting,
 } from "src/sortedtable";
-import { DATE_FORMAT, Duration } from "src/util";
+import { DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT, Duration } from "src/util";
 import { InsightExecEnum, TransactionInsightEvent } from "src/insights";
 import {
   InsightCell,
@@ -81,7 +81,7 @@ export function makeTransactionInsightsColumns(
       name: "startTime",
       title: insightsTableTitles.startTime(execType),
       cell: (item: TransactionInsightEvent) =>
-        item.startTime.format(DATE_FORMAT),
+        item.startTime.format(DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT),
       sort: (item: TransactionInsightEvent) => item.startTime.unix(),
     },
     {

--- a/pkg/ui/workspaces/cluster-ui/src/util/format.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/format.ts
@@ -179,7 +179,7 @@ export const DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT =
 export const DATE_FORMAT_24_UTC = "MMM DD, YYYY [at] H:mm UTC";
 export const DATE_WITH_SECONDS_FORMAT_24_UTC = "MMM DD, YYYY [at] H:mm:ss UTC";
 export const DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT_24_UTC =
-"MMM DD, YYYY [at] H:mm:ss:ms UTC";
+  "MMM DD, YYYY [at] H:mm:ss:ms UTC";
 
 export function RenderCount(yesCount: Long, totalCount: Long): string {
   if (longToInt(yesCount) == 0) {

--- a/pkg/ui/workspaces/cluster-ui/src/util/format.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/format.ts
@@ -170,12 +170,16 @@ export const DurationFitScale =
   };
 
 export const DATE_FORMAT = "MMM DD, YYYY [at] H:mm";
+export const DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT =
+  "MMM DD, YYYY [at] H:mm:ss:ms";
 
 /**
- * Alternate 24 hour UTC format
+ * Alternate 24 hour UTC formats
  */
 export const DATE_FORMAT_24_UTC = "MMM DD, YYYY [at] H:mm UTC";
 export const DATE_WITH_SECONDS_FORMAT_24_UTC = "MMM DD, YYYY [at] H:mm:ss UTC";
+export const DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT_24_UTC =
+"MMM DD, YYYY [at] H:mm:ss:ms UTC";
 
 export function RenderCount(yesCount: Long, totalCount: Long): string {
   if (longToInt(yesCount) == 0) {


### PR DESCRIPTION
Backport 1/1 commits from #92571.

/cc @cockroachdb/release

---

This commit adds seconds and milliseconds to the timestamp values on the Insights pages in the DB Console.

Fixes #91936.

Loom: https://www.loom.com/share/1aa7e5ca81984b1190f67a1748506aae

Release note (ui change): The Insights pages in the DB Console now show the seconds and milliseconds for all timestamp values.

Release justification: low-risk update to existing functionality