### PR TITLE
sql: avoid an allocation in SetIndexRecommendations

### DIFF
--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -737,9 +737,7 @@ func (m execNodeTraceMetadata) annotateExplain(
 func (ih *instrumentationHelper) SetIndexRecommendations(
 	ctx context.Context, idxRec *idxrecommendations.IndexRecCache, planner *planner, isInternal bool,
 ) {
-	opc := planner.optPlanningCtx
-	opc.reset(ctx)
-	stmtType := opc.p.stmt.AST.StatementType()
+	stmtType := planner.stmt.AST.StatementType()
 
 	reset := false
 	var recommendations []indexrec.Rec
@@ -750,6 +748,8 @@ func (ih *instrumentationHelper) SetIndexRecommendations(
 		stmtType,
 		isInternal,
 	) {
+		opc := &planner.optPlanningCtx
+		opc.reset(ctx)
 		f := opc.optimizer.Factory()
 		evalCtx := opc.p.EvalContext()
 		f.Init(ctx, evalCtx, opc.catalog)


### PR DESCRIPTION
This commit fixes the code in `SetIndexRecommendations` to not create a copy of `optPlanningCtx` - we can just use the one that we have on the `planner` directly by taking its pointer. This is what we do in all other places.
```
name                           old time/op    new time/op    delta
Select1/Cockroach-24              158µs ± 5%     159µs ± 5%    ~     (p=0.631 n=10+10)
Select1/MultinodeCockroach-24     164µs ± 2%     165µs ± 2%    ~     (p=0.842 n=9+10)

name                           old alloc/op   new alloc/op   delta
Select1/Cockroach-24             23.0kB ± 1%    22.3kB ± 1%  -3.41%  (p=0.000 n=10+10)
Select1/MultinodeCockroach-24    22.5kB ± 2%    21.7kB ± 2%  -3.29%  (p=0.000 n=10+9)

name                           old allocs/op  new allocs/op  delta
Select1/Cockroach-24                208 ± 2%       205 ± 1%  -1.11%  (p=0.006 n=10+10)
Select1/MultinodeCockroach-24       184 ± 0%       182 ± 0%  -1.14%  (p=0.000 n=9+8)
```

Epic: None

Release note: None