### PR TITLE
kvcoord: improve slow range RPC logging

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -1555,6 +1555,7 @@ func slowRangeRPCWarningStr(
 	dur time.Duration,
 	attempts int64,
 	desc *roachpb.RangeDescriptor,
+	lease *roachpb.Lease,
 	err error,
 	br *roachpb.BatchResponse,
 ) {
@@ -1562,8 +1563,10 @@ func slowRangeRPCWarningStr(
 	if resp == nil {
 		resp = br
 	}
-	s.Printf("have been waiting %.2fs (%d attempts) for RPC %s to %s; resp: %s",
-		dur.Seconds(), attempts, ba, desc, resp)
+	s.Printf(
+		"have been waiting %.2fs (%d attempts) for RPC %s to %s (leaseholder: %s); resp: %s",
+		dur.Seconds(), attempts, ba, desc, lease.Replica, resp,
+	)
 }
 
 func slowRangeRPCReturnWarningStr(s *redact.StringBuilder, dur time.Duration, attempts int64) {
@@ -1672,11 +1675,11 @@ func (ds *DistSender) sendPartialBatch(
 		if dur := timeutil.Since(tBegin); dur > slowDistSenderThreshold && !tBegin.IsZero() {
 			{
 				var s redact.StringBuilder
-				slowRangeRPCWarningStr(&s, ba, dur, attempts, routingTok.Desc(), err, reply)
+				slowRangeRPCWarningStr(&s, ba, dur, attempts, routingTok.Desc(), routingTok.Lease(), err, reply)
 				log.Warningf(ctx, "slow range RPC: %v", &s)
 			}
 			// If the RPC wasn't successful, defer the logging of a message once the
-			// RPC is not retried any more.
+			// RPC is not retried anymore.
 			if err != nil || reply.Error != nil {
 				ds.metrics.SlowRPCs.Inc(1)
 				defer func(tBegin time.Time, attempts int64) {

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -4478,12 +4478,23 @@ func TestDistSenderSlowLogMessage(t *testing.T) {
 	ba.Add(get)
 	br := &roachpb.BatchResponse{}
 	br.Error = roachpb.NewError(errors.New("boom"))
-	desc := &roachpb.RangeDescriptor{RangeID: 9, StartKey: roachpb.RKey("x"), EndKey: roachpb.RKey("z")}
+	repl := roachpb.ReplicaDescriptor{
+		NodeID:    20,
+		StoreID:   20,
+		ReplicaID: 5,
+	}
+	desc := &roachpb.RangeDescriptor{
+		RangeID:          9,
+		StartKey:         roachpb.RKey("x"),
+		EndKey:           roachpb.RKey("z"),
+		InternalReplicas: []roachpb.ReplicaDescriptor{repl},
+	}
+	lease := &roachpb.Lease{Replica: repl}
 	{
 		exp := `have been waiting 8.16s (120 attempts) for RPC Get [‹"a"›,/Min) to` +
-			` r9:‹{x-z}› [<no replicas>, next=0, gen=0]; resp: ‹(err: boom)›`
+			` r9:‹{x-z}› [(n20,s20):5, next=0, gen=0] (leaseholder: (n20,s20):5); resp: ‹(err: boom)›`
 		var s redact.StringBuilder
-		slowRangeRPCWarningStr(&s, ba, dur, attempts, desc, nil /* err */, br)
+		slowRangeRPCWarningStr(&s, ba, dur, attempts, desc, lease, nil /* err */, br)
 		act := s.RedactableString()
 		require.EqualValues(t, exp, act)
 	}


### PR DESCRIPTION
This patch adds information about the DistSender's understanding of a range's leaseholder to the `slow range RPC`. This doesn't say much about the leaseholder information getting updated at a lower level (`sendToReplicas`) or which replicas were tried. However, its nice to have in the common case for when some node in the cluster is experiencing network problems.

Epic: none

Release note: None