### PR TITLE
trigram: support multi-byte string trigrams; perf improvements

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/trigram_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/trigram_builtins
@@ -5,6 +5,7 @@ SELECT show_trgm(str) FROM (VALUES
     ('ab'),
     ('abc'),
     ('abcd'),
+    ('Приветhi'),
     (NULL)
   ) tbl(str)
 ----
@@ -13,6 +14,7 @@ SELECT show_trgm(str) FROM (VALUES
 {"  a"," ab","ab "}
 {"  a"," ab",abc,"bc "}
 {"  a"," ab",abc,bcd,"cd "}
+{"  п"," пр","hi ",вет,етh,иве,при,рив,тhi}
 NULL
 
 # Test that we sort the output trigrams.

--- a/pkg/sql/logictest/testdata/logic_test/trigram_indexes
+++ b/pkg/sql/logictest/testdata/logic_test/trigram_indexes
@@ -29,7 +29,8 @@ CREATE INDEX ON a USING GIST(t gist_trgm_ops)
 statement ok
 INSERT INTO a VALUES (1, 'foozoopa'),
                      (2, 'Foo'),
-                     (3, 'blah')
+                     (3, 'blah'),
+                     (4, 'Приветhi')
 
 query IT rowsort
 SELECT * FROM a@a_t_idx WHERE t ILIKE '%Foo%'
@@ -83,6 +84,31 @@ SELECT * FROM a@a_t_idx WHERE t LIKE 'blahf'
 query IT
 SELECT * FROM a@a_t_idx WHERE t LIKE 'fblah'
 ----
+
+query IT
+SELECT * FROM a@a_t_idx WHERE t LIKE 'Приветhi'
+----
+4  Приветhi
+
+query IT
+SELECT * FROM a@a_t_idx WHERE t LIKE 'Привет%'
+----
+4  Приветhi
+
+query IT
+SELECT * FROM a@a_t_idx WHERE t LIKE 'Приве%'
+----
+4  Приветhi
+
+query IT
+SELECT * FROM a@a_t_idx WHERE t LIKE '%иве%'
+----
+4  Приветhi
+
+query IT
+SELECT * FROM a@a_t_idx WHERE t LIKE '%тhi%'
+----
+4  Приветhi
 
 # Test the acceleration of the % similarity operator.
 # By default, the threshold for searching is .3.

--- a/pkg/util/trigram/trigram.go
+++ b/pkg/util/trigram/trigram.go
@@ -11,7 +11,6 @@
 package trigram
 
 import (
-	"fmt"
 	"sort"
 	"strings"
 	"unicode"
@@ -19,7 +18,8 @@ import (
 )
 
 // MakeTrigrams returns the downcased, sorted and de-duplicated trigrams for an
-// input string. Non-alphanumeric characters are treated as word boundaries.
+// input string. Non-alphanumeric characters (calculated via unicode's Letter
+// and Number designations) are treated as word boundaries.
 // Words are separately trigrammed. If pad is true, the string will be padded
 // with 2 spaces at the front and 1 at the back, producing 3 extra trigrams.
 func MakeTrigrams(s string, pad bool) []string {
@@ -30,54 +30,43 @@ func MakeTrigrams(s string, pad bool) []string {
 	// Downcase the initial string.
 	s = strings.ToLower(s)
 
-	// Find words.
-	words := strings.FieldsFunc(s, func(r rune) bool {
-		return !unicode.IsLetter(r) && !unicode.IsNumber(r)
-	})
-
 	// Approximately pre-size as if the string is all 1 big word.
-	output := make([]string, 0, len(s))
+	output := make([]string, 0, len(s)+2)
 
-	for _, word := range words {
-		if pad {
-			word = fmt.Sprintf("  %s ", word)
-		}
-		nRunes := utf8.RuneCountInString(word)
-		if nRunes == len(word) {
-			// Fast path for words that have no wide characters.
-			// If not padding, n will be less than 0, so we'll leave the loop as
-			// desired, since words less than length 3 have no trigrams.
-			n := len(word) - 2
-			for i := 0; i < n; i++ {
-				output = append(output, word[i:i+3])
+	start := -1
+	oneByteCharsOnly := true
+	// Loop through the input string searching for word boundaries. For each found
+	// word, generate trigrams and add to the output list. The start and end
+	// variables are used to track the beginning and end of the current word
+	// throughout the loop.
+	// This loop would be more ergonomic with strings.FieldsFunc, but doing so
+	// costs twice the allocations.
+	for end, r := range s {
+		if !unicode.IsLetter(r) && !unicode.IsNumber(r) {
+			// Non-word char.
+			if start < 0 {
+				// Keep going until we find a word char to start the run.
+				continue
 			}
+			// We found a word span. Reset the span and handle it below.
 		} else {
-			// There are some wide characters, so we need to assemble trigrams
-			// in a more careful way than just taking 3-byte windows: we have to
-			// decode each code point to find its width so we can make
-			// windows of 3 codepoints.
-			//
-			// Note that this behavior differs from Postgres: Postgres computes
-			// a hash of the 3 codepoint windows and takes the first 3 bytes of
-			// the hash as the trigram. This is due to limitations in Postgres
-			// and is a dubious way of computing a trigram.
-			// Our method should provide fewer false positives, but note that
-			// users shouldn't see any differences due to this change.
-			nFound := 0
-			charWidths := []int{0, 0}
-			for i, w := 0, 0; i < len(word); i += w {
-				_, w = utf8.DecodeRuneInString(word[i:])
-				if nFound < 2 {
-					charWidths[nFound] = w
-					nFound += 1
-					continue
-				}
-				// Now that we've found our first 2 widths, we can begin assembling the
-				// trigrams.
-				output = append(output, word[i-charWidths[0]-charWidths[1]:i+w])
-				charWidths[0], charWidths[1] = charWidths[1], w
+			// Word char.
+			if start < 0 {
+				start = end
 			}
+			if oneByteCharsOnly && r >= utf8.RuneSelf {
+				oneByteCharsOnly = false
+			}
+			continue
 		}
+
+		output = generateTrigrams(output, s[start:end], pad, oneByteCharsOnly)
+		oneByteCharsOnly = true
+		start = -1
+	}
+	if start >= 0 {
+		// Collect final word.
+		output = generateTrigrams(output, s[start:], pad, oneByteCharsOnly)
 	}
 
 	if len(output) == 0 {
@@ -101,6 +90,53 @@ func MakeTrigrams(s string, pad bool) []string {
 	output = output[:lastUniqueIdx+1]
 
 	return output
+}
+
+func generateTrigrams(appendTo []string, word string, pad bool, onlyOneByteChars bool) []string {
+	if pad {
+		var sb strings.Builder
+		sb.Grow(len(word) + 3)
+		sb.WriteString("  ")
+		sb.WriteString(word)
+		sb.WriteByte(' ')
+		word = sb.String()
+	}
+	if onlyOneByteChars {
+		// Fast path for words that have no wide characters.
+		// If not padding, n will be less than 0, so we'll leave the loop as
+		// desired, since words less than length 3 have no trigrams.
+		n := len(word) - 2
+		for i := 0; i < n; i++ {
+			appendTo = append(appendTo, word[i:i+3])
+		}
+	} else {
+		// There are some wide characters, so we need to assemble trigrams
+		// in a more careful way than just taking 3-byte windows: we have to
+		// decode each code point to find its width so we can make
+		// windows of 3 codepoints.
+		//
+		// Note that this behavior differs from Postgres: Postgres computes
+		// a hash of the 3 codepoint windows and takes the first 3 bytes of
+		// the hash as the trigram. This is due to limitations in Postgres
+		// and is a dubious way of computing a trigram.
+		// Our method should provide fewer false positives, but note that
+		// users shouldn't see any differences due to this change.
+		nFound := 0
+		charWidths := []int{0, 0}
+		for i, w := 0, 0; i < len(word); i += w {
+			_, w = utf8.DecodeRuneInString(word[i:])
+			if nFound < 2 {
+				charWidths[nFound] = w
+				nFound += 1
+				continue
+			}
+			// Now that we've found our first 2 widths, we can begin assembling the
+			// trigrams.
+			appendTo = append(appendTo, word[i-charWidths[0]-charWidths[1]:i+w])
+			charWidths[0], charWidths[1] = charWidths[1], w
+		}
+	}
+	return appendTo
 }
 
 // Similarity returns a trigram similarity measure between two strings. 1.0

--- a/pkg/util/trigram/trigram_test.go
+++ b/pkg/util/trigram/trigram_test.go
@@ -38,6 +38,10 @@ func TestMakeTrigrams(t *testing.T) {
 		{"bcaabc",
 			[]string{"  b", " bc", "aab", "abc", "bc ", "bca", "caa"},
 			[]string{"aab", "abc", "bca", "caa"}},
+		{"Приветhi",
+			[]string{"  п", " пр", "hi ", "вет", "етh", "иве", "при", "рив", "тhi"},
+			[]string{"вет", "етh", "иве", "при", "рив", "тhi"},
+		},
 	} {
 		padded := MakeTrigrams(tc.s, true)
 		unpadded := MakeTrigrams(tc.s, false)
@@ -83,10 +87,17 @@ func TestSimilarity(t *testing.T) {
 }
 
 func BenchmarkSimilarity(b *testing.B) {
-	x := "trigram"
-	y := "trigarm"
-	for i := 0; i < b.N; i++ {
-		s := Similarity(x, y)
-		assert.InDelta(b, s, .3333, 0.0001)
+	for _, t := range []struct {
+		x string
+		y string
+	}{
+		{"trigram", "trigarm"},
+		{"Приветhi", "Привeтho"},
+	} {
+		b.Run(t.x+t.y, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = Similarity(t.x, t.y)
+			}
+		})
 	}
 }

--- a/pkg/util/trigram/trigram_test.go
+++ b/pkg/util/trigram/trigram_test.go
@@ -81,3 +81,12 @@ func TestSimilarity(t *testing.T) {
 		assert.InDelta(t, tc.want, Similarity(tc.l, tc.r), 0.0001, "for %s %% %s", tc.l, tc.r)
 	}
 }
+
+func BenchmarkSimilarity(b *testing.B) {
+	x := "trigram"
+	y := "trigarm"
+	for i := 0; i < b.N; i++ {
+		s := Similarity(x, y)
+		assert.InDelta(b, s, .3333, 0.0001)
+	}
+}


### PR DESCRIPTION
Fixes #93744 
Related to #93830

- Add multi-byte character support
- Improve performance

```
name           old time/op    new time/op    delta
Similarity-32    1.72µs ± 0%    0.60µs ± 3%  -64.98%  (p=0.000 n=9+10)

name           old alloc/op   new alloc/op   delta
Similarity-32    1.32kB ± 0%    0.37kB ± 0%  -72.10%  (p=0.000 n=10+10)

name           old allocs/op  new allocs/op  delta
Similarity-32      15.0 ± 0%       6.0 ± 0%  -60.00%  (p=0.000 n=10+10)
```

Release note (sql change): previously, trigrams ignored multi-byte characters from input strings. This is now corrected.