### PR TITLE
release-22.2: sql: improve and clean up tracing a bit

### DIFF
--- a/pkg/sql/colexec/columnarizer.go
+++ b/pkg/sql/colexec/columnarizer.go
@@ -63,6 +63,12 @@ type Columnarizer struct {
 	metadataAllocator *colmem.Allocator
 	input             execinfra.RowSource
 	da                tree.DatumAlloc
+	// getWrappedExecStats, if non-nil, is the function to get the execution
+	// statistics of the wrapped row-by-row processor. We store it separately
+	// from execinfra.ProcessorBaseNoHelper.ExecStatsForTrace so that the
+	// function is not called when the columnarizer is being drained (which is
+	// after the vectorized stats are processed).
+	getWrappedExecStats func() *execinfrapb.ComponentStats
 
 	batch           coldata.Batch
 	vecs            coldata.TypedVecs
@@ -177,7 +183,7 @@ func (c *Columnarizer) Init(ctx context.Context) {
 	}
 	c.initialized = true
 	c.accumulatedMeta = make([]execinfrapb.ProducerMetadata, 0, 1)
-	ctx = c.StartInternalNoSpan(ctx)
+	ctx = c.StartInternal(ctx, "columnarizer" /* name */)
 	c.input.Start(ctx)
 	if execStatsHijacker, ok := c.input.(execinfra.ExecStatsForTraceHijacker); ok {
 		// The columnarizer is now responsible for propagating the execution
@@ -191,7 +197,7 @@ func (c *Columnarizer) Init(ctx context.Context) {
 		// Still, just to be safe, we delay the hijacking until Init so that in
 		// case the assumption is wrong, we still get the stats from the wrapped
 		// processor.
-		c.ExecStatsForTrace = execStatsHijacker.HijackExecStatsForTrace()
+		c.getWrappedExecStats = execStatsHijacker.HijackExecStatsForTrace()
 	}
 }
 
@@ -203,10 +209,10 @@ func (c *Columnarizer) GetStats() *execinfrapb.ComponentStats {
 		))
 	}
 	componentID := c.FlowCtx.ProcessorComponentID(c.ProcessorID)
-	if c.removedFromFlow || c.ExecStatsForTrace == nil {
+	if c.removedFromFlow || c.getWrappedExecStats == nil {
 		return &execinfrapb.ComponentStats{Component: componentID}
 	}
-	s := c.ExecStatsForTrace()
+	s := c.getWrappedExecStats()
 	s.Component = componentID
 	return s
 }

--- a/pkg/sql/colexec/materializer.go
+++ b/pkg/sql/colexec/materializer.go
@@ -260,19 +260,7 @@ func (m *Materializer) OutputTypes() []*types.T {
 
 // Start is part of the execinfra.RowSource interface.
 func (m *Materializer) Start(ctx context.Context) {
-	if len(m.drainHelper.statsCollectors) > 0 {
-		// Since we're collecting stats, we'll derive a separate tracing span
-		// for them. If we don't do this, then the stats would be attached to
-		// the span of the materializer's user, and if that user itself has a
-		// lot of payloads to attach (e.g. a joinReader attaching the KV keys it
-		// looked up), then the stats might be dropped based on the maximum size
-		// of structured payload per tracing span of 10KiB (see
-		// tracing.maxStructuredBytesPerSpan). Deriving a separate span
-		// guarantees that the stats won't be dropped.
-		ctx = m.StartInternal(ctx, "materializer" /* name */)
-	} else {
-		ctx = m.StartInternalNoSpan(ctx)
-	}
+	ctx = m.StartInternal(ctx, "materializer" /* name */)
 	// We can encounter an expected error during Init (e.g. an operator
 	// attempts to allocate a batch, but the memory budget limit has been
 	// reached), so we need to wrap it with a catcher.

--- a/pkg/sql/colflow/colrpc/BUILD.bazel
+++ b/pkg/sql/colflow/colrpc/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_cockroachdb_redact//:redact",
+        "@io_opentelemetry_go_otel//attribute",
     ],
 )
 

