### PR TITLE
server: don't return ErrInvalidTenant on failed query

### DIFF
--- a/pkg/server/server_controller.go
+++ b/pkg/server/server_controller.go
@@ -469,7 +469,7 @@ func (s *Server) newServerForTenant(
 	datums, err := ie.QueryRow(ctx, "get-tenant-id", nil, /* txn */
 		`SELECT id, active FROM system.tenants WHERE name = $1 LIMIT 1`, tenantName)
 	if err != nil {
-		return nil, errors.Mark(err, ErrInvalidTenant)
+		return nil, err
 	}
 	if datums == nil {
 		return nil, errors.Mark(errors.Newf("no tenant found with name %q", tenantName), ErrInvalidTenant)


### PR DESCRIPTION
This error seems intended to have a specific meaning, but we were returning it on a generic query failure.

Release note: None
Epic: None