### PR TITLE
kvserver: handle AddSST for standalone log application

### DIFF
--- a/pkg/kv/kvserver/app_batch.go
+++ b/pkg/kv/kvserver/app_batch.go
@@ -13,7 +13,6 @@ package kvserver
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvadmission"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftlog"
@@ -32,7 +31,6 @@ type appBatchStats struct {
 	numEntriesProcessed      int
 	numEntriesProcessedBytes int64
 	numEmptyEntries          int
-	followerStoreWriteBytes  kvadmission.FollowerStoreWriteBytes
 	// NB: update `merge` when adding a new field.
 }
 
@@ -41,7 +39,6 @@ func (s *appBatchStats) merge(ss appBatchStats) {
 	s.numEntriesProcessed += ss.numEntriesProcessed
 	s.numEntriesProcessedBytes += ss.numEntriesProcessedBytes
 	ss.numEmptyEntries += ss.numEmptyEntries
-	s.followerStoreWriteBytes.Merge(ss.followerStoreWriteBytes)
 }
 
 // appBatch is the in-progress foundation for standalone log entry

--- a/pkg/kv/kvserver/app_batch.go
+++ b/pkg/kv/kvserver/app_batch.go
@@ -27,6 +27,9 @@ type appBatchStats struct {
 	// numEntries
 	// numEntriesBytes
 	// numEntriesEmpty
+
+	// numMutations is the number of keys mutated, both via
+	// WriteBatch and AddSST.
 	numMutations             int
 	numEntriesProcessed      int
 	numEntriesProcessedBytes int64

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/apply"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/ctpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvadmission"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -44,9 +45,10 @@ import (
 // TODO(ajwerner): add metrics to go with these stats.
 type applyCommittedEntriesStats struct {
 	appBatchStats
-	numBatchesProcessed  int // TODO(sep-raft-log): numBatches
-	stateAssertions      int
-	numConfChangeEntries int
+	followerStoreWriteBytes kvadmission.FollowerStoreWriteBytes
+	numBatchesProcessed     int // TODO(sep-raft-log): numBatches
+	stateAssertions         int
+	numConfChangeEntries    int
 }
 
 // replicaStateMachine implements the apply.StateMachine interface.


### PR DESCRIPTION
This moves the standalone portions of AddSST to `appBatch`.  We chose to
track the stats on `appBatch` because that is nice for unit testing of
the SST application path. We'll keep stats exclusive to
`replicaAppBatch` only if they depend on context not available in
standalone mode (e.g. is the proposer waiting locally), as is the case
for `followerStoreWriteBytes`.

Epic: CRDB-220
Release note: None
