### PR TITLE
release-22.2: tochar: implement cache for parse format

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -496,6 +496,7 @@ go_library(
         "//pkg/util/syncutil/singleflight",
         "//pkg/util/timeutil",
         "//pkg/util/timeutil/pgdate",
+        "//pkg/util/tochar",
         "//pkg/util/tracing",
         "//pkg/util/tracing/collector",
         "//pkg/util/tracing/tracingpb",

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -71,6 +71,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tochar"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"golang.org/x/net/trace"
@@ -284,7 +285,8 @@ type Server struct {
 
 	insights insights.Provider
 
-	reCache *tree.RegexpCache
+	reCache           *tree.RegexpCache
+	toCharFormatCache *tochar.FormatCache
 
 	// pool is the parent monitor for all session monitors.
 	pool *mon.BytesMonitor
@@ -393,6 +395,7 @@ func NewServer(cfg *ExecutorConfig, pool *mon.BytesMonitor) *Server {
 		reportedStatsController: reportedSQLStatsController,
 		insights:                insightsProvider,
 		reCache:                 tree.NewRegexpCache(512),
+		toCharFormatCache:       tochar.NewFormatCache(512),
 		indexUsageStats: idxusage.NewLocalIndexUsageStats(&idxusage.Config{
 			ChannelSize: idxusage.DefaultChannelSize,
 			Setting:     cfg.Settings,
@@ -2766,6 +2769,7 @@ func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalCo
 			PreparedStatementState:         &ex.extraTxnState.prepStmtsNamespace,
 			SessionDataStack:               ex.sessionDataStack,
 			ReCache:                        ex.server.reCache,
+			ToCharFormatCache:              ex.server.toCharFormatCache,
 			SQLStatsController:             ex.server.sqlStatsController,
 			SchemaTelemetryController:      ex.server.schemaTelemetryController,
 			IndexUsageStatsController:      ex.server.indexUsageStatsController,

--- a/pkg/sql/distsql/BUILD.bazel
+++ b/pkg/sql/distsql/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//pkg/util/mon",
         "//pkg/util/pprofutil",
         "//pkg/util/timeutil",
+        "//pkg/util/tochar",
         "//pkg/util/tracing",
         "//pkg/util/tracing/grpcinterceptor",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2440,10 +2440,10 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"interval", types.Interval}, {"format", types.String}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				d := tree.MustBeDInterval(args[0])
 				f := tree.MustBeDString(args[1])
-				s, err := tochar.DurationToChar(d.Duration, string(f))
+				s, err := tochar.DurationToChar(d.Duration, ctx.ToCharFormatCache, string(f))
 				return tree.NewDString(s), err
 			},
 			Info:       "Convert an interval to a string using the given format.",
@@ -2452,10 +2452,10 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"timestamp", types.Timestamp}, {"format", types.String}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				ts := tree.MustBeDTimestamp(args[0])
 				f := tree.MustBeDString(args[1])
-				s, err := tochar.TimeToChar(ts.Time, string(f))
+				s, err := tochar.TimeToChar(ts.Time, ctx.ToCharFormatCache, string(f))
 				return tree.NewDString(s), err
 			},
 			Info:       "Convert an timestamp to a string using the given format.",
@@ -2464,10 +2464,10 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"timestamptz", types.TimestampTZ}, {"format", types.String}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				ts := tree.MustBeDTimestampTZ(args[0])
 				f := tree.MustBeDString(args[1])
-				s, err := tochar.TimeToChar(ts.Time, string(f))
+				s, err := tochar.TimeToChar(ts.Time, ctx.ToCharFormatCache, string(f))
 				return tree.NewDString(s), err
 			},
 			Info:       "Convert a timestamp with time zone to a string using the given format.",

