### PR TITLE
release-22.2: sql: fix UDF arg formatting in EXPLAIN

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/udf
+++ b/pkg/sql/opt/exec/execbuilder/testdata/udf
@@ -95,3 +95,21 @@ SELECT fetch_a_of_1_strict(NULL::INT)
 query T kvtrace
 SELECT fetch_a_of_2_strict(1, NULL::INT)
 ----
+
+# Regression test for #88259. Arguments to UDFs should be formatted correctly in
+# EXPLAIN output.
+statement ok
+CREATE FUNCTION f88259(a INT, b INT) RETURNS INT LANGUAGE SQL IMMUTABLE STRICT AS $$
+  SELECT a + b
+$$
+
+query T
+EXPLAIN (VERBOSE) SELECT f88259(333, 444)
+----
+distribution: local
+vectorized: true
+·
+• values
+  columns: (f88259)
+  size: 1 column, 1 row
+  row 0, expr 0: f88259(333, 444)

--- a/pkg/sql/sem/tree/routine.go
+++ b/pkg/sql/sem/tree/routine.go
@@ -106,10 +106,10 @@ func (node *RoutineExpr) ResolvedType() *types.T {
 func (node *RoutineExpr) Format(ctx *FmtCtx) {
 	ctx.Printf("%s(", node.Name)
 	for i := range node.Input {
-		node.Input[i].Format(ctx)
 		if i > 0 {
 			ctx.WriteString(", ")
 		}
+		node.Input[i].Format(ctx)
 	}
 	ctx.WriteByte(')')
 }


### PR DESCRIPTION
Backport 1/1 commits from #93322.

/cc @cockroachdb/release

---

Epic: None

Fixes #88259

Release note: None

Release justification: Minor bug fix for UDFs.
