### PR TITLE
.github: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,9 +6,12 @@
 # - every file under ./pkg has to have at least one owner, and each owner must
 #   be present in TEAMS.yaml (either as a map key or an alias).
 # - you can opt out of GitHub-requested code review assignments (while
-#   maintaining team ownership) by suffixing the handle with `-noreview`.
-#   (This will essentially make it an unknown team to GitHub, but our internal
-#   tooling continues to recognize the original team).
+#   maintaining team ownership) prefixing the line with `#!`.
+#   (This will hide the line from GitHub, but our internal tooling continues to
+#   parse it).
+# - there is a special team @cockroachdb/unowned (only to be used with #! prefix as
+#   to not confuse Github) for the rare situations in which a file has no canonical owner.
+#   Please use this sparingly.
 #
 # Remember, *the last rule to match wins*, and you need a trailing slash to get
 # recursive ownership of a directory.
@@ -18,7 +21,7 @@
 # [3]: pkg/internal/codeowners
 
 /.github/                    @cockroachdb/dev-inf
-/.github/CODEOWNERS          @cockroachdb/unowned
+#!/.github/CODEOWNERS          @cockroachdb/unowned
 
 /build/                      @cockroachdb/dev-inf
 
@@ -95,7 +98,7 @@
 /pkg/cli/                    @cockroachdb/cli-prs
 # last-rule-wins so bulk i/o takes userfile.go even though cli-prs takes pkg/cli
 /pkg/cli/userfile.go         @cockroachdb/disaster-recovery
-/pkg/cli/auth.go             @cockroachdb/unowned        @cockroachdb/prodsec @cockroachdb/cli-prs
+/pkg/cli/auth.go             @cockroachdb/prodsec @cockroachdb/cli-prs
 /pkg/cli/cert*.go            @cockroachdb/cli-prs        @cockroachdb/prodsec
 /pkg/cli/demo*.go            @cockroachdb/sql-sessions @cockroachdb/server-prs @cockroachdb/cli-prs
 /pkg/cli/democluster         @cockroachdb/sql-sessions @cockroachdb/server-prs @cockroachdb/cli-prs
@@ -112,19 +115,19 @@
 /pkg/cli/mt_proxy.go         @cockroachdb/sqlproxy-prs   @cockroachdb/server-prs
 /pkg/cli/mt_start_sql.go     @cockroachdb/sqlproxy-prs   @cockroachdb/server-prs
 /pkg/cli/mt_test_directory.go @cockroachdb/sqlproxy-prs  @cockroachdb/server-prs
-/pkg/cli/connect*.go         @cockroachdb/unowned        @cockroachdb/cli-prs @cockroachdb/prodsec
-/pkg/cli/init.go             @cockroachdb/unowned        @cockroachdb/cli-prs
+/pkg/cli/connect*.go         @cockroachdb/cli-prs @cockroachdb/prodsec
+/pkg/cli/init.go             @cockroachdb/cli-prs
 /pkg/cli/log*.go             @cockroachdb/obs-inf-prs    @cockroachdb/cli-prs
 /pkg/cli/debug_logconfig.go  @cockroachdb/obs-inf-prs    @cockroachdb/cli-prs
 /pkg/cli/debug_merg_logs*.go @cockroachdb/obs-inf-prs    @cockroachdb/cli-prs
 
 /pkg/server/                             @cockroachdb/cli-prs
-/pkg/server/addjoin*.go                  @cockroachdb/unowned     @cockroachdb/server-prs @cockroachdb/prodsec
+/pkg/server/addjoin*.go                  @cockroachdb/server-prs @cockroachdb/prodsec
 /pkg/server/admin*.go                    @cockroachdb/obs-inf-prs @cockroachdb/server-prs
 /pkg/server/api_v2*.go                   @cockroachdb/obs-inf-prs @cockroachdb/server-prs
-/pkg/server/api_v2_auth*.go              @cockroachdb/unowned     @cockroachdb/obs-inf-prs @cockroachdb/server-prs @cockroachdb/prodsec
-/pkg/server/authentication*.go           @cockroachdb/unowned     @cockroachdb/server-prs  @cockroachdb/prodsec
-/pkg/server/auto_tls_init*go             @cockroachdb/unowned     @cockroachdb/server-prs  @cockroachdb/prodsec
+/pkg/server/api_v2_auth*.go              @cockroachdb/obs-inf-prs @cockroachdb/server-prs @cockroachdb/prodsec
+/pkg/server/authentication*.go           @cockroachdb/server-prs  @cockroachdb/prodsec
+/pkg/server/auto_tls_init*go             @cockroachdb/server-prs  @cockroachdb/prodsec
 /pkg/server/clock_monotonicity.go        @cockroachdb/kv-prs
 /pkg/server/combined_statement_stats*.go @cockroachdb/sql-observability @cockroachdb/obs-inf-prs
 /pkg/server/decommission*.go             @cockroachdb/kv-prs      @cockroachdb/server-prs
@@ -134,7 +137,7 @@
 /pkg/server/heapprofiler/                @cockroachdb/obs-inf-prs @cockroachdb/server-prs
 /pkg/server/import_ts*.go                @cockroachdb/obs-inf-prs @cockroachdb/server-prs  @cockroachdb/kv-prs
 /pkg/server/init*.go                     @cockroachdb/kv-prs      @cockroachdb/server-prs
-/pkg/server/init_handshake.go            @cockroachdb/unowned     @cockroachdb/server-prs  @cockroachdb/prodsec
+/pkg/server/init_handshake.go            @cockroachdb/server-prs  @cockroachdb/prodsec
 /pkg/server/loss_of_quorum*.go           @cockroachdb/kv-prs
 /pkg/server/node_http*.go                @cockroachdb/obs-inf-prs @cockroachdb/server-prs
 /pkg/server/node_tenant*go               @cockroachdb/obs-inf-prs @cockroachdb/multi-tenant @cockroachdb/server-prs
