### PR TITLE
multitenant: move RELOCATE LEASE tenant check from SQL to KV layer

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/tenant_unsupported
+++ b/pkg/ccl/logictestccl/testdata/logic_test/tenant_unsupported
@@ -60,17 +60,23 @@ ALTER TABLE kv SCATTER
 statement error operation is unsupported in multi-tenancy mode
 ALTER TABLE kv EXPERIMENTAL_RELOCATE VALUES (ARRAY[1], 'k')
 
-statement error operation is unsupported in multi-tenancy mode
+statement error pq: rpc error: code = Unauthenticated desc = request \[1 AdmTransferLease\] not permitted
 ALTER TABLE kv EXPERIMENTAL_RELOCATE LEASE VALUES (1, 'k')
 
 statement error operation is unsupported in multi-tenancy mode
 SELECT crdb_internal.check_consistency(true, '', '')
 
-statement error operation is unsupported in multi-tenancy mode
-ALTER RANGE 1 RELOCATE LEASE TO 2
+query ITT colnames
+ALTER RANGE (SELECT min(range_id) FROM [SHOW RANGES FROM TABLE kv]) RELOCATE LEASE TO 2
+----
+range_id  pretty      result
+55        /Tenant/10  rpc error: code = Unauthenticated desc = request [1 AdmTransferLease] not permitted
 
-statement error operation is unsupported in multi-tenancy mode
-ALTER RANGE RELOCATE LEASE TO 2 FOR SELECT range_id from crdb_internal.ranges where table_name = 'kv'
+query ITT colnames
+ALTER RANGE RELOCATE LEASE TO 2 FOR SELECT range_id FROM [SHOW RANGES FROM TABLE kv]
+----
+range_id  pretty      result
+55        /Tenant/10  rpc error: code = Unauthenticated desc = request [1 AdmTransferLease] not permitted
 
 statement error operation is unsupported in multi-tenancy mode
 ALTER RANGE 1 RELOCATE FROM 1 TO 2

--- a/pkg/kv/BUILD.bazel
+++ b/pkg/kv/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/kv/kvserver/closedts",
         "//pkg/roachpb",
         "//pkg/settings",
+        "//pkg/sql/oppurpose",
         "//pkg/sql/sessiondatapb",
         "//pkg/storage/enginepb",
         "//pkg/testutils",

