### PR TITLE
roachprod: bug fixes for azure.Extend

### DIFF
--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -337,7 +337,7 @@ func (p *Provider) Extend(vms vm.List, lifetime time.Duration) error {
 	if err != nil {
 		return err
 	}
-	client := compute.NewVirtualMachinesClient(*sub.ID)
+	client := compute.NewVirtualMachinesClient(*sub.SubscriptionID)
 	if client.Authorizer, err = p.getAuthorizer(); err != nil {
 		return err
 	}
@@ -348,10 +348,16 @@ func (p *Provider) Extend(vms vm.List, lifetime time.Duration) error {
 		if err != nil {
 			return err
 		}
+		// N.B. VirtualMachineUpdate below overwrites _all_ VM tags. Hence, we must copy all unmodified tags.
+		tags := make(map[string]*string)
+		// Copy all known VM tags.
+		for k, v := range m.Labels {
+			tags[k] = to.StringPtr(v)
+		}
+		// Overwrite Lifetime tag.
+		tags[vm.TagLifetime] = to.StringPtr(lifetime.String())
 		update := compute.VirtualMachineUpdate{
-			Tags: map[string]*string{
-				vm.TagLifetime: to.StringPtr(lifetime.String()),
-			},
+			Tags: tags,
 		}
 		futures[idx], err = client.Update(ctx, vmParts.resourceGroup, vmParts.resourceName, update)
 		if err != nil {


### PR DESCRIPTION
roachprod extend is intended to extend the lifetime of an existing cluster. This functionality was previously broken in Azure.

The changes fix the two existing bugs, namely the use of the fully-qualified subscription path (instead of the id), and the truncation of all the existing VM tags--Tags in
compute.VirtualMachineUpdate must include _all_ tags, not just the modified one.

Epic: none

Release note: None