### PR TITLE
kvcoord: include replica info in RangeIterator.Seek into trace

### DIFF
--- a/pkg/kv/kvclient/kvcoord/range_iter.go
+++ b/pkg/kv/kvclient/kvcoord/range_iter.go
@@ -179,7 +179,8 @@ func (ri *RangeIterator) Next(ctx context.Context) {
 
 // Seek positions the iterator at the specified key.
 func (ri *RangeIterator) Seek(ctx context.Context, key roachpb.RKey, scanDir ScanDirection) {
-	if log.HasSpanOrEvent(ctx) {
+	logEvents := log.HasSpanOrEvent(ctx)
+	if logEvents {
 		rev := ""
 		if scanDir == Descending {
 			rev = " (rev)"
@@ -220,8 +221,8 @@ func (ri *RangeIterator) Seek(ctx context.Context, key roachpb.RKey, scanDir Sca
 			}
 			continue
 		}
-		if log.V(2) {
-			log.Infof(ctx, "key: %s, desc: %s", ri.key, rngInfo.Desc())
+		if logEvents {
+			log.Eventf(ctx, "key: %s, desc: %s", ri.key, rngInfo.Desc())
 		}
 
 		ri.token = rngInfo

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_trace
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_trace
@@ -32,7 +32,8 @@ SET tracing = on, kv; SELECT * FROM abc JOIN def ON d = c WHERE a > 1 AND e > 1;
 # We should not be fetching /def/def_pkey/1/1 key because it fails 'e > 1'
 # filter.
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader' AND message NOT LIKE 'querying next range%'
+SELECT message FROM [SHOW KV TRACE FOR SESSION]
+  WHERE operation = 'join reader' AND message NOT LIKE 'querying next range%' AND message NOT LIKE 'key: %, desc: %'
 ----
 Scan /Table/107/1/{1/2-2}
 fetched: /def/def_pkey/1/2 -> <undecoded>
@@ -147,7 +148,8 @@ SET tracing = off;
 # We should not be fetching the key with '2020-01-01 00:00:00+00:00' value for
 # the 'time' column since it doesn't satisfy the filter on 'time'.
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader' AND message NOT LIKE 'querying next range%'
+SELECT message FROM [SHOW KV TRACE FOR SESSION]
+  WHERE operation = 'join reader' AND message NOT LIKE 'querying next range%' AND message NOT LIKE 'key: %, desc: %'
 ----
 Scan /Table/109/1/{1/2020-01-01T00:00:00.000000001Z-2}, /Table/109/1/{2/2020-01-01T00:00:00.000000001Z-3}
 fetched: /metric_values/metric_values_pkey/1/'2020-01-01 00:00:01+00:00'/nullable/value -> /1/1
@@ -168,7 +170,8 @@ SET tracing = off;
 
 # The start boundary of the spans should exclude NULL values.
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader' AND message NOT LIKE 'querying next range%'
+SELECT message FROM [SHOW KV TRACE FOR SESSION]
+  WHERE operation = 'join reader' AND message NOT LIKE 'querying next range%' AND message NOT LIKE 'key: %, desc: %'
 ----
 Scan /Table/109/1/1/{!NULL-2020-01-01T00:00:00Z}, /Table/109/1/2/{!NULL-2020-01-01T00:00:00Z}
 
@@ -186,7 +189,8 @@ SET tracing = off;
 # We should not be fetching two keys with '2020-01-01 00:00:00+00:00' value for
 # the 'time' column since they don't satisfy the filter on 'time'.
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader' AND message NOT LIKE 'querying next range%'
+SELECT message FROM [SHOW KV TRACE FOR SESSION]
+  WHERE operation = 'join reader' AND message NOT LIKE 'querying next range%' AND message NOT LIKE 'key: %, desc: %'
 ----
 Scan /Table/110/1/1/{1920-01-01T23:59:59.000000999Z-!NULL}, /Table/110/1/2/{1920-01-01T23:59:59.000000999Z-!NULL}
 
@@ -205,7 +209,8 @@ SET tracing = off;
 # We should not be fetching /metric_values/secondary/1/1 key because it fails
 # 'nullable > 1' filter.
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader' AND message NOT LIKE 'querying next range%'
+SELECT message FROM [SHOW KV TRACE FOR SESSION]
+  WHERE operation = 'join reader' AND message NOT LIKE 'querying next range%' AND message NOT LIKE 'key: %, desc: %'
 ----
 Scan /Table/109/2/{1/2-2}, /Table/109/2/{2/2-3}
 fetched: /metric_values/secondary/2/2/'2020-01-01 00:00:01+00:00' -> <undecoded>
@@ -229,7 +234,8 @@ SET tracing = off;
 # We should not be fetching two keys with NULL values for the 'nullable' column
 # since they don't satisfy the filter on 'nullable'.
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader' AND message NOT LIKE 'querying next range%'
+SELECT message FROM [SHOW KV TRACE FOR SESSION]
+  WHERE operation = 'join reader' AND message NOT LIKE 'querying next range%' AND message NOT LIKE 'key: %, desc: %'
 ----
 Scan /Table/109/2/1/{!NULL--10}, /Table/109/2/2/{!NULL--10}
 fetched: /metric_values/secondary/2/-11/'2020-01-01 00:01:01+00:00' -> <undecoded>
@@ -253,7 +259,8 @@ SET tracing = off;
 # We should not be fetching two keys with NULL values for the 'nullable' column
 # since they don't satisfy the filter on 'nullable'.
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader' AND message NOT LIKE 'querying next range%'
+SELECT message FROM [SHOW KV TRACE FOR SESSION]
+  WHERE operation = 'join reader' AND message NOT LIKE 'querying next range%' AND message NOT LIKE 'key: %, desc: %'
 ----
 Scan /Table/109/2/1/{!NULL--9}, /Table/109/2/2/{!NULL--9}
 fetched: /metric_values/secondary/2/-11/'2020-01-01 00:01:01+00:00' -> <undecoded>
@@ -279,7 +286,8 @@ SET tracing = off;
 # We should not be fetching two keys with NULL values for the 'nullable' column
 # since they don't satisfy the filter on 'nullable'.
 query T
-SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE operation = 'join reader' AND message NOT LIKE 'querying next range%'
+SELECT message FROM [SHOW KV TRACE FOR SESSION]
+  WHERE operation = 'join reader' AND message NOT LIKE 'querying next range%' AND message NOT LIKE 'key: %, desc: %'
 ----
 Scan /Table/109/2/1/{!NULL--9}, /Table/109/2/2/{!NULL--9}
 fetched: /metric_values/secondary/2/-11/'2020-01-01 00:01:01+00:00' -> <undecoded>

--- a/pkg/sql/show_trace.go
+++ b/pkg/sql/show_trace.go
@@ -167,6 +167,7 @@ var kvMsgRegexp = regexp.MustCompile(
 		"^Get ",
 		"^Scan ",
 		"^querying next range at ",
+		"^key:.*, desc: ",
 		"^output row: ",
 		"^rows affected: ",
 		"^execution failed after ",


### PR DESCRIPTION
This commit modifies the existing "info" log message into an "event"
when seeking the range iterator. This makes it so that the result of the
seek (the replica information) is included into the trace. Additionally,
this commit includes the corresponding message to be included into the
KV trace. The original "info" log message was added about five years ago
and probably hasn't been that useful.

Here is an example of the trace event:
```
key: /NamespaceTable/30/1/100/101/"t"/4/1, desc: r32:/NamespaceTable/{30-Max} [(n1,s1):1, next=2, gen=0]
```

Informs: https://github.com/cockroachlabs/support/issues/1933.

Release note: None