--- a/pkg/sql/sem/eval/BUILD.bazel
+++ b/pkg/sql/sem/eval/BUILD.bazel
@@ -81,6 +81,7 @@ go_library(
         "//pkg/util/timeofday",
         "//pkg/util/timeutil",
         "//pkg/util/timeutil/pgdate",
+        "//pkg/util/tochar",
         "//pkg/util/tracing",
         "//pkg/util/trigram",
         "//pkg/util/uuid",

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeofday"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
+	"github.com/cockroachdb/cockroach/pkg/util/tochar"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
@@ -160,7 +161,8 @@ type Context struct {
 	// The transaction in which the statement is executing.
 	Txn *kv.Txn
 
-	ReCache *tree.RegexpCache
+	ReCache           *tree.RegexpCache
+	ToCharFormatCache *tochar.FormatCache
 
 	// TODO(mjibson): remove prepareOnly in favor of a 2-step prepare-exec solution
 	// that is also able to save the plan to skip work during the exec step.

--- a/pkg/util/tochar/BUILD.bazel
+++ b/pkg/util/tochar/BUILD.bazel
@@ -4,6 +4,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "tochar",
     srcs = [
+        "cache.go",
         "constants.go",
         "tochar.go",
     ],
@@ -12,7 +13,9 @@ go_library(
     deps = [
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
+        "//pkg/util/cache",
         "//pkg/util/duration",
+        "//pkg/util/syncutil",
         "//pkg/util/timeutil/pgdate",
         "@com_github_cockroachdb_errors//:errors",
     ],
@@ -20,7 +23,10 @@ go_library(
 
 go_test(
     name = "tochar_test",
-    srcs = ["tochar_test.go"],
+    srcs = [
+        "cache_test.go",
+        "tochar_test.go",
+    ],
     args = ["-test.timeout=295s"],
     data = glob(["testdata/**"]),
     embed = [":tochar"],

--- a/pkg/util/tochar/cache.go
+++ b/pkg/util/tochar/cache.go
@@ -1,0 +1,62 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tochar
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/util/cache"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+const maxCacheKeySize = 100
+
+// FormatCache is a cache used to store parsing info used for to_char.
+// It is thread safe, and is safe to use by `nil` caches.
+type FormatCache struct {
+	mu struct {
+		syncutil.RWMutex
+		cache *cache.UnorderedCache
+	}
+}
+
+// NewFormatCache returns a new FormatCache.
+func NewFormatCache(size int) *FormatCache {
+	ret := &FormatCache{}
+	ret.mu.cache = cache.NewUnorderedCache(cache.Config{
+		Policy: cache.CacheLRU,
+		ShouldEvict: func(s int, key, value interface{}) bool {
+			return s > size
+		},
+	})
+	return ret
+}
+
+func (pc *FormatCache) lookup(fmtString string) []formatNode {
+	if pc != nil && len(fmtString) <= maxCacheKeySize {
+		if ret, ok := func() ([]formatNode, bool) {
+			pc.mu.RLock()
+			defer pc.mu.RUnlock()
+			ret, ok := pc.mu.cache.Get(fmtString)
+			if ok {
+				return ret.([]formatNode), true
+			}
+			return nil, false
+		}(); ok {
+			return ret
+		}
+
+		r := parseFormat(fmtString)
+		pc.mu.Lock()
+		defer pc.mu.Unlock()
+		pc.mu.cache.Add(fmtString, r)
+		return r
+	}
+	return parseFormat(fmtString)
+}

--- a/pkg/util/tochar/cache_test.go
+++ b/pkg/util/tochar/cache_test.go
@@ -1,0 +1,42 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tochar
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatCache(t *testing.T) {
+	c := NewFormatCache(1)
+	hh24 := parseFormat("HH24")
+
+	// Cache is correctly populated.
+	result := c.lookup("HH24")
+	require.Equal(t, hh24, result)
+	rInt, ok := c.mu.cache.Get("HH24")
+	require.True(t, ok)
+	require.Equal(t, hh24, rInt.([]formatNode))
+
+	// Cache does not cache large format strings.
+	longStr := strings.Repeat(",", maxCacheKeySize+1)
+	longFmt := parseFormat(longStr)
+	// result should still be the same.
+	result = c.lookup(longStr)
+	require.Equal(t, longFmt, result)
+	// But the entry should not be in the cache.
+	_, ok = c.mu.cache.Get(longStr)
+	require.False(t, ok)
+	_, ok = c.mu.cache.Get("HH24")
+	require.True(t, ok)
+}

--- a/pkg/util/tochar/tochar.go
+++ b/pkg/util/tochar/tochar.go
@@ -25,14 +25,13 @@ import (
 )
 
 // TimeToChar converts a time and a `to_char` format string to a string.
-func TimeToChar(t time.Time, f string) (string, error) {
-	return timeToChar(timeWrapper{t}, parseFormat(f))
+func TimeToChar(t time.Time, c *FormatCache, f string) (string, error) {
+	return timeToChar(timeWrapper{t}, c.lookup(f))
 }
 
 // DurationToChar converts a duration and a `to_char` format string to a string.
-func DurationToChar(d duration.Duration, f string) (string, error) {
-	// TODO(#sql-experience): consider caching parse formats.
-	return timeToChar(makeToCharDuration(d), parseFormat(f))
+func DurationToChar(d duration.Duration, c *FormatCache, f string) (string, error) {
+	return timeToChar(makeToCharDuration(d), c.lookup(f))
 }
 
 // timeInterface is intended as a pass through to timeToChar.


### PR DESCRIPTION
Backport 1/1 commits from #91564.

/cc @cockroachdb/release

Release justification: major perf improvement for new feature

---

Implemented a basic cache for parse formats, similar to `ReCache`. Haven't done any memory monitoring as the space this takes is predictable - cache size * maxCacheKeySize * some constant for vars.

Before:
```
BenchmarkTimeToChar-10        	  761224	      1577 ns/op
BenchmarkIntervalToChar-10    	  552865	      2226 ns/op
```

After:
```
BenchmarkTimeToChar-10        	 1719128	       702.8 ns/op
BenchmarkIntervalToChar-10    	 1551093	       771.4 ns/op
```

Epic: None

Release note (sql change, performance improvement): `to_char` now has caching for parse formats, marking a speedup when running to_char with the same format between sessions.
