### PR TITLE
colencoding: remove redundant check when unmarshalling

### DIFF
--- a/pkg/sql/colencoding/BUILD.bazel
+++ b/pkg/sql/colencoding/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
         "//pkg/util",
+        "//pkg/util/buildutil",
         "//pkg/util/duration",
         "//pkg/util/encoding",
         "//pkg/util/uuid",


### PR DESCRIPTION
This commit removes a redundant check for whether a single value (in the legacy format) is nil or not when unmarshalling that value. The only place where we call the corresponding function checks for non-zero length value already, so we now convert the check into an assertion.

Epic: None

Release note: None