### PR TITLE
tracing: fix race

### DIFF
--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -1391,7 +1391,7 @@ func (s *crdbSpan) SetRecordingType(to tracingpb.RecordingType) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, child := range s.mu.openChildren {
-		child.SetRecordingType(to)
+		child.i.crdb.SetRecordingType(to)
 	}
 }
 

--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -72,11 +72,15 @@ type crdbSpan struct {
 }
 
 type childRef struct {
-	spanRef
+	_spanRef spanRef
 	// collectRecording is set if this child's recording should be included in the
 	// parent's recording. This is usually the case, except for children created
 	// with the WithDetachedRecording() option.
 	collectRecording bool
+}
+
+func (c childRef) span() *crdbSpan {
+	return c._spanRef.i.crdb
 }
 
 type crdbSpanMu struct {
@@ -609,10 +613,10 @@ func (s *crdbSpan) finish() bool {
 		children = make([]spanRef, len(s.mu.openChildren))
 		for i := range s.mu.openChildren {
 			c := &s.mu.openChildren[i]
-			c.parentFinished()
+			c.span().parentFinished()
 			// Move ownership of the child reference, and also nil out the pointer to
 			// the child, making it available for GC.
-			children[i] = c.spanRef.move()
+			children[i] = c._spanRef.move()
 		}
 		s.mu.openChildren = nil // The children were moved away.
 		s.mu.Unlock()
@@ -734,7 +738,7 @@ func (s *crdbSpan) getVerboseRecording(includeDetachedChildren bool, finishing b
 		openRecordings := make([]Trace, 0, len(s.mu.openChildren))
 		for _, openChild := range s.mu.openChildren {
 			if openChild.collectRecording || includeDetachedChildren {
-				openChildSp := openChild.Span.i.crdb
+				openChildSp := openChild.span()
 				openChildRecording := openChildSp.getVerboseRecording(includeDetachedChildren, false /* finishing */)
 				openRecordings = append(openRecordings, openChildRecording)
 
@@ -1042,7 +1046,7 @@ func (s *crdbSpan) appendStructuredEventsRecursivelyLocked(
 	buffer = s.appendStructuredEventsLocked(buffer)
 	for _, c := range s.mu.openChildren {
 		if c.collectRecording || includeDetachedChildren {
-			sp := c.Span.i.crdb
+			sp := c.span()
 			sp.mu.Lock()
 			buffer = sp.appendStructuredEventsRecursivelyLocked(buffer, includeDetachedChildren)
 			sp.mu.Unlock()
@@ -1080,7 +1084,7 @@ func (s *crdbSpan) getChildrenMetadataRecursivelyLocked(
 	// For each of s' open children, recurse to collect their metadata.
 	for _, c := range s.mu.openChildren {
 		if c.collectRecording || includeDetachedChildren {
-			sp := c.Span.i.crdb
+			sp := c.span()
 			sp.mu.Lock()
 			sp.getChildrenMetadataRecursivelyLocked(childrenMetadata,
 				true /*includeRootMetadata */, includeDetachedChildren)
@@ -1276,7 +1280,7 @@ func (s *crdbSpan) addChildLocked(child *Span, collectChildRec bool) bool {
 
 	s.mu.openChildren = append(
 		s.mu.openChildren,
-		childRef{spanRef: makeSpanRef(child), collectRecording: collectChildRec},
+		childRef{_spanRef: makeSpanRef(child), collectRecording: collectChildRec},
 	)
 	return true
 }
@@ -1299,7 +1303,7 @@ func (s *crdbSpan) childFinished(child *crdbSpan) {
 	var childIdx int
 	found := false
 	for i, c := range s.mu.openChildren {
-		sp := c.Span.i.crdb
+		sp := c.span()
 		if sp == child {
 			childIdx = i
 			found = true
@@ -1340,7 +1344,7 @@ func (s *crdbSpan) childFinished(child *crdbSpan) {
 
 	collectChildRec := s.mu.openChildren[childIdx].collectRecording
 	// Drop the child's reference.
-	if s.mu.openChildren[childIdx].decRef() {
+	if s.mu.openChildren[childIdx]._spanRef.decRef() {
 		// We're going to use the child below, so we don't want it to be
 		// re-allocated yet. It shouldn't be re-allocated, because each span holds a
 		// reference to itself that's only dropped at the end of Span.Finish() (and
@@ -1380,7 +1384,7 @@ func (s *crdbSpan) visitOpenChildren(visitor func(child *crdbSpan)) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, c := range s.mu.openChildren {
-		visitor(c.Span.i.crdb)
+		visitor(c.span())
 	}
 }
 
@@ -1391,7 +1395,7 @@ func (s *crdbSpan) SetRecordingType(to tracingpb.RecordingType) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, child := range s.mu.openChildren {
-		child.i.crdb.SetRecordingType(to)
+		child.span().SetRecordingType(to)
 	}
 }
 

--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -1376,11 +1376,11 @@ func (s *crdbSpan) parentFinished() {
 // visitOpenChildren calls the visitor for every open child. The receiver's lock
 // is held for the duration of the iteration, so the visitor should be quick.
 // The visitor is not allowed to hold on to children after it returns.
-func (s *crdbSpan) visitOpenChildren(visitor func(child *Span)) {
+func (s *crdbSpan) visitOpenChildren(visitor func(child *crdbSpan)) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, c := range s.mu.openChildren {
-		visitor(c.spanRef.Span)
+		visitor(c.Span.i.crdb)
 	}
 }
 

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -549,11 +549,6 @@ func (sp *Span) UpdateGoroutineIDToCurrent() {
 	sp.i.crdb.setGoroutineID(goid.Get())
 }
 
-// parentFinished makes sp a root.
-func (sp *Span) parentFinished() {
-	sp.i.crdb.parentFinished()
-}
-
 // reset prepares sp for (re-)use.
 //
 // sp might be a re-allocated span that was previously used and Finish()ed. In

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -686,13 +686,6 @@ func (sp *Span) reset(
 	sp.finishStack = ""
 }
 
-// visitOpenChildren calls the visitor for every open child. The receiver's lock
-// is held for the duration of the iteration, so the visitor should be quick.
-// The visitor is not allowed to hold on to children after it returns.
-func (sp *Span) visitOpenChildren(visitor func(sp *Span)) {
-	sp.i.crdb.visitOpenChildren(visitor)
-}
-
 // SetOtelStatus sets the status of the OpenTelemetry span (if any).
 func (sp *Span) SetOtelStatus(code codes.Code, msg string) {
 	if sp.i.otelSpan == nil {

--- a/pkg/util/tracing/span_test.go
+++ b/pkg/util/tracing/span_test.go
@@ -1481,3 +1481,32 @@ func TestFinishedChildrenMetadata(t *testing.T) {
 		fn(tracingpb.RecordingStructured)
 	})
 }
+
+// Test races between finishing a span and enabling and getting the recording of
+// a parent. When operating on the parent, the parent descends into its open
+// children. If the child if being finished at the same time, there's a fragile
+// period where the child has been marked as finished, but still linked into the
+// parent. This test checks that a use-after-Finish panic is not triggered by
+// the child in this situation.
+func TestFinishGetRecordingRace(t *testing.T) {
+	ctx := context.Background()
+	tr := NewTracerWithOpt(ctx,
+		WithTracingMode(TracingModeActiveSpansRegistry),
+		// Scream on use-after-finish. That's how this test would fail if there was
+		// a bug.
+		WithUseAfterFinishOpt(true /* panicOnUseAfterFinish */, false /* debugUseAfterFinish */),
+		// Inhibit span reuse; the reuse make use-after-finish detection less
+		// reliable.
+		WithSpanReusePercent(0),
+	)
+	for i := 0; i < 100; i++ {
+		root := tr.StartSpan("root")
+		child := tr.StartSpan("child", WithParent(root))
+		go func() {
+			child.Finish()
+		}()
+		root.SetRecordingType(tracingpb.RecordingVerbose)
+		root.GetConfiguredRecording()
+		root.Finish()
+	}
+}

--- a/pkg/util/tracing/span_test.go
+++ b/pkg/util/tracing/span_test.go
@@ -370,7 +370,7 @@ func TestChildSpanRegisteredWithRecordingParent(t *testing.T) {
 	defer ch.Finish()
 	children := sp.i.crdb.mu.openChildren
 	require.Len(t, children, 1)
-	require.Equal(t, ch.i.crdb, children[0].spanRef.i.crdb)
+	require.Equal(t, ch.i.crdb, children[0].span())
 	ch.RecordStructured(&types.Int32Value{Value: 5})
 	// Check that the child's structured event is in the recording.
 	rec := sp.GetRecording(tracingpb.RecordingStructured)

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -382,6 +382,13 @@ type Tracer struct {
 type SpanRegistry struct {
 	mu struct {
 		syncutil.Mutex
+		// m stores all the currently open spans. Note that a span being present
+		// here proves that the corresponding Span.Finish() call has not yet
+		// completed (but crdbSpan.Finish() might have finished), therefor the span
+		// cannot be reused while present in the registry. At the same time, note
+		// that Span.Finish() can be called on these spans so, when using one of
+		// these spans, we need to be prepared for that use to be concurrent with
+		// the Finish() call.
 		m map[tracingpb.SpanID]*crdbSpan
 	}
 }
@@ -457,11 +464,11 @@ func (r *SpanRegistry) VisitRoots(visitor func(span RegistrySpan) error) error {
 	return nil
 }
 
-// visitTrace recursively calls the visitor on sp and all its descedents.
-func visitTrace(sp *Span, visitor func(sp RegistrySpan)) {
-	visitor(sp.i.crdb)
-	sp.visitOpenChildren(func(sp *Span) {
-		visitTrace(sp, visitor)
+// visitTrace recursively calls the visitor on sp and all its descendants.
+func visitTrace(sp *crdbSpan, visitor func(sp RegistrySpan)) {
+	visitor(sp)
+	sp.visitOpenChildren(func(child *crdbSpan) {
+		visitTrace(child, visitor)
 	})
 }
 
@@ -486,7 +493,7 @@ func (r *SpanRegistry) VisitSpans(visitor func(span RegistrySpan)) {
 	}()
 
 	for _, sp := range spans {
-		visitTrace(sp.Span, visitor)
+		visitTrace(sp.Span.i.crdb, visitor)
 	}
 }
 
@@ -1394,6 +1401,9 @@ func (t *Tracer) ExtractMetaFrom(carrier Carrier) (SpanMeta, error) {
 }
 
 // RegistrySpan is the interface used by clients of the active span registry.
+//
+// Note that RegistrySpans can be Finish()ed concurrently with their use, so all
+// methods must work with concurrent Finish() calls.
 type RegistrySpan interface {
 	// TraceID returns the id of the trace that this span is part of.
 	TraceID() tracingpb.TraceID


### PR DESCRIPTION
We had a race between finishing a child span and enabling recording on
the parent, which could result in a use-after-Finish on the child. When
enabling the parent's recording, the parent calls into the open
children. If the child is being Finish()ed at the same time, the child
Span is first marked as "finished", and only then unlinked from the
parent, so the parent might call into a child that's marked as finished.
This was detected as a use-after-Finish. This patch fixes it by having
the parent call directly into the child's crdbSpan, instead of calling
the child's higher-level Span. By going straight to the implementation,
the use-after-Finish detection is bypassed. The call into the child is
safe because, by being still linked into the parent, the child is not
yet subject to reuse (protecting against calls concurrent with reuses is
the general point of the use-after-Finish detection).

In most places the parent was already going directly to the child's
crdbSpan, except for the one call site fixed by this patch.

Release note: None
Epic: None