### PR TITLE
nstree: fix Catalog namespace validation error messages

### DIFF
--- a/pkg/cli/testdata/doctor/test_examine_zipdir
+++ b/pkg/cli/testdata/doctor/test_examine_zipdir
@@ -9,7 +9,7 @@ Examining 37 descriptors and 42 namespace entries...
   ParentID  52, ParentSchemaID 29: relation "vehicle_location_histories" (56): referenced database ID 52: referenced descriptor not found
   ParentID  52, ParentSchemaID 29: relation "promo_codes" (57): referenced database ID 52: referenced descriptor not found
   ParentID  52, ParentSchemaID 29: relation "user_promo_codes" (58): referenced database ID 52: referenced descriptor not found
-  ParentID   0, ParentSchemaID  0: namespace entry "movr" (52): descriptor not found
+  ParentID   0, ParentSchemaID  0: namespace entry "movr" (52): referenced descriptor not found
 Examining 2 jobs...
 job 587337426984566785: running schema change GC refers to missing table descriptor(s) [59]; existing descriptors that still need to be dropped []; job safe to delete: true.
 ERROR: validation failed

--- a/pkg/cli/testdata/doctor/test_examine_zipdir_verbose
+++ b/pkg/cli/testdata/doctor/test_examine_zipdir_verbose
@@ -50,7 +50,7 @@ Examining 37 descriptors and 42 namespace entries...
   ParentID  52, ParentSchemaID 29: relation "user_promo_codes" (58): referenced database ID 52: referenced descriptor not found
   ParentID  52, ParentSchemaID 29: relation "user_promo_codes" (58): processed
   ParentID   0, ParentSchemaID  0: namespace entry "defaultdb" (50): processed
-  ParentID   0, ParentSchemaID  0: namespace entry "movr" (52): descriptor not found
+  ParentID   0, ParentSchemaID  0: namespace entry "movr" (52): referenced descriptor not found
   ParentID   0, ParentSchemaID  0: namespace entry "postgres" (51): processed
   ParentID   0, ParentSchemaID  0: namespace entry "system" (1): processed
   ParentID   1, ParentSchemaID  0: namespace entry "public" (29): processed

--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -499,9 +499,9 @@ UPDATE system.namespace SET id = %d WHERE id = %d;
 		{fmt.Sprintf("%d", schemaID), fmt.Sprintf("[%d]", databaseID), "public", "",
 			fmt.Sprintf(`schema "public" (%d): referenced database ID %d: referenced descriptor not found`, schemaID, databaseID),
 		},
-		{fmt.Sprintf("%d", databaseID), "t", "", "", `descriptor not found`},
-		{fmt.Sprintf("%d", tableFkTblID), "defaultdb", "public", "fktbl", `descriptor not found`},
-		{fmt.Sprintf("%d", fakeID), fmt.Sprintf("[%d]", databaseID), "public", "test", `descriptor not found`},
+		{fmt.Sprintf("%d", databaseID), "t", "", "", `referenced descriptor not found`},
+		{fmt.Sprintf("%d", tableFkTblID), "defaultdb", "public", "fktbl", `referenced descriptor not found`},
+		{fmt.Sprintf("%d", fakeID), fmt.Sprintf("[%d]", databaseID), "public", "test", `referenced descriptor not found`},
 	})
 }
 

--- a/pkg/sql/doctor/doctor_test.go
+++ b/pkg/sql/doctor/doctor_test.go
@@ -243,7 +243,7 @@ func TestExamineDescriptors(t *testing.T) {
 			},
 			expected: `Examining 2 descriptors and 2 namespace entries...
   ParentID  52, ParentSchemaID 29: relation "t" (51): expected matching namespace entry, found none
-  ParentID   0, ParentSchemaID 29: namespace entry "t" (51): no matching name info found in non-dropped relation "t"
+  ParentID   0, ParentSchemaID 29: namespace entry "t" (51): mismatched name "t" in relation descriptor
 `,
 		},
 		{ // 8
@@ -372,7 +372,7 @@ func TestExamineDescriptors(t *testing.T) {
 				{NameInfo: descpb.NameInfo{Name: "causes_error"}, ID: 2},
 			},
 			expected: `Examining 0 descriptors and 4 namespace entries...
-  ParentID   0, ParentSchemaID  0: namespace entry "causes_error" (2): descriptor not found
+  ParentID   0, ParentSchemaID  0: namespace entry "causes_error" (2): referenced descriptor not found
 `,
 		},
 		{ // 14
@@ -380,7 +380,7 @@ func TestExamineDescriptors(t *testing.T) {
 				{NameInfo: descpb.NameInfo{Name: "null"}, ID: int64(descpb.InvalidID)},
 			},
 			expected: `Examining 0 descriptors and 1 namespace entries...
-  ParentID   0, ParentSchemaID  0: namespace entry "null" (0): invalid descriptor ID
+  ParentID   0, ParentSchemaID  0: namespace entry "null" (0): invalid namespace entry
 `,
 		},
 		{ // 15
@@ -415,7 +415,7 @@ func TestExamineDescriptors(t *testing.T) {
 				{NameInfo: descpb.NameInfo{Name: "db"}, ID: 52},
 			},
 			expected: `Examining 2 descriptors and 2 namespace entries...
-  ParentID  52, ParentSchemaID 29: namespace entry "t" (51): no matching name info in draining names of dropped relation
+  ParentID  52, ParentSchemaID 29: namespace entry "t" (51): descriptor is being dropped
 `,
 		},
 		{ // 17

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -1025,10 +1025,10 @@ query ITTTT colnames
 SELECT * FROM "".crdb_internal.invalid_objects
 ----
 id   database_name  schema_name  obj_name  error
-500  baddb          ·            ·         descriptor not found
-501  system         badschema    ·         descriptor not found
-502  system         public       badobj    descriptor not found
-503  system         [404]        badobj    descriptor not found
+500  baddb          ·            ·         referenced descriptor not found
+501  system         badschema    ·         referenced descriptor not found
+502  system         public       badobj    referenced descriptor not found
+503  system         [404]        badobj    referenced descriptor not found
 
 statement ok
 SELECT crdb_internal.unsafe_delete_namespace_entry(0, 0, 'baddb', 500, true);

--- a/pkg/upgrade/upgrades/precondition_before_starting_an_upgrade_external_test.go
+++ b/pkg/upgrade/upgrades/precondition_before_starting_an_upgrade_external_test.go
@@ -119,7 +119,7 @@ func TestPreconditionBeforeStartingAnUpgrade(t *testing.T) {
 		require.Error(t, err, "upgrade should be refused because precondition is violated.")
 		require.Equal(t, "pq: verifying precondition for version 22.1-2: "+
 			"there exists invalid descriptors as listed below; fix these descriptors before attempting to upgrade again:\n"+
-			"invalid descriptor: defaultdb.public.temp_tbl (104) because 'no matching name info found in non-dropped relation \"t\"'",
+			"invalid descriptor: defaultdb.public.temp_tbl (104) because 'mismatched name \"t\" in relation descriptor'",
 			strings.ReplaceAll(err.Error(), "1000022", "22"))
 		// The cluster version should remain at `v0`.
 		ts.tdb.CheckQueryResults(t, "SHOW CLUSTER SETTING version", [][]string{{v0.String()}})


### PR DESCRIPTION
These mention draining names, but draining names have been removed two major versions ago.

Fixes #93724.

Release note: None