### PR TITLE
sql: elements proto to allow space or comments at the end

### DIFF
--- a/pkg/sql/schemachanger/scpb/element_generator.go
+++ b/pkg/sql/schemachanger/scpb/element_generator.go
@@ -118,7 +118,7 @@ func getElementNames(inProtoFile string) (names []string, _ error) {
 		elementProtoRegexp = regexp.MustCompile(`(?s)message ElementProto {
   option \(gogoproto.onlyone\) = true;
 (?P<fields>(` + elementFieldPat + "\n)+)" +
-			"}",
+			"\\s*}",
 		)
 		elementFieldRegexp  = regexp.MustCompile(elementFieldPat)
 		elementFieldTypeIdx = elementFieldRegexp.SubexpIndex("type")

--- a/pkg/sql/schemachanger/scpb/elements.proto
+++ b/pkg/sql/schemachanger/scpb/elements.proto
@@ -121,6 +121,8 @@ message ElementProto {
 
   // Enum type elements.
   EnumTypeValue enum_type_value = 120 [(gogoproto.moretags) = "parent:\"EnumType\""];
+
+  // Next element group start id: 140
 }
 
 // TypeT is a wrapper for a types.T which contains its user-defined type ID


### PR DESCRIPTION
Epic: None.

I don't know why I spent time on this...but previously we can't have empty line or comment as the last line of the Element proto definition. This pr fixes that.

Release note: None.