### PR TITLE
roachpb,sql: limit the syntax of tenant names

### DIFF
--- a/pkg/roachpb/tenant.go
+++ b/pkg/roachpb/tenant.go
@@ -13,6 +13,7 @@ package roachpb
 import (
 	"context"
 	"math"
+	"regexp"
 	"strconv"
 
 	"github.com/cockroachdb/errors"
@@ -143,6 +144,20 @@ func (n TenantName) Equal(o TenantName) bool {
 // NB: The system tenant cannot be renamed.
 func IsSystemTenantName(tenantName TenantName) bool {
 	return tenantName == "system"
+}
+
+// We limit tenant names to what is allowed in a DNS hostname, so
+// that we can use SNI to identify tenants and also as a prefix
+// to a database name in connection strings. However there cannot
+// be a hyphen at the end.
+var tenantNameRe = regexp.MustCompile(`^[a-z0-9]([a-z0-9---]{0,98}[a-z0-9])?$`)
+
+func (n TenantName) IsValid() error {
+	if !tenantNameRe.MatchString(string(n)) {
+		return errors.WithHint(errors.Newf("invalid tenant name"),
+			"Tenant names must start and end with a lowercase letter or digit, contain only lowercase letters, digits or hyphens, with a maximum of 100 characters.")
+	}
+	return nil
 }
 
 // Silence unused warning.

--- a/pkg/sql/logictest/testdata/logic_test/tenant
+++ b/pkg/sql/logictest/testdata/logic_test/tenant
@@ -13,6 +13,22 @@ CREATE TENANT "tenant-one"
 statement ok
 CREATE TENANT "two"
 
+statement error invalid tenant name
+CREATE TENANT "ABC"
+
+statement error invalid tenant name
+CREATE TENANT "-a-"
+
+# More than 100 characters.
+statement error invalid tenant name
+CREATE TENANT "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
+
+statement error invalid tenant name
+CREATE TENANT "invalid_name"
+
+statement error invalid tenant name
+CREATE TENANT "invalid.name"
+
 statement ok
 CREATE TENANT three
 
@@ -165,3 +181,9 @@ id  active  name             crdb_internal.pb_to_json
 6   false   NULL             {"droppedName": "five-requiring-quotes", "id": "6", "name": "", "state": "DROP", "tenantReplicationJobId": "0"}
 7   false   NULL             {"droppedName": "to-be-reclaimed", "id": "7", "name": "", "state": "DROP", "tenantReplicationJobId": "0"}
 8   true    to-be-reclaimed  {"droppedName": "", "id": "8", "name": "to-be-reclaimed", "state": "ACTIVE", "tenantReplicationJobId": "0"}
+
+# More valid tenant names.
+statement ok
+CREATE TENANT "1";
+CREATE TENANT "a-b";
+CREATE TENANT "hello-100"

--- a/pkg/sql/logictest/testdata/logic_test/tenant_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/tenant_builtins
@@ -12,6 +12,15 @@ SELECT crdb_internal.create_tenant(5)
 ----
 5
 
+query error invalid tenant name
+SELECT crdb_internal.create_tenant(10, 'ABC')
+
+query error invalid tenant name
+SELECT crdb_internal.create_tenant(10, 'invalid_name')
+
+query error invalid tenant name
+SELECT crdb_internal.create_tenant(10, 'invalid.name')
+
 query I
 SELECT crdb_internal.create_tenant(10, 'tenant-number-ten')
 ----
@@ -54,6 +63,21 @@ query I
 SELECT crdb_internal.rename_tenant(5, 'my-new-tenant-name')
 ----
 5
+
+query error invalid tenant name
+SELECT crdb_internal.rename_tenant(5, 'AAA')
+
+query error invalid tenant name
+SELECT crdb_internal.rename_tenant(5, '-a-')
+
+query error invalid tenant name
+SELECT crdb_internal.rename_tenant(5, '11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111')
+
+query error invalid tenant name
+SELECT crdb_internal.rename_tenant(5, 'invalid_name')
+
+query error invalid tenant name
+SELECT crdb_internal.rename_tenant(5, 'invalid.name')
 
 # Check for duplicate names.
 query error name "tenant-number-ten" is already taken

--- a/pkg/sql/tenant.go
+++ b/pkg/sql/tenant.go
@@ -88,6 +88,11 @@ func CreateTenantRecord(
 	if err := rejectIfSystemTenant(info.ID, op); err != nil {
 		return roachpb.TenantID{}, err
 	}
+	if info.Name != "" {
+		if err := info.Name.IsValid(); err != nil {
+			return roachpb.TenantID{}, pgerror.WithCandidateCode(err, pgcode.Syntax)
+		}
+	}
 
 	tenID := info.ID
 	if tenID == 0 {
@@ -789,6 +794,10 @@ func TestingUpdateTenantRecord(
 func (p *planner) RenameTenant(
 	ctx context.Context, tenantID uint64, tenantName roachpb.TenantName,
 ) error {
+	if err := tenantName.IsValid(); err != nil {
+		return pgerror.WithCandidateCode(err, pgcode.Syntax)
+	}
+
 	if err := p.RequireAdminRole(ctx, "rename tenant"); err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #92613.

This commit limits the lexicographical structure of tenant names to be that of DNS hostnames: start with a letter, followed by a combination of letters, digits or hyphens. In particular periods and underscores are not allowed.

Release note: None