### PR TITLE
release-22.1: TEAMS: rename sql-experience to sql-sessions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,15 +38,15 @@
 /pkg/sql/show_create*.go     @cockroachdb/sql-syntax-prs
 /pkg/sql/types/              @cockroachdb/sql-syntax-prs
 
-/pkg/sql/crdb_internal.go    @cockroachdb/sql-experience
-/pkg/sql/pg_catalog.go       @cockroachdb/sql-experience
-/pkg/sql/pgwire/             @cockroachdb/sql-experience
-/pkg/sql/sem/builtins/       @cockroachdb/sql-experience
-/pkg/sql/vtable/             @cockroachdb/sql-experience
+/pkg/sql/crdb_internal.go    @cockroachdb/sql-sessions
+/pkg/sql/pg_catalog.go       @cockroachdb/sql-sessions
+/pkg/sql/pgwire/             @cockroachdb/sql-sessions
+/pkg/sql/sem/builtins/       @cockroachdb/sql-sessions
+/pkg/sql/vtable/             @cockroachdb/sql-sessions
 
-/pkg/sql/sessiondata/        @cockroachdb/sql-experience
-/pkg/sql/tests/rsg_test.go   @cockroachdb/sql-experience
-/pkg/sql/ttl                 @cockroachdb/sql-experience
+/pkg/sql/sessiondata/        @cockroachdb/sql-sessions
+/pkg/sql/tests/rsg_test.go   @cockroachdb/sql-sessions
+/pkg/sql/ttl                 @cockroachdb/sql-sessions
 
 /pkg/ccl/schemachangerccl/   @cockroachdb/sql-schema
 /pkg/sql/catalog/            @cockroachdb/sql-schema
@@ -71,12 +71,12 @@
 /pkg/cli/                    @cockroachdb/cli-prs
 # last-rule-wins so bulk i/o takes userfile.go even though cli-prs takes pkg/cli
 /pkg/cli/userfile.go         @cockroachdb/disaster-recovery
-/pkg/cli/demo*.go            @cockroachdb/cli-prs @cockroachdb/sql-experience @cockroachdb/server-prs
+/pkg/cli/demo*.go            @cockroachdb/cli-prs @cockroachdb/sql-sessions @cockroachdb/server-prs
 /pkg/cli/debug*.go           @cockroachdb/cli-prs @cockroachdb/kv-prs
 /pkg/cli/debug_job_trace*.go @cockroachdb/disaster-recovery
 /pkg/cli/doctor*.go          @cockroachdb/cli-prs @cockroachdb/sql-schema
 /pkg/cli/import_test.go      @cockroachdb/cli-prs @cockroachdb/disaster-recovery
-/pkg/cli/sql*.go             @cockroachdb/cli-prs @cockroachdb/sql-experience
+/pkg/cli/sql*.go             @cockroachdb/cli-prs @cockroachdb/sql-sessions
 /pkg/cli/start*.go           @cockroachdb/cli-prs @cockroachdb/server-prs
 /pkg/cli/mt_proxy.go         @cockroachdb/sqlproxy-prs @cockroachdb/server-prs
 /pkg/cli/mt_start_sql.go     @cockroachdb/sqlproxy-prs @cockroachdb/server-prs
@@ -120,7 +120,7 @@
 
 /pkg/gen/                    @cockroachdb/dev-inf
 
-/pkg/acceptance/             @cockroachdb/sql-experience
+/pkg/acceptance/             @cockroachdb/sql-sessions
 /pkg/base/                   @cockroachdb/server-prs
 /pkg/bench/                  @cockroachdb/sql-queries-noreview
 /pkg/bench/rttanalysis       @cockroachdb/sql-schema
@@ -146,27 +146,27 @@
 /pkg/ccl/testccl/workload/schemachange/ @cockroachdb/sql-schema
 /pkg/ccl/testutilsccl/       @cockroachdb/test-eng-noreview
 /pkg/ccl/utilccl/            @cockroachdb/server-prs
