### PR TITLE
ui: preserve backwards compatibility for managed-service

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/recentStatementDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/recentStatementDetailsConnected.tsx
@@ -47,3 +47,11 @@ const mapDispatchToProps = (
 export const RecentStatementDetailsPageConnected = withRouter(
   connect(mapStateToProps, mapDispatchToProps)(RecentStatementDetails),
 );
+
+// Prior to 23.1, this component was called
+// ActiveStatementDetailsPageConnected. We keep the alias here to avoid
+// breaking the multi-version support in managed-service's console code.
+// When managed-service drops support for 22.2 (around the end of 2024?),
+// we can remove this code.
+export const ActiveStatementDetailsPageConnected =
+  RecentStatementDetailsPageConnected;

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/recentTransactionDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/recentTransactionDetailsConnected.tsx
@@ -45,3 +45,11 @@ const mapDispatchToProps = (
 export const RecentTransactionDetailsPageConnected = withRouter(
   connect(mapStateToProps, mapDispatchToProps)(RecentTransactionDetails),
 );
+
+// Prior to 23.1, this component was called
+// ActiveTransactionDetailsPageConnected. We keep the alias here to avoid
+// breaking the multi-version support in managed-service's console code.
+// When managed-service drops support for 22.2 (around the end of 2024?),
+// we can remove this code.
+export const ActiveTransactionDetailsPageConnected =
+  RecentTransactionDetailsPageConnected;


### PR DESCRIPTION
These components were renamed in #91860, but the support in managed-service for loading multiple versions of cluster-ui doesn't like it when we do that; it expects changes to be purely additive.

We choose here to provide aliases to the old names, rather than undoing the rename completely, so that we can eventually switch managed-service over to the new names once the old versions have fallen out of the support window.

Epic: none
Release note: None