### PR TITLE
ui: show txn idle time in txn detail page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -343,6 +343,16 @@ export class TransactionDetails extends React.Component<
                 <span className={cx("tooltip-info")}>unavailable</span>
               </Tooltip>
             );
+            const meanIdleLatency = transactionSampled ? (
+              <Text>
+                {formatNumberForDisplay(
+                  _.get(transactionStats, "idle_lat.mean", 0),
+                  duration,
+                )}
+              </Text>
+            ) : (
+              unavailableTooltip
+            );
             const meansRows = `${formatNumberForDisplay(
               transactionStats.rows_read.mean,
               formatTwoPlaces,
@@ -431,6 +441,10 @@ export class TransactionDetails extends React.Component<
                             Transaction resource usage
                           </Heading>
                         </div>
+                        <SummaryCardItem
+                          label="Idle latency"
+                          value={meanIdleLatency}
+                        />
                         <SummaryCardItem
                           label="Mean rows/bytes read"
                           value={meansRows}


### PR DESCRIPTION
Part of #86667

|Before|After|
|--|--|
|<img width="1628" alt="Screen Shot 2022-12-02 at 3 16 08 PM" src="https://user-images.githubusercontent.com/5261/205379330-e1990261-9ca4-4d73-878f-a21ed0a90412.png">|<img width="1628" alt="Screen Shot 2022-12-02 at 3 16 15 PM" src="https://user-images.githubusercontent.com/5261/205379338-956a1801-07db-48e8-9a9c-bbe9e84fb5b6.png">|

Release note (ui change): The "Transaction resource usage" card on the transaction fingerprint page now includes an "Idle latency" row, representing the time spent by the application performing other work while holding this transaction open.