### PR TITLE
kv: shallow copy BatchRequest before attaching to trace

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1294,7 +1294,7 @@ func setupSpanForIncomingRPC(
 			tracing.WithServerSpanKind)
 	}
 
-	newSpan.SetLazyTag("request", ba)
+	newSpan.SetLazyTag("request", ba.ShallowCopy())
 	return ctx, spanForRequest{
 		needRecording: needRecordingCollection,
 		tenID:         tenID,


### PR DESCRIPTION
Fixes #91578.
Fixes #92215.
Fixes #92228.

This commit fixes a race condition between `(*BatchRequest).SetActiveTimestamp()` and `(*BatchRequest).String()`. The race was fallout from #86958, where we stopped performing a shallow copy of the request when calling `Stores.SendWithWriteBytes`.

This commit fixes the issue by handing the trace a shallow copy of the request so that mutations to the request cannot race with lazy trace tag inflation.

Release note: None