### PR TITLE
release-22.1: backupccl: speed up listing in some backup callsites

### DIFF
--- a/pkg/ccl/backupccl/manifest_handling.go
+++ b/pkg/ccl/backupccl/manifest_handling.go
@@ -1162,7 +1162,7 @@ func getEncryptionInfoFiles(ctx context.Context, dest cloud.ExternalStorage) ([]
 	var files []string
 	// Look for all files in dest that start with "/ENCRYPTION-INFO"
 	// and return them.
-	err := dest.List(ctx, "", "", func(p string) error {
+	err := dest.List(ctx, "", listingDelimDataSlash, func(p string) error {
 		paths := strings.Split(p, "/")
 		p = paths[len(paths)-1]
 		if match := strings.HasPrefix(p, backupEncryptionInfoFile); match {
@@ -1321,7 +1321,7 @@ func checkForPreviousBackup(
 
 	// Check for the presence of a BACKUP-LOCK file with a job ID different from
 	// that of our job.
-	if err := defaultStore.List(ctx, "", "", func(s string) error {
+	if err := defaultStore.List(ctx, "", listingDelimDataSlash, func(s string) error {
 		s = strings.TrimPrefix(s, "/")
 		if strings.HasPrefix(s, backupLockFilePrefix) {
 			jobIDSuffix := strings.TrimPrefix(s, backupLockFilePrefix)


### PR DESCRIPTION
This is a backport of https://github.com/cockroachdb/cockroach/pull/93072.

There were a couple of calls to List that would list all the files in the backup destination bucket. In the presence of a large number of files, usually SST files in the data/ folder, this listing could be very slow. This could manifest as a RESTORE command hanging during the planning phase when we go to resolve encryption information from the base backup bucket.

To fix this, we add a delimiter to the List call that will make skipping over all files in the data/ directory much cheaper.

Informs: cockroachlabs/support#1937

Release note (bug fix): speedup slow listing calls that could manifest as restore queries hanging during execution, in the presence of several backup files

Release justification: low risk change to speedup listing of backup metadata files in some codepaths