### PR TITLE
sql: do not split disjunctions when the keys are trivial

### DIFF
--- a/pkg/sql/opt/xform/rules/select.opt
+++ b/pkg/sql/opt/xform/rules/select.opt
@@ -93,14 +93,16 @@
 # constraints do not need to be duplicated in the left and right scans of the
 # union.
 #
-# Also note that this rule only matches Selects that have strict keys. See
-# SplitDisjunctionAddKey which handles Selects that do not have strict keys.
+# Also note that this rule only matches Selects that have non-trivial strict
+# keys. See SplitDisjunctionAddKey which handles Selects that do not have strict
+# keys.
 [SplitDisjunction, Explore]
 (Select
     $input:(Scan
             $scanPrivate:* & (IsCanonicalScan $scanPrivate)
         ) &
-        (HasStrictKey $input)
+        (HasStrictKey $input) &
+        ^(HasZeroOrOneRow $input)
     $filters:* &
         (Let
             (

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -9807,3 +9807,32 @@ select
  │    └── columns: col2:3!null col3:4!null col4:5!null
  └── filters
       └── col2:3 < 4 [outer=(3), constraints=(/3: (/NULL - /3]; tight)]
+
+# Reproduction for #83976. Do not split disjunctions with trivial columns.
+exec-ddl
+CREATE TABLE table83976 (c INT AS (5) STORED NOT NULL, UNIQUE INDEX (c));
+----
+
+opt expect-not=SplitDisjunction
+SELECT * FROM table83976 WHERE c IS NULL OR rowid IS NULL
+----
+project
+ ├── columns: c:1!null
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── select
+      ├── columns: c:1!null rowid:2!null
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      ├── fd: ()-->(1,2)
+      ├── scan table83976
+      │    ├── columns: c:1!null rowid:2!null
+      │    ├── computed column expressions
+      │    │    └── c:1
+      │    │         └── 5
+      │    ├── cardinality: [0 - 1]
+      │    ├── key: ()
+      │    └── fd: ()-->(1,2)
+      └── filters
+           └── (c:1 IS NULL) OR (rowid:2 IS NULL) [outer=(1,2)]


### PR DESCRIPTION
When building an expression with `distinct on`, the optimizer returns an error if there are no grouping columns, since these cases should be removed with normalization rules. However, in `SplitDisjunction` we introduce a new `distinct on` expression during exploration without triggering normalization rules. This can lead to unexpected errors for some queries that have trivial, i.e., constant single value, key columns that are not added to grouping columns.

This change modifies `SplitDisjunction` to check for trivial key columns before applying the exploration rule. `HasStrictKey` is not sufficient, since trivial functional dependencies are encoded as strict keys.

Epic: CRDB-20535
Fixes: #83976
Release note (bug fix): Fixes a bug for queries with disjunctions (i.e., contains `OR`) where all the columns referenced in the disjunctions are known to have a single value.