### PR TITLE
release-22.1: kvcoord: include replica info in RangeIterator.Seek into trace

### DIFF
--- a/pkg/kv/kvclient/kvcoord/range_iter.go
+++ b/pkg/kv/kvclient/kvcoord/range_iter.go
@@ -167,7 +167,8 @@ func (ri *RangeIterator) Next(ctx context.Context) {
 
 // Seek positions the iterator at the specified key.
 func (ri *RangeIterator) Seek(ctx context.Context, key roachpb.RKey, scanDir ScanDirection) {
-	if log.HasSpanOrEvent(ctx) {
+	logEvents := log.HasSpanOrEvent(ctx)
+	if logEvents {
 		rev := ""
 		if scanDir == Descending {
 			rev = " (rev)"
@@ -204,8 +205,8 @@ func (ri *RangeIterator) Seek(ctx context.Context, key roachpb.RKey, scanDir Sca
 			}
 			continue
 		}
-		if log.V(2) {
-			log.Infof(ctx, "key: %s, desc: %s", ri.key, rngInfo.Desc())
+		if logEvents {
+			log.Eventf(ctx, "key: %s, desc: %s", ri.key, rngInfo.Desc())
 		}
 
 		ri.token = rngInfo

--- a/pkg/sql/show_trace.go
+++ b/pkg/sql/show_trace.go
@@ -165,6 +165,7 @@ var kvMsgRegexp = regexp.MustCompile(
 		"^Get ",
 		"^Scan ",
 		"^querying next range at ",
+		"^key:.*, desc: ",
 		"^output row: ",
 		"^rows affected: ",
 		"^execution failed after ",


### PR DESCRIPTION
Backport 1/1 commits from #92947.

/cc @cockroachdb/release

---

This commit modifies the existing "info" log message into an "event"
when seeking the range iterator. This makes it so that the result of the
seek (the replica information) is included into the trace. Additionally,
this commit includes the corresponding message to be included into the
KV trace. The original "info" log message was added about five years ago
and probably hasn't been that useful.

Here is an example of the trace event:
```
key: /NamespaceTable/30/1/100/101/"t"/4/1, desc: r32:/NamespaceTable/{30-Max} [(n1,s1):1, next=2, gen=0]
```

Informs: https://github.com/cockroachlabs/support/issues/1933.

Release note: None

Release justification: low-risk debugging improvement.