### PR TITLE
statusccl: temporarily serve /_status/nodes to tenants

### DIFF
--- a/pkg/server/serverpb/status.go
+++ b/pkg/server/serverpb/status.go
@@ -39,6 +39,7 @@ type SQLStatusServer interface {
 	UserSQLRoles(context.Context, *UserSQLRolesRequest) (*UserSQLRolesResponse, error)
 	TxnIDResolution(context.Context, *TxnIDResolutionRequest) (*TxnIDResolutionResponse, error)
 	TransactionContentionEvents(context.Context, *TransactionContentionEventsRequest) (*TransactionContentionEventsResponse, error)
+	Nodes(context.Context, *NodesRequest) (*NodesResponse, error)
 	NodesList(context.Context, *NodesListRequest) (*NodesListResponse, error)
 	ListExecutionInsights(context.Context, *ListExecutionInsightsRequest) (*ListExecutionInsightsResponse, error)
 	LogFilesList(context.Context, *LogFilesListRequest) (*LogFilesListResponse, error)

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1491,6 +1491,44 @@ func (s *statusServer) NodesList(
 	return s.serverIterator.nodesList(ctx)
 }
 
+// Nodes returns a limited subset of the full NodesResponse.
+//
+// Its existence is a stop-gap measure to support running much of our UI code
+// on multiregion tenant clusters. Longer-term, we will need to reconsider
+// the overall architecture (e.g. store node ids in sqlstats, map node id ->
+// region at UI display time) because sql instances are far more ephemeral
+// than cluster nodes, and this Nodes endpoint is only able to answer for
+// currently-live sql instances. What I think we want is to store locality
+// information directly in the sqlstats tables, sourced from some new tracing
+// in the distsql flow.
+func (s *statusServer) Nodes(
+	ctx context.Context, req *serverpb.NodesRequest,
+) (*serverpb.NodesResponse, error) {
+	ctx = propagateGatewayMetadata(ctx)
+	ctx = s.AnnotateCtx(ctx)
+
+	if err := s.privilegeChecker.requireViewActivityOrViewActivityRedactedPermission(ctx); err != nil {
+		// NB: not using serverError() here since the priv checker
+		// already returns a proper gRPC error status.
+		return nil, err
+	}
+
+	instances, err := s.sqlServer.sqlInstanceReader.GetAllInstances(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var resp serverpb.NodesResponse
+	for _, instance := range instances {
+		resp.Nodes = append(resp.Nodes, statuspb.NodeStatus{
+			Desc: roachpb.NodeDescriptor{
+				NodeID:   roachpb.NodeID(instance.InstanceID),
+				Locality: instance.Locality,
+			},
+		})
+	}
+	return &resp, err
+}
+
 // Nodes returns all node statuses.
 //
 // Do not use this method inside the server code! Use

--- a/pkg/ui/workspaces/cluster-ui/src/util/proto.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/proto.spec.ts
@@ -66,5 +66,10 @@ describe("Proto utils", () => {
         statusWithRolledMetrics.metrics,
       );
     });
+
+    it("does not explode when node fields are missing", () => {
+      const emptyNodeStatus: Partial<INodeStatus> = {};
+      assert.deepEqual(rollupStoreMetrics(emptyNodeStatus), {});
+    });
   });
 });

--- a/pkg/ui/workspaces/cluster-ui/src/util/proto.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/proto.ts
@@ -21,6 +21,9 @@ export type StatusMetrics = typeof nodeStatus.metrics;
  * with metrics from `store_statuses.metrics` object.
  */
 export function rollupStoreMetrics(ns: INodeStatus): StatusMetrics {
+  if (!ns.store_statuses) {
+    return ns.metrics || {};
+  }
   return ns.store_statuses
     .map(ss => ss.metrics)
     .reduce((acc, i) => {


### PR DESCRIPTION
Fixes #92065
Part of #89949

Our current UI architecture has many of the SQL Activity pages mapping node or sql instance ids to regions at page load time, using the response from this `/_status/nodes` endpoint to get the information it needs.

This approach is problematic for ephemeral serverless tenants but will need a broader reimagining, probably ending up with us storing locality information directly in many of the sqlstats tables, which will probably require something like sending instance localities along in the distsql tracing. An initial exploration in this direction happened in #92259.

In the meantime, as a stop-gap measure, we implement a reduced version of this `/_status/nodes` endpoint for tenants, keeping the SQL Activity pages somewhat working for multiregion tenants.

Release note: None