### PR TITLE
cluster-ui: increase response size for databases endpoint

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/databasesApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/databasesApi.ts
@@ -10,6 +10,7 @@
 
 import {
   executeInternalSql,
+  LARGE_RESULT_SIZE,
   SqlExecutionRequest,
   sqlResultsAreEmpty,
 } from "./sqlApi";
@@ -34,6 +35,7 @@ export const databasesRequest: SqlExecutionRequest = {
     },
   ],
   execute: true,
+  max_result_size: LARGE_RESULT_SIZE,
 };
 
 // getDatabasesList fetches databases names from the database. Callers of


### PR DESCRIPTION
Epic: none

This change increase the payload size to 50KiB (from the default size of 10KiB) for the /databases endpoint, accomodating clusters with many databases.  Change originates from this slack discussion: https://cockroachlabs.slack.com/archives/C0159JK877C/p1670248852576439.

Some improvements to be made in future PRs:
- allow rendering of partial results, where the response contains both data (that can be displayed) and an error
- support pagination, so we don't have to continually increase the response size (not scalable)

Release note: None