### PR TITLE
rpc: log RPC heartbeat errors at error level

### DIFF
--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -2009,7 +2009,7 @@ func (rpcCtx *Context) runHeartbeat(
 					} else {
 						buf.Printf("closing connection after: %s", retErr)
 					}
-					log.Health.Infof(ctx, "%s", buf)
+					log.Health.Errorf(ctx, "%s", buf)
 				}
 			}
 		}


### PR DESCRIPTION
Currently heartbeat failures are logged at level INFO. This makes it hard to identify them as anomalies when scanning the log files. This commit changes the level to ERROR to make them stand out during troubleshooting.

Epic: none
Release note: None