### PR TITLE
tree: convert TSVECTOR and TSQUERY to JSON elements as strings

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/tsvector
+++ b/pkg/sql/logictest/testdata/logic_test/tsvector
@@ -50,3 +50,16 @@ SELECT repeat('a', 1<<20)::tsvector
 
 query error string is too long for tsquery
 SELECT repeat('a', 1<<20)::tsquery
+
+# TSVECTOR should convert to a JSON element as a string.
+query T
+VALUES ( json_build_array('''D'':236A,377C,622A ''SDfdZ'' ''aIjQScIT'':213A,418A,827A ''pHhJoarX'':106C,486C ''pjApqSC'' ''qXLpyjUM'':547C ''uWSPY'':10A,822B':::TSVECTOR)::JSONB
+       )
+----
+["'D':236A,377C,622A 'SDfdZ' 'aIjQScIT':213A,418A,827A 'pHhJoarX':106C,486C 'pjApqSC' 'qXLpyjUM':547C 'uWSPY':10A,822B"]
+
+# TSQUERY should convert to a JSON element as a string.
+query T
+VALUES ( json_build_array($$'cat' & 'rat'$$:::TSQUERY)::JSONB)
+----
+["'cat' & 'rat'"]

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -3712,7 +3712,8 @@ func AsJSON(
 	case *DTimestamp:
 		// This is RFC3339Nano, but without the TZ fields.
 		return json.FromString(formatTime(t.UTC(), "2006-01-02T15:04:05.999999999")), nil
-	case *DDate, *DUuid, *DOid, *DInterval, *DBytes, *DIPAddr, *DTime, *DTimeTZ, *DBitArray, *DBox2D:
+	case *DDate, *DUuid, *DOid, *DInterval, *DBytes, *DIPAddr, *DTime, *DTimeTZ, *DBitArray, *DBox2D,
+		*DTSVector, *DTSQuery:
 		return json.FromString(AsStringWithFlags(t, FmtBareStrings, FmtDataConversionConfig(dcc))), nil
 	case *DGeometry:
 		return json.FromSpatialObject(t.Geometry.SpatialObject(), geo.DefaultGeoJSONDecimalDigits)


### PR DESCRIPTION
Fixes #92998

This adds support for converting TSVECTOR and TSQUERY data types to JSON elements via functions such as json_build_array.

Release note: None