### PR TITLE
roachtest: increase tpccbench warehouses

### DIFF
--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -836,8 +836,8 @@ func registerTPCC(r registry.Registry) {
 		Nodes: 12,
 		CPUs:  16,
 
-		LoadWarehouses: gceOrAws(cloud, 10000, 10000),
-		EstimatedMax:   gceOrAws(cloud, 8350, 8000),
+		LoadWarehouses: gceOrAws(cloud, 11500, 11500),
+		EstimatedMax:   gceOrAws(cloud, 10000, 10000),
 
 		Tags: []string{`weekly`},
 	})
@@ -846,8 +846,8 @@ func registerTPCC(r registry.Registry) {
 		CPUs:         16,
 		Distribution: multiZone,
 
-		LoadWarehouses: 5000,
-		EstimatedMax:   2500,
+		LoadWarehouses: 6500,
+		EstimatedMax:   5000,
 	})
 	registerTPCCBenchSpec(r, tpccBenchSpec{
 		Nodes:        9,


### PR DESCRIPTION
tpccbench/nodes=12/cpu=16 and tpccbench/nodes=6/cpu=16/multi-az max warehouses is now consistently at the number of loaded warehouses. This patch increases the loaded warehouses and estimated maximum.

resolves #93715

Release note: None