### PR TITLE
server,sql: ensure that temp tables wait to know about other instances

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1166,6 +1166,10 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	execCfg.SpanConfigLimiter = spanConfig.limiter
 	execCfg.SpanConfigSplitter = spanConfig.splitter
 
+	var waitForInstanceReaderStarted func(context.Context) error
+	if cfg.sqlInstanceReader != nil {
+		waitForInstanceReaderStarted = cfg.sqlInstanceReader.WaitForStarted
+	}
 	temporaryObjectCleaner := sql.NewTemporaryObjectCleaner(
 		cfg.Settings,
 		cfg.db,
@@ -1176,6 +1180,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		sqlExecutorTestingKnobs,
 		ieFactory,
 		collectionFactory,
+		waitForInstanceReaderStarted,
 	)
 
 	reporter := &diagnostics.Reporter{


### PR DESCRIPTION
In #92666 we stopped waiting for the sqlinstance.Reader to know about all the other instances synchronously at startup. Waiting for this information requires out-of-region RPCs. The hazard here is that in the temp table tests which lower the grace period for temp tables dramatically, we might delete temp tables which should not be deleted. By waiting for these instances, we deflake the test.

Epic: none
Fixes: #92895

Release note: None