### PR TITLE
sql: use privilege.Kind value as Kind.Mask() value

### DIFF
--- a/pkg/sql/privilege/BUILD.bazel
+++ b/pkg/sql/privilege/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "@com_github_cockroachdb_errors//:errors",
+        "@org_golang_x_exp//maps",
     ],
 )
 
@@ -30,6 +31,7 @@ go_test(
         ":privilege",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "@com_github_stretchr_testify//require",
     ],
 )
 

--- a/pkg/sql/privilege/kind_string.go
+++ b/pkg/sql/privilege/kind_string.go
@@ -8,42 +8,66 @@ func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
-	_ = x[ALL-1]
-	_ = x[CREATE-2]
-	_ = x[DROP-3]
-	_ = x[DEPRECATEDGRANT-4]
-	_ = x[SELECT-5]
-	_ = x[INSERT-6]
-	_ = x[DELETE-7]
-	_ = x[UPDATE-8]
-	_ = x[USAGE-9]
-	_ = x[ZONECONFIG-10]
-	_ = x[CONNECT-11]
-	_ = x[RULE-12]
-	_ = x[MODIFYCLUSTERSETTING-13]
-	_ = x[EXTERNALCONNECTION-14]
-	_ = x[VIEWACTIVITY-15]
-	_ = x[VIEWACTIVITYREDACTED-16]
-	_ = x[VIEWCLUSTERSETTING-17]
-	_ = x[CANCELQUERY-18]
-	_ = x[NOSQLLOGIN-19]
-	_ = x[EXECUTE-20]
-	_ = x[VIEWCLUSTERMETADATA-21]
-	_ = x[VIEWDEBUG-22]
-	_ = x[BACKUP-23]
-	_ = x[RESTORE-24]
-	_ = x[EXTERNALIOIMPLICITACCESS-25]
-	_ = x[CHANGEFEED-26]
+	_ = x[ALL-2]
+	_ = x[CREATE-4]
+	_ = x[DROP-8]
+	_ = x[SELECT-32]
+	_ = x[INSERT-64]
+	_ = x[DELETE-128]
+	_ = x[UPDATE-256]
+	_ = x[USAGE-512]
+	_ = x[ZONECONFIG-1024]
+	_ = x[CONNECT-2048]
+	_ = x[RULE-4096]
+	_ = x[MODIFYCLUSTERSETTING-8192]
+	_ = x[EXTERNALCONNECTION-16384]
+	_ = x[VIEWACTIVITY-32768]
+	_ = x[VIEWACTIVITYREDACTED-65536]
+	_ = x[VIEWCLUSTERSETTING-131072]
+	_ = x[CANCELQUERY-262144]
+	_ = x[NOSQLLOGIN-524288]
+	_ = x[EXECUTE-1048576]
+	_ = x[VIEWCLUSTERMETADATA-2097152]
+	_ = x[VIEWDEBUG-4194304]
+	_ = x[BACKUP-8388608]
+	_ = x[RESTORE-16777216]
+	_ = x[EXTERNALIOIMPLICITACCESS-33554432]
+	_ = x[CHANGEFEED-67108864]
 }
 
-const _Kind_name = "ALLCREATEDROPGRANTSELECTINSERTDELETEUPDATEUSAGEZONECONFIGCONNECTRULEMODIFYCLUSTERSETTINGEXTERNALCONNECTIONVIEWACTIVITYVIEWACTIVITYREDACTEDVIEWCLUSTERSETTINGCANCELQUERYNOSQLLOGINEXECUTEVIEWCLUSTERMETADATAVIEWDEBUGBACKUPRESTOREEXTERNALIOIMPLICITACCESSCHANGEFEED"
+const _Kind_name = "ALLCREATEDROPSELECTINSERTDELETEUPDATEUSAGEZONECONFIGCONNECTRULEMODIFYCLUSTERSETTINGEXTERNALCONNECTIONVIEWACTIVITYVIEWACTIVITYREDACTEDVIEWCLUSTERSETTINGCANCELQUERYNOSQLLOGINEXECUTEVIEWCLUSTERMETADATAVIEWDEBUGBACKUPRESTOREEXTERNALIOIMPLICITACCESSCHANGEFEED"
 
