### PR TITLE
sql,server: fetch privileges for virtual tables on startup

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1519,6 +1519,9 @@ func (s *SQLServer) preStart(
 	)
 
 	scheduledlogging.Start(ctx, stopper, s.execCfg.DB, s.execCfg.Settings, s.internalExecutor, s.execCfg.CaptureIndexUsageStatsKnobs)
+	if err := stopper.RunAsyncTask(ctx, "warm-synthetic-privilege-cache", s.execCfg.WarmSyntheticPrivilegeCacheForVirtualTables); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/roleoption"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessioninit"
@@ -40,10 +41,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/syntheticprivilege"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil/singleflight"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 )
@@ -939,4 +942,108 @@ func insufficientPrivilegeError(
 	return pgerror.Newf(pgcode.InsufficientPrivilege,
 		"user %s does not have %s privilege on %s %s",
 		user, kind, typeForError, object.GetName())
+}
+
+// WarmSyntheticPrivilegeCacheForVirtualTables will attempt to access
+// each virtual table, and, in doing so, will cache the privileges for those
+// virtual tables. This work is done in parallel. It aids in reducing the cold
+// start latency when accessing virtual tables which themselves list virtual
+// tables.
+func (cfg *ExecutorConfig) WarmSyntheticPrivilegeCacheForVirtualTables(ctx context.Context) {
+	if !cfg.Settings.Version.IsActive(ctx, clusterversion.V22_2SystemPrivilegesTable) {
+		return
+	}
+
+	start := timeutil.Now()
+	var err error
+	cfg.SyntheticPrivilegeCache.WarmingGroup.Add(1)
+	defer func() {
+		cfg.SyntheticPrivilegeCache.WarmingGroup.Done()
+		if err != nil {
+			log.Warningf(ctx, "failed to warm privileges for virtual tables: %v", err)
+		} else {
+			log.Infof(ctx, "warmed privileges for virtual tables in %v", timeutil.Since(start))
+		}
+	}()
+
+	var tableVersions []descpb.DescriptorVersion
+	vtablePathToPrivilegeAccumulator := make(map[string]*catpb.PrivilegeDescriptor)
+	query := fmt.Sprintf(
+		`SELECT path, username, privileges, grant_options FROM system.%s WHERE path LIKE '/%s/%%'`,
+		catconstants.SystemPrivilegeTableName,
+		syntheticprivilege.VirtualTablePathPrefix,
+	)
+	err = cfg.InternalExecutorFactory.DescsTxnWithExecutor(
+		ctx,
+		cfg.DB,
+		nil, /* sessionData */
+		func(ctx context.Context, txn *kv.Txn, descsCol *descs.Collection, ie sqlutil.InternalExecutor) (retErr error) {
+			_, systemPrivDesc, err := descsCol.GetImmutableTableByName(
+				ctx,
+				txn,
+				syntheticprivilege.SystemPrivilegesTableName,
+				tree.ObjectLookupFlagsWithRequired(),
+			)
+			if err != nil {
+				return err
+			}
+			if systemPrivDesc.IsUncommittedVersion() {
+				// This shouldn't ever happen, but if it does somehow, then we can't pre-warm the cache.
+				logcrash.ReportOrPanic(ctx, &cfg.Settings.SV, "cannot warm cache: %s is at an uncommitted version", syntheticprivilege.SystemPrivilegesTableName)
+				return errors.Newf("%s is at an uncommitted version", syntheticprivilege.SystemPrivilegesTableName)
+			}
+			tableVersions = []descpb.DescriptorVersion{systemPrivDesc.GetVersion()}
+
+			it, err := ie.QueryIteratorEx(
+				ctx, `get-vtable-privileges`, txn, sessiondata.NodeUserSessionDataOverride, query,
+			)
+			if err != nil {
+				return err
+			}
+			defer func() {
+				retErr = errors.CombineErrors(retErr, it.Close())
+			}()
+
+			for {
+				ok, err := it.Next(ctx)
+				if err != nil {
+					return err
+				}
+				if !ok {
+					break
+				}
+				path := tree.MustBeDString(it.Cur()[0])
+				user := tree.MustBeDString(it.Cur()[1])
+				privArr := tree.MustBeDArray(it.Cur()[2])
+				grantOptionArr := tree.MustBeDArray(it.Cur()[3])
+				privDesc, ok := vtablePathToPrivilegeAccumulator[string(path)]
+				if !ok {
+					privDesc = &catpb.PrivilegeDescriptor{}
+				}
+				if err := accumulatePrivilegeDescriptorFromSystemPrivilegesRow(privilege.VirtualTable, privDesc, user, privArr, grantOptionArr); err != nil {
+					return err
+				}
+				vtablePathToPrivilegeAccumulator[string(path)] = privDesc
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return
+	}
+
+	for scName := range catconstants.VirtualSchemaNames {
+		sc, _ := cfg.VirtualSchemas.GetVirtualSchema(scName)
+		sc.VisitTables(func(object catalog.VirtualObject) {
+			vtablePriv := syntheticprivilege.VirtualTablePrivilege{
+				SchemaName: scName,
+				TableName:  sc.Desc().GetName(),
+			}
+			privDesc, ok := vtablePathToPrivilegeAccumulator[vtablePriv.GetPath()]
+			if !ok {
+				privDesc = vtablePriv.GetFallbackPrivileges()
+			}
+			cfg.SyntheticPrivilegeCache.MaybeWriteBackToCache(ctx, tableVersions, vtablePriv.GetPath(), *privDesc)
+		})
+	}
 }

--- a/pkg/sql/cacheutil/BUILD.bazel
+++ b/pkg/sql/cacheutil/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/sql/catalog/descpb",
+        "//pkg/util/ctxgroup",
         "//pkg/util/log",
         "//pkg/util/mon",
         "//pkg/util/stop",

--- a/pkg/sql/grant_revoke_system.go
+++ b/pkg/sql/grant_revoke_system.go
@@ -305,7 +305,6 @@ func synthesizePrivilegeDescriptor(
 		return spo.GetFallbackPrivileges(), nil
 	}
 
-	cache.WarmingGroup.Wait()
 	_, desc, err := descsCol.GetImmutableTableByName(
 		ctx,
 		txn,

--- a/pkg/sql/grant_revoke_system.go
+++ b/pkg/sql/grant_revoke_system.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/sql/cacheutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catprivilege"
@@ -271,7 +272,8 @@ func (p *planner) getPrivilegeDescriptor(
 				TableName:  d.GetName(),
 			}
 			return synthesizePrivilegeDescriptor(
-				ctx, p.ExecCfg(), p.ExecCfg().InternalExecutor, p.Descriptors(), p.Txn(), vDesc,
+				ctx, p.ExecCfg().Settings.Version, p.ExecCfg().SyntheticPrivilegeCache,
+				p.ExecCfg().InternalExecutor, p.Descriptors(), p.Txn(), vDesc,
 			)
 		}
 		return d.GetPrivileges(), nil
@@ -279,7 +281,8 @@ func (p *planner) getPrivilegeDescriptor(
 		return d.GetPrivileges(), nil
 	case syntheticprivilege.Object:
 		return synthesizePrivilegeDescriptor(
-			ctx, p.ExecCfg(), p.ExecCfg().InternalExecutor, p.Descriptors(), p.Txn(), d,
+			ctx, p.ExecCfg().Settings.Version, p.ExecCfg().SyntheticPrivilegeCache,
+			p.ExecCfg().InternalExecutor, p.Descriptors(), p.Txn(), d,
 		)
 	}
 	return nil, errors.AssertionFailedf("unknown privilege.Object type %T", po)
@@ -290,16 +293,19 @@ func (p *planner) getPrivilegeDescriptor(
 // PrivilegeDescriptor.
 func synthesizePrivilegeDescriptor(
 	ctx context.Context,
-	execCfg *ExecutorConfig,
+	version clusterversion.Handle,
+	cache *cacheutil.Cache,
 	ie sqlutil.InternalExecutor,
 	descsCol *descs.Collection,
 	txn *kv.Txn,
 	spo syntheticprivilege.Object,
 ) (*catpb.PrivilegeDescriptor, error) {
-	if !execCfg.Settings.Version.IsActive(ctx, spo.SystemPrivilegesTableVersionGate()) {
+	if !version.IsActive(ctx, spo.SystemPrivilegesTableVersionGate()) {
 		// Fall back to defaults if the version gate is not active yet.
 		return spo.GetFallbackPrivileges(), nil
 	}
+
+	cache.WarmingGroup.Wait()
 	_, desc, err := descsCol.GetImmutableTableByName(
 		ctx,
 		txn,
@@ -313,7 +319,6 @@ func synthesizePrivilegeDescriptor(
 		return synthesizePrivilegeDescriptorFromSystemPrivilegesTable(ctx, ie, txn, spo)
 	}
 	var tableVersions []descpb.DescriptorVersion
-	cache := execCfg.SyntheticPrivilegeCache
 	found, privileges, retErr := func() (bool, catpb.PrivilegeDescriptor, error) {
 		cache.Lock()
 		defer cache.Unlock()
@@ -353,7 +358,7 @@ func synthesizePrivilegeDescriptor(
 // resolve the PrivilegeDescriptor from the cache.
 func synthesizePrivilegeDescriptorFromSystemPrivilegesTable(
 	ctx context.Context, ie sqlutil.InternalExecutor, txn *kv.Txn, spo syntheticprivilege.Object,
-) (privileges *catpb.PrivilegeDescriptor, retErr error) {
+) (privDesc *catpb.PrivilegeDescriptor, retErr error) {
 
 	query := fmt.Sprintf(
 		`SELECT username, privileges, grant_options FROM system.%s WHERE path='%s'`,
@@ -370,7 +375,7 @@ func synthesizePrivilegeDescriptorFromSystemPrivilegesTable(
 		retErr = errors.CombineErrors(retErr, it.Close())
 	}()
 
-	privileges = &catpb.PrivilegeDescriptor{}
+	privDesc = &catpb.PrivilegeDescriptor{}
 	for {
 		ok, err := it.Next(ctx)
 		if err != nil {
@@ -382,42 +387,11 @@ func synthesizePrivilegeDescriptorFromSystemPrivilegesTable(
 
 		user := tree.MustBeDString(it.Cur()[0])
 		privArr := tree.MustBeDArray(it.Cur()[1])
-		var privilegeStrings []string
-		for _, elem := range privArr.Array {
-			privilegeStrings = append(privilegeStrings, string(tree.MustBeDString(elem)))
-		}
-
 		grantOptionArr := tree.MustBeDArray(it.Cur()[2])
-		var grantOptionStrings []string
-		for _, elem := range grantOptionArr.Array {
-			grantOptionStrings = append(grantOptionStrings, string(tree.MustBeDString(elem)))
-		}
-		privs, err := privilege.ListFromStrings(privilegeStrings)
+		err = accumulatePrivilegeDescriptorFromSystemPrivilegesRow(spo.GetObjectType(), privDesc, user, privArr, grantOptionArr)
 		if err != nil {
 			return nil, err
 		}
-		grantOptions, err := privilege.ListFromStrings(grantOptionStrings)
-		if err != nil {
-			return nil, err
-		}
-		privsWithGrantOption := privilege.ListFromBitField(
-			privs.ToBitField()&grantOptions.ToBitField(),
-			spo.GetObjectType(),
-		)
-		privsWithoutGrantOption := privilege.ListFromBitField(
-			privs.ToBitField()&^privsWithGrantOption.ToBitField(),
-			spo.GetObjectType(),
-		)
-		privileges.Grant(
-			username.MakeSQLUsernameFromPreNormalizedString(string(user)),
-			privsWithGrantOption,
-			true, /* withGrantOption */
-		)
-		privileges.Grant(
-			username.MakeSQLUsernameFromPreNormalizedString(string(user)),
-			privsWithoutGrantOption,
-			false, /* withGrantOption */
-		)
 	}
 
 	// To avoid having to insert a row for public for each virtual
@@ -426,14 +400,14 @@ func synthesizePrivilegeDescriptorFromSystemPrivilegesTable(
 	// grant. If there is an empty row for Public, then public
 	// does not have grant.
 	if spo.GetObjectType() == privilege.VirtualTable {
-		if _, found := privileges.FindUser(username.PublicRoleName()); !found {
-			privileges.Grant(username.PublicRoleName(), privilege.List{privilege.SELECT}, false)
+		if _, found := privDesc.FindUser(username.PublicRoleName()); !found {
+			privDesc.Grant(username.PublicRoleName(), privilege.List{privilege.SELECT}, false)
 		}
 	}
 
 	// We use InvalidID to skip checks on the root/admin roles having
 	// privileges.
-	if err := privileges.Validate(
+	if err := privDesc.Validate(
 		descpb.InvalidID,
 		spo.GetObjectType(),
 		spo.GetPath(),
@@ -441,5 +415,49 @@ func synthesizePrivilegeDescriptorFromSystemPrivilegesTable(
 	); err != nil {
 		return nil, err
 	}
-	return privileges, err
+	return privDesc, err
+}
+
+func accumulatePrivilegeDescriptorFromSystemPrivilegesRow(
+	objectType privilege.ObjectType,
+	privileges *catpb.PrivilegeDescriptor,
+	user tree.DString,
+	privArr, grantOptionArr *tree.DArray,
+) (retErr error) {
+	var privilegeStrings []string
+	for _, elem := range privArr.Array {
+		privilegeStrings = append(privilegeStrings, string(tree.MustBeDString(elem)))
+	}
+
+	var grantOptionStrings []string
+	for _, elem := range grantOptionArr.Array {
+		grantOptionStrings = append(grantOptionStrings, string(tree.MustBeDString(elem)))
+	}
+	privs, err := privilege.ListFromStrings(privilegeStrings)
+	if err != nil {
+		return err
+	}
+	grantOptions, err := privilege.ListFromStrings(grantOptionStrings)
+	if err != nil {
+		return err
+	}
+	privsWithGrantOption := privilege.ListFromBitField(
+		privs.ToBitField()&grantOptions.ToBitField(),
+		objectType,
+	)
+	privsWithoutGrantOption := privilege.ListFromBitField(
+		privs.ToBitField()&^privsWithGrantOption.ToBitField(),
+		objectType,
+	)
+	privileges.Grant(
+		username.MakeSQLUsernameFromPreNormalizedString(string(user)),
+		privsWithGrantOption,
+		true, /* withGrantOption */
+	)
+	privileges.Grant(
+		username.MakeSQLUsernameFromPreNormalizedString(string(user)),
+		privsWithoutGrantOption,
+		false, /* withGrantOption */
+	)
+	return nil
 }

--- a/pkg/sql/syntheticprivilege/BUILD.bazel
+++ b/pkg/sql/syntheticprivilege/BUILD.bazel
@@ -4,6 +4,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "syntheticprivilege",
     srcs = [
+        "accumulator.go",
         "constants.go",
         "external_connection_privilege.go",
         "global_privilege.go",

--- a/pkg/sql/syntheticprivilege/accumulator.go
+++ b/pkg/sql/syntheticprivilege/accumulator.go
@@ -1,0 +1,85 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package syntheticprivilege
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/errors"
+)
+
+// Accumulator accumulates different rows of system.privileges
+// and combines them into one PrivilegeDescriptor.
+type Accumulator struct {
+	desc       *catpb.PrivilegeDescriptor
+	objectType privilege.ObjectType
+	path       string
+}
+
+// NewAccumulator initializes a Accumulator.
+func NewAccumulator(objectType privilege.ObjectType, path string) *Accumulator {
+	return &Accumulator{
+		desc:       &catpb.PrivilegeDescriptor{},
+		objectType: objectType,
+		path:       path,
+	}
+}
+
+// AddRow adds a row from system.privileges into the accumulator.
+func (s *Accumulator) AddRow(path, user tree.DString, privArr, grantOptionArr *tree.DArray) error {
+	if string(path) != s.path {
+		return errors.AssertionFailedf("mismatched path in Accumulator; expected %s, got %s", s.path, path)
+	}
+
+	var privilegeStrings []string
+	for _, elem := range privArr.Array {
+		privilegeStrings = append(privilegeStrings, string(tree.MustBeDString(elem)))
+	}
+
+	var grantOptionStrings []string
+	for _, elem := range grantOptionArr.Array {
+		grantOptionStrings = append(grantOptionStrings, string(tree.MustBeDString(elem)))
+	}
+	privs, err := privilege.ListFromStrings(privilegeStrings)
+	if err != nil {
+		return err
+	}
+	grantOptions, err := privilege.ListFromStrings(grantOptionStrings)
+	if err != nil {
+		return err
+	}
+	privsWithGrantOption := privilege.ListFromBitField(
+		privs.ToBitField()&grantOptions.ToBitField(),
+		s.objectType,
+	)
+	privsWithoutGrantOption := privilege.ListFromBitField(
+		privs.ToBitField()&^privsWithGrantOption.ToBitField(),
+		s.objectType,
+	)
+	s.desc.Grant(
+		username.MakeSQLUsernameFromPreNormalizedString(string(user)),
+		privsWithGrantOption,
+		true, /* withGrantOption */
+	)
+	s.desc.Grant(
+		username.MakeSQLUsernameFromPreNormalizedString(string(user)),
+		privsWithoutGrantOption,
+		false, /* withGrantOption */
+	)
+	return nil
+}
+
+// GetDescriptor returns the privilege descriptor.
+func (s *Accumulator) GetDescriptor() *catpb.PrivilegeDescriptor {
+	return s.desc
+}

--- a/pkg/sql/syntheticprivilege/synthetic_privilege_registry.go
+++ b/pkg/sql/syntheticprivilege/synthetic_privilege_registry.go
@@ -11,6 +11,7 @@
 package syntheticprivilege
 
 import (
+	"fmt"
 	"reflect"
 	"regexp"
 	"strings"
@@ -52,8 +53,8 @@ var registry = []*Metadata{
 		val:    reflect.TypeOf((*GlobalPrivilege)(nil)),
 	},
 	{
-		prefix: "/vtable",
-		regex:  regexp.MustCompile(`(/vtable/((?P<SchemaName>.*))/((?P<TableName>.*)))$`),
+		prefix: fmt.Sprintf("/%s", VirtualTablePathPrefix),
+		regex:  regexp.MustCompile(fmt.Sprintf(`(/%s/((?P<SchemaName>.*))/((?P<TableName>.*)))$`, VirtualTablePathPrefix)),
 		val:    reflect.TypeOf((*VirtualTablePrivilege)(nil)),
 	},
 	{

--- a/pkg/sql/syntheticprivilege/vtable_privilege.go
+++ b/pkg/sql/syntheticprivilege/vtable_privilege.go
@@ -32,9 +32,12 @@ const VirtualTablePrivilegeType = "VirtualTable"
 
 var _ Object = &VirtualTablePrivilege{}
 
+// VirtualTablePathPrefix is the prefix used for virtual table privileges in system.privileges.
+const VirtualTablePathPrefix = "vtable"
+
 // GetPath implements the Object interface.
 func (p *VirtualTablePrivilege) GetPath() string {
-	return fmt.Sprintf("/vtable/%s/%s", p.SchemaName, p.TableName)
+	return fmt.Sprintf("/%s/%s/%s", VirtualTablePathPrefix, p.SchemaName, p.TableName)
 }
 
 // SystemPrivilegesTableVersionGate implements the Object interface.


### PR DESCRIPTION
This is a reworking of #93437
fixes #93182

This commit attempts to alleviate the pain caused by synthetic virtual table privileges introduced in 22.2. We need to fetch privileges for virtual tables to determine whether the user has access. This is done lazily. However, when a user attempts to read a virtual table like pg_class or run `SHOW TABLES` it will force the privileges to be determined for each virtual table (of which there are 290 at the time of writing). This sequential process can be somewhat slow in a single region cluster and will be *very* slow in an MR cluster.

This patch attempts to somewhat alleviate this pain by scanning the table eagerly during server startup.

Release note (performance improvement): In 22.2 we introduced privileges on virtual tables (system catalogs like pg_catalog, information_schema, and crdb_internal). A problem with this new feature is that we now must fetch those privileges into a cache before we can use those tables or determine their visibility in other system catalogs. This process used to occur on-demand, when the privilege was needed. Now we'll fetch these privileges eagerly during startup to mitigate the latency when accessing pg_catalog right after the server boots up.