### PR TITLE
roachtest: pin loop variable in `failover` tests

### DIFF
--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -38,6 +38,7 @@ func registerFailover(r registry.Registry) {
 		failureModeBlackholeSend,
 		failureModeCrash,
 	} {
+		failureMode := failureMode // pin loop variable
 		r.Add(registry.TestSpec{
 			Name:    fmt.Sprintf("failover/non-system/%s", failureMode),
 			Owner:   registry.OwnerKV,


### PR DESCRIPTION
Sigh, missed the closures here.

Epic: none
Release note: None