@@ -143,7 +146,7 @@
 /pkg/server/server_http*.go              @cockroachdb/obs-inf-prs @cockroachdb/server-prs
 /pkg/server/server_import_ts*.go         @cockroachdb/obs-inf-prs @cockroachdb/kv-prs
 /pkg/server/serverpb/                    @cockroachdb/obs-inf-prs @cockroachdb/server-prs
-/pkg/server/serverpb/authentication*     @cockroachdb/unowned     @cockroachdb/obs-inf-prs @cockroachdb/prodsec @cockroachdb/server-prs
+/pkg/server/serverpb/authentication*     @cockroachdb/obs-inf-prs @cockroachdb/prodsec @cockroachdb/server-prs
 /pkg/server/serverpb/index_reco*         @cockroachdb/sql-observability @cockroachdb/obs-inf-prs
 /pkg/server/serverrules/                 @cockroachdb/obs-inf-prs @cockroachdb/server-prs
 /pkg/server/settingswatcher/             @cockroachdb/multi-tenant @cockroachdb/server-prs
@@ -153,7 +156,7 @@
 /pkg/server/status/                      @cockroachdb/obs-inf-prs @cockroachdb/server-prs
 /pkg/server/systemconfigwatcher/         @cockroachdb/kv-prs      @cockroachdb/multi-tenant
 /pkg/server/tenant*.go                   @cockroachdb/obs-inf-prs @cockroachdb/multi-tenant @cockroachdb/server-prs
-/pkg/server/tenantsettingswatcher/       @cockroachdb/unowned     @cockroachdb/multi-tenant
+/pkg/server/tenantsettingswatcher/       @cockroachdb/multi-tenant
 /pkg/server/testserver*.go               @cockroachdb/test-eng    @cockroachdb/server-prs
 /pkg/server/tracedumper/                 @cockroachdb/obs-inf-prs @cockroachdb/server-prs
 /pkg/server/user*.go                     @cockroachdb/obs-inf-prs @cockroachdb/server-prs @cockroachdb/prodsec
@@ -214,7 +217,7 @@
 /pkg/gen/gen.bzl             @cockroachdb/dev-inf
 
 /pkg/acceptance/             @cockroachdb/sql-sessions
-/pkg/base/                   @cockroachdb/unowned @cockroachdb/kv-prs @cockroachdb/server-prs
+/pkg/base/                   @cockroachdb/kv-prs @cockroachdb/server-prs
 /pkg/bench/                  @cockroachdb/sql-queries-noreview
 /pkg/bench/rttanalysis       @cockroachdb/sql-schema
 /pkg/blobs/                  @cockroachdb/disaster-recovery
@@ -223,18 +226,18 @@
 /pkg/ccl/buildccl/           @cockroachdb/dev-inf
 /pkg/ccl/cliccl/             @cockroachdb/cli-prs
 /pkg/ccl/cmdccl/stub-schema-registry/ @cockroachdb/cdc-prs
-/pkg/ccl/gssapiccl/          @cockroachdb/unowned
+#!/pkg/ccl/gssapiccl/        @cockroachdb/unowned
 /pkg/ccl/jwtauthccl/         @cockroachdb/cloud-identity
 /pkg/ccl/kvccl/              @cockroachdb/kv-noreview
 /pkg/ccl/kvccl/kvtenantccl/  @cockroachdb/multi-tenant
-/pkg/ccl/upgradeccl/         @cockroachdb/unowned
+#!/pkg/ccl/upgradeccl/       @cockroachdb/unowned
 /pkg/ccl/logictestccl/       @cockroachdb/sql-queries-noreview
 /pkg/ccl/sqlitelogictestccl/ @cockroachdb/sql-queries-noreview
 /pkg/ccl/multiregionccl/     @cockroachdb/multiregion
 /pkg/ccl/multitenantccl/     @cockroachdb/multi-tenant
-/pkg/ccl/oidcccl/            @cockroachdb/unowned
+#!/pkg/ccl/oidcccl/          @cockroachdb/unowned
 /pkg/ccl/partitionccl/       @cockroachdb/sql-schema @cockroachdb/multiregion
-/pkg/ccl/serverccl/          @cockroachdb/unowned @cockroachdb/server-prs
+/pkg/ccl/serverccl/          @cockroachdb/server-prs
 /pkg/ccl/serverccl/server_sql* @cockroachdb/multi-tenant @cockroachdb/server-prs
 /pkg/ccl/serverccl/tenant_*  @cockroachdb/multi-tenant @cockroachdb/server-prs
 /pkg/ccl/serverccl/statusccl @cockroachdb/sql-observability @cockroachdb/multi-tenant
@@ -243,7 +246,7 @@
 /pkg/ccl/testccl/sqlccl/     @cockroachdb/sql-queries
 /pkg/ccl/testccl/workload/schemachange/ @cockroachdb/sql-schema
 /pkg/ccl/testutilsccl/       @cockroachdb/test-eng-noreview
-/pkg/ccl/utilccl/            @cockroachdb/unowned @cockroachdb/server-prs
+/pkg/ccl/utilccl/            @cockroachdb/server-prs
 /pkg/ccl/workloadccl/        @cockroachdb/sql-sessions-noreview @cockroachdb/test-eng
 /pkg/ccl/benchccl/rttanalysisccl/     @cockroachdb/sql-schema
 /pkg/clusterversion/         @cockroachdb/kv-prs-noreview
@@ -357,14 +360,14 @@
 /pkg/roachpb/tenant*         @cockroachdb/kv-prs
 /pkg/roachpb/testdata/ambi*  @cockroachdb/kv-prs
 /pkg/roachpb/testdata/repl*  @cockroachdb/kv-prs
