### PR TITLE
asim: make simulator deterministic

### DIFF
--- a/pkg/kv/kvserver/asim/BUILD.bazel
+++ b/pkg/kv/kvserver/asim/BUILD.bazel
@@ -20,7 +20,6 @@ go_library(
         "//pkg/roachpb",
         "//pkg/util/encoding/csv",
         "//pkg/util/log",
-        "//pkg/util/shuffle",
     ],
 )
 

--- a/pkg/kv/kvserver/asim/BUILD.bazel
+++ b/pkg/kv/kvserver/asim/BUILD.bazel
@@ -36,6 +36,7 @@ go_test(
         "//pkg/kv/kvserver/asim/config",
         "//pkg/kv/kvserver/asim/state",
         "//pkg/kv/kvserver/asim/workload",
+        "//pkg/roachpb",
         "//pkg/testutils/skip",
         "//pkg/util/timeutil",
         "@com_github_stretchr_testify//require",

--- a/pkg/kv/kvserver/asim/asim.go
+++ b/pkg/kv/kvserver/asim/asim.go
@@ -104,6 +104,7 @@ func NewSimulator(
 			settings.PacerLoopInterval,
 			settings.PacerMinIterInterval,
 			settings.PacerMaxIterIterval,
+			settings.Seed,
 		)
 		controllers[storeID] = op.NewController(
 			changer,

--- a/pkg/kv/kvserver/asim/asim_test.go
+++ b/pkg/kv/kvserver/asim/asim_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/config"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/state"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/workload"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/stretchr/testify/require"
@@ -157,4 +158,63 @@ func TestAllocatorSimulatorSpeed(t *testing.T) {
 
 	fmt.Println(time.Duration(minRunTime).Seconds())
 	require.Less(t, minRunTime, requiredRunTime)
+}
+
+func TestAllocatorSimulatorDeterministic(t *testing.T) {
+
+	start := state.TestingStartTime()
+	settings := config.DefaultSimulationSettings()
+
+	runs := 3
+	end := start.Add(15 * time.Minute)
+	bgInterval := 10 * time.Second
+	interval := 2 * time.Second
+	preGossipStart := start.Add(-settings.StateExchangeInterval - settings.StateExchangeDelay)
+
+	stores := 7
+	replsPerRange := 3
+	replicasPerStore := 100
+	// NB: We want 100 replicas per store, so the number of ranges required
+	// will be 1/3 of the total replicas.
+	ranges := (replicasPerStore * stores) / replsPerRange
+	// NB: In this test we are using a uniform workload and expect to see at
+	// most 3 splits occur due to range size, therefore the keyspace need not
+	// be larger than 3 keys per range.
+	keyspace := 3 * ranges
+	// Track the run to compare against for determinism.
+	var refRun []roachpb.StoreDescriptor
+
+	for run := 0; run < runs; run++ {
+		rwg := make([]workload.Generator, 1)
+		rwg[0] = testCreateWorkloadGenerator(start, stores, int64(keyspace))
+		exchange := state.NewFixedDelayExhange(preGossipStart, settings.StateExchangeInterval, settings.StateExchangeDelay)
+		changer := state.NewReplicaChanger()
+		m := asim.NewMetricsTracker() // no output
+		replicaDistribution := make([]float64, stores)
+
+		// NB: Here create half of the stores with equal replica counts, the
+		// other half have no replicas. This will lead to a flurry of activity
+		// rebalancing towards these stores, based on the replica count
+		// imbalance.
+		for i := 0; i < stores/2; i++ {
+			replicaDistribution[i] = 1.0 / float64(stores/2)
+		}
+		for i := stores / 2; i < stores; i++ {
+			replicaDistribution[i] = 0
+		}
+
+		s := state.NewTestStateReplDistribution(replicaDistribution, ranges, replsPerRange, keyspace)
+		testPreGossipStores(s, exchange, preGossipStart)
+		sim := asim.NewSimulator(start, end, interval, bgInterval, rwg, s, exchange, changer, settings, m)
+
+		ctx := context.Background()
+		sim.RunSim(ctx)
+		descs := s.StoreDescriptors()
+
+		if run == 0 {
+			refRun = descs
+			continue
+		}
+		require.Equal(t, refRun, descs)
+	}
 }

--- a/pkg/kv/kvserver/asim/metrics_tracker_test.go
+++ b/pkg/kv/kvserver/asim/metrics_tracker_test.go
@@ -41,7 +41,7 @@ func Example_tickEmptyState() {
 	_ = m.Tick(start, s)
 	// Output:
 	//tick,c_ranges,c_write,c_write_b,c_read,c_read_b,s_ranges,s_write,s_write_b,s_read,s_read_b,c_lease_moves,c_replica_moves,c_replica_b_moves
-	//2022-03-21 11:00:00 +0000 UTC,1,0,0,0,0,0,0,0,0,1,0,0
+	//2022-03-21 11:00:00 +0000 UTC,1,0,0,0,0,0,0,0,0,0,0,0
 }
 
 func TestTickEmptyState(t *testing.T) {
@@ -55,7 +55,7 @@ func TestTickEmptyState(t *testing.T) {
 
 	expected :=
 		"tick,c_ranges,c_write,c_write_b,c_read,c_read_b,s_ranges,s_write,s_write_b,s_read,s_read_b,c_lease_moves,c_replica_moves,c_replica_b_moves\n" +
-			"2022-03-21 11:00:00 +0000 UTC,1,0,0,0,0,0,0,0,0,1,0,0\n"
+			"2022-03-21 11:00:00 +0000 UTC,1,0,0,0,0,0,0,0,0,0,0,0\n"
 	require.Equal(t, expected, buf.String())
 }
 
@@ -68,8 +68,8 @@ func Example_multipleWriters() {
 	// Output:
 	//tick,c_ranges,c_write,c_write_b,c_read,c_read_b,s_ranges,s_write,s_write_b,s_read,s_read_b,c_lease_moves,c_replica_moves,c_replica_b_moves
 	//tick,c_ranges,c_write,c_write_b,c_read,c_read_b,s_ranges,s_write,s_write_b,s_read,s_read_b,c_lease_moves,c_replica_moves,c_replica_b_moves
-	//2022-03-21 11:00:00 +0000 UTC,1,0,0,0,0,0,0,0,0,1,0,0
-	//2022-03-21 11:00:00 +0000 UTC,1,0,0,0,0,0,0,0,0,1,0,0
+	//2022-03-21 11:00:00 +0000 UTC,1,0,0,0,0,0,0,0,0,0,0,0
+	//2022-03-21 11:00:00 +0000 UTC,1,0,0,0,0,0,0,0,0,0,0,0
 }
 
 func Example_leaseTransfer() {
@@ -81,7 +81,7 @@ func Example_leaseTransfer() {
 	_ = m.Tick(start, s)
 	// Output:
 	//tick,c_ranges,c_write,c_write_b,c_read,c_read_b,s_ranges,s_write,s_write_b,s_read,s_read_b,c_lease_moves,c_replica_moves,c_replica_b_moves
-	//2022-03-21 11:00:00 +0000 UTC,1,0,0,0,0,0,0,0,0,2,0,0
+	//2022-03-21 11:00:00 +0000 UTC,1,0,0,0,0,0,0,0,0,1,0,0
 }
 
 func Example_rebalance() {
@@ -100,7 +100,7 @@ func Example_rebalance() {
 	_ = m.Tick(start, s)
 	// Output:
 	//tick,c_ranges,c_write,c_write_b,c_read,c_read_b,s_ranges,s_write,s_write_b,s_read,s_read_b,c_lease_moves,c_replica_moves,c_replica_b_moves
-	//2022-03-21 11:00:00 +0000 UTC,1,3,21,2,9,1,7,2,9,2,1,7
+	//2022-03-21 11:00:00 +0000 UTC,1,3,21,2,9,1,7,2,9,1,1,7
 }
 
 func Example_workload() {

--- a/pkg/kv/kvserver/asim/op/controller_test.go
+++ b/pkg/kv/kvserver/asim/op/controller_test.go
@@ -82,7 +82,7 @@ func TestLeaseTransferOp(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			ctx := context.Background()
-			s := state.NewTestStateReplCounts(map[state.StoreID]int{1: tc.ranges + 1, 2: tc.ranges + 1, 3: tc.ranges + 1}, 3)
+			s := state.NewTestStateReplCounts(map[state.StoreID]int{1: tc.ranges + 1, 2: tc.ranges + 1, 3: tc.ranges + 1}, 3, 1000 /* keyspace */)
 			settings := config.DefaultSimulationSettings()
 			changer := state.NewReplicaChanger()
 			controller := NewController(changer, allocatorimpl.Allocator{}, settings)
@@ -267,7 +267,7 @@ func TestRelocateRangeOp(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			ctx := context.Background()
-			s := state.NewTestStateReplCounts(map[state.StoreID]int{1: 3, 2: 3, 3: 3, 4: 0, 5: 0, 6: 0}, 3)
+			s := state.NewTestStateReplCounts(map[state.StoreID]int{1: 3, 2: 3, 3: 3, 4: 0, 5: 0, 6: 0}, 3, 1000 /* keyspace */)
 			changer := state.NewReplicaChanger()
 			allocator := s.MakeAllocator(state.StoreID(1))
 			controller := NewController(changer, allocator, settings)

--- a/pkg/kv/kvserver/asim/op/controller_test.go
+++ b/pkg/kv/kvserver/asim/op/controller_test.go
@@ -291,7 +291,8 @@ func TestRelocateRangeOp(t *testing.T) {
 			// Update the storepool for informing allocator decisions.
 			storeDescriptors := s.StoreDescriptors()
 			exchange.Put(state.OffsetTick(start, 0), storeDescriptors...)
-			for storeID := range s.Stores() {
+			for _, store := range s.Stores() {
+				storeID := store.StoreID()
 				s.UpdateStorePool(storeID, exchange.Get(state.OffsetTick(start, 1), roachpb.StoreID(storeID)))
 			}
 
@@ -342,8 +343,8 @@ func TestRelocateRangeOp(t *testing.T) {
 						leaseholder: int64(leaseholderStore.StoreID()),
 						voters:      []int64{},
 					}
-					for storeID := range rng.Replicas() {
-						rState.voters = append(rState.voters, int64(storeID))
+					for _, repl := range rng.Replicas() {
+						rState.voters = append(rState.voters, int64(repl.StoreID()))
 					}
 					sort.Slice(rState.voters, func(i, j int) bool {
 						return rState.voters[i] < rState.voters[j]

--- a/pkg/kv/kvserver/asim/pacer.go
+++ b/pkg/kv/kvserver/asim/pacer.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/state"
-	"github.com/cockroachdb/cockroach/pkg/util/shuffle"
 )
 
 // ReplicaPacer controls the speed of considering a replica.
@@ -38,12 +37,15 @@ type ReplicaScanner struct {
 	maxIterInvterval   time.Duration
 	iterInterval       time.Duration
 	visited            int
+
+	shuffler func(n int, swap func(i, j int))
 }
 
 // NewScannerReplicaPacer returns a scanner replica pacer.
 func NewScannerReplicaPacer(
 	nextReplsFn func() []state.Replica,
 	targetLoopInterval, minIterInterval, maxIterInterval time.Duration,
+	seed int64,
 ) *ReplicaScanner {
 	return &ReplicaScanner{
 		nextReplsFn:        nextReplsFn,
@@ -51,6 +53,7 @@ func NewScannerReplicaPacer(
 		targetLoopInterval: targetLoopInterval,
 		minIterInvterval:   minIterInterval,
 		maxIterInvterval:   maxIterInterval,
+		shuffler:           state.NewShuffler(seed),
 	}
 }
 
@@ -75,7 +78,7 @@ func (rp *ReplicaScanner) resetPacerLoop(tick time.Time) {
 
 	// Avoid the same replicas being processed in the same order in each
 	// iteration.
-	shuffle.Shuffle(rp)
+	rp.shuffler(rp.Len(), rp.Swap)
 
 	// Reset the counter and tracker vars.
 	rp.visited = 0

--- a/pkg/kv/kvserver/asim/pacer_test.go
+++ b/pkg/kv/kvserver/asim/pacer_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/config"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/state"
 	"github.com/stretchr/testify/require"
 )
@@ -89,7 +90,13 @@ func TestScannerReplicaPacer(t *testing.T) {
 		nextReplsFn := createNextRepls(tc.replCount)
 
 		t.Run(tc.desc, func(t *testing.T) {
-			pacer := NewScannerReplicaPacer(nextReplsFn, tc.loopInterval, tc.minInterval, tc.maxInterval)
+			pacer := NewScannerReplicaPacer(
+				nextReplsFn,
+				tc.loopInterval,
+				tc.minInterval,
+				tc.maxInterval,
+				config.DefaultSimulationSettings().Seed,
+			)
 			results := make([]int, 0, 1)
 			for _, tick := range tc.ticks {
 				replsThisTick := 0

--- a/pkg/kv/kvserver/asim/pacer_test.go
+++ b/pkg/kv/kvserver/asim/pacer_test.go
@@ -26,7 +26,7 @@ func TestScannerReplicaPacer(t *testing.T) {
 	start := state.TestingStartTime()
 
 	createNextRepls := func(replicas int) func() []state.Replica {
-		s := state.NewTestStateReplCounts(map[state.StoreID]int{1: replicas}, 1 /* replsPerRange */)
+		s := state.NewTestStateReplCounts(map[state.StoreID]int{1: replicas}, 1 /* replsPerRange */, 1000 /* keyspace */)
 		return s.NextReplicasFn(state.StoreID(1))
 	}
 

--- a/pkg/kv/kvserver/asim/queue/replicate_queue_test.go
+++ b/pkg/kv/kvserver/asim/queue/replicate_queue_test.go
@@ -75,7 +75,7 @@ func TestReplicateQueue(t *testing.T) {
 	}
 
 	testingState := func(replicaCounts map[state.StoreID]int, replicationFactor int32) state.State {
-		s := state.NewTestStateReplCounts(replicaCounts, 3 /* replsPerRange */)
+		s := state.NewTestStateReplCounts(replicaCounts, 2 /* replsPerRange */, 1000 /* keyspace */)
 		spanConfig := roachpb.SpanConfig{NumVoters: replicationFactor, NumReplicas: replicationFactor}
 		for _, r := range s.Ranges() {
 			s.SetSpanConfig(r.RangeID(), spanConfig)

--- a/pkg/kv/kvserver/asim/queue/split_queue_test.go
+++ b/pkg/kv/kvserver/asim/queue/split_queue_test.go
@@ -40,7 +40,7 @@ func TestSplitQueue(t *testing.T) {
 		replicationFactor int32,
 		leaseholder state.StoreID,
 	) state.State {
-		s := state.NewTestStateReplCounts(replicaCounts, int(replicationFactor))
+		s := state.NewTestStateReplCounts(replicaCounts, int(replicationFactor), 1000 /* keyspace */)
 		spanConfig := roachpb.SpanConfig{
 			NumVoters:   replicationFactor,
 			NumReplicas: replicationFactor,

--- a/pkg/kv/kvserver/asim/state/change_test.go
+++ b/pkg/kv/kvserver/asim/state/change_test.go
@@ -54,11 +54,12 @@ func testMakeLeaseTransferChange(rangeKey Key, target StoreID) func(s State) Cha
 }
 
 func testMakeReplicaState(replCounts map[StoreID]int) (State, Range) {
-	state := NewTestStateReplCounts(replCounts, 3 /* replsPerRange */)
-	// The first range has ID 1, this is the initial range in the keyspace.
-	// We split that and use the rhs, range 2.
+	numReplicas := 0
+	for _, count := range replCounts {
+		numReplicas += count
+	}
+	state := NewTestStateReplCounts(replCounts, numReplicas, 50 /* keyspace */)
 	rng, _ := state.Range(RangeID(2))
-	state.TransferLease(rng.RangeID(), 1)
 	return state, rng
 }
 

--- a/pkg/kv/kvserver/asim/state/change_test.go
+++ b/pkg/kv/kvserver/asim/state/change_test.go
@@ -67,7 +67,8 @@ func testGetAllReplLocations(
 ) (map[int64][]int, map[int64][]int) {
 	rmapView := make(map[int64][]int)
 	storeView := make(map[int64][]int)
-	for rangeID, rng := range state.Ranges() {
+	for _, rng := range state.Ranges() {
+		rangeID := rng.RangeID()
 		if _, ok := excludedRanges[rangeID]; ok {
 			continue
 		}
@@ -81,7 +82,8 @@ func testGetAllReplLocations(
 
 func testGetLHLocations(state State, excludedRanges map[RangeID]bool) map[int64]int {
 	leases := make(map[int64]int)
-	for rangeID := range state.Ranges() {
+	for _, rng := range state.Ranges() {
+		rangeID := rng.RangeID()
 		if _, ok := excludedRanges[rangeID]; ok {
 			continue
 		}
@@ -95,14 +97,14 @@ func testGetLHLocations(state State, excludedRanges map[RangeID]bool) map[int64]
 func testGetReplLocations(state State, r Range) ([]int, []int) {
 	storeView := []int{}
 	for _, store := range state.Stores() {
-		if _, ok := store.Replicas()[r.RangeID()]; ok {
+		if _, ok := store.Replica(r.RangeID()); ok {
 			storeView = append(storeView, int(store.StoreID()))
 		}
 	}
 
 	rmapView := []int{}
-	for storeID := range r.Replicas() {
-		rmapView = append(rmapView, int(storeID))
+	for _, replica := range r.Replicas() {
+		rmapView = append(rmapView, int(replica.StoreID()))
 	}
 
 	sort.Ints(rmapView)
@@ -185,9 +187,9 @@ func TestReplicaChange(t *testing.T) {
 			change.Apply(state)
 			replLocations, _ := testGetReplLocations(state, r)
 			leaseholder := -1
-			for storeID, repl := range r.Replicas() {
+			for _, repl := range r.Replicas() {
 				if repl.HoldsLease() {
-					leaseholder = int(storeID)
+					leaseholder = int(repl.StoreID())
 				}
 			}
 			require.Equal(t, tc.expectedReplicas, replLocations)

--- a/pkg/kv/kvserver/asim/state/helpers.go
+++ b/pkg/kv/kvserver/asim/state/helpers.go
@@ -12,6 +12,7 @@ package state
 
 import (
 	"context"
+	"math/rand"
 	"sort"
 	"time"
 
@@ -25,6 +26,15 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
+
+// NewShuffler returns a function which will shuffle elements determinstically
+// but without order.
+func NewShuffler(seed int64) func(n int, swap func(i, j int)) {
+	r := rand.New(rand.NewSource(seed))
+	return func(n int, swap func(i, j int)) {
+		r.Shuffle(n, swap)
+	}
+}
 
 // TestingStartTime returns a start time that may be used for tests.
 func TestingStartTime() time.Time {

--- a/pkg/kv/kvserver/asim/state/impl.go
+++ b/pkg/kv/kvserver/asim/state/impl.go
@@ -161,25 +161,30 @@ func (s *state) ClusterInfo() ClusterInfo {
 }
 
 // Stores returns all stores that exist in this state.
-func (s *state) Stores() map[StoreID]Store {
-	stores := make(map[StoreID]Store)
-	for storeID, store := range s.stores {
-		stores[storeID] = store
+func (s *state) Stores() []Store {
+	stores := make([]Store, 0, len(s.stores))
+	for _, store := range s.stores {
+		stores = append(stores, store)
 	}
+	sort.Slice(stores, func(i, j int) bool { return stores[i].StoreID() < stores[j].StoreID() })
 	return stores
 }
 
 // StoreDescriptors returns the descriptors for all stores that exist in
 // this state.
 func (s *state) StoreDescriptors() []roachpb.StoreDescriptor {
-	s.updateStoreCapacities()
-	storeDescriptors := make([]roachpb.StoreDescriptor, len(s.stores))
-	iter := 0
-	for _, store := range s.stores {
-		storeDescriptors[iter] = store.desc
-		iter++
+	storeDescriptors := []roachpb.StoreDescriptor{}
+	for _, store := range s.Stores() {
+		s.updateStoreCapacity(store.StoreID())
+		storeDescriptors = append(storeDescriptors, store.Descriptor())
 	}
 	return storeDescriptors
+}
+
+func (s *state) updateStoreCapacity(storeID StoreID) {
+	if store, ok := s.stores[storeID]; ok {
+		store.desc.Capacity = Capacity(s, storeID)
+	}
 }
 
 // Store returns the Store with ID StoreID. This fails if no Store exists
@@ -189,12 +194,12 @@ func (s *state) Store(storeID StoreID) (Store, bool) {
 	return store, ok
 }
 
-// Nodes returns all nodes that exist in this state.
-func (s *state) Nodes() map[NodeID]Node {
-	nodes := make(map[NodeID]Node)
-	for nodeID, node := range s.nodes {
-		nodes[nodeID] = node
+func (s *state) Nodes() []Node {
+	nodes := make([]Node, 0, len(s.nodes))
+	for _, node := range s.nodes {
+		nodes = append(nodes, node)
 	}
+	sort.Slice(nodes, func(i, j int) bool { return nodes[i].NodeID() < nodes[j].NodeID() })
 	return nodes
 }
 
@@ -229,11 +234,12 @@ func (s *state) rng(rangeID RangeID) (*rng, bool) {
 }
 
 // Ranges returns all ranges that exist in this state.
-func (s *state) Ranges() map[RangeID]Range {
-	ranges := make(map[RangeID]Range)
-	for rangeID, r := range s.ranges.rangeMap {
-		ranges[rangeID] = r
+func (s *state) Ranges() []Range {
+	ranges := []Range{}
+	for _, r := range s.ranges.rangeMap {
+		ranges = append(ranges, r)
 	}
+	sort.Slice(ranges, func(i, j int) bool { return ranges[i].RangeID() < ranges[j].RangeID() })
 	return ranges
 }
 
@@ -258,13 +264,13 @@ func (r replicaList) Less(i, j int) bool {
 // Replicas returns all replicas that exist on a store.
 func (s *state) Replicas(storeID StoreID) []Replica {
 	replicas := []Replica{}
-	store, ok := s.Store(storeID)
+	store, ok := s.stores[storeID]
 	if !ok {
 		return replicas
 	}
 
-	repls := replicaList{}
-	for rangeID := range store.Replicas() {
+	repls := make(replicaList, 0, len(store.replicas))
+	for rangeID := range store.replicas {
 		rng := s.ranges.rangeMap[rangeID]
 		if replica := rng.replicas[storeID]; replica != nil {
 			repls = append(repls, replica)
@@ -602,7 +608,7 @@ func (s *state) ValidTransfer(rangeID RangeID, storeID StoreID) bool {
 	}
 	rng, _ := s.Range(rangeID)
 	store, _ := s.Store(storeID)
-	repl, ok := store.Replicas()[rangeID]
+	repl, ok := store.Replica(rangeID)
 	// A replica for the range does not exist on the store, we cannot transfer
 	// a lease to it.
 	if !ok {
@@ -656,12 +662,6 @@ func (s *state) applyLoad(rng *rng, le workload.LoadEvent) {
 		return
 	}
 	s.loadsplits[store.StoreID()].Record(s.clock.Now(), rng.rangeID, le)
-}
-
-func (s *state) updateStoreCapacities() {
-	for storeID, store := range s.stores {
-		store.desc.Capacity = Capacity(s, storeID)
-	}
 }
 
 // ReplicaLoad returns the usage information for the Range with ID
@@ -878,9 +878,11 @@ func (s *store) Descriptor() roachpb.StoreDescriptor {
 	return s.desc
 }
 
-// Replicas returns all replicas that are on this store.
-func (s *store) Replicas() map[RangeID]ReplicaID {
-	return s.replicas
+// Replica returns a the Replica belonging to the Range with ID RangeID, if
+// it exists, otherwise false.
+func (s *store) Replica(rangeID RangeID) (ReplicaID, bool) {
+	replicaID, ok := s.replicas[rangeID]
+	return replicaID, ok
 }
 
 // rng is an implementation of the Range interface.
@@ -932,12 +934,20 @@ func (r *rng) SpanConfig() roachpb.SpanConfig {
 }
 
 // Replicas returns all replicas which exist for this range.
-func (r *rng) Replicas() map[StoreID]Replica {
-	replicas := make(map[StoreID]Replica)
-	for storeID, replica := range r.replicas {
-		replicas[storeID] = replica
+func (r *rng) Replicas() []Replica {
+	replicas := make(replicaList, 0, len(r.replicas))
+	for _, replica := range r.replicas {
+		replicas = append(replicas, replica)
 	}
+	sort.Sort(replicas)
 	return replicas
+}
+
+// Replica returns the replica that is on the store with ID StoreID if it
+// exists, else false.
+func (r *rng) Replica(storeID StoreID) (Replica, bool) {
+	replica, ok := r.replicas[storeID]
+	return replica, ok
 }
 
 // Leaseholder returns the ID of the leaseholder for this Range if there is

--- a/pkg/kv/kvserver/asim/state/load.go
+++ b/pkg/kv/kvserver/asim/state/load.go
@@ -121,12 +121,10 @@ func Capacity(state State, storeID StoreID) roachpb.StoreCapacity {
 	// the following missing fields: capacity, available, used, l0sublevels,
 	// bytesperreplica, writesperreplica.
 	capacity := roachpb.StoreCapacity{}
-	store, ok := state.Store(storeID)
-	if !ok {
-		return capacity
-	}
 
-	for rangeID, replicaID := range store.Replicas() {
+	for _, repl := range state.Replicas(storeID) {
+		rangeID := repl.Range()
+		replicaID := repl.ReplicaID()
 		rng, _ := state.Range(rangeID)
 		if rng.Leaseholder() == replicaID {
 			// TODO(kvoli): We currently only consider load on the leaseholder

--- a/pkg/kv/kvserver/asim/state/state.go
+++ b/pkg/kv/kvserver/asim/state/state.go
@@ -47,16 +47,17 @@ type State interface {
 	// with ID StoreID.
 	Store(StoreID) (Store, bool)
 	// Stores returns all stores that exist in this state.
-	Stores() map[StoreID]Store
+	Stores() []Store
 	// TODO(kvoli,lidorcarmel): This method is O(replicas), as it computes the
 	// store descriptor at request time. In a 64 store simulator cluster, with
 	// 5000 replicas per store, this function accounted for 50% of the total
 	// runtime in profiling. We should investigate optimizing it, by way of
 	// incremental descriptor computation, when replicas, leases or load is
 	// changed.
+	// StoreDescriptors returns the descriptors for the StoreIDs given.
 	StoreDescriptors() []roachpb.StoreDescriptor
 	// Nodes returns all nodes that exist in this state.
-	Nodes() map[NodeID]Node
+	Nodes() []Node
 	// RangeFor returns the range containing Key in [StartKey, EndKey). This
 	// cannot fail.
 	RangeFor(Key) Range
@@ -64,7 +65,7 @@ type State interface {
 	// with ID RangeID.
 	Range(RangeID) (Range, bool)
 	// Ranges returns all ranges that exist in this state.
-	Ranges() map[RangeID]Range
+	Ranges() []Range
 	// RangeCount returns the number of ranges currently in the cluster.
 	RangeCount() int64
 	// Replicas returns all replicas that exist on a store.
@@ -178,8 +179,9 @@ type Store interface {
 	Descriptor() roachpb.StoreDescriptor
 	// String returns a string representing the state of the store.
 	String() string
-	// Replicas returns all replicas that are on this store.
-	Replicas() map[RangeID]ReplicaID
+	// Replica returns the ID of the Replica belonging to the Range with ID
+	// RangeID, if it exists, otherwise false.
+	Replica(RangeID) (ReplicaID, bool)
 }
 
 // Range is a slice of the keyspace, which may have replicas that exist on
@@ -194,7 +196,10 @@ type Range interface {
 	// SpanConfig returns the span config for this range.
 	SpanConfig() roachpb.SpanConfig
 	// Replicas returns all replicas which exist for this range.
-	Replicas() map[StoreID]Replica
+	Replicas() []Replica
+	// Replica returns the replica that is on the store with ID StoreID if it
+	// exists, else false.
+	Replica(StoreID) (Replica, bool)
 	// Leaseholder returns the ID of the leaseholder for this Range if there is
 	// one, otherwise it returns a ReplicaID -1.
 	Leaseholder() ReplicaID

--- a/pkg/kv/kvserver/asim/state/state_test.go
+++ b/pkg/kv/kvserver/asim/state/state_test.go
@@ -371,10 +371,42 @@ func TestOrderedStateLists(t *testing.T) {
 	// Test an empty state, where there should be nothing.
 	s := NewState(config.DefaultSimulationSettings())
 	assertListsOrdered(s)
-	// Test a even distribution with 100 stores, 10k ranges and 1m keyspace.
+	// Test an even distribution with 100 stores, 10k ranges and 1m keyspace.
 	s = NewTestStateEvenDistribution(100, 10000, 3, 1000000)
 	assertListsOrdered(s)
 	// Test a skewed distribution with 100 stores, 10k ranges and 1m keyspace.
 	s = NewTestStateSkewedDistribution(100, 10000, 3, 1000000)
 	assertListsOrdered(s)
+}
+
+// TestNewStateDeterministic asserts that the state returned from the new state
+// utility functions is deterministic.
+func TestNewStateDeterministic(t *testing.T) {
+
+	testCases := []struct {
+		desc       string
+		newStateFn func() State
+	}{
+		{
+			desc:       "even distribution",
+			newStateFn: func() State { return NewTestStateEvenDistribution(7, 1400, 3, 10000) },
+		},
+		{
+			desc:       "skewed distribution",
+			newStateFn: func() State { return NewTestStateSkewedDistribution(7, 1400, 3, 10000) },
+		},
+		{
+			desc:       "replica distribution raw ",
+			newStateFn: func() State { return NewTestStateReplDistribution([]float64{0.2, 0.2, 0.2, 0.2, 0.2}, 5, 3, 10000) },
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			ref := tc.newStateFn()
+			for i := 0; i < 5; i++ {
+				require.Equal(t, ref.Ranges(), tc.newStateFn().Ranges())
+			}
+		})
+	}
 }

--- a/pkg/kv/kvserver/asim/storerebalancer/replica_rankings_test.go
+++ b/pkg/kv/kvserver/asim/storerebalancer/replica_rankings_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestHottestRanges(t *testing.T) {
-	s := state.NewTestStateReplCounts(map[state.StoreID]int{1: 6, 2: 6, 3: 6}, 3)
+	s := state.NewTestStateReplCounts(map[state.StoreID]int{1: 6, 2: 6, 3: 6}, 3, 1000 /* keyspace */)
 	// Set the QPS to be a testing rate to be rangeID * 100 for each range.
 	// NB: Normally the subsequent lease transfer would erase the QPS, however
 	// here the testing rate remains constants despite resets of actual counts.


### PR DESCRIPTION
This pr introduces several patches that move the allocator simulator towards being deterministic. This is asserted on in the final commit which asserts on e2e determinism.

Part of #83990

Release note: None