### PR TITLE
release-22.1: sql: fix volatility of <void> IS NOT DISTINCT FROM <unknown>

### DIFF
--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2393,8 +2393,8 @@ var CmpOps = cmpOpFixups(map[treecmp.ComparisonOperatorSymbol]cmpOpOverload{
 		// not occur. Therefore, to allow the comparison
 		// `''::VOID IS DISTINCT FROM NULL`, an explicit equivalence with Unknown is
 		// added:
-		makeIsFn(types.Void, types.Unknown, VolatilityStable),
-		makeIsFn(types.Unknown, types.Void, VolatilityStable),
+		makeIsFn(types.Void, types.Unknown, VolatilityLeakProof),
+		makeIsFn(types.Unknown, types.Void, VolatilityLeakProof),
 
 		// Tuple comparison.
 		&CmpOp{


### PR DESCRIPTION
Backport 1/1 commits from #93713.

/cc @cockroachdb/release

---

The volatility should be leakproof, not stable. This was an oversight in #93652.

Epic: None
Release note: None

----

Release justification: low risk bug fix
