### PR TITLE
bazci: fix null pointer exception

### DIFF
--- a/pkg/cmd/bazci/bazci.go
+++ b/pkg/cmd/bazci/bazci.go
@@ -210,7 +210,7 @@ func (s *monitorBuildServer) handleBuildEvent(
 				if testResult.run > 1 {
 					outputDir = filepath.Join(outputDir, fmt.Sprintf("run_%d", testResult.run))
 				}
-				if summary.ShardCount > 1 {
+				if summary != nil && summary.ShardCount > 1 {
 					outputDir = filepath.Join(outputDir, fmt.Sprintf("shard_%d_of_%d", testResult.shard, summary.ShardCount))
 				}
 				if testResult.attempt > 1 {


### PR DESCRIPTION
Under some circumstances (failed builds) this test summary will be
empty. I'm not sure exactly why, but this fixes a null pointer
exception that otherwise pops up in this scenario.

Closes #93522.

Epic: None
Release note: None