### PR TITLE
log: fix bug in AmbientContext.ResetAndAnnotateCtx

### DIFF
--- a/pkg/util/log/ambient_context.go
+++ b/pkg/util/log/ambient_context.go
@@ -138,9 +138,7 @@ func (ac *AmbientContext) ResetAndAnnotateCtx(ctx context.Context) context.Conte
 		if ac.eventLog != nil && tracing.SpanFromContext(ctx) == nil && eventLogFromCtx(ctx) == nil {
 			ctx = embedCtxEventLog(ctx, ac.eventLog)
 		}
-		if ac.tags != nil {
-			ctx = logtags.WithTags(ctx, ac.tags)
-		}
+		ctx = logtags.WithTags(ctx, ac.tags)
 		if ac.ServerIDs != nil {
 			ctx = context.WithValue(ctx, ServerIdentificationContextKey{}, ac.ServerIDs)
 		}

--- a/pkg/util/log/ambient_context_test.go
+++ b/pkg/util/log/ambient_context_test.go
@@ -113,4 +113,11 @@ func TestResetAndAnnotateCtx(t *testing.T) {
 	if exp, val := "[a1] test", FormatWithContextTags(ctx, "test"); val != exp {
 		t.Errorf("expected '%s', got '%s'", exp, val)
 	}
+
+	ctx = logtags.AddTag(context.Background(), "b", 2)
+	ac = AmbientContext{}
+	ctx = ac.ResetAndAnnotateCtx(ctx)
+	if exp, val := "test", FormatWithContextTags(ctx, "test"); val != exp {
+		t.Errorf("expected '%s', got '%s'", exp, val)
+	}
 }


### PR DESCRIPTION
The bug was that if the AmbientContext didn't have any tags, the tags in the passed in context were being preserved instead of being wiped.

Release note: None
Epic: None