### PR TITLE
cli/sql: properly support special COPY input mode

### DIFF
--- a/pkg/cli/clisqlshell/BUILD.bazel
+++ b/pkg/cli/clisqlshell/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "context.go",
         "doc.go",
         "editor.go",
+        "editor_bimodal.go",
         "editor_bubbline.go",
         "editor_bufio.go",
         "editor_editline.go",

--- a/pkg/cli/clisqlshell/editor.go
+++ b/pkg/cli/clisqlshell/editor.go
@@ -46,7 +46,10 @@ func getEditor(useEditor bool, displayPrompt bool) editor {
 	if useLibEdit {
 		return &editlineReader{}
 	}
-	return &bubblineReader{}
+	return &bimodalEditor{
+		main: &bubblineReader{},
+		copy: &bufioReader{displayPrompt: displayPrompt},
+	}
 }
 
 var useLibEdit = envutil.EnvOrDefaultBool("COCKROACH_SQL_FORCE_LIBEDIT", false)

--- a/pkg/cli/clisqlshell/editor_bimodal.go
+++ b/pkg/cli/clisqlshell/editor_bimodal.go
@@ -1,0 +1,83 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package clisqlshell
+
+import (
+	"os"
+
+	"github.com/cockroachdb/errors"
+)
+
+// bimodalEditor redirects the input to either a "main" editor
+// (outside of COPY mode) or a "copy" editor (inside COPY).
+// This is because the main editor may be multi-line and
+// thus inadequate for input of COPY data.
+type bimodalEditor struct {
+	sql  sqlShell
+	main editor
+	copy editor
+}
+
+var _ editor = (*bimodalEditor)(nil)
+
+func (e *bimodalEditor) init(
+	win, wout, werr *os.File, sqlS sqlShell, maxHistEntries int, histFile string,
+) (cleanupFn func(), err error) {
+	e.sql = sqlS
+	c1, err := e.main.init(win, wout, werr, sqlS, maxHistEntries, histFile)
+	if err != nil {
+		return c1, err
+	}
+	c2, err := e.copy.init(win, wout, werr, sqlS, maxHistEntries, histFile)
+	cleanupFn = func() {
+		c1()
+		c2()
+	}
+	return cleanupFn, err
+}
+
+func (e *bimodalEditor) selected() editor {
+	if e.sql.inCopy() {
+		return e.copy
+	}
+	return e.main
+}
+
+func (e *bimodalEditor) errInterrupted() error {
+	return e.selected().errInterrupted()
+}
+
+func (e *bimodalEditor) getOutputStream() *os.File {
+	return e.selected().getOutputStream()
+}
+
+func (e *bimodalEditor) getLine() (string, error) {
+	return e.selected().getLine()
+}
+
+func (e *bimodalEditor) addHistory(line string) error {
+	return errors.CombineErrors(
+		e.copy.addHistory(line),
+		e.main.addHistory(line))
+}
+
+func (e *bimodalEditor) canPrompt() bool {
+	return e.main.canPrompt()
+}
+
+func (e *bimodalEditor) setPrompt(prompt string) {
+	e.copy.setPrompt(prompt)
+	e.main.setPrompt(prompt)
+}
+
+func (e *bimodalEditor) multilineEdit() bool {
+	return e.selected().multilineEdit()
+}

--- a/pkg/cli/interactive_tests/test_copy.tcl
+++ b/pkg/cli/interactive_tests/test_copy.tcl
@@ -4,11 +4,15 @@ source [file join [file dirname $argv0] common.tcl]
 
 start_server $argv
 
-spawn $argv sql --no-line-editor
+spawn $argv sql 
 eexpect root@
 
-send "DROP TABLE IF EXISTS t;\r"
-send "CREATE TABLE t (id INT PRIMARY KEY, t TEXT);\r"
+send "drop table if exists t;\r"
+eexpect "DROP TABLE"
+eexpect root@
+send "create table t (id INT PRIMARY KEY, t TEXT);\r"
+eexpect "CREATE TABLE"
+eexpect root@
 
 start_test "Check that errors are reported as appropriate."
 
@@ -98,25 +102,29 @@ eexpect eof
 spawn $argv sql
 eexpect root@
 
-start_test "check CTRL+C during COPY exits the COPY mode as appropriate"
+## The following test can be re-enabled after fixing this issue:
+# https://github.com/cockroachdb/cockroach/issues/93053
 
-send "COPY t FROM STDIN CSV;\r"
-eexpect ">>"
-send "5,cancel me\r"
+# start_test "check CTRL+C during COPY exits the COPY mode as appropriate"
+#
+# send "COPY t FROM STDIN CSV;\r"
+# eexpect ">>"
+# send "5,cancel me\r"
+#
+# interrupt
+#
+# eexpect "ERROR: COPY canceled by user"
+# eexpect root@
+#
+# send "SELECT * FROM t ORDER BY id ASC;\r"
+# eexpect "(6 rows)"
+# eexpect root@
+#
+# end_test
 
-interrupt
-
-eexpect "ERROR: COPY canceled by user"
+send "truncate table t;\r"
+eexpect "TRUNCATE"
 eexpect root@
-
-send "SELECT * FROM t ORDER BY id ASC;\r"
-eexpect "(6 rows)"
-eexpect root@
-
-send "TRUNCATE TABLE t;\r"
-eexpect root@
-
-end_test
 
 send_eof
 eexpect eof
@@ -128,7 +136,10 @@ eexpect ":/# "
 
 start_test "Test file input invalid"
 
-send "cat >/tmp/test_copy.sql <<EOF\rCOPY t FROM STDIN CSV;\rinvalid text;,t\rEOF\r"
+send "cat >/tmp/test_copy.sql <<EOF\r"
+send "COPY t FROM STDIN CSV;\r"
+send "invalid text;,t\r"
+send "EOF\r"
 eexpect ":/# "
 send "$argv sql --insecure -f /tmp/test_copy.sql\r"
 eexpect "ERROR: could not parse"
@@ -141,7 +152,12 @@ end_test
 
 start_test "Test file input with valid content"
 
-send "cat >/tmp/test_copy.sql <<EOF\rCOPY t FROM STDIN CSV;\r1,a\r\\.\r\rCOPY t FROM STDIN;\rEOF\r"
+send "cat >/tmp/test_copy.sql <<EOF\r"
+send "COPY t FROM STDIN CSV;\r"
+send "1,a\r"
+send "\\.\r\r"
+send "COPY t FROM STDIN;\r"
+send "EOF\r"
 # Tab doesn't work nicely in cat<<EOF, so use echo to append the character with tab.
 send "echo -e '2\\tb' >> /tmp/test_copy.sql\r"
 eexpect ":/# "


### PR DESCRIPTION
Fixes #93031.
Epic: CRDB-22182
When in COPY mode, multi-line input is disabled and the tab key inputs raw ASCII TAB characters.

This commit achieves this by redirecting the input to either the interactive editor or the bufio-based editor, depending on whether the current mode is COPY.

NB: using ctrl+c while in COPY mode will not work with this patch, but that is caused by a separate issue #93053 and the behavior will be restored when that separate issue is fixed. In the meantime the user can use `\.` or ctrl+d to terminate their input.

Release note: None