### PR TITLE
sql/opt: Refactor and add regnamespace to foldOIDFamilyCast

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/record
+++ b/pkg/sql/logictest/testdata/logic_test/record
@@ -98,7 +98,7 @@ a[]
 query T
 SELECT pg_typeof(ARRAY[(1, 3)::a, (1, 2)::a])::regtype::oid::regtype
 ----
-_record
+a[]
 
 # You can't drop the type descriptor.
 statement error cannot modify table record type \"a\"

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -1122,6 +1122,30 @@ vectorized: true
   spans: [/boolean[] - /boolean[]]
 
 query T
+EXPLAIN (VERBOSE) SELECT * FROM pg_type WHERE oid = 1::regtype
+----
+distribution: local
+vectorized: true
+·
+• virtual table
+  columns: (oid, typname, typnamespace, typowner, typlen, typbyval, typtype, typcategory, typispreferred, typisdefined, typdelim, typrelid, typelem, typarray, typinput, typoutput, typreceive, typsend, typmodin, typmodout, typanalyze, typalign, typstorage, typnotnull, typbasetype, typtypmod, typndims, typcollation, typdefaultbin, typdefault, typacl)
+  estimated row count: 10 (missing stats)
+  table: pg_type@pg_type_oid_idx
+  spans: [/1 - /1]
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM pg_type WHERE oid = 1::regtype::oid
+----
+distribution: local
+vectorized: true
+·
+• virtual table
+  columns: (oid, typname, typnamespace, typowner, typlen, typbyval, typtype, typcategory, typispreferred, typisdefined, typdelim, typrelid, typelem, typarray, typinput, typoutput, typreceive, typsend, typmodin, typmodout, typanalyze, typalign, typstorage, typnotnull, typbasetype, typtypmod, typndims, typcollation, typdefaultbin, typdefault, typacl)
+  estimated row count: 10 (missing stats)
+  table: pg_type@pg_type_oid_idx
+  spans: [/1 - /1]
+
+query T
 EXPLAIN (VERBOSE) SELECT CASE WHEN current_database() = 'test' THEN 42 ELSE 1/3 END
 ----
 distribution: local

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -1146,6 +1146,18 @@ vectorized: true
   spans: [/1 - /1]
 
 query T
+EXPLAIN (VERBOSE) SELECT * FROM pg_namespace WHERE oid = 'public'::regnamespace
+----
+distribution: local
+vectorized: true
+·
+• virtual table
+  columns: (oid, nspname, nspowner, nspacl)
+  estimated row count: 10 (missing stats)
+  table: pg_namespace@pg_namespace_oid_idx
+  spans: [/public - /public]
+
+query T
 EXPLAIN (VERBOSE) SELECT CASE WHEN current_database() = 'test' THEN 42 ELSE 1/3 END
 ----
 distribution: local

--- a/pkg/sql/opt/norm/fold_constants_funcs.go
+++ b/pkg/sql/opt/norm/fold_constants_funcs.go
@@ -335,7 +335,7 @@ func (c *CustomFuncs) foldOIDFamilyCast(
 	var dOid *tree.DOid
 
 	switch typ.Oid() {
-	case oid.T_oid, oid.T_regtype, oid.T_regproc, oid.T_regprocedure:
+	case oid.T_oid, oid.T_regtype, oid.T_regproc, oid.T_regprocedure, oid.T_regnamespace:
 		switch inputFamily {
 		case types.StringFamily, types.OidFamily, types.IntFamily:
 			cDatum, err := eval.PerformCast(c.f.ctx, c.f.evalCtx, datum, typ)

--- a/pkg/sql/opt/norm/fold_constants_funcs.go
+++ b/pkg/sql/opt/norm/fold_constants_funcs.go
@@ -333,25 +333,16 @@ func (c *CustomFuncs) foldOIDFamilyCast(
 
 	inputFamily := input.DataType().Family()
 	var dOid *tree.DOid
-	var err error
 
 	switch typ.Oid() {
-	case oid.T_oid:
+	case oid.T_oid, oid.T_regtype, oid.T_regproc, oid.T_regprocedure:
 		switch inputFamily {
-		case types.StringFamily:
-			s := tree.MustBeDString(datum)
-			dOid, err = tree.ParseDOidAsInt(string(s))
+		case types.StringFamily, types.OidFamily, types.IntFamily:
+			cDatum, err := eval.PerformCast(c.f.ctx, c.f.evalCtx, datum, typ)
 			if err != nil {
-				return nil, true, err
+				return nil, false, err
 			}
-		case types.IntFamily:
-			i := tree.MustBeDInt(datum)
-			dOid, err = tree.IntToOid(i)
-			if err != nil {
-				return nil, true, err
-			}
-		case types.OidFamily:
-			dOid = tree.NewDOidWithType(tree.MustBeDOid(datum).Oid, types.Oid)
+			dOid = tree.MustBeDOid(cDatum)
 		default:
 			return nil, false, nil
 		}
@@ -371,55 +362,9 @@ func (c *CustomFuncs) foldOIDFamilyCast(
 
 			c.mem.Metadata().AddDependency(opt.DepByName(&resName), ds, privilege.SELECT)
 			dOid = tree.NewDOidWithName(oid.Oid(ds.PostgresDescriptorID()), types.RegClass, string(tn.ObjectName))
-		default:
-			return nil, false, nil
-		}
-	case oid.T_regtype:
-		switch inputFamily {
-		case types.StringFamily:
-			s := tree.MustBeDString(datum)
-			typRef, err := parser.GetTypeFromValidSQLSyntax(string(s))
-			if err != nil {
-				return nil, true, err
-			}
-
-			var resolvedTyp *types.T
-			var isArray bool
-			switch t := typRef.(type) {
-			case *tree.ArrayTypeReference:
-				resolvedTyp, err = c.f.catalog.ResolveType(c.f.ctx, t.ElementType.(*tree.UnresolvedObjectName))
-				if err != nil {
-					return nil, true, err
-				}
-				isArray = true
-			case *tree.UnresolvedObjectName:
-				resolvedTyp, err = c.f.catalog.ResolveType(c.f.ctx, t)
-				if err != nil {
-					return nil, true, err
-				}
-			case *types.T:
-				resolvedTyp = t
-			default:
-				return nil, false, nil
-			}
-
-			if isArray {
-				resolvedTyp = types.MakeArray(resolvedTyp)
-			}
-			dOid = tree.NewDOidWithTypeAndName(resolvedTyp.Oid(), types.RegType, resolvedTyp.SQLStandardName())
 
 		default:
 			return nil, false, nil
-		}
-	case oid.T_regproc, oid.T_regprocedure:
-		switch inputFamily {
-		case types.StringFamily, types.OidFamily, types.IntFamily:
-			cDatum, err := eval.PerformCast(c.f.ctx, c.f.evalCtx, datum, typ)
-			if err != nil {
-				return nil, false, err
-			}
-
-			dOid = tree.MustBeDOid(cDatum)
 		}
 	default:
 		return nil, false, nil


### PR DESCRIPTION
Part of: #91022

**sql/opt: Refactor foldOIDFamilyCast to use PerformCast**
This commit simplifies the switch used to handle each cast
to the OID family.

Release note: None

**sql/opt: Add regnamespace to foldOIDFamilyCast**
Adds regnamespace to foldOIDFamilyCast. Due to there being
no index on pg_namespace at this time, this change is a
no-op.

Release note: None