### PR TITLE
sql/logictest: fix flake in TestLogic_distinct_on

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distinct_on
+++ b/pkg/sql/logictest/testdata/logic_test/distinct_on
@@ -393,16 +393,15 @@ INSERT INTO author VALUES
   (5, 'Eve', 'Crime'),
   (6, 'Bart', null);
 
-query ITT
+query T
 SELECT
-  DISTINCT ON ("genre") *
+  DISTINCT ON ("genre") genre
 FROM
   "public"."author"
 ORDER BY
-  "genre" ASC NULLS LAST,
-  "id" ASC NULLS LAST
+  "genre" ASC NULLS LAST
 ----
-1  Alice  Action
-2  Bob    Biography
-3  Carol  Crime
-6  Bart   NULL
+Action
+Biography
+Crime
+NULL


### PR DESCRIPTION
Make sure the query results are deterministic.

Fixes #93719

Release note: None