### PR TITLE
kv/kvserver: skip TestProtectedTimestamps

### DIFF
--- a/pkg/kv/kvserver/client_protectedts_test.go
+++ b/pkg/kv/kvserver/client_protectedts_test.go
@@ -47,6 +47,7 @@ import (
 func TestProtectedTimestamps(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.WithIssue(t, 93497, "flaky test")
 	ctx := context.Background()
 
 	// This test is too slow to run with race.


### PR DESCRIPTION
It's flaky and failing very frequently.

Epic: none
Release note: None