### PR TITLE
backupccl: remove encryption metamorphic from backup2TB roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -618,7 +618,7 @@ func registerBackup(r registry.Registry) {
 		Name:              fmt.Sprintf("backup/2TB/%s", backup2TBSpec),
 		Owner:             registry.OwnerDisasterRecovery,
 		Cluster:           backup2TBSpec,
-		EncryptionSupport: registry.EncryptionMetamorphic,
+		EncryptionSupport: registry.EncryptionAlwaysDisabled,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			rows := rows2TiB
 			if c.IsLocal() {


### PR DESCRIPTION
We have been observing high throughput variance in our backup2TB roachtest since https://github.com/cockroachdb/cockroach/pull/90316. This test is the only backup roachtest that reports performance, as it's the only test in [roachperf](https://roachperf.crdb.dev/?filter=backup&view=backup%2F2TB%2Fn10cpu4&tab=gce).  The variance is currently so large that is hard to detect any meaningful regressions. 

We're not exactly sure why we're seeing such large perf variance, but since this is our only perf backup test, we might as well take [Jackson's advice ](https://cockroachlabs.slack.com/archives/C2C5FKPPB/p1670948837448919?thread_ts=1670351376.174379&cid=C2C5FKPPB)to disable the metamporphic encryption setting for perf based tests, and remove one less variable that could be affecting the perf variance. It looks like metamorphic encryption was introduced on 5/18, way before this variance spike. Metamorphic encryption could be interacting with steven's diff in some way to cause the variance though. Who knows. We haven't dug into it yet. 


<img width="894" alt="image" src="https://user-images.githubusercontent.com/35438895/207396692-438845a6-22d3-4669-90ad-244814626fa3.png">

Epic: None

Release note: None