### PR TITLE
jobsprotectedtsccl: deflake TestJobsProtectedTimestamp

### DIFF
--- a/pkg/ccl/jobsccl/jobsprotectedtsccl/BUILD.bazel
+++ b/pkg/ccl/jobsccl/jobsprotectedtsccl/BUILD.bazel
@@ -25,6 +25,7 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/security/username",
         "//pkg/server",
+        "//pkg/settings/cluster",
         "//pkg/sql",
         "//pkg/sql/catalog/descpb",
         "//pkg/testutils",


### PR DESCRIPTION
The flake was due to the GC job completing rapidly.

Fixes #92806

Release note: None