### PR TITLE
upgrades: fix desc ID sequence definition to match expectation

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -247,6 +247,7 @@ go_library(
         "@com_github_kr_pretty//:pretty",
         "@com_github_lib_pq//:pq",
         "@com_github_montanaflynn_stats//:stats",
+        "@com_github_pmezard_go_difflib//difflib",
         "@com_github_prometheus_client_golang//api",
         "@com_github_prometheus_client_golang//api/prometheus/v1:prometheus",
         "@com_github_prometheus_common//model",


### PR DESCRIPTION
Before this change, the test fails with:

```
Diff:
@@ -29,11 +29,11 @@
 	"lastUpdated" TIMESTAMP NOT NULL DEFAULT now():::TIMESTAMP,
 	"valueType" STRING NULL,
 	CONSTRAINT "primary" PRIMARY KEY (name ASC),
 	FAMILY "fam_0_name_value_lastUpdated_valueType" (name, value, "lastUpdated", "valueType")
 );
-CREATE SEQUENCE public.descriptor_id_seq MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1;
+CREATE SEQUENCE public.descriptor_id_seq MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 104;
 CREATE TABLE public.tenants (
 	id INT8 NOT NULL,
 	active BOOL NOT NULL DEFAULT true,
 	info BYTES NULL,
 	name STRING NULL AS (crdb_internal.pb_to_json('cockroach.sql.sqlbase.TenantInfo':::STRING, info)->>'name':::STRING) VIRTUAL,
----

```

This was revealed by #93487 which fixed the broken roachtest. Expect a few more of these.
Fixes: #93602

Release note: None