### PR TITLE
ui: click to make graph legend sticky

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/graphs/visualization/visualizations.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/graphs/visualization/visualizations.module.scss
@@ -61,7 +61,6 @@
 }
 
 .visualization-graph-sizing {
-  height: calc(30% - 200px);
   min-height: 300px;
 }
 

--- a/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/linegraph.styl
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/linegraph.styl
@@ -26,6 +26,7 @@ $viz-sides = 62px
   height 100%
   .uplot
     display flex
+    flex-direction column
     > .u-legend
       display none
       position absolute
@@ -45,15 +46,13 @@ $viz-sides = 62px
     // stick the legend to the char's bottom.
     // Chart height is hardcoded to 300px (pkg/ui/src/views/cluster/util/graphs.ts)
     > .u-legend.u-legend--place-bottom
-      top 300px!important
-      left 0!important
+      position relative
+      top 0!important // Necessary because uPlot adds top/left on hover to make legend appear near mouse pointer
+      left 0!important // Necessary because uPlot adds top/left on hover to make legend appear near mouse pointer
       width auto
       margin-left -1px
       margin-right -1px
-      border-top none
-      border-radius 0px 0px 5px 5px
       padding-left 50px
-
       // the first line in the legend represents Y-axis and it occupies an entire line
       // to stand out from the rest of x-axis values
       > tr:first-child

--- a/pkg/ui/workspaces/db-console/src/views/cluster/util/graphs.ts
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/util/graphs.ts
@@ -107,8 +107,18 @@ export function configureUPlotLineChart(
             legend.style.display = "block";
           };
 
+          // persistLegend determines if legend should continue showing even when mouse
+          // hovers away.
+          let persistLegend = false;
+
+          over.addEventListener("click", () => {
+            persistLegend = !persistLegend;
+          });
+
           over.onmouseleave = () => {
-            legend.style.display = "none";
+            if (!persistLegend) {
+              legend.style.display = "none";
+            }
           };
         },
         setCursor: (self: uPlot) => {
@@ -139,6 +149,9 @@ export function configureUPlotLineChart(
     //     key: "sync-everything",
     //   },
     // },
+    cursor: {
+      lock: true,
+    },
     legend: {
       show: true,
 


### PR DESCRIPTION
Previously, hovering over a graph would make a legend appear but there was no way to persist the legend when the mouse moved away. This made carefully looking through denser graphs very challenging as it was tough to know which value corresponded to which series.

This commit introduces two changes to line graph behavior. First, clicking while hovering in a graph will stop the points from following the mouse, allowing you to cross-reference with the legend. Second, the legend will continue to persist even when you move the mouse away.

Epic: None

Resolves: #65031
Resolves: #65036

Release note (ui change): Graphs can be clicked on to toggle legend "stickiness" and make the points stop following the mouse. This makes it easier to read dense graphs with many series plotted together.