### PR TITLE
sql: implement pg_get_function_arguments

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -3446,6 +3446,8 @@ table. Returns an error if validation fails.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="pg_function_is_visible"></a><code>pg_function_is_visible(oid: oid) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether the function with the given OID belongs to one of the schemas on the search path.</p>
 </span></td><td>Stable</td></tr>
+<tr><td><a name="pg_get_function_arguments"></a><code>pg_get_function_arguments(func_oid: oid) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the argument list (with defaults) necessary to identify a function, in the form it would need to appear in within CREATE FUNCTION.</p>
+</span></td><td>Stable</td></tr>
 <tr><td><a name="pg_get_function_identity_arguments"></a><code>pg_get_function_identity_arguments(func_oid: oid) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the argument list (without defaults) necessary to identify a function, in the form it would need to appear in within ALTER FUNCTION, for instance.</p>
 </span></td><td>Stable</td></tr>
 <tr><td><a name="pg_get_function_result"></a><code>pg_get_function_result(func_oid: oid) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the types of the result of the specified function.</p>

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -2628,6 +2628,28 @@ SELECT pg_type_is_visible('int'::regtype), pg_type_is_visible(NULL), pg_type_is_
 ----
 true  NULL  NULL
 
+# Sanity check pg_get_function_arguments.
+query T
+SELECT pg_get_function_arguments('convert_from'::regproc::oid)
+----
+bytea, text
+
+# This produces an empty string in Postgres too.
+query T
+SELECT pg_get_function_arguments('version'::regproc::oid)
+----
+·
+
+query T
+SELECT pg_get_function_arguments('array_length'::regproc)
+----
+anyarray, int8
+
+query T
+SELECT pg_get_function_arguments((select oid from pg_proc where proname='variance' and proargtypes[0] = 'int'::regtype))
+----
+int8
+
 # Sanity check pg_get_function_identity_arguments.
 query T
 SELECT pg_get_function_identity_arguments('convert_from'::regproc::oid)

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -1220,6 +1220,7 @@ var builtinOidsBySignature = map[string]oid.Oid{
 	`pg_get_expr(pg_node_tree: string, relation_oid: oid) -> string`:                                    1403,
 	`pg_get_expr(pg_node_tree: string, relation_oid: oid, pretty_bool: bool) -> string`:                 1404,
 	`pg_get_functiondef(func_oid: oid) -> string`:                                                       2035,
+	`pg_get_function_arguments(func_oid: oid) -> string`:                                                2060,
 	`pg_get_function_identity_arguments(func_oid: oid) -> string`:                                       1409,
 	`pg_get_function_result(func_oid: oid) -> string`:                                                   1408,
 	`pg_get_indexdef(index_oid: oid) -> string`:                                                         1410,


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/91073

Release note (sql change): Added the pg_get_function_arguments builtin
function. This returns the argument list (with defaults) necessary to
identify the function with a given OID.