### PR TITLE
sql,server: fetch privileges for virtual tables on startup

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1519,6 +1519,11 @@ func (s *SQLServer) preStart(
 	)
 
 	scheduledlogging.Start(ctx, stopper, s.execCfg.DB, s.execCfg.Settings, s.internalExecutor, s.execCfg.CaptureIndexUsageStatsKnobs)
+	sql.WarmSyntheticSchemaPrivilegeCacheForVirtualTables(
+		ctx, stopper, s.execCfg.Settings.Version,
+		s.execCfg.SyntheticPrivilegeCache, s.execCfg.VirtualSchemas,
+		s.execCfg.InternalExecutorFactory, s.execCfg.DB,
+	)
 	return nil
 }
 


### PR DESCRIPTION
This commit attempts to alleviate the pain caused by synthetic virtual table privileges introduced in 22.2. We need to fetch privileges for virtual tables to determine whether the user has access. This is done lazily. However, when a user attempts to read a virtual table like pg_class or run `SHOW TABLES` it will force the privileges to be determined for each virtual table (of which there are 290 at the time of writing). This sequential process can be somewhat slow in a single region cluster and will be *very* slow in an MR cluster.

This patch attempts to somewhat alleviate this pain by kicking off goroutines to fetch these privileges eagerly at server startup. This is okay, but is pretty expensive. Each privilege fetch itself internally runs a query which means we're running 290 statements in 290 transactions to fetch this information.

Ideally we'd do something better, like pre-warm the cache with one scan against the system table.

Partially addresses #93182.

Epic: CRDB-18596

Release note (performance improvement): In 22.2 we introduced privileges on virtual tables (system catalogs like pg_catalog, information_schema, and crdb_internal). A problem with this new feature is that we now must fetch those privileges into a cache before we can use those tables or determine their visibility in other system catalogs. This process used to occur on-demand, when the privilege was needed. Now we'll fetch these privileges eagerly during startup, with some parallelism, to mitigate the latency when accessing pg_catalog right after the server boots up.