### PR TITLE
release-22.2: server: fix error message

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -457,7 +457,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 			}
 			info, err := cfg.sqlInstanceProvider.GetInstance(cfg.rpcContext.MasterCtx, base.SQLInstanceID(nodeID))
 			if err != nil {
-				return nil, errors.Errorf("unable to look up descriptor for nsql%d", nodeID)
+				return nil, errors.Wrapf(err, "unable to look up descriptor for n%d", nodeID)
 			}
 			return &util.UnresolvedAddr{AddressField: info.InstanceAddr}, nil
 		}


### PR DESCRIPTION
Backport 1/1 commits from #93734.

/cc @cockroachdb/release

Release justification: fix an error

---

This was first introduced in 677a7d54e21b94e486b650f9951af25622987648

Epic: None
Release note: None