-/pkg/ccl/workloadccl/        @cockroachdb/sql-experience-noreview
-/pkg/ccl/benchccl/rttanalysisccl/     @cockroachdb/sql-experience
+/pkg/ccl/workloadccl/        @cockroachdb/sql-sessions-noreview
+/pkg/ccl/benchccl/rttanalysisccl/     @cockroachdb/sql-schema
 /pkg/clusterversion/         @cockroachdb/kv-prs-noreview
 /pkg/cmd/allocsim/           @cockroachdb/kv-prs
 /pkg/cmd/bazci/              @cockroachdb/dev-inf
 /pkg/cmd/cmdutil/            @cockroachdb/dev-inf
-/pkg/cmd/cmp-protocol/       @cockroachdb/sql-experience
-/pkg/cmd/cmp-sql/            @cockroachdb/sql-experience
-/pkg/cmd/cmpconn/            @cockroachdb/sql-experience
+/pkg/cmd/cmp-protocol/       @cockroachdb/sql-sessions
+/pkg/cmd/cmp-sql/            @cockroachdb/sql-sessions
+/pkg/cmd/cmpconn/            @cockroachdb/sql-sessions
 /pkg/cmd/cockroach/          @cockroachdb/cli-prs
 /pkg/cmd/cockroach-oss/      @cockroachdb/cli-prs
 /pkg/cmd/cockroach-short/    @cockroachdb/cli-prs
 /pkg/cmd/compile-build/      @cockroachdb/dev-inf
-/pkg/cmd/cr2pg/              @cockroachdb/sql-experience
+/pkg/cmd/cr2pg/              @cockroachdb/sql-sessions
 /pkg/cmd/dev/                @cockroachdb/dev-inf
 /pkg/cmd/docgen/             @cockroachdb/docs
 /pkg/cmd/docs-issue-generation/ @cockroachdb/dev-inf
 /pkg/cmd/fuzz/               @cockroachdb/test-eng
-/pkg/cmd/generate-binary/    @cockroachdb/sql-experience
+/pkg/cmd/generate-binary/    @cockroachdb/sql-sessions
 /pkg/cmd/generate-distdir/ @cockroachdb/dev-inf
-/pkg/cmd/generate-metadata-tables/ @cockroachdb/sql-experience
+/pkg/cmd/generate-metadata-tables/ @cockroachdb/sql-sessions
 /pkg/cmd/generate-spatial-ref-sys/ @cockroachdb/geospatial
 /pkg/cmd/generate-test-suites/ @cockroachdb/dev-inf
 /pkg/cmd/generate-staticcheck/ @cockroachdb/dev-inf
@@ -196,7 +196,7 @@
 /pkg/cmd/roachtest/tests     @cockroachdb/test-eng-noreview
 /pkg/cmd/roachvet/           @cockroachdb/dev-inf
 /pkg/cmd/skip-test/          @cockroachdb/test-eng
-/pkg/cmd/skiperrs/           @cockroachdb/sql-experience
+/pkg/cmd/skiperrs/           @cockroachdb/sql-sessions
 /pkg/cmd/skipped-tests/      @cockroachdb/test-eng
 /pkg/cmd/smithcmp/           @cockroachdb/sql-queries
 /pkg/cmd/smithtest/          @cockroachdb/sql-queries
@@ -205,11 +205,11 @@
 /pkg/cmd/uptodate/           @cockroachdb/dev-inf
 /pkg/cmd/urlcheck/           @cockroachdb/docs
 /pkg/cmd/whoownsit/          @cockroachdb/test-eng
-/pkg/cmd/workload/           @cockroachdb/sql-experience-noreview
+/pkg/cmd/workload/           @cockroachdb/sql-sessions-noreview
 /pkg/cmd/wraprules/          @cockroachdb/obs-inf-prs-noreview
 /pkg/cmd/zerosum/            @cockroachdb/kv-noreview
 /pkg/col/                    @cockroachdb/sql-queries
