### PR TITLE
multitenant: retain range splits after TRUNCATE for secondary tenants

### DIFF
--- a/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
@@ -500,6 +500,10 @@ func (s mockNodeStore) GetNodeDescriptor(id roachpb.NodeID) (*roachpb.NodeDescri
 	return nil, errorutil.NewNodeNotFoundError(id)
 }
 
+func (s mockNodeStore) GetNodeDescriptorCount() int {
+	return len(s)
+}
+
 func (s mockNodeStore) GetStoreDescriptor(id roachpb.StoreID) (*roachpb.StoreDescriptor, error) {
 	return nil, errorutil.NewStoreNotFoundError(id)
 }

--- a/pkg/ccl/kvccl/kvtenantccl/connector.go
+++ b/pkg/ccl/kvccl/kvtenantccl/connector.go
@@ -340,6 +340,13 @@ func (c *Connector) GetNodeDescriptor(nodeID roachpb.NodeID) (*roachpb.NodeDescr
 	return desc, nil
 }
 
+// GetNodeDescriptorCount implements the kvcoord.NodeDescStore interface.
+func (c *Connector) GetNodeDescriptorCount() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.mu.nodeDescs)
+}
+
 // GetStoreDescriptor implements the kvcoord.NodeDescStore interface.
 func (c *Connector) GetStoreDescriptor(storeID roachpb.StoreID) (*roachpb.StoreDescriptor, error) {
 	c.mu.RLock()

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -562,6 +562,16 @@ func (g *Gossip) GetNodeDescriptor(nodeID roachpb.NodeID) (*roachpb.NodeDescript
 	return g.getNodeDescriptor(nodeID, false /* locked */)
 }
 
+// GetNodeDescriptorCount gets the number of node descriptors.
+func (g *Gossip) GetNodeDescriptorCount() int {
+	count := 0
+	g.nodeDescs.Range(func(key int64, value unsafe.Pointer) bool {
+		count++
+		return true
+	})
+	return count
+}
+
 // GetStoreDescriptor looks up the descriptor of the node by ID.
 func (g *Gossip) GetStoreDescriptor(storeID roachpb.StoreID) (*roachpb.StoreDescriptor, error) {
 	if value, ok := g.storeDescs.Load(int64(storeID)); ok {

--- a/pkg/kv/kvclient/kvcoord/node_store.go
+++ b/pkg/kv/kvclient/kvcoord/node_store.go
@@ -19,6 +19,10 @@ type NodeDescStore interface {
 	// GetNodeDescriptor looks up the node descriptor by node ID.
 	// It returns an error if the node is not known by the cache.
 	GetNodeDescriptor(roachpb.NodeID) (*roachpb.NodeDescriptor, error)
+	// GetNodeDescriptorCount get the number of node descriptors in the cache.
+	// TODO(ewall): Replace this function with a new KV endpoint for 23.1.
+	//  See https://github.com/cockroachdb/cockroach/issues/93549.
+	GetNodeDescriptorCount() int
 	// GetStoreDescriptor looks up the store descriptor by store ID.
 	// It returns an error if the store is not known by the cache.
 	GetStoreDescriptor(roachpb.StoreID) (*roachpb.StoreDescriptor, error)

--- a/pkg/kv/kvclient/kvcoord/replica_slice_test.go
+++ b/pkg/kv/kvclient/kvcoord/replica_slice_test.go
@@ -43,6 +43,11 @@ func (ns *mockNodeStore) GetNodeDescriptor(nodeID roachpb.NodeID) (*roachpb.Node
 	return nil, errorutil.NewNodeNotFoundError(nodeID)
 }
 
+// GetNodeDescriptorCount is part of the NodeDescStore interface.
+func (ns *mockNodeStore) GetNodeDescriptorCount() int {
+	return len(ns.nodes)
+}
+
 // GetStoreDescriptor is part of the NodeDescStore interface.
 func (ns *mockNodeStore) GetStoreDescriptor(
 	storeID roachpb.StoreID,

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -141,6 +141,10 @@ func (m mockNodeStore) GetNodeDescriptor(id roachpb.NodeID) (*roachpb.NodeDescri
 	return m.desc, nil
 }
 
+func (m mockNodeStore) GetNodeDescriptorCount() int {
+	return 1
+}
+
 func (m mockNodeStore) GetStoreDescriptor(id roachpb.StoreID) (*roachpb.StoreDescriptor, error) {
 	return nil, errorutil.NewStoreNotFoundError(id)
 }

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -291,7 +291,6 @@ go_library(
         "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/kv",
-        "//pkg/kv/kvclient",
         "//pkg/kv/kvclient/kvcoord",
         "//pkg/kv/kvclient/kvtenant",
         "//pkg/kv/kvclient/rangecache",

--- a/pkg/sql/multitenant_admin_function_test.go
+++ b/pkg/sql/multitenant_admin_function_test.go
@@ -390,7 +390,6 @@ func TestTruncateTable(t *testing.T) {
 			true,  /* allowSplitAndScatter */
 			false, /* skipSQLSystemTenantCheck */
 		)
-		// TODO(ewall): Retain splits after `TRUNCATE` for secondary tenants.
-		execQueries(db, "secondary", [][]string{{"", ""}})
+		execQueries(db, "secondary", [][]string{{"", "/104/2/1"}, {"/104/2/1", ""}})
 	}()
 }

--- a/pkg/sql/oppurpose/op_purpose.go
+++ b/pkg/sql/oppurpose/op_purpose.go
@@ -25,6 +25,8 @@ const (
 	SplitManual = roachpb.AdminSplitRequest_ARBITRARY
 	// SplitManualTest is a split caused by a manual action test.
 	SplitManualTest = roachpb.AdminSplitRequest_INGESTION
+	// SplitTruncate is a split caused by a truncate.
+	SplitTruncate = roachpb.AdminSplitRequest_INGESTION
 
 	// UnsplitManual is a split caused by a manual action.
 	UnsplitManual = roachpb.AdminUnsplitRequest_ARBITRARY


### PR DESCRIPTION
Fixes #69499
Fixes #82944

Existing split points are preserved after a TRUNCATE statement is executed by a secondary tenant.

Release note: None