### PR TITLE
cluster-ui: move database details endpoint to use sql-over-http

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/clusterLocksApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/clusterLocksApi.ts
@@ -81,7 +81,7 @@ WHERE
 
   return executeInternalSql<ClusterLockColumns>(request).then(result => {
     if (sqlResultsAreEmpty(result)) {
-      return formatApiResult(
+      return formatApiResult<ClusterLockState[]>(
         [],
         result.error,
         "retrieving cluster locks information",
@@ -126,7 +126,7 @@ WHERE
       }
     });
 
-    return formatApiResult(
+    return formatApiResult<ClusterLockState[]>(
       Object.values(locks),
       result.error,
       "retrieving luster locks information",

--- a/pkg/ui/workspaces/cluster-ui/src/api/contentionApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/contentionApi.ts
@@ -60,7 +60,7 @@ export async function getContentionDetailsApi(
   const result = await executeInternalSql<ContentionResponseColumns>(request);
 
   if (sqlResultsAreEmpty(result)) {
-    return formatApiResult(
+    return formatApiResult<ContentionDetails[]>(
       [],
       result.error,
       "retrieving contention information",
@@ -94,7 +94,7 @@ export async function getContentionDetailsApi(
     });
   });
 
-  return formatApiResult(
+  return formatApiResult<ContentionDetails[]>(
     contentionDetails,
     result.error,
     "retrieving insights information",

--- a/pkg/ui/workspaces/cluster-ui/src/api/databaseDetailsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/databaseDetailsApi.ts
@@ -1,0 +1,316 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import {
+  executeInternalSql,
+  LARGE_RESULT_SIZE,
+  SqlExecutionErrorMessage,
+  SqlExecutionRequest,
+  SqlStatement,
+  SqlTxnResult,
+  txnResultIsEmpty,
+} from "./sqlApi";
+import { recommendDropUnusedIndex } from "../insights";
+
+type DatabaseDetailsResponse = {
+  grants_resp: DatabaseGrantsResponse;
+  tables_resp: DatabaseTablesResponse;
+  id_resp: DatabaseIdResponse;
+  stats?: DatabaseDetailsStats;
+  error?: SqlExecutionErrorMessage;
+};
+
+function newDatabaseDetailsResponse(): DatabaseDetailsResponse {
+  return {
+    grants_resp: { grants: [] },
+    tables_resp: { tables: [] },
+    id_resp: { id: { database_id: "" } },
+    stats: {
+      ranges_data: {
+        count: 0,
+        regions: [],
+      },
+      index_stats: { num_index_recommendations: 0 },
+    },
+  };
+}
+
+type DatabaseDetailsStats = {
+  ranges_data: DatabaseRangesData;
+  index_stats: DatabaseIndexUsageStatsResponse;
+};
+
+type DatabaseRangesData = {
+  // missing_tables (not sure if this is necessary)
+  count?: number;
+  // approximate_disk_bytes: number (can't get this currently - range_size_mb in SHOW RANGES gives total uncompressed disk space - not the same... this is used for 'Live Data')
+  // node_ids?: number (don't think we can get this currently, SHOW RANGES only shows replica ids)
+  regions: string[];
+  error?: Error;
+};
+
+type DatabaseIdResponse = {
+  id: DatabaseIdRow;
+  error?: Error;
+};
+
+type DatabaseIdRow = {
+  database_id: string;
+};
+
+const getDatabaseId = (dbName: string): DatabaseDetailsQuery<DatabaseIdRow> => {
+  const stmt: SqlStatement = {
+    sql: `SELECT crdb_internal.get_database_id($1) as database_id`,
+    arguments: [dbName],
+  };
+  const addToDatabaseDetail = (
+    txn_result: SqlTxnResult<DatabaseIdRow>,
+    resp: DatabaseDetailsResponse,
+  ) => {
+    if (!txnResultIsEmpty(txn_result)) {
+      resp.id_resp.id.database_id = txn_result.rows[0].database_id;
+    }
+    if (txn_result.error) {
+      resp.id_resp.error = txn_result.error;
+    }
+  };
+  return {
+    stmt,
+    addToDatabaseDetail,
+  };
+};
+
+type DatabaseGrantsResponse = {
+  grants: DatabaseGrantsRow[];
+  error?: Error;
+};
+
+type DatabaseGrantsRow = {
+  database_name: string;
+  grantee: string;
+  privilege_type: string;
+  is_grantable: boolean;
+};
+
+const getDatabaseGrantsQuery = (
+  dbName: string,
+): DatabaseDetailsQuery<DatabaseGrantsRow> => {
+  const stmt: SqlStatement = {
+    sql: `SELECT * FROM [SHOW GRANTS ON DATABASE ${dbName}]`,
+  };
+  const addToDatabaseDetail = (
+    txn_result: SqlTxnResult<DatabaseGrantsRow>,
+    resp: DatabaseDetailsResponse,
+  ) => {
+    if (!txnResultIsEmpty(txn_result)) {
+      resp.grants_resp.grants = txn_result.rows;
+      if (txn_result.error) {
+        resp.grants_resp.error = txn_result.error;
+      }
+    }
+  };
+  return {
+    stmt,
+    addToDatabaseDetail,
+  };
+};
+
+type DatabaseTablesResponse = {
+  tables: DatabaseTablesRow[];
+  error?: Error;
+};
+
+type DatabaseTablesRow = {
+  table_schema: string;
+  table_name: string;
+};
+
+const getDatabaseTablesQuery = (
+  dbName: string,
+): DatabaseDetailsQuery<DatabaseTablesRow> => {
+  const stmt: SqlStatement = {
+    sql: `SELECT table_schema, table_name FROM ${dbName}.information_schema.tables WHERE table_catalog = $1 AND table_type != 'SYSTEM VIEW' ORDER BY table_name`,
+    arguments: [dbName],
+  };
+  const addToDatabaseDetail = (
+    txn_result: SqlTxnResult<DatabaseTablesRow>,
+    resp: DatabaseDetailsResponse,
+  ) => {
+    if (!txnResultIsEmpty(txn_result)) {
+      resp.tables_resp.tables = txn_result.rows;
+    }
+    if (txn_result.error) {
+      resp.tables_resp.error = txn_result.error;
+    }
+  };
+  return {
+    stmt,
+    addToDatabaseDetail,
+  };
+};
+
+type DatabaseRangesRow = {
+  range_id: number;
+  table_id: number;
+  database_name: string;
+  schema_name: string;
+  table_name: string;
+  replicas: number[];
+  regions: string[];
+  range_size: number;
+};
+
+const getDatabaseRanges = (
+  dbName: string,
+): DatabaseDetailsQuery<DatabaseRangesRow> => {
+  const stmt: SqlStatement = {
+    sql: `SELECT
+            r.range_id,
+            t.table_id,
+            t.database_name,
+            t.name as table_name,
+            t.schema_name,
+            r.replicas,
+            ARRAY(SELECT DISTINCT split_part(split_part(unnest(replica_localities),',',1),'=',2)) as regions,
+            (crdb_internal.range_stats(s.start_key) ->>'key_bytes') ::INT +
+            (crdb_internal.range_stats(s.start_key)->>'val_bytes')::INT +
+            coalesce((crdb_internal.range_stats(s.start_key)->>'range_key_bytes')::INT, 0) +
+            coalesce((crdb_internal.range_stats(s.start_key)->>'range_val_bytes')::INT, 0) AS range_size
+          FROM crdb_internal.tables as t
+          JOIN ${dbName}.crdb_internal.table_spans as s ON s.descriptor_id = t.table_id
+          JOIN crdb_internal.ranges_no_leases as r ON s.start_key < r.end_key AND s.end_key > r.start_key
+          WHERE t.database_name = $1`,
+    arguments: [dbName],
+  };
+  const addToDatabaseDetail = (
+    txn_result: SqlTxnResult<DatabaseRangesRow>,
+    resp: DatabaseDetailsResponse,
+  ) => {
+    if (!txnResultIsEmpty(txn_result)) {
+      txn_result.rows.forEach(row => {
+        resp.stats.ranges_data.regions = row.regions;
+      });
+      resp.stats.ranges_data.count = txn_result.rows.length;
+    }
+    if (txn_result.error) {
+      resp.stats.ranges_data.error = txn_result.error;
+    }
+  };
+  return {
+    stmt,
+    addToDatabaseDetail,
+  };
+};
+
+type DatabaseIndexUsageStatsResponse = {
+  num_index_recommendations?: number;
+  error?: Error;
+};
+
+export type DatabaseIndexUsageStatsRow = {
+  database_name: string;
+  table_name: string;
+  table_id: number;
+  index_name: string;
+  index_id: number;
+  index_type: string;
+  total_reads: number;
+  last_read: string;
+  created_at: string;
+  unused_threshold: string;
+};
+
+const getDatabaseIndexUsageStats = (
+  dbName: string,
+): DatabaseDetailsQuery<DatabaseIndexUsageStatsRow> => {
+  const stmt: SqlStatement = {
+    sql: `SELECT
+            t.database_name,
+            ti.descriptor_name as table_name,
+            ti.descriptor_id as table_id,
+            ti.index_name,
+            ti.index_id,
+            ti.index_type,
+            total_reads,
+            last_read,
+            ti.created_at,
+            (SELECT value FROM crdb_internal.cluster_settings WHERE variable = 'sql.index_recommendation.drop_unused_duration') AS unused_threshold
+          FROM ${dbName}.crdb_internal.index_usage_statistics AS us
+                 JOIN ${dbName}.crdb_internal.table_indexes AS ti ON (us.index_id = ti.index_id AND us.table_id = ti.descriptor_id AND index_type = 'secondary')
+                 JOIN ${dbName}.crdb_internal.tables AS t ON (ti.descriptor_id = t.table_id AND t.database_name != 'system')`,
+  };
+  const addToDatabaseDetail = (
+    txn_result: SqlTxnResult<DatabaseIndexUsageStatsRow>,
+    resp: DatabaseDetailsResponse,
+  ) => {
+    txn_result.rows?.forEach(row => {
+      const rec = recommendDropUnusedIndex(row);
+      if (rec.recommend) {
+        resp.stats.index_stats.num_index_recommendations += 1;
+      }
+    });
+    if (txn_result.error) {
+      resp.stats.index_stats.error = txn_result.error;
+    }
+  };
+  return {
+    stmt,
+    addToDatabaseDetail,
+  };
+};
+
+type DatabaseDetailsRow =
+  | DatabaseIdRow
+  | DatabaseGrantsRow
+  | DatabaseTablesRow
+  | DatabaseRangesRow
+  | DatabaseIndexUsageStatsRow;
+
+type DatabaseDetailsQuery<RowType> = {
+  stmt: SqlStatement;
+  addToDatabaseDetail: (
+    response: SqlTxnResult<RowType>,
+    dbDetail: DatabaseDetailsResponse,
+  ) => void;
+};
+
+export async function getDatabaseDetails(databaseName: string) {
+  const databaseDetailQueries: DatabaseDetailsQuery<DatabaseDetailsRow>[] = [
+    getDatabaseId(databaseName),
+    getDatabaseGrantsQuery(databaseName),
+    getDatabaseTablesQuery(databaseName),
+    getDatabaseRanges(databaseName),
+    getDatabaseIndexUsageStats(databaseName),
+  ];
+
+  const req: SqlExecutionRequest = {
+    execute: true,
+    statements: databaseDetailQueries.map(query => query.stmt),
+    max_result_size: LARGE_RESULT_SIZE,
+  };
+
+  const resp: DatabaseDetailsResponse = newDatabaseDetailsResponse();
+
+  const res = await executeInternalSql<DatabaseDetailsRow>(req);
+
+  res.execution.txn_results.forEach(txn_result => {
+    if (txn_result.rows) {
+      const query: DatabaseDetailsQuery<DatabaseDetailsRow> =
+        databaseDetailQueries[txn_result.statement - 1];
+      query.addToDatabaseDetail(txn_result, resp);
+    }
+  });
+
+  if (res.error) {
+    resp.error = res.error;
+  }
+
+  return resp;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/api/databaseDetailsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/databaseDetailsApi.ts
@@ -10,7 +10,11 @@
 
 import {
   executeInternalSql,
+  formatApiResult,
   LARGE_RESULT_SIZE,
+  LONG_TIMEOUT,
+  SqlApiQueryResponse,
+  SqlApiResponse,
   SqlExecutionErrorMessage,
   SqlExecutionRequest,
   SqlStatement,
@@ -18,58 +22,55 @@ import {
   txnResultIsEmpty,
 } from "./sqlApi";
 import { IndexUsageStatistic, recommendDropUnusedIndex } from "../insights";
-import { Format, Identifier } from "./safesql";
+import { Format, Identifier, QualifiedIdentifier } from "./safesql";
 import moment from "moment";
-import { withTimeout } from "./util";
+import { fromHexString, withTimeout } from "./util";
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+
+const { ZoneConfig } = cockroach.config.zonepb;
+const { ZoneConfigurationLevel } = cockroach.server.serverpb;
+type ZoneConfigType = cockroach.config.zonepb.ZoneConfig;
+type ZoneConfigLevelType = cockroach.server.serverpb.ZoneConfigurationLevel;
 
 export type DatabaseDetailsResponse = {
-  grants_resp: DatabaseGrantsResponse;
-  tables_resp: DatabaseTablesResponse;
-  id_resp: DatabaseIdResponse;
+  id_resp: SqlApiQueryResponse<DatabaseIdRow>;
+  grants_resp: SqlApiQueryResponse<DatabaseGrantsResponse>;
+  tables_resp: SqlApiQueryResponse<DatabaseTablesResponse>;
+  zone_config_resp: SqlApiQueryResponse<DatabaseZoneConfigResponse>;
   stats?: DatabaseDetailsStats;
   error?: SqlExecutionErrorMessage;
 };
 
-export function newDatabaseDetailsResponse(): DatabaseDetailsResponse {
+function newDatabaseDetailsResponse(): DatabaseDetailsResponse {
   return {
+    id_resp: { database_id: "" },
     grants_resp: { grants: [] },
     tables_resp: { tables: [] },
-    id_resp: { id: { database_id: "" } },
+    zone_config_resp: {
+      zone_config: new ZoneConfig({
+        inherited_constraints: true,
+        inherited_lease_preferences: true,
+      }),
+      zone_config_level: ZoneConfigurationLevel.CLUSTER,
+    },
     stats: {
       ranges_data: {
-        count: 0,
+        range_count: 0,
+        live_bytes: 0,
+        total_bytes: 0,
+        // Note: we are currently populating this with replica ids which do not map 1 to 1
         node_ids: [],
         regions: [],
+      },
+      pebble_data: {
+        approximate_disk_bytes: 0,
       },
       index_stats: { num_index_recommendations: 0 },
     },
   };
 }
 
-type DatabaseDetailsStats = {
-  pebble_data?: DatabasePebbleData;
-  ranges_data: DatabaseRangesData;
-  index_stats: DatabaseIndexUsageStatsResponse;
-};
-
-type DatabasePebbleData = {
-  approximate_disk_bytes: number; // (can't get this currently via SQL)
-};
-
-type DatabaseRangesData = {
-  count: number;
-  // TODO(thomas): currently we are using replicas to populate node ids
-  // which does not map 1 to 1.
-  node_ids: number[];
-  regions: string[];
-  error?: Error;
-};
-
-type DatabaseIdResponse = {
-  id: DatabaseIdRow;
-  error?: Error;
-};
-
+// Database ID
 type DatabaseIdRow = {
   database_id: string;
 };
@@ -85,8 +86,9 @@ const getDatabaseId: DatabaseDetailsQuery<DatabaseIdRow> = {
     txn_result: SqlTxnResult<DatabaseIdRow>,
     resp: DatabaseDetailsResponse,
   ) => {
-    if (!txnResultIsEmpty(txn_result)) {
-      resp.id_resp.id.database_id = txn_result.rows[0].database_id;
+    // Check that txn_result.rows[0].database_id is not null
+    if (!txnResultIsEmpty(txn_result) && txn_result.rows[0].database_id) {
+      resp.id_resp.database_id = txn_result.rows[0].database_id;
     }
     if (txn_result.error) {
       resp.id_resp.error = txn_result.error;
@@ -94,24 +96,23 @@ const getDatabaseId: DatabaseDetailsQuery<DatabaseIdRow> = {
   },
 };
 
+// Database Grants
 type DatabaseGrantsResponse = {
   grants: DatabaseGrantsRow[];
-  error?: Error;
 };
 
 type DatabaseGrantsRow = {
-  database_name: string;
-  grantee: string;
-  privilege_type: string;
-  is_grantable: boolean;
+  user: string;
+  privileges: string[];
 };
 
 const getDatabaseGrantsQuery: DatabaseDetailsQuery<DatabaseGrantsRow> = {
   createStmt: dbName => {
     return {
-      sql: Format(`SHOW GRANTS ON DATABASE %1`, [
-        new Identifier(dbName),
-      ]),
+      sql: `SELECT grantee as user, array_agg(privilege_type) as privileges
+            FROM crdb_internal.cluster_database_privileges
+            WHERE database_name = $1 group by grantee`,
+      arguments: [dbName],
     };
   },
   addToDatabaseDetail: (
@@ -127,9 +128,9 @@ const getDatabaseGrantsQuery: DatabaseDetailsQuery<DatabaseGrantsRow> = {
   },
 };
 
+// Database Tables
 type DatabaseTablesResponse = {
-  tables: DatabaseTablesRow[];
-  error?: Error;
+  tables: string[];
 };
 
 type DatabaseTablesRow = {
@@ -141,7 +142,10 @@ const getDatabaseTablesQuery: DatabaseDetailsQuery<DatabaseTablesRow> = {
   createStmt: dbName => {
     return {
       sql: Format(
-        `SELECT table_schema, table_name FROM %1.information_schema.tables WHERE table_type != 'SYSTEM VIEW' ORDER BY table_name`,
+        `SELECT table_schema, table_name
+         FROM %1.information_schema.tables
+         WHERE table_type != 'SYSTEM VIEW'
+         ORDER BY table_name`,
         [new Identifier(dbName)],
       ),
     };
@@ -151,7 +155,13 @@ const getDatabaseTablesQuery: DatabaseDetailsQuery<DatabaseTablesRow> = {
     resp: DatabaseDetailsResponse,
   ) => {
     if (!txnResultIsEmpty(txn_result)) {
-      resp.tables_resp.tables = txn_result.rows;
+      resp.tables_resp.tables = txn_result.rows.map(row => {
+        const escTableName = new QualifiedIdentifier([
+          row.table_schema,
+          row.table_name,
+        ]).SQLString();
+        return `${escTableName}`;
+      });
     }
     if (txn_result.error) {
       resp.tables_resp.error = txn_result.error;
@@ -159,72 +169,199 @@ const getDatabaseTablesQuery: DatabaseDetailsQuery<DatabaseTablesRow> = {
   },
 };
 
-type DatabaseRangesRow = {
-  replicas: number[];
-  regions: string[];
-  range_size: number;
+// Database Zone Config
+type DatabaseZoneConfigResponse = {
+  zone_config: ZoneConfigType;
+  zone_config_level: ZoneConfigLevelType;
 };
 
-const getDatabaseRanges: DatabaseDetailsQuery<DatabaseRangesRow> = {
+type DatabaseZoneConfigRow = {
+  zone_config_hex_string: string;
+};
+
+const getDatabaseZoneConfig: DatabaseDetailsQuery<DatabaseZoneConfigRow> = {
   createStmt: dbName => {
     return {
-      // Note: include `drop_time is NULL` to make use of virtual index.
-      sql: Format(
-        `SELECT
-            r.replicas,
-            ARRAY(SELECT DISTINCT split_part(split_part(unnest(replica_localities),',',1),'=',2)) as regions,
-            (crdb_internal.range_stats(s.start_key) ->>'key_bytes') ::INT +
-            (crdb_internal.range_stats(s.start_key)->>'val_bytes')::INT +
-            coalesce((crdb_internal.range_stats(s.start_key)->>'range_key_bytes')::INT, 0) +
-            coalesce((crdb_internal.range_stats(s.start_key)->>'range_val_bytes')::INT, 0) AS range_size
-          FROM crdb_internal.tables as t
-          JOIN %1.crdb_internal.table_spans as s ON s.descriptor_id = t.table_id
-          JOIN crdb_internal.ranges_no_leases as r ON s.start_key < r.end_key AND s.end_key > r.start_key
-          WHERE t.database_name = $1 and t.drop_time is NULL`,
-        [new Identifier(dbName)],
-      ),
+      sql: `SELECT 
+        encode(
+          crdb_internal.get_zone_config(
+            (SELECT crdb_internal.get_database_id($1))
+          ),
+          'hex'
+        ) as zone_config_hex_string`,
       arguments: [dbName],
     };
   },
   addToDatabaseDetail: (
-    txn_result: SqlTxnResult<DatabaseRangesRow>,
+    txn_result: SqlTxnResult<DatabaseZoneConfigRow>,
     resp: DatabaseDetailsResponse,
   ) => {
-    // Build set of unique regions for this database.
-    const regions = new Set<string>();
-    // Build set of unique replicas for this database.
-    const replicas = new Set<number>();
-    if (!txnResultIsEmpty(txn_result)) {
-      txn_result.rows.forEach(row => {
-        row.regions.forEach(regions.add, regions);
-        row.replicas.forEach(replicas.add, replicas);
-      });
-      resp.stats.ranges_data.regions = Array.from(regions.values());
-      resp.stats.ranges_data.node_ids = Array.from(replicas.values());
-      resp.stats.ranges_data.count = txn_result.rows.length;
+    if (
+      !txnResultIsEmpty(txn_result) &&
+      // Check that txn_result.rows[0].zone_config_hex_string is not null
+      // and not empty.
+      txn_result.rows[0].zone_config_hex_string &&
+      txn_result.rows[0].zone_config_hex_string.length !== 0
+    ) {
+      const zoneConfigHexString = txn_result.rows[0].zone_config_hex_string;
+      // Try to decode the zone config bytes response.
+      try {
+        // Parse the bytes from the hex string.
+        const zoneConfigBytes = fromHexString(zoneConfigHexString);
+        // Decode the bytes using ZoneConfig protobuf.
+        resp.zone_config_resp.zone_config = ZoneConfig.decode(
+          new Uint8Array(zoneConfigBytes),
+        );
+        resp.zone_config_resp.zone_config_level =
+          ZoneConfigurationLevel.DATABASE;
+      } catch (e) {
+        console.error(
+          `Database Details API - encountered an error decoding zone config string: ${zoneConfigHexString}`,
+        );
+        // Catch and assign the error if we encounter one decoding.
+        resp.zone_config_resp.error = e;
+        resp.zone_config_resp.zone_config_level =
+          ZoneConfigurationLevel.UNKNOWN;
+      }
     }
     if (txn_result.error) {
-      resp.stats.ranges_data.error = txn_result.error;
+      resp.id_resp.error = txn_result.error;
     }
   },
 };
 
-type DatabaseIndexUsageStatsResponse = {
-  num_index_recommendations?: number;
-  error?: Error;
+// Database Stats
+type DatabaseDetailsStats = {
+  pebble_data: DatabasePebbleData;
+  ranges_data: DatabaseRangesData;
+  index_stats: DatabaseIndexUsageStatsResponse;
 };
+
+type DatabasePebbleData = {
+  approximate_disk_bytes: number;
+};
+
+type DatabaseRangesData = SqlApiQueryResponse<{
+  range_count: number;
+  live_bytes: number;
+  total_bytes: number;
+  // Note: we are currently populating this with replica ids which do not map 1 to 1
+  node_ids: number[];
+  regions: string[];
+}>;
+
+type DatabaseSpanStatsRow = {
+  approximate_disk_bytes: number;
+  live_bytes: number;
+  total_bytes: number;
+  range_count: number;
+};
+
+const getDatabaseSpanStats: DatabaseDetailsQuery<DatabaseSpanStatsRow> = {
+  createStmt: dbName => {
+    return {
+      sql: `SELECT
+            sum(range_count) as range_count,
+            sum(approximate_disk_bytes) as approximate_disk_bytes,
+            sum(live_bytes) as live_bytes,
+            sum(total_bytes) as total_bytes
+          FROM crdb_internal.tenant_span_stats((SELECT crdb_internal.get_database_id($1)))`,
+      arguments: [dbName],
+    };
+  },
+  addToDatabaseDetail: (
+    txn_result: SqlTxnResult<DatabaseSpanStatsRow>,
+    resp: DatabaseDetailsResponse,
+  ) => {
+    if (txn_result && txn_result.error) {
+      resp.stats.ranges_data.error = txn_result.error;
+    }
+    if (txnResultIsEmpty(txn_result)) {
+      return;
+    }
+    if (txn_result.rows.length === 1) {
+      const row = txn_result.rows[0];
+      resp.stats.pebble_data.approximate_disk_bytes =
+        row.approximate_disk_bytes;
+      resp.stats.ranges_data.range_count = row.range_count;
+      resp.stats.ranges_data.live_bytes = row.live_bytes;
+      resp.stats.ranges_data.total_bytes = row.total_bytes;
+    } else {
+      resp.stats.ranges_data.error = new Error(
+        `DatabaseDetails - Span Stats, expected 1 row, got ${txn_result.rows.length}`,
+      );
+    }
+  },
+};
+
+type DatabaseReplicasRegionsRow = {
+  replicas: number[];
+  regions: string[];
+};
+
+const getDatabaseReplicasAndRegions: DatabaseDetailsQuery<DatabaseReplicasRegionsRow> =
+  {
+    createStmt: dbName => {
+      return {
+        sql: Format(
+          `WITH
+          replicasAndregions as (
+              SELECT
+                r.replicas,
+                ARRAY(SELECT DISTINCT split_part(split_part(unnest(replica_localities),',',1),'=',2)) as regions
+              FROM crdb_internal.tables as t
+                     JOIN %1.crdb_internal.table_spans as s ON s.descriptor_id = t.table_id
+             JOIN crdb_internal.ranges_no_leases as r ON s.start_key < r.end_key AND s.end_key > r.start_key
+           WHERE t.database_name = $1
+          ),
+          unique_replicas AS (SELECT array_agg(distinct(unnest(replicas))) as replicas FROM replicasAndRegions),
+          unique_regions AS (SELECT array_agg(distinct(unnest(regions))) as regions FROM replicasAndRegions)
+          SELECT replicas, regions FROM unique_replicas CROSS JOIN unique_regions`,
+          [new Identifier(dbName)],
+        ),
+        arguments: [dbName],
+      };
+    },
+    addToDatabaseDetail: (
+      txn_result: SqlTxnResult<DatabaseReplicasRegionsRow>,
+      resp: DatabaseDetailsResponse,
+    ) => {
+      if (!txnResultIsEmpty(txn_result)) {
+        resp.stats.ranges_data.regions = txn_result.rows[0].regions;
+        resp.stats.ranges_data.node_ids = txn_result.rows[0].replicas;
+      }
+      if (txn_result.error) {
+        resp.stats.ranges_data.error = txn_result.error;
+      }
+    },
+  };
+
+type DatabaseIndexUsageStatsResponse = SqlApiQueryResponse<{
+  num_index_recommendations?: number;
+}>;
 
 const getDatabaseIndexUsageStats: DatabaseDetailsQuery<IndexUsageStatistic> = {
   createStmt: dbName => {
     return {
       sql: Format(
-        `SELECT
-            $1 as database_name,
-            last_read,
-            ti.created_at,
-            (SELECT value FROM crdb_internal.cluster_settings WHERE variable = 'sql.index_recommendation.drop_unused_duration') AS unused_threshold
-          FROM %1.crdb_internal.index_usage_statistics AS us
-                 JOIN %1.crdb_internal.table_indexes AS ti ON (us.index_id = ti.index_id AND us.table_id = ti.descriptor_id AND index_type = 'secondary')`,
+        `WITH cs AS (
+          SELECT value 
+              FROM crdb_internal.cluster_settings 
+          WHERE variable = 'sql.index_recommendation.drop_unused_duration'
+          )
+          SELECT * FROM (SELECT
+                  ti.created_at,
+                  us.last_read,
+                  us.total_reads,
+                  cs.value as unused_threshold,
+                  cs.value::interval as interval_threshold,
+                  now() - COALESCE(us.last_read AT TIME ZONE 'UTC', COALESCE(ti.created_at, '0001-01-01')) as unused_interval
+                  FROM %1.crdb_internal.index_usage_statistics AS us
+                  JOIN %1.crdb_internal.table_indexes AS ti ON (us.index_id = ti.index_id AND us.table_id = ti.descriptor_id AND ti.index_type = 'secondary')
+                  CROSS JOIN cs
+                 WHERE $1 != 'system')
+               WHERE unused_interval > interval_threshold
+               ORDER BY total_reads DESC;`,
         [new Identifier(dbName)],
       ),
       arguments: [dbName],
@@ -250,7 +387,9 @@ export type DatabaseDetailsRow =
   | DatabaseIdRow
   | DatabaseGrantsRow
   | DatabaseTablesRow
-  | DatabaseRangesRow
+  | DatabaseZoneConfigRow
+  | DatabaseSpanStatsRow
+  | DatabaseReplicasRegionsRow
   | IndexUsageStatistic;
 
 type DatabaseDetailsQuery<RowType> = {
@@ -265,8 +404,10 @@ const databaseDetailQueries: DatabaseDetailsQuery<DatabaseDetailsRow>[] = [
   getDatabaseId,
   getDatabaseGrantsQuery,
   getDatabaseTablesQuery,
-  getDatabaseRanges,
+  getDatabaseReplicasAndRegions,
   getDatabaseIndexUsageStats,
+  getDatabaseZoneConfig,
+  getDatabaseSpanStats,
 ];
 
 export function createDatabaseDetailsReq(dbName: string): SqlExecutionRequest {
@@ -274,31 +415,36 @@ export function createDatabaseDetailsReq(dbName: string): SqlExecutionRequest {
     execute: true,
     statements: databaseDetailQueries.map(query => query.createStmt(dbName)),
     max_result_size: LARGE_RESULT_SIZE,
+    timeout: LONG_TIMEOUT,
   };
 }
 
 export async function getDatabaseDetails(
   databaseName: string,
   timeout?: moment.Duration,
-): Promise<DatabaseDetailsResponse> {
+): Promise<SqlApiResponse<DatabaseDetailsResponse>> {
+  return withTimeout(fetchDatabaseDetails(databaseName), timeout);
+}
+
+async function fetchDatabaseDetails(
+  databaseName: string,
+): Promise<SqlApiResponse<DatabaseDetailsResponse>> {
+  const detailsResponse: DatabaseDetailsResponse = newDatabaseDetailsResponse();
   const req: SqlExecutionRequest = createDatabaseDetailsReq(databaseName);
-  const resp: DatabaseDetailsResponse = newDatabaseDetailsResponse();
-
-  return withTimeout(executeInternalSql<DatabaseDetailsRow>(req), timeout).then(
-    res => {
-      res.execution.txn_results.forEach(txn_result => {
-        if (txn_result.rows) {
-          const query: DatabaseDetailsQuery<DatabaseDetailsRow> =
-            databaseDetailQueries[txn_result.statement - 1];
-          query.addToDatabaseDetail(txn_result, resp);
-        }
-      });
-
-      if (res.error) {
-        resp.error = res.error;
-      }
-
-      return resp;
-    },
+  const resp = await executeInternalSql<DatabaseDetailsRow>(req);
+  resp.execution.txn_results.forEach(txn_result => {
+    if (txn_result.rows) {
+      const query: DatabaseDetailsQuery<DatabaseDetailsRow> =
+        databaseDetailQueries[txn_result.statement - 1];
+      query.addToDatabaseDetail(txn_result, detailsResponse);
+    }
+  });
+  if (resp.error) {
+    detailsResponse.error = resp.error;
+  }
+  return formatApiResult<DatabaseDetailsResponse>(
+    detailsResponse,
+    detailsResponse.error,
+    "retrieving database details information",
   );
 }

--- a/pkg/ui/workspaces/cluster-ui/src/api/eventsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/eventsApi.ts
@@ -98,10 +98,14 @@ export function getNonRedactedEvents(
     timeout,
   ).then(result => {
     if (sqlResultsAreEmpty(result)) {
-      return formatApiResult([], result.error, "retrieving events information");
+      return formatApiResult<EventColumns[]>(
+        [],
+        result.error,
+        "retrieving events information",
+      );
     }
 
-    return formatApiResult(
+    return formatApiResult<EventColumns[]>(
       result.execution.txn_results[0].rows,
       result.error,
       "retrieving events information",

--- a/pkg/ui/workspaces/cluster-ui/src/api/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/index.ts
@@ -23,3 +23,4 @@ export * from "./sqlApi";
 export * from "./tracezApi";
 export * from "./databasesApi";
 export * from "./eventsApi";
+export * from "./databaseDetailsApi";

--- a/pkg/ui/workspaces/cluster-ui/src/api/schemaInsightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/schemaInsightsApi.ts
@@ -212,7 +212,11 @@ export async function getSchemaInsights(): Promise<
 
   const results: InsightRecommendation[] = [];
   if (sqlResultsAreEmpty(result)) {
-    return formatApiResult([], result.error, "retrieving insights information");
+    return formatApiResult<InsightRecommendation[]>(
+      [],
+      result.error,
+      "retrieving insights information",
+    );
   }
   result.execution.txn_results.map(txn_result => {
     // Note: txn_result.statement values begin at 1, not 0.
@@ -222,7 +226,7 @@ export async function getSchemaInsights(): Promise<
       results.push(...insightQuery.toSchemaInsight(txn_result));
     }
   });
-  return formatApiResult(
+  return formatApiResult<InsightRecommendation[]>(
     results,
     result.error,
     "retrieving insights information",

--- a/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
@@ -57,7 +57,7 @@ export type SqlExecutionErrorMessage = {
   message: string;
   code: string;
   severity: string;
-  source: { file: string; line: number; function: "string" };
+  source: { file: string; line: number; function: string };
 };
 
 export type SqlApiResponse<ResultType> = {
@@ -124,9 +124,7 @@ export function sqlResultsAreEmpty(
 ): boolean {
   return (
     !result.execution?.txn_results?.length ||
-    result.execution.txn_results.every(
-      txn => !txn.rows || txn.rows.length === 0,
-    )
+    result.execution.txn_results.every(txn => txnResultIsEmpty(txn))
   );
 }
 
@@ -193,4 +191,8 @@ export function formatApiResult(
     maxSizeReached: maxSizeError,
     results: results,
   };
+}
+
+export function txnResultIsEmpty(txn_result: SqlTxnResult<unknown>): boolean {
+  return !txn_result.rows || txn_result.rows?.length === 0;
 }

--- a/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
@@ -65,6 +65,8 @@ export type SqlApiResponse<ResultType> = {
   results: ResultType;
 };
 
+export type SqlApiQueryResponse<Result> = Result & { error?: Error };
+
 export const SQL_API_PATH = "/api/v2/sql/";
 
 /**
@@ -79,7 +81,7 @@ export function executeSql<RowType>(
   // TODO(maryliag) remove this part of code when cloud is updated with
   // a new CRDB release.
   if (!req.database) {
-    req.database = "system";
+    req.database = FALLBACK_DB;
   }
   return fetchDataJSON<SqlExecutionResponse<RowType>, SqlExecutionRequest>(
     SQL_API_PATH,
@@ -90,6 +92,7 @@ export function executeSql<RowType>(
 export const INTERNAL_SQL_API_APP = "$ internal-console";
 export const LONG_TIMEOUT = "300s";
 export const LARGE_RESULT_SIZE = 50000; // 50 kib
+export const FALLBACK_DB = "system";
 
 /**
  * executeInternalSql executes the provided SQL statements with
@@ -172,11 +175,11 @@ export function isMaxSizeError(message: string): boolean {
   return !!message?.includes("max result size exceeded");
 }
 
-export function formatApiResult(
-  results: Array<any>,
+export function formatApiResult<ResultType>(
+  results: ResultType,
   error: SqlExecutionErrorMessage,
   errorMessageContext: string,
-): SqlApiResponse<any> {
+): SqlApiResponse<ResultType> {
   const maxSizeError = isMaxSizeError(error?.message);
 
   if (error && !maxSizeError) {

--- a/pkg/ui/workspaces/cluster-ui/src/api/stmtInsightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/stmtInsightsApi.ts
@@ -158,11 +158,15 @@ export async function getStmtInsightsApi(
   const result = await executeInternalSql<StmtInsightsResponseRow>(request);
 
   if (sqlResultsAreEmpty(result)) {
-    return formatApiResult([], result.error, "retrieving insights information");
+    return formatApiResult<StmtInsightEvent[]>(
+      [],
+      result.error,
+      "retrieving insights information",
+    );
   }
   const stmtInsightEvent = formatStmtInsights(result.execution?.txn_results[0]);
   await addStmtContentionInfoApi(stmtInsightEvent);
-  return formatApiResult(
+  return formatApiResult<StmtInsightEvent[]>(
     stmtInsightEvent,
     result.error,
     "retrieving insights information",

--- a/pkg/ui/workspaces/cluster-ui/src/api/txnInsightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/txnInsightsApi.ts
@@ -424,10 +424,14 @@ export async function getTxnInsightsApi(
   const result = await executeInternalSql<TxnInsightsResponseRow>(request);
 
   if (sqlResultsAreEmpty(result)) {
-    return formatApiResult([], result.error, "retrieving insights information");
+    return formatApiResult<TxnInsightEvent[]>(
+      [],
+      result.error,
+      "retrieving insights information",
+    );
   }
 
-  return formatApiResult(
+  return formatApiResult<TxnInsightEvent[]>(
     result.execution.txn_results[0].rows.map(formatTxnInsightsRow),
     result.error,
     "retrieving insights information",

--- a/pkg/ui/workspaces/cluster-ui/src/api/util.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/util.ts
@@ -40,3 +40,6 @@ export class TimeoutError extends Error {
     this.timeout = timeout;
   }
 }
+
+export const fromHexString = (hexString: string): Uint8Array =>
+  Uint8Array.from(hexString.match(/.{1,2}/g).map(byte => parseInt(byte, 16)));

--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
@@ -265,11 +265,7 @@ export class DatabaseDetailsPage extends React.Component<
   }
 
   private refresh(): void {
-    if (
-      !this.props.loaded &&
-      !this.props.loading &&
-      this.props.lastError === undefined
-    ) {
+    if (!this.props.loaded && !this.props.loading && !this.props.lastError) {
       return this.props.refreshDatabaseDetails(this.props.name);
     }
 

--- a/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.stories.tsx
@@ -102,7 +102,6 @@ const withData: DatabasesPageProps = {
       sizeInBytes: _.random(1000.0) * 1024 ** _.random(1, 2),
       tableCount: _.random(5, 100),
       rangeCount: _.random(50, 500),
-      missingTables: [],
       nodesByRegionString:
         "gcp-europe-west1(n8), gcp-us-east1(n1), gcp-us-west1(n6)",
       numIndexRecommendations: 0,

--- a/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.tsx
@@ -315,12 +315,7 @@ export class DatabasesPage extends React.Component<
         this.setState({ lastDetailsError: lastDetailsError });
       }
 
-      if (
-        !database.loaded &&
-        !database.loading &&
-        (database.lastError === undefined ||
-          database.lastError?.name === "GetDatabaseInfoError")
-      ) {
+      if (!database.loaded && !database.loading && !database.lastError) {
         this.props.refreshDatabaseDetails(database.name);
         return;
       }

--- a/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databasesPage/databasesPage.tsx
@@ -81,10 +81,6 @@ const booleanSettingCx = classnames.bind(booleanSettingStyles);
 //       rangeCount: number;
 //       nodes: number[];
 //       nodesByRegionString: string;
-//       missingTables: { // DatabasesPageDataMissingTable[]
-//         loading: boolean;
-//         name: string;
-//       }[];
 //     }[];
 //   }
 export interface DatabasesPageData {
@@ -109,7 +105,6 @@ export interface DatabasesPageDataDatabase {
   sizeInBytes: number;
   tableCount: number;
   rangeCount: number;
-  missingTables: DatabasesPageDataMissingTable[];
   // Array of node IDs used to unambiguously filter by node and region.
   nodes?: number[];
   // String of nodes grouped by region in alphabetical order, e.g.
@@ -119,22 +114,9 @@ export interface DatabasesPageDataDatabase {
   numIndexRecommendations: number;
 }
 
-// A "missing" table is one for which we were unable to gather size and range
-// count information during the backend call to fetch DatabaseDetails. We
-// expose it here so that the component has the opportunity to try to refresh
-// those properties for the table directly.
-export interface DatabasesPageDataMissingTable {
-  // Note that we don't need a "loaded" property here because we expect
-  // the reducers supplying our properties to remove a missing table from
-  // the list once we've loaded its data.
-  loading: boolean;
-  name: string;
-}
-
 export interface DatabasesPageActions {
   refreshDatabases: () => void;
   refreshDatabaseDetails: (database: string) => void;
-  refreshTableStats: (database: string, table: string) => void;
   refreshSettings: () => void;
   refreshNodes?: () => void;
   onFilterChange?: (value: Filters) => void;
@@ -342,12 +324,6 @@ export class DatabasesPage extends React.Component<
         this.props.refreshDatabaseDetails(database.name);
         return;
       }
-
-      database.missingTables.forEach(table => {
-        if (!table.loading) {
-          return this.props.refreshTableStats(database.name, table.name);
-        }
-      });
     });
   }
 

--- a/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/indexUsageStatsRec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/indexUsageStatsRec.ts
@@ -21,6 +21,7 @@ type dropIndexRecommendation = {
 };
 
 export interface IndexUsageStatistic {
+  database_name?: string;
   created_at?: string;
   last_read?: string;
   unused_threshold: string;
@@ -29,6 +30,13 @@ export interface IndexUsageStatistic {
 export function recommendDropUnusedIndex(
   indexUsageStat: IndexUsageStatistic,
 ): dropIndexRecommendation {
+  if (
+    indexUsageStat.database_name &&
+    indexUsageStat.database_name === "system"
+  ) {
+    return { recommend: false, reason: "" };
+  }
+
   const createdAt = indexUsageStat.created_at
     ? moment.utc(indexUsageStat.created_at)
     : minDate;

--- a/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/indexUsageStatsRec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/indexUsageStatsRec.ts
@@ -21,7 +21,6 @@ type dropIndexRecommendation = {
 };
 
 export interface IndexUsageStatistic {
-  database_name?: string;
   created_at?: string;
   last_read?: string;
   unused_threshold: string;
@@ -30,13 +29,6 @@ export interface IndexUsageStatistic {
 export function recommendDropUnusedIndex(
   indexUsageStat: IndexUsageStatistic,
 ): dropIndexRecommendation {
-  if (
-    indexUsageStat.database_name &&
-    indexUsageStat.database_name === "system"
-  ) {
-    return { recommend: false, reason: "" };
-  }
-
   const createdAt = indexUsageStat.created_at
     ? moment.utc(indexUsageStat.created_at)
     : minDate;

--- a/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/indexUsageStatsRec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/indexUsageStatsRec.ts
@@ -8,7 +8,6 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { ClusterIndexUsageStatistic } from "../../api/schemaInsightsApi";
 import moment from "moment";
 
 export const indexNeverUsedReason =
@@ -21,14 +20,20 @@ type dropIndexRecommendation = {
   reason: string;
 };
 
+export interface IndexUsageStatistic {
+  created_at?: string;
+  last_read?: string;
+  unused_threshold: string;
+}
+
 export function recommendDropUnusedIndex(
-  clusterIndexUsageStat: ClusterIndexUsageStatistic,
+  indexUsageStat: IndexUsageStatistic,
 ): dropIndexRecommendation {
-  const createdAt = clusterIndexUsageStat.created_at
-    ? moment.utc(clusterIndexUsageStat.created_at)
+  const createdAt = indexUsageStat.created_at
+    ? moment.utc(indexUsageStat.created_at)
     : minDate;
-  const lastRead = clusterIndexUsageStat.last_read
-    ? moment.utc(clusterIndexUsageStat.last_read)
+  const lastRead = indexUsageStat.last_read
+    ? moment.utc(indexUsageStat.last_read)
     : minDate;
   let lastActive = createdAt;
   if (lastActive.isSame(minDate) && !lastRead.isSame(minDate)) {
@@ -40,7 +45,7 @@ export function recommendDropUnusedIndex(
   }
 
   const unusedThreshold = moment.duration(
-    "PT" + clusterIndexUsageStat.unused_threshold.toUpperCase(),
+    "PT" + indexUsageStat.unused_threshold.toUpperCase(),
   );
   return {
     recommend: true,

--- a/pkg/ui/workspaces/cluster-ui/src/sql/box.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sql/box.tsx
@@ -13,7 +13,7 @@ import { Highlight } from "./highlight";
 import classNames from "classnames/bind";
 
 import styles from "./sqlhighlight.module.scss";
-import * as protos from "@cockroachlabs/crdb-protobuf-client";
+import { api as clusterUiApi } from "../index";
 
 export enum SqlBoxSize {
   small = "small",
@@ -23,7 +23,7 @@ export enum SqlBoxSize {
 
 export interface SqlBoxProps {
   value: string;
-  zone?: protos.cockroach.server.serverpb.DatabaseDetailsResponse;
+  zone?: clusterUiApi.DatabaseDetailsResponse;
   className?: string;
   size?: SqlBoxSize;
 }

--- a/pkg/ui/workspaces/cluster-ui/src/sql/highlight.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sql/highlight.tsx
@@ -39,7 +39,7 @@ export class Highlight extends React.Component<SqlBoxProps> {
 
   renderZone = (): React.ReactElement => {
     const { zone } = this.props;
-    const zoneConfig = zone.zone_config;
+    const zoneConfig = zone.zone_config_resp.zone_config;
     return (
       <span className={cx("sql-highlight", "hljs")}>
         <span className="hljs-keyword">CONFIGURE ZONE USING</span>

--- a/pkg/ui/workspaces/cluster-ui/src/util/format.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/format.spec.ts
@@ -76,7 +76,7 @@ describe("Format utils", () => {
     });
   });
 
-  describe.only("EncodeUriName", () => {
+  describe("EncodeUriName", () => {
     it("decode simple string no special characters", () => {
       expect(EncodeUriName("123abc")).toBe("123abc");
     });

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.spec.ts
@@ -10,7 +10,7 @@
 
 import {
   generateTableID,
-  databaseRequestToID,
+  databaseRequestPayloadToID,
   tableRequestToID,
 } from "./apiReducers";
 import * as protos from "src/js/protos";
@@ -34,9 +34,7 @@ describe("table id generator", function () {
 describe("request to string functions", function () {
   it("correctly generates a string from a database details request", function () {
     const database = "testDatabase";
-    const databaseRequest =
-      new protos.cockroach.server.serverpb.DatabaseDetailsRequest({ database });
-    expect(databaseRequestToID(databaseRequest)).toEqual(database);
+    expect(databaseRequestPayloadToID(database)).toEqual(database);
   });
   it("correctly generates a string from a table details request", function () {
     const database = "testDatabase";

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -105,14 +105,12 @@ const databasesReducerObj = new CachedDataReducer(
 );
 export const refreshDatabases = databasesReducerObj.refresh;
 
-export const databaseRequestToID = (
-  req: api.DatabaseDetailsRequestMessage,
-): string => req.database;
+export const databaseRequestPayloadToID = (dbName: string): string => dbName;
 
 const databaseDetailsReducerObj = new KeyedCachedDataReducer(
-  api.getDatabaseDetails,
+  clusterUiApi.getDatabaseDetails,
   "databaseDetails",
-  databaseRequestToID,
+  databaseRequestPayloadToID,
   null,
   moment.duration(10, "m"),
 );
@@ -533,7 +531,7 @@ export interface APIReducersState {
   version: CachedDataReducerState<VersionList>;
   locations: CachedDataReducerState<api.LocationsResponseMessage>;
   databases: CachedDataReducerState<clusterUiApi.DatabasesListResponse>;
-  databaseDetails: KeyedCachedDataReducerState<api.DatabaseDetailsResponseMessage>;
+  databaseDetails: KeyedCachedDataReducerState<clusterUiApi.DatabaseDetailsResponse>;
   tableDetails: KeyedCachedDataReducerState<api.TableDetailsResponseMessage>;
   tableStats: KeyedCachedDataReducerState<api.TableStatsResponseMessage>;
   indexStats: KeyedCachedDataReducerState<api.IndexStatsResponseMessage>;

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -531,7 +531,9 @@ export interface APIReducersState {
   version: CachedDataReducerState<VersionList>;
   locations: CachedDataReducerState<api.LocationsResponseMessage>;
   databases: CachedDataReducerState<clusterUiApi.DatabasesListResponse>;
-  databaseDetails: KeyedCachedDataReducerState<clusterUiApi.DatabaseDetailsResponse>;
+  databaseDetails: KeyedCachedDataReducerState<
+    clusterUiApi.SqlApiResponse<clusterUiApi.DatabaseDetailsResponse>
+  >;
   tableDetails: KeyedCachedDataReducerState<api.TableDetailsResponseMessage>;
   tableStats: KeyedCachedDataReducerState<api.TableStatsResponseMessage>;
   indexStats: KeyedCachedDataReducerState<api.IndexStatsResponseMessage>;

--- a/pkg/ui/workspaces/db-console/src/util/api.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.spec.ts
@@ -23,6 +23,7 @@ import Severity = cockroach.util.log.Severity;
 import {
   buildSQLApiDatabasesResponse,
   buildSQLApiEventsResponse,
+  buildSqlExecutionResponse,
 } from "src/util/fakeApi";
 
 describe("rest api", function () {
@@ -114,56 +115,98 @@ describe("rest api", function () {
     it("correctly requests info about a specific database", function () {
       // Mock out the fetch query
       fetchMock.mock({
-        matcher: `${api.API_PREFIX}/databases/${dbName}`,
-        method: "GET",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          "X-Cockroach-API-Session": "cookie",
+        },
+        matcher: clusterUiApi.SQL_API_PATH,
+        method: "POST",
         response: (_url: string, requestObj: RequestInit) => {
-          expect(requestObj.body).toBeUndefined();
-          const encodedResponse =
-            protos.cockroach.server.serverpb.DatabaseDetailsResponse.encode({
-              table_names: ["table1", "table2"],
-              grants: [
-                { user: "root", privileges: ["ALL"] },
-                { user: "other", privileges: [] },
-              ],
-            }).finish();
+          expect(JSON.parse(requestObj.body.toString())).toEqual({
+            ...clusterUiApi.createDatabaseDetailsReq(dbName),
+            application_name: clusterUiApi.INTERNAL_SQL_API_APP,
+          });
+          const mockResp =
+            buildSqlExecutionResponse<clusterUiApi.DatabaseDetailsRow>([
+              // Database ID query
+              { rows: [{ database_id: "1" }] },
+              // Database grants query
+              {
+                rows: [
+                  {
+                    database_name: "test",
+                    grantee: "admin",
+                    privilege_type: "ALL",
+                    is_grantable: true,
+                  },
+                  {
+                    database_name: "test",
+                    grantee: "public",
+                    privilege_type: "CONNECT",
+                    is_grantable: false,
+                  },
+                ],
+              },
+              // Database tables query
+              {
+                rows: [{ table_schema: "public", table_name: "table1" }],
+              },
+              // Database ranges query
+              {
+                rows: [
+                  {
+                    replicas: [1, 2, 3],
+                    regions: ["gcp-europe-west1", "gcp-europe-west2"],
+                    range_size: 125,
+                  },
+                ],
+              },
+              // Database index usage statistics query
+              {
+                rows: [
+                  {
+                    database_name: "test",
+                    last_read: new Date().toISOString(),
+                    created_at: new Date().toISOString(),
+                    unused_threshold: "30m",
+                  },
+                ],
+              },
+            ]);
+
           return {
-            body: encodedResponse,
+            body: JSON.stringify(mockResp),
           };
         },
       });
 
-      return api
-        .getDatabaseDetails(
-          new protos.cockroach.server.serverpb.DatabaseDetailsRequest({
-            database: dbName,
-          }),
-        )
-        .then(result => {
-          expect(
-            fetchMock.calls(`${api.API_PREFIX}/databases/${dbName}`).length,
-          ).toBe(1);
-          expect(result.table_names.length).toBe(2);
-          expect(result.grants.length).toBe(2);
-        });
+      return clusterUiApi.getDatabaseDetails(dbName).then(result => {
+        expect(fetchMock.calls(clusterUiApi.SQL_API_PATH).length).toBe(1);
+        expect(result.id_resp.id.database_id).toEqual("1");
+        expect(result.tables_resp.tables.length).toBe(1);
+        expect(result.grants_resp.grants.length).toBe(2);
+        expect(result.stats.ranges_data.count).toBe(1);
+        expect(result.stats.index_stats.num_index_recommendations).toBe(0);
+      });
     });
 
     it("correctly handles an error", function (done) {
       // Mock out the fetch query, but return a 500 status code
       fetchMock.mock({
-        matcher: `${api.API_PREFIX}/databases/${dbName}`,
-        method: "GET",
+        matcher: clusterUiApi.SQL_API_PATH,
+        method: "POST",
         response: (_url: string, requestObj: RequestInit) => {
-          expect(requestObj.body).toBeUndefined();
+          expect(JSON.parse(requestObj.body.toString())).toEqual({
+            ...clusterUiApi.createDatabaseDetailsReq(dbName),
+            application_name: clusterUiApi.INTERNAL_SQL_API_APP,
+          });
           return { throws: new Error() };
         },
       });
 
-      api
-        .getDatabaseDetails(
-          new protos.cockroach.server.serverpb.DatabaseDetailsRequest({
-            database: dbName,
-          }),
-        )
+      clusterUiApi
+        .getDatabaseDetails(dbName)
         .then(_result => {
           done(new Error("Request unexpectedly succeeded."));
         })
@@ -176,21 +219,19 @@ describe("rest api", function () {
     it("correctly times out", function (done) {
       // Mock out the fetch query, but return a promise that's never resolved to test the timeout
       fetchMock.mock({
-        matcher: `${api.API_PREFIX}/databases/${dbName}`,
-        method: "GET",
+        matcher: clusterUiApi.SQL_API_PATH,
+        method: "POST",
         response: (_url: string, requestObj: RequestInit) => {
-          expect(requestObj.body).toBeUndefined();
+          expect(JSON.parse(requestObj.body.toString())).toEqual({
+            ...clusterUiApi.createDatabaseDetailsReq(dbName),
+            application_name: clusterUiApi.INTERNAL_SQL_API_APP,
+          });
           return new Promise<any>(() => {});
         },
       });
 
-      api
-        .getDatabaseDetails(
-          new protos.cockroach.server.serverpb.DatabaseDetailsRequest({
-            database: dbName,
-          }),
-          moment.duration(0),
-        )
+      clusterUiApi
+        .getDatabaseDetails(dbName, moment.duration(0))
         .then(_result => {
           done(new Error("Request unexpectedly succeeded."));
         })

--- a/pkg/ui/workspaces/db-console/src/util/api.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.spec.ts
@@ -23,8 +23,11 @@ import Severity = cockroach.util.log.Severity;
 import {
   buildSQLApiDatabasesResponse,
   buildSQLApiEventsResponse,
-  buildSqlExecutionResponse,
+  stubSqlApiCall,
 } from "src/util/fakeApi";
+
+const { ZoneConfig } = cockroach.config.zonepb;
+const { ZoneConfigurationLevel } = cockroach.server.serverpb;
 
 describe("rest api", function () {
   describe("databases request", function () {
@@ -109,97 +112,122 @@ describe("rest api", function () {
 
   describe("database details request", function () {
     const dbName = "test";
+    const mockOldDate = new Date(2023, 2, 3);
+    const mockZoneConfig = new ZoneConfig({
+      inherited_constraints: true,
+      inherited_lease_preferences: true,
+      null_voter_constraints_is_empty: true,
+      global_reads: true,
+      gc: {
+        ttl_seconds: 100,
+      },
+    });
+    const mockZoneConfigBytes = ZoneConfig.encode(mockZoneConfig).finish();
+    const mockZoneConfigHexString = Array.from(mockZoneConfigBytes)
+      .map(x => x.toString(16).padStart(2, "0"))
+      .join("");
 
     afterEach(fetchMock.restore);
 
     it("correctly requests info about a specific database", function () {
       // Mock out the fetch query
-      fetchMock.mock({
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "application/json",
-          "X-Cockroach-API-Session": "cookie",
-        },
-        matcher: clusterUiApi.SQL_API_PATH,
-        method: "POST",
-        response: (_url: string, requestObj: RequestInit) => {
-          expect(JSON.parse(requestObj.body.toString())).toEqual({
-            ...clusterUiApi.createDatabaseDetailsReq(dbName),
-            application_name: clusterUiApi.INTERNAL_SQL_API_APP,
-          });
-          const mockResp =
-            buildSqlExecutionResponse<clusterUiApi.DatabaseDetailsRow>([
-              // Database ID query
-              { rows: [{ database_id: "1" }] },
-              // Database grants query
+      stubSqlApiCall<clusterUiApi.DatabaseDetailsRow>(
+        clusterUiApi.createDatabaseDetailsReq(dbName),
+        [
+          // Database ID query
+          { rows: [{ database_id: "1" }] },
+          // Database grants query
+          {
+            rows: [
               {
-                rows: [
-                  {
-                    database_name: "test",
-                    grantee: "admin",
-                    privilege_type: "ALL",
-                    is_grantable: true,
-                  },
-                  {
-                    database_name: "test",
-                    grantee: "public",
-                    privilege_type: "CONNECT",
-                    is_grantable: false,
-                  },
-                ],
+                user: "admin",
+                privileges: ["ALL"],
               },
-              // Database tables query
               {
-                rows: [{ table_schema: "public", table_name: "table1" }],
+                user: "public",
+                privileges: ["CONNECT"],
               },
-              // Database ranges query
+            ],
+          },
+          // Database tables query
+          {
+            rows: [{ table_schema: "public", table_name: "table1" }],
+          },
+          // Database replicas and regions query
+          {
+            rows: [
               {
-                rows: [
-                  {
-                    replicas: [1, 2, 3],
-                    regions: ["gcp-europe-west1", "gcp-europe-west2"],
-                    range_size: 125,
-                  },
-                ],
+                replicas: [1, 2, 3],
+                regions: ["gcp-europe-west1", "gcp-europe-west2"],
               },
-              // Database index usage statistics query
+            ],
+          },
+          // Database index usage statistics query
+          {
+            rows: [
               {
-                rows: [
-                  {
-                    database_name: "test",
-                    last_read: new Date().toISOString(),
-                    created_at: new Date().toISOString(),
-                    unused_threshold: "30m",
-                  },
-                ],
+                last_read: mockOldDate.toISOString(),
+                created_at: mockOldDate.toISOString(),
+                unused_threshold: "1m",
               },
-            ]);
-
-          return {
-            body: JSON.stringify(mockResp),
-          };
-        },
-      });
+            ],
+          },
+          // Database zone config query
+          {
+            rows: [
+              {
+                zone_config_hex_string: mockZoneConfigHexString,
+              },
+            ],
+          },
+          {
+            rows: [
+              {
+                approximate_disk_bytes: 100,
+                live_bytes: 200,
+                total_bytes: 300,
+                range_count: 400,
+              },
+            ],
+          },
+        ],
+        1,
+      );
 
       return clusterUiApi.getDatabaseDetails(dbName).then(result => {
         expect(fetchMock.calls(clusterUiApi.SQL_API_PATH).length).toBe(1);
-        expect(result.id_resp.id.database_id).toEqual("1");
-        expect(result.tables_resp.tables.length).toBe(1);
-        expect(result.grants_resp.grants.length).toBe(2);
-        expect(result.stats.ranges_data.count).toBe(1);
-        expect(result.stats.index_stats.num_index_recommendations).toBe(0);
+        expect(result.results.id_resp.database_id).toEqual("1");
+        expect(result.results.tables_resp.tables.length).toBe(1);
+        expect(result.results.grants_resp.grants.length).toBe(2);
+        expect(result.results.stats.index_stats.num_index_recommendations).toBe(
+          1,
+        );
+        expect(result.results.zone_config_resp.zone_config).toEqual(
+          mockZoneConfig,
+        );
+        expect(result.results.zone_config_resp.zone_config_level).toBe(
+          ZoneConfigurationLevel.DATABASE,
+        );
+        expect(result.results.stats.pebble_data.approximate_disk_bytes).toBe(
+          100,
+        );
+        expect(result.results.stats.ranges_data.live_bytes).toBe(200);
+        expect(result.results.stats.ranges_data.total_bytes).toBe(300);
+        expect(result.results.stats.ranges_data.range_count).toBe(400);
       });
     });
 
     it("correctly handles an error", function (done) {
       // Mock out the fetch query, but return a 500 status code
+      const req = clusterUiApi.createDatabaseDetailsReq(dbName);
       fetchMock.mock({
         matcher: clusterUiApi.SQL_API_PATH,
         method: "POST",
         response: (_url: string, requestObj: RequestInit) => {
           expect(JSON.parse(requestObj.body.toString())).toEqual({
-            ...clusterUiApi.createDatabaseDetailsReq(dbName),
+            ...req,
             application_name: clusterUiApi.INTERNAL_SQL_API_APP,
+            database: req.database || clusterUiApi.FALLBACK_DB,
           });
           return { throws: new Error() };
         },
@@ -218,13 +246,15 @@ describe("rest api", function () {
 
     it("correctly times out", function (done) {
       // Mock out the fetch query, but return a promise that's never resolved to test the timeout
+      const req = clusterUiApi.createDatabaseDetailsReq(dbName);
       fetchMock.mock({
         matcher: clusterUiApi.SQL_API_PATH,
         method: "POST",
         response: (_url: string, requestObj: RequestInit) => {
           expect(JSON.parse(requestObj.body.toString())).toEqual({
-            ...clusterUiApi.createDatabaseDetailsReq(dbName),
+            ...req,
             application_name: clusterUiApi.INTERNAL_SQL_API_APP,
+            database: req.database || clusterUiApi.FALLBACK_DB,
           });
           return new Promise<any>(() => {});
         },
@@ -352,7 +382,7 @@ describe("rest api", function () {
           expect(JSON.parse(requestObj.body.toString())).toEqual({
             ...clusterUiApi.buildEventsSQLRequest({}),
             application_name: clusterUiApi.INTERNAL_SQL_API_APP,
-            database: "system",
+            database: clusterUiApi.FALLBACK_DB,
           });
           return {
             body: JSON.stringify(
@@ -387,7 +417,7 @@ describe("rest api", function () {
           expect(JSON.parse(requestObj.body.toString())).toEqual({
             ...clusterUiApi.buildEventsSQLRequest(req),
             application_name: clusterUiApi.INTERNAL_SQL_API_APP,
-            database: "system",
+            database: clusterUiApi.FALLBACK_DB,
           });
           return {
             body: JSON.stringify(
@@ -420,7 +450,7 @@ describe("rest api", function () {
           expect(JSON.parse(requestObj.body.toString())).toEqual({
             ...clusterUiApi.buildEventsSQLRequest({}),
             application_name: clusterUiApi.INTERNAL_SQL_API_APP,
-            database: "system",
+            database: clusterUiApi.FALLBACK_DB,
           });
           return { throws: new Error() };
         },
@@ -446,7 +476,7 @@ describe("rest api", function () {
           expect(JSON.parse(requestObj.body.toString())).toEqual({
             ...clusterUiApi.buildEventsSQLRequest({}),
             application_name: clusterUiApi.INTERNAL_SQL_API_APP,
-            database: "system",
+            database: clusterUiApi.FALLBACK_DB,
           });
           return new Promise<any>(() => {});
         },

--- a/pkg/ui/workspaces/db-console/src/util/api.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.ts
@@ -19,11 +19,6 @@ import * as protos from "src/js/protos";
 import { FixLong } from "src/util/fixLong";
 import { propsToQueryString } from "src/util/query";
 
-export type DatabaseDetailsRequestMessage =
-  protos.cockroach.server.serverpb.DatabaseDetailsRequest;
-export type DatabaseDetailsResponseMessage =
-  protos.cockroach.server.serverpb.DatabaseDetailsResponse;
-
 export type TableDetailsRequestMessage =
   protos.cockroach.server.serverpb.TableDetailsRequest;
 export type TableDetailsResponseMessage =
@@ -349,25 +344,6 @@ export type APIRequestFn<TReq, TResponse> = (
 
 const serverpb = protos.cockroach.server.serverpb;
 const tspb = protos.cockroach.ts.tspb;
-
-// getDatabaseDetails gets details for a specific database
-export function getDatabaseDetails(
-  req: DatabaseDetailsRequestMessage,
-  timeout?: moment.Duration,
-): Promise<DatabaseDetailsResponseMessage> {
-  const queryString = req.include_stats ? "?include_stats=true" : "";
-
-  const promiseErr = IsValidateUriName(req.database);
-  if (promiseErr) {
-    return promiseErr;
-  }
-  return timeoutFetch(
-    serverpb.DatabaseDetailsResponse,
-    `${API_PREFIX}/databases/${EncodeUriName(req.database)}${queryString}`,
-    null,
-    timeout,
-  );
-}
 
 // getTableDetails gets details for a specific table
 export function getTableDetails(

--- a/pkg/ui/workspaces/db-console/src/util/fakeApi.ts
+++ b/pkg/ui/workspaces/db-console/src/util/fakeApi.ts
@@ -14,9 +14,9 @@ import { api as clusterUiApi } from "@cockroachlabs/cluster-ui";
 import { cockroach } from "src/js/protos";
 import { API_PREFIX, STATUS_PREFIX } from "src/util/api";
 import fetchMock from "src/util/fetch-mock";
+import moment from "moment";
 
 const {
-  DatabaseDetailsResponse,
   SettingsResponse,
   TableDetailsResponse,
   TableStatsResponse,
@@ -64,6 +64,62 @@ export function stubClusterSettings(
     SettingsResponse.encode(response),
     API_PREFIX,
   );
+}
+
+// Same as SqlTxnResult, but all fields are optional.
+export type mockSqlTxnResult<RowType> = {
+  statement?: number; // Statement index from input array
+  tag?: string; // Short stmt tag
+  start?: string; // Start timestamp, encoded as RFC3339
+  end?: string; // End timestamp, encoded as RFC3339
+  rows_affected?: number;
+  columns?: clusterUiApi.SqlResultColumn[];
+  rows?: RowType[];
+  error?: Error;
+};
+
+// buildSqlTxnResult provides default values for mandatory fields
+// of a SqlTxnResult.
+function buildSqlTxnResult<RowType>(
+  mock: mockSqlTxnResult<RowType>,
+): clusterUiApi.SqlTxnResult<RowType> {
+  const statement = mock.statement ? mock.statement : 1;
+  const rowsAffected = mock.rows_affected ? mock.rows_affected : 0;
+  const startTimestamp = mock.start ? mock.start : new Date().toISOString();
+  const endTimestamp = mock.end
+    ? mock.end
+    : moment(startTimestamp).add(1, "s").toISOString();
+  const stmtTag = mock.tag ? mock.tag : "SELECT";
+  return {
+    statement: statement,
+    tag: stmtTag,
+    start: startTimestamp,
+    end: endTimestamp,
+    rows_affected: rowsAffected,
+    columns: mock.columns,
+    rows: mock.rows,
+    error: mock.error,
+  };
+}
+
+export function buildSqlExecutionResponse<T>(
+  mockTxnResults: mockSqlTxnResult<T>[],
+  error?: clusterUiApi.SqlExecutionErrorMessage,
+): clusterUiApi.SqlExecutionResponse<T> {
+  const sqlTxnResults: clusterUiApi.SqlTxnResult<T>[] = mockTxnResults.map(
+    (mock, idx) => {
+      mock.statement = idx + 1;
+      return buildSqlTxnResult(mock);
+    },
+  );
+  const resp: clusterUiApi.SqlExecutionResponse<T> = {
+    execution: {
+      retries: 0,
+      txn_results: sqlTxnResults,
+    },
+    error: error,
+  };
+  return resp;
 }
 
 export function buildSQLApiDatabasesResponse(databases: string[]) {
@@ -187,15 +243,29 @@ export function stubDatabases(databases: string[]) {
   });
 }
 
-export function stubDatabaseDetails(
-  database: string,
-  response: cockroach.server.serverpb.IDatabaseDetailsResponse,
+export function stubSqlApiCall<T>(
+  req: any,
+  mockTxnResults: mockSqlTxnResult<T>[],
 ) {
-  stubGet(
-    `/databases/${database}?include_stats=true`,
-    DatabaseDetailsResponse.encode(response),
-    API_PREFIX,
-  );
+  const response = buildSqlExecutionResponse(mockTxnResults);
+  fetchMock.mock({
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      "X-Cockroach-API-Session": "cookie",
+    },
+    matcher: clusterUiApi.SQL_API_PATH,
+    method: "POST",
+    response: (_url: string, requestObj: RequestInit) => {
+      expect(JSON.parse(requestObj.body.toString())).toEqual({
+        ...req,
+        application_name: clusterUiApi.INTERNAL_SQL_API_APP,
+      });
+      return {
+        body: JSON.stringify(response),
+      };
+    },
+  });
 }
 
 export function stubNodesUI(
@@ -242,4 +312,23 @@ export function stubIndexStats(
 
 function stubGet(path: string, writer: $protobuf.Writer, prefix: string) {
   fetchMock.get(`${prefix}${path}`, writer.finish());
+}
+
+export function createMockDatabaseRangesForTable(
+  numRangesCreate: number,
+  numNodes: number,
+): clusterUiApi.DatabaseDetailsRow[] {
+  const res = [];
+  const replicas = [];
+  for (let i = 1; i <= numNodes; i++) {
+    replicas.push(i);
+  }
+  for (let i = 0; i < numRangesCreate; i++) {
+    res.push({
+      replicas: replicas,
+      regions: ["gcp-europe-west1", "gcp-europe-west2"],
+      range_size: 10,
+    });
+  }
+  return res;
 }

--- a/pkg/ui/workspaces/db-console/src/util/fakeApi.ts
+++ b/pkg/ui/workspaces/db-console/src/util/fakeApi.ts
@@ -66,62 +66,6 @@ export function stubClusterSettings(
   );
 }
 
-// Same as SqlTxnResult, but all fields are optional.
-export type mockSqlTxnResult<RowType> = {
-  statement?: number; // Statement index from input array
-  tag?: string; // Short stmt tag
-  start?: string; // Start timestamp, encoded as RFC3339
-  end?: string; // End timestamp, encoded as RFC3339
-  rows_affected?: number;
-  columns?: clusterUiApi.SqlResultColumn[];
-  rows?: RowType[];
-  error?: Error;
-};
-
-// buildSqlTxnResult provides default values for mandatory fields
-// of a SqlTxnResult.
-function buildSqlTxnResult<RowType>(
-  mock: mockSqlTxnResult<RowType>,
-): clusterUiApi.SqlTxnResult<RowType> {
-  const statement = mock.statement ? mock.statement : 1;
-  const rowsAffected = mock.rows_affected ? mock.rows_affected : 0;
-  const startTimestamp = mock.start ? mock.start : new Date().toISOString();
-  const endTimestamp = mock.end
-    ? mock.end
-    : moment(startTimestamp).add(1, "s").toISOString();
-  const stmtTag = mock.tag ? mock.tag : "SELECT";
-  return {
-    statement: statement,
-    tag: stmtTag,
-    start: startTimestamp,
-    end: endTimestamp,
-    rows_affected: rowsAffected,
-    columns: mock.columns,
-    rows: mock.rows,
-    error: mock.error,
-  };
-}
-
-export function buildSqlExecutionResponse<T>(
-  mockTxnResults: mockSqlTxnResult<T>[],
-  error?: clusterUiApi.SqlExecutionErrorMessage,
-): clusterUiApi.SqlExecutionResponse<T> {
-  const sqlTxnResults: clusterUiApi.SqlTxnResult<T>[] = mockTxnResults.map(
-    (mock, idx) => {
-      mock.statement = idx + 1;
-      return buildSqlTxnResult(mock);
-    },
-  );
-  const resp: clusterUiApi.SqlExecutionResponse<T> = {
-    execution: {
-      retries: 0,
-      txn_results: sqlTxnResults,
-    },
-    error: error,
-  };
-  return resp;
-}
-
 export function buildSQLApiDatabasesResponse(databases: string[]) {
   const rows: clusterUiApi.DatabasesColumns[] = databases.map(database => {
     return {
@@ -222,7 +166,7 @@ export function buildSQLApiEventsResponse(events: clusterUiApi.EventsResponse) {
   };
 }
 
-export function stubDatabases(databases: string[]) {
+export function stubDatabases(databases: string[], times?: number) {
   const response = buildSQLApiDatabasesResponse(databases);
   fetchMock.mock({
     headers: {
@@ -240,31 +184,7 @@ export function stubDatabases(databases: string[]) {
         body: JSON.stringify(response),
       };
     },
-  });
-}
-
-export function stubSqlApiCall<T>(
-  req: any,
-  mockTxnResults: mockSqlTxnResult<T>[],
-) {
-  const response = buildSqlExecutionResponse(mockTxnResults);
-  fetchMock.mock({
-    headers: {
-      Accept: "application/json",
-      "Content-Type": "application/json",
-      "X-Cockroach-API-Session": "cookie",
-    },
-    matcher: clusterUiApi.SQL_API_PATH,
-    method: "POST",
-    response: (_url: string, requestObj: RequestInit) => {
-      expect(JSON.parse(requestObj.body.toString())).toEqual({
-        ...req,
-        application_name: clusterUiApi.INTERNAL_SQL_API_APP,
-      });
-      return {
-        body: JSON.stringify(response),
-      };
-    },
+    times: times,
   });
 }
 
@@ -280,7 +200,9 @@ export function stubTableDetails(
   response: cockroach.server.serverpb.ITableDetailsResponse,
 ) {
   stubGet(
-    `/databases/${database}/tables/${table}`,
+    `/databases/${encodeURIComponent(database)}/tables/${encodeURIComponent(
+      table,
+    )}`,
     TableDetailsResponse.encode(response),
     API_PREFIX,
   );
@@ -292,7 +214,9 @@ export function stubTableStats(
   response: cockroach.server.serverpb.ITableStatsResponse,
 ) {
   stubGet(
-    `/databases/${database}/tables/${table}/stats`,
+    `/databases/${encodeURIComponent(database)}/tables/${encodeURIComponent(
+      table,
+    )}/stats`,
     TableStatsResponse.encode(response),
     API_PREFIX,
   );
@@ -331,4 +255,89 @@ export function createMockDatabaseRangesForTable(
     });
   }
   return res;
+}
+
+export function stubSqlApiCall<T>(
+  req: clusterUiApi.SqlExecutionRequest,
+  mockTxnResults: mockSqlTxnResult<T>[],
+  times?: number,
+) {
+  const response = buildSqlExecutionResponse(mockTxnResults);
+  fetchMock.mock({
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      "X-Cockroach-API-Session": "cookie",
+    },
+    matcher: clusterUiApi.SQL_API_PATH,
+    method: "POST",
+    response: (_url: string, requestObj: RequestInit) => {
+      expect(JSON.parse(requestObj.body.toString())).toEqual({
+        ...req,
+        application_name:
+          req.application_name || clusterUiApi.INTERNAL_SQL_API_APP,
+        database: req.database || clusterUiApi.FALLBACK_DB,
+      });
+      return {
+        body: JSON.stringify(response),
+      };
+    },
+    times: times,
+  });
+}
+
+export function buildSqlExecutionResponse<T>(
+  mockTxnResults: mockSqlTxnResult<T>[],
+  error?: clusterUiApi.SqlExecutionErrorMessage,
+): clusterUiApi.SqlExecutionResponse<T> {
+  const sqlTxnResults: clusterUiApi.SqlTxnResult<T>[] = mockTxnResults.map(
+    (mock, idx) => {
+      mock.statement = idx + 1;
+      return buildSqlTxnResult(mock);
+    },
+  );
+  const resp: clusterUiApi.SqlExecutionResponse<T> = {
+    execution: {
+      retries: 0,
+      txn_results: sqlTxnResults,
+    },
+    error: error,
+  };
+  return resp;
+}
+
+// Same as SqlTxnResult, but all fields are optional.
+export type mockSqlTxnResult<RowType> = {
+  statement?: number; // Statement index from input array
+  tag?: string; // Short stmt tag
+  start?: string; // Start timestamp, encoded as RFC3339
+  end?: string; // End timestamp, encoded as RFC3339
+  rows_affected?: number;
+  columns?: clusterUiApi.SqlResultColumn[];
+  rows?: RowType[];
+  error?: Error;
+};
+
+// buildSqlTxnResult provides default values for mandatory fields
+// of a SqlTxnResult.
+function buildSqlTxnResult<RowType>(
+  mock: mockSqlTxnResult<RowType>,
+): clusterUiApi.SqlTxnResult<RowType> {
+  const statement = mock.statement ? mock.statement : 1;
+  const rowsAffected = mock.rows_affected ? mock.rows_affected : 0;
+  const startTimestamp = mock.start ? mock.start : new Date().toISOString();
+  const endTimestamp = mock.end
+    ? mock.end
+    : moment(startTimestamp).add(1, "s").toISOString();
+  const stmtTag = mock.tag ? mock.tag : "SELECT";
+  return {
+    statement: statement,
+    tag: stmtTag,
+    start: startTimestamp,
+    end: endTimestamp,
+    rows_affected: rowsAffected,
+    columns: mock.columns,
+    rows: mock.rows,
+    error: mock.error,
+  };
 }

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.spec.ts
@@ -21,6 +21,7 @@ import {
   defaultFilters,
   util,
   ViewMode,
+  api as clusterUiApi,
 } from "@cockroachlabs/cluster-ui";
 
 import { AdminUIState, createAdminUIStore } from "src/redux/state";
@@ -141,12 +142,24 @@ describe("Database Details Page", function () {
   });
 
   it("makes a row for each table", async function () {
-    fakeApi.stubDatabaseDetails("things", {
-      table_names: ["foo", "bar"],
-    });
+    fakeApi.stubSqlApiCall<clusterUiApi.DatabaseDetailsRow>(
+      clusterUiApi.createDatabaseDetailsReq("things"),
+      [
+        // Id
+        { rows: [] },
+        // Grants
+        { rows: [] },
+        // Tables
+        {
+          rows: [
+            { table_schema: "public", table_name: "foo" },
+            { table_schema: "public", table_name: "bar" },
+          ],
+        },
+      ],
+    );
 
     await driver.refreshDatabaseDetails();
-
     driver.assertProperties({
       loading: false,
       loaded: true,
@@ -220,9 +233,22 @@ describe("Database Details Page", function () {
   });
 
   it("loads table details", async function () {
-    fakeApi.stubDatabaseDetails("things", {
-      table_names: ["foo", "bar"],
-    });
+    fakeApi.stubSqlApiCall<clusterUiApi.DatabaseDetailsRow>(
+      clusterUiApi.createDatabaseDetailsReq("things"),
+      [
+        // Id
+        { rows: [] },
+        // Grants
+        { rows: [] },
+        // Tables
+        {
+          rows: [
+            { table_schema: "public", table_name: "foo" },
+            { table_schema: "public", table_name: "bar" },
+          ],
+        },
+      ],
+    );
 
     fakeApi.stubTableDetails("things", "foo", {
       grants: [
@@ -378,9 +404,19 @@ describe("Database Details Page", function () {
   });
 
   it("sorts roles meaningfully", async function () {
-    fakeApi.stubDatabaseDetails("things", {
-      table_names: ["foo"],
-    });
+    fakeApi.stubSqlApiCall<clusterUiApi.DatabaseDetailsRow>(
+      clusterUiApi.createDatabaseDetailsReq("things"),
+      [
+        // Id
+        { rows: [] },
+        // Grants
+        { rows: [] },
+        // Tables
+        {
+          rows: [{ table_schema: "public", table_name: "foo" }],
+        },
+      ],
+    );
 
     fakeApi.stubTableDetails("things", "foo", {
       grants: [
@@ -407,9 +443,19 @@ describe("Database Details Page", function () {
   });
 
   it("sorts grants meaningfully", async function () {
-    fakeApi.stubDatabaseDetails("things", {
-      table_names: ["foo"],
-    });
+    fakeApi.stubSqlApiCall<clusterUiApi.DatabaseDetailsRow>(
+      clusterUiApi.createDatabaseDetailsReq("things"),
+      [
+        // Id
+        { rows: [] },
+        // Grants
+        { rows: [] },
+        // Tables
+        {
+          rows: [{ table_schema: "public", table_name: "foo" }],
+        },
+      ],
+    );
 
     fakeApi.stubTableDetails("things", "foo", {
       grants: [
@@ -440,9 +486,22 @@ describe("Database Details Page", function () {
   });
 
   it("loads table stats", async function () {
-    fakeApi.stubDatabaseDetails("things", {
-      table_names: ["foo", "bar"],
-    });
+    fakeApi.stubSqlApiCall<clusterUiApi.DatabaseDetailsRow>(
+      clusterUiApi.createDatabaseDetailsReq("things"),
+      [
+        // Id
+        { rows: [] },
+        // Grants
+        { rows: [] },
+        // Tables
+        {
+          rows: [
+            { table_schema: "public", table_name: "foo" },
+            { table_schema: "public", table_name: "bar" },
+          ],
+        },
+      ],
+    );
 
     fakeApi.stubTableStats("things", "foo", {
       range_count: new Long(4200),

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.spec.ts
@@ -127,7 +127,7 @@ describe("Database Details Page", function () {
     driver.assertProperties({
       loading: false,
       loaded: false,
-      lastError: undefined,
+      lastError: null,
       name: "things",
       search: null,
       filters: defaultFilters,
@@ -175,7 +175,7 @@ describe("Database Details Page", function () {
       sortSettingGrants: { ascending: true, columnTitle: "name" },
       tables: [
         {
-          name: "foo",
+          name: `"public"."foo"`,
           details: {
             loading: false,
             loaded: false,
@@ -202,7 +202,7 @@ describe("Database Details Page", function () {
           },
         },
         {
-          name: "bar",
+          name: `"public"."bar"`,
           details: {
             loading: false,
             loaded: false,
@@ -250,7 +250,7 @@ describe("Database Details Page", function () {
       ],
     );
 
-    fakeApi.stubTableDetails("things", "foo", {
+    fakeApi.stubTableDetails("things", `"public"."foo"`, {
       grants: [
         { user: "admin", privileges: ["CREATE"] },
         { user: "public", privileges: ["SELECT"] },
@@ -310,7 +310,7 @@ describe("Database Details Page", function () {
       data_live_percentage: 2.0,
     });
 
-    fakeApi.stubTableDetails("things", "bar", {
+    fakeApi.stubTableDetails("things", `"public"."bar"`, {
       grants: [
         { user: "root", privileges: ["ALL"] },
         { user: "app", privileges: ["INSERT"] },
@@ -363,10 +363,10 @@ describe("Database Details Page", function () {
     });
 
     await driver.refreshDatabaseDetails();
-    await driver.refreshTableDetails("foo");
-    await driver.refreshTableDetails("bar");
+    await driver.refreshTableDetails(`"public"."foo"`);
+    await driver.refreshTableDetails(`"public"."bar"`);
 
-    driver.assertTableDetails("foo", {
+    driver.assertTableDetails(`"public"."foo"`, {
       loading: false,
       loaded: true,
       lastError: null,
@@ -384,7 +384,7 @@ describe("Database Details Page", function () {
       livePercentage: 2.0,
     });
 
-    driver.assertTableDetails("bar", {
+    driver.assertTableDetails(`"public"."bar"`, {
       loading: false,
       loaded: true,
       lastError: null,
@@ -418,7 +418,7 @@ describe("Database Details Page", function () {
       ],
     );
 
-    fakeApi.stubTableDetails("things", "foo", {
+    fakeApi.stubTableDetails("things", `"public"."foo"`, {
       grants: [
         { user: "bzuckercorn", privileges: ["ALL"] },
         { user: "bloblaw", privileges: ["ALL"] },
@@ -430,9 +430,9 @@ describe("Database Details Page", function () {
     });
 
     await driver.refreshDatabaseDetails();
-    await driver.refreshTableDetails("foo");
+    await driver.refreshTableDetails(`"public"."foo"`);
 
-    driver.assertTableRoles("foo", [
+    driver.assertTableRoles(`"public"."foo"`, [
       "root",
       "admin",
       "public",
@@ -457,7 +457,7 @@ describe("Database Details Page", function () {
       ],
     );
 
-    fakeApi.stubTableDetails("things", "foo", {
+    fakeApi.stubTableDetails("things", `"public"."foo"`, {
       grants: [
         {
           user: "admin",
@@ -471,9 +471,9 @@ describe("Database Details Page", function () {
     });
 
     await driver.refreshDatabaseDetails();
-    await driver.refreshTableDetails("foo");
+    await driver.refreshTableDetails(`"public"."foo"`);
 
-    driver.assertTableGrants("foo", [
+    driver.assertTableGrants(`"public"."foo"`, [
       "ALL",
       "CREATE",
       "DROP",
@@ -503,21 +503,21 @@ describe("Database Details Page", function () {
       ],
     );
 
-    fakeApi.stubTableStats("things", "foo", {
+    fakeApi.stubTableStats("things", `"public"."foo"`, {
       range_count: new Long(4200),
       approximate_disk_bytes: new Long(44040192),
     });
 
-    fakeApi.stubTableStats("things", "bar", {
+    fakeApi.stubTableStats("things", `"public"."bar"`, {
       range_count: new Long(1023),
       approximate_disk_bytes: new Long(8675309),
     });
 
     await driver.refreshDatabaseDetails();
-    await driver.refreshTableStats("foo");
-    await driver.refreshTableStats("bar");
+    await driver.refreshTableStats(`"public"."foo"`);
+    await driver.refreshTableStats(`"public"."bar"`);
 
-    driver.assertTableStats("foo", {
+    driver.assertTableStats(`"public"."foo"`, {
       loading: false,
       loaded: true,
       lastError: null,
@@ -527,7 +527,7 @@ describe("Database Details Page", function () {
       nodesByRegionString: "",
     });
 
-    driver.assertTableStats("bar", {
+    driver.assertTableStats(`"public"."bar"`, {
       loading: false,
       loaded: true,
       lastError: null,

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.ts
@@ -37,8 +37,7 @@ import {
 } from "src/redux/nodes";
 import { getNodesByRegionString, normalizePrivileges } from "../utils";
 
-const { DatabaseDetailsRequest, TableDetailsRequest, TableStatsRequest } =
-  cockroach.server.serverpb;
+const { TableDetailsRequest, TableStatsRequest } = cockroach.server.serverpb;
 
 function normalizeRoles(raw: string[]): string[] {
   const rolePrecedence: Record<string, number> = {
@@ -130,69 +129,71 @@ export const mapStateToProps = createSelector(
       search: searchLocalTables,
       nodeRegions: nodeRegions,
       isTenant: isTenant,
-      tables: _.map(databaseDetails[database]?.data?.table_names, table => {
-        const tableId = generateTableID(database, table);
+      tables: _.map(
+        databaseDetails[database]?.data?.tables_resp.tables,
+        tableRow => {
+          const table = tableRow.table_name;
+          const tableId = generateTableID(database, table);
 
-        const details = tableDetails[tableId];
-        const stats = tableStats[tableId];
+          const details = tableDetails[tableId];
+          const stats = tableStats[tableId];
 
-        const roles = normalizeRoles(_.map(details?.data?.grants, "user"));
-        const grants = normalizePrivileges(
-          _.flatMap(details?.data?.grants, "privileges"),
-        );
-        const nodes = stats?.data?.node_ids || [];
-        const numIndexes = _.uniq(
-          _.map(details?.data?.indexes, index => index.name),
-        ).length;
-        return {
-          name: table,
-          details: {
-            loading: !!details?.inFlight,
-            loaded: !!details?.valid,
-            lastError: details?.lastError,
-            columnCount: details?.data?.columns?.length || 0,
-            indexCount: numIndexes,
-            userCount: roles.length,
-            roles: roles,
-            grants: grants,
-            statsLastUpdated: details?.data?.stats_last_created_at
-              ? util.TimestampToMoment(details?.data?.stats_last_created_at)
-              : null,
-            hasIndexRecommendations:
-              details?.data?.has_index_recommendations || false,
-            totalBytes: FixLong(
-              details?.data?.data_total_bytes || 0,
-            ).toNumber(),
-            liveBytes: FixLong(details?.data?.data_live_bytes || 0).toNumber(),
-            livePercentage: details?.data?.data_live_percentage || 0,
-          },
-          stats: {
-            loading: !!stats?.inFlight,
-            loaded: !!stats?.valid,
-            lastError: stats?.lastError,
-            replicationSizeInBytes: FixLong(
-              stats?.data?.approximate_disk_bytes || 0,
-            ).toNumber(),
-            nodes: nodes,
-            rangeCount: FixLong(stats?.data?.range_count || 0).toNumber(),
-            nodesByRegionString: getNodesByRegionString(
-              nodes,
-              nodeRegions,
-              isTenant,
-            ),
-          },
-        };
-      }),
+          const roles = normalizeRoles(_.map(details?.data?.grants, "user"));
+          const grants = normalizePrivileges(
+            _.flatMap(details?.data?.grants, "privileges"),
+          );
+          const nodes = stats?.data?.node_ids || [];
+          const numIndexes = _.uniq(
+            _.map(details?.data?.indexes, index => index.name),
+          ).length;
+          return {
+            name: table,
+            details: {
+              loading: !!details?.inFlight,
+              loaded: !!details?.valid,
+              lastError: details?.lastError,
+              columnCount: details?.data?.columns?.length || 0,
+              indexCount: numIndexes,
+              userCount: roles.length,
+              roles: roles,
+              grants: grants,
+              statsLastUpdated: details?.data?.stats_last_created_at
+                ? util.TimestampToMoment(details?.data?.stats_last_created_at)
+                : null,
+              hasIndexRecommendations:
+                details?.data?.has_index_recommendations || false,
+              totalBytes: FixLong(
+                details?.data?.data_total_bytes || 0,
+              ).toNumber(),
+              liveBytes: FixLong(
+                details?.data?.data_live_bytes || 0,
+              ).toNumber(),
+              livePercentage: details?.data?.data_live_percentage || 0,
+            },
+            stats: {
+              loading: !!stats?.inFlight,
+              loaded: !!stats?.valid,
+              lastError: stats?.lastError,
+              replicationSizeInBytes: FixLong(
+                stats?.data?.approximate_disk_bytes || 0,
+              ).toNumber(),
+              nodes: nodes,
+              rangeCount: FixLong(stats?.data?.range_count || 0).toNumber(),
+              nodesByRegionString: getNodesByRegionString(
+                nodes,
+                nodeRegions,
+                isTenant,
+              ),
+            },
+          };
+        },
+      ),
     };
   },
 );
 
 export const mapDispatchToProps = {
-  refreshDatabaseDetails: (database: string) => {
-    return refreshDatabaseDetails(
-      new DatabaseDetailsRequest({ database, include_stats: true }),
-    );
-  },
+  refreshDatabaseDetails,
   refreshTableDetails: (database: string, table: string) => {
     return refreshTableDetails(new TableDetailsRequest({ database, table }));
   },

--- a/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databaseDetailsPage/redux.ts
@@ -35,7 +35,11 @@ import {
   nodeRegionsByIDSelector,
   selectIsMoreThanOneNode,
 } from "src/redux/nodes";
-import { getNodesByRegionString, normalizePrivileges } from "../utils";
+import {
+  combineLoadingErrors,
+  getNodesByRegionString,
+  normalizePrivileges,
+} from "../utils";
 
 const { TableDetailsRequest, TableStatsRequest } = cockroach.server.serverpb;
 
@@ -119,7 +123,11 @@ export const mapStateToProps = createSelector(
     return {
       loading: !!databaseDetails[database]?.inFlight,
       loaded: !!databaseDetails[database]?.valid,
-      lastError: databaseDetails[database]?.lastError,
+      lastError: combineLoadingErrors(
+        databaseDetails[database]?.lastError,
+        databaseDetails[database]?.data?.maxSizeReached,
+        null,
+      ),
       name: database,
       showNodeRegionsColumn,
       viewMode,
@@ -130,9 +138,8 @@ export const mapStateToProps = createSelector(
       nodeRegions: nodeRegions,
       isTenant: isTenant,
       tables: _.map(
-        databaseDetails[database]?.data?.tables_resp.tables,
-        tableRow => {
-          const table = tableRow.table_name;
+        databaseDetails[database]?.data?.results.tables_resp.tables,
+        table => {
           const tableId = generateTableID(database, table);
 
           const details = tableDetails[tableId];

--- a/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.spec.ts
@@ -10,14 +10,13 @@
 
 import { createMemoryHistory } from "history";
 import _ from "lodash";
-import Long from "long";
 import { bindActionCreators, Store } from "redux";
 import {
   DatabasesPageActions,
   DatabasesPageData,
   DatabasesPageDataDatabase,
-  DatabasesPageDataMissingTable,
   defaultFilters,
+  api as clusterUiApi,
 } from "@cockroachlabs/cluster-ui";
 
 import { AdminUIState, createAdminUIStore } from "src/redux/state";
@@ -48,10 +47,6 @@ class TestDriver {
     return this.actions.refreshNodes();
   }
 
-  async refreshTableStats(database: string, table: string) {
-    return this.actions.refreshTableStats(database, table);
-  }
-
   async refreshSettings() {
     return this.actions.refreshSettings();
   }
@@ -67,26 +62,12 @@ class TestDriver {
     expect(this.findDatabase(database)).toEqual(expected);
   }
 
-  assertMissingTableProperties(
-    database: string,
-    table: string,
-    expected: DatabasesPageDataMissingTable,
-  ) {
-    expect(this.findMissingTable(this.findDatabase(database), table)).toEqual(
-      expected,
-    );
-  }
-
   private findDatabase(name: string) {
     return _.find(this.properties().databases, row => row.name == name);
   }
-
-  private findMissingTable(database: DatabasesPageDataDatabase, name: string) {
-    return _.find(database.missingTables, table => table.name == name);
-  }
 }
 
-describe("Databases Page", function () {
+describe.only("Databases Page", function () {
   let driver: TestDriver;
 
   beforeEach(function () {
@@ -147,7 +128,6 @@ describe("Databases Page", function () {
           tableCount: 0,
           rangeCount: 0,
           nodesByRegionString: "",
-          missingTables: [],
           numIndexRecommendations: 0,
         },
         {
@@ -160,7 +140,6 @@ describe("Databases Page", function () {
           tableCount: 0,
           rangeCount: 0,
           nodesByRegionString: "",
-          missingTables: [],
           numIndexRecommendations: 0,
         },
       ],
@@ -206,209 +185,113 @@ describe("Databases Page", function () {
 
     fakeApi.stubDatabases(["system", "test"]);
 
-    fakeApi.stubDatabaseDetails("system", {
-      table_names: ["foo", "bar"],
-      stats: {
-        node_ids: [1, 2, 4],
-        missing_tables: [],
-        range_count: new Long(3),
-        approximate_disk_bytes: new Long(7168),
-      },
-    });
-
-    fakeApi.stubDatabaseDetails("test", {
-      table_names: ["widgets"],
-      stats: {
-        node_ids: [3, 5, 6],
-        missing_tables: [],
-        range_count: new Long(42),
-        approximate_disk_bytes: new Long(1234),
-      },
-    });
+    fakeApi.stubSqlApiCall<clusterUiApi.DatabaseDetailsRow>(
+      clusterUiApi.createDatabaseDetailsReq("system"),
+      [
+        // Id
+        { rows: [] },
+        // Grants
+        { rows: [] },
+        // Tables
+        {
+          rows: [
+            { table_schema: "public", table_name: "foo" },
+            { table_schema: "public", table_name: "bar" },
+          ],
+        },
+        // Ranges
+        {
+          rows: [
+            {
+              replicas: [1,2,3],
+              regions: ["gcp-europe-west1", "gcp-europe-west2"],
+              range_size: 10,
+            },
+            {
+              replicas: [1,2,3],
+              regions: ["gcp-europe-west1", "gcp-europe-west2"],
+              range_size: 10,
+            },
+            {
+              replicas: [1,2,3],
+              regions: ["gcp-europe-west1", "gcp-europe-west2"],
+              range_size: 10,
+            }
+          ],
+        },
+      ],
+    );
 
     await driver.refreshNodes();
     await driver.refreshDatabases();
     await driver.refreshDatabaseDetails("system");
-    await driver.refreshDatabaseDetails("test");
 
     driver.assertDatabaseProperties("system", {
       loading: false,
       loaded: true,
       lastError: null,
       name: "system",
-      nodes: [1, 2, 4],
-      sizeInBytes: 7168,
+      nodes: [1, 2, 3],
+      sizeInBytes: 0, // TODO(thomas): fix when we have disk size
       tableCount: 2,
       rangeCount: 3,
-      nodesByRegionString: "gcp-us-east1(n1,n2,n4)",
-      missingTables: [],
+      nodesByRegionString: "gcp-us-east1(n1,n2), gcp-europe-west1(n3)",
       numIndexRecommendations: 0,
     });
+
+    fakeApi.stubSqlApiCall<clusterUiApi.DatabaseDetailsRow>(
+      clusterUiApi.createDatabaseDetailsReq("test"),
+      [
+        // Id
+        { rows: [] },
+        // Grants
+        { rows: [] },
+        // Tables
+        {
+          rows: [{ table_schema: "public", table_name: "widgets" }],
+        },
+        // Ranges
+        {
+          rows: [
+            {
+              replicas: [1,2,3,4,5,6],
+              regions: ["gcp-europe-west1", "gcp-europe-west2"],
+              range_size: 10,
+            },
+            {
+              replicas: [1,2,3,4,5,6],
+              regions: ["gcp-europe-west1", "gcp-europe-west2"],
+              range_size: 10,
+            },
+            {
+              replicas: [1,2,3,4,5,6],
+              regions: ["gcp-europe-west1", "gcp-europe-west2"],
+              range_size: 10,
+            },
+            {
+              replicas: [1,2,3,4,5,6],
+              regions: ["gcp-europe-west1", "gcp-europe-west2"],
+              range_size: 10,
+            }
+          ],
+        },
+      ],
+    );
+
+    await driver.refreshDatabaseDetails("test");
 
     driver.assertDatabaseProperties("test", {
       loading: false,
       loaded: true,
       lastError: null,
       name: "test",
-      nodes: [3, 5, 6],
-      sizeInBytes: 1234,
+      nodes: [1, 2, 3, 4, 5, 6],
+      sizeInBytes: 0, // TODO(thomas): fix when we have disk size
       tableCount: 1,
-      rangeCount: 42,
-      nodesByRegionString: "gcp-europe-west1(n3,n6), gcp-europe-west2(n5)",
-      missingTables: [],
+      rangeCount: 4,
+      nodesByRegionString:
+        "gcp-us-east1(n1,n2,n4), gcp-europe-west2(n5), gcp-europe-west1(n3,n6)",
       numIndexRecommendations: 0,
-    });
-  });
-
-  describe("fallback cases", function () {
-    describe("missing tables", function () {
-      it("exposes them so the component can refresh them", async function () {
-        fakeApi.stubDatabases(["system"]);
-
-        fakeApi.stubDatabaseDetails("system", {
-          table_names: ["foo", "bar"],
-          stats: {
-            missing_tables: [{ name: "bar" }],
-            range_count: new Long(3),
-            approximate_disk_bytes: new Long(7168),
-          },
-        });
-
-        await driver.refreshDatabases();
-        await driver.refreshDatabaseDetails("system");
-
-        driver.assertDatabaseProperties("system", {
-          loading: false,
-          loaded: true,
-          lastError: null,
-          name: "system",
-          nodes: [],
-          sizeInBytes: 7168,
-          tableCount: 2,
-          rangeCount: 3,
-          nodesByRegionString: "",
-          missingTables: [{ loading: false, name: "bar" }],
-          numIndexRecommendations: 0,
-        });
-      });
-
-      it("merges available individual stats into the totals", async function () {
-        fakeApi.stubDatabases(["system"]);
-
-        fakeApi.stubDatabaseDetails("system", {
-          table_names: ["foo", "bar"],
-          stats: {
-            missing_tables: [{ name: "bar" }],
-            range_count: new Long(3),
-            approximate_disk_bytes: new Long(7168),
-          },
-        });
-
-        fakeApi.stubTableStats("system", "bar", {
-          range_count: new Long(5),
-          approximate_disk_bytes: new Long(1024),
-        });
-
-        await driver.refreshDatabases();
-        await driver.refreshDatabaseDetails("system");
-        await driver.refreshTableStats("system", "bar");
-
-        driver.assertDatabaseProperties("system", {
-          loading: false,
-          loaded: true,
-          lastError: null,
-          name: "system",
-          nodes: [],
-          sizeInBytes: 8192,
-          tableCount: 2,
-          rangeCount: 8,
-          nodesByRegionString: "",
-          missingTables: [],
-          numIndexRecommendations: 0,
-        });
-      });
-    });
-
-    describe("missing stats", function () {
-      it("builds a list of missing tables", async function () {
-        fakeApi.stubDatabases(["system"]);
-
-        fakeApi.stubDatabaseDetails("system", {
-          table_names: ["foo", "bar"],
-        });
-
-        await driver.refreshDatabases();
-        await driver.refreshDatabaseDetails("system");
-
-        driver.assertDatabaseProperties("system", {
-          loading: false,
-          loaded: true,
-          lastError: null,
-          name: "system",
-          nodes: [],
-          sizeInBytes: 0,
-          tableCount: 2,
-          rangeCount: 0,
-          nodesByRegionString: "",
-          missingTables: [
-            { loading: false, name: "foo" },
-            { loading: false, name: "bar" },
-          ],
-          numIndexRecommendations: 0,
-        });
-      });
-
-      it("merges individual stats into the totals", async function () {
-        fakeApi.stubDatabases(["system"]);
-
-        fakeApi.stubDatabaseDetails("system", {
-          table_names: ["foo", "bar"],
-        });
-
-        fakeApi.stubTableStats("system", "foo", {
-          range_count: new Long(3),
-          approximate_disk_bytes: new Long(7168),
-        });
-
-        fakeApi.stubTableStats("system", "bar", {
-          range_count: new Long(5),
-          approximate_disk_bytes: new Long(1024),
-        });
-
-        await driver.refreshDatabases();
-        await driver.refreshDatabaseDetails("system");
-        await driver.refreshTableStats("system", "foo");
-
-        driver.assertDatabaseProperties("system", {
-          loading: false,
-          loaded: true,
-          lastError: null,
-          name: "system",
-          nodes: [],
-          sizeInBytes: 7168,
-          tableCount: 2,
-          rangeCount: 3,
-          nodesByRegionString: "",
-          missingTables: [{ loading: false, name: "bar" }],
-          numIndexRecommendations: 0,
-        });
-
-        await driver.refreshTableStats("system", "bar");
-
-        driver.assertDatabaseProperties("system", {
-          loading: false,
-          loaded: true,
-          lastError: null,
-          name: "system",
-          nodes: [],
-          sizeInBytes: 8192,
-          tableCount: 2,
-          rangeCount: 8,
-          nodesByRegionString: "",
-          missingTables: [],
-          numIndexRecommendations: 0,
-        });
-      });
     });
   });
 });

--- a/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.spec.ts
@@ -67,7 +67,7 @@ class TestDriver {
   }
 }
 
-describe.only("Databases Page", function () {
+describe("Databases Page", function () {
   let driver: TestDriver;
 
   beforeEach(function () {
@@ -121,7 +121,7 @@ describe.only("Databases Page", function () {
         {
           loading: false,
           loaded: false,
-          lastError: undefined,
+          lastError: null,
           name: "system",
           nodes: [],
           sizeInBytes: 0,
@@ -133,7 +133,7 @@ describe.only("Databases Page", function () {
         {
           loading: false,
           loaded: false,
-          lastError: undefined,
+          lastError: null,
           name: "test",
           nodes: [],
           sizeInBytes: 0,
@@ -154,6 +154,7 @@ describe.only("Databases Page", function () {
   });
 
   it("fills in database details and node/region info", async function () {
+    const oldDate = new Date(2020, 12, 25, 0, 0, 0, 0);
     const regions = [
       "gcp-us-east1",
       "gcp-us-east1",
@@ -183,10 +184,10 @@ describe.only("Databases Page", function () {
       nodes: nodes,
     });
 
-    fakeApi.stubDatabases(["system", "test"]);
+    fakeApi.stubDatabases(["test"], 1);
 
     fakeApi.stubSqlApiCall<clusterUiApi.DatabaseDetailsRow>(
-      clusterUiApi.createDatabaseDetailsReq("system"),
+      clusterUiApi.createDatabaseDetailsReq("test"),
       [
         // Id
         { rows: [] },
@@ -199,85 +200,55 @@ describe.only("Databases Page", function () {
             { table_schema: "public", table_name: "bar" },
           ],
         },
-        // Ranges
+        // Regions and replicas
         {
           rows: [
             {
-              replicas: [1,2,3],
+              replicas: [1, 2, 3],
               regions: ["gcp-europe-west1", "gcp-europe-west2"],
-              range_size: 10,
             },
             {
-              replicas: [1,2,3],
+              replicas: [1, 2, 3],
               regions: ["gcp-europe-west1", "gcp-europe-west2"],
-              range_size: 10,
             },
             {
-              replicas: [1,2,3],
+              replicas: [1, 2, 3],
               regions: ["gcp-europe-west1", "gcp-europe-west2"],
-              range_size: 10,
-            }
+            },
+          ],
+        },
+        // Index Usage Stats
+        {
+          rows: [
+            // Generate drop index recommendation
+            {
+              last_read: oldDate.toISOString(),
+              created_at: oldDate.toISOString(),
+              unused_threshold: "1s",
+            },
+          ],
+        },
+        // Zone Config
+        {
+          rows: [],
+        },
+        // Span Stats
+        {
+          rows: [
+            {
+              approximate_disk_bytes: 100,
+              live_bytes: 200,
+              total_bytes: 300,
+              range_count: 400,
+            },
           ],
         },
       ],
+      1,
     );
 
     await driver.refreshNodes();
     await driver.refreshDatabases();
-    await driver.refreshDatabaseDetails("system");
-
-    driver.assertDatabaseProperties("system", {
-      loading: false,
-      loaded: true,
-      lastError: null,
-      name: "system",
-      nodes: [1, 2, 3],
-      sizeInBytes: 0, // TODO(thomas): fix when we have disk size
-      tableCount: 2,
-      rangeCount: 3,
-      nodesByRegionString: "gcp-us-east1(n1,n2), gcp-europe-west1(n3)",
-      numIndexRecommendations: 0,
-    });
-
-    fakeApi.stubSqlApiCall<clusterUiApi.DatabaseDetailsRow>(
-      clusterUiApi.createDatabaseDetailsReq("test"),
-      [
-        // Id
-        { rows: [] },
-        // Grants
-        { rows: [] },
-        // Tables
-        {
-          rows: [{ table_schema: "public", table_name: "widgets" }],
-        },
-        // Ranges
-        {
-          rows: [
-            {
-              replicas: [1,2,3,4,5,6],
-              regions: ["gcp-europe-west1", "gcp-europe-west2"],
-              range_size: 10,
-            },
-            {
-              replicas: [1,2,3,4,5,6],
-              regions: ["gcp-europe-west1", "gcp-europe-west2"],
-              range_size: 10,
-            },
-            {
-              replicas: [1,2,3,4,5,6],
-              regions: ["gcp-europe-west1", "gcp-europe-west2"],
-              range_size: 10,
-            },
-            {
-              replicas: [1,2,3,4,5,6],
-              regions: ["gcp-europe-west1", "gcp-europe-west2"],
-              range_size: 10,
-            }
-          ],
-        },
-      ],
-    );
-
     await driver.refreshDatabaseDetails("test");
 
     driver.assertDatabaseProperties("test", {
@@ -285,13 +256,12 @@ describe.only("Databases Page", function () {
       loaded: true,
       lastError: null,
       name: "test",
-      nodes: [1, 2, 3, 4, 5, 6],
-      sizeInBytes: 0, // TODO(thomas): fix when we have disk size
-      tableCount: 1,
-      rangeCount: 4,
-      nodesByRegionString:
-        "gcp-us-east1(n1,n2,n4), gcp-europe-west2(n5), gcp-europe-west1(n3,n6)",
-      numIndexRecommendations: 0,
+      nodes: [1, 2, 3],
+      sizeInBytes: 100,
+      tableCount: 2,
+      rangeCount: 400,
+      nodesByRegionString: "gcp-europe-west1(n3), gcp-us-east1(n1,n2)",
+      numIndexRecommendations: 1,
     });
   });
 });

--- a/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/databasesPage/redux.ts
@@ -8,7 +8,6 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import _ from "lodash";
 import { createSelector } from "reselect";
 import { LocalSetting } from "src/redux/localsettings";
 import {
@@ -18,25 +17,19 @@ import {
   Filters,
 } from "@cockroachlabs/cluster-ui";
 
-import { cockroach } from "src/js/protos";
 import {
-  generateTableID,
-  refreshDatabaseDetails,
   refreshDatabases,
+  refreshDatabaseDetails,
   refreshNodes,
   refreshSettings,
-  refreshTableStats,
 } from "src/redux/apiReducers";
 import { AdminUIState } from "src/redux/state";
-import { FixLong } from "src/util/fixLong";
 import {
   nodeRegionsByIDSelector,
   selectIsMoreThanOneNode,
 } from "src/redux/nodes";
 import { getNodesByRegionString } from "../utils";
 import { selectAutomaticStatsCollectionEnabled } from "src/redux/clusterSettings";
-
-const { DatabaseDetailsRequest, TableStatsRequest } = cockroach.server.serverpb;
 
 const selectLoading = createSelector(
   (state: AdminUIState) => state.cachedData.databases,
@@ -77,59 +70,27 @@ const searchLocalSetting = new LocalSetting(
 const selectDatabases = createSelector(
   (state: AdminUIState) => state.cachedData.databases.data,
   (state: AdminUIState) => state.cachedData.databaseDetails,
-  (state: AdminUIState) => state.cachedData.tableStats,
   (state: AdminUIState) => nodeRegionsByIDSelector(state),
   (_: AdminUIState) => isTenant,
   (
     databases,
     databaseDetails,
-    tableStats,
     nodeRegions,
     isTenant,
   ): DatabasesPageDataDatabase[] =>
     (databases?.databases || []).map(database => {
       const details = databaseDetails[database];
-
       const stats = details?.data?.stats;
-      let sizeInBytes = FixLong(stats?.approximate_disk_bytes || 0).toNumber();
-      let rangeCount = FixLong(stats?.range_count || 0).toNumber();
-      const nodes = stats?.node_ids || [];
-
-      // We offer the component a chance to refresh any table-level stats we
-      // weren't able to gather during the initial database details call, by
-      // exposing a list of "missing tables."
-      //
-      // Furthermore, when the database-level stats are completely absent
-      // from the database details response (perhaps we're talking to an
-      // older backend that doesn't support them), we mark _all_ the tables
-      // as "missing", so that the component can trigger refresh calls for
-      // all of their individual stats.
-
-      const possiblyMissingTables = stats
-        ? stats.missing_tables.map(table => table.name)
-        : details?.data?.table_names;
-
-      const [individuallyLoadedTables, missingTables] = _.partition(
-        possiblyMissingTables,
-        table => {
-          return !!tableStats[generateTableID(database, table)]?.valid;
-        },
-      );
-
-      individuallyLoadedTables.forEach(table => {
-        const stats = tableStats[generateTableID(database, table)];
-        sizeInBytes += FixLong(
-          stats?.data?.approximate_disk_bytes || 0,
-        ).toNumber();
-        rangeCount += FixLong(stats?.data?.range_count || 0).toNumber();
-      });
-
+      const sizeInBytes = stats?.pebble_data?.approximate_disk_bytes || 0;
+      const rangeCount = stats?.ranges_data.count || 0;
+      const nodes = stats?.ranges_data.node_ids || [];
       const nodesByRegionString = getNodesByRegionString(
         nodes,
         nodeRegions,
         isTenant,
       );
-      const numIndexRecommendations = stats?.num_index_recommendations || 0;
+      const numIndexRecommendations =
+        stats?.index_stats.num_index_recommendations || 0;
 
       const combinedErr = combineLoadingErrors(
         details?.lastError,
@@ -142,17 +103,11 @@ const selectDatabases = createSelector(
         lastError: combinedErr,
         name: database,
         sizeInBytes: sizeInBytes,
-        tableCount: details?.data?.table_names?.length || 0,
+        tableCount: details?.data?.tables_resp.tables?.length || 0,
         rangeCount: rangeCount,
         nodes: nodes,
         nodesByRegionString,
         numIndexRecommendations,
-        missingTables: missingTables.map(table => {
-          return {
-            loading: !!tableStats[generateTableID(database, table)]?.inFlight,
-            name: table,
-          };
-        }),
       };
     }),
 );
@@ -198,14 +153,7 @@ export const mapStateToProps = (state: AdminUIState): DatabasesPageData => ({
 export const mapDispatchToProps = {
   refreshSettings,
   refreshDatabases,
-  refreshDatabaseDetails: (database: string) => {
-    return refreshDatabaseDetails(
-      new DatabaseDetailsRequest({ database, include_stats: true }),
-    );
-  },
-  refreshTableStats: (database: string, table: string) => {
-    return refreshTableStats(new TableStatsRequest({ database, table }));
-  },
+  refreshDatabaseDetails,
   refreshNodes,
   onSortingChange: (
     _tableName: string,

--- a/pkg/ui/workspaces/db-console/src/views/databases/utils.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/utils.ts
@@ -100,3 +100,41 @@ export function normalizePrivileges(raw: string[]): string[] {
     privilege => privilegePrecedence[privilege] || 100,
   );
 }
+
+export function combineLoadingErrors(
+  detailsErr: Error,
+  isMaxSizeError: boolean,
+  dbList: string,
+): Error {
+  if (dbList && detailsErr) {
+    return new GetDatabaseInfoError(
+      `Failed to load all databases and database details. Partial results are shown. Debug info: ${dbList}, details error: ${detailsErr}`,
+    );
+  }
+
+  if (dbList) {
+    return new GetDatabaseInfoError(
+      `Failed to load all databases. Partial results are shown. Debug info: ${dbList}`,
+    );
+  }
+
+  if (detailsErr) {
+    return detailsErr;
+  }
+
+  if (isMaxSizeError) {
+    return new GetDatabaseInfoError(
+      `Failed to load all databases and database details. Partial results are shown. Debug info: Max size limit reached fetching database details`,
+    );
+  }
+
+  return null;
+}
+
+export class GetDatabaseInfoError extends Error {
+  constructor(message: string) {
+    super(message);
+
+    this.name = this.constructor.name;
+  }
+}


### PR DESCRIPTION
Part of: https://github.com/cockroachdb/cockroach/issues/89429
Addresses: #90261

This change moves the existing database details endpoint to use sql-over-http.

The data for database details is populated using 7 queries, which fetch
the database's:
- ID
- grants
- tables
- replicas and regions
- index usage statistics
- zone configuration
- span statistics

This PR also changes the structure of the database details response.
Each field within the overlying database details response encapsulates
the response of one of the queries. Query failures are captured at the
top-level of the response and within the corresponding response field
for the query (scoping query failures to each transaction).

Additionally, we no longer fetch `missing_tables` as we are no longer fetching table stats per table, but in a single query.

**DEMO**
https://www.loom.com/share/3a51bf5a8f3c41089fc5acae9ff29fcf

Release note: None