### PR TITLE
diagnosticccl: minor test clean

### DIFF
--- a/pkg/ccl/serverccl/diagnosticsccl/reporter_test.go
+++ b/pkg/ccl/serverccl/diagnosticsccl/reporter_test.go
@@ -88,7 +88,7 @@ func TestTenantReport(t *testing.T) {
 	require.NotZero(t, len(last.FeatureUsage))
 
 	// Call PeriodicallyReportDiagnostics and ensure it sends out a report.
-	reporter.PeriodicallyReportDiagnostics(ctx, rt.server.Stopper())
+	reporter.PeriodicallyReportDiagnostics(ctx, tenant.Stopper())
 	testutils.SucceedsSoon(t, func() error {
 		if rt.diagServer.NumRequests() != 2 {
 			return errors.Errorf("did not receive a diagnostics report")


### PR DESCRIPTION
This test was using a storage node's Stopper in conjunction with a tenant server's component (the Reporter). That's not kosher - we were creating a trace having a parent span created with the storage node's Tracer, and a child created with the tenant's Tracer. Combining Tracers like that in a single trace is not allowed. The test is getting away with it because the parent span happened to be created with the "sterile" option, and sterile spans were allowed to be combined with children created with other Tracers as an exception for arcane reasons, but that's going away.

Release note: None
Epic: None