### PR TITLE
ui: fix ts/query returning no data for graphs by adjusting sample size

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/shared/containers/metricDataProvider/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/containers/metricDataProvider/index.tsx
@@ -37,7 +37,11 @@ import {
 } from "@cockroachlabs/cluster-ui";
 import { History } from "history";
 import { refreshSettings } from "src/redux/apiReducers";
-import { selectTimeScale } from "src/redux/timeScale";
+import { selectTimeScale, adjustTimeScale } from "src/redux/timeScale";
+import {
+  selectResolution10sStorageTTL,
+  selectResolution30mStorageTTL,
+} from "src/redux/clusterSettings";
 
 /**
  * queryFromProps is a helper method which generates a TimeSeries Query data
@@ -248,26 +252,40 @@ class MetricsDataProvider extends React.Component<
 
 // timeInfoSelector converts the current global time window into a set of Long
 // timestamps, which can be sent with requests to the server.
-const timeInfoSelector = createSelector(selectTimeScale, scale => {
-  if (!_.isObject(scale)) {
-    return null;
-  }
-  const [startMoment, endMoment] = toDateRange(scale);
-  const start = startMoment.valueOf();
-  const end = endMoment.valueOf();
-  const syncedScale = findClosestTimeScale(
-    defaultTimeScaleOptions,
-    util.MilliToSeconds(end - start),
-  );
+const timeInfoSelector = createSelector(
+  selectResolution10sStorageTTL,
+  selectResolution30mStorageTTL,
+  selectTimeScale,
+  (sTTL, mTTL, scale) => {
+    if (!_.isObject(scale)) {
+      return null;
+    }
+    const [startMoment, endMoment] = toDateRange(scale);
+    const start = startMoment.valueOf();
+    const end = endMoment.valueOf();
+    const syncedScale = findClosestTimeScale(
+      defaultTimeScaleOptions,
+      util.MilliToSeconds(end - start),
+    );
+    // Call adjustTimeScale to handle the case where the sample size
+    // (also known as resolution) is too small for a start and end time
+    // that is before the data's ttl.
+    const adjusted = adjustTimeScale(
+      { ...syncedScale, fixedWindowEnd: false },
+      { start: startMoment, end: endMoment },
+      sTTL,
+      mTTL,
+    );
 
-  return {
-    start: Long.fromNumber(util.MilliToNano(start)),
-    end: Long.fromNumber(util.MilliToNano(end)),
-    sampleDuration: Long.fromNumber(
-      util.MilliToNano(syncedScale.sampleSize.asMilliseconds()),
-    ),
-  };
-});
+    return {
+      start: Long.fromNumber(util.MilliToNano(start)),
+      end: Long.fromNumber(util.MilliToNano(end)),
+      sampleDuration: Long.fromNumber(
+        util.MilliToNano(adjusted.timeScale.sampleSize.asMilliseconds()),
+      ),
+    };
+  },
+);
 
 const current = () => {
   let now = moment();


### PR DESCRIPTION
This change fixes a bug where selecting a relatively small timeframe in the past causes no data to render on graphs. This is because selecting a small time window that is earlier than the `timeseries.storage.resolution_10s.ttl` will make a ts/query request with a high resolution which would be no longer stored. The change calls an existing function which will adjust the resolution based on the start time and end time of the selection and the storage settings so that data will be returned but at a lower resolution.

Fixes: https://github.com/cockroachlabs/support/issues/1940

Release note (bug fix): fix ts/query returning no data for graphs by adjusting sample size

![Screen Shot 2022-12-08 at 6 27 37 PM](https://user-images.githubusercontent.com/17861665/206588333-8b502195-fde1-41e1-967d-280998307003.png)
