### PR TITLE
coldata: add native support of enums

### DIFF
--- a/pkg/col/colserde/BUILD.bazel
+++ b/pkg/col/colserde/BUILD.bazel
@@ -61,6 +61,7 @@ go_test(
         "@com_github_apache_arrow_go_arrow//array",
         "@com_github_apache_arrow_go_arrow//memory",
         "@com_github_cockroachdb_apd_v3//:apd",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/col/typeconv/typeconv.go
+++ b/pkg/col/typeconv/typeconv.go
@@ -36,7 +36,13 @@ func TypeFamilyToCanonicalTypeFamily(family types.Family) types.Family {
 	switch family {
 	case types.BoolFamily:
 		return types.BoolFamily
-	case types.BytesFamily, types.StringFamily, types.UuidFamily, types.EncodedKeyFamily:
+	case types.BytesFamily, types.StringFamily, types.UuidFamily, types.EncodedKeyFamily, types.EnumFamily:
+		// Note that by using Bytes family as the canonical one for other type
+		// families we allow the execution engine to evaluate invalid operations
+		// (e.g. the concat binary operation between a UUID and an enum "has"
+		// the execution engine support). However, it's not a big deal since the
+		// type-checking for validity of operations is done before the query
+		// reaches the execution engine.
 		return types.BytesFamily
 	case types.DecimalFamily:
 		return types.DecimalFamily

--- a/pkg/sql/colconv/datum_to_vec.eg.go
+++ b/pkg/sql/colconv/datum_to_vec.eg.go
@@ -157,6 +157,15 @@ func GetDatumToPhysicalFn(ct *types.T) func(tree.Datum) interface{} {
 				return datum.(*tree.DJSON).JSON
 			}
 		}
+	case types.EnumFamily:
+		switch ct.Width() {
+		case -1:
+		default:
+			return func(datum tree.Datum) interface{} {
+
+				return datum.(*tree.DEnum).PhysicalRep
+			}
+		}
 	case types.EncodedKeyFamily:
 		switch ct.Width() {
 		case -1:

--- a/pkg/sql/colconv/vec_to_datum.eg.go
+++ b/pkg/sql/colconv/vec_to_datum.eg.go
@@ -677,6 +677,34 @@ func ColVecToDatumAndDeselect(
 						converted[destIdx] = _converted
 					}
 				}
+			case types.EnumFamily:
+				switch ct.Width() {
+				case -1:
+				default:
+					typedCol := col.Bytes()
+					for idx = 0; idx < length; idx++ {
+						{
+							destIdx = idx
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						if nulls.NullAt(srcIdx) {
+							//gcassert:bce
+							converted[destIdx] = tree.DNull
+							continue
+						}
+						v := typedCol.Get(srcIdx)
+						e, err := tree.MakeDEnumFromPhysicalRepresentation(ct, v)
+						if err != nil {
+							colexecerror.InternalError(err)
+						}
+						_converted := da.NewDEnum(e)
+						//gcassert:bce
+						converted[destIdx] = _converted
+					}
+				}
 			case typeconv.DatumVecCanonicalTypeFamily:
 			default:
 				switch ct.Width() {
@@ -1039,6 +1067,29 @@ func ColVecToDatumAndDeselect(
 						_ = true
 						v := typedCol.Get(srcIdx)
 						_converted := da.NewDInterval(tree.DInterval{Duration: v})
+						//gcassert:bce
+						converted[destIdx] = _converted
+					}
+				}
+			case types.EnumFamily:
+				switch ct.Width() {
+				case -1:
+				default:
+					typedCol := col.Bytes()
+					for idx = 0; idx < length; idx++ {
+						{
+							destIdx = idx
+						}
+						{
+							//gcassert:bce
+							srcIdx = sel[idx]
+						}
+						v := typedCol.Get(srcIdx)
+						e, err := tree.MakeDEnumFromPhysicalRepresentation(ct, v)
+						if err != nil {
+							colexecerror.InternalError(err)
+						}
+						_converted := da.NewDEnum(e)
 						//gcassert:bce
 						converted[destIdx] = _converted
 					}
@@ -1479,6 +1530,33 @@ func ColVecToDatum(
 							_ = true
 							v := typedCol.Get(srcIdx)
 							_converted := da.NewDInterval(tree.DInterval{Duration: v})
+							converted[destIdx] = _converted
+						}
+					}
+				case types.EnumFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Bytes()
+						for idx = 0; idx < length; idx++ {
+							{
+								//gcassert:bce
+								destIdx = sel[idx]
+							}
+							{
+								//gcassert:bce
+								srcIdx = sel[idx]
+							}
+							if nulls.NullAt(srcIdx) {
+								converted[destIdx] = tree.DNull
+								continue
+							}
+							v := typedCol.Get(srcIdx)
+							e, err := tree.MakeDEnumFromPhysicalRepresentation(ct, v)
+							if err != nil {
+								colexecerror.InternalError(err)
+							}
+							_converted := da.NewDEnum(e)
 							converted[destIdx] = _converted
 						}
 					}
@@ -1930,6 +2008,33 @@ func ColVecToDatum(
 							converted[destIdx] = _converted
 						}
 					}
+				case types.EnumFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Bytes()
+						for idx = 0; idx < length; idx++ {
+							{
+								destIdx = idx
+							}
+							{
+								srcIdx = idx
+							}
+							if nulls.NullAt(srcIdx) {
+								//gcassert:bce
+								converted[destIdx] = tree.DNull
+								continue
+							}
+							v := typedCol.Get(srcIdx)
+							e, err := tree.MakeDEnumFromPhysicalRepresentation(ct, v)
+							if err != nil {
+								colexecerror.InternalError(err)
+							}
+							_converted := da.NewDEnum(e)
+							//gcassert:bce
+							converted[destIdx] = _converted
+						}
+					}
 				case typeconv.DatumVecCanonicalTypeFamily:
 				default:
 					switch ct.Width() {
@@ -2296,6 +2401,29 @@ func ColVecToDatum(
 							converted[destIdx] = _converted
 						}
 					}
