### PR TITLE
opt: reduce allocations in props.histogramIter

### DIFF
--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -1091,16 +1091,16 @@ project
  ├── fd: ()-->(6)
  ├── index-join t47742
  │    ├── columns: a:1(int) t47742.b:2(bool!null)
- │    ├── stats: [rows=3063.5, distinct(2)=1.0025, null(2)=0]
- │    │   histogram(2)=  0    0    0.0024693 3063.5
- │    │                <--- false ----------- true
+ │    ├── stats: [rows=3063.5, distinct(2)=1, null(2)=0]
+ │    │   histogram(2)=  0 3063.5
+ │    │                <--- true
  │    ├── fd: ()-->(2)
  │    └── scan t47742@b_idx
  │         ├── columns: t47742.b:2(bool!null) rowid:3(int!null)
  │         ├── constraint: /-2/3: [/true - /true]
- │         ├── stats: [rows=3063.5, distinct(2)=11, null(2)=0]
- │         │   histogram(2)=  0   0    0.0024693 3063.5
- │         │                <--- NULL ----------- true
+ │         ├── stats: [rows=3063.5, distinct(2)=1, null(2)=0]
+ │         │   histogram(2)=  0 3063.5
+ │         │                <--- true
  │         ├── key: (3)
  │         └── fd: ()-->(2)
  └── projections

