### PR TITLE
opt: inline UDFs as subqueries

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -2336,7 +2336,7 @@ soundex
 
 # Only the volatile functions should see the changes made by the UPDATE in the
 # CTE.
-query IIIIIIII colnames
+query IIIIIIII colnames,rowsort
 WITH u AS (
   UPDATE kv SET v = v + 10 RETURNING k
 )

--- a/pkg/sql/opt/exec/execbuilder/testdata/udf
+++ b/pkg/sql/opt/exec/execbuilder/testdata/udf
@@ -102,9 +102,9 @@ statement ok
 CREATE TABLE t93210 (
   a INT PRIMARY KEY
 );
-CREATE FUNCTION fn93210() RETURNS INT STABLE LANGUAGE SQL AS 'SELECT a FROM t93210';
+CREATE FUNCTION fn93210() RETURNS INT VOLATILE LANGUAGE SQL AS 'SELECT a FROM t93210';
 
-# The body of the UDF should have no assignment cast expressions.
+# The query plan should have no assignment cast expressions.
 query T
 EXPLAIN (OPT, TYPES)
 SELECT fn93210()
@@ -112,7 +112,7 @@ SELECT fn93210()
 values
  ├── columns: fn93210:4(int)
  ├── cardinality: [1 - 1]
- ├── stable
+ ├── volatile
  ├── stats: [rows=1]
  ├── cost: 0.02
  ├── key: ()
@@ -138,7 +138,7 @@ values
 # Regression test for #88259. Arguments to UDFs should be formatted correctly in
 # EXPLAIN output.
 statement ok
-CREATE FUNCTION f88259(a INT, b INT) RETURNS INT LANGUAGE SQL IMMUTABLE STRICT AS $$
+CREATE FUNCTION f88259(a INT, b INT) RETURNS INT LANGUAGE SQL VOLATILE STRICT AS $$
   SELECT a + b
 $$
 

--- a/pkg/sql/opt/norm/rules/inline.opt
+++ b/pkg/sql/opt/norm/rules/inline.opt
@@ -1,6 +1,7 @@
 # =============================================================================
-# inline.opt contains normalization patterns that replace a variable reference
-# with the expression to which that variable is bound. For example:
+# inline.opt contains normalization patterns that replace variable or function
+# references with the expression to which the variable or function is bound. For
+# example:
 #
 #   SELECT x2+1 FROM (SELECT x+1 AS x2 FROM a)
 #
@@ -293,3 +294,11 @@
 )
 =>
 (InlineProjectProject $input $projections $passthrough)
+
+# InlineUDF converts a UDF to a subquery. A UDF can only be inlined if it is
+# non-volatile and has a single statement in the function body. See
+# IsInlinableUDF for more details.
+[InlineUDF, Normalize]
+(UDF $args:* $private:* & (IsInlinableUDF $args $private))
+=>
+(ConvertUDFToSubquery $args $private)

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -1079,3 +1079,231 @@ project
  │         └── k:1 > 0 [outer=(1), constraints=(/1: [/1 - ]; tight)]
  └── projections
       └── k:1 + 2 [as=c:8, outer=(1), immutable]
