### PR TITLE
kv/bulk: use estimated file size to limit batch sizes

### DIFF
--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -310,6 +310,11 @@ func (fw *SSTWriter) put(key MVCCKey, value []byte) error {
 	return fw.fw.Set(fw.scratch, value)
 }
 
+// EstimatedSize returns the value of sstable.Writer.EstimatedSize.
+func (fw *SSTWriter) EstimatedSize() int64 {
+	return int64(fw.fw.EstimatedSize())
+}
+
 // ApplyBatchRepr implements the Writer interface.
 func (fw *SSTWriter) ApplyBatchRepr(repr []byte, sync bool) error {
 	panic("unimplemented")


### PR DESCRIPTION
Previously we would impose the kv.bulk_ingest.batch_size limit of 16MiB on the amount of logical data added to the SST being sent in the batch. However this often ends up causing batches to be significantly smaller than 16MiB, due to data such as index entries compressing extremely well resulting in an SST containing 16MiB of logical data being as small as 2MiB in many cases, causing batches to be sent well before they need to be. The SST size, not the size of its content, it what determines the request size in memory, so we can can limit based on their actual rather than logical content size. Doing so is expected to have benefits beyond simply sending bigger requests to dodge some per-request fixed overhead, such as reducing the number of individual files added to the LSM by adding larger files, making smaller pebble manifests after sustained non-overlapping ingestion (overlapping ingestion would trigger compactions that combine these small files in the process, however non-overlapping ingestion using many tiny files can leave all those files in L6 indefinitely).

Release note: none.
Epic: none.