### PR TITLE
backupccl: speed up listing in some backup callsites

### DIFF
--- a/pkg/ccl/backupccl/backupbase/constants.go
+++ b/pkg/ccl/backupccl/backupbase/constants.go
@@ -43,4 +43,9 @@ const (
 	// DefaultIncrementalsSubdir is the default name of the subdirectory to which
 	// incremental backups will be written.
 	DefaultIncrementalsSubdir = "incrementals"
+
+	// ListingDelimDataSlash is used when listing to find backups/backup metadata
+	// and groups all the data sst files in each backup, which start with "data/",
+	// into a single result that can be skipped over quickly.
+	ListingDelimDataSlash = "data/"
 )

--- a/pkg/ccl/backupccl/backupdest/backup_destination.go
+++ b/pkg/ccl/backupccl/backupdest/backup_destination.go
@@ -480,7 +480,7 @@ func ListFullBackupsInCollection(
 	ctx context.Context, store cloud.ExternalStorage,
 ) ([]string, error) {
 	var backupPaths []string
-	if err := store.List(ctx, "", listingDelimDataSlash, func(f string) error {
+	if err := store.List(ctx, "", backupbase.ListingDelimDataSlash, func(f string) error {
 		if backupPathRE.MatchString(f) {
 			backupPaths = append(backupPaths, f)
 		}

--- a/pkg/ccl/backupccl/backupdest/incrementals.go
+++ b/pkg/ccl/backupccl/backupdest/incrementals.go
@@ -27,11 +27,6 @@ import (
 // The default subdirectory for incremental backups.
 const (
 	incBackupSubdirGlob = "/[0-9]*/[0-9]*.[0-9][0-9]/"
-
-	// listingDelimDataSlash is used when listing to find backups and groups all the
-	// data sst files in each backup, which start with "data/", into a single result
-	// that can be skipped over quickly.
-	listingDelimDataSlash = "data/"
 )
 
 // backupSubdirRE identifies the portion of a larger path that refers to the full backup subdirectory.
@@ -65,7 +60,7 @@ func FindPriorBackups(
 	defer sp.Finish()
 
 	var prev []string
-	if err := store.List(ctx, "", listingDelimDataSlash, func(p string) error {
+	if err := store.List(ctx, "", backupbase.ListingDelimDataSlash, func(p string) error {
 		if ok, err := path.Match(incBackupSubdirGlob+backupbase.BackupManifestName, p); err != nil {
 			return err
 		} else if ok {

--- a/pkg/ccl/backupccl/backupencryption/BUILD.bazel
+++ b/pkg/ccl/backupccl/backupencryption/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
+        "//pkg/ccl/backupccl/backupbase",
         "//pkg/ccl/storageccl",
         "//pkg/cloud",
         "//pkg/jobs/jobspb",

--- a/pkg/ccl/backupccl/backupencryption/encryption.go
+++ b/pkg/ccl/backupccl/backupencryption/encryption.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backupbase"
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -483,7 +484,7 @@ func GetEncryptionInfoFiles(ctx context.Context, dest cloud.ExternalStorage) ([]
 	var files []string
 	// Look for all files in dest that start with "/ENCRYPTION-INFO"
 	// and return them.
-	err := dest.List(ctx, "", "", func(p string) error {
+	err := dest.List(ctx, "", backupbase.ListingDelimDataSlash, func(p string) error {
 		paths := strings.Split(p, "/")
 		p = paths[len(paths)-1]
 		if match := strings.HasPrefix(p, backupEncryptionInfoFile); match {

--- a/pkg/ccl/backupccl/backupinfo/manifest_handling.go
+++ b/pkg/ccl/backupccl/backupinfo/manifest_handling.go
@@ -1021,7 +1021,7 @@ func CheckForPreviousBackup(
 
 	// Check for the presence of a BACKUP-LOCK file with a job ID different from
 	// that of our job.
-	if err := defaultStore.List(ctx, "", "", func(s string) error {
+	if err := defaultStore.List(ctx, "", backupbase.ListingDelimDataSlash, func(s string) error {
 		s = strings.TrimPrefix(s, "/")
 		if strings.HasPrefix(s, BackupLockFilePrefix) {
 			jobIDSuffix := strings.TrimPrefix(s, BackupLockFilePrefix)


### PR DESCRIPTION
There were a couple of calls to `List` that would list all the files in the backup destination bucket. In the presence of a large number of files, usually SST files in the `data/` folder, this listing could be very slow. This could manifest as a RESTORE command hanging during the planning phase when we go to resolve encryption information from the base backup bucket.

To fix this, we add a `delimiter` to the `List` call that will make skipping over all files in the `data/` directory much cheaper.

Informs: https://github.com/cockroachlabs/support/issues/1937

Release note (bug fix): speedup slow listing calls that could manifest as restore queries hanging during execution, in the presence of several backup files