### PR TITLE
changefeedccl: Allow equivalent types in projection

### DIFF
--- a/pkg/ccl/changefeedccl/cdceval/expr_eval_test.go
+++ b/pkg/ccl/changefeedccl/cdceval/expr_eval_test.go
@@ -51,7 +51,7 @@ func TestEvaluator(t *testing.T) {
 CREATE TABLE foo (
   a INT, 
   b STRING, 
-  c STRING,
+  c VARCHAR,
   d STRING AS (concat(b, c)) VIRTUAL,
   e status DEFAULT 'inactive',
   f STRING,


### PR DESCRIPTION
Prior PR #85177 erroneously removed cast when assigning projection values (we may yet have to bring this back).

This PR allows equivalent types when assigning projection values.

Epic: none
Release note: none