### PR TITLE
changefeedccl: webhook sink rewrite for increased throughput

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "sink_external_connection.go",
         "sink_kafka.go",
         "sink_kafka_connection.go",
+        "sink_processor.go",
         "sink_pubsub.go",
         "sink_sql.go",
         "sink_webhook.go",

--- a/pkg/ccl/changefeedccl/changefeedbase/settings.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/settings.go
@@ -279,3 +279,14 @@ var EventConsumerElasticCPUControlEnabled = settings.RegisterBoolSetting(
 	"determines whether changefeed event processing integrates with elastic CPU control",
 	true,
 )
+
+// WebhookSinkWorkers specifies the number of workers to use to handle batching
+// and emitting to a webhook sink.
+var WebhookSinkWorkers = settings.RegisterIntSetting(
+	settings.TenantWritable,
+	"changefeed.webhook_sink_workers",
+	"the number of workers to use when emitting events to the sink: "+
+		"0 assigns a reasonable default, >0 assigns the setting value",
+	0,
+	settings.NonNegativeInt,
+)

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -174,9 +174,11 @@ func getSink(
 			if err != nil {
 				return nil, err
 			}
+
+			numWorkers := changefeedbase.WebhookSinkWorkers.Get(&serverCfg.Settings.SV)
 			return validateOptionsAndMakeSink(changefeedbase.WebhookValidOptions, func() (Sink, error) {
 				return makeWebhookSink(ctx, sinkURL{URL: u}, encodingOpts, webhookOpts,
-					defaultWorkerCount(), timeutil.DefaultTimeSource{}, metricsBuilder)
+					int(numWorkers), timeutil.DefaultTimeSource{}, metricsBuilder)
 			})
 		case isPubsubSink(u):
 			// TODO: add metrics to pubsubsink

