### PR TITLE
ttl: remove deprecated ttl_* storage param todos

### DIFF
--- a/pkg/sql/storageparam/tablestorageparam/table_storage_param.go
+++ b/pkg/sql/storageparam/tablestorageparam/table_storage_param.go
@@ -198,7 +198,6 @@ var tableParams = map[string]tableParam{
 			return nil
 		},
 	},
-	// todo(wall): remove in 23.1
 	`ttl_automatic_column`: {
 		onSet: func(ctx context.Context, po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
 			evalCtx.ClientNoticeSender.BufferClientNotice(ctx, ttlAutomaticColumnNotice)
@@ -316,7 +315,6 @@ var tableParams = map[string]tableParam{
 			return nil
 		},
 	},
-	// todo(wall): remove in 23.1
 	`ttl_range_concurrency`: {
 		onSet: func(ctx context.Context, po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
 			evalCtx.ClientNoticeSender.BufferClientNotice(ctx, ttlRangeConcurrencyNotice)


### PR DESCRIPTION
Fixes #93058
    
Remove TODOs to remove ttl_automatic_column and ttl_range_concurrency.
    
Release note: None
