### PR TITLE
flowinfra: create flow runner waiter goroutine as a task

### DIFF
--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -156,6 +156,7 @@ var retiredSettings = map[string]struct{}{
 	"sql.catalog.descs.validate_on_write.enabled": {},
 	"sql.distsql.max_running_flows":               {},
 	"sql.distsql.flow_scheduler_queueing.enabled": {},
+	"sql.distsql.drain.cancel_after_wait.enabled": {},
 }
 
 // sqlDefaultSettings is the list of "grandfathered" existing sql.defaults

--- a/pkg/sql/distsql/BUILD.bazel
+++ b/pkg/sql/distsql/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
         "//pkg/kv",
         "//pkg/roachpb",
         "//pkg/server/telemetry",
-        "//pkg/settings",
         "//pkg/sql/catalog/catsessiondata",
         "//pkg/sql/catalog/descs",
         "//pkg/sql/colflow",

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
-	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catsessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/colflow"
@@ -139,15 +138,6 @@ func (ds *ServerImpl) NumRemoteRunningFlows() int {
 	return ds.remoteFlowRunner.NumRunningFlows()
 }
 
-// TODO(yuzefovich): remove this setting in 23.1.
-var cancelRunningQueriesAfterFlowDrainWait = settings.RegisterBoolSetting(
-	settings.TenantWritable,
-	"sql.distsql.drain.cancel_after_wait.enabled",
-	"determines whether queries that are still running on a node being drained "+
-		"are forcefully canceled after waiting the 'server.shutdown.query_wait' period",
-	true,
-)
-
 // Drain changes the node's draining state through gossip and drains the
 // server's flowRegistry. See flowRegistry.Drain for more details.
 func (ds *ServerImpl) Drain(
@@ -167,8 +157,7 @@ func (ds *ServerImpl) Drain(
 		// wait a minimum time for the draining state to be gossiped.
 		minWait = 0
 	}
-	cancelStillRunning := cancelRunningQueriesAfterFlowDrainWait.Get(&ds.Settings.SV)
-	ds.flowRegistry.Drain(flowWait, minWait, reporter, cancelStillRunning)
+	ds.flowRegistry.Drain(flowWait, minWait, reporter)
 }
 
 // setDraining changes the node's draining state through gossip to the provided

--- a/pkg/sql/distsql/setup_flow_after_drain_test.go
+++ b/pkg/sql/distsql/setup_flow_after_drain_test.go
@@ -47,8 +47,7 @@ func TestSetupFlowAfterDrain(t *testing.T) {
 		remoteFlowRunner,
 	)
 	distSQLSrv.flowRegistry.Drain(
-		time.Duration(0) /* flowDrainWait */, time.Duration(0), /* minFlowDrainWait */
-		nil /* reporter */, false, /* cancelStillRunning */
+		time.Duration(0) /* flowDrainWait */, time.Duration(0) /* minFlowDrainWait */, nil, /* reporter */
 	)
 
 	// We create some flow; it doesn't matter what.

