### PR TITLE
release-22.1: server: introduce `COCKROACH_FALLBACK_SPANCONFIG_NUM_REPLICAS_OVERRIDE`

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -395,6 +395,7 @@ go_test(
         "//pkg/util/contextutil",
         "//pkg/util/ctxgroup",
         "//pkg/util/encoding",
+        "//pkg/util/envutil",
         "//pkg/util/hlc",
         "//pkg/util/humanizeutil",
         "//pkg/util/leaktest",

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -71,6 +71,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ts"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/goschedstats"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -569,6 +570,12 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 			// We do the same for opting out of strict GC enforcement; it
 			// really only applies to user table ranges
 			fallbackConf.GCPolicy.IgnoreStrictEnforcement = true
+
+			// fallbackSpanConfigNumReplicasOverride controls what replication
+			// factor is used for ranges with no explicit span configs set.
+			var fallbackSpanConfigNumReplicasOverride = envutil.EnvOrDefaultInt(
+				"COCKROACH_FALLBACK_SPANCONFIG_NUM_REPLICAS_OVERRIDE", int(fallbackConf.NumReplicas))
+			fallbackConf.NumReplicas = int32(fallbackSpanConfigNumReplicasOverride)
 
 			spanConfig.subscriber = spanconfigkvsubscriber.New(
 				clock,


### PR DESCRIPTION
It controls what replication factor is used for ranges with no explicit span configs set. This is a backportable form of the spanconfig.store.fallback_config_override we added in #92466.

Release note: None
Release justification: Introduce an env var that would've come in handy in an internal escalation -- it allows users to control what replication factor is used for ranges not explicitly referenced by zone configs. Without this env var, the value used is a hardcoded default of 3.