### PR TITLE
docs: fix missing whitespace in pg_backend_pid docs

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -3432,7 +3432,7 @@ table. Returns an error if validation fails.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="oid"></a><code>oid(int: <a href="int.html">int</a>) &rarr; oid</code></td><td><span class="funcdesc"><p>Converts an integer to an OID.</p>
 </span></td><td>Immutable</td></tr>
-<tr><td><a name="pg_backend_pid"></a><code>pg_backend_pid() &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns a numerical ID attached to this session. This ID is part of the query cancellation key used by the wire protocol. This function was only added for compatibility, and unlike in Postgres, thereturned value does not correspond to a real process ID.</p>
+<tr><td><a name="pg_backend_pid"></a><code>pg_backend_pid() &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns a numerical ID attached to this session. This ID is part of the query cancellation key used by the wire protocol. This function was only added for compatibility, and unlike in Postgres, the returned value does not correspond to a real process ID.</p>
 </span></td><td>Stable</td></tr>
 <tr><td><a name="pg_collation_for"></a><code>pg_collation_for(str: anyelement) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the collation of the argument</p>
 </span></td><td>Stable</td></tr>

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -552,7 +552,7 @@ var pgBuiltins = map[string]builtinDefinition{
 			},
 			Info: "Returns a numerical ID attached to this session. This ID is " +
 				"part of the query cancellation key used by the wire protocol. This " +
-				"function was only added for compatibility, and unlike in Postgres, the" +
+				"function was only added for compatibility, and unlike in Postgres, the " +
 				"returned value does not correspond to a real process ID.",
 			Volatility: volatility.Stable,
 		},


### PR DESCRIPTION
Epic: None

Release note: None