### PR TITLE
sql: fix volatility of <void> IS NOT DISTINCT FROM <unknown>

### DIFF
--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -1734,8 +1734,8 @@ var CmpOps = cmpOpFixups(map[treecmp.ComparisonOperatorSymbol]*CmpOpOverloads{
 		// not occur. Therefore, to allow the comparison
 		// `''::VOID IS DISTINCT FROM NULL`, an explicit equivalence with Unknown is
 		// added:
-		makeIsFn(types.Void, types.Unknown, volatility.Stable),
-		makeIsFn(types.Unknown, types.Void, volatility.Stable),
+		makeIsFn(types.Void, types.Unknown, volatility.Leakproof),
+		makeIsFn(types.Unknown, types.Void, volatility.Leakproof),
 
 		// Tuple comparison.
 		{


### PR DESCRIPTION
The volatility should be leakproof, not stable. This was an oversight in #93652.

Epic: None
Release note: None