### PR TITLE
streamingest,sql: better tenant status for replicated tenants

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -2652,9 +2652,9 @@ The swap_ordinate_string parameter is a 2-character string naming the ordinates 
 </span></td><td>Volatile</td></tr>
 <tr><td><a name="crdb_internal.start_replication_stream"></a><code>crdb_internal.start_replication_stream(tenant_name: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>This function can be used on the producer side to start a replication stream for the specified tenant. The returned stream ID uniquely identifies created stream. The caller must periodically invoke crdb_internal.heartbeat_stream() function to notify that the replication is still ongoing.</p>
 </span></td><td>Volatile</td></tr>
-<tr><td><a name="crdb_internal.stream_ingestion_stats_json"></a><code>crdb_internal.stream_ingestion_stats_json(job_id: <a href="int.html">int</a>) &rarr; jsonb</code></td><td><span class="funcdesc"><p>DEPRECATED, consider using <code>SHOW TENANT name WITH REPLICATION STATS</code></p>
+<tr><td><a name="crdb_internal.stream_ingestion_stats_json"></a><code>crdb_internal.stream_ingestion_stats_json(job_id: <a href="int.html">int</a>) &rarr; jsonb</code></td><td><span class="funcdesc"><p>DEPRECATED, consider using <code>SHOW TENANT name WITH REPLICATION STATUS</code></p>
 </span></td><td>Volatile</td></tr>
-<tr><td><a name="crdb_internal.stream_ingestion_stats_pb"></a><code>crdb_internal.stream_ingestion_stats_pb(job_id: <a href="int.html">int</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>DEPRECATED, consider using <code>SHOW TENANT name WITH REPLICATION STATS</code></p>
+<tr><td><a name="crdb_internal.stream_ingestion_stats_pb"></a><code>crdb_internal.stream_ingestion_stats_pb(job_id: <a href="int.html">int</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>DEPRECATED, consider using <code>SHOW TENANT name WITH REPLICATION STATUS</code></p>
 </span></td><td>Volatile</td></tr>
 <tr><td><a name="crdb_internal.stream_partition"></a><code>crdb_internal.stream_partition(stream_id: <a href="int.html">int</a>, partition_spec: <a href="bytes.html">bytes</a>) &rarr; tuple{bytes AS stream_event}</code></td><td><span class="funcdesc"><p>Stream partition data</p>
 </span></td><td>Volatile</td></tr></tbody>

--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -2652,9 +2652,9 @@ The swap_ordinate_string parameter is a 2-character string naming the ordinates 
 </span></td><td>Volatile</td></tr>
 <tr><td><a name="crdb_internal.start_replication_stream"></a><code>crdb_internal.start_replication_stream(tenant_name: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>This function can be used on the producer side to start a replication stream for the specified tenant. The returned stream ID uniquely identifies created stream. The caller must periodically invoke crdb_internal.heartbeat_stream() function to notify that the replication is still ongoing.</p>
 </span></td><td>Volatile</td></tr>
-<tr><td><a name="crdb_internal.stream_ingestion_stats_json"></a><code>crdb_internal.stream_ingestion_stats_json(job_id: <a href="int.html">int</a>) &rarr; jsonb</code></td><td><span class="funcdesc"><p>This function can be used on the ingestion side to get a statistics summary of a stream ingestion job in json format.</p>
+<tr><td><a name="crdb_internal.stream_ingestion_stats_json"></a><code>crdb_internal.stream_ingestion_stats_json(job_id: <a href="int.html">int</a>) &rarr; jsonb</code></td><td><span class="funcdesc"><p>DEPRECATED, consider using <code>SHOW TENANT name WITH REPLICATION STATS</code></p>
 </span></td><td>Volatile</td></tr>
-<tr><td><a name="crdb_internal.stream_ingestion_stats_pb"></a><code>crdb_internal.stream_ingestion_stats_pb(job_id: <a href="int.html">int</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>This function can be used on the ingestion side to get a statistics summary of a stream ingestion job in protobuf format.</p>
+<tr><td><a name="crdb_internal.stream_ingestion_stats_pb"></a><code>crdb_internal.stream_ingestion_stats_pb(job_id: <a href="int.html">int</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>DEPRECATED, consider using <code>SHOW TENANT name WITH REPLICATION STATS</code></p>
 </span></td><td>Volatile</td></tr>
 <tr><td><a name="crdb_internal.stream_partition"></a><code>crdb_internal.stream_partition(stream_id: <a href="int.html">int</a>, partition_spec: <a href="bytes.html">bytes</a>) &rarr; tuple{bytes AS stream_event}</code></td><td><span class="funcdesc"><p>Stream partition data</p>
 </span></td><td>Volatile</td></tr></tbody>

--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal
@@ -166,18 +166,13 @@ SELECT a.* FROM crdb_internal.partitions AS a JOIN crdb_internal.partitions AS b
 
 subtest replication-builtins
 
-user testuser
-
-query error pq: crdb_internal\.stream_ingestion_stats_json\(\): replication restricted to ADMIN role
-SELECT crdb_internal.stream_ingestion_stats_json(unique_rowid());
-
 user root
-
-query error pq: crdb_internal\.stream_ingestion_stats_json\(\): job.*does not exist
-SELECT crdb_internal.stream_ingestion_stats_json(unique_rowid());
-
-query error pq: crdb_internal\.stream_ingestion_stats_json\(\): job.*is not a stream ingestion job
-SELECT crdb_internal.stream_ingestion_stats_json(id) FROM (SELECT id FROM system.jobs LIMIT 1);
 
 query error pq: crdb_internal\.replication_stream_spec\(\): job.*is not a replication stream job
 SELECT crdb_internal.replication_stream_spec(crdb_internal.create_sql_schema_telemetry_job())
+
+query error pq: crdb_internal\.stream_ingestion_stats_json\(\): unimplemented
+SELECT crdb_internal.stream_ingestion_stats_json(1);
+
+query error pq: crdb_internal\.stream_ingestion_stats_pb\(\): unimplemented
+SELECT crdb_internal.stream_ingestion_stats_pb(1);

--- a/pkg/ccl/streamingccl/streamingest/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamingest/BUILD.bazel
@@ -54,6 +54,7 @@ go_library(
         "//pkg/sql/types",
         "//pkg/storage",
         "//pkg/storage/enginepb",
+        "//pkg/testutils/sqlutils",
         "//pkg/util/ctxgroup",
         "//pkg/util/hlc",
         "//pkg/util/log",
@@ -68,6 +69,7 @@ go_library(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_cockroachdb_redact//:redact",
+        "@com_github_stretchr_testify//require",
     ],
 )
 
@@ -129,7 +131,6 @@ go_test(
         "//pkg/testutils/testcluster",
         "//pkg/upgrade/upgradebase",
         "//pkg/util/hlc",
-        "//pkg/util/json",
         "//pkg/util/leaktest",
         "//pkg/util/limit",
         "//pkg/util/log",

--- a/pkg/ccl/streamingccl/streamingest/stream_ingest_manager.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingest_manager.go
@@ -38,9 +38,11 @@ func (r *streamIngestManagerImpl) CompleteStreamIngestion(
 
 // GetStreamIngestionStats implements streaming.StreamIngestManager interface.
 func (r *streamIngestManagerImpl) GetStreamIngestionStats(
-	ctx context.Context, ingestionJobID jobspb.JobID,
+	ctx context.Context,
+	streamIngestionDetails jobspb.StreamIngestionDetails,
+	jobProgress jobspb.Progress,
 ) (*streampb.StreamIngestionStats, error) {
-	return getStreamIngestionStats(ctx, r.evalCtx, r.txn, ingestionJobID)
+	return getStreamIngestionStats(ctx, streamIngestionDetails, jobProgress)
 }
 
 func newStreamIngestManagerWithPrivilegesCheck(

--- a/pkg/ccl/streamingccl/streamingest/stream_replication_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_replication_e2e_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
-	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
@@ -42,7 +41,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -347,16 +345,6 @@ func configureClusterSettings(setting map[string]string) []string {
 	return res
 }
 
-func streamIngestionStats(
-	t *testing.T, sqlRunner *sqlutils.SQLRunner, ingestionJobID int,
-) *streampb.StreamIngestionStats {
-	stats, rawStats := &streampb.StreamIngestionStats{}, make([]byte, 0)
-	row := sqlRunner.QueryRow(t, "SELECT crdb_internal.stream_ingestion_stats_pb($1)", ingestionJobID)
-	row.Scan(&rawStats)
-	require.NoError(t, protoutil.Unmarshal(rawStats, stats))
-	return stats
-}
-
 func runningStatus(t *testing.T, sqlRunner *sqlutils.SQLRunner, ingestionJobID int) string {
 	p := jobutils.GetJobProgress(t, sqlRunner, jobspb.JobID(ingestionJobID))
 	return p.RunningStatus
@@ -453,7 +441,7 @@ func TestTenantStreamingProducerJobTimedOut(t *testing.T) {
 	c.compareResult("SELECT * FROM d.t1")
 	c.compareResult("SELECT * FROM d.t2")
 
-	stats := streamIngestionStats(t, c.destSysSQL, ingestionJobID)
+	stats := streamIngestionStats(t, ctx, c.destSysSQL, ingestionJobID)
 
 	require.NotNil(t, stats.ReplicationLagInfo)
 	require.True(t, srcTime.LessEq(stats.ReplicationLagInfo.MinIngestedTimestamp))
@@ -517,7 +505,7 @@ func TestTenantStreamingPauseResumeIngestion(t *testing.T) {
 	// Pause ingestion.
 	c.destSysSQL.Exec(t, fmt.Sprintf("PAUSE JOB %d", ingestionJobID))
 	jobutils.WaitForJobToPause(t, c.destSysSQL, jobspb.JobID(ingestionJobID))
-	pausedCheckpoint := streamIngestionStats(t, c.destSysSQL, ingestionJobID).
+	pausedCheckpoint := streamIngestionStats(t, ctx, c.destSysSQL, ingestionJobID).
 		ReplicationLagInfo.MinIngestedTimestamp
 	// Check we paused at a timestamp greater than the previously reached high watermark
 	require.True(t, srcTime.LessEq(pausedCheckpoint))
@@ -528,7 +516,7 @@ func TestTenantStreamingPauseResumeIngestion(t *testing.T) {
 	// to src cluster checkpoints events, the job high watermark may change.
 	<-time.NewTimer(3 * time.Second).C
 	require.Equal(t, pausedCheckpoint,
-		streamIngestionStats(t, c.destSysSQL, ingestionJobID).ReplicationLagInfo.MinIngestedTimestamp)
+		streamIngestionStats(t, ctx, c.destSysSQL, ingestionJobID).ReplicationLagInfo.MinIngestedTimestamp)
 
 	// Resume ingestion.
 	c.destSysSQL.Exec(t, fmt.Sprintf("RESUME JOB %d", ingestionJobID))
@@ -579,7 +567,7 @@ func TestTenantStreamingPauseOnPermanentJobError(t *testing.T) {
 	require.Equal(t, 2, ingestionStarts)
 
 	// Check we didn't make any progress.
-	require.Nil(t, streamIngestionStats(t, c.destSysSQL, ingestionJobID).ReplicationLagInfo)
+	require.Nil(t, streamIngestionStats(t, ctx, c.destSysSQL, ingestionJobID).ReplicationLagInfo)
 
 	// Resume ingestion.
 	c.destSysSQL.Exec(t, fmt.Sprintf("RESUME JOB %d", ingestionJobID))
@@ -744,7 +732,7 @@ func TestTenantStreamingCancelIngestion(t *testing.T) {
 		jobutils.WaitForJobToCancel(c.t, c.srcSysSQL, jobspb.JobID(producerJobID))
 
 		// Check if the producer job has released protected timestamp.
-		stats := streamIngestionStats(t, c.destSysSQL, ingestionJobID)
+		stats := streamIngestionStats(t, ctx, c.destSysSQL, ingestionJobID)
 		require.NotNil(t, stats.ProducerStatus)
 		require.Nil(t, stats.ProducerStatus.ProtectedTimestamp)
 
@@ -814,7 +802,7 @@ func TestTenantStreamingDropTenantCancelsStream(t *testing.T) {
 		jobutils.WaitForJobToCancel(c.t, c.srcSysSQL, jobspb.JobID(producerJobID))
 
 		// Check if the producer job has released protected timestamp.
-		stats := streamIngestionStats(t, c.destSysSQL, ingestionJobID)
+		stats := streamIngestionStats(t, ctx, c.destSysSQL, ingestionJobID)
 		require.NotNil(t, stats.ProducerStatus)
 		require.Nil(t, stats.ProducerStatus.ProtectedTimestamp)
 
@@ -1128,7 +1116,7 @@ func TestTenantReplicationProtectedTimestampManagement(t *testing.T) {
 		// greater or equal to the frontier we know we have replicated up until.
 		waitForProducerProtection := func(c *tenantStreamingClusters, frontier hlc.Timestamp, replicationJobID int) {
 			testutils.SucceedsSoon(t, func() error {
-				stats := streamIngestionStats(t, c.destSysSQL, replicationJobID)
+				stats := streamIngestionStats(t, ctx, c.destSysSQL, replicationJobID)
 				if stats.ProducerStatus == nil {
 					return errors.New("nil ProducerStatus")
 				}
@@ -1240,7 +1228,7 @@ func TestTenantReplicationProtectedTimestampManagement(t *testing.T) {
 		}
 
 		// Check if the producer job has released protected timestamp.
-		stats := streamIngestionStats(t, c.destSysSQL, replicationJobID)
+		stats := streamIngestionStats(t, ctx, c.destSysSQL, replicationJobID)
 		require.NotNil(t, stats.ProducerStatus)
 		require.Nil(t, stats.ProducerStatus.ProtectedTimestamp)
 

--- a/pkg/ccl/streamingccl/streamingest/stream_replication_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_replication_e2e_test.go
@@ -1290,7 +1290,7 @@ func TestTenantStreamingShowTenant(t *testing.T) {
 	row.Scan(&id, &dest, &status, &source, &sourceUri, &jobId, &maxReplTime, &protectedTime)
 	require.Equal(t, 2, id)
 	require.Equal(t, "destination", dest)
-	require.Equal(t, "ADD", status)
+	require.Equal(t, "REPLICATING", status)
 	require.Equal(t, "source", source)
 	require.Equal(t, c.srcURL.String(), sourceUri)
 	require.Equal(t, ingestionJobID, jobId)

--- a/pkg/sql/sem/builtins/replication_builtins.go
+++ b/pkg/sql/sem/builtins/replication_builtins.go
@@ -12,7 +12,6 @@ package builtins
 
 import (
 	"context"
-	gojson "encoding/json"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
@@ -89,30 +88,10 @@ var replicationBuiltins = map[string]builtinDefinition{
 			},
 			ReturnType: tree.FixedReturnType(types.Jsonb),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				if args[0] == tree.DNull {
-					return tree.DNull, errors.New("job_id cannot be specified with null argument")
-				}
-				mgr, err := evalCtx.StreamManagerFactory.GetStreamIngestManager(ctx)
-				if err != nil {
-					return nil, err
-				}
-				ingestionJobID := int64(tree.MustBeDInt(args[0]))
-				stats, err := mgr.GetStreamIngestionStats(ctx, jobspb.JobID(ingestionJobID))
-				if err != nil {
-					return nil, err
-				}
-				jsonStats, err := gojson.Marshal(stats)
-				if err != nil {
-					return nil, err
-				}
-				jsonDatum, err := tree.ParseDJSON(string(jsonStats))
-				if err != nil {
-					return nil, err
-				}
-				return jsonDatum, nil
+				// Keeping this builtin as 'unimplemented' in order to reserve the oid.
+				return tree.DNull, errors.New("unimplemented")
 			},
-			Info: "This function can be used on the ingestion side to get a statistics summary " +
-				"of a stream ingestion job in json format.",
+			Info:       "DEPRECATED, consider using `SHOW TENANT name WITH REPLICATION STATS`",
 			Volatility: volatility.Volatile,
 		},
 	),
@@ -129,26 +108,10 @@ var replicationBuiltins = map[string]builtinDefinition{
 			},
 			ReturnType: tree.FixedReturnType(types.Bytes),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				if args[0] == tree.DNull {
-					return tree.DNull, errors.New("job_id cannot be specified with null argument")
-				}
-				mgr, err := evalCtx.StreamManagerFactory.GetStreamIngestManager(ctx)
-				if err != nil {
-					return nil, err
-				}
-				ingestionJobID := int64(tree.MustBeDInt(args[0]))
-				stats, err := mgr.GetStreamIngestionStats(ctx, jobspb.JobID(ingestionJobID))
-				if err != nil {
-					return nil, err
-				}
-				rawStatus, err := protoutil.Marshal(stats)
-				if err != nil {
-					return nil, err
-				}
-				return tree.NewDBytes(tree.DBytes(rawStatus)), nil
+				// Keeping this builtin as 'unimplemented' in order to reserve the oid.
+				return tree.DNull, errors.New("unimplemented")
 			},
-			Info: "This function can be used on the ingestion side to get a statistics summary " +
-				"of a stream ingestion job in protobuf format.",
+			Info:       "DEPRECATED, consider using `SHOW TENANT name WITH REPLICATION STATS`",
 			Volatility: volatility.Volatile,
 		},
 	),

--- a/pkg/sql/sem/builtins/replication_builtins.go
+++ b/pkg/sql/sem/builtins/replication_builtins.go
@@ -91,7 +91,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 				// Keeping this builtin as 'unimplemented' in order to reserve the oid.
 				return tree.DNull, errors.New("unimplemented")
 			},
-			Info:       "DEPRECATED, consider using `SHOW TENANT name WITH REPLICATION STATS`",
+			Info:       "DEPRECATED, consider using `SHOW TENANT name WITH REPLICATION STATUS`",
 			Volatility: volatility.Volatile,
 		},
 	),
@@ -111,7 +111,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 				// Keeping this builtin as 'unimplemented' in order to reserve the oid.
 				return tree.DNull, errors.New("unimplemented")
 			},
-			Info:       "DEPRECATED, consider using `SHOW TENANT name WITH REPLICATION STATS`",
+			Info:       "DEPRECATED, consider using `SHOW TENANT name WITH REPLICATION STATUS`",
 			Volatility: volatility.Volatile,
 		},
 	),

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -770,6 +770,7 @@ type StreamIngestManager interface {
 	// GetStreamIngestionStats gets a statistics summary for a stream ingestion job.
 	GetStreamIngestionStats(
 		ctx context.Context,
-		ingestionJobID jobspb.JobID,
+		streamIngestionDetails jobspb.StreamIngestionDetails,
+		jobProgress jobspb.Progress,
 	) (*streampb.StreamIngestionStats, error)
 }


### PR DESCRIPTION
Currently the status of the destination tenant during replication is `ADD` which is not ideal.

This commit changes the status to be, roughly, the status of the replication job. The destination tenant status can be:
`DROP` - the tenant was dropped.
`ADD` - the job is still pending, not replicating yet (should be transient).
`REPLICATING` - the replication job is running (perhaps pause was requested).
`REPLICATION PAUSED` - the replication job was paused.
`ACTIVE` - there was a cutover and now the tenant is active.

These are all OK statuses, if we get any other job status:
`failed`, `reverting`, `succeeded`, `canceled`, `cancel-requested`, `revert-failed`.
(this should be an exhaustive list) then we consider the status unexpected and in that case the `SHOW TENANT` command will print:
`REPLICATION UNKNOWN (%s)`
for example:
`REPLICATION UNKNOWN (succeeded)`

Epic: CRDB-18752
Fixes: #93446

Release note: None