--- a/pkg/ccl/changefeedccl/sink_processor.go
+++ b/pkg/ccl/changefeedccl/sink_processor.go
@@ -1,0 +1,458 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedccl
+
+import (
+	"context"
+	"hash/crc32"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvevent"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/system"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
+)
+
+// ThinSink is the interface to an external sink used by a sink processor.
+// Messages go through two steps, an Encoding step which creates a payload of
+// one or more messages, then an Emit stage which sends the payload, with
+// EmitPayload potentially being retried multiple times with the same payload if
+// errors are observed.
+type ThinSink interface {
+	EncodeBatch([]MessagePayload) (SinkPayload, error)
+	EncodeResolvedMessage(ResolvedMessagePayload) (SinkPayload, error)
+	EmitPayload(SinkPayload) error
+	Close() error
+}
+
+// SinkPayload is an interface representing a sink-specific representation of a
+// batch of messages that is ready to be emitted by its EmitRow method.
+type SinkPayload interface{}
+
+// MessagePayload represents a KV event to be emitted.
+type MessagePayload struct {
+	key []byte
+	val []byte
+}
+
+// ResolvedMessagePayload represents a Resolved event to be emitted.
+type ResolvedMessagePayload struct {
+	body       []byte
+	resolvedTs hlc.Timestamp
+}
+
+// sinkProcessor takes a ThinSink and handles the tasks necessary to emit kv and
+// resolved messages to it in a parallel, efficient, and resilient manner.
+//
+// KV messages arrive through single-threaded calls to EmitRow and are then fanned
+// out to a group of worker threads.  Each worker aggregates messages into
+// batches and emits them to the underlying sink either when there are enough
+// messages batched or enough time has passed.  Batch emits are retried
+// according to the given retry.Options.  To maintain per-key ordering, each
+// worker only ever has one batch being emitted at a time.
+//
+// Resolved messages are simply sent to the sink directly, therefore it is
+// assumed that EmitResolvedTimestamp is only called _after_ all prior KV events
+// have been flushed.
+//
+// Closing the sinkProcessor will wait for all buffered messages to drain out of
+// their worker as no-ops rather than terminating workers immediately, as this
+// makes the race-condition-free code easier to reason about.
+type sinkProcessor struct {
+	ctx context.Context
+
+	sink ThinSink
+
+	flushCfg   batchConfig
+	retryOpts  retry.Options
+	timeSource timeutil.TimeSource
+	keyInValue bool
+
+	numWorkers  int
+	eventChans  []chan rowWorkerPayload
+	workerGroup ctxgroup.Group
+
+	// sinkProcessor uses a WaitGroup to be able to block until all messages have
+	// been flushed to the sink.  It is *crucial* that *every* message that enters
+	// EmitRow resulting in an Add() has a matching Done() or Add(-n) such that
+	// the inFlight counter is always eventually returned to 0 and calls to Wait()
+	// will not block forever.
+	inFlight sync.WaitGroup
+
+	// Upon an error or a Close(), closing is atomically set to 1 to signal
+	// workers to drain messages out and return inFlight to 0.
+	closing int32
+	mu      struct {
+		syncutil.Mutex
+		closeErr error
+	}
+
+	metrics metricsRecorder
+}
+
+var _ Sink = (*sinkProcessor)(nil) // sinkProcessor should implement Sink
+
+// Messages are sharded across goroutines by hashing the key to ensure that
+// per-key ordering is maintained.
+func (sp *sinkProcessor) workerIndex(key []byte) uint32 {
+	return crc32.ChecksumIEEE(key) % uint32(sp.numWorkers)
+}
+
+func defaultSinkProcessorNumWorkers() int {
+	// With a webhook sink on a 3 node 16cpu cluster on tpcc.order_line this was
+	// observed to produce 222k messages per second without any batching, which is
+	// more than enough.  Larger multiples result in more CPU usage.
+	//
+	// TODO(samiskin): Verify throughput when emits are slower to complete.
+	return 5 * system.NumCPU()
+}
+
+type sinkProcessorConfig struct {
+	numWorkers int
+	timeSource timeutil.TimeSource
+	flushCfg   batchConfig
+	retryOpts  retry.Options
+	keyInValue bool
+}
+
+func makeSinkProcessor(
+	ctx context.Context, sink ThinSink, cfg sinkProcessorConfig, mb metricsRecorderBuilder,
+) (Sink, error) {
+	if err := validateBatchConfig(cfg.flushCfg); err != nil {
+		return nil, err
+	}
+	var timeSource timeutil.TimeSource = timeutil.DefaultTimeSource{}
+	if cfg.timeSource != nil {
+		timeSource = cfg.timeSource
+	}
+
+	numWorkers := cfg.numWorkers
+	if numWorkers == 0 {
+		numWorkers = defaultSinkProcessorNumWorkers()
+	}
+
+	sp := sinkProcessor{
+		ctx:         ctx,
+		numWorkers:  numWorkers,
+		sink:        sink,
+		eventChans:  make([]chan rowWorkerPayload, numWorkers),
+		workerGroup: ctxgroup.WithContext(ctx),
+		closing:     0,
+		timeSource:  timeSource,
+		flushCfg:    cfg.flushCfg,
+		retryOpts:   cfg.retryOpts,
+		keyInValue:  cfg.keyInValue,
+		metrics:     mb(requiresResourceAccounting),
+	}
+
+	for i := 0; i < sp.numWorkers; i++ {
+		i := i
+		sp.eventChans[i] = make(chan rowWorkerPayload)
+		sp.workerGroup.GoCtx(func(ctx context.Context) error {
+			return sp.startRowWorker(i)
+		})
+	}
+
+	return &sp, nil
+}
+
+func (sp *sinkProcessor) EmitRow(
+	ctx context.Context,
+	topic TopicDescriptor,
+	key, value []byte,
+	updated, mvcc hlc.Timestamp,
+	alloc kvevent.Alloc,
+) error {
+	if atomic.LoadInt32(&sp.closing) != 0 {
+		sp.mu.Lock()
+		defer sp.mu.Unlock()
+		return sp.mu.closeErr
+	}
+
+	sp.inFlight.Add(1)
+
+	worker := sp.workerIndex(key)
+	sp.eventChans[worker] <- rowWorkerPayload{
+		msg: MessagePayload{
+			key: key,
+			val: value,
+		},
+		mvcc:  mvcc,
+		alloc: alloc,
+	}
+
+	sp.metrics.recordMessageSize(int64(len(key) + len(value)))
+	return nil
+}
+
+func (sp *sinkProcessor) Dial() error {
+	return nil
+}
+
+type rowWorkerPayload struct {
+	msg   MessagePayload
+	alloc kvevent.Alloc
+	mvcc  hlc.Timestamp
+}
+
+func (sp *sinkProcessor) EmitResolvedTimestamp(
+	ctx context.Context, encoder Encoder, resolved hlc.Timestamp,
+) error {
+	defer sp.metrics.recordResolvedCallback()()
+	if atomic.LoadInt32(&sp.closing) != 0 {
+		sp.mu.Lock()
+		defer sp.mu.Unlock()
+		return sp.mu.closeErr
+	}
+
+	data, err := encoder.EncodeResolvedTimestamp(ctx, "", resolved)
+	if err != nil {
+		return err
+	}
+	encoded, err := sp.sink.EncodeResolvedMessage(ResolvedMessagePayload{
+		resolvedTs: resolved,
+		body:       data,
+	})
+	if err != nil {
+		return err
+	}
+
+	sp.inFlight.Add(1)
+	defer sp.inFlight.Done()
+	defer sp.metrics.recordResolvedCallback()()
+	return sp.sendWithRetries(encoded, 1)
+}
+
+// startRowWorker creates a rowWorker which handles aggregating individual
+// messages into batches which can be forwarded to a separate batchWorker to be
+// emitted to the sink.
+func (sp *sinkProcessor) startRowWorker(workerIndex int) error {
+	// currentBatch tracks the current aggregation of messages prior to flush
+	currentBatch := newMessageBatch()
+
+	// TODO(samiskin): Investigate different numbers for this buffer size, this
+	// number is just re-using the value from sink_cloudstorage
+	batchCh := make(chan batchWorkerMessage, 256)
+	defer close(batchCh)
+
+	flushBatch := func() {
+		if currentBatch.isEmpty() {
+			return
+		}
+
+		// Reuse the same batch to avoid need for garbage collection
+		defer currentBatch.reset()
+
+		// Process messages into a payload ready to be emitted to the sink
+		sinkPayload, err := sp.sink.EncodeBatch(currentBatch.buffer)
+		if err != nil {
+			defer sp.inFlight.Add(-len(currentBatch.buffer))
+			sp.handleError(err)
+			return
+		}
+
+		// Send the encoded batch to a separate worker so that flushes do not block
+		// further message aggregation
+		batchCh <- batchWorkerMessage{
+			sinkPayload: sinkPayload,
+			alloc:       currentBatch.alloc,
+			numMessages: len(currentBatch.buffer),
+			mvcc:        currentBatch.mvcc,
+			kvBytes:     currentBatch.bufferBytes,
+		}
+	}
+
+	// Start a worker to handle sending / retrying sink payloads
+	sp.workerGroup.GoCtx(func(ctx context.Context) error {
+		sp.startBatchWorker(batchCh)
+		return nil
+	})
+
+	flushTimer := sp.timeSource.NewTimer()
+
+	for {
+		select {
+		case msg, ok := <-sp.eventChans[workerIndex]:
+			if !ok {
+				flushBatch() // Ensure all batched messages are handled prior to exit.
+				return nil
+			}
+
+			// If we're closing, allow all messages in the channel to drain out to
+			// ensure that inFlight is correctly reset.
+			if atomic.LoadInt32(&sp.closing) != 0 {
+				sp.inFlight.Done()
+				continue
+			}
+
+			// If the batch is about to no longer be empty, start the flush timer
+			if currentBatch.isEmpty() && time.Duration(sp.flushCfg.Frequency) > 0 {
+				flushTimer.Reset(time.Duration(sp.flushCfg.Frequency))
+			}
+			currentBatch.moveIntoBuffer(msg, sp.keyInValue)
+
+			if sp.shouldFlushBatch(currentBatch) {
+				sp.metrics.recordSizeBasedFlush()
+				flushBatch()
+			}
+		case <-flushTimer.Ch():
+			flushTimer.MarkRead()
+			flushBatch()
+		}
+	}
+}
+
+func (sp *sinkProcessor) shouldFlushBatch(batch messageBatch) bool {
+	switch {
+	// all zero values is interpreted as flush every time
+	case sp.flushCfg.Messages == 0 && sp.flushCfg.Bytes == 0 && sp.flushCfg.Frequency == 0:
+		return true
+	// messages threshold has been reached
+	case sp.flushCfg.Messages > 0 && len(batch.buffer) >= sp.flushCfg.Messages:
+		return true
+	// bytes threshold has been reached
+	case sp.flushCfg.Bytes > 0 && batch.bufferBytes >= sp.flushCfg.Bytes:
+		return true
+	default:
+		return false
+	}
+}
+
+type batchWorkerMessage struct {
+	sinkPayload SinkPayload
+	numMessages int
+	mvcc        hlc.Timestamp
+	alloc       kvevent.Alloc
+	kvBytes     int
+}
+
+// startBatchWorker creates a batchWorker which handles sending batches of
+// messages to the external sink, attempting to retry if needed.
+func (sp *sinkProcessor) startBatchWorker(batchCh chan batchWorkerMessage) {
+	// Batch handling is in its own function to ensure that sp.inFlight.Done is
+	// always called even on error/drain cases.
+	handleBatch := func(batch batchWorkerMessage) {
+		defer sp.inFlight.Add(-batch.numMessages)
+
+		if atomic.LoadInt32(&sp.closing) != 0 {
+			return
+		}
+
+		defer sp.metrics.recordFlushRequestCallback()()
+		err := sp.sendWithRetries(batch.sinkPayload, batch.numMessages)
+		if err != nil {
+			sp.handleError(err)
+			return
+		}
+
+		emitTime := timeutil.Now()
+		sp.metrics.recordEmittedBatch(
+			emitTime, batch.numMessages, batch.mvcc, batch.kvBytes, sinkDoesNotCompress)
+
+		batch.alloc.Release(sp.ctx)
+	}
+
+	for batch := range batchCh {
+		handleBatch(batch)
+	}
+}
+
+func (sp *sinkProcessor) sendWithRetries(payload SinkPayload, numMessages int) error {
+	initialSend := true
+	return retry.WithMaxAttempts(sp.ctx, sp.retryOpts, sp.retryOpts.MaxRetries+1, func() error {
+		if !initialSend {
+			sp.metrics.recordInternalRetry(int64(numMessages), false)
+		}
+		err := sp.sink.EmitPayload(payload)
+		initialSend = false
+		return err
+	})
+}
+
+func (sp *sinkProcessor) Flush(ctx context.Context) error {
+	sp.inFlight.Wait()
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	if sp.mu.closeErr != nil {
+		return sp.mu.closeErr
+	}
+	return nil
+}
+
+func (sp *sinkProcessor) handleError(err error) {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	sp.mu.closeErr = err
+	atomic.StoreInt32(&sp.closing, 1)
+}
+
+func (sp *sinkProcessor) Close() error {
+	atomic.StoreInt32(&sp.closing, 1)
+	for _, eventCh := range sp.eventChans {
+		close(eventCh)
+	}
+	_ = sp.workerGroup.Wait()
+	return sp.sink.Close()
+}
+
+type messageBatch struct {
+	buffer      []MessagePayload
+	bufferBytes int
+	alloc       kvevent.Alloc
+	mvcc        hlc.Timestamp
+}
+
+func newMessageBatch() messageBatch {
+	return messageBatch{
+		buffer:      make([]MessagePayload, 0),
+		bufferBytes: 0,
+	}
+}
+
+func (mb *messageBatch) isEmpty() bool {
+	return len(mb.buffer) == 0
+}
+
+func (mb *messageBatch) reset() {
+	mb.buffer = mb.buffer[:0]
+	mb.bufferBytes = 0
+	mb.alloc = kvevent.Alloc{}
+}
+
+func (mb *messageBatch) moveIntoBuffer(p rowWorkerPayload, keyInValue bool) {
+	mb.buffer = append(mb.buffer, p.msg)
+	mb.bufferBytes += len(p.msg.val)
+
+	// Don't double-count the key bytes if the key is included in the value
+	if !keyInValue {
+		mb.bufferBytes += len(p.msg.key)
+	}
+
+	if mb.mvcc.IsEmpty() || p.mvcc.Less(mb.mvcc) {
+		mb.mvcc = p.mvcc
+	}
+
+	mb.alloc.Merge(&p.alloc)
+}
+
+func validateBatchConfig(cfg batchConfig) error {
+	if cfg.Messages < 0 || cfg.Bytes < 0 || cfg.Frequency < 0 {
+		return errors.Errorf("invalid flush configuration: all values must be non-negative")
+	}
+	if (cfg.Messages > 0 || cfg.Bytes > 0) && cfg.Frequency == 0 {
+		return errors.Errorf("invalid flush configuration: frequency is not set, messages may never be sent")
+	}
+	return nil
+}

