### PR TITLE
bench: add tenant benchmark

### DIFF
--- a/pkg/bench/BUILD.bazel
+++ b/pkg/bench/BUILD.bazel
@@ -12,12 +12,15 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
+        "//pkg/ccl",
+        "//pkg/server",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "@com_github_go_sql_driver_mysql//:mysql",
         "@com_github_lib_pq//:pq",
+        "@com_github_stretchr_testify//require",
     ],
 )
 


### PR DESCRIPTION
This patch adds another mode for the benchmarks in the pkg/bench - run against an in-memory tenant in a single-node cluster. Currently, the difference between that and single-node cockroach on BenchmarkSQL, for example, is major.

Release note: None
Epic: None