### PR TITLE
sql: propagate session_id into subqueries

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1618,6 +1618,7 @@ func (ex *connExecutor) execWithDistSQLEngine(
 			ex.resetEvalCtx(&factoryEvalCtx, planner.txn, planner.ExtendedEvalContext().StmtTimestamp)
 			factoryEvalCtx.Placeholders = &planner.semaCtx.Placeholders
 			factoryEvalCtx.Annotations = &planner.semaCtx.Annotations
+			factoryEvalCtx.SessionID = planner.ExtendedEvalContext().SessionID
 			return &factoryEvalCtx
 		}
 	}

--- a/pkg/sql/logictest/testdata/logic_test/subquery
+++ b/pkg/sql/logictest/testdata/logic_test/subquery
@@ -665,3 +665,13 @@ SELECT * FROM abc WHERE NOT EXISTS (SELECT * FROM xyz WHERE (abc.a = xyz.x OR ab
 12  13  14
 
 ### End Split Disjunctions Tests
+
+# Regression test for SHOW session_id in a subquery.
+# See https://github.com/cockroachdb/cockroach/issues/93739
+let $session_id
+SHOW session_id
+
+query B
+select lower((select session_id from [show session_id])) = lower('$session_id')
+----
+true


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/93739

Release note (bug fix): Fixed a bug where the session_id session variable would not be properly set if used from a subquery,