### PR TITLE
schemachanger: Implement `ADD UNIQUE WITHOUT INDEX`

### DIFF
--- a/pkg/ccl/schemachangerccl/backup_base_generated_test.go
+++ b/pkg/ccl/schemachangerccl/backup_base_generated_test.go
@@ -58,6 +58,11 @@ func TestBackupbase_alter_table_add_primary_key_drop_rowid(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	sctest.Backup(t, "pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid", newCluster)
 }
+func TestBackupbase_alter_table_add_unique_without_index(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.Backup(t, "pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_unique_without_index", newCluster)
+}
 func TestBackupbase_alter_table_alter_primary_key_drop_rowid(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1505,8 +1505,6 @@ func (e InvalidIndexesError) Error() string {
 
 // ValidateConstraint validates the constraint against all rows
 // in `tbl`.
-//
-// TODO (xiang): Support validating UNIQUE_WITHOUT_INDEX constraint in this function.
 func ValidateConstraint(
 	ctx context.Context,
 	tableDesc catalog.TableDescriptor,
@@ -1556,6 +1554,15 @@ func ValidateConstraint(
 				func() error {
 					return validateForeignKey(ctx, tableDesc.(*tabledesc.Mutable), targetTable, fk.ForeignKeyDesc(),
 						indexIDForValidation, txn, ie)
+				},
+			)
+		case catconstants.ConstraintTypeUniqueWithoutIndex:
+			uwi := constraint.AsUniqueWithoutIndex()
+			return ie.WithSyntheticDescriptors(
+				[]catalog.Descriptor{tableDesc},
+				func() error {
+					return validateUniqueConstraint(ctx, tableDesc, uwi.GetName(), uwi.CollectKeyColumnIDs().Ordered(),
+						uwi.GetPredicate(), indexIDForValidation, ie, txn, sessionData.User(), false)
 				},
 			)
 		default:
@@ -2049,6 +2056,7 @@ func countIndexRowsAndMaybeCheckUniqueness(
 					idx.GetName(),
 					idx.IndexDesc().KeyColumnIDs[idx.ImplicitPartitioningColumnCount():],
 					idx.GetPredicate(),
+					0, /* indexIDForValidation */
 					ie,
 					txn,
 					username.NodeUserName(),
@@ -2737,6 +2745,7 @@ func validateUniqueWithoutIndexConstraintInTxn(
 				uc.Name,
 				uc.ColumnIDs,
 				uc.Predicate,
+				0, /* indexIDForValidation */
 				ie,
 				txn,
 				user,

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -1560,7 +1560,9 @@ statement ok
 INSERT INTO unique_without_index (e, f) VALUES (1, 1), (1, 2)
 
 # But trying to add a unique constraint now fails.
-statement error pgcode 23505 pq: could not create unique constraint "my_unique_e"\nDETAIL: Key \(e\)=\(1\) is duplicated\.
+# Note that we omit the constraint name in the expected error message because if the declarative schema changer is used,
+# the constraint name, at the time of validation failure, is still a place-holder name.
+statement error pgcode 23505 pq: could not create unique constraint ".*"\nDETAIL: Key \(e\)=\(1\) is duplicated\.
 ALTER TABLE unique_without_index ADD CONSTRAINT my_unique_e UNIQUE WITHOUT INDEX (e)
 
 # We can create not-valid constraints, however.
@@ -1603,11 +1605,14 @@ SELECT usage_count
  WHERE feature_name = 'sql.schema_changer.errors.constraint_violation';
 
 # Trying to add a partial unique constraint fails when there are duplicates.
-statement error pgcode 23505 pq: could not create unique constraint "uniq_a_1"\nDETAIL: Key \(a\)=\(1\) is duplicated\.
+statement error pgcode 23505 pq: could not create unique constraint ".*"\nDETAIL: Key \(a\)=\(1\) is duplicated\.
 ALTER TABLE unique_without_index_partial ADD CONSTRAINT uniq_a_1 UNIQUE WITHOUT INDEX (a) WHERE b > 0 OR c > 0
 
 # Sanity: Check the number of user errors and
 # database errors in the test.
+# We only do this check for the legacy schema changer because the declarative schema changer does not increment
+# exactly the same counters.
+onlyif config local-legacy-schema-changer
 query B
 SELECT usage_count > $constraint_violations_before
   FROM crdb_internal.feature_usage

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -5627,6 +5627,7 @@ func TestTableValidityWhileAddingUniqueConstraint(t *testing.T) {
 	if _, err := sqlDB.Exec(`
 CREATE DATABASE t;
 CREATE TABLE t.tab (a INT PRIMARY KEY, b INT, c INT);
+SET use_declarative_schema_changer = off;
 `); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
@@ -54,6 +54,8 @@ var supportedAlterTableStatements = map[reflect.Type]supportedAlterTableCommand{
 		// Support ALTER TABLE ... ADD PRIMARY KEY
 		if d, ok := t.ConstraintDef.(*tree.UniqueConstraintTableDef); ok && d.PrimaryKey && t.ValidationBehavior == tree.ValidationDefault {
 			return true
+		} else if ok && d.WithoutIndex && t.ValidationBehavior == tree.ValidationDefault {
+			return true
 		}
 
 		// Support ALTER TABLE ... ADD CONSTRAINT CHECK
@@ -75,9 +77,10 @@ var supportedAlterTableStatements = map[reflect.Type]supportedAlterTableCommand{
 // They key is constructed as "ADD" + constraint type + validation behavior, joined with "_".
 // E.g. "ADD_PRIMARY_KEY_DEFAULT", "ADD_CHECK_SKIP", "ADD_FOREIGN_KEY_DEFAULT", etc.
 var alterTableAddConstraintMinSupportedClusterVersion = map[string]clusterversion.Key{
-	"ADD_PRIMARY_KEY_DEFAULT": clusterversion.V22_2Start,
-	"ADD_CHECK_DEFAULT":       clusterversion.V23_1Start,
-	"ADD_FOREIGN_KEY_DEFAULT": clusterversion.V23_1Start,
+	"ADD_PRIMARY_KEY_DEFAULT":          clusterversion.V22_2Start,
+	"ADD_CHECK_DEFAULT":                clusterversion.V23_1Start,
+	"ADD_FOREIGN_KEY_DEFAULT":          clusterversion.V23_1Start,
+	"ADD_UNIQUE_WITHOUT_INDEX_DEFAULT": clusterversion.V23_1Start,
 }
 
 func init() {
@@ -166,6 +169,8 @@ func alterTableAddConstraintSupportedInCurrentClusterVersion(
 	case *tree.UniqueConstraintTableDef:
 		if d.PrimaryKey {
 			cmdKey = "ADD_PRIMARY_KEY"
+		} else if d.WithoutIndex {
+			cmdKey = "ADD_UNIQUE_WITHOUT_INDEX"
 		}
 	case *tree.CheckConstraintTableDef:
 		cmdKey = "ADD_CHECK"

--- a/pkg/sql/schemachanger/scexec/scmutationexec/helpers.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/helpers.go
@@ -219,10 +219,26 @@ func enqueueAddCheckConstraintMutation(
 	return nil
 }
 
+func enqueueAddUniqueWithoutIndexConstraintMutation(
+	tbl *tabledesc.Mutable, uwi *descpb.UniqueWithoutIndexConstraint,
+) error {
+	tbl.AddUniqueWithoutIndexMutation(uwi, descpb.DescriptorMutation_ADD)
+	tbl.NextMutationID--
+	return nil
+}
+
 func enqueueDropCheckConstraintMutation(
 	tbl *tabledesc.Mutable, ck *descpb.TableDescriptor_CheckConstraint,
 ) error {
 	tbl.AddCheckMutation(ck, descpb.DescriptorMutation_DROP)
+	tbl.NextMutationID--
+	return nil
+}
+
+func enqueueDropUniqueWithoutIndexConstraintMutation(
+	tbl *tabledesc.Mutable, uwi *descpb.UniqueWithoutIndexConstraint,
+) error {
+	tbl.AddUniqueWithoutIndexMutation(uwi, descpb.DescriptorMutation_DROP)
 	tbl.NextMutationID--
 	return nil
 }

--- a/pkg/sql/schemachanger/scop/mutation.go
+++ b/pkg/sql/schemachanger/scop/mutation.go
@@ -368,6 +368,39 @@ type RemoveForeignKeyBackReference struct {
 	OriginConstraintID descpb.ConstraintID
 }
 
+// MakeAbsentUniqueWithoutIndexConstraintWriteOnly adds a non-existent
+// unique_without_index constraint to the table in the WRITE_ONLY state.
+type MakeAbsentUniqueWithoutIndexConstraintWriteOnly struct {
+	mutationOp
+	TableID      descpb.ID
+	ConstraintID descpb.ConstraintID
+	ColumnIDs    []descpb.ColumnID
+	Predicate    *scpb.Expression
+}
+
+// MakeValidatedUniqueWithoutIndexConstraintPublic moves a new, validated unique_without_index
+// constraint from mutation to public.
+type MakeValidatedUniqueWithoutIndexConstraintPublic struct {
+	mutationOp
+	TableID      descpb.ID
+	ConstraintID descpb.ConstraintID
+}
+
+// MakePublicUniqueWithoutIndexConstraintValidated moves a public
+// unique_without_index constraint to VALIDATED.
+type MakePublicUniqueWithoutIndexConstraintValidated struct {
+	mutationOp
+	TableID      descpb.ID
+	ConstraintID descpb.ConstraintID
+}
+
+// RemoveUniqueWithoutIndexConstraint removes a unique_without_index from the origin table.
+type RemoveUniqueWithoutIndexConstraint struct {
+	mutationOp
+	TableID      descpb.ID
+	ConstraintID descpb.ConstraintID
+}
+
 // RemoveSchemaParent removes the schema - parent database relationship.
 type RemoveSchemaParent struct {
 	mutationOp

--- a/pkg/sql/schemachanger/scop/mutation_visitor_generated.go
+++ b/pkg/sql/schemachanger/scop/mutation_visitor_generated.go
@@ -63,6 +63,10 @@ type MutationVisitor interface {
 	MakePublicForeignKeyConstraintValidated(context.Context, MakePublicForeignKeyConstraintValidated) error
 	RemoveForeignKeyConstraint(context.Context, RemoveForeignKeyConstraint) error
 	RemoveForeignKeyBackReference(context.Context, RemoveForeignKeyBackReference) error
+	MakeAbsentUniqueWithoutIndexConstraintWriteOnly(context.Context, MakeAbsentUniqueWithoutIndexConstraintWriteOnly) error
+	MakeValidatedUniqueWithoutIndexConstraintPublic(context.Context, MakeValidatedUniqueWithoutIndexConstraintPublic) error
+	MakePublicUniqueWithoutIndexConstraintValidated(context.Context, MakePublicUniqueWithoutIndexConstraintValidated) error
+	RemoveUniqueWithoutIndexConstraint(context.Context, RemoveUniqueWithoutIndexConstraint) error
 	RemoveSchemaParent(context.Context, RemoveSchemaParent) error
 	AddIndexPartitionInfo(context.Context, AddIndexPartitionInfo) error
 	LogEvent(context.Context, LogEvent) error
@@ -308,6 +312,26 @@ func (op RemoveForeignKeyConstraint) Visit(ctx context.Context, v MutationVisito
 // Visit is part of the MutationOp interface.
 func (op RemoveForeignKeyBackReference) Visit(ctx context.Context, v MutationVisitor) error {
 	return v.RemoveForeignKeyBackReference(ctx, op)
+}
+
+// Visit is part of the MutationOp interface.
+func (op MakeAbsentUniqueWithoutIndexConstraintWriteOnly) Visit(ctx context.Context, v MutationVisitor) error {
+	return v.MakeAbsentUniqueWithoutIndexConstraintWriteOnly(ctx, op)
+}
+
+// Visit is part of the MutationOp interface.
+func (op MakeValidatedUniqueWithoutIndexConstraintPublic) Visit(ctx context.Context, v MutationVisitor) error {
+	return v.MakeValidatedUniqueWithoutIndexConstraintPublic(ctx, op)
+}
+
+// Visit is part of the MutationOp interface.
+func (op MakePublicUniqueWithoutIndexConstraintValidated) Visit(ctx context.Context, v MutationVisitor) error {
+	return v.MakePublicUniqueWithoutIndexConstraintValidated(ctx, op)
+}
+
+// Visit is part of the MutationOp interface.
+func (op RemoveUniqueWithoutIndexConstraint) Visit(ctx context.Context, v MutationVisitor) error {
+	return v.RemoveUniqueWithoutIndexConstraint(ctx, op)
 }
 
 // Visit is part of the MutationOp interface.

--- a/pkg/sql/schemachanger/scpb/elements.proto
+++ b/pkg/sql/schemachanger/scpb/elements.proto
@@ -328,6 +328,10 @@ message UniqueWithoutIndexConstraint {
   repeated uint32 column_ids = 3 [(gogoproto.customname) = "ColumnIDs", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.ColumnID"];
   // Predicate, if non-nil, means a partial uniqueness constraint.
   Expression predicate = 4 [(gogoproto.customname) = "Predicate"];
+  // IndexIDForValidation is the index id to hint to the unique_without_index
+  // constraint validation SQL query about which index to validate against.
+  // It is used exclusively by sql.validateUniqueConstraint.
+  uint32 index_id_for_validation = 5 [(gogoproto.customname) = "IndexIDForValidation", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.IndexID"];
 }
 
 message CheckConstraint {

--- a/pkg/sql/schemachanger/scpb/uml/table.puml
+++ b/pkg/sql/schemachanger/scpb/uml/table.puml
@@ -81,6 +81,7 @@ UniqueWithoutIndexConstraint :  TableID
 UniqueWithoutIndexConstraint :  ConstraintID
 UniqueWithoutIndexConstraint : []ColumnIDs
 UniqueWithoutIndexConstraint :  Predicate
+UniqueWithoutIndexConstraint :  IndexIDForValidation
 
 object CheckConstraint
 

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_unique_without_index_constraint.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_unique_without_index_constraint.go
@@ -19,19 +19,71 @@ func init() {
 	opRegistry.register((*scpb.UniqueWithoutIndexConstraint)(nil),
 		toPublic(
 			scpb.Status_ABSENT,
+			to(scpb.Status_WRITE_ONLY,
+				emit(func(this *scpb.UniqueWithoutIndexConstraint) *scop.MakeAbsentUniqueWithoutIndexConstraintWriteOnly {
+					return &scop.MakeAbsentUniqueWithoutIndexConstraintWriteOnly{
+						TableID:      this.TableID,
+						ConstraintID: this.ConstraintID,
+						ColumnIDs:    this.ColumnIDs,
+						Predicate:    this.Predicate,
+					}
+				}),
+				emit(func(this *scpb.UniqueWithoutIndexConstraint) *scop.UpdateTableBackReferencesInTypes {
+					if this.Predicate == nil || this.Predicate.UsesTypeIDs == nil || len(this.Predicate.UsesTypeIDs) == 0 {
+						return nil
+					}
+					return &scop.UpdateTableBackReferencesInTypes{
+						TypeIDs:               this.Predicate.UsesTypeIDs,
+						BackReferencedTableID: this.TableID,
+					}
+				}),
+				emit(func(this *scpb.UniqueWithoutIndexConstraint) *scop.UpdateBackReferencesInSequences {
+					if this.Predicate == nil || this.Predicate.UsesSequenceIDs == nil || len(this.Predicate.UsesSequenceIDs) == 0 {
+						return nil
+					}
+					return &scop.UpdateBackReferencesInSequences{
+						SequenceIDs:           this.Predicate.UsesSequenceIDs,
+						BackReferencedTableID: this.TableID,
+					}
+				}),
+			),
+			to(scpb.Status_VALIDATED,
+				emit(func(this *scpb.UniqueWithoutIndexConstraint) *scop.ValidateConstraint {
+					return &scop.ValidateConstraint{
+						TableID:              this.TableID,
+						ConstraintID:         this.ConstraintID,
+						IndexIDForValidation: this.IndexIDForValidation,
+					}
+				}),
+			),
 			to(scpb.Status_PUBLIC,
-				emit(func(this *scpb.UniqueWithoutIndexConstraint) *scop.NotImplemented {
-					return notImplemented(this)
+				emit(func(this *scpb.UniqueWithoutIndexConstraint) *scop.MakeValidatedUniqueWithoutIndexConstraintPublic {
+					return &scop.MakeValidatedUniqueWithoutIndexConstraintPublic{
+						TableID:      this.TableID,
+						ConstraintID: this.ConstraintID,
+					}
 				}),
 			),
 		),
 		toAbsent(
 			scpb.Status_PUBLIC,
+			to(scpb.Status_VALIDATED,
+				emit(func(this *scpb.UniqueWithoutIndexConstraint) *scop.MakePublicUniqueWithoutIndexConstraintValidated {
+					return &scop.MakePublicUniqueWithoutIndexConstraintValidated{
+						TableID:      this.TableID,
+						ConstraintID: this.ConstraintID,
+					}
+				}),
+			),
+			equiv(scpb.Status_WRITE_ONLY),
 			to(scpb.Status_ABSENT,
 				// TODO(postamar): remove revertibility constraint when possible
 				revertible(false),
-				emit(func(this *scpb.UniqueWithoutIndexConstraint) *scop.NotImplemented {
-					return notImplemented(this)
+				emit(func(this *scpb.UniqueWithoutIndexConstraint) *scop.RemoveUniqueWithoutIndexConstraint {
+					return &scop.RemoveUniqueWithoutIndexConstraint{
+						TableID:      this.TableID,
+						ConstraintID: this.ConstraintID,
+					}
 				}),
 			),
 		),

--- a/pkg/sql/schemachanger/scplan/internal/rules/helpers.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/helpers.go
@@ -375,7 +375,7 @@ func isIndexDependent(e scpb.Element) bool {
 // when we properly support adding/dropping them in the new schema changer.
 func isSupportedNonIndexBackedConstraint(e scpb.Element) bool {
 	switch e.(type) {
-	case *scpb.CheckConstraint, *scpb.ForeignKeyConstraint:
+	case *scpb.CheckConstraint, *scpb.ForeignKeyConstraint, *scpb.UniqueWithoutIndexConstraint:
 		return true
 	}
 	return false

--- a/pkg/sql/schemachanger/scplan/internal/rules/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/testdata/deprules
@@ -1446,6 +1446,103 @@ deprules
     - descriptorIsNotBeingDropped($prev)
     - joinTargetNode($prev, $prev-target, $prev-node)
     - joinTargetNode($next, $next-target, $next-node)
+- name: 'UniqueWithoutIndexConstraint transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED'
+  from: prev-node
+  kind: PreviousTransactionPrecedence
+  to: next-node
+  query:
+    - $prev[Type] = '*scpb.UniqueWithoutIndexConstraint'
+    - $next[Type] = '*scpb.UniqueWithoutIndexConstraint'
+    - $prev[DescID] = $_
+    - $prev[Self] = $next
+    - $prev-target[Self] = $next-target
+    - $prev-target[TargetStatus] = ABSENT
+    - $prev-node[CurrentStatus] = PUBLIC
+    - $next-node[CurrentStatus] = VALIDATED
+    - descriptorIsNotBeingDropped($prev)
+    - joinTargetNode($prev, $prev-target, $prev-node)
+    - joinTargetNode($next, $next-target, $next-node)
+- name: 'UniqueWithoutIndexConstraint transitions to ABSENT uphold 2-version invariant: VALIDATED->ABSENT'
+  from: prev-node
+  kind: PreviousTransactionPrecedence
+  to: next-node
+  query:
+    - $prev[Type] = '*scpb.UniqueWithoutIndexConstraint'
+    - $next[Type] = '*scpb.UniqueWithoutIndexConstraint'
+    - $prev[DescID] = $_
+    - $prev[Self] = $next
+    - $prev-target[Self] = $next-target
+    - $prev-target[TargetStatus] = ABSENT
+    - $prev-node[CurrentStatus] = VALIDATED
+    - $next-node[CurrentStatus] = ABSENT
+    - descriptorIsNotBeingDropped($prev)
+    - nodeNotExistsWithStatusIn_WRITE_ONLY($prev-target)
+    - joinTargetNode($prev, $prev-target, $prev-node)
+    - joinTargetNode($next, $next-target, $next-node)
+- name: 'UniqueWithoutIndexConstraint transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED'
+  from: prev-node
+  kind: PreviousTransactionPrecedence
+  to: next-node
+  query:
+    - $prev[Type] = '*scpb.UniqueWithoutIndexConstraint'
+    - $next[Type] = '*scpb.UniqueWithoutIndexConstraint'
+    - $prev[DescID] = $_
+    - $prev[Self] = $next
+    - $prev-target[Self] = $next-target
+    - $prev-target[TargetStatus] = ABSENT
+    - $prev-node[CurrentStatus] = WRITE_ONLY
+    - $next-node[CurrentStatus] = VALIDATED
+    - descriptorIsNotBeingDropped($prev)
+    - joinTargetNode($prev, $prev-target, $prev-node)
+    - joinTargetNode($next, $next-target, $next-node)
+- name: 'UniqueWithoutIndexConstraint transitions to PUBLIC uphold 2-version invariant: ABSENT->WRITE_ONLY'
+  from: prev-node
+  kind: PreviousTransactionPrecedence
+  to: next-node
+  query:
+    - $prev[Type] = '*scpb.UniqueWithoutIndexConstraint'
+    - $next[Type] = '*scpb.UniqueWithoutIndexConstraint'
+    - $prev[DescID] = $_
+    - $prev[Self] = $next
+    - $prev-target[Self] = $next-target
+    - $prev-target[TargetStatus] = PUBLIC
+    - $prev-node[CurrentStatus] = ABSENT
+    - $next-node[CurrentStatus] = WRITE_ONLY
+    - descriptorIsNotBeingDropped($prev)
+    - joinTargetNode($prev, $prev-target, $prev-node)
+    - joinTargetNode($next, $next-target, $next-node)
+- name: 'UniqueWithoutIndexConstraint transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC'
+  from: prev-node
+  kind: PreviousTransactionPrecedence
+  to: next-node
+  query:
+    - $prev[Type] = '*scpb.UniqueWithoutIndexConstraint'
+    - $next[Type] = '*scpb.UniqueWithoutIndexConstraint'
+    - $prev[DescID] = $_
+    - $prev[Self] = $next
+    - $prev-target[Self] = $next-target
+    - $prev-target[TargetStatus] = PUBLIC
+    - $prev-node[CurrentStatus] = VALIDATED
+    - $next-node[CurrentStatus] = PUBLIC
+    - descriptorIsNotBeingDropped($prev)
+    - joinTargetNode($prev, $prev-target, $prev-node)
+    - joinTargetNode($next, $next-target, $next-node)
+- name: 'UniqueWithoutIndexConstraint transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->VALIDATED'
+  from: prev-node
+  kind: PreviousTransactionPrecedence
+  to: next-node
+  query:
+    - $prev[Type] = '*scpb.UniqueWithoutIndexConstraint'
+    - $next[Type] = '*scpb.UniqueWithoutIndexConstraint'
+    - $prev[DescID] = $_
+    - $prev[Self] = $next
+    - $prev-target[Self] = $next-target
+    - $prev-target[TargetStatus] = PUBLIC
+    - $prev-node[CurrentStatus] = WRITE_ONLY
+    - $next-node[CurrentStatus] = VALIDATED
+    - descriptorIsNotBeingDropped($prev)
+    - joinTargetNode($prev, $prev-target, $prev-node)
+    - joinTargetNode($next, $next-target, $next-node)
 - name: column dependents exist before column becomes public
   from: dependent-node
   kind: Precedence
@@ -1626,11 +1723,12 @@ deprules
   kind: Precedence
   to: dependent-node
   query:
-    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint']
+    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint']
     - $dependent[Type] IN ['*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment']
     - joinOnConstraintID($constraint, $dependent, $table-id, $constraint-id)
-    - transient($constraint-target, $dependent-target)
-    - $constraint-node[CurrentStatus] = TRANSIENT_VALIDATED
+    - $constraint-target[TargetStatus] = ABSENT
+    - $constraint-node[CurrentStatus] = VALIDATED
+    - $dependent-target[TargetStatus] = TRANSIENT_ABSENT
     - $dependent-node[CurrentStatus] = TRANSIENT_ABSENT
     - joinTargetNode($constraint, $constraint-target, $constraint-node)
     - joinTargetNode($dependent, $dependent-target, $dependent-node)
@@ -1639,21 +1737,7 @@ deprules
   kind: Precedence
   to: dependent-node
   query:
-    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint']
-    - $dependent[Type] IN ['*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment']
-    - joinOnConstraintID($constraint, $dependent, $table-id, $constraint-id)
-    - $constraint-target[TargetStatus] = TRANSIENT_ABSENT
-    - $constraint-node[CurrentStatus] = TRANSIENT_VALIDATED
-    - $dependent-target[TargetStatus] = ABSENT
-    - $dependent-node[CurrentStatus] = ABSENT
-    - joinTargetNode($constraint, $constraint-target, $constraint-node)
-    - joinTargetNode($dependent, $dependent-target, $dependent-node)
-- name: constraint no longer public before dependents
-  from: constraint-node
-  kind: Precedence
-  to: dependent-node
-  query:
-    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint']
+    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint']
     - $dependent[Type] IN ['*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment']
     - joinOnConstraintID($constraint, $dependent, $table-id, $constraint-id)
     - toAbsent($constraint-target, $dependent-target)
@@ -1666,13 +1750,26 @@ deprules
   kind: Precedence
   to: dependent-node
   query:
-    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint']
+    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint']
     - $dependent[Type] IN ['*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment']
     - joinOnConstraintID($constraint, $dependent, $table-id, $constraint-id)
-    - $constraint-target[TargetStatus] = ABSENT
-    - $constraint-node[CurrentStatus] = VALIDATED
-    - $dependent-target[TargetStatus] = TRANSIENT_ABSENT
+    - transient($constraint-target, $dependent-target)
+    - $constraint-node[CurrentStatus] = TRANSIENT_VALIDATED
     - $dependent-node[CurrentStatus] = TRANSIENT_ABSENT
+    - joinTargetNode($constraint, $constraint-target, $constraint-node)
+    - joinTargetNode($dependent, $dependent-target, $dependent-node)
+- name: constraint no longer public before dependents
+  from: constraint-node
+  kind: Precedence
+  to: dependent-node
+  query:
+    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint']
+    - $dependent[Type] IN ['*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment']
+    - joinOnConstraintID($constraint, $dependent, $table-id, $constraint-id)
+    - $constraint-target[TargetStatus] = TRANSIENT_ABSENT
+    - $constraint-node[CurrentStatus] = TRANSIENT_VALIDATED
+    - $dependent-target[TargetStatus] = ABSENT
+    - $dependent-node[CurrentStatus] = ABSENT
     - joinTargetNode($constraint, $constraint-target, $constraint-node)
     - joinTargetNode($dependent, $dependent-target, $dependent-node)
 - name: dependent view absent before secondary index
@@ -1683,10 +1780,10 @@ deprules
     - $view[Type] = '*scpb.View'
     - $index[Type] = '*scpb.SecondaryIndex'
     - viewReferencesIndex(*scpb.View, *scpb.SecondaryIndex)($view, $index)
-    - $view-target[TargetStatus] = ABSENT
-    - $view-node[CurrentStatus] = ABSENT
-    - $index-target[TargetStatus] = TRANSIENT_ABSENT
-    - $index-node[CurrentStatus] = TRANSIENT_ABSENT
+    - $view-target[TargetStatus] = TRANSIENT_ABSENT
+    - $view-node[CurrentStatus] = TRANSIENT_ABSENT
+    - $index-target[TargetStatus] = ABSENT
+    - $index-node[CurrentStatus] = ABSENT
     - joinTargetNode($view, $view-target, $view-node)
     - joinTargetNode($index, $index-target, $index-node)
 - name: dependent view absent before secondary index
@@ -1697,10 +1794,9 @@ deprules
     - $view[Type] = '*scpb.View'
     - $index[Type] = '*scpb.SecondaryIndex'
     - viewReferencesIndex(*scpb.View, *scpb.SecondaryIndex)($view, $index)
-    - $view-target[TargetStatus] = TRANSIENT_ABSENT
+    - transient($view-target, $index-target)
     - $view-node[CurrentStatus] = TRANSIENT_ABSENT
-    - $index-target[TargetStatus] = ABSENT
-    - $index-node[CurrentStatus] = ABSENT
+    - $index-node[CurrentStatus] = TRANSIENT_ABSENT
     - joinTargetNode($view, $view-target, $view-node)
     - joinTargetNode($index, $index-target, $index-node)
 - name: dependent view absent before secondary index
@@ -1724,8 +1820,9 @@ deprules
     - $view[Type] = '*scpb.View'
     - $index[Type] = '*scpb.SecondaryIndex'
     - viewReferencesIndex(*scpb.View, *scpb.SecondaryIndex)($view, $index)
-    - transient($view-target, $index-target)
-    - $view-node[CurrentStatus] = TRANSIENT_ABSENT
+    - $view-target[TargetStatus] = ABSENT
+    - $view-node[CurrentStatus] = ABSENT
+    - $index-target[TargetStatus] = TRANSIENT_ABSENT
     - $index-node[CurrentStatus] = TRANSIENT_ABSENT
     - joinTargetNode($view, $view-target, $view-node)
     - joinTargetNode($index, $index-target, $index-node)
@@ -1737,10 +1834,10 @@ deprules
     - $view[Type] = '*scpb.View'
     - $index[Type] = '*scpb.SecondaryIndex'
     - viewReferencesIndex(*scpb.View, *scpb.SecondaryIndex)($view, $index)
-    - $view-target[TargetStatus] = ABSENT
-    - $view-node[CurrentStatus] = DROPPED
-    - $index-target[TargetStatus] = TRANSIENT_ABSENT
-    - $index-node[CurrentStatus] = TRANSIENT_VALIDATED
+    - $view-target[TargetStatus] = TRANSIENT_ABSENT
+    - $view-node[CurrentStatus] = TRANSIENT_DROPPED
+    - $index-target[TargetStatus] = ABSENT
+    - $index-node[CurrentStatus] = VALIDATED
     - joinTargetNode($view, $view-target, $view-node)
     - joinTargetNode($index, $index-target, $index-node)
 - name: dependent view no longer public before secondary index
@@ -1777,12 +1874,40 @@ deprules
     - $view[Type] = '*scpb.View'
     - $index[Type] = '*scpb.SecondaryIndex'
     - viewReferencesIndex(*scpb.View, *scpb.SecondaryIndex)($view, $index)
-    - $view-target[TargetStatus] = TRANSIENT_ABSENT
-    - $view-node[CurrentStatus] = TRANSIENT_DROPPED
-    - $index-target[TargetStatus] = ABSENT
-    - $index-node[CurrentStatus] = VALIDATED
+    - $view-target[TargetStatus] = ABSENT
+    - $view-node[CurrentStatus] = DROPPED
+    - $index-target[TargetStatus] = TRANSIENT_ABSENT
+    - $index-node[CurrentStatus] = TRANSIENT_VALIDATED
     - joinTargetNode($view, $view-target, $view-node)
     - joinTargetNode($index, $index-target, $index-node)
+- name: dependents removed before column
+  from: dependent-node
+  kind: Precedence
+  to: column-node
+  query:
+    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexColumn']
+    - $column[Type] = '*scpb.Column'
+    - joinOnColumnID($dependent, $column, $table-id, $col-id)
+    - $dependent-target[TargetStatus] = ABSENT
+    - $dependent-node[CurrentStatus] = ABSENT
+    - $column-target[TargetStatus] = TRANSIENT_ABSENT
+    - $column-node[CurrentStatus] = TRANSIENT_ABSENT
+    - joinTargetNode($dependent, $dependent-target, $dependent-node)
+    - joinTargetNode($column, $column-target, $column-node)
+- name: dependents removed before column
+  from: dependent-node
+  kind: Precedence
+  to: column-node
+  query:
+    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexColumn']
+    - $column[Type] = '*scpb.Column'
+    - joinOnColumnID($dependent, $column, $table-id, $col-id)
+    - $dependent-target[TargetStatus] = TRANSIENT_ABSENT
+    - $dependent-node[CurrentStatus] = TRANSIENT_ABSENT
+    - $column-target[TargetStatus] = ABSENT
+    - $column-node[CurrentStatus] = ABSENT
+    - joinTargetNode($dependent, $dependent-target, $dependent-node)
+    - joinTargetNode($column, $column-target, $column-node)
 - name: dependents removed before column
   from: dependent-node
   kind: Precedence
@@ -1809,54 +1934,13 @@ deprules
     - $column-node[CurrentStatus] = ABSENT
     - joinTargetNode($dependent, $dependent-target, $dependent-node)
     - joinTargetNode($column, $column-target, $column-node)
-- name: dependents removed before column
-  from: dependent-node
-  kind: Precedence
-  to: column-node
-  query:
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexColumn']
-    - $column[Type] = '*scpb.Column'
-    - joinOnColumnID($dependent, $column, $table-id, $col-id)
-    - $dependent-target[TargetStatus] = TRANSIENT_ABSENT
-    - $dependent-node[CurrentStatus] = TRANSIENT_ABSENT
-    - $column-target[TargetStatus] = ABSENT
-    - $column-node[CurrentStatus] = ABSENT
-    - joinTargetNode($dependent, $dependent-target, $dependent-node)
-    - joinTargetNode($column, $column-target, $column-node)
-- name: dependents removed before column
-  from: dependent-node
-  kind: Precedence
-  to: column-node
-  query:
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexColumn']
-    - $column[Type] = '*scpb.Column'
-    - joinOnColumnID($dependent, $column, $table-id, $col-id)
-    - $dependent-target[TargetStatus] = ABSENT
-    - $dependent-node[CurrentStatus] = ABSENT
-    - $column-target[TargetStatus] = TRANSIENT_ABSENT
-    - $column-node[CurrentStatus] = TRANSIENT_ABSENT
-    - joinTargetNode($dependent, $dependent-target, $dependent-node)
-    - joinTargetNode($column, $column-target, $column-node)
 - name: dependents removed before constraint
   from: dependents-node
   kind: Precedence
   to: constraint-node
   query:
     - $dependents[Type] IN ['*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment']
-    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint']
-    - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
-    - toAbsent($dependents-target, $constraint-target)
-    - $dependents-node[CurrentStatus] = ABSENT
-    - $constraint-node[CurrentStatus] = ABSENT
-    - joinTargetNode($dependents, $dependents-target, $dependents-node)
-    - joinTargetNode($constraint, $constraint-target, $constraint-node)
-- name: dependents removed before constraint
-  from: dependents-node
-  kind: Precedence
-  to: constraint-node
-  query:
-    - $dependents[Type] IN ['*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment']
-    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint']
+    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - transient($dependents-target, $constraint-target)
     - $dependents-node[CurrentStatus] = TRANSIENT_ABSENT
@@ -1869,7 +1953,20 @@ deprules
   to: constraint-node
   query:
     - $dependents[Type] IN ['*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment']
-    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint']
+    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint']
+    - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
+    - toAbsent($dependents-target, $constraint-target)
+    - $dependents-node[CurrentStatus] = ABSENT
+    - $constraint-node[CurrentStatus] = ABSENT
+    - joinTargetNode($dependents, $dependents-target, $dependents-node)
+    - joinTargetNode($constraint, $constraint-target, $constraint-node)
+- name: dependents removed before constraint
+  from: dependents-node
+  kind: Precedence
+  to: constraint-node
+  query:
+    - $dependents[Type] IN ['*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment']
+    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - $dependents-target[TargetStatus] = TRANSIENT_ABSENT
     - $dependents-node[CurrentStatus] = TRANSIENT_ABSENT
@@ -1883,7 +1980,7 @@ deprules
   to: constraint-node
   query:
     - $dependents[Type] IN ['*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment']
-    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint']
+    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint']
     - joinOnConstraintID($dependents, $constraint, $table-id, $constraint-id)
     - $dependents-target[TargetStatus] = ABSENT
     - $dependents-node[CurrentStatus] = ABSENT
@@ -1899,10 +1996,10 @@ deprules
     - $dependent[Type] IN ['*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnIndexID($dependent, $index, $table-id, $index-id)
-    - $dependent-target[TargetStatus] = TRANSIENT_ABSENT
-    - $dependent-node[CurrentStatus] = TRANSIENT_ABSENT
-    - $index-target[TargetStatus] = ABSENT
-    - $index-node[CurrentStatus] = ABSENT
+    - $dependent-target[TargetStatus] = ABSENT
+    - $dependent-node[CurrentStatus] = ABSENT
+    - $index-target[TargetStatus] = TRANSIENT_ABSENT
+    - $index-node[CurrentStatus] = TRANSIENT_ABSENT
     - joinTargetNode($dependent, $dependent-target, $dependent-node)
     - joinTargetNode($index, $index-target, $index-node)
 - name: dependents removed before index
@@ -1939,10 +2036,10 @@ deprules
     - $dependent[Type] IN ['*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn']
     - $index[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnIndexID($dependent, $index, $table-id, $index-id)
-    - $dependent-target[TargetStatus] = ABSENT
-    - $dependent-node[CurrentStatus] = ABSENT
-    - $index-target[TargetStatus] = TRANSIENT_ABSENT
-    - $index-node[CurrentStatus] = TRANSIENT_ABSENT
+    - $dependent-target[TargetStatus] = TRANSIENT_ABSENT
+    - $dependent-node[CurrentStatus] = TRANSIENT_ABSENT
+    - $index-target[TargetStatus] = ABSENT
+    - $index-node[CurrentStatus] = ABSENT
     - joinTargetNode($dependent, $dependent-target, $dependent-node)
     - joinTargetNode($index, $index-target, $index-node)
 - name: descriptor DROPPED in transaction before removal
@@ -1977,7 +2074,7 @@ deprules
   to: dependent-node
   query:
     - $descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType']
-    - $dependent[Type] IN ['*scpb.ColumnFamily', '*scpb.UniqueWithoutIndexConstraint', '*scpb.TableComment', '*scpb.RowLevelTTL', '*scpb.TableZoneConfig', '*scpb.TablePartitioning', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalitySecondaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn', '*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment', '*scpb.Namespace', '*scpb.Owner', '*scpb.UserPrivileges', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseComment', '*scpb.SchemaParent', '*scpb.SchemaComment', '*scpb.ObjectParent', '*scpb.EnumTypeValue', '*scpb.CompositeTypeAttrType', '*scpb.CompositeTypeAttrName']
+    - $dependent[Type] IN ['*scpb.ColumnFamily', '*scpb.TableComment', '*scpb.RowLevelTTL', '*scpb.TableZoneConfig', '*scpb.TablePartitioning', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalitySecondaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn', '*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment', '*scpb.Namespace', '*scpb.Owner', '*scpb.UserPrivileges', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseComment', '*scpb.SchemaParent', '*scpb.SchemaComment', '*scpb.ObjectParent', '*scpb.EnumTypeValue', '*scpb.CompositeTypeAttrType', '*scpb.CompositeTypeAttrName']
     - joinOnDescID($descriptor, $dependent, $desc-id)
     - toAbsent($descriptor-target, $dependent-target)
     - $descriptor-node[CurrentStatus] = DROPPED
@@ -1991,7 +2088,7 @@ deprules
   to: referencing-via-attr-node
   query:
     - $referenced-descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType', '*scpb.CompositeType']
-    - $referencing-via-attr[Type] IN ['*scpb.ColumnFamily', '*scpb.UniqueWithoutIndexConstraint', '*scpb.TableComment', '*scpb.RowLevelTTL', '*scpb.TableZoneConfig', '*scpb.TablePartitioning', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalitySecondaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn', '*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment', '*scpb.Namespace', '*scpb.Owner', '*scpb.UserPrivileges', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseComment', '*scpb.SchemaParent', '*scpb.SchemaComment', '*scpb.ObjectParent', '*scpb.EnumTypeValue', '*scpb.CompositeTypeAttrType', '*scpb.CompositeTypeAttrName']
+    - $referencing-via-attr[Type] IN ['*scpb.ColumnFamily', '*scpb.TableComment', '*scpb.RowLevelTTL', '*scpb.TableZoneConfig', '*scpb.TablePartitioning', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalitySecondaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn', '*scpb.ConstraintWithoutIndexName', '*scpb.ConstraintComment', '*scpb.Namespace', '*scpb.Owner', '*scpb.UserPrivileges', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseComment', '*scpb.SchemaParent', '*scpb.SchemaComment', '*scpb.ObjectParent', '*scpb.EnumTypeValue', '*scpb.CompositeTypeAttrType', '*scpb.CompositeTypeAttrName']
     - joinReferencedDescID($referencing-via-attr, $referenced-descriptor, $desc-id)
     - toAbsent($referenced-descriptor-target, $referencing-via-attr-target)
     - $referenced-descriptor-node[CurrentStatus] = DROPPED
@@ -2099,7 +2196,7 @@ deprules
   to: constraint-node
   query:
     - $index[Type] = '*scpb.PrimaryIndex'
-    - $constraint[Type] IN ['*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint']
+    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint']
     - joinOnDescID($index, $constraint, $table-id)
     - $index[IndexID] = $index-id-for-validation
     - $constraint[IndexID] = $index-id-for-validation

--- a/pkg/sql/schemachanger/sctest/end_to_end.go
+++ b/pkg/sql/schemachanger/sctest/end_to_end.go
@@ -184,6 +184,7 @@ func EndToEndSideEffects(t *testing.T, relPath string, newCluster NewClusterFunc
 					// changer will allow non-fully implemented operations.
 					sd.NewSchemaChangerMode = sessiondatapb.UseNewSchemaChangerUnsafe
 					sd.ApplicationName = ""
+					sd.EnableUniqueWithoutIndexConstraints = true // this allows `ADD UNIQUE WITHOUT INDEX` in the testing suite.
 				})),
 				sctestdeps.WithTestingKnobs(&scexec.TestingKnobs{
 					BeforeStage: func(p scplan.Plan, stageIdx int) error {

--- a/pkg/sql/schemachanger/sctest_generated_test.go
+++ b/pkg/sql/schemachanger/sctest_generated_test.go
@@ -220,6 +220,31 @@ func TestRollback_alter_table_add_primary_key_drop_rowid(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	sctest.Rollback(t, "pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid", sctest.SingleNodeCluster)
 }
+func TestEndToEndSideEffects_alter_table_add_unique_without_index(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.EndToEndSideEffects(t, "pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_unique_without_index", sctest.SingleNodeCluster)
+}
+func TestExecuteWithDMLInjection_alter_table_add_unique_without_index(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.ExecuteWithDMLInjection(t, "pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_unique_without_index", sctest.SingleNodeCluster)
+}
+func TestGenerateSchemaChangeCorpus_alter_table_add_unique_without_index(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.GenerateSchemaChangeCorpus(t, "pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_unique_without_index", sctest.SingleNodeCluster)
+}
+func TestPause_alter_table_add_unique_without_index(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.Pause(t, "pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_unique_without_index", sctest.SingleNodeCluster)
+}
+func TestRollback_alter_table_add_unique_without_index(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	sctest.Rollback(t, "pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_unique_without_index", sctest.SingleNodeCluster)
+}
 func TestEndToEndSideEffects_alter_table_alter_primary_key_drop_rowid(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_unique_without_index
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_unique_without_index
@@ -1,0 +1,146 @@
+setup
+CREATE TABLE t (i INT PRIMARY KEY, j INT);
+SET experimental_enable_unique_without_index_constraints = true;
+----
+...
++object {100 101 t} -> 104
+
+test
+ALTER TABLE t ADD UNIQUE WITHOUT INDEX (j);
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: ALTER TABLE
+increment telemetry for sql.schema.alter_table
+increment telemetry for sql.schema.alter_table.add_constraint
+## StatementPhase stage 1 of 1 with 1 MutationType op
+upsert descriptor #104
+  ...
+     id: 104
+     modificationTime: {}
+  +  mutations:
+  +  - constraint:
+  +      check: {}
+  +      constraintType: UNIQUE_WITHOUT_INDEX
+  +      foreignKey: {}
+  +      name: crdb_internal_constraint_2_name_placeholder
+  +      uniqueWithoutIndexConstraint:
+  +        columnIds:
+  +        - 2
+  +        constraintId: 2
+  +        name: crdb_internal_constraint_2_name_placeholder
+  +        tableId: 104
+  +        validity: Validating
+  +    direction: ADD
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+     name: t
+     nextColumnId: 3
+  -  nextConstraintId: 2
+  +  nextConstraintId: 3
+     nextFamilyId: 1
+     nextIndexId: 2
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "1"
+  +  version: "2"
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 1 with 2 MutationType ops
+upsert descriptor #104
+  ...
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  +  declarativeSchemaChangerState:
+  +    authorization:
+  +      userName: root
+  +    currentStatuses: <redacted>
+  +    jobId: "1"
+  +    relevantStatements:
+  +    - statement:
+  +        redactedStatement: ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD CONSTRAINT ‹unique_j›
+  +          UNIQUE WITHOUT INDEX (‹j›)
+  +        statement: ALTER TABLE t ADD UNIQUE WITHOUT INDEX (j)
+  +        statementTag: ALTER TABLE
+  +    revertible: true
+  +    targetRanks: <redacted>
+  +    targets: <redacted>
+     families:
+     - columnIds:
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "1"
+  +  version: "2"
+create job #1 (non-cancelable: false): "ALTER TABLE defaultdb.public.t ADD CONSTRAINT unique_j UNIQUE WITHOUT INDEX (j)"
+  descriptor IDs: [104]
+# end PreCommitPhase
+commit transaction #1
+notified job registry to adopt jobs: [1]
+# begin PostCommitPhase
+begin transaction #2
+commit transaction #2
+begin transaction #3
+## PostCommitPhase stage 1 of 2 with 1 ValidationType op
+validate UNIQUE WITHOUT INDEX constraint crdb_internal_constraint_2_name_placeholder in table #104
+commit transaction #3
+begin transaction #4
+## PostCommitPhase stage 2 of 2 with 4 MutationType ops
+upsert descriptor #104
+  ...
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  -  declarativeSchemaChangerState:
+  -    authorization:
+  -      userName: root
+  -    currentStatuses: <redacted>
+  -    jobId: "1"
+  -    relevantStatements:
+  -    - statement:
+  -        redactedStatement: ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD CONSTRAINT ‹unique_j›
+  -          UNIQUE WITHOUT INDEX (‹j›)
+  -        statement: ALTER TABLE t ADD UNIQUE WITHOUT INDEX (j)
+  -        statementTag: ALTER TABLE
+  -    revertible: true
+  -    targetRanks: <redacted>
+  -    targets: <redacted>
+     families:
+     - columnIds:
+  ...
+     id: 104
+     modificationTime: {}
+  -  mutations:
+  -  - constraint:
+  -      check: {}
+  -      constraintType: UNIQUE_WITHOUT_INDEX
+  -      foreignKey: {}
+  -      name: crdb_internal_constraint_2_name_placeholder
+  -      uniqueWithoutIndexConstraint:
+  -        columnIds:
+  -        - 2
+  -        constraintId: 2
+  -        name: crdb_internal_constraint_2_name_placeholder
+  -        tableId: 104
+  -        validity: Validating
+  -    direction: ADD
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+     name: t
+     nextColumnId: 3
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "2"
+  +  uniqueWithoutIndexConstraints:
+  +  - columnIds:
+  +    - 2
+  +    constraintId: 2
+  +    name: unique_j
+  +    tableId: 104
+  +  version: "3"
+update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
+commit transaction #4
+# end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_add_unique_without_index
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_add_unique_without_index
@@ -1,0 +1,34 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT);
+SET experimental_enable_unique_without_index_constraints = true;
+
+/* test */
+EXPLAIN (ddl) ALTER TABLE t ADD UNIQUE WITHOUT INDEX (j);
+----
+Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD CONSTRAINT ‹unique_j› UNIQUE WITHOUT INDEX (‹j›); 
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 1 element transitioning toward PUBLIC
+ │         │    └── ABSENT → WRITE_ONLY UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+ │         └── 1 Mutation operation
+ │              └── MakeAbsentUniqueWithoutIndexConstraintWriteOnly {"ConstraintID":2,"TableID":104}
+ ├── PreCommitPhase
+ │    └── Stage 1 of 1 in PreCommitPhase
+ │         └── 2 Mutation operations
+ │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
+ │              └── CreateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ └── PostCommitPhase
+      ├── Stage 1 of 2 in PostCommitPhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── WRITE_ONLY → VALIDATED UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+      │    └── 1 Validation operation
+      │         └── ValidateConstraint {"ConstraintID":2,"TableID":104}
+      └── Stage 2 of 2 in PostCommitPhase
+           ├── 2 elements transitioning toward PUBLIC
+           │    ├── VALIDATED → PUBLIC UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+           │    └── ABSENT    → PUBLIC ConstraintWithoutIndexName:{DescID: 104, Name: unique_j, ConstraintID: 2}
+           └── 4 Mutation operations
+                ├── SetConstraintName {"ConstraintID":2,"Name":"unique_j","TableID":104}
+                ├── MakeValidatedUniqueWithoutIndexConstraintPublic {"ConstraintID":2,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_add_unique_without_index.rollback_1_of_2
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_add_unique_without_index.rollback_1_of_2
@@ -1,0 +1,17 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT);
+SET experimental_enable_unique_without_index_constraints = true;
+
+/* test */
+ALTER TABLE t ADD UNIQUE WITHOUT INDEX (j);
+EXPLAIN (ddl) rollback at post-commit stage 1 of 2;
+----
+Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD CONSTRAINT ‹unique_j› UNIQUE WITHOUT INDEX (‹j›); 
+ └── PostCommitNonRevertiblePhase
+      └── Stage 1 of 1 in PostCommitNonRevertiblePhase
+           ├── 1 element transitioning toward ABSENT
+           │    └── WRITE_ONLY → ABSENT UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+           └── 3 Mutation operations
+                ├── RemoveUniqueWithoutIndexConstraint {"ConstraintID":2,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_add_unique_without_index.rollback_2_of_2
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_add_unique_without_index.rollback_2_of_2
@@ -1,0 +1,17 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT);
+SET experimental_enable_unique_without_index_constraints = true;
+
+/* test */
+ALTER TABLE t ADD UNIQUE WITHOUT INDEX (j);
+EXPLAIN (ddl) rollback at post-commit stage 2 of 2;
+----
+Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD CONSTRAINT ‹unique_j› UNIQUE WITHOUT INDEX (‹j›); 
+ └── PostCommitNonRevertiblePhase
+      └── Stage 1 of 1 in PostCommitNonRevertiblePhase
+           ├── 1 element transitioning toward ABSENT
+           │    └── WRITE_ONLY → ABSENT UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+           └── 3 Mutation operations
+                ├── RemoveUniqueWithoutIndexConstraint {"ConstraintID":2,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_unique_without_index
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_unique_without_index
@@ -1,0 +1,107 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT);
+SET experimental_enable_unique_without_index_constraints = true;
+
+/* test */
+EXPLAIN (ddl, verbose) ALTER TABLE t ADD UNIQUE WITHOUT INDEX (j);
+----
+• Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD CONSTRAINT ‹unique_j› UNIQUE WITHOUT INDEX (‹j›); 
+│
+├── • StatementPhase
+│   │
+│   └── • Stage 1 of 1 in StatementPhase
+│       │
+│       ├── • 1 element transitioning toward PUBLIC
+│       │   │
+│       │   └── • UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+│       │       │ ABSENT → WRITE_ONLY
+│       │       │
+│       │       └── • PreviousTransactionPrecedence dependency from ABSENT UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+│       │             rule: "UniqueWithoutIndexConstraint transitions to PUBLIC uphold 2-version invariant: ABSENT->WRITE_ONLY"
+│       │
+│       └── • 1 Mutation operation
+│           │
+│           └── • MakeAbsentUniqueWithoutIndexConstraintWriteOnly
+│                 ColumnIDs:
+│                 - 2
+│                 ConstraintID: 2
+│                 TableID: 104
+│
+├── • PreCommitPhase
+│   │
+│   └── • Stage 1 of 1 in PreCommitPhase
+│       │
+│       └── • 2 Mutation operations
+│           │
+│           ├── • SetJobStateOnDescriptor
+│           │     DescriptorID: 104
+│           │     Initialize: true
+│           │
+│           └── • CreateSchemaChangerJob
+│                 Authorization:
+│                   UserName: root
+│                 DescriptorIDs:
+│                 - 104
+│                 JobID: 1
+│                 RunningStatus: PostCommitPhase stage 1 of 2 with 1 ValidationType op pending
+│                 Statements:
+│                 - statement: ALTER TABLE t ADD UNIQUE WITHOUT INDEX (j)
+│                   redactedstatement: ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD CONSTRAINT ‹unique_j›
+│                     UNIQUE WITHOUT INDEX (‹j›)
+│                   statementtag: ALTER TABLE
+│
+└── • PostCommitPhase
+    │
+    ├── • Stage 1 of 2 in PostCommitPhase
+    │   │
+    │   ├── • 1 element transitioning toward PUBLIC
+    │   │   │
+    │   │   └── • UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+    │   │       │ WRITE_ONLY → VALIDATED
+    │   │       │
+    │   │       └── • PreviousTransactionPrecedence dependency from WRITE_ONLY UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+    │   │             rule: "UniqueWithoutIndexConstraint transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->VALIDATED"
+    │   │
+    │   └── • 1 Validation operation
+    │       │
+    │       └── • ValidateConstraint
+    │             ConstraintID: 2
+    │             TableID: 104
+    │
+    └── • Stage 2 of 2 in PostCommitPhase
+        │
+        ├── • 2 elements transitioning toward PUBLIC
+        │   │
+        │   ├── • UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+        │   │   │ VALIDATED → PUBLIC
+        │   │   │
+        │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+        │   │   │     rule: "UniqueWithoutIndexConstraint transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+        │   │   │
+        │   │   └── • SameStagePrecedence dependency from PUBLIC ConstraintWithoutIndexName:{DescID: 104, Name: unique_j, ConstraintID: 2}
+        │   │         rule: "constraint dependent public right before constraint"
+        │   │
+        │   └── • ConstraintWithoutIndexName:{DescID: 104, Name: unique_j, ConstraintID: 2}
+        │         ABSENT → PUBLIC
+        │
+        └── • 4 Mutation operations
+            │
+            ├── • SetConstraintName
+            │     ConstraintID: 2
+            │     Name: unique_j
+            │     TableID: 104
+            │
+            ├── • MakeValidatedUniqueWithoutIndexConstraintPublic
+            │     ConstraintID: 2
+            │     TableID: 104
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 104
+            │     JobID: 1
+            │
+            └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
+                  IsNonCancelable: true
+                  JobID: 1
+                  RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_unique_without_index.rollback_1_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_unique_without_index.rollback_1_of_2
@@ -1,0 +1,41 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT);
+SET experimental_enable_unique_without_index_constraints = true;
+
+/* test */
+ALTER TABLE t ADD UNIQUE WITHOUT INDEX (j);
+EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 2;
+----
+• Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD CONSTRAINT ‹unique_j› UNIQUE WITHOUT INDEX (‹j›); 
+│
+└── • PostCommitNonRevertiblePhase
+    │
+    └── • Stage 1 of 1 in PostCommitNonRevertiblePhase
+        │
+        ├── • 1 element transitioning toward ABSENT
+        │   │
+        │   └── • UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+        │       │ WRITE_ONLY → ABSENT
+        │       │
+        │       ├── • PreviousTransactionPrecedence dependency from WRITE_ONLY UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+        │       │     rule: "UniqueWithoutIndexConstraint transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED"
+        │       │
+        │       └── • Precedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: unique_j, ConstraintID: 2}
+        │             rule: "dependents removed before constraint"
+        │
+        └── • 3 Mutation operations
+            │
+            ├── • RemoveUniqueWithoutIndexConstraint
+            │     ConstraintID: 2
+            │     TableID: 104
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 104
+            │     JobID: 1
+            │
+            └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
+                  IsNonCancelable: true
+                  JobID: 1
+                  RunningStatus: all stages completed

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_unique_without_index.rollback_2_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_unique_without_index.rollback_2_of_2
@@ -1,0 +1,41 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT);
+SET experimental_enable_unique_without_index_constraints = true;
+
+/* test */
+ALTER TABLE t ADD UNIQUE WITHOUT INDEX (j);
+EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 2;
+----
+• Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD CONSTRAINT ‹unique_j› UNIQUE WITHOUT INDEX (‹j›); 
+│
+└── • PostCommitNonRevertiblePhase
+    │
+    └── • Stage 1 of 1 in PostCommitNonRevertiblePhase
+        │
+        ├── • 1 element transitioning toward ABSENT
+        │   │
+        │   └── • UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+        │       │ WRITE_ONLY → ABSENT
+        │       │
+        │       ├── • PreviousTransactionPrecedence dependency from WRITE_ONLY UniqueWithoutIndexConstraint:{DescID: 104, ConstraintID: 2}
+        │       │     rule: "UniqueWithoutIndexConstraint transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED"
+        │       │
+        │       └── • Precedence dependency from ABSENT ConstraintWithoutIndexName:{DescID: 104, Name: unique_j, ConstraintID: 2}
+        │             rule: "dependents removed before constraint"
+        │
+        └── • 3 Mutation operations
+            │
+            ├── • RemoveUniqueWithoutIndexConstraint
+            │     ConstraintID: 2
+            │     TableID: 104
+            │
+            ├── • RemoveJobStateFromDescriptor
+            │     DescriptorID: 104
+            │     JobID: 1
+            │
+            └── • UpdateSchemaChangerJob
+                  DescriptorIDsToRemove:
+                  - 104
+                  IsNonCancelable: true
+                  JobID: 1
+                  RunningStatus: all stages completed

--- a/pkg/sql/scrub_unique_constraint.go
+++ b/pkg/sql/scrub_unique_constraint.go
@@ -124,7 +124,8 @@ func (o *sqlUniqueConstraintCheckOperation) Start(params runParams) error {
 		asOf = fmt.Sprintf("AS OF SYSTEM TIME '%s'", o.asOf.AsOfSystemTime())
 	}
 	tableName := fmt.Sprintf("%s.%s", o.tableName.Catalog(), o.tableName.Table())
-	dup, _, err := duplicateRowQuery(o.tableDesc, o.cols, o.predicate, false /* limitResults */)
+	dup, _, err := duplicateRowQuery(o.tableDesc, o.cols, o.predicate,
+		0 /* indexIDForValidation */, false /* limitResults */)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR implements `ADD UNIQUE WITHOUT INDEX` in the declarative schema changer.
In general, it follows the same recipe for `ADD CHECK`.


Epic: None