-/pkg/roachpb/version*        @cockroachdb/unowned
+#!/pkg/roachpb/version*      @cockroachdb/unowned
 /pkg/roachprod/              @cockroachdb/test-eng
 /pkg/rpc/                    @cockroachdb/kv-prs
-/pkg/rpc/auth.go             @cockroachdb/unowned @cockroachdb/server-prs @cockroachdb/kv-prs @cockroachdb/prodsec
+/pkg/rpc/auth.go             @cockroachdb/server-prs @cockroachdb/kv-prs @cockroachdb/prodsec
 /pkg/scheduledjobs/          @cockroachdb/jobs-prs
-/pkg/security/               @cockroachdb/unowned @cockroachdb/server-prs @cockroachdb/prodsec
-/pkg/security/clientsecopts/ @cockroachdb/unowned @cockroachdb/server-prs @cockroachdb/sql-sessions @cockroachdb/prodsec
-/pkg/settings/               @cockroachdb/unowned
+/pkg/security/               @cockroachdb/server-prs @cockroachdb/prodsec
+/pkg/security/clientsecopts/ @cockroachdb/server-prs @cockroachdb/sql-sessions @cockroachdb/prodsec
+#!/pkg/settings/             @cockroachdb/unowned
 /pkg/spanconfig/             @cockroachdb/kv-prs
 /pkg/repstream/              @cockroachdb/disaster-recovery
 /pkg/testutils/              @cockroachdb/test-eng-noreview
@@ -373,7 +376,7 @@
 /pkg/testutils/jobutils/     @cockroachdb/jobs-prs
 /pkg/ts/                     @cockroachdb/kv-prs
 /pkg/ts/catalog/             @cockroachdb/obs-inf-prs
-/pkg/util/                   @cockroachdb/unowned
+#!/pkg/util/                 @cockroachdb/unowned
 /pkg/util/log/               @cockroachdb/obs-inf-prs
 /pkg/util/addr/              @cockroachdb/cli-prs @cockroachdb/obs-inf-prs
 /pkg/util/metric/            @cockroachdb/obs-inf-prs
@@ -390,9 +393,12 @@
 # as they are mostly - but not only - generated code that changes with
 # changes to the Go code in the package.
 **/BUILD.bazel               @cockroachdb/dev-inf-noreview
-# Avoid mass pings when updating proto tooling.
+# Own the generated proto files to someone. They're not
+# checked in, but since our owners tooling isn't aware
+# of that we still want this rule to pass lints locally.
+#
 # For some reason, **/*.pb.go does not work (in the
 # sense that ./pkg/cmd/whoownsit will not match this
 # pattern to any files).
-**.pb.go                     @cockroachdb/unowned
-**.pb.gw.go                  @cockroachdb/unowned
+#!**.pb.go                   @cockroachdb/unowned
+#!**.pb.gw.go                @cockroachdb/unowned

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,8 +13,14 @@
 #   to not confuse Github) for the rare situations in which a file has no canonical owner.
 #   Please use this sparingly.
 #
+#   TODO(test-eng): it would be good to lint that following a `#!` marker all mentioned
+#   teams match @cockroachdb/{unowned,*-noreview}.
+#
 # Remember, *the last rule to match wins*, and you need a trailing slash to get
 # recursive ownership of a directory.
+#
+# When you send a PR to update this file, please look at the "Files" tab and
+# fix any errors Github reports.
 #
 # [1]: https://github.com/blog/2392-introducing-code-owners
 # [2]: https://help.github.com/articles/about-codeowners/
@@ -30,12 +36,12 @@
 
 /Makefile                    @cockroachdb/dev-inf
 
-/pkg/sql/                    @cockroachdb/sql-queries-noreview
+#!/pkg/sql/                    @cockroachdb/sql-queries-noreview
 
 /pkg/sql/inverted/           @cockroachdb/sql-queries
 /pkg/sql/opt/                @cockroachdb/sql-queries
 /pkg/sql/opt_*.go            @cockroachdb/sql-queries
-/pkg/sql/opt/exec/execbuilder/testdata/ @cockroachdb/sql-queries-noreview
+#!/pkg/sql/opt/exec/execbuilder/testdata/ @cockroachdb/sql-queries-noreview
 /pkg/sql/plan_opt*.go        @cockroachdb/sql-queries
 /pkg/sql/querycache/         @cockroachdb/sql-queries
 /pkg/sql/span/               @cockroachdb/sql-queries
@@ -44,8 +50,8 @@
 /pkg/sql/col*                @cockroachdb/sql-queries
 /pkg/sql/distsql*.go         @cockroachdb/sql-queries
 /pkg/sql/exec*               @cockroachdb/sql-queries
-/pkg/sql/exec_log*.go        @cockroachdb/sql-queries-noreview
-/pkg/sql/exec_util*.go       @cockroachdb/sql-queries-noreview
+#!/pkg/sql/exec_log*.go        @cockroachdb/sql-queries-noreview
+#!/pkg/sql/exec_util*.go       @cockroachdb/sql-queries-noreview
 /pkg/sql/flowinfra/          @cockroachdb/sql-queries
 /pkg/sql/physicalplan/       @cockroachdb/sql-queries
 /pkg/sql/row*                @cockroachdb/sql-queries
@@ -213,12 +219,12 @@
 /pkg/ccl/sqlproxyccl/        @cockroachdb/sqlproxy-prs @cockroachdb/server-prs
 
 /pkg/gen/                    @cockroachdb/dev-inf
