### PR TITLE
pkg/ui: Add span details component to tracez_v2.

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/tracez/snapshot.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/tracez/snapshot.module.scss
@@ -13,6 +13,7 @@
   display: flex;
   flex-flow: column;
   height: 100%;
+  font-family: $font-family--base;
 }
 
 .no-results {
@@ -66,6 +67,7 @@
 
 .table-title-time {
   width: 20ch;
+  margin-right: 4px;
 }
 
 .tag-group {
@@ -104,7 +106,66 @@
   padding-top: 1px;
 }
 
+.icon-gray {
+  fill: lightgray;
+  height: 10px;
+  width: 10px;
+  padding-top: 1px;
+}
+
 .section {
   flex: 0 0 auto;
-  padding: 12px 24px 140px 0px;
+  padding: 12px 24px 12px 0px;
+}
+
+.span-section {
+  background-color: $colors--neutral-0;
+  padding: 12px;
+  margin-right: 12px;
+  margin-bottom: 12px;
+}
+
+.bottom-padding {
+  padding-bottom: 140px;
+}
+
+.span-snapshot-key {
+  font-family: $font-family--bold;
+}
+
+.span-snapshot-key-value {
+  padding-bottom: 4px;
+}
+
+.span-snapshot-column {
+  min-width: fit-content;
+}
+
+.span-snapshot-columns {
+  display: flex;
+  flex-direction: row;
+  gap: 24px;
+}
+
+.span-header-columns {
+  display: flex;
+  flex-direction: row;
+  padding-bottom: 12px;
+  padding-right: 12px;
+  align-items: center;
+}
+
+.span-details-title {
+  color: $colors--neutral-7;
+  font-family: $font-family--semi-bold;
+  font-style: normal;
+  font-stretch: normal;
+  font-size: 20px;
+  padding-bottom: 0px;
+  margin-bottom: 0px;
+  width: 100%;
+}
+
+.span-details-raw-trace-button {
+  flex-shrink: 0;
 }

--- a/pkg/ui/workspaces/cluster-ui/src/tracez/snapshot/rawTraceComponent.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/tracez/snapshot/rawTraceComponent.tsx
@@ -1,0 +1,73 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { GetTraceResponse } from "src/api";
+import Long from "long";
+import { Loading } from "src/loading";
+import React, { useEffect } from "react";
+import classNames from "classnames/bind";
+import styles from "../snapshot.module.scss";
+const cx = classNames.bind(styles);
+
+export const RawTraceComponent: React.FC<{
+  nodeID: string;
+  snapshotID: number;
+  traceID: Long;
+  rawTrace: GetTraceResponse;
+  rawTraceLoading: boolean;
+  rawTraceError?: Error;
+  refreshRawTrace: (req: {
+    nodeID: string;
+    snapshotID: number;
+    traceID: Long;
+  }) => void;
+}> = props => {
+  const {
+    nodeID,
+    snapshotID,
+    traceID,
+    rawTrace,
+    rawTraceLoading,
+    rawTraceError,
+    refreshRawTrace,
+  } = props;
+
+  useEffect(() => {
+    if (!(nodeID && snapshotID && traceID)) {
+      return;
+    }
+    refreshRawTrace({
+      nodeID,
+      snapshotID,
+      traceID,
+    });
+  }, [nodeID, snapshotID, traceID, refreshRawTrace]);
+
+  return (
+    <Loading
+      loading={rawTraceLoading}
+      page={"raw trace"}
+      error={rawTraceError}
+      render={() => {
+        return (
+          <>
+            <section
+              data-testid="raw-trace-component"
+              className={cx("span-section")}
+            >
+              <pre>{rawTrace?.serialized_recording}</pre>
+            </section>
+            <div className={cx("bottom-padding")} />
+          </>
+        );
+      }}
+    />
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/tracez/snapshot/snapshotComponent.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/tracez/snapshot/snapshotComponent.tsx
@@ -1,0 +1,161 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { Helmet } from "react-helmet";
+import { commonStyles } from "src/common";
+import { PageConfig, PageConfigItem } from "src/pageConfig";
+import { Button, Icon } from "@cockroachlabs/ui-components";
+import { Dropdown } from "src/dropdown";
+import { Loading } from "src/loading";
+import { SpanTable } from "./spanTable";
+import React, { useMemo } from "react";
+import classNames from "classnames/bind";
+import styles from "../snapshot.module.scss";
+import { TimestampToMoment } from "src/util";
+import { SortSetting } from "src/sortedtable";
+import {
+  GetTracingSnapshotResponse,
+  ListTracingSnapshotsResponse,
+} from "src/api";
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import Long from "long";
+const cx = classNames.bind(styles);
+
+export const SnapshotComponent: React.FC<{
+  sort: SortSetting;
+  changeSortSetting: (value: SortSetting) => void;
+  nodes?: cockroach.server.status.statuspb.INodeStatus[];
+  nodeID: string;
+  onNodeSelected: (_: string) => void;
+  snapshots: ListTracingSnapshotsResponse;
+  snapshotID: number;
+  snapshot: GetTracingSnapshotResponse;
+  onSnapshotSelected: (_: number) => void;
+  isLoading: boolean;
+  error: Error;
+  spanDetailsURL: (_: Long) => string;
+  takeAndLoadSnapshot: () => void;
+}> = props => {
+  const {
+    sort,
+    changeSortSetting,
+    nodes,
+    nodeID,
+    onNodeSelected,
+    snapshots,
+    snapshotID,
+    snapshot,
+    onSnapshotSelected,
+    isLoading,
+    error,
+    spanDetailsURL,
+    takeAndLoadSnapshot,
+  } = props;
+
+  const snapshotsAsJson = JSON.stringify(snapshots);
+
+  const [snapshotItems, snapshotName] = useMemo(() => {
+    if (!snapshots) {
+      return [[], ""];
+    }
+    let selectedName = "";
+    const items = snapshots.snapshots.map(snapshotInfo => {
+      const id = snapshotInfo.snapshot_id.toNumber();
+      const time = TimestampToMoment(snapshotInfo.captured_at).format(
+        "MMM D, YYYY [at] HH:mm:ss",
+      );
+      const out = {
+        name: "Snapshot " + id + ": " + time,
+        value: id,
+      };
+      if (id === snapshotID) {
+        selectedName = out.name;
+      }
+      return out;
+    });
+    return [items, selectedName];
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [snapshotsAsJson, snapshotID]);
+
+  const [nodeItems, nodeName] = useMemo(() => {
+    if (!nodes) {
+      return [[], ""];
+    }
+    let selectedName = "";
+    const items = nodes.map(node => {
+      const id = node.desc.node_id.toString();
+      const out = {
+        name: "Node " + id,
+        value: id,
+      };
+      if (id === nodeID) {
+        selectedName = out.name;
+      }
+      return out;
+    });
+    return [items, selectedName];
+  }, [nodes, nodeID]);
+
+  return (
+    <div className={cx("snapshots-page")}>
+      <Helmet title="Snapshots" />
+      <h3
+        data-testid="snapshot-component-title"
+        className={commonStyles("base-heading")}
+      >
+        Snapshots
+      </h3>
+      <div>
+        <PageConfig>
+          <PageConfigItem>
+            <Button onClick={takeAndLoadSnapshot} intent="secondary">
+              <Icon iconName="Download" /> Take snapshot
+            </Button>
+          </PageConfigItem>
+          <PageConfigItem>
+            <Dropdown items={nodeItems} onChange={onNodeSelected}>
+              {nodeName}
+            </Dropdown>
+          </PageConfigItem>
+          {snapshotItems.length > 0 && (
+            <PageConfigItem>
+              <Dropdown<number>
+                items={snapshotItems}
+                onChange={onSnapshotSelected}
+              >
+                {snapshotName}
+              </Dropdown>
+            </PageConfigItem>
+          )}
+        </PageConfig>
+      </div>
+      <section className={cx("section")}>
+        {snapshotID ? (
+          <Loading
+            loading={isLoading}
+            page={"snapshots"}
+            error={error}
+            render={() => (
+              <SpanTable
+                snapshot={snapshot?.snapshot}
+                setSort={changeSortSetting}
+                sort={sort}
+                spanDetailsURL={spanDetailsURL}
+              />
+            )}
+          />
+        ) : (
+          "No snapshots found on this node."
+        )}
+      </section>
+      <div className={cx("bottom-padding")} />
+    </div>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/tracez/snapshot/spanComponent.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/tracez/snapshot/spanComponent.tsx
@@ -1,0 +1,254 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React, { useCallback, useMemo, useState } from "react";
+import moment from "moment";
+import { Helmet } from "react-helmet";
+import { commonStyles } from "src/common";
+import classNames from "classnames/bind";
+import styles from "../snapshot.module.scss";
+import { Loading } from "src/loading";
+import { SpanTable, formatDurationHours, TagCell } from "./spanTable";
+import { TimestampToMoment } from "src/util";
+import { SortSetting } from "src/sortedtable";
+import {
+  GetTracingSnapshotResponse,
+  SetTraceRecordingTypeResponse,
+  Span,
+} from "src/api";
+import { CircleFilled } from "src/icon";
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import RecordingMode = cockroach.util.tracing.tracingpb.RecordingMode;
+import { Switch } from "antd";
+import "antd/lib/switch/style";
+import Long from "long";
+import { Button } from "src/button";
+import { useHistory } from "react-router-dom";
+
+const cx = classNames.bind(styles);
+
+const SpanStatus: React.FC<{
+  span: Span;
+  setTraceRecordingType: (
+    nodeID: string,
+    traceID: Long,
+    mode: RecordingMode,
+  ) => Promise<SetTraceRecordingTypeResponse>;
+  nodeID: string;
+}> = props => {
+  const { span, setTraceRecordingType, nodeID } = props;
+  const spanID = span?.span_id;
+  const [recordingInFlight, setRecordingInFlight] = useState(false);
+  const traceID = span?.trace_id;
+  const recording = span?.current_recording_mode != RecordingMode.OFF;
+
+  const toggleRecording = useCallback(() => {
+    setRecordingInFlight(true);
+    const targetState = recording ? RecordingMode.OFF : RecordingMode.VERBOSE;
+    const resp = setTraceRecordingType(nodeID, traceID, targetState);
+    resp
+      .then(() => {
+        span.current_recording_mode = targetState;
+      })
+      .finally(() => {
+        setRecordingInFlight(false);
+      });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    nodeID,
+    spanID,
+    traceID,
+    recording,
+    setTraceRecordingType,
+    setRecordingInFlight,
+  ]);
+
+  if (!span?.current) {
+    return (
+      <div className={cx("span-snapshot-key-value")}>
+        <div className={cx("span-snapshot-key")}>Status</div>
+        {/* Use a viewbox to shrink the icon just a bit while leaving it centered.*/}
+        <CircleFilled className={cx("icon-gray")} viewBox={"-1 -1 12 12"} />
+        &nbsp; Inactive
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className={cx("span-snapshot-key-value")}>
+        <div className={cx("span-snapshot-key")}>Status</div>
+        {/* Use a viewbox to shrink the icon just a bit while leaving it centered.*/}
+        <CircleFilled
+          className={recording ? cx("icon-red") : cx("icon-green")}
+          viewBox={"-1 -1 12 12"}
+        />
+        &nbsp; Active{recording && ", Recording"}
+      </div>
+      <div className={cx("span-snapshot-key-value")}>
+        <div className={cx("span-snapshot-key")}>Recording</div>
+        <Switch
+          checkedChildren={"On"}
+          unCheckedChildren={"Off"}
+          checked={recording}
+          disabled={recordingInFlight}
+          onClick={toggleRecording}
+        />
+      </div>
+    </>
+  );
+};
+
+export const SpanComponent: React.FC<{
+  snapshot: GetTracingSnapshotResponse;
+  sort: SortSetting;
+  changeSortSetting: (_: SortSetting) => void;
+  spanDetailsURL: (_: Long) => string;
+  span: Span;
+
+  rawTraceURL: (_: Long) => string;
+
+  snapshotError: Error;
+  snapshotLoading: boolean;
+  setTraceRecordingType: (
+    nodeID: string,
+    traceID: Long,
+    recordingMode: RecordingMode,
+  ) => Promise<SetTraceRecordingTypeResponse>;
+  nodeID: string;
+}> = props => {
+  const {
+    snapshot,
+    sort,
+    changeSortSetting,
+    span,
+    spanDetailsURL,
+    snapshotError,
+    snapshotLoading,
+    nodeID,
+    rawTraceURL,
+    setTraceRecordingType,
+  } = props;
+  const snapshotID = snapshot?.snapshot.snapshot_id;
+  const spans = snapshot?.snapshot.spans;
+  const spanID = span?.span_id;
+  const childFilteredSnapshot = useMemo(() => {
+    return {
+      ...snapshot?.snapshot,
+      spans: spans?.filter(s => s.parent_span_id.equals(spanID)),
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [nodeID, snapshotID, spanID]);
+
+  const parentFilteredSnapshot = useMemo(() => {
+    return {
+      ...snapshot?.snapshot,
+      spans: spans?.filter(s => s.span_id.equals(span.parent_span_id)),
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [nodeID, snapshotID, spanID]);
+
+  const snapshotTime = useMemo(() => {
+    return TimestampToMoment(snapshot?.snapshot.captured_at);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [nodeID, snapshotID]);
+
+  const startTime = useMemo(
+    () => {
+      return TimestampToMoment(span?.start);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [nodeID, snapshotID, spanID],
+  );
+
+  const history = useHistory();
+  return (
+    <div className={cx("snapshots-page")}>
+      <Helmet title={"Span " + spanID?.toString()} />
+      <div
+        data-testid="span-component-title"
+        className={cx("span-header-columns")}
+      >
+        <h3 className={cx("span-details-title")}>{span?.operation}</h3>
+        <Button
+          className={cx("span-details-raw-trace-button")}
+          type={"secondary"}
+          onClick={() => {
+            history.push(rawTraceURL(span.span_id));
+          }}
+        >
+          View Raw Trace
+        </Button>
+      </div>
+      <section className={cx("span-section", "span-snapshot-columns")}>
+        <div className={cx("span-snapshot-column")}>
+          <div className={cx("span-snapshot-key-value")}>
+            <div className={cx("span-snapshot-key")}>Snapshot Time (UTC)</div>
+            {snapshotTime.format("YYYY-MM-DD HH:mm:ss.SSS")}
+          </div>
+          <div className={cx("span-snapshot-key-value")}>
+            <div className={cx("span-snapshot-key")}>Start Time (UTC)</div>
+            {startTime.format("YYYY-MM-DD HH:mm:ss.SSS")}
+          </div>
+          <div className={cx("span-snapshot-key-value")}>
+            <div className={cx("span-snapshot-key")}>Duration</div>
+            {formatDurationHours(moment.duration(snapshotTime.diff(startTime)))}
+          </div>
+          <SpanStatus
+            span={span}
+            setTraceRecordingType={setTraceRecordingType}
+            nodeID={nodeID}
+          />
+        </div>
+        <div>
+          <div className={cx("span-snapshot-key", "span-snapshot-key-value")}>
+            Tags
+          </div>
+          {span && <TagCell span={span} defaultExpanded={true} />}
+        </div>
+      </section>
+      {parentFilteredSnapshot.spans?.length > 0 && (
+        <section className={cx("span-section")}>
+          <h3 className={commonStyles("base-heading")}>Parent Span</h3>
+          <Loading
+            loading={snapshotLoading}
+            page={"snapshots"}
+            error={snapshotError}
+            render={() => (
+              <SpanTable
+                snapshot={parentFilteredSnapshot}
+                spanDetailsURL={spanDetailsURL}
+              />
+            )}
+          />
+        </section>
+      )}
+      {childFilteredSnapshot.spans?.length > 0 && (
+        <section className={cx("span-section")}>
+          <h3 className={commonStyles("base-heading")}>Child Spans</h3>
+          <Loading
+            loading={snapshotLoading}
+            page={"snapshots"}
+            error={snapshotError}
+            render={() => (
+              <SpanTable
+                snapshot={childFilteredSnapshot}
+                setSort={changeSortSetting}
+                sort={sort}
+                spanDetailsURL={spanDetailsURL}
+              />
+            )}
+          />
+        </section>
+      )}
+      <div className={cx("bottom-padding")} />
+    </div>
+  );
+};

--- a/pkg/ui/workspaces/db-console/src/app.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.tsx
@@ -80,11 +80,11 @@ import RecentStatementDetails from "./views/statements/recentStatementDetailsCon
 import RecentTransactionDetails from "./views/transactions/recentTransactionDetailsConnected";
 import "styl/app.styl";
 import { Tracez } from "src/views/tracez/tracez";
-import SnapshotPage from "src/views/tracez_v2/snapshotPage";
 import InsightsOverviewPage from "./views/insights/insightsOverview";
 import TransactionInsightDetailsPage from "./views/insights/transactionInsightDetailsPage";
 import StatementInsightDetailsPage from "./views/insights/statementInsightDetailsPage";
 import { CockroachCloudContext } from "@cockroachlabs/cluster-ui";
+import { SnapshotRouter } from "src/views/tracez_v2/snapshotRoutes";
 
 // NOTE: If you are adding a new path to the router, and that path contains any
 // components that are personally identifying information, you MUST update the
@@ -323,21 +323,7 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
                   {/* debug pages */}
                   <Route exact path="/debug" component={Debug} />
                   <Route exact path="/debug/tracez" component={Tracez} />
-                  <Route
-                    exact
-                    path="/debug/tracez_v2"
-                    component={SnapshotPage}
-                  />
-                  <Route
-                    exact
-                    path="/debug/tracez_v2/node/:nodeID"
-                    component={SnapshotPage}
-                  />
-                  <Route
-                    exact
-                    path="/debug/tracez_v2/node/:nodeID/snapshot/:snapshotID"
-                    component={SnapshotPage}
-                  />
+                  <Route path="/debug/tracez_v2" component={SnapshotRouter} />
                   <Route exact path="/debug/redux" component={ReduxDebug} />
                   <Route exact path="/debug/chart" component={CustomChart} />
                   <Route

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -32,6 +32,7 @@ import { VersionList } from "src/interfaces/cockroachlabs";
 import { versionCheck } from "src/util/cockroachlabsAPI";
 import { INodeStatus, RollupStoreMetrics } from "src/util/proto";
 import * as protos from "src/js/protos";
+import Long from "long";
 
 const { generateStmtDetailsToID } = util;
 
@@ -499,7 +500,6 @@ const snapshotsReducerObj = new KeyedCachedDataReducer(
   clusterUiApi.listTracingSnapshots,
   "snapshots",
   (nodeID: string): string => nodeID,
-  moment.duration(1, "s"),
 );
 export const refreshSnapshots = snapshotsReducerObj.refresh;
 
@@ -512,9 +512,21 @@ const snapshotReducerObj = new KeyedCachedDataReducer(
   clusterUiApi.getTracingSnapshot,
   "snapshot",
   snapshotKey,
-  moment.duration(1, "s"),
 );
 export const refreshSnapshot = snapshotReducerObj.refresh;
+
+export const rawTraceKey = (req: {
+  nodeID: string;
+  snapshotID: number;
+  traceID: Long;
+}): string =>
+  req.nodeID + "/" + req.snapshotID.toString() + "/" + req.traceID?.toString();
+const rawTraceReducerObj = new KeyedCachedDataReducer(
+  clusterUiApi.getRawTrace,
+  "rawTrace",
+  rawTraceKey,
+);
+export const refreshRawTrace = rawTraceReducerObj.refresh;
 
 export interface APIReducersState {
   cluster: CachedDataReducerState<api.ClusterResponseMessage>;
@@ -559,6 +571,7 @@ export interface APIReducersState {
   schedule: KeyedCachedDataReducerState<clusterUiApi.Schedule>;
   snapshots: KeyedCachedDataReducerState<clusterUiApi.ListTracingSnapshotsResponse>;
   snapshot: KeyedCachedDataReducerState<clusterUiApi.GetTracingSnapshotResponse>;
+  rawTrace: KeyedCachedDataReducerState<clusterUiApi.GetTraceResponse>;
 }
 
 export const apiReducersReducer = combineReducers<APIReducersState>({
@@ -611,6 +624,7 @@ export const apiReducersReducer = combineReducers<APIReducersState>({
   [scheduleReducerObj.actionNamespace]: scheduleReducerObj.reducer,
   [snapshotsReducerObj.actionNamespace]: snapshotsReducerObj.reducer,
   [snapshotReducerObj.actionNamespace]: snapshotReducerObj.reducer,
+  [rawTraceReducerObj.actionNamespace]: rawTraceReducerObj.reducer,
 });
 
 export { CachedDataReducerState, KeyedCachedDataReducerState };

--- a/pkg/ui/workspaces/db-console/src/views/tracez_v2/snapshotRoutes.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/tracez_v2/snapshotRoutes.tsx
@@ -1,0 +1,60 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { Route, Switch, useHistory, useRouteMatch } from "react-router-dom";
+import React, { useEffect } from "react";
+import SnapshotPage from "src/views/tracez_v2/snapshotPage";
+import { join } from "path";
+import { getDataFromServer } from "src/util/dataFromServer";
+
+const NodePicker: React.FC = () => {
+  // If no node was provided, navigate explicitly to the local node.
+  const { url } = useRouteMatch();
+  const history = useHistory();
+  useEffect(() => {
+    let targetNodeID = getDataFromServer().NodeID;
+    if (!targetNodeID) {
+      targetNodeID = "local";
+    }
+    history.location.pathname = join(url, "/node/", targetNodeID);
+    history.replace(history.location);
+  }, [url, history]);
+
+  return null;
+};
+
+export const SnapshotRouter = () => {
+  const { path } = useRouteMatch();
+  return (
+    <Switch>
+      <Route exact path={path} component={NodePicker} />
+      <Route
+        exact
+        path={join(path, "/node/:nodeID")}
+        component={SnapshotPage}
+      />
+      <Route
+        exact
+        path={join(path, "/node/:nodeID/snapshot/:snapshotID")}
+        component={SnapshotPage}
+      />
+      <Route
+        exact
+        path={join(path, "/node/:nodeID/snapshot/:snapshotID/span/:spanID")}
+        component={SnapshotPage}
+      />
+      <Route
+        exact
+        path={join(path, "/node/:nodeID/snapshot/:snapshotID/span/:spanID/raw")}
+        component={SnapshotPage}
+      />
+    </Switch>
+  );
+};


### PR DESCRIPTION
This PR adds the "span details" and "raw trace" screens to the new tracez_v2 page. Previously, only the "snapshot details (i.e. list spans) screen existed on that page. The detailed span information page is where users will go to dig in to the specifics of a span. In particular, we'll display accumulated data on child spans of that page, helping navigate to problem segments more easily.

Note that this PR brings the v2 page up to feature parity with the v1 page. Though the redesign is not yet complete, we'll be able to turn down the v1 page after this lands.

This PR also modifies the route structure a little to encapsulate better.

Release note: None

<img width="1583" alt="Screen Shot 2022-12-07 at 1 52 26 PM" src="https://user-images.githubusercontent.com/261508/206270214-9708e298-cc8e-4a69-9554-8bfb8555277c.png">

<img width="1583" alt="Screen Shot 2022-12-07 at 1 51 59 PM" src="https://user-images.githubusercontent.com/261508/206270152-8d0a36f0-c64d-40bd-a47e-1573039e33ac.png">

<img width="1664" alt="Screen Shot 2022-12-05 at 12 12 41 PM" src="https://user-images.githubusercontent.com/261508/206269949-a62130c7-53cf-4655-84ae-8f6c42d4e66e.png">

Informs https://github.com/cockroachdb/cockroach/issues/83679