### PR TITLE
kvserver: clarify consistency checker stats delta message

### DIFF
--- a/pkg/kv/kvnemesis/env.go
+++ b/pkg/kv/kvnemesis/env.go
@@ -75,7 +75,7 @@ func (e *Env) CheckConsistency(ctx context.Context, span roachpb.Span) []error {
 		case roachpb.CheckConsistencyResponse_RANGE_CONSISTENT_STATS_ESTIMATED.String():
 			// Ok.
 		default:
-			failures = append(failures, errors.Errorf("range %d (%s) %s: %s", rangeID, key, status, detail))
+			failures = append(failures, errors.Errorf("range %d (%s) %s:\n%s", rangeID, key, status, detail))
 		}
 	}
 	return failures

--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -191,7 +191,8 @@ func (r *Replica) checkConsistencyImpl(
 			// or stats maintenance, but it could also hint at the replica having diverged from its peers.
 			res.Status = roachpb.CheckConsistencyResponse_RANGE_CONSISTENT_STATS_INCORRECT
 		}
-		res.Detail += fmt.Sprintf("stats - recomputation: %+v\n", enginepb.MVCCStats(results[0].Response.Delta))
+		res.Detail += fmt.Sprintf("delta (stats-computed): %+v\n",
+			enginepb.MVCCStats(results[0].Response.Delta))
 	} else if len(missing) > 0 {
 		// No inconsistency was detected, but we didn't manage to inspect all replicas.
 		res.Status = roachpb.CheckConsistencyResponse_RANGE_INDETERMINATE


### PR DESCRIPTION
The error message on consistency checker stats mismatches could be misleading. E.g. a test failure said:

```
RANGE_CONSISTENT_STATS_INCORRECT: stats: {ContainsEstimates:0 LastUpdateNanos:1670581562071848089 IntentAge:0 GCBytesAge:22800 LiveBytes:0 LiveCount:0 KeyBytes:0 KeyCount:0 ValBytes:0 ValCount:0 IntentBytes:0 IntentCount:0 SeparatedIntentCount:0 RangeKeyCount:1 RangeKeyBytes:60 RangeValCount:2 RangeValBytes:20 SysBytes:4314 SysCount:51 AbortSpanBytes:3927}
stats - recomputation: {ContainsEstimates:0 LastUpdateNanos:1670581562071848089 IntentAge:0 GCBytesAge:0 LiveBytes:0 LiveCount:0 KeyBytes:0 KeyCount:0 ValBytes:0 ValCount:0 IntentBytes:0 IntentCount:0 SeparatedIntentCount:0 RangeKeyCount:0 RangeKeyBytes:0 RangeValCount:0 RangeValBytes:0 SysBytes:10 SysCount:0 AbortSpanBytes:0}
```

This could be read as "recomputed stats", i.e. the absolute value of the recomputed stats, indicating possible data loss. However, it is the delta of the stats minus the recomputed stats, i.e. a 10-byte discrepancy in `SysBytes`. This patch clarifies the message.

Touches #93312.

Epic: none
Release note: None