-/pkg/gen/*.bzl               @cockroachdb/dev-inf-noreview
+#!/pkg/gen/*.bzl               @cockroachdb/dev-inf-noreview
 /pkg/gen/gen.bzl             @cockroachdb/dev-inf
 
 /pkg/acceptance/             @cockroachdb/sql-sessions
 /pkg/base/                   @cockroachdb/kv-prs @cockroachdb/server-prs
-/pkg/bench/                  @cockroachdb/sql-queries-noreview
+#!/pkg/bench/                  @cockroachdb/sql-queries-noreview
 /pkg/bench/rttanalysis       @cockroachdb/sql-schema
 /pkg/blobs/                  @cockroachdb/disaster-recovery
 /pkg/build/                  @cockroachdb/dev-inf
@@ -228,11 +234,11 @@
 /pkg/ccl/cmdccl/stub-schema-registry/ @cockroachdb/cdc-prs
 #!/pkg/ccl/gssapiccl/        @cockroachdb/unowned
 /pkg/ccl/jwtauthccl/         @cockroachdb/cloud-identity
-/pkg/ccl/kvccl/              @cockroachdb/kv-noreview
+#!/pkg/ccl/kvccl/              @cockroachdb/kv-noreview
 /pkg/ccl/kvccl/kvtenantccl/  @cockroachdb/multi-tenant
 #!/pkg/ccl/upgradeccl/       @cockroachdb/unowned
-/pkg/ccl/logictestccl/       @cockroachdb/sql-queries-noreview
-/pkg/ccl/sqlitelogictestccl/ @cockroachdb/sql-queries-noreview
+#!/pkg/ccl/logictestccl/       @cockroachdb/sql-queries-noreview
+#!/pkg/ccl/sqlitelogictestccl/ @cockroachdb/sql-queries-noreview
 /pkg/ccl/multiregionccl/     @cockroachdb/multiregion
 /pkg/ccl/multitenantccl/     @cockroachdb/multi-tenant
 #!/pkg/ccl/oidcccl/          @cockroachdb/unowned
@@ -245,11 +251,11 @@
 /pkg/ccl/testccl/authccl/    @cockroachdb/cloud-identity
 /pkg/ccl/testccl/sqlccl/     @cockroachdb/sql-queries
 /pkg/ccl/testccl/workload/schemachange/ @cockroachdb/sql-schema
-/pkg/ccl/testutilsccl/       @cockroachdb/test-eng-noreview
+#!/pkg/ccl/testutilsccl/       @cockroachdb/test-eng-noreview
 /pkg/ccl/utilccl/            @cockroachdb/server-prs
-/pkg/ccl/workloadccl/        @cockroachdb/sql-sessions-noreview @cockroachdb/test-eng
+/pkg/ccl/workloadccl/        @cockroachdb/test-eng #! @cockroachdb/sql-sessions-noreview
 /pkg/ccl/benchccl/rttanalysisccl/     @cockroachdb/sql-schema
-/pkg/clusterversion/         @cockroachdb/kv-prs-noreview
+#!/pkg/clusterversion/         @cockroachdb/kv-prs-noreview
 /pkg/cmd/allocsim/           @cockroachdb/kv-prs
 /pkg/cmd/bazci/              @cockroachdb/dev-inf
 /pkg/cmd/cloudupload/        @cockroachdb/dev-inf
@@ -299,7 +305,7 @@
 # is the Owner for the roachtest, but until we unify these
 # two concepts of ownership we don't want to ping test-eng
 # on each test change.
-/pkg/cmd/roachtest/tests     @cockroachdb/test-eng-noreview
+#!/pkg/cmd/roachtest/tests     @cockroachdb/test-eng-noreview
 /pkg/cmd/roachvet/           @cockroachdb/dev-inf
 /pkg/cmd/skip-test/          @cockroachdb/test-eng
 /pkg/cmd/skiperrs/           @cockroachdb/sql-sessions
@@ -312,14 +318,14 @@
 /pkg/cmd/uptodate/           @cockroachdb/dev-inf
 /pkg/cmd/urlcheck/           @cockroachdb/docs
 /pkg/cmd/whoownsit/          @cockroachdb/test-eng
-/pkg/cmd/workload/           @cockroachdb/sql-sessions-noreview @cockroachdb/test-eng
-/pkg/cmd/wraprules/          @cockroachdb/obs-inf-prs-noreview
-/pkg/cmd/zerosum/            @cockroachdb/kv-noreview
+/pkg/cmd/workload/           @cockroachdb/test-eng #! @cockroachdb/sql-sessions-noreview
+#!/pkg/cmd/wraprules/          @cockroachdb/obs-inf-prs-noreview
+#!/pkg/cmd/zerosum/            @cockroachdb/kv-noreview
 /pkg/col/                    @cockroachdb/sql-queries
 /pkg/compose/                @cockroachdb/sql-sessions
 /pkg/config/                 @cockroachdb/kv-prs @cockroachdb/server-prs
 /pkg/docs/                   @cockroachdb/docs
-/pkg/featureflag/            @cockroachdb/cli-prs-noreview
+#!/pkg/featureflag/            @cockroachdb/cli-prs-noreview
 /pkg/gossip/                 @cockroachdb/kv-prs
 /pkg/internal/client/requestbatcher/ @cockroachdb/kv-prs
 /pkg/internal/codeowners/    @cockroachdb/test-eng
@@ -331,15 +337,15 @@
 /pkg/keys/                   @cockroachdb/kv-prs
 /pkg/keysbase/               @cockroachdb/kv-prs
 # Don't ping KV on updates to reserved descriptor IDs and such.
-/pkg/keys/constants.go       @cockroachdb/kv-prs-noreview
-/pkg/upgrade/                @cockroachdb/kv-prs-noreview @cockroachdb/sql-schema
+#!/pkg/keys/constants.go       @cockroachdb/kv-prs-noreview
+/pkg/upgrade/                @cockroachdb/sql-schema
 /pkg/multitenant/            @cockroachdb/multi-tenant
 /pkg/release/                @cockroachdb/dev-inf
 /pkg/roachpb/.gitattributes  @cockroachdb/dev-inf
 /pkg/roachpb/ambiguous_*     @cockroachdb/kv-prs
 /pkg/roachpb/api*            @cockroachdb/kv-prs
 /pkg/roachpb/batch*          @cockroachdb/kv-prs
-/pkg/roachpb/BUILD.bazel     @cockroachdb/kv-prs-noreview
+#!/pkg/roachpb/BUILD.bazel     @cockroachdb/kv-prs-noreview
 /pkg/roachpb/data*           @cockroachdb/kv-prs
 /pkg/roachpb/dep_test.go     @cockroachdb/dev-inf
 /pkg/roachpb/error*          @cockroachdb/kv-prs
@@ -349,7 +355,7 @@
 /pkg/roachpb/index*          @cockroachdb/sql-observability
 /pkg/roachpb/internal*       @cockroachdb/kv-prs
 /pkg/roachpb/io-formats*     @cockroachdb/disaster-recovery
-/pkg/roachpb/main_test.go    @cockroachdb/kv-prs-noreview
+#!/pkg/roachpb/main_test.go    @cockroachdb/kv-prs-noreview
 /pkg/roachpb/merge_spans*    @cockroachdb/kv-prs
 /pkg/roachpb/metadata*       @cockroachdb/kv-prs
 /pkg/roachpb/method*         @cockroachdb/kv-prs
@@ -370,7 +376,7 @@
 #!/pkg/settings/             @cockroachdb/unowned
 /pkg/spanconfig/             @cockroachdb/kv-prs
 /pkg/repstream/              @cockroachdb/disaster-recovery
-/pkg/testutils/              @cockroachdb/test-eng-noreview
+#!/pkg/testutils/              @cockroachdb/test-eng-noreview
 /pkg/testutils/reduce/       @cockroachdb/sql-queries
 /pkg/testutils/sqlutils/     @cockroachdb/sql-queries
 /pkg/testutils/jobutils/     @cockroachdb/jobs-prs
@@ -385,14 +391,15 @@
 /pkg/util/admission/         @cockroachdb/admission-control
 /pkg/util/schedulerlatency/  @cockroachdb/admission-control
 /pkg/util/tracing            @cockroachdb/obs-inf-prs
-/pkg/workload/               @cockroachdb/sql-sessions-noreview @cockroachdb/test-eng
+/pkg/workload/               @cockroachdb/test-eng #! @cockroachdb/sql-sessions-noreview
 /pkg/obs/                    @cockroachdb/obs-inf-prs
 /pkg/obsservice/             @cockroachdb/obs-inf-prs
 
 # Own all bazel files to dev-inf, but don't request reviews for them
 # as they are mostly - but not only - generated code that changes with
 # changes to the Go code in the package.
-**/BUILD.bazel               @cockroachdb/dev-inf-noreview
+#!**/BUILD.bazel               @cockroachdb/dev-inf-noreview
+
 # Own the generated proto files to someone. They're not
 # checked in, but since our owners tooling isn't aware
 # of that we still want this rule to pass lints locally.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -272,7 +272,7 @@
 /pkg/cmd/compile-build/      @cockroachdb/dev-inf
 /pkg/cmd/cr2pg/              @cockroachdb/sql-sessions
 /pkg/cmd/dev/                @cockroachdb/dev-inf