--- a/pkg/sql/opt/props/histogram.go
+++ b/pkg/sql/opt/props/histogram.go
@@ -328,8 +328,18 @@ func (h *Histogram) filter(
 		if filteredSpan.Compare(&keyCtx, &left) != 0 {
 			// The bucket was cut off in the middle. Get the resulting filtered
 			// bucket.
+			//
+			// The span generated from the bucket may have an exclusive bound in
+			// order to avoid a datum allocation for the majority of cases where
+			// the span does not intersect the bucket. If the span does
+			// intersect with the bucket, we transform the bucket span into an
+			// inclusive one to make it easier to work with. Note that this
+			// conversion is best-effort; not all datums support Next or Prev
+			// which allow exclusive ranges to be converted to inclusive ones.
+			cmpStarts := filteredSpan.CompareStarts(&keyCtx, &left)
+			filteredSpan.PreferInclusive(&keyCtx)
 			filteredBucket = getFilteredBucket(&iter, &keyCtx, &filteredSpan, colOffset)
-			if !desc && filteredSpan.CompareStarts(&keyCtx, &left) != 0 {
+			if !desc && cmpStarts != 0 {
 				// We need to add an empty bucket before the new bucket.
 				ub := h.getPrevUpperBound(filteredSpan.StartKey(), filteredSpan.StartBoundary(), colOffset)
 				filtered.addEmptyBucket(ub, desc)
@@ -362,7 +372,7 @@ func (h *Histogram) filter(
 		// bucket if needed.
 		if iter.next() {
 			// The remaining buckets from the original histogram have been removed.
-			filtered.addEmptyBucket(iter.lb, desc)
+			filtered.addEmptyBucket(iter.inclusiveLowerBound(), desc)
 		} else if lastBucket := filtered.buckets[len(filtered.buckets)-1]; lastBucket.NumRange != 0 {
 			iter.setIdx(0)
 			span := makeSpanFromBucket(&iter, prefix)
@@ -496,8 +506,10 @@ type histogramIter struct {
 	desc bool
 	idx  int
 	b    *cat.HistogramBucket
-	lb   tree.Datum
-	ub   tree.Datum
+	elb  tree.Datum // exclusive lower bound
+	lb   tree.Datum // inclusive lower bound
+	eub  tree.Datum // exclusive upper bound
+	ub   tree.Datum // inclusive upper bound
 }
 
 // init initializes a histogramIter to point to the first bucket of the given
@@ -531,15 +543,18 @@ func (hi *histogramIter) setIdx(i int) {
 // the "next" bucket is actually the previous bucket in the histogram. Returns
 // false if there are no more buckets.
 func (hi *histogramIter) next() (ok bool) {
-	getBounds := func() (lb, ub tree.Datum) {
+	getBounds := func() (elb, lb, eub, ub tree.Datum) {
 		hi.b = &hi.h.buckets[hi.idx]
 		ub = hi.b.UpperBound
 		if hi.idx == 0 {
 			lb = ub
 		} else {
-			lb = hi.h.getNextLowerBound(hi.h.upperBound(hi.idx - 1))
+			elb = hi.h.upperBound(hi.idx - 1)
 		}
-		return lb, ub
+		// We return an exclusive upper bound, eub, even though it is always nil
+		// because it makes it easier to handle both the iter.desc=true and
+		// iter.desc=false cases below.
+		return elb, lb, nil /* eub */, ub
 	}
 
 	if hi.desc {
@@ -547,24 +562,83 @@ func (hi *histogramIter) next() (ok bool) {
 		if hi.idx < 0 {
 			return false
 		}
-		hi.ub, hi.lb = getBounds()
+		// If iter.desc=true, the lower bounds are greater than the upper
+		// bounds. Either hi.eub or hi.ub will be set, hi.elb will always be
+		// nil, and hi.lb will always be non-nil.
+		hi.eub, hi.ub, hi.elb, hi.lb = getBounds()
 	} else {
 		hi.idx++
 		if hi.idx >= hi.h.bucketCount() {
 			return false
 		}
-		hi.lb, hi.ub = getBounds()
+		// If iter.desc=false, the lower bounds are less than the upper bounds.
+		// Either hi.elb or hi.lb will be set, hi.eub will always be nil, and
+		// hi.ub will always be non-nil.
+		hi.elb, hi.lb, hi.eub, hi.ub = getBounds()
 	}
 
 	return true
 }
 
+// lowerBound returns the lower bound of the current bucket, and whether the
+// bound is inclusive or exclusive. It will never allocate a new datum.
+func (hi *histogramIter) lowerBound() (tree.Datum, constraint.SpanBoundary) {
+	if hi.lb != nil {
+		return hi.lb, constraint.IncludeBoundary
+	}
+	return hi.elb, constraint.ExcludeBoundary
+}
+
+// inclusiveLowerBound returns the inclusive lower bound of the current bucket.
+// It may allocate a new datum.
+func (hi *histogramIter) inclusiveLowerBound() tree.Datum {
+	if hi.lb == nil {
+		// hi.lb is only nil if iter.desc=false (see histogramIter.next), which
+		// means that the lower bounds are less than the upper bounds. So the
+		// inclusive lower bound is greater than the exclusive lower bound. For
+		// example, the range (/10 - /20] is equivalent to [/11 - /20].
+		hi.lb = hi.h.getNextLowerBound(hi.elb)
+	}
+	return hi.lb
+}
+
+// upperBound returns the upper bound of the current bucket, and whether the
+// bound is inclusive or exclusive. It will never allocate a new datum.
+func (hi *histogramIter) upperBound() (tree.Datum, constraint.SpanBoundary) {
+	if hi.ub != nil {
+		return hi.ub, constraint.IncludeBoundary
+	}
+	return hi.eub, constraint.ExcludeBoundary
+}
+
+// inclusiveUpperBound returns the inclusive upper bound of the current bucket.
+// It may allocate a new datum.
+func (hi *histogramIter) inclusiveUpperBound() tree.Datum {
+	if hi.ub == nil {
+		// hi.ub is only nil if iter.desc=true (see histogramIter.next), which
+		// means that the lower bounds are greater than the upper bounds. So the
+		// inclusive upper bound is greater than the exclusive upper bound. For
+		// example, the range [/20 - /10) is equivalent to [/20 - /11].
+		hi.ub = hi.h.getNextLowerBound(hi.eub)
+	}
+	return hi.ub
+}
+
 func makeSpanFromBucket(iter *histogramIter, prefix []tree.Datum) (span constraint.Span) {
+	start, startBoundary := iter.lowerBound()
+	end, endBoundary := iter.upperBound()
+	if start.Compare(iter.h.evalCtx, end) == 0 &&
+		(startBoundary == constraint.IncludeBoundary || endBoundary == constraint.IncludeBoundary) {
+		// If the start and ends are equal and one of the boundaries is
+		// inclusive, the other boundary should be inclusive.
+		startBoundary = constraint.IncludeBoundary
+		endBoundary = constraint.IncludeBoundary
+	}
 	span.Init(
-		constraint.MakeCompositeKey(append(prefix[:len(prefix):len(prefix)], iter.lb)...),
-		constraint.IncludeBoundary,
-		constraint.MakeCompositeKey(append(prefix[:len(prefix):len(prefix)], iter.ub)...),
-		constraint.IncludeBoundary,
+		constraint.MakeCompositeKey(append(prefix[:len(prefix):len(prefix)], start)...),
+		startBoundary,
+		constraint.MakeCompositeKey(append(prefix[:len(prefix):len(prefix)], end)...),
+		endBoundary,
 	)
 	return span
 }
@@ -605,8 +679,8 @@ func getFilteredBucket(
 ) *cat.HistogramBucket {
 	spanLowerBound := filteredSpan.StartKey().Value(colOffset)
 	spanUpperBound := filteredSpan.EndKey().Value(colOffset)
-	bucketLowerBound := iter.lb
-	bucketUpperBound := iter.ub
+	bucketLowerBound := iter.inclusiveLowerBound()
+	bucketUpperBound := iter.inclusiveUpperBound()
 	b := iter.b
 
 	// Check that the given span is contained in the bucket.


### PR DESCRIPTION
This commit reduces allocations in props.histogramIter by delaying datum allocations for bucket bounds until absolutely necessary. Instead, we prefer using the upper bound of the previous bucket as an exclusive lower bound of the current bucket because no datum allocation is necessary.

This significantly reduces the number allocations, especially when filtering a histogram by a span that includes many buckets. It reduces the number of bytes allocated, especially when the histogram bounds are larger values, such as strings larger than several bytes. The benefits can be observed in one of the optimizer micro-benchmarks:

```
name                                                                    old time/op    new time/op    delta
Phases/single-col-histogram-range/Simple/Parse-16                         13.1µs ±19%    10.5µs ± 2%  -19.66%  (p=0.008 n=5+5)
Phases/single-col-histogram-range/Simple/OptBuildNoNorm-16                95.5µs ± 3%    77.4µs ±36%     ~     (p=0.190 n=4+5)
Phases/single-col-histogram-range/Simple/OptBuildNorm-16                   144µs ± 5%     108µs ± 3%  -24.76%  (p=0.008 n=5+5)
Phases/single-col-histogram-range/Simple/Explore-16                        176µs ±17%     114µs ± 2%  -34.93%  (p=0.008 n=5+5)
Phases/single-col-histogram-range/Simple/ExecBuild-16                      161µs ± 2%     121µs ± 1%  -24.61%  (p=0.008 n=5+5)
Phases/single-col-histogram-range/Prepared/AssignPlaceholdersNoNorm-16    56.2µs ± 2%    41.8µs ± 5%  -25.69%  (p=0.008 n=5+5)
Phases/single-col-histogram-range/Prepared/AssignPlaceholdersNorm-16      55.8µs ± 3%    42.1µs ± 3%  -24.53%  (p=0.008 n=5+5)
Phases/single-col-histogram-range/Prepared/Explore-16                     65.0µs ± 8%    50.5µs ± 5%  -22.24%  (p=0.008 n=5+5)
Phases/single-col-histogram-range/Prepared/ExecBuild-16                   73.0µs ± 3%    57.4µs ± 7%  -21.48%  (p=0.008 n=5+5)

name                                                                    old alloc/op   new alloc/op   delta
Phases/single-col-histogram-range/Simple/Parse-16                         3.25kB ± 0%    3.25kB ± 0%     ~     (all equal)
Phases/single-col-histogram-range/Simple/OptBuildNoNorm-16                33.5kB ± 0%    17.9kB ± 0%  -46.52%  (p=0.008 n=5+5)
Phases/single-col-histogram-range/Simple/OptBuildNorm-16                  57.4kB ± 0%    26.2kB ± 0%  -54.37%  (p=0.008 n=5+5)
Phases/single-col-histogram-range/Simple/Explore-16                       60.2kB ± 0%    29.0kB ± 0%  -51.81%  (p=0.008 n=5+5)
Phases/single-col-histogram-range/Simple/ExecBuild-16                     61.7kB ± 0%    30.5kB ± 0%  -50.56%  (p=0.008 n=5+5)
Phases/single-col-histogram-range/Prepared/AssignPlaceholdersNoNorm-16    26.0kB ± 0%    10.5kB ± 0%  -59.83%  (p=0.008 n=5+5)
Phases/single-col-histogram-range/Prepared/AssignPlaceholdersNorm-16      26.0kB ± 0%    10.5kB ± 0%  -59.83%  (p=0.008 n=5+5)
Phases/single-col-histogram-range/Prepared/Explore-16                     28.3kB ± 0%    12.7kB ± 0%  -55.07%  (p=0.008 n=5+5)
Phases/single-col-histogram-range/Prepared/ExecBuild-16                   29.8kB ± 0%    14.2kB ± 0%  -52.32%  (p=0.008 n=5+5)

name                                                                    old allocs/op  new allocs/op  delta
Phases/single-col-histogram-range/Simple/Parse-16                           20.0 ± 0%      20.0 ± 0%     ~     (all equal)
Phases/single-col-histogram-range/Simple/OptBuildNoNorm-16                   608 ± 0%       282 ± 0%  -53.62%  (p=0.008 n=5+5)
Phases/single-col-histogram-range/Simple/OptBuildNorm-16                   1.15k ± 0%     0.50k ± 0%  -56.55%  (p=0.008 n=5+5)
Phases/single-col-histogram-range/Simple/Explore-16                        1.16k ± 0%     0.51k ± 0%  -56.06%  (p=0.008 n=5+5)
Phases/single-col-histogram-range/Simple/ExecBuild-16                      1.17k ± 0%     0.52k ± 0%  -55.63%  (p=0.008 n=5+5)
Phases/single-col-histogram-range/Prepared/AssignPlaceholdersNoNorm-16       564 ± 0%       238 ± 0%  -57.80%  (p=0.008 n=5+5)
Phases/single-col-histogram-range/Prepared/AssignPlaceholdersNorm-16         564 ± 0%       238 ± 0%  -57.80%  (p=0.008 n=5+5)
Phases/single-col-histogram-range/Prepared/Explore-16                        573 ± 0%       247 ± 0%  -56.89%  (p=0.008 n=5+5)
Phases/single-col-histogram-range/Prepared/ExecBuild-16                      582 ± 0%       256 ± 0%  -56.01%  (p=0.008 n=5+5)
```

Fixes #89982

Epic: None

Release note: None