### PR TITLE
sql: resolve schema should check required privilege

### DIFF
--- a/pkg/sql/schemachanger/scbuild/builder_state.go
+++ b/pkg/sql/schemachanger/scbuild/builder_state.go
@@ -661,7 +661,11 @@ func (b *builderState) ResolveSchema(
 			"%s permission denied for schema %q", p.RequiredPrivilege.String(), name))
 	case catalog.SchemaUserDefined:
 		b.ensureDescriptor(sc.GetID())
-		b.mustOwn(sc.GetID())
+		if p.RequireOwnership {
+			b.mustOwn(sc.GetID())
+		} else {
+			b.checkPrivilege(sc.GetID(), p.RequiredPrivilege)
+		}
 	default:
 		panic(errors.AssertionFailedf("unknown schema kind %d", sc.SchemaKind()))
 	}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
@@ -272,6 +272,10 @@ type ResolveParams struct {
 	// RequiredPrivilege defines the privilege required for the resolved
 	// descriptor.
 	RequiredPrivilege privilege.Kind
+
+	// RequireOwnership if set to true, requires current user be the owner of the
+	// resolved descriptor. It preempts RequiredPrivilege.
+	RequireOwnership bool
 }
 
 // NameResolver looks up elements in the catalog by name, and vice-versa.

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_schema.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_schema.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
-	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
@@ -30,7 +29,7 @@ func DropSchema(b BuildCtx, n *tree.DropSchema) {
 	for _, name := range n.Names {
 		elts := b.ResolveSchema(name, ResolveParams{
 			IsExistenceOptional: n.IfExists,
-			RequiredPrivilege:   privilege.DROP,
+			RequireOwnership:    true,
 		})
 		_, _, sc := scpb.FindSchema(elts)
 		if sc == nil {


### PR DESCRIPTION
Previously, for some reason, we require ownership when resolving a schema in declarative schema changer. That means the required privilege flag makes no effect. This pr changes it to check the actual required privilege.

Epic: None

Release note: None.