### PR TITLE
sql: skip BenchmarkPhases

### DIFF
--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -668,7 +668,8 @@ func init() {
 // BenchmarkPhases measures the time that each of the optimization phases takes
 // to run. See the comments for the Phase enumeration for more details
 // on what each phase includes.
-func BenchmarkPhases(b *testing.B) {
+// TODO: unskip once #93565 is resolved.
+func Skip_BenchmarkPhases(b *testing.B) {
 	for _, query := range queriesToTest(b) {
 		h := newHarness(b, query, schemas)
 		b.Run(query.name, func(b *testing.B) {


### PR DESCRIPTION
It's failing too often, leading to a lot of noise. See #93565.

Epic: none
Release note: None