### PR TITLE
kvserver: remove unused params

### DIFF
--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/settings"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
@@ -137,8 +136,6 @@ func splitSnapshotWarningStr(rangeID roachpb.RangeID, status *raft.Status) strin
 // right side is assigned rightRangeID and starts at splitKey. The supplied
 // expiration is the "sticky bit" stored on the right descriptor.
 func prepareSplitDescs(
-	ctx context.Context,
-	st *cluster.Settings,
 	rightRangeID roachpb.RangeID,
 	splitKey roachpb.RKey,
 	expiration hlc.Timestamp,
@@ -187,8 +184,7 @@ func splitTxnAttempt(
 	desc := oldDesc
 	oldDesc = nil // prevent accidental use
 
-	leftDesc, rightDesc := prepareSplitDescs(
-		ctx, store.ClusterSettings(), rightRangeID, splitKey, expiration, desc)
+	leftDesc, rightDesc := prepareSplitDescs(rightRangeID, splitKey, expiration, desc)
 
 	// Update existing range descriptor for left hand side of
 	// split. Note that we mutate the descriptor for the left hand

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -192,7 +192,7 @@ func splitTxnAttempt(
 	{
 		b := txn.NewBatch()
 		leftDescKey := keys.RangeDescriptorKey(leftDesc.StartKey)
-		if err := updateRangeDescriptor(ctx, b, leftDescKey, dbDescValue, leftDesc); err != nil {
+		if err := updateRangeDescriptor(b, leftDescKey, dbDescValue, leftDesc); err != nil {
 			return err
 		}
 		// Commit this batch first to ensure that the transaction record
@@ -216,7 +216,7 @@ func splitTxnAttempt(
 
 	// Write range descriptor for right hand side of the split.
 	rightDescKey := keys.RangeDescriptorKey(rightDesc.StartKey)
-	if err := updateRangeDescriptor(ctx, b, rightDescKey, nil, rightDesc); err != nil {
+	if err := updateRangeDescriptor(b, rightDescKey, nil, rightDesc); err != nil {
 		return err
 	}
 
@@ -258,7 +258,7 @@ func splitTxnStickyUpdateAttempt(
 
 	b := txn.NewBatch()
 	descKey := keys.RangeDescriptorKey(desc.StartKey)
-	if err := updateRangeDescriptor(ctx, b, descKey, dbDescValue, &newDesc); err != nil {
+	if err := updateRangeDescriptor(b, descKey, dbDescValue, &newDesc); err != nil {
 		return err
 	}
 	if err := updateRangeAddressing(b, &newDesc); err != nil {
@@ -476,7 +476,7 @@ func (r *Replica) adminUnsplitWithDescriptor(
 		descKey := keys.RangeDescriptorKey(newDesc.StartKey)
 
 		b := txn.NewBatch()
-		if err := updateRangeDescriptor(ctx, b, descKey, dbDescValue, &newDesc); err != nil {
+		if err := updateRangeDescriptor(b, descKey, dbDescValue, &newDesc); err != nil {
 			return err
 		}
 		if err := updateRangeAddressing(b, &newDesc); err != nil {
@@ -711,7 +711,7 @@ func (r *Replica) AdminMerge(
 
 		// Update the range descriptor for the receiving range.
 		leftDescKey := keys.RangeDescriptorKey(updatedLeftDesc.StartKey)
-		if err := updateRangeDescriptor(ctx, b, leftDescKey,
+		if err := updateRangeDescriptor(b, leftDescKey,
 			dbOrigLeftDescValue, /* oldValue */
 			&updatedLeftDesc,    /* newDesc */
 		); err != nil {
@@ -719,7 +719,7 @@ func (r *Replica) AdminMerge(
 		}
 
 		// Remove the range descriptor for the deleted range.
-		if err := updateRangeDescriptor(ctx, b, rightDescKey,
+		if err := updateRangeDescriptor(b, rightDescKey,
 			dbRightDescKV.Value.TagAndDataBytes(), /* oldValue */
 			nil,                                   /* newDesc */
 		); err != nil {
@@ -2386,7 +2386,7 @@ func execChangeReplicasTxn(
 
 				// Important: the range descriptor must be the first thing touched in the transaction
 				// so the transaction record is co-located with the range being modified.
-				if err := updateRangeDescriptor(ctx, b, descKey, dbDescValue, crt.Desc); err != nil {
+				if err := updateRangeDescriptor(b, descKey, dbDescValue, crt.Desc); err != nil {
 					return err
 				}
 
@@ -3008,11 +3008,7 @@ func conditionalGetDescValueFromDB(
 // descriptor, a CommitTrigger must be used to update the in-memory
 // descriptor; it will not automatically be copied from newDesc.
 func updateRangeDescriptor(
-	ctx context.Context,
-	b *kv.Batch,
-	descKey roachpb.Key,
-	oldValue []byte,
-	newDesc *roachpb.RangeDescriptor,
+	b *kv.Batch, descKey roachpb.Key, oldValue []byte, newDesc *roachpb.RangeDescriptor,
 ) error {
 	// This is subtle: []byte(nil) != interface{}(nil). A []byte(nil) refers to
 	// an empty value. An interface{}(nil) refers to a non-existent value. So

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -286,7 +286,7 @@ func (tc *testContext) addBogusReplicaToRangeDesc(
 		Header: roachpb.Header{Timestamp: tc.Clock().Now()},
 	}
 	descKey := keys.RangeDescriptorKey(oldDesc.StartKey)
-	if err := updateRangeDescriptor(ctx, &ba, descKey, dbDescKV.Value.TagAndDataBytes(), &newDesc); err != nil {
+	if err := updateRangeDescriptor(&ba, descKey, dbDescKV.Value.TagAndDataBytes(), &newDesc); err != nil {
 		return roachpb.ReplicaDescriptor{}, err
 	}
 	if err := tc.store.DB().Run(ctx, &ba); err != nil {


### PR DESCRIPTION
This change removes unused params in helpers called by various range split paths.

Epic: none