### PR TITLE
kvserver: log replicate queue traces only when expensive logging enabled

### DIFF
--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -823,7 +823,7 @@ func (rq *replicateQueue) processOneChangeWithTracing(
 		exceededDuration := loggingThreshold > time.Duration(0) && processDuration > loggingThreshold
 
 		var traceOutput string
-		traceLoggingNeeded := err != nil || exceededDuration
+		traceLoggingNeeded := (err != nil || exceededDuration) && log.ExpensiveLogEnabled(ctx, 1)
 		if traceLoggingNeeded {
 			// If we have tracing spans from execChangeReplicasTxn, filter it from
 			// the recording so that we can render the traces to the log without it,

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -795,6 +795,7 @@ func TestReplicateQueueDecommissioningNonVoters(t *testing.T) {
 func TestReplicateQueueTracingOnError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s := log.ScopeWithoutShowLogs(t)
+	_ = log.SetVModule("replicate_queue=2")
 	defer s.Close(t)
 
 	// NB: This test injects a fake failure during replica rebalancing, and we use


### PR DESCRIPTION
While we previously logged replicate queue traces on both errors and slow processing at INFO level, we will now only log the error message on INFO and include the trace when the `vmodule` level is increased. This allows us to decrease the verbosity on these error/slow replica processing cases by default, while still incorporating the traces if verbosity is incresed.

Epic: None

Release note: None