### PR TITLE
changefeedccl: Fix error handling in mixed version state

### DIFF
--- a/pkg/ccl/changefeedccl/cdcevent/rowfetcher_cache.go
+++ b/pkg/ccl/changefeedccl/cdcevent/rowfetcher_cache.go
@@ -110,7 +110,7 @@ func refreshUDT(
 	}); err != nil {
 		// Manager can return all kinds of errors during chaos, but based on
 		// its usage, none of them should ever be terminal.
-		return nil, err
+		return nil, changefeedbase.MarkRetryableError(err)
 	}
 	// Immediately release the lease, since we only need it for the exact
 	// timestamp requested.
@@ -144,7 +144,7 @@ func (c *rowFetcherCache) tableDescForKey(
 	if err != nil {
 		// Manager can return all kinds of errors during chaos, but based on
 		// its usage, none of them should ever be terminal.
-		return nil, family, err
+		return nil, family, changefeedbase.MarkRetryableError(err)
 	}
 	tableDesc = desc.Underlying().(catalog.TableDescriptor)
 	// Immediately release the lease, since we only need it for the exact

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -3558,7 +3558,7 @@ func TestChangefeedRetryableError(t *testing.T) {
 		knobs.BeforeEmitRow = func(_ context.Context) error {
 			switch atomic.LoadInt64(&failEmit) {
 			case 1:
-				return errors.New("synthetic retryable error")
+				return changefeedbase.MarkRetryableError(fmt.Errorf("synthetic retryable error"))
 			case 2:
 				return changefeedbase.WithTerminalError(errors.New("synthetic terminal error"))
 			default:

--- a/pkg/ccl/changefeedccl/changefeedbase/errors.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/errors.go
@@ -77,6 +77,14 @@ func (e *terminalError) Error() string {
 	return "terminal changefeed error"
 }
 
+// TODO(yevgeniy): retryableError and all machinery related
+// to MarkRetryableError maybe removed once 23.1 is released.
+type retryableError struct{}
+
+func (e *retryableError) Error() string {
+	return "retryable changefeed error"
+}
+
 // WithTerminalError decorates underlying error to indicate
 // that the error is a terminal changefeed error.
 func WithTerminalError(cause error) error {
@@ -84,6 +92,14 @@ func WithTerminalError(cause error) error {
 		return nil
 	}
 	return errors.Mark(cause, &terminalError{})
+}
+
+// MarkRetryableError wraps the given error, marking it as retryable.s
+func MarkRetryableError(cause error) error {
+	if cause == nil {
+		return nil
+	}
+	return errors.Mark(cause, &retryableError{})
 }
 
 // AsTerminalError determines if the cause error is a terminal changefeed

--- a/pkg/ccl/changefeedccl/schema_registry.go
+++ b/pkg/ccl/changefeedccl/schema_registry.go
@@ -199,7 +199,7 @@ func (r *confluentSchemaRegistry) doWithRetry(ctx context.Context, fn func() err
 		}
 		log.VInfof(ctx, 2, "retrying schema registry operation: %s", err.Error())
 	}
-	return err
+	return changefeedbase.MarkRetryableError(err)
 }
 
 func gracefulClose(ctx context.Context, toClose io.ReadCloser) {

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -299,6 +299,74 @@ func (u *sinkURL) String() string {
 	return u.URL.String()
 }
 
+// errorWrapperSink delegates to another sink and marks all returned errors as
+// retryable. During changefeed setup, we use the sink once without this to
+// verify configuration, but in the steady state, no sink error should be
+// terminal.
+type errorWrapperSink struct {
+	wrapped externalResource
+}
+
+// EmitRow implements Sink interface.
+func (s errorWrapperSink) EmitRow(
+	ctx context.Context,
+	topic TopicDescriptor,
+	key, value []byte,
+	updated, mvcc hlc.Timestamp,
+	alloc kvevent.Alloc,
+) error {
+	if err := s.wrapped.(EventSink).EmitRow(ctx, topic, key, value, updated, mvcc, alloc); err != nil {
+		return changefeedbase.MarkRetryableError(err)
+	}
+	return nil
+}
+
+// EmitResolvedTimestamp implements Sink interface.
+func (s errorWrapperSink) EmitResolvedTimestamp(
+	ctx context.Context, encoder Encoder, resolved hlc.Timestamp,
+) error {
+	if err := s.wrapped.(ResolvedTimestampSink).EmitResolvedTimestamp(ctx, encoder, resolved); err != nil {
+		return changefeedbase.MarkRetryableError(err)
+	}
+	return nil
+}
+
+// Flush implements Sink interface.
+func (s errorWrapperSink) Flush(ctx context.Context) error {
+	if err := s.wrapped.(EventSink).Flush(ctx); err != nil {
+		return changefeedbase.MarkRetryableError(err)
+	}
+	return nil
+}
+
+// Close implements Sink interface.
+func (s errorWrapperSink) Close() error {
+	if err := s.wrapped.Close(); err != nil {
+		return changefeedbase.MarkRetryableError(err)
+	}
+	return nil
+}
+
+// EncodeAndEmitRow implements SinkWithEncoder interface.
+func (s errorWrapperSink) EncodeAndEmitRow(
+	ctx context.Context,
+	updatedRow cdcevent.Row,
+	prevRow cdcevent.Row,
+	topic TopicDescriptor,
+	updated, mvcc hlc.Timestamp,
+	alloc kvevent.Alloc,
+) error {
+	if sinkWithEncoder, ok := s.wrapped.(SinkWithEncoder); ok {
+		return sinkWithEncoder.EncodeAndEmitRow(ctx, updatedRow, prevRow, topic, updated, mvcc, alloc)
+	}
+	return errors.AssertionFailedf("Expected a sink with encoder for, found %T", s.wrapped)
+}
+
+// Dial implements Sink interface.
+func (s errorWrapperSink) Dial() error {
+	return s.wrapped.Dial()
+}
+
 // encDatumRowBuffer is a FIFO of `EncDatumRow`s.
 //
 // TODO(dan): There's some potential allocation savings here by reusing the same


### PR DESCRIPTION
Prior PR #90810 changed error handling approach used by CDC to be "retry by default".

The above PR failed to account for some of the
situations that may arrise in mixed version state. In particular, when upgrading, if the aggregator node gets restarted with the new version, while the coordinator still runs old binary, *and* the new aggregator encounters a retryable error, that error would not be explicitly marked as retryable, causing the old coordinator binary to treat the error as a terminal error.

Other combination (new coordinator, old aggregator) is not succeptible to this situation.

This PR partially reverts changes in the #90810 so previously retryable errors continue to be explicitly marked as retryable.

There is no need to introduce version gates since the error handling should be backward compatible, and with this PR, operate correctly in the mixed version state.

Epic: None

Release note: none