### PR TITLE
[DEMO] metrics: add per-statement metric persistence in TSDB

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -933,6 +933,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		eventsServer:             eventsServer,
 		admissionPacerFactory:    gcoords.Elastic,
 		rangeDescIteratorFactory: rangedesc.NewIteratorFactory(db),
+		tsDB:                     tsDB,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -100,6 +100,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/syntheticprivilegecache"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
+	"github.com/cockroachdb/cockroach/pkg/ts"
 	"github.com/cockroachdb/cockroach/pkg/upgrade"
 	"github.com/cockroachdb/cockroach/pkg/upgrade/upgradebase"
 	"github.com/cockroachdb/cockroach/pkg/upgrade/upgradecluster"
@@ -368,6 +369,8 @@ type sqlServerArgs struct {
 	// rangeDescIteratorFactory is used to construct iterators over range
 	// descriptors.
 	rangeDescIteratorFactory rangedesc.IteratorFactory
+
+	tsDB *ts.DB
 }
 
 type monitorAndMetrics struct {
@@ -943,6 +946,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		RangeStatsFetcher:          rangeStatsFetcher,
 		EventsExporter:             cfg.eventsServer,
 		NodeDescs:                  cfg.nodeDescs,
+		TSDB:                       cfg.tsDB,
 	}
 
 	if sqlSchemaChangerTestingKnobs := cfg.TestingKnobs.SQLSchemaChanger; sqlSchemaChangerTestingKnobs != nil {

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -471,6 +471,8 @@ go_library(
         "//pkg/storage",
         "//pkg/storage/enginepb",
         "//pkg/testutils/serverutils",
+        "//pkg/ts",
+        "//pkg/ts/tspb",
         "//pkg/upgrade",
         "//pkg/upgrade/upgradebase",
         "//pkg/util",

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -95,6 +95,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/syntheticprivilegecache"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/ts"
 	"github.com/cockroachdb/cockroach/pkg/upgrade"
 	"github.com/cockroachdb/cockroach/pkg/upgrade/upgradebase"
 	"github.com/cockroachdb/cockroach/pkg/util/bitarray"
@@ -1344,6 +1345,8 @@ type ExecutorConfig struct {
 
 	// NodeDescs stores {Store,Node}Descriptors in an in-memory cache.
 	NodeDescs kvcoord.NodeDescStore
+
+	TSDB *ts.DB
 }
 
 // UpdateVersionSystemSettingHook provides a callback that allows us

--- a/pkg/ui/workspaces/db-console/src/views/cluster/util/graphs.ts
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/util/graphs.ts
@@ -186,7 +186,7 @@ export function configureUPlotLineChart(
           // value determines how these values show up in the legend
           value: (_u: uPlot, rawValue: number) =>
             getLatestYAxisDomain().guideFormat(rawValue),
-          spanGaps: false,
+          spanGaps: true,
         };
       }),
     ],

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/customChart/customMetric.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/customChart/customMetric.tsx
@@ -13,7 +13,7 @@ import * as React from "react";
 import Select from "react-select";
 
 import * as protos from "src/js/protos";
-import { AxisUnits } from "@cockroachlabs/cluster-ui";
+import { api as clusterUiApi, AxisUnits } from "@cockroachlabs/cluster-ui";
 import Dropdown, { DropdownOption } from "src/views/shared/components/dropdown";
 
 import { MetricOption } from "./metricOption";
@@ -69,13 +69,17 @@ export class CustomChartState {
 interface CustomMetricRowProps {
   metricOptions: DropdownOption[];
   nodeOptions: DropdownOption[];
+  diagnosticFingerprints: clusterUiApi.StatementDiagnosticsReport[];
   index: number;
   rowState: CustomMetricState;
   onChange: (index: number, newState: CustomMetricState) => void;
   onDelete: (index: number) => void;
 }
 
-export class CustomMetricRow extends React.Component<CustomMetricRowProps> {
+export class CustomMetricRow extends React.Component<
+  CustomMetricRowProps,
+  CustomMetricState
+> {
   changeState(newState: Partial<CustomMetricState>) {
     this.props.onChange(
       this.props.index,
@@ -137,6 +141,16 @@ export class CustomMetricRow extends React.Component<CustomMetricRowProps> {
       },
     } = this.props;
 
+    let nodeOptionsOrFingerprints = nodeOptions;
+    if (metric === "experimental.per.statement") {
+      nodeOptionsOrFingerprints = this.props.diagnosticFingerprints.map(df => {
+        return {
+          label: df.statement_fingerprint,
+          value: df.statement_fingerprint,
+        };
+      });
+    }
+
     return (
       <tr>
         <td>
@@ -197,7 +211,7 @@ export class CustomMetricRow extends React.Component<CustomMetricRowProps> {
               clearable={false}
               searchable={false}
               value={source}
-              options={nodeOptions}
+              options={nodeOptionsOrFingerprints}
               onChange={this.changeSource}
             />
           </div>
@@ -225,6 +239,7 @@ export class CustomMetricRow extends React.Component<CustomMetricRowProps> {
 interface CustomChartTableProps {
   metricOptions: DropdownOption[];
   nodeOptions: DropdownOption[];
+  diagnosticFingerprints: clusterUiApi.StatementDiagnosticsReport[];
   index: number;
   chartState: CustomChartState;
   onChange: (index: number, newState: CustomChartState) => void;
@@ -301,6 +316,7 @@ export class CustomChartTable extends React.Component<CustomChartTableProps> {
                 key={i}
                 metricOptions={this.props.metricOptions}
                 nodeOptions={this.props.nodeOptions}
+                diagnosticFingerprints={this.props.diagnosticFingerprints}
                 index={i}
                 rowState={row}
                 onChange={this.updateMetricRow}


### PR DESCRIPTION
THIS IS JUST A DEMO! NOT PRODUCTION CODE!

This is a demonstration of how the "source" field in the tsdb metric can be
used to store per-statement metrics in the TSDB. When statement diagnostics are
enabled for a query fingerprint, until the expiry of the diagnostics request,
timeseries data will be collected for the fingerprint and is accessible for
rendering in the Custom Chart page of DB Console by selecting the
`experimental.per.statement` metric name, and then selecting a fingerprint from
the "Source" column.

The writing to TSDB is done in the instrumentation code that decides whether to
record the diagnostic bundle.