### PR TITLE
logictest,schemachanger: reduce cpu tags

### DIFF
--- a/pkg/ccl/logictestccl/tests/multiregion-15node-5region-3azs/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-15node-5region-3azs/BUILD.bazel
@@ -11,7 +11,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     shard_count = 4,
-    tags = ["cpu:4"],
+    tags = ["cpu:3"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-no-los/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-no-los/BUILD.bazel
@@ -11,7 +11,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     shard_count = 16,
-    tags = ["cpu:4"],
+    tags = ["cpu:3"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-tenant/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-tenant/BUILD.bazel
@@ -11,7 +11,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     shard_count = 13,
-    tags = ["cpu:4"],
+    tags = ["cpu:3"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-vec-off/BUILD.bazel
@@ -11,7 +11,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     shard_count = 7,
-    tags = ["cpu:4"],
+    tags = ["cpu:3"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/BUILD.bazel
@@ -11,7 +11,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     shard_count = 16,
-    tags = ["cpu:4"],
+    tags = ["cpu:3"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/ccl/schemachangerccl/BUILD.bazel
+++ b/pkg/ccl/schemachangerccl/BUILD.bazel
@@ -17,7 +17,7 @@ go_test(
     ],
     embed = [":schemachangerccl"],
     shard_count = 16,
-    tags = ["cpu:3"],
+    tags = ["cpu:2"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",

--- a/pkg/cmd/generate-logictest/templates.go
+++ b/pkg/cmd/generate-logictest/templates.go
@@ -266,7 +266,7 @@ go_test(
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep{{ end }}
     ],
     shard_count = {{ if gt .TestCount 16 }}16{{ else }}{{ .TestCount }}{{end}},
-    tags = ["cpu:{{ if gt .NumCPU 4 }}4{{ else }}{{ .NumCPU }}{{ end }}"],
+    tags = ["cpu:{{ if gt .NumCPU 3 }}3{{ else }}{{ .NumCPU }}{{ end }}"],
     deps = [
         "//pkg/build/bazel",{{ if .Ccl }}
         "//pkg/ccl",{{ end }}

--- a/pkg/sql/logictest/tests/multiregion-9node-3region-3azs/BUILD.bazel
+++ b/pkg/sql/logictest/tests/multiregion-9node-3region-3azs/BUILD.bazel
@@ -11,7 +11,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep
     ],
     shard_count = 1,
-    tags = ["cpu:4"],
+    tags = ["cpu:3"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/security/securityassets",


### PR DESCRIPTION
This is a somewhat reckless choice, but we spend a ton of time waiting for resources.

Epic: none

Release note: None