### PR TITLE
build: pass environment variables to pebble test runs

### DIFF
--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_crossversion_impl.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_crossversion_impl.sh
@@ -31,6 +31,7 @@ test_args="--test_arg=-test.v $test_args"
 
 $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- \
                                       test @com_github_cockroachdb_pebble//internal/metamorphic/crossversion:crossversion_test \
+                                      --test_env TC_SERVER_URL \
                                       --test_timeout=25200 '--test_filter=TestMetaCrossVersion$' \
                                       --define gotags=bazel,invariants \
                                       --run_under "@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts 'XML_OUTPUT_FILE=$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci merge-test-xmls' -maxtime 6h -maxfails 1 -stderr -p 1" \

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_impl.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_impl.sh
@@ -18,6 +18,7 @@ exit_status=0
 # correct flags in the reproduction command.
 $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --formatter=pebble-metamorphic -- test --config=ci \
                                       @com_github_cockroachdb_pebble//internal/metamorphic:metamorphic_test \
+                                      --test_env TC_SERVER_URL \
                                       --test_timeout=25200 '--test_filter=TestMeta$' \
                                       --define gotags=bazel,invariants \
                                       --run_under "@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts 'XML_OUTPUT_FILE=$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci merge-test-xmls' -maxtime 6h -maxfails 1 -stderr -p 1" \

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_race_impl.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_race_impl.sh
@@ -18,6 +18,7 @@ exit_status=0
 # correct flags in the reproduction command.
 $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --formatter=pebble-metamorphic -- test --config=race --config=ci \
                                       @com_github_cockroachdb_pebble//internal/metamorphic:metamorphic_test \
+                                      --test_env TC_SERVER_URL \
                                       --test_timeout=14400 '--test_filter=TestMeta$' \
                                       --define gotags=bazel,invariants \
                                       --run_under "@com_github_cockroachdb_stress//:stress -bazel -shardable-artifacts 'XML_OUTPUT_FILE=$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci merge-test-xmls' -maxtime 3h -maxfails 1 -stderr -p 1" \


### PR DESCRIPTION
Currently, despite the `TC_SERVER_URL` environment variable - used for generating links to TeamCity artifacts and test runs - being passed through to the test environment, it is not passed to the unit test run. This results in links rendering without the host part of the URL.

Pass through the environment variable to the unit test with the `--test_env` flag.

Release note: None.

Epic: CRDB-20293