### PR TITLE
cli: demo uses in-process tenant infrastructure by default

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -330,4 +330,8 @@ type TestTenantArgs struct {
 	// CockroachDB upgrades and periodically reports diagnostics to
 	// Cockroach Labs. Should remain disabled during unit testing.
 	StartDiagnosticsReporting bool
+
+	// InProcessTenant is used to initialize tenants through the
+	// kv server's `serverController` in the same process.
+	InProcessTenant bool
 }

--- a/pkg/bench/BUILD.bazel
+++ b/pkg/bench/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//pkg/base",
         "//pkg/ccl",
+        "//pkg/roachpb",
         "//pkg/server",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",

--- a/pkg/bench/foreachdb.go
+++ b/pkg/bench/foreachdb.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
@@ -67,7 +68,7 @@ func benchmarkTenantCockroach(b *testing.B, f BenchmarkFn) {
 	require.NoError(b, err)
 
 	// Get a SQL connection to the test tenant.
-	sqlAddr := s.(*server.TestServer).TestingGetSQLAddrForTenant(ctx, tenantName)
+	sqlAddr := s.(*server.TestServer).TestingGetSQLAddrForTenant(ctx, roachpb.TenantName(tenantName))
 	tenantDB := serverutils.OpenDBConn(b, sqlAddr, "bench", false, s.Stopper())
 
 	// The benchmarks sometime hit the default span limit, so we increase it.

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -1333,7 +1333,16 @@ More information about the geo-partitioned replicas topology can be found at:
 		Description: `
 If set, cockroach demo will start separate in-memory KV and SQL servers in multi-tenancy mode.
 The SQL shell will be connected to the first tenant, and can be switched between tenants
-and the system tenant using the \connect command.`,
+and the system tenant using the \connect command. By default the tenant will be initialized
+in-process. Use --simulate-separate-tenant-process to emulate a separate tenant process.
+`,
+	}
+
+	DemoInProcessTenant = FlagInfo{
+		Name: "in-process-tenant",
+		Description: `
+If set, and --multitenant is set to true, the tenant process will be started
+in-process.`,
 	}
 
 	DemoNoLicense = FlagInfo{

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -618,6 +618,7 @@ func setDemoContextDefaults() {
 	demoCtx.HTTPPort, _ = strconv.Atoi(base.DefaultHTTPPort)
 	demoCtx.WorkloadMaxQPS = 25
 	demoCtx.Multitenant = true
+	demoCtx.InProcessTenant = true
 	demoCtx.DefaultEnableRangefeeds = true
 
 	demoCtx.pidFile = ""

--- a/pkg/cli/democluster/context.go
+++ b/pkg/cli/democluster/context.go
@@ -97,6 +97,9 @@ type Context struct {
 	// DefaultEnableRangefeeds is true if rangefeeds should start
 	// out enabled.
 	DefaultEnableRangefeeds bool
+
+	// InProcessTenant is true if we want to emulate an in-process tenant.
+	InProcessTenant bool
 }
 
 // IsInteractive returns true if the demo cluster configuration

--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -444,6 +444,7 @@ func (c *transientCluster) Start(ctx context.Context) (err error) {
 							},
 						},
 					},
+					InProcessTenant: c.demoCtx.InProcessTenant,
 				})
 				c.stopper.AddCloser(stop.CloserFn(func() {
 					stopCtx := context.Background()

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -793,9 +793,11 @@ func init() {
 		cliflagcfg.BoolFlag(f, &demoCtx.DefaultEnableRangefeeds, cliflags.DemoEnableRangefeeds)
 
 		cliflagcfg.BoolFlag(f, &demoCtx.Multitenant, cliflags.DemoMultitenant)
+		cliflagcfg.BoolFlag(f, &demoCtx.InProcessTenant, cliflags.DemoInProcessTenant)
 		// TODO(knz): Currently the multitenant UX for 'demo' is not
 		// satisfying for end-users. Let's not advertise it too much.
 		_ = f.MarkHidden(cliflags.DemoMultitenant.Name)
+		_ = f.MarkHidden(cliflags.DemoInProcessTenant.Name)
 
 		cliflagcfg.BoolFlag(f, &demoCtx.SimulateLatency, cliflags.Global)
 		// We also support overriding the GEOS library path for 'demo'.

--- a/pkg/server/debug/server.go
+++ b/pkg/server/debug/server.go
@@ -68,7 +68,7 @@ type Server struct {
 	spy        logSpy
 }
 
-type serverTickleFn = func(ctx context.Context, name string) error
+type serverTickleFn = func(ctx context.Context, name roachpb.TenantName) error
 
 // NewServer sets up a debug server.
 func NewServer(
@@ -301,7 +301,7 @@ func (h handleTickle) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	ctx := r.Context()
-	err := serverTickleFn(h)(ctx, name)
+	err := serverTickleFn(h)(ctx, roachpb.TenantName(name))
 	if err != nil {
 		fmt.Fprint(w, err)
 		return

--- a/pkg/server/node_http_router_test.go
+++ b/pkg/server/node_http_router_test.go
@@ -193,6 +193,7 @@ func TestRouteToNode(t *testing.T) {
 
 		resp, err := client.Get(s.AdminURL() + fmt.Sprintf("/_status/vars?%s=%s", RemoteNodeID, "2"))
 		require.NoError(t, err)
+		defer resp.Body.Close()
 		// We expect some error here. It's difficult to know what
 		// will happen because in different stress scenarios, the
 		// node may still have an address available, in which

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -990,7 +990,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		// TODO(knz): Remove this once
 		// https://github.com/cockroachdb/cockroach/issues/84585 is
 		// implemented.
-		func(ctx context.Context, name string) error {
+		func(ctx context.Context, name roachpb.TenantName) error {
 			d, err := sc.getOrCreateServer(ctx, name)
 			if err != nil {
 				return err

--- a/pkg/server/server_controller.go
+++ b/pkg/server/server_controller.go
@@ -88,7 +88,7 @@ type serverEntry struct {
 // If the specified tenant name is invalid (tenant does not exist or
 // is not active), the returned error will contain the
 // ErrInvalidTenant mark, which can be checked with errors.Is.
-type newServerFn func(ctx context.Context, tenantName string, index int, deregister func()) (onDemandServer, error)
+type newServerFn func(ctx context.Context, tenantName roachpb.TenantName, index int, deregister func()) (onDemandServer, error)
 
 // serverController manages a fleet of multiple servers side-by-side.
 // They are instantiated on demand the first time they are accessed.
@@ -108,7 +108,7 @@ type serverController struct {
 		//
 		// TODO(knz): Detect when the mapping of name to tenant ID has
 		// changed, and invalidate the entry.
-		servers map[string]serverEntry
+		servers map[roachpb.TenantName]serverEntry
 
 		// nextServerIdx is the index to provide to the next call to
 		// newServerFn.
@@ -126,7 +126,7 @@ func newServerController(
 		stopper:     parentStopper,
 		newServerFn: newServerFn,
 	}
-	c.mu.servers = map[string]serverEntry{
+	c.mu.servers = map[roachpb.TenantName]serverEntry{
 		catconstants.SystemTenantName: {
 			server:     systemServer,
 			shouldStop: false,
@@ -140,7 +140,7 @@ func newServerController(
 // the given tenant name, and instantiates the server if none exists
 // yet.
 func (c *serverController) getOrCreateServer(
-	ctx context.Context, tenantName string,
+	ctx context.Context, tenantName roachpb.TenantName,
 ) (onDemandServer, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -227,21 +227,21 @@ func (c *serverController) httpMux(w http.ResponseWriter, r *http.Request) {
 	s.getHTTPHandlerFn()(w, r)
 }
 
-func getTenantNameFromHTTPRequest(r *http.Request) (string, bool) {
+func getTenantNameFromHTTPRequest(r *http.Request) (roachpb.TenantName, bool) {
 	// Highest priority is manual override on the URL query parameters.
 	const tenantNameParamInQueryURL = "tenant_name"
 	if tenantName := r.URL.Query().Get(tenantNameParamInQueryURL); tenantName != "" {
-		return tenantName, true
+		return roachpb.TenantName(tenantName), true
 	}
 
 	// If not in parameters, try an explicit header.
 	if tenantName := r.Header.Get(TenantSelectHeader); tenantName != "" {
-		return tenantName, true
+		return roachpb.TenantName(tenantName), true
 	}
 
 	// No parameter, no explicit header. Is there a cookie?
 	if c, _ := r.Cookie(TenantSelectCookieName); c != nil && c.Value != "" {
-		return c.Value, true
+		return roachpb.TenantName(c.Value), true
 	}
 
 	// No luck so far.
@@ -251,8 +251,8 @@ func getTenantNameFromHTTPRequest(r *http.Request) (string, bool) {
 	return catconstants.SystemTenantName, false
 }
 
-func (c *serverController) getCurrentTenantNames() []string {
-	var serverNames []string
+func (c *serverController) getCurrentTenantNames() []roachpb.TenantName {
+	var serverNames []roachpb.TenantName
 	c.mu.Lock()
 	for name := range c.mu.servers {
 		serverNames = append(serverNames, name)
@@ -261,10 +261,10 @@ func (c *serverController) getCurrentTenantNames() []string {
 	return serverNames
 }
 
-func getSessionFromCookie(sessionStr string, name string) string {
+func getSessionFromCookie(sessionStr string, name roachpb.TenantName) string {
 	sessionsInfo := strings.Split(sessionStr, ",")
 	for idx, info := range sessionsInfo {
-		if info == name && idx != 0 {
+		if info == string(name) && idx != 0 {
 			return sessionsInfo[idx-1]
 		}
 	}
@@ -311,7 +311,7 @@ func (c *serverController) attemptLoginToAllTenants() http.Handler {
 				log.Warningf(ctx, "unable to find session cookie for tenant %q", name)
 			} else {
 				tenantNameToSetCookieSlice = append(tenantNameToSetCookieSlice, sessionCookieValue{
-					name:      name,
+					name:      string(name),
 					setCookie: setCookieHeader,
 				})
 			}
@@ -434,7 +434,7 @@ func (c *serverController) attemptLogoutFromAllTenants() http.Handler {
 
 // TestingGetSQLAddrForTenant extracts the SQL address for the target tenant.
 // Used in tests until https://github.com/cockroachdb/cockroach/issues/84585 is resolved.
-func (s *Server) TestingGetSQLAddrForTenant(ctx context.Context, tenant string) string {
+func (s *Server) TestingGetSQLAddrForTenant(ctx context.Context, tenant roachpb.TenantName) string {
 	ts, err := s.serverController.getOrCreateServer(ctx, tenant)
 	if err != nil {
 		panic(err)
@@ -460,7 +460,7 @@ var ErrInvalidTenant error = errInvalidTenantMarker{}
 // is not active), the returned error will contain the
 // ErrInvalidTenant mark, which can be checked with errors.Is.
 func (s *Server) newServerForTenant(
-	ctx context.Context, tenantName string, index int, deregister func(),
+	ctx context.Context, tenantName roachpb.TenantName, index int, deregister func(),
 ) (onDemandServer, error) {
 	// Look up the ID of the requested tenant.
 	//

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -797,7 +797,7 @@ func (ts *TestServer) StartTenant(
 			}
 		} else if params.TenantName != "" {
 			_, err := ts.InternalExecutor().(*sql.InternalExecutor).Exec(ctx, "rename-test-tenant", nil,
-				`SELECT crdb_internal.rename_tenant($1, $2)`, params.TenantID, params.TenantName)
+				`SELECT crdb_internal.rename_tenant($1, $2)`, params.TenantID.ToUint64(), params.TenantName)
 			if err != nil {
 				return nil, err
 			}
@@ -927,39 +927,62 @@ func (ts *TestServer) StartTenant(
 		baseCfg.HTTPAddr = newAddr
 		baseCfg.HTTPAdvertiseAddr = newAddr
 	}
-	sw, err := NewTenantServer(
-		ctx,
-		stopper,
-		baseCfg,
-		sqlCfg,
-	)
+
+	if !params.InProcessTenant {
+		sw, err := NewTenantServer(
+			ctx,
+			stopper,
+			baseCfg,
+			sqlCfg,
+		)
+		if err != nil {
+			return nil, err
+		}
+		go func() {
+			// If the server requests a shutdown, do that simply by stopping the
+			// tenant's stopper.
+			select {
+			case <-sw.ShutdownRequested():
+				stopper.Stop(sw.AnnotateCtx(context.Background()))
+			case <-stopper.ShouldQuiesce():
+			}
+		}()
+
+		if err := sw.Start(ctx); err != nil {
+			return nil, err
+		}
+
+		hts := &httpTestServer{}
+		hts.t.authentication = sw.authentication
+		hts.t.sqlServer = sw.sqlServer
+
+		return &TestTenant{
+			SQLServer:      sw.sqlServer,
+			Cfg:            &baseCfg,
+			httpTestServer: hts,
+			drain:          sw.drainServer,
+		}, err
+	}
+
+	ts.serverController.tenantBaseCfg = &baseCfg
+	onDemandServer, err := ts.serverController.getOrCreateServer(ctx, params.TenantName)
 	if err != nil {
 		return nil, err
 	}
-	go func() {
-		// If the server requests a shutdown, do that simply by stopping the
-		// tenant's stopper.
-		select {
-		case <-sw.ShutdownRequested():
-			stopper.Stop(sw.AnnotateCtx(context.Background()))
-		case <-stopper.ShouldQuiesce():
-		}
-	}()
-
-	if err := sw.Start(ctx); err != nil {
-		return nil, err
-	}
+	sw := onDemandServer.(*tenantServerWrapper)
 
 	hts := &httpTestServer{}
-	hts.t.authentication = sw.authentication
-	hts.t.sqlServer = sw.sqlServer
+	hts.t.authentication = sw.server.authentication
+	hts.t.sqlServer = sw.server.sqlServer
+	hts.t.tenantName = params.TenantName
 
 	return &TestTenant{
-		SQLServer:      sw.sqlServer,
-		Cfg:            &baseCfg,
+		SQLServer:      sw.server.sqlServer,
+		Cfg:            sw.server.sqlServer.cfg,
 		httpTestServer: hts,
-		drain:          sw.drainServer,
+		drain:          sw.server.drainServer,
 	}, err
+
 }
 
 // ExpectedInitialRangeCount returns the expected number of ranges that should

--- a/pkg/server/testserver_http.go
+++ b/pkg/server/testserver_http.go
@@ -19,6 +19,7 @@ import (
 	"net/url"
 	"sync"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -33,6 +34,7 @@ type httpTestServer struct {
 		// of *Server, which are also embedded in TestServer.
 		authentication *authenticationServer
 		sqlServer      *SQLServer
+		tenantName     roachpb.TenantName
 	}
 
 	// authClient is an http.Client that has been authenticated to access the
@@ -45,6 +47,19 @@ type httpTestServer struct {
 	}
 }
 
+type tenantHeaderDecorator struct {
+	http.RoundTripper
+
+	tenantName roachpb.TenantName
+}
+
+func (t tenantHeaderDecorator) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Add(TenantSelectHeader, string(t.tenantName))
+	return t.RoundTripper.RoundTrip(req)
+}
+
+var _ http.RoundTripper = &tenantHeaderDecorator{}
+
 // AdminURL implements TestServerInterface.
 func (ts *httpTestServer) AdminURL() string {
 	return ts.t.sqlServer.execCfg.RPCContext.Config.AdminURL().String()
@@ -52,7 +67,15 @@ func (ts *httpTestServer) AdminURL() string {
 
 // GetUnauthenticatedHTTPClient implements TestServerInterface.
 func (ts *httpTestServer) GetUnauthenticatedHTTPClient() (http.Client, error) {
-	return ts.t.sqlServer.execCfg.RPCContext.GetHTTPClient()
+	client, err := ts.t.sqlServer.execCfg.RPCContext.GetHTTPClient()
+	if err != nil {
+		return client, err
+	}
+	client.Transport = &tenantHeaderDecorator{
+		RoundTripper: client.Transport,
+		tenantName:   ts.t.tenantName,
+	}
+	return client, nil
 }
 
 // GetAdminHTTPClient implements the TestServerInterface.
@@ -128,9 +151,12 @@ func (ts *httpTestServer) getAuthenticatedHTTPClientAndCookie(
 			if err != nil {
 				return err
 			}
-			authClient.httpClient.Transport = &v2AuthDecorator{
-				RoundTripper: authClient.httpClient.Transport,
-				session:      base64.StdEncoding.EncodeToString(rawCookieBytes),
+			authClient.httpClient.Transport = &tenantHeaderDecorator{
+				RoundTripper: &v2AuthDecorator{
+					RoundTripper: authClient.httpClient.Transport,
+					session:      base64.StdEncoding.EncodeToString(rawCookieBytes),
+				},
+				tenantName: ts.t.tenantName,
 			}
 			authClient.httpClient.Jar = cookieJar
 			authClient.cookie = rawCookie


### PR DESCRIPTION
Previously, using `--multitenant=true` in demo would run an in-process tenant
that was configured to behave like an out-of-process one.

Given the goal of a unified architecture where all SQL interactions occur with
a tenant context, the multitenant demo will now use the `serverController` to
instantiate tenants, which will mimic UA clusters that will be the default in
the future.

An additional flag `--in-process-tenant` has been added that allows for
overriding this behavior at runtime. Setting this to `false` will use the test
server tenant infra that simulates an "out of process" tenant. This behavior
was retained also to keep prior tenant tests stable.

Informs #94310
Informs #94308.
Epic: CRDB-14537

Release note: None