### PR TITLE
sql: fix bug when evaluating UDFs with empty bodies

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -2622,3 +2622,16 @@ DROP FUNCTION f_test_exec_dropped;
 
 statement error pq: unknown function: f_test_exec_dropped\(\): function undefined
 SELECT f_test_exec_dropped(321);
+
+
+subtest regression_tests
+
+# Regression test for #93083. UDFs with empty bodies should execute successfully
+# and return NULL.
+statement ok
+CREATE FUNCTION f93083() RETURNS INT LANGUAGE SQL AS '';
+
+query I
+SELECT f93083()
+----
+NULL

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -539,7 +539,7 @@ func (b *Builder) buildFunction(
 	}
 
 	overload := f.ResolvedOverload()
-	if overload.Body != "" {
+	if overload.IsUDF {
 		return b.buildUDF(f, def, inScope, outScope, outCol, colRefs)
 	}
 

--- a/pkg/sql/opt/testutils/testcat/function.go
+++ b/pkg/sql/opt/testutils/testcat/function.go
@@ -95,6 +95,7 @@ func (tc *Catalog) CreateFunction(c *tree.CreateFunction) {
 	overload := &tree.Overload{
 		Types:             paramTypes,
 		ReturnType:        tree.FixedReturnType(retType),
+		IsUDF:             true,
 		Body:              body,
 		Volatility:        v,
 		CalledOnNullInput: calledOnNullInput,


### PR DESCRIPTION
This commit fixes a bug that an caused internal error when executing a UDF with an empty body.

Epic: None

Fixes #93083

Release notes (bug fix): A bug has been fixed that caused an internal error when trying to execute a UDF with an empty function body. This bug was present since UDFs were introduced in version 22.2.0.