-/pkg/cmd/docgen/             @cockroachdb/docs
+/pkg/cmd/docgen/             @cockroachdb/docs-infra-prs
 /pkg/cmd/docs-issue-generation/ @cockroachdb/dev-inf
 /pkg/cmd/fuzz/               @cockroachdb/test-eng
 /pkg/cmd/generate-binary/    @cockroachdb/sql-sessions
@@ -318,7 +318,7 @@
 /pkg/cmd/teamcity-trigger/   @cockroachdb/dev-inf
 /pkg/cmd/testfilter/         @cockroachdb/test-eng
 /pkg/cmd/uptodate/           @cockroachdb/dev-inf
-/pkg/cmd/urlcheck/           @cockroachdb/docs
+/pkg/cmd/urlcheck/           @cockroachdb/docs-infra-prs
 /pkg/cmd/whoownsit/          @cockroachdb/test-eng
 /pkg/cmd/workload/           @cockroachdb/test-eng #! @cockroachdb/sql-sessions-noreview
 #!/pkg/cmd/wraprules/          @cockroachdb/obs-inf-prs-noreview
@@ -326,7 +326,7 @@
 /pkg/col/                    @cockroachdb/sql-queries
 /pkg/compose/                @cockroachdb/sql-sessions
 /pkg/config/                 @cockroachdb/kv-prs @cockroachdb/server-prs
-/pkg/docs/                   @cockroachdb/docs
+/pkg/docs/                   @cockroachdb/docs-infra-prs
 #!/pkg/featureflag/            @cockroachdb/cli-prs-noreview
 /pkg/gossip/                 @cockroachdb/kv-prs
 /pkg/internal/client/requestbatcher/ @cockroachdb/kv-prs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -183,8 +183,21 @@
 
 /pkg/geo/                    @cockroachdb/spatial
 
