### PR TITLE
rpc: don't impersonate calling tenant when doing local RPCs

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -330,6 +330,7 @@ go_test(
     tags = ["cpu:2"],
     deps = [
         "//pkg/base",
+        "//pkg/ccl",
         "//pkg/cli/exit",
         "//pkg/clusterversion",
         "//pkg/config",

--- a/pkg/roachpb/tenant.go
+++ b/pkg/roachpb/tenant.go
@@ -118,8 +118,22 @@ func IsSystemTenantID(id uint64) bool {
 type tenantKey struct{}
 
 // NewContextForTenant creates a new context with tenant information attached.
+// An empty tenID clears the respective key from the context.
 func NewContextForTenant(ctx context.Context, tenID TenantID) context.Context {
-	return context.WithValue(ctx, tenantKey{}, tenID)
+	var val any
+	if tenID.IsSet() {
+		val = tenID
+	} else {
+		val = nil
+	}
+
+	ctxTenantID, _ := TenantFromContext(ctx)
+	if tenID == ctxTenantID {
+		// The context already has the right tenant, or no tenant at all.
+		return ctx
+	}
+
+	return context.WithValue(ctx, tenantKey{}, val)
 }
 
 // TenantFromContext returns the tenant information in ctx if it exists.

--- a/pkg/rpc/auth.go
+++ b/pkg/rpc/auth.go
@@ -64,8 +64,8 @@ func (a kvAuth) unaryInterceptor(
 	if err != nil {
 		return nil, err
 	}
-	if tenID != (roachpb.TenantID{}) {
-		ctx = contextWithTenant(ctx, tenID)
+	ctx = contextWithTenant(ctx, tenID)
+	if tenID.IsSet() {
 		if err := a.tenant.authorize(tenID, info.FullMethod, req); err != nil {
 			return nil, err
 		}
@@ -81,8 +81,8 @@ func (a kvAuth) streamInterceptor(
 	if err != nil {
 		return err
 	}
+	ctx = contextWithTenant(ctx, tenID)
 	if tenID != (roachpb.TenantID{}) {
-		ctx = contextWithTenant(ctx, tenID)
 		origSS := ss
 		ss = &wrappedServerStream{
 			ServerStream: origSS,

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -658,6 +658,11 @@ func (t *TestTenant) RPCAddr() string {
 	return t.Cfg.Addr
 }
 
+// DB is part of the TestTenantInterface.
+func (t *TestTenant) DB() *kv.DB {
+	return t.execCfg.DB
+}
+
 // PGServer is part of TestTenantInterface.
 func (t *TestTenant) PGServer() interface{} {
 	return t.pgServer

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -127,9 +127,6 @@ type TestServerInterface interface {
 	// Note: use ServingRPCAddr() instead unless specific reason not to.
 	RPCAddr() string
 
-	// DB returns a *client.DB instance for talking to this KV server.
-	DB() *kv.DB
-
 	// LeaseManager() returns the *sql.LeaseManager as an interface{}.
 	LeaseManager() interface{}
 

--- a/pkg/testutils/serverutils/test_tenant_shim.go
+++ b/pkg/testutils/serverutils/test_tenant_shim.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -46,6 +47,9 @@ type TestTenantInterface interface {
 
 	// RPCAddr returns the tenant's RPC address.
 	RPCAddr() string
+
+	// DB returns a handle to the cluster's KV interface.
+	DB() *kv.DB
 
 	// PGServer returns the tenant's *pgwire.Server as an interface{}.
 	PGServer() interface{}


### PR DESCRIPTION
This patch fixes a bug around tenant authentication: say a KV server is serving a tenant RPC. During this serving, it makes another RPC. If that RPC ends up going to itself and using the internalClientAdapter to bypass gRPC, then the inner RPC ends up carrying the tenant's identity in its ctx. If the RPC goes to another node, that node will treat the RPC as coming from a KV server / the system tenant.

I presume this inconsistency was not intended. It has condequences like the fact that, in the local case, the tenant ends up being charged twice against its request limit, whereas if the inner RPC is remote, it's only charged once. This seems backwards, if anything.

This patch fixes it by wiping out any tenant identity from the RPC ctx when handling local RPCs.

Release note: None
Epic: None