### PR TITLE
ttl: Change all TTL tests to be multi-tenant compatible

### DIFF
--- a/pkg/sql/distsql_plan_backfill_test.go
+++ b/pkg/sql/distsql_plan_backfill_test.go
@@ -82,7 +82,7 @@ func TestDistBackfill(t *testing.T) {
 	for i := numNodes - 1; i > 0; i-- {
 		sps = append(sps, serverutils.SplitPoint{TargetNodeIdx: i, Vals: []interface{}{n * n / numNodes * i}})
 	}
-	tc.SplitTable(t, descNumToStr, sps)
+	tc.SplitTable(t, descNumToStr, keys.SystemSQLCodec, sps)
 
 	db := tc.ServerConn(0)
 	db.SetMaxOpenConns(1)

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -628,7 +628,7 @@ CREATE UNIQUE INDEX vidx ON t.test (v);
 	for i := 1; i <= numNodes-1; i++ {
 		sps = append(sps, serverutils.SplitPoint{TargetNodeIdx: i, Vals: []interface{}{maxValue / numNodes * i}})
 	}
-	tc.SplitTable(t, tableDesc, sps)
+	tc.SplitTable(t, tableDesc, keys.SystemSQLCodec, sps)
 
 	ctx := context.Background()
 
@@ -813,7 +813,7 @@ CREATE UNIQUE INDEX vidx ON t.test (v);
 	for i := 1; i <= numNodes-1; i++ {
 		sps = append(sps, serverutils.SplitPoint{TargetNodeIdx: i, Vals: []interface{}{maxValue / numNodes * i}})
 	}
-	tc.SplitTable(t, tableDesc, sps)
+	tc.SplitTable(t, tableDesc, keys.SystemSQLCodec, sps)
 
 	// number of keys == 2 * number of rows; 1 column family and 1 index entry
 	// for each row.
@@ -927,7 +927,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 	for i := 1; i <= numNodes-1; i++ {
 		sps = append(sps, serverutils.SplitPoint{TargetNodeIdx: i, Vals: []interface{}{maxValue / numNodes * i}})
 	}
-	tc.SplitTable(t, tableDesc, sps)
+	tc.SplitTable(t, tableDesc, keys.SystemSQLCodec, sps)
 
 	ctx := context.Background()
 
@@ -3845,7 +3845,7 @@ func TestBackfillCompletesOnChunkBoundary(t *testing.T) {
 	for i := 1; i <= numNodes-1; i++ {
 		sps = append(sps, serverutils.SplitPoint{TargetNodeIdx: i, Vals: []interface{}{maxValue / numNodes * i}})
 	}
-	tc.SplitTable(t, tableDesc, sps)
+	tc.SplitTable(t, tableDesc, keys.SystemSQLCodec, sps)
 
 	// Run some schema changes.
 	testCases := []struct {
@@ -4146,7 +4146,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 	for i := 1; i <= numNodes-1; i++ {
 		sps = append(sps, serverutils.SplitPoint{TargetNodeIdx: i, Vals: []interface{}{maxValue / numNodes * i}})
 	}
-	tc.SplitTable(t, tableDesc, sps)
+	tc.SplitTable(t, tableDesc, keys.SystemSQLCodec, sps)
 
 	testCases := []struct {
 		sql    string
@@ -4862,7 +4862,7 @@ func TestCancelSchemaChange(t *testing.T) {
 	for i := 1; i <= numSplits-1; i++ {
 		sps = append(sps, serverutils.SplitPoint{TargetNodeIdx: i % numNodes, Vals: []interface{}{maxValue / numSplits * i}})
 	}
-	tc.SplitTable(t, tableDesc, sps)
+	tc.SplitTable(t, tableDesc, keys.SystemSQLCodec, sps)
 
 	ctx := context.Background()
 	if err := sqltestutils.CheckTableKeyCount(ctx, kvDB, 1, maxValue); err != nil {
@@ -5927,7 +5927,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 	for i := 1; i < numNodes-1; i++ {
 		sps = append(sps, serverutils.SplitPoint{TargetNodeIdx: i, Vals: []interface{}{maxValue / 2}})
 	}
-	tc.SplitTable(t, tableDesc, sps)
+	tc.SplitTable(t, tableDesc, keys.SystemSQLCodec, sps)
 
 	bg := ctxgroup.WithContext(ctx)
 	bg.Go(func() error {

--- a/pkg/testutils/serverutils/test_cluster_shim.go
+++ b/pkg/testutils/serverutils/test_cluster_shim.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -39,8 +40,11 @@ type TestClusterInterface interface {
 	// with.
 	NumServers() int
 
-	// Server returns the TestServerInterface corresponding to a specific node.
+	// Server returns the TestServerInterface corresponding to a specific server index.
 	Server(idx int) TestServerInterface
+
+	// Server returns the TestServerInterface corresponding to a specific roachpb.NodeID.
+	ServerByNodeID(nodeID roachpb.NodeID) (int, TestServerInterface)
 
 	// NodeIDs returns the IDs of the nodes in the cluster.
 	NodeIDs() []roachpb.NodeID
@@ -229,7 +233,7 @@ type TestClusterInterface interface {
 	//
 	// TODO(radu): we should verify that the queries in tests using SplitTable
 	// are indeed distributed as intended.
-	SplitTable(t *testing.T, desc catalog.TableDescriptor, sps []SplitPoint)
+	SplitTable(t *testing.T, desc catalog.TableDescriptor, codec keys.SQLCodec, sps []SplitPoint)
 }
 
 // SplitPoint describes a split point that is passed to SplitTable.


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/87061

Secondary tenants can now run `SHOW RANGES` and `ALTER TABLE x SPLIT AT`. Remove system-tenant-specific code from TTL tests.

Release note: None