### PR TITLE
cli: update hot-ranges.sh to partition by stat

### DIFF
--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -278,7 +278,10 @@ find . -name cpu.pprof -print0 | xargs -0 go tool pprof -tags
 	{
 		s := zc.clusterPrinter.start("hot range summary script")
 		if err := z.createRaw(s, debugBase+"/hot-ranges.sh", []byte(`#!/bin/sh
-find . -path './nodes/*/ranges/*.json' -print0 | xargs -0 grep per_second | sort -rhk3 | head -n 20
+for stat in "queries" "writes" "reads" "write_bytes" "read_bytes"; do
+	echo "$stat"
+	find . -path './nodes/*/ranges/*.json' -print0 | xargs -0 grep "$stat"_per_second | sort -rhk3 | head -n 10
+done
 `)); err != nil {
 			return err
 		}
@@ -288,7 +291,11 @@ find . -path './nodes/*/ranges/*.json' -print0 | xargs -0 grep per_second | sort
 	{
 		s := zc.clusterPrinter.start("tenant hot range summary script")
 		if err := z.createRaw(s, debugBase+"/hot-ranges-tenant.sh", []byte(`#!/bin/sh
-find . -path './tenant_ranges/*/*.json' -print0 | xargs -0 grep per_second | sort -rhk3 | head -n 20`)); err != nil {
+for stat in "queries" "writes" "reads" "write_bytes" "read_bytes"; do
+    echo "$stat"_per_second
+    find . -path './tenant_ranges/*/*.json' -print0 | xargs -0 grep "$stat"_per_second | sort -rhk3 | head -n 10
+done
+`)); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Previously, the `hot-ranges.sh` script included in the debug.zip would search on `per_second` and sort the results in decreasing order to find the hottest ranges. This led to only `...bytes_per_second` stats being shown as these are naturally much larger.

This patch partitions the output by stat type and decreases the number of ranges shown for each to be 10, from 20.

```
$ bash hot-ranges.sh
queries_per_second
./nodes/3/ranges/53.json:    "queries_per_second": 3519.400149838166,
...
./nodes/1/ranges/6.json:    "queries_per_second": 2.1880460621086653,
writes_per_second
./nodes/2/ranges/4.json:    "writes_per_second": 484.8488586548376
...
./nodes/1/ranges/56.json:    "writes_per_second": 169.5680299863464,
write_bytes_per_second
./nodes/3/ranges/4.json:    "write_bytes_per_second": 56974.461173490185,
...
./nodes/1/ranges/48.json:    "write_bytes_per_second": 61.07806291608187,
reads_per_second
./nodes/1/ranges/56.json:    "reads_per_second": 3572.871223311532,
...
./nodes/2/ranges/16.json:    "reads_per_second": 20.815148015913003,
read_bytes_per_second
./nodes/3/ranges/3.json:    "read_bytes_per_second": 88918.55688243368
...
./nodes/2/ranges/16.json:    "read_bytes_per_second": 7085.639843323259
```

resolves: #93515

Release note (cli change): Partition the debug utility script `hot-ranges.sh` output by statistics: `queries_per_second`, `writes_per_second`, `read_bytes_per_second`,
`write_bytes_per_second`. Decrease the number of  ranges  shown under each heading from 20 to 10.