### PR TITLE
build: fix little typo in generated `DEPS.bzl`

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -2,7 +2,7 @@ load("@bazel_gazelle//:deps.bzl", "go_repository")
 
 # PRO-TIP: You can inject temorary changes to any of these dependencies by
 # by pointing to an alternate remote to clone from. Delete the `sha256`,
-# `strip_prefix`, and ` + `urls` parameters, and add `vcs = "git"` as well as a
+# `strip_prefix`, and `urls` parameters, and add `vcs = "git"` as well as a
 # custom `remote` and `commit`. For example:
 #     go_repository(
 #        name = "com_github_cockroachdb_sentry_go",

--- a/pkg/cmd/mirror/mirror.go
+++ b/pkg/cmd/mirror/mirror.go
@@ -337,7 +337,7 @@ func dumpNewDepsBzl(
 
 # PRO-TIP: You can inject temorary changes to any of these dependencies by
 # by pointing to an alternate remote to clone from. Delete the ` + "`sha256`" + `,
-# ` + "`strip_prefix`, and ` + `urls`" + ` parameters, and add ` + "`vcs = \"git\"`" + ` as well as a
+# ` + "`strip_prefix`, and `urls` parameters, and add `vcs = \"git\"`" + ` as well as a
 # custom ` + "`remote` and `commit`" + `. For example:
 #     go_repository(
 #        name = "com_github_cockroachdb_sentry_go",


### PR DESCRIPTION
Epic: None
Release note: None