### PR TITLE
sql: fix bug when using glob which matches nothing

### DIFF
--- a/pkg/sql/grant_revoke.go
+++ b/pkg/sql/grant_revoke.go
@@ -539,6 +539,7 @@ func (p *planner) getTablePatternsComposition(
 	if targets.Tables.SequenceOnly {
 		return sequenceOnly, nil
 	}
+	var allObjectIDs []descpb.ID
 	for _, tableTarget := range targets.Tables.TablePatterns {
 		tableGlob, err := tableTarget.NormalizeTablePattern()
 		if err != nil {
@@ -548,48 +549,56 @@ func (p *planner) getTablePatternsComposition(
 		if err != nil {
 			return unknownComposition, err
 		}
+		allObjectIDs = append(allObjectIDs, objectIDs...)
+	}
 
-		// Check if the table is a virtual table.
-		var virtualTableIDs descpb.IDs
-		var nonVirtualTableIDs descpb.IDs
-		for _, objectID := range objectIDs {
-			isVirtual := false
-			for _, vs := range virtualSchemas {
-				if _, ok := vs.tableDefs[objectID]; ok {
-					isVirtual = true
-					break
-				}
+	if len(allObjectIDs) == 0 {
+		return unknownComposition, nil
+	}
+
+	// Check if the table is a virtual table.
+	var virtualIDs descpb.IDs
+	var nonVirtualIDs descpb.IDs
+	for _, objectID := range allObjectIDs {
+		isVirtual := false
+		for _, vs := range virtualSchemas {
+			if _, ok := vs.tableDefs[objectID]; ok {
+				isVirtual = true
+				break
 			}
+		}
 
-			if isVirtual {
-				virtualTableIDs = append(nonVirtualTableIDs, objectID)
-			} else {
-				nonVirtualTableIDs = append(virtualTableIDs, objectID)
+		if isVirtual {
+			virtualIDs = append(nonVirtualIDs, objectID)
+		} else {
+			nonVirtualIDs = append(virtualIDs, objectID)
+		}
+	}
+	haveVirtualTables := virtualIDs.Len() > 0
+	haveNonVirtualTables := nonVirtualIDs.Len() > 0
+	if haveVirtualTables && haveNonVirtualTables {
+		return unknownComposition, pgerror.Newf(
+			pgcode.FeatureNotSupported, "cannot mix grants between virtual and non-virtual tables",
+		)
+	}
+	if !haveNonVirtualTables {
+		return virtualTablesOnly, nil
+	}
+	// Note that part of the reason the code is structured this way is that
+	// resolving mutable descriptors for virtual table IDs results in an error.
+	muts, err := p.Descriptors().GetMutableDescriptorsByID(ctx, p.txn, nonVirtualIDs...)
+	if err != nil {
+		return unknownComposition, err
+	}
+
+	for _, mut := range muts {
+		if mut != nil && mut.DescriptorType() == catalog.Table {
+			tableDesc, err := catalog.AsTableDescriptor(mut)
+			if err != nil {
+				return unknownComposition, err
 			}
-		}
-
-		if len(nonVirtualTableIDs) != 0 && len(virtualTableIDs) != 0 {
-			return unknownComposition, errors.Newf("cannot mix grants between virtual and non-virtual tables")
-		}
-
-		if len(nonVirtualTableIDs) == 0 {
-			return virtualTablesOnly, nil
-		}
-
-		muts, err := p.Descriptors().GetMutableDescriptorsByID(ctx, p.txn, nonVirtualTableIDs...)
-		if err != nil {
-			return unknownComposition, err
-		}
-
-		for _, mut := range muts {
-			if mut != nil && mut.DescriptorType() == catalog.Table {
-				tableDesc, err := catalog.AsTableDescriptor(mut)
-				if err != nil {
-					return unknownComposition, err
-				}
-				if !tableDesc.IsSequence() {
-					return containsTable, nil
-				}
+			if !tableDesc.IsSequence() {
+				return containsTable, nil
 			}
 		}
 	}

--- a/pkg/sql/grant_revoke_system.go
+++ b/pkg/sql/grant_revoke_system.go
@@ -244,8 +244,10 @@ func (n *changeNonDescriptorBackedPrivilegesNode) makeSystemPrivilegeObject(
 func (p *planner) SynthesizePrivilegeDescriptor(
 	ctx context.Context, privilegeObjectPath string, privilegeObjectType privilege.ObjectType,
 ) (*catpb.PrivilegeDescriptor, error) {
-	_, desc, err := p.Descriptors().GetImmutableTableByName(ctx, p.Txn(),
-		syntheticprivilege.SystemPrivilegesTableName, tree.ObjectLookupFlagsWithRequired())
+	_, desc, err := p.Descriptors().GetImmutableTableByName(
+		ctx, p.Txn(), syntheticprivilege.SystemPrivilegesTableName,
+		tree.ObjectLookupFlagsWithRequired(),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -2021,3 +2021,29 @@ REVOKE SELECT ON system.lease FROM testuser
 # we error explicitly instead of getting 100% compatibility.
 statement error invalid privilege type RULE for table
 GRANT RULE ON t TO testuser
+
+# This glob expands to no tables, that should be fine and should return the
+# correct errors.
+statement error pgcode 42704 no object matched
+GRANT SELECT ON TABLE empty.* TO testuser;
+
+statement ok
+create schema empty.sc
+
+statement error pgcode 42704 no object matched
+GRANT SELECT ON TABLE empty.sc.* TO testuser;
+
+# Add a test to ensure that when you mix virtual and physical tables in a grant
+# that you get the error we
+subtest mixed_virtual_physical
+
+statement ok
+CREATE DATABASE db;
+USE db;
+CREATE TABLE t (i INT);
+
+statement error pgcode 0A000 cannot mix grants between virtual and non-virtual tables
+GRANT SELECT ON TABLE t, crdb_internal.tables TO testuser;
+
+statement error pgcode 0A000 cannot mix grants between virtual and non-virtual tables
+GRANT SELECT ON TABLE crdb_internal.tables, t TO testuser;


### PR DESCRIPTION
Logic in the 22.2 cycle for synthetic privileges erroneously assumed that if no physical tables matched, that it must mean that virtual tables matched. It also assumed that if the first entry in a pattern matched, it applied to all entries. Both of these assumptions were wrong. They lead to ugly panics.

Fixes: #92483

Release note (bug fix): Fixed a bug whereby glob patterns which matched no tables in `GRANT` or `REVOKE` statements would return an internal error with a confusing message as opposed to the appropriate "no objects matched" error.