### PR TITLE
release-22.1: opt, sqlsmith: fix incorrect output with NULLS LAST in window and aggregate functions

### DIFF
--- a/pkg/internal/sqlsmith/relational.go
+++ b/pkg/internal/sqlsmith/relational.go
@@ -448,6 +448,16 @@ func (s *Smither) randDirection() tree.Direction {
 	return orderDirections[s.rnd.Intn(len(orderDirections))]
 }
 
+var nullsOrders = []tree.NullsOrder{
+	tree.DefaultNullsOrder,
+	tree.NullsFirst,
+	tree.NullsLast,
+}
+
+func (s *Smither) randNullsOrder() tree.NullsOrder {
+	return nullsOrders[s.rnd.Intn(len(nullsOrders))]
+}
+
 var nullabilities = []tree.Nullability{
 	tree.NotNull,
 	tree.Null,
@@ -700,7 +710,8 @@ func makeSelect(s *Smither) (tree.Statement, bool) {
 			}
 			order[i] = &tree.Order{
 				Expr:       expr,
-				NullsOrder: tree.NullsFirst,
+				Direction:  s.randDirection(),
+				NullsOrder: s.randNullsOrder(),
 			}
 		}
 		stmt = &tree.Select{
@@ -1181,8 +1192,9 @@ func (s *Smither) makeOrderBy(refs colRefs) tree.OrderBy {
 			continue
 		}
 		ob = append(ob, &tree.Order{
-			Expr:      ref.item,
-			Direction: s.randDirection(),
+			Expr:       ref.item,
+			Direction:  s.randDirection(),
+			NullsOrder: s.randNullsOrder(),
 		})
 	}
 	return ob

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -3802,3 +3802,115 @@ query I
 SELECT min(a) FROM t2 WHERE (b <= 11 AND c < 50) OR (b = 11 AND c = 50) OR (b >= 11 AND c > 50)
 ----
 0
+
+# Regression test for incorrectly ignoring NULLS LAST in aggregate functions (#91295).
+statement ok
+CREATE TABLE nulls_last_test (
+    id INT NULL,
+    k INT NULL,
+    v VARCHAR(3) NULL
+);
+INSERT INTO nulls_last_test VALUES
+  (1, 1, 'foo'),
+  (2, null, null),
+  (null, null, 'bar'),
+  (3, 3, 'baz');
+
+query T
+SELECT array_agg(id ORDER BY id NULLS LAST) FROM nulls_last_test
+----
+{1,2,3,NULL}
+
+# It should work with tuples too.
+query T
+SELECT array_agg((k, v) ORDER BY (k, v)) FROM nulls_last_test
+----
+{"(,)","(,bar)","(1,foo)","(3,baz)"}
+
+query T
+SELECT array_agg((k, v) ORDER BY (k, v) NULLS LAST) FROM nulls_last_test
+----
+{"(1,foo)","(3,baz)","(,bar)","(,)"}
+
+# Tuples with projections also work.
+query T
+SELECT array_agg((k, v) ORDER BY (k+1, v||'foo')) FROM nulls_last_test;
+----
+{"(,)","(,bar)","(1,foo)","(3,baz)"}
+
+query T
+SELECT array_agg((k, v) ORDER BY (k+1, v||'foo') NULLS LAST) FROM nulls_last_test;
+----
+{"(1,foo)","(3,baz)","(,bar)","(,)"}
+
+# Using the session variable, we should get results that match Postgres.
+statement ok
+SET null_ordered_last = true
+
+query T
+SELECT array_agg(id ORDER BY id) FROM nulls_last_test
+----
+{1,2,3,NULL}
+
+query T
+SELECT array_agg((k, v) ORDER BY (k, v)) FROM nulls_last_test
+----
+{"(1,foo)","(3,baz)","(,bar)","(,)"}
+
+# TODO(#93558): This does not match Postgres.
+# Postgres returns:
+#   {"(1,foo)","(3,baz)","(,bar)","(,)"}
+query T
+SELECT array_agg((k, v) ORDER BY (k, v) NULLS FIRST) FROM nulls_last_test
+----
+{"(,)","(,bar)","(1,foo)","(3,baz)"}
+
+query T
+SELECT array_agg((k, v) ORDER BY (k+1, v||'foo')) FROM nulls_last_test;
+----
+{"(1,foo)","(3,baz)","(,bar)","(,)"}
+
+# TODO(#93558): This does not match Postgres.
+# Postgres returns:
+#   {"(1,foo)","(3,baz)","(,bar)","(,)"}
+query T
+SELECT array_agg((k, v) ORDER BY (k+1, v||'foo') NULLS FIRST) FROM nulls_last_test;
+----
+{"(,)","(,bar)","(1,foo)","(3,baz)"}
+
+# TODO(#93558): This test case is broken and shows the limit of our
+# optimizer-based approach for NULLS LAST.
+# Postgres returns:
+#   {"(1,1)","(1,)","(,)",NULL}
+query T
+WITH t (x, y) AS (
+  VALUES
+    ((1, 1), 1),
+    ((NULL::RECORD), 2),
+    ((1, NULL::INT), 3),
+    ((NULL::INT, NULL::INT), 4)
+)
+SELECT array_agg(x ORDER BY x)
+FROM t;
+----
+{"(1,)","(1,1)",NULL,"(,)"}
+
+# TODO(#93558): This test case is broken and shows the limit of our
+# optimizer-based approach for NULLS LAST.
+# Postgres returns:
+#   {NULL,"(1,1)","(1,)","(,)"}
+query T
+WITH t (x, y) AS (
+  VALUES
+    ((1, 1), 1),
+    ((NULL::RECORD), 2),
+    ((1, NULL::INT), 3),
+    ((NULL::INT, NULL::INT), 4)
+)
+SELECT array_agg(x ORDER BY x NULLS FIRST)
+FROM t;
+----
+{NULL,"(,)","(1,)","(1,1)"}
+
+statement ok
+RESET null_ordered_last

