### PR TITLE
streamingest: c2c UX fixes

### DIFF
--- a/pkg/ccl/streamingccl/replicationtestutils/BUILD.bazel
+++ b/pkg/ccl/streamingccl/replicationtestutils/BUILD.bazel
@@ -69,6 +69,7 @@ go_library(
         "//pkg/util/hlc",
         "//pkg/util/protoutil",
         "//pkg/util/syncutil",
+        "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/ccl/streamingccl/replicationtestutils/BUILD.bazel
+++ b/pkg/ccl/streamingccl/replicationtestutils/BUILD.bazel
@@ -46,6 +46,7 @@ go_library(
         "//pkg/base",
         "//pkg/ccl/changefeedccl/changefeedbase",
         "//pkg/ccl/streamingccl",
+        "//pkg/ccl/streamingccl/replicationutils",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/keys",

--- a/pkg/ccl/streamingccl/replicationtestutils/testutils.go
+++ b/pkg/ccl/streamingccl/replicationtestutils/testutils.go
@@ -17,12 +17,14 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/replicationutils"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
@@ -30,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -151,9 +154,9 @@ func (c *TenantStreamingClusters) Cutover(
 }
 
 // StartStreamReplication producer job ID and ingestion job ID.
-func (c *TenantStreamingClusters) StartStreamReplication() (int, int) {
-	var ingestionJobID, streamProducerJobID int
-	c.DestSysSQL.QueryRow(c.T, c.BuildCreateTenantQuery()).Scan(&ingestionJobID, &streamProducerJobID)
+func (c *TenantStreamingClusters) StartStreamReplication(ctx context.Context) (int, int) {
+	c.DestSysSQL.Exec(c.T, c.BuildCreateTenantQuery())
+	streamProducerJobID, ingestionJobID := GetStreamJobIds(c.T, ctx, c.DestSysSQL, c.Args.DestTenantName)
 	return streamProducerJobID, ingestionJobID
 }
 
@@ -351,4 +354,21 @@ func ConfigureClusterSettings(setting map[string]string) []string {
 func RunningStatus(t *testing.T, sqlRunner *sqlutils.SQLRunner, ingestionJobID int) string {
 	p := jobutils.GetJobProgress(t, sqlRunner, jobspb.JobID(ingestionJobID))
 	return p.RunningStatus
+}
+
+// GetStreamJobIds returns the jod ids of the producer and ingestion jobs.
+func GetStreamJobIds(
+	t *testing.T,
+	ctx context.Context,
+	sqlRunner *sqlutils.SQLRunner,
+	destTenantName roachpb.TenantName,
+) (producer int, consumer int) {
+	var tenantInfoBytes []byte
+	var tenantInfo descpb.TenantInfo
+	sqlRunner.QueryRow(t, "SELECT info FROM system.tenants WHERE name=$1",
+		destTenantName).Scan(&tenantInfoBytes)
+	require.NoError(t, protoutil.Unmarshal(tenantInfoBytes, &tenantInfo))
+
+	stats := replicationutils.TestingGetStreamIngestionStatsNoHeartbeatFromReplicationJob(t, ctx, sqlRunner, int(tenantInfo.TenantReplicationJobID))
+	return int(stats.IngestionDetails.StreamID), int(tenantInfo.TenantReplicationJobID)
 }

--- a/pkg/ccl/streamingccl/streamclient/client.go
+++ b/pkg/ccl/streamingccl/streamclient/client.go
@@ -152,7 +152,7 @@ func NewStreamClient(
 	case "postgres", "postgresql":
 		// The canonical PostgreSQL URL scheme is "postgresql", however our
 		// own client commands also accept "postgres".
-		return newPartitionedStreamClient(ctx, streamURL)
+		return NewPartitionedStreamClient(ctx, streamURL)
 	case RandomGenScheme:
 		streamClient, err = newRandomStreamClient(streamURL)
 		if err != nil {

--- a/pkg/ccl/streamingccl/streamclient/partitioned_stream_client.go
+++ b/pkg/ccl/streamingccl/streamclient/partitioned_stream_client.go
@@ -41,7 +41,7 @@ type partitionedStreamClient struct {
 	}
 }
 
-func newPartitionedStreamClient(
+func NewPartitionedStreamClient(
 	ctx context.Context, remote *url.URL,
 ) (*partitionedStreamClient, error) {
 

--- a/pkg/ccl/streamingccl/streamclient/partitioned_stream_client_test.go
+++ b/pkg/ccl/streamingccl/streamclient/partitioned_stream_client_test.go
@@ -6,7 +6,7 @@
 //
 //     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
 
-package streamclient
+package streamclient_test
 
 import (
 	"context"
@@ -21,6 +21,7 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/kvccl/kvtenantccl" // Ensure we can start tenant.
 	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/replicationtestutils"
+	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/streamclient"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -42,7 +43,7 @@ import (
 )
 
 type subscriptionFeedSource struct {
-	sub Subscription
+	sub streamclient.Subscription
 }
 
 var _ replicationtestutils.FeedSource = (*subscriptionFeedSource)(nil)
@@ -117,7 +118,7 @@ INSERT INTO d.t2 VALUES (2);
 	}
 
 	maybeInlineURL := maybeGenerateInlineURL(&h.PGUrl)
-	client, err := newPartitionedStreamClient(ctx, maybeInlineURL)
+	client, err := streamclient.NewPartitionedStreamClient(ctx, maybeInlineURL)
 	defer func() {
 		require.NoError(t, client.Close(ctx))
 	}()
@@ -197,7 +198,7 @@ INSERT INTO d.t2 VALUES (2);
 	url, err := streamingccl.StreamAddress(top.Partitions[0].SrcAddr).URL()
 	require.NoError(t, err)
 	// Create a new stream client with the given partition address.
-	subClient, err := newPartitionedStreamClient(ctx, url)
+	subClient, err := streamclient.NewPartitionedStreamClient(ctx, url)
 	defer func() {
 		require.NoError(t, subClient.Close(ctx))
 	}()

--- a/pkg/ccl/streamingccl/streamingest/alter_replication_job_test.go
+++ b/pkg/ccl/streamingccl/streamingest/alter_replication_job_test.go
@@ -49,7 +49,11 @@ func TestAlterTenantPauseResume(t *testing.T) {
 	var cutoverTime time.Time
 	c.DestSysSQL.QueryRow(t, "SELECT clock_timestamp()").Scan(&cutoverTime)
 
-	c.DestSysSQL.Exec(c.T, `ALTER TENANT $1 COMPLETE REPLICATION TO SYSTEM TIME $2::string`, args.DestTenantName, cutoverTime)
+	var cutoverStr string
+	c.DestSysSQL.QueryRow(c.T, `ALTER TENANT $1 COMPLETE REPLICATION TO SYSTEM TIME $2::string`,
+		args.DestTenantName, cutoverTime).Scan(&cutoverStr)
+	cutoverOutput := replicationtestutils.DecimalTimeToHLC(t, cutoverStr)
+	require.Equal(t, cutoverTime, cutoverOutput.GoTime())
 	jobutils.WaitForJobToSucceed(c.T, c.DestSysSQL, jobspb.JobID(ingestionJobID))
 	cleanupTenant := c.CreateDestTenantSQL(ctx)
 	defer func() {

--- a/pkg/ccl/streamingccl/streamingest/alter_replication_job_test.go
+++ b/pkg/ccl/streamingccl/streamingest/alter_replication_job_test.go
@@ -30,7 +30,7 @@ func TestAlterTenantPauseResume(t *testing.T) {
 
 	c, cleanup := replicationtestutils.CreateTenantStreamingClusters(ctx, t, args)
 	defer cleanup()
-	producerJobID, ingestionJobID := c.StartStreamReplication()
+	producerJobID, ingestionJobID := c.StartStreamReplication(ctx)
 
 	jobutils.WaitForJobToRun(t, c.SrcSysSQL, jobspb.JobID(producerJobID))
 	jobutils.WaitForJobToRun(t, c.DestSysSQL, jobspb.JobID(ingestionJobID))

--- a/pkg/ccl/streamingccl/streamingest/datadriven_test.go
+++ b/pkg/ccl/streamingccl/streamingest/datadriven_test.go
@@ -95,7 +95,7 @@ func TestDataDriven(t *testing.T) {
 				})
 
 			case "start-replication-stream":
-				ds.producerJobID, ds.replicationJobID = ds.replicationClusters.StartStreamReplication()
+				ds.producerJobID, ds.replicationJobID = ds.replicationClusters.StartStreamReplication(ctx)
 
 			case "wait-until-high-watermark":
 				var highWaterMark string

--- a/pkg/ccl/streamingccl/streamingest/replication_random_client_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_random_client_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/kvccl/kvtenantccl" // To start tenants.
+	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/replicationtestutils"
 	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/streamclient"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -242,8 +243,9 @@ func TestStreamIngestionJobWithRandomClient(t *testing.T) {
 	_, err = conn.Exec(`SET enable_experimental_stream_replication = true`)
 	require.NoError(t, err)
 
-	var ingestionJobID, producerJobID int
-	require.NoError(t, conn.QueryRow(query).Scan(&ingestionJobID, &producerJobID))
+	_, err = conn.Exec(query)
+	require.NoError(t, err)
+	_, ingestionJobID := replicationtestutils.GetStreamJobIds(t, ctx, sqlDB, "30")
 
 	// Start the ingestion stream and wait for at least one AddSSTable to ensure the job is running.
 	allowResponse <- struct{}{}

--- a/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
@@ -55,7 +55,7 @@ func TestTenantStreamingProducerJobTimedOut(t *testing.T) {
 	c, cleanup := replicationtestutils.CreateTenantStreamingClusters(ctx, t, args)
 	defer cleanup()
 
-	producerJobID, ingestionJobID := c.StartStreamReplication()
+	producerJobID, ingestionJobID := c.StartStreamReplication(ctx)
 
 	jobutils.WaitForJobToRun(c.T, c.SrcSysSQL, jobspb.JobID(producerJobID))
 	jobutils.WaitForJobToRun(c.T, c.DestSysSQL, jobspb.JobID(ingestionJobID))
@@ -116,7 +116,7 @@ func TestTenantStreamingPauseResumeIngestion(t *testing.T) {
 	c, cleanup := replicationtestutils.CreateTenantStreamingClusters(ctx, t, args)
 	defer cleanup()
 
-	producerJobID, ingestionJobID := c.StartStreamReplication()
+	producerJobID, ingestionJobID := c.StartStreamReplication(ctx)
 
 	jobutils.WaitForJobToRun(c.T, c.SrcSysSQL, jobspb.JobID(producerJobID))
 	jobutils.WaitForJobToRun(c.T, c.DestSysSQL, jobspb.JobID(ingestionJobID))
@@ -190,7 +190,7 @@ func TestTenantStreamingPauseOnPermanentJobError(t *testing.T) {
 	ingestErrCh <- errors.Newf("ingestion error from test")
 	close(ingestErrCh)
 
-	producerJobID, ingestionJobID := c.StartStreamReplication()
+	producerJobID, ingestionJobID := c.StartStreamReplication(ctx)
 	jobutils.WaitForJobToRun(c.T, c.SrcSysSQL, jobspb.JobID(producerJobID))
 	jobutils.WaitForJobToPause(c.T, c.DestSysSQL, jobspb.JobID(ingestionJobID))
 
@@ -241,7 +241,7 @@ func TestTenantStreamingCheckpoint(t *testing.T) {
 	c, cleanup := replicationtestutils.CreateTenantStreamingClusters(ctx, t, args)
 	defer cleanup()
 
-	producerJobID, ingestionJobID := c.StartStreamReplication()
+	producerJobID, ingestionJobID := c.StartStreamReplication(ctx)
 
 	// Helper to read job progress
 	jobRegistry := c.DestSysServer.JobRegistry().(*jobs.Registry)
@@ -337,7 +337,7 @@ func TestTenantStreamingCancelIngestion(t *testing.T) {
 	testCancelIngestion := func(t *testing.T, cancelAfterPaused bool) {
 		c, cleanup := replicationtestutils.CreateTenantStreamingClusters(ctx, t, args)
 		defer cleanup()
-		producerJobID, ingestionJobID := c.StartStreamReplication()
+		producerJobID, ingestionJobID := c.StartStreamReplication(ctx)
 
 		jobutils.WaitForJobToRun(c.T, c.SrcSysSQL, jobspb.JobID(producerJobID))
 		jobutils.WaitForJobToRun(c.T, c.DestSysSQL, jobspb.JobID(ingestionJobID))
@@ -413,7 +413,7 @@ func TestTenantStreamingDropTenantCancelsStream(t *testing.T) {
 	testCancelIngestion := func(t *testing.T, cancelAfterPaused bool) {
 		c, cleanup := replicationtestutils.CreateTenantStreamingClusters(ctx, t, args)
 		defer cleanup()
-		producerJobID, ingestionJobID := c.StartStreamReplication()
+		producerJobID, ingestionJobID := c.StartStreamReplication(ctx)
 
 		c.DestSysSQL.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'")
 		c.DestSysSQL.Exec(t, "SET CLUSTER SETTING kv.protectedts.reconciliation.interval = '1ms';")
@@ -480,7 +480,7 @@ func TestTenantStreamingUnavailableStreamAddress(t *testing.T) {
 	replicationtestutils.CreateScatteredTable(t, c, 3)
 	srcScatteredData := c.SrcTenantSQL.QueryStr(c.T, "SELECT * FROM d.scattered ORDER BY key")
 
-	producerJobID, ingestionJobID := c.StartStreamReplication()
+	producerJobID, ingestionJobID := c.StartStreamReplication(ctx)
 	jobutils.WaitForJobToRun(c.T, c.SrcSysSQL, jobspb.JobID(producerJobID))
 	jobutils.WaitForJobToRun(c.T, c.DestSysSQL, jobspb.JobID(ingestionJobID))
 
@@ -561,7 +561,7 @@ func TestTenantStreamingCutoverOnSourceFailure(t *testing.T) {
 	c, cleanup := replicationtestutils.CreateTenantStreamingClusters(ctx, t, args)
 	defer cleanup()
 
-	producerJobID, ingestionJobID := c.StartStreamReplication()
+	producerJobID, ingestionJobID := c.StartStreamReplication(ctx)
 
 	jobutils.WaitForJobToRun(c.T, c.SrcSysSQL, jobspb.JobID(producerJobID))
 	jobutils.WaitForJobToRun(c.T, c.DestSysSQL, jobspb.JobID(ingestionJobID))
@@ -602,7 +602,7 @@ func TestTenantStreamingDeleteRange(t *testing.T) {
 	c, cleanup := replicationtestutils.CreateTenantStreamingClusters(ctx, t, replicationtestutils.DefaultTenantStreamingClustersArgs)
 	defer cleanup()
 
-	producerJobID, ingestionJobID := c.StartStreamReplication()
+	producerJobID, ingestionJobID := c.StartStreamReplication(ctx)
 	jobutils.WaitForJobToRun(c.T, c.SrcSysSQL, jobspb.JobID(producerJobID))
 	jobutils.WaitForJobToRun(c.T, c.DestSysSQL, jobspb.JobID(ingestionJobID))
 
@@ -686,7 +686,7 @@ func TestTenantStreamingMultipleNodes(t *testing.T) {
 
 	replicationtestutils.CreateScatteredTable(t, c, 3)
 
-	producerJobID, ingestionJobID := c.StartStreamReplication()
+	producerJobID, ingestionJobID := c.StartStreamReplication(ctx)
 	jobutils.WaitForJobToRun(c.T, c.SrcSysSQL, jobspb.JobID(producerJobID))
 	jobutils.WaitForJobToRun(c.T, c.DestSysSQL, jobspb.JobID(ingestionJobID))
 
@@ -805,7 +805,7 @@ func TestTenantReplicationProtectedTimestampManagement(t *testing.T) {
 		c.DestSysSQL.Exec(t, "SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'")
 		c.DestSysSQL.Exec(t, "SET CLUSTER SETTING kv.protectedts.reconciliation.interval = '1ms';")
 
-		producerJobID, replicationJobID := c.StartStreamReplication()
+		producerJobID, replicationJobID := c.StartStreamReplication(ctx)
 
 		jobutils.WaitForJobToRun(c.T, c.SrcSysSQL, jobspb.JobID(producerJobID))
 		jobutils.WaitForJobToRun(c.T, c.DestSysSQL, jobspb.JobID(replicationJobID))
@@ -895,7 +895,7 @@ func TestTenantStreamingShowTenant(t *testing.T) {
 
 	c, cleanup := replicationtestutils.CreateTenantStreamingClusters(ctx, t, args)
 	defer cleanup()
-	producerJobID, ingestionJobID := c.StartStreamReplication()
+	producerJobID, ingestionJobID := c.StartStreamReplication(ctx)
 
 	jobutils.WaitForJobToRun(c.T, c.SrcSysSQL, jobspb.JobID(producerJobID))
 	jobutils.WaitForJobToRun(c.T, c.DestSysSQL, jobspb.JobID(ingestionJobID))

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job_test.go
@@ -118,14 +118,14 @@ SET enable_experimental_stream_replication = true;
 	pgURL, cleanupSink := sqlutils.PGUrl(t, source.ServingSQLAddr(), t.Name(), url.User(username.RootUser))
 	defer cleanupSink()
 
-	var ingestionJobID, streamProducerJobID int64
 	var startTime string
 	sourceSQL.QueryRow(t, "SELECT cluster_logical_timestamp()").Scan(&startTime)
 
-	destSQL.QueryRow(t,
+	destSQL.Exec(t,
 		`CREATE TENANT "destination-tenant" FROM REPLICATION OF "source-tenant" ON $1 `,
 		pgURL.String(),
-	).Scan(&ingestionJobID, &streamProducerJobID)
+	)
+	streamProducerJobID, ingestionJobID := replicationtestutils.GetStreamJobIds(t, ctx, destSQL, "destination-tenant")
 
 	sourceSQL.Exec(t, `
 CREATE DATABASE d;
@@ -141,7 +141,7 @@ INSERT INTO d.t2 VALUES (2);
 	jobutils.WaitForJobToSucceed(t, destSQL, jobspb.JobID(ingestionJobID))
 	jobutils.WaitForJobToSucceed(t, sourceDBRunner, jobspb.JobID(streamProducerJobID))
 
-	stats := replicationutils.TestingGetStreamIngestionStatsFromReplicationJob(t, ctx, destSQL, int(ingestionJobID))
+	stats := replicationutils.TestingGetStreamIngestionStatsFromReplicationJob(t, ctx, destSQL, ingestionJobID)
 	require.Equal(t, cutoverTime, stats.IngestionProgress.CutoverTime.GoTime())
 	require.Equal(t, streampb.StreamReplicationStatus_STREAM_INACTIVE, stats.ProducerStatus.StreamStatus)
 
@@ -309,7 +309,7 @@ func TestReplicationJobResumptionStartTime(t *testing.T) {
 	defer close(planned)
 	defer close(canContinue)
 
-	producerJobID, replicationJobID := c.StartStreamReplication()
+	producerJobID, replicationJobID := c.StartStreamReplication(ctx)
 	jobutils.WaitForJobToRun(c.T, c.SrcSysSQL, jobspb.JobID(producerJobID))
 	jobutils.WaitForJobToRun(c.T, c.DestSysSQL, jobspb.JobID(replicationJobID))
 

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 )
@@ -42,14 +41,9 @@ func streamIngestionJobDescription(
 	return tree.AsStringWithFQNames(streamIngestion, ann), nil
 }
 
-var resultColumns = colinfo.ResultColumns{
-	{Name: "ingestion_job_id", Typ: types.Int},
-	{Name: "producer_job_id", Typ: types.Int},
-}
-
 func ingestionTypeCheck(
 	ctx context.Context, stmt tree.Statement, p sql.PlanHookState,
-) (matched bool, header colinfo.ResultColumns, _ error) {
+) (matched bool, _ colinfo.ResultColumns, _ error) {
 	ingestionStmt, ok := stmt.(*tree.CreateTenantFromReplication)
 	if !ok {
 		return false, nil, nil
@@ -61,7 +55,7 @@ func ingestionTypeCheck(
 		return false, nil, err
 	}
 
-	return true, resultColumns, nil
+	return true, nil, nil
 }
 
 func ingestionPlanHook(
@@ -107,7 +101,7 @@ func ingestionPlanHook(
 		retentionTTLSeconds = ret
 	}
 
-	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
+	fn := func(ctx context.Context, _ []sql.PlanNode, _ chan<- tree.Datums) error {
 		ctx, span := tracing.ChildSpan(ctx, stmt.StatementTag())
 		defer span.Finish()
 
@@ -209,18 +203,15 @@ func ingestionPlanHook(
 			Details:     streamIngestionDetails,
 		}
 
-		sj, err := p.ExecCfg().JobRegistry.CreateAdoptableJobWithTxn(ctx, jr,
-			jobID, p.Txn())
+		_, err = p.ExecCfg().JobRegistry.CreateAdoptableJobWithTxn(ctx, jr, jobID, p.Txn())
 		if err != nil {
 			return err
 		}
 
-		resultsCh <- tree.Datums{tree.NewDInt(tree.DInt(sj.ID())),
-			tree.NewDInt(tree.DInt(replicationProducerSpec.StreamID))}
 		return nil
 	}
 
-	return fn, resultColumns, nil, false, nil
+	return fn, nil, nil, false, nil
 }
 
 func init() {

--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -202,6 +202,7 @@ go_library(
         "//pkg/server",
         "//pkg/server/serverpb",
         "//pkg/sql",
+        "//pkg/sql/catalog/descpb",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sem/tree",

--- a/pkg/sql/catalog/colinfo/result_columns.go
+++ b/pkg/sql/catalog/colinfo/result_columns.go
@@ -289,10 +289,10 @@ var TenantColumnsWithReplication = ResultColumns{
 	{Name: "source_cluster_uri", Typ: types.String},
 	{Name: "replication_job_id", Typ: types.Int},
 	// The latest fully replicated time.
-	{Name: "replicated_time", Typ: types.Timestamp},
+	{Name: "replicated_time", Typ: types.TimestampTZ},
 	// The protected timestamp on the destination cluster, meaning we cannot
 	// cutover to before this time.
-	{Name: "retained_time", Typ: types.Timestamp},
+	{Name: "retained_time", Typ: types.TimestampTZ},
 }
 
 // RangesNoLeases is the schema for crdb_internal.ranges_no_leases.

--- a/pkg/sql/show_tenant.go
+++ b/pkg/sql/show_tenant.go
@@ -207,11 +207,20 @@ func (n *showTenantNode) Values() tree.Datums {
 		sourceClusterUri = tree.NewDString(n.replicationInfo.IngestionDetails.StreamAddress)
 		if n.replicationInfo.ReplicationLagInfo != nil {
 			minIngested := n.replicationInfo.ReplicationLagInfo.MinIngestedTimestamp.WallTime
-			// The latest fully replicated time.
-			replicatedTimestamp, _ = tree.MakeDTimestamp(timeutil.Unix(0, minIngested), time.Nanosecond)
+			// The latest fully replicated time. Truncating to the nearest microsecond
+			// because if we don't, then MakeDTimestamp rounds to the nearest
+			// microsecond. In that case a user may want to cutover to a rounded-up
+			// time, which is a time that we may never replicate to. Instead, we show
+			// a time that we know we replicated to.
+			replicatedTimestamp, _ = tree.MakeDTimestamp(timeutil.Unix(0, minIngested).Truncate(time.Microsecond), time.Nanosecond)
 		}
-		// The protected timestamp on the destination cluster.
-		retainedTimestamp, _ = tree.MakeDTimestamp(timeutil.Unix(0, n.protectedTimestamp.WallTime), time.Nanosecond)
+		// The protected timestamp on the destination cluster. Same as with the
+		// replicatedTimestamp, we want to show a retained time that is within the
+		// window (retained to replicated) and not below it. We take a timestamp
+		// that is greater than the protected timestamp by a microsecond or less
+		// (it's not exactly ceil but close enough).
+		retainedCeil := timeutil.Unix(0, n.protectedTimestamp.WallTime).Truncate(time.Microsecond).Add(time.Microsecond)
+		retainedTimestamp, _ = tree.MakeDTimestamp(retainedCeil, time.Nanosecond)
 	}
 
 	return tree.Datums{

--- a/pkg/sql/show_tenant.go
+++ b/pkg/sql/show_tenant.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -206,21 +205,21 @@ func (n *showTenantNode) Values() tree.Datums {
 		sourceTenantName = tree.NewDString(string(n.replicationInfo.IngestionDetails.SourceTenantName))
 		sourceClusterUri = tree.NewDString(n.replicationInfo.IngestionDetails.StreamAddress)
 		if n.replicationInfo.ReplicationLagInfo != nil {
-			minIngested := n.replicationInfo.ReplicationLagInfo.MinIngestedTimestamp.WallTime
+			minIngested := n.replicationInfo.ReplicationLagInfo.MinIngestedTimestamp
 			// The latest fully replicated time. Truncating to the nearest microsecond
 			// because if we don't, then MakeDTimestamp rounds to the nearest
 			// microsecond. In that case a user may want to cutover to a rounded-up
 			// time, which is a time that we may never replicate to. Instead, we show
 			// a time that we know we replicated to.
-			replicatedTimestamp, _ = tree.MakeDTimestamp(timeutil.Unix(0, minIngested).Truncate(time.Microsecond), time.Nanosecond)
+			replicatedTimestamp, _ = tree.MakeDTimestampTZ(minIngested.GoTime().Truncate(time.Microsecond), time.Nanosecond)
 		}
 		// The protected timestamp on the destination cluster. Same as with the
 		// replicatedTimestamp, we want to show a retained time that is within the
 		// window (retained to replicated) and not below it. We take a timestamp
 		// that is greater than the protected timestamp by a microsecond or less
 		// (it's not exactly ceil but close enough).
-		retainedCeil := timeutil.Unix(0, n.protectedTimestamp.WallTime).Truncate(time.Microsecond).Add(time.Microsecond)
-		retainedTimestamp, _ = tree.MakeDTimestamp(retainedCeil, time.Nanosecond)
+		retainedCeil := n.protectedTimestamp.GoTime().Truncate(time.Microsecond).Add(time.Microsecond)
+		retainedTimestamp, _ = tree.MakeDTimestampTZ(retainedCeil, time.Nanosecond)
 	}
 
 	return tree.Datums{


### PR DESCRIPTION
CREATE TENANT FROM REPLICATION: currently has an output (the job ids of the producer and consumer). This PR removes the output.

ALTER TENANT PAUSE/RESUME: currently prints the job id, and this PR removes the output.

ALTER TENANT COMPLETE: currently prints the job id. This PR changes the output to be the cutover timestamp. The rational is that the user may not know the cutover time because LATEST or NOW() etc. was used.

Fixes: #94706

Epic: CRDB-18752

Release note: None