### PR TITLE
ttl: remove 22.1 compatibility tests

### DIFF
--- a/pkg/sql/ttl/ttljob/BUILD.bazel
+++ b/pkg/sql/ttl/ttljob/BUILD.bazel
@@ -65,7 +65,6 @@ go_test(
     deps = [
         "//pkg/base",
         "//pkg/ccl/kvccl/kvtenantccl",
-        "//pkg/clusterversion",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/jobs/jobstest",


### PR DESCRIPTION
Informs https://github.com/cockroachdb/cockroach/issues/87060

This removes leftover compatibility tests from 22.1.

Release note: None