--- a/pkg/sql/logictest/testdata/logic_test/order_by
+++ b/pkg/sql/logictest/testdata/logic_test/order_by
@@ -572,3 +572,34 @@ NULL  6
 2     NULL
 2     5
 4     8
+
+# Using the session variable, we should get results that match Postgres.
+# TODO(#93558): This test case is broken and shows the limit of our
+# approach to using an optimizer-based approach for NULLS LAST.
+# Postgres returns:
+#      x   | y
+#   -------+---
+#    (1,1) | 1
+#    (1,)  | 3
+#    (,)   | 4
+#          | 2
+#
+query TI
+WITH t (x, y) AS (
+  VALUES
+    ((1, 1), 1),
+    ((NULL::RECORD), 2),
+    ((1, NULL::INT), 3),
+    ((NULL::INT, NULL::INT), 4)
+)
+SELECT *
+FROM t
+ORDER BY x;
+----
+(1,)   3
+(1,1)  1
+NULL   2
+(,)    4
+
+statement ok
+RESET null_ordered_last

--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -4345,3 +4345,51 @@ query I
 SELECT lead(x, 10, y::INT4) OVER () FROM (VALUES (1, 2)) v(x, y);
 ----
 2
+
+# Regression test for incorrectly ignoring NULLS LAST in window functions (#91295).
+statement ok
+CREATE TABLE nulls_last_test (
+    id INT NULL
+);
+INSERT INTO nulls_last_test VALUES
+  (1),
+  (2),
+  (null),
+  (3);
+
+query III
+SELECT
+  id,
+  row_number() OVER (ORDER BY id NULLS LAST) AS row_num_using_nulls_last,
+  row_number() OVER (ORDER BY COALESCE(id, 999)) AS row_num_using_coalesce
+FROM
+  nulls_last_test
+ORDER BY
+  id NULLS LAST
+----
+1     1  1
+2     2  2
+3     3  3
+NULL  4  4
+
+statement ok
+SET null_ordered_last = true
+
+# We should get the same result using the session variable.
+query III
+SELECT
+  id,
+  row_number() OVER (ORDER BY id) AS row_num_using_nulls_last,
+  row_number() OVER (ORDER BY COALESCE(id, 999)) AS row_num_using_coalesce
+FROM
+  nulls_last_test
+ORDER BY
+  id
+----
+1     1  1
+2     2  2
+3     3  3
+NULL  4  4
+
+statement ok
+RESET null_ordered_last

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -716,7 +716,18 @@ func (b *Builder) buildAggregateFunction(
 	// If we have ORDER BY, add the ordering columns to the tempScope.
 	if f.OrderBy != nil {
 		for _, o := range f.OrderBy {
-			b.buildAggArg(o.Expr.(tree.TypedExpr), &info, tempScope, fromScope)
+			// ORDER BY (a, b) => ORDER BY a, b.
+			te := fromScope.resolveType(o.Expr, types.Any)
+			cols := flattenTuples([]tree.TypedExpr{te})
+
+			nullsDefaultOrder := b.hasDefaultNullsOrder(o)
+			for _, e := range cols {
+				if !nullsDefaultOrder {
+					expr := tree.NewTypedIsNullExpr(e)
+					b.buildAggArg(expr, &info, tempScope, fromScope)
+				}
+				b.buildAggArg(e, &info, tempScope, fromScope)
+			}
 		}
 	}
 

--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -285,6 +285,7 @@ func (b *Builder) hasDefaultNullsOrder(order *tree.Order) bool {
 		telemetry.Inc(sqltelemetry.OrderByNullsNonStandardCounter)
 		return false
 	}
+	telemetry.Inc(sqltelemetry.OrderByNullsStandardCounter)
 	return true
 }
 

