### PR TITLE
backupccl: cast wrapped Array datums properly when exporting to Parquet

### DIFF
--- a/pkg/sql/importer/exportparquet.go
+++ b/pkg/sql/importer/exportparquet.go
@@ -605,7 +605,7 @@ func NewParquetColumn(typ *types.T, name string, nullable bool) (ParquetColumn, 
 				if elt.ResolvedType().Family() == types.UnknownFamily {
 					// skip encoding the datum
 				} else {
-					el, err = grandChild.encodeFn(elt)
+					el, err = grandChild.encodeFn(tree.UnwrapDOidWrapper(elt))
 					if err != nil {
 						return col, err
 					}

--- a/pkg/sql/importer/exportparquet_test.go
+++ b/pkg/sql/importer/exportparquet_test.go
@@ -161,7 +161,7 @@ func validateDatum(t *testing.T, expected tree.Datum, actual tree.Datum, typ *ty
 		eArr := expected.(*tree.DArray)
 		aArr := actual.(*tree.DArray)
 		for i := 0; i < eArr.Len(); i++ {
-			validateDatum(t, eArr.Array[i], aArr.Array[i], typ.ArrayContents())
+			validateDatum(t, tree.UnwrapDOidWrapper(eArr.Array[i]), aArr.Array[i], typ.ArrayContents())
 		}
 	case types.DateFamily:
 		// pgDate.orig property doesn't matter and can cause the test to fail


### PR DESCRIPTION
If we're encoding a DOidWrapper, then we want to cast the wrapped datum. But this is not being done when encoding Array datums when exporting to parquet.

This bug was found from the TestRandomParquetExports test. Since it randomly generates tables, reproducing this bug would be hard. So I am pasting a snippet of code that can be used to reproduced it (the table schema was copied from the test log output. Also, this snippet is incomplete, it is merely intended to document the schema which caused the test to fail. Most of the code is copied from
exportparquet_test.go):

```
		sqlDB.Exec(t, `
CREATE TABLE table1 (
        	col1_0 NAME[] NOT NULL,
        	col1_1 STRING NOT NULL,
        	col1_2 CHAR NULL,
        	col1_3 INT8 NOT NULL,
        	col1_4 STRING NOT NULL AS (lower(col1_2)) VIRTUAL,
        	col1_5 STRING NULL AS (lower(col1_2)) VIRTUAL,
        	col1_6 STRING NOT NULL AS (lower(col1_2)) STORED,
        	        	CONSTRAINT table1_pkey PRIMARY KEY (col1_4 ASC, col1_1 ASC, col1_3 ASC, col1_6 ASC, col1_0 ASC),
        	INDEX table1_col1_0_col1_3_col1_5_col1_1_col1_2_idx (col1_0 ASC, col1_3 ASC, col1_5 DESC, col1_1 ASC, col1_2 DESC) WHERE (((col1_1 = 'X':::STRING) AND (col1_5 <= e'\x00':::STRING)) OR (col1_2 > e'\'':::STRING)) OR (col1_3 > 32767:::INT8) NOT VISIBLE,
        	INVERTED INDEX table1_col1_4_col1_3_col1_0_col1_2_col1_6_col1_1_col1_5_idx (col1_4 DESC, col1_3 DESC, col1_0 ASC, col1_2 DESC, col1_6 ASC, col1_1 ASC, col1_5 gin_trgm_ops),
        	UNIQUE INDEX table1_col1_0_col1_2_col1_3_col1_1_col1_6_col1_5_key (col1_0 ASC, col1_2 ASC, col1_3 DESC, col1_1 ASC, col1_6 ASC, col1_5 DESC),
        	INDEX table1_col1_6_col1_2_col1_1_col1_4_col1_3_idx (col1_6 ASC, col1_2 ASC, col1_1 ASC, col1_4 ASC, col1_3 ASC),
        	INDEX table1_expr_col1_5_idx (lower(col1_2) DESC, col1_5 ASC),
        	FAMILY fam_0_col1_2_col1_6_col1_1 (col1_2, col1_6, col1_1),
        	FAMILY fam_1_col1_0 (col1_0),
        	FAMILY fam_2_col1_3 (col1_3)
        	);
`)
numRows, err := randgen.PopulateTableWithRandData(rng, db, "table1", 20)
// Ensure the table only contains columns supported by EXPORT Parquet. If an
// unsupported column cannot be dropped, try populating another table
tableName := "table1"
if err := func() error {
    _, cols, err := ie.QueryRowExWithCols(
        ctx,
        "",
        nil,
        sessiondata.InternalExecutorOverride{
            User:     username.RootUserName(),
            Database: dbName},
        fmt.Sprintf("SELECT * FROM %s LIMIT 1", tableName))
    require.NoError(t, err)

    for _, col := range cols {
        _, err := importer.NewParquetColumn(col.Typ, "", false)
        if err != nil {
            _, err = sqlDB.DB.ExecContext(ctx, fmt.Sprintf(`ALTER TABLE %s DROP COLUMN %s`, tableName, col.Name))
            if err != nil {
                return err
            }
        }
    }
    return nil
}(); err != nil {
    continue
}
success = true
break
}

With the table created and the data populated, if we run 'EXPORT INTO
PARQUET 'nodelocal://0/table1' FROM SELECT * FROM table1', it should throw
an error.
```

To fix this, we will cast the wrapped datum for Array datums also.

Resolves: #92199

Release note (bug fix): Fixed a bug where encoding of Array type to Parquet format would fail in some cases during `EXPORT` command.