--- a/pkg/ccl/changefeedccl/sink_webhook.go
+++ b/pkg/ccl/changefeedccl/sink_webhook.go
@@ -15,7 +15,6 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"hash/crc32"
 	"io"
 	"math"
 	"net"
@@ -26,12 +25,8 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
-	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvevent"
-	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
-	"github.com/cockroachdb/cockroach/pkg/util/system"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
@@ -52,220 +47,7 @@ func isWebhookSink(u *url.URL) bool {
 	}
 }
 
-type webhookSink struct {
-	// Webhook configuration.
-	parallelism int
-	retryCfg    retry.Options
-	batchCfg    batchConfig
-	ts          timeutil.TimeSource
-	format      changefeedbase.FormatType
-
-	// Webhook destination.
-	url        sinkURL
-	authHeader string
-	client     *httputil.Client
-
-	// messages are written onto batch channel
-	// which batches matches based on batching configuration.
-	batchChan chan webhookMessage
-
-	// flushDone channel signaled when flushing completes.
-	flushDone chan struct{}
-
-	// errChan is written to indicate an error while sending message.
-	errChan chan error
-
-	// parallelism workers are created and controlled by the workerGroup, running with workerCtx.
-	// each worker gets its own events channel.
-	workerCtx   context.Context
-	workerGroup ctxgroup.Group
-	exitWorkers func() // Signaled to shut down all workers.
-	eventsChans []chan []messagePayload
-	metrics     metricsRecorder
-}
-
-type webhookSinkPayload struct {
-	Payload []json.RawMessage `json:"payload"`
-	Length  int               `json:"length"`
-}
-
-type encodedPayload struct {
-	data     []byte
-	alloc    kvevent.Alloc
-	emitTime time.Time
-	mvcc     hlc.Timestamp
-}
-
-func encodePayloadJSONWebhook(messages []messagePayload) (encodedPayload, error) {
-	result := encodedPayload{
-		emitTime: timeutil.Now(),
-	}
-
-	payload := make([]json.RawMessage, len(messages))
-	for i, m := range messages {
-		result.alloc.Merge(&m.alloc)
-		payload[i] = m.val
-		if m.emitTime.Before(result.emitTime) {
-			result.emitTime = m.emitTime
-		}
-		if result.mvcc.IsEmpty() || m.mvcc.Less(result.mvcc) {
-			result.mvcc = m.mvcc
-		}
-	}
-
-	body := &webhookSinkPayload{
-		Payload: payload,
-		Length:  len(payload),
-	}
-	j, err := json.Marshal(body)
-	if err != nil {
-		return encodedPayload{}, err
-	}
-	result.data = j
-	return result, err
-}
-
-func encodePayloadCSVWebhook(messages []messagePayload) (encodedPayload, error) {
-	result := encodedPayload{
-		emitTime: timeutil.Now(),
-	}
-
-	var mergedMsgs []byte
-	for _, m := range messages {
-		result.alloc.Merge(&m.alloc)
-		mergedMsgs = append(mergedMsgs, m.val...)
-		if m.emitTime.Before(result.emitTime) {
-			result.emitTime = m.emitTime
-		}
-		if result.mvcc.IsEmpty() || m.mvcc.Less(result.mvcc) {
-			result.mvcc = m.mvcc
-		}
-	}
-
-	result.data = mergedMsgs
-	return result, nil
-}
-
-type messagePayload struct {
-	// Payload message fields.
-	key      []byte
-	val      []byte
-	alloc    kvevent.Alloc
-	emitTime time.Time
-	mvcc     hlc.Timestamp
-}
-
-// webhookMessage contains either messagePayload or a flush request.
-type webhookMessage struct {
-	flushDone *chan struct{}
-	payload   messagePayload
-}
-
-type batch struct {
-	buffer      []messagePayload
-	bufferBytes int
-}
-
-func (b *batch) addToBuffer(m messagePayload) {
-	b.bufferBytes += len(m.val)
-	b.buffer = append(b.buffer, m)
-}
-
-func (b *batch) reset() {
-	b.buffer = b.buffer[:0]
-	b.bufferBytes = 0
-}
-
-type batchConfig struct {
-	Bytes, Messages int          `json:",omitempty"`
-	Frequency       jsonDuration `json:",omitempty"`
-}
-
-type jsonMaxRetries int
-
-func (j *jsonMaxRetries) UnmarshalJSON(b []byte) error {
-	var i int64
-	// try to parse as int
-	i, err := strconv.ParseInt(string(b), 10, 64)
-	if err == nil {
-		if i <= 0 {
-			return errors.Errorf("max retry count must be a positive integer. use 'inf' for infinite retries.")
-		}
-		*j = jsonMaxRetries(i)
-	} else {
-		// if that fails, try to parse as string (only accept 'inf')
-		var s string
-		// using unmarshal here to remove quotes around the string
-		if err := json.Unmarshal(b, &s); err != nil {
-			return err
-		}
-		if strings.ToLower(s) == "inf" {
-			// if used wants infinite retries, set to zero as retry.Options interprets this as infinity
-			*j = 0
-		} else if n, err := strconv.Atoi(s); err == nil { // also accept ints as strings
-			*j = jsonMaxRetries(n)
-		} else {
-			return errors.Errorf("max retries must be either a positive int or 'inf' for infinite retries.")
-		}
-	}
-	return nil
-}
-
-// wrapper structs to unmarshal json, retry.Options will be the actual config
-type retryConfig struct {
-	Max     jsonMaxRetries `json:",omitempty"`
-	Backoff jsonDuration   `json:",omitempty"`
-}
-
-// proper JSON schema for webhook sink config:
-//
-//	{
-//	  "Flush": {
-//		   "Messages":  ...,
-//		   "Bytes":     ...,
-//		   "Frequency": ...,
-//	  },
-//		 "Retry": {
-//		   "Max":     ...,
-//		   "Backoff": ...,
-//	  }
-//	}
-type webhookSinkConfig struct {
-	Flush batchConfig `json:",omitempty"`
-	Retry retryConfig `json:",omitempty"`
-}
-
-func (s *webhookSink) getWebhookSinkConfig(
-	jsonStr changefeedbase.SinkSpecificJSONConfig,
-) (batchCfg batchConfig, retryCfg retry.Options, err error) {
-	retryCfg = defaultRetryConfig()
-
-	var cfg webhookSinkConfig
-	cfg.Retry.Max = jsonMaxRetries(retryCfg.MaxRetries)
-	cfg.Retry.Backoff = jsonDuration(retryCfg.InitialBackoff)
-	if jsonStr != `` {
-		// set retry defaults to be overridden if included in JSON
-		if err = json.Unmarshal([]byte(jsonStr), &cfg); err != nil {
-			return batchCfg, retryCfg, errors.Wrapf(err, "error unmarshalling json")
-		}
-	}
-
-	// don't support negative values
-	if cfg.Flush.Messages < 0 || cfg.Flush.Bytes < 0 || cfg.Flush.Frequency < 0 ||
-		cfg.Retry.Max < 0 || cfg.Retry.Backoff < 0 {
-		return batchCfg, retryCfg, errors.Errorf("invalid option value %s, all config values must be non-negative", changefeedbase.OptWebhookSinkConfig)
-	}
-
-	// errors if other batch values are set, but frequency is not
-	if (cfg.Flush.Messages > 0 || cfg.Flush.Bytes > 0) && cfg.Flush.Frequency == 0 {
-		return batchCfg, retryCfg, errors.Errorf("invalid option value %s, flush frequency is not set, messages may never be sent", changefeedbase.OptWebhookSinkConfig)
-	}
-
-	retryCfg.MaxRetries = int(cfg.Retry.Max)
-	retryCfg.InitialBackoff = time.Duration(cfg.Retry.Backoff)
-	return cfg.Flush, retryCfg, nil
-}
-
+// The webhook sink uses sinkProcessor with its SinkPayload being HTTP requests
 func makeWebhookSink(
 	ctx context.Context,
 	u sinkURL,
@@ -275,58 +57,62 @@ func makeWebhookSink(
 	source timeutil.TimeSource,
 	mb metricsRecorderBuilder,
 ) (Sink, error) {
-	if u.Scheme != changefeedbase.SinkSchemeWebhookHTTPS {
-		return nil, errors.Errorf(`this sink requires %s`, changefeedbase.SinkSchemeHTTPS)
+	thinSink, err := makeWebhookThinSink(ctx, u, encodingOpts, opts)
+	if err != nil {
+		return nil, err
 	}
+
+	cfg := sinkProcessorConfig{
+		numWorkers: parallelism,
+		timeSource: source,
+		keyInValue: true,
+	}
+
+	cfg.flushCfg, cfg.retryOpts, err = getWebhookSinkConfig(opts.JSONConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	sp, err := makeSinkProcessor(context.Background(), thinSink, cfg, mb)
+	if err != nil {
+		return nil, err
+	}
+	return sp, nil
+}
+
+type webhookThinSink struct {
+	ctx        context.Context
+	format     changefeedbase.FormatType
+	url        sinkURL
+	authHeader string
+	client     *httputil.Client
+}
+
+var _ ThinSink = (*webhookThinSink)(nil)
+
+func makeWebhookThinSink(
+	ctx context.Context,
+	u sinkURL,
+	encodingOpts changefeedbase.EncodingOptions,
+	opts changefeedbase.WebhookSinkOptions,
+) (ThinSink, error) {
+	err := validateWebhookOpts(u, encodingOpts, opts)
+	if err != nil {
+		return nil, err
+	}
+
 	u.Scheme = strings.TrimPrefix(u.Scheme, `webhook-`)
 
-	switch encodingOpts.Format {
-	case changefeedbase.OptFormatJSON:
-	case changefeedbase.OptFormatCSV:
-	default:
-		return nil, errors.Errorf(`this sink is incompatible with %s=%s`,
-			changefeedbase.OptFormat, encodingOpts.Format)
-	}
-
-	switch encodingOpts.Envelope {
-	case changefeedbase.OptEnvelopeWrapped, changefeedbase.OptEnvelopeBare:
-	default:
-		return nil, errors.Errorf(`this sink is incompatible with %s=%s`,
-			changefeedbase.OptEnvelope, encodingOpts.Envelope)
-	}
-
-	if encodingOpts.Envelope != changefeedbase.OptEnvelopeBare && !encodingOpts.KeyInValue {
-		return nil, errors.Errorf(`this sink requires the WITH %s option`, changefeedbase.OptKeyInValue)
-	}
-
-	if !encodingOpts.TopicInValue {
-		return nil, errors.Errorf(`this sink requires the WITH %s option`, changefeedbase.OptTopicInValue)
+	sink := &webhookThinSink{
+		ctx:        ctx,
+		authHeader: opts.AuthHeader,
+		format:     encodingOpts.Format,
 	}
 
 	var connTimeout time.Duration
 	if opts.ClientTimeout != nil {
 		connTimeout = *opts.ClientTimeout
 	}
-
-	ctx, cancel := context.WithCancel(ctx)
-
-	sink := &webhookSink{
-		workerCtx:   ctx,
-		authHeader:  opts.AuthHeader,
-		exitWorkers: cancel,
-		parallelism: parallelism,
-		ts:          source,
-		metrics:     mb(requiresResourceAccounting),
-		format:      encodingOpts.Format,
-	}
-
-	var err error
-	sink.batchCfg, sink.retryCfg, err = sink.getWebhookSinkConfig(opts.JSONConfig)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error processing option %s", changefeedbase.OptWebhookSinkConfig)
-	}
-
-	// TODO(yevgeniy): Establish HTTP connection in Dial().
 	sink.client, err = makeWebhookClient(u, connTimeout)
 	if err != nil {
 		return nil, err
@@ -353,7 +139,12 @@ func makeWebhookClient(u sinkURL, timeout time.Duration) (*httputil.Client, erro
 		Client: &http.Client{
 			Timeout: timeout,
 			Transport: &http.Transport{
-				DialContext: (&net.Dialer{Timeout: timeout}).DialContext,
+				DialContext:     (&net.Dialer{Timeout: timeout}).DialContext,
+				IdleConnTimeout: 90 * time.Second, // taken from DefaultTransport
+
+				// Raising this value to 200 makes little difference while reducing it
+				// to 50 results in an ~8% reduction in throughput.
+				MaxIdleConnsPerHost: 100,
 			},
 		},
 	}
@@ -415,227 +206,82 @@ func makeWebhookClient(u sinkURL, timeout time.Duration) (*httputil.Client, erro
 	return client, nil
 }
 
-func defaultRetryConfig() retry.Options {
-	opts := retry.Options{
-		InitialBackoff: 500 * time.Millisecond,
-		MaxRetries:     3,
-		Multiplier:     2,
-	}
-	// max backoff should be initial * 2 ^ maxRetries
-	opts.MaxBackoff = opts.InitialBackoff * time.Duration(int(math.Pow(2.0, float64(opts.MaxRetries))))
-	return opts
-}
-
-// defaultWorkerCount() is the number of CPU's on the machine
-func defaultWorkerCount() int {
-	return system.NumCPU()
-}
-
-func (s *webhookSink) Dial() error {
-	s.setupWorkers()
-	return nil
-}
-
-func (s *webhookSink) setupWorkers() {
-	// setup events channels to send to workers and the worker group
-	s.eventsChans = make([]chan []messagePayload, s.parallelism)
-	s.workerGroup = ctxgroup.WithContext(s.workerCtx)
-	s.batchChan = make(chan webhookMessage)
-
-	// an error channel with buffer for the first error.
-	s.errChan = make(chan error, 1)
-
-	// flushDone notified when flush completes.
-	s.flushDone = make(chan struct{})
-
-	s.workerGroup.GoCtx(func(ctx context.Context) error {
-		s.batchWorker()
-		return nil
-	})
-	for i := 0; i < s.parallelism; i++ {
-		s.eventsChans[i] = make(chan []messagePayload)
-		j := i
-		s.workerGroup.GoCtx(func(ctx context.Context) error {
-			s.workerLoop(j)
-			return nil
-		})
-	}
-}
-
-func (s *webhookSink) shouldSendBatch(b batch) bool {
-	// similar to sarama, send batch if:
-	// everything is zero (default)
-	// any one of the conditions are met UNLESS the condition is zero which means never batch
-	switch {
-	// all zero values should batch every time, otherwise batch will wait forever
-	case s.batchCfg.Messages == 0 && s.batchCfg.Bytes == 0 && s.batchCfg.Frequency == 0:
-		return true
-	// messages threshold has been reached
-	case s.batchCfg.Messages > 0 && len(b.buffer) >= s.batchCfg.Messages:
-		return true
-	// bytes threshold has been reached
-	case s.batchCfg.Bytes > 0 && b.bufferBytes >= s.batchCfg.Bytes:
-		return true
-	default:
-		return false
-	}
-}
-
-func (s *webhookSink) splitAndSendBatch(batch []messagePayload) error {
-	workerBatches := make([][]messagePayload, s.parallelism)
-	for _, msg := range batch {
-		// split batch into per-worker batches
-		i := s.workerIndex(msg.key)
-		workerBatches[i] = append(workerBatches[i], msg)
-	}
-	for i, workerBatch := range workerBatches {
-		// don't send empty batches
-		if len(workerBatch) > 0 {
-			select {
-			case <-s.workerCtx.Done():
-				return s.workerCtx.Err()
-			case s.eventsChans[i] <- workerBatch:
-			}
-		}
-	}
-	return nil
-}
-
-// flushWorkers sends flush request to each worker and waits for each one to acknowledge.
-func (s *webhookSink) flushWorkers(done chan struct{}) error {
-	for i := 0; i < len(s.eventsChans); i++ {
-		// Ability to write a nil message to events channel indicates that
-		// the worker has processed all other messages.
-		select {
-		case <-s.workerCtx.Done():
-			return s.workerCtx.Err()
-		case s.eventsChans[i] <- nil:
-		}
-	}
-
-	select {
-	case <-s.workerCtx.Done():
-		return s.workerCtx.Err()
-	case done <- struct{}{}:
-		return nil
-	}
-}
-
-// batchWorker ingests messages from EmitRow into a batch and splits them into
-// per-worker batches to be sent separately
-func (s *webhookSink) batchWorker() {
-	var batchTracker batch
-	batchTimer := s.ts.NewTimer()
-	defer batchTimer.Stop()
-
-	for {
-		select {
-		case <-s.workerCtx.Done():
-			return
-		case msg := <-s.batchChan:
-			flushRequested := msg.flushDone != nil
-
-			if !flushRequested {
-				batchTracker.addToBuffer(msg.payload)
-			}
-
-			if s.shouldSendBatch(batchTracker) || flushRequested {
-				if err := s.splitAndSendBatch(batchTracker.buffer); err != nil {
-					s.exitWorkersWithError(err)
-					return
-				}
-				batchTracker.reset()
-
-				if flushRequested {
-					if err := s.flushWorkers(*msg.flushDone); err != nil {
-						s.exitWorkersWithError(err)
-						return
-					}
-				}
-			} else {
-				if len(batchTracker.buffer) == 1 && time.Duration(s.batchCfg.Frequency) > 0 {
-					// only start timer when first message appears
-					batchTimer.Reset(time.Duration(s.batchCfg.Frequency))
-				}
-			}
-		// check the channel for time expiry. the batch should have at least one
-		// message in it. If it doesn't, the timer has been carried over from a
-		// previous batch, and the new batch will be empty so it won't send. If
-		// the new batch has at least one element, the timer will be reset so it'll
-		// be updated.
-		case <-batchTimer.Ch():
-			batchTimer.MarkRead()
-			if len(batchTracker.buffer) > 0 {
-				if err := s.splitAndSendBatch(batchTracker.buffer); err != nil {
-					s.exitWorkersWithError(err)
-					return
-				}
-				batchTracker.reset()
-			}
-		}
-	}
-}
-
-func (s *webhookSink) workerLoop(workerIndex int) {
-	for {
-		select {
-		case <-s.workerCtx.Done():
-			return
-		case msgs := <-s.eventsChans[workerIndex]:
-			if msgs == nil {
-				// It's a flush request: if we read it, it means all outstanding
-				// requests for this worker have been completed.
-				continue
-			}
-
-			var encoded encodedPayload
-			var err error
-			switch s.format {
-			case changefeedbase.OptFormatJSON:
-				encoded, err = encodePayloadJSONWebhook(msgs)
-			case changefeedbase.OptFormatCSV:
-				encoded, err = encodePayloadCSVWebhook(msgs)
-			}
-			if err != nil {
-				s.exitWorkersWithError(err)
-				return
-			}
-			if err := s.sendMessageWithRetries(s.workerCtx, encoded.data); err != nil {
-				s.exitWorkersWithError(err)
-				return
-			}
-			encoded.alloc.Release(s.workerCtx)
-			s.metrics.recordEmittedBatch(
-				encoded.emitTime, len(msgs), encoded.mvcc, len(encoded.data), sinkDoesNotCompress)
-		}
-	}
-}
-
-func (s *webhookSink) sendMessageWithRetries(ctx context.Context, reqBody []byte) error {
-	requestFunc := func() error {
-		return s.sendMessage(ctx, reqBody)
-	}
-	return retry.WithMaxAttempts(ctx, s.retryCfg, s.retryCfg.MaxRetries+1, requestFunc)
-}
-
-func (s *webhookSink) sendMessage(ctx context.Context, reqBody []byte) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.url.String(), bytes.NewReader(reqBody))
+func (ws *webhookThinSink) makePayloadForBytes(body []byte) (SinkPayload, error) {
+	req, err := http.NewRequestWithContext(ws.ctx, http.MethodPost, ws.url.String(), bytes.NewReader(body))
 	if err != nil {
-		return err
+		return nil, err
 	}
-	switch s.format {
+	switch ws.format {
 	case changefeedbase.OptFormatJSON:
 		req.Header.Set("Content-Type", applicationTypeJSON)
 	case changefeedbase.OptFormatCSV:
 		req.Header.Set("Content-Type", applicationTypeCSV)
 	}
 
-	if s.authHeader != "" {
-		req.Header.Set(authorizationHeader, s.authHeader)
+	if ws.authHeader != "" {
+		req.Header.Set(authorizationHeader, ws.authHeader)
 	}
 
-	var res *http.Response
-	res, err = s.client.Do(req)
+	return req, nil
+}
+
+func (ws *webhookThinSink) EncodeBatch(batch []MessagePayload) (SinkPayload, error) {
+	var reqBody []byte
+	var err error
+
+	switch ws.format {
+	case changefeedbase.OptFormatJSON:
+		reqBody, err = encodeWebhookMsgJSON(batch)
+	case changefeedbase.OptFormatCSV:
+		reqBody, err = encodeWebhookMsgCSV(batch)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return ws.makePayloadForBytes(reqBody)
+}
+
+type webhookJsonEvent struct {
+	Payload []json.RawMessage `json:"payload"`
+	Length  int               `json:"length"`
+}
+
+func encodeWebhookMsgJSON(messages []MessagePayload) ([]byte, error) {
+	payload := make([]json.RawMessage, len(messages))
+	for i, m := range messages {
+		payload[i] = m.val
+	}
+
+	body := &webhookJsonEvent{
+		Payload: payload,
+		Length:  len(payload),
+	}
+	j, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	return j, err
+}
+
+func encodeWebhookMsgCSV(messages []MessagePayload) ([]byte, error) {
+	var mergedMsgs []byte
+	for _, m := range messages {
+		mergedMsgs = append(mergedMsgs, m.val...)
+	}
+	return mergedMsgs, nil
+}
+
+func (ws *webhookThinSink) EncodeResolvedMessage(
+	payload ResolvedMessagePayload,
+) (SinkPayload, error) {
+	return ws.makePayloadForBytes(payload.body)
+}
+
+func (ws *webhookThinSink) EmitPayload(batch SinkPayload) error {
+	req := batch.(*http.Request)
+	res, err := ws.client.Do(req)
 	if err != nil {
 		return err
 	}
@@ -651,130 +297,141 @@ func (s *webhookSink) sendMessage(ctx context.Context, reqBody []byte) error {
 	return nil
 }
 
-// workerIndex assigns rows each to a worker goroutine based on the hash of its
-// primary key. This is to ensure that each message with the same key gets
-// deterministically assigned to the same worker. Since we have a channel per
-// worker, we can ensure per-worker ordering and therefore guarantee per-key
-// ordering.
-func (s *webhookSink) workerIndex(key []byte) uint32 {
-	return crc32.ChecksumIEEE(key) % uint32(s.parallelism)
+func (ws *webhookThinSink) Close() error {
+	ws.client.CloseIdleConnections()
+	return nil
 }
 
-// exitWorkersWithError saves the first error message encountered by webhook workers,
-// and requests all workers to terminate.
-func (s *webhookSink) exitWorkersWithError(err error) {
-	// errChan has buffer size 1, first error will be saved to the buffer and
-	// subsequent errors will be ignored
-	select {
-	case s.errChan <- err:
-		s.exitWorkers()
-	default:
+func getWebhookSinkConfig(
+	jsonStr changefeedbase.SinkSpecificJSONConfig,
+) (batchCfg batchConfig, retryCfg retry.Options, err error) {
+	retryCfg = defaultRetryConfig()
+
+	var cfg webhookSinkConfig
+	cfg.Retry.Max = jsonMaxRetries(retryCfg.MaxRetries)
+	cfg.Retry.Backoff = jsonDuration(retryCfg.InitialBackoff)
+	if jsonStr != `` {
+		// set retry defaults to be overridden if included in JSON
+		if err = json.Unmarshal([]byte(jsonStr), &cfg); err != nil {
+			return batchCfg, retryCfg, errors.Wrapf(err, "error unmarshalling json")
+		}
 	}
-}
 
-// sinkError checks to see if any errors occurred inside workers go routines.
-func (s *webhookSink) sinkError() error {
-	select {
-	case err := <-s.errChan:
-		return err
-	default:
-		return nil
+	// don't support negative values
+	if cfg.Flush.Messages < 0 || cfg.Flush.Bytes < 0 || cfg.Flush.Frequency < 0 ||
+		cfg.Retry.Max < 0 || cfg.Retry.Backoff < 0 {
+		return batchCfg, retryCfg, errors.Errorf("invalid option value %s, all config values must be non-negative", changefeedbase.OptWebhookSinkConfig)
 	}
+
+	// errors if other batch values are set, but frequency is not
+	if (cfg.Flush.Messages > 0 || cfg.Flush.Bytes > 0) && cfg.Flush.Frequency == 0 {
+		return batchCfg, retryCfg, errors.Errorf("invalid option value %s, flush frequency is not set, messages may never be sent", changefeedbase.OptWebhookSinkConfig)
+	}
+
+	retryCfg.MaxRetries = int(cfg.Retry.Max)
+	retryCfg.InitialBackoff = time.Duration(cfg.Retry.Backoff)
+	return cfg.Flush, retryCfg, nil
 }
 
-func (s *webhookSink) EmitRow(
-	ctx context.Context,
-	topic TopicDescriptor,
-	key, value []byte,
-	updated, mvcc hlc.Timestamp,
-	alloc kvevent.Alloc,
+func validateWebhookOpts(
+	u sinkURL, encodingOpts changefeedbase.EncodingOptions, opts changefeedbase.WebhookSinkOptions,
 ) error {
-	select {
-	// check the webhook sink context in case workers have been terminated
-	case <-s.workerCtx.Done():
-		// check again for error in case it triggered since last check
-		// will return more verbose error instead of "context canceled"
-		return errors.CombineErrors(s.workerCtx.Err(), s.sinkError())
-	case <-ctx.Done():
-		return ctx.Err()
-	case err := <-s.errChan:
-		return err
-	case s.batchChan <- webhookMessage{
-		payload: messagePayload{
-			key:      key,
-			val:      value,
-			alloc:    alloc,
-			emitTime: timeutil.Now(),
-			mvcc:     mvcc,
-		}}:
-		s.metrics.recordMessageSize(int64(len(key) + len(value)))
-	}
-	return nil
-}
-
-func (s *webhookSink) EmitResolvedTimestamp(
-	ctx context.Context, encoder Encoder, resolved hlc.Timestamp,
-) error {
-	defer s.metrics.recordResolvedCallback()()
-
-	payload, err := encoder.EncodeResolvedTimestamp(ctx, "", resolved)
-	if err != nil {
-		return err
+	if u.Scheme != changefeedbase.SinkSchemeWebhookHTTPS {
+		return errors.Errorf(`this sink requires %s`, changefeedbase.SinkSchemeHTTPS)
 	}
 
-	select {
-	// check the webhook sink context in case workers have been terminated
-	case <-s.workerCtx.Done():
-		return s.workerCtx.Err()
-	// non-blocking check for error, restart changefeed if encountered
-	case <-s.errChan:
-		return err
+	switch encodingOpts.Format {
+	case changefeedbase.OptFormatJSON:
+	case changefeedbase.OptFormatCSV:
 	default:
+		return errors.Errorf(`this sink is incompatible with %s=%s`,
+			changefeedbase.OptFormat, encodingOpts.Format)
 	}
 
-	// do worker logic directly here instead (there's no point using workers for
-	// resolved timestamps since there are no keys and everything must be
-	// in order)
-	if err := s.sendMessageWithRetries(ctx, payload); err != nil {
-		s.exitWorkersWithError(err)
-		return err
+	switch encodingOpts.Envelope {
+	case changefeedbase.OptEnvelopeWrapped, changefeedbase.OptEnvelopeBare:
+	default:
+		return errors.Errorf(`this sink is incompatible with %s=%s`,
+			changefeedbase.OptEnvelope, encodingOpts.Envelope)
+	}
+
+	if encodingOpts.Envelope != changefeedbase.OptEnvelopeBare && !encodingOpts.KeyInValue {
+		return errors.Errorf(`this sink requires the WITH %s option`, changefeedbase.OptKeyInValue)
+	}
+
+	if !encodingOpts.TopicInValue {
+		return errors.Errorf(`this sink requires the WITH %s option`, changefeedbase.OptTopicInValue)
 	}
 
 	return nil
 }
 
-func (s *webhookSink) Flush(ctx context.Context) error {
-	s.metrics.recordFlushRequestCallback()()
-
-	// Send flush request.
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case err := <-s.errChan:
-		return err
-	case s.batchChan <- webhookMessage{flushDone: &s.flushDone}:
-	}
-
-	// Wait for flush completion -- or an error.
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case err := <-s.errChan:
-		return err
-	case <-s.flushDone:
-		return s.sinkError()
-	}
+type batchConfig struct {
+	Bytes, Messages int          `json:",omitempty"`
+	Frequency       jsonDuration `json:",omitempty"`
 }
 
-func (s *webhookSink) Close() error {
-	s.exitWorkers()
-	// ignore errors here since we're closing the sink anyway
-	_ = s.workerGroup.Wait()
-	close(s.batchChan)
-	close(s.errChan)
-	for _, eventsChan := range s.eventsChans {
-		close(eventsChan)
+type jsonMaxRetries int
+
+func (j *jsonMaxRetries) UnmarshalJSON(b []byte) error {
+	var i int64
+	// try to parse as int
+	i, err := strconv.ParseInt(string(b), 10, 64)
+	if err == nil {
+		if i <= 0 {
+			return errors.Errorf("max retry count must be a positive integer. use 'inf' for infinite retries.")
+		}
+		*j = jsonMaxRetries(i)
+	} else {
+		// if that fails, try to parse as string (only accept 'inf')
+		var s string
+		// using unmarshal here to remove quotes around the string
+		if err := json.Unmarshal(b, &s); err != nil {
+			return err
+		}
+		if strings.ToLower(s) == "inf" {
+			// if used wants infinite retries, set to zero as retry.Options interprets this as infinity
+			*j = 0
+		} else if n, err := strconv.Atoi(s); err == nil { // also accept ints as strings
+			*j = jsonMaxRetries(n)
+		} else {
+			return errors.Errorf("max retries must be either a positive int or 'inf' for infinite retries.")
+		}
 	}
-	s.client.CloseIdleConnections()
 	return nil
+}
+
+// wrapper structs to unmarshal json, retry.Options will be the actual config
+type retryConfig struct {
+	Max     jsonMaxRetries `json:",omitempty"`
+	Backoff jsonDuration   `json:",omitempty"`
+}
+
+// proper JSON schema for webhook sink config:
+//
+//	{
+//	  "Flush": {
+//		   "Messages":  ...,
+//		   "Bytes":     ...,
+//		   "Frequency": ...,
+//	  },
+//		 "Retry": {
+//		   "Max":     ...,
+//		   "Backoff": ...,
+//	  }
+//	}
+type webhookSinkConfig struct {
+	Flush batchConfig `json:",omitempty"`
+	Retry retryConfig `json:",omitempty"`
+}
+
+func defaultRetryConfig() retry.Options {
+	opts := retry.Options{
+		InitialBackoff: 500 * time.Millisecond,
+		MaxRetries:     3,
+		Multiplier:     2,
+	}
+	// max backoff should be initial * 2 ^ maxRetries
+	opts.MaxBackoff = opts.InitialBackoff * time.Duration(int(math.Pow(2.0, float64(opts.MaxRetries))))
+	return opts
 }

--- a/pkg/ccl/changefeedccl/sink_webhook_test.go
+++ b/pkg/ccl/changefeedccl/sink_webhook_test.go
@@ -172,8 +172,7 @@ func TestWebhookSink(t *testing.T) {
 		require.NoError(t, sinkSrcNoCert.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, zeroAlloc))
 
 		require.Regexp(t, "x509", sinkSrcNoCert.Flush(context.Background()))
-		require.EqualError(t, sinkSrcNoCert.EmitRow(context.Background(), nil, nil, nil, zeroTS, zeroTS, zeroAlloc),
-			`context canceled`)
+		require.Regexp(t, "x509", sinkSrcNoCert.EmitRow(context.Background(), nil, nil, nil, zeroTS, zeroTS, zeroAlloc))
 
 		params.Set(changefeedbase.SinkParamSkipTLSVerify, "true")
 		sinkDestHost.RawQuery = params.Encode()
@@ -191,8 +190,8 @@ func TestWebhookSink(t *testing.T) {
 		err = sinkSrc.Flush(context.Background())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), fmt.Sprintf(`Post "%s":`, sinkDest.URL()))
-		require.EqualError(t, sinkSrc.EmitRow(context.Background(), nil, nil, nil, zeroTS, zeroTS, zeroAlloc),
-			`context canceled`)
+		require.Error(t, sinkSrc.EmitRow(context.Background(), nil, nil, nil, zeroTS, zeroTS, zeroAlloc))
+		require.NoError(t, sinkSrc.Close())
 
 		sinkDestHTTP, err := cdctest.StartMockWebhookSinkInsecure()
 		require.NoError(t, err)
@@ -207,8 +206,7 @@ func TestWebhookSink(t *testing.T) {
 		require.EqualError(t, sinkSrcWrongProtocol.Flush(context.Background()),
 			fmt.Sprintf(`Post "%s": http: server gave HTTP response to HTTPS client`, fmt.Sprintf("https://%s", strings.TrimPrefix(sinkDestHTTP.URL(),
 				"http://"))))
-		require.EqualError(t, sinkSrcWrongProtocol.EmitRow(context.Background(), nil, nil, nil, zeroTS, zeroTS, zeroAlloc),
-			`context canceled`)
+		require.Error(t, sinkSrcWrongProtocol.EmitRow(context.Background(), nil, nil, nil, zeroTS, zeroTS, zeroAlloc))
 
 		sinkDestSecure, err := cdctest.StartMockWebhookSinkSecure(cert)
 		require.NoError(t, err)
@@ -305,8 +303,7 @@ func TestWebhookSinkWithAuthOptions(t *testing.T) {
 		require.NoError(t, sinkSrcNoCreds.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, zeroAlloc))
 
 		require.EqualError(t, sinkSrcNoCreds.Flush(context.Background()), "401 Unauthorized: ")
-		require.EqualError(t, sinkSrcNoCreds.EmitRow(context.Background(), nil, nil, nil, zeroTS, zeroTS, zeroAlloc),
-			`context canceled`)
+		require.Error(t, sinkSrcNoCreds.EmitRow(context.Background(), nil, nil, nil, zeroTS, zeroTS, zeroAlloc))
 
 		// wrong credentials should result in a 401 as well
 		var wrongAuthHeader string
@@ -318,8 +315,7 @@ func TestWebhookSinkWithAuthOptions(t *testing.T) {
 		require.NoError(t, sinkSrcWrongCreds.EmitRow(context.Background(), nil, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, zeroAlloc))
 
 		require.EqualError(t, sinkSrcWrongCreds.Flush(context.Background()), "401 Unauthorized: ")
-		require.EqualError(t, sinkSrcWrongCreds.EmitRow(context.Background(), nil, nil, nil, zeroTS, zeroTS, zeroAlloc),
-			`context canceled`)
+		require.Error(t, sinkSrcWrongCreds.EmitRow(context.Background(), nil, nil, nil, zeroTS, zeroTS, zeroAlloc))
 
 		require.NoError(t, sinkSrc.Close())
 		require.NoError(t, sinkSrcNoCreds.Close())


### PR DESCRIPTION
Epic: https://cockroachlabs.atlassian.net/browse/CRDB-11356
Resolves https://github.com/cockroachdb/cockroach/issues/84676

This PR addresses two existing issues:
1. The unbatched webhook sink's maximum throughput is incredibly low, 600-800 messages per second for an n1-standard-16 3 node cluster. Batching increases throughput however it is still far below other sinks (batching every 500 messages results can result a 20k mps throughput while kafka on the same cluster and data does 212k).
2. The addition of new sinks is difficult as many would have to re-implement their own parallelism/batching/retrying logic.

---

The reason for 1, why the sink is so much slower than other sinks, is for two main reasons:
- a) While the actual sending of http requests is spread across multiple
  worker goroutines, taking requests and batching them together is done
  *synchronously* in a single batching worker.  Once that batch is full
  the messages within it are then sharded out to the workers, each
  forming their own arbitrarily smaller batches, which the batching
  worker then blocks on until all requests have completed.  This means
  in the default batch-size-1 case the sink is essentially single
  threaded, forming a batch and blocking on it each time.
- b) HTTP Requests are all sent to the same host and are being subject to
  the default transport MaxIdleConnsPerHost setting which is 2.  This
  means that at most 2 underlying TCP connections can be reused between
  requests, and the rest have to start entirely new ones, using up
  ports.

Fixing a) without b) results in a non-batched throughput of 1200-1800 with huge variation, producing tons of "cannot assign requested address" errors that propagate to job retries.

Fixing b) alone by simply setting MaxIdleConnsPerHost to 100, the default MaxIdleConns value, immediately increases the throughput of a non-batched webhook sink from 800 to 48k.

Fixing the two together as is done in this PR **increases the non-batched throughput to 229k messages per second**.  Without batching this unfortunately does use a large amount of CPU, 70% in the test, therefore batching is still recommended (with a batch size of 500 throughput **increased to 333k** while cpu usage was at 25%).

For context on the throughput numbers, on the same data and cluster a default Kafka sink puts out 214k messages per second at 21% cpu while a default cloudstorage sink does 468k at 27% cpu.  The old webhook with a batch size of 500 puts out 20.6k messages per second.


<img width="1098" alt="Screenshot 2022-12-04 at 10 14 49 PM" src="https://user-images.githubusercontent.com/6236424/205657049-fd8f3fb9-f27e-4045-ac8e-76a3b1b4768a.png">

In the image above from left to right we see the Emitted Messages for default cloudstorage, webhook v2 (batch size of 500), webhook v2 (default batch size of 1), default kafka (using a larger batch size for kafka didn't make much difference), webhook v1 (batch size of 500), and then default webhook v1 which is too small to see.

Note that these numbers do not factor in the performance during times of many errors in sending to the sink.  Much of the kafka AsyncProducer complexity is due to how it handles retries.

---

The reason for 2 is that the parallelism/batching/retry/metrics logic for the webhook and pubsub sinks are intertwined with their respective sink-specific logic.

This PR splits out the sink-specific logic into a `ThinSink` interface who's only responsibility is to encode batches of messages into payloads to be sent and emit those payloads, and the
parallelism/batching/retry/metrics logic into a `sinkProcessor`.

```go
// SinkPayload is to be casted within the ThinSink implementation to its own actual 
// payload that it can send, for example for webhook its an http.Request.
type SinkPayload interface{}

type MessagePayload struct {
  key []byte
  val []byte
}

type ResolvedMessagePayload struct {
  body       []byte
  resolvedTs hlc.Timestamp
}

type ThinSink interface {
  EncodeBatch([]MessagePayload) (SinkPayload, error)
  EncodeResolvedMessage(ResolvedMessagePayload) (SinkPayload, error)
  EmitPayload(SinkPayload) error
  Close() error
}
```

This should allow for other simple sinks that fit a "just emit a batch of messages somewhere" pattern to be added more easily with no duplicated work.

Note that this PR only implements the sinkProcessor to the extent of the needs of the Webhook sink.  A followup PR will be made to move the Pubsub sink into this framework and will bring along further changes to sinkProcessor to support multiple topics.

For now testing this PR is still relying on the existing webhook sink tests, however once sinkProcessor is extended to support pubsub as well the tests will be refactored as well into sinkProcessor-specific tests and then thin-sink-specific tests.

Another potential improvement to add here is to add a throttling setting as with the new throughputs it may be overwhelming to downstream endpoints.

---

Release note (performance improvement): The Changefeed webhook sink has been rewritten to support substantially larger throughputs, to a similar magnitude as the kafka sink.