-# The KV team generally owns ./pkg/kv/... but some of it belongs to Repl.
-/pkg/kv/                                @cockroachdb/kv-prs
+# The KV team generally owns ./pkg/kv/... but not all of it. By convention,
+# inside of the /pkg/kv tree, we list out rules for each subdirectory, i.e. when
+# a new directory is created CODEOWNERS should mandate a new line below. This
+# serves as a lint that ownership is properly considered at creation time.
+/pkg/kv/*.*                             @cockroachdb/kv-prs
+/pkg/kv/bulk/                           @cockroachdb/disaster-recovery
+/pkg/kv/kvbase/                         @cockroachdb/kv-prs
+/pkg/kv/kvclient/                       @cockroachdb/kv-prs
+/pkg/kv/kvclient/kvcoord/*rangefeed*    @cockroachdb/repl-prs
+/pkg/kv/kvclient/kvstreamer             @cockroachdb/sql-queries
+/pkg/kv/kvclient/rangefeed/             @cockroachdb/repl-prs
+/pkg/kv/kvnemesis/                      @cockroachdb/kv-prs
+/pkg/kv/kvprober/                       @cockroachdb/kv-prs
+# Same subdirectory rule as above for `/pkg/kv`
+/pkg/kv/kvserver/*.*                    @cockroachdb/kv-prs
 /pkg/kv/kvserver/*circuit*.go           @cockroachdb/repl-prs
 /pkg/kv/kvserver/*closed*ts*.go         @cockroachdb/repl-prs
 /pkg/kv/kvserver/*_app*.go              @cockroachdb/repl-prs
@@ -196,16 +209,44 @@
 /pkg/kv/kvserver/*raft*/                @cockroachdb/repl-prs
 /pkg/kv/kvserver/*rangefeed*.go         @cockroachdb/repl-prs
 /pkg/kv/kvserver/*sideload*.go          @cockroachdb/repl-prs
+/pkg/kv/kvserver/abortspan/             @cockroachdb/kv-prs
+/pkg/kv/kvserver/allocator/             @cockroachdb/kv-prs
 /pkg/kv/kvserver/apply/                 @cockroachdb/repl-prs
+/pkg/kv/kvserver/asim/                  @cockroachdb/kv-prs
+/pkg/kv/kvserver/batcheval/             @cockroachdb/kv-prs
 /pkg/kv/kvserver/closedts/              @cockroachdb/repl-prs
+/pkg/kv/kvserver/concurrency/           @cockroachdb/kv-prs
+/pkg/kv/kvserver/constraint/            @cockroachdb/kv-prs
+/pkg/kv/kvserver/diskmap/               @cockroachdb/kv-prs
+/pkg/kv/kvserver/gc/                    @cockroachdb/kv-prs
+/pkg/kv/kvserver/idalloc/               @cockroachdb/kv-prs
+/pkg/kv/kvserver/intentresolver/        @cockroachdb/kv-prs
+/pkg/kv/kvserver/kvadmission/           @cockroachdb/kv-prs
+/pkg/kv/kvserver/kvserverbase/          @cockroachdb/kv-prs
+/pkg/kv/kvserver/kvserverpb/            @cockroachdb/kv-prs
+/pkg/kv/kvserver/liveness/              @cockroachdb/kv-prs
 /pkg/kv/kvserver/logstore/              @cockroachdb/repl-prs
+/pkg/kv/kvserver/loqrecovery/           @cockroachdb/repl-prs
+/pkg/kv/kvserver/multiqueue/            @cockroachdb/kv-prs
+/pkg/kv/kvserver/protectedts/           @cockroachdb/repl-prs
 /pkg/kv/kvserver/rangefeed/             @cockroachdb/repl-prs
+/pkg/kv/kvserver/rangelog/              @cockroachdb/kv-prs
 /pkg/kv/kvserver/rditer/                @cockroachdb/repl-prs
-/pkg/kv/kvclient/kvcoord/*rangefeed*    @cockroachdb/repl-prs
-/pkg/kv/kvclient/rangefeed/             @cockroachdb/repl-prs
+/pkg/kv/kvserver/readsummary/           @cockroachdb/kv-prs
+/pkg/kv/kvserver/replicastats/          @cockroachdb/kv-prs
+/pkg/kv/kvserver/reports/               @cockroachdb/kv-prs
+/pkg/kv/kvserver/spanlatch/             @cockroachdb/kv-prs
+/pkg/kv/kvserver/spanset/               @cockroachdb/kv-prs
+/pkg/kv/kvserver/split/                 @cockroachdb/kv-prs
+/pkg/kv/kvserver/stateloader/           @cockroachdb/kv-prs
+/pkg/kv/kvserver/tenantrate/            @cockroachdb/kv-prs
+#!/pkg/kv/kvserver/testdata/            @cockroachdb/kv-prs-noreview
+/pkg/kv/kvserver/tscache/               @cockroachdb/kv-prs
+/pkg/kv/kvserver/txnrecovery/           @cockroachdb/kv-prs
+/pkg/kv/kvserver/txnwait/               @cockroachdb/kv-prs
+/pkg/kv/kvserver/uncertainty/           @cockroachdb/kv-prs
 
 /pkg/ccl/spanconfigccl/      @cockroachdb/kv-prs
-/pkg/kv/kvclient/kvstreamer  @cockroachdb/sql-queries
 
 /pkg/ccl/storageccl/engineccl   @cockroachdb/storage
 /pkg/storage/                   @cockroachdb/storage

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -181,7 +181,7 @@
 /pkg/cloud/                  @cockroachdb/disaster-recovery
 /pkg/sql/distsql_plan_csv.go @cockroachdb/disaster-recovery
 
-/pkg/geo/                    @cockroachdb/geospatial
+/pkg/geo/                    @cockroachdb/spatial
 
 # The KV team generally owns ./pkg/kv/... but some of it belongs to Repl.
 /pkg/kv/                                @cockroachdb/kv-prs
@@ -279,10 +279,10 @@
 /pkg/cmd/generate-distdir/ @cockroachdb/dev-inf
 /pkg/cmd/generate-logictest/       @cockroachdb/dev-inf
 /pkg/cmd/generate-metadata-tables/ @cockroachdb/sql-sessions
-/pkg/cmd/generate-spatial-ref-sys/ @cockroachdb/geospatial
+/pkg/cmd/generate-spatial-ref-sys/ @cockroachdb/spatial
 /pkg/cmd/generate-bazel-extra/ @cockroachdb/dev-inf
 /pkg/cmd/generate-staticcheck/ @cockroachdb/dev-inf
-/pkg/cmd/geoviz/             @cockroachdb/geospatial
+/pkg/cmd/geoviz/             @cockroachdb/spatial
 /pkg/cmd/github-post/        @cockroachdb/test-eng
 /pkg/cmd/github-pull-request-make/ @cockroachdb/dev-inf
 /pkg/cmd/gossipsim/          @cockroachdb/kv-prs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -272,7 +272,7 @@
 /pkg/cmd/compile-build/      @cockroachdb/dev-inf
 /pkg/cmd/cr2pg/              @cockroachdb/sql-sessions
 /pkg/cmd/dev/                @cockroachdb/dev-inf
-/pkg/cmd/docgen/             @cockroachdb/docs-infra-prs
+#!/pkg/cmd/docgen/             @cockroachdb/docs-infra-prs
 /pkg/cmd/docs-issue-generation/ @cockroachdb/dev-inf
 /pkg/cmd/fuzz/               @cockroachdb/test-eng
 /pkg/cmd/generate-binary/    @cockroachdb/sql-sessions
@@ -318,7 +318,7 @@
 /pkg/cmd/teamcity-trigger/   @cockroachdb/dev-inf
 /pkg/cmd/testfilter/         @cockroachdb/test-eng
 /pkg/cmd/uptodate/           @cockroachdb/dev-inf
-/pkg/cmd/urlcheck/           @cockroachdb/docs-infra-prs
+#!/pkg/cmd/urlcheck/           @cockroachdb/docs-infra-prs
 /pkg/cmd/whoownsit/          @cockroachdb/test-eng
 /pkg/cmd/workload/           @cockroachdb/test-eng #! @cockroachdb/sql-sessions-noreview
 #!/pkg/cmd/wraprules/          @cockroachdb/obs-inf-prs-noreview
@@ -326,7 +326,10 @@
 /pkg/col/                    @cockroachdb/sql-queries
 /pkg/compose/                @cockroachdb/sql-sessions
 /pkg/config/                 @cockroachdb/kv-prs @cockroachdb/server-prs
-/pkg/docs/                   @cockroachdb/docs-infra-prs
+# TODO(nickvigilante): add the cockroach repo to the docs-infra-prs team so that
+# Github stops complaining. Then remove the #! prefix here and on the other lines
+# that mention this team.
+#!/pkg/docs/                   @cockroachdb/docs-infra-prs
 #!/pkg/featureflag/            @cockroachdb/cli-prs-noreview
 /pkg/gossip/                 @cockroachdb/kv-prs
 /pkg/internal/client/requestbatcher/ @cockroachdb/kv-prs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -208,10 +208,10 @@
 /pkg/ccl/storageccl/engineccl   @cockroachdb/storage
 /pkg/storage/                   @cockroachdb/storage
 
-/pkg/ui/                     @cockroachdb/cluster-ui-prs
-/pkg/ui/embedded.go          @cockroachdb/cluster-ui-prs
-/pkg/ui/src/js/protos.d.ts   @cockroachdb/cluster-ui-prs
-/pkg/ui/src/js/protos.js     @cockroachdb/cluster-ui-prs
+/pkg/ui/                     @cockroachdb/admin-ui-prs
+/pkg/ui/embedded.go          @cockroachdb/admin-ui-prs
+/pkg/ui/src/js/protos.d.ts   @cockroachdb/admin-ui-prs
+/pkg/ui/src/js/protos.js     @cockroachdb/admin-ui-prs
 
 /docs/generated/http/        @cockroachdb/http-api-prs @cockroachdb/server-prs
 /pkg/cmd/docgen/http.go      @cockroachdb/http-api-prs @cockroachdb/server-prs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -170,7 +170,9 @@
 
 /pkg/ccl/jobsccl/            @cockroachdb/jobs-prs
 /pkg/ccl/changefeedccl/      @cockroachdb/cdc-prs
-/pkg/ccl/streamingccl/       @cockroachdb/tenant-streaming
+# TODO(dt): either add the cockroach repository to this team or remove this team from
+# CODEOWNERS.
+#!/pkg/ccl/streamingccl/       @cockroachdb/tenant-streaming
 
 /pkg/ccl/backupccl/          @cockroachdb/disaster-recovery
 /pkg/ccl/backupccl/*_job.go  @cockroachdb/disaster-recovery @cockroachdb/jobs-prs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -172,7 +172,27 @@
 
 /pkg/geo/                    @cockroachdb/geospatial
 
-/pkg/kv/                     @cockroachdb/kv-prs
+# The KV team generally owns ./pkg/kv/... but some of it belongs to Repl.
+/pkg/kv/                                @cockroachdb/kv-prs
+/pkg/kv/kvserver/*circuit*.go           @cockroachdb/repl-prs
+/pkg/kv/kvserver/*closed*ts*.go         @cockroachdb/repl-prs
+/pkg/kv/kvserver/*_app*.go              @cockroachdb/repl-prs
+/pkg/kv/kvserver/*closed_timestamp*.go  @cockroachdb/repl-prs
+/pkg/kv/kvserver/*consistency*.go       @cockroachdb/repl-prs
+/pkg/kv/kvserver/*probe*.go             @cockroachdb/repl-prs
+/pkg/kv/kvserver/*proposal*.go          @cockroachdb/repl-prs
+/pkg/kv/kvserver/*raft*.go              @cockroachdb/repl-prs
+/pkg/kv/kvserver/*raft*/                @cockroachdb/repl-prs
+/pkg/kv/kvserver/*rangefeed*.go         @cockroachdb/repl-prs
+/pkg/kv/kvserver/*sideload*.go          @cockroachdb/repl-prs
+/pkg/kv/kvserver/apply/                 @cockroachdb/repl-prs
+/pkg/kv/kvserver/closedts/              @cockroachdb/repl-prs
+/pkg/kv/kvserver/logstore/              @cockroachdb/repl-prs
+/pkg/kv/kvserver/rangefeed/             @cockroachdb/repl-prs
+/pkg/kv/kvserver/rditer/                @cockroachdb/repl-prs
+/pkg/kv/kvclient/kvcoord/*rangefeed*    @cockroachdb/repl-prs
+/pkg/kv/kvclient/rangefeed/             @cockroachdb/repl-prs
+
 /pkg/ccl/spanconfigccl/      @cockroachdb/kv-prs
 /pkg/kv/kvclient/kvstreamer  @cockroachdb/sql-queries
 

--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -19,6 +19,8 @@
 
 cockroachdb/docs:
   triage_column_id: 3971225
+  aliases:
+    cockroachdb/docs-infra-prs: other
 cockroachdb/sql-sessions:
   aliases:
     cockroachdb/sql-syntax-prs: other

--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -45,7 +45,7 @@ cockroachdb/replication:
   aliases:
     cockroachdb/repl-prs: other
   label: T-kv-replication
-cockroachdb/geospatial:
+cockroachdb/spatial:
   triage_column_id: 9487269
 cockroachdb/dev-inf:
   triage_column_id: 10210759

--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -73,9 +73,9 @@ cockroachdb/server:
     cockroachdb/server-prs: other
     cockroachdb/http-api-prs: other
   triage_column_id: 2521812
-cockroachdb/cluster-ui:
+cockroachdb/admin-ui:
   aliases:
-    cockroachdb/cluster-ui-prs: other
+    cockroachdb/admin-ui-prs: other
   triage_column_id: 6598672
 cockroachdb/obs-inf-prs:
   triage_column_id: 14196277

--- a/pkg/internal/codeowners/codeowners.go
+++ b/pkg/internal/codeowners/codeowners.go
@@ -53,10 +53,7 @@ func LoadCodeOwners(r io.Reader, teams map[team.Alias]team.Team) (*CodeOwners, e
 		if s.Err() != nil {
 			return nil, s.Err()
 		}
-		t := s.Text()
-		if strings.HasPrefix(t, "#!") {
-			t = t[2:]
-		}
+		t := strings.Replace(s.Text(), "#!", "", -1)
 		if strings.HasPrefix(t, "#") {
 			continue
 		}

--- a/pkg/internal/codeowners/codeowners.go
+++ b/pkg/internal/codeowners/codeowners.go
@@ -54,6 +54,9 @@ func LoadCodeOwners(r io.Reader, teams map[team.Alias]team.Team) (*CodeOwners, e
 			return nil, s.Err()
 		}
 		t := s.Text()
+		if strings.HasPrefix(t, "#!") {
+			t = t[2:]
+		}
 		if strings.HasPrefix(t, "#") {
 			continue
 		}

--- a/pkg/internal/codeowners/codeowners_test.go
+++ b/pkg/internal/codeowners/codeowners_test.go
@@ -30,6 +30,7 @@ func TestMatch(t *testing.T) {
 /a/b* @cockroachdb/team-b @cockroachdb/team-a
 **/c/ @cockroachdb/team-c
 #!/q/ @cockroachdb/team-q
