### PR TITLE
release-22.2: TEAMS: rename sql-experience to sql-sessions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -58,16 +58,16 @@
 /pkg/sql/show_create*.go     @cockroachdb/sql-syntax-prs
 /pkg/sql/types/              @cockroachdb/sql-syntax-prs
 
-/pkg/sql/crdb_internal.go    @cockroachdb/sql-experience
-/pkg/sql/pg_catalog.go       @cockroachdb/sql-experience
-/pkg/sql/pgwire/             @cockroachdb/sql-experience @cockroachdb/server-prs
-/pkg/sql/pgwire/auth.go      @cockroachdb/sql-experience @cockroachdb/server-prs @cockroachdb/prodsec
-/pkg/sql/sem/builtins/       @cockroachdb/sql-experience
-/pkg/sql/vtable/             @cockroachdb/sql-experience
+/pkg/sql/crdb_internal.go    @cockroachdb/sql-sessions
+/pkg/sql/pg_catalog.go       @cockroachdb/sql-sessions
+/pkg/sql/pgwire/             @cockroachdb/sql-sessions @cockroachdb/server-prs
+/pkg/sql/pgwire/auth.go      @cockroachdb/sql-sessions @cockroachdb/server-prs @cockroachdb/prodsec
+/pkg/sql/sem/builtins/       @cockroachdb/sql-sessions
+/pkg/sql/vtable/             @cockroachdb/sql-sessions
 
-/pkg/sql/sessiondata/        @cockroachdb/sql-experience
-/pkg/sql/tests/rsg_test.go   @cockroachdb/sql-experience
-/pkg/sql/ttl                 @cockroachdb/sql-experience
+/pkg/sql/sessiondata/        @cockroachdb/sql-sessions
+/pkg/sql/tests/rsg_test.go   @cockroachdb/sql-sessions
+/pkg/sql/ttl                 @cockroachdb/sql-sessions
 
 /pkg/ccl/schemachangerccl/   @cockroachdb/sql-schema
 /pkg/sql/catalog/            @cockroachdb/sql-schema
@@ -94,17 +94,17 @@
 /pkg/cli/userfile.go         @cockroachdb/disaster-recovery
 /pkg/cli/auth.go             @cockroachdb/unowned        @cockroachdb/prodsec @cockroachdb/cli-prs
 /pkg/cli/cert*.go            @cockroachdb/cli-prs        @cockroachdb/prodsec
-/pkg/cli/demo*.go            @cockroachdb/sql-experience @cockroachdb/server-prs @cockroachdb/cli-prs
-/pkg/cli/democluster         @cockroachdb/sql-experience @cockroachdb/server-prs @cockroachdb/cli-prs
+/pkg/cli/demo*.go            @cockroachdb/sql-sessions @cockroachdb/server-prs @cockroachdb/cli-prs
+/pkg/cli/democluster         @cockroachdb/sql-sessions @cockroachdb/server-prs @cockroachdb/cli-prs
 /pkg/cli/debug*.go           @cockroachdb/kv-prs         @cockroachdb/cli-prs
 /pkg/cli/debug_job_trace*.go @cockroachdb/jobs-prs
 /pkg/cli/doctor*.go          @cockroachdb/sql-schema     @cockroachdb/cli-prs
 /pkg/cli/import_test.go      @cockroachdb/disaster-recovery        @cockroachdb/cli-prs
