### PR TITLE
kvserver: add BenchmarkReplicaProposal

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -285,6 +285,7 @@ go_test(
         "replica_lease_renewal_test.go",
         "replica_metrics_test.go",
         "replica_probe_test.go",
+        "replica_proposal_bench_test.go",
         "replica_proposal_buf_test.go",
         "replica_protected_timestamp_test.go",
         "replica_raft_overload_test.go",

--- a/pkg/kv/kvserver/replica_proposal_bench_test.go
+++ b/pkg/kv/kvserver/replica_proposal_bench_test.go
@@ -1,0 +1,102 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kvserver_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/stretchr/testify/require"
+)
+
+// BenchmarkReplicaProposal starts a single-voter store and repeatedly
+// overwrites the same key with a large payload.
+//
+// It is intended to be sensitive to allocations and memory copies on the write
+// path. It intentionally does not cover the SQL layer or the transport between
+// kvcoord and kvserver. These add significant overheads and can be explored
+// using `pkg/sql/tests.BenchmarkKV`.
+func BenchmarkReplicaProposal(b *testing.B) {
+	const kb = 1 << 10
+	const mb = kb * kb
+	for _, bytes := range []int64{
+		256,
+		512,
+		1 * kb,
+		256 * kb,
+		512 * kb,
+		1 * mb, // pebble max batch reuse limit is 1mb
+		2 * mb,
+	} {
+		for _, withFollower := range []bool{false, true} {
+			b.Run(fmt.Sprintf("bytes=%s,withFollower=%t", humanizeutil.IBytes(bytes), withFollower), func(b *testing.B) {
+				runBenchmarkReplicaProposal(b, bytes, withFollower)
+			})
+		}
+	}
+}
+
+func runBenchmarkReplicaProposal(b *testing.B, bytes int64, withFollower bool) {
+	defer leaktest.AfterTest(b)()
+	defer log.Scope(b).Close(b)
+	ctx := context.Background()
+
+	nodes := 1
+	if withFollower {
+		nodes = 2
+	}
+
+	args := base.TestClusterArgs{}
+	args.ReplicationMode = base.ReplicationManual
+	tc := testcluster.StartTestCluster(b, nodes, args)
+	defer tc.Stopper().Stop(ctx)
+
+	k := tc.ScratchRange(b)
+
+	if withFollower {
+		// Two voters implies that the second node has to ack everything before it
+		// goes through, so it won't trail behind. It might trail a bit in entry
+		// application but we live with that.
+		tc.AddNonVotersOrFatal(b, k, tc.Target(1))
+	}
+
+	rng, _ := randutil.NewPseudoRand()
+	value := roachpb.MakeValueFromString(
+		randutil.RandString(rng, int(bytes), randutil.PrintableKeyAlphabet),
+	)
+	req := roachpb.NewPut(k, value)
+	var ba roachpb.BatchRequest
+	ba.Add(req)
+
+	repl, _, err := tc.Server(0).GetStores().(*kvserver.Stores).GetReplicaForRangeID(
+		ctx, tc.LookupRangeOrFatal(b, k).RangeID)
+	require.NoError(b, err)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ba.Timestamp = repl.Clock().Now()
+		_, pErr := repl.Send(ctx, &ba)
+		if err := pErr.GoError(); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+	b.SetBytes(bytes)
+}


### PR DESCRIPTION
This benchmark is sensitive to allocations in the write path,
and also captures the allocations during encoding/decoding.

I've started looking at it a bit already and there is lots we
can improve. This benchmark establishes a useful baseline.

<details>
<summary>Details</summary>

