### PR TITLE
sql/pgwire: skip TestParseClientProvidedSessionParameters

### DIFF
--- a/pkg/sql/pgwire/conn_test.go
+++ b/pkg/sql/pgwire/conn_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -1336,6 +1337,7 @@ func TestConnServerAbortsOnRepeatedErrors(t *testing.T) {
 
 func TestParseClientProvidedSessionParameters(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 93469, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	// Start a pgwire "server".


### PR DESCRIPTION
Refs: #93469

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Resolves #93500
Epic: None
Release note: None