### PR TITLE
acceptance: pre-build docker images used by compose

### DIFF
--- a/pkg/acceptance/compose/gss/README.md
+++ b/pkg/acceptance/compose/gss/README.md
@@ -1,0 +1,8 @@
+## Updating the `kdc`/`psql`/`python` images
+
+- (One-time setup) Depending on how your Docker instance is configured, you may have to run `docker run --privileged --rm tonistiigi/binfmt --install all`. This will install `qemu` emulators on your system for platforms besides your native one.
+- Build the image for both platforms and publish the cross-platform manifest. Note that the non-native build for your image will be very slow since it will have to emulate.
+```
+    ./build-push-gss.sh kdc
+```
+- Pass `python` or `psql` instead of `kdc` if that's what you need.

--- a/pkg/acceptance/compose/gss/build-push-gss.sh
+++ b/pkg/acceptance/compose/gss/build-push-gss.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -xeuo pipefail
+
+TARGET=$1
+TAG=$(date +%Y%m%d-%H%M%S)
+docker buildx create --use
+docker buildx build --push --platform linux/amd64,linux/arm64 -t cockroachdb/acceptance-gss-$TARGET:$TAG ./$TARGET

--- a/pkg/acceptance/compose/gss/docker-compose-python.yml
+++ b/pkg/acceptance/compose/gss/docker-compose-python.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   kdc:
-    build: ./kdc
+    image: cockroachdb/acceptance-gss-kdc:20221214-131000
     volumes:
       - ./kdc/start.sh:/start.sh
       - keytab:/keytab
@@ -17,7 +17,7 @@ services:
       - keytab:/keytab
       - ${COCKROACH_BINARY:-../../../../cockroach-linux-2.6.32-gnu-amd64}:/cockroach/cockroach
   python:
-    build: ./python
+    image: cockroachdb/acceptance-gss-python:20221214-141947
     user: "${UID}:${GID}"
     depends_on:
       - cockroach

--- a/pkg/acceptance/compose/gss/docker-compose.yml
+++ b/pkg/acceptance/compose/gss/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   kdc:
-    build: ./kdc
+    image: cockroachdb/acceptance-gss-kdc:20221214-131000
     volumes:
       - ./kdc/start.sh:/start.sh
       - keytab:/keytab
@@ -17,7 +17,7 @@ services:
       - keytab:/keytab
       - ${COCKROACH_BINARY:-../../../../cockroach-linux-2.6.32-gnu-amd64}:/cockroach/cockroach
   psql:
-    build: ./psql
+    image: cockroachdb/acceptance-gss-psql:20221215-102339
     user: "${UID}:${GID}"
     depends_on:
       - cockroach

--- a/pkg/acceptance/compose/gss/psql/Dockerfile
+++ b/pkg/acceptance/compose/gss/psql/Dockerfile
@@ -6,7 +6,7 @@ RUN go test -v -c -tags gss_compose -o gss.test
 
 # Copy the test binary to an image with psql and krb installed.
 FROM postgres:15
-
+ARG TARGETPLATFORM
 RUN apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
   ca-certificates \
@@ -15,18 +15,16 @@ RUN apt-get update && \
 
 COPY --from=builder /workspace/gss.test .
 
-# This Dockerfile is only used by docker-compose and built on-demand on the same architecture so it is safe
-# to assume the target arch based on the host arch.
-RUN ARCH=`uname -m`; \
-    if [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ]; then \
-      curl -fsSL "https://github.com/benesch/autouseradd/releases/download/1.3.0/autouseradd-1.3.0-arm64.tar.gz" -o autouseradd.tar.gz && \
-      SHASUM=b216bebfbe30c3c156144cff07233654e23025e26ab5827058c9b284e130599e; \
-    else \
-      curl -fsSL "https://github.com/benesch/autouseradd/releases/download/1.3.0/autouseradd-1.3.0-amd64.tar.gz" -o autouseradd.tar.gz && \
-      SHASUM=442dae58b727a79f81368127fac141d7f95501ffa05f8c48943d27c4e807deb7; \
-    fi; \
-    echo "$SHASUM autouseradd.tar.gz" | sha256sum -c -; \
-    tar xzf autouseradd.tar.gz --strip-components 1; \
-    rm autouseradd.tar.gz;
+RUN \
+if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+  curl -fsSL "https://github.com/benesch/autouseradd/releases/download/1.3.0/autouseradd-1.3.0-arm64.tar.gz" -o autouseradd.tar.gz && \
+  SHASUM=b216bebfbe30c3c156144cff07233654e23025e26ab5827058c9b284e130599e; \
+else \
+  curl -fsSL "https://github.com/benesch/autouseradd/releases/download/1.3.0/autouseradd-1.3.0-amd64.tar.gz" -o autouseradd.tar.gz && \
+  SHASUM=442dae58b727a79f81368127fac141d7f95501ffa05f8c48943d27c4e807deb7; \
+fi; \
+echo "$SHASUM autouseradd.tar.gz" | sha256sum -c -; \
+tar xzf autouseradd.tar.gz --strip-components 1; \
+rm autouseradd.tar.gz;
 
 ENTRYPOINT ["autouseradd", "--user", "roach", "--no-create-home", "/start.sh"]