--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -168,14 +168,7 @@ func (b *Builder) analyzeOrderByArg(
 
 	// Set NULL order. The default order in Cockroach if null_ordered_last=False
 	// is nulls first for ascending order and nulls last for descending order.
-	nullsDefaultOrder := true
-	if (b.evalCtx.SessionData().NullOrderedLast && order.NullsOrder == tree.DefaultNullsOrder) ||
-		(order.NullsOrder != tree.DefaultNullsOrder &&
-			((order.NullsOrder == tree.NullsFirst && order.Direction == tree.Descending) ||
-				(order.NullsOrder == tree.NullsLast && order.Direction != tree.Descending))) {
-		nullsDefaultOrder = false
-		telemetry.Inc(sqltelemetry.OrderByNullsNonStandardCounter)
-	}
+	nullsDefaultOrder := b.hasDefaultNullsOrder(order)
 
 	// Analyze the ORDER BY column(s).
 	start := len(orderByScope.cols)
@@ -279,6 +272,20 @@ func (b *Builder) analyzeExtraArgument(
 		}
 		extraColsScope.addColumn(scopeColName(""), e)
 	}
+}
+
+// hasDefaultNullsOrder returns whether the provided ordering uses the default
+// ordering for NULLs. The default order in Cockroach if null_ordered_last=False
+// is nulls first for ascending order and nulls last for descending order.
+func (b *Builder) hasDefaultNullsOrder(order *tree.Order) bool {
+	if (b.evalCtx.SessionData().NullOrderedLast && order.NullsOrder == tree.DefaultNullsOrder) ||
+		(order.NullsOrder != tree.DefaultNullsOrder &&
+			((order.NullsOrder == tree.NullsFirst && order.Direction == tree.Descending) ||
+				(order.NullsOrder == tree.NullsLast && order.Direction != tree.Descending))) {
+		telemetry.Inc(sqltelemetry.OrderByNullsNonStandardCounter)
+		return false
+	}
+	return true
 }
 
 func ensureColumnOrderable(e tree.TypedExpr) {

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -4781,3 +4781,30 @@ project
                      │              └── unnest:2
                      └── projections
                           └── CASE WHEN arr:1 IS NULL THEN '[]' ELSE json_agg:3 END [as=json_agg:4]
+
+# Regression test for incorrectly ignoring NULLS LAST in aggregate functions (#91295).
+exec-ddl
+CREATE TABLE nulls_last_test (
+    id INT NULL
+)
+----
+
+build
+SELECT array_agg(id ORDER BY id NULLS LAST) FROM nulls_last_test
+----
+scalar-group-by
+ ├── columns: array_agg:6
+ ├── window partition=() ordering=+5,+1
+ │    ├── columns: id:1 rowid:2!null crdb_internal_mvcc_timestamp:3 tableoid:4 column5:5!null array_agg:6
+ │    ├── project
+ │    │    ├── columns: column5:5!null id:1 rowid:2!null crdb_internal_mvcc_timestamp:3 tableoid:4
+ │    │    ├── scan nulls_last_test
+ │    │    │    └── columns: id:1 rowid:2!null crdb_internal_mvcc_timestamp:3 tableoid:4
+ │    │    └── projections
+ │    │         └── id:1 IS NULL [as=column5:5]
+ │    └── windows
+ │         └── array-agg [as=array_agg:6, frame="range from unbounded to unbounded"]
+ │              └── id:1
+ └── aggregations
+      └── const-agg [as=array_agg:6]
+           └── array_agg:6

--- a/pkg/sql/opt/optbuilder/testdata/window
+++ b/pkg/sql/opt/optbuilder/testdata/window
@@ -1473,3 +1473,66 @@ ORDER BY
   rank() OVER()
 ----
 error (42P20): rank(): window functions are not allowed in ORDER BY
+
+# Regression test for incorrectly ignoring NULLS LAST in window functions (#91295).
+exec-ddl
+CREATE TABLE nulls_last_test (
+    id INT NULL,
+    k INT NULL,
+    v STRING NULL
+)
+----
+
+build
+SELECT
+  id,
+  row_number() OVER (ORDER BY id NULLS LAST),
+  rank() OVER (ORDER BY k NULLS FIRST, v NULLS LAST),
+  row_number() OVER (ORDER BY (k, v) NULLS LAST)
+FROM
+  nulls_last_test
+----
+project
+ ├── columns: id:1 row_number:7 rank:8 row_number:9
+ └── window partition=() ordering=+12,+2,+11,+3
+      ├── columns: id:1 k:2 v:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6 row_number:7 rank:8 row_number:9 row_number_1_nulls_ordering_1_1:10!null rank_2_nulls_ordering_2_1:11!null row_number_3_nulls_ordering_1_1:12!null
+      ├── window partition=() ordering=+2,+11,+3
+      │    ├── columns: id:1 k:2 v:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6 row_number:7 rank:8 row_number_1_nulls_ordering_1_1:10!null rank_2_nulls_ordering_2_1:11!null row_number_3_nulls_ordering_1_1:12!null
+      │    ├── window partition=() ordering=+10,+1
+      │    │    ├── columns: id:1 k:2 v:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6 row_number:7 row_number_1_nulls_ordering_1_1:10!null rank_2_nulls_ordering_2_1:11!null row_number_3_nulls_ordering_1_1:12!null
+      │    │    ├── project
+      │    │    │    ├── columns: row_number_1_nulls_ordering_1_1:10!null rank_2_nulls_ordering_2_1:11!null row_number_3_nulls_ordering_1_1:12!null id:1 k:2 v:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+      │    │    │    ├── scan nulls_last_test
+      │    │    │    │    └── columns: id:1 k:2 v:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+      │    │    │    └── projections
+      │    │    │         ├── id:1 IS NULL [as=row_number_1_nulls_ordering_1_1:10]
+      │    │    │         ├── v:3 IS NULL [as=rank_2_nulls_ordering_2_1:11]
+      │    │    │         └── k:2 IS NULL [as=row_number_3_nulls_ordering_1_1:12]
+      │    │    └── windows
+      │    │         └── row-number [as=row_number:7]
+      │    └── windows
+      │         └── rank [as=rank:8]
+      └── windows
+           └── row-number [as=row_number:9]
+
+build
+SELECT
+  rank() OVER w
+FROM nulls_last_test WINDOW w as (PARTITION BY k ORDER BY v NULLS LAST)
+ORDER BY rank() OVER w
+----
+sort
+ ├── columns: rank:7
+ ├── ordering: +7
+ └── project
+      ├── columns: rank:7
+      └── window partition=(2) ordering=+8,+3
+           ├── columns: id:1 k:2 v:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6 rank:7 rank_1_nulls_ordering_1_1:8!null
+           ├── project
+           │    ├── columns: rank_1_nulls_ordering_1_1:8!null id:1 k:2 v:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+           │    ├── scan nulls_last_test
+           │    │    └── columns: id:1 k:2 v:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+           │    └── projections
+           │         └── v:3 IS NULL [as=rank_1_nulls_ordering_1_1:8]
+           └── windows
+                └── rank [as=rank:7]

--- a/pkg/sql/opt/optbuilder/window.go
+++ b/pkg/sql/opt/optbuilder/window.go
@@ -409,13 +409,34 @@ func (b *Builder) buildWindowOrdering(
 		te := inScope.resolveType(t.Expr, types.Any)
 		cols := flattenTuples([]tree.TypedExpr{te})
 
-		for _, e := range cols {
+		nullsDefaultOrder := b.hasDefaultNullsOrder(t)
+		for k, e := range cols {
+			if !nullsDefaultOrder {
+				expr := tree.NewTypedIsNullExpr(e)
+				col := outScope.findExistingCol(expr, false /* allowSideEffects */)
+				if col == nil {
+					// Use an anonymous name because the column cannot be referenced
+					// in other expressions.
+					colName := scopeColName("").WithMetadataName(
+						fmt.Sprintf("%s_%d_nulls_ordering_%d_%d", funcName, windowIndex+1, j+1, k+1),
+					)
+					col = b.synthesizeColumn(
+						outScope,
+						colName,
+						expr.ResolvedType(),
+						expr,
+						b.buildScalar(expr, inScope, nil, nil, nil),
+					)
+				}
+				ord = append(ord, opt.MakeOrderingColumn(col.id, t.Direction == tree.Descending))
+			}
+
 			col := outScope.findExistingCol(e, false /* allowSideEffects */)
 			if col == nil {
 				// Use an anonymous name because the column cannot be referenced
 				// in other expressions.
 				colName := scopeColName("").WithMetadataName(
-					fmt.Sprintf("%s_%d_orderby_%d", funcName, windowIndex+1, j+1),
+					fmt.Sprintf("%s_%d_orderby_%d_%d", funcName, windowIndex+1, j+1, k+1),
 				)
 				col = b.synthesizeColumn(
 					outScope,

--- a/pkg/sql/sqltelemetry/planning.go
+++ b/pkg/sql/sqltelemetry/planning.go
@@ -132,6 +132,11 @@ var CreateStatisticsUseCounter = telemetry.GetCounterOnce("sql.plan.stats.create
 // FIRST).
 var OrderByNullsNonStandardCounter = telemetry.GetCounterOnce("sql.plan.opt.order-by-nulls-non-standard")
 
+// OrderByNullsStandardCounter is to be incremented whenever a standard
+// ordering of nulls is used for ORDER BY (either ASC NULLS FIRST or DESC NULLS
+// LAST).
+var OrderByNullsStandardCounter = telemetry.GetCounterOnce("sql.plan.opt.order-by-nulls-standard")
+
 // TurnAutoStatsOnUseCounter is to be incremented whenever automatic stats
 // collection is explicitly enabled.
 var TurnAutoStatsOnUseCounter = telemetry.GetCounterOnce("sql.plan.automatic-stats.enabled")


### PR DESCRIPTION
Backport 3/3 commits from #93426.

/cc @cockroachdb/release

---

**opt: fix incorrect output with `NULLS LAST` in window and aggregate functions**

Prior to this commit, window and aggregate functions dropped any `NULLS LAST`
modifier on their order by clauses. This commit updates the optbuilder to
add an implicit `col IS NULL` ordering column for each column `col` that uses
`NULLS LAST`.

Fixes https://github.com/cockroachdb/cockroach/issues/91295

Release note (bug fix): Fixed a bug in which the non-default nulls ordering,
`NULLS LAST`, was ignored in window and aggregate functions. This bug could cause
incorrect query results when `NULLS LAST` was used, and was introduced in 22.1.0.
This is now fixed.

**sqlsmith: added support for randomly using `NULLS FIRST` or `NULLS LAST`**

Prior to this commit, SQLSmith did not produce queries that used the
non-default nulls ordering. This commit adds support for sometimes using
`NULLS FIRST` or `NULLS LAST` with ordering clauses.

Release note: None

----

Release justification: Low-risk fix to a correctness issue.