+
+# --------------------------------------------------
+# InlineUDF
+# --------------------------------------------------
+
+exec-ddl
+CREATE FUNCTION add(x INT, y INT) RETURNS INT IMMUTABLE LANGUAGE SQL AS $$
+  SELECT x + y
+$$
+----
+
+norm expect=InlineUDF
+SELECT add(1, i) FROM (VALUES (1), (2), (3)) v(i)
+----
+project
+ ├── columns: add:5!null
+ ├── cardinality: [3 - 3]
+ ├── immutable
+ ├── values
+ │    ├── columns: column1:1!null
+ │    ├── cardinality: [3 - 3]
+ │    ├── (1,)
+ │    ├── (2,)
+ │    └── (3,)
+ └── projections
+      └── column1:1 + 1 [as=add:5, outer=(1), immutable]
+
+norm expect=InlineUDF
+SELECT k FROM a WHERE add(i, 1) = 10
+----
+project
+ ├── columns: k:1!null
+ ├── key: (1)
+ └── select
+      ├── columns: k:1!null i:2!null
+      ├── key: (1)
+      ├── fd: ()-->(2)
+      ├── scan a
+      │    ├── columns: k:1!null i:2
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      └── filters
+           └── i:2 = 9 [outer=(2), constraints=(/2: [/9 - /9]; tight), fd=()-->(2)]
+
+# Nested UDFs should be inlined.
+norm expect=InlineUDF
+SELECT add(10, add(i, 20)) FROM a WHERE add(k, add(10, f::INT)) = 100
+----
+project
+ ├── columns: add:20
+ ├── immutable
+ ├── select
+ │    ├── columns: i:2 "?column?":13!null
+ │    ├── immutable
+ │    ├── fd: ()-->(13)
+ │    ├── project
+ │    │    ├── columns: "?column?":13 i:2
+ │    │    ├── immutable
+ │    │    ├── scan a
+ │    │    │    ├── columns: k:1!null i:2 f:3
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2,3)
+ │    │    └── projections
+ │    │         └── k:1 + (f:3::INT8 + 10) [as="?column?":13, outer=(1,3), immutable]
+ │    └── filters
+ │         └── "?column?":13 = 100 [outer=(13), constraints=(/13: [/100 - /100]; tight), fd=()-->(13)]
+ └── projections
+      └── (i:2 + 20) + 10 [as=add:20, outer=(2), immutable]
+
+exec-ddl
+CREATE FUNCTION min_x() RETURNS INT STABLE LANGUAGE SQL AS $$
+  SELECT x FROM xy ORDER BY x LIMIT 1
+$$
+----
+
+# Stable UDFs should be inline. Presentation and ordering are preserved.
+norm expect=InlineUDF
+SELECT k, min_x() FROM a WHERE k = min_x()
+----
+project
+ ├── columns: k:1!null min_x:16
+ ├── key: (1)
+ ├── fd: (1)-->(16)
+ ├── select
+ │    ├── columns: k:1!null
+ │    ├── key: (1)
+ │    ├── scan a
+ │    │    ├── columns: k:1!null
+ │    │    └── key: (1)
+ │    └── filters
+ │         └── eq [outer=(1), subquery, constraints=(/1: (/NULL - ])]
+ │              ├── k:1
+ │              └── subquery
+ │                   └── limit
+ │                        ├── columns: x:8!null
+ │                        ├── internal-ordering: +8
+ │                        ├── cardinality: [0 - 1]
+ │                        ├── key: ()
+ │                        ├── fd: ()-->(8)
+ │                        ├── scan xy
+ │                        │    ├── columns: x:8!null
+ │                        │    ├── key: (8)
+ │                        │    ├── ordering: +8
+ │                        │    └── limit hint: 1.00
+ │                        └── 1
+ └── projections
+      └── subquery [as=min_x:16, subquery]
+           └── limit
+                ├── columns: x:12!null
+                ├── internal-ordering: +12
+                ├── cardinality: [0 - 1]
+                ├── key: ()
+                ├── fd: ()-->(12)
+                ├── scan xy
+                │    ├── columns: x:12!null
+                │    ├── key: (12)
+                │    ├── ordering: +12
+                │    └── limit hint: 1.00
+                └── 1
+
+exec-ddl
+CREATE FUNCTION min_x_gt(i INT) RETURNS INT STABLE LANGUAGE SQL AS $$
+  SELECT x FROM xy WHERE x > i ORDER BY x LIMIT 1
+$$
+----
+
+# Nested stable UDFs should be inline.
+norm expect=InlineUDF
+SELECT k FROM a WHERE k = min_x_gt(min_x_gt(0))
+----
+select
+ ├── columns: k:1!null
+ ├── key: (1)
+ ├── scan a
+ │    ├── columns: k:1!null
+ │    └── key: (1)
+ └── filters
+      └── eq [outer=(1), subquery, constraints=(/1: (/NULL - ])]
+           ├── k:1
+           └── subquery
+                └── limit
+                     ├── columns: x:14!null
+                     ├── internal-ordering: +14
+                     ├── cardinality: [0 - 1]
+                     ├── key: ()
+                     ├── fd: ()-->(14)
+                     ├── select
+                     │    ├── columns: x:14!null
+                     │    ├── key: (14)
+                     │    ├── ordering: +14
+                     │    ├── limit hint: 1.00
+                     │    ├── scan xy
+                     │    │    ├── columns: x:14!null
+                     │    │    ├── key: (14)
+                     │    │    ├── ordering: +14
+                     │    │    └── limit hint: 3.00
+                     │    └── filters
+                     │         └── gt [outer=(14), subquery, constraints=(/14: (/NULL - ])]
+                     │              ├── x:14
+                     │              └── subquery
+                     │                   └── limit
+                     │                        ├── columns: x:9!null
+                     │                        ├── internal-ordering: +9
+                     │                        ├── cardinality: [0 - 1]
+                     │                        ├── key: ()
+                     │                        ├── fd: ()-->(9)
+                     │                        ├── select
+                     │                        │    ├── columns: x:9!null
+                     │                        │    ├── key: (9)
+                     │                        │    ├── ordering: +9
+                     │                        │    ├── limit hint: 1.00
+                     │                        │    ├── scan xy
+                     │                        │    │    ├── columns: x:9!null
+                     │                        │    │    ├── key: (9)
+                     │                        │    │    ├── ordering: +9
+                     │                        │    │    └── limit hint: 3.00
+                     │                        │    └── filters
+                     │                        │         └── x:9 > 0 [outer=(9), constraints=(/9: [/1 - ]; tight)]
+                     │                        └── 1
+                     └── 1
+
+# UDFs with volatile arguments are not inlined.
+norm expect-not=InlineUDF
+SELECT add((random()*10)::INT, i) FROM a
+----
+project
+ ├── columns: add:11
+ ├── volatile
+ ├── scan a
+ │    └── columns: i:2
+ └── projections
+      └── add((random() * 10.0)::INT8, i:2) [as=add:11, outer=(2), volatile, udf]
+
+exec-ddl
+CREATE FUNCTION vol() RETURNS INT VOLATILE LANGUAGE SQL AS $$
+  SELECT 1;
+$$
+----
+
+# Volatile UDFs are not inlined.
+norm expect-not=InlineUDF
+SELECT vol() FROM a
+----
+project
+ ├── columns: vol:9
+ ├── volatile
+ ├── scan a
+ └── projections
+      └── vol() [as=vol:9, volatile, udf]
+
+exec-ddl
+CREATE FUNCTION multi_stmt() RETURNS INT IMMUTABLE LANGUAGE SQL AS $$
+  SELECT 1;
+  SELECT 2;
+$$
+----
+
+# Multi-statement UDFs are not inlined.
+norm expect-not=InlineUDF
+SELECT multi_stmt() FROM a
+----
+project
+ ├── columns: multi_stmt:10
+ ├── immutable
+ ├── fd: ()-->(10)
+ ├── scan a
+ └── projections
+      └── multi_stmt() [as=multi_stmt:10, immutable, udf]

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -683,6 +683,9 @@ func (b *Builder) buildUDF(
 			// The limit expression will maintain the desired ordering, if any,
 			// so the physical props ordering can be cleared. The presentation
 			// must remain.
+			// TODO(mgartner): For SETOF functions, we may need to maintain the
+			// ordering without the LIMIT. Make sure to account for this in
+			// ConvertUDFToSubquery.
 			physProps.Ordering = props.OrderingChoice{}
 
 			// If there are multiple output columns, we must combine them into a


### PR DESCRIPTION
UDFs are now inlined as subqueries by a normalization rule when possible, speeding up their evaluation.

Epic: CRDB-20370

Release note (performance improvement): Some types of user-defined functions are now inlined in query plans as relation expressions, which speeds up their evaluation. UDFs must be non-volatile and have a single statement in the function body to be inlined.