### PR TITLE
release-22.1: sql: fix internal error when planning void IS NULL or void is NOT NULL

### DIFF
--- a/docs/generated/sql/operators.md
+++ b/docs/generated/sql/operators.md
@@ -446,9 +446,11 @@
 <tr><td>timetz <code>IS NOT DISTINCT FROM</code> timetz</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td>tuple <code>IS NOT DISTINCT FROM</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td>unknown <code>IS NOT DISTINCT FROM</code> unknown</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td>unknown <code>IS NOT DISTINCT FROM</code> void</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="uuid.html">uuid</a> <code>IS NOT DISTINCT FROM</code> <a href="uuid.html">uuid</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="uuid.html">uuid[]</a> <code>IS NOT DISTINCT FROM</code> <a href="uuid.html">uuid[]</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td>varbit <code>IS NOT DISTINCT FROM</code> varbit</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td>void <code>IS NOT DISTINCT FROM</code> unknown</td><td><a href="bool.html">bool</a></td></tr>
 </tbody></table>
 <table><thead>
 <tr><td><code>LIKE</code></td><td>Return</td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/void
+++ b/pkg/sql/logictest/testdata/logic_test/void
@@ -25,3 +25,39 @@ query T
 SELECT crdb_internal.void_func()
 ----
 ·
+
+# Regression test for #83754. Note that Postgres is inconsistent
+# in evaluation. For example, `SELECT ''::VOID IS DISTINCT FROM NULL::UNKNOWN;`
+# errors out, but `SELECT ''::VOID IS DISTINCT FROM NULL;` does not.
+# This is due to normalization into an IS NOT NULL op when one operand is NULL.
+# The NULL with type cast is not recognized as NULL.
+query B
+SELECT ''::VOID IS DISTINCT FROM NULL
+----
+true
+
+query B
+SELECT ''::VOID IS DISTINCT FROM NULL::UNKNOWN
+----
+true
+
+# Regression test for #93572. This should not fail with an internal error.
+query B
+WITH tab(x) AS (VALUES (''::VOID)) SELECT x IS NULL FROM tab
+----
+false
+
+query B
+WITH tab(x) AS (VALUES (NULL::VOID)) SELECT x IS NULL FROM tab
+----
+true
+
+query B
+WITH tab(x) AS (VALUES (''::VOID)) SELECT x IS NOT NULL FROM tab
+----
+true
+
+query B
+WITH tab(x) AS (VALUES (NULL::VOID)) SELECT x IS NOT NULL FROM tab
+----
+false


### PR DESCRIPTION
Backport 1/1 commits from #93652.

/cc @cockroachdb/release

---

This commit adds support for comparisons between columns of type void and NULL using `col IS NULL` or `col IS NOT NULL`, by adding an explicit overload.

Fixes #93572
Fixes #93710

Release note (bug fix): Fixed an internal error that could occur when comparing a column of type void to NULL using `col IS NULL` or `col IS NOT NULL`.

----

Release justification: low risk bug fix