### PR TITLE
.bazelrc: use explicit PATH on macOS

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,6 +9,8 @@
 # Note that .bazelrc.user should be in your checkout (next to this file), not
 # your home directory.
 
+build --enable_platform_specific_config
+
 # Define a set up flag aliases, so people can use `--cross` instead of the
 # longer `//build/toolchains:cross_flag`.
 build --flag_alias=crdb_test=//build/toolchains:crdb_test_flag
@@ -98,8 +100,8 @@ build:crosslinuxs390xbase --config=cross
 # devdarwinx86_64 is a legacy setting that implies `--config=dev`.
 build:devdarwinx86_64 --config=dev
 build:dev --config=simplestamp
-build:dev --action_env=PATH
-build:dev --host_action_env=PATH
+build:macos --action_env=PATH=/opt/homebrew/bin:/opt/local/bin:/usr/local/bin:/usr/bin:/bin
+build:macos --host_action_env=PATH=/opt/homebrew/bin:/opt/local/bin:/usr/local/bin:/usr/bin:/bin
 
 # --config=simplestamp configures the build to stamp the build with inferred
 # information about the configuration.


### PR DESCRIPTION
Previously we added action_env=PATH for build:dev after developers who were on ARM-based MacOS were seeing errors about cmake or other tools invoked by bazel not being found on that platform. These errors were due to it being installed by homebrew in the new, arm-specific path under /opt, rather than the old homebrew path under /usr/local, only the latter of which was in the default PATH used by the bazel rule. Setting action_env=PATH allowed the user's PATH, which presumably included their homebrew install path wherever it was, to take precedence.

However, doing so has the unfortunate effect of meaning that our builds and their cache fingerprints are very sensitive to changes in PATH, inclusion of workspace-specific directories, etc. In particular, the rules_go recommended editor setup invokes go tools, including gopls and in turn bazel, with a PATH that includes the bazel-sandbox go sdk install.

Rather than just give up on using a single default PATH and switch entirely to the user's PATH, we can instead just adjust the default PATH used on macOS to include the new homebrew path as well as the old one, which should resolve the original issue of not finding homebrew-installed tools on arm MacOS but without pulling in the entire user's PATH variable.

Release note: none.
Epic: none.

Fixes #92085.