+				case types.EnumFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Bytes()
+						for idx = 0; idx < length; idx++ {
+							{
+								//gcassert:bce
+								destIdx = sel[idx]
+							}
+							{
+								//gcassert:bce
+								srcIdx = sel[idx]
+							}
+							v := typedCol.Get(srcIdx)
+							e, err := tree.MakeDEnumFromPhysicalRepresentation(ct, v)
+							if err != nil {
+								colexecerror.InternalError(err)
+							}
+							_converted := da.NewDEnum(e)
+							converted[destIdx] = _converted
+						}
+					}
 				case typeconv.DatumVecCanonicalTypeFamily:
 				default:
 					switch ct.Width() {
@@ -2656,6 +2784,28 @@ func ColVecToDatum(
 							//gcassert:bce
 							v := typedCol.Get(srcIdx)
 							_converted := da.NewDInterval(tree.DInterval{Duration: v})
+							//gcassert:bce
+							converted[destIdx] = _converted
+						}
+					}
+				case types.EnumFamily:
+					switch ct.Width() {
+					case -1:
+					default:
+						typedCol := col.Bytes()
+						for idx = 0; idx < length; idx++ {
+							{
+								destIdx = idx
+							}
+							{
+								srcIdx = idx
+							}
+							v := typedCol.Get(srcIdx)
+							e, err := tree.MakeDEnumFromPhysicalRepresentation(ct, v)
+							if err != nil {
+								colexecerror.InternalError(err)
+							}
+							_converted := da.NewDEnum(e)
 							//gcassert:bce
 							converted[destIdx] = _converted
 						}

--- a/pkg/sql/colencoding/key_encoding.go
+++ b/pkg/sql/colencoding/key_encoding.go
@@ -154,7 +154,7 @@ func decodeTableKeyToCol(
 			rkey, d, err = encoding.DecodeDecimalDescending(key, scratch[:0])
 		}
 		vecs.DecimalCols[colIdx][rowIdx] = d
-	case types.BytesFamily, types.StringFamily, types.UuidFamily:
+	case types.BytesFamily, types.StringFamily, types.UuidFamily, types.EnumFamily:
 		if dir == catpb.IndexColumn_ASC {
 			// We ask for the deep copy to be made so that scratch doesn't
 			// reference the memory of key - this allows us to return scratch
@@ -163,6 +163,7 @@ func decodeTableKeyToCol(
 			// GCed.
 			rkey, scratch, err = encoding.DecodeBytesAscendingDeepCopy(key, scratch[:0])
 		} else {
+			// DecodeBytesDescending always performs a deep copy.
 			rkey, scratch, err = encoding.DecodeBytesDescending(key, scratch[:0])
 		}
 		// Set() performs a deep copy, so it is safe to return the scratch slice
@@ -259,7 +260,7 @@ func UnmarshalColumnValueToCol(
 		vecs.Float64Cols[colIdx][rowIdx] = v
 	case types.DecimalFamily:
 		err = value.GetDecimalInto(&vecs.DecimalCols[colIdx][rowIdx])
-	case types.BytesFamily, types.StringFamily, types.UuidFamily:
+	case types.BytesFamily, types.StringFamily, types.UuidFamily, types.EnumFamily:
 		var v []byte
 		v, err = value.GetBytes()
 		vecs.BytesCols[colIdx].Set(rowIdx, v)

--- a/pkg/sql/colencoding/value_encoding.go
+++ b/pkg/sql/colencoding/value_encoding.go
@@ -60,7 +60,7 @@ func DecodeTableValueToCol(
 		// original buffer.
 		buf, b, err = encoding.DecodeBoolValue(origBuf)
 		vecs.BoolCols[colIdx][rowIdx] = b
-	case types.BytesFamily, types.StringFamily:
+	case types.BytesFamily, types.StringFamily, types.EnumFamily:
 		var data []byte
 		buf, data, err = encoding.DecodeUntaggedBytesValue(buf)
 		vecs.BytesCols[colIdx].Set(rowIdx, data)

--- a/pkg/sql/colexec/colexecbase/cast_tmpl.go
+++ b/pkg/sql/colexec/colexecbase/cast_tmpl.go
@@ -97,9 +97,10 @@ func isIdentityCast(fromType, toType *types.T) bool {
 		// by float64 physically.
 		return true
 	}
-	if fromType.Family() == types.UuidFamily && toType.Family() == types.BytesFamily {
-		// The cast from UUID to Bytes is an identity because we don't need to
-		// perform any conversion since both are represented in the same way.
+	if toType.Family() == types.BytesFamily && (fromType.Family() == types.UuidFamily || fromType.Family() == types.EnumFamily) {
+		// The casts from UUID or enum to Bytes is an identity because we don't
+		// need to perform any conversion since both are represented in the same
+		// way.
 		return true
 	}
 	return false
@@ -489,6 +490,14 @@ func (c *cast_NAMEOp) Next() coldata.Batch {
 	sel := batch.Selection()
 	inputVec := batch.ColVec(c.colIdx)
 	outputVec := batch.ColVec(c.outputIdx)
+	// {{if eq $fromFamily "types.EnumFamily"}}
+	// {{/*
+	//     TODO(yuzefovich): fromType should really be propagated as an
+	//     argument, but it is only used in one cast at the moment, so we're
+	//     being lazy.
+	// */}}
+	fromType := inputVec.Type()
+	// {{end}}
 	toType := outputVec.Type()
 	// Remove unused warnings.
 	_ = toType

--- a/pkg/sql/colexec/colexectestutils/utils.go
+++ b/pkg/sql/colexec/colexectestutils/utils.go
@@ -1016,6 +1016,15 @@ func (s *opTestInput) Next() coldata.Batch {
 						}
 						col.Index(outputIdx).Set(reflect.ValueOf(d))
 					case types.BytesFamily:
+						if vec.Type().Family() == types.EnumFamily {
+							enumMeta := s.typs[i].TypeMeta.EnumData
+							if enumMeta == nil {
+								colexecerror.InternalError(errors.AssertionFailedf("unexpectedly empty enum metadata in opTestInput"))
+							}
+							reps := enumMeta.PhysicalRepresentations
+							setColVal(vec, outputIdx, reps[rng.Intn(len(reps))], s.evalCtx)
+							break
+						}
 						newBytes := make([]byte, rng.Intn(16)+1)
 						rng.Read(newBytes)
 						setColVal(vec, outputIdx, newBytes, s.evalCtx)

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_base.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_base.go
@@ -236,7 +236,7 @@ func newArgWidthOverloadBase(
 
 func (b *argWidthOverloadBase) IsBytesLike() bool {
 	switch b.CanonicalTypeFamily {
-	case types.JsonFamily, types.BytesFamily:
+	case types.BytesFamily, types.JsonFamily:
 		return true
 	}
 	return false
@@ -768,6 +768,7 @@ type nonDatumDatumCustomizer struct {
 
 func registerTypeCustomizers() {
 	typeCustomizers = make(map[typePair]typeCustomizer)
+	// Same type customizers.
 	registerTypeCustomizer(typePair{types.BoolFamily, anyWidth, types.BoolFamily, anyWidth}, boolCustomizer{})
 	registerTypeCustomizer(typePair{types.BytesFamily, anyWidth, types.BytesFamily, anyWidth}, bytesCustomizer{})
 	registerTypeCustomizer(typePair{types.DecimalFamily, anyWidth, types.DecimalFamily, anyWidth}, decimalCustomizer{})
@@ -775,8 +776,6 @@ func registerTypeCustomizers() {
 	registerTypeCustomizer(typePair{types.TimestampTZFamily, anyWidth, types.TimestampTZFamily, anyWidth}, timestampCustomizer{})
 	registerTypeCustomizer(typePair{types.IntervalFamily, anyWidth, types.IntervalFamily, anyWidth}, intervalCustomizer{})
 	registerTypeCustomizer(typePair{types.JsonFamily, anyWidth, types.JsonFamily, anyWidth}, jsonCustomizer{})
-	registerTypeCustomizer(typePair{types.JsonFamily, anyWidth, types.BytesFamily, anyWidth}, jsonBytesCustomizer{})
-	registerTypeCustomizer(typePair{types.JsonFamily, anyWidth, typeconv.DatumVecCanonicalTypeFamily, anyWidth}, jsonDatumCustomizer{})
 	registerTypeCustomizer(typePair{typeconv.DatumVecCanonicalTypeFamily, anyWidth, typeconv.DatumVecCanonicalTypeFamily, anyWidth}, datumCustomizer{})
 	for _, leftIntWidth := range supportedWidthsByCanonicalTypeFamily[types.IntFamily] {
 		for _, rightIntWidth := range supportedWidthsByCanonicalTypeFamily[types.IntFamily] {
@@ -807,6 +806,8 @@ func registerTypeCustomizers() {
 	registerTypeCustomizer(typePair{types.IntervalFamily, anyWidth, types.TimestampTZFamily, anyWidth}, intervalTimestampCustomizer{})
 	registerTypeCustomizer(typePair{types.IntervalFamily, anyWidth, types.DecimalFamily, anyWidth}, intervalDecimalCustomizer{})
 	registerTypeCustomizer(typePair{types.DecimalFamily, anyWidth, types.IntervalFamily, anyWidth}, decimalIntervalCustomizer{})
+	registerTypeCustomizer(typePair{types.JsonFamily, anyWidth, types.BytesFamily, anyWidth}, jsonBytesCustomizer{})
+	registerTypeCustomizer(typePair{types.JsonFamily, anyWidth, typeconv.DatumVecCanonicalTypeFamily, anyWidth}, jsonDatumCustomizer{})
 
 	for _, compatibleFamily := range compatibleCanonicalTypeFamilies[typeconv.DatumVecCanonicalTypeFamily] {
 		if compatibleFamily != typeconv.DatumVecCanonicalTypeFamily {

--- a/pkg/sql/colexec/execgen/cmd/execgen/rowtovec_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/rowtovec_gen.go
@@ -98,6 +98,7 @@ var rowToVecConversionTmpls = map[familyWidthPair]string{
 	{types.TimestampFamily, anyWidth}:                `%[1]s.(*tree.DTimestamp).Time`,
 	{types.TimestampTZFamily, anyWidth}:              `%[1]s.(*tree.DTimestampTZ).Time`,
 	{types.IntervalFamily, anyWidth}:                 `%[1]s.(*tree.DInterval).Duration`,
+	{types.EnumFamily, anyWidth}:                     `%[1]s.(*tree.DEnum).PhysicalRep`,
 	{typeconv.DatumVecCanonicalTypeFamily, anyWidth}: `%[1]s`,
 }
 

--- a/pkg/sql/colexec/execgen/cmd/execgen/vec_to_datum_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/vec_to_datum_gen.go
@@ -98,9 +98,14 @@ var vecToDatumConversionTmpls = map[types.Family]string{
 							colexecerror.InternalError(err)
 						}
 						%[1]s := %[3]s.NewDUuid(tree.DUuid{UUID: id})`,
-	types.TimestampFamily:                `%[1]s := %[3]s.NewDTimestamp(tree.DTimestamp{Time: %[2]s})`,
-	types.TimestampTZFamily:              `%[1]s := %[3]s.NewDTimestampTZ(tree.DTimestampTZ{Time: %[2]s})`,
-	types.IntervalFamily:                 `%[1]s := %[3]s.NewDInterval(tree.DInterval{Duration: %[2]s})`,
+	types.TimestampFamily:   `%[1]s := %[3]s.NewDTimestamp(tree.DTimestamp{Time: %[2]s})`,
+	types.TimestampTZFamily: `%[1]s := %[3]s.NewDTimestampTZ(tree.DTimestampTZ{Time: %[2]s})`,
+	types.IntervalFamily:    `%[1]s := %[3]s.NewDInterval(tree.DInterval{Duration: %[2]s})`,
+	types.EnumFamily: `e, err := tree.MakeDEnumFromPhysicalRepresentation(ct, %[2]s)
+						if err != nil {
+							colexecerror.InternalError(err)
+						}
+						%[1]s := %[3]s.NewDEnum(e)`,
 	typeconv.DatumVecCanonicalTypeFamily: `%[1]s := %[2]s.(tree.Datum)`,
 }
 
@@ -129,6 +134,7 @@ func genVecToDatum(inputFileContents string, wr io.Writer) error {
 		types.BoolFamily, types.IntFamily, types.FloatFamily, types.DecimalFamily,
 		types.DateFamily, types.BytesFamily, types.EncodedKeyFamily, types.JsonFamily,
 		types.UuidFamily, types.TimestampFamily, types.TimestampTZFamily, types.IntervalFamily,
+		types.EnumFamily,
 	}
 	for _, typeFamily := range optimizedTypeFamilies {
 		canonicalTypeFamily := typeconv.TypeFamilyToCanonicalTypeFamily(typeFamily)

--- a/pkg/sql/colexec/rowtovec.eg.go
+++ b/pkg/sql/colexec/rowtovec.eg.go
@@ -164,6 +164,14 @@ func EncDatumRowToColVecs(
 					v := datum.(*tree.DJSON).JSON
 					vecs.JSONCols[vecs.ColsMap[vecIdx]].Set(rowIdx, v)
 				}
+			case types.EnumFamily:
+				switch t.Width() {
+				case -1:
+				default:
+
+					v := datum.(*tree.DEnum).PhysicalRep
+					vecs.BytesCols[vecs.ColsMap[vecIdx]].Set(rowIdx, v)
+				}
 			case types.EncodedKeyFamily:
 				switch t.Width() {
 				case -1:

--- a/pkg/sql/colmem/allocator.go
+++ b/pkg/sql/colmem/allocator.go
@@ -412,14 +412,14 @@ func (a *Allocator) MaybeAppendColumn(b coldata.Batch, t *types.T, colIdx int) {
 		// We have a vector with an unexpected type, so we panic.
 		colexecerror.InternalError(errors.AssertionFailedf(
 			"trying to add a column of %s type at index %d but %s vector already present",
-			t, colIdx, presentType,
+			t.SQLString(), colIdx, presentType.SQLString(),
 		))
 	} else if colIdx > width {
 		// We have a batch of unexpected width which indicates an error in the
 		// planning stage.
 		colexecerror.InternalError(errors.AssertionFailedf(
 			"trying to add a column of %s type at index %d but batch has width %d",
-			t, colIdx, width,
+			t.SQLString(), colIdx, width,
 		))
 	}
 	estimatedMemoryUsage := EstimateBatchSizeBytes([]*types.T{t}, desiredCapacity)
@@ -616,7 +616,7 @@ func EstimateBatchSizeBytes(vecTypes []*types.T, batchLength int) int64 {
 			// Types that have a statically known size.
 			acc += GetFixedSizeTypeSize(t)
 		default:
-			colexecerror.InternalError(errors.AssertionFailedf("unhandled type %s", t))
+			colexecerror.InternalError(errors.AssertionFailedf("unhandled type %s", t.SQLString()))
 		}
 	}
 	// For byte arrays, we initially allocate a constant number of bytes for
@@ -657,7 +657,7 @@ func GetFixedSizeTypeSize(t *types.T) (size int64) {
 	case types.IntervalFamily:
 		size = memsize.Duration
 	default:
-		colexecerror.InternalError(errors.AssertionFailedf("unhandled type %s", t))
+		colexecerror.InternalError(errors.AssertionFailedf("unhandled type %s", t.SQLString()))
 	}
 	return size
 }
@@ -910,10 +910,13 @@ func (h *SetAccountingHelper) ResetMaybeReallocate(
 		if !h.bytesLikeVecIdxs.Empty() {
 			h.bytesLikeVectors = h.bytesLikeVectors[:0]
 			for vecIdx, ok := h.bytesLikeVecIdxs.Next(0); ok; vecIdx, ok = h.bytesLikeVecIdxs.Next(vecIdx + 1) {
-				if vecs[vecIdx].CanonicalTypeFamily() == types.BytesFamily {
+				switch vecs[vecIdx].CanonicalTypeFamily() {
+				case types.BytesFamily:
 					h.bytesLikeVectors = append(h.bytesLikeVectors, vecs[vecIdx].Bytes())
-				} else {
+				case types.JsonFamily:
 					h.bytesLikeVectors = append(h.bytesLikeVectors, &vecs[vecIdx].JSON().Bytes)
+				default:
+					colexecerror.InternalError(errors.AssertionFailedf("unexpected bytes-like type: %s", typs[vecIdx].SQLString()))
 				}
 			}
 			h.prevBytesLikeTotalSize = h.getBytesLikeTotalSize()

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -4936,6 +4936,18 @@ func GetEnumComponentsFromPhysicalRep(typ *types.T, rep []byte) ([]byte, string,
 	return meta.PhysicalRepresentations[idx], meta.LogicalRepresentations[idx], nil
 }
 
+// GetEnumComponentsFromLogicalRep returns the physical and logical components
+// for an enum of the requested type. It returns an error if it cannot find a
+// matching logical representation.
+func GetEnumComponentsFromLogicalRep(typ *types.T, rep string) ([]byte, string, error) {
+	idx, err := typ.EnumGetIdxOfLogical(rep)
+	if err != nil {
+		return nil, "", err
+	}
+	meta := typ.TypeMeta.EnumData
+	return meta.PhysicalRepresentations[idx], meta.LogicalRepresentations[idx], nil
+}
+
 // NewDEnum initializes a new DEnum from its argument.
 func NewDEnum(e DEnum) *DEnum {
 	return &e
@@ -4972,12 +4984,6 @@ func MakeDEnumFromLogicalRepresentation(typ *types.T, rep string) (DEnum, error)
 	idx, err := typ.EnumGetIdxOfLogical(rep)
 	if err != nil {
 		return DEnum{}, err
-	}
-	// If this enum member is read only, we cannot construct it from the logical
-	// representation. This is to ensure that it will not be written until all
-	// nodes in the cluster are able to decode the physical representation.
-	if typ.TypeMeta.EnumData.IsMemberReadOnly[idx] {
-		return DEnum{}, errors.Newf("enum value %q is not yet public", rep)
 	}
 	return DEnum{
 		EnumTyp:     typ,

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -2614,6 +2614,13 @@ func (t *T) EnumGetIdxOfLogical(logical string) (int, error) {
 	reps := t.TypeMeta.EnumData.LogicalRepresentations
 	for i := range reps {
 		if reps[i] == logical {
+			// If this enum member is read only, we cannot construct it from the
+			// logical representation. This is to ensure that it will not be
+			// written until all nodes in the cluster are able to decode the
+			// physical representation.
+			if t.TypeMeta.EnumData.IsMemberReadOnly[i] {
+				return 0, errors.Newf("enum value %q is not yet public", logical)
+			}
 			return i, nil
 		}
 	}


### PR DESCRIPTION
This commit adds the native support of enum types to the vectorized
engine. We store them via their physical representation, so we can
easily reuse `Bytes` vector for almost all operations, and, thus, we
just mark the enum family as having the bytes family as its canonical
representation. There are only a handful of places where we need to go
from the physical representation to either the logical one or to the
`DEnum`:
- when constructing the pgwire message to the client (in both text and
binary format the logical representation is used)
- when converting from columnar to row-by-row format (fully-fledged
`DEnum` is constructed)
- casts.

In all of these places we already have access to the precise typing
information (similar to what we have for UUIDs which are supported via
the bytes canonical type family already).

I can really see only one downside to such implementation - in some
places the resolution based on the canonical (rather than actual) type
family might be too coarse. For example, we have `<bytes> || <bytes>`
binary operator (`concat`). As it currently stands the execution will
proceed to perform the concatenation between two UUIDs or between a
BYTES value and a UUID, and now we'll be adding enums into the mix.
However, the type checking is performed earlier on the query execution
path, so I think it is acceptable since the execution should never
reach such a setup.

An additional benefit of this work is that we'll be able to support the
KV projection pushdown in presence of enums - on the KV server side
we'll just operate with the physical representations and won't need to
have access to the hydrated type whereas on the client side we'll have
the hydrated type, so we'll be able to do all operations.

Addresses: #42043.
Informs: #92954.

Epic: CRDB-14837

Release note: None