### PR TITLE
ui: prevent polling /settings, /nodes_ui and /cluster endpoints on incorrect login

### DIFF
--- a/pkg/ui/workspaces/db-console/src/redux/alerts.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/alerts.spec.ts
@@ -17,7 +17,7 @@ import { cockroach } from "src/js/protos";
 import { API_PREFIX } from "src/util/api";
 import fetchMock from "src/util/fetch-mock";
 
-import { AdminUIState, createAdminUIStore } from "./state";
+import { AdminUIState, AppDispatch, createAdminUIStore } from "./state";
 import {
   AlertLevel,
   alertDataSync,
@@ -49,6 +49,7 @@ import {
 } from "./apiReducers";
 import Long from "long";
 import MembershipStatus = cockroach.kv.kvserver.liveness.livenesspb.MembershipStatus;
+import { loginSuccess } from "./login";
 
 describe("alerts", function () {
   let store: Store<AdminUIState>;
@@ -536,7 +537,8 @@ describe("alerts", function () {
         method: "GET",
         response: () => 500,
       });
-
+      const loginDispatch = dispatch as AppDispatch;
+      loginDispatch(loginSuccess("test"));
       sync = alertDataSync(store);
     });
 

--- a/pkg/ui/workspaces/db-console/src/redux/alerts.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/alerts.ts
@@ -653,6 +653,17 @@ export function alertDataSync(store: Store<AdminUIState>) {
     // Always refresh health.
     dispatch(refreshHealth());
 
+    // We should not send out requests to the endpoints below if
+    // the user has not successfully logged in since the requests
+    // will always return with a 401 error.
+    if (
+      !state.login ||
+      !state.login.loggedInUser ||
+      state.login.loggedInUser == ``
+    ) {
+      return;
+    }
+
     // Load persistent settings which have not yet been loaded.
     const uiData = state.uiData;
     if (uiData !== lastUIData) {

--- a/pkg/ui/workspaces/db-console/src/redux/login.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/login.ts
@@ -179,7 +179,7 @@ interface LoginSuccessAction extends Action {
   loggedInUser: string;
 }
 
-function loginSuccess(loggedInUser: string): LoginSuccessAction {
+export function loginSuccess(loggedInUser: string): LoginSuccessAction {
   return {
     type: LOGIN_SUCCESS,
     loggedInUser,


### PR DESCRIPTION
This change fixes an issue where if the user
incorrectly submits the wrong username/pwd
combo on the login page, polling kicks off
for the /settings, /nodes_ui and /cluster
endpoints which is not correct as they will
continuously return 401 errors. Adding an
early exit that checks for the login state
prevents this issue from occuring.

Found from working on #92694.

Epic: none

Release note (ui change): prevent polling /settings, /nodes_ui and /cluster endpoints on incorrect login.