### PR TITLE
multitenant: move UNSPLIT ALL tenant check from SQL to KV layer

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/tenant_unsupported
+++ b/pkg/ccl/logictestccl/testdata/logic_test/tenant_unsupported
@@ -51,7 +51,7 @@ ALTER TABLE kv SPLIT AT VALUES ('foo')
 statement error pq: could not UNSPLIT AT \('foo'\): rpc error: code = Unauthenticated desc = request \[1 AdmUnsplit\] not permitted
 ALTER TABLE kv UNSPLIT AT VALUES ('foo')
 
-statement error operation is unsupported in multi-tenancy mode
+statement ok
 ALTER TABLE kv UNSPLIT ALL
 
 statement error pq: rpc error: code = Unauthenticated desc = request \[1 AdmScatter\] not permitted

--- a/pkg/sql/multitenant_admin_function_test.go
+++ b/pkg/sql/multitenant_admin_function_test.go
@@ -174,25 +174,21 @@ func TestMultiTenantAdminFunction(t *testing.T) {
 		},
 		{
 			desc:                 "ALTER TABLE x UNSPLIT ALL",
+			setup:                "ALTER TABLE t SPLIT AT VALUES (1);",
 			query:                "ALTER TABLE t UNSPLIT ALL;",
-			expectedErrorMessage: errorutil.UnsupportedWithMultiTenancyMessage,
+			expectedErrorMessage: "request [1 AdmUnsplit] not permitted",
+			allowSplitAndScatter: true,
 		},
 		{
-			desc:                     "ALTER TABLE x UNSPLIT ALL SkipSQLSystemTenantCheck",
-			query:                    "ALTER TABLE t UNSPLIT ALL;",
-			skipSQLSystemTenantCheck: true,
-		},
-		{
-			desc:                 "ALTER INDEX x UNSPLIT ALL",
-			setup:                "CREATE INDEX idx on t(i);",
+			desc: "ALTER INDEX x UNSPLIT ALL",
+			// Multiple setup statements required because of https://github.com/cockroachdb/cockroach/issues/90535.
+			setups: []string{
+				"CREATE INDEX idx on t(i);",
+				"ALTER INDEX t@idx SPLIT AT VALUES (1);",
+			},
 			query:                "ALTER INDEX t@idx UNSPLIT ALL;",
-			expectedErrorMessage: errorutil.UnsupportedWithMultiTenancyMessage,
-		},
-		{
-			desc:                     "ALTER INDEX x UNSPLIT ALL SkipSQLSystemTenantCheck",
-			setup:                    "CREATE INDEX idx on t(i);",
-			query:                    "ALTER INDEX t@idx UNSPLIT ALL;",
-			skipSQLSystemTenantCheck: true,
+			expectedErrorMessage: "request [1 AdmUnsplit] not permitted",
+			allowSplitAndScatter: true,
 		},
 		{
 			desc:                 "ALTER TABLE x SCATTER",

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1997,10 +1997,6 @@ func (ef *execFactory) ConstructAlterTableUnsplitAll(index cat.Index) (exec.Node
 		return nil, err
 	}
 
-	if !ef.planner.ExecCfg().IsSystemTenant() {
-		return nil, errorutil.UnsupportedWithMultiTenancy(54254)
-	}
-
 	return &unsplitAllNode{
 		tableDesc: index.Table().(*optTable).desc,
 		index:     index.(*optIndex).idx,


### PR DESCRIPTION
Fixes #93151

Remove the system tenant check from execFactory.ConstructAlterTableUnsplitAll and use the existing AdminUnsplitRequest check in reqAllowed.

Release note: None