### PR TITLE
bazci: insert `--config ci` if necessary

### DIFF
--- a/pkg/cmd/bazci/bazci.go
+++ b/pkg/cmd/bazci/bazci.go
@@ -333,6 +333,18 @@ func bazciImpl(cmd *cobra.Command, args []string) error {
 	}
 	args = append(args, fmt.Sprintf("--build_event_binary_file=%s", bepLoc))
 	args = append(args, fmt.Sprintf("--bes_backend=grpc://127.0.0.1:%d", port))
+	// Insert `--config ci` if it's not already in the args list.
+	hasCiConfig := false
+	for idx, arg := range args {
+		if arg == "--config=ci" || arg == "--config=cinolint" ||
+			(arg == "--config" && idx < len(args)-1 && (args[idx+1] == "ci" || args[idx+1] == "cinolint")) {
+			hasCiConfig = true
+			break
+		}
+	}
+	if !hasCiConfig {
+		args = append(args, "--config", "ci")
+	}
 	fmt.Println("running bazel w/ args: ", shellescape.QuoteCommand(args))
 	bazelCmd := exec.Command("bazel", args...)
 	bazelCmd.Stdout = os.Stdout


### PR DESCRIPTION
All builds and tests in CI need this --config argument.

Epic: None
Release note: None