### PR TITLE
sql,backupccl: add replica oracle that prefers non-leaseholders, use in backup

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -102,6 +102,7 @@ go_library(
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/pgwire/pgnotice",
         "//pkg/sql/physicalplan",
+        "//pkg/sql/physicalplan/replicaoracle",
         "//pkg/sql/privilege",
         "//pkg/sql/protoreflect",
         "//pkg/sql/roleoption",

--- a/pkg/ccl/backupccl/restore_processor_planning.go
+++ b/pkg/ccl/backupccl/restore_processor_planning.go
@@ -100,7 +100,7 @@ func distRestore(
 
 	makePlan := func(ctx context.Context, dsp *sql.DistSQLPlanner) (*sql.PhysicalPlan, *sql.PlanningCtx, error) {
 
-		planCtx, sqlInstanceIDs, err := dsp.SetupAllNodesPlanning(ctx, execCtx.ExtendedEvalContext(), execCtx.ExecCfg())
+		planCtx, sqlInstanceIDs, err := dsp.SetupAllNodesPlanning(ctx, execCtx.ExtendedEvalContext(), execCtx.ExecCfg(), nil)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -347,8 +347,7 @@ func makePlan(
 			distMode = sql.DistributionTypeNone
 		}
 
-		planCtx := dsp.NewPlanningCtx(ctx, execCtx.ExtendedEvalContext(), nil /* planner */, blankTxn,
-			sql.DistributionType(distMode))
+		planCtx := dsp.NewPlanningCtx(ctx, execCtx.ExtendedEvalContext(), nil, blankTxn, sql.DistributionType(distMode), nil)
 		spanPartitions, err := dsp.PartitionSpans(ctx, planCtx, trackedSpans)
 		if err != nil {
 			return nil, nil, err

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
@@ -260,7 +260,7 @@ func ingest(ctx context.Context, execCtx sql.JobExecContext, ingestionJob *jobs.
 		evalCtx := execCtx.ExtendedEvalContext()
 		dsp := execCtx.DistSQLPlanner()
 
-		planCtx, sqlInstanceIDs, err := dsp.SetupAllNodesPlanning(ctx, evalCtx, execCtx.ExecCfg())
+		planCtx, sqlInstanceIDs, err := dsp.SetupAllNodesPlanning(ctx, evalCtx, execCtx.ExecCfg(), nil)
 
 		if err != nil {
 			return err

--- a/pkg/ccl/streamingccl/streamproducer/stream_lifetime.go
+++ b/pkg/ccl/streamingccl/streamproducer/stream_lifetime.go
@@ -221,8 +221,7 @@ func getReplicationStreamSpec(
 	// Partition the spans with SQLPlanner
 	var noTxn *kv.Txn
 	dsp := jobExecCtx.DistSQLPlanner()
-	planCtx := dsp.NewPlanningCtx(ctx, jobExecCtx.ExtendedEvalContext(),
-		nil /* planner */, noTxn, sql.DistributionTypeSystemTenantOnly)
+	planCtx := dsp.NewPlanningCtx(ctx, jobExecCtx.ExtendedEvalContext(), nil, noTxn, sql.DistributionTypeSystemTenantOnly, nil)
 
 	details, ok := j.Details().(jobspb.StreamReplicationDetails)
 	if !ok {

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -728,6 +728,7 @@ go_test(
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/pgwire/pgwirebase",
         "//pkg/sql/physicalplan",
+        "//pkg/sql/physicalplan/replicaoracle",
         "//pkg/sql/privilege",
         "//pkg/sql/querycache",
         "//pkg/sql/randgen",

--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -324,8 +324,7 @@ func runPlanInsidePlan(
 	if distributePlan.WillDistribute() {
 		distributeType = DistributionTypeAlways
 	}
-	planCtx := params.p.extendedEvalCtx.ExecCfg.DistSQLPlanner.NewPlanningCtx(
-		ctx, evalCtx, &plannerCopy, params.p.txn, distributeType)
+	planCtx := params.p.extendedEvalCtx.ExecCfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, &plannerCopy, params.p.txn, distributeType, nil)
 	planCtx.planner.curPlan.planComponents = *plan
 	planCtx.ExtendedEvalCtx.Planner = &plannerCopy
 	planCtx.ExtendedEvalCtx.StreamManagerFactory = &plannerCopy

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1585,8 +1585,7 @@ func (ex *connExecutor) execWithDistSQLEngine(
 	defer recv.Release()
 
 	evalCtx := planner.ExtendedEvalContext()
-	planCtx := ex.server.cfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, planner,
-		planner.txn, distribute)
+	planCtx := ex.server.cfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, planner, planner.txn, distribute, nil)
 	planCtx.stmtType = recv.stmtType
 	// Skip the diagram generation since on this "main" query path we can get it
 	// via the statement bundle.

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -618,8 +618,7 @@ func (r *createStatsResumer) Resume(ctx context.Context, execCtx interface{}) er
 			}
 		}
 
-		planCtx := dsp.NewPlanningCtx(ctx, evalCtx, nil /* planner */, txn,
-			DistributionTypeSystemTenantOnly)
+		planCtx := dsp.NewPlanningCtx(ctx, evalCtx, nil, txn, DistributionTypeSystemTenantOnly, nil)
 		// CREATE STATS flow doesn't produce any rows and only emits the
 		// metadata, so we can use a nil rowContainerHelper.
 		resultWriter := NewRowResultWriter(nil /* rowContainer */)

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -4228,6 +4228,7 @@ func (dsp *DistSQLPlanner) NewPlanningCtx(
 	planner *planner,
 	txn *kv.Txn,
 	distributionType DistributionType,
+	oracle replicaoracle.Oracle,
 ) *PlanningCtx {
 	distribute := distributionType == DistributionTypeAlways || (distributionType == DistributionTypeSystemTenantOnly && evalCtx.Codec.ForSystemTenant())
 	planCtx := &PlanningCtx{
@@ -4254,7 +4255,7 @@ func (dsp *DistSQLPlanner) NewPlanningCtx(
 		// we still need to instantiate a full planning context.
 		planCtx.parallelizeScansIfLocal = true
 	}
-	planCtx.spanIter = dsp.spanResolver.NewSpanResolverIterator(txn)
+	planCtx.spanIter = dsp.spanResolver.NewSpanResolverIterator(txn, oracle)
 	planCtx.nodeStatuses = make(map[base.SQLInstanceID]NodeStatus)
 	planCtx.nodeStatuses[dsp.gatewaySQLInstanceID] = NodeOK
 	return planCtx

--- a/pkg/sql/distsql_plan_changefeed.go
+++ b/pkg/sql/distsql_plan_changefeed.go
@@ -139,7 +139,7 @@ func PlanCDCExpression(
 		return cdcPlan, errors.AssertionFailedf("unexpected query structure")
 	}
 
-	planCtx := p.DistSQLPlanner().NewPlanningCtx(ctx, &p.extendedEvalCtx, p, p.txn, DistributionTypeNone)
+	planCtx := p.DistSQLPlanner().NewPlanningCtx(ctx, &p.extendedEvalCtx, p, p.txn, DistributionTypeNone, nil)
 
 	return CDCExpressionPlan{
 		Plan:         p.curPlan.main,

--- a/pkg/sql/distsql_plan_ctas.go
+++ b/pkg/sql/distsql_plan_ctas.go
@@ -35,8 +35,7 @@ func PlanAndRunCTAS(
 	if !isLocal {
 		distribute = DistributionTypeSystemTenantOnly
 	}
-	planCtx := dsp.NewPlanningCtx(ctx, planner.ExtendedEvalContext(), planner,
-		txn, distribute)
+	planCtx := dsp.NewPlanningCtx(ctx, planner.ExtendedEvalContext(), planner, txn, distribute, nil)
 	planCtx.stmtType = tree.Rows
 
 	physPlan, cleanup, err := dsp.createPhysPlan(ctx, planCtx, in)

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -1606,8 +1606,7 @@ func (dsp *DistSQLPlanner) planAndRunSubquery(
 	if distributeSubquery {
 		distribute = DistributionTypeAlways
 	}
-	subqueryPlanCtx := dsp.NewPlanningCtx(ctx, evalCtx, planner, planner.txn,
-		distribute)
+	subqueryPlanCtx := dsp.NewPlanningCtx(ctx, evalCtx, planner, planner.txn, distribute, nil)
 	subqueryPlanCtx.stmtType = tree.Rows
 	subqueryPlanCtx.skipDistSQLDiagramGeneration = skipDistSQLDiagramGeneration
 	if planner.instrumentation.ShouldSaveFlows() {
@@ -1938,7 +1937,7 @@ func (dsp *DistSQLPlanner) planAndRunPostquery(
 	if distributePostquery {
 		distribute = DistributionTypeAlways
 	}
-	postqueryPlanCtx := dsp.NewPlanningCtx(ctx, evalCtx, planner, planner.txn, distribute)
+	postqueryPlanCtx := dsp.NewPlanningCtx(ctx, evalCtx, planner, planner.txn, distribute, nil)
 	postqueryPlanCtx.stmtType = tree.Rows
 	// Postqueries are only executed on the main query path where we skip the
 	// diagram generation.

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -177,8 +177,7 @@ func TestDistSQLRunningInAbortedTxn(t *testing.T) {
 		// We need distribute = true so that executing the plan involves marshaling
 		// the root txn meta to leaf txns. Local flows can start in aborted txns
 		// because they just use the root txn.
-		planCtx := execCfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, p, nil,
-			DistributionTypeSystemTenantOnly)
+		planCtx := execCfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, p, nil, DistributionTypeSystemTenantOnly, nil)
 		planCtx.stmtType = recv.stmtType
 
 		execCfg.DistSQLPlanner.PlanAndRun(

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -78,7 +78,7 @@ func newDistSQLSpecExecFactory(
 		distribute = DistributionTypeSystemTenantOnly
 	}
 	evalCtx := p.ExtendedEvalContext()
-	e.planCtx = e.dsp.NewPlanningCtx(ctx, evalCtx, e.planner, e.planner.txn, distribute)
+	e.planCtx = e.dsp.NewPlanningCtx(ctx, evalCtx, e.planner, e.planner.txn, distribute, nil)
 	return e
 }
 

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -126,8 +126,7 @@ func newPlanningCtxForExplainPurposes(
 	if distribution.WillDistribute() {
 		distribute = DistributionTypeAlways
 	}
-	planCtx := distSQLPlanner.NewPlanningCtx(params.ctx, params.extendedEvalCtx,
-		params.p, params.p.txn, distribute)
+	planCtx := distSQLPlanner.NewPlanningCtx(params.ctx, params.extendedEvalCtx, params.p, params.p.txn, distribute, nil)
 	planCtx.planner.curPlan.subqueryPlans = subqueryPlans
 	for i := range planCtx.planner.curPlan.subqueryPlans {
 		p := &planCtx.planner.curPlan.subqueryPlans[i]

--- a/pkg/sql/importer/import_processor_planning.go
+++ b/pkg/sql/importer/import_processor_planning.go
@@ -75,7 +75,7 @@ func distImport(
 	makePlan := func(ctx context.Context, dsp *sql.DistSQLPlanner) (*sql.PhysicalPlan, *sql.PlanningCtx, error) {
 		evalCtx := execCtx.ExtendedEvalContext()
 
-		planCtx, sqlInstanceIDs, err := dsp.SetupAllNodesPlanning(ctx, evalCtx, execCtx.ExecCfg())
+		planCtx, sqlInstanceIDs, err := dsp.SetupAllNodesPlanning(ctx, evalCtx, execCtx.ExecCfg(), nil)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/sql/index_backfiller.go
+++ b/pkg/sql/index_backfiller.go
@@ -168,8 +168,7 @@ func (ib *IndexBackfillPlanner) plan(
 	) error {
 		sd := NewFakeSessionData(ib.execCfg.SV())
 		evalCtx = createSchemaChangeEvalCtx(ctx, ib.execCfg, sd, nowTimestamp, descriptors)
-		planCtx = ib.execCfg.DistSQLPlanner.NewPlanningCtx(ctx, &evalCtx,
-			nil /* planner */, txn, DistributionTypeSystemTenantOnly)
+		planCtx = ib.execCfg.DistSQLPlanner.NewPlanningCtx(ctx, &evalCtx, nil, txn, DistributionTypeSystemTenantOnly, nil)
 		// TODO(ajwerner): Adopt util.ConstantWithMetamorphicTestRange for the
 		// batch size. Also plumb in a testing knob.
 		chunkSize := indexBackfillBatchSize.Get(&ib.execCfg.Settings.SV)

--- a/pkg/sql/mvcc_backfiller.go
+++ b/pkg/sql/mvcc_backfiller.go
@@ -128,8 +128,7 @@ func (im *IndexBackfillerMergePlanner) plan(
 	) error {
 		sd := NewFakeSessionData(im.execCfg.SV())
 		evalCtx = createSchemaChangeEvalCtx(ctx, im.execCfg, sd, txn.ReadTimestamp(), descriptors)
-		planCtx = im.execCfg.DistSQLPlanner.NewPlanningCtx(ctx, &evalCtx, nil /* planner */, txn,
-			DistributionTypeSystemTenantOnly)
+		planCtx = im.execCfg.DistSQLPlanner.NewPlanningCtx(ctx, &evalCtx, nil, txn, DistributionTypeSystemTenantOnly, nil)
 
 		spec, err := initIndexBackfillMergerSpec(*tableDesc.TableDesc(), addedIndexes, temporaryIndexes, mergeTimestamp)
 		if err != nil {

--- a/pkg/sql/physicalplan/fake_span_resolver.go
+++ b/pkg/sql/physicalplan/fake_span_resolver.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan/replicaoracle"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
@@ -65,7 +66,9 @@ type fakeSpanResolverIterator struct {
 }
 
 // NewSpanResolverIterator is part of the SpanResolver interface.
-func (fsr *fakeSpanResolver) NewSpanResolverIterator(txn *kv.Txn) SpanResolverIterator {
+func (fsr *fakeSpanResolver) NewSpanResolverIterator(
+	txn *kv.Txn, optionalOracle replicaoracle.Oracle,
+) SpanResolverIterator {
 	rng, _ := randutil.NewTestRand()
 	return &fakeSpanResolverIterator{fsr: fsr, db: txn.DB(), rng: rng}
 }

--- a/pkg/sql/physicalplan/fake_span_resolver_test.go
+++ b/pkg/sql/physicalplan/fake_span_resolver_test.go
@@ -54,7 +54,7 @@ func TestFakeSpanResolver(t *testing.T) {
 	db := tc.Server(0).DB()
 
 	txn := kv.NewTxn(ctx, db, tc.Server(0).NodeID())
-	it := resolver.NewSpanResolverIterator(txn)
+	it := resolver.NewSpanResolverIterator(txn, nil)
 
 	tableDesc := desctestutils.TestingGetPublicTableDescriptor(db, keys.SystemSQLCodec, "test", "t")
 	primIdxValDirs := catalogkeys.IndexKeyValDirs(tableDesc.GetPrimaryIndex())

--- a/pkg/sql/physicalplan/replicaoracle/oracle.go
+++ b/pkg/sql/physicalplan/replicaoracle/oracle.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"math"
 	"math/rand"
+	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
@@ -38,6 +39,8 @@ var (
 	BinPackingChoice = RegisterPolicy(newBinPackingOracle)
 	// ClosestChoice chooses the node closest to the current node.
 	ClosestChoice = RegisterPolicy(newClosestOracle)
+	// PreferFollowerChoice prefers choosing followers over leaseholders.
+	PreferFollowerChoice = RegisterPolicy(newPreferFollowerOracle)
 )
 
 // Config is used to construct an OracleFactory.
@@ -287,4 +290,41 @@ func latencyFunc(rpcCtx *rpc.Context) kvcoord.LatencyFunc {
 		return rpcCtx.RemoteClocks.Latency
 	}
 	return nil
+}
+
+type preferFollowerOracle struct {
+	nodeDescs kvcoord.NodeDescStore
+}
+
+func newPreferFollowerOracle(cfg Config) Oracle {
+	return &preferFollowerOracle{nodeDescs: cfg.NodeDescs}
+}
+
+func (o preferFollowerOracle) ChoosePreferredReplica(
+	ctx context.Context,
+	_ *kv.Txn,
+	desc *roachpb.RangeDescriptor,
+	_ *roachpb.ReplicaDescriptor,
+	_ roachpb.RangeClosedTimestampPolicy,
+	_ QueryState,
+) (roachpb.ReplicaDescriptor, error) {
+	replicas, err := replicaSliceOrErr(ctx, o.nodeDescs, desc, kvcoord.AllExtantReplicas)
+	if err != nil {
+		return roachpb.ReplicaDescriptor{}, err
+	}
+
+	leaseholders, err := replicaSliceOrErr(ctx, o.nodeDescs, desc, kvcoord.OnlyPotentialLeaseholders)
+	if err != nil {
+		return roachpb.ReplicaDescriptor{}, err
+	}
+	leaseholderNodeIDs := make(map[roachpb.NodeID]bool)
+	for i := range leaseholders {
+		leaseholderNodeIDs[leaseholders[i].NodeID] = true
+	}
+
+	sort.Slice(replicas, func(i, j int) bool {
+		return !leaseholderNodeIDs[replicas[i].NodeID] && leaseholderNodeIDs[replicas[j].NodeID]
+	})
+
+	return replicas[0].ReplicaDescriptor, nil
 }

--- a/pkg/sql/physicalplan/replicaoracle/oracle_test.go
+++ b/pkg/sql/physicalplan/replicaoracle/oracle_test.go
@@ -42,7 +42,7 @@ func TestClosest(t *testing.T) {
 		ctx := context.Background()
 		stopper := stop.NewStopper()
 		defer stopper.Stop(ctx)
-		g, _ := makeGossip(t, stopper)
+		g, _ := makeGossip(t, stopper, []int{2, 3})
 		nd2, err := g.GetNodeDescriptor(2)
 		require.NoError(t, err)
 		o := NewOracle(ClosestChoice, Config{
@@ -83,7 +83,7 @@ func TestClosest(t *testing.T) {
 	})
 }
 
-func makeGossip(t *testing.T, stopper *stop.Stopper) (*gossip.Gossip, *hlc.Clock) {
+func makeGossip(t *testing.T, stopper *stop.Stopper, nodeIDs []int) (*gossip.Gossip, *hlc.Clock) {
 	clock := hlc.NewClockWithSystemTimeSource(time.Nanosecond /* maxOffset */)
 	ctx := context.Background()
 	rpcContext := rpc.NewInsecureTestingContext(ctx, clock, stopper)
@@ -97,7 +97,8 @@ func makeGossip(t *testing.T, stopper *stop.Stopper) (*gossip.Gossip, *hlc.Clock
 	if err := g.AddInfo(gossip.KeySentinel, nil, time.Hour); err != nil {
 		t.Fatal(err)
 	}
-	for i := roachpb.NodeID(2); i <= 3; i++ {
+	for _, id := range nodeIDs {
+		i := roachpb.NodeID(id)
 		err := g.AddInfoProto(gossip.MakeNodeIDKey(i), newNodeDesc(i), gossip.NodeDescriptorTTL)
 		if err != nil {
 			t.Fatal(err)
@@ -118,5 +119,50 @@ func newNodeDesc(nodeID roachpb.NodeID) *roachpb.NodeDescriptor {
 				},
 			},
 		},
+	}
+}
+
+func TestPreferFollower(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	g, _ := makeGossip(t, stopper, []int{2, 3, 4, 5, 6})
+	o := NewOracle(PreferFollowerChoice, Config{
+		NodeDescs: g,
+	})
+	internalReplicas := []roachpb.ReplicaDescriptor{
+		{ReplicaID: 2, NodeID: 2, StoreID: 2, Type: roachpb.VOTER_FULL},
+		{ReplicaID: 3, NodeID: 3, StoreID: 3, Type: roachpb.VOTER_FULL},
+		{ReplicaID: 4, NodeID: 4, StoreID: 4, Type: roachpb.VOTER_FULL},
+		{ReplicaID: 5, NodeID: 5, StoreID: 5, Type: roachpb.NON_VOTER},
+		{ReplicaID: 6, NodeID: 6, StoreID: 6, Type: roachpb.NON_VOTER},
+	}
+	rand.Shuffle(len(internalReplicas), func(i, j int) {
+		internalReplicas[i], internalReplicas[j] = internalReplicas[j], internalReplicas[i]
+	})
+	info, err := o.ChoosePreferredReplica(
+		ctx,
+		nil, /* txn */
+		&roachpb.RangeDescriptor{
+			InternalReplicas: internalReplicas,
+		},
+		nil, /* leaseHolder */
+		roachpb.LAG_BY_CLUSTER_SETTING,
+		QueryState{},
+	)
+	if err != nil {
+		t.Fatalf("Failed to choose follower replica: %v", err)
+	}
+
+	fullVoters := make(map[roachpb.NodeID]bool)
+	for _, r := range internalReplicas {
+		if r.Type == roachpb.VOTER_FULL {
+			fullVoters[r.NodeID] = true
+		}
+	}
+
+	if fullVoters[info.NodeID] {
+		t.Fatalf("Chose a VOTER_FULL replica: %d", info.NodeID)
 	}
 }

--- a/pkg/sql/physicalplan/span_resolver_test.go
+++ b/pkg/sql/physicalplan/span_resolver_test.go
@@ -111,7 +111,7 @@ func TestSpanResolverUsesCaches(t *testing.T) {
 
 	// Resolve the spans. Since the range descriptor cache doesn't have any
 	// leases, all the ranges should be grouped and "assigned" to replica 0.
-	replicas, err := resolveSpans(context.Background(), lr.NewSpanResolverIterator(nil), spans...)
+	replicas, err := resolveSpans(context.Background(), lr.NewSpanResolverIterator(nil, nil), spans...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -138,7 +138,7 @@ func TestSpanResolverUsesCaches(t *testing.T) {
 	if err := populateCache(tc.Conns[3], 3 /* expectedNumRows */); err != nil {
 		t.Fatal(err)
 	}
-	replicas, err = resolveSpans(context.Background(), lr.NewSpanResolverIterator(nil), spans...)
+	replicas, err = resolveSpans(context.Background(), lr.NewSpanResolverIterator(nil, nil), spans...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -209,7 +209,7 @@ func TestSpanResolver(t *testing.T) {
 		replicaoracle.BinPackingChoice)
 
 	ctx := context.Background()
-	it := lr.NewSpanResolverIterator(nil)
+	it := lr.NewSpanResolverIterator(nil, nil)
 
 	testCases := []struct {
 		spans    []roachpb.Span
@@ -308,7 +308,7 @@ func TestMixedDirections(t *testing.T) {
 		replicaoracle.BinPackingChoice)
 
 	ctx := context.Background()
-	it := lr.NewSpanResolverIterator(nil)
+	it := lr.NewSpanResolverIterator(nil, nil)
 
 	spans := []spanWithDir{
 		orient(kvcoord.Ascending, makeSpan(tableDesc, 11, 15))[0],

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -153,8 +153,7 @@ func (dsp *DistSQLPlanner) Exec(
 		distributionType = DistributionTypeSystemTenantOnly
 	}
 	evalCtx := p.ExtendedEvalContext()
-	planCtx := execCfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, p, p.txn,
-		distributionType)
+	planCtx := execCfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, p, p.txn, distributionType, nil)
 	planCtx.stmtType = recv.stmtType
 
 	dsp.PlanAndRun(ctx, evalCtx, planCtx, p.txn, p.curPlan.main, recv)
@@ -180,8 +179,7 @@ func (dsp *DistSQLPlanner) ExecLocalAll(
 
 	distributionType := DistributionType(DistributionTypeNone)
 	evalCtx := p.ExtendedEvalContext()
-	planCtx := execCfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, p, p.txn,
-		distributionType)
+	planCtx := execCfg.DistSQLPlanner.NewPlanningCtx(ctx, evalCtx, p, p.txn, distributionType, nil)
 	planCtx.stmtType = recv.stmtType
 
 	var evalCtxFactory func() *extendedEvalContext

--- a/pkg/sql/ttl/ttljob/ttljob.go
+++ b/pkg/sql/ttl/ttljob/ttljob.go
@@ -207,7 +207,7 @@ func (t rowLevelTTLResumer) Resume(ctx context.Context, execCtx interface{}) err
 
 		// We don't return the compatible nodes here since PartitionSpans will
 		// filter out incompatible nodes.
-		planCtx, _, err := distSQLPlanner.SetupAllNodesPlanning(ctx, evalCtx, execCfg)
+		planCtx, _, err := distSQLPlanner.SetupAllNodesPlanning(ctx, evalCtx, execCfg, nil)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Following #91405 which enables followers to serve ExportRequests, this patch introduces an oracle that prefers non-potential-leaseholders when selecting a replica. This oracle is then used in backups so that ExportRequests during backups have a preference to be served by non-leaseholders.

Release note: None