--- a/pkg/acceptance/compose/gss/python/Dockerfile
+++ b/pkg/acceptance/compose/gss/python/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.10
+ARG TARGETPLATFORM
 ENV PYTHONUNBUFFERED 1
 
 RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
@@ -9,19 +10,17 @@ RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-k
   krb5-user \
   postgresql-client-11
 
-# This Dockerfile is only used by docker-compose and built on-demand on the same architecture so it is safe
-# to assume the target arch based on the host arch.
-RUN ARCH=`uname -m`; \
-    if [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ]; then \
-      curl -fsSL "https://github.com/benesch/autouseradd/releases/download/1.3.0/autouseradd-1.3.0-arm64.tar.gz" -o autouseradd.tar.gz && \
-      SHASUM=b216bebfbe30c3c156144cff07233654e23025e26ab5827058c9b284e130599e; \
-    else \
-      curl -fsSL "https://github.com/benesch/autouseradd/releases/download/1.3.0/autouseradd-1.3.0-amd64.tar.gz" -o autouseradd.tar.gz && \
-      SHASUM=442dae58b727a79f81368127fac141d7f95501ffa05f8c48943d27c4e807deb7; \
-    fi; \
-    echo "$SHASUM autouseradd.tar.gz" | sha256sum -c -; \
-    tar xzf autouseradd.tar.gz --strip-components 1; \
-    rm autouseradd.tar.gz;
+RUN \
+if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+  curl -fsSL "https://github.com/benesch/autouseradd/releases/download/1.3.0/autouseradd-1.3.0-arm64.tar.gz" -o autouseradd.tar.gz && \
+  SHASUM=b216bebfbe30c3c156144cff07233654e23025e26ab5827058c9b284e130599e; \
+else \
+  curl -fsSL "https://github.com/benesch/autouseradd/releases/download/1.3.0/autouseradd-1.3.0-amd64.tar.gz" -o autouseradd.tar.gz && \
+  SHASUM=442dae58b727a79f81368127fac141d7f95501ffa05f8c48943d27c4e807deb7; \
+fi; \
+echo "$SHASUM autouseradd.tar.gz" | sha256sum -c -; \
+tar xzf autouseradd.tar.gz --strip-components 1; \
+rm autouseradd.tar.gz;
 
 RUN mkdir /code
 WORKDIR /code

--- a/pkg/acceptance/testdata/README.md
+++ b/pkg/acceptance/testdata/README.md
@@ -12,18 +12,14 @@ dependency on an external package repository into our CI pipeline. That means
 that if you update a language's dependencies (e.g., `node/package.json`), you'll
 need to update the image.
 
-To build a new acceptance image:
+## Updating the `acceptance` image
 
-```bash
-$ docker build -t cockroachdb/acceptance .
+- (One-time setup) Depending on how your Docker instance is configured, you may have to run `docker run --privileged --rm tonistiigi/binfmt --install all`. This will install `qemu` emulators on your system for platforms besides your native one.
+- Build the image for both platforms and publish the cross-platform manifest. Note that the non-native build for your image will be very slow since it will have to emulate.
 ```
-
-To push the just-built acceptance image to the registry:
-
-```bash
-$ version=$(date +%Y%m%d-%H%M%S)
-$ docker tag cockroachdb/acceptance cockroachdb/acceptance:$version
-$ docker push cockroachdb/acceptance:$version
+    TAG=$(date +%Y%m%d-%H%M%S)
+    docker buildx create --use
+    docker buildx build --push --platform linux/amd64,linux/arm64 -t cockroachdb/acceptance:$TAG .
 ```
 
 No need to have your changes reviewed before you push an image, as we pin the


### PR DESCRIPTION
This change involved creating new dockerhub repos
for the changed images and pre building them instead of building them while testing. This makes acceptance tests in CI more stable.

Release note: None
Epic: none