### PR TITLE
sql: implement fine-grained transaction error redaction

### DIFF
--- a/pkg/kv/BUILD.bazel
+++ b/pkg/kv/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "//pkg/util/uuid",
         "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner.go
@@ -12,7 +12,6 @@ package kvcoord
 
 import (
 	"context"
-	"fmt"
 	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
@@ -23,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/redact"
 	"github.com/google/btree"
 )
 
@@ -778,7 +778,7 @@ func (tp *txnPipeliner) adjustError(
 	if ime, ok := pErr.GetDetail().(*roachpb.IntentMissingError); ok {
 		log.VEventf(ctx, 2, "transforming intent missing error into retry: %v", ime)
 		err := roachpb.NewTransactionRetryError(
-			roachpb.RETRY_ASYNC_WRITE_FAILURE, fmt.Sprintf("missing intent on: %s", ime.Key))
+			roachpb.RETRY_ASYNC_WRITE_FAILURE, redact.Sprintf("missing intent on: %s", ime.Key))
 		retryErr := roachpb.NewErrorWithTxn(err, pErr.GetTxn())
 		retryErr.Index = pErr.Index
 		return retryErr

--- a/pkg/kv/kvserver/batcheval/transaction.go
+++ b/pkg/kv/kvserver/batcheval/transaction.go
@@ -13,13 +13,13 @@ package batcheval
 import (
 	"bytes"
 	"context"
-	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // ErrTransactionUnsupported is returned when a non-transactional command is
@@ -50,7 +50,7 @@ func VerifyTransaction(
 			reason = roachpb.TransactionStatusError_REASON_TXN_COMMITTED
 		}
 		return roachpb.NewTransactionStatusError(reason,
-			fmt.Sprintf("cannot perform %s with txn status %v", args.Method(), h.Txn.Status))
+			redact.Sprintf("cannot perform %s with txn status %v", args.Method(), h.Txn.Status))
 	}
 	return nil
 }

--- a/pkg/kv/mock_transactional_sender.go
+++ b/pkg/kv/mock_transactional_sender.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/redact"
 )
 
 // MockTransactionalSender allows a function to be used as a TxnSender.