-/pkg/cli/sql*.go             @cockroachdb/sql-experience @cockroachdb/cli-prs
-/pkg/cli/clisqlshell/        @cockroachdb/sql-experience @cockroachdb/cli-prs
-/pkg/cli/clisqlclient/       @cockroachdb/sql-experience @cockroachdb/cli-prs
-/pkg/cli/clisqlcfg/          @cockroachdb/sql-experience @cockroachdb/cli-prs
-/pkg/cli/clisqlexec/         @cockroachdb/sql-experience @cockroachdb/cli-prs
+/pkg/cli/sql*.go             @cockroachdb/sql-sessions @cockroachdb/cli-prs
+/pkg/cli/clisqlshell/        @cockroachdb/sql-sessions @cockroachdb/cli-prs
+/pkg/cli/clisqlclient/       @cockroachdb/sql-sessions @cockroachdb/cli-prs
+/pkg/cli/clisqlcfg/          @cockroachdb/sql-sessions @cockroachdb/cli-prs
+/pkg/cli/clisqlexec/         @cockroachdb/sql-sessions @cockroachdb/cli-prs
 /pkg/cli/start*.go           @cockroachdb/cli-prs        @cockroachdb/server-prs
 /pkg/cli/mt_proxy.go         @cockroachdb/sqlproxy-prs   @cockroachdb/server-prs
 /pkg/cli/mt_start_sql.go     @cockroachdb/sqlproxy-prs   @cockroachdb/server-prs
@@ -136,7 +136,7 @@
 /pkg/server/node_http*.go                @cockroachdb/obs-inf-prs @cockroachdb/server-prs
 /pkg/server/node_tenant*go               @cockroachdb/obs-inf-prs @cockroachdb/multi-tenant @cockroachdb/server-prs
 /pkg/server/node_tombstone*.go           @cockroachdb/kv-prs      @cockroachdb/server-prs
-/pkg/server/pgurl/                       @cockroachdb/sql-experience @cockroachdb/cli-prs
+/pkg/server/pgurl/                       @cockroachdb/sql-sessions @cockroachdb/cli-prs
 /pkg/server/server_http*.go              @cockroachdb/obs-inf-prs @cockroachdb/server-prs
 /pkg/server/server_import_ts*.go         @cockroachdb/obs-inf-prs @cockroachdb/kv-prs
 /pkg/server/serverpb/                    @cockroachdb/obs-inf-prs @cockroachdb/server-prs
