### PR TITLE
sqlproxyccl: support cancel request after SSLRequest

### DIFF
--- a/pkg/ccl/sqlproxyccl/frontend_admitter_test.go
+++ b/pkg/ccl/sqlproxyccl/frontend_admitter_test.go
@@ -154,6 +154,7 @@ func TestFrontendAdmitWithCancel(t *testing.T) {
 	fe := FrontendAdmit(srv, nil)
 	require.NoError(t, fe.Err)
 	require.NotNil(t, fe.Conn)
+	require.NotNil(t, fe.CancelRequest)
 	require.Nil(t, fe.Msg)
 }
 
@@ -187,11 +188,9 @@ func TestFrontendAdmitWithSSLAndCancel(t *testing.T) {
 	tlsConfig, err := tlsConfig()
 	require.NoError(t, err)
 	fe := FrontendAdmit(srv, tlsConfig)
-	require.EqualError(t, fe.Err,
-		"codeUnexpectedStartupMessage: "+
-			"unsupported post-TLS startup message: *pgproto3.CancelRequest",
-	)
+	require.NoError(t, fe.Err)
 	require.NotNil(t, fe.Conn)
+	require.NotNil(t, fe.CancelRequest)
 	require.Nil(t, fe.Msg)
 }
 


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/93425

This supports the cancel request from more clients, and matches the behavior of the CRDB SQL server.

Release note: None