### PR TITLE
release-22.2: storage: never elide resume key in MVCCExportToSST

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_export.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export.go
@@ -203,11 +203,21 @@ func evalExport(
 		}
 		data := destFile.Data()
 
-		// NB: This should only happen on the first page of results. If there were
-		// more data to be read that lead to pagination then we'd see it in this
-		// page. Break out of the loop because there must be no data to export.
+		// NB: This should only happen in two cases:
+		//
+		// 1. There was nothing to export for this span.
+		//
+		// 2. We hit a resource constraint that led to an
+		//    early exit and thus have a resume key despite
+		//    not having data.
 		if summary.DataSize == 0 {
-			break
+			if resume.Key != nil {
+				start = resume.Key
+				resumeKeyTS = resume.Timestamp
+				continue
+			} else {
+				break
+			}
 		}
 
 		span := roachpb.Span{Key: start}

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -6139,9 +6139,9 @@ func MVCCExportToSST(
 	}
 
 	if rows.BulkOpSummary.DataSize == 0 {
-		// If no records were added to the sstable, skip completing it and return a
-		// nil slice – the export code will discard it anyway (based on 0 DataSize).
-		return roachpb.BulkOpSummary{}, MVCCKey{}, nil
+		// If no records were added to the sstable, skip
+		// completing it and return an empty summary.
+		return roachpb.BulkOpSummary{}, resumeKey, nil
 	}
 
 	if err := sstWriter.Finish(); err != nil {

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -5828,6 +5828,7 @@ func MVCCExportToSST(
 		rangeKeyMasking = opts.EndTS
 	}
 
+	elasticCPUHandle := admission.ElasticCPUWorkHandleFromContext(ctx)
 	iter := NewMVCCIncrementalIterator(reader, MVCCIncrementalIterOptions{
 		KeyTypes:             IterKeyTypePointsAndRanges,
 		StartKey:             opts.StartKey.Key,
@@ -5840,7 +5841,10 @@ func MVCCExportToSST(
 	defer iter.Close()
 
 	paginated := opts.TargetSize > 0
-	trackKeyBoundary := paginated || opts.ResourceLimiter != nil
+
+	hasElasticCPULimiter := elasticCPUHandle != nil
+	hasTimeBasedResourceLimiter := opts.ResourceLimiter != nil
+	trackKeyBoundary := paginated || hasTimeBasedResourceLimiter || hasElasticCPULimiter
 	firstIteration := true
 	skipTombstones := !opts.ExportAllRevisions && opts.StartTS.IsEmpty()
 
@@ -5882,7 +5886,6 @@ func MVCCExportToSST(
 		return maxSize
 	}
 
-	elasticCPUHandle := admission.ElasticCPUWorkHandleFromContext(ctx)
 	iter.SeekGE(opts.StartKey)
 	for {
 		if ok, err := iter.Valid(); err != nil {
@@ -5900,15 +5903,15 @@ func MVCCExportToSST(
 			curKey = append(curKey[:0], unsafeKey.Key...)
 		}
 
-		// TODO(irfansharif): Remove this time-based resource limiter once
-		// enabling elastic CPU limiting by default. There needs to be a
-		// compelling reason to need two mechanisms.
-		if opts.ResourceLimiter != nil {
+		if firstIteration {
 			// Don't check resources on first iteration to ensure we can make some progress regardless
 			// of starvation. Otherwise operations could spin indefinitely.
-			if firstIteration {
-				firstIteration = false
-			} else {
+			firstIteration = false
+		} else {
+			// TODO(irfansharif): Remove this time-based resource limiter once
+			// enabling elastic CPU limiting by default. There needs to be a
+			// compelling reason to need two mechanisms.
+			if opts.ResourceLimiter != nil {
 				// In happy day case we want to only stop at key boundaries as it allows callers to use
 				// produced sst's directly. But if we can't find key boundary within reasonable number of
 				// iterations we would split mid key.
@@ -5928,16 +5931,17 @@ func MVCCExportToSST(
 					break
 				}
 			}
-		}
 
-		// Check if we're over our allotted CPU time + on a key boundary (we
-		// prefer callers being able to use SSTs directly). Going over limit is
-		// accounted for in admission control by penalizing the subsequent
-		// request, so doing it slightly is fine.
-		if overLimit, _ := elasticCPUHandle.OverLimit(); overLimit && isNewKey {
-			resumeKey = unsafeKey.Clone()
-			resumeKey.Timestamp = hlc.Timestamp{}
-			break
+			// Check if we're over our allotted CPU time + on a key boundary (we
+			// prefer callers being able to use SSTs directly). Going over limit is
+			// accounted for in admission control by penalizing the subsequent
+			// request, so doing it slightly is fine.
+			stopAllowed := isNewKey || opts.StopMidKey
+			if overLimit, _ := elasticCPUHandle.OverLimit(); overLimit && stopAllowed {
+				resumeKey = unsafeKey.Clone()
+				resumeKey.Timestamp = hlc.Timestamp{}
+				break
+			}
 		}
 
 		// When we encounter an MVCC range tombstone stack, we buffer it in
@@ -5995,7 +5999,7 @@ func MVCCExportToSST(
 				reachedTargetSize := opts.TargetSize > 0 && uint64(curSize) >= opts.TargetSize
 				newSize := curSize + maxRangeKeysSizeIfTruncated(rangeKeys.Bounds.Key)
 				reachedMaxSize := opts.MaxSize > 0 && newSize > int64(opts.MaxSize)
-				if paginated && (reachedTargetSize || reachedMaxSize) {
+				if curSize > 0 && paginated && (reachedTargetSize || reachedMaxSize) {
 					rangeKeys.Clear()
 					rangeKeysSize = 0
 					resumeKey = unsafeKey.Clone()
@@ -6141,6 +6145,11 @@ func MVCCExportToSST(
 	if rows.BulkOpSummary.DataSize == 0 {
 		// If no records were added to the sstable, skip
 		// completing it and return an empty summary.
+		//
+		// We still propogate the resumeKey because our
+		// iteration may have been halted because of resource
+		// limitiations before any keys were added to the
+		// returned SST.
 		return roachpb.BulkOpSummary{}, resumeKey, nil
 	}
 

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -5964,8 +5964,8 @@ func TestMVCCExportToSSTResourceLimits(t *testing.T) {
 
 // TestMVCCExportToSSTExhaustedAtStart is a regression test for a bug
 // in which mis-handling of resume spans would cause MVCCExportToSST
-// would return an empty resume key in cases where out various
-// resource limiters caused an early return of a resume span.
+// to return an empty resume key in cases where the resource limiters
+// caused an early return of a resume span.
 func TestMVCCExportToSSTExhaustedAtStart(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -6039,6 +6039,108 @@ func TestMVCCExportToSSTExhaustedAtStart(t *testing.T) {
 				EndTS:              limits.maxTimestamp,
 				ExportAllRevisions: true,
 			})
+		})
+	t.Run("elastic CPU limit always exhausted",
+		func(t *testing.T) {
+			engine := createTestPebbleEngine()
+			defer engine.Close()
+
+			limits := dataLimits{
+				minKey:          minKey,
+				maxKey:          maxKey,
+				minTimestamp:    minTimestamp,
+				maxTimestamp:    maxTimestamp,
+				tombstoneChance: 0.01,
+			}
+			generateData(t, engine, limits, (limits.maxKey-limits.minKey)*10)
+			data := exportAllData(t, engine, queryLimits{
+				minKey:       minKey,
+				maxKey:       maxKey,
+				minTimestamp: minTimestamp,
+				maxTimestamp: maxTimestamp,
+				latest:       false,
+			})
+
+			// Our ElasticCPUWorkHandle will always
+			// fail. But, we should still make progress,
+			// one key at a time.
+			ctx := admission.ContextWithElasticCPUWorkHandle(context.Background(), admission.TestingNewElasticCPUHandleWithCallback(func() (bool, time.Duration) {
+				return false, 0
+			}))
+			assertExportEqualWithOptions(t, ctx, engine, data, MVCCExportOptions{
+				StartKey:           MVCCKey{Key: testKey(limits.minKey), Timestamp: limits.minTimestamp},
+				EndKey:             testKey(limits.maxKey),
+				StartTS:            limits.minTimestamp,
+				EndTS:              limits.maxTimestamp,
+				ExportAllRevisions: true,
+			})
+		})
+	t.Run("elastic CPU limit exhausted respects StopMidKey",
+		func(t *testing.T) {
+			engine := createTestPebbleEngine()
+			defer engine.Close()
+
+			// Construct a data set that contains 6
+			// revisions of the same key.
+			//
+			// We expect that MVCCExportToSST with
+			// ExportAllRevisions set to true but with
+			// StopMidKey set to false to always return
+			// all or none of this key.
+			revisionCount := 6
+			rng := rand.New(rand.NewSource(timeutil.Now().Unix()))
+			key := testKey(6)
+			start := minTimestamp.Add(1, 0)
+			nextKey := func(i int64) MVCCKey { return MVCCKey{Key: key, Timestamp: start.Add(i, 0)} }
+			nextValue := func() MVCCValue { return MVCCValue{Value: roachpb.MakeValueFromBytes(randutil.RandBytes(rng, 256))} }
+			for i := 0; i < revisionCount; i++ {
+				require.NoError(t, engine.PutMVCC(nextKey(int64(i)), nextValue()), "write data to test storage")
+			}
+			require.NoError(t, engine.Flush(), "Flush engine data")
+
+			sstFile := &MemFile{}
+			opts := MVCCExportOptions{
+				StartKey:           MVCCKey{Key: testKey(minKey), Timestamp: minTimestamp},
+				EndKey:             testKey(maxKey),
+				StartTS:            minTimestamp,
+				EndTS:              maxTimestamp,
+				ExportAllRevisions: true,
+				ResourceLimiter:    nil,
+				StopMidKey:         false,
+			}
+
+			// Create an ElasticCPUWorkHandler that will
+			// simulate a resource constraint failure
+			// after some number of loop iterations.
+			ctx := context.Background()
+			callsBeforeFailure := 2
+			ctx = admission.ContextWithElasticCPUWorkHandle(ctx, admission.TestingNewElasticCPUHandleWithCallback(func() (bool, time.Duration) {
+				if callsBeforeFailure > 0 {
+					callsBeforeFailure--
+					return false, 0
+				}
+				return true, 0
+			}))
+
+			// With StopMidKey=false, we expect 6
+			// revisions or 0 revisions.
+			_, _, err := MVCCExportToSST(ctx, st, engine, opts, sstFile)
+			require.NoError(t, err)
+			chunk := sstToKeys(t, sstFile.Data())
+			require.Equal(t, 6, len(chunk))
+
+			// With StopMidKey=true, we can stop in the
+			// middle of iteration.
+			callsBeforeFailure = 2
+			sstFile = &MemFile{}
+			opts.StopMidKey = true
+			_, _, err = MVCCExportToSST(ctx, st, engine, opts, sstFile)
+			require.NoError(t, err)
+			chunk = sstToKeys(t, sstFile.Data())
+			// We expect 3 here rather than 2 because the
+			// first iteration never calls the handler.
+			require.Equal(t, 3, len(chunk))
+
 		})
 	t.Run("resource limit exhausted",
 		func(t *testing.T) {

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/zerofields"
+	"github.com/cockroachdb/cockroach/pkg/util/admission"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -5888,6 +5889,7 @@ func TestWillOverflow(t *testing.T) {
 
 func TestMVCCExportToSSTResourceLimits(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
 	engine := createTestPebbleEngine()
 	defer engine.Close()
@@ -5959,6 +5961,149 @@ func TestMVCCExportToSSTResourceLimits(t *testing.T) {
 			})
 	}
 }
+
+// TestMVCCExportToSSTExhaustedAtStart is a regression test for a bug
+// in which mis-handling of resume spans would cause MVCCExportToSST
+// would return an empty resume key in cases where out various
+// resource limiters caused an early return of a resume span.
+func TestMVCCExportToSSTExhaustedAtStart(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	st := cluster.MakeTestingClusterSettings()
+
+	var (
+		minKey       = int64(0)
+		maxKey       = int64(1000)
+		minTimestamp = hlc.Timestamp{WallTime: 100000}
+		maxTimestamp = hlc.Timestamp{WallTime: 200000}
+	)
+
+	assertExportEqualWithOptions := func(t *testing.T, ctx context.Context, engine Engine, expectedData []MVCCKey, initialOpts MVCCExportOptions) {
+		dataIndex := 0
+		startKey := initialOpts.StartKey
+		for len(startKey.Key) > 0 {
+			sstFile := &MemFile{}
+			opts := initialOpts
+			opts.StartKey = startKey
+			_, resumeKey, err := MVCCExportToSST(ctx, st, engine, opts, sstFile)
+			require.NoError(t, err)
+			chunk := sstToKeys(t, sstFile.Data())
+			require.LessOrEqual(t, len(chunk), len(expectedData)-dataIndex, "remaining test data")
+			for _, key := range chunk {
+				require.True(t, key.Equal(expectedData[dataIndex]), "returned key is not equal")
+				dataIndex++
+			}
+			startKey = resumeKey
+		}
+		require.Equal(t, len(expectedData), dataIndex, "not all expected data was consumed")
+	}
+	t.Run("elastic CPU limit exhausted",
+		func(t *testing.T) {
+			engine := createTestPebbleEngine()
+			defer engine.Close()
+
+			limits := dataLimits{
+				minKey:          minKey,
+				maxKey:          maxKey,
+				minTimestamp:    minTimestamp,
+				maxTimestamp:    maxTimestamp,
+				tombstoneChance: 0.01,
+			}
+			generateData(t, engine, limits, (limits.maxKey-limits.minKey)*10)
+			data := exportAllData(t, engine, queryLimits{
+				minKey:       minKey,
+				maxKey:       maxKey,
+				minTimestamp: minTimestamp,
+				maxTimestamp: maxTimestamp,
+				latest:       false,
+			})
+
+			// Our ElasticCPUWorkHandle will fail on the
+			// very first call. As a result, the very
+			// first resturn from MVCCExportToSST will
+			// actually contain no data but _should_
+			// return a resume key.
+			firstCall := true
+			ctx := admission.ContextWithElasticCPUWorkHandle(context.Background(), admission.TestingNewElasticCPUHandleWithCallback(func() (bool, time.Duration) {
+				if firstCall {
+					firstCall = false
+					return true, 0
+				}
+				return false, 0
+			}))
+			assertExportEqualWithOptions(t, ctx, engine, data, MVCCExportOptions{
+				StartKey:           MVCCKey{Key: testKey(limits.minKey), Timestamp: limits.minTimestamp},
+				EndKey:             testKey(limits.maxKey),
+				StartTS:            limits.minTimestamp,
+				EndTS:              limits.maxTimestamp,
+				ExportAllRevisions: true,
+			})
+		})
+	t.Run("resource limit exhausted",
+		func(t *testing.T) {
+			engine := createTestPebbleEngine()
+			defer engine.Close()
+
+			// Construct a data set that contains 4
+			// tombstones followed by 1 non-tombstone.
+			//
+			// We expect that MVCCExportToSST with
+			// ExportAllRevisions set to false and with no
+			// start timestamp will elide the tombstones.
+			rng := rand.New(rand.NewSource(timeutil.Now().Unix()))
+			timestamp := minTimestamp.Add(rand.Int63n(maxTimestamp.WallTime-minTimestamp.WallTime), 0)
+			require.NoError(t, engine.PutMVCC(MVCCKey{Key: testKey(6), Timestamp: timestamp}, MVCCValue{}), "write data to test storage")
+			require.NoError(t, engine.PutMVCC(MVCCKey{Key: testKey(7), Timestamp: timestamp}, MVCCValue{}), "write data to test storage")
+			require.NoError(t, engine.PutMVCC(MVCCKey{Key: testKey(8), Timestamp: timestamp}, MVCCValue{}), "write data to test storage")
+			value := MVCCValue{Value: roachpb.MakeValueFromBytes(randutil.RandBytes(rng, 256))}
+			require.NoError(t, engine.PutMVCC(MVCCKey{Key: testKey(9), Timestamp: timestamp}, value), "write data to test storage")
+			require.NoError(t, engine.Flush(), "Flush engine data")
+
+			data := exportAllData(t, engine, queryLimits{
+				minKey: minKey,
+				maxKey: maxKey,
+				// Tombstones are only elided when
+				// StartTS isn't set on the export
+				// request.
+				minTimestamp: hlc.Timestamp{},
+				maxTimestamp: maxTimestamp,
+				latest:       true,
+			})
+
+			firstCall := true
+			assertExportEqualWithOptions(t, context.Background(), engine, data, MVCCExportOptions{
+				StartKey: MVCCKey{Key: testKey(minKey), Timestamp: minTimestamp},
+				EndKey:   testKey(maxKey),
+				// No StartTS to ensure that
+				// tombstones are elided.
+				EndTS:              maxTimestamp,
+				ExportAllRevisions: false,
+				// The ResourceLimiter will
+				// return ResourceLimitReached
+				// on the very first call.
+				ResourceLimiter: &callbackResourceLimiter{
+					func() ResourceLimitReached {
+						if firstCall {
+							firstCall = false
+							return ResourceLimitReachedHard
+						}
+						return ResourceLimitNotReached
+					},
+				},
+			})
+		})
+}
+
+type callbackResourceLimiter struct {
+	cb func() ResourceLimitReached
+}
+
+func (c *callbackResourceLimiter) IsExhausted() ResourceLimitReached {
+	return c.cb()
+}
+
+var _ ResourceLimiter = &callbackResourceLimiter{}
 
 type countingResourceLimiter struct {
 	softCount int64

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -6039,6 +6039,7 @@ func TestMVCCExportToSSTExhaustedAtStart(t *testing.T) {
 				EndTS:              limits.maxTimestamp,
 				ExportAllRevisions: true,
 			})
+			require.False(t, firstCall)
 		})
 	t.Run("elastic CPU limit always exhausted",
 		func(t *testing.T) {

--- a/pkg/storage/testdata/mvcc_histories/export
+++ b/pkg/storage/testdata/mvcc_histories/export
@@ -557,10 +557,10 @@ error: (*storage.ExceedMaxSizeError:) export size (12 bytes) exceeds max size (1
 
 # MaxSize with TargetSize will bail out before exceeding MaxSize, but it
 # depends on StopMidKey.
-run ok
+run error
 export k=a end=z ts=6 allRevisions targetSize=1 maxSize=1
 ----
-export: 
+error: (*storage.ExceedMaxSizeError:) export size (3 bytes) exceeds max size (1 bytes)
 
 run error
 export k=a end=z ts=6 allRevisions targetSize=10 maxSize=10

--- a/pkg/util/admission/elastic_cpu_work_handle.go
+++ b/pkg/util/admission/elastic_cpu_work_handle.go
@@ -73,14 +73,6 @@ func (h *ElasticCPUWorkHandle) OverLimit() (overLimit bool, difference time.Dura
 		return false, time.Duration(0)
 	}
 
-	// TODO(ssd): It would be nice to get this in some zero-cost
-	// way. We could make ElasticCPUWorkHandle an interface and
-	// then allow for testing implementations. Not sure if the
-	// indirect call is better or worse than the conditional.
-	if h.testingOverrideOverLimit != nil {
-		return h.testingOverrideOverLimit()
-	}
-
 	// What we're effectively doing is just:
 	//
 	// 		runningTime := h.runningTime()
@@ -102,6 +94,10 @@ func (h *ElasticCPUWorkHandle) OverLimit() (overLimit bool, difference time.Dura
 }
 
 func (h *ElasticCPUWorkHandle) overLimitInner() (overLimit bool, difference time.Duration) {
+	if h.testingOverrideOverLimit != nil {
+		return h.testingOverrideOverLimit()
+	}
+
 	runningTime := h.runningTime()
 	if runningTime >= h.allotted {
 		return true, grunning.Difference(runningTime, h.allotted)


### PR DESCRIPTION
Backport 5/5 commits from #92825. The backport merge conflict was with https://github.com/cockroachdb/cockroach/commit/b0c957dcc99f8c1ba2b22aa8e8676aeb8e9a585a and https://github.com/cockroachdb/cockroach/commit/1acfcc8d512a66eefef148c6f1fbcb1421b62098, only around `mvcc.go`  and `testdata/mvcc_histories/export_fingerprint`.

/cc @cockroachdb/release

---

MVCCExportToSST checks if no data has been written to the SST and avoids calling Finish() on the writer in that case. However, it was previously also returning an empty resume key in that case, regardless of the resume key's previous value.

Returning an empty resume key was OK since it was assumed that if the SST had no data, then there couldn't possibly be anything to resume.

However, when this method was extended to support cooperative resource management, it now has two cases in which the main iteration loop of the export may return a resume key despite not having written any data.

First, the Elastic CPU work handler is called unconditionally. If the CPU work handler was already over the limit on the first call, then we return immediately and with no data and a resume key set.

Second, the time-based resource limiter is called after the first iteration of the loop. While typically allowing one iteration will result in data being written to the SST before the exhaustion condition can be hit; if there is a long string of deletion tombstones that are not being added to our response, then it is possible that we've completed iterations of the loop without any data being written.

As a result of dropping this resume key, users of ExportRequest such as backup would then assume that their work was done. As a result, a backup may not contain all of the expected data.

Elastic CPU limiting and the time-based resource limiter are disabled by default in previous releases.

Elastic CPU limiting is enabled by default on master.

Epic: None

Release note (bug fix): Fix a bug that would result in incomplete backups when non-default, non-public resource limiting settings (kv.bulk_sst.max_request_time or
admission.elastic_cpu.enabled) were enabled.

Release justification: Bug fix.