### PR TITLE
kvserver: refactor replicaAppBatch for standalone log application

### DIFF
--- a/pkg/kv/kvserver/app_batch.go
+++ b/pkg/kv/kvserver/app_batch.go
@@ -47,11 +47,11 @@ import (
 //
 // [^1]: https://github.com/cockroachdb/cockroach/issues/75729
 type appBatch struct {
-	mutations               int
-	entries                 int
-	entryBytes              int64
-	emptyEntries            int
-	followerStoreWriteBytes kvadmission.FollowerStoreWriteBytes
+	numMutations             int
+	numEntriesProcessed      int
+	numEntriesProcessedBytes int64
+	numEmptyEntries          int
+	followerStoreWriteBytes  kvadmission.FollowerStoreWriteBytes
 	// TODO(tbg): this will absorb the following fields from replicaAppBatch:
 	//
 	// - batch
@@ -129,7 +129,7 @@ func (b *appBatch) addWriteBatch(
 	if mutations, err := storage.PebbleBatchCount(wb.Data); err != nil {
 		log.Errorf(ctx, "unable to read header of committed WriteBatch: %+v", err)
 	} else {
-		b.mutations += mutations
+		b.numMutations += mutations
 	}
 	if err := batch.ApplyBatchRepr(wb.Data, false); err != nil {
 		return errors.Wrapf(err, "unable to apply WriteBatch")

--- a/pkg/kv/kvserver/app_batch.go
+++ b/pkg/kv/kvserver/app_batch.go
@@ -105,6 +105,14 @@ func (b *appBatch) toCheckedCmd(
 	}
 }
 
+// runPreAddTriggers runs any triggers that must fire before the command is
+// added to the appBatch's pebble batch. That is, the pebble batch at this point
+// will have materialized the raft log up to but excluding the current command.
+func (b *appBatch) runPreAddTriggers(ctx context.Context, cmd *raftlog.ReplicatedCmd) error {
+	// None currently.
+	return nil
+}
+
 // addWriteBatch adds the command's writes to the batch.
 func (b *appBatch) addWriteBatch(
 	ctx context.Context, batch storage.Batch, cmd *replicatedCmd,
@@ -121,5 +129,11 @@ func (b *appBatch) addWriteBatch(
 	if err := batch.ApplyBatchRepr(wb.Data, false); err != nil {
 		return errors.Wrapf(err, "unable to apply WriteBatch")
 	}
+	return nil
+}
+
+func (b *appBatch) runPostAddTriggers(ctx context.Context, cmd *raftlog.ReplicatedCmd) error {
+	// TODO(sep-raft-log): currently they are commingled in runPostAddTriggersReplicaOnly,
+	// extract them from that method.
 	return nil
 }

--- a/pkg/kv/kvserver/app_batch.go
+++ b/pkg/kv/kvserver/app_batch.go
@@ -13,6 +13,7 @@ package kvserver
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvadmission"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftlog"
@@ -46,7 +47,11 @@ import (
 //
 // [^1]: https://github.com/cockroachdb/cockroach/issues/75729
 type appBatch struct {
-	mutations int
+	mutations               int
+	entries                 int
+	entryBytes              int64
+	emptyEntries            int
+	followerStoreWriteBytes kvadmission.FollowerStoreWriteBytes
 	// TODO(tbg): this will absorb the following fields from replicaAppBatch:
 	//
 	// - batch

--- a/pkg/kv/kvserver/app_batch.go
+++ b/pkg/kv/kvserver/app_batch.go
@@ -24,6 +24,10 @@ import (
 )
 
 type appBatchStats struct {
+	// TODO(sep-raft-log):
+	// numEntries
+	// numEntriesBytes
+	// numEntriesEmpty
 	numMutations             int
 	numEntriesProcessed      int
 	numEntriesProcessedBytes int64

--- a/pkg/kv/kvserver/apply/task.go
+++ b/pkg/kv/kvserver/apply/task.go
@@ -71,6 +71,10 @@ var ErrRemoved = errors.New("replica removed")
 type EphemeralBatch interface {
 	// Stage inserts a Command into the Batch. In doing so, the Command is
 	// checked for rejection and a CheckedCommand is returned.
+	//
+	// TODO(tbg): consider renaming this to Add, so that in implementations
+	// of this we less unambiguously refer to "staging" commands into the
+	// pebble batch.
 	Stage(context.Context, Command) (CheckedCommand, error)
 	// Close closes the batch and releases any resources that it holds.
 	Close()

--- a/pkg/kv/kvserver/apply/task.go
+++ b/pkg/kv/kvserver/apply/task.go
@@ -25,6 +25,8 @@ import (
 // All state transitions performed by the state machine are expected to be
 // deterministic, which ensures that if each instance is driven from the
 // same consistent shared log, they will all stay in sync.
+//
+// The implementation may not be and commonly is not thread safe.
 type StateMachine interface {
 	// NewEphemeralBatch creates an EphemeralBatch. This kind of batch is not able
 	// to make changes to the StateMachine, but can be used for the purpose of
@@ -39,6 +41,9 @@ type StateMachine interface {
 	// that a group of Commands will have on the replicated state machine.
 	// Commands are staged in the batch one-by-one and then the entire batch is
 	// applied to the StateMachine at once via its ApplyToStateMachine method.
+	//
+	// There must only be a single EphemeralBatch *or* Batch open at any given
+	// point in time.
 	NewBatch() Batch
 	// ApplySideEffects applies the in-memory side-effects of a Command to
 	// the replicated state machine. The method will be called in the order

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -124,6 +124,10 @@ func (b *replicaAppBatch) Stage(
 		return nil, err
 	}
 
+	// TODO(tbg): if we rename Stage to Add we could less ambiguously
+	// use the verb "stage" instead of "add" for all of the methods
+	// below.
+
 	if err := b.runPreAddTriggersReplicaOnly(ctx, cmd); err != nil {
 		return nil, err
 	}
@@ -197,8 +201,6 @@ func (b *replicaAppBatch) runPreAddTriggersReplicaOnly(
 // staged in the replicaAppBatch's write batch.
 //
 // May mutate `cmd`.
-//
-// All errors from this method are fatal for this Replica.
 func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 	ctx context.Context, cmd *replicatedCmd,
 ) error {

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -148,11 +148,11 @@ func (b *replicaAppBatch) Stage(
 	// non-trivial ReplicatedState updates until later (without ever staging
 	// them in the batch) is sufficient.
 	b.stageTrivialReplicatedEvalResult(ctx, cmd)
-	b.ab.entries++
+	b.ab.numEntriesProcessed++
 	size := len(cmd.Data)
-	b.ab.entryBytes += int64(size)
+	b.ab.numEntriesProcessedBytes += int64(size)
 	if size == 0 {
-		b.ab.emptyEntries++
+		b.ab.numEmptyEntries++
 	}
 
 	// The command was checked by shouldApplyCommand, so it can be returned
@@ -541,7 +541,7 @@ func (b *replicaAppBatch) stageTrivialReplicatedEvalResult(
 // application.
 func (b *replicaAppBatch) ApplyToStateMachine(ctx context.Context) error {
 	if log.V(4) {
-		log.Infof(ctx, "flushing batch %v of %d entries", b.state, b.ab.entries)
+		log.Infof(ctx, "flushing batch %v of %d entries", b.state, b.ab.numEntriesProcessed)
 	}
 
 	// Add the replica applied state key to the write batch if this change
@@ -610,7 +610,7 @@ func (b *replicaAppBatch) ApplyToStateMachine(ctx context.Context) error {
 
 	// Record the write activity, passing a 0 nodeID because replica.writeStats
 	// intentionally doesn't track the origin of the writes.
-	b.r.loadStats.writeKeys.RecordCount(float64(b.ab.mutations), 0)
+	b.r.loadStats.writeKeys.RecordCount(float64(b.ab.numMutations), 0)
 
 	now := timeutil.Now()
 	if needsSplitBySize && r.splitQueueThrottle.ShouldProcess(now) {
@@ -641,10 +641,10 @@ func (b *replicaAppBatch) addAppliedStateKeyToBatch(ctx context.Context) error {
 }
 
 func (b *replicaAppBatch) recordStatsOnCommit() {
-	b.applyStats.entriesProcessed += b.ab.entries
-	b.applyStats.entriesProcessedBytes += b.ab.entryBytes
-	b.applyStats.numEmptyEntries += b.ab.emptyEntries
-	b.applyStats.batchesProcessed++
+	b.applyStats.numEntriesProcessed += b.ab.numEntriesProcessed
+	b.applyStats.numEntriesProcessedBytes += b.ab.numEntriesProcessedBytes
+	b.applyStats.numEmptyEntries += b.ab.numEmptyEntries
+	b.applyStats.numBatchesProcessed++
 	b.applyStats.followerStoreWriteBytes.Merge(b.ab.followerStoreWriteBytes)
 
 	elapsed := timeutil.Since(b.start)
@@ -739,7 +739,7 @@ func (b *replicaAppBatch) assertNoCmdClosedTimestampRegression(
 				"This assertion will fire again on restart; to ignore run with env var COCKROACH_RAFT_CLOSEDTS_ASSERTIONS_ENABLED=false\n"+
 				"Raft log tail:\n%s",
 			cmd.ID, cmd.Term, cmd.Index(), existingClosed, newClosed, b.state.Lease, req, cmd.LeaseIndex,
-			prevReq, b.closedTimestampSetter.lease, b.closedTimestampSetter.leaseIdx, b.ab.entries,
+			prevReq, b.closedTimestampSetter.lease, b.closedTimestampSetter.leaseIdx, b.ab.numEntriesProcessed,
 			logTail)
 	}
 	return nil

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -214,7 +214,11 @@ func (b *replicaAppBatch) runPreAddTriggersReplicaOnly(
 		// We only need the logical op log for rangefeeds, and in standalone
 		// application there are no listening rangefeeds. So we do this only
 		// in Replica application.
-		b.r.populatePrevValsInLogicalOpLogRaftMuLocked(ctx, ops, b.batch)
+		if p, filter := b.r.getRangefeedProcessorAndFilter(); p != nil {
+			if err := populatePrevValsInLogicalOpLog(ctx, filter, ops, b.batch); err != nil {
+				b.r.disconnectRangefeedWithErr(p, roachpb.NewError(err))
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -641,11 +641,8 @@ func (b *replicaAppBatch) addAppliedStateKeyToBatch(ctx context.Context) error {
 }
 
 func (b *replicaAppBatch) recordStatsOnCommit() {
-	b.applyStats.numEntriesProcessed += b.ab.numEntriesProcessed
-	b.applyStats.numEntriesProcessedBytes += b.ab.numEntriesProcessedBytes
-	b.applyStats.numEmptyEntries += b.ab.numEmptyEntries
+	b.applyStats.appBatchStats.merge(b.ab.appBatchStats)
 	b.applyStats.numBatchesProcessed++
-	b.applyStats.followerStoreWriteBytes.Merge(b.ab.followerStoreWriteBytes)
 
 	elapsed := timeutil.Since(b.start)
 	b.r.store.metrics.RaftCommandCommitLatency.RecordValue(elapsed.Nanoseconds())

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -209,7 +209,9 @@ func changeRemovesStore(
 
 // runPreApplyTriggersBeforeStagingWriteBatch runs any triggers that must fire
 // before a command is applied to the state machine but after the command is
-// staged in the replicaAppBatch's write batch. It may modify the command.
+// staged in the replicaAppBatch's write batch. The batch at this point will
+// represent the raft log up to but excluding the command that is currently
+// being applied.
 func (b *replicaAppBatch) runPreApplyTriggersBeforeStagingWriteBatch(
 	ctx context.Context, cmd *replicatedCmd,
 ) error {
@@ -223,6 +225,8 @@ func (b *replicaAppBatch) runPreApplyTriggersBeforeStagingWriteBatch(
 // runPreApplyTriggersAfterStagingWriteBatch runs any triggers that must fire
 // before a command is applied to the state machine but after the command is
 // staged in the replicaAppBatch's write batch.
+//
+// All errors from this method are fatal for this Replica.
 func (b *replicaAppBatch) runPreApplyTriggersAfterStagingWriteBatch(
 	ctx context.Context, cmd *replicatedCmd,
 ) error {

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -38,8 +38,8 @@ import (
 type replicaAppBatch struct {
 	ab appBatch
 
-	r  *Replica
-	sm *replicaStateMachine
+	r          *Replica
+	applyStats *applyCommittedEntriesStats
 
 	// batch accumulates writes implied by the raft entries in this batch.
 	batch storage.Batch
@@ -653,11 +653,11 @@ func (b *replicaAppBatch) addAppliedStateKeyToBatch(ctx context.Context) error {
 }
 
 func (b *replicaAppBatch) recordStatsOnCommit() {
-	b.sm.stats.entriesProcessed += b.entries
-	b.sm.stats.entriesProcessedBytes += b.entryBytes
-	b.sm.stats.numEmptyEntries += b.emptyEntries
-	b.sm.stats.batchesProcessed++
-	b.sm.stats.followerStoreWriteBytes.Merge(b.followerStoreWriteBytes)
+	b.applyStats.entriesProcessed += b.entries
+	b.applyStats.entriesProcessedBytes += b.entryBytes
+	b.applyStats.numEmptyEntries += b.emptyEntries
+	b.applyStats.batchesProcessed++
+	b.applyStats.followerStoreWriteBytes.Merge(b.followerStoreWriteBytes)
 
 	elapsed := timeutil.Since(b.start)
 	b.r.store.metrics.RaftCommandCommitLatency.RecordValue(elapsed.Nanoseconds())

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/apply"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvadmission"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -59,12 +58,7 @@ type replicaAppBatch struct {
 	// be only one) removes this replica from the range.
 	changeRemovesReplica bool
 
-	// Statistics.
-	entries                 int
-	entryBytes              int64
-	emptyEntries            int
-	start                   time.Time
-	followerStoreWriteBytes kvadmission.FollowerStoreWriteBytes
+	start time.Time // time at NewBatch()
 
 	// Reused by addAppliedStateKeyToBatch to avoid heap allocations.
 	asAlloc enginepb.RangeAppliedState
@@ -154,11 +148,11 @@ func (b *replicaAppBatch) Stage(
 	// non-trivial ReplicatedState updates until later (without ever staging
 	// them in the batch) is sufficient.
 	b.stageTrivialReplicatedEvalResult(ctx, cmd)
-	b.entries++
+	b.ab.entries++
 	size := len(cmd.Data)
-	b.entryBytes += int64(size)
+	b.ab.entryBytes += int64(size)
 	if size == 0 {
-		b.emptyEntries++
+		b.ab.emptyEntries++
 	}
 
 	// The command was checked by shouldApplyCommand, so it can be returned
@@ -239,9 +233,9 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 	// (AddSST for example).
 	if !cmd.IsLocal() {
 		writeBytes, ingestedBytes := cmd.getStoreWriteByteSizes()
-		b.followerStoreWriteBytes.NumEntries++
-		b.followerStoreWriteBytes.WriteBytes += writeBytes
-		b.followerStoreWriteBytes.IngestedBytes += ingestedBytes
+		b.ab.followerStoreWriteBytes.NumEntries++
+		b.ab.followerStoreWriteBytes.WriteBytes += writeBytes
+		b.ab.followerStoreWriteBytes.IngestedBytes += ingestedBytes
 	}
 
 	// MVCC history mutations violate the closed timestamp, modifying data that
@@ -547,7 +541,7 @@ func (b *replicaAppBatch) stageTrivialReplicatedEvalResult(
 // application.
 func (b *replicaAppBatch) ApplyToStateMachine(ctx context.Context) error {
 	if log.V(4) {
-		log.Infof(ctx, "flushing batch %v of %d entries", b.state, b.entries)
+		log.Infof(ctx, "flushing batch %v of %d entries", b.state, b.ab.entries)
 	}
 
 	// Add the replica applied state key to the write batch if this change
@@ -647,11 +641,11 @@ func (b *replicaAppBatch) addAppliedStateKeyToBatch(ctx context.Context) error {
 }
 
 func (b *replicaAppBatch) recordStatsOnCommit() {
-	b.applyStats.entriesProcessed += b.entries
-	b.applyStats.entriesProcessedBytes += b.entryBytes
-	b.applyStats.numEmptyEntries += b.emptyEntries
+	b.applyStats.entriesProcessed += b.ab.entries
+	b.applyStats.entriesProcessedBytes += b.ab.entryBytes
+	b.applyStats.numEmptyEntries += b.ab.emptyEntries
 	b.applyStats.batchesProcessed++
-	b.applyStats.followerStoreWriteBytes.Merge(b.followerStoreWriteBytes)
+	b.applyStats.followerStoreWriteBytes.Merge(b.ab.followerStoreWriteBytes)
 
 	elapsed := timeutil.Since(b.start)
 	b.r.store.metrics.RaftCommandCommitLatency.RecordValue(elapsed.Nanoseconds())
@@ -745,7 +739,7 @@ func (b *replicaAppBatch) assertNoCmdClosedTimestampRegression(
 				"This assertion will fire again on restart; to ignore run with env var COCKROACH_RAFT_CLOSEDTS_ASSERTIONS_ENABLED=false\n"+
 				"Raft log tail:\n%s",
 			cmd.ID, cmd.Term, cmd.Index(), existingClosed, newClosed, b.state.Lease, req, cmd.LeaseIndex,
-			prevReq, b.closedTimestampSetter.lease, b.closedTimestampSetter.leaseIdx, b.entries,
+			prevReq, b.closedTimestampSetter.lease, b.closedTimestampSetter.leaseIdx, b.ab.entries,
 			logTail)
 	}
 	return nil

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -544,11 +544,6 @@ func (b *replicaAppBatch) stageTrivialReplicatedEvalResult(
 	// serialize on the stats key.
 	deltaStats := res.Delta.ToStats()
 	b.state.Stats.Add(deltaStats)
-
-	if res.State != nil && res.State.GCHint != nil {
-		b.r.handleGCHintResult(ctx, res.State.GCHint)
-		res.State.GCHint = nil
-	}
 }
 
 // ApplyToStateMachine implements the apply.Batch interface. The method handles

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -177,23 +177,6 @@ func (b *replicaAppBatch) Stage(
 	return cmd, nil
 }
 
-// addWriteBatch adds the command's writes to the batch.
-func (b *replicaAppBatch) addWriteBatch(ctx context.Context, cmd *replicatedCmd) error {
-	wb := cmd.Cmd.WriteBatch
-	if wb == nil {
-		return nil
-	}
-	if mutations, err := storage.PebbleBatchCount(wb.Data); err != nil {
-		log.Errorf(ctx, "unable to read header of committed WriteBatch: %+v", err)
-	} else {
-		b.mutations += mutations
-	}
-	if err := b.batch.ApplyBatchRepr(wb.Data, false); err != nil {
-		return errors.Wrapf(err, "unable to apply WriteBatch")
-	}
-	return nil
-}
-
 // changeRemovesStore returns true if any of the removals in this change have storeID.
 func changeRemovesStore(
 	desc *roachpb.RangeDescriptor, change *kvserverpb.ChangeReplicas, storeID roachpb.StoreID,

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -46,15 +46,15 @@ type replicaAppBatch struct {
 	// state is this batch's view of the replica's state. It is copied from
 	// under the Replica.mu when the batch is initialized and is updated in
 	// stageTrivialReplicatedEvalResult.
+	//
+	// This is a shallow copy so any mutations inside of pointer fields need
+	// to copy-on-write. The exception to this is `state.Stats`, for which
+	// backing memory has already been provided and which may thus be
+	// modified directly.
 	state kvserverpb.ReplicaState
 	// closedTimestampSetter maintains historical information about the
 	// advancement of the closed timestamp.
 	closedTimestampSetter closedTimestampSetterInfo
-	// stats is stored on the application batch to avoid an allocation in
-	// tracking the batch's view of replicaState. All pointer fields in
-	// replicaState other than Stats are overwritten completely rather than
-	// updated in-place.
-	stats enginepb.MVCCStats
 	// changeRemovesReplica tracks whether the command in the batch (there must
 	// be only one) removes this replica from the range.
 	changeRemovesReplica bool

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -523,9 +523,6 @@ func (b *replicaAppBatch) runPostAddTriggers(ctx context.Context, cmd *replicate
 func (b *replicaAppBatch) stageTrivialReplicatedEvalResult(
 	ctx context.Context, cmd *replicatedCmd,
 ) {
-	if cmd.Index() == 0 {
-		log.Fatalf(ctx, "raft entry with index 0")
-	}
 	b.state.RaftAppliedIndex = cmd.Index()
 	b.state.RaftAppliedIndexTerm = cmd.Term
 

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -280,6 +280,12 @@ func (sm *replicaStateMachine) handleNonTrivialReplicatedEvalResult(
 			sm.r.handleVersionResult(ctx, newVersion)
 			rResult.State.Version = nil
 		}
+
+		if rResult.State.GCHint != nil {
+			sm.r.handleGCHintResult(ctx, rResult.State.GCHint)
+			rResult.State.GCHint = nil
+		}
+
 		if (*rResult.State == kvserverpb.ReplicaState{}) {
 			rResult.State = nil
 		}

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -44,7 +44,7 @@ import (
 // TODO(ajwerner): add metrics to go with these stats.
 type applyCommittedEntriesStats struct {
 	appBatchStats
-	numBatchesProcessed  int
+	numBatchesProcessed  int // TODO(sep-raft-log): numBatches
 	stateAssertions      int
 	numConfChangeEntries int
 }

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -69,6 +70,13 @@ type replicaStateMachine struct {
 	ephemeralBatch ephemeralReplicaAppBatch
 	// stats are updated during command application and reset by moveStats.
 	applyStats applyCommittedEntriesStats
+
+	// stats backs the currently open replicaAppBatch's view of the State field of
+	// kvserverpb.ReplicaState (which is otherwise backed directly by the
+	// Replica's in-memory state). This avoids an allocation per Stage() call as
+	// Stage() is now alloed to update this memory directly, whereas all other
+	// mutations need to copy-on-write.
+	stats enginepb.MVCCStats
 }
 
 // getStateMachine returns the Replica's apply.StateMachine. The Replica's
@@ -135,7 +143,7 @@ func (sm *replicaStateMachine) NewBatch() apply.Batch {
 	b.batch = r.store.engine.NewBatch()
 	r.mu.RLock()
 	b.state = r.mu.state
-	b.state.Stats = &b.stats
+	b.state.Stats = &sm.stats
 	*b.state.Stats = *r.mu.state.Stats
 	b.closedTimestampSetter = r.mu.closedTimestampSetter
 	r.mu.RUnlock()

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/apply"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/ctpb"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvadmission"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -44,13 +43,10 @@ import (
 //
 // TODO(ajwerner): add metrics to go with these stats.
 type applyCommittedEntriesStats struct {
-	numBatchesProcessed      int
-	numEntriesProcessed      int
-	numEntriesProcessedBytes int64
-	stateAssertions          int
-	numEmptyEntries          int
-	numConfChangeEntries     int
-	followerStoreWriteBytes  kvadmission.FollowerStoreWriteBytes
+	appBatchStats
+	numBatchesProcessed  int
+	stateAssertions      int
+	numConfChangeEntries int
 }
 
 // replicaStateMachine implements the apply.StateMachine interface.

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -131,7 +131,7 @@ func (sm *replicaStateMachine) NewBatch() apply.Batch {
 	r := sm.r
 	b := &sm.batch
 	b.r = r
-	b.sm = sm
+	b.applyStats = &sm.stats
 	b.batch = r.store.engine.NewBatch()
 	r.mu.RLock()
 	b.state = r.mu.state

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -44,13 +44,13 @@ import (
 //
 // TODO(ajwerner): add metrics to go with these stats.
 type applyCommittedEntriesStats struct {
-	batchesProcessed        int
-	entriesProcessed        int
-	entriesProcessedBytes   int64
-	stateAssertions         int
-	numEmptyEntries         int
-	numConfChangeEntries    int
-	followerStoreWriteBytes kvadmission.FollowerStoreWriteBytes
+	numBatchesProcessed      int
+	numEntriesProcessed      int
+	numEntriesProcessedBytes int64
+	stateAssertions          int
+	numEmptyEntries          int
+	numConfChangeEntries     int
+	followerStoreWriteBytes  kvadmission.FollowerStoreWriteBytes
 }
 
 // replicaStateMachine implements the apply.StateMachine interface.

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -621,9 +621,9 @@ func (s handleRaftReadyStats) SafeFormat(p redact.SafePrinter, _ rune) {
 	if b, n := s.append.SideloadedBytes, s.append.SideloadedEntries; n > 0 || b > 0 {
 		p.Printf("append-sst=%s (%d), ", humanizeutil.IBytes(b), n)
 	}
-	if b, n := s.apply.entriesProcessedBytes, s.apply.entriesProcessed; n > 0 || b > 0 {
+	if b, n := s.apply.numEntriesProcessedBytes, s.apply.numEntriesProcessed; n > 0 || b > 0 {
 		p.Printf("apply=%s (%d", humanizeutil.IBytes(b), n)
-		if c := s.apply.batchesProcessed; c > 1 {
+		if c := s.apply.numBatchesProcessed; c > 1 {
 			p.Printf(" in %d batches", c)
 		}
 		p.SafeString(")")

--- a/pkg/kv/kvserver/replica_raft_test.go
+++ b/pkg/kv/kvserver/replica_raft_test.go
@@ -79,12 +79,14 @@ func Test_handleRaftReadyStats_SafeFormat(t *testing.T) {
 		tApplicationBegin: ts(1),
 		tApplicationEnd:   ts(2),
 		apply: applyCommittedEntriesStats{
-			numBatchesProcessed:      9,
-			numEntriesProcessed:      2,
-			numEntriesProcessedBytes: 3,
-			stateAssertions:          4,
-			numEmptyEntries:          5,
-			numConfChangeEntries:     6,
+			numBatchesProcessed: 9,
+			appBatchStats: appBatchStats{
+				numEntriesProcessed:      2,
+				numEntriesProcessedBytes: 3,
+				numEmptyEntries:          5,
+			},
+			stateAssertions:      4,
+			numConfChangeEntries: 6,
 		},
 		append: logstore.AppendStats{
 			Begin:             ts(2),

--- a/pkg/kv/kvserver/replica_raft_test.go
+++ b/pkg/kv/kvserver/replica_raft_test.go
@@ -79,12 +79,12 @@ func Test_handleRaftReadyStats_SafeFormat(t *testing.T) {
 		tApplicationBegin: ts(1),
 		tApplicationEnd:   ts(2),
 		apply: applyCommittedEntriesStats{
-			batchesProcessed:      9,
-			entriesProcessed:      2,
-			entriesProcessedBytes: 3,
-			stateAssertions:       4,
-			numEmptyEntries:       5,
-			numConfChangeEntries:  6,
+			numBatchesProcessed:      9,
+			numEntriesProcessed:      2,
+			numEntriesProcessedBytes: 3,
+			stateAssertions:          4,
+			numEmptyEntries:          5,
+			numConfChangeEntries:     6,
 		},
 		append: logstore.AppendStats{
 			Begin:             ts(2),

--- a/pkg/kv/kvserver/store_merge.go
+++ b/pkg/kv/kvserver/store_merge.go
@@ -133,7 +133,7 @@ func (s *Store) MergeRange(
 	// we'll drop atomically with extending the right-hand side down below.
 	ph, err := s.removeInitializedReplicaRaftMuLocked(ctx, rightRepl, rightDesc.NextReplicaID, RemoveOptions{
 		// The replica was destroyed by the tombstones added to the batch in
-		// runPreApplyTriggersAfterStagingWriteBatch.
+		// runPostAddTriggers.
 		DestroyData:       false,
 		InsertPlaceholder: true,
 	})


### PR DESCRIPTION
This long (but individually small) sequence of commits moves `(*replicaAppBatch).Stage` close to the structure that was prototyped in https://github.com/cockroachdb/cockroach/pull/93265, where it has the following steps:

- command checks (standalone)
- testing interceptors (replica)
- pre-add triggers (standalone)
- pre-add triggers (replica)
- add (to pebble batch, standalone)
- post-add triggers (standalone)
- post-add triggers (replica)

In standalone application (e.g. for https://github.com/cockroachdb/cockroach/issues/93244) we'd use an `apply.Batch` that is an `appBatch`, instead of a `replicaAppBatch`, i.e. skip all of the (replica) steps above.

This PR doesn't get us all the way there - we still need to tease apart the `post-add triggers (replica)` step, which currently contains code that should be in `post-add triggers (standalone)`; this is best tackled in a separate PR since it's going to be quite a bit of work.

Touches https://github.com/cockroachdb/cockroach/issues/75729.

Epic: CRDB-220
Release note: None