### PR TITLE
sql: auto-commit if DDL statements are encountered in implicit txns

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1944,10 +1944,13 @@ func (ex *connExecutor) execCmd() error {
 			// https://www.postgresql.org/docs/14/protocol-flow.html.
 			// The behavior is configurable, in case users want to preserve the
 			// behavior from v21.2 and earlier.
+			// Similar to Postgres if the current statement is DDL, we will force
+			// a commit to ensure database consistency.
 			implicitTxnForBatch := ex.sessionData().EnableImplicitTransactionForBatchStatements
 			canAutoCommit := ex.implicitTxn() &&
 				(tcmd.LastInBatchBeforeShowCommitTimestamp ||
-					tcmd.LastInBatch || !implicitTxnForBatch)
+					tcmd.LastInBatch || !implicitTxnForBatch ||
+					tcmd.AST.StatementType() == tree.TypeDDL)
 			ev, payload, err = ex.execStmt(
 				ctx, tcmd.Statement, nil /* prepared */, nil /* pinfo */, stmtRes, canAutoCommit,
 			)


### PR DESCRIPTION
When executing multi-statement implicit transactions we did not issue a commit until the last statement was encountered. This could be problematic in certain scenarios, since if we are executing DDL statements some of these rely on jobs which need to be completed before the next statement can be executed. To address this, this patch forces implicit transactions to commit for each DDL statement, this is allowed by the Postgres specifications.

Fixes: #93010

Release note (bug fix): Implicit multi-statement implicit transactions did not commit for DDL statements properly, which could cause later queries to encounter executed in such transactions. Following the Postgres specification multi-statement will implicitly commit for DDL statements when encountered.