+/qq/ @cockroachdb/team-q #! @cockroachdb/team-b-noreview
 `
 	teams := map[team.Alias]team.Team{
 		"cockroachdb/team-a": {},
@@ -52,6 +53,7 @@ func TestMatch(t *testing.T) {
 		{"no/owner/", nil},
 		{"hmm/what/about/c/file", []team.Team{teams["cockroachdb/team-c"]}},
 		{"q/foo.txt", []team.Team{teams["cockroachdb/team-q"]}},
+		{"qq/foo.txt", []team.Team{teams["cockroachdb/team-q"], teams["cockroachdb/team-b"]}},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/internal/codeowners/codeowners_test.go
+++ b/pkg/internal/codeowners/codeowners_test.go
@@ -29,11 +29,13 @@ func TestMatch(t *testing.T) {
 /b/ @cockroachdb/team-b-noreview
 /a/b* @cockroachdb/team-b @cockroachdb/team-a
 **/c/ @cockroachdb/team-c
+#!/q/ @cockroachdb/team-q
 `
 	teams := map[team.Alias]team.Team{
 		"cockroachdb/team-a": {},
 		"cockroachdb/team-b": {},
 		"cockroachdb/team-c": {},
+		"cockroachdb/team-q": {},
 	}
 
 	codeOwners, err := LoadCodeOwners(strings.NewReader(owners), teams)
@@ -49,6 +51,7 @@ func TestMatch(t *testing.T) {
 		{"a/bob", []team.Team{teams["cockroachdb/team-b"], teams["cockroachdb/team-a"]}},
 		{"no/owner/", nil},
 		{"hmm/what/about/c/file", []team.Team{teams["cockroachdb/team-c"]}},
+		{"q/foo.txt", []team.Team{teams["cockroachdb/team-q"]}},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
We've had the Replication team for a while and it's about time it
started formally owning some files.

I arrived at these updates by going through

```
go run ./pkg/cmd/whoownsit --walk ./pkg/kv/kvserver/
```

I then noticed Github's validation of the CODEOWNERs file failed, which inspired the subsequent commits. They introduce a `#!` syntax such that we can selectively hide teams from Github.

cc @dt and @nickvigilante, the @cockroachdb/tenant-streaming and @cockroachdb/docs-infra-prs need the repo added to them so that Github accepts them. I worked around that for now by using the newly introduced `#!` but the teams won't get PR pings.

Epic: none
Release note: None