-/pkg/compose/                @cockroachdb/sql-experience
+/pkg/compose/                @cockroachdb/sql-sessions
 /pkg/config/                 @cockroachdb/server-prs
 /pkg/docs/                   @cockroachdb/docs
 /pkg/featureflag/            @cockroachdb/cli-prs-noreview
@@ -272,7 +272,7 @@
 /pkg/util/metric             @cockroachdb/obs-inf-prs
 /pkg/util/stop               @cockroachdb/server-prs
 /pkg/util/tracing            @cockroachdb/obs-inf-prs
-/pkg/workload/               @cockroachdb/sql-experience-noreview
+/pkg/workload/               @cockroachdb/sql-sessions-noreview
 
 # Allow the security team to have insight into changes to
 # authn/authz code.
@@ -280,7 +280,6 @@
 /pkg/cli/auth.go                       @cockroachdb/prodsec
 /pkg/rpc/auth.go                       @cockroachdb/prodsec
 /pkg/sql/pgwire/auth.go                @cockroachdb/prodsec
-
 
 # Own all bazel files to dev-inf, but don't request reviews for them
 # as they are mostly - but not only - generated code that changes with

--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -19,13 +19,13 @@
 
 cockroachdb/docs:
   triage_column_id: 3971225
-cockroachdb/sql-experience:
+cockroachdb/sql-sessions:
   aliases:
     cockroachdb/sql-syntax-prs: other
     cockroachdb/sqlproxy-prs: other
     cockroachdb/sql-api-prs: other
   triage_column_id: 7259065
-  label: T-sql-experience
+  label: T-sql-sessions
 cockroachdb/sql-schema:
   triage_column_id: 8946818
 cockroachdb/sql-queries:

--- a/pkg/cmd/roachtest/registry/owners.go
+++ b/pkg/cmd/roachtest/registry/owners.go
@@ -16,7 +16,7 @@ type Owner string
 
 // The allowable values of Owner.
 const (
-	OwnerSQLExperience    Owner = `sql-experience`
+	OwnerSQLExperience    Owner = `sql-sessions`
 	OwnerDisasterRecovery Owner = `disaster-recovery`
 	OwnerCDC              Owner = `cdc`
 	OwnerKV               Owner = `kv`

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -13697,7 +13697,7 @@ interval_value:
     $$.val = &tree.CastExpr{
       Expr: tree.NewStrVal($2),
       Type: t,
-      // TODO(#sql-experience): This should be CastPrepend, but
+      // TODO(#sql-sessions): This should be CastPrepend, but
       // that does not work with parenthesized expressions
       // (using FmtAlwaysGroupExprs).
       SyntaxMode: tree.CastShort,
@@ -13715,7 +13715,7 @@ interval_value:
       Type: types.MakeInterval(
         types.IntervalTypeMetadata{Precision: prec, PrecisionIsSet: true},
       ),
-      // TODO(#sql-experience): This should be CastPrepend, but
+      // TODO(#sql-sessions): This should be CastPrepend, but
       // that does not work with parenthesized expressions
       // (using FmtAlwaysGroupExprs).
       SyntaxMode: tree.CastShort,

--- a/pkg/sql/sem/tree/constant.go
+++ b/pkg/sql/sem/tree/constant.go
@@ -309,7 +309,7 @@ func (expr *NumVal) ResolveAsType(
 	case types.FloatFamily:
 		if strings.EqualFold(expr.origString, "NaN") {
 			// We need to check NaN separately since expr.value is unknownVal for NaN.
-			// TODO(sql-experience): unknownVal is also used for +Inf and -Inf,
+			// TODO(sql-sessions): unknownVal is also used for +Inf and -Inf,
 			// so we may need to handle those in the future too.
 			expr.resFloat = DFloat(math.NaN())
 		} else {


### PR DESCRIPTION
Backport 1/1 commits from #93607.

/cc @cockroachdb/release

Release justification: non code changes

---

Epic: None
Release note: None
