### PR TITLE
multitenantccl/tenantcostserver: deflake TestDataDriven

### DIFF
--- a/pkg/ccl/multitenantccl/tenantcostserver/server_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostserver/server_test.go
@@ -41,10 +41,10 @@ import (
 
 func TestDataDriven(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
 
 	datadriven.Walk(t, testutils.TestDataPath(t), func(t *testing.T, path string) {
 		defer leaktest.AfterTest(t)()
+		defer log.Scope(t).Close(t)
 
 		var ts testState
 		ts.start(t)


### PR DESCRIPTION
Fixes #93462

The scope for the outer test instead of per file subtest was creating problems for leaktest.

Release note: None