@@ -191,7 +191,7 @@
 /pkg/gen/*.bzl               @cockroachdb/dev-inf-noreview
 /pkg/gen/gen.bzl             @cockroachdb/dev-inf
 
-/pkg/acceptance/             @cockroachdb/sql-experience
+/pkg/acceptance/             @cockroachdb/sql-sessions
 /pkg/base/                   @cockroachdb/unowned @cockroachdb/kv-prs @cockroachdb/server-prs
 /pkg/bench/                  @cockroachdb/sql-queries-noreview
 /pkg/bench/rttanalysis       @cockroachdb/sql-schema
@@ -223,30 +223,30 @@
 /pkg/ccl/testccl/workload/schemachange/ @cockroachdb/sql-schema
 /pkg/ccl/testutilsccl/       @cockroachdb/test-eng-noreview
 /pkg/ccl/utilccl/            @cockroachdb/unowned @cockroachdb/server-prs
-/pkg/ccl/workloadccl/        @cockroachdb/sql-experience-noreview
-/pkg/ccl/benchccl/rttanalysisccl/     @cockroachdb/sql-experience
+/pkg/ccl/workloadccl/        @cockroachdb/sql-sessions-noreview
+/pkg/ccl/benchccl/rttanalysisccl/     @cockroachdb/sql-schema
 /pkg/clusterversion/         @cockroachdb/kv-prs-noreview
 /pkg/cmd/allocsim/           @cockroachdb/kv-prs
 /pkg/cmd/bazci/              @cockroachdb/dev-inf
 /pkg/cmd/cloudupload/        @cockroachdb/dev-inf
 /pkg/cmd/cmdutil/            @cockroachdb/dev-inf
-/pkg/cmd/cmp-protocol/       @cockroachdb/sql-experience
-/pkg/cmd/cmp-sql/            @cockroachdb/sql-experience
-/pkg/cmd/cmpconn/            @cockroachdb/sql-experience
+/pkg/cmd/cmp-protocol/       @cockroachdb/sql-sessions
+/pkg/cmd/cmp-sql/            @cockroachdb/sql-sessions
+/pkg/cmd/cmpconn/            @cockroachdb/sql-sessions
 /pkg/cmd/cockroach/          @cockroachdb/cli-prs
 /pkg/cmd/cockroach-oss/      @cockroachdb/cli-prs
 /pkg/cmd/cockroach-short/    @cockroachdb/cli-prs
-/pkg/cmd/cockroach-sql/      @cockroachdb/sql-experience @cockroachdb/cli-prs
+/pkg/cmd/cockroach-sql/      @cockroachdb/sql-sessions @cockroachdb/cli-prs
 /pkg/cmd/compile-build/      @cockroachdb/dev-inf
-/pkg/cmd/cr2pg/              @cockroachdb/sql-experience
+/pkg/cmd/cr2pg/              @cockroachdb/sql-sessions
 /pkg/cmd/dev/                @cockroachdb/dev-inf
 /pkg/cmd/docgen/             @cockroachdb/docs
 /pkg/cmd/docs-issue-generation/ @cockroachdb/dev-inf
 /pkg/cmd/fuzz/               @cockroachdb/test-eng
-/pkg/cmd/generate-binary/    @cockroachdb/sql-experience
+/pkg/cmd/generate-binary/    @cockroachdb/sql-sessions
 /pkg/cmd/generate-distdir/ @cockroachdb/dev-inf
 /pkg/cmd/generate-logictest/       @cockroachdb/dev-inf
-/pkg/cmd/generate-metadata-tables/ @cockroachdb/sql-experience
+/pkg/cmd/generate-metadata-tables/ @cockroachdb/sql-sessions
 /pkg/cmd/generate-spatial-ref-sys/ @cockroachdb/geospatial
 /pkg/cmd/generate-bazel-extra/ @cockroachdb/dev-inf
 /pkg/cmd/generate-staticcheck/ @cockroachdb/dev-inf
@@ -277,7 +277,7 @@
 /pkg/cmd/roachtest/tests     @cockroachdb/test-eng-noreview
 /pkg/cmd/roachvet/           @cockroachdb/dev-inf
 /pkg/cmd/skip-test/          @cockroachdb/test-eng
-/pkg/cmd/skiperrs/           @cockroachdb/sql-experience
+/pkg/cmd/skiperrs/           @cockroachdb/sql-sessions
 /pkg/cmd/skipped-tests/      @cockroachdb/test-eng
 /pkg/cmd/smith/              @cockroachdb/sql-queries
 /pkg/cmd/smithcmp/           @cockroachdb/sql-queries
@@ -287,11 +287,11 @@
 /pkg/cmd/uptodate/           @cockroachdb/dev-inf
 /pkg/cmd/urlcheck/           @cockroachdb/docs
 /pkg/cmd/whoownsit/          @cockroachdb/test-eng
-/pkg/cmd/workload/           @cockroachdb/sql-experience-noreview
+/pkg/cmd/workload/           @cockroachdb/sql-sessions-noreview
 /pkg/cmd/wraprules/          @cockroachdb/obs-inf-prs-noreview
 /pkg/cmd/zerosum/            @cockroachdb/kv-noreview
 /pkg/col/                    @cockroachdb/sql-queries
-/pkg/compose/                @cockroachdb/sql-experience
+/pkg/compose/                @cockroachdb/sql-sessions
 /pkg/config/                 @cockroachdb/kv-prs @cockroachdb/server-prs
 /pkg/docs/                   @cockroachdb/docs
 /pkg/featureflag/            @cockroachdb/cli-prs-noreview
@@ -341,7 +341,7 @@
 /pkg/rpc/auth.go             @cockroachdb/unowned @cockroachdb/server-prs @cockroachdb/kv-prs @cockroachdb/prodsec
 /pkg/scheduledjobs/          @cockroachdb/jobs-prs
 /pkg/security/               @cockroachdb/unowned @cockroachdb/server-prs @cockroachdb/prodsec
-/pkg/security/clientsecopts/ @cockroachdb/unowned @cockroachdb/server-prs @cockroachdb/sql-experience @cockroachdb/prodsec
+/pkg/security/clientsecopts/ @cockroachdb/unowned @cockroachdb/server-prs @cockroachdb/sql-sessions @cockroachdb/prodsec
 /pkg/settings/               @cockroachdb/unowned
 /pkg/spanconfig/             @cockroachdb/kv-prs
 /pkg/startupmigrations/      @cockroachdb/unowned @cockroachdb/sql-schema
@@ -360,7 +360,7 @@
 /pkg/util/grunning/          @cockroachdb/kv-prs
 /pkg/util/admission/         @cockroachdb/kv-prs
 /pkg/util/tracing            @cockroachdb/obs-inf-prs
-/pkg/workload/               @cockroachdb/sql-experience-noreview
+/pkg/workload/               @cockroachdb/sql-sessions-noreview
 /pkg/obs/                    @cockroachdb/obs-inf-prs
 /pkg/obsservice/             @cockroachdb/obs-inf-prs
 

--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -19,13 +19,13 @@
 
 cockroachdb/docs:
   triage_column_id: 3971225
-cockroachdb/sql-experience:
+cockroachdb/sql-sessions:
   aliases:
     cockroachdb/sql-syntax-prs: other
     cockroachdb/sqlproxy-prs: other
     cockroachdb/sql-api-prs: other
   triage_column_id: 7259065
-  label: T-sql-experience
+  label: T-sql-sessions
 cockroachdb/sql-schema:
   triage_column_id: 8946818
 cockroachdb/sql-queries:

--- a/pkg/cmd/roachtest/registry/owners.go
+++ b/pkg/cmd/roachtest/registry/owners.go
@@ -16,7 +16,7 @@ type Owner string
 
 // The allowable values of Owner.
 const (
-	OwnerSQLExperience    Owner = `sql-experience`
+	OwnerSQLExperience    Owner = `sql-sessions`
 	OwnerDisasterRecovery Owner = `disaster-recovery`
 	OwnerCDC              Owner = `cdc`
 	OwnerKV               Owner = `kv`

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -14838,7 +14838,7 @@ interval_value:
     $$.val = &tree.CastExpr{
       Expr: tree.NewStrVal($2),
       Type: t,
-      // TODO(#sql-experience): This should be CastPrepend, but
+      // TODO(#sql-sessions): This should be CastPrepend, but
       // that does not work with parenthesized expressions
       // (using FmtAlwaysGroupExprs).
       SyntaxMode: tree.CastShort,
@@ -14856,7 +14856,7 @@ interval_value:
       Type: types.MakeInterval(
         types.IntervalTypeMetadata{Precision: prec, PrecisionIsSet: true},
       ),
-      // TODO(#sql-experience): This should be CastPrepend, but
+      // TODO(#sql-sessions): This should be CastPrepend, but
       // that does not work with parenthesized expressions
       // (using FmtAlwaysGroupExprs).
       SyntaxMode: tree.CastShort,

--- a/pkg/sql/sem/tree/constant.go
+++ b/pkg/sql/sem/tree/constant.go
@@ -345,7 +345,7 @@ func (expr *NumVal) ResolveAsType(
 			if strings.EqualFold(expr.origString, "NaN") {
 				// We need to check NaN separately since expr.value is
 				// unknownVal for NaN.
-				// TODO(sql-experience): unknownVal is also used for +Inf and
+				// TODO(sql-sessions): unknownVal is also used for +Inf and
 				// -Inf, so we may need to handle those in the future too.
 				expr.resFloat = DFloat(math.NaN())
 			} else {

--- a/pkg/util/tochar/tochar.go
+++ b/pkg/util/tochar/tochar.go
@@ -599,7 +599,6 @@ func (d dchSuffix) zeroPad2PlusNeg(val int) int {
 // parseFormat matches parse_format. We do not take in a flags like PG  as we only do
 // datetime related items (the logic here will change if we support numeric types).
 // Taken from https://github.com/postgres/postgres/blob/b0b72c64a0ce7bf5dd78a80b33d85c89c943ad0d/src/backend/utils/adt/formatting.c#L1146.
-// TODO(#sql-experience): consider caching parse formats.
 func parseFormat(f string) []formatNode {
 	var ret []formatNode
 	for len(f) > 0 {


### PR DESCRIPTION
Backport 1/1 commits from #93607.

/cc @cockroachdb/release

Release justification: non code changes

---

Epic: None
Release note: None
