### PR TITLE
cli/demo: ensure that the user sees FATAL output

### DIFF
--- a/pkg/cli/interactive_tests/test_log_flags.tcl
+++ b/pkg/cli/interactive_tests/test_log_flags.tcl
@@ -80,6 +80,19 @@ send "$argv debug reset-quorum 123 --log='sinks: {stderr: {format: json }}'\r"
 eexpect "\"severity\":\"ERROR\""
 eexpect "connection to server failed"
 eexpect ":/# "
+end_test
+
+start_test "Check that by default, cockroach demo shows the fatal errors"
+send "$argv demo --no-line-editor --empty\r"
+eexpect "Welcome"
+eexpect "root@"
+eexpect "defaultdb>"
+send "select crdb_internal.force_log_fatal('hello'||'world');\r"
+eexpect "helloworld"
+eexpect "appreciates your feedback"
+eexpect ":/# "
+end_test
+
 
 send "exit 0\r"
 eexpect eof

--- a/pkg/cli/log_flags.go
+++ b/pkg/cli/log_flags.go
@@ -92,8 +92,12 @@ func setupLogging(ctx context.Context, cmd *cobra.Command, isServerCmd, applyCon
 	if isDemoCmd(cmd) {
 		// `cockroach demo` is special: it starts a server, but without
 		// disk and interactively. We don't want to litter the console
-		// with warning or error messages unless overridden.
-		h.Config.Sinks.Stderr.Filter = severity.NONE
+		// with warning or error messages unless overridden; however,
+		// should the command encounter a log.Fatal event, we want
+		// to inform the user (who is guaranteed to be looking at the screen).
+		//
+		// NB: this can be overridden from the command line as usual.
+		h.Config.Sinks.Stderr.Filter = severity.FATAL
 	} else if !isServerCmd && !isWorkloadCmd(cmd) {
 		// Client commands don't typically have a log directory so they
 		// naturally default to stderr logging. However, we don't want

--- a/pkg/cli/testdata/logflags
+++ b/pkg/cli/testdata/logflags
@@ -123,7 +123,7 @@ demo
 config: {<fileDefaultsNoDir>,
 <fluentDefaults>,
 <httpDefaults>,
-sinks: {<stderrCfg(NONE,false)>}}
+sinks: {<stderrCfg(FATAL,false)>}}
 
 
 subtest end


### PR DESCRIPTION
Fixes #93320.

Prior to this patch, when running `cockroach demo`, and the process runs into an internal error resulting in a FATAL event, the process would terminate with status code 7 (as expected) but nothing was printed on the screen. This latter part is confusing and sub-optimal:

- `cockroach demo` is used with a human in front of the screen, and that human is "learning" / "exploring", and thus surprised if something breaks without feedback.
- `demo` does not otherwise save logging output to files where the fatal event could be inspected afterwards.

This commit fixes that.

Release note: None