### PR TITLE
server: set the idProvider for the system tenant

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -835,6 +835,8 @@ func (cfg *Config) InitNode(ctx context.Context) error {
 		cfg.GossipBootstrapAddresses = addresses
 	}
 
+	cfg.BaseConfig.idProvider.SetTenant(roachpb.SystemTenantID)
+
 	return nil
 }
 


### PR DESCRIPTION
Before this patch, servers running on behalf of the system tenant did not have their idProvider set. It seems like a good idea for all the servers to have this set, for consistency. I'm looking to use the idProvider more in the future, particularly since it's present in all ctx's. I want the system tenant to affirmatively identify itself through as such through this provider - for example when performing local RPCs.

Release note: None
Epic: None