### PR TITLE
sql: partition lease table when optimizing system database for MR

### DIFF
--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -2470,6 +2470,7 @@ func (p *planner) OptimizeSystemDatabase(ctx context.Context) error {
 	rbrTables := []string{
 		"sqlliveness",
 		"sql_instances",
+		"lease",
 	}
 
 	if !systemschema.TestSupportMultiRegion() {


### PR DESCRIPTION
This is an oversight from #92588. Testing will come in #92826.

Epic: CRDB-18596

Release note: None