### PR TITLE
sql: Define more columns in `pg_catalog.pg_statistic_ext`

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4371,7 +4371,14 @@ statement ok
 CREATE TABLE stxtbl(a INT, b INT, c INT);
 CREATE STATISTICS stxobj ON b, c FROM stxtbl;
 
-query TTOOTTT colnames
+statement ok
+CREATE SCHEMA test;
+CREATE TABLE test.stxtbl2(a INT, b INT, c INT);
+CREATE STATISTICS stxobj2 ON a, c FROM test.stxtbl2;
+CREATE TABLE stx(stx) AS SELECT generate_series(1,100);
+ANALYZE stx;
+
+query TTOOITT colnames
 SELECT
   relname,
   stxname,
@@ -4384,7 +4391,10 @@ FROM pg_statistic_ext
 JOIN pg_class ON pg_statistic_ext.stxrelid = pg_class.oid
 ----
 relname  stxname  stxnamespace  stxowner  stxstattarget  stxkeys  stxkind
-stxtbl   stxobj   NULL          NULL      NULL           {2,3}    NULL
+stxtbl   stxobj   105           NULL      -1             {2,3}    {d}
+stxtbl2  stxobj2  189           NULL      -1             {1,3}    {d}
+stx      NULL     105           NULL      -1             {2}      {d}
+stx      NULL     105           NULL      -1             {1}      {d}
 
 # Test that pg_shadow doesn't include roles that can't login
 query B colnames
@@ -4764,3 +4774,4 @@ WHERE
     AND t.typname LIKE 'myt%';
 ----
 0
+

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catprivilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemadesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
@@ -3506,8 +3507,12 @@ var pgCatalogStatisticExtTable = virtualSchemaTable{
 	comment: `pg_statistic_ext has the statistics objects created with CREATE STATISTICS
 https://www.postgresql.org/docs/13/catalog-pg-statistic-ext.html`,
 	schema: vtable.PgCatalogStatisticExt,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		query := `SELECT "statisticID", name, "tableID", "columnIDs" FROM system.table_statistics;`
+	populate: func(ctx context.Context, p *planner, db catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+
+		//  '{d}' refers to Postgres code for n-distinct statistics or multi-column
+		//  statistics.
+		query := `SELECT "tableID", name, "columnIDs", "statisticID", '{d}'::"char"[] FROM system.table_statistics;`
+
 		rows, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.QueryBuffered(
 			ctx, "read-statistics-objects", p.txn, query,
 		)
@@ -3515,26 +3520,35 @@ https://www.postgresql.org/docs/13/catalog-pg-statistic-ext.html`,
 			return err
 		}
 		h := makeOidHasher()
+		statTgt := tree.NewDInt(-1)
 
 		for _, row := range rows {
-			statisticsID := tree.MustBeDInt(row[0])
-			name := tree.MustBeDString(row[1])
-			tableID := tree.MustBeDInt(row[2])
-			columnIDs := tree.MustBeDArray(row[3])
+			tableID := tree.MustBeDInt(row[0])
+			columnIDs := tree.MustBeDArray(row[2])
+			statisticsID := tree.MustBeDInt(row[3])
+			statisticsKind := tree.MustBeDArray(row[4])
 
 			// The statisticsID is generated from unique_rowid() so it won't fit in a
 			// uint32.
 			h.writeUInt64(uint64(statisticsID))
 			statisticsOID := h.getOid()
+
+			tn, err := descs.GetTableNameByID(ctx, p.Txn(), p.descCollection, descpb.ID(tableID))
+			if err != nil {
+				return err
+			}
+
+			statSchema := db.GetSchemaID(tn.Schema())
+
 			if err := addRow(
 				statisticsOID,                // oid
 				tableOid(descpb.ID(tableID)), // stxrelid
-				&name,                        // stxname
-				tree.DNull,                   // stxnamespace
+				row[1],                       // stxname
+				schemaOid(statSchema),        // stxnamespace
 				tree.DNull,                   // stxowner
-				tree.DNull,                   // stxstattarget
+				statTgt,                      // stxstattarget
 				columnIDs,                    // stxkeys
-				tree.DNull,                   // stxkind
+				statisticsKind,               // stxkind
 			); err != nil {
 				return err
 			}


### PR DESCRIPTION
Epic: CRDB-23454
Fixes: #88108
Fixes: #93430

This commit makes sure the `stxnamespace`, `stxkind` and `stxstattarget` columns are defined in `pg_statistics_ext`.

Release note: The `stxnamespace`, `stxkind` and
`stxstattarget` columns are now defined in
`pg_statistics_ext`.  Also `pg_statistics_ext` 
no longer crashes when stxname is null.