### PR TITLE
release-22.1: ui: use relative paths for /uiconfig and /api/v2

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/basePath.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/basePath.ts
@@ -10,6 +10,13 @@
 
 let path = "";
 
-export const setBasePath = (basePath: string) => (path = basePath);
+/**
+ * Sets the base URL to use that all API paths are appended to in
+ * the app. When running Cluster UI components embedded elsewhere, this is
+ * helpful to ensure that requests are routed to your particular cluster when
+ * it's not served from the Base URL of your application. This path should
+ * **not** include a trailing slash.
+ */
+export const setBasePath = (basePath: string): string => (path = basePath);
 
-export const getBasePath = () => path;
+export const getBasePath = (): string => path;

--- a/pkg/ui/workspaces/cluster-ui/src/api/fetchData.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/fetchData.ts
@@ -115,7 +115,7 @@ export function fetchDataJSON<ResponseType, RequestType>(
 
   const basePath = getBasePath();
 
-  return fetch(`${basePath}${path}`, params).then(response => {
+  return fetch(`${basePath}/${path}`, params).then(response => {
     if (!response.ok) {
       throw new RequestError(
         response.statusText,

--- a/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
@@ -60,7 +60,7 @@ export type SqlExecutionErrorMessage = {
   source: { file: string; line: number; function: "string" };
 };
 
-export const SQL_API_PATH = "/api/v2/sql/";
+export const SQL_API_PATH = "api/v2/sql/";
 
 /**
  * executeSql executes the provided SQL statements in a single transaction


### PR DESCRIPTION
Backport 1/1 commits from #91430.

/cc @cockroachdb/release

---

Previously, we were using absolute paths for newer endpoints, mostly by accident, not by design. When the DB Console and CRDB were behind a proxy with a different Base URL than `/`, these absolute paths would fail since they were not relative to the new base. This would cause various DB Console features to break.

This change modifies the paths to be relative in order to adapt to various base paths.

Resolves: #91429

Epic: None

Release note (ops change): Fixed a bug that would break certain DB Console requests when CRDB was run behind a proxy that changed the base URL.

Release justification: small bugfix to support proxying to sql endpoints