### PR TITLE
*: make use of common user InternalExecutorOverride structs (part 2)

### DIFF
--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -980,7 +980,7 @@ func (b *backupResumer) maybeNotifyScheduledJobCompletion(
 			ctx,
 			"lookup-schedule-info",
 			txn,
-			sessiondata.InternalExecutorOverride{User: username.NodeUserName()},
+			sessiondata.NodeUserSessionDataOverride,
 			fmt.Sprintf(
 				"SELECT created_by_id FROM %s WHERE id=$1 AND created_by_type=$2",
 				env.SystemJobsTableName()),

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1880,7 +1880,7 @@ func revalidateIndexes(
 				runner,
 				false, /* withFirstMutationPublic */
 				true,  /* gatherAllInvalid */
-				sessiondata.InternalExecutorOverride{},
+				sessiondata.NoSessionDataOverride,
 				execCfg.ProtectedTimestampManager,
 			); err != nil {
 				if invalid := (sql.InvalidIndexesError{}); errors.As(err, &invalid) {
@@ -1900,7 +1900,7 @@ func revalidateIndexes(
 				runner,
 				false, /* withFirstMutationPublic */
 				true,  /* gatherAllInvalid */
-				sessiondata.InternalExecutorOverride{},
+				sessiondata.NoSessionDataOverride,
 				execCfg.ProtectedTimestampManager,
 			); err != nil {
 				if invalid := (sql.InvalidIndexesError{}); errors.As(err, &invalid) {

--- a/pkg/ccl/backupccl/schedule_pts_chaining.go
+++ b/pkg/ccl/backupccl/schedule_pts_chaining.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptpb"
 	roachpb "github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/scheduledjobs"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -102,7 +101,7 @@ func maybeUpdateSchedulePTSRecord(
 			ctx,
 			"lookup-schedule-info",
 			txn,
-			sessiondata.InternalExecutorOverride{User: username.NodeUserName()},
+			sessiondata.NodeUserSessionDataOverride,
 			fmt.Sprintf(
 				"SELECT created_by_id FROM %s WHERE id=$1 AND created_by_type=$2",
 				env.SystemJobsTableName()),

--- a/pkg/cloud/externalconn/record.go
+++ b/pkg/cloud/externalconn/record.go
@@ -96,7 +96,7 @@ func LoadExternalConnection(
 	// privilege. We run the query as `node` since the user might not have
 	// `SELECT` on the system table.
 	row, cols, err := ex.QueryRowExWithCols(ctx, "lookup-schedule", txn,
-		sessiondata.InternalExecutorOverride{User: username.NodeUserName()},
+		sessiondata.NodeUserSessionDataOverride,
 		fmt.Sprintf("SELECT * FROM system.external_connections WHERE connection_name = '%s'", name))
 
 	if err != nil {
@@ -292,7 +292,7 @@ func (e *MutableExternalConnection) Create(
 	// since the user might not have `INSERT` on the system table.
 	createQuery := "INSERT INTO system.external_connections (%s) VALUES (%s) RETURNING connection_name"
 	row, retCols, err := ex.QueryRowExWithCols(ctx, "ExternalConnection.Create", txn,
-		sessiondata.InternalExecutorOverride{User: username.NodeUserName()},
+		sessiondata.NodeUserSessionDataOverride,
 		fmt.Sprintf(createQuery, strings.Join(cols, ","), generatePlaceholders(len(qargs))),
 		qargs...,
 	)

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -667,7 +667,7 @@ func (r *Registry) GetJobInfo(
 ) ([]byte, bool, error) {
 	row, err := r.ex.QueryRowEx(
 		ctx, "job-info-get", txn,
-		sessiondata.InternalExecutorOverride{User: username.NodeUserName()},
+		sessiondata.NodeUserSessionDataOverride,
 		"SELECT value FROM system.job_info WHERE job_id = $1 AND info_key = $2 ORDER BY written DESC LIMIT 1",
 		jobID, infoKey,
 	)
@@ -700,7 +700,7 @@ func (r *Registry) IterateJobInfo(
 	// TODO(dt): verify this predicate hits the index.
 	rows, err := r.ex.QueryIteratorEx(
 		ctx, "job-info-iter", txn,
-		sessiondata.InternalExecutorOverride{User: username.NodeUserName()},
+		sessiondata.NodeUserSessionDataOverride,
 		`SELECT info_key, value 
 		FROM system.job_info 
 		WHERE job_id = $1 AND substring(info_key for $2) = $3 
@@ -757,7 +757,7 @@ func (r *Registry) WriteJobInfo(
 	// First clear out any older revisions of this info.
 	_, err := r.ex.ExecEx(
 		ctx, "job-info-write", txn,
-		sessiondata.InternalExecutorOverride{User: username.NodeUserName()},
+		sessiondata.NodeUserSessionDataOverride,
 		"DELETE FROM system.job_info WHERE job_id = $1 AND info_key = $2",
 		jobID, infoKey,
 	)
@@ -768,7 +768,7 @@ func (r *Registry) WriteJobInfo(
 	// Write the new info, using the same transaction.
 	_, err = r.ex.ExecEx(
 		ctx, "job-info-write", txn,
-		sessiondata.InternalExecutorOverride{User: username.NodeUserName()},
+		sessiondata.NodeUserSessionDataOverride,
 		`INSERT INTO system.job_info (job_id, info_key, written, value) VALUES ($1, $2, now(), $3)`,
 		jobID, infoKey, value,
 	)

--- a/pkg/kv/kvserver/protectedts/ptstorage/BUILD.bazel
+++ b/pkg/kv/kvserver/protectedts/ptstorage/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "//pkg/kv",
         "//pkg/kv/kvserver/protectedts",
         "//pkg/kv/kvserver/protectedts/ptpb",
-        "//pkg/security/username",
         "//pkg/settings/cluster",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",

--- a/pkg/kv/kvserver/reports/BUILD.bazel
+++ b/pkg/kv/kvserver/reports/BUILD.bazel
@@ -22,7 +22,6 @@ go_library(
         "//pkg/kv/kvserver/allocator/storepool",
         "//pkg/kv/kvserver/liveness",
         "//pkg/roachpb",
-        "//pkg/security/username",
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/sql/catalog",

--- a/pkg/kv/kvserver/reports/reporter.go
+++ b/pkg/kv/kvserver/reports/reporter.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/storepool"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -803,7 +802,7 @@ func getReportGenerationTime(
 		ctx,
 		"get-previous-timestamp",
 		txn,
-		sessiondata.InternalExecutorOverride{User: username.NodeUserName()},
+		sessiondata.NodeUserSessionDataOverride,
 		"select generated from system.reports_meta where id = $1",
 		rid,
 	)

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1917,9 +1917,7 @@ func (s *adminServer) SetUIData(
 		query := `UPSERT INTO system.ui (key, value, "lastUpdated") VALUES ($1, $2, now())`
 		rowsAffected, err := ie.ExecEx(
 			ctx, "admin-set-ui-data", nil, /* txn */
-			sessiondata.InternalExecutorOverride{
-				User: username.RootUserName(),
-			},
+			sessiondata.RootUserSessionDataOverride,
 			query, makeUIKey(userName, key), val)
 		if err != nil {
 			return nil, serverError(ctx, err)

--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -162,9 +161,7 @@ func collectCombinedStatements(
 	const expectedNumDatums = 8
 
 	it, err := ie.QueryIteratorEx(ctx, "combined-stmts-by-interval", nil,
-		sessiondata.InternalExecutorOverride{
-			User: username.NodeUserName(),
-		}, query, args...)
+		sessiondata.NodeUserSessionDataOverride, query, args...)
 
 	if err != nil {
 		return nil, serverError(ctx, err)
@@ -274,9 +271,7 @@ func collectCombinedTransactions(
 	const expectedNumDatums = 6
 
 	it, err := ie.QueryIteratorEx(ctx, "combined-txns-by-interval", nil,
-		sessiondata.InternalExecutorOverride{
-			User: username.NodeUserName(),
-		}, query, args...)
+		sessiondata.NodeUserSessionDataOverride, query, args...)
 
 	if err != nil {
 		return nil, serverError(ctx, err)
@@ -502,9 +497,7 @@ func getTotalStatementDetails(
 	var statement serverpb.StatementDetailsResponse_CollectedStatementSummary
 
 	row, err := ie.QueryRowEx(ctx, "combined-stmts-details-total", nil,
-		sessiondata.InternalExecutorOverride{
-			User: username.NodeUserName(),
-		}, query, args...)
+		sessiondata.NodeUserSessionDataOverride, query, args...)
 
 	if err != nil {
 		return statement, serverError(ctx, err)
@@ -593,9 +586,7 @@ func getStatementDetailsPerAggregatedTs(
 	const expectedNumDatums = 5
 
 	it, err := ie.QueryIteratorEx(ctx, "combined-stmts-details-by-aggregated-timestamp", nil,
-		sessiondata.InternalExecutorOverride{
-			User: username.NodeUserName(),
-		}, query, args...)
+		sessiondata.NodeUserSessionDataOverride, query, args...)
 
 	if err != nil {
 		return nil, serverError(ctx, err)
@@ -668,9 +659,7 @@ func getExplainPlanFromGist(ctx context.Context, ie *sql.InternalExecutor, planG
 	args = append(args, planGist)
 
 	it, err := ie.QueryIteratorEx(ctx, "combined-stmts-details-get-explain-plan", nil,
-		sessiondata.InternalExecutorOverride{
-			User: username.NodeUserName(),
-		}, query, args...)
+		sessiondata.NodeUserSessionDataOverride, query, args...)
 
 	if err != nil {
 		return planError
@@ -708,9 +697,7 @@ func getIdxAndTableName(ctx context.Context, ie *sql.InternalExecutor, indexInfo
 	args = append(args, indexID)
 
 	row, err := ie.QueryRowEx(ctx, "combined-stmts-details-get-index-and-table-names", nil,
-		sessiondata.InternalExecutorOverride{
-			User: username.NodeUserName(),
-		}, `SELECT descriptor_name, index_name FROM crdb_internal.table_indexes 
+		sessiondata.NodeUserSessionDataOverride, `SELECT descriptor_name, index_name FROM crdb_internal.table_indexes 
     WHERE descriptor_id =$1 AND index_id=$2`, args...)
 	if err != nil {
 		return indexInfo
@@ -775,9 +762,7 @@ func getStatementDetailsPerPlanHash(
 	args = append(args, limit)
 
 	it, err := ie.QueryIteratorEx(ctx, "combined-stmts-details-by-plan-hash", nil,
-		sessiondata.InternalExecutorOverride{
-			User: username.NodeUserName(),
-		}, query, args...)
+		sessiondata.NodeUserSessionDataOverride, query, args...)
 
 	if err != nil {
 		return nil, serverError(ctx, err)

--- a/pkg/server/import_ts.go
+++ b/pkg/server/import_ts.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/ts"
@@ -77,9 +76,7 @@ func maybeImportTS(ctx context.Context, s *Server) (returnErr error) {
 	} {
 		if _, err := s.sqlServer.internalExecutor.ExecEx(
 			ctx, "tsdump-cfg", nil, /* txn */
-			sessiondata.InternalExecutorOverride{
-				User: username.RootUserName(),
-			},
+			sessiondata.RootUserSessionDataOverride,
 			stmt,
 		); err != nil {
 			return errors.Wrapf(err, "%s", stmt)

--- a/pkg/server/statement_diagnostics_requests.go
+++ b/pkg/server/statement_diagnostics_requests.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -145,9 +144,7 @@ func (s *statusServer) StatementDiagnosticsRequests(
 	}
 	// TODO(davidh): Add pagination to this request.
 	it, err := s.internalExecutor.QueryIteratorEx(ctx, "stmt-diag-get-all", nil, /* txn */
-		sessiondata.InternalExecutorOverride{
-			User: username.RootUserName(),
-		},
+		sessiondata.RootUserSessionDataOverride,
 		fmt.Sprintf(`SELECT
 			id,
 			statement_fingerprint,
@@ -233,9 +230,7 @@ func (s *statusServer) StatementDiagnostics(
 
 	var err error
 	row, err := s.internalExecutor.QueryRowEx(ctx, "stmt-diag-get-one", nil, /* txn */
-		sessiondata.InternalExecutorOverride{
-			User: username.RootUserName(),
-		},
+		sessiondata.RootUserSessionDataOverride,
 		`SELECT
 			id,
 			statement_fingerprint,

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1486,7 +1486,7 @@ func (sc *SchemaChanger) validateIndexes(ctx context.Context) error {
 				runHistoricalTxn,
 				true,  /* withFirstMutationPubic */
 				false, /* gatherAllInvalid */
-				sessiondata.InternalExecutorOverride{},
+				sessiondata.NoSessionDataOverride,
 				sc.execCfg.ProtectedTimestampManager,
 			)
 		})
@@ -1502,7 +1502,7 @@ func (sc *SchemaChanger) validateIndexes(ctx context.Context) error {
 				runHistoricalTxn,
 				true,  /* withFirstMutationPublic */
 				false, /* gatherAllInvalid */
-				sessiondata.InternalExecutorOverride{},
+				sessiondata.NoSessionDataOverride,
 				sc.execCfg.ProtectedTimestampManager,
 			)
 		})

--- a/pkg/sql/catalog/schematelemetry/schematelemetrycontroller/controller.go
+++ b/pkg/sql/catalog/schematelemetry/schematelemetrycontroller/controller.go
@@ -316,7 +316,7 @@ func GetSchemaTelemetryScheduleID(
 		ctx,
 		"check-existing-schema-telemetry-schedule",
 		txn,
-		sessiondata.InternalExecutorOverride{User: username.NodeUserName()},
+		sessiondata.NodeUserSessionDataOverride,
 		`SELECT schedule_id FROM system.scheduled_jobs WHERE schedule_name = $1 ORDER BY schedule_id ASC LIMIT 1`,
 		SchemaTelemetryScheduleName,
 	)

--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -70,9 +70,7 @@ func validateCheckExpr(
 		ctx,
 		"validate check constraint",
 		txn,
-		sessiondata.InternalExecutorOverride{
-			User: username.RootUserName(),
-		},
+		sessiondata.RootUserSessionDataOverride,
 		queryStr)
 	if err != nil {
 		return err

--- a/pkg/sql/compact_sql_stats.go
+++ b/pkg/sql/compact_sql_stats.go
@@ -124,7 +124,7 @@ func (r *sqlStatsCompactionResumer) getScheduleID(
 	ctx context.Context, ie sqlutil.InternalExecutor, txn *kv.Txn, env scheduledjobs.JobSchedulerEnv,
 ) (scheduleID int64, _ error) {
 	row, err := ie.QueryRowEx(ctx, "lookup-sql-stats-schedule", txn,
-		sessiondata.InternalExecutorOverride{User: username.NodeUserName()},
+		sessiondata.NodeUserSessionDataOverride,
 		fmt.Sprintf("SELECT created_by_id FROM %s WHERE id=$1 AND created_by_type=$2", env.SystemJobsTableName()),
 		r.job.ID(), jobs.CreatedByScheduledJobs,
 	)

--- a/pkg/sql/contention/txnidcache/BUILD.bazel
+++ b/pkg/sql/contention/txnidcache/BUILD.bazel
@@ -43,7 +43,6 @@ go_test(
         "//pkg/roachpb",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
-        "//pkg/security/username",
         "//pkg/server",
         "//pkg/settings/cluster",
         "//pkg/sql",

--- a/pkg/sql/contention/txnidcache/txn_id_cache_test.go
+++ b/pkg/sql/contention/txnidcache/txn_id_cache_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/contention/txnidcache"
@@ -150,9 +149,7 @@ func TestTransactionIDCache(t *testing.T) {
 				ctx,
 				appName,
 				txn,
-				sessiondata.InternalExecutorOverride{
-					User: username.RootUserName(),
-				},
+				sessiondata.RootUserSessionDataOverride,
 				stmt,
 			)
 			require.NoError(t, err)

--- a/pkg/sql/control_schedules.go
+++ b/pkg/sql/control_schedules.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/scheduledjobs"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -72,7 +71,7 @@ func loadSchedule(params runParams, scheduleID tree.Datum) (*jobs.ScheduledJob, 
 	datums, cols, err := params.ExecCfg().InternalExecutor.QueryRowExWithCols(
 		params.ctx,
 		"load-schedule",
-		params.p.Txn(), sessiondata.InternalExecutorOverride{User: username.NodeUserName()},
+		params.p.Txn(), sessiondata.NodeUserSessionDataOverride,
 		fmt.Sprintf(
 			"SELECT schedule_id, next_run, schedule_expr, executor_type, execution_args, owner FROM %s WHERE schedule_id = $1",
 			env.ScheduledJobsTableName(),

--- a/pkg/sql/create_external_connection.go
+++ b/pkg/sql/create_external_connection.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/kv"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
@@ -128,7 +127,7 @@ func (p *planner) createExternalConnection(
 			ec.name, p.User().SQLIdentifier())
 		_, err = ie.ExecEx(params.ctx,
 			"grant-on-create-external-connection", txn,
-			sessiondata.InternalExecutorOverride{User: username.NodeUserName()}, grantStatement)
+			sessiondata.NodeUserSessionDataOverride, grantStatement)
 		if err != nil {
 			return errors.Wrap(err, "failed to grant on newly created External Connection")
 		}

--- a/pkg/sql/drop_external_connection.go
+++ b/pkg/sql/drop_external_connection.go
@@ -14,7 +14,6 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
@@ -73,7 +72,7 @@ func (p *planner) dropExternalConnection(params runParams, n *tree.DropExternalC
 		params.ctx,
 		dropExternalConnectionOp,
 		params.p.Txn(),
-		sessiondata.InternalExecutorOverride{User: username.NodeUserName()},
+		sessiondata.NodeUserSessionDataOverride,
 		`DELETE FROM system.external_connections WHERE connection_name = $1`, name,
 	); err != nil {
 		return errors.Wrapf(err, "failed to delete external connection")
@@ -85,7 +84,7 @@ func (p *planner) dropExternalConnection(params runParams, n *tree.DropExternalC
 		params.ctx,
 		dropExternalConnectionOp,
 		params.p.Txn(),
-		sessiondata.InternalExecutorOverride{User: username.NodeUserName()},
+		sessiondata.NodeUserSessionDataOverride,
 		`DELETE FROM system.privileges WHERE path = $1`, ecPrivilege.GetPath(),
 	); err != nil {
 		return errors.Wrapf(err, "failed to delete external connection")

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -755,7 +755,7 @@ func (ie *InternalExecutor) maybeRootSessionDataOverride(
 			ApplicationName: catconstants.InternalAppNamePrefix + "-" + opName,
 		}
 	}
-	o := sessiondata.InternalExecutorOverride{}
+	o := sessiondata.NoSessionDataOverride
 	sd := ie.sessionDataStack.Top()
 	if sd.User().Undefined() {
 		o.User = username.RootUserName()

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
@@ -73,9 +72,7 @@ func (p *planner) getLiveClusterRegions(ctx context.Context) (LiveClusterRegions
 func GetLiveClusterRegions(ctx context.Context, p PlanHookState) (LiveClusterRegions, error) {
 	// Non-admin users can't access the crdb_internal.kv_node_status table, which
 	// this query hits, so we must override the user here.
-	override := sessiondata.InternalExecutorOverride{
-		User: username.RootUserName(),
-	}
+	override := sessiondata.RootUserSessionDataOverride
 
 	it, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.QueryIteratorEx(
 		ctx,

--- a/pkg/sql/scheduledlogging/captured_index_usage_stats.go
+++ b/pkg/sql/scheduledlogging/captured_index_usage_stats.go
@@ -314,7 +314,7 @@ func getAllDatabaseNames(ctx context.Context, ie sqlutil.InternalExecutor) (tree
 		ctx,
 		"get-all-db-names",
 		nil,
-		sessiondata.InternalExecutorOverride{User: username.NodeUserName()},
+		sessiondata.NodeUserSessionDataOverride,
 		`SELECT database_name FROM [SHOW DATABASES]`,
 	)
 	if err != nil {

--- a/pkg/sql/schemachanger/scexec/exec_validation.go
+++ b/pkg/sql/schemachanger/scexec/exec_validation.go
@@ -13,7 +13,6 @@ package scexec
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scerrors"
@@ -39,9 +38,7 @@ func executeValidateUniqueIndex(
 		return err
 	}
 	// Execute the validation operation as a root user.
-	execOverride := sessiondata.InternalExecutorOverride{
-		User: username.RootUserName(),
-	}
+	execOverride := sessiondata.RootUserSessionDataOverride
 	if index.GetType() == descpb.IndexDescriptor_FORWARD {
 		err = deps.Validator().ValidateForwardIndexes(ctx, deps.TransactionalJobRegistry().CurrentJob(), table, []catalog.Index{index}, execOverride)
 	} else {
@@ -76,9 +73,7 @@ func executeValidateCheckConstraint(
 	}
 
 	// Execute the validation operation as a root user.
-	execOverride := sessiondata.InternalExecutorOverride{
-		User: username.RootUserName(),
-	}
+	execOverride := sessiondata.RootUserSessionDataOverride
 	err = deps.Validator().ValidateCheckConstraint(ctx, table, check, op.IndexIDForValidation, execOverride)
 	if err != nil {
 		return scerrors.SchemaChangerUserError(err)

--- a/pkg/sql/show_create_external_connection.go
+++ b/pkg/sql/show_create_external_connection.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -49,7 +48,7 @@ func loadExternalConnections(
 		datums, _, err := params.ExecCfg().InternalExecutor.QueryBufferedExWithCols(
 			params.ctx,
 			"load-external-connections",
-			params.p.Txn(), sessiondata.InternalExecutorOverride{User: username.NodeUserName()},
+			params.p.Txn(), sessiondata.NodeUserSessionDataOverride,
 			"SELECT connection_name FROM system.external_connections")
 		if err != nil {
 			return nil, err

--- a/pkg/sql/sqlstats/persistedsqlstats/compaction_exec.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/compaction_exec.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -118,7 +117,7 @@ func (c *StatsCompactor) getRowCountForShard(
 	row, err := c.ie.QueryRowEx(ctx,
 		"scan-row-count",
 		nil,
-		sessiondata.InternalExecutorOverride{User: username.NodeUserName()},
+		sessiondata.NodeUserSessionDataOverride,
 		stmt,
 		shardIdx,
 	)
@@ -215,7 +214,7 @@ func (c *StatsCompactor) executeDeleteStmt(
 	it, err := c.ie.QueryIteratorEx(ctx,
 		"delete-old-sql-stats",
 		nil, /* txn */
-		sessiondata.InternalExecutorOverride{User: username.NodeUserName()},
+		sessiondata.NodeUserSessionDataOverride,
 		delStmt,
 		qargs...,
 	)

--- a/pkg/sql/sqlstats/persistedsqlstats/compaction_scheduling.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/compaction_scheduling.go
@@ -106,7 +106,7 @@ func checkExistingCompactionSchedule(
 	query := "SELECT count(*) FROM system.scheduled_jobs WHERE schedule_name = $1"
 
 	row, err := ie.QueryRowEx(ctx, "check-existing-sql-stats-schedule", txn,
-		sessiondata.InternalExecutorOverride{User: username.NodeUserName()},
+		sessiondata.NodeUserSessionDataOverride,
 		query, compactionScheduleName,
 	)
 

--- a/pkg/sql/sqlstats/persistedsqlstats/controller.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/controller.go
@@ -14,7 +14,6 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -70,9 +69,7 @@ func (s *Controller) ResetClusterSQLStats(ctx context.Context) error {
 			ctx,
 			"reset-sql-stats",
 			nil, /* txn */
-			sessiondata.InternalExecutorOverride{
-				User: username.NodeUserName(),
-			},
+			sessiondata.NodeUserSessionDataOverride,
 			"TRUNCATE "+tableName); err != nil {
 			return err
 		}

--- a/pkg/sql/sqlstats/persistedsqlstats/flush.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/flush.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
@@ -331,9 +330,7 @@ DO NOTHING
 		ctx,
 		"insert-txn-stats",
 		txn, /* txn */
-		sessiondata.InternalExecutorOverride{
-			User: username.NodeUserName(),
-		},
+		sessiondata.NodeUserSessionDataOverride,
 		insertStmt,
 		aggregatedTs,            // aggregated_ts
 		serializedFingerprintID, // fingerprint_id
@@ -373,9 +370,7 @@ WHERE fingerprint_id = $2
 		ctx,
 		"update-stmt-stats",
 		txn, /* txn */
-		sessiondata.InternalExecutorOverride{
-			User: username.NodeUserName(),
-		},
+		sessiondata.NodeUserSessionDataOverride,
 		updateStmt,
 		statistics,              // statistics
 		serializedFingerprintID, // fingerprint_id
@@ -433,9 +428,7 @@ WHERE fingerprint_id = $3
 		ctx,
 		"update-stmt-stats",
 		txn, /* txn */
-		sessiondata.InternalExecutorOverride{
-			User: username.NodeUserName(),
-		},
+		sessiondata.NodeUserSessionDataOverride,
 		updateStmt,
 		statistics,                         // statistics
 		indexRecommendations,               // index_recommendations
@@ -529,9 +522,7 @@ DO NOTHING
 		ctx,
 		"insert-stmt-stats",
 		txn, /* txn */
-		sessiondata.InternalExecutorOverride{
-			User: username.NodeUserName(),
-		},
+		sessiondata.NodeUserSessionDataOverride,
 		insertStmt,
 		args...,
 	)
@@ -566,9 +557,7 @@ FOR UPDATE
 		ctx,
 		"fetch-txn-stats",
 		txn, /* txn */
-		sessiondata.InternalExecutorOverride{
-			User: username.NodeUserName(),
-		},
+		sessiondata.NodeUserSessionDataOverride,
 		readStmt,                // stmt
 		serializedFingerprintID, // fingerprint_id
 		appName,                 // app_name
@@ -624,9 +613,7 @@ FOR UPDATE
 		ctx,
 		"fetch-stmt-stats",
 		txn, /* txn */
-		sessiondata.InternalExecutorOverride{
-			User: username.NodeUserName(),
-		},
+		sessiondata.NodeUserSessionDataOverride,
 		readStmt,                           // stmt
 		serializedFingerprintID,            // fingerprint_id
 		serializedTransactionFingerprintID, // transaction_fingerprint_id

--- a/pkg/sql/sqlstats/persistedsqlstats/scheduled_job_monitor.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/scheduled_job_monitor.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/scheduledjobs"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -117,9 +116,7 @@ func (j *jobMonitor) getSchedule(
 		ctx,
 		"load-sql-stats-scheduled-job",
 		txn,
-		sessiondata.InternalExecutorOverride{
-			User: username.NodeUserName(),
-		},
+		sessiondata.NodeUserSessionDataOverride,
 		"SELECT schedule_id FROM system.scheduled_jobs WHERE schedule_name = $1",
 		compactionScheduleName,
 	)

--- a/pkg/sql/sqlstats/persistedsqlstats/stmt_reader.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/stmt_reader.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
@@ -89,7 +88,7 @@ func (s *PersistedSQLStats) persistedStmtStatsIter(
 		ctx,
 		"read-stmt-stats",
 		nil, /* txn */
-		sessiondata.InternalExecutorOverride{User: username.NodeUserName()},
+		sessiondata.NodeUserSessionDataOverride,
 		query,
 	)
 

--- a/pkg/sql/sqlstats/persistedsqlstats/txn_reader.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/txn_reader.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
@@ -87,7 +86,7 @@ func (s *PersistedSQLStats) persistedTxnStatsIter(
 		ctx,
 		"read-txn-stats",
 		nil, /* txn */
-		sessiondata.InternalExecutorOverride{User: username.NodeUserName()},
+		sessiondata.NodeUserSessionDataOverride,
 		query,
 	)
 

--- a/pkg/sql/stmtdiagnostics/BUILD.bazel
+++ b/pkg/sql/stmtdiagnostics/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
         "//pkg/clusterversion",
         "//pkg/kv",
         "//pkg/multitenant",
-        "//pkg/security/username",
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/sql/sem/tree",

--- a/pkg/sql/stmtdiagnostics/statement_diagnostics.go
+++ b/pkg/sql/stmtdiagnostics/statement_diagnostics.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/multitenant"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -310,9 +309,7 @@ func (r *Registry) insertRequestInternal(
 	err := r.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		// Check if there's already a pending request for this fingerprint.
 		row, err := r.ie.QueryRowEx(ctx, "stmt-diag-check-pending", txn,
-			sessiondata.InternalExecutorOverride{
-				User: username.RootUserName(),
-			},
+			sessiondata.RootUserSessionDataOverride,
 			`SELECT count(1) FROM system.statement_diagnostics_requests
 				WHERE
 					completed = false AND
@@ -391,9 +388,7 @@ func (r *Registry) insertRequestInternal(
 // CancelRequest is part of the server.StmtDiagnosticsRequester interface.
 func (r *Registry) CancelRequest(ctx context.Context, requestID int64) error {
 	row, err := r.ie.QueryRowEx(ctx, "stmt-diag-cancel-request", nil, /* txn */
-		sessiondata.InternalExecutorOverride{
-			User: username.RootUserName(),
-		},
+		sessiondata.RootUserSessionDataOverride,
 		// Rather than deleting the row from the table, we choose to mark the
 		// request as "expired" by setting `expires_at` into the past. This will
 		// allow any queries that are currently being traced for this request to
@@ -668,9 +663,7 @@ func (r *Registry) pollRequests(ctx context.Context) error {
 			extraColumns = ", sampling_probability"
 		}
 		it, err := r.ie.QueryIteratorEx(ctx, "stmt-diag-poll", nil, /* txn */
-			sessiondata.InternalExecutorOverride{
-				User: username.RootUserName(),
-			},
+			sessiondata.RootUserSessionDataOverride,
 			fmt.Sprintf(`SELECT id, statement_fingerprint, min_execution_latency, expires_at%s
 				FROM system.statement_diagnostics_requests
 				WHERE completed = false AND (expires_at IS NULL OR expires_at > now())`, extraColumns),

--- a/pkg/sql/ttl/ttljob/ttljob_processor.go
+++ b/pkg/sql/ttl/ttljob/ttljob_processor.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -268,9 +267,7 @@ func (t *ttlProcessor) runTTLOnSpan(
 			ctx,
 			"pre-select-delete-statement",
 			nil, /* txn */
-			sessiondata.InternalExecutorOverride{
-				User: username.RootUserName(),
-			},
+			sessiondata.RootUserSessionDataOverride,
 			preSelectStatement,
 		); err != nil {
 			return spanRowCount, err

--- a/pkg/upgrade/upgrades/schema_changes.go
+++ b/pkg/upgrade/upgrades/schema_changes.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/kv"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
@@ -129,7 +128,7 @@ func migrateTable(
 			ctx,
 			fmt.Sprintf("migration-alter-table-%d", storedTableID),
 			nil, /* txn */
-			sessiondata.InternalExecutorOverride{User: username.NodeUserName()},
+			sessiondata.NodeUserSessionDataOverride,
 			op.query); err != nil {
 			return err
 		}

--- a/pkg/upgrade/upgrades/wait_for_del_range_in_gc_job.go
+++ b/pkg/upgrade/upgrades/wait_for_del_range_in_gc_job.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -124,9 +123,7 @@ func collectJobIDsFromQuery(
 	ctx context.Context, ie sqlutil.InternalExecutor, opName string, query string,
 ) (jobIDs []jobspb.JobID, retErr error) {
 	it, err := ie.QueryIteratorEx(ctx, opName, nil, /* txn */
-		sessiondata.InternalExecutorOverride{
-			User: username.NodeUserName(),
-		}, query)
+		sessiondata.NodeUserSessionDataOverride, query)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This patch replaces manually created `InternalExecutorOverride`
structs that override the user to either the root user or the
node user to use `sessiondata.RootUserSessionDataOverride` and
`sessiondata.NodeUserSessionDataOverride` vars respectively.
It also replaces usages of empty `InternalExecutorOverride`
structs with `sessiondata.NoSessionDataOverride`.

Epic: None

Release note: None