### PR TITLE
tracing: set redactability on individual spans (and their children)

### DIFF
--- a/pkg/util/tracing/BUILD.bazel
+++ b/pkg/util/tracing/BUILD.bazel
@@ -84,6 +84,7 @@ go_test(
         "//pkg/util/tracing/tracingpb",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_gogo_protobuf//types",
         "@com_github_stretchr_testify//require",
         "@io_opentelemetry_go_otel//attribute",

--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -1149,6 +1149,9 @@ func (s *crdbSpan) getRecordingNoChildrenLocked(
 		if s.recordingType() == tracingpb.RecordingVerbose {
 			rs.EnsureTagGroup(tracingpb.AnonymousTagGroupName).AddTag("_verbose", "1")
 		}
+		if s.sp.i.redactable || s.tracer.Redactable() {
+			rs.EnsureTagGroup(tracingpb.AnonymousTagGroupName).AddTag("_redactable", "")
+		}
 		if s.mu.recording.droppedLogs {
 			rs.EnsureTagGroup(tracingpb.AnonymousTagGroupName).AddTag("_dropped_logs", "")
 		}

--- a/pkg/util/tracing/test_utils.go
+++ b/pkg/util/tracing/test_utils.go
@@ -174,6 +174,14 @@ func CheckRecordedSpans(rec tracingpb.Recording, expected string) error {
 //	    t.Fatal(err)
 //	}
 func CheckRecording(rec tracingpb.Recording, expected string) error {
+	return checkRecording(rec, expected, false /* redact */)
+}
+
+func CheckRedactedRecording(rec tracingpb.Recording, expected string) error {
+	return checkRecording(rec, expected, true /* redact */)
+}
+
+func checkRecording(rec tracingpb.Recording, expected string, redact bool) error {
 	normalize := func(rec string) string {
 		// normalize the string form of a recording for ease of comparison.
 		//
@@ -231,8 +239,14 @@ func CheckRecording(rec tracingpb.Recording, expected string) error {
 		sortChildrenMetadataByName(rec[i].ChildrenMetadata)
 	}
 
+	var got string
+	if redact {
+		got = string(rec.Redact())
+	} else {
+		got = rec.String()
+	}
 	exp := normalize(expected)
-	got := normalize(rec.String())
+	got = normalize(got)
 	if got != exp {
 		diff := difflib.UnifiedDiff{
 			A:        difflib.SplitLines(exp),

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -979,6 +979,7 @@ func (t *Tracer) newSpan(
 	otelSpan oteltrace.Span,
 	netTr trace.Trace,
 	sterile bool,
+	redactable bool,
 ) *Span {
 	if t.testing.MaintainAllocationCounters {
 		atomic.AddInt32(&t.spansCreated, 1)
@@ -987,7 +988,7 @@ func (t *Tracer) newSpan(
 	h.span.reset(
 		traceID, spanID, operation, goroutineID,
 		startTime, logTags, eventListeners, kind,
-		otelSpan, netTr, sterile)
+		otelSpan, netTr, sterile, redactable)
 	return &h.span
 }
 
@@ -1190,7 +1191,7 @@ child operation: %s, tracer created at:
 	s := t.newSpan(
 		traceID, spanID, opName, uint64(goid.Get()),
 		startTime, opts.LogTags, opts.EventListeners, opts.SpanKind,
-		otelSpan, netTr, opts.Sterile)
+		otelSpan, netTr, opts.Sterile, opts.redactable())
 
 	s.i.crdb.SetRecordingType(opts.recordingType())
 	s.i.crdb.parentSpanID = opts.parentSpanID()

--- a/pkg/util/tracing/tracingpb/recorded_span.go
+++ b/pkg/util/tracing/tracingpb/recorded_span.go
@@ -196,5 +196,5 @@ func (m OperationMetadata) SafeFormat(s redact.SafePrinter, _ rune) {
 	if m.ContainsUnfinished {
 		s.Printf(", unfinished")
 	}
-	s.Print("}")
+	s.Printf("}")
 }

--- a/pkg/util/tracing/tracingpb/tracing.proto
+++ b/pkg/util/tracing/tracingpb/tracing.proto
@@ -43,5 +43,6 @@ message TraceInfo {
   }
 
   OtelInfo otel = 4;
-}
 
+  bool redactable = 5;
+}


### PR DESCRIPTION
For redaction of statement diagnostics bundles we need the ability to redact traces of query execution. The general ability to redact traces was added in #70562 and #73405, but due to performance impact, fine-grained redaction was turned off by default and redactability was made configurable per tracer.

When tracing query execution for a redacted statement bundle, we want fine-grained redaction for a specific span (and its children) regardless of its tracer's redactability. This change addresses this by plumbing through a flag to set redactability on individual spans, which is inherited by child spans.

(I considered making this another recording mode instead of a separate field, but redactability seems like an orthogonal concern to verbose or structured recording mode. Plus we may want to remove this flag one day if we enable fine-grained redaction for all traces, and that will be easier with it as a separate field.)

Epic: CRDB-19756

Release note: None