### PR TITLE
ui: prevent additional RPC fanout in insights api

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/insightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/insightsApi.ts
@@ -665,6 +665,9 @@ const workloadInsightsQuery: InsightQuery<
   // Note that we don't filter by problem != 'None', so that we can get all
   // stmts in the problematic transaction.
   query: `
+WITH insightsTable as (
+  SELECT * FROM crdb_internal.cluster_execution_insights
+) 
 SELECT
   session_id,
   insights.txn_id as txn_id,
@@ -695,9 +698,9 @@ FROM
     SELECT
      txn_id,
      row_number() OVER ( PARTITION BY txn_fingerprint_id ORDER BY end_time DESC ) as rank
-    FROM crdb_internal.cluster_execution_insights
+    FROM insightsTable
   ) as latestTxns
-JOIN crdb_internal.cluster_execution_insights AS insights
+JOIN insightsTable AS insights
 ON latestTxns.txn_id = insights.txn_id
 WHERE latestTxns.rank = 1 AND app_name NOT LIKE '${INTERNAL_APP_NAME_PREFIX}%'
  `,


### PR DESCRIPTION
Previously the query used to fetch insights was triggering 2 cluster-wide RPC fanouts by doing a self-join on `crdb_internal.cluster_execution_insights`.
We should buffer the insights virtual table to prevent an additional fanout to construct the table again.

Epic: none

Release note: None