### PR TITLE
tracing: fix leak detector

### DIFF
--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -606,7 +606,7 @@ func (sp *Span) reset(
 			// quiet. We've detected a Span leak nonetheless, but it's likely that the
 			// test that leaked the span has already finished. Panicking in the middle
 			// of an unrelated test would be poor UX.
-			if sp.Tracer().closed() {
+			if sp.i.Tracer().closed() {
 				return
 			}
 			panic(fmt.Sprintf("Span not finished or references not released; "+


### PR DESCRIPTION
The tracer installs a finalizer for spans, aimed at detecting "leaked spans": spans whose reference counter never reached 0. There was a bug in the finalizer: it called sp.Tracer(), which panics if use-after-Finish detection is enabled. In case a finished span was leaked, this would cause the finalizer to panic with the wrong message - "use after finish" instead of "leak". This patch fixes it by bypassing the use-after-finish protection.

Release note: None
Epic: None