### PR TITLE
testcat: fast stats building for inverted indexes

### DIFF
--- a/pkg/sql/opt/testutils/testcat/alter_table.go
+++ b/pkg/sql/opt/testutils/testcat/alter_table.go
@@ -78,7 +78,7 @@ func injectTableStats(tt *Table, statsExpr tree.Expr) {
 	}
 	tt.Stats = make([]*TableStat, len(stats))
 	for i := range stats {
-		tt.Stats[i] = &TableStat{js: stats[i], tt: tt}
+		tt.Stats[i] = &TableStat{js: stats[i], tt: tt, evalCtx: &evalCtx}
 	}
 	// Call ColumnOrdinal on all possible columns to assert that
 	// the column names are valid.

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -1169,8 +1169,9 @@ func (p *Partition) SetDatums(datums []tree.Datums) {
 
 // TableStat implements the cat.TableStatistic interface for testing purposes.
 type TableStat struct {
-	js stats.JSONStatistic
-	tt *Table
+	js      stats.JSONStatistic
+	tt      *Table
+	evalCtx *eval.Context
 }
 
 var _ cat.TableStatistic = &TableStat{}
@@ -1216,7 +1217,11 @@ func (ts *TableStat) AvgSize() uint64 {
 
 // Histogram is part of the cat.TableStatistic interface.
 func (ts *TableStat) Histogram() []cat.HistogramBucket {
-	evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+	evalCtx := ts.evalCtx
+	if evalCtx == nil {
+		evalCtxVal := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+		evalCtx = &evalCtxVal
+	}
 	if ts.js.HistogramColumnType == "" || ts.js.HistogramBuckets == nil {
 		return nil
 	}
@@ -1248,7 +1253,7 @@ func (ts *TableStat) Histogram() []cat.HistogramBucket {
 
 	for i := offset; i < len(histogram); i++ {
 		bucket := &ts.js.HistogramBuckets[i-offset]
-		datum, err := rowenc.ParseDatumStringAs(context.Background(), colType, bucket.UpperBound, &evalCtx)
+		datum, err := rowenc.ParseDatumStringAs(context.Background(), colType, bucket.UpperBound, evalCtx)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Fixes #92906

opt tests involving inverted indexes with stats are slower than necessary because the slightly heavyweight `MakeTestingEvalContext` is called every time a scan or inverted join on the index is processed.

This change reuses the existing `eval.Context`, which also avoids a mutex lock.

Example speedup:
```
./dev test pkg/sql/opt/xform --filter TestExternal/postgis-tutorial-idx --stress
```
Without fix:
```
93 runs so far, 0 failures, over 5s
229 runs so far, 0 failures, over 10s
393 runs so far, 0 failures, over 15s
556 runs so far, 0 failures, over 20s
721 runs so far, 0 failures, over 25s
889 runs so far, 0 failures, over 30s
```
With fix:
```
148 runs so far, 0 failures, over 5s
332 runs so far, 0 failures, over 10s
510 runs so far, 0 failures, over 15s
688 runs so far, 0 failures, over 20s
871 runs so far, 0 failures, over 25s
1054 runs so far, 0 failures, over 30s
```

Release note: None