--- a/pkg/sql/flowinfra/flow_registry.go
+++ b/pkg/sql/flowinfra/flow_registry.go
@@ -456,7 +456,6 @@ func (fr *FlowRegistry) Drain(
 	flowDrainWait time.Duration,
 	minFlowDrainWait time.Duration,
 	reporter func(int, redact.SafeString),
-	cancelStillRunning bool,
 ) {
 	allFlowsDone := make(chan struct{}, 1)
 	start := timeutil.Now()
@@ -483,16 +482,14 @@ func (fr *FlowRegistry) Drain(
 			time.Sleep(expectedConnectionTime)
 			fr.Lock()
 		}
-		if cancelStillRunning {
-			// Now cancel all still running flows.
-			for _, f := range fr.flows {
-				if f.flow != nil && f.flow.ctxCancel != nil {
-					// f.flow might be nil when ConnectInboundStream() was
-					// called, but the consumer of that inbound stream hasn't
-					// been scheduled yet.
-					// f.flow.ctxCancel might be nil in tests.
-					f.flow.ctxCancel()
-				}
+		// Now cancel all still running flows.
+		for _, f := range fr.flows {
+			if f.flow != nil && f.flow.ctxCancel != nil {
+				// f.flow might be nil when ConnectInboundStream() was
+				// called, but the consumer of that inbound stream hasn't
+				// been scheduled yet.
+				// f.flow.ctxCancel might be nil in tests.
+				f.flow.ctxCancel()
 			}
 		}
 		fr.Unlock()

--- a/pkg/sql/flowinfra/flow_registry_test.go
+++ b/pkg/sql/flowinfra/flow_registry_test.go
@@ -393,7 +393,7 @@ func TestFlowRegistryDrain(t *testing.T) {
 		registerFlow(t, id)
 		drainDone := make(chan struct{})
 		go func() {
-			reg.Drain(math.MaxInt64 /* flowDrainWait */, 0 /* minFlowDrainWait */, nil /* reporter */, false /* cancelStillRunning */)
+			reg.Drain(math.MaxInt64 /* flowDrainWait */, 0 /* minFlowDrainWait */, nil /* reporter */)
 			drainDone <- struct{}{}
 		}()
 		// Be relatively sure that the FlowRegistry is draining.
@@ -406,7 +406,7 @@ func TestFlowRegistryDrain(t *testing.T) {
 	// DrainTimeout verifies that Drain returns once the timeout expires.
 	t.Run("DrainTimeout", func(t *testing.T) {
 		registerFlow(t, id)
-		reg.Drain(0 /* flowDrainWait */, 0 /* minFlowDrainWait */, nil /* reporter */, false /* cancelStillRunning */)
+		reg.Drain(0 /* flowDrainWait */, 0 /* minFlowDrainWait */, nil /* reporter */)
 		reg.UnregisterFlow(id)
 		reg.Undrain()
 	})
@@ -417,7 +417,7 @@ func TestFlowRegistryDrain(t *testing.T) {
 		registerFlow(t, id)
 		drainDone := make(chan struct{})
 		go func() {
-			reg.Drain(math.MaxInt64 /* flowDrainWait */, 0 /* minFlowDrainWait */, nil /* reporter */, false /* cancelStillRunning */)
+			reg.Drain(math.MaxInt64 /* flowDrainWait */, 0 /* minFlowDrainWait */, nil /* reporter */)
 			drainDone <- struct{}{}
 		}()
 		// Be relatively sure that the FlowRegistry is draining.
@@ -460,7 +460,7 @@ func TestFlowRegistryDrain(t *testing.T) {
 		}
 		defer func() { reg.testingRunBeforeDrainSleep = nil }()
 		go func() {
-			reg.Drain(math.MaxInt64 /* flowDrainWait */, 0 /* minFlowDrainWait */, nil /* reporter */, false /* cancelStillRunning */)
+			reg.Drain(math.MaxInt64 /* flowDrainWait */, 0 /* minFlowDrainWait */, nil /* reporter */)
 			drainDone <- struct{}{}
 		}()
 		if err := <-errChan; err != nil {
@@ -488,7 +488,7 @@ func TestFlowRegistryDrain(t *testing.T) {
 		minFlowDrainWait := 10 * time.Millisecond
 		start := timeutil.Now()
 		go func() {
-			reg.Drain(math.MaxInt64 /* flowDrainWait */, minFlowDrainWait, nil /* reporter */, false /* cancelStillRunning */)
+			reg.Drain(math.MaxInt64 /* flowDrainWait */, minFlowDrainWait, nil /* reporter */)
 			drainDone <- struct{}{}
 		}()
 		// Be relatively sure that the FlowRegistry is draining.


### PR DESCRIPTION
**distsql: always cancel running queries after flow drain wait time**

This commit removes a cluster setting that determines whether the flows
still running when `server.shutdown.query_wait` elapses are canceled. In
22.2 we introduced this setting with a default value of `true` (meaning
to cancel long-running queries after the wait period) out of caution,
but now it should be safe to remove this escape hatch and always cancel
those stragglers - this was always the intention after all.

Release note: None

**flowinfra: create flow runner waiter goroutine as a task**

This commit makes the change to create goroutine that is spun up to wait
for the remote flow to finish and to clean up after it as a task on the
stopper. This change allows us to fix the possible race between the server
quiescing (which closes the temp engine) and the vectorized flow cleanup
(which might delete its temp storage directory).

Some care had to be taken to prevent some types of races: on one hand, we
cannot start the flow until the new async waiter task is spun up because
in that case the bug this commit is fixing is still present; on the
other hand, the async task cannot block on `Flow.Wait` method until the
flow is started successfully. Such a setup requires coordination between
the new async task and the flow being started in the current goroutine.

Fixes: #92504.
Fixes: #92903.

Release note: None