### PR TITLE
release-22.2: cdc/bank: increase resolved timestamp frequency

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -344,7 +344,7 @@ func runCDCBank(ctx context.Context, t test.Test, c cluster.Cluster) {
 		// we need to set a min_checkpoint_frequency here because if we
 		// use the default 30s duration, the test will likely not be able
 		// to finish within 30 minutes
-		{"min_checkpoint_frequency", "'10s'"},
+		{"min_checkpoint_frequency", "'2s'"},
 		{"diff", ""},
 	}
 	_, err := newChangefeedCreator(db, "bank.bank", kafka.sinkURL(ctx)).With(options...).Create()
@@ -435,6 +435,10 @@ func runCDCBank(ctx context.Context, t test.Test, c cluster.Cluster) {
 			baV,
 		}
 		v := cdctest.MakeCountValidator(validators)
+
+		timeSpentValidatingRows := 0 * time.Second
+		numRowsValidated := 0
+
 		for {
 			m, ok := <-messageBuf
 			if !ok {
@@ -447,16 +451,25 @@ func runCDCBank(ctx context.Context, t test.Test, c cluster.Cluster) {
 
 			partitionStr := strconv.Itoa(int(m.Partition))
 			if len(m.Key) > 0 {
+				startTime := timeutil.Now()
 				if err := v.NoteRow(partitionStr, string(m.Key), string(m.Value), updated); err != nil {
 					return err
 				}
+				timeSpentValidatingRows += timeutil.Since(startTime)
+				numRowsValidated++
 			} else {
+				noteResolvedStartTime := timeutil.Now()
 				if err := v.NoteResolved(partitionStr, resolved); err != nil {
 					return err
 				}
 				l.Printf("%d of %d resolved timestamps validated, latest is %s behind realtime",
 					v.NumResolvedWithRows, requestedResolved, timeutil.Since(resolved.GoTime()))
 
+				l.Printf("%s was spent validating this resolved timestamp: %s", timeutil.Since(noteResolvedStartTime))
+				l.Printf("%s was spent validating %d rows", timeSpentValidatingRows, numRowsValidated)
+
+				numRowsValidated = 0
+				timeSpentValidatingRows = 0
 			}
 		}
 		if failures := v.Failures(); len(failures) > 0 {


### PR DESCRIPTION
Backport 1/1 commits from https://github.com/cockroachdb/cockroach/pull/93467


--- 
Previously, we would emit resolved timestamps at a maximum frequency of 1 message per 10 seconds in the cdc/bank roachtest. Recently, we have seen failures due to validation being slow. To fix this, we increased the resolved timestamp frequency to be a maximum of 1 per 2 seconds so there are fewer rows we need to validate.

Epic: none

Release note: None

Release justification: This change modifies a roachtest to be less flakey. It also adds some more observability to it. This change does not modify production code.