### PR TITLE
server: don't reset the tenant log tag

### DIFF
--- a/pkg/roachpb/tenant.go
+++ b/pkg/roachpb/tenant.go
@@ -159,6 +159,3 @@ func (n TenantName) IsValid() error {
 	}
 	return nil
 }
-
-// Silence unused warning.
-var _ = TenantFromContext

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1155,6 +1155,9 @@ func (n *Node) Batch(
 	tenantID, ok := roachpb.TenantFromContext(ctx)
 	if !ok {
 		tenantID = roachpb.SystemTenantID
+	} else {
+		// We had this tag before the ResetAndAnnotateCtx() call above.
+		ctx = logtags.AddTag(ctx, "tenant", tenantID.String())
 	}
 
 	// Requests from tenants don't have gateway node id set but are required for


### PR DESCRIPTION
The "tenant=x" tag was inadvertently cleared on Batch RPCs.

Release note: None
Epic: None