### PR TITLE
tree: return DEnum value from MakeDEnum* functions

### DIFF
--- a/pkg/ccl/changefeedccl/avro.go
+++ b/pkg/ccl/changefeedccl/avro.go
@@ -610,7 +610,11 @@ func typeToAvroSchema(typ *types.T) (*avroSchemaField, error) {
 				return d.(*tree.DEnum).LogicalRep, nil
 			},
 			func(x interface{}) (tree.Datum, error) {
-				return tree.MakeDEnumFromLogicalRepresentation(typ, x.(string))
+				e, err := tree.MakeDEnumFromLogicalRepresentation(typ, x.(string))
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDEnum(e), nil
 			},
 		)
 	case types.ArrayFamily:

--- a/pkg/sql/importer/exportparquet.go
+++ b/pkg/sql/importer/exportparquet.go
@@ -410,7 +410,11 @@ func NewParquetColumn(typ *types.T, name string, nullable bool) (ParquetColumn, 
 			return []byte(d.(*tree.DEnum).LogicalRep), nil
 		}
 		col.DecodeFn = func(x interface{}) (tree.Datum, error) {
-			return tree.MakeDEnumFromLogicalRepresentation(typ, string(x.([]byte)))
+			e, err := tree.MakeDEnumFromLogicalRepresentation(typ, string(x.([]byte)))
+			if err != nil {
+				return nil, err
+			}
+			return tree.NewDEnum(e), nil
 		}
 	case types.Box2DFamily:
 		populateLogicalStringCol(schemaEl)

--- a/pkg/sql/opt/constraint/span_test.go
+++ b/pkg/sql/opt/constraint/span_test.go
@@ -1112,5 +1112,5 @@ func makeEnums(t *testing.T) tree.Datums {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return tree.Datums{enumHello, enumHey, enumHi}
+	return tree.Datums{&enumHello, &enumHey, &enumHi}
 }

--- a/pkg/sql/pgwire/pgwirebase/encoding.go
+++ b/pkg/sql/pgwire/pgwirebase/encoding.go
@@ -829,7 +829,11 @@ func DecodeDatum(
 		if err := validateStringBytes(b); err != nil {
 			return nil, err
 		}
-		return tree.MakeDEnumFromLogicalRepresentation(typ, string(b))
+		e, err := tree.MakeDEnumFromLogicalRepresentation(typ, string(b))
+		if err != nil {
+			return nil, err
+		}
+		return tree.NewDEnum(e), nil
 	}
 	switch id {
 	case oid.T_text, oid.T_varchar, oid.T_unknown:

--- a/pkg/sql/randgen/datum.go
+++ b/pkg/sql/randgen/datum.go
@@ -277,7 +277,7 @@ func RandDatumWithNullChance(
 		if err != nil {
 			panic(err)
 		}
-		return d
+		return tree.NewDEnum(d)
 	case types.VoidFamily:
 		return tree.DVoidDatum
 	case types.TSVectorFamily:

--- a/pkg/sql/sem/eval/cast.go
+++ b/pkg/sql/sem/eval/cast.go
@@ -264,9 +264,17 @@ func performCastWithoutPrecisionTruncation(
 	case types.EnumFamily:
 		switch v := d.(type) {
 		case *tree.DString:
-			return tree.MakeDEnumFromLogicalRepresentation(t, string(*v))
+			e, err := tree.MakeDEnumFromLogicalRepresentation(t, string(*v))
+			if err != nil {
+				return nil, err
+			}
+			return tree.NewDEnum(e), nil
 		case *tree.DBytes:
-			return tree.MakeDEnumFromPhysicalRepresentation(t, []byte(*v))
+			e, err := tree.MakeDEnumFromPhysicalRepresentation(t, []byte(*v))
+			if err != nil {
+				return nil, err
+			}
+			return tree.NewDEnum(e), nil
 		case *tree.DEnum:
 			return d, nil
 		}

--- a/pkg/sql/sem/tree/constant.go
+++ b/pkg/sql/sem/tree/constant.go
@@ -609,7 +609,11 @@ func (expr *StrVal) ResolveAsType(
 			expr.resBytes = DBytes(expr.s)
 			return &expr.resBytes, nil
 		case types.EnumFamily:
-			return MakeDEnumFromPhysicalRepresentation(typ, []byte(expr.s))
+			e, err := MakeDEnumFromPhysicalRepresentation(typ, []byte(expr.s))
+			if err != nil {
+				return nil, err
+			}
+			return NewDEnum(e), nil
 		case types.UuidFamily:
 			return ParseDUuidFromBytes([]byte(expr.s))
 		case types.StringFamily:

--- a/pkg/sql/sem/tree/format_test.go
+++ b/pkg/sql/sem/tree/format_test.go
@@ -330,7 +330,7 @@ func TestFormatExpr2(t *testing.T) {
 		},
 		{tree.NewDTuple(
 			types.MakeTuple([]*types.T{enumType, enumType}),
-			tree.DNull, enumHi),
+			tree.DNull, &enumHi),
 			tree.FmtParsable,
 			`(NULL:::greeting, 'hi':::greeting)`,
 		},
@@ -339,13 +339,13 @@ func TestFormatExpr2(t *testing.T) {
 		// enclosing tuple for serialization purposes.
 		{tree.NewDTuple(
 			types.MakeTuple([]*types.T{enumType, enumType}),
-			enumHi, enumHello),
+			&enumHi, &enumHello),
 			tree.FmtSerializable,
 			`(x'4201':::@100500, x'42':::@100500)`,
 		},
 		{tree.NewDTuple(
 			types.MakeTuple([]*types.T{enumType, enumType}),
-			tree.DNull, enumHi),
+			tree.DNull, &enumHi),
 			tree.FmtSerializable,
 			`(NULL:::@100500, x'4201':::@100500)`,
 		},

--- a/pkg/sql/sem/tree/parse_string.go
+++ b/pkg/sql/sem/tree/parse_string.go
@@ -90,7 +90,11 @@ func ParseAndRequireString(
 	case types.UuidFamily:
 		d, err = ParseDUuidFromString(s)
 	case types.EnumFamily:
-		d, err = MakeDEnumFromLogicalRepresentation(t, s)
+		var e DEnum
+		e, err = MakeDEnumFromLogicalRepresentation(t, s)
+		if err == nil {
+			d = NewDEnum(e)
+		}
 	case types.TSQueryFamily:
 		d, err = ParseDTSQuery(s)
 	case types.TSVectorFamily:

--- a/pkg/sql/stats/histogram_test.go
+++ b/pkg/sql/stats/histogram_test.go
@@ -810,12 +810,12 @@ func makeEnums(t *testing.T) tree.Datums {
 		},
 	}
 	res := make(tree.Datums, len(enumMembers))
-	var err error
 	for i := range enumMembers {
-		res[i], err = tree.MakeDEnumFromLogicalRepresentation(enumType, enumMembers[i])
+		e, err := tree.MakeDEnumFromLogicalRepresentation(enumType, enumMembers[i])
 		if err != nil {
 			t.Fatal(err)
 		}
+		res[i] = tree.NewDEnum(e)
 	}
 	return res
 }


### PR DESCRIPTION
This commit makes it so that we return a `DEnum` value (rather than
a pointer) from `MakeDEnum*` functions to make it in line with how we
construct all other datums. In some cases we do want to use the returned
value to copy it into the batch-allocated (via `DatumAlloc`) enum.

Epic: None

Release note: None
