### PR TITLE
release-22.2: ui: fix link for index from insights

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/indexUsageStatsRec.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/indexUsageStatsRec.spec.ts
@@ -30,6 +30,7 @@ describe("recommendDropUnusedIndex", () => {
       table_name: "test_table",
       database_id: 1,
       database_name: "test_db",
+      schema_name: "public",
       unused_threshold: "10h0m0s",
     };
     it("should not recommend index to be dropped", () => {
@@ -49,6 +50,7 @@ describe("recommendDropUnusedIndex", () => {
       table_name: "test_table",
       database_id: 1,
       database_name: "test_db",
+      schema_name: "public",
       unused_threshold: "10h0m0s",
     };
     it("should recommend index to be dropped with the reason that the index is never used", () => {
@@ -68,6 +70,7 @@ describe("recommendDropUnusedIndex", () => {
       table_name: "test_table",
       database_id: 1,
       database_name: "test_db",
+      schema_name: "public",
       unused_threshold: "0h30m0s",
     };
     it("should recommend index to be dropped with the reason that it has exceeded the configured index unuse duration", () => {
@@ -92,6 +95,7 @@ describe("recommendDropUnusedIndex", () => {
         table_name: "test_table",
         database_id: 1,
         database_name: "test_db",
+        schema_name: "public",
         unused_threshold: "10h0m0s",
       };
       it("should not recommend index to be dropped", () => {
@@ -113,6 +117,7 @@ describe("recommendDropUnusedIndex", () => {
         table_name: "test_table",
         database_id: 1,
         database_name: "test_db",
+        schema_name: "public",
         unused_threshold: "0h30m0s",
       };
       it("should recommend index to be dropped with the reason that it has exceeded the configured index unuse duration", () => {

--- a/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/schemaInsights.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/schemaInsights.fixture.ts
@@ -19,6 +19,7 @@ export const SchemaInsightsPropsFixture: SchemaInsightsViewProps = {
         table: "table_name",
         indexID: 1,
         indexName: "index_name",
+        schema: "public",
         lastUsed:
           "This index has not been used and can be removed for better write performance.",
       },
@@ -30,6 +31,7 @@ export const SchemaInsightsPropsFixture: SchemaInsightsViewProps = {
         table: "table_name2",
         indexID: 2,
         indexName: "index_name2",
+        schema: "public",
         lastUsed:
           "This index has not been used in over 9 days, 5 hours, and 3 minutes and can be removed for better write performance.",
       },

--- a/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
@@ -276,6 +276,7 @@ export interface InsightRecommendation {
 
 export interface indexDetails {
   table: string;
+  schema: string;
   indexID: number;
   indexName: string;
   lastUsed?: string;

--- a/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.tsx
@@ -76,7 +76,8 @@ function typeCell(value: string): React.ReactElement {
 
 function descriptionCell(
   insightRec: InsightRecommendation,
-  disableStmtLink?: boolean,
+  disableStmtLink: boolean,
+  isCockroachCloud: boolean,
 ): React.ReactElement {
   const clusterSettingsLink = (
     <>
@@ -91,6 +92,11 @@ function descriptionCell(
     insightRec.execution?.statement,
     insightRec.execution?.summary,
   );
+
+  const indexLink = isCockroachCloud
+    ? `databases/${insightRec.database}/${insightRec.indexDetails?.schema}/${insightRec.indexDetails?.table}/${insightRec.indexDetails?.indexName}`
+    : `database/${insightRec.database}/table/${insightRec.indexDetails?.table}/index/${insightRec.indexDetails?.indexName}`;
+
   switch (insightRec.type) {
     case "CreateIndex":
     case "ReplaceIndex":
@@ -130,10 +136,7 @@ function descriptionCell(
         <>
           <div className={cx("description-item")}>
             <span className={cx("label-bold")}>Index: </span>{" "}
-            <Link
-              to={`database/${insightRec.database}/table/${insightRec.indexDetails.table}/index/${insightRec.indexDetails.indexName}`}
-              className={cx("table-link")}
-            >
+            <Link to={indexLink} className={cx("table-link")}>
               {insightRec.indexDetails.indexName}
             </Link>
           </div>
@@ -296,7 +299,7 @@ export function makeInsightsColumns(
       name: "details",
       title: insightsTableTitles.details(),
       cell: (item: InsightRecommendation) =>
-        descriptionCell(item, disableStmtLink),
+        descriptionCell(item, disableStmtLink, isCockroachCloud),
       sort: (item: InsightRecommendation) => item.type,
     },
     {

--- a/pkg/ui/workspaces/cluster-ui/src/store/schemaInsights/schemaInsights.sagas.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/schemaInsights/schemaInsights.sagas.spec.ts
@@ -49,6 +49,7 @@ describe("SchemaInsights sagas", () => {
         table: "test_table",
         indexName: "test_idx",
         indexID: 1,
+        schema: "public",
         lastUsed: "2022-08-22T22:30:02Z",
       },
     },


### PR DESCRIPTION
Backport 1/1 commits from #92953.

/cc @cockroachdb/release

---

Previously, the link to index details on the
drop index insights was using the URL format used by DB Console only. This commit updates to use the correct format when loading from CC Console.

Fix #92944

Release note (bug fix): Fix link to index details on drop index insights on CC Console.

---
Release justification: bug fix