### PR TITLE
kv: add hint to split backpressure error

### DIFF
--- a/pkg/kv/kvserver/replica_backpressure.go
+++ b/pkg/kv/kvserver/replica_backpressure.go
@@ -180,17 +180,21 @@ func (r *Replica) maybeBackpressureBatch(ctx context.Context, ba *roachpb.BatchR
 			return nil
 		}
 
+		const errHint = `For help understanding this error and troubleshooting, visit:
+
+    https://www.cockroachlabs.com/docs/stable/common-errors.html#split-failed-while-applying-backpressure-are-rows-updated-in-a-tight-loop`
+
 		// Wait for the callback to be called.
 		select {
 		case <-ctx.Done():
-			return errors.Wrapf(
+			return errors.WithHint(errors.Wrapf(
 				ctx.Err(), "aborted while applying backpressure to %s on range %s", ba, r.Desc(),
-			)
+			), errHint)
 		case err := <-splitC:
 			if err != nil {
-				return errors.Wrapf(
+				return errors.WithHint(errors.Wrapf(
 					err, "split failed while applying backpressure to %s on range %s", ba, r.Desc(),
-				)
+				), errHint)
 			}
 		}
 	}


### PR DESCRIPTION
Informs #92705.

This commit adds a hint to the split backpressure error that links to the corresponding FAQ in our docs. This will help users understand and troubleshooting the error.

In the SQL shell, this looks like:
```
root@localhost:26257/defaultdb> update foo set v=v||'1' where id = 0;

ERROR: split failed while applying backpressure to Put [/Table/104/1/0/0,/Min), [txn: 28df4a6a] on range r55:/{Table/104-Max} [(n1,s1):1, next=2, gen=1]: could not find valid split key
HINT: For help understanding this error and troubleshooting, visit:

    https://www.cockroachlabs.com/docs/stable/common-errors.html#split-failed-while-applying-backpressure-are-rows-updated-in-a-tight-loop
```

Release note: None.