```
BenchmarkReplicaProposal/bytes=256_B,withFollower=false-24         	    6416	    191618 ns/op	   1.34 MB/s	   20630 B/op	      86 allocs/op
BenchmarkReplicaProposal/bytes=256_B,withFollower=false-24         	    6788	    191021 ns/op	   1.34 MB/s	   20866 B/op	      85 allocs/op
BenchmarkReplicaProposal/bytes=256_B,withFollower=false-24         	    6408	    199786 ns/op	   1.28 MB/s	   20690 B/op	      86 allocs/op
BenchmarkReplicaProposal/bytes=256_B,withFollower=false-24         	    6896	    196956 ns/op	   1.30 MB/s	   20901 B/op	      84 allocs/op
BenchmarkReplicaProposal/bytes=256_B,withFollower=false-24         	    5599	    196997 ns/op	   1.30 MB/s	   20878 B/op	      91 allocs/op
BenchmarkReplicaProposal/bytes=256_B,withFollower=true-24          	    5085	    244054 ns/op	   1.05 MB/s	   43171 B/op	     204 allocs/op
BenchmarkReplicaProposal/bytes=256_B,withFollower=true-24          	    5110	    222853 ns/op	   1.15 MB/s	   42719 B/op	     203 allocs/op
BenchmarkReplicaProposal/bytes=256_B,withFollower=true-24          	    5188	    228833 ns/op	   1.12 MB/s	   43219 B/op	     202 allocs/op
BenchmarkReplicaProposal/bytes=256_B,withFollower=true-24          	    4962	    226162 ns/op	   1.13 MB/s	   42905 B/op	     206 allocs/op
BenchmarkReplicaProposal/bytes=256_B,withFollower=true-24          	    5496	    218142 ns/op	   1.17 MB/s	   42497 B/op	     198 allocs/op
BenchmarkReplicaProposal/bytes=512_B,withFollower=false-24         	    6284	    191820 ns/op	   2.67 MB/s	   24910 B/op	      87 allocs/op
BenchmarkReplicaProposal/bytes=512_B,withFollower=false-24         	    5676	    202978 ns/op	   2.52 MB/s	   25310 B/op	      90 allocs/op
BenchmarkReplicaProposal/bytes=512_B,withFollower=false-24         	    6174	    197549 ns/op	   2.59 MB/s	   25391 B/op	      88 allocs/op
BenchmarkReplicaProposal/bytes=512_B,withFollower=false-24         	    6688	    199835 ns/op	   2.56 MB/s	   24914 B/op	      85 allocs/op
BenchmarkReplicaProposal/bytes=512_B,withFollower=false-24         	    6118	    192424 ns/op	   2.66 MB/s	   25335 B/op	      88 allocs/op
BenchmarkReplicaProposal/bytes=512_B,withFollower=true-24          	    4556	    234737 ns/op	   2.18 MB/s	   54510 B/op	     215 allocs/op
BenchmarkReplicaProposal/bytes=512_B,withFollower=true-24          	    5650	    228136 ns/op	   2.24 MB/s	   51957 B/op	     197 allocs/op
BenchmarkReplicaProposal/bytes=512_B,withFollower=true-24          	    4815	    233736 ns/op	   2.19 MB/s	   53292 B/op	     210 allocs/op
BenchmarkReplicaProposal/bytes=512_B,withFollower=true-24          	    4994	    238701 ns/op	   2.14 MB/s	   52846 B/op	     207 allocs/op
BenchmarkReplicaProposal/bytes=512_B,withFollower=true-24          	    5128	    243775 ns/op	   2.10 MB/s	   53090 B/op	     204 allocs/op
BenchmarkReplicaProposal/bytes=1.0_KiB,withFollower=false-24       	    5977	    216012 ns/op	   4.74 MB/s	   33739 B/op	      90 allocs/op
BenchmarkReplicaProposal/bytes=1.0_KiB,withFollower=false-24       	    6087	    211506 ns/op	   4.84 MB/s	   33942 B/op	      89 allocs/op
BenchmarkReplicaProposal/bytes=1.0_KiB,withFollower=false-24       	    5740	    221454 ns/op	   4.62 MB/s	   34900 B/op	      91 allocs/op
BenchmarkReplicaProposal/bytes=1.0_KiB,withFollower=false-24       	    5078	    211623 ns/op	   4.84 MB/s	   34355 B/op	      96 allocs/op
BenchmarkReplicaProposal/bytes=1.0_KiB,withFollower=false-24       	    6180	    214860 ns/op	   4.77 MB/s	   33860 B/op	      89 allocs/op
BenchmarkReplicaProposal/bytes=1.0_KiB,withFollower=true-24        	    4521	    243088 ns/op	   4.21 MB/s	   74568 B/op	     218 allocs/op
BenchmarkReplicaProposal/bytes=1.0_KiB,withFollower=true-24        	    5107	    249893 ns/op	   4.10 MB/s	   72845 B/op	     208 allocs/op
BenchmarkReplicaProposal/bytes=1.0_KiB,withFollower=true-24        	    5328	    251357 ns/op	   4.07 MB/s	   71105 B/op	     205 allocs/op
BenchmarkReplicaProposal/bytes=1.0_KiB,withFollower=true-24        	    5136	    256008 ns/op	   4.00 MB/s	   71471 B/op	     207 allocs/op
BenchmarkReplicaProposal/bytes=1.0_KiB,withFollower=true-24        	    4312	    250351 ns/op	   4.09 MB/s	   73218 B/op	     222 allocs/op
BenchmarkReplicaProposal/bytes=256_KiB,withFollower=false-24       	     393	   2947991 ns/op	  88.92 MB/s	 6254456 B/op	    1007 allocs/op
BenchmarkReplicaProposal/bytes=256_KiB,withFollower=false-24       	     367	   2947527 ns/op	  88.94 MB/s	 6149981 B/op	    1051 allocs/op
BenchmarkReplicaProposal/bytes=256_KiB,withFollower=false-24       	     350	   3196925 ns/op	  82.00 MB/s	 6146575 B/op	    1088 allocs/op
BenchmarkReplicaProposal/bytes=256_KiB,withFollower=false-24       	     339	   3176083 ns/op	  82.54 MB/s	 6406584 B/op	    1482 allocs/op
BenchmarkReplicaProposal/bytes=256_KiB,withFollower=false-24       	     344	   2966022 ns/op	  88.38 MB/s	 6386156 B/op	    1467 allocs/op
BenchmarkReplicaProposal/bytes=256_KiB,withFollower=true-24        	     349	   3133140 ns/op	  83.67 MB/s	15385402 B/op	    2100 allocs/op
BenchmarkReplicaProposal/bytes=256_KiB,withFollower=true-24        	     358	   3767973 ns/op	  69.57 MB/s	15493940 B/op	    1888 allocs/op
BenchmarkReplicaProposal/bytes=256_KiB,withFollower=true-24        	     345	   3409452 ns/op	  76.89 MB/s	15157098 B/op	    2125 allocs/op
BenchmarkReplicaProposal/bytes=256_KiB,withFollower=true-24        	     337	   3574113 ns/op	  73.35 MB/s	14800254 B/op	    2238 allocs/op
BenchmarkReplicaProposal/bytes=256_KiB,withFollower=true-24        	     302	   3500321 ns/op	  74.89 MB/s	14754797 B/op	    2233 allocs/op
BenchmarkReplicaProposal/bytes=512_KiB,withFollower=false-24       	     171	   6140263 ns/op	  85.39 MB/s	11589150 B/op	    2016 allocs/op
BenchmarkReplicaProposal/bytes=512_KiB,withFollower=false-24       	     177	   6235944 ns/op	  84.08 MB/s	11858391 B/op	    1981 allocs/op
BenchmarkReplicaProposal/bytes=512_KiB,withFollower=false-24       	     177	   6531580 ns/op	  80.27 MB/s	11811576 B/op	    1980 allocs/op
BenchmarkReplicaProposal/bytes=512_KiB,withFollower=false-24       	     169	   6137642 ns/op	  85.42 MB/s	11847589 B/op	    2062 allocs/op
BenchmarkReplicaProposal/bytes=512_KiB,withFollower=false-24       	     178	   6277507 ns/op	  83.52 MB/s	11587012 B/op	    1956 allocs/op
BenchmarkReplicaProposal/bytes=512_KiB,withFollower=true-24        	     190	   6699962 ns/op	  78.25 MB/s	29210929 B/op	    3700 allocs/op
BenchmarkReplicaProposal/bytes=512_KiB,withFollower=true-24        	     188	   6100540 ns/op	  85.94 MB/s	27142927 B/op	    3741 allocs/op
BenchmarkReplicaProposal/bytes=512_KiB,withFollower=true-24        	     182	   6198056 ns/op	  84.59 MB/s	27700878 B/op	    3861 allocs/op
BenchmarkReplicaProposal/bytes=512_KiB,withFollower=true-24        	     188	   6860292 ns/op	  76.42 MB/s	28421147 B/op	    3775 allocs/op
BenchmarkReplicaProposal/bytes=512_KiB,withFollower=true-24        	     166	   6727971 ns/op	  77.93 MB/s	29195299 B/op	    4183 allocs/op
BenchmarkReplicaProposal/bytes=1.0_MiB,withFollower=false-24       	      90	  14043645 ns/op	  74.67 MB/s	26112575 B/op	    3705 allocs/op
BenchmarkReplicaProposal/bytes=1.0_MiB,withFollower=false-24       	     100	  14021047 ns/op	  74.79 MB/s	26625743 B/op	    3414 allocs/op
BenchmarkReplicaProposal/bytes=1.0_MiB,withFollower=false-24       	     100	  14479893 ns/op	  72.42 MB/s	26373749 B/op	    3416 allocs/op
BenchmarkReplicaProposal/bytes=1.0_MiB,withFollower=false-24       	     100	  14453966 ns/op	  72.55 MB/s	26754822 B/op	    3408 allocs/op
BenchmarkReplicaProposal/bytes=1.0_MiB,withFollower=false-24       	     100	  15069785 ns/op	  69.58 MB/s	26633447 B/op	    3405 allocs/op
BenchmarkReplicaProposal/bytes=1.0_MiB,withFollower=true-24        	     100	  13655196 ns/op	  76.79 MB/s	58189394 B/op	    6974 allocs/op
BenchmarkReplicaProposal/bytes=1.0_MiB,withFollower=true-24        	     100	  13449555 ns/op	  77.96 MB/s	58744677 B/op	    6996 allocs/op
BenchmarkReplicaProposal/bytes=1.0_MiB,withFollower=true-24        	      94	  14871413 ns/op	  70.51 MB/s	57907082 B/op	    7310 allocs/op
BenchmarkReplicaProposal/bytes=1.0_MiB,withFollower=true-24        	      86	  14096974 ns/op	  74.38 MB/s	57828970 B/op	    7917 allocs/op
BenchmarkReplicaProposal/bytes=1.0_MiB,withFollower=true-24        	      93	  13200500 ns/op	  79.43 MB/s	57236491 B/op	    7339 allocs/op
BenchmarkReplicaProposal/bytes=2.0_MiB,withFollower=false-24       	      46	  32206226 ns/op	  65.12 MB/s	49982156 B/op	    7070 allocs/op
BenchmarkReplicaProposal/bytes=2.0_MiB,withFollower=false-24       	     100	  31125013 ns/op	  67.38 MB/s	53214548 B/op	    4546 allocs/op
BenchmarkReplicaProposal/bytes=2.0_MiB,withFollower=false-24       	      99	  29512775 ns/op	  71.06 MB/s	52824055 B/op	    4478 allocs/op
BenchmarkReplicaProposal/bytes=2.0_MiB,withFollower=false-24       	     100	  32609457 ns/op	  64.31 MB/s	53559644 B/op	    4243 allocs/op
BenchmarkReplicaProposal/bytes=2.0_MiB,withFollower=false-24       	     100	  31367867 ns/op	  66.86 MB/s	53998391 B/op	    4611 allocs/op
BenchmarkReplicaProposal/bytes=2.0_MiB,withFollower=true-24        	      90	  30787238 ns/op	  68.12 MB/s	118740574 B/op	    9334 allocs/op
BenchmarkReplicaProposal/bytes=2.0_MiB,withFollower=true-24        	     100	  31738433 ns/op	  66.08 MB/s	119257599 B/op	    8795 allocs/op
BenchmarkReplicaProposal/bytes=2.0_MiB,withFollower=true-24        	     100	  30595635 ns/op	  68.54 MB/s	118523692 B/op	    9104 allocs/op
BenchmarkReplicaProposal/bytes=2.0_MiB,withFollower=true-24        	     100	  32403900 ns/op	  64.72 MB/s	119062375 B/op	    9103 allocs/op
BenchmarkReplicaProposal/bytes=2.0_MiB,withFollower=true-24        	      93	  31248016 ns/op	  67.11 MB/s	118541721 B/op	    9066 allocs/op
```

</details>

Epic: none
Release note: None
