### PR TITLE
roachtest: fix latency assertions in `follower-reads` test

### DIFF
--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -641,8 +641,9 @@ func verifySQLLatency(
 		// Ask for 10s intervals.
 		SampleNanos: (10 * time.Second).Nanoseconds(),
 		Queries: []tspb.Query{{
-			Name:    "cr.node.sql.service.latency-p90",
-			Sources: sources,
+			Name:             "cr.node.sql.service.latency-p90",
+			Sources:          sources,
+			SourceAggregator: tspb.TimeSeriesQueryAggregator_MAX.Enum(),
 		}},
 	}
 	var response tspb.TimeSeriesQueryResponse


### PR DESCRIPTION
The `follower-reads` tests assert that per-node p90 SQL latency is below 25ms, to detect cross-region reads. However, the time series query defaulted to `SUM` aggregation across nodes rather then `MAX`, which makes the test overly sensitive to latency increases. This patch changes the query to use `MAX` aggregation.

Resolves #92512.
Resolves #93252.
Resolves #93494.

Epic: none
Release note: None