### PR TITLE
release-22.2: testcat: fast stats building for inverted indexes

### DIFF
--- a/pkg/sql/opt/testutils/testcat/alter_table.go
+++ b/pkg/sql/opt/testutils/testcat/alter_table.go
@@ -78,7 +78,7 @@ func injectTableStats(tt *Table, statsExpr tree.Expr) {
 	}
 	tt.Stats = make([]*TableStat, len(stats))
 	for i := range stats {
-		tt.Stats[i] = &TableStat{js: stats[i], tt: tt}
+		tt.Stats[i] = &TableStat{js: stats[i], tt: tt, evalCtx: &evalCtx}
 	}
 	// Call ColumnOrdinal on all possible columns to assert that
 	// the column names are valid.


### PR DESCRIPTION
Backport 1/1 commits from #92974.

/cc @cockroachdb/release

---

Fixes #92906
Fixes #93006

opt tests involving inverted indexes with stats are slower than necessary because the slightly heavyweight `MakeTestingEvalContext` is called every time a scan or inverted join on the index is processed.

This change reuses the existing `eval.Context`, which also avoids a mutex lock.

Example speedup:
```
./dev test pkg/sql/opt/xform --filter TestExternal/postgis-tutorial-idx --stress
```
Without fix:
```
93 runs so far, 0 failures, over 5s
229 runs so far, 0 failures, over 10s
393 runs so far, 0 failures, over 15s
556 runs so far, 0 failures, over 20s
721 runs so far, 0 failures, over 25s
889 runs so far, 0 failures, over 30s
```
With fix:
```
148 runs so far, 0 failures, over 5s
332 runs so far, 0 failures, over 10s
510 runs so far, 0 failures, over 15s
688 runs so far, 0 failures, over 20s
871 runs so far, 0 failures, over 25s
1054 runs so far, 0 failures, over 30s
```

Release note: None

Release Justification: Fixes test-only issue