### PR TITLE
sql: enable storage for tsvector/tsquery

### DIFF
--- a/pkg/sql/alter_column_type.go
+++ b/pkg/sql/alter_column_type.go
@@ -104,7 +104,7 @@ func AlterColumnType(
 		}
 	}
 
-	err = colinfo.ValidateColumnDefType(typ)
+	err = colinfo.ValidateColumnDefType(ctx, params.EvalContext().Settings.Version, typ)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/catalog/colinfo/BUILD.bazel
+++ b/pkg/sql/catalog/colinfo/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/descpb",

--- a/pkg/sql/catalog/tabledesc/table.go
+++ b/pkg/sql/catalog/tabledesc/table.go
@@ -151,7 +151,7 @@ func MakeColumnDefDescs(
 	if err != nil {
 		return nil, err
 	}
-	if err = colinfo.ValidateColumnDefType(resType); err != nil {
+	if err = colinfo.ValidateColumnDefType(ctx, evalCtx.Settings.Version, resType); err != nil {
 		return nil, err
 	}
 	col.Type = resType

--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsql"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
@@ -223,7 +224,8 @@ CREATE TABLE t.test (k INT);
 		t.Fatal(err)
 	}
 	colDef := alterCmd.AST.(*tree.AlterTable).Cmds[0].(*tree.AlterTableAddColumn).ColumnDef
-	cdd, err := tabledesc.MakeColumnDefDescs(ctx, colDef, nil, nil)
+	evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
+	cdd, err := tabledesc.MakeColumnDefDescs(ctx, colDef, nil, evalCtx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/logictest/testdata/logic_test/tsvector
+++ b/pkg/sql/logictest/testdata/logic_test/tsvector
@@ -3,26 +3,102 @@ SELECT 'foo:1,2 bar:3'::tsvector @@ 'foo <-> bar'::tsquery, 'foo <-> bar'::tsque
 ----
 true  true
 
-statement error cannot be used for table columns
-CREATE TABLE a (v tsvector)
+statement ok
+CREATE TABLE a (v tsvector, q tsquery)
 
-statement error cannot be used for table columns
-CREATE TABLE a (q tsquery)
+statement ok
+INSERT INTO a VALUES('foo:1,2 bar:4B'::tsvector, 'foo <2> bar'::tsquery)
 
-# Uncomment once tsvector and tsquery are usable as table columns.
-#
-# statement ok
-# INSERT INTO a VALUES('foo:1,2 bar:4B'::tsvector, 'foo <2> bar'::tsquery)
-#
-# query TT
-# SELECT * FROM a
-# ----
-# 'bar':4B 'foo':1,2  'foo' <2> 'bar'
+query TT
+SELECT * FROM a
+----
+'bar':4B 'foo':1,2  'foo' <2> 'bar'
 
 query BB
 SELECT 'foo:1,2 bar:4B'::tsvector @@ 'foo <2> bar'::tsquery, 'foo:1,2 bar:4B' @@ 'foo <-> bar'::tsquery
 ----
 true  false
+
+query BB
+SELECT v @@ 'foo <2> bar'::tsquery, v @@ 'foo <-> bar'::tsquery FROM a
+----
+true  false
+
+query B
+SELECT v @@ q FROM a
+----
+true
+
+# Test column modifiers.
+
+statement ok
+CREATE TABLE b (a INT PRIMARY KEY DEFAULT 1, v tsvector DEFAULT 'foo:1' ON UPDATE 'bar:2', v2 tsvector AS (v) STORED, v3 tsvector AS (v) VIRTUAL)
+
+statement ok
+CREATE TABLE c (a INT PRIMARY KEY DEFAULT 1, q tsquery DEFAULT 'foo' ON UPDATE 'bar', q2 tsquery AS (q) STORED, q3 tsquery AS (q) VIRTUAL)
+
+statement ok
+INSERT INTO b DEFAULT VALUES
+
+statement ok
+INSERT INTO c DEFAULT VALUES
+
+query ITTT
+SELECT * FROM b
+----
+1  'foo':1  'foo':1  'foo':1
+
+query ITTT
+SELECT * FROM c
+----
+1  'foo'  'foo'  'foo'
+
+statement ok
+UPDATE b SET a = 2 WHERE a = 1
+
+statement ok
+UPDATE c SET a = 2 WHERE a = 1
+
+query ITTT
+SELECT * FROM b
+----
+2  'bar':2  'bar':2  'bar':2
+
+query ITTT
+SELECT * FROM c
+----
+2  'bar'  'bar'  'bar'
+
+statement ok
+INSERT INTO b VALUES (3, 'foo:1,5 zoop:3')
+
+statement error can't order by column type TSVECTOR
+SELECT * FROM b ORDER BY v
+
+statement error can't order by column type TSQUERY
+SELECT * FROM c ORDER BY q
+
+statement error arrays of tsvector not allowed
+CREATE TABLE tsarray(a tsvector[])
+
+statement error arrays of tsquery not allowed
+CREATE TABLE tsarray(a tsquery[])
+
+statement error unsupported comparison operator
+SELECT a, v FROM b WHERE v > 'bar:2'::tsvector
+
+statement error unsupported comparison operator
+SELECT a, q FROM c WHERE q > 'abc'::tsquery
+
+query IT
+SELECT a, v FROM b WHERE v = 'bar:2'::tsvector
+----
+2  'bar':2
+
+query IT
+SELECT a, q FROM c WHERE q = 'bar'::tsquery
+----
+2  'bar'
 
 # Ensure truncation of long position lists.
 query T

--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -285,8 +285,13 @@ func (b *Builder) analyzeExtraArgument(
 
 func ensureColumnOrderable(e tree.TypedExpr) {
 	typ := e.ResolvedType()
-	if typ.Family() == types.JsonFamily ||
-		(typ.Family() == types.ArrayFamily && typ.ArrayContents().Family() == types.JsonFamily) {
+	if typ.Family() == types.ArrayFamily {
+		typ = typ.ArrayContents()
+	}
+	switch typ.Family() {
+	case types.JsonFamily:
 		panic(unimplementedWithIssueDetailf(35706, "", "can't order by column type jsonb"))
+	case types.TSQueryFamily, types.TSVectorFamily:
+		panic(unimplementedWithIssueDetailf(92165, "", "can't order by column type %s", typ.SQLString()))
 	}
 }

--- a/pkg/sql/randgen/BUILD.bazel
+++ b/pkg/sql/randgen/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/geo/geopb",
         "//pkg/keys",
         "//pkg/roachpb",
+        "//pkg/settings/cluster",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",

--- a/pkg/sql/randgen/doc.go
+++ b/pkg/sql/randgen/doc.go
@@ -11,5 +11,7 @@
 /*
 Package randgen provides utility functions for generating random syntax trees,
 datums, encoded datums, types, and more. It useful in randomized tests.
+
+It should not be used outside of a testing context.
 */
 package randgen

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -196,10 +196,14 @@ func (t virtualSchemaTable) initVirtualTableDesc(
 			privilege.List{},
 			username.NodeUserName(),
 		),
-		nil,                        /* affected */
-		&semaCtx,                   /* semaCtx */
-		nil,                        /* evalCtx */
-		&sessiondata.SessionData{}, /* sessionData */
+		nil,      /* affected */
+		&semaCtx, /* semaCtx */
+		// We explicitly pass in a half-baked EvalContext because we don't need to
+		// evaluate any expressions to initialize virtual tables. We do need to
+		// pass in the cluster settings to make sure that functions can properly
+		// evaluate version gates, though.
+		&eval.Context{Settings: st}, /* evalCtx */
+		&sessiondata.SessionData{},  /* sessionData */
 		tree.PersistencePermanent,
 	)
 	if err != nil {
@@ -323,7 +327,11 @@ func (v virtualSchemaView) initVirtualTableDesc(
 			username.NodeUserName(),
 		),
 		nil, // semaCtx
-		nil, // evalCtx
+		// We explicitly pass in a half-baked EvalContext because we don't need to
+		// evaluate any expressions to initialize virtual tables. We do need to
+		// pass in the cluster settings to make sure that functions can properly
+		// evaluate version gates, though.
+		&eval.Context{Settings: st}, /* evalCtx */
 		st,
 		tree.PersistencePermanent,
 		false, // isMultiRegion


### PR DESCRIPTION
This commit adds the ability to store tsvector and tsquery data in ordinary, unindexed columns.

Updates #41288
This functionality is gated behind the 23.1 version.

Epic: CRDB-22357

Release note (sql change): permit non-indexed storage of tsvector and tsquery datatypes