### PR TITLE
backupccl: add tpcc cluster replication roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -67,11 +68,14 @@ type c2cSetup struct {
 	dst clusterInfo
 }
 
-func setupC2C(ctx context.Context, t test.Test, c cluster.Cluster) (*c2cSetup, func()) {
+func setupC2C(
+	ctx context.Context, t test.Test, c cluster.Cluster, srcKVNodes,
+	dstKVNodes int,
+) (*c2cSetup, func()) {
 	c.Put(ctx, t.Cockroach(), "./cockroach")
-	srcCluster := c.Range(1, 3)
-	dstCluster := c.Range(4, 6)
-	srcTenantNode := 7
+	srcCluster := c.Range(1, srcKVNodes)
+	dstCluster := c.Range(srcKVNodes+1, srcKVNodes+dstKVNodes)
+	srcTenantNode := srcKVNodes + dstKVNodes + 1
 	c.Put(ctx, t.DeprecatedWorkload(), "./workload", c.Node(srcTenantNode))
 
 	srcStartOps := option.DefaultStartOpts()
@@ -80,7 +84,7 @@ func setupC2C(ctx context.Context, t test.Test, c cluster.Cluster) (*c2cSetup, f
 	c.Start(ctx, t.L(), srcStartOps, srcClusterSetting, srcCluster)
 
 	dstStartOps := option.DefaultStartOpts()
-	dstStartOps.RoachprodOpts.InitTarget = 4
+	dstStartOps.RoachprodOpts.InitTarget = srcKVNodes + 1
 	dstClusterSetting := install.MakeClusterSettings(install.SecureOption(true))
 	c.Start(ctx, t.L(), dstStartOps, dstClusterSetting, dstCluster)
 
@@ -134,9 +138,72 @@ func setupC2C(ctx context.Context, t test.Test, c cluster.Cluster) (*c2cSetup, f
 		db:      destDB,
 		kvNodes: dstCluster}
 
+	// Currently, a tenant has by default a 10m RU burst limit, which can be
+	// reached during these tests. To prevent RU limit throttling, add 10B RUs to
+	// the tenant.
+	srcTenantInfo.sql.Exec(t, `SELECT crdb_internal.update_tenant_resource_limits($1, 10000000000, 0,
+10000000000, now(), 0);`, srcTenantInfo.ID)
+
 	return &c2cSetup{
 		src: srcTenantInfo,
 		dst: destTenantInfo}, cleanup
+}
+
+type streamingWorkload interface {
+	// name returns the name of the workload
+	name() string
+
+	// sourceInitCmd returns a command that will populate the src cluster with data before the
+	// replication stream begins
+	sourceInitCmd(pgURL string) string
+
+	// sourceRunCmd returns a command that will run a workload for the given duration on the src
+	// cluster during the replication stream.
+	sourceRunCmd(pgURL string, duration time.Duration) string
+}
+
+type replicateTPCC struct {
+	warehouses int
+}
+
+func (tpcc replicateTPCC) name() string {
+	return fmt.Sprintf("tpcc/warehouses=%d", tpcc.warehouses)
+}
+
+func (tpcc replicateTPCC) sourceInitCmd(pgURL string) string {
+	return fmt.Sprintf(`./workload init tpcc --data-loader import --warehouses %d '%s'`,
+		tpcc.warehouses, pgURL)
+}
+
+func (tpcc replicateTPCC) sourceRunCmd(pgURL string, duration time.Duration) string {
+	return fmt.Sprintf(`./workload run tpcc --warehouses %d --duration %d '%s'`,
+		tpcc.warehouses, int(duration.Minutes()), pgURL)
+}
+
+type replicationTestSpec struct {
+	// srcKVNodes is the number kv nodes on the source cluster
+	srcKVNodes int
+
+	// dstKVNodes is the number kv nodes on the destination cluster
+	dstKVNodes int
+
+	// cpus is the per node cpu count
+	cpus int
+
+	// pdSize specifies the pd-ssd volume (in GB). If set to 0, local ssds are used
+	pdSize int
+
+	// workload specifies the streaming workload
+	workload streamingWorkload
+
+	// workloadDuration specifies how long the workload will run
+	workloadDuration time.Duration
+
+	// cutover specifies how soon before the workload ends to choose a cutover timestamp
+	cutover time.Duration
+
+	// timeout specifies when the roachtest should fail due to timeout
+	timeout time.Duration
 }
 
 func registerClusterToCluster(r registry.Registry) {
@@ -146,7 +213,7 @@ func registerClusterToCluster(r registry.Registry) {
 		Cluster:         r.MakeClusterSpec(7),
 		RequiresLicense: true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-			setup, cleanup := setupC2C(ctx, t, c)
+			setup, cleanup := setupC2C(ctx, t, c, 3, 3)
 			defer cleanup()
 			var (
 				kvWorkloadDuration = "15m"
@@ -185,7 +252,10 @@ func registerClusterToCluster(r registry.Registry) {
 			m.Wait()
 
 			t.Status("waiting for replication stream to cutover")
-			cutoverTime := stopReplicationStream(t, setup.dst.sql, ingestionJobID)
+			// Cut over the ingestion job and the job will stop eventually.
+			var cutoverTime time.Time
+			setup.dst.sql.QueryRow(t, "SELECT clock_timestamp()").Scan(&cutoverTime)
+			stopReplicationStream(t, setup.dst.sql, ingestionJobID, cutoverTime)
 			compareTenantFingerprintsAtTimestamp(
 				t,
 				setup.src.sql,
@@ -196,6 +266,103 @@ func registerClusterToCluster(r registry.Registry) {
 			lv.assertValid(t)
 		},
 	})
+
+	for _, sp := range []replicationTestSpec{
+		{
+			srcKVNodes:       4,
+			dstKVNodes:       4,
+			cpus:             8,
+			pdSize:           1000,
+			workload:         replicateTPCC{warehouses: 1000},
+			timeout:          3 * time.Hour,
+			workloadDuration: 10 * time.Minute,
+			cutover:          5 * time.Minute,
+		},
+	} {
+		name := fmt.Sprintf("c2c/%s/cutover=%d/nodes=%dto%d/cpus=%d",
+			sp.workload.name(),
+			int(sp.cutover.Minutes()),
+			sp.srcKVNodes,
+			sp.dstKVNodes,
+			sp.cpus)
+
+		clusterOps := make([]spec.Option, 0)
+		clusterOps = append(clusterOps, spec.CPU(sp.cpus))
+		if sp.pdSize != 0 {
+			clusterOps = append(clusterOps, spec.VolumeSize(sp.pdSize))
+		}
+
+		r.Add(registry.TestSpec{
+			Name:            name,
+			Owner:           registry.OwnerDisasterRecovery,
+			Cluster:         r.MakeClusterSpec(sp.dstKVNodes+sp.srcKVNodes+1, clusterOps...),
+			RequiresLicense: true,
+			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+
+				setup, cleanup := setupC2C(ctx, t, c, sp.srcKVNodes, sp.dstKVNodes)
+				defer cleanup()
+				m := c.NewMonitor(ctx, setup.src.kvNodes.Merge(setup.dst.kvNodes))
+
+				t.Status("populating source cluster before replication")
+				if initCmd := sp.workload.sourceInitCmd(setup.src.tenant.secureURL()); initCmd != "" {
+					c.Run(ctx, c.Node(setup.src.sqlNode), initCmd)
+				}
+
+				t.Status("starting replication stream")
+				streamReplStmt := fmt.Sprintf("CREATE TENANT %q FROM REPLICATION OF %q ON '%s'",
+					setup.dst.name, setup.src.name, setup.src.pgURL)
+				var ingestionJobID, streamProducerJobID int
+				setup.dst.sql.QueryRow(t, streamReplStmt).Scan(&ingestionJobID, &streamProducerJobID)
+
+				// begin the source cluster workload
+				workloadDoneCh := make(chan struct{})
+				m.Go(func(ctx context.Context) error {
+					defer close(workloadDoneCh)
+					cmd := sp.workload.sourceRunCmd(setup.src.tenant.secureURL(), sp.workloadDuration)
+					c.Run(ctx, c.Node(setup.src.sqlNode), cmd)
+					return nil
+				})
+
+				cutoverTime := chooseCutover(t, setup.dst.sql, sp.workloadDuration, sp.cutover)
+				t.Status("Cutover Time Chosen: %s", cutoverTime.String())
+
+				// TODO(ssd): The job doesn't record the initial
+				// statement time, so we can't correctly measure the
+				// initial scan time here.
+				lv := makeLatencyVerifier("stream-ingestion", 0, 2*time.Minute, t.L(), getStreamIngestionJobInfo, t.Status, false)
+				defer lv.maybeLogLatencyHist()
+
+				m.Go(func(ctx context.Context) error {
+					return lv.pollLatency(ctx, setup.dst.db, ingestionJobID, time.Second, workloadDoneCh)
+				})
+
+				t.Status("waiting for replication stream to return high watermark")
+				waitForHighWatermark(t, setup.dst.db, ingestionJobID)
+
+				t.Status("waiting for src cluster workload to complete")
+				m.Wait()
+
+				t.Status("waiting for replication stream to cutover")
+				// Cut over the ingestion job and the job will stop eventually.
+				// TODO(msbutler): measure cutover time.
+				stopReplicationStream(t, setup.dst.sql, ingestionJobID, cutoverTime)
+				compareTenantFingerprintsAtTimestamp(
+					t,
+					setup.src.sql,
+					setup.dst.sql,
+					setup.src.ID,
+					setup.dst.ID,
+					hlc.Timestamp{WallTime: cutoverTime.UnixNano()})
+				lv.assertValid(t)
+			},
+		})
+	}
+}
+
+func chooseCutover(t test.Test, dstSQL *sqlutils.SQLRunner, workloadDuration time.Duration, cutover time.Duration) time.Time {
+	var currentTime time.Time
+	dstSQL.QueryRow(t, "SELECT clock_timestamp()").Scan(&currentTime)
+	return currentTime.Add(workloadDuration - cutover)
 }
 
 func compareTenantFingerprintsAtTimestamp(
@@ -276,10 +443,9 @@ func waitForHighWatermark(t test.Test, db *gosql.DB, ingestionJobID int) {
 	}, 5*time.Minute)
 }
 
-func stopReplicationStream(t test.Test, destSQL *sqlutils.SQLRunner, ingestionJob int) time.Time {
-	// Cut over the ingestion job and the job will stop eventually.
-	var cutoverTime time.Time
-	destSQL.QueryRow(t, "SELECT clock_timestamp()").Scan(&cutoverTime)
+func stopReplicationStream(
+	t test.Test, destSQL *sqlutils.SQLRunner, ingestionJob int, cutoverTime time.Time,
+) {
 	destSQL.Exec(t, `SELECT crdb_internal.complete_stream_ingestion_job($1, $2)`, ingestionJob, cutoverTime)
 	err := retry.ForDuration(time.Minute*5, func() error {
 		var status string
@@ -299,7 +465,6 @@ func stopReplicationStream(t test.Test, destSQL *sqlutils.SQLRunner, ingestionJo
 		return nil
 	})
 	require.NoError(t, err)
-	return cutoverTime
 }
 
 func srcClusterSettings(t test.Test, db *sqlutils.SQLRunner) {


### PR DESCRIPTION
This pr adds an end to end cluster replication roachtest described in #92697

A follow up PR will add infrastructure to send initial scan and cutover time benchmarks to roachperf.

Release Note: None