### PR TITLE
sql: use crdb_internal.scan for validating inverted with DistSQL support for indexes

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -144,6 +144,7 @@ go_library(
         "join.go",
         "join_predicate.go",
         "join_token.go",
+        "kv_scan.go",
         "limit.go",
         "lookup_join.go",
         "max_one_row.go",

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1704,34 +1704,18 @@ func ValidateInvertedIndexes(
 
 		grp.GoCtx(func(ctx context.Context) error {
 			// KV scan can be used to get the index length.
-			// TODO (lucy): Switch to using DistSQL to get the count, so that we get
-			// distributed execution and avoid bypassing the SQL decoding
 			start := timeutil.Now()
-			var idxLen int64
-			span := tableDesc.IndexSpan(codec, idx.GetID())
-			key := span.Key
-			endKey := span.EndKey
-			if err := runHistoricalTxn.Exec(ctx, func(
-				ctx context.Context, txn descs.Txn,
-			) error {
-				for {
-					kvs, err := txn.KV().Scan(ctx, key, endKey, 1000000)
-					if err != nil {
-						return err
-					}
-					if len(kvs) == 0 {
-						break
-					}
-					idxLen += int64(len(kvs))
-					key = kvs[len(kvs)-1].Key.PrefixEnd()
-				}
-				return nil
-			}); err != nil {
+			idxLen, err := countIndexRowsAndMaybeCheckUniqueness(ctx,
+				tableDesc,
+				idx,
+				true, /*withFirstMutationPublic*/
+				runHistoricalTxn,
+				execOverride)
+			if err != nil {
 				return err
 			}
 			log.Infof(ctx, "inverted index %s/%s count = %d, took %s",
 				tableDesc.GetName(), idx.GetName(), idxLen, timeutil.Since(start))
-
 			select {
 			case <-countReady[i]:
 				if idxLen != expectedCount[i] {
@@ -2057,13 +2041,14 @@ func countIndexRowsAndMaybeCheckUniqueness(
 	runHistoricalTxn descs.HistoricalInternalExecTxnRunner,
 	execOverride sessiondata.InternalExecutorOverride,
 ) (int64, error) {
+	idxIsInverted := idx.GetType() == descpb.IndexDescriptor_INVERTED
 	// If we are doing a REGIONAL BY ROW locality change, we can
 	// bypass the uniqueness check below as we are only adding or
 	// removing an implicit partitioning column.  Scan the
 	// mutations if we're assuming the first mutation to be public
 	// to see if we have a locality config swap.
-	skipUniquenessChecks := false
-	if withFirstMutationPublic {
+	skipUniquenessChecks := idxIsInverted
+	if withFirstMutationPublic && !idxIsInverted {
 		mutations := tableDesc.AllMutations()
 		if len(mutations) > 0 {
 			mutationID := mutations[0].MutationID()
@@ -2127,6 +2112,10 @@ func countIndexRowsAndMaybeCheckUniqueness(
 		// as a filter to the query to force scanning the index.
 		if idx.IsPartial() {
 			query = fmt.Sprintf(`%s WHERE %s`, query, idx.GetPredicate())
+		}
+		// Inverted indexes can use a more trivial query.
+		if idxIsInverted {
+			query = fmt.Sprintf(`SELECT count(1) FROM crdb_internal.scan(crdb_internal.index_span(%d, %d))`, desc.GetID(), idx.GetID())
 		}
 		return txn.WithSyntheticDescriptors([]catalog.Descriptor{desc}, func() error {
 			row, err := txn.QueryRowEx(ctx, "verify-idx-count", txn.KV(), execOverride, query)

--- a/pkg/sql/catalog/colinfo/result_columns.go
+++ b/pkg/sql/catalog/colinfo/result_columns.go
@@ -334,3 +334,11 @@ const RangesExtraRenders = `
 	coalesce((crdb_internal.range_stats(start_key)->>'range_key_bytes')::INT, 0) +
 	coalesce((crdb_internal.range_stats(start_key)->>'range_val_bytes')::INT, 0) AS range_size
 `
+
+// KvScanColumns are the results for KV scans, which will have
+// a fixed output.
+var KvScanColumns = ResultColumns{
+	{Name: "key", Typ: types.Bytes},
+	{Name: "value", Typ: types.Bytes},
+	{Name: "ts", Typ: types.String},
+}

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -1250,3 +1250,8 @@ func (e *distSQLSpecExecFactory) ConstructLiteralValues(
 ) (exec.Node, error) {
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: literal values")
 }
+
+// ConstructKvScan is part of the exec.Factory interface.
+func (ef *distSQLSpecExecFactory) ConstructKvScan(span roachpb.Span) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: kv scan")
+}

--- a/pkg/sql/execinfrapb/flow_diagram.go
+++ b/pkg/sql/execinfrapb/flow_diagram.go
@@ -541,6 +541,13 @@ func (s *ExportSpec) summary() (string, []string) {
 }
 
 // summary implements the diagramCellType interface.
+func (s *KVScanReaderSpec) summary() (string, []string) {
+	return "KVScanReaderSpec", []string{
+		fmt.Sprintf("Spans: %v", s.Spans),
+	}
+}
+
+// summary implements the diagramCellType interface.
 func (s *BulkRowWriterSpec) summary() (string, []string) {
 	return "BulkRowWriterSpec", []string{}
 }

--- a/pkg/sql/execinfrapb/processors.proto
+++ b/pkg/sql/execinfrapb/processors.proto
@@ -127,9 +127,10 @@ message ProcessorCoreUnion {
   optional CloudStorageTestSpec cloudStorageTest = 42;
   optional InsertSpec insert = 43;
   optional IngestStoppedSpec ingestStopped = 44;
+  optional KVScanReaderSpec kvScanReader = 45;
 
   reserved 6, 12, 14, 17, 18, 19, 20;
-  // NEXT ID: 45.
+  // NEXT ID: 46.
 }
 
 // NoopCoreSpec indicates a "no-op" processor core. This is used when we just

--- a/pkg/sql/execinfrapb/processors_sql.proto
+++ b/pkg/sql/execinfrapb/processors_sql.proto
@@ -1088,7 +1088,7 @@ message HashGroupJoinerSpec {
   optional AggregatorSpec aggregator_spec = 3 [(gogoproto.nullable) = false];
 }
 
-// InsertSpec is a limited insert processor that can only handle vectorized 
+// InsertSpec is a limited insert processor that can only handle vectorized
 // batch inserts for rows affected insert queries (ie doesn't support returning
 // rows or inserts from select).
 message InsertSpec {
@@ -1097,8 +1097,14 @@ message InsertSpec {
     (gogoproto.customname) = "ColumnIDs",
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb.ColumnID"
   ];
-  // The serialized bytes from intsets.Fast.Encode. 
+  // The serialized bytes from intsets.Fast.Encode.
   optional bytes check_ords = 3;
   // Whether the insert should be autocommitted.
   optional bool auto_commit = 4 [(gogoproto.nullable) = false];
 }
+
+// KVScanReaderSpec reads raw key/value information from a given span.
+ message KVScanReaderSpec {
+   // Spans are the spans to read.
+   repeated roachpb.Span spans = 1 [(gogoproto.nullable) = false];
+ }

--- a/pkg/sql/kv_scan.go
+++ b/pkg/sql/kv_scan.go
@@ -1,0 +1,44 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+// kvScanNode used for planning distributed execution
+// of raw KV scans.
+type kvScanNode struct {
+	optColumnsSlot
+	span roachpb.Span
+}
+
+// startExec is part of the planNode interface.
+func (e *kvScanNode) startExec(params runParams) error {
+	panic("kvScanNode cannot be run in local mode")
+}
+
+// Next is part of the planNode interface.
+func (e *kvScanNode) Next(params runParams) (bool, error) {
+	panic("kvScanNode cannot be run in local mode")
+}
+
+// Values is part of the planNode interface.
+func (e *kvScanNode) Values() tree.Datums {
+	panic("kvScanNode cannot be run in local mode")
+}
+
+// Close is part of the planNode interface.
+func (e *kvScanNode) Close(ctx context.Context) {
+}

--- a/pkg/sql/logictest/testdata/logic_test/index_scan_opt
+++ b/pkg/sql/logictest/testdata/logic_test/index_scan_opt
@@ -1,0 +1,67 @@
+# LogicTest: 5node
+
+# This family of test validates an optimization for scanning indexes via
+# crdb_internal.scan which will modify these queries to use DistSQL processing.
+subtest query-indexes
+
+statement ok
+CREATE TABLE q1(val int primary key, n varchar(25), FAMILY "primary" (val, n));
+
+let $q_id
+SELECT id FROM system.namespace WHERE name = 'q1';
+
+query TTT
+SELECT * FROM crdb_internal.scan(crdb_internal.index_span($q_id,1));
+----
+
+query TTT
+SELECT * FROM crdb_internal.scan(crdb_internal.table_span($q_id));
+----
+
+statement ok
+INSERT INTO q1 VALUES (1, 'cat'),(2, 'cow'),(3, 'mouse'),(4, 'lion'),(5, 'tiger'),(6, 'wolf');
+
+statement ok
+CREATE INDEX i1 on q1(val, n)
+
+query I
+SELECT count(*) FROM crdb_internal.scan(crdb_internal.index_span($q_id,1));
+----
+6
+
+query I
+SELECT count(*)  FROM crdb_internal.scan(crdb_internal.index_span($q_id,2));
+----
+6
+
+query I
+SELECT count(*) FROM crdb_internal.scan(crdb_internal.table_span($q_id));
+----
+12
+
+
+query TT
+SELECT crdb_internal.pretty_key(key, 0), encode(value, 'hex') FROM crdb_internal.scan(crdb_internal.table_span($q_id));
+----
+/106/1/1/0          56f874340a2603636174
+/106/1/2/0          dffd0fe30a2603636f77
+/106/1/3/0          18d02d720a26056d6f757365
+/106/1/4/0          5e1bbc380a26046c696f6e
+/106/1/5/0          ddbcb0140a26057469676572
+/106/1/6/0          d68ee3630a2604776f6c66
+/106/2/1/"cat"/0    0000000003
+/106/2/2/"cow"/0    0000000003
+/106/2/3/"mouse"/0  0000000003
+/106/2/4/"lion"/0   0000000003
+/106/2/5/"tiger"/0  0000000003
+/106/2/6/"wolf"/0   0000000003
+
+query TT
+SELECT crdb_internal.pretty_key(key, 0),  encode(value, 'hex') FROM crdb_internal.scan(crdb_internal.index_span($q_id, 1));
+----
+/106/1/1/0  56f874340a2603636174
+/106/1/2/0  dffd0fe30a2603636f77
+/106/1/3/0  18d02d720a26056d6f757365
+/106/1/4/0  5e1bbc380a26046c696f6e
+/106/1/5/0  ddbcb0140a26057469676572
+/106/1/6/0  d68ee3630a2604776f6c66

--- a/pkg/sql/logictest/tests/5node/BUILD.bazel
+++ b/pkg/sql/logictest/tests/5node/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    shard_count = 20,
+    shard_count = 21,
     tags = [
         "cpu:3",
     ],

--- a/pkg/sql/logictest/tests/5node/generated_test.go
+++ b/pkg/sql/logictest/tests/5node/generated_test.go
@@ -170,6 +170,13 @@ func TestLogic_hash_join_dist(
 	runLogicTest(t, "hash_join_dist")
 }
 
+func TestLogic_index_scan_opt(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "index_scan_opt")
+}
+
 func TestLogic_inv_stats(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/exec/BUILD.bazel
+++ b/pkg/sql/opt/exec/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     # Pin the dependencies required in the auto-generated code.
     deps = [
+        "//pkg/roachpb",  #keep
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",  # keep
         "//pkg/sql/inverted",

--- a/pkg/sql/opt/exec/execbuilder/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/opt/exec/execbuilder",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/roachpb",
         "//pkg/server/telemetry",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -352,6 +352,9 @@ func (b *Builder) buildRelational(e memo.RelExpr) (execPlan, error) {
 	case *memo.ExportExpr:
 		ep, err = b.buildExport(t)
 
+	case *memo.KvScanExpr:
+		ep, err = b.buildKvScan(t)
+
 	default:
 		switch {
 		case opt.IsSetOp(e):

--- a/pkg/sql/opt/exec/execbuilder/testdata/index_scan_opt
+++ b/pkg/sql/opt/exec/execbuilder/testdata/index_scan_opt
@@ -1,0 +1,79 @@
+# LogicTest: 5node
+
+# This family of test validates an optimization for scanning indexes via
+# crdb_internal.scan which will modify these queries to use DistSQL processing.
+subtest query-indexes
+
+statement ok
+CREATE TABLE q1(val int primary key, n varchar(25));
+
+let $q_id
+SELECT id FROM system.namespace WHERE name = 'q1';
+
+
+statement ok
+INSERT INTO q1 VALUES (1, 'cat'),(2, 'cow'),(3, 'mouse'),(4, 'lion'),(5, 'tiger'),(6, 'wolf');
+
+query T
+EXPLAIN SELECT * FROM crdb_internal.scan(crdb_internal.table_span($q_id));
+----
+distribution: local
+vectorized: false
+·
+• kv scan
+  span: /Table/10{6-7}
+
+query T
+EXPLAIN ANALYZE SELECT *  FROM crdb_internal.scan(crdb_internal.index_span($q_id,2));
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+maximum memory usage: <hidden>
+network usage: <hidden>
+·
+• kv scan
+  span: /Table/106/{2-3}
+
+query T
+EXPLAIN SELECT * FROM crdb_internal.scan(crdb_internal.table_span($q_id));
+----
+distribution: local
+vectorized: false
+·
+• kv scan
+  span: /Table/10{6-7}
+
+
+statement ok
+PREPARE Q1 AS SELECT * FROM crdb_internal.scan(crdb_internal.table_span($1));
+
+query T
+EXPLAIN ANALYZE EXECUTE Q1($q_id);
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+maximum memory usage: <hidden>
+network usage: <hidden>
+·
+• kv scan
+  span: /Table/10{6-7}
+
+statement ok
+PREPARE Q2 AS SELECT * FROM crdb_internal.scan(crdb_internal.index_span($1, $2));
+
+query T
+EXPLAIN ANALYZE EXECUTE Q2($q_id, $q_id);
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+maximum memory usage: <hidden>
+network usage: <hidden>
+·
+• kv scan
+  span: /Table/106/10{6-7}

--- a/pkg/sql/opt/exec/execbuilder/tests/5node/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/5node/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
-    shard_count = 29,
+    shard_count = 30,
     tags = [
         "cpu:3",
     ],

--- a/pkg/sql/opt/exec/execbuilder/tests/5node/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/5node/generated_test.go
@@ -217,6 +217,13 @@ func TestExecBuild_explain_analyze_plans(
 	runExecBuildLogicTest(t, "explain_analyze_plans")
 }
 
+func TestExecBuild_index_scan_opt(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runExecBuildLogicTest(t, "index_scan_opt")
+}
+
 func TestExecBuild_inverted_filter_geospatial_dist(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -310,6 +310,7 @@ var nodeNames = [...]string{
 	insertOp:               "insert",
 	invertedFilterOp:       "inverted filter",
 	invertedJoinOp:         "inverted join",
+	kvScanOp:               "kv scan",
 	limitOp:                "limit",
 	lookupJoinOp:           "", // This node does not have a fixed name.
 	max1RowOp:              "max1row",
@@ -950,6 +951,10 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 		if a.subjectReplicas != tree.RelocateLease {
 			ob.Expr("from", a.fromStoreID, nil /* columns */)
 		}
+
+	case kvScanOp:
+		a := n.args.(*kvScanArgs)
+		ob.Attr("span", a.Span)
 
 	case simpleProjectOp,
 		serializingProjectOp,

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -36,7 +36,7 @@ import (
 )
 
 func init() {
-	if numOperators != 61 {
+	if numOperators != 62 {
 		// This error occurs when an operator has been added or removed in
 		// pkg/sql/opt/exec/explain/factory.opt. If an operator is added at the
 		// end of factory.opt, simply adjust the hardcoded value above. If an

--- a/pkg/sql/opt/exec/explain/result_columns.go
+++ b/pkg/sql/opt/exec/explain/result_columns.go
@@ -191,6 +191,9 @@ func getResultColumns(
 		}
 		return colinfo.ShowTraceColumns, nil
 
+	case kvScanOp:
+		return colinfo.KvScanColumns, nil
+
 	case createTableOp, createTableAsOp, createViewOp, controlJobsOp, controlSchedulesOp,
 		cancelQueriesOp, cancelSessionsOp, createStatisticsOp, errorIfRowsOp, deleteRangeOp,
 		createFunctionOp:

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -785,3 +785,10 @@ define LiteralValues {
 define ShowCompletions {
     Command *tree.ShowCompletions
 }
+
+# KvScan preforms a raw KV scan which is used to back the DistSQL implementation,
+# of crdb_internal.scan.
+define KvScan {
+    # Spans that we are scanning.s
+    Span roachpb.Span
+}

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -2806,3 +2806,29 @@ func CanBeCompositeSensitive(md *opt.Metadata, e opt.Expr) bool {
 	isCompositeInsensitive, _ := check(e)
 	return !isCompositeInsensitive
 }
+
+func (b *logicalPropsBuilder) buildKvScanProps(kvScan *KvScanExpr, rel *props.Relational) {
+	BuildSharedProps(kvScan, &rel.Shared, b.evalCtx)
+
+	// Output Columns
+	// --------------
+	rel.OutputCols = kvScan.Cols
+
+	// Not Null Columns
+	// ----------------
+	// All columns are assumed to be nullable.
+
+	// Outer Columns
+	// -------------
+	// No outer columns.
+
+	// Functional Dependencies
+	// -----------------------
+	// Empty FD set.
+
+	// Cardinality
+	// -----------
+	rel.Cardinality = props.AnyCardinality
+
+	b.sb.buildKvScan(kvScan, rel)
+}

--- a/pkg/sql/opt/norm/BUILD.bazel
+++ b/pkg/sql/opt/norm/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/kv/kvpb",
+        "//pkg/roachpb",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/opt",
         "//pkg/sql/opt/cat",

--- a/pkg/sql/opt/norm/general_funcs.go
+++ b/pkg/sql/opt/norm/general_funcs.go
@@ -12,6 +12,7 @@ package norm
 
 import (
 	"github.com/cockroachdb/apd/v3"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
@@ -1091,4 +1092,118 @@ func (c *CustomFuncs) DuplicateJoinPrivate(jp *memo.JoinPrivate) *memo.JoinPriva
 		Flags:            jp.Flags,
 		SkipReorderJoins: jp.SkipReorderJoins,
 	}
+}
+
+// MakeKvScanFromZip takes a zip containing a call to
+// crdb_internal.scan and converts it into an
+// IndexScan expression, which can directly read from indexes.
+func (c *CustomFuncs) MakeKvScanFromZip(exp memo.RelExpr, zip memo.ZipExpr) memo.RelExpr {
+	item := zip.Child(0).(*memo.ZipItem)
+	scanExpr := item.Fn.(*memo.FunctionExpr)
+	var span tree.DArray
+	switch expr := scanExpr.Args.Child(0).(type) {
+	case *memo.FunctionExpr:
+		var tableIDVal opt.TableID
+		var indexIDVal cat.IndexOrdinal
+		if tableIDConstExpr, ok := expr.Args.Child(0).(*memo.ConstExpr); ok {
+			tableIDVal = opt.TableID(*tableIDConstExpr.Value.(*tree.DInt))
+		} else {
+			panic(errors.AssertionFailedf("index scans can only be generated from constants"))
+		}
+		if expr.Args.ChildCount() == 2 {
+			if indexIDConstExpr, ok := expr.Args.Child(1).(*memo.ConstExpr); ok {
+				indexIDVal = cat.IndexOrdinal(*indexIDConstExpr.Value.(*tree.DInt))
+			} else {
+				panic(errors.AssertionFailedf("index scans can only be generated from constants"))
+			}
+		}
+		var prefix roachpb.Key
+		if indexIDVal == 0 {
+			prefix = c.f.evalCtx.Codec.TablePrefix(uint32(tableIDVal))
+		} else {
+			prefix = c.f.evalCtx.Codec.IndexPrefix(uint32(tableIDVal), uint32(indexIDVal))
+		}
+
+		if err := span.Append(tree.NewDBytes(tree.DBytes(prefix))); err != nil {
+			panic(err)
+		}
+		if err := span.Append(tree.NewDBytes(tree.DBytes(prefix.PrefixEnd()))); err != nil {
+			panic(err)
+		}
+	case *memo.ConstExpr:
+		span = *expr.Value.(*tree.DArray)
+	}
+
+	// Collect metadata statistics if we are scanning a table
+	// and index with this query.
+	mdTableID, indexID := func() (opt.TableID, cat.IndexOrdinal) {
+		startKey := roachpb.Key(*span.Array[0].(*tree.DBytes))
+		_, tableID, err := c.f.evalCtx.Codec.DecodeTablePrefix(startKey)
+		if err != nil {
+			return 0, 0
+		}
+		// Error is intentionally ignored, if the index is missing.
+		_, _, indexID, _ := c.f.evalCtx.Codec.DecodeIndexPrefix(startKey)
+		ds, _, err := c.f.catalog.ResolveDataSourceByID(c.f.ctx, cat.Flags{AvoidDescriptorCaches: true}, cat.StableID(tableID))
+		if err != nil {
+			return 0, 0
+		}
+		fullName, err := c.f.catalog.FullyQualifiedName(c.f.ctx, ds)
+		if err != nil {
+			return 0, 0
+		}
+		mdTableID := c.f.Metadata().AddTable(ds.(cat.Table), &fullName)
+		return mdTableID, cat.IndexOrdinal(indexID)
+	}()
+
+	indexScan := c.f.ConstructKvScan(&memo.KvScanPrivate{
+		Span:  &span,
+		Cols:  item.Cols.ToSet(),
+		Table: mdTableID,
+		Index: indexID,
+	})
+	return indexScan
+}
+
+// IsKvScanBuiltin determines if crdb_internal.scan
+// is executed by this operation, in a manner in which it can be
+// optimized into an index scan expression.
+func (c *CustomFuncs) IsKvScanBuiltin(zip memo.ZipExpr) bool {
+	if zip.ChildCount() != 1 {
+		return false
+	}
+	item, ok := zip.Child(0).(*memo.ZipItem)
+	if !ok {
+		return false
+	}
+	functionExpr, ok := item.Fn.(*memo.FunctionExpr)
+	if !ok {
+		return false
+	}
+	if functionExpr.Name != "crdb_internal.scan" {
+		return false
+	}
+	// We can only transform ones with constant values.
+	if len(functionExpr.Args) != 1 {
+		return false
+	}
+	switch expr := functionExpr.Args.Child(0).(type) {
+	case *memo.FunctionExpr:
+		if (expr.Name == "crdb_internal.index_span" && len(expr.Args) == 2) ||
+			(expr.Name == "crdb_internal.table_span" && len(expr.Args) == 1) {
+			for child := 0; child < expr.Args.ChildCount(); child++ {
+				if expr, ok := expr.Args.Child(child).(*memo.ConstExpr); !ok ||
+					expr.Typ != types.Int {
+					return false
+				}
+			}
+			return true
+		}
+	case *memo.ConstExpr:
+		if expr.Typ == types.BytesArray &&
+			len(expr.Value.(*tree.DArray).Array) == 2 {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/sql/opt/norm/rules/project_set.opt
+++ b/pkg/sql/opt/norm/rules/project_set.opt
@@ -25,3 +25,11 @@
     []
     (EmptyJoinPrivate)
 )
+
+# ConvertProjectionSetRawScanToKvScan converts a project set,
+# containing an invocation to crdb_internal.scan directly
+# into an index scan expression that supports distributed execution.
+[ConvertProjectionSetRawScanToKvScan, Normalize]
+(ProjectSet $input:* $zip:* & (IsKvScanBuiltin $zip))
+=>
+(MakeKvScanFromZip $input $zip)

--- a/pkg/sql/opt/norm/testdata/rules/project_set
+++ b/pkg/sql/opt/norm/testdata/rules/project_set
@@ -309,3 +309,120 @@ project
       │    └── columns: j:3
       └── zip
            └── json_array_elements(j:3) [outer=(3), immutable]
+
+# --------------------------------------------------
+# ConvertProjectionSetRawScanToKvScan
+# --------------------------------------------------
+
+# Basic case with constant values.
+norm expect=ConvertProjectionSetRawScanToKvScan
+SELECT * FROM crdb_internal.scan(crdb_internal.table_span(105))
+----
+kv-scan
+ └── columns: key:1 value:2 ts:3
+
+# Basic case with constant values.
+norm expect=ConvertProjectionSetRawScanToKvScan
+SELECT * FROM crdb_internal.scan(crdb_internal.index_span(105, 1))
+----
+kv-scan
+ └── columns: key:1 value:2 ts:3
+
+# Multiple times in from list with inner join.
+norm expect=ConvertProjectionSetRawScanToKvScan
+SELECT * FROM crdb_internal.scan(crdb_internal.index_span(105, 1)) as A, crdb_internal.scan(crdb_internal.table_span(105)) as B WHERE A.value <> B.value
+----
+inner-join (cross)
+ ├── columns: key:1 value:2!null ts:3 key:4 value:5!null ts:6
+ ├── kv-scan
+ │    └── columns: key:1 value:2 ts:3
+ ├── kv-scan
+ │    └── columns: key:4 value:5 ts:6
+ └── filters
+      └── value:2 != value:5 [outer=(2,5), constraints=(/2: (/NULL - ]; /5: (/NULL - ])]
+
+# Multiple times on the FROM list with predicate with aggregation + inner join.
+norm expect=ConvertProjectionSetRawScanToKvScan
+SELECT min(A.ts), max(B.ts) FROM crdb_internal.scan(crdb_internal.index_span(105, 1)) as A, crdb_internal.scan(crdb_internal.table_span(105)) as B WHERE A.value <> B.value
+----
+scalar-group-by
+ ├── columns: min:7 max:8
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(7,8)
+ ├── inner-join (cross)
+ │    ├── columns: key:1 value:2!null ts:3 key:4 value:5!null ts:6
+ │    ├── kv-scan
+ │    │    └── columns: key:1 value:2 ts:3
+ │    ├── kv-scan
+ │    │    └── columns: key:4 value:5 ts:6
+ │    └── filters
+ │         └── value:2 != value:5 [outer=(2,5), constraints=(/2: (/NULL - ]; /5: (/NULL - ])]
+ └── aggregations
+      ├── min [as=min:7, outer=(3)]
+      │    └── ts:3
+      └── max [as=max:8, outer=(6)]
+           └── ts:6
+
+# Used in the SELECT list, so this rule should not apply.
+norm expect-not=ConvertProjectionSetRawScanToKvScan
+SELECT crdb_internal.scan(crdb_internal.index_span(105, 1)), crdb_internal.scan(crdb_internal.table_span(105))
+----
+project
+ ├── columns: crdb_internal.scan:7 crdb_internal.scan:8
+ ├── stable
+ ├── project-set
+ │    ├── columns: key:1 value:2 ts:3 key:4 value:5 ts:6
+ │    ├── stable
+ │    ├── values
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── key: ()
+ │    │    └── ()
+ │    └── zip
+ │         ├── crdb_internal.scan(ARRAY['\xf189','\xf18a']) [stable]
+ │         └── crdb_internal.scan(ARRAY['\xf1','\xf2']) [stable]
+ └── projections
+      ├── ((key:1, value:2, ts:3) AS key, value, ts) [as=crdb_internal.scan:7, outer=(1-3)]
+      └── ((key:4, value:5, ts:6) AS key, value, ts) [as=crdb_internal.scan:8, outer=(4-6)]
+
+# Using variables, so this rule should be skipped.
+norm expect-not=ConvertProjectionSetRawScanToKvScan
+SELECT * FROM crdb_internal.scan(crdb_internal.table_span($1))
+----
+project-set
+ ├── columns: key:1 value:2 ts:3
+ ├── stable, has-placeholder
+ ├── values
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    └── ()
+ └── zip
+      └── crdb_internal.scan(crdb_internal.table_span($1)) [stable]
+
+# Using variables, so this rule should be skipped.
+norm expect-not=ConvertProjectionSetRawScanToKvScan
+SELECT * FROM crdb_internal.scan(crdb_internal.index_span(105, $1))
+----
+project-set
+ ├── columns: key:1 value:2 ts:3
+ ├── stable, has-placeholder
+ ├── values
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    └── ()
+ └── zip
+      └── crdb_internal.scan(crdb_internal.index_span(105, $1)) [stable]
+
+# Using a variables, so this rule should be skipped.
+norm expect-not=ConvertProjectionSetRawScanToKvScan
+SELECT * FROM crdb_internal.scan(crdb_internal.index_span($1, 1))
+----
+project-set
+ ├── columns: key:1 value:2 ts:3
+ ├── stable, has-placeholder
+ ├── values
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    └── ()
+ └── zip
+      └── crdb_internal.scan(crdb_internal.index_span($1, 1)) [stable]

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -1417,3 +1417,32 @@ define FakeRel {
 define FakeRelPrivate {
     Props RelPropsPtr
 }
+
+# KvScan is relational operator that can read raw values form indexes directly,
+# it is only currently used to back a transformation from
+# crdb_internal.scan s to this operator. For this operator to be
+# used we need to know both the index and table upfront, and cannot use place
+# holder values.
+[Relational]
+define KvScan {
+    _ KvScanPrivate
+}
+
+[Private]
+define KvScanPrivate {
+    # Table identifies the table to scan, if this table scan is limited to
+    # a single table and used for determining stats.
+    Table TableID
+
+    # Index identifies the index to scan, if this scan is limited to a single
+    # index and used for determining stats.
+    Index IndexOrdinal
+
+    # Cols specifies the set of columns that the scan operator projects. This
+    # may be a subset of the columns that the table/index contains.
+    Cols ColSet
+
+    # Datum specifies the Start/End keys as a byte array that we will
+    # be scanning using a raw KV scan.
+    Span Datum
+}

--- a/pkg/sql/opt/optgen/cmd/optgen/exec_explain_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/exec_explain_gen.go
@@ -30,6 +30,7 @@ func (g *execExplainGen) generate(compiled *lang.CompiledExpr, w io.Writer) {
 	g.w.write("package explain\n\n")
 
 	g.w.nestIndent("import (\n")
+	g.w.writeIndent("\"github.com/cockroachdb/cockroach/pkg/roachpb\"\n")
 	g.w.writeIndent("\"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo\"\n")
 	g.w.writeIndent("\"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb\"\n")
 	g.w.writeIndent("\"github.com/cockroachdb/cockroach/pkg/sql/opt\"\n")

--- a/pkg/sql/opt/optgen/cmd/optgen/exec_factory_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/exec_factory_gen.go
@@ -30,6 +30,7 @@ func (g *execFactoryGen) generate(compiled *lang.CompiledExpr, w io.Writer) {
 
 	g.w.nestIndent("import (\n")
 	g.w.writeIndent("\"context\"\n\n")
+	g.w.writeIndent("\"github.com/cockroachdb/cockroach/pkg/roachpb\"\n")
 	g.w.writeIndent("\"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb\"\n")
 	g.w.writeIndent("\"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo\"\n")
 	g.w.writeIndent("\"github.com/cockroachdb/cockroach/pkg/sql/opt/cat\"\n")

--- a/pkg/sql/opt/optgen/cmd/optgen/exec_plan_gist_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/exec_plan_gist_gen.go
@@ -30,6 +30,7 @@ func (g *execPlanGistGen) generate(compiled *lang.CompiledExpr, w io.Writer) {
 	g.w.write("package explain\n\n")
 
 	g.w.nestIndent("import (\n")
+	g.w.writeIndent("\"github.com/cockroachdb/cockroach/pkg/roachpb\"\n")
 	g.w.writeIndent("\"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo\"\n")
 	g.w.writeIndent("\"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb\"\n")
 	g.w.writeIndent("\"github.com/cockroachdb/cockroach/pkg/sql/opt\"\n")

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/execexplain
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/execexplain
@@ -31,6 +31,7 @@ define HashJoin {
 package explain
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/inverted"

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/execfactory
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/execfactory
@@ -24,6 +24,7 @@ package exec
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/inverted"

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/execplangist
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/execplangist
@@ -31,6 +31,7 @@ define HashJoin {
 package explain
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/inverted"

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -2177,6 +2177,13 @@ func (ef *execFactory) ConstructExplain(
 	return n, nil
 }
 
+// ConstructKvScan is part of the exec.Factory interface.
+func (ef *execFactory) ConstructKvScan(span roachpb.Span) (exec.Node, error) {
+	return &kvScanNode{
+		span: span,
+	}, nil
+}
+
 // renderBuilder encapsulates the code to build a renderNode.
 type renderBuilder struct {
 	r   *renderNode

--- a/pkg/sql/plan_columns.go
+++ b/pkg/sql/plan_columns.go
@@ -128,6 +128,8 @@ func getPlanColumns(plan planNode, mut bool) colinfo.ResultColumns {
 		return n.getColumns(mut, colinfo.SequenceSelectColumns)
 	case *exportNode:
 		return n.getColumns(mut, colinfo.ExportColumns)
+	case *kvScanNode:
+		return n.getColumns(mut, colinfo.KvScanColumns)
 	case *completionsNode:
 		return n.getColumns(mut, colinfo.ShowCompletionsColumns)
 

--- a/pkg/sql/rowexec/BUILD.bazel
+++ b/pkg/sql/rowexec/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "joinreader.go",
         "joinreader_span_generator.go",
         "joinreader_strategies.go",
+        "kv_scan.go",
         "mergejoiner.go",
         "noop.go",
         "ordinality.go",

--- a/pkg/sql/rowexec/kv_scan.go
+++ b/pkg/sql/rowexec/kv_scan.go
@@ -1,0 +1,176 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rowexec
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+)
+
+// kvScan is used read raw KV values in a computation flow for purposes,
+// of mainly implementing crdb_internal.scan. This execinfra.RowSource
+// only returns a row format of key, value, and ts.
+type kvScan struct {
+	execinfra.ProcessorBase
+	spans           []roachpb.Span
+	rowIdx          int
+	bytesRead       int64
+	rowsRead        int64
+	scanResponses   []kvpb.ResponseUnion
+	currentResponse int
+	row             rowenc.EncDatumRow
+}
+
+// Start is part of the execinfra.RowSource interface.
+func (ks *kvScan) Start(ctx context.Context) {
+	ctx = ks.StartInternal(ctx, "index-scan")
+	// Set up the first batch.
+	ba := ks.EvalCtx.Txn.NewBatch()
+	for spanIdx := range ks.spans {
+		scan := kvpb.NewScan(ks.spans[spanIdx].Key,
+			ks.spans[spanIdx].EndKey,
+			false)
+		ba.AddRawRequest(scan)
+	}
+	ba.Header.MaxSpanRequestKeys = int64(rowinfra.ProductionKVBatchSize)
+	ba.Header.TargetBytes = int64(rowinfra.GetDefaultBatchBytesLimit(false))
+	err := ks.EvalCtx.Txn.Run(ctx, ba)
+	if err != nil {
+		ks.MoveToDraining(err)
+	}
+	ks.scanResponses = ba.RawResponse().Responses
+	// Set up the results for the rows.
+	ks.row = make(rowenc.EncDatumRow, 3)
+}
+
+// getNextScan will issue any additional scans to read additional data,
+// using any response spans.
+func (ks *kvScan) getNextScan(ctx context.Context) error {
+	// Generate a new batch with all of the resume spans
+	// from our first request.
+	ba := ks.EvalCtx.Txn.NewBatch()
+	for i := ks.currentResponse; i < len(ks.scanResponses); i++ {
+		scan := ks.scanResponses[i].GetScan()
+		nextSpan := scan.ResumeSpan
+		scanRequest := kvpb.NewScan(nextSpan.Key,
+			nextSpan.EndKey,
+			false /*forUpdate*/)
+		ba.AddRawRequest(scanRequest)
+	}
+	ba.Header.MaxSpanRequestKeys = int64(rowinfra.ProductionKVBatchSize)
+	err := ks.EvalCtx.Txn.Run(ctx, ba)
+	if err != nil {
+		return err
+	}
+	ks.scanResponses = ba.RawResponse().Responses
+	ks.currentResponse = 0
+	ks.rowIdx = 0
+	return nil
+}
+
+// Next is part of the execinfra.RowSource interface.
+func (ks *kvScan) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata) {
+	if ks.State != execinfra.StateRunning {
+		return nil, ks.DrainHelper()
+	}
+	moreRows := true
+	var err error
+	for moreRows {
+		currentScan := ks.scanResponses[ks.currentResponse].GetScan()
+		// The current scan is out of data, so check if we have more
+		// data.
+		if ks.rowIdx >= len(currentScan.Rows) {
+			// If there is a resume span, then we need to
+			// make another request to continue.
+			if currentScan.ResumeSpan != nil {
+				err = ks.getNextScan(ks.Ctx())
+				if !moreRows || err != nil {
+					ks.MoveToDraining(err)
+					return nil, ks.DrainHelper()
+				}
+				continue
+			}
+			// Otherwise, check if the next response has data
+			ks.currentResponse++
+			ks.rowIdx = 0
+
+			// No more data left, so we are finished.
+			if ks.currentResponse == len(ks.scanResponses) {
+				ks.MoveToDraining(err)
+				return nil, ks.DrainHelper()
+			}
+			continue
+		}
+		// Encode the row from the raw scan response.
+		ks.row[0] = rowenc.DatumToEncDatum(types.Bytes, tree.NewDBytes(tree.DBytes(currentScan.Rows[ks.rowIdx].Key)))
+		ks.row[1] = rowenc.DatumToEncDatum(types.Bytes, tree.NewDBytes(tree.DBytes(currentScan.Rows[ks.rowIdx].Value.RawBytes)))
+		ks.row[2] = rowenc.DatumToEncDatum(types.String, tree.NewDString(currentScan.Rows[ks.rowIdx].Value.Timestamp.String()))
+
+		ks.bytesRead += int64(currentScan.Rows[ks.rowIdx].Size())
+		ks.rowsRead += 1
+		ks.rowIdx++
+		if row := ks.ProcessRowHelper(ks.row); row != nil {
+			return row, nil
+		}
+	}
+	return nil, nil
+}
+
+func (ks *kvScan) generateMeta() []execinfrapb.ProducerMetadata {
+	var trailingMeta []execinfrapb.ProducerMetadata
+	nodeID, ok := ks.FlowCtx.NodeID.OptionalNodeID()
+	if ok {
+		ranges := execinfra.MisplannedRanges(ks.Ctx(), ks.spans, nodeID, ks.FlowCtx.Cfg.RangeCache)
+		if ranges != nil {
+			trailingMeta = append(trailingMeta, execinfrapb.ProducerMetadata{Ranges: ranges})
+		}
+	}
+	if tfs := execinfra.GetLeafTxnFinalState(ks.Ctx(), ks.FlowCtx.Txn); tfs != nil {
+		trailingMeta = append(trailingMeta, execinfrapb.ProducerMetadata{LeafTxnFinalState: tfs})
+	}
+
+	meta := execinfrapb.GetProducerMeta()
+	meta.Metrics = execinfrapb.GetMetricsMeta()
+	meta.Metrics.BytesRead = ks.bytesRead
+	meta.Metrics.RowsRead = ks.rowsRead
+	return append(trailingMeta, *meta)
+}
+
+func (ks *kvScan) generateTrailingMeta() []execinfrapb.ProducerMetadata {
+	// We need to generate metadata before closing the processor because
+	// InternalClose() updates tr.Ctx to the "original" context.
+	trailingMeta := ks.generateMeta()
+	ks.InternalClose()
+	return trailingMeta
+}
+
+// newKvScan creates a kvScan.
+func newKvScan(
+	ctx context.Context,
+	flowCtx *execinfra.FlowCtx,
+	processorID int32,
+	spec execinfrapb.KVScanReaderSpec,
+	post *execinfrapb.PostProcessSpec,
+) (*kvScan, error) {
+	tmpScan := &kvScan{spans: spec.Spans}
+	err := tmpScan.Init(ctx, tmpScan, post, []*types.T{types.Bytes, types.Bytes, types.String}, flowCtx, processorID, nil, execinfra.ProcStateOpts{
+		TrailingMetaCallback: tmpScan.generateTrailingMeta,
+	})
+	return tmpScan, err
+}

--- a/pkg/sql/rowexec/processors.go
+++ b/pkg/sql/rowexec/processors.go
@@ -404,6 +404,9 @@ func NewProcessor(
 		}
 		return NewGenerativeSplitAndScatterProcessor(ctx, flowCtx, processorID, *core.GenerativeSplitAndScatter, post)
 	}
+	if core.KvScanReader != nil {
+		return newKvScan(ctx, flowCtx, processorID, *core.KvScanReader, post)
+	}
 	return nil, errors.Errorf("unsupported processor core %q", core)
 }
 

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -424,6 +424,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&groupNode{}):                               "group",
 	reflect.TypeOf(&hookFnNode{}):                              "plugin",
 	reflect.TypeOf(&indexJoinNode{}):                           "index join",
+	reflect.TypeOf(&kvScanNode{}):                              "index scan",
 	reflect.TypeOf(&insertNode{}):                              "insert",
 	reflect.TypeOf(&insertFastPathNode{}):                      "insert fast path",
 	reflect.TypeOf(&invertedFilterNode{}):                      "inverted filter",


### PR DESCRIPTION
This PR will do the following:

1. Add a new optimizer transformation that converts calls of crdb_internal.scan (with a constant crdb_internal.index_span) into a new IndexScan expression, which will allow us to generate a DistSQL processor.
3. Adop crdb_internal.scan for validating inverted indexes.

Epic: None

First attempt at doing this, optimizer bits and the query execution bits might need some tweaks / adjustment based on best conventions.