### PR TITLE
base: remove old testing knobs

### DIFF
--- a/pkg/base/testing_knobs.go
+++ b/pkg/base/testing_knobs.go
@@ -29,7 +29,6 @@ type TestingKnobs struct {
 	SQLTypeSchemaChanger         ModuleTestingKnobs
 	GCJob                        ModuleTestingKnobs
 	PGWireTestingKnobs           ModuleTestingKnobs
-	StartupMigrationManager      ModuleTestingKnobs
 	DistSQL                      ModuleTestingKnobs
 	SQLEvalContext               ModuleTestingKnobs
 	NodeLiveness                 ModuleTestingKnobs


### PR DESCRIPTION
The testing knobs for startup migrations don't exist anymore.

Release note: None
Epic: None