### PR TITLE
util/json: fix infinite loop with unterminated \u

### DIFF
--- a/pkg/util/json/json_test.go
+++ b/pkg/util/json/json_test.go
@@ -368,6 +368,13 @@ func TestJSONErrors(t *testing.T) {
 
 		testCase(`{"a":["b","c"]}]`, trailingChars, useStdGoJSON),
 		testCase(`{"a":["b","c"]}]`, trailingChars, useFastJSONParser),
+
+		testCase(`\u`, `unable to decode JSON: invalid character .* looking for beginning of value`, useStdGoJSON),
+		testCase(`\u`, `invalid JSON token`, useFastJSONParser),
+		testCase(`\u1`, `unable to decode JSON: invalid character .* looking for beginning of value`, useStdGoJSON),
+		testCase(`\u1`, `invalid JSON token`, useFastJSONParser),
+		testCase(`\u111z`, `unable to decode JSON: invalid character .* looking for beginning of value`, useStdGoJSON),
+		testCase(`\u111z`, `invalid JSON token`, useFastJSONParser),
 	}
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%s/%s", tc.implName, tc.input), func(t *testing.T) {

--- a/pkg/util/json/tokenizer/scanner_test.go
+++ b/pkg/util/json/tokenizer/scanner_test.go
@@ -101,6 +101,13 @@ func TestParseString(t *testing.T) {
 	testParseString(t, `"\""`, `"""`)
 	testParseString(t, `"\\\\\\\\\t"`, `"\\\\	"`)
 	testParseString(t, `"\\b"`, `"\b"`)
+	// Regression test: unterminated escape code.
+	testParseString(t, `"\u"`, ``)
+	testParseString(t, `"\u2"`, ``)
+	testParseString(t, `"\u23"`, ``)
+	testParseString(t, `"\u234"`, ``)
+	testParseString(t, `"\u2345"`, `"⍅"`)
+	testParseString(t, `"\u2z45"`, ``)
 }
 
 func testParseString(t *testing.T, json, want string) {


### PR DESCRIPTION
Closes #93366

Previously, an unterminated \u code in a JSON string would cause the database to loop forever.

Release note: None