### PR TITLE
physicalplan: pool physical infra allocations

### DIFF
--- a/pkg/sql/distsql_plan_set_op_test.go
+++ b/pkg/sql/distsql_plan_set_op_test.go
@@ -60,10 +60,10 @@ func TestMergeResultTypesForSetOp(t *testing.T) {
 			}
 		}
 	}
-	infra := physicalplan.MakePhysicalInfrastructure(uuid.FastMakeV4(), base.SQLInstanceID(1))
+	infra := physicalplan.NewPhysicalInfrastructure(uuid.FastMakeV4(), base.SQLInstanceID(1))
 	var leftPlan, rightPlan PhysicalPlan
-	leftPlan.PhysicalInfrastructure = &infra
-	rightPlan.PhysicalInfrastructure = &infra
+	leftPlan.PhysicalInfrastructure = infra
+	rightPlan.PhysicalInfrastructure = infra
 	leftPlan.ResultRouters = []physicalplan.ProcessorIdx{infra.AddProcessor(physicalplan.Processor{})}
 	rightPlan.ResultRouters = []physicalplan.ProcessorIdx{infra.AddProcessor(physicalplan.Processor{})}
 	for _, td := range testData {

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -50,7 +50,8 @@ func (n *explainVecNode) startExec(params runParams) error {
 	defer func() {
 		planCtx.planner.curPlan.subqueryPlans = outerSubqueries
 	}()
-	physPlan, err := newPhysPlanForExplainPurposes(params.ctx, planCtx, distSQLPlanner, n.plan.main)
+	physPlan, cleanup, err := newPhysPlanForExplainPurposes(params.ctx, planCtx, distSQLPlanner, n.plan.main)
+	defer cleanup()
 	if err != nil {
 		if len(n.plan.subqueryPlans) > 0 {
 			return errors.New("running EXPLAIN (VEC) on this query is " +

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -335,6 +335,8 @@ type physicalPlanTop struct {
 	// closed explicitly since we don't have a planNode tree that performs the
 	// closure.
 	planNodesToClose []planNode
+	// onClose, if non-nil, will be called when closing this object.
+	onClose func()
 }
 
 func (p *physicalPlanTop) Close(ctx context.Context) {
@@ -342,6 +344,10 @@ func (p *physicalPlanTop) Close(ctx context.Context) {
 		plan.Close(ctx)
 	}
 	p.planNodesToClose = nil
+	if p.onClose != nil {
+		p.onClose()
+		p.onClose = nil
+	}
 }
 
 // planMaybePhysical is a utility struct representing a plan. It can currently


### PR DESCRIPTION
This commit adds pooling of allocations of `PhysicalInfrastructure` structs which allows us to reuse some of the slices. The object is released on the local flow cleanup (i.e. after the execution) even though it could have been released sooner (after the physical planning) since we have a convenient place to do so.
```
name                           old time/op    new time/op    delta
Select1/Cockroach-24              161µs ± 6%     160µs ± 6%    ~     (p=0.620 n=20+20)
Select1/MultinodeCockroach-24     167µs ± 4%     167µs ± 3%    ~     (p=0.989 n=20+20)

name                           old alloc/op   new alloc/op   delta
Select1/Cockroach-24             23.0kB ± 1%    22.4kB ± 1%  -2.61%  (p=0.000 n=18+20)
Select1/MultinodeCockroach-24    22.5kB ± 3%    22.1kB ± 3%  -2.16%  (p=0.000 n=20+19)

name                           old allocs/op  new allocs/op  delta
Select1/Cockroach-24                208 ± 1%       207 ± 1%  -0.58%  (p=0.032 n=18+20)
Select1/MultinodeCockroach-24       184 ± 0%       184 ± 0%    ~     (p=0.824 n=19+17)
```

Epic: None

Release note: None