### PR TITLE
sql: remove unused param of CreatePrivilegesFromDefaultPrivileges

### DIFF
--- a/pkg/sql/catalog/catprivilege/default_privilege.go
+++ b/pkg/sql/catalog/catprivilege/default_privilege.go
@@ -167,7 +167,6 @@ func CreatePrivilegesFromDefaultPrivileges(
 	dbID descpb.ID,
 	user username.SQLUsername,
 	targetObject privilege.TargetObjectType,
-	databasePrivileges *catpb.PrivilegeDescriptor,
 ) *catpb.PrivilegeDescriptor {
 	// If a new system table is being created (which should only be doable by
 	// an internal user account), make sure it gets the correct privileges.

--- a/pkg/sql/catalog/catprivilege/default_privilege_test.go
+++ b/pkg/sql/catalog/catprivilege/default_privilege_test.go
@@ -169,7 +169,7 @@ func TestGrantDefaultPrivileges(t *testing.T) {
 
 		newPrivileges := CreatePrivilegesFromDefaultPrivileges(
 			defaultPrivileges, nil, /* schemaDefaultPrivilegeDescriptor */
-			nonSystemDatabaseID, tc.objectCreator, tc.targetObject, &catpb.PrivilegeDescriptor{},
+			nonSystemDatabaseID, tc.objectCreator, tc.targetObject,
 		)
 
 		for _, grantee := range tc.grantees {
@@ -281,7 +281,7 @@ func TestRevokeDefaultPrivileges(t *testing.T) {
 
 		newPrivileges := CreatePrivilegesFromDefaultPrivileges(
 			defaultPrivileges, nil, /* schemaDefaultPrivilegeDescriptor */
-			nonSystemDatabaseID, tc.objectCreator, tc.targetObject, &catpb.PrivilegeDescriptor{},
+			nonSystemDatabaseID, tc.objectCreator, tc.targetObject,
 		)
 
 		for _, grantee := range tc.grantees {
@@ -307,7 +307,7 @@ func TestRevokeDefaultPrivilegesFromEmptyList(t *testing.T) {
 
 	newPrivileges := CreatePrivilegesFromDefaultPrivileges(
 		defaultPrivileges, nil, /* schemaDefaultPrivilegeDescriptor */
-		nonSystemDatabaseID, creatorUser, privilege.Tables, &catpb.PrivilegeDescriptor{},
+		nonSystemDatabaseID, creatorUser, privilege.Tables,
 	)
 
 	if newPrivileges.AnyPrivilege(fooUser) {
@@ -323,7 +323,7 @@ func TestCreatePrivilegesFromDefaultPrivilegesForSystemDatabase(t *testing.T) {
 	creatorUser := username.MakeSQLUsernameFromPreNormalizedString("creator")
 	newPrivileges := CreatePrivilegesFromDefaultPrivileges(
 		defaultPrivileges, nil, /* schemaDefaultPrivilegeDescriptor */
-		keys.SystemDatabaseID, creatorUser, privilege.Tables, &catpb.PrivilegeDescriptor{},
+		keys.SystemDatabaseID, creatorUser, privilege.Tables,
 	)
 
 	if !newPrivileges.Owner().IsNodeUser() {
@@ -342,7 +342,7 @@ func TestPresetDefaultPrivileges(t *testing.T) {
 	for _, targetObject := range targetObjectTypes {
 		newPrivileges := CreatePrivilegesFromDefaultPrivileges(
 			defaultPrivileges, nil, /* schemaDefaultPrivilegeDescriptor */
-			nonSystemDatabaseID, creatorUser, targetObject, &catpb.PrivilegeDescriptor{},
+			nonSystemDatabaseID, creatorUser, targetObject,
 		)
 
 		if !newPrivileges.CheckPrivilege(creatorUser, privilege.ALL) {
@@ -368,7 +368,7 @@ func TestPresetDefaultPrivilegesInSchema(t *testing.T) {
 	for _, targetObject := range targetObjectTypes {
 		newPrivileges := CreatePrivilegesFromDefaultPrivileges(
 			defaultPrivileges, nil, /* schemaDefaultPrivilegeDescriptor */
-			nonSystemDatabaseID, creatorUser, targetObject, &catpb.PrivilegeDescriptor{},
+			nonSystemDatabaseID, creatorUser, targetObject,
 		)
 
 		// The owner always has ALL privileges.
@@ -683,7 +683,6 @@ func TestDefaultPrivileges(t *testing.T) {
 			tc.dbID,
 			tc.objectCreator,
 			tc.targetObject,
-			&catpb.PrivilegeDescriptor{},
 		)
 
 		for _, userAndGrant := range tc.expectedGrantsOnObject {

--- a/pkg/sql/catalog/ingesting/privileges.go
+++ b/pkg/sql/catalog/ingesting/privileges.go
@@ -156,8 +156,8 @@ func getIngestingPrivilegesForTableOrSchema(
 		}
 
 		updatedPrivileges = catprivilege.CreatePrivilegesFromDefaultPrivileges(
-			dbDefaultPrivileges, schemaDefaultPrivileges,
-			parentDB.GetID(), user, targetObject, parentDB.GetPrivileges())
+			dbDefaultPrivileges, schemaDefaultPrivileges, parentDB.GetID(), user, targetObject,
+		)
 	}
 	return updatedPrivileges, nil
 }

--- a/pkg/sql/create_function.go
+++ b/pkg/sql/create_function.go
@@ -295,7 +295,6 @@ func (n *createFunctionNode) getMutableFuncDesc(
 		n.dbDesc.GetID(),
 		params.SessionData().User(),
 		privilege.Functions,
-		n.dbDesc.GetPrivileges(),
 	)
 
 	newUdfDesc := funcdesc.NewMutableFunctionDescriptor(

--- a/pkg/sql/create_schema.go
+++ b/pkg/sql/create_schema.go
@@ -156,7 +156,6 @@ func CreateSchemaDescriptorWithPrivileges(
 		db.GetID(),
 		user,
 		privilege.Schemas,
-		db.GetPrivileges(),
 	)
 
 	privs.SetOwner(owner)

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -115,7 +115,6 @@ func doCreateSequence(
 		dbDesc.GetID(),
 		sessionData.User(),
 		privilege.Sequences,
-		dbDesc.GetPrivileges(),
 	)
 
 	if persistence.IsTemporary() {

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -361,7 +361,6 @@ func (n *createTableNode) startExec(params runParams) error {
 		n.dbDesc.GetID(),
 		params.SessionData().User(),
 		privilege.Tables,
-		n.dbDesc.GetPrivileges(),
 	)
 	if n.n.As() {
 		asCols := planColumns(n.sourcePlan)

--- a/pkg/sql/create_type.go
+++ b/pkg/sql/create_type.go
@@ -363,7 +363,6 @@ func CreateEnumTypeDesc(
 		dbDesc.GetID(),
 		params.SessionData().User(),
 		privilege.Types,
-		dbDesc.GetPrivileges(),
 	)
 
 	enumKind := descpb.TypeDescriptor_ENUM
@@ -438,7 +437,6 @@ func CreateCompositeTypeDesc(
 		dbDesc.GetID(),
 		params.SessionData().User(),
 		privilege.Types,
-		dbDesc.GetPrivileges(),
 	)
 
 	return typedesc.NewBuilder(&descpb.TypeDescriptor{

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -194,7 +194,6 @@ func (n *createViewNode) startExec(params runParams) error {
 		n.dbDesc.GetID(),
 		params.SessionData().User(),
 		privilege.Tables,
-		n.dbDesc.GetPrivileges(),
 	)
 
 	var newDesc *tabledesc.Mutable


### PR DESCRIPTION
Last parameter of the function is not used at all.

Epic: None

Release note: None