### PR TITLE
release-22.2: sql: add version gate for system privs during DROP ROLE

### DIFF
--- a/pkg/sql/drop_role.go
+++ b/pkg/sql/drop_role.go
@@ -16,6 +16,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
@@ -586,6 +587,9 @@ func addDependentPrivilegesFromSystemPrivileges(
 	privilegeObjectFormatter *tree.FmtCtx,
 	userNamesToDependentPrivileges map[username.SQLUsername][]objectAndType,
 ) (retErr error) {
+	if !p.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.SystemPrivilegesTable) {
+		return nil
+	}
 	names := make([]string, len(usernames))
 	for i, username := range usernames {
 		names[i] = username.Normalized()


### PR DESCRIPTION
Release justification: bug fix

Epic: None

Release note (bug fix): Fixed a bug that could happen when dropping a
user/role before the upgrade to v22.2 was finalized.