@@ -178,7 +179,9 @@ func (m *MockTransactionalSender) UpdateStateOnRemoteRetryableErr(
 func (m *MockTransactionalSender) DisablePipelining() error { return nil }
 
 // PrepareRetryableError is part of the client.TxnSender interface.
-func (m *MockTransactionalSender) PrepareRetryableError(ctx context.Context, msg string) error {
+func (m *MockTransactionalSender) PrepareRetryableError(
+	ctx context.Context, msg redact.RedactableString,
+) error {
 	return roachpb.NewTransactionRetryWithProtoRefreshError(msg, m.txn.ID, *m.txn.Clone())
 }
 

--- a/pkg/kv/sender.go
+++ b/pkg/kv/sender.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/redact"
 )
 
 // TxnType specifies whether a transaction is the root (parent)
@@ -255,7 +256,7 @@ type TxnSender interface {
 	// PrepareRetryableError generates a
 	// TransactionRetryWithProtoRefreshError with a payload initialized
 	// from this txn.
-	PrepareRetryableError(ctx context.Context, msg string) error
+	PrepareRetryableError(ctx context.Context, msg redact.RedactableString) error
 
 	// TestingCloneTxn returns a clone of the transaction's current
 	// proto. This is for use by tests only. Use

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // asyncRollbackTimeout is the context timeout during rollback() for a client
@@ -1419,7 +1420,9 @@ func (txn *Txn) SetFixedTimestamp(ctx context.Context, ts hlc.Timestamp) error {
 // bumped to the extent that txn.ReadTimestamp is racheted up to txn.WriteTimestamp.
 // TODO(andrei): This method should take in an up-to-date timestamp, but
 // unfortunately its callers don't currently have that handy.
-func (txn *Txn) GenerateForcedRetryableError(ctx context.Context, msg string) error {
+func (txn *Txn) GenerateForcedRetryableError(
+	ctx context.Context, msg redact.RedactableString,
+) error {
 	txn.mu.Lock()
 	defer txn.mu.Unlock()
 	now := txn.db.clock.NowAsClockTimestamp()

--- a/pkg/roachpb/ambiguous_result_error.go
+++ b/pkg/roachpb/ambiguous_result_error.go
@@ -78,10 +78,6 @@ func (e *AmbiguousResultError) unwrapOrDefault() error {
 	return cause
 }
 
-func (e *AmbiguousResultError) message(_ *Error) string {
-	return fmt.Sprintf("result is ambiguous: %v", e.unwrapOrDefault())
-}
-
 // Type is part of the ErrorDetailInterface.
 func (e *AmbiguousResultError) Type() ErrorDetailType {
 	return AmbiguousResultErrType

--- a/pkg/roachpb/errors.proto
+++ b/pkg/roachpb/errors.proto
@@ -243,7 +243,11 @@ enum TransactionRetryReason {
 // retried, usually with an increased transaction timestamp.
 message TransactionRetryError {
   optional TransactionRetryReason reason = 1 [(gogoproto.nullable) = false];
+  // Note: Deprecated. `extra_msg_redactable` takes precedence if present.
+  // Both fields will be populated in 23.1.
+  // TODO(davidh): Remove in 23.2
   optional string extra_msg = 2 [(gogoproto.nullable) = false];
+  optional string extra_msg_redactable = 3 [(gogoproto.nullable) = false, (gogoproto.customtype) = "github.com/cockroachdb/redact.RedactableString"];
 }
 
 // A TransactionStatusError indicates that the transaction status is
@@ -253,6 +257,9 @@ message TransactionRetryError {
 // regression in transaction epoch or timestamp, both of which may
 // only monotonically increase.
 message TransactionStatusError {
+  // Note: Deprecated. `msg_redactable` takes precedence if present.
+  // Both fields will be populated in 23.1.
+  // TODO(davidh): Remove in 23.2
   optional string msg = 1 [(gogoproto.nullable) = false];
 
   // Reason specifies what caused the error.
@@ -265,6 +272,7 @@ message TransactionStatusError {
     reserved 1;
   }
   optional Reason reason = 2 [(gogoproto.nullable) = false];
+  optional string msg_redactable = 3 [(gogoproto.nullable) = false, (gogoproto.customtype) = "github.com/cockroachdb/redact.RedactableString"];
 }
 
 // A WriteIntentError indicates that one or more write intents belonging
@@ -449,6 +457,9 @@ message UnhandledRetryableError {
 // client.Sender() interface).
 message TransactionRetryWithProtoRefreshError {
   // A user-readable message.
+  // Note: Deprecated in favor of `msg_redactable` below. Both fields will be
+  // populated in 23.1. Presence of `msg_redactable` will take precedence.
+  // TODO(davidh): Remove in 23.2
   optional string msg = 1 [(gogoproto.nullable) = false];
 
   // The ID of the transaction being restarted. The client is supposed to check
@@ -464,6 +475,9 @@ message TransactionRetryWithProtoRefreshError {
   // before, but with an incremented epoch and timestamp, or a completely new
   // Transaction.
   optional roachpb.Transaction transaction = 3 [(gogoproto.nullable) = false];
+
+  // A user-readable message containing redaction markers.
+  optional string msg_redactable = 4 [(gogoproto.nullable) = false, (gogoproto.customtype) = "github.com/cockroachdb/redact.RedactableString"];
 }
 
 // TxnAlreadyEncounteredErrorError indicates that an operation tried to use a

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -64,6 +64,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 	"github.com/lib/pq/oid"
 	"go.opentelemetry.io/otel/attribute"
 )
@@ -934,7 +935,7 @@ func (ex *connExecutor) commitSQLTransaction(
 			// Generating a forced retry error here, right after resetting the
 			// transaction is not exactly necessary, but it's a sound way to
 			// generate the only type of ClientVisibleRetryError we have.
-			err = ex.state.mu.txn.GenerateForcedRetryableError(ctx, err.Error())
+			err = ex.state.mu.txn.GenerateForcedRetryableError(ctx, redact.Sprint(err))
 		}
 		return ex.makeErrEvent(err, ast)
 	}

--- a/pkg/sql/pgwire/pgerror/BUILD.bazel
+++ b/pkg/sql/pgwire/pgerror/BUILD.bazel
@@ -52,6 +52,7 @@ go_test(
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//testutils",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_kr_pretty//:pretty",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/sql/pgwire/pgerror/flatten_test.go
+++ b/pkg/sql/pgwire/pgerror/flatten_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/testutils"
+	"github.com/cockroachdb/redact"
 	"github.com/stretchr/testify/require"
 )
 
@@ -85,7 +86,7 @@ func TestFlatten(t *testing.T) {
 			},
 		},
 		{
-			errors.Wrap(&roachpb.TransactionRetryWithProtoRefreshError{Msg: "woo"}, ""),
+			errors.Wrap(&roachpb.TransactionRetryWithProtoRefreshError{MsgRedactable: "woo"}, ""),
 			func(t testutils.T, e *pgerror.Error) {
 				t.CheckRegexpEqual(e.Message, "restart transaction: .* woo")
 				t.CheckEqual(pgcode.MakeCode(e.Code), pgcode.SerializationFailure)
@@ -114,7 +115,7 @@ func TestFlatten(t *testing.T) {
 		{
 			errors.Wrap(
 				roachpb.NewTransactionRetryWithProtoRefreshError(
-					roachpb.NewReadWithinUncertaintyIntervalError(hlc.Timestamp{}, hlc.Timestamp{}, hlc.Timestamp{}, nil).Error(),
+					redact.Sprint(roachpb.NewReadWithinUncertaintyIntervalError(hlc.Timestamp{}, hlc.Timestamp{}, hlc.Timestamp{}, nil)),
 					uuid.MakeV4(),
 					roachpb.Transaction{},
 				),
@@ -127,7 +128,7 @@ func TestFlatten(t *testing.T) {
 		{
 			errors.Wrap(
 				roachpb.NewTransactionRetryWithProtoRefreshError(
-					roachpb.NewTransactionRetryError(roachpb.RETRY_SERIALIZABLE, "").Error(),
+					redact.Sprint(roachpb.NewTransactionRetryError(roachpb.RETRY_SERIALIZABLE, "")),
 					uuid.MakeV4(),
 					roachpb.Transaction{},
 				),
@@ -140,7 +141,7 @@ func TestFlatten(t *testing.T) {
 		{
 			errors.Wrap(
 				roachpb.NewTransactionRetryWithProtoRefreshError(
-					roachpb.NewTransactionAbortedError(roachpb.ABORT_REASON_PUSHER_ABORTED).Error(),
+					redact.Sprint(roachpb.NewTransactionAbortedError(roachpb.ABORT_REASON_PUSHER_ABORTED)),
 					uuid.MakeV4(),
 					roachpb.Transaction{},
 				),

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/shuffle"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 	"github.com/lib/pq"
 	"github.com/stretchr/testify/require"
 )
@@ -1639,7 +1640,7 @@ func TestTxnAutoRetryReasonAvailable(t *testing.T) {
 			if req, ok := args.Req.(*roachpb.GetRequest); ok {
 				if bytes.Contains(req.Key, retriedStmtKey) && retryCount < numRetries {
 					return roachpb.NewErrorWithTxn(roachpb.NewTransactionRetryError(roachpb.RETRY_REASON_UNKNOWN,
-						fmt.Sprintf("injected err %d", retryCount+1)), args.Hdr.Txn)
+						redact.Sprintf("injected err %d", retryCount+1)), args.Hdr.Txn)
 				}
 			}
 			return nil

--- a/pkg/storage/testdata/mvcc_histories/conditional_put
+++ b/pkg/storage/testdata/mvcc_histories/conditional_put
@@ -32,7 +32,7 @@ cput k=k v=v ts=123,3
 ----
 >> at end:
 data: "k"/123.000000000,2 -> /BYTES/v
-error: (*roachpb.ConditionFailedError:) unexpected value: raw_bytes:"\000\000\000\000\003v" timestamp:<wall_time:123000000000 logical:2 > 
+error: (*roachpb.ConditionFailedError:) unexpected value: raw_bytes:"\000\000\000\000\003v" timestamp:<wall_time:123000000000 logical:2 >
 
 # Conditional put expecting wrong value2, will fail.
 
@@ -41,7 +41,7 @@ cput k=k v=v cond=v2 ts=123,4
 ----
 >> at end:
 data: "k"/123.000000000,2 -> /BYTES/v
-error: (*roachpb.ConditionFailedError:) unexpected value: raw_bytes:"\000\000\000\000\003v" timestamp:<wall_time:123000000000 logical:2 > 
+error: (*roachpb.ConditionFailedError:) unexpected value: raw_bytes:"\000\000\000\000\003v" timestamp:<wall_time:123000000000 logical:2 >
 
 # Move to an empty value. Will succeed.
 
@@ -89,7 +89,7 @@ cput k=k2 v= cond=v allow_missing ts=123,8
 data: "k"/123.000000000,5 -> /BYTES/
 data: "k"/123.000000000,2 -> /BYTES/v
 data: "k2"/123.000000000,7 -> /BYTES/v2
-error: (*roachpb.ConditionFailedError:) unexpected value: raw_bytes:"\000\000\000\000\003v2" timestamp:<wall_time:123000000000 logical:7 > 
+error: (*roachpb.ConditionFailedError:) unexpected value: raw_bytes:"\000\000\000\000\003v2" timestamp:<wall_time:123000000000 logical:7 >
 
 # Try to move key2 (which has value2) from value2 to empty. Expect success.
 

--- a/pkg/storage/testdata/mvcc_histories/conditional_put_write_too_old
+++ b/pkg/storage/testdata/mvcc_histories/conditional_put_write_too_old
@@ -16,7 +16,7 @@ cput ts=1 k=k v=v2
 ----
 >> at end:
 data: "k"/10.000000000,0 -> /BYTES/v1
-error: (*roachpb.ConditionFailedError:) unexpected value: raw_bytes:"\000\000\000\000\003v1" timestamp:<wall_time:10000000000 > 
+error: (*roachpb.ConditionFailedError:) unexpected value: raw_bytes:"\000\000\000\000\003v1" timestamp:<wall_time:10000000000 >
 
 # Now do a non-transactional put @t=1 with expectation of value1; will "succeed" @t=10,1 with WriteTooOld.
 run error

--- a/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_cput
+++ b/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_cput
@@ -32,7 +32,7 @@ cput t=A k=k cond=a v=c
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10} ts=11.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/11.000000000,0 -> /BYTES/a
 data: "k"/1.000000000,0 -> /BYTES/first
-error: (*roachpb.ConditionFailedError:) unexpected value: raw_bytes:"\000\000\000\000\003first" timestamp:<wall_time:1000000000 > 
+error: (*roachpb.ConditionFailedError:) unexpected value: raw_bytes:"\000\000\000\000\003first" timestamp:<wall_time:1000000000 >
 
 # Condition succeeds to find the original value.
 
@@ -78,7 +78,7 @@ cput t=B k=k cond=b v=c
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20} ts=11.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/11.000000000,0 -> /BYTES/b
 data: "k"/1.000000000,0 -> /BYTES/first
-error: (*roachpb.ConditionFailedError:) unexpected value: raw_bytes:"\000\000\000\000\003a" timestamp:<> 
+error: (*roachpb.ConditionFailedError:) unexpected value: raw_bytes:"\000\000\000\000\003a" timestamp:<>
 
 # However it succeeds to find the write before that.
 
@@ -126,7 +126,7 @@ cput t=C k=k cond=c v=d
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30} ts=11.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}{20 /BYTES/b}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/11.000000000,0 -> /BYTES/c
 data: "k"/1.000000000,0 -> /BYTES/first
-error: (*roachpb.ConditionFailedError:) unexpected value: raw_bytes:"\000\000\000\000\003a" timestamp:<> 
+error: (*roachpb.ConditionFailedError:) unexpected value: raw_bytes:"\000\000\000\000\003a" timestamp:<>
 
 run error
 cput t=C k=k cond=b v=d
@@ -135,7 +135,7 @@ cput t=C k=k cond=b v=d
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30} ts=11.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}{20 /BYTES/b}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/11.000000000,0 -> /BYTES/c
 data: "k"/1.000000000,0 -> /BYTES/first
-error: (*roachpb.ConditionFailedError:) unexpected value: raw_bytes:"\000\000\000\000\003a" timestamp:<> 
+error: (*roachpb.ConditionFailedError:) unexpected value: raw_bytes:"\000\000\000\000\003a" timestamp:<>
 
 # However it succeeds to find the write before that.
 
@@ -182,7 +182,7 @@ cput t=D k=k cond=a v=c
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20} ts=11.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/11.000000000,0 -> /BYTES/b
 data: "k"/1.000000000,0 -> /BYTES/first
-error: (*roachpb.ConditionFailedError:) unexpected value: raw_bytes:"\000\000\000\000\003first" timestamp:<wall_time:1000000000 > 
+error: (*roachpb.ConditionFailedError:) unexpected value: raw_bytes:"\000\000\000\000\003first" timestamp:<wall_time:1000000000 >
 
 run error
 cput t=D k=k cond=b v=c
@@ -191,7 +191,7 @@ cput t=D k=k cond=b v=c
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20} ts=11.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/11.000000000,0 -> /BYTES/b
 data: "k"/1.000000000,0 -> /BYTES/first
-error: (*roachpb.ConditionFailedError:) unexpected value: raw_bytes:"\000\000\000\000\003first" timestamp:<wall_time:1000000000 > 
+error: (*roachpb.ConditionFailedError:) unexpected value: raw_bytes:"\000\000\000\000\003first" timestamp:<wall_time:1000000000 >
 
 # However it succeeds to find the write before that.
 

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_conflicts
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_conflicts
@@ -214,7 +214,7 @@ data: "g"/1.000000000,0 -> /BYTES/g1
 data: "i"/1.000000000,0 -> /INT/1
 data: "j"/1.000000000,0 -> /INT/1
 stats: key_count=7 key_bytes=146 val_count=11 val_bytes=115 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=4 live_bytes=131 gc_bytes_age=16010 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
-error: (*roachpb.ConditionFailedError:) unexpected value: timestamp:<wall_time:5000000000 > 
+error: (*roachpb.ConditionFailedError:) unexpected value: timestamp:<wall_time:5000000000 >
 
 # A CPut replay of an intent expecting a value covered by a range tombstone
 # should error because of the range tombstone covering it.
@@ -240,7 +240,7 @@ data: "g"/1.000000000,0 -> /BYTES/g1
 data: "i"/1.000000000,0 -> /INT/1
 data: "j"/1.000000000,0 -> /INT/1
 stats: key_count=7 key_bytes=146 val_count=11 val_bytes=115 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=4 live_bytes=131 gc_bytes_age=16010 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
-error: (*roachpb.ConditionFailedError:) unexpected value: timestamp:<wall_time:5000000000 > 
+error: (*roachpb.ConditionFailedError:) unexpected value: timestamp:<wall_time:5000000000 >
 
 # A CPut replacing an existing but ignored intent expecting a value covered
 # by a range tombstone should error because of the range tombstone covering it.
@@ -269,7 +269,7 @@ data: "g"/1.000000000,0 -> /BYTES/g1
 data: "i"/1.000000000,0 -> /INT/1
 data: "j"/1.000000000,0 -> /INT/1
 stats: key_count=7 key_bytes=146 val_count=11 val_bytes=115 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=4 live_bytes=131 gc_bytes_age=16010 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
-error: (*roachpb.ConditionFailedError:) unexpected value: timestamp:<wall_time:5000000000 > 
+error: (*roachpb.ConditionFailedError:) unexpected value: timestamp:<wall_time:5000000000 >
 
 # An InitPut with failOnTombstones above a range tombstone should error.
 run stats error
@@ -293,7 +293,7 @@ data: "g"/1.000000000,0 -> /BYTES/g1
 data: "i"/1.000000000,0 -> /INT/1
 data: "j"/1.000000000,0 -> /INT/1
 stats: key_count=7 key_bytes=146 val_count=11 val_bytes=115 range_key_count=2 range_key_bytes=35 range_val_count=3 live_count=4 live_bytes=131 gc_bytes_age=16010 intent_count=1 intent_bytes=18 separated_intent_count=1 intent_age=93
-error: (*roachpb.ConditionFailedError:) unexpected value: timestamp:<wall_time:5000000000 > 
+error: (*roachpb.ConditionFailedError:) unexpected value: timestamp:<wall_time:5000000000 >
 
 # An InitPut with a different value as an existing key should succeed when there's
 # a range tombstone covering the existing value.

--- a/pkg/testutils/lint/passes/fmtsafe/functions.go
+++ b/pkg/testutils/lint/passes/fmtsafe/functions.go
@@ -154,6 +154,8 @@ var requireConstFmt = map[string]bool{
 	"github.com/cockroachdb/cockroach/pkg/kv/kvnemesis.l":                 true,
 	"(*github.com/cockroachdb/cockroach/pkg/kv/kvnemesis.logLogger).Logf": true,
 
+	"(github.com/cockroachdb/cockroach/pkg/roachpb.TestPrinter).Printf": true,
+
 	// Error things are populated in the init() message.
 }
 


### PR DESCRIPTION
Previously, transaction errors would be redacted in full since there was no redaction implemented for their internals. This commit updates all the errors defined in pkg/roachpb/errors.proto to implement `SafeErrorFormatter` in order to be properly redacted.

The tests in place are checking to see that redaction markers *do not* appear in the logs. They will be in place when Errors contain redacted values such as Keys containing row data.

An additional test was added to the telemetry logging suite to ensure that these errors are surfaced unredacted in telemetry logs as well.

Some message fields in Error protobufs have been updated to use `RedactedString` to better support fine grained redaction. A simple migration was applied for those fields but further work may be necessary for further improvements.

Epic: CRDB-12732
Resolves: CRDB-14087

Release note (ops change): Transaction errors will contain more detailed information in redacted logs.