### PR TITLE
clisqlshell: correctly handle sending zero input for COPY

### DIFF
--- a/pkg/cli/clisqlshell/sql.go
+++ b/pkg/cli/clisqlshell/sql.go
@@ -1015,6 +1015,7 @@ func (c *cliState) doStartLine(nextState cliStateEnum) cliStateEnum {
 	c.atEOF = false
 	c.partialLines = c.partialLines[:0]
 	c.partialStmtsLen = 0
+	c.concatLines = ""
 
 	c.useContinuePrompt = false
 
@@ -1325,7 +1326,8 @@ func (c *cliState) doHandleCliCmd(loopState, nextState cliStateEnum) cliStateEnu
 
 	case `\.`:
 		if c.inCopy() {
-			c.concatLines += "\n" + `\.`
+			c.partialLines = append(c.partialLines, `\.`)
+			c.partialStmtsLen++
 			return cliRunStatement
 		}
 		return c.invalidSyntax(errState)
@@ -1755,7 +1757,7 @@ func (c *cliState) doPrepareStatementLine(
 		(c.inCopy() && (strings.HasSuffix(c.concatLines, "\n"+`\.`) || c.atEOF)) ||
 		// We're always at the end of a statement if EOF is reached in the
 		// single statement mode.
-		c.singleStatement && c.atEOF
+		(c.singleStatement && c.atEOF)
 	if c.atEOF {
 		// Definitely no more input expected.
 		if !endOfStmt {

--- a/pkg/cli/interactive_tests/test_copy.tcl
+++ b/pkg/cli/interactive_tests/test_copy.tcl
@@ -28,6 +28,22 @@ eexpect "could not parse"
 
 end_test
 
+start_test "check EMPTY copy"
+
+send "COPY t FROM STDIN;\r"
+eexpect ">>"
+send_eof
+eexpect "COPY 0"
+eexpect root@
+
+send "COPY t FROM STDIN;\r"
+eexpect ">>"
+send "\\.\r"
+eexpect "COPY 0"
+eexpect root@
+
+end_test
+
 start_test "multi statement with COPY"
 send "SELECT 1; COPY t FROM STDIN CSV;\r"
 eexpect "COPY together with other statements in a query string is not supported"


### PR DESCRIPTION
Resolves #93051
Epic: CRDB-22182

Release note (bug fix): Previously, empty COPY commands would not escape after an EOF character or error if encountering a `\.` with no input. This is now resolved.