### PR TITLE
ui: install Cypress native binary just in time

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -280,6 +280,17 @@ yarn_install(
     strict_visibility = False,
     yarn_lock = "//pkg/ui/workspaces/e2e-tests:yarn.lock",
     symlink_node_modules = True,
+    environment = {
+        # Don't automatically install the native Cypress binary, since not all
+        # platforms that build CRDB have Cypress binaries to install:
+        # https://docs.cypress.io/guides/getting-started/installing-cypress#System-requirements
+        #
+        # The native binary will be installed by `./dev ui e2e` just-in-time.
+        # While unsupported platforms will still encounter errors at that
+        # point, UI end-to-end tests aren't part of the core build or test
+        # flows and are intended for regression testing by CRDB developers.
+        "CYPRESS_INSTALL_BINARY": "0",
+    }
 )
 
 yarn_install(

--- a/pkg/cmd/dev/testdata/datadriven/ui
+++ b/pkg/cmd/dev/testdata/datadriven/ui
@@ -153,6 +153,7 @@ bazel info workspace --color=no
 bazel info workspace --color=no
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/e2e-tests install
 bazel build //pkg/cmd/cockroach:cockroach --config=with_ui
+bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/e2e-tests cypress install
 crdb-checkout/pkg/ui/workspaces/e2e-tests/build/start-crdb-then.sh bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/e2e-tests cy:run
 
 exec
@@ -162,6 +163,7 @@ bazel info workspace --color=no
 bazel info workspace --color=no
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/e2e-tests install
 bazel build //pkg/cmd/cockroach:cockroach --config=with_ui
+bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/e2e-tests cypress install
 crdb-checkout/pkg/ui/workspaces/e2e-tests/build/start-crdb-then.sh bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/e2e-tests cy:run ./foo/bar
 
 exec
@@ -171,4 +173,5 @@ bazel info workspace --color=no
 bazel info workspace --color=no
 bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/e2e-tests install
 bazel build //pkg/cmd/cockroach:cockroach --config=with_ui
+bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/e2e-tests cypress install
 crdb-checkout/pkg/ui/workspaces/e2e-tests/build/start-crdb-then.sh bazel run @yarn//:yarn -- --silent --cwd crdb-checkout/pkg/ui/workspaces/e2e-tests cy:debug

--- a/pkg/cmd/dev/ui.go
+++ b/pkg/cmd/dev/ui.go
@@ -576,6 +576,14 @@ launching test in a real browser. Extra flags are passed directly to the
 				return fmt.Errorf("unable to build cockroach with UI: %w", err)
 			}
 
+			// Ensure the native Cypress binary is installed.
+			cyInstallArgv := buildBazelYarnArgv("--silent", "--cwd", uiDirs.e2eTests, "cypress", "install")
+			logCommand("bazel", cyInstallArgv...)
+			err = d.exec.CommandContextInheritingStdStreams(ctx, "bazel", cyInstallArgv...)
+			if err != nil {
+				return fmt.Errorf("unable to install Cypress native package: %w", err)
+			}
+
 			// Run Cypress tests, passing any extra args through to 'cypress'
 			startCrdbThenSh := path.Join(uiDirs.e2eTests, "build/start-crdb-then.sh")
 			runCypressArgv := append(

--- a/pkg/ui/not-yarn-workspace.sh
+++ b/pkg/ui/not-yarn-workspace.sh
@@ -7,7 +7,8 @@ set -euo pipefail
   yarn --cwd workspaces/db-console/src/js install
   yarn --cwd workspaces/cluster-ui install
   yarn --cwd workspaces/db-console install
-  yarn --cwd workspaces/e2e-tests install
+  # Don't install the native Cypress binary immediately. ./dev ui e2e will do that just in time.
+  CYPRESS_INSTALL_BINARY=0 yarn --cwd workspaces/e2e-tests install
 )
 
 cat << "EOF"


### PR DESCRIPTION
Previously, the native binary for the UI end-to-end testing framework
Cypress[1] was installed immediately when starting any full build of
CockroachDB (i.e. anything that includes the web UI). This caused errors
on the non-Windows, non-Darwin, non-Linux operating systems that Cypress
doesn't support[2], including FreeBSD and illumos. Since those tests
aren't part of the core build or test suite, build failures are an
unnecessarily harsh failure mode. Download the native Cypress binary
only when necessary, restoring the ability for users on FreeBSD,
illumos, and others to build CockroachDB.

[1] https://cypress.io/
[2] https://docs.cypress.io/guides/getting-started/installing-cypress#Operating-System

Fixes: https://github.com/cockroachdb/cockroach/issues/87369

Release note (build change): The native binary for Cypress is now only
downloaded and installed when UI end- to-end tests are run, instead of
eagerly downloading it on all platforms at build-time. This restores
the ability for non-{Windows, Darwin, Linux} platforms like FreeBSD and
illumos to build CRDB without modifications, which broke in the initial
22.2 release.