--- a/pkg/kv/batch.go
+++ b/pkg/kv/batch.go
@@ -745,7 +745,10 @@ func (b *Batch) adminUnsplit(splitKeyIn interface{}, class roachpb.AdminUnsplitR
 // adminTransferLease is only exported on DB. It is here for symmetry with the
 // other operations.
 func (b *Batch) adminTransferLease(
-	key interface{}, target roachpb.StoreID, bypassSafetyChecks bool,
+	key interface{},
+	target roachpb.StoreID,
+	bypassSafetyChecks bool,
+	class roachpb.AdminTransferLeaseRequest_Class,
 ) {
 	k, err := marshalKey(key)
 	if err != nil {
@@ -758,6 +761,7 @@ func (b *Batch) adminTransferLease(
 		},
 		Target:             target,
 		BypassSafetyChecks: bypassSafetyChecks,
+		Class:              class,
 	}
 	b.appendReqs(req)
 	b.initResult(1, 0, notRaw, nil)

--- a/pkg/kv/db.go
+++ b/pkg/kv/db.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/oppurpose"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
@@ -650,10 +651,13 @@ func (db *DB) AdminUnsplit(
 // lease holder has applied it (so it might not know immediately that it is the
 // new lease holder).
 func (db *DB) AdminTransferLease(
-	ctx context.Context, key interface{}, target roachpb.StoreID,
+	ctx context.Context,
+	key interface{},
+	target roachpb.StoreID,
+	class roachpb.AdminTransferLeaseRequest_Class,
 ) error {
 	b := &Batch{}
-	b.adminTransferLease(key, target, false /* bypassSafetyChecks */)
+	b.adminTransferLease(key, target, false /* bypassSafetyChecks */, class)
 	return getOneErr(db.Run(ctx, b), b)
 }
 
@@ -664,7 +668,7 @@ func (db *DB) AdminTransferLeaseBypassingSafetyChecks(
 	ctx context.Context, key interface{}, target roachpb.StoreID,
 ) error {
 	b := &Batch{}
-	b.adminTransferLease(key, target, true /* bypassSafetyChecks */)
+	b.adminTransferLease(key, target, true /* bypassSafetyChecks */, oppurpose.TransferLeaseBypassChecks)
 	return getOneErr(db.Run(ctx, b), b)
 }
 

--- a/pkg/kv/db_test.go
+++ b/pkg/kv/db_test.go
@@ -689,7 +689,7 @@ func TestDBDecommissionedOperations(t *testing.T) {
 			return db.NewTxn(ctx, "").Put(ctx, key, value)
 		}},
 		{"AdminTransferLease", func() error {
-			return db.AdminTransferLease(ctx, scratchKey, srv.GetFirstStoreID())
+			return db.AdminTransferLease(ctx, scratchKey, srv.GetFirstStoreID(), roachpb.AdminTransferLeaseRequest_ORGANIZATION)
 		}},
 	}
 

--- a/pkg/kv/kvnemesis/BUILD.bazel
+++ b/pkg/kv/kvnemesis/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/kv/kvserver/liveness",
         "//pkg/roachpb",
         "//pkg/sql/catalog/bootstrap",
+        "//pkg/sql/oppurpose",
         "//pkg/storage",
         "//pkg/storage/enginepb",
         "//pkg/util/bufalloc",

--- a/pkg/kv/kvnemesis/applier.go
+++ b/pkg/kv/kvnemesis/applier.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvnemesis/kvnemesisutil"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/oppurpose"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -119,7 +120,7 @@ func applyOp(ctx context.Context, env *Env, db *kv.DB, op *Operation) {
 		*DeleteRangeUsingTombstoneOperation:
 		applyClientOp(ctx, db, op, false)
 	case *SplitOperation:
-		err := db.AdminSplit(ctx, o.Key, hlc.MaxTimestamp, roachpb.AdminSplitRequest_INGESTION)
+		err := db.AdminSplit(ctx, o.Key, hlc.MaxTimestamp, oppurpose.SplitNemesis)
 		o.Result = resultInit(ctx, err)
 	case *MergeOperation:
 		err := db.AdminMerge(ctx, o.Key)
@@ -129,7 +130,7 @@ func applyOp(ctx context.Context, env *Env, db *kv.DB, op *Operation) {
 		_, err := db.AdminChangeReplicas(ctx, o.Key, desc, o.Changes)
 		o.Result = resultInit(ctx, err)
 	case *TransferLeaseOperation:
-		err := db.AdminTransferLease(ctx, o.Key, o.Target)
+		err := db.AdminTransferLease(ctx, o.Key, o.Target, oppurpose.TransferLeaseNemesis)
 		o.Result = resultInit(ctx, err)
 	case *ChangeZoneOperation:
 		err := updateZoneConfigInEnv(ctx, env, o.Type)

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -164,6 +164,7 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/spanconfig",
         "//pkg/spanconfig/spanconfigstore",
+        "//pkg/sql/oppurpose",
         "//pkg/storage",
         "//pkg/storage/enginepb",
         "//pkg/storage/fs",

--- a/pkg/kv/kvserver/client_lease_test.go
+++ b/pkg/kv/kvserver/client_lease_test.go
@@ -214,7 +214,7 @@ func TestCannotTransferLeaseToVoterDemoting(t *testing.T) {
 	atomic.StoreInt64(&scratchRangeID, int64(desc.RangeID))
 	// Make sure n1 has the lease to start with.
 	err := tc.Server(0).DB().AdminTransferLease(context.Background(),
-		scratchStartKey, tc.Target(0).StoreID)
+		scratchStartKey, tc.Target(0).StoreID, roachpb.AdminTransferLeaseRequest_ORGANIZATION)
 	require.NoError(t, err)
 
 	// The test proceeds as follows:
@@ -243,7 +243,7 @@ func TestCannotTransferLeaseToVoterDemoting(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			err := tc.Server(0).DB().AdminTransferLease(context.Background(),
-				scratchStartKey, tc.Target(2).StoreID)
+				scratchStartKey, tc.Target(2).StoreID, roachpb.AdminTransferLeaseRequest_ORGANIZATION)
 			require.Error(t, err)
 			require.Regexp(t,
 				// The error generated during evaluation.
@@ -314,7 +314,7 @@ func TestTransferLeaseToVoterDemotingFails(t *testing.T) {
 	atomic.StoreInt64(&scratchRangeID, int64(desc.RangeID))
 	// Make sure n1 has the lease to start with.
 	err := tc.Server(0).DB().AdminTransferLease(context.Background(),
-		scratchStartKey, tc.Target(0).StoreID)
+		scratchStartKey, tc.Target(0).StoreID, roachpb.AdminTransferLeaseRequest_ORGANIZATION)
 	require.NoError(t, err)
 
 	// The test proceeds as follows:
@@ -354,7 +354,7 @@ func TestTransferLeaseToVoterDemotingFails(t *testing.T) {
 			// This should fail since the last leaseholder wasn't n3
 			// (wasLastLeaseholder = false in CheckCanReceiveLease).
 			err = tc.Server(0).DB().AdminTransferLease(context.Background(),
-				scratchStartKey, tc.Target(2).StoreID)
+				scratchStartKey, tc.Target(2).StoreID, roachpb.AdminTransferLeaseRequest_ORGANIZATION)
 			require.EqualError(t, err, `replica cannot hold lease`)
 			// Make sure the lease is still on n1.
 			leaseHolder, err = tc.FindRangeLeaseHolder(desc, nil)
@@ -410,7 +410,7 @@ func TestTransferLeaseDuringJointConfigWithDeadIncomingVoter(t *testing.T) {
 	key := tc.ScratchRange(t)
 	desc := tc.AddVotersOrFatal(t, key, tc.Targets(1, 2)...)
 	// Make sure n1 has the lease to start with.
-	err := tc.Server(0).DB().AdminTransferLease(ctx, key, tc.Target(0).StoreID)
+	err := tc.Server(0).DB().AdminTransferLease(ctx, key, tc.Target(0).StoreID, roachpb.AdminTransferLeaseRequest_ORGANIZATION)
 	require.NoError(t, err)
 	store0, repl0 := getFirstStoreReplica(t, tc.Server(0), key)
 
@@ -517,7 +517,7 @@ func internalTransferLeaseFailureDuringJointConfig(t *testing.T, isManual bool) 
 	desc := tc.AddVotersOrFatal(t, scratchStartKey, tc.Targets(1, 2)...)
 	// Make sure n1 has the lease to start with.
 	err := tc.Server(0).DB().AdminTransferLease(context.Background(),
-		scratchStartKey, tc.Target(0).StoreID)
+		scratchStartKey, tc.Target(0).StoreID, roachpb.AdminTransferLeaseRequest_ORGANIZATION)
 	require.NoError(t, err)
 
 	// The next lease transfer should fail.
@@ -545,7 +545,7 @@ func internalTransferLeaseFailureDuringJointConfig(t *testing.T, isManual bool) 
 	if isManual {
 		// Manually transfer the lease to n1 (VOTER_DEMOTING_LEARNER).
 		err = tc.Server(0).DB().AdminTransferLease(context.Background(),
-			scratchStartKey, tc.Target(0).StoreID)
+			scratchStartKey, tc.Target(0).StoreID, roachpb.AdminTransferLeaseRequest_ORGANIZATION)
 		require.NoError(t, err)
 		// Make sure n1 has the lease
 		leaseHolder, err := tc.FindRangeLeaseHolder(desc, nil)

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/sql/oppurpose"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
@@ -3112,7 +3113,7 @@ func (r *Replica) relocateReplicas(
 		// seems like a good idea to return any errors here to the caller (or
 		// to retry some errors appropriately).
 		if err := r.store.DB().AdminTransferLease(
-			ctx, startKey, target.StoreID,
+			ctx, startKey, target.StoreID, oppurpose.TransferLeaseRelocateReplicas,
 		); err != nil {
 			log.Warningf(ctx, "while transferring lease: %+v", err)
 			if r.store.TestingKnobs().DontIgnoreFailureToTransferLease {

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -948,6 +948,10 @@ message AdminMergeResponse {
 // holder for a range. The target of the lease transfer needs to be a valid
 // replica of the range.
 message AdminTransferLeaseRequest {
+  enum Class {
+    ARBITRARY = 0;
+    ORGANIZATION = 1;
+  }
   RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   int32 target = 2 [(gogoproto.casttype) = "StoreID"];
   // When set to true, bypass_safety_checks configures the lease transfer to
@@ -958,6 +962,7 @@ message AdminTransferLeaseRequest {
   // alive and caught up on its log (e.g. they just sent it a snapshot) and also
   // can't tolerate rejected lease transfers.
   bool bypass_safety_checks = 3;
+  Class class = 4;
 }
 
 message AdminTransferLeaseResponse {

--- a/pkg/rpc/auth_tenant.go
+++ b/pkg/rpc/auth_tenant.go
@@ -194,6 +194,8 @@ func reqAllowed(r roachpb.Request, tenID roachpb.TenantID) bool {
 		return t.Class != roachpb.AdminScatterRequest_ARBITRARY || tenID.IsSystem()
 	case *roachpb.AdminSplitRequest:
 		return t.Class != roachpb.AdminSplitRequest_ARBITRARY || tenID.IsSystem()
+	case *roachpb.AdminTransferLeaseRequest:
+		return t.Class != roachpb.AdminTransferLeaseRequest_ARBITRARY || tenID.IsSystem()
 	case *roachpb.AdminUnsplitRequest:
 		return t.Class != roachpb.AdminUnsplitRequest_ARBITRARY || tenID.IsSystem()
 	}

--- a/pkg/sql/multitenant_admin_function_test.go
+++ b/pkg/sql/multitenant_admin_function_test.go
@@ -37,8 +37,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const createTable = "CREATE TABLE t(i int PRIMARY KEY);"
-const rangeErrorMessage = "RangeIterator failed to seek"
+const (
+	createTable      = "CREATE TABLE t(i int PRIMARY KEY);"
+	systemRangeID    = "54"
+	secondaryRangeID = "55"
+	systemKey        = "/Table/53"
+	secondaryKey     = "/Tenant/10"
+)
 
 type testClusterCfg struct {
 	base.TestClusterArgs
@@ -253,11 +258,6 @@ func TestMultiTenantAdminFunction(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	// TODO(ewall): When moving tenant capability check to KV,
-	//  merge test w/ SkipSQLSystemTenantCheck variant into single test case if
-	//  1) test case has expectedSecondaryErrorMessage: errorutil.UnsupportedWithMultiTenancyMessage
-	//  and
-	//  2) SkipSQLSystemTenantCheck variant has no error result AND no error inside "success" result
 	testCases := []struct {
 		desc string
 		// Prereq setup statement(s) that must succeed.
@@ -276,47 +276,24 @@ func TestMultiTenantAdminFunction(t *testing.T) {
 		expectedSecondaryErrorMessage string
 		// Used for tests that have SPLIT AT as a prereq (eg UNSPLIT AT).
 		allowSplitAndScatter bool
-		// Used as a stop-gap to bypass the system tenant check and test incomplete functionality.
-		skipSQLSystemTenantCheck bool
 	}{
 		{
-			desc:                          "ALTER RANGE x RELOCATE LEASE",
-			query:                         "ALTER RANGE (SELECT min(range_id) FROM [SHOW RANGES FROM TABLE t]) RELOCATE LEASE TO 1;",
-			expectedSystemResult:          [][]string{{"54", "/Table/53", "ok"}},
-			expectedSecondaryErrorMessage: errorutil.UnsupportedWithMultiTenancyMessage,
+			desc:                    "ALTER RANGE x RELOCATE LEASE",
+			query:                   "ALTER RANGE (SELECT min(range_id) FROM [SHOW RANGES FROM TABLE t]) RELOCATE LEASE TO 1;",
+			expectedSystemResult:    [][]string{{systemRangeID, systemKey, "ok"}},
+			expectedSecondaryResult: [][]string{{secondaryRangeID, secondaryKey, "request [1 AdmTransferLease] not permitted"}},
 		},
 		{
-			desc:                     "ALTER RANGE x RELOCATE LEASE SkipSQLSystemTenantCheck",
-			query:                    "ALTER RANGE (SELECT min(range_id) FROM [SHOW RANGES FROM TABLE t]) RELOCATE LEASE TO 1;",
-			expectedSystemResult:     [][]string{{"54", "/Table/53", "ok"}},
-			expectedSecondaryResult:  [][]string{{"55", "", rangeErrorMessage}},
-			skipSQLSystemTenantCheck: true,
-		},
-		{
-			desc:                          "ALTER RANGE RELOCATE LEASE",
-			query:                         "ALTER RANGE RELOCATE LEASE TO 1 FOR (SELECT min(range_id) FROM [SHOW RANGES FROM TABLE t]);",
-			expectedSystemResult:          [][]string{{"54", "/Table/53", "ok"}},
-			expectedSecondaryErrorMessage: errorutil.UnsupportedWithMultiTenancyMessage,
-		},
-		{
-			desc:                     "ALTER RANGE RELOCATE LEASE SkipSQLSystemTenantCheck",
-			query:                    "ALTER RANGE RELOCATE LEASE TO 1 FOR (SELECT min(range_id) FROM [SHOW RANGES FROM TABLE t]);",
-			expectedSystemResult:     [][]string{{"54", "/Table/53", "ok"}},
-			expectedSecondaryResult:  [][]string{{"55", "", rangeErrorMessage}},
-			skipSQLSystemTenantCheck: true,
+			desc:                    "ALTER RANGE RELOCATE LEASE",
+			query:                   "ALTER RANGE RELOCATE LEASE TO 1 FOR (SELECT min(range_id) FROM [SHOW RANGES FROM TABLE t]);",
+			expectedSystemResult:    [][]string{{systemRangeID, systemKey, "ok"}},
+			expectedSecondaryResult: [][]string{{secondaryRangeID, secondaryKey, "request [1 AdmTransferLease] not permitted"}},
 		},
 		{
 			desc:                          "ALTER TABLE x EXPERIMENTAL_RELOCATE LEASE",
 			query:                         "ALTER TABLE t EXPERIMENTAL_RELOCATE LEASE SELECT 1, 1;",
-			expectedSystemResult:          [][]string{{"\xbd", "/Table/53"}},
-			expectedSecondaryErrorMessage: errorutil.UnsupportedWithMultiTenancyMessage,
-		},
-		{
-			desc:                          "ALTER TABLE x EXPERIMENTAL_RELOCATE LEASE SkipSQLSystemTenantCheck",
-			query:                         "ALTER TABLE t EXPERIMENTAL_RELOCATE LEASE SELECT 1, 1;",
-			expectedSystemResult:          [][]string{{"\xbd", "/Table/53"}},
-			expectedSecondaryErrorMessage: rangeErrorMessage,
-			skipSQLSystemTenantCheck:      true,
+			expectedSystemResult:          [][]string{{"\xbd", systemKey}},
+			expectedSecondaryErrorMessage: "request [1 AdmTransferLease] not permitted",
 		},
 		{
 			desc:                          "ALTER TABLE x SPLIT AT",
@@ -372,7 +349,7 @@ func TestMultiTenantAdminFunction(t *testing.T) {
 		{
 			desc:                          "ALTER TABLE x SCATTER",
 			query:                         "ALTER TABLE t SCATTER;",
-			expectedSystemResult:          [][]string{{"\xbd", "/Table/53"}},
+			expectedSystemResult:          [][]string{{"\xbd", systemKey}},
 			expectedSecondaryErrorMessage: "request [1 AdmScatter] not permitted",
 		},
 		{
@@ -428,7 +405,7 @@ func TestMultiTenantAdminFunction(t *testing.T) {
 			func() {
 				_, testServer, cleanup := createTestCluster(t, cfg)
 				defer cleanup()
-				db := createSecondaryTenantDB(t, testServer, tc.allowSplitAndScatter, tc.skipSQLSystemTenantCheck)
+				db := createSecondaryTenantDB(t, testServer, tc.allowSplitAndScatter, false /*skipSQLSystemTenantCheck*/)
 				execQueries(db, "secondary", tc.expectedSecondaryResult, tc.expectedSecondaryErrorMessage)
 			}()
 		})
@@ -499,27 +476,27 @@ func TestRelocateVoters(t *testing.T) {
 		{
 			desc:                          "ALTER RANGE x RELOCATE VOTERS",
 			query:                         "ALTER RANGE (SELECT min(range_id) FROM [SHOW RANGES FROM TABLE t]) RELOCATE VOTERS FROM %[1]s TO %[2]s;",
-			expectedSystemResult:          [][]string{{"54", "/Table/53", "ok"}},
+			expectedSystemResult:          [][]string{{systemRangeID, systemKey, "ok"}},
 			expectedSecondaryErrorMessage: errorutil.UnsupportedWithMultiTenancyMessage,
 		},
 		{
 			desc:                     "ALTER RANGE x RELOCATE VOTERS SkipSQLSystemTenantCheck",
 			query:                    "ALTER RANGE (SELECT min(range_id) FROM [SHOW RANGES FROM TABLE t]) RELOCATE VOTERS FROM %[1]s TO %[2]s;",
-			expectedSystemResult:     [][]string{{"54", "/Table/53", "ok"}},
-			expectedSecondaryResult:  [][]string{{"55", "", rangeErrorMessage}},
+			expectedSystemResult:     [][]string{{systemRangeID, systemKey, "ok"}},
+			expectedSecondaryResult:  [][]string{{secondaryRangeID, secondaryKey, "request [1 AdmChangeReplicas] not permitted"}},
 			skipSQLSystemTenantCheck: true,
 		},
 		{
 			desc:                          "ALTER RANGE RELOCATE VOTERS",
 			query:                         "ALTER RANGE RELOCATE VOTERS FROM %[1]s TO %[2]s FOR (SELECT min(range_id) FROM [SHOW RANGES FROM TABLE t]);",
-			expectedSystemResult:          [][]string{{"54", "/Table/53", "ok"}},
+			expectedSystemResult:          [][]string{{systemRangeID, systemKey, "ok"}},
 			expectedSecondaryErrorMessage: errorutil.UnsupportedWithMultiTenancyMessage,
 		},
 		{
 			desc:                     "ALTER RANGE RELOCATE VOTERS SkipSQLSystemTenantCheck",
 			query:                    "ALTER RANGE RELOCATE VOTERS FROM %[1]s TO %[2]s FOR (SELECT min(range_id) FROM [SHOW RANGES FROM TABLE t]);",
-			expectedSystemResult:     [][]string{{"54", "/Table/53", "ok"}},
-			expectedSecondaryResult:  [][]string{{"55", "", rangeErrorMessage}},
+			expectedSystemResult:     [][]string{{systemRangeID, systemKey, "ok"}},
+			expectedSecondaryResult:  [][]string{{secondaryRangeID, secondaryKey, "request [1 AdmChangeReplicas] not permitted"}},
 			skipSQLSystemTenantCheck: true,
 		},
 	}
@@ -620,14 +597,14 @@ func TestExperimentalRelocateVoters(t *testing.T) {
 		{
 			desc:                          "ALTER TABLE x EXPERIMENTAL_RELOCATE VOTERS",
 			query:                         "ALTER TABLE t EXPERIMENTAL_RELOCATE VOTERS VALUES (ARRAY[%[1]s], 1);",
-			expectedSystemResult:          [][]string{{"\xbd", "/Table/53"}},
+			expectedSystemResult:          [][]string{{"\xbd", systemKey}},
 			expectedSecondaryErrorMessage: errorutil.UnsupportedWithMultiTenancyMessage,
 		},
 		{
 			desc:                          "ALTER TABLE x EXPERIMENTAL_RELOCATE VOTERS SkipSQLSystemTenantCheck",
 			query:                         "ALTER TABLE t EXPERIMENTAL_RELOCATE VOTERS VALUES (ARRAY[%[1]s], 1);",
-			expectedSystemResult:          [][]string{{"\xbd", "/Table/53"}},
-			expectedSecondaryErrorMessage: rangeErrorMessage,
+			expectedSystemResult:          [][]string{{"\xbd", systemKey}},
+			expectedSecondaryErrorMessage: "request [1 AdmRelocateRng] not permitted",
 			skipSQLSystemTenantCheck:      true,
 		},
 	}
@@ -726,27 +703,27 @@ func TestRelocateNonVoters(t *testing.T) {
 		{
 			desc:                          "ALTER RANGE x RELOCATE NONVOTERS",
 			query:                         "ALTER RANGE (SELECT min(range_id) FROM [SHOW RANGES FROM TABLE t]) RELOCATE NONVOTERS FROM %[1]s TO %[2]s;",
-			expectedSystemResult:          [][]string{{"54", "/Table/53", "ok"}},
+			expectedSystemResult:          [][]string{{systemRangeID, systemKey, "ok"}},
 			expectedSecondaryErrorMessage: errorutil.UnsupportedWithMultiTenancyMessage,
 		},
 		{
 			desc:                     "ALTER RANGE x RELOCATE NONVOTERS SkipSQLSystemTenantCheck",
 			query:                    "ALTER RANGE (SELECT min(range_id) FROM [SHOW RANGES FROM TABLE t]) RELOCATE NONVOTERS FROM %[1]s TO %[2]s;",
-			expectedSystemResult:     [][]string{{"54", "/Table/53", "ok"}},
-			expectedSecondaryResult:  [][]string{{"55", "", rangeErrorMessage}},
+			expectedSystemResult:     [][]string{{systemRangeID, systemKey, "ok"}},
+			expectedSecondaryResult:  [][]string{{secondaryRangeID, secondaryKey, "request [1 AdmChangeReplicas] not permitted"}},
 			skipSQLSystemTenantCheck: true,
 		},
 		{
 			desc:                          "ALTER RANGE RELOCATE NONVOTERS",
 			query:                         "ALTER RANGE RELOCATE NONVOTERS FROM %[1]s TO %[2]s FOR (SELECT min(range_id) FROM [SHOW RANGES FROM TABLE t]);",
-			expectedSystemResult:          [][]string{{"54", "/Table/53", "ok"}},
+			expectedSystemResult:          [][]string{{systemRangeID, systemKey, "ok"}},
 			expectedSecondaryErrorMessage: errorutil.UnsupportedWithMultiTenancyMessage,
 		},
 		{
 			desc:                     "ALTER RANGE RELOCATE NONVOTERS SkipSQLSystemTenantCheck",
 			query:                    "ALTER RANGE RELOCATE NONVOTERS FROM %[1]s TO %[2]s FOR (SELECT min(range_id) FROM [SHOW RANGES FROM TABLE t]);",
-			expectedSystemResult:     [][]string{{"54", "/Table/53", "ok"}},
-			expectedSecondaryResult:  [][]string{{"55", "", rangeErrorMessage}},
+			expectedSystemResult:     [][]string{{systemRangeID, systemKey, "ok"}},
+			expectedSecondaryResult:  [][]string{{secondaryRangeID, secondaryKey, "request [1 AdmChangeReplicas] not permitted"}},
 			skipSQLSystemTenantCheck: true,
 		},
 	}
@@ -844,14 +821,14 @@ func TestExperimentalRelocateNonVoters(t *testing.T) {
 		{
 			desc:                          "ALTER TABLE x EXPERIMENTAL_RELOCATE NONVOTERS",
 			query:                         "ALTER TABLE t EXPERIMENTAL_RELOCATE NONVOTERS VALUES (ARRAY[%[1]s], 1);",
-			expectedSystemResult:          [][]string{{"\xbd", "/Table/53"}},
+			expectedSystemResult:          [][]string{{"\xbd", systemKey}},
 			expectedSecondaryErrorMessage: errorutil.UnsupportedWithMultiTenancyMessage,
 		},
 		{
 			desc:                          "ALTER TABLE x EXPERIMENTAL_RELOCATE NONVOTERS SkipSQLSystemTenantCheck",
 			query:                         "ALTER TABLE t EXPERIMENTAL_RELOCATE NONVOTERS VALUES (ARRAY[%[1]s], 1);",
-			expectedSystemResult:          [][]string{{"\xbd", "/Table/53"}},
-			expectedSecondaryErrorMessage: rangeErrorMessage,
+			expectedSystemResult:          [][]string{{"\xbd", systemKey}},
+			expectedSecondaryErrorMessage: "request [1 AdmRelocateRng] not permitted",
 			skipSQLSystemTenantCheck:      true,
 		},
 	}

--- a/pkg/sql/oppurpose/op_purpose.go
+++ b/pkg/sql/oppurpose/op_purpose.go
@@ -27,6 +27,8 @@ const (
 	SplitManualTest = roachpb.AdminSplitRequest_INGESTION
 	// SplitTruncate is a split caused by a truncate.
 	SplitTruncate = roachpb.AdminSplitRequest_INGESTION
+	// SplitNemesis is a split caused by kvnemesis.
+	SplitNemesis = roachpb.AdminSplitRequest_INGESTION
 
 	// UnsplitManual is a split caused by a manual action.
 	UnsplitManual = roachpb.AdminUnsplitRequest_ARBITRARY
@@ -45,4 +47,13 @@ const (
 	ScatterManual = roachpb.AdminScatterRequest_ARBITRARY
 	// ScatterManualTest is a split caused by a manual action test.
 	ScatterManualTest = roachpb.AdminScatterRequest_INGESTION
+
+	// TransferLeaseManual is a lease transfer caused by a manual action.
+	TransferLeaseManual = roachpb.AdminTransferLeaseRequest_ARBITRARY
+	// TransferLeaseBypassChecks is a lease transfer that bypasses safety checks.
+	TransferLeaseBypassChecks = roachpb.AdminTransferLeaseRequest_ORGANIZATION
+	// TransferLeaseNemesis is a lease transfer caused by kvnemesis.
+	TransferLeaseNemesis = roachpb.AdminTransferLeaseRequest_ORGANIZATION
+	// TransferLeaseRelocateReplicas is a lease transfer caused by relocating replicas.
+	TransferLeaseRelocateReplicas = roachpb.AdminTransferLeaseRequest_ORGANIZATION
 )

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1957,14 +1957,11 @@ func (ef *execFactory) ConstructAlterTableSplit(
 		return nil, err
 	}
 
-	knobs := ef.planner.ExecCfg().TenantTestingKnobs
 	return &splitNode{
 		tableDesc:      index.Table().(*optTable).desc,
 		index:          index.(*optIndex).idx,
 		rows:           input.(planNode),
 		expirationTime: expirationTime,
-		// Tests can override tenant split permissions to allow secondary tenants to split.
-		testAllowSplitAndScatter: knobs != nil && knobs.AllowSplitAndScatter,
 	}, nil
 }
 
@@ -2007,7 +2004,7 @@ func (ef *execFactory) ConstructAlterTableUnsplitAll(index cat.Index) (exec.Node
 func (ef *execFactory) ConstructAlterTableRelocate(
 	index cat.Index, input exec.Node, relocateSubject tree.RelocateSubject,
 ) (exec.Node, error) {
-	if !ef.planner.ExecCfg().IsSystemTenant() {
+	if relocateSubject != tree.RelocateLease && !ef.planner.ExecCfg().IsSystemTenant() {
 		return nil, errorutil.UnsupportedWithMultiTenancy(54250)
 	}
 
@@ -2026,7 +2023,8 @@ func (ef *execFactory) ConstructAlterRangeRelocate(
 	toStoreID tree.TypedExpr,
 	fromStoreID tree.TypedExpr,
 ) (exec.Node, error) {
-	if !ef.planner.ExecCfg().IsSystemTenant() {
+
+	if relocateSubject != tree.RelocateLease && !ef.planner.ExecCfg().IsSystemTenant() {
 		return nil, errorutil.UnsupportedWithMultiTenancy(54250)
 	}
 

--- a/pkg/sql/relocate.go
+++ b/pkg/sql/relocate.go
@@ -14,13 +14,12 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
-	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
+	"github.com/cockroachdb/cockroach/pkg/sql/oppurpose"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
 
@@ -111,20 +110,33 @@ func (n *relocateNode) Next(params runParams) (bool, error) {
 	}
 	rowKey = keys.MakeFamilyKey(rowKey, 0)
 
-	rangeDesc, err := lookupRangeDescriptor(params.ctx, execCfg.DB, rowKey)
+	rKey := keys.MustAddr(rowKey)
+
+	span := roachpb.Span{
+		Key:    rKey.AsRawKey(),
+		EndKey: rKey.PrefixEnd().AsRawKey(),
+	}
+	rangeDescIterator, err := execCfg.RangeDescIteratorFactory.NewIterator(params.ctx, span)
 	if err != nil {
-		return false, errors.Wrapf(err, "error looking up range descriptor")
+		return false, err
+	}
+	var rangeDesc roachpb.RangeDescriptor
+	found := false
+	for rangeDescIterator.Valid() {
+		rangeDesc = rangeDescIterator.CurRangeDescriptor()
+		found = true
+		break
+	}
+	if !found {
+		return false, errors.Newf("range descriptor not found")
 	}
 	n.run.lastRangeStartKey = rangeDesc.StartKey.AsRawKey()
 
-	existingVoters := rangeDesc.Replicas().Voters().ReplicationTargets()
-	existingNonVoters := rangeDesc.Replicas().NonVoters().ReplicationTargets()
 	switch n.subjectReplicas {
 	case tree.RelocateLease:
-		if err = execCfg.DB.AdminTransferLease(params.ctx, rowKey, leaseStoreID); err != nil {
-			return false, err
-		}
+		err = execCfg.DB.AdminTransferLease(params.ctx, rowKey, leaseStoreID, oppurpose.TransferLeaseManual)
 	case tree.RelocateNonVoters:
+		existingVoters := rangeDesc.Replicas().Voters().ReplicationTargets()
 		err = execCfg.DB.AdminRelocateRange(
 			params.ctx,
 			rowKey,
@@ -133,6 +145,7 @@ func (n *relocateNode) Next(params runParams) (bool, error) {
 			true, /* transferLeaseToFirstVoter */
 		)
 	case tree.RelocateVoters:
+		existingNonVoters := rangeDesc.Replicas().NonVoters().ReplicationTargets()
 		err = execCfg.DB.AdminRelocateRange(
 			params.ctx,
 			rowKey,
@@ -141,16 +154,13 @@ func (n *relocateNode) Next(params runParams) (bool, error) {
 			true, /* transferLeaseToFirstVoter */
 		)
 	default:
-		return false, errors.AssertionFailedf("unknown relocate mode: %v", n.subjectReplicas)
+		err = errors.AssertionFailedf("unknown relocate mode: %v", n.subjectReplicas)
 	}
 	// TODO(aayush): If the `AdminRelocateRange` call failed because it found that
 	// the range was already in the process of being rebalanced, we currently fail
 	// the statement. We should consider instead force-removing these learners
 	// when `AdminRelocateRange` calls are issued by SQL.
-	if err != nil {
-		return false, err
-	}
-	return true, nil
+	return err == nil, err
 }
 
 func (n *relocateNode) Values() tree.Datums {
@@ -162,26 +172,4 @@ func (n *relocateNode) Values() tree.Datums {
 
 func (n *relocateNode) Close(ctx context.Context) {
 	n.rows.Close(ctx)
-}
-
-func lookupRangeDescriptor(
-	ctx context.Context, db *kv.DB, rowKey []byte,
-) (roachpb.RangeDescriptor, error) {
-	startKey := keys.RangeMetaKey(keys.MustAddr(rowKey))
-	endKey := keys.Meta2Prefix.PrefixEnd()
-	kvs, err := db.Scan(ctx, startKey, endKey, 1)
-	if err != nil {
-		return roachpb.RangeDescriptor{}, err
-	}
-	if len(kvs) != 1 {
-		log.Fatalf(ctx, "expected 1 KV, got %v", kvs)
-	}
-	var desc roachpb.RangeDescriptor
-	if err := kvs[0].ValueProto(&desc); err != nil {
-		return roachpb.RangeDescriptor{}, err
-	}
-	if desc.EndKey.Equal(rowKey) {
-		log.Fatalf(ctx, "row key should not be valid range split point: %s", keys.PrettyPrint(nil /* valDirs */, rowKey))
-	}
-	return desc, nil
 }

--- a/pkg/sql/relocate_range.go
+++ b/pkg/sql/relocate_range.go
@@ -14,8 +14,8 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
-	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/oppurpose"
 	"github.com/cockroachdb/cockroach/pkg/sql/paramparse"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/errors"
@@ -34,9 +34,9 @@ type relocateRange struct {
 // relocateRunState contains the run-time state of
 // relocateRange during local execution.
 type relocateRunState struct {
-	toStoreDesc   *roachpb.StoreDescriptor
-	fromStoreDesc *roachpb.StoreDescriptor
-	results       relocateResults
+	toTarget   roachpb.ReplicationTarget
+	fromTarget roachpb.ReplicationTarget
+	results    relocateResults
 }
 
 // relocateResults captures the results of the last relocate run
@@ -46,42 +46,33 @@ type relocateResults struct {
 	err       error
 }
 
-// relocateRequest is an internal data structure that describes a relocation.
-type relocateRequest struct {
-	rangeID         roachpb.RangeID
-	subjectReplicas tree.RelocateSubject
-	toStoreDesc     *roachpb.StoreDescriptor
-	fromStoreDesc   *roachpb.StoreDescriptor
-}
+func (n *relocateRange) startExec(params runParams) (err error) {
 
-func (n *relocateRange) startExec(params runParams) error {
-	toStoreID, err := paramparse.DatumAsInt(params.ctx, params.EvalContext(), "TO", n.toStoreID)
-	if err != nil {
-		return err
-	}
-	var fromStoreID int64
-	if n.subjectReplicas != tree.RelocateLease {
-		// The from expression is NULL if the target is LEASE.
-		fromStoreID, err = paramparse.DatumAsInt(params.ctx, params.EvalContext(), "FROM", n.fromStoreID)
+	typedExprToReplicationTarget := func(typedExpr tree.TypedExpr, name string) (target roachpb.ReplicationTarget, _ error) {
+		storeID, err := paramparse.DatumAsInt(params.ctx, params.EvalContext(), name, typedExpr)
 		if err != nil {
-			return err
+			return target, err
 		}
+		if storeID <= 0 {
+			return target, errors.Errorf("invalid target %s store ID %d for RELOCATE", name, typedExpr)
+		}
+		// Lookup all the store descriptors upfront, so we don't have to do it for each
+		// range we are working with.
+		storeDesc, err := params.ExecCfg().NodeDescs.GetStoreDescriptor(roachpb.StoreID(storeID))
+		if err != nil {
+			return target, err
+		}
+		target.NodeID = storeDesc.Node.NodeID
+		target.StoreID = storeDesc.StoreID
+		return target, nil
 	}
 
-	if toStoreID <= 0 {
-		return errors.Errorf("invalid target to store ID %d for RELOCATE", n.toStoreID)
-	}
-	if n.subjectReplicas != tree.RelocateLease && fromStoreID <= 0 {
-		return errors.Errorf("invalid target from store ID %d for RELOCATE", n.fromStoreID)
-	}
-	// Lookup all the store descriptors upfront, so we dont have to do it for each
-	// range we are working with.
-	n.run.toStoreDesc, err = params.ExecCfg().NodeDescs.GetStoreDescriptor(roachpb.StoreID(toStoreID))
+	n.run.toTarget, err = typedExprToReplicationTarget(n.toStoreID, "TO")
 	if err != nil {
 		return err
 	}
 	if n.subjectReplicas != tree.RelocateLease {
-		n.run.fromStoreDesc, err = params.ExecCfg().NodeDescs.GetStoreDescriptor(roachpb.StoreID(fromStoreID))
+		n.run.fromTarget, err = typedExprToReplicationTarget(n.fromStoreID, "FROM")
 		if err != nil {
 			return err
 		}
@@ -97,14 +88,9 @@ func (n *relocateRange) Next(params runParams) (bool, error) {
 	if datum == tree.DNull {
 		return true, nil
 	}
-	rangeID := roachpb.RangeID(tree.MustBeDInt(datum))
 
-	rangeDesc, err := relocate(params, relocateRequest{
-		rangeID:         rangeID,
-		subjectReplicas: n.subjectReplicas,
-		fromStoreDesc:   n.run.fromStoreDesc,
-		toStoreDesc:     n.run.toStoreDesc,
-	})
+	rangeID := roachpb.RangeID(tree.MustBeDInt(datum))
+	rangeDesc, err := n.relocate(params, rangeID)
 
 	// record the results of the relocation run, so we can output it.
 	n.run.results = relocateResults{
@@ -135,78 +121,48 @@ func (n *relocateRange) Close(ctx context.Context) {
 	n.rows.Close(ctx)
 }
 
-func relocate(params runParams, req relocateRequest) (*roachpb.RangeDescriptor, error) {
-	rangeDesc, err := lookupRangeDescriptorByRangeID(params.ctx, params.extendedEvalCtx.ExecCfg.DB, req.rangeID)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error looking up range descriptor")
-	}
-
-	if req.subjectReplicas == tree.RelocateLease {
-		err := params.p.ExecCfg().DB.AdminTransferLease(params.ctx, rangeDesc.StartKey, req.toStoreDesc.StoreID)
-		return rangeDesc, err
-	}
-
-	toTarget := roachpb.ReplicationTarget{NodeID: req.toStoreDesc.Node.NodeID, StoreID: req.toStoreDesc.StoreID}
-	fromTarget := roachpb.ReplicationTarget{NodeID: req.fromStoreDesc.Node.NodeID, StoreID: req.fromStoreDesc.StoreID}
-	if req.subjectReplicas == tree.RelocateNonVoters {
-		_, err := params.p.ExecCfg().DB.AdminChangeReplicas(
-			params.ctx, rangeDesc.StartKey, *rangeDesc, []roachpb.ReplicationChange{
-				{ChangeType: roachpb.ADD_NON_VOTER, Target: toTarget},
-				{ChangeType: roachpb.REMOVE_NON_VOTER, Target: fromTarget},
-			},
-		)
-		return rangeDesc, err
-	}
-	_, err = params.p.ExecCfg().DB.AdminChangeReplicas(
-		params.ctx, rangeDesc.StartKey, *rangeDesc, []roachpb.ReplicationChange{
-			{ChangeType: roachpb.ADD_VOTER, Target: toTarget},
-			{ChangeType: roachpb.REMOVE_VOTER, Target: fromTarget},
-		},
-	)
-	// TODO(aayush): If the `AdminChangeReplicas`call failed because it found that
-	// the range was already in the process of being rebalanced, we currently fail
-	// the statement. We should consider instead force-removing these learners
-	// when `AdminChangeReplicas` calls are issued by SQL.
-	return rangeDesc, err
-}
-
-func lookupRangeDescriptorByRangeID(
-	ctx context.Context, db *kv.DB, rangeID roachpb.RangeID,
+func (n *relocateRange) relocate(
+	params runParams, rangeID roachpb.RangeID,
 ) (*roachpb.RangeDescriptor, error) {
-	var descriptor roachpb.RangeDescriptor
-	sentinelErr := errors.Errorf("sentinel")
-	err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-		return txn.Iterate(ctx, keys.MetaMin, keys.MetaMax, 100,
-			func(rows []kv.KeyValue) error {
-				var desc roachpb.RangeDescriptor
-				for _, row := range rows {
-					err := row.ValueProto(&desc)
-					if err != nil {
-						return errors.Wrapf(err, "unable to unmarshal range descriptor from %s", row.Key)
-					}
-					// In small enough clusters it's possible for the same range
-					// descriptor to be stored in both meta1 and meta2. This
-					// happens when some range spans both the meta and the user
-					// keyspace. Consider when r1 is [/Min,
-					// /System/NodeLiveness); we'll store the range descriptor
-					// in both /Meta2/<r1.EndKey> and in /Meta1/KeyMax[1].
-					//
-					// [1]: See kvserver.rangeAddressing.
-					// For the purposes of this code, we just return the first range
-					// descriptor we find.
-					if desc.RangeID == rangeID {
-						descriptor = desc
-						return sentinelErr
-					}
-				}
-				return nil
-			})
-	})
-	if errors.Is(err, sentinelErr) {
-		return &descriptor, nil
-	}
+	execCfg := params.ExecCfg()
+	rangeDescIterator, err := execCfg.RangeDescIteratorFactory.NewIterator(params.ctx, execCfg.Codec.TenantSpan())
 	if err != nil {
 		return nil, err
 	}
-	return nil, errors.Errorf("Descriptor for range %d is not found", rangeID)
+	found := false
+	var rangeDesc roachpb.RangeDescriptor
+	for rangeDescIterator.Valid() {
+		rangeDesc = rangeDescIterator.CurRangeDescriptor()
+		if rangeDesc.RangeID == rangeID {
+			found = true
+			break
+		}
+		rangeDescIterator.Next()
+	}
+	if !found {
+		return nil, errors.Errorf("Descriptor for range %d is not found", rangeID)
+	}
+
+	if n.subjectReplicas == tree.RelocateLease {
+		err := execCfg.DB.AdminTransferLease(params.ctx, rangeDesc.StartKey, n.run.toTarget.StoreID, oppurpose.TransferLeaseManual)
+		return &rangeDesc, err
+	}
+
+	toChangeType := roachpb.ADD_VOTER
+	fromChangeType := roachpb.REMOVE_VOTER
+	if n.subjectReplicas == tree.RelocateNonVoters {
+		toChangeType = roachpb.ADD_NON_VOTER
+		fromChangeType = roachpb.REMOVE_NON_VOTER
+	}
+	_, err = execCfg.DB.AdminChangeReplicas(
+		params.ctx, rangeDesc.StartKey, rangeDesc, []roachpb.ReplicationChange{
+			{ChangeType: toChangeType, Target: n.run.toTarget},
+			{ChangeType: fromChangeType, Target: n.run.fromTarget},
+		},
+	)
+	// TODO(aayush): If the `AdminChangeReplicas` call failed because it found that
+	//  the range was already in the process of being rebalanced, we currently fail
+	//  the statement. We should consider instead force-removing these learners
+	//  when `AdminChangeReplicas` calls are issued by SQL.
+	return &rangeDesc, err
 }

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -1025,7 +1025,7 @@ func (tc *TestCluster) TransferRangeLease(
 	rangeDesc roachpb.RangeDescriptor, dest roachpb.ReplicationTarget,
 ) error {
 	err := tc.Servers[0].DB().AdminTransferLease(context.TODO(),
-		rangeDesc.StartKey.AsRawKey(), dest.StoreID)
+		rangeDesc.StartKey.AsRawKey(), dest.StoreID, roachpb.AdminTransferLeaseRequest_ORGANIZATION)
 	if err != nil {
 		return errors.Wrapf(err, "%q: transfer lease unexpected error", rangeDesc.StartKey)
 	}


### PR DESCRIPTION
Fixes #93452
    
Move the {EXPERIMENTAL_}RELOCATE LEASE tenant check from the SQL to KV layer
to prepare for tenant capabilities work. This check will eventually be replaced
by a tenant capabilities lookup to determine if the tenant can perform the
requested KV operation (AdmTransferLease in this case). `Codec.ForSystemTenant()`
checks still exist in the SQL and will be handled in separate PRs.
    
Release note: None