### PR TITLE
colexec: minor clarification around planning of closers

### DIFF
--- a/pkg/sql/colexec/colexecdisk/disk_spiller.go
+++ b/pkg/sql/colexec/colexecdisk/disk_spiller.go
@@ -78,7 +78,7 @@ func NewOneInputDiskSpiller(
 	inMemoryMemMonitorName redact.RedactableString,
 	diskBackedOpConstructor func(input colexecop.Operator) colexecop.Operator,
 	spillingCallbackFn func(),
-) colexecop.Operator {
+) colexecop.ClosableOperator {
 	diskBackedOpInput := newBufferExportingOperator(inMemoryOp, input)
 	return &diskSpillerBase{
 		inputs:                 []colexecop.Operator{input},
@@ -145,7 +145,7 @@ func NewTwoInputDiskSpiller(
 	inMemoryMemMonitorName redact.RedactableString,
 	diskBackedOpConstructor func(inputOne, inputTwo colexecop.Operator) colexecop.Operator,
 	spillingCallbackFn func(),
-) colexecop.Operator {
+) colexecop.ClosableOperator {
 	diskBackedOpInputOne := newBufferExportingOperator(inMemoryOp, inputOne)
 	diskBackedOpInputTwo := newBufferExportingOperator(inMemoryOp, inputTwo)
 	return &diskSpillerBase{

--- a/pkg/sql/colexec/colexecdisk/external_sort_test.go
+++ b/pkg/sql/colexec/colexecdisk/external_sort_test.go
@@ -112,7 +112,9 @@ func TestExternalSortMemoryAccounting(t *testing.T) {
 		queueCfg, sem, &monitorRegistry,
 	)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(closers))
+	// We expect the disk spiller as well as the external sorter to be included
+	// into the set of closers.
+	require.Equal(t, 2, len(closers))
 
 	sorter.Init(ctx)
 	for b := sorter.Next(); b.Length() > 0; b = sorter.Next() {

--- a/pkg/sql/colexec/external_distinct_test.go
+++ b/pkg/sql/colexec/external_distinct_test.go
@@ -69,14 +69,15 @@ func TestExternalDistinct(t *testing.T) {
 			var outputOrdering execinfrapb.Ordering
 			verifier := colexectestutils.UnorderedVerifier
 			// Check that the disk spiller, the external distinct, and the
-			// disk-backed sort were added as Closers.
-			numExpectedClosers := 3
+			// disk-backed sort (which includes both the disk spiller and the
+			// sort) were added as Closers.
+			numExpectedClosers := 4
 			if tc.isOrderedOnDistinctCols {
 				outputOrdering = convertDistinctColsToOrdering(tc.distinctCols)
 				verifier = colexectestutils.OrderedVerifier
-				// The final disk-backed sort must also be added as a
-				// Closer.
-				numExpectedClosers++
+				// The disk spiller and the sort included in the final
+				// disk-backed sort must also be added as Closers.
+				numExpectedClosers += 2
 			}
 			tc.runTests(t, verifier, func(input []colexecop.Operator) (colexecop.Operator, error) {
 				// A sorter should never exceed ExternalSorterMinPartitions, even
@@ -193,8 +194,8 @@ func TestExternalDistinctSpilling(t *testing.T) {
 			)
 			require.NoError(t, err)
 			// Check that the disk spiller, the external distinct, and the
-			// disk-backed sort were added as Closers.
-			numExpectedClosers := 3
+			// disk-backed sort (which accounts for two) were added as Closers.
+			numExpectedClosers := 4
 			require.Equal(t, numExpectedClosers, len(closers))
 			numRuns++
 			return distinct, nil

--- a/pkg/sql/colexec/external_hash_aggregator_test.go
+++ b/pkg/sql/colexec/external_hash_aggregator_test.go
@@ -112,13 +112,14 @@ func TestExternalHashAggregator(t *testing.T) {
 			}
 			var numExpectedClosers int
 			if cfg.diskSpillingEnabled {
-				// The external sorter, the disk spiller, and the external hash
-				// aggregator should be added as Closers.
-				numExpectedClosers = 3
+				// The external sorter (accounting for two closers), the disk
+				// spiller, and the external hash aggregator should be added as
+				// Closers.
+				numExpectedClosers = 4
 				if len(tc.spec.OutputOrdering.Columns) > 0 {
 					// When the output ordering is required, we also plan
-					// another external sort.
-					numExpectedClosers++
+					// another external sort which accounts for two closers.
+					numExpectedClosers += 2
 				}
 			} else {
 				// Only the in-memory hash aggregator should be added.

--- a/pkg/sql/colexec/external_hash_joiner_test.go
+++ b/pkg/sql/colexec/external_hash_joiner_test.go
@@ -86,9 +86,11 @@ func TestExternalHashJoiner(t *testing.T) {
 						numForcedRepartitions, delegateFDAcquisitions, sem,
 						&monitorRegistry,
 					)
-					// Expect three closers. These are the external hash joiner, and
-					// one external sorter for each input.
-					require.Equal(t, 3, len(closers))
+					// Expect six closers:
+					// - 1 for the disk spiller
+					// - 1 for the external hash joiner
+					// - 2 for each of the external sorts (4 total here).
+					require.Equal(t, 6, len(closers))
 					return hjOp, err
 				})
 				for i, sem := range semsToCheck {

--- a/pkg/sql/colexec/external_sort_test.go
+++ b/pkg/sql/colexec/external_sort_test.go
@@ -99,8 +99,9 @@ func TestExternalSort(t *testing.T) {
 							numForcedRepartitions, false /* delegateFDAcquisition */, queueCfg, sem,
 							&monitorRegistry,
 						)
-						// Check that the sort was added as a Closer.
-						require.Equal(t, 1, len(closers))
+						// Check that the sort as well as the disk spiller were
+						// added as Closers.
+						require.Equal(t, 2, len(closers))
 						return sorter, err
 					})
 				for i, sem := range semsToCheck {
@@ -200,7 +201,7 @@ func TestExternalSortRandomized(t *testing.T) {
 							)
 							// TODO(asubiotto): Explicitly Close when testing.T is passed into
 							//  this constructor and we do a substring match.
-							require.Equal(t, 1, len(closers))
+							require.Equal(t, 2, len(closers))
 							return sorter, err
 						})
 					for i, sem := range semsToCheck {


### PR DESCRIPTION
This commit makes it so that we always include the disk spiller into the set of closers. Previously, we would do it in some places but not all. In particular, we would not include it for the external sort and the external hash join. This is not a correctness issue since the disk spiller itself doesn't need to release the resources and we did include the operators that do need to release stuff, yet in the spirit of being more bullet-proof, it's better to be more consistent.

As a result, some tests needed to be adjusted.

Epic: None

Release note: None