-var _Kind_index = [...]uint16{0, 3, 9, 13, 18, 24, 30, 36, 42, 47, 57, 64, 68, 88, 106, 118, 138, 156, 167, 177, 184, 203, 212, 218, 225, 249, 259}
+var _Kind_map = map[Kind]string{
+	2:        _Kind_name[0:3],
+	4:        _Kind_name[3:9],
+	8:        _Kind_name[9:13],
+	32:       _Kind_name[13:19],
+	64:       _Kind_name[19:25],
+	128:      _Kind_name[25:31],
+	256:      _Kind_name[31:37],
+	512:      _Kind_name[37:42],
+	1024:     _Kind_name[42:52],
+	2048:     _Kind_name[52:59],
+	4096:     _Kind_name[59:63],
+	8192:     _Kind_name[63:83],
+	16384:    _Kind_name[83:101],
+	32768:    _Kind_name[101:113],
+	65536:    _Kind_name[113:133],
+	131072:   _Kind_name[133:151],
+	262144:   _Kind_name[151:162],
+	524288:   _Kind_name[162:172],
+	1048576:  _Kind_name[172:179],
+	2097152:  _Kind_name[179:198],
+	4194304:  _Kind_name[198:207],
+	8388608:  _Kind_name[207:213],
+	16777216: _Kind_name[213:220],
+	33554432: _Kind_name[220:244],
+	67108864: _Kind_name[244:254],
+}
 
 func (i Kind) String() string {
-	i -= 1
-	if i >= Kind(len(_Kind_index)-1) {
-		return "Kind(" + strconv.FormatInt(int64(i+1), 10) + ")"
+	if str, ok := _Kind_map[i]; ok {
+		return str
 	}
-	return _Kind_name[_Kind_index[i]:_Kind_index[i+1]]
+	return "Kind(" + strconv.FormatInt(int64(i), 10) + ")"
 }

--- a/pkg/sql/privilege/privilege.go
+++ b/pkg/sql/privilege/privilege.go
@@ -12,12 +12,14 @@ package privilege
 
 import (
 	"bytes"
+	"math"
 	"sort"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/errors"
+	"golang.org/x/exp/maps"
 )
 
 //go:generate stringer -type=Kind -linecomment
@@ -31,34 +33,60 @@ type Kind uint32
 // Do not change values of privileges. These correspond to the position
 // of the privilege in a bit field and are expected to stay constant.
 const (
-	ALL    Kind = 1
-	CREATE Kind = 2
-	DROP   Kind = 3
-	// DEPRECATEDGRANT is a placeholder to make sure that 4 is not reused.
-	// It was previously used for the GRANT privilege that has been replaced with the more granular Privilege.GrantOption.
-	DEPRECATEDGRANT          Kind = 4 // GRANT
-	SELECT                   Kind = 5
-	INSERT                   Kind = 6
-	DELETE                   Kind = 7
-	UPDATE                   Kind = 8
-	USAGE                    Kind = 9
-	ZONECONFIG               Kind = 10
-	CONNECT                  Kind = 11
-	RULE                     Kind = 12
-	MODIFYCLUSTERSETTING     Kind = 13
-	EXTERNALCONNECTION       Kind = 14
-	VIEWACTIVITY             Kind = 15
-	VIEWACTIVITYREDACTED     Kind = 16
-	VIEWCLUSTERSETTING       Kind = 17
-	CANCELQUERY              Kind = 18
-	NOSQLLOGIN               Kind = 19
-	EXECUTE                  Kind = 20
-	VIEWCLUSTERMETADATA      Kind = 21
-	VIEWDEBUG                Kind = 22
-	BACKUP                   Kind = 23
-	RESTORE                  Kind = 24
-	EXTERNALIOIMPLICITACCESS Kind = 25
-	CHANGEFEED               Kind = 26
+	// The first bit is reserved.
+	_ Kind = 1 << iota
+	ALL
+	CREATE
+	DROP
+	// GRANT was previously used for the GRANT privilege that has been replaced with the more granular Privilege.GrantOption.
+	_
+	SELECT
+	INSERT
+	DELETE
+	UPDATE
+	USAGE
+	ZONECONFIG
+	CONNECT
+	RULE
+	MODIFYCLUSTERSETTING
+	EXTERNALCONNECTION
+	VIEWACTIVITY
+	VIEWACTIVITYREDACTED
+	VIEWCLUSTERSETTING
+	CANCELQUERY
+	NOSQLLOGIN
+	EXECUTE
+	VIEWCLUSTERMETADATA
+	VIEWDEBUG
+	BACKUP
+	RESTORE
+	EXTERNALIOIMPLICITACCESS
+	CHANGEFEED
+)
+
+var (
+	// MinKind is used to iterate over Kinds.
+	MinKind = func() Kind {
+		keys := maps.Keys(_Kind_map)
+		min := Kind(math.MaxUint32)
+		for _, key := range keys {
+			if key < min {
+				min = key
+			}
+		}
+		return min
+	}()
+	// MaxKind is used to iterate over Kinds.
+	MaxKind = func() Kind {
+		keys := maps.Keys(_Kind_map)
+		max := Kind(0)
+		for _, key := range keys {
+			if key > max {
+				max = key
+			}
+		}
+		return max
+	}()
 )
 
 // Privilege represents a privilege parsed from an Access Privilege Inquiry
@@ -133,7 +161,7 @@ var (
 
 // Mask returns the bitmask for a given privilege.
 func (k Kind) Mask() uint32 {
-	return 1 << k
+	return uint32(k)
 }
 
 // IsSetIn returns true if this privilege kind is set in the supplied bitfield.
@@ -141,41 +169,14 @@ func (k Kind) IsSetIn(bits uint32) bool {
 	return bits&k.Mask() != 0
 }
 
-// ByValue is just an array of privilege kinds sorted by value.
-var ByValue = [...]Kind{
-	ALL, CREATE, DROP, SELECT, INSERT, DELETE, UPDATE, USAGE, ZONECONFIG, CONNECT, RULE,
-	MODIFYCLUSTERSETTING, EXTERNALCONNECTION, VIEWACTIVITY, VIEWACTIVITYREDACTED, VIEWCLUSTERSETTING,
-	CANCELQUERY, NOSQLLOGIN, EXECUTE, VIEWCLUSTERMETADATA, VIEWDEBUG, BACKUP,
-}
-
 // ByName is a map of string -> kind value.
-var ByName = map[string]Kind{
-	"ALL":                      ALL,
-	"CHANGEFEED":               CHANGEFEED,
-	"CONNECT":                  CONNECT,
-	"CREATE":                   CREATE,
-	"DROP":                     DROP,
-	"SELECT":                   SELECT,
-	"INSERT":                   INSERT,
-	"DELETE":                   DELETE,
-	"UPDATE":                   UPDATE,
-	"ZONECONFIG":               ZONECONFIG,
-	"USAGE":                    USAGE,
-	"RULE":                     RULE,
-	"MODIFYCLUSTERSETTING":     MODIFYCLUSTERSETTING,
-	"EXTERNALCONNECTION":       EXTERNALCONNECTION,
-	"VIEWACTIVITY":             VIEWACTIVITY,
-	"VIEWACTIVITYREDACTED":     VIEWACTIVITYREDACTED,
-	"VIEWCLUSTERSETTING":       VIEWCLUSTERSETTING,
-	"CANCELQUERY":              CANCELQUERY,
-	"NOSQLLOGIN":               NOSQLLOGIN,
-	"EXECUTE":                  EXECUTE,
-	"VIEWCLUSTERMETADATA":      VIEWCLUSTERMETADATA,
-	"VIEWDEBUG":                VIEWDEBUG,
-	"BACKUP":                   BACKUP,
-	"RESTORE":                  RESTORE,
-	"EXTERNALIOIMPLICITACCESS": EXTERNALIOIMPLICITACCESS,
-}
+var ByName = func() map[string]Kind {
+	m := make(map[string]Kind)
+	for k, v := range _Kind_map {
+		m[v] = k
+	}
+	return m
+}()
 
 // List is a list of privileges.
 type List []Kind


### PR DESCRIPTION
Informs https://github.com/cockroachdb/cockroach/issues/93612

privilege.Kind values are only ever used to bitshift (1<<kind).
Replace hard coded const values with the more idomatic 1<<iota.
Replace hard coded ByName mapping with function.

Release note: None