### PR TITLE
kv: use correct sequence number when scanning for conflicting intents

### DIFF
--- a/pkg/kv/kvnemesis/kvnemesis_test.go
+++ b/pkg/kv/kvnemesis/kvnemesis_test.go
@@ -181,10 +181,6 @@ func testKVNemesisImpl(t *testing.T, cfg kvnemesisTestCfg) {
 		sqlDBs[i] = tc.ServerConn(i)
 	}
 	sqlutils.MakeSQLRunner(sqlDBs[0]).Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)
-	// TODO(arul): remove this line when #92189 is addressed.
-	//
-	// See: https://github.com/cockroachdb/cockroach/issues/93164.
-	sqlutils.MakeSQLRunner(sqlDBs[0]).Exec(t, `SET CLUSTER SETTING kv.transaction.dropping_latches_before_eval.enabled = false`)
 	// Turn net/trace on, which results in real trace spans created throughout.
 	// This gives kvnemesis a chance to hit NPEs related to tracing.
 	sqlutils.MakeSQLRunner(sqlDBs[0]).Exec(t, `SET CLUSTER SETTING trace.debug.enable = true`)


### PR DESCRIPTION
A read only request scans the lock table before it can proceed with dropping latches. It can only evaluate if no conflicting intents are found. While doing so, it also determines if the MVCC scan evaluation needs to consult intent history (by using the interleaved iterator).

The MVCC scan evaluation needs to consult intent history if we discover an intent by the transaction performing the read operation at a higher sequence number or a higher timestamp. The correct sequence numbers to compare here are those on the `BatchRequest`, and not on the transaction. Before this patch, we were using the sequence number on the transaction, which could lead us to wrongly conclude that the use of an intent interleaving iterator wasn't required.

Specifically, if the batch of the following construction was retried on the server:

```
b.Scan(a, e)
b.Put(b, "value")
```

The scan would end up (erroneously) reading "value" at key b.

As part of this patch, I've also renamed `ScanConflictingIntents` to `ScanConflictingIntentsForDroppingLatchesEarly` -- the function isn't as generalized as the old name would suggest.

Closes #92217
Closes #92189

Release note: None