--- a/pkg/sql/colflow/colrpc/outbox.go
+++ b/pkg/sql/colflow/colrpc/outbox.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"github.com/cockroachdb/redact"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 // flowStreamClient is a utility interface used to mock out the RPC layer.
@@ -165,6 +166,8 @@ func (o *Outbox) Run(
 	ctx, o.span = execinfra.ProcessorSpan(ctx, "outbox")
 	if o.span != nil {
 		defer o.span.Finish()
+		o.span.SetTag(execinfrapb.FlowIDTagKey, attribute.StringValue(flowID.String()))
+		o.span.SetTag(execinfrapb.StreamIDTagKey, attribute.IntValue(int(streamID)))
 	}
 
 	o.runnerCtx = ctx

--- a/pkg/sql/colflow/flow_coordinator.go
+++ b/pkg/sql/colflow/flow_coordinator.go
@@ -117,7 +117,7 @@ func (f *FlowCoordinator) OutputTypes() []*types.T {
 
 // Start is part of the execinfra.RowSource interface.
 func (f *FlowCoordinator) Start(ctx context.Context) {
-	ctx = f.StartInternalNoSpan(ctx)
+	ctx = f.StartInternal(ctx, "flow coordinator" /* name */)
 	if err := colexecerror.CatchVectorizedRuntimeError(func() {
 		f.input.Start(ctx)
 	}); err != nil {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2700,35 +2700,14 @@ func getMessagesForSubtrace(
 		return nil, errors.Errorf("duplicate span %d", span.SpanID)
 	}
 	var allLogs []logRecordRow
-	const spanStartMsgTemplate = "=== SPAN START: %s ==="
 
-	// spanStartMsgs are metadata about the span, e.g. the operation name and tags
-	// contained in the span. They are added as one log message.
-	spanStartMsgs := make([]string, 0)
-
-	spanStartMsgs = append(spanStartMsgs, fmt.Sprintf(spanStartMsgTemplate, span.Operation))
-
-	for _, tg := range span.TagGroups {
-		var prefix string
-		if tg.Name != tracingpb.AnonymousTagGroupName {
-			prefix = fmt.Sprintf("%s-", tg.Name)
-		}
-		for _, tag := range tg.Tags {
-			if !strings.HasPrefix(tag.Key, tracing.TagPrefix) {
-				// Not a tag to be output.
-				continue
-			}
-			spanStartMsgs = append(spanStartMsgs, fmt.Sprintf("%s%s: %s", prefix, tag.Key, tag.Value))
-		}
-	}
-
-	// This message holds all the spanStartMsgs and marks the beginning of the
-	// span, to indicate the start time and duration of the span.
+	// This message marks the beginning of the span, to indicate the start time
+	// and duration of the span.
 	allLogs = append(
 		allLogs,
 		logRecordRow{
 			timestamp: span.StartTime,
-			msg:       strings.Join(spanStartMsgs, "\n"),
+			msg:       fmt.Sprintf("=== SPAN START: %s ===", span.Operation),
 			span:      span,
 			index:     0,
 		},

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1497,10 +1497,6 @@ type ExecutorTestingKnobs struct {
 	// to use a transaction, and, in doing so, more deterministically allocate
 	// descriptor IDs at the cost of decreased parallelism.
 	UseTransactionalDescIDGenerator bool
-
-	// NoStatsCollectionWithVerboseTracing is used to disable the execution
-	// statistics collection in presence of the verbose tracing.
-	NoStatsCollectionWithVerboseTracing bool
 }
 
 // PGWireTestingKnobs contains knobs for the pgwire module.

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -850,24 +850,11 @@ func ProcessorSpan(ctx context.Context, name string) (context.Context, *tracing.
 //
 // so that the caller doesn't mistakenly use old ctx object.
 func (pb *ProcessorBaseNoHelper) StartInternal(ctx context.Context, name string) context.Context {
-	return pb.startImpl(ctx, true /* createSpan */, name)
-}
-
-// StartInternalNoSpan does the same as StartInternal except that it does not
-// start a span. This is used by pass-through components whose goal is to be a
-// silent translation layer for components that actually do work (e.g. a
-// planNodeToRowSource wrapping an insertNode, or a columnarizer wrapping a
-// rowexec flow).
-func (pb *ProcessorBaseNoHelper) StartInternalNoSpan(ctx context.Context) context.Context {
-	return pb.startImpl(ctx, false /* createSpan */, "")
-}
-
-func (pb *ProcessorBaseNoHelper) startImpl(
-	ctx context.Context, createSpan bool, spanName string,
-) context.Context {
 	pb.origCtx = ctx
-	if createSpan {
-		pb.ctx, pb.span = ProcessorSpan(ctx, spanName)
+	noSpan := pb.FlowCtx != nil && pb.FlowCtx.Cfg != nil &&
+		pb.FlowCtx.Cfg.TestingKnobs.ProcessorNoTracingSpan
+	if !noSpan {
+		pb.ctx, pb.span = ProcessorSpan(ctx, name)
 		if pb.span != nil && pb.span.IsVerbose() {
 			pb.span.SetTag(execinfrapb.FlowIDTagKey, attribute.StringValue(pb.FlowCtx.ID.String()))
 			pb.span.SetTag(execinfrapb.ProcessorIDTagKey, attribute.IntValue(int(pb.ProcessorID)))

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -299,6 +299,10 @@ type TestingKnobs struct {
 	// when responding to SetupFlow RPCs, after the flow is set up but before it
 	// is started.
 	SetupFlowCb func(context.Context, base.SQLInstanceID, *execinfrapb.SetupFlowRequest) error
+
+	// ProcessorNoTracingSpan is used to disable the creation of a tracing span
+	// in ProcessorBase.StartInternal if the tracing is enabled.
+	ProcessorNoTracingSpan bool
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/sql/execinfrapb/BUILD.bazel
+++ b/pkg/sql/execinfrapb/BUILD.bazel
@@ -54,7 +54,6 @@ go_library(
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
-        "//pkg/util/tracing",
         "//pkg/util/tracing/tracingpb",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/execinfrapb/component_stats.go
+++ b/pkg/sql/execinfrapb/component_stats.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/optional"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/dustin/go-humanize"
 	"github.com/gogo/protobuf/types"
@@ -59,15 +58,15 @@ func FlowComponentID(instanceID base.SQLInstanceID, flowID FlowID) ComponentID {
 	}
 }
 
-// FlowIDTagKey is the key used for flow id tags in tracing spans.
 const (
-	FlowIDTagKey = tracing.TagPrefix + "flowid"
+	// FlowIDTagKey is the key used for flow id tags in tracing spans.
+	FlowIDTagKey = "cockroach.flowid"
 
 	// StreamIDTagKey is the key used for stream id tags in tracing spans.
-	StreamIDTagKey = tracing.TagPrefix + "streamid"
+	StreamIDTagKey = "cockroach.streamid"
 
 	// ProcessorIDTagKey is the key used for processor id tags in tracing spans.
-	ProcessorIDTagKey = tracing.TagPrefix + "processorid"
+	ProcessorIDTagKey = "cockroach.processorid"
 )
 
 // StatsForQueryPlan returns the statistics as a list of strings that can be

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -280,7 +280,7 @@ func (ih *instrumentationHelper) Setup(
 	}()
 
 	if sp := tracing.SpanFromContext(ctx); sp != nil {
-		if sp.IsVerbose() && !cfg.TestingKnobs.NoStatsCollectionWithVerboseTracing {
+		if sp.IsVerbose() {
 			// If verbose tracing was enabled at a higher level, stats
 			// collection is enabled so that stats are shown in the traces, but
 			// no extra work is needed by the instrumentationHelper.

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -230,10 +230,10 @@ query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 WHERE message LIKE '%DelRange%' OR message LIKE '%DelRng%'
 ----
-batch flow coordinator  DelRange /Table/110/1 - /Table/110/2
-dist sender send        r52: sending batch 1 DelRng to (n1,s1):1
-batch flow coordinator  DelRange /Table/110/1/601/0 - /Table/110/2
-dist sender send        r52: sending batch 1 DelRng to (n1,s1):1
+delete range      DelRange /Table/110/1 - /Table/110/2
+dist sender send  r52: sending batch 1 DelRng to (n1,s1):1
+delete range      DelRange /Table/110/1/601/0 - /Table/110/2
+dist sender send  r52: sending batch 1 DelRng to (n1,s1):1
 
 # Ensure that DelRange requests are autocommitted when DELETE FROM happens on a
 # chunk of fewer than 600 keys.
@@ -251,8 +251,8 @@ query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 WHERE message LIKE '%Del%' OR message LIKE '%sending batch%'
 ----
-batch flow coordinator  Del /Table/110/1/5/0
-dist sender send        r52: sending batch 1 Del, 1 EndTxn to (n1,s1):1
+delete range      Del /Table/110/1/5/0
+dist sender send  r52: sending batch 1 Del, 1 EndTxn to (n1,s1):1
 
 # Ensure that we send DelRanges when doing a point delete operation on a table
 # that has multiple column families.
@@ -270,8 +270,8 @@ query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 WHERE message LIKE '%Del%' OR message LIKE '%sending batch%'
 ----
-batch flow coordinator  DelRange /Table/111/1/5 - /Table/111/1/6
-dist sender send        r52: sending batch 1 DelRng to (n1,s1):1
+delete range      DelRange /Table/111/1/5 - /Table/111/1/6
+dist sender send  r52: sending batch 1 DelRng to (n1,s1):1
 
 statement ok
 CREATE TABLE xyz (

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -36,17 +36,19 @@ WHERE message LIKE '%SPAN START%' OR message LIKE '%pos%executing%';
 5   === SPAN START: optimizer ===                        optimizer
 6   === SPAN START: consuming rows ===                   consuming rows
 7   === SPAN START: flow ===                             flow
+8   === SPAN START: values ===                           values
 3   [Open pos:?] executing ExecStmt: COMMIT TRANSACTION  sql txn
-8   === SPAN START: sql query ===                        sql query
-9   === SPAN START: commit sql txn ===                   commit sql txn
+9   === SPAN START: sql query ===                        sql query
+10  === SPAN START: commit sql txn ===                   commit sql txn
 0   [NoTxn pos:?] executing ExecStmt: SELECT 2           session recording
-10  === SPAN START: sql txn ===                          sql txn
-10  [Open pos:?] executing ExecStmt: SELECT 2            sql txn
-11  === SPAN START: sql query ===                        sql query
-12  === SPAN START: optimizer ===                        optimizer
-13  === SPAN START: consuming rows ===                   consuming rows
-14  === SPAN START: flow ===                             flow
-15  === SPAN START: commit sql txn ===                   commit sql txn
+11  === SPAN START: sql txn ===                          sql txn
+11  [Open pos:?] executing ExecStmt: SELECT 2            sql txn
+12  === SPAN START: sql query ===                        sql query
+13  === SPAN START: optimizer ===                        optimizer
+14  === SPAN START: consuming rows ===                   consuming rows
+15  === SPAN START: flow ===                             flow
+16  === SPAN START: values ===                           values
+17  === SPAN START: commit sql txn ===                   commit sql txn
 0   [NoTxn pos:?] executing Sync                         session recording
 0   [NoTxn pos:?] executing ExecStmt: SET TRACING = off  session recording
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/show_trace
+++ b/pkg/sql/opt/exec/execbuilder/testdata/show_trace
@@ -50,11 +50,11 @@ SET tracing = on,kv,results; CREATE DATABASE t; SET tracing = off
 query TT
 $trace_query
 ----
-batch flow coordinator  CPut /NamespaceTable/30/1/106/0/"public"/4/1 -> 107
-batch flow coordinator  CPut /Table/3/1/107/2/1 -> schema:<name:"public" id:107 state:PUBLIC offline_reason:"" modification_time:<> version:1 parent_id:106 privileges:<users:<user_proto:"admin" privileges:2 with_grant_option:2 > users:<user_proto:"public" privileges:516 with_grant_option:0 > users:<user_proto:"root" privileges:2 with_grant_option:2 > owner_proto:"admin" version:2 > >
-batch flow coordinator  CPut /NamespaceTable/30/1/0/0/"t"/4/1 -> 106
-batch flow coordinator  CPut /Table/3/1/106/2/1 -> database:<name:"t" id:106 modification_time:<> version:1 privileges:<users:<user_proto:"admin" privileges:2 with_grant_option:2 > users:<user_proto:"public" privileges:2048 with_grant_option:0 > users:<user_proto:"root" privileges:2 with_grant_option:2 > owner_proto:"root" version:2 > schemas:<key:"public" value:<id:107 > > state:PUBLIC offline_reason:"" default_privileges:<type:DATABASE > >
-sql query               rows affected: 0
+create database  CPut /NamespaceTable/30/1/106/0/"public"/4/1 -> 107
+create database  CPut /Table/3/1/107/2/1 -> schema:<name:"public" id:107 state:PUBLIC offline_reason:"" modification_time:<> version:1 parent_id:106 privileges:<users:<user_proto:"admin" privileges:2 with_grant_option:2 > users:<user_proto:"public" privileges:516 with_grant_option:0 > users:<user_proto:"root" privileges:2 with_grant_option:2 > owner_proto:"admin" version:2 > >
+create database  CPut /NamespaceTable/30/1/0/0/"t"/4/1 -> 106
+create database  CPut /Table/3/1/106/2/1 -> database:<name:"t" id:106 modification_time:<> version:1 privileges:<users:<user_proto:"admin" privileges:2 with_grant_option:2 > users:<user_proto:"public" privileges:2048 with_grant_option:0 > users:<user_proto:"root" privileges:2 with_grant_option:2 > owner_proto:"root" version:2 > schemas:<key:"public" value:<id:107 > > state:PUBLIC offline_reason:"" default_privileges:<type:DATABASE > >
+sql query        rows affected: 0
 
 
 # More KV operations.
@@ -64,9 +64,9 @@ SET tracing = on,kv,results; CREATE TABLE t.kv(k INT PRIMARY KEY, v INT, FAMILY 
 query TT
 $trace_query
 ----
-batch flow coordinator  CPut /NamespaceTable/30/1/106/107/"kv"/4/1 -> 108
-batch flow coordinator  CPut /Table/3/1/108/2/1 -> table:<name:"kv" id:108 version:1 modification_time:<> parent_id:106 unexposed_parent_schema_id:107 columns:<name:"k" id:1 type:<family: IntFamily width: 64 precision: 0 locale: "" visible_type: 0 oid: 20 time_precision_is_set: false > nullable:false hidden:false inaccessible:false generated_as_identity_type:NOT_IDENTITY_COLUMN virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > columns:<name:"v" id:2 type:<family: IntFamily width: 64 precision: 0 locale: "" visible_type: 0 oid: 20 time_precision_is_set: false > nullable:true hidden:false inaccessible:false generated_as_identity_type:NOT_IDENTITY_COLUMN virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"kv_pkey" id:1 unique:true version:4 key_column_names:"k" key_column_directions:ASC store_column_names:"v" key_column_ids:1 store_column_ids:2 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:false encoding_type:1 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" use_delete_preserving_encoding:false created_at_nanos:... constraint_id:1 not_visible:false > next_index_id:2 privileges:<users:<user_proto:"admin" privileges:2 with_grant_option:2 > users:<user_proto:"root" privileges:2 with_grant_option:2 > owner_proto:"root" version:2 > next_mutation_id:1 format_version:3 state:PUBLIC offline_reason:"" view_query:"" is_materialized_view:false refresh_view_required:false drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"" create_as_of_time:<> temporary:false partition_all_by:false exclude_data_from_backup:false next_constraint_id:2 import_start_wall_time:0 >
-sql query               rows affected: 0
+create table  CPut /NamespaceTable/30/1/106/107/"kv"/4/1 -> 108
+create table  CPut /Table/3/1/108/2/1 -> table:<name:"kv" id:108 version:1 modification_time:<> parent_id:106 unexposed_parent_schema_id:107 columns:<name:"k" id:1 type:<family: IntFamily width: 64 precision: 0 locale: "" visible_type: 0 oid: 20 time_precision_is_set: false > nullable:false hidden:false inaccessible:false generated_as_identity_type:NOT_IDENTITY_COLUMN virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > columns:<name:"v" id:2 type:<family: IntFamily width: 64 precision: 0 locale: "" visible_type: 0 oid: 20 time_precision_is_set: false > nullable:true hidden:false inaccessible:false generated_as_identity_type:NOT_IDENTITY_COLUMN virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"kv_pkey" id:1 unique:true version:4 key_column_names:"k" key_column_directions:ASC store_column_names:"v" key_column_ids:1 store_column_ids:2 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:false encoding_type:1 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" use_delete_preserving_encoding:false created_at_nanos:... constraint_id:1 not_visible:false > next_index_id:2 privileges:<users:<user_proto:"admin" privileges:2 with_grant_option:2 > users:<user_proto:"root" privileges:2 with_grant_option:2 > owner_proto:"root" version:2 > next_mutation_id:1 format_version:3 state:PUBLIC offline_reason:"" view_query:"" is_materialized_view:false refresh_view_required:false drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"" create_as_of_time:<> temporary:false partition_all_by:false exclude_data_from_backup:false next_constraint_id:2 import_start_wall_time:0 >
+sql query     rows affected: 0
 
 # We avoid using the full trace output, because that would make the
 # ensuing trace especially chatty, as it traces the index backfill at
@@ -80,8 +80,8 @@ SET tracing = on,kv,results; CREATE UNIQUE INDEX woo ON t.kv(v); SET tracing = o
 query TT
 $trace_query
 ----
-batch flow coordinator  Put /Table/3/1/108/2/1 -> table:<name:"kv" id:108 version:2 modification_time:<> parent_id:106 unexposed_parent_schema_id:107 columns:<name:"k" id:1 type:<family: IntFamily width: 64 precision: 0 locale: "" visible_type: 0 oid: 20 time_precision_is_set: false > nullable:false hidden:false inaccessible:false generated_as_identity_type:NOT_IDENTITY_COLUMN virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > columns:<name:"v" id:2 type:<family: IntFamily width: 64 precision: 0 locale: "" visible_type: 0 oid: 20 time_precision_is_set: false > nullable:true hidden:false inaccessible:false generated_as_identity_type:NOT_IDENTITY_COLUMN virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"kv_pkey" id:1 unique:true version:4 key_column_names:"k" key_column_directions:ASC store_column_names:"v" key_column_ids:1 store_column_ids:2 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:false encoding_type:1 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" use_delete_preserving_encoding:false created_at_nanos:... constraint_id:1 not_visible:false > next_index_id:4 privileges:<users:<user_proto:"admin" privileges:2 with_grant_option:2 > users:<user_proto:"root" privileges:2 with_grant_option:2 > owner_proto:"root" version:2 > mutations:<index:<name:"woo" id:2 unique:true version:3 key_column_names:"v" key_column_directions:ASC key_column_ids:2 key_suffix_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:true encoding_type:0 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" use_delete_preserving_encoding:false created_at_nanos:... constraint_id:2 not_visible:false > state:BACKFILLING direction:ADD mutation_id:1 rollback:false > mutations:<index:<name:"kv_v_crdb_internal_dpe_key" id:3 unique:true version:3 key_column_names:"v" key_column_directions:ASC key_column_ids:2 key_suffix_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:true encoding_type:0 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" use_delete_preserving_encoding:true created_at_nanos:... constraint_id:3 not_visible:false > state:DELETE_ONLY direction:ADD mutation_id:1 rollback:false > next_mutation_id:2 format_version:3 state:PUBLIC offline_reason:"" view_query:"" is_materialized_view:false refresh_view_required:false mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"" create_as_of_time:<...> temporary:false partition_all_by:false exclude_data_from_backup:false next_constraint_id:4 import_start_wall_time:0 >
-sql query               rows affected: 0
+create index  Put /Table/3/1/108/2/1 -> table:<name:"kv" id:108 version:2 modification_time:<> parent_id:106 unexposed_parent_schema_id:107 columns:<name:"k" id:1 type:<family: IntFamily width: 64 precision: 0 locale: "" visible_type: 0 oid: 20 time_precision_is_set: false > nullable:false hidden:false inaccessible:false generated_as_identity_type:NOT_IDENTITY_COLUMN virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > columns:<name:"v" id:2 type:<family: IntFamily width: 64 precision: 0 locale: "" visible_type: 0 oid: 20 time_precision_is_set: false > nullable:true hidden:false inaccessible:false generated_as_identity_type:NOT_IDENTITY_COLUMN virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"kv_pkey" id:1 unique:true version:4 key_column_names:"k" key_column_directions:ASC store_column_names:"v" key_column_ids:1 store_column_ids:2 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:false encoding_type:1 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" use_delete_preserving_encoding:false created_at_nanos:... constraint_id:1 not_visible:false > next_index_id:4 privileges:<users:<user_proto:"admin" privileges:2 with_grant_option:2 > users:<user_proto:"root" privileges:2 with_grant_option:2 > owner_proto:"root" version:2 > mutations:<index:<name:"woo" id:2 unique:true version:3 key_column_names:"v" key_column_directions:ASC key_column_ids:2 key_suffix_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:true encoding_type:0 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" use_delete_preserving_encoding:false created_at_nanos:... constraint_id:2 not_visible:false > state:BACKFILLING direction:ADD mutation_id:1 rollback:false > mutations:<index:<name:"kv_v_crdb_internal_dpe_key" id:3 unique:true version:3 key_column_names:"v" key_column_directions:ASC key_column_ids:2 key_suffix_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:true encoding_type:0 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" use_delete_preserving_encoding:true created_at_nanos:... constraint_id:3 not_visible:false > state:DELETE_ONLY direction:ADD mutation_id:1 rollback:false > next_mutation_id:2 format_version:3 state:PUBLIC offline_reason:"" view_query:"" is_materialized_view:false refresh_view_required:false mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"" create_as_of_time:<...> temporary:false partition_all_by:false exclude_data_from_backup:false next_constraint_id:4 import_start_wall_time:0 >
+sql query     rows affected: 0
 
 statement ok
 SET tracing = on,kv,results; INSERT INTO t.kv(k, v) VALUES (1,2); SET tracing = off
@@ -89,10 +89,10 @@ SET tracing = on,kv,results; INSERT INTO t.kv(k, v) VALUES (1,2); SET tracing = 
 query TT
 $trace_query
 ----
-batch flow coordinator  CPut /Table/108/1/1/0 -> /TUPLE/2:2:Int/2
-batch flow coordinator  InitPut /Table/108/2/2/0 -> /BYTES/0x89
-batch flow coordinator  fast path completed
-sql query               rows affected: 1
+count      CPut /Table/108/1/1/0 -> /TUPLE/2:2:Int/2
+count      InitPut /Table/108/2/2/0 -> /BYTES/0x89
+count      fast path completed
+sql query  rows affected: 1
 
 
 statement error duplicate key value
@@ -102,9 +102,9 @@ query TT
 set tracing=off;
 $trace_query
 ----
-batch flow coordinator  CPut /Table/108/1/1/0 -> /TUPLE/2:2:Int/2
-batch flow coordinator  InitPut /Table/108/2/2/0 -> /BYTES/0x89
-sql query               execution failed after 0 rows: duplicate key value violates unique constraint "kv_pkey"
+count      CPut /Table/108/1/1/0 -> /TUPLE/2:2:Int/2
+count      InitPut /Table/108/2/2/0 -> /BYTES/0x89
+sql query  execution failed after 0 rows: duplicate key value violates unique constraint "kv_pkey"
 
 statement error duplicate key value
 SET tracing = on,kv,results; INSERT INTO t.kv(k, v) VALUES (2,2); SET tracing = off
@@ -113,9 +113,9 @@ query TT
 set tracing=off;
 $trace_query
 ----
-batch flow coordinator  CPut /Table/108/1/2/0 -> /TUPLE/2:2:Int/2
-batch flow coordinator  InitPut /Table/108/2/2/0 -> /BYTES/0x8a
-sql query               execution failed after 0 rows: duplicate key value violates unique constraint "woo"
+count      CPut /Table/108/1/2/0 -> /TUPLE/2:2:Int/2
+count      InitPut /Table/108/2/2/0 -> /BYTES/0x8a
+sql query  execution failed after 0 rows: duplicate key value violates unique constraint "woo"
 
 statement ok
 SET tracing = on,kv,results; CREATE TABLE t.kv2 AS TABLE t.kv;
@@ -126,9 +126,9 @@ SET tracing = off
 query TT
 $trace_query
 ----
-batch flow coordinator  CPut /NamespaceTable/30/1/106/107/"kv2"/4/1 -> 109
-batch flow coordinator  CPut /Table/3/1/109/2/1 -> table:<name:"kv2" id:109 version:1 modification_time:<> parent_id:106 unexposed_parent_schema_id:107 columns:<name:"k" id:1 type:<family: IntFamily width: 64 precision: 0 locale: "" visible_type: 0 oid: 20 time_precision_is_set: false > nullable:true hidden:false inaccessible:false generated_as_identity_type:NOT_IDENTITY_COLUMN virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > columns:<name:"v" id:2 type:<family: IntFamily width: 64 precision: 0 locale: "" visible_type: 0 oid: 20 time_precision_is_set: false > nullable:true hidden:false inaccessible:false generated_as_identity_type:NOT_IDENTITY_COLUMN virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > columns:<name:"rowid" id:3 type:<family: IntFamily width: 64 precision: 0 locale: "" visible_type: 0 oid: 20 time_precision_is_set: false > nullable:false default_expr:"unique_rowid()" hidden:true inaccessible:false generated_as_identity_type:NOT_IDENTITY_COLUMN virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"kv2_pkey" id:1 unique:true version:4 key_column_names:"rowid" key_column_directions:ASC store_column_names:"k" store_column_names:"v" key_column_ids:3 store_column_ids:1 store_column_ids:2 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:false encoding_type:1 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" use_delete_preserving_encoding:false created_at_nanos:... constraint_id:1 not_visible:false > next_index_id:2 privileges:<users:<user_proto:"admin" privileges:2 with_grant_option:2 > users:<user_proto:"root" privileges:2 with_grant_option:2 > owner_proto:"root" version:2 > next_mutation_id:1 format_version:3 state:ADD offline_reason:"" view_query:"" is_materialized_view:false refresh_view_required:false drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"TABLE t.public.kv" create_as_of_time:<> temporary:false partition_all_by:false exclude_data_from_backup:false next_constraint_id:2 import_start_wall_time:0 >
-sql query               rows affected: 0
+create table  CPut /NamespaceTable/30/1/106/107/"kv2"/4/1 -> 109
+create table  CPut /Table/3/1/109/2/1 -> table:<name:"kv2" id:109 version:1 modification_time:<> parent_id:106 unexposed_parent_schema_id:107 columns:<name:"k" id:1 type:<family: IntFamily width: 64 precision: 0 locale: "" visible_type: 0 oid: 20 time_precision_is_set: false > nullable:true hidden:false inaccessible:false generated_as_identity_type:NOT_IDENTITY_COLUMN virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > columns:<name:"v" id:2 type:<family: IntFamily width: 64 precision: 0 locale: "" visible_type: 0 oid: 20 time_precision_is_set: false > nullable:true hidden:false inaccessible:false generated_as_identity_type:NOT_IDENTITY_COLUMN virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > columns:<name:"rowid" id:3 type:<family: IntFamily width: 64 precision: 0 locale: "" visible_type: 0 oid: 20 time_precision_is_set: false > nullable:false default_expr:"unique_rowid()" hidden:true inaccessible:false generated_as_identity_type:NOT_IDENTITY_COLUMN virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"kv2_pkey" id:1 unique:true version:4 key_column_names:"rowid" key_column_directions:ASC store_column_names:"k" store_column_names:"v" key_column_ids:3 store_column_ids:1 store_column_ids:2 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:false encoding_type:1 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" use_delete_preserving_encoding:false created_at_nanos:... constraint_id:1 not_visible:false > next_index_id:2 privileges:<users:<user_proto:"admin" privileges:2 with_grant_option:2 > users:<user_proto:"root" privileges:2 with_grant_option:2 > owner_proto:"root" version:2 > next_mutation_id:1 format_version:3 state:ADD offline_reason:"" view_query:"" is_materialized_view:false refresh_view_required:false drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"TABLE t.public.kv" create_as_of_time:<> temporary:false partition_all_by:false exclude_data_from_backup:false next_constraint_id:2 import_start_wall_time:0 >
+sql query     rows affected: 0
 
 statement ok
 SET tracing = on,kv,results; UPDATE t.kv2 SET v = v + 2;
@@ -139,11 +139,11 @@ SET tracing = off
 query TT
 $trace_query
 ----
-colbatchscan            Scan /Table/109/{1-2}
-colbatchscan            fetched: /kv2/kv2_pkey/-9222809086901354496/k/v -> /1/2
-batch flow coordinator  Put /Table/109/1/-9222809086901354496/0 -> /TUPLE/1:1:Int/1/1:2:Int/4
-batch flow coordinator  fast path completed
-sql query               rows affected: 1
+colbatchscan  Scan /Table/109/{1-2}
+colbatchscan  fetched: /kv2/kv2_pkey/-9222809086901354496/k/v -> /1/2
+count         Put /Table/109/1/-9222809086901354496/0 -> /TUPLE/1:1:Int/1/1:2:Int/4
+count         fast path completed
+sql query     rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; DELETE FROM t.kv2; SET tracing = off
@@ -151,9 +151,9 @@ SET tracing = on,kv,results; DELETE FROM t.kv2; SET tracing = off
 query TT
 $trace_query
 ----
-batch flow coordinator  DelRange /Table/109/1 - /Table/109/2
-batch flow coordinator  fast path completed
-sql query               rows affected: 1
+delete range  DelRange /Table/109/1 - /Table/109/2
+delete range  fast path completed
+sql query     rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; DROP TABLE t.kv2
@@ -177,12 +177,12 @@ SET tracing = off
 query TT
 $trace_query
 ----
-colbatchscan            Scan /Table/108/{1-2}
-colbatchscan            fetched: /kv/kv_pkey/1/v -> /2
-batch flow coordinator  Del /Table/108/2/2/0
-batch flow coordinator  Del /Table/108/1/1/0
-batch flow coordinator  fast path completed
-sql query               rows affected: 1
+colbatchscan  Scan /Table/108/{1-2}
+colbatchscan  fetched: /kv/kv_pkey/1/v -> /2
+count         Del /Table/108/2/2/0
+count         Del /Table/108/1/1/0
+count         fast path completed
+sql query     rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; DROP INDEX t.kv@woo CASCADE
@@ -193,8 +193,8 @@ SET tracing = off
 query TT
 $trace_query
 ----
-batch flow coordinator  Put /Table/3/1/108/2/1 -> table:<name:"kv" id:108 version:8 modification_time:<> parent_id:106 unexposed_parent_schema_id:107 columns:<name:"k" id:1 type:<family: IntFamily width: 64 precision: 0 locale: "" visible_type: 0 oid: 20 time_precision_is_set: false > nullable:false hidden:false inaccessible:false generated_as_identity_type:NOT_IDENTITY_COLUMN virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > columns:<name:"v" id:2 type:<family: IntFamily width: 64 precision: 0 locale: "" visible_type: 0 oid: 20 time_precision_is_set: false > nullable:true hidden:false inaccessible:false generated_as_identity_type:NOT_IDENTITY_COLUMN virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"kv_pkey" id:1 unique:true version:4 key_column_names:"k" key_column_directions:ASC store_column_names:"v" key_column_ids:1 store_column_ids:2 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:false encoding_type:1 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" use_delete_preserving_encoding:false created_at_nanos:... constraint_id:1 not_visible:false > next_index_id:4 privileges:<users:<user_proto:"admin" privileges:2 with_grant_option:2 > users:<user_proto:"root" privileges:2 with_grant_option:2 > owner_proto:"root" version:2 > mutations:<index:<name:"woo" id:2 unique:true version:3 key_column_names:"v" key_column_directions:ASC key_column_ids:2 key_suffix_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:true encoding_type:0 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" use_delete_preserving_encoding:false created_at_nanos:... constraint_id:2 not_visible:false > state:WRITE_ONLY direction:DROP mutation_id:2 rollback:false > next_mutation_id:3 format_version:3 state:PUBLIC offline_reason:"" view_query:"" is_materialized_view:false refresh_view_required:false mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"" create_as_of_time:<...> temporary:false partition_all_by:false exclude_data_from_backup:false next_constraint_id:4 import_start_wall_time:0 >
-sql query               rows affected: 0
+drop index  Put /Table/3/1/108/2/1 -> table:<name:"kv" id:108 version:8 modification_time:<> parent_id:106 unexposed_parent_schema_id:107 columns:<name:"k" id:1 type:<family: IntFamily width: 64 precision: 0 locale: "" visible_type: 0 oid: 20 time_precision_is_set: false > nullable:false hidden:false inaccessible:false generated_as_identity_type:NOT_IDENTITY_COLUMN virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > columns:<name:"v" id:2 type:<family: IntFamily width: 64 precision: 0 locale: "" visible_type: 0 oid: 20 time_precision_is_set: false > nullable:true hidden:false inaccessible:false generated_as_identity_type:NOT_IDENTITY_COLUMN virtual:false pg_attribute_num:0 alter_column_type_in_progress:false system_column_kind:NONE > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"kv_pkey" id:1 unique:true version:4 key_column_names:"k" key_column_directions:ASC store_column_names:"v" key_column_ids:1 store_column_ids:2 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:false encoding_type:1 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" use_delete_preserving_encoding:false created_at_nanos:... constraint_id:1 not_visible:false > next_index_id:4 privileges:<users:<user_proto:"admin" privileges:2 with_grant_option:2 > users:<user_proto:"root" privileges:2 with_grant_option:2 > owner_proto:"root" version:2 > mutations:<index:<name:"woo" id:2 unique:true version:3 key_column_names:"v" key_column_directions:ASC key_column_ids:2 key_suffix_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION match:SIMPLE > interleave:<> partitioning:<num_columns:0 num_implicit_columns:0 > type:FORWARD created_explicitly:true encoding_type:0 sharded:<is_sharded:false name:"" shard_buckets:0 > disabled:false geo_config:<> predicate:"" use_delete_preserving_encoding:false created_at_nanos:... constraint_id:2 not_visible:false > state:WRITE_ONLY direction:DROP mutation_id:2 rollback:false > next_mutation_id:3 format_version:3 state:PUBLIC offline_reason:"" view_query:"" is_materialized_view:false refresh_view_required:false mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED drop_job_id:0 create_query:"" create_as_of_time:<...> temporary:false partition_all_by:false exclude_data_from_backup:false next_constraint_id:4 import_start_wall_time:0 >
+sql query   rows affected: 0
 
 statement ok
 SET tracing = on,kv,results; DROP TABLE t.kv

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -699,11 +699,11 @@ query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send' AND operation != 'kv.DistSender: sending partial batch'
 ----
-colbatchscan            Scan /Table/120/1/2/0
-batch flow coordinator  CPut /Table/120/1/2/0 -> /TUPLE/2:2:Int/3
-batch flow coordinator  InitPut /Table/120/2/3/0 -> /BYTES/0x8a
-batch flow coordinator  fast path completed
-sql query               rows affected: 1
+colbatchscan  Scan /Table/120/1/2/0
+count         CPut /Table/120/1/2/0 -> /TUPLE/2:2:Int/3
+count         InitPut /Table/120/2/3/0 -> /BYTES/0x8a
+count         fast path completed
+sql query     rows affected: 1
 
 statement ok
 SET tracing = on,kv,results; UPSERT INTO t.kv(k, v) VALUES (1,2); SET tracing = off
@@ -712,11 +712,11 @@ query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send' AND operation != 'kv.DistSender: sending partial batch'
 ----
-colbatchscan            Scan /Table/120/1/1/0
-batch flow coordinator  CPut /Table/120/1/1/0 -> /TUPLE/2:2:Int/2
-batch flow coordinator  InitPut /Table/120/2/2/0 -> /BYTES/0x89
-batch flow coordinator  fast path completed
-sql query               rows affected: 1
+colbatchscan  Scan /Table/120/1/1/0
+count         CPut /Table/120/1/1/0 -> /TUPLE/2:2:Int/2
+count         InitPut /Table/120/2/2/0 -> /BYTES/0x89
+count         fast path completed
+sql query     rows affected: 1
 
 statement error duplicate key value
 SET tracing = on,kv,results; UPSERT INTO t.kv(k, v) VALUES (2,2); SET tracing = off
@@ -726,9 +726,9 @@ set tracing=off;
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send' AND operation != 'kv.DistSender: sending partial batch'
 ----
-colbatchscan            Scan /Table/120/1/2/0
-colbatchscan            fetched: /kv/kv_pkey/2/v -> /3
-batch flow coordinator  Put /Table/120/1/2/0 -> /TUPLE/2:2:Int/2
-batch flow coordinator  Del /Table/120/2/3/0
-batch flow coordinator  CPut /Table/120/2/2/0 -> /BYTES/0x8a (expecting does not exist)
-sql query               execution failed after 0 rows: duplicate key value violates unique constraint "woo"
+colbatchscan  Scan /Table/120/1/2/0
+colbatchscan  fetched: /kv/kv_pkey/2/v -> /3
+count         Put /Table/120/1/2/0 -> /TUPLE/2:2:Int/2
+count         Del /Table/120/2/3/0
+count         CPut /Table/120/2/2/0 -> /BYTES/0x8a (expecting does not exist)
+sql query     execution failed after 0 rows: duplicate key value violates unique constraint "woo"

--- a/pkg/sql/plan_node_to_row_source.go
+++ b/pkg/sql/plan_node_to_row_source.go
@@ -149,7 +149,7 @@ func (p *planNodeToRowSource) SetInput(ctx context.Context, input execinfra.RowS
 }
 
 func (p *planNodeToRowSource) Start(ctx context.Context) {
-	ctx = p.StartInternalNoSpan(ctx)
+	ctx = p.StartInternal(ctx, nodeName(p.node))
 	p.params.ctx = ctx
 	// This starts all of the nodes below this node.
 	if err := startExec(p.params, p.node); err != nil {

--- a/pkg/sql/rowexec/project_set.go
+++ b/pkg/sql/rowexec/project_set.go
@@ -311,13 +311,18 @@ func (ps *projectSetProcessor) toEncDatum(d tree.Datum, colIdx int) rowenc.EncDa
 }
 
 func (ps *projectSetProcessor) close() {
-	ps.InternalCloseEx(func() {
-		for _, gen := range ps.gens {
-			if gen != nil {
-				gen.Close(ps.Ctx())
-			}
+	if ps.Closed {
+		return
+	}
+	// Close all generator functions before the context is replaced in
+	// InternalClose().
+	for i, gen := range ps.gens {
+		if gen != nil {
+			gen.Close(ps.Ctx())
+			ps.gens[i] = nil
 		}
-	})
+	}
+	ps.InternalClose()
 }
 
 // ConsumerClosed is part of the RowSource interface.

--- a/pkg/sql/tests/autocommit_extended_protocol_test.go
+++ b/pkg/sql/tests/autocommit_extended_protocol_test.go
@@ -58,7 +58,7 @@ func TestInsertFastPathExtendedProtocol(t *testing.T) {
 		var msg, operation string
 		err = rows.Scan(&msg, &operation)
 		require.NoError(t, err)
-		if msg == "autocommit enabled" && operation == "batch flow coordinator" {
+		if msg == "autocommit enabled" && operation == "count" {
 			fastPathEnabled = true
 		}
 	}

--- a/pkg/upgrade/upgrademanager/BUILD.bazel
+++ b/pkg/upgrade/upgrademanager/BUILD.bazel
@@ -51,7 +51,7 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/settings/cluster",
-        "//pkg/sql",
+        "//pkg/sql/execinfra",
         "//pkg/sql/sqlutil",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -27,11 +27,6 @@ import (
 	"golang.org/x/net/trace"
 )
 
-const (
-	// TagPrefix is prefixed to all tags that should be output in SHOW TRACE.
-	TagPrefix = "cockroach."
-)
-
 // Span is the tracing Span that we use in CockroachDB. Depending on the tracing
 // configuration, it can hold anywhere between zero and three destinations for
 // trace information:


### PR DESCRIPTION
Backport 3/3 commits from #87317.

/cc @cockroachdb/release

---

**tracing: omit distsql ids from SHOW TRACE**

This commit removes the custom handling of tracing tags with
`cockroach.` prefix when populating the output of SHOW TRACE.
Previously, all tags with this prefix would be included into the "start
span" message, possibly taking up multiple lines in the SHOW TRACE
output. However, there is only one user of those tags - ids of different
components of DistSQL infrastructure, and I don't think it's helpful to
have those ids in the output at all, so this commit removes this ability
and makes the "start span" message nicer.

This special handling was introduced four years ago in
60978aae73f765f95a83bb4fa7f7d0f3af050c12 and at that time there might
have been a reason to have some special handling of these tags (so that
they become visible when viewing the jaeger trace), but that is not
necessary anymore (I believe because we now always propagate all tags
across nodes).

Release justification: low-risk cleanup.

Release note: None

**execinfra: clean up ProcessorBase a bit**

This commit performs the following cleanup:
- it removes the redundant `InternalClose` implementations. At some
point last year an "extended" version was introduced to take in
a closure to be called when the processor is being closed. There is only
one user for that, and it can itself do the necessary cleanup before
calling `InternalClose`
- it removes the update to `rowIdx` of `ProcOutputHelper` (which tracks
how many rows the helper has emitted) when the processor is closed. The
idea behind this was to protect from the future calls to `Next` method
so that the helper doesn't emit more rows once it is closed, but it is
not allowed by the interface anyway - once the processor is closed, no
new calls to `Next` are allowed, so this protection was meaningless.
However, what prompted me to look into this was the fact that the
`rowIdx` field was being set to `MaxInt64` which would trip up the stats
collection change in the following commit.

Release justification: low-risk cleanup.

Release note: None

**sql: improve tracing of some things**

This commit makes it so that we create a tracing span for all
processors. Previously, out of performance considerations, we elided the
spans for the columnarizer, materializer, planNodeToRowSource, and
flowCoordinator, but given the improvements to tracing in the last year
or so it doesn't seem necessary to do that anymore. In particular so
given that we don't create tracing spans by default any way, only when
the tracing is enabled for the statement.

Additionally, this commit adds a couple of tags to the tracing span of
the vectorized outbox (similar to what we have in the row-by-row
engine).

Release justification: low-risk improvement.

Release note: None
