### PR TITLE
release-22.1: sql: fixes sql.stats.flush.interval description

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -166,7 +166,7 @@ sql.stats.automatic_collection.fraction_stale_rows	float	0.2	target fraction of 
 sql.stats.automatic_collection.min_stale_rows	integer	500	target minimum number of stale rows per table that will trigger a statistics refresh
 sql.stats.cleanup.recurrence	string	@hourly	cron-tab recurrence for SQL Stats cleanup job
 sql.stats.flush.enabled	boolean	true	if set, SQL execution statistics are periodically flushed to disk
-sql.stats.flush.interval	duration	10m0s	the interval at which SQL execution statistics are flushed to disk, this value must be less than or equal to sql.stats.aggregation.interval
+sql.stats.flush.interval	duration	10m0s	the interval at which SQL execution statistics are flushed to disk, this value must be less than or equal to 1 hour
 sql.stats.histogram_collection.enabled	boolean	true	histogram collection mode
 sql.stats.multi_column_collection.enabled	boolean	true	multi-column statistics collection mode
 sql.stats.persisted_rows.max	integer	1000000	maximum number of rows of statement and transaction statistics that will be persisted in the system tables

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -182,7 +182,7 @@
 <tr><td><code>sql.stats.automatic_collection.min_stale_rows</code></td><td>integer</td><td><code>500</code></td><td>target minimum number of stale rows per table that will trigger a statistics refresh</td></tr>
 <tr><td><code>sql.stats.cleanup.recurrence</code></td><td>string</td><td><code>@hourly</code></td><td>cron-tab recurrence for SQL Stats cleanup job</td></tr>
 <tr><td><code>sql.stats.flush.enabled</code></td><td>boolean</td><td><code>true</code></td><td>if set, SQL execution statistics are periodically flushed to disk</td></tr>
-<tr><td><code>sql.stats.flush.interval</code></td><td>duration</td><td><code>10m0s</code></td><td>the interval at which SQL execution statistics are flushed to disk, this value must be less than or equal to sql.stats.aggregation.interval</td></tr>
+<tr><td><code>sql.stats.flush.interval</code></td><td>duration</td><td><code>10m0s</code></td><td>the interval at which SQL execution statistics are flushed to disk, this value must be less than or equal to 1 hour</td></tr>
 <tr><td><code>sql.stats.histogram_collection.enabled</code></td><td>boolean</td><td><code>true</code></td><td>histogram collection mode</td></tr>
 <tr><td><code>sql.stats.multi_column_collection.enabled</code></td><td>boolean</td><td><code>true</code></td><td>multi-column statistics collection mode</td></tr>
 <tr><td><code>sql.stats.persisted_rows.max</code></td><td>integer</td><td><code>1000000</code></td><td>maximum number of rows of statement and transaction statistics that will be persisted in the system tables</td></tr>

--- a/pkg/sql/sqlstats/persistedsqlstats/cluster_settings.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/cluster_settings.go
@@ -24,7 +24,7 @@ var SQLStatsFlushInterval = settings.RegisterDurationSetting(
 	settings.TenantWritable,
 	"sql.stats.flush.interval",
 	"the interval at which SQL execution statistics are flushed to disk, "+
-		"this value must be less than or equal to sql.stats.aggregation.interval",
+		"this value must be less than or equal to 1 hour",
 	time.Minute*10,
 	settings.NonNegativeDurationWithMaximum(time.Hour*24),
 ).WithPublic()


### PR DESCRIPTION
Backport 1/1 commits from #92594.

/cc @cockroachdb/release

---

The setting sql.stats.aggregation.interval is not 
documented by design. This updates the description 
of the sql.stats.flush.interval setting to use the default 
value of sql.stats.aggregation.interval instead since 
that setting is not documented.

closes: #81252

Release note: none

Release justification: Category 2: Bug fixes and
low-risk updates to new functionality
