### PR TITLE
*: lower default GC TTL to 4h

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/alter_table_locality
+++ b/pkg/ccl/logictestccl/testdata/logic_test/alter_table_locality
@@ -67,14 +67,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
-                              range_min_bytes = 134217728,
-                              range_max_bytes = 536870912,
-                              gc.ttlseconds = 90000,
-                              num_replicas = 5,
-                              num_voters = 3,
-                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                              voter_constraints = '[+region=ca-central-1]',
-                              lease_preferences = '[[+region=ca-central-1]]'
+                                range_min_bytes = 134217728,
+                                range_max_bytes = 536870912,
+                                gc.ttlseconds = 14400,
+                                num_replicas = 5,
+                                num_voters = 3,
+                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                voter_constraints = '[+region=ca-central-1]',
+                                lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 CREATE TABLE regional_by_row_as (
@@ -124,14 +124,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_as
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
-                              range_min_bytes = 134217728,
-                              range_max_bytes = 536870912,
-                              gc.ttlseconds = 90000,
-                              num_replicas = 5,
-                              num_voters = 3,
-                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                              voter_constraints = '[+region=ca-central-1]',
-                              lease_preferences = '[[+region=ca-central-1]]'
+                                range_min_bytes = 134217728,
+                                range_max_bytes = 536870912,
+                                gc.ttlseconds = 14400,
+                                num_replicas = 5,
+                                num_voters = 3,
+                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                voter_constraints = '[+region=ca-central-1]',
+                                lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 CREATE TABLE regional_by_table_in_primary_region (
@@ -177,14 +177,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_primary_region
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
-                              range_min_bytes = 134217728,
-                              range_max_bytes = 536870912,
-                              gc.ttlseconds = 90000,
-                              num_replicas = 5,
-                              num_voters = 3,
-                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                              voter_constraints = '[+region=ca-central-1]',
-                              lease_preferences = '[[+region=ca-central-1]]'
+                                range_min_bytes = 134217728,
+                                range_max_bytes = 536870912,
+                                gc.ttlseconds = 14400,
+                                num_replicas = 5,
+                                num_voters = 3,
+                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                voter_constraints = '[+region=ca-central-1]',
+                                lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 CREATE TABLE regional_by_table_no_region (
@@ -230,14 +230,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_no_region
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
-                              range_min_bytes = 134217728,
-                              range_max_bytes = 536870912,
-                              gc.ttlseconds = 90000,
-                              num_replicas = 5,
-                              num_voters = 3,
-                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                              voter_constraints = '[+region=ca-central-1]',
-                              lease_preferences = '[[+region=ca-central-1]]'
+                                range_min_bytes = 134217728,
+                                range_max_bytes = 536870912,
+                                gc.ttlseconds = 14400,
+                                num_replicas = 5,
+                                num_voters = 3,
+                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                voter_constraints = '[+region=ca-central-1]',
+                                lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 CREATE TABLE regional_by_table_in_us_east (
@@ -283,14 +283,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_us_east
 ----
 TABLE regional_by_table_in_us_east  ALTER TABLE regional_by_table_in_us_east CONFIGURE ZONE USING
-                                    range_min_bytes = 134217728,
-                                    range_max_bytes = 536870912,
-                                    gc.ttlseconds = 90000,
-                                    num_replicas = 5,
-                                    num_voters = 3,
-                                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                    voter_constraints = '[+region=us-east-1]',
-                                    lease_preferences = '[[+region=us-east-1]]'
+                                      range_min_bytes = 134217728,
+                                      range_max_bytes = 536870912,
+                                      gc.ttlseconds = 14400,
+                                      num_replicas = 5,
+                                      num_voters = 3,
+                                      constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                      voter_constraints = '[+region=us-east-1]',
+                                      lease_preferences = '[[+region=us-east-1]]'
 
 statement ok
 CREATE TABLE created_as_global (pk INT PRIMARY KEY, i int, FAMILY (pk, i)) LOCALITY GLOBAL
@@ -332,15 +332,15 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE created_as_global
 ----
 TABLE created_as_global  ALTER TABLE created_as_global CONFIGURE ZONE USING
-                         range_min_bytes = 134217728,
-                         range_max_bytes = 536870912,
-                         gc.ttlseconds = 90000,
-                         global_reads = true,
-                         num_replicas = 5,
-                         num_voters = 3,
-                         constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                         voter_constraints = '[+region=ca-central-1]',
-                         lease_preferences = '[[+region=ca-central-1]]'
+                           range_min_bytes = 134217728,
+                           range_max_bytes = 536870912,
+                           gc.ttlseconds = 14400,
+                           global_reads = true,
+                           num_replicas = 5,
+                           num_voters = 3,
+                           constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                           voter_constraints = '[+region=ca-central-1]',
+                           lease_preferences = '[[+region=ca-central-1]]'
 
 # Altering from GLOBAL
 statement ok
@@ -383,14 +383,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE created_as_global
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
-                              range_min_bytes = 134217728,
-                              range_max_bytes = 536870912,
-                              gc.ttlseconds = 90000,
-                              num_replicas = 5,
-                              num_voters = 3,
-                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                              voter_constraints = '[+region=ca-central-1]',
-                              lease_preferences = '[[+region=ca-central-1]]'
+                                range_min_bytes = 134217728,
+                                range_max_bytes = 536870912,
+                                gc.ttlseconds = 14400,
+                                num_replicas = 5,
+                                num_voters = 3,
+                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                voter_constraints = '[+region=ca-central-1]',
+                                lease_preferences = '[[+region=ca-central-1]]'
 
 # Alter back, to get back to original state
 statement ok
@@ -436,14 +436,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE created_as_global
 ----
 TABLE created_as_global  ALTER TABLE created_as_global CONFIGURE ZONE USING
-                         range_min_bytes = 134217728,
-                         range_max_bytes = 536870912,
-                         gc.ttlseconds = 90000,
-                         num_replicas = 5,
-                         num_voters = 3,
-                         constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                         voter_constraints = '[+region=ap-southeast-2]',
-                         lease_preferences = '[[+region=ap-southeast-2]]'
+                           range_min_bytes = 134217728,
+                           range_max_bytes = 536870912,
+                           gc.ttlseconds = 14400,
+                           num_replicas = 5,
+                           num_voters = 3,
+                           constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                           voter_constraints = '[+region=ap-southeast-2]',
+                           lease_preferences = '[[+region=ap-southeast-2]]'
 
 # Alter back, to get back to original state
 statement ok
@@ -489,14 +489,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE created_as_global
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
-                              range_min_bytes = 134217728,
-                              range_max_bytes = 536870912,
-                              gc.ttlseconds = 90000,
-                              num_replicas = 5,
-                              num_voters = 3,
-                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                              voter_constraints = '[+region=ca-central-1]',
-                              lease_preferences = '[[+region=ca-central-1]]'
+                                range_min_bytes = 134217728,
+                                range_max_bytes = 536870912,
+                                gc.ttlseconds = 14400,
+                                num_replicas = 5,
+                                num_voters = 3,
+                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                voter_constraints = '[+region=ca-central-1]',
+                                lease_preferences = '[[+region=ca-central-1]]'
 
 # Alter back, to get back to original state
 statement ok
@@ -560,15 +560,15 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE created_as_global
 ----
 TABLE created_as_global  ALTER TABLE created_as_global CONFIGURE ZONE USING
-                         range_min_bytes = 134217728,
-                         range_max_bytes = 536870912,
-                         gc.ttlseconds = 90000,
-                         global_reads = true,
-                         num_replicas = 5,
-                         num_voters = 3,
-                         constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                         voter_constraints = '[+region=ca-central-1]',
-                         lease_preferences = '[[+region=ca-central-1]]'
+                           range_min_bytes = 134217728,
+                           range_max_bytes = 536870912,
+                           gc.ttlseconds = 14400,
+                           global_reads = true,
+                           num_replicas = 5,
+                           num_voters = 3,
+                           constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                           voter_constraints = '[+region=ca-central-1]',
+                           lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 ALTER TABLE created_as_global ADD COLUMN crdb_region INT;
@@ -630,14 +630,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE created_as_global
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
-                              range_min_bytes = 134217728,
-                              range_max_bytes = 536870912,
-                              gc.ttlseconds = 90000,
-                              num_replicas = 5,
-                              num_voters = 3,
-                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                              voter_constraints = '[+region=ca-central-1]',
-                              lease_preferences = '[[+region=ca-central-1]]'
+                                range_min_bytes = 134217728,
+                                range_max_bytes = 536870912,
+                                gc.ttlseconds = 14400,
+                                num_replicas = 5,
+                                num_voters = 3,
+                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                voter_constraints = '[+region=ca-central-1]',
+                                lease_preferences = '[[+region=ca-central-1]]'
 
 query T
 INSERT INTO created_as_global (pk) VALUES (1) RETURNING crdb_region
@@ -737,14 +737,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE created_as_global
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
-                              range_min_bytes = 134217728,
-                              range_max_bytes = 536870912,
-                              gc.ttlseconds = 90000,
-                              num_replicas = 5,
-                              num_voters = 3,
-                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                              voter_constraints = '[+region=ca-central-1]',
-                              lease_preferences = '[[+region=ca-central-1]]'
+                                range_min_bytes = 134217728,
+                                range_max_bytes = 536870912,
+                                gc.ttlseconds = 14400,
+                                num_replicas = 5,
+                                num_voters = 3,
+                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                voter_constraints = '[+region=ca-central-1]',
+                                lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW CREATE TABLE created_as_global
@@ -840,14 +840,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE created_as_global
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
-                              range_min_bytes = 134217728,
-                              range_max_bytes = 536870912,
-                              gc.ttlseconds = 90000,
-                              num_replicas = 5,
-                              num_voters = 3,
-                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                              voter_constraints = '[+region=ca-central-1]',
-                              lease_preferences = '[[+region=ca-central-1]]'
+                                range_min_bytes = 134217728,
+                                range_max_bytes = 536870912,
+                                gc.ttlseconds = 14400,
+                                num_replicas = 5,
+                                num_voters = 3,
+                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                voter_constraints = '[+region=ca-central-1]',
+                                lease_preferences = '[[+region=ca-central-1]]'
 
 # Altering from REGIONAL BY ROW IN PRIMARY REGION
 
@@ -894,14 +894,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_primary_region
 ----
 TABLE regional_by_table_in_primary_region  ALTER TABLE regional_by_table_in_primary_region CONFIGURE ZONE USING
-                                           range_min_bytes = 134217728,
-                                           range_max_bytes = 536870912,
-                                           gc.ttlseconds = 90000,
-                                           num_replicas = 5,
-                                           num_voters = 3,
-                                           constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                           voter_constraints = '[+region=ap-southeast-2]',
-                                           lease_preferences = '[[+region=ap-southeast-2]]'
+                                             range_min_bytes = 134217728,
+                                             range_max_bytes = 536870912,
+                                             gc.ttlseconds = 14400,
+                                             num_replicas = 5,
+                                             num_voters = 3,
+                                             constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                             voter_constraints = '[+region=ap-southeast-2]',
+                                             lease_preferences = '[[+region=ap-southeast-2]]'
 
 # Alter back to original state
 statement ok
@@ -944,14 +944,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_primary_region
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
-                              range_min_bytes = 134217728,
-                              range_max_bytes = 536870912,
-                              gc.ttlseconds = 90000,
-                              num_replicas = 5,
-                              num_voters = 3,
-                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                              voter_constraints = '[+region=ca-central-1]',
-                              lease_preferences = '[[+region=ca-central-1]]'
+                                range_min_bytes = 134217728,
+                                range_max_bytes = 536870912,
+                                gc.ttlseconds = 14400,
+                                num_replicas = 5,
+                                num_voters = 3,
+                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                voter_constraints = '[+region=ca-central-1]',
+                                lease_preferences = '[[+region=ca-central-1]]'
 
 # Alter to same state
 statement ok
@@ -994,14 +994,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_primary_region
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
-                              range_min_bytes = 134217728,
-                              range_max_bytes = 536870912,
-                              gc.ttlseconds = 90000,
-                              num_replicas = 5,
-                              num_voters = 3,
-                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                              voter_constraints = '[+region=ca-central-1]',
-                              lease_preferences = '[[+region=ca-central-1]]'
+                                range_min_bytes = 134217728,
+                                range_max_bytes = 536870912,
+                                gc.ttlseconds = 14400,
+                                num_replicas = 5,
+                                num_voters = 3,
+                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                voter_constraints = '[+region=ca-central-1]',
+                                lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 ALTER TABLE regional_by_table_in_primary_region SET LOCALITY REGIONAL BY TABLE
@@ -1043,14 +1043,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_primary_region
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
-                              range_min_bytes = 134217728,
-                              range_max_bytes = 536870912,
-                              gc.ttlseconds = 90000,
-                              num_replicas = 5,
-                              num_voters = 3,
-                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                              voter_constraints = '[+region=ca-central-1]',
-                              lease_preferences = '[[+region=ca-central-1]]'
+                                range_min_bytes = 134217728,
+                                range_max_bytes = 536870912,
+                                gc.ttlseconds = 14400,
+                                num_replicas = 5,
+                                num_voters = 3,
+                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                voter_constraints = '[+region=ca-central-1]',
+                                lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 ALTER TABLE regional_by_table_in_primary_region SET LOCALITY GLOBAL
@@ -1092,15 +1092,15 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_primary_region
 ----
 TABLE regional_by_table_in_primary_region  ALTER TABLE regional_by_table_in_primary_region CONFIGURE ZONE USING
-                                           range_min_bytes = 134217728,
-                                           range_max_bytes = 536870912,
-                                           gc.ttlseconds = 90000,
-                                           global_reads = true,
-                                           num_replicas = 5,
-                                           num_voters = 3,
-                                           constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                           voter_constraints = '[+region=ca-central-1]',
-                                           lease_preferences = '[[+region=ca-central-1]]'
+                                             range_min_bytes = 134217728,
+                                             range_max_bytes = 536870912,
+                                             gc.ttlseconds = 14400,
+                                             global_reads = true,
+                                             num_replicas = 5,
+                                             num_voters = 3,
+                                             constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                             voter_constraints = '[+region=ca-central-1]',
+                                             lease_preferences = '[[+region=ca-central-1]]'
 
 # Drop the table and recreate it to get back to original state (this is required because alter table
 # from global to regional by table is not yet implemented).
@@ -1156,14 +1156,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_no_region
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
-                              range_min_bytes = 134217728,
-                              range_max_bytes = 536870912,
-                              gc.ttlseconds = 90000,
-                              num_replicas = 5,
-                              num_voters = 3,
-                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                              voter_constraints = '[+region=ca-central-1]',
-                              lease_preferences = '[[+region=ca-central-1]]'
+                                range_min_bytes = 134217728,
+                                range_max_bytes = 536870912,
+                                gc.ttlseconds = 14400,
+                                num_replicas = 5,
+                                num_voters = 3,
+                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                voter_constraints = '[+region=ca-central-1]',
+                                lease_preferences = '[[+region=ca-central-1]]'
 
 # Drop and recreate the table to get it back to the "no region" state.
 statement ok
@@ -1216,14 +1216,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_no_region
 ----
 TABLE regional_by_table_no_region  ALTER TABLE regional_by_table_no_region CONFIGURE ZONE USING
-                                   range_min_bytes = 134217728,
-                                   range_max_bytes = 536870912,
-                                   gc.ttlseconds = 90000,
-                                   num_replicas = 5,
-                                   num_voters = 3,
-                                   constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                   voter_constraints = '[+region=ap-southeast-2]',
-                                   lease_preferences = '[[+region=ap-southeast-2]]'
+                                     range_min_bytes = 134217728,
+                                     range_max_bytes = 536870912,
+                                     gc.ttlseconds = 14400,
+                                     num_replicas = 5,
+                                     num_voters = 3,
+                                     constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                     voter_constraints = '[+region=ap-southeast-2]',
+                                     lease_preferences = '[[+region=ap-southeast-2]]'
 
 # Drop and recreate the table to get it back to the "no region" state.
 statement ok
@@ -1271,14 +1271,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_no_region
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
-                              range_min_bytes = 134217728,
-                              range_max_bytes = 536870912,
-                              gc.ttlseconds = 90000,
-                              num_replicas = 5,
-                              num_voters = 3,
-                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                              voter_constraints = '[+region=ca-central-1]',
-                              lease_preferences = '[[+region=ca-central-1]]'
+                                range_min_bytes = 134217728,
+                                range_max_bytes = 536870912,
+                                gc.ttlseconds = 14400,
+                                num_replicas = 5,
+                                num_voters = 3,
+                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                voter_constraints = '[+region=ca-central-1]',
+                                lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 ALTER TABLE regional_by_table_no_region SET LOCALITY GLOBAL
@@ -1319,15 +1319,15 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_no_region
 ----
 TABLE regional_by_table_no_region  ALTER TABLE regional_by_table_no_region CONFIGURE ZONE USING
-                                   range_min_bytes = 134217728,
-                                   range_max_bytes = 536870912,
-                                   gc.ttlseconds = 90000,
-                                   global_reads = true,
-                                   num_replicas = 5,
-                                   num_voters = 3,
-                                   constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                   voter_constraints = '[+region=ca-central-1]',
-                                   lease_preferences = '[[+region=ca-central-1]]'
+                                     range_min_bytes = 134217728,
+                                     range_max_bytes = 536870912,
+                                     gc.ttlseconds = 14400,
+                                     global_reads = true,
+                                     num_replicas = 5,
+                                     num_voters = 3,
+                                     constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                     voter_constraints = '[+region=ca-central-1]',
+                                     lease_preferences = '[[+region=ca-central-1]]'
 
 # Drop the table and recreate it with columns appropriate for
 # REGIONAL BY ROW transformations.
@@ -1408,14 +1408,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_no_region
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
-                              range_min_bytes = 134217728,
-                              range_max_bytes = 536870912,
-                              gc.ttlseconds = 90000,
-                              num_replicas = 5,
-                              num_voters = 3,
-                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                              voter_constraints = '[+region=ca-central-1]',
-                              lease_preferences = '[[+region=ca-central-1]]'
+                                range_min_bytes = 134217728,
+                                range_max_bytes = 536870912,
+                                gc.ttlseconds = 14400,
+                                num_replicas = 5,
+                                num_voters = 3,
+                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                voter_constraints = '[+region=ca-central-1]',
+                                lease_preferences = '[[+region=ca-central-1]]'
 
 # Drop the table and recreate it with columns appropriate for
 # REGIONAL BY ROW AS transformations.
@@ -1480,14 +1480,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_no_region
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
-                              range_min_bytes = 134217728,
-                              range_max_bytes = 536870912,
-                              gc.ttlseconds = 90000,
-                              num_replicas = 5,
-                              num_voters = 3,
-                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                              voter_constraints = '[+region=ca-central-1]',
-                              lease_preferences = '[[+region=ca-central-1]]'
+                                range_min_bytes = 134217728,
+                                range_max_bytes = 536870912,
+                                gc.ttlseconds = 14400,
+                                num_replicas = 5,
+                                num_voters = 3,
+                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                voter_constraints = '[+region=ca-central-1]',
+                                lease_preferences = '[[+region=ca-central-1]]'
 
 # Altering from REGIONAL BY ROW IN "us-east-1"
 
@@ -1531,14 +1531,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_us_east
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
-                              range_min_bytes = 134217728,
-                              range_max_bytes = 536870912,
-                              gc.ttlseconds = 90000,
-                              num_replicas = 5,
-                              num_voters = 3,
-                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                              voter_constraints = '[+region=ca-central-1]',
-                              lease_preferences = '[[+region=ca-central-1]]'
+                                range_min_bytes = 134217728,
+                                range_max_bytes = 536870912,
+                                gc.ttlseconds = 14400,
+                                num_replicas = 5,
+                                num_voters = 3,
+                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                voter_constraints = '[+region=ca-central-1]',
+                                lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 ALTER TABLE regional_by_table_in_us_east SET LOCALITY REGIONAL BY TABLE in "us-east-1"
@@ -1583,14 +1583,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_us_east
 ----
 TABLE regional_by_table_in_us_east  ALTER TABLE regional_by_table_in_us_east CONFIGURE ZONE USING
-                                    range_min_bytes = 134217728,
-                                    range_max_bytes = 536870912,
-                                    gc.ttlseconds = 90000,
-                                    num_replicas = 5,
-                                    num_voters = 3,
-                                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                    voter_constraints = '[+region=ap-southeast-2]',
-                                    lease_preferences = '[[+region=ap-southeast-2]]'
+                                      range_min_bytes = 134217728,
+                                      range_max_bytes = 536870912,
+                                      gc.ttlseconds = 14400,
+                                      num_replicas = 5,
+                                      num_voters = 3,
+                                      constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                      voter_constraints = '[+region=ap-southeast-2]',
+                                      lease_preferences = '[[+region=ap-southeast-2]]'
 
 statement ok
 ALTER TABLE regional_by_table_in_us_east SET LOCALITY REGIONAL BY TABLE in "us-east-1"
@@ -1635,14 +1635,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_us_east
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
-                              range_min_bytes = 134217728,
-                              range_max_bytes = 536870912,
-                              gc.ttlseconds = 90000,
-                              num_replicas = 5,
-                              num_voters = 3,
-                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                              voter_constraints = '[+region=ca-central-1]',
-                              lease_preferences = '[[+region=ca-central-1]]'
+                                range_min_bytes = 134217728,
+                                range_max_bytes = 536870912,
+                                gc.ttlseconds = 14400,
+                                num_replicas = 5,
+                                num_voters = 3,
+                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                voter_constraints = '[+region=ca-central-1]',
+                                lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 ALTER TABLE regional_by_table_in_us_east SET LOCALITY GLOBAL
@@ -1684,15 +1684,15 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_us_east
 ----
 TABLE regional_by_table_in_us_east  ALTER TABLE regional_by_table_in_us_east CONFIGURE ZONE USING
-                                    range_min_bytes = 134217728,
-                                    range_max_bytes = 536870912,
-                                    gc.ttlseconds = 90000,
-                                    global_reads = true,
-                                    num_replicas = 5,
-                                    num_voters = 3,
-                                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                    voter_constraints = '[+region=ca-central-1]',
-                                    lease_preferences = '[[+region=ca-central-1]]'
+                                      range_min_bytes = 134217728,
+                                      range_max_bytes = 536870912,
+                                      gc.ttlseconds = 14400,
+                                      global_reads = true,
+                                      num_replicas = 5,
+                                      num_voters = 3,
+                                      constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                      voter_constraints = '[+region=ca-central-1]',
+                                      lease_preferences = '[[+region=ca-central-1]]'
 
 # Drop the table and recreate it with columns appropriate for
 # REGIONAL BY ROW transformations.
@@ -1756,14 +1756,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_us_east
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
-                              range_min_bytes = 134217728,
-                              range_max_bytes = 536870912,
-                              gc.ttlseconds = 90000,
-                              num_replicas = 5,
-                              num_voters = 3,
-                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                              voter_constraints = '[+region=ca-central-1]',
-                              lease_preferences = '[[+region=ca-central-1]]'
+                                range_min_bytes = 134217728,
+                                range_max_bytes = 536870912,
+                                gc.ttlseconds = 14400,
+                                num_replicas = 5,
+                                num_voters = 3,
+                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                voter_constraints = '[+region=ca-central-1]',
+                                lease_preferences = '[[+region=ca-central-1]]'
 
 # Drop the table and recreate it with columns appropriate for
 # REGIONAL BY ROW AS transformations.
@@ -1828,14 +1828,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_us_east
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
-                              range_min_bytes = 134217728,
-                              range_max_bytes = 536870912,
-                              gc.ttlseconds = 90000,
-                              num_replicas = 5,
-                              num_voters = 3,
-                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                              voter_constraints = '[+region=ca-central-1]',
-                              lease_preferences = '[[+region=ca-central-1]]'
+                                range_min_bytes = 134217728,
+                                range_max_bytes = 536870912,
+                                gc.ttlseconds = 14400,
+                                num_replicas = 5,
+                                num_voters = 3,
+                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                voter_constraints = '[+region=ca-central-1]',
+                                lease_preferences = '[[+region=ca-central-1]]'
 
 # Altering from REGIONAL BY ROW
 
@@ -1864,14 +1864,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
-                              range_min_bytes = 134217728,
-                              range_max_bytes = 536870912,
-                              gc.ttlseconds = 90000,
-                              num_replicas = 5,
-                              num_voters = 3,
-                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                              voter_constraints = '[+region=ca-central-1]',
-                              lease_preferences = '[[+region=ca-central-1]]'
+                                range_min_bytes = 134217728,
+                                range_max_bytes = 536870912,
+                                gc.ttlseconds = 14400,
+                                num_replicas = 5,
+                                num_voters = 3,
+                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                voter_constraints = '[+region=ca-central-1]',
+                                lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 DROP TABLE regional_by_row;
@@ -1911,14 +1911,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row
 ----
 TABLE regional_by_row  ALTER TABLE regional_by_row CONFIGURE ZONE USING
-                       range_min_bytes = 134217728,
-                       range_max_bytes = 536870912,
-                       gc.ttlseconds = 90000,
-                       num_replicas = 5,
-                       num_voters = 3,
-                       constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                       voter_constraints = '[+region=ap-southeast-2]',
-                       lease_preferences = '[[+region=ap-southeast-2]]'
+                         range_min_bytes = 134217728,
+                         range_max_bytes = 536870912,
+                         gc.ttlseconds = 14400,
+                         num_replicas = 5,
+                         num_voters = 3,
+                         constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                         voter_constraints = '[+region=ap-southeast-2]',
+                         lease_preferences = '[[+region=ap-southeast-2]]'
 
 statement ok
 DROP TABLE regional_by_row;
@@ -1958,14 +1958,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
-                              range_min_bytes = 134217728,
-                              range_max_bytes = 536870912,
-                              gc.ttlseconds = 90000,
-                              num_replicas = 5,
-                              num_voters = 3,
-                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                              voter_constraints = '[+region=ca-central-1]',
-                              lease_preferences = '[[+region=ca-central-1]]'
+                                range_min_bytes = 134217728,
+                                range_max_bytes = 536870912,
+                                gc.ttlseconds = 14400,
+                                num_replicas = 5,
+                                num_voters = 3,
+                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                voter_constraints = '[+region=ca-central-1]',
+                                lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 DROP TABLE regional_by_row;
@@ -2005,15 +2005,15 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row
 ----
 TABLE regional_by_row  ALTER TABLE regional_by_row CONFIGURE ZONE USING
-                       range_min_bytes = 134217728,
-                       range_max_bytes = 536870912,
-                       gc.ttlseconds = 90000,
-                       global_reads = true,
-                       num_replicas = 5,
-                       num_voters = 3,
-                       constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                       voter_constraints = '[+region=ca-central-1]',
-                       lease_preferences = '[[+region=ca-central-1]]'
+                         range_min_bytes = 134217728,
+                         range_max_bytes = 536870912,
+                         gc.ttlseconds = 14400,
+                         global_reads = true,
+                         num_replicas = 5,
+                         num_voters = 3,
+                         constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                         voter_constraints = '[+region=ca-central-1]',
+                         lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 DROP TABLE regional_by_row;
@@ -2071,14 +2071,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
-                              range_min_bytes = 134217728,
-                              range_max_bytes = 536870912,
-                              gc.ttlseconds = 90000,
-                              num_replicas = 5,
-                              num_voters = 3,
-                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                              voter_constraints = '[+region=ca-central-1]',
-                              lease_preferences = '[[+region=ca-central-1]]'
+                                range_min_bytes = 134217728,
+                                range_max_bytes = 536870912,
+                                gc.ttlseconds = 14400,
+                                num_replicas = 5,
+                                num_voters = 3,
+                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                voter_constraints = '[+region=ca-central-1]',
+                                lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 ALTER TABLE regional_by_row SET LOCALITY REGIONAL BY ROW AS crdb_region
@@ -2122,14 +2122,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
-                              range_min_bytes = 134217728,
-                              range_max_bytes = 536870912,
-                              gc.ttlseconds = 90000,
-                              num_replicas = 5,
-                              num_voters = 3,
-                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                              voter_constraints = '[+region=ca-central-1]',
-                              lease_preferences = '[[+region=ca-central-1]]'
+                                range_min_bytes = 134217728,
+                                range_max_bytes = 536870912,
+                                gc.ttlseconds = 14400,
+                                num_replicas = 5,
+                                num_voters = 3,
+                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                voter_constraints = '[+region=ca-central-1]',
+                                lease_preferences = '[[+region=ca-central-1]]'
 
 # Go back from REGIONAL BY ROW AS crdb_region to just REGIONAL BY ROW.
 statement ok
@@ -2174,14 +2174,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
-                              range_min_bytes = 134217728,
-                              range_max_bytes = 536870912,
-                              gc.ttlseconds = 90000,
-                              num_replicas = 5,
-                              num_voters = 3,
-                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                              voter_constraints = '[+region=ca-central-1]',
-                              lease_preferences = '[[+region=ca-central-1]]'
+                                range_min_bytes = 134217728,
+                                range_max_bytes = 536870912,
+                                gc.ttlseconds = 14400,
+                                num_replicas = 5,
+                                num_voters = 3,
+                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                voter_constraints = '[+region=ca-central-1]',
+                                lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 CREATE TABLE regional_by_row_to_regional_by_row_as (
@@ -2238,14 +2238,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_to_regional_by_row_as
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
-                              range_min_bytes = 134217728,
-                              range_max_bytes = 536870912,
-                              gc.ttlseconds = 90000,
-                              num_replicas = 5,
-                              num_voters = 3,
-                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                              voter_constraints = '[+region=ca-central-1]',
-                              lease_preferences = '[[+region=ca-central-1]]'
+                                range_min_bytes = 134217728,
+                                range_max_bytes = 536870912,
+                                gc.ttlseconds = 14400,
+                                num_replicas = 5,
+                                num_voters = 3,
+                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                voter_constraints = '[+region=ca-central-1]',
+                                lease_preferences = '[[+region=ca-central-1]]'
 
 # Altering from REGIONAL BY ROW AS
 
@@ -2292,14 +2292,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_as
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
-                              range_min_bytes = 134217728,
-                              range_max_bytes = 536870912,
-                              gc.ttlseconds = 90000,
-                              num_replicas = 5,
-                              num_voters = 3,
-                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                              voter_constraints = '[+region=ca-central-1]',
-                              lease_preferences = '[[+region=ca-central-1]]'
+                                range_min_bytes = 134217728,
+                                range_max_bytes = 536870912,
+                                gc.ttlseconds = 14400,
+                                num_replicas = 5,
+                                num_voters = 3,
+                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                voter_constraints = '[+region=ca-central-1]',
+                                lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 DROP TABLE regional_by_row_as;
@@ -2358,14 +2358,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_as
 ----
 TABLE regional_by_row_as  ALTER TABLE regional_by_row_as CONFIGURE ZONE USING
-                          range_min_bytes = 134217728,
-                          range_max_bytes = 536870912,
-                          gc.ttlseconds = 90000,
-                          num_replicas = 5,
-                          num_voters = 3,
-                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                          voter_constraints = '[+region=ap-southeast-2]',
-                          lease_preferences = '[[+region=ap-southeast-2]]'
+                            range_min_bytes = 134217728,
+                            range_max_bytes = 536870912,
+                            gc.ttlseconds = 14400,
+                            num_replicas = 5,
+                            num_voters = 3,
+                            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                            voter_constraints = '[+region=ap-southeast-2]',
+                            lease_preferences = '[[+region=ap-southeast-2]]'
 
 statement ok
 DROP TABLE regional_by_row_as;
@@ -2424,14 +2424,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_as
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
-                              range_min_bytes = 134217728,
-                              range_max_bytes = 536870912,
-                              gc.ttlseconds = 90000,
-                              num_replicas = 5,
-                              num_voters = 3,
-                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                              voter_constraints = '[+region=ca-central-1]',
-                              lease_preferences = '[[+region=ca-central-1]]'
+                                range_min_bytes = 134217728,
+                                range_max_bytes = 536870912,
+                                gc.ttlseconds = 14400,
+                                num_replicas = 5,
+                                num_voters = 3,
+                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                voter_constraints = '[+region=ca-central-1]',
+                                lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 DROP TABLE regional_by_row_as;
@@ -2490,15 +2490,15 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_as
 ----
 TABLE regional_by_row_as  ALTER TABLE regional_by_row_as CONFIGURE ZONE USING
-                          range_min_bytes = 134217728,
-                          range_max_bytes = 536870912,
-                          gc.ttlseconds = 90000,
-                          global_reads = true,
-                          num_replicas = 5,
-                          num_voters = 3,
-                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                          voter_constraints = '[+region=ca-central-1]',
-                          lease_preferences = '[[+region=ca-central-1]]'
+                            range_min_bytes = 134217728,
+                            range_max_bytes = 536870912,
+                            gc.ttlseconds = 14400,
+                            global_reads = true,
+                            num_replicas = 5,
+                            num_voters = 3,
+                            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                            voter_constraints = '[+region=ca-central-1]',
+                            lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 CREATE TABLE regional_by_row_as_to_regional_by_row (
@@ -2553,14 +2553,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_as_to_regional_by_row
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
-                              range_min_bytes = 134217728,
-                              range_max_bytes = 536870912,
-                              gc.ttlseconds = 90000,
-                              num_replicas = 5,
-                              num_voters = 3,
-                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                              voter_constraints = '[+region=ca-central-1]',
-                              lease_preferences = '[[+region=ca-central-1]]'
+                                range_min_bytes = 134217728,
+                                range_max_bytes = 536870912,
+                                gc.ttlseconds = 14400,
+                                num_replicas = 5,
+                                num_voters = 3,
+                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                voter_constraints = '[+region=ca-central-1]',
+                                lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 DROP TABLE regional_by_row_as;
@@ -2615,14 +2615,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_as
 ----
 DATABASE alter_locality_test  ALTER DATABASE alter_locality_test CONFIGURE ZONE USING
-                              range_min_bytes = 134217728,
-                              range_max_bytes = 536870912,
-                              gc.ttlseconds = 90000,
-                              num_replicas = 5,
-                              num_voters = 3,
-                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                              voter_constraints = '[+region=ca-central-1]',
-                              lease_preferences = '[[+region=ca-central-1]]'
+                                range_min_bytes = 134217728,
+                                range_max_bytes = 536870912,
+                                gc.ttlseconds = 14400,
+                                num_replicas = 5,
+                                num_voters = 3,
+                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                voter_constraints = '[+region=ca-central-1]',
+                                lease_preferences = '[[+region=ca-central-1]]'
 
 # Set a table with a gc.ttlseconds to be a non-default value, and check this is
 # the same after a change to REGIONAL BY TABLE IN PRIMARY REGION, which overrides
@@ -2657,14 +2657,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE rbt_table_gc_ttl
 ----
 TABLE rbt_table_gc_ttl  ALTER TABLE rbt_table_gc_ttl CONFIGURE ZONE USING
-                        range_min_bytes = 134217728,
-                        range_max_bytes = 536870912,
-                        gc.ttlseconds = 90000,
-                        num_replicas = 5,
-                        num_voters = 3,
-                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                        voter_constraints = '[+region=us-east-1]',
-                        lease_preferences = '[[+region=us-east-1]]'
+                          range_min_bytes = 134217728,
+                          range_max_bytes = 536870912,
+                          gc.ttlseconds = 14400,
+                          num_replicas = 5,
+                          num_voters = 3,
+                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                          voter_constraints = '[+region=us-east-1]',
+                          lease_preferences = '[[+region=us-east-1]]'
 
 statement ok
 ALTER TABLE rbt_table_gc_ttl CONFIGURE ZONE USING gc.ttlseconds = 999;

--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal
@@ -80,37 +80,37 @@ query TT
 SELECT * FROM [SHOW ALL ZONE CONFIGURATIONS] ORDER BY 1
 ----
 INDEX test.public.t4@myt4index  ALTER INDEX test.public.t4@myt4index CONFIGURE ZONE USING
-                                num_replicas = 5
+                                  num_replicas = 5
 RANGE default                   ALTER RANGE default CONFIGURE ZONE USING
-                                range_min_bytes = 134217728,
-                                range_max_bytes = 536870912,
-                                gc.ttlseconds = 90000,
-                                num_replicas = 3,
-                                constraints = '[]',
-                                lease_preferences = '[]'
+                                  range_min_bytes = 134217728,
+                                  range_max_bytes = 536870912,
+                                  gc.ttlseconds = 14400,
+                                  num_replicas = 3,
+                                  constraints = '[]',
+                                  lease_preferences = '[]'
 RANGE liveness                  ALTER RANGE liveness CONFIGURE ZONE USING
-                                range_min_bytes = 134217728,
-                                range_max_bytes = 536870912,
-                                gc.ttlseconds = 600,
-                                num_replicas = 5,
-                                constraints = '[]',
-                                lease_preferences = '[]'
+                                  range_min_bytes = 134217728,
+                                  range_max_bytes = 536870912,
+                                  gc.ttlseconds = 600,
+                                  num_replicas = 5,
+                                  constraints = '[]',
+                                  lease_preferences = '[]'
 RANGE meta                      ALTER RANGE meta CONFIGURE ZONE USING
-                                range_min_bytes = 134217728,
-                                range_max_bytes = 536870912,
-                                gc.ttlseconds = 3600,
-                                num_replicas = 5,
-                                constraints = '[]',
-                                lease_preferences = '[]'
+                                  range_min_bytes = 134217728,
+                                  range_max_bytes = 536870912,
+                                  gc.ttlseconds = 3600,
+                                  num_replicas = 5,
+                                  constraints = '[]',
+                                  lease_preferences = '[]'
 RANGE system                    ALTER RANGE system CONFIGURE ZONE USING
-                                range_min_bytes = 134217728,
-                                range_max_bytes = 536870912,
-                                gc.ttlseconds = 90000,
-                                num_replicas = 5,
-                                constraints = '[]',
-                                lease_preferences = '[]'
+                                  range_min_bytes = 134217728,
+                                  range_max_bytes = 536870912,
+                                  gc.ttlseconds = 14400,
+                                  num_replicas = 5,
+                                  constraints = '[]',
+                                  lease_preferences = '[]'
 TABLE test.public.t4            ALTER TABLE test.public.t4 CONFIGURE ZONE USING
-                                num_replicas = 7
+                                  num_replicas = 7
 
 query error pq: user testuser has no privileges on database db2
 SHOW ZONE CONFIGURATION FOR DATABASE db2
@@ -128,34 +128,34 @@ query TT
 SHOW ZONE CONFIGURATION FOR INDEX myt4index
 ----
 INDEX test.public.t4@myt4index  ALTER INDEX test.public.t4@myt4index CONFIGURE ZONE USING
-                                range_min_bytes = 134217728,
-                                range_max_bytes = 536870912,
-                                gc.ttlseconds = 90000,
-                                num_replicas = 5,
-                                constraints = '[]',
-                                lease_preferences = '[]'
+                                  range_min_bytes = 134217728,
+                                  range_max_bytes = 536870912,
+                                  gc.ttlseconds = 14400,
+                                  num_replicas = 5,
+                                  constraints = '[]',
+                                  lease_preferences = '[]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE t4
 ----
 TABLE t4  ALTER TABLE t4 CONFIGURE ZONE USING
-          range_min_bytes = 134217728,
-          range_max_bytes = 536870912,
-          gc.ttlseconds = 90000,
-          num_replicas = 7,
-          constraints = '[]',
-          lease_preferences = '[]'
+            range_min_bytes = 134217728,
+            range_max_bytes = 536870912,
+            gc.ttlseconds = 14400,
+            num_replicas = 7,
+            constraints = '[]',
+            lease_preferences = '[]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR RANGE default
 ----
 RANGE default  ALTER RANGE default CONFIGURE ZONE USING
-               range_min_bytes = 134217728,
-               range_max_bytes = 536870912,
-               gc.ttlseconds = 90000,
-               num_replicas = 3,
-               constraints = '[]',
-               lease_preferences = '[]'
+                 range_min_bytes = 134217728,
+                 range_max_bytes = 536870912,
+                 gc.ttlseconds = 14400,
+                 num_replicas = 3,
+                 constraints = '[]',
+                 lease_preferences = '[]'
 
 # This test checks that generator backed tables do not concurrently
 # access transactions. It does this by scanning two virtual tables at a time.

--- a/pkg/ccl/logictestccl/testdata/logic_test/distsql_partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/distsql_partitioning
@@ -17,23 +17,23 @@ SHOW PARTITIONS FROM DATABASE test
 ----
 database_name  table_name  partition_name  parent_partition  column_names  index_name  partition_value  zone_config  full_zone_config
 test           t1          p1              NULL              x             t1@t1_pkey  (1)              NULL         range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[]',
-lease_preferences = '[]'
-test                      t1  p2  NULL  x  t1@t1_pkey  (2)  NULL  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[]',
-lease_preferences = '[]'
-test                      t1  p3  NULL  x  t1@t1_pkey  (3)  NULL  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[]',
-lease_preferences = '[]'
+                                                                                                                     range_max_bytes = 536870912,
+                                                                                                                     gc.ttlseconds = 14400,
+                                                                                                                     num_replicas = 3,
+                                                                                                                     constraints = '[]',
+                                                                                                                     lease_preferences = '[]'
+test           t1          p2              NULL              x             t1@t1_pkey  (2)              NULL         range_min_bytes = 134217728,
+                                                                                                                     range_max_bytes = 536870912,
+                                                                                                                     gc.ttlseconds = 14400,
+                                                                                                                     num_replicas = 3,
+                                                                                                                     constraints = '[]',
+                                                                                                                     lease_preferences = '[]'
+test           t1          p3              NULL              x             t1@t1_pkey  (3)              NULL         range_min_bytes = 134217728,
+                                                                                                                     range_max_bytes = 536870912,
+                                                                                                                     gc.ttlseconds = 14400,
+                                                                                                                     num_replicas = 3,
+                                                                                                                     constraints = '[]',
+                                                                                                                     lease_preferences = '[]'
 
 statement ok
 ALTER PARTITION p1 OF TABLE t1 CONFIGURE ZONE USING constraints='[+dc=dc1]';
@@ -45,67 +45,67 @@ SHOW PARTITIONS FROM DATABASE test
 ----
 database_name  table_name  partition_name  parent_partition  column_names  index_name  partition_value  zone_config                full_zone_config
 test           t1          p1              NULL              x             t1@t1_pkey  (1)              constraints = '[+dc=dc1]'  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[+dc=dc1]',
-lease_preferences = '[]'
-test                      t1  p2  NULL  x  t1@t1_pkey  (2)  constraints = '[+dc=dc2]'  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[+dc=dc2]',
-lease_preferences = '[]'
-test                      t1  p3  NULL  x  t1@t1_pkey  (3)  constraints = '[+dc=dc3]'  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[+dc=dc3]',
-lease_preferences = '[]'
+                                                                                                                                   range_max_bytes = 536870912,
+                                                                                                                                   gc.ttlseconds = 14400,
+                                                                                                                                   num_replicas = 3,
+                                                                                                                                   constraints = '[+dc=dc1]',
+                                                                                                                                   lease_preferences = '[]'
+test           t1          p2              NULL              x             t1@t1_pkey  (2)              constraints = '[+dc=dc2]'  range_min_bytes = 134217728,
+                                                                                                                                   range_max_bytes = 536870912,
+                                                                                                                                   gc.ttlseconds = 14400,
+                                                                                                                                   num_replicas = 3,
+                                                                                                                                   constraints = '[+dc=dc2]',
+                                                                                                                                   lease_preferences = '[]'
+test           t1          p3              NULL              x             t1@t1_pkey  (3)              constraints = '[+dc=dc3]'  range_min_bytes = 134217728,
+                                                                                                                                   range_max_bytes = 536870912,
+                                                                                                                                   gc.ttlseconds = 14400,
+                                                                                                                                   num_replicas = 3,
+                                                                                                                                   constraints = '[+dc=dc3]',
+                                                                                                                                   lease_preferences = '[]'
 
 query TTTTTTTTT
 SHOW PARTITIONS FROM TABLE t1
 ----
 test  t1  p1  NULL  x  t1@t1_pkey  (1)  constraints = '[+dc=dc1]'  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[+dc=dc1]',
-lease_preferences = '[]'
-test                      t1  p2  NULL  x  t1@t1_pkey  (2)  constraints = '[+dc=dc2]'  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[+dc=dc2]',
-lease_preferences = '[]'
-test                      t1  p3  NULL  x  t1@t1_pkey  (3)  constraints = '[+dc=dc3]'  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[+dc=dc3]',
-lease_preferences = '[]'
+                                                                   range_max_bytes = 536870912,
+                                                                   gc.ttlseconds = 14400,
+                                                                   num_replicas = 3,
+                                                                   constraints = '[+dc=dc1]',
+                                                                   lease_preferences = '[]'
+test  t1  p2  NULL  x  t1@t1_pkey  (2)  constraints = '[+dc=dc2]'  range_min_bytes = 134217728,
+                                                                   range_max_bytes = 536870912,
+                                                                   gc.ttlseconds = 14400,
+                                                                   num_replicas = 3,
+                                                                   constraints = '[+dc=dc2]',
+                                                                   lease_preferences = '[]'
+test  t1  p3  NULL  x  t1@t1_pkey  (3)  constraints = '[+dc=dc3]'  range_min_bytes = 134217728,
+                                                                   range_max_bytes = 536870912,
+                                                                   gc.ttlseconds = 14400,
+                                                                   num_replicas = 3,
+                                                                   constraints = '[+dc=dc3]',
+                                                                   lease_preferences = '[]'
 
 query TTTTTTTTT
 SHOW PARTITIONS FROM INDEX t1@t1_pkey
 ----
 test  t1  p1  NULL  x  t1@t1_pkey  (1)  constraints = '[+dc=dc1]'  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[+dc=dc1]',
-lease_preferences = '[]'
-test                      t1  p2  NULL  x  t1@t1_pkey  (2)  constraints = '[+dc=dc2]'  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[+dc=dc2]',
-lease_preferences = '[]'
-test                      t1  p3  NULL  x  t1@t1_pkey  (3)  constraints = '[+dc=dc3]'  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[+dc=dc3]',
-lease_preferences = '[]'
+                                                                   range_max_bytes = 536870912,
+                                                                   gc.ttlseconds = 14400,
+                                                                   num_replicas = 3,
+                                                                   constraints = '[+dc=dc1]',
+                                                                   lease_preferences = '[]'
+test  t1  p2  NULL  x  t1@t1_pkey  (2)  constraints = '[+dc=dc2]'  range_min_bytes = 134217728,
+                                                                   range_max_bytes = 536870912,
+                                                                   gc.ttlseconds = 14400,
+                                                                   num_replicas = 3,
+                                                                   constraints = '[+dc=dc2]',
+                                                                   lease_preferences = '[]'
+test  t1  p3  NULL  x  t1@t1_pkey  (3)  constraints = '[+dc=dc3]'  range_min_bytes = 134217728,
+                                                                   range_max_bytes = 536870912,
+                                                                   gc.ttlseconds = 14400,
+                                                                   num_replicas = 3,
+                                                                   constraints = '[+dc=dc3]',
+                                                                   lease_preferences = '[]'
 
 statement ok
 CREATE TABLE t2 (x INT PRIMARY KEY)
@@ -123,68 +123,68 @@ ALTER PARTITION p2 OF TABLE t2 CONFIGURE ZONE USING constraints='[+dc=dc2]'
 query TTTTTTTTT
 SHOW PARTITIONS FROM DATABASE test
 ----
-test  t1  p1  NULL  x  t1@t1_pkey  (1)  constraints = '[+dc=dc1]'  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[+dc=dc1]',
-lease_preferences = '[]'
-test                      t1  p2  NULL  x  t1@t1_pkey  (2)  constraints = '[+dc=dc2]'  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[+dc=dc2]',
-lease_preferences = '[]'
-test                      t1  p3  NULL  x  t1@t1_pkey  (3)  constraints = '[+dc=dc3]'  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[+dc=dc3]',
-lease_preferences = '[]'
-test                      t2  p1  NULL  x  t2@t2_pkey  (1) TO (2)  constraints = '[+dc=dc1]'  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[+dc=dc1]',
-lease_preferences = '[]'
-test                      t2  p2  NULL  x  t2@t2_pkey  (2) TO (3)  constraints = '[+dc=dc2]'  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[+dc=dc2]',
-lease_preferences = '[]'
+test  t1  p1  NULL  x  t1@t1_pkey  (1)         constraints = '[+dc=dc1]'  range_min_bytes = 134217728,
+                                                                          range_max_bytes = 536870912,
+                                                                          gc.ttlseconds = 14400,
+                                                                          num_replicas = 3,
+                                                                          constraints = '[+dc=dc1]',
+                                                                          lease_preferences = '[]'
+test  t1  p2  NULL  x  t1@t1_pkey  (2)         constraints = '[+dc=dc2]'  range_min_bytes = 134217728,
+                                                                          range_max_bytes = 536870912,
+                                                                          gc.ttlseconds = 14400,
+                                                                          num_replicas = 3,
+                                                                          constraints = '[+dc=dc2]',
+                                                                          lease_preferences = '[]'
+test  t1  p3  NULL  x  t1@t1_pkey  (3)         constraints = '[+dc=dc3]'  range_min_bytes = 134217728,
+                                                                          range_max_bytes = 536870912,
+                                                                          gc.ttlseconds = 14400,
+                                                                          num_replicas = 3,
+                                                                          constraints = '[+dc=dc3]',
+                                                                          lease_preferences = '[]'
+test  t2  p1  NULL  x  t2@t2_pkey  (1) TO (2)  constraints = '[+dc=dc1]'  range_min_bytes = 134217728,
+                                                                          range_max_bytes = 536870912,
+                                                                          gc.ttlseconds = 14400,
+                                                                          num_replicas = 3,
+                                                                          constraints = '[+dc=dc1]',
+                                                                          lease_preferences = '[]'
+test  t2  p2  NULL  x  t2@t2_pkey  (2) TO (3)  constraints = '[+dc=dc2]'  range_min_bytes = 134217728,
+                                                                          range_max_bytes = 536870912,
+                                                                          gc.ttlseconds = 14400,
+                                                                          num_replicas = 3,
+                                                                          constraints = '[+dc=dc2]',
+                                                                          lease_preferences = '[]'
 
 query TTTTTTTTT
 SHOW PARTITIONS FROM TABLE t2
 ----
 test  t2  p1  NULL  x  t2@t2_pkey  (1) TO (2)  constraints = '[+dc=dc1]'  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[+dc=dc1]',
-lease_preferences = '[]'
-test                      t2  p2  NULL  x  t2@t2_pkey  (2) TO (3)  constraints = '[+dc=dc2]'  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[+dc=dc2]',
-lease_preferences = '[]'
+                                                                          range_max_bytes = 536870912,
+                                                                          gc.ttlseconds = 14400,
+                                                                          num_replicas = 3,
+                                                                          constraints = '[+dc=dc1]',
+                                                                          lease_preferences = '[]'
+test  t2  p2  NULL  x  t2@t2_pkey  (2) TO (3)  constraints = '[+dc=dc2]'  range_min_bytes = 134217728,
+                                                                          range_max_bytes = 536870912,
+                                                                          gc.ttlseconds = 14400,
+                                                                          num_replicas = 3,
+                                                                          constraints = '[+dc=dc2]',
+                                                                          lease_preferences = '[]'
 
 query TTTTTTTTT
 SHOW PARTITIONS FROM INDEX t2@t2_pkey
 ----
 test  t2  p1  NULL  x  t2@t2_pkey  (1) TO (2)  constraints = '[+dc=dc1]'  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[+dc=dc1]',
-lease_preferences = '[]'
-test                      t2  p2  NULL  x  t2@t2_pkey  (2) TO (3)  constraints = '[+dc=dc2]'  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[+dc=dc2]',
-lease_preferences = '[]'
+                                                                          range_max_bytes = 536870912,
+                                                                          gc.ttlseconds = 14400,
+                                                                          num_replicas = 3,
+                                                                          constraints = '[+dc=dc1]',
+                                                                          lease_preferences = '[]'
+test  t2  p2  NULL  x  t2@t2_pkey  (2) TO (3)  constraints = '[+dc=dc2]'  range_min_bytes = 134217728,
+                                                                          range_max_bytes = 536870912,
+                                                                          gc.ttlseconds = 14400,
+                                                                          num_replicas = 3,
+                                                                          constraints = '[+dc=dc2]',
+                                                                          lease_preferences = '[]'
 
 statement ok
 CREATE TABLE t3 (x INT PRIMARY KEY, y INT, INDEX sec (y))
@@ -211,73 +211,73 @@ query TTTTTTTTT
 SHOW PARTITIONS FROM TABLE t3
 ----
 test  t3  p1  NULL  x  t3@t3_pkey  (1)  constraints = '[+dc=dc1]'  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[+dc=dc1]',
-lease_preferences = '[]'
-test                      t3  p2  NULL  x  t3@t3_pkey  (2)  constraints = '[+dc=dc2]'  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[+dc=dc2]',
-lease_preferences = '[]'
-test                      t3  p3  NULL  y  t3@sec  (3)  constraints = '[+dc=dc3]'  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[+dc=dc3]',
-lease_preferences = '[]'
-test                      t3  p4  NULL  y  t3@sec  (4)  constraints = '[+dc=dc4]'  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[+dc=dc4]',
-lease_preferences = '[]'
+                                                                   range_max_bytes = 536870912,
+                                                                   gc.ttlseconds = 14400,
+                                                                   num_replicas = 3,
+                                                                   constraints = '[+dc=dc1]',
+                                                                   lease_preferences = '[]'
+test  t3  p2  NULL  x  t3@t3_pkey  (2)  constraints = '[+dc=dc2]'  range_min_bytes = 134217728,
+                                                                   range_max_bytes = 536870912,
+                                                                   gc.ttlseconds = 14400,
+                                                                   num_replicas = 3,
+                                                                   constraints = '[+dc=dc2]',
+                                                                   lease_preferences = '[]'
+test  t3  p3  NULL  y  t3@sec      (3)  constraints = '[+dc=dc3]'  range_min_bytes = 134217728,
+                                                                   range_max_bytes = 536870912,
+                                                                   gc.ttlseconds = 14400,
+                                                                   num_replicas = 3,
+                                                                   constraints = '[+dc=dc3]',
+                                                                   lease_preferences = '[]'
+test  t3  p4  NULL  y  t3@sec      (4)  constraints = '[+dc=dc4]'  range_min_bytes = 134217728,
+                                                                   range_max_bytes = 536870912,
+                                                                   gc.ttlseconds = 14400,
+                                                                   num_replicas = 3,
+                                                                   constraints = '[+dc=dc4]',
+                                                                   lease_preferences = '[]'
 
 query TTTTTTTTT
 SHOW PARTITIONS FROM INDEX t3@*
 ----
 test  t3  p1  NULL  x  t3@t3_pkey  (1)  constraints = '[+dc=dc1]'  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[+dc=dc1]',
-lease_preferences = '[]'
-test                      t3  p2  NULL  x  t3@t3_pkey  (2)  constraints = '[+dc=dc2]'  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[+dc=dc2]',
-lease_preferences = '[]'
-test                      t3  p3  NULL  y  t3@sec  (3)  constraints = '[+dc=dc3]'  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[+dc=dc3]',
-lease_preferences = '[]'
-test                      t3  p4  NULL  y  t3@sec  (4)  constraints = '[+dc=dc4]'  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[+dc=dc4]',
-lease_preferences = '[]'
+                                                                   range_max_bytes = 536870912,
+                                                                   gc.ttlseconds = 14400,
+                                                                   num_replicas = 3,
+                                                                   constraints = '[+dc=dc1]',
+                                                                   lease_preferences = '[]'
+test  t3  p2  NULL  x  t3@t3_pkey  (2)  constraints = '[+dc=dc2]'  range_min_bytes = 134217728,
+                                                                   range_max_bytes = 536870912,
+                                                                   gc.ttlseconds = 14400,
+                                                                   num_replicas = 3,
+                                                                   constraints = '[+dc=dc2]',
+                                                                   lease_preferences = '[]'
+test  t3  p3  NULL  y  t3@sec      (3)  constraints = '[+dc=dc3]'  range_min_bytes = 134217728,
+                                                                   range_max_bytes = 536870912,
+                                                                   gc.ttlseconds = 14400,
+                                                                   num_replicas = 3,
+                                                                   constraints = '[+dc=dc3]',
+                                                                   lease_preferences = '[]'
+test  t3  p4  NULL  y  t3@sec      (4)  constraints = '[+dc=dc4]'  range_min_bytes = 134217728,
+                                                                   range_max_bytes = 536870912,
+                                                                   gc.ttlseconds = 14400,
+                                                                   num_replicas = 3,
+                                                                   constraints = '[+dc=dc4]',
+                                                                   lease_preferences = '[]'
 
 query TTTTTTTTT
 SHOW PARTITIONS FROM INDEX t3@sec
 ----
 test  t3  p3  NULL  y  t3@sec  (3)  constraints = '[+dc=dc3]'  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[+dc=dc3]',
-lease_preferences = '[]'
-test                      t3  p4  NULL  y  t3@sec  (4)  constraints = '[+dc=dc4]'  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[+dc=dc4]',
-lease_preferences = '[]'
+                                                               range_max_bytes = 536870912,
+                                                               gc.ttlseconds = 14400,
+                                                               num_replicas = 3,
+                                                               constraints = '[+dc=dc3]',
+                                                               lease_preferences = '[]'
+test  t3  p4  NULL  y  t3@sec  (4)  constraints = '[+dc=dc4]'  range_min_bytes = 134217728,
+                                                               range_max_bytes = 536870912,
+                                                               gc.ttlseconds = 14400,
+                                                               num_replicas = 3,
+                                                               constraints = '[+dc=dc4]',
+                                                               lease_preferences = '[]'
 
 statement ok
 CREATE TABLE t4 (x INT, y INT, PRIMARY KEY (x, y))
@@ -303,36 +303,36 @@ ALTER PARTITION p2_a OF TABLE t4 CONFIGURE ZONE USING constraints='[+dc=dc5]'
 query TTTTTTTTT
 SHOW PARTITIONS FROM TABLE t4
 ----
-test  t4  p1  NULL  x  t4@t4_pkey  (1)  constraints = '[+dc=dc1]'  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[+dc=dc1]',
-lease_preferences = '[]'
-test                      t4  p1_a  p1  y  t4@t4_pkey  (2)  constraints = '[+dc=dc2]'  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[+dc=dc2]',
-lease_preferences = '[]'
-test                      t4  p1_b  p1  y  t4@t4_pkey  (3)  constraints = '[+dc=dc3]'  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[+dc=dc3]',
-lease_preferences = '[]'
-test                      t4  p2  NULL  x  t4@t4_pkey  (4)  constraints = '[+dc=dc4]'  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[+dc=dc4]',
-lease_preferences = '[]'
-test                      t4  p2_a  p2  y  t4@t4_pkey  (5)  constraints = '[+dc=dc5]'  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[+dc=dc5]',
-lease_preferences = '[]'
+test  t4  p1    NULL  x  t4@t4_pkey  (1)  constraints = '[+dc=dc1]'  range_min_bytes = 134217728,
+                                                                     range_max_bytes = 536870912,
+                                                                     gc.ttlseconds = 14400,
+                                                                     num_replicas = 3,
+                                                                     constraints = '[+dc=dc1]',
+                                                                     lease_preferences = '[]'
+test  t4  p1_a  p1    y  t4@t4_pkey  (2)  constraints = '[+dc=dc2]'  range_min_bytes = 134217728,
+                                                                     range_max_bytes = 536870912,
+                                                                     gc.ttlseconds = 14400,
+                                                                     num_replicas = 3,
+                                                                     constraints = '[+dc=dc2]',
+                                                                     lease_preferences = '[]'
+test  t4  p1_b  p1    y  t4@t4_pkey  (3)  constraints = '[+dc=dc3]'  range_min_bytes = 134217728,
+                                                                     range_max_bytes = 536870912,
+                                                                     gc.ttlseconds = 14400,
+                                                                     num_replicas = 3,
+                                                                     constraints = '[+dc=dc3]',
+                                                                     lease_preferences = '[]'
+test  t4  p2    NULL  x  t4@t4_pkey  (4)  constraints = '[+dc=dc4]'  range_min_bytes = 134217728,
+                                                                     range_max_bytes = 536870912,
+                                                                     gc.ttlseconds = 14400,
+                                                                     num_replicas = 3,
+                                                                     constraints = '[+dc=dc4]',
+                                                                     lease_preferences = '[]'
+test  t4  p2_a  p2    y  t4@t4_pkey  (5)  constraints = '[+dc=dc5]'  range_min_bytes = 134217728,
+                                                                     range_max_bytes = 536870912,
+                                                                     gc.ttlseconds = 14400,
+                                                                     num_replicas = 3,
+                                                                     constraints = '[+dc=dc5]',
+                                                                     lease_preferences = '[]'
 
 # Partitioning inheritance test.
 statement ok
@@ -351,11 +351,11 @@ query TTTTTTTTT
 SHOW PARTITIONS FROM TABLE partitioning.inheritance
 ----
 partitioning  inheritance  p1  NULL  x  inheritance@inheritance_pkey  (1)  NULL  range_min_bytes = 64000,
-range_max_bytes = 75000,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[]',
-lease_preferences = '[]'
+                                                                                 range_max_bytes = 75000,
+                                                                                 gc.ttlseconds = 14400,
+                                                                                 num_replicas = 3,
+                                                                                 constraints = '[]',
+                                                                                 lease_preferences = '[]'
 
 statement ok
 ALTER TABLE partitioning.inheritance CONFIGURE ZONE USING gc.ttlseconds=80000

--- a/pkg/ccl/logictestccl/testdata/logic_test/global_placement_restricted
+++ b/pkg/ccl/logictestccl/testdata/logic_test/global_placement_restricted
@@ -17,15 +17,15 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE test
 ----
 TABLE test  ALTER TABLE test CONFIGURE ZONE USING
-            range_min_bytes = 134217728,
-            range_max_bytes = 536870912,
-            gc.ttlseconds = 90000,
-            global_reads = true,
-            num_replicas = 5,
-            num_voters = 3,
-            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-            voter_constraints = '[+region=ca-central-1]',
-            lease_preferences = '[[+region=ca-central-1]]'
+              range_min_bytes = 134217728,
+              range_max_bytes = 536870912,
+              gc.ttlseconds = 14400,
+              global_reads = true,
+              num_replicas = 5,
+              num_voters = 3,
+              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+              voter_constraints = '[+region=ca-central-1]',
+              lease_preferences = '[[+region=ca-central-1]]'
 
 # Alter to RESTRICTED and see that our non-voter constraints remain.
 statement ok
@@ -35,15 +35,15 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE test
 ----
 TABLE test  ALTER TABLE test CONFIGURE ZONE USING
-            range_min_bytes = 134217728,
-            range_max_bytes = 536870912,
-            gc.ttlseconds = 90000,
-            global_reads = true,
-            num_replicas = 5,
-            num_voters = 3,
-            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-            voter_constraints = '[+region=ca-central-1]',
-            lease_preferences = '[[+region=ca-central-1]]'
+              range_min_bytes = 134217728,
+              range_max_bytes = 536870912,
+              gc.ttlseconds = 14400,
+              global_reads = true,
+              num_replicas = 5,
+              num_voters = 3,
+              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+              voter_constraints = '[+region=ca-central-1]',
+              lease_preferences = '[[+region=ca-central-1]]'
 
 # Make sure placement restricted doesn't invalidate zone configs.
 statement ok
@@ -56,15 +56,15 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE test
 ----
 TABLE test  ALTER TABLE test CONFIGURE ZONE USING
-            range_min_bytes = 134217728,
-            range_max_bytes = 536870912,
-            gc.ttlseconds = 90000,
-            global_reads = true,
-            num_replicas = 4,
-            num_voters = 3,
-            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1}',
-            voter_constraints = '[+region=ca-central-1]',
-            lease_preferences = '[[+region=ca-central-1]]'
+              range_min_bytes = 134217728,
+              range_max_bytes = 536870912,
+              gc.ttlseconds = 14400,
+              global_reads = true,
+              num_replicas = 4,
+              num_voters = 3,
+              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1}',
+              voter_constraints = '[+region=ca-central-1]',
+              lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 ALTER DATABASE testdb ADD REGION "us-east-1"
@@ -73,15 +73,15 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE test
 ----
 TABLE test  ALTER TABLE test CONFIGURE ZONE USING
-            range_min_bytes = 134217728,
-            range_max_bytes = 536870912,
-            gc.ttlseconds = 90000,
-            global_reads = true,
-            num_replicas = 5,
-            num_voters = 3,
-            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-            voter_constraints = '[+region=ca-central-1]',
-            lease_preferences = '[[+region=ca-central-1]]'
+              range_min_bytes = 134217728,
+              range_max_bytes = 536870912,
+              gc.ttlseconds = 14400,
+              global_reads = true,
+              num_replicas = 5,
+              num_voters = 3,
+              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+              voter_constraints = '[+region=ca-central-1]',
+              lease_preferences = '[[+region=ca-central-1]]'
 
 # Change primary region to ensure zone config is rebuilt on table changes.
 statement ok
@@ -91,15 +91,15 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE test
 ----
 TABLE test  ALTER TABLE test CONFIGURE ZONE USING
-            range_min_bytes = 134217728,
-            range_max_bytes = 536870912,
-            gc.ttlseconds = 90000,
-            global_reads = true,
-            num_replicas = 5,
-            num_voters = 3,
-            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-            voter_constraints = '[+region=ap-southeast-2]',
-            lease_preferences = '[[+region=ap-southeast-2]]'
+              range_min_bytes = 134217728,
+              range_max_bytes = 536870912,
+              gc.ttlseconds = 14400,
+              global_reads = true,
+              num_replicas = 5,
+              num_voters = 3,
+              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+              voter_constraints = '[+region=ap-southeast-2]',
+              lease_preferences = '[[+region=ap-southeast-2]]'
 
 # Alter to DEFAULT and see that our zone config is unchanged.
 statement ok
@@ -109,15 +109,15 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE test
 ----
 TABLE test  ALTER TABLE test CONFIGURE ZONE USING
-            range_min_bytes = 134217728,
-            range_max_bytes = 536870912,
-            gc.ttlseconds = 90000,
-            global_reads = true,
-            num_replicas = 5,
-            num_voters = 3,
-            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-            voter_constraints = '[+region=ap-southeast-2]',
-            lease_preferences = '[[+region=ap-southeast-2]]'
+              range_min_bytes = 134217728,
+              range_max_bytes = 536870912,
+              gc.ttlseconds = 14400,
+              global_reads = true,
+              num_replicas = 5,
+              num_voters = 3,
+              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+              voter_constraints = '[+region=ap-southeast-2]',
+              lease_preferences = '[[+region=ap-southeast-2]]'
 
 # Check that coming back from placement restricted results in a valid zone
 # config.

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region
@@ -231,67 +231,67 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE region_test_db
 ----
 DATABASE region_test_db  ALTER DATABASE region_test_db CONFIGURE ZONE USING
-                         range_min_bytes = 134217728,
-                         range_max_bytes = 536870912,
-                         gc.ttlseconds = 90000,
-                         num_replicas = 3,
-                         num_voters = 3,
-                         constraints = '{+region=ap-southeast-2: 1}',
-                         voter_constraints = '[+region=ap-southeast-2]',
-                         lease_preferences = '[[+region=ap-southeast-2]]'
+                           range_min_bytes = 134217728,
+                           range_max_bytes = 536870912,
+                           gc.ttlseconds = 14400,
+                           num_replicas = 3,
+                           num_voters = 3,
+                           constraints = '{+region=ap-southeast-2: 1}',
+                           voter_constraints = '[+region=ap-southeast-2]',
+                           lease_preferences = '[[+region=ap-southeast-2]]'
 
 # copy of the previous test but using FROM instead of FOR
 query TT
 SHOW ZONE CONFIGURATION FROM DATABASE region_test_db
 ----
 DATABASE region_test_db  ALTER DATABASE region_test_db CONFIGURE ZONE USING
-                         range_min_bytes = 134217728,
-                         range_max_bytes = 536870912,
-                         gc.ttlseconds = 90000,
-                         num_replicas = 3,
-                         num_voters = 3,
-                         constraints = '{+region=ap-southeast-2: 1}',
-                         voter_constraints = '[+region=ap-southeast-2]',
-                         lease_preferences = '[[+region=ap-southeast-2]]'
+                           range_min_bytes = 134217728,
+                           range_max_bytes = 536870912,
+                           gc.ttlseconds = 14400,
+                           num_replicas = 3,
+                           num_voters = 3,
+                           constraints = '{+region=ap-southeast-2: 1}',
+                           voter_constraints = '[+region=ap-southeast-2]',
+                           lease_preferences = '[[+region=ap-southeast-2]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR DATABASE multi_region_test_db
 ----
 DATABASE multi_region_test_db  ALTER DATABASE multi_region_test_db CONFIGURE ZONE USING
-                               range_min_bytes = 134217728,
-                               range_max_bytes = 536870912,
-                               gc.ttlseconds = 90000,
-                               num_replicas = 5,
-                               num_voters = 5,
-                               constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                               voter_constraints = '{+region=ca-central-1: 2}',
-                               lease_preferences = '[[+region=ca-central-1]]'
+                                 range_min_bytes = 134217728,
+                                 range_max_bytes = 536870912,
+                                 gc.ttlseconds = 14400,
+                                 num_replicas = 5,
+                                 num_voters = 5,
+                                 constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                 voter_constraints = '{+region=ca-central-1: 2}',
+                                 lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR DATABASE multi_region_test_explicit_primary_region_db
 ----
 DATABASE multi_region_test_explicit_primary_region_db  ALTER DATABASE multi_region_test_explicit_primary_region_db CONFIGURE ZONE USING
-                                                       range_min_bytes = 134217728,
-                                                       range_max_bytes = 536870912,
-                                                       gc.ttlseconds = 90000,
-                                                       num_replicas = 5,
-                                                       num_voters = 5,
-                                                       constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                                       voter_constraints = '{+region=ap-southeast-2: 2}',
-                                                       lease_preferences = '[[+region=ap-southeast-2]]'
+                                                         range_min_bytes = 134217728,
+                                                         range_max_bytes = 536870912,
+                                                         gc.ttlseconds = 14400,
+                                                         num_replicas = 5,
+                                                         num_voters = 5,
+                                                         constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                         voter_constraints = '{+region=ap-southeast-2: 2}',
+                                                         lease_preferences = '[[+region=ap-southeast-2]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR DATABASE multi_region_test_survive_zone_failure_db
 ----
 DATABASE multi_region_test_survive_zone_failure_db  ALTER DATABASE multi_region_test_survive_zone_failure_db CONFIGURE ZONE USING
-                                                    range_min_bytes = 134217728,
-                                                    range_max_bytes = 536870912,
-                                                    gc.ttlseconds = 90000,
-                                                    num_replicas = 5,
-                                                    num_voters = 3,
-                                                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                                    voter_constraints = '[+region=us-east-1]',
-                                                    lease_preferences = '[[+region=us-east-1]]'
+                                                      range_min_bytes = 134217728,
+                                                      range_max_bytes = 536870912,
+                                                      gc.ttlseconds = 14400,
+                                                      num_replicas = 5,
+                                                      num_voters = 3,
+                                                      constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                      voter_constraints = '[+region=us-east-1]',
+                                                      lease_preferences = '[[+region=us-east-1]]'
 
 statement error PRIMARY REGION must be specified when using SURVIVE
 CREATE DATABASE no_primary_region SURVIVE ZONE FAILURE
@@ -400,14 +400,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE regional_primary_region_table
 ----
 DATABASE multi_region_test_db  ALTER DATABASE multi_region_test_db CONFIGURE ZONE USING
-                               range_min_bytes = 134217728,
-                               range_max_bytes = 536870912,
-                               gc.ttlseconds = 90000,
-                               num_replicas = 5,
-                               num_voters = 5,
-                               constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                               voter_constraints = '{+region=ca-central-1: 2}',
-                               lease_preferences = '[[+region=ca-central-1]]'
+                                 range_min_bytes = 134217728,
+                                 range_max_bytes = 536870912,
+                                 gc.ttlseconds = 14400,
+                                 num_replicas = 5,
+                                 num_voters = 5,
+                                 constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                 voter_constraints = '{+region=ca-central-1: 2}',
+                                 lease_preferences = '[[+region=ca-central-1]]'
 
 statement error cannot set PARTITION BY on a table in a multi-region enabled database
 ALTER TABLE regional_primary_region_table PARTITION BY LIST (id) (
@@ -435,14 +435,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE regional_implicit_primary_region_table
 ----
 DATABASE multi_region_test_db  ALTER DATABASE multi_region_test_db CONFIGURE ZONE USING
-                               range_min_bytes = 134217728,
-                               range_max_bytes = 536870912,
-                               gc.ttlseconds = 90000,
-                               num_replicas = 5,
-                               num_voters = 5,
-                               constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                               voter_constraints = '{+region=ca-central-1: 2}',
-                               lease_preferences = '[[+region=ca-central-1]]'
+                                 range_min_bytes = 134217728,
+                                 range_max_bytes = 536870912,
+                                 gc.ttlseconds = 14400,
+                                 num_replicas = 5,
+                                 num_voters = 5,
+                                 constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                 voter_constraints = '{+region=ca-central-1: 2}',
+                                 lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 CREATE TABLE "regional_us-east-1_table" (a int) LOCALITY REGIONAL BY TABLE IN "us-east-1"
@@ -460,14 +460,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE "regional_us-east-1_table"
 ----
 TABLE "regional_us-east-1_table"  ALTER TABLE "regional_us-east-1_table" CONFIGURE ZONE USING
-                                  range_min_bytes = 134217728,
-                                  range_max_bytes = 536870912,
-                                  gc.ttlseconds = 90000,
-                                  num_replicas = 5,
-                                  num_voters = 5,
-                                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                  voter_constraints = '{+region=us-east-1: 2}',
-                                  lease_preferences = '[[+region=us-east-1]]'
+                                    range_min_bytes = 134217728,
+                                    range_max_bytes = 536870912,
+                                    gc.ttlseconds = 14400,
+                                    num_replicas = 5,
+                                    num_voters = 5,
+                                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                    voter_constraints = '{+region=us-east-1: 2}',
+                                    lease_preferences = '[[+region=us-east-1]]'
 
 statement error region "test4" has not been added to database "multi_region_test_db"\nHINT: available regions: ap-southeast-2, ca-central-1, us-east-1
 CREATE TABLE regional_test4_table (a int) LOCALITY REGIONAL BY TABLE IN "test4"
@@ -488,15 +488,15 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE global_table
 ----
 TABLE global_table  ALTER TABLE global_table CONFIGURE ZONE USING
-                    range_min_bytes = 134217728,
-                    range_max_bytes = 536870912,
-                    gc.ttlseconds = 90000,
-                    global_reads = true,
-                    num_replicas = 5,
-                    num_voters = 5,
-                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                    voter_constraints = '{+region=ca-central-1: 2}',
-                    lease_preferences = '[[+region=ca-central-1]]'
+                      range_min_bytes = 134217728,
+                      range_max_bytes = 536870912,
+                      gc.ttlseconds = 14400,
+                      global_reads = true,
+                      num_replicas = 5,
+                      num_voters = 5,
+                      constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                      voter_constraints = '{+region=ca-central-1: 2}',
+                      lease_preferences = '[[+region=ca-central-1]]'
 
 statement error cannot set PARTITION BY on a table in a multi-region enabled database
 ALTER TABLE global_table PARTITION BY LIST (id) (
@@ -576,14 +576,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE alter_test_db
 ----
 DATABASE alter_test_db  ALTER DATABASE alter_test_db CONFIGURE ZONE USING
-                        range_min_bytes = 134217728,
-                        range_max_bytes = 536870912,
-                        gc.ttlseconds = 90000,
-                        num_replicas = 4,
-                        num_voters = 3,
-                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1}',
-                        voter_constraints = '[+region=ca-central-1]',
-                        lease_preferences = '[[+region=ca-central-1]]'
+                          range_min_bytes = 134217728,
+                          range_max_bytes = 536870912,
+                          gc.ttlseconds = 14400,
+                          num_replicas = 4,
+                          num_voters = 3,
+                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1}',
+                          voter_constraints = '[+region=ca-central-1]',
+                          lease_preferences = '[[+region=ca-central-1]]'
 
 # Test adding a region after first region.
 query T noticetrace
@@ -608,14 +608,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE alter_test_db
 ----
 DATABASE alter_test_db  ALTER DATABASE alter_test_db CONFIGURE ZONE USING
-                        range_min_bytes = 134217728,
-                        range_max_bytes = 536870912,
-                        gc.ttlseconds = 90000,
-                        num_replicas = 5,
-                        num_voters = 3,
-                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                        voter_constraints = '[+region=ca-central-1]',
-                        lease_preferences = '[[+region=ca-central-1]]'
+                          range_min_bytes = 134217728,
+                          range_max_bytes = 536870912,
+                          gc.ttlseconds = 14400,
+                          num_replicas = 5,
+                          num_voters = 3,
+                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                          voter_constraints = '[+region=ca-central-1]',
+                          lease_preferences = '[[+region=ca-central-1]]'
 
 # Failure testing for ADD REGION.
 statement error region "test" does not exist
@@ -654,12 +654,12 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE alter_primary_region_db
 ----
 RANGE default  ALTER RANGE default CONFIGURE ZONE USING
-               range_min_bytes = 134217728,
-               range_max_bytes = 536870912,
-               gc.ttlseconds = 90000,
-               num_replicas = 3,
-               constraints = '[]',
-               lease_preferences = '[]'
+                 range_min_bytes = 134217728,
+                 range_max_bytes = 536870912,
+                 gc.ttlseconds = 14400,
+                 num_replicas = 3,
+                 constraints = '[]',
+                 lease_preferences = '[]'
 
 query TTBBT colnames
 show regions from database alter_primary_region_db
@@ -680,12 +680,12 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE alter_primary_region_db
 ----
 RANGE default  ALTER RANGE default CONFIGURE ZONE USING
-               range_min_bytes = 134217728,
-               range_max_bytes = 536870912,
-               gc.ttlseconds = 90000,
-               num_replicas = 3,
-               constraints = '[]',
-               lease_preferences = '[]'
+                 range_min_bytes = 134217728,
+                 range_max_bytes = 536870912,
+                 gc.ttlseconds = 14400,
+                 num_replicas = 3,
+                 constraints = '[]',
+                 lease_preferences = '[]'
 
 statement ok
 ALTER DATABASE alter_primary_region_db PRIMARY REGION "ca-central-1"
@@ -694,14 +694,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE alter_primary_region_db
 ----
 DATABASE alter_primary_region_db  ALTER DATABASE alter_primary_region_db CONFIGURE ZONE USING
-                                  range_min_bytes = 134217728,
-                                  range_max_bytes = 536870912,
-                                  gc.ttlseconds = 90000,
-                                  num_replicas = 3,
-                                  num_voters = 3,
-                                  constraints = '{+region=ca-central-1: 1}',
-                                  voter_constraints = '[+region=ca-central-1]',
-                                  lease_preferences = '[[+region=ca-central-1]]'
+                                    range_min_bytes = 134217728,
+                                    range_max_bytes = 536870912,
+                                    gc.ttlseconds = 14400,
+                                    num_replicas = 3,
+                                    num_voters = 3,
+                                    constraints = '{+region=ca-central-1: 1}',
+                                    voter_constraints = '[+region=ca-central-1]',
+                                    lease_preferences = '[[+region=ca-central-1]]'
 
 query TTBBT colnames
 show regions from database alter_primary_region_db
@@ -725,14 +725,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE alter_primary_region_db
 ----
 DATABASE alter_primary_region_db  ALTER DATABASE alter_primary_region_db CONFIGURE ZONE USING
-                                  range_min_bytes = 134217728,
-                                  range_max_bytes = 536870912,
-                                  gc.ttlseconds = 90000,
-                                  num_replicas = 4,
-                                  num_voters = 3,
-                                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1}',
-                                  voter_constraints = '[+region=ca-central-1]',
-                                  lease_preferences = '[[+region=ca-central-1]]'
+                                    range_min_bytes = 134217728,
+                                    range_max_bytes = 536870912,
+                                    gc.ttlseconds = 14400,
+                                    num_replicas = 4,
+                                    num_voters = 3,
+                                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1}',
+                                    voter_constraints = '[+region=ca-central-1]',
+                                    lease_preferences = '[[+region=ca-central-1]]'
 
 query TTTT colnames
 SHOW ENUMS FROM alter_primary_region_db.public
@@ -754,14 +754,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE alter_primary_region_db
 ----
 DATABASE alter_primary_region_db  ALTER DATABASE alter_primary_region_db CONFIGURE ZONE USING
-                                  range_min_bytes = 134217728,
-                                  range_max_bytes = 536870912,
-                                  gc.ttlseconds = 90000,
-                                  num_replicas = 4,
-                                  num_voters = 3,
-                                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1}',
-                                  voter_constraints = '[+region=ap-southeast-2]',
-                                  lease_preferences = '[[+region=ap-southeast-2]]'
+                                    range_min_bytes = 134217728,
+                                    range_max_bytes = 536870912,
+                                    gc.ttlseconds = 14400,
+                                    num_replicas = 4,
+                                    num_voters = 3,
+                                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1}',
+                                    voter_constraints = '[+region=ap-southeast-2]',
+                                    lease_preferences = '[[+region=ap-southeast-2]]'
 
 query TTTT colnames
 SHOW ENUMS FROM alter_primary_region_db.public
@@ -802,14 +802,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE alter_survive_db
 ----
 DATABASE alter_survive_db  ALTER DATABASE alter_survive_db CONFIGURE ZONE USING
-                           range_min_bytes = 134217728,
-                           range_max_bytes = 536870912,
-                           gc.ttlseconds = 90000,
-                           num_replicas = 5,
-                           num_voters = 3,
-                           constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                           voter_constraints = '[+region=ca-central-1]',
-                           lease_preferences = '[[+region=ca-central-1]]'
+                             range_min_bytes = 134217728,
+                             range_max_bytes = 536870912,
+                             gc.ttlseconds = 14400,
+                             num_replicas = 5,
+                             num_voters = 3,
+                             constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                             voter_constraints = '[+region=ca-central-1]',
+                             lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 create table t_no_locality (i int)
@@ -818,14 +818,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE t_no_locality
 ----
 DATABASE alter_survive_db  ALTER DATABASE alter_survive_db CONFIGURE ZONE USING
-                           range_min_bytes = 134217728,
-                           range_max_bytes = 536870912,
-                           gc.ttlseconds = 90000,
-                           num_replicas = 5,
-                           num_voters = 3,
-                           constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                           voter_constraints = '[+region=ca-central-1]',
-                           lease_preferences = '[[+region=ca-central-1]]'
+                             range_min_bytes = 134217728,
+                             range_max_bytes = 536870912,
+                             gc.ttlseconds = 14400,
+                             num_replicas = 5,
+                             num_voters = 3,
+                             constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                             voter_constraints = '[+region=ca-central-1]',
+                             lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 CREATE TABLE t_global (i int) LOCALITY GLOBAL
@@ -834,15 +834,15 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE t_global
 ----
 TABLE t_global  ALTER TABLE t_global CONFIGURE ZONE USING
-                range_min_bytes = 134217728,
-                range_max_bytes = 536870912,
-                gc.ttlseconds = 90000,
-                global_reads = true,
-                num_replicas = 5,
-                num_voters = 3,
-                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                voter_constraints = '[+region=ca-central-1]',
-                lease_preferences = '[[+region=ca-central-1]]'
+                  range_min_bytes = 134217728,
+                  range_max_bytes = 536870912,
+                  gc.ttlseconds = 14400,
+                  global_reads = true,
+                  num_replicas = 5,
+                  num_voters = 3,
+                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                  voter_constraints = '[+region=ca-central-1]',
+                  lease_preferences = '[[+region=ca-central-1]]'
 
 query TTTTTT colnames
 SHOW DATABASES
@@ -865,14 +865,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE alter_survive_db
 ----
 DATABASE alter_survive_db  ALTER DATABASE alter_survive_db CONFIGURE ZONE USING
-                           range_min_bytes = 134217728,
-                           range_max_bytes = 536870912,
-                           gc.ttlseconds = 90000,
-                           num_replicas = 5,
-                           num_voters = 3,
-                           constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                           voter_constraints = '[+region=ca-central-1]',
-                           lease_preferences = '[[+region=ca-central-1]]'
+                             range_min_bytes = 134217728,
+                             range_max_bytes = 536870912,
+                             gc.ttlseconds = 14400,
+                             num_replicas = 5,
+                             num_voters = 3,
+                             constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                             voter_constraints = '[+region=ca-central-1]',
+                             lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 alter database alter_survive_db survive region failure
@@ -898,41 +898,41 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE alter_survive_db
 ----
 DATABASE alter_survive_db  ALTER DATABASE alter_survive_db CONFIGURE ZONE USING
-                           range_min_bytes = 134217728,
-                           range_max_bytes = 536870912,
-                           gc.ttlseconds = 90000,
-                           num_replicas = 5,
-                           num_voters = 5,
-                           constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                           voter_constraints = '{+region=ca-central-1: 2}',
-                           lease_preferences = '[[+region=ca-central-1]]'
+                             range_min_bytes = 134217728,
+                             range_max_bytes = 536870912,
+                             gc.ttlseconds = 14400,
+                             num_replicas = 5,
+                             num_voters = 5,
+                             constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                             voter_constraints = '{+region=ca-central-1: 2}',
+                             lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE t_no_locality
 ----
 DATABASE alter_survive_db  ALTER DATABASE alter_survive_db CONFIGURE ZONE USING
-                           range_min_bytes = 134217728,
-                           range_max_bytes = 536870912,
-                           gc.ttlseconds = 90000,
-                           num_replicas = 5,
-                           num_voters = 5,
-                           constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                           voter_constraints = '{+region=ca-central-1: 2}',
-                           lease_preferences = '[[+region=ca-central-1]]'
+                             range_min_bytes = 134217728,
+                             range_max_bytes = 536870912,
+                             gc.ttlseconds = 14400,
+                             num_replicas = 5,
+                             num_voters = 5,
+                             constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                             voter_constraints = '{+region=ca-central-1: 2}',
+                             lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE t_global
 ----
 TABLE t_global  ALTER TABLE t_global CONFIGURE ZONE USING
-                range_min_bytes = 134217728,
-                range_max_bytes = 536870912,
-                gc.ttlseconds = 90000,
-                global_reads = true,
-                num_replicas = 5,
-                num_voters = 5,
-                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                voter_constraints = '{+region=ca-central-1: 2}',
-                lease_preferences = '[[+region=ca-central-1]]'
+                  range_min_bytes = 134217728,
+                  range_max_bytes = 536870912,
+                  gc.ttlseconds = 14400,
+                  global_reads = true,
+                  num_replicas = 5,
+                  num_voters = 5,
+                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                  voter_constraints = '{+region=ca-central-1: 2}',
+                  lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 alter database alter_survive_db survive zone failure
@@ -958,41 +958,41 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE alter_survive_db
 ----
 DATABASE alter_survive_db  ALTER DATABASE alter_survive_db CONFIGURE ZONE USING
-                           range_min_bytes = 134217728,
-                           range_max_bytes = 536870912,
-                           gc.ttlseconds = 90000,
-                           num_replicas = 5,
-                           num_voters = 3,
-                           constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                           voter_constraints = '[+region=ca-central-1]',
-                           lease_preferences = '[[+region=ca-central-1]]'
+                             range_min_bytes = 134217728,
+                             range_max_bytes = 536870912,
+                             gc.ttlseconds = 14400,
+                             num_replicas = 5,
+                             num_voters = 3,
+                             constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                             voter_constraints = '[+region=ca-central-1]',
+                             lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE t_no_locality
 ----
 DATABASE alter_survive_db  ALTER DATABASE alter_survive_db CONFIGURE ZONE USING
-                           range_min_bytes = 134217728,
-                           range_max_bytes = 536870912,
-                           gc.ttlseconds = 90000,
-                           num_replicas = 5,
-                           num_voters = 3,
-                           constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                           voter_constraints = '[+region=ca-central-1]',
-                           lease_preferences = '[[+region=ca-central-1]]'
+                             range_min_bytes = 134217728,
+                             range_max_bytes = 536870912,
+                             gc.ttlseconds = 14400,
+                             num_replicas = 5,
+                             num_voters = 3,
+                             constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                             voter_constraints = '[+region=ca-central-1]',
+                             lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE t_global
 ----
 TABLE t_global  ALTER TABLE t_global CONFIGURE ZONE USING
-                range_min_bytes = 134217728,
-                range_max_bytes = 536870912,
-                gc.ttlseconds = 90000,
-                global_reads = true,
-                num_replicas = 5,
-                num_voters = 3,
-                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                voter_constraints = '[+region=ca-central-1]',
-                lease_preferences = '[[+region=ca-central-1]]'
+                  range_min_bytes = 134217728,
+                  range_max_bytes = 536870912,
+                  gc.ttlseconds = 14400,
+                  global_reads = true,
+                  num_replicas = 5,
+                  num_voters = 3,
+                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                  voter_constraints = '[+region=ca-central-1]',
+                  lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 CREATE DATABASE no_initial_region;
@@ -1032,14 +1032,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE no_initial_region.t
 ----
 DATABASE no_initial_region  ALTER DATABASE no_initial_region CONFIGURE ZONE USING
-                            range_min_bytes = 134217728,
-                            range_max_bytes = 536870912,
-                            gc.ttlseconds = 90000,
-                            num_replicas = 3,
-                            num_voters = 3,
-                            constraints = '{+region=us-east-1: 1}',
-                            voter_constraints = '[+region=us-east-1]',
-                            lease_preferences = '[[+region=us-east-1]]'
+                              range_min_bytes = 134217728,
+                              range_max_bytes = 536870912,
+                              gc.ttlseconds = 14400,
+                              num_replicas = 3,
+                              num_voters = 3,
+                              constraints = '{+region=us-east-1: 1}',
+                              voter_constraints = '[+region=us-east-1]',
+                              lease_preferences = '[[+region=us-east-1]]'
 
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE no_initial_region.t]
@@ -1136,12 +1136,12 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE global_table
 ----
 RANGE default  ALTER RANGE default CONFIGURE ZONE USING
-               range_min_bytes = 134217728,
-               range_max_bytes = 536870912,
-               gc.ttlseconds = 90000,
-               num_replicas = 3,
-               constraints = '[]',
-               lease_preferences = '[]'
+                 range_min_bytes = 134217728,
+                 range_max_bytes = 536870912,
+                 gc.ttlseconds = 14400,
+                 num_replicas = 3,
+                 constraints = '[]',
+                 lease_preferences = '[]'
 
 # Test a table that is implicitly homed in the primary region because it was
 # created before the first region was added to the multi-region DB.
@@ -1273,12 +1273,12 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE drop_primary_regions_db
 ----
 RANGE default  ALTER RANGE default CONFIGURE ZONE USING
-               range_min_bytes = 134217728,
-               range_max_bytes = 536870912,
-               gc.ttlseconds = 90000,
-               num_replicas = 3,
-               constraints = '[]',
-               lease_preferences = '[]'
+                 range_min_bytes = 134217728,
+                 range_max_bytes = 536870912,
+                 gc.ttlseconds = 14400,
+                 num_replicas = 3,
+                 constraints = '[]',
+                 lease_preferences = '[]'
 
 # Accessing the table should work without an issue even after the database is
 # no longer multi-region.
@@ -1295,14 +1295,14 @@ SHOW ZONE CONFIGURATION FOR TABLE drop_primary_regions_db.primary
 ----
 target                            raw_config_sql
 DATABASE drop_primary_regions_db  ALTER DATABASE drop_primary_regions_db CONFIGURE ZONE USING
-                                  range_min_bytes = 134217728,
-                                  range_max_bytes = 536870912,
-                                  gc.ttlseconds = 90000,
-                                  num_replicas = 3,
-                                  num_voters = 3,
-                                  constraints = '{+region=ca-central-1: 1}',
-                                  voter_constraints = '[+region=ca-central-1]',
-                                  lease_preferences = '[[+region=ca-central-1]]'
+                                    range_min_bytes = 134217728,
+                                    range_max_bytes = 536870912,
+                                    gc.ttlseconds = 14400,
+                                    num_replicas = 3,
+                                    num_voters = 3,
+                                    constraints = '{+region=ca-central-1: 1}',
+                                    voter_constraints = '[+region=ca-central-1]',
+                                    lease_preferences = '[[+region=ca-central-1]]'
 
 
 
@@ -1325,14 +1325,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE zone_config_drop_region
 ----
 DATABASE zone_config_drop_region  ALTER DATABASE zone_config_drop_region CONFIGURE ZONE USING
-                          range_min_bytes = 134217728,
-                          range_max_bytes = 536870912,
-                          gc.ttlseconds = 90000,
-                          num_replicas = 5,
-                          num_voters = 3,
-                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                          voter_constraints = '[+region=ca-central-1]',
-                          lease_preferences = '[[+region=ca-central-1]]'
+                                    range_min_bytes = 134217728,
+                                    range_max_bytes = 536870912,
+                                    gc.ttlseconds = 14400,
+                                    num_replicas = 5,
+                                    num_voters = 3,
+                                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                    voter_constraints = '[+region=ca-central-1]',
+                                    lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 ALTER DATABASE zone_config_drop_region DROP REGION "us-east-1"
@@ -1341,14 +1341,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE zone_config_drop_region
 ----
 DATABASE zone_config_drop_region  ALTER DATABASE zone_config_drop_region CONFIGURE ZONE USING
-                          range_min_bytes = 134217728,
-                          range_max_bytes = 536870912,
-                          gc.ttlseconds = 90000,
-                          num_replicas = 4,
-                          num_voters = 3,
-                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1}',
-                          voter_constraints = '[+region=ca-central-1]',
-                          lease_preferences = '[[+region=ca-central-1]]'
+                                    range_min_bytes = 134217728,
+                                    range_max_bytes = 536870912,
+                                    gc.ttlseconds = 14400,
+                                    num_replicas = 4,
+                                    num_voters = 3,
+                                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1}',
+                                    voter_constraints = '[+region=ca-central-1]',
+                                    lease_preferences = '[[+region=ca-central-1]]'
 
 #
 # Tests with views and sequences.
@@ -1410,15 +1410,15 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE mat_view2
 ----
 TABLE mat_view2  ALTER TABLE mat_view2 CONFIGURE ZONE USING
-                 range_min_bytes = 134217728,
-                 range_max_bytes = 536870912,
-                 gc.ttlseconds = 90000,
-                 global_reads = true,
-                 num_replicas = 3,
-                 num_voters = 3,
-                 constraints = '{+region=ap-southeast-2: 1}',
-                 voter_constraints = '[+region=ap-southeast-2]',
-                 lease_preferences = '[[+region=ap-southeast-2]]'
+                   range_min_bytes = 134217728,
+                   range_max_bytes = 536870912,
+                   gc.ttlseconds = 14400,
+                   global_reads = true,
+                   num_replicas = 3,
+                   num_voters = 3,
+                   constraints = '{+region=ap-southeast-2: 1}',
+                   voter_constraints = '[+region=ap-southeast-2]',
+                   lease_preferences = '[[+region=ap-southeast-2]]'
 
 statement ok
 ALTER DATABASE db_with_views_and_sequences DROP REGION "ap-southeast-2"

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_backup
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_backup
@@ -57,15 +57,15 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE global_table
 ----
 TABLE global_table  ALTER TABLE global_table CONFIGURE ZONE USING
-                    range_min_bytes = 134217728,
-                    range_max_bytes = 536870912,
-                    gc.ttlseconds = 90000,
-                    global_reads = true,
-                    num_replicas = 5,
-                    num_voters = 3,
-                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                    voter_constraints = '[+region=ca-central-1]',
-                    lease_preferences = '[[+region=ca-central-1]]'
+                      range_min_bytes = 134217728,
+                      range_max_bytes = 536870912,
+                      gc.ttlseconds = 14400,
+                      global_reads = true,
+                      num_replicas = 5,
+                      num_voters = 3,
+                      constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                      voter_constraints = '[+region=ca-central-1]',
+                      lease_preferences = '[[+region=ca-central-1]]'
 
 query TTT
 SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_row_table]
@@ -112,14 +112,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_table
 ----
 DATABASE "mr-backup-1"  ALTER DATABASE "mr-backup-1" CONFIGURE ZONE USING
-                        range_min_bytes = 134217728,
-                        range_max_bytes = 536870912,
-                        gc.ttlseconds = 90000,
-                        num_replicas = 5,
-                        num_voters = 3,
-                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                        voter_constraints = '[+region=ca-central-1]',
-                        lease_preferences = '[[+region=ca-central-1]]'
+                          range_min_bytes = 134217728,
+                          range_max_bytes = 536870912,
+                          gc.ttlseconds = 14400,
+                          num_replicas = 5,
+                          num_voters = 3,
+                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                          voter_constraints = '[+region=ca-central-1]',
+                          lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW CREATE TABLE regional_by_row_table
@@ -147,14 +147,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_primary_region
 ----
 DATABASE "mr-backup-1"  ALTER DATABASE "mr-backup-1" CONFIGURE ZONE USING
-                        range_min_bytes = 134217728,
-                        range_max_bytes = 536870912,
-                        gc.ttlseconds = 90000,
-                        num_replicas = 5,
-                        num_voters = 3,
-                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                        voter_constraints = '[+region=ca-central-1]',
-                        lease_preferences = '[[+region=ca-central-1]]'
+                          range_min_bytes = 134217728,
+                          range_max_bytes = 536870912,
+                          gc.ttlseconds = 14400,
+                          num_replicas = 5,
+                          num_voters = 3,
+                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                          voter_constraints = '[+region=ca-central-1]',
+                          lease_preferences = '[[+region=ca-central-1]]'
 
 query TTT
 SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_table_in_ca_central_1]
@@ -165,14 +165,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_ca_central_1
 ----
 TABLE regional_by_table_in_ca_central_1  ALTER TABLE regional_by_table_in_ca_central_1 CONFIGURE ZONE USING
-                                         range_min_bytes = 134217728,
-                                         range_max_bytes = 536870912,
-                                         gc.ttlseconds = 90000,
-                                         num_replicas = 5,
-                                         num_voters = 3,
-                                         constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                         voter_constraints = '[+region=ca-central-1]',
-                                         lease_preferences = '[[+region=ca-central-1]]'
+                                           range_min_bytes = 134217728,
+                                           range_max_bytes = 536870912,
+                                           gc.ttlseconds = 14400,
+                                           num_replicas = 5,
+                                           num_voters = 3,
+                                           constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                           voter_constraints = '[+region=ca-central-1]',
+                                           lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 CREATE DATABASE "mr-backup-2" primary region "ap-southeast-2" regions "ca-central-1", "us-east-1"
@@ -227,15 +227,15 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE global_table
 ----
 TABLE global_table  ALTER TABLE global_table CONFIGURE ZONE USING
-                    range_min_bytes = 134217728,
-                    range_max_bytes = 536870912,
-                    gc.ttlseconds = 90000,
-                    global_reads = true,
-                    num_replicas = 5,
-                    num_voters = 3,
-                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                    voter_constraints = '[+region=ap-southeast-2]',
-                    lease_preferences = '[[+region=ap-southeast-2]]'
+                      range_min_bytes = 134217728,
+                      range_max_bytes = 536870912,
+                      gc.ttlseconds = 14400,
+                      global_reads = true,
+                      num_replicas = 5,
+                      num_voters = 3,
+                      constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                      voter_constraints = '[+region=ap-southeast-2]',
+                      lease_preferences = '[[+region=ap-southeast-2]]'
 
 query TTT
 SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_row_table]
@@ -282,14 +282,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_table
 ----
 DATABASE "mr-backup-2"  ALTER DATABASE "mr-backup-2" CONFIGURE ZONE USING
-                        range_min_bytes = 134217728,
-                        range_max_bytes = 536870912,
-                        gc.ttlseconds = 90000,
-                        num_replicas = 5,
-                        num_voters = 3,
-                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                        voter_constraints = '[+region=ap-southeast-2]',
-                        lease_preferences = '[[+region=ap-southeast-2]]'
+                          range_min_bytes = 134217728,
+                          range_max_bytes = 536870912,
+                          gc.ttlseconds = 14400,
+                          num_replicas = 5,
+                          num_voters = 3,
+                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                          voter_constraints = '[+region=ap-southeast-2]',
+                          lease_preferences = '[[+region=ap-southeast-2]]'
 
 query TT
 SHOW CREATE TABLE regional_by_row_table
@@ -317,14 +317,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_primary_region
 ----
 DATABASE "mr-backup-2"  ALTER DATABASE "mr-backup-2" CONFIGURE ZONE USING
-                        range_min_bytes = 134217728,
-                        range_max_bytes = 536870912,
-                        gc.ttlseconds = 90000,
-                        num_replicas = 5,
-                        num_voters = 3,
-                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                        voter_constraints = '[+region=ap-southeast-2]',
-                        lease_preferences = '[[+region=ap-southeast-2]]'
+                          range_min_bytes = 134217728,
+                          range_max_bytes = 536870912,
+                          gc.ttlseconds = 14400,
+                          num_replicas = 5,
+                          num_voters = 3,
+                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                          voter_constraints = '[+region=ap-southeast-2]',
+                          lease_preferences = '[[+region=ap-southeast-2]]'
 
 query TTT
 SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_table_in_ca_central_1]
@@ -335,41 +335,41 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_ca_central_1
 ----
 TABLE regional_by_table_in_ca_central_1  ALTER TABLE regional_by_table_in_ca_central_1 CONFIGURE ZONE USING
-                                         range_min_bytes = 134217728,
-                                         range_max_bytes = 536870912,
-                                         gc.ttlseconds = 90000,
-                                         num_replicas = 5,
-                                         num_voters = 3,
-                                         constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                         voter_constraints = '[+region=ca-central-1]',
-                                         lease_preferences = '[[+region=ca-central-1]]'
+                                           range_min_bytes = 134217728,
+                                           range_max_bytes = 536870912,
+                                           gc.ttlseconds = 14400,
+                                           num_replicas = 5,
+                                           num_voters = 3,
+                                           constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                           voter_constraints = '[+region=ca-central-1]',
+                                           lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR DATABASE "mr-backup-1"
 ----
 DATABASE "mr-backup-1"  ALTER DATABASE "mr-backup-1" CONFIGURE ZONE USING
-                        range_min_bytes = 134217728,
-                        range_max_bytes = 536870912,
-                        gc.ttlseconds = 90000,
-                        num_replicas = 5,
-                        num_voters = 3,
-                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                        voter_constraints = '[+region=ca-central-1]',
-                        lease_preferences = '[[+region=ca-central-1]]'
+                          range_min_bytes = 134217728,
+                          range_max_bytes = 536870912,
+                          gc.ttlseconds = 14400,
+                          num_replicas = 5,
+                          num_voters = 3,
+                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                          voter_constraints = '[+region=ca-central-1]',
+                          lease_preferences = '[[+region=ca-central-1]]'
 
 
 query TT
 SHOW ZONE CONFIGURATION FOR DATABASE "mr-backup-2"
 ----
 DATABASE "mr-backup-2"  ALTER DATABASE "mr-backup-2" CONFIGURE ZONE USING
-                        range_min_bytes = 134217728,
-                        range_max_bytes = 536870912,
-                        gc.ttlseconds = 90000,
-                        num_replicas = 5,
-                        num_voters = 3,
-                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                        voter_constraints = '[+region=ap-southeast-2]',
-                        lease_preferences = '[[+region=ap-southeast-2]]'
+                          range_min_bytes = 134217728,
+                          range_max_bytes = 536870912,
+                          gc.ttlseconds = 14400,
+                          num_replicas = 5,
+                          num_voters = 3,
+                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                          voter_constraints = '[+region=ap-southeast-2]',
+                          lease_preferences = '[[+region=ap-southeast-2]]'
 
 statement ok
 ALTER DATABASE "mr-backup-1" CONFIGURE ZONE USING gc.ttlseconds = 1;
@@ -424,14 +424,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE "mr-backup-1"
 ----
 DATABASE "mr-backup-1"  ALTER DATABASE "mr-backup-1" CONFIGURE ZONE USING
-                        range_min_bytes = 134217728,
-                        range_max_bytes = 536870912,
-                        gc.ttlseconds = 90000,
-                        num_replicas = 5,
-                        num_voters = 3,
-                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                        voter_constraints = '[+region=ca-central-1]',
-                        lease_preferences = '[[+region=ca-central-1]]'
+                          range_min_bytes = 134217728,
+                          range_max_bytes = 536870912,
+                          gc.ttlseconds = 14400,
+                          num_replicas = 5,
+                          num_voters = 3,
+                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                          voter_constraints = '[+region=ca-central-1]',
+                          lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 use "mr-backup-1"
@@ -445,15 +445,15 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE global_table
 ----
 TABLE global_table  ALTER TABLE global_table CONFIGURE ZONE USING
-                    range_min_bytes = 134217728,
-                    range_max_bytes = 536870912,
-                    gc.ttlseconds = 90000,
-                    global_reads = true,
-                    num_replicas = 5,
-                    num_voters = 3,
-                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                    voter_constraints = '[+region=ca-central-1]',
-                    lease_preferences = '[[+region=ca-central-1]]'
+                      range_min_bytes = 134217728,
+                      range_max_bytes = 536870912,
+                      gc.ttlseconds = 14400,
+                      global_reads = true,
+                      num_replicas = 5,
+                      num_voters = 3,
+                      constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                      voter_constraints = '[+region=ca-central-1]',
+                      lease_preferences = '[[+region=ca-central-1]]'
 
 query TTT
 SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_row_table]
@@ -500,14 +500,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_table
 ----
 DATABASE "mr-backup-1"  ALTER DATABASE "mr-backup-1" CONFIGURE ZONE USING
-                        range_min_bytes = 134217728,
-                        range_max_bytes = 536870912,
-                        gc.ttlseconds = 90000,
-                        num_replicas = 5,
-                        num_voters = 3,
-                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                        voter_constraints = '[+region=ca-central-1]',
-                        lease_preferences = '[[+region=ca-central-1]]'
+                          range_min_bytes = 134217728,
+                          range_max_bytes = 536870912,
+                          gc.ttlseconds = 14400,
+                          num_replicas = 5,
+                          num_voters = 3,
+                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                          voter_constraints = '[+region=ca-central-1]',
+                          lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW CREATE TABLE regional_by_row_table
@@ -535,14 +535,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_primary_region
 ----
 DATABASE "mr-backup-1"  ALTER DATABASE "mr-backup-1" CONFIGURE ZONE USING
-                        range_min_bytes = 134217728,
-                        range_max_bytes = 536870912,
-                        gc.ttlseconds = 90000,
-                        num_replicas = 5,
-                        num_voters = 3,
-                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                        voter_constraints = '[+region=ca-central-1]',
-                        lease_preferences = '[[+region=ca-central-1]]'
+                          range_min_bytes = 134217728,
+                          range_max_bytes = 536870912,
+                          gc.ttlseconds = 14400,
+                          num_replicas = 5,
+                          num_voters = 3,
+                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                          voter_constraints = '[+region=ca-central-1]',
+                          lease_preferences = '[[+region=ca-central-1]]'
 
 query TTT
 SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_table_in_ca_central_1]
@@ -553,14 +553,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_ca_central_1
 ----
 TABLE regional_by_table_in_ca_central_1  ALTER TABLE regional_by_table_in_ca_central_1 CONFIGURE ZONE USING
-                                         range_min_bytes = 134217728,
-                                         range_max_bytes = 536870912,
-                                         gc.ttlseconds = 90000,
-                                         num_replicas = 5,
-                                         num_voters = 3,
-                                         constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                         voter_constraints = '[+region=ca-central-1]',
-                                         lease_preferences = '[[+region=ca-central-1]]'
+                                           range_min_bytes = 134217728,
+                                           range_max_bytes = 536870912,
+                                           gc.ttlseconds = 14400,
+                                           num_replicas = 5,
+                                           num_voters = 3,
+                                           constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                           voter_constraints = '[+region=ca-central-1]',
+                                           lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 RESTORE DATABASE "mr-backup-2" FROM 'nodelocal://0/mr-backup-2/'
@@ -579,14 +579,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE "mr-backup-2"
 ----
 DATABASE "mr-backup-2"  ALTER DATABASE "mr-backup-2" CONFIGURE ZONE USING
-                        range_min_bytes = 134217728,
-                        range_max_bytes = 536870912,
-                        gc.ttlseconds = 90000,
-                        num_replicas = 5,
-                        num_voters = 3,
-                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                        voter_constraints = '[+region=ap-southeast-2]',
-                        lease_preferences = '[[+region=ap-southeast-2]]'
+                          range_min_bytes = 134217728,
+                          range_max_bytes = 536870912,
+                          gc.ttlseconds = 14400,
+                          num_replicas = 5,
+                          num_voters = 3,
+                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                          voter_constraints = '[+region=ap-southeast-2]',
+                          lease_preferences = '[[+region=ap-southeast-2]]'
 
 statement ok
 use "mr-backup-2"
@@ -600,15 +600,15 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE global_table
 ----
 TABLE global_table  ALTER TABLE global_table CONFIGURE ZONE USING
-                    range_min_bytes = 134217728,
-                    range_max_bytes = 536870912,
-                    gc.ttlseconds = 90000,
-                    global_reads = true,
-                    num_replicas = 5,
-                    num_voters = 3,
-                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                    voter_constraints = '[+region=ap-southeast-2]',
-                    lease_preferences = '[[+region=ap-southeast-2]]'
+                      range_min_bytes = 134217728,
+                      range_max_bytes = 536870912,
+                      gc.ttlseconds = 14400,
+                      global_reads = true,
+                      num_replicas = 5,
+                      num_voters = 3,
+                      constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                      voter_constraints = '[+region=ap-southeast-2]',
+                      lease_preferences = '[[+region=ap-southeast-2]]'
 
 query TTT
 SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_row_table]
@@ -655,14 +655,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_table
 ----
 DATABASE "mr-backup-2"  ALTER DATABASE "mr-backup-2" CONFIGURE ZONE USING
-                        range_min_bytes = 134217728,
-                        range_max_bytes = 536870912,
-                        gc.ttlseconds = 90000,
-                        num_replicas = 5,
-                        num_voters = 3,
-                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                        voter_constraints = '[+region=ap-southeast-2]',
-                        lease_preferences = '[[+region=ap-southeast-2]]'
+                          range_min_bytes = 134217728,
+                          range_max_bytes = 536870912,
+                          gc.ttlseconds = 14400,
+                          num_replicas = 5,
+                          num_voters = 3,
+                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                          voter_constraints = '[+region=ap-southeast-2]',
+                          lease_preferences = '[[+region=ap-southeast-2]]'
 
 query TT
 SHOW CREATE TABLE regional_by_row_table
@@ -690,14 +690,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_primary_region
 ----
 DATABASE "mr-backup-2"  ALTER DATABASE "mr-backup-2" CONFIGURE ZONE USING
-                        range_min_bytes = 134217728,
-                        range_max_bytes = 536870912,
-                        gc.ttlseconds = 90000,
-                        num_replicas = 5,
-                        num_voters = 3,
-                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                        voter_constraints = '[+region=ap-southeast-2]',
-                        lease_preferences = '[[+region=ap-southeast-2]]'
+                          range_min_bytes = 134217728,
+                          range_max_bytes = 536870912,
+                          gc.ttlseconds = 14400,
+                          num_replicas = 5,
+                          num_voters = 3,
+                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                          voter_constraints = '[+region=ap-southeast-2]',
+                          lease_preferences = '[[+region=ap-southeast-2]]'
 
 query TTT
 SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_table_in_ca_central_1]
@@ -708,14 +708,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_ca_central_1
 ----
 TABLE regional_by_table_in_ca_central_1  ALTER TABLE regional_by_table_in_ca_central_1 CONFIGURE ZONE USING
-                                         range_min_bytes = 134217728,
-                                         range_max_bytes = 536870912,
-                                         gc.ttlseconds = 90000,
-                                         num_replicas = 5,
-                                         num_voters = 3,
-                                         constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                         voter_constraints = '[+region=ca-central-1]',
-                                         lease_preferences = '[[+region=ca-central-1]]'
+                                           range_min_bytes = 134217728,
+                                           range_max_bytes = 536870912,
+                                           gc.ttlseconds = 14400,
+                                           num_replicas = 5,
+                                           num_voters = 3,
+                                           constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                           voter_constraints = '[+region=ca-central-1]',
+                                           lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 DROP DATABASE "mr-backup-1";
@@ -748,27 +748,27 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE "mr-backup-1"
 ----
 DATABASE "mr-backup-1"  ALTER DATABASE "mr-backup-1" CONFIGURE ZONE USING
-                        range_min_bytes = 134217728,
-                        range_max_bytes = 536870912,
-                        gc.ttlseconds = 90000,
-                        num_replicas = 5,
-                        num_voters = 3,
-                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                        voter_constraints = '[+region=ca-central-1]',
-                        lease_preferences = '[[+region=ca-central-1]]'
+                          range_min_bytes = 134217728,
+                          range_max_bytes = 536870912,
+                          gc.ttlseconds = 14400,
+                          num_replicas = 5,
+                          num_voters = 3,
+                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                          voter_constraints = '[+region=ca-central-1]',
+                          lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR DATABASE "mr-backup-2"
 ----
 DATABASE "mr-backup-2"  ALTER DATABASE "mr-backup-2" CONFIGURE ZONE USING
-                        range_min_bytes = 134217728,
-                        range_max_bytes = 536870912,
-                        gc.ttlseconds = 90000,
-                        num_replicas = 5,
-                        num_voters = 3,
-                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                        voter_constraints = '[+region=ap-southeast-2]',
-                        lease_preferences = '[[+region=ap-southeast-2]]'
+                          range_min_bytes = 134217728,
+                          range_max_bytes = 536870912,
+                          gc.ttlseconds = 14400,
+                          num_replicas = 5,
+                          num_voters = 3,
+                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                          voter_constraints = '[+region=ap-southeast-2]',
+                          lease_preferences = '[[+region=ap-southeast-2]]'
 
 statement ok
 use "mr-backup-1"
@@ -782,15 +782,15 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE global_table
 ----
 TABLE global_table  ALTER TABLE global_table CONFIGURE ZONE USING
-                    range_min_bytes = 134217728,
-                    range_max_bytes = 536870912,
-                    gc.ttlseconds = 90000,
-                    global_reads = true,
-                    num_replicas = 5,
-                    num_voters = 3,
-                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                    voter_constraints = '[+region=ca-central-1]',
-                    lease_preferences = '[[+region=ca-central-1]]'
+                      range_min_bytes = 134217728,
+                      range_max_bytes = 536870912,
+                      gc.ttlseconds = 14400,
+                      global_reads = true,
+                      num_replicas = 5,
+                      num_voters = 3,
+                      constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                      voter_constraints = '[+region=ca-central-1]',
+                      lease_preferences = '[[+region=ca-central-1]]'
 
 query TTT
 SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_row_table]
@@ -837,14 +837,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_table
 ----
 DATABASE "mr-backup-1"  ALTER DATABASE "mr-backup-1" CONFIGURE ZONE USING
-                        range_min_bytes = 134217728,
-                        range_max_bytes = 536870912,
-                        gc.ttlseconds = 90000,
-                        num_replicas = 5,
-                        num_voters = 3,
-                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                        voter_constraints = '[+region=ca-central-1]',
-                        lease_preferences = '[[+region=ca-central-1]]'
+                          range_min_bytes = 134217728,
+                          range_max_bytes = 536870912,
+                          gc.ttlseconds = 14400,
+                          num_replicas = 5,
+                          num_voters = 3,
+                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                          voter_constraints = '[+region=ca-central-1]',
+                          lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW CREATE TABLE regional_by_row_table
@@ -872,14 +872,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_primary_region
 ----
 DATABASE "mr-backup-1"  ALTER DATABASE "mr-backup-1" CONFIGURE ZONE USING
-                        range_min_bytes = 134217728,
-                        range_max_bytes = 536870912,
-                        gc.ttlseconds = 90000,
-                        num_replicas = 5,
-                        num_voters = 3,
-                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                        voter_constraints = '[+region=ca-central-1]',
-                        lease_preferences = '[[+region=ca-central-1]]'
+                          range_min_bytes = 134217728,
+                          range_max_bytes = 536870912,
+                          gc.ttlseconds = 14400,
+                          num_replicas = 5,
+                          num_voters = 3,
+                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                          voter_constraints = '[+region=ca-central-1]',
+                          lease_preferences = '[[+region=ca-central-1]]'
 
 query TTT
 SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_table_in_ca_central_1]
@@ -890,14 +890,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_ca_central_1
 ----
 TABLE regional_by_table_in_ca_central_1  ALTER TABLE regional_by_table_in_ca_central_1 CONFIGURE ZONE USING
-                                         range_min_bytes = 134217728,
-                                         range_max_bytes = 536870912,
-                                         gc.ttlseconds = 90000,
-                                         num_replicas = 5,
-                                         num_voters = 3,
-                                         constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                         voter_constraints = '[+region=ca-central-1]',
-                                         lease_preferences = '[[+region=ca-central-1]]'
+                                           range_min_bytes = 134217728,
+                                           range_max_bytes = 536870912,
+                                           gc.ttlseconds = 14400,
+                                           num_replicas = 5,
+                                           num_voters = 3,
+                                           constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                           voter_constraints = '[+region=ca-central-1]',
+                                           lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 use "mr-backup-2"
@@ -911,15 +911,15 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE global_table
 ----
 TABLE global_table  ALTER TABLE global_table CONFIGURE ZONE USING
-                    range_min_bytes = 134217728,
-                    range_max_bytes = 536870912,
-                    gc.ttlseconds = 90000,
-                    global_reads = true,
-                    num_replicas = 5,
-                    num_voters = 3,
-                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                    voter_constraints = '[+region=ap-southeast-2]',
-                    lease_preferences = '[[+region=ap-southeast-2]]'
+                      range_min_bytes = 134217728,
+                      range_max_bytes = 536870912,
+                      gc.ttlseconds = 14400,
+                      global_reads = true,
+                      num_replicas = 5,
+                      num_voters = 3,
+                      constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                      voter_constraints = '[+region=ap-southeast-2]',
+                      lease_preferences = '[[+region=ap-southeast-2]]'
 
 query TTT
 SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_row_table]
@@ -966,14 +966,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_table
 ----
 DATABASE "mr-backup-2"  ALTER DATABASE "mr-backup-2" CONFIGURE ZONE USING
-                        range_min_bytes = 134217728,
-                        range_max_bytes = 536870912,
-                        gc.ttlseconds = 90000,
-                        num_replicas = 5,
-                        num_voters = 3,
-                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                        voter_constraints = '[+region=ap-southeast-2]',
-                        lease_preferences = '[[+region=ap-southeast-2]]'
+                          range_min_bytes = 134217728,
+                          range_max_bytes = 536870912,
+                          gc.ttlseconds = 14400,
+                          num_replicas = 5,
+                          num_voters = 3,
+                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                          voter_constraints = '[+region=ap-southeast-2]',
+                          lease_preferences = '[[+region=ap-southeast-2]]'
 
 query TT
 SHOW CREATE TABLE regional_by_row_table
@@ -1001,14 +1001,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_primary_region
 ----
 DATABASE "mr-backup-2"  ALTER DATABASE "mr-backup-2" CONFIGURE ZONE USING
-                        range_min_bytes = 134217728,
-                        range_max_bytes = 536870912,
-                        gc.ttlseconds = 90000,
-                        num_replicas = 5,
-                        num_voters = 3,
-                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                        voter_constraints = '[+region=ap-southeast-2]',
-                        lease_preferences = '[[+region=ap-southeast-2]]'
+                          range_min_bytes = 134217728,
+                          range_max_bytes = 536870912,
+                          gc.ttlseconds = 14400,
+                          num_replicas = 5,
+                          num_voters = 3,
+                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                          voter_constraints = '[+region=ap-southeast-2]',
+                          lease_preferences = '[[+region=ap-southeast-2]]'
 
 query TTT
 SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_table_in_ca_central_1]
@@ -1019,14 +1019,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_ca_central_1
 ----
 TABLE regional_by_table_in_ca_central_1  ALTER TABLE regional_by_table_in_ca_central_1 CONFIGURE ZONE USING
-                                         range_min_bytes = 134217728,
-                                         range_max_bytes = 536870912,
-                                         gc.ttlseconds = 90000,
-                                         num_replicas = 5,
-                                         num_voters = 3,
-                                         constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                         voter_constraints = '[+region=ca-central-1]',
-                                         lease_preferences = '[[+region=ca-central-1]]'
+                                           range_min_bytes = 134217728,
+                                           range_max_bytes = 536870912,
+                                           gc.ttlseconds = 14400,
+                                           num_replicas = 5,
+                                           num_voters = 3,
+                                           constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                           voter_constraints = '[+region=ca-central-1]',
+                                           lease_preferences = '[[+region=ca-central-1]]'
 
 # Backup and restore individual multi-region tables.
 subtest multiregion_table_backup_and_restore
@@ -1134,14 +1134,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_primary_region
 ----
 DATABASE "mr-backup-2"  ALTER DATABASE "mr-backup-2" CONFIGURE ZONE USING
-                        range_min_bytes = 134217728,
-                        range_max_bytes = 536870912,
-                        gc.ttlseconds = 90000,
-                        num_replicas = 5,
-                        num_voters = 3,
-                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                        voter_constraints = '[+region=ap-southeast-2]',
-                        lease_preferences = '[[+region=ap-southeast-2]]'
+                          range_min_bytes = 134217728,
+                          range_max_bytes = 536870912,
+                          gc.ttlseconds = 14400,
+                          num_replicas = 5,
+                          num_voters = 3,
+                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                          voter_constraints = '[+region=ap-southeast-2]',
+                          lease_preferences = '[[+region=ap-southeast-2]]'
 
 query TTT
 SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE regional_by_table_in_ca_central_1]
@@ -1152,14 +1152,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_ca_central_1
 ----
 TABLE regional_by_table_in_ca_central_1  ALTER TABLE regional_by_table_in_ca_central_1 CONFIGURE ZONE USING
-                                         range_min_bytes = 134217728,
-                                         range_max_bytes = 536870912,
-                                         gc.ttlseconds = 90000,
-                                         num_replicas = 5,
-                                         num_voters = 3,
-                                         constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                         voter_constraints = '[+region=ca-central-1]',
-                                         lease_preferences = '[[+region=ca-central-1]]'
+                                           range_min_bytes = 134217728,
+                                           range_max_bytes = 536870912,
+                                           gc.ttlseconds = 14400,
+                                           num_replicas = 5,
+                                           num_voters = 3,
+                                           constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                           voter_constraints = '[+region=ca-central-1]',
+                                           lease_preferences = '[[+region=ca-central-1]]'
 
 query TTT
 SELECT partition_name, index_name, zone_config FROM [SHOW PARTITIONS FROM TABLE global_table]
@@ -1170,15 +1170,15 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE global_table
 ----
 TABLE global_table  ALTER TABLE global_table CONFIGURE ZONE USING
-                    range_min_bytes = 134217728,
-                    range_max_bytes = 536870912,
-                    gc.ttlseconds = 90000,
-                    global_reads = true,
-                    num_replicas = 5,
-                    num_voters = 3,
-                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                    voter_constraints = '[+region=ap-southeast-2]',
-                    lease_preferences = '[[+region=ap-southeast-2]]'
+                      range_min_bytes = 134217728,
+                      range_max_bytes = 536870912,
+                      gc.ttlseconds = 14400,
+                      global_reads = true,
+                      num_replicas = 5,
+                      num_voters = 3,
+                      constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                      voter_constraints = '[+region=ap-southeast-2]',
+                      lease_preferences = '[[+region=ap-southeast-2]]'
 
 
 statement ok
@@ -1195,12 +1195,12 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE non_mr_table
 ----
 RANGE default  ALTER RANGE default CONFIGURE ZONE USING
-                           range_min_bytes = 134217728,
-                           range_max_bytes = 536870912,
-                           gc.ttlseconds = 90000,
-                           num_replicas = 3,
-                           constraints = '[]',
-                           lease_preferences = '[]'
+                 range_min_bytes = 134217728,
+                 range_max_bytes = 536870912,
+                 gc.ttlseconds = 14400,
+                 num_replicas = 3,
+                 constraints = '[]',
+                 lease_preferences = '[]'
 
 statement ok
 BACKUP TABLE non_mr_table TO 'nodelocal://0/non_mr_table/'
@@ -1215,12 +1215,12 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE non_mr_table
 ----
 RANGE default  ALTER RANGE default CONFIGURE ZONE USING
-                           range_min_bytes = 134217728,
-                           range_max_bytes = 536870912,
-                           gc.ttlseconds = 90000,
-                           num_replicas = 3,
-                           constraints = '[]',
-                           lease_preferences = '[]'
+                 range_min_bytes = 134217728,
+                 range_max_bytes = 536870912,
+                 gc.ttlseconds = 14400,
+                 num_replicas = 3,
+                 constraints = '[]',
+                 lease_preferences = '[]'
 
 statement ok
 RESTORE TABLE non_mr_table FROM 'nodelocal://0/non_mr_table/' WITH into_db = 'mr-backup-1'
@@ -1237,14 +1237,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE non_mr_table
 ----
 DATABASE "mr-backup-1"  ALTER DATABASE "mr-backup-1" CONFIGURE ZONE USING
-                                    range_min_bytes = 134217728,
-                                    range_max_bytes = 536870912,
-                                    gc.ttlseconds = 90000,
-                                    num_replicas = 5,
-                                    num_voters = 3,
-                                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                    voter_constraints = '[+region=ca-central-1]',
-                                    lease_preferences = '[[+region=ca-central-1]]'
+                          range_min_bytes = 134217728,
+                          range_max_bytes = 536870912,
+                          gc.ttlseconds = 14400,
+                          num_replicas = 5,
+                          num_voters = 3,
+                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                          voter_constraints = '[+region=ca-central-1]',
+                          lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW CREATE TABLE non_mr_table
@@ -1357,15 +1357,15 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE global_table
 ----
 TABLE global_table  ALTER TABLE global_table CONFIGURE ZONE USING
-                    range_min_bytes = 134217728,
-                    range_max_bytes = 536870912,
-                    gc.ttlseconds = 90000,
-                    global_reads = true,
-                    num_replicas = 4,
-                    num_voters = 3,
-                    constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
-                    voter_constraints = '[+region=ap-southeast-2]',
-                    lease_preferences = '[[+region=ap-southeast-2]]'
+                      range_min_bytes = 134217728,
+                      range_max_bytes = 536870912,
+                      gc.ttlseconds = 14400,
+                      global_reads = true,
+                      num_replicas = 4,
+                      num_voters = 3,
+                      constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                      voter_constraints = '[+region=ap-southeast-2]',
+                      lease_preferences = '[[+region=ap-southeast-2]]'
 
 
 statement ok
@@ -1385,14 +1385,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_table_in_primary_region
 ----
 DATABASE "mr-restore-1"  ALTER DATABASE "mr-restore-1" CONFIGURE ZONE USING
-                         range_min_bytes = 134217728,
-                         range_max_bytes = 536870912,
-                         gc.ttlseconds = 90000,
-                         num_replicas = 4,
-                         num_voters = 3,
-                         constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
-                         voter_constraints = '[+region=ap-southeast-2]',
-                         lease_preferences = '[[+region=ap-southeast-2]]'
+                           range_min_bytes = 134217728,
+                           range_max_bytes = 536870912,
+                           gc.ttlseconds = 14400,
+                           num_replicas = 4,
+                           num_voters = 3,
+                           constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                           voter_constraints = '[+region=ap-southeast-2]',
+                           lease_preferences = '[[+region=ap-southeast-2]]'
 
 query TTTTT colnames
 SHOW REGIONS

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_config_extensions
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_config_extensions
@@ -27,27 +27,27 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
 ----
 DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING
-                            range_min_bytes = 134217728,
-                            range_max_bytes = 536870912,
-                            gc.ttlseconds = 90000,
-                            num_replicas = 5,
-                            num_voters = 5,
-                            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                            voter_constraints = '{+region=ca-central-1: 2}',
-                            lease_preferences = '[[+region=ca-central-1]]'
+                              range_min_bytes = 134217728,
+                              range_max_bytes = 536870912,
+                              gc.ttlseconds = 14400,
+                              num_replicas = 5,
+                              num_voters = 5,
+                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              voter_constraints = '{+region=ca-central-1: 2}',
+                              lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE tbl
 ----
 DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING
-                            range_min_bytes = 134217728,
-                            range_max_bytes = 536870912,
-                            gc.ttlseconds = 90000,
-                            num_replicas = 5,
-                            num_voters = 5,
-                            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                            voter_constraints = '{+region=ca-central-1: 2}',
-                            lease_preferences = '[[+region=ca-central-1]]'
+                              range_min_bytes = 134217728,
+                              range_max_bytes = 536870912,
+                              gc.ttlseconds = 14400,
+                              num_replicas = 5,
+                              num_voters = 5,
+                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              voter_constraints = '{+region=ca-central-1: 2}',
+                              lease_preferences = '[[+region=ca-central-1]]'
 
 
 # REGIONAL zone config extensions.
@@ -59,27 +59,27 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
 ----
 DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING
-                            range_min_bytes = 134217728,
-                            range_max_bytes = 536870912,
-                            gc.ttlseconds = 90000,
-                            num_replicas = 9,
-                            num_voters = 5,
-                            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                            voter_constraints = '{+region=ca-central-1: 2}',
-                            lease_preferences = '[[+region=ca-central-1]]'
+                              range_min_bytes = 134217728,
+                              range_max_bytes = 536870912,
+                              gc.ttlseconds = 14400,
+                              num_replicas = 9,
+                              num_voters = 5,
+                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              voter_constraints = '{+region=ca-central-1: 2}',
+                              lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE tbl
 ----
 DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING
-                            range_min_bytes = 134217728,
-                            range_max_bytes = 536870912,
-                            gc.ttlseconds = 90000,
-                            num_replicas = 9,
-                            num_voters = 5,
-                            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                            voter_constraints = '{+region=ca-central-1: 2}',
-                            lease_preferences = '[[+region=ca-central-1]]'
+                              range_min_bytes = 134217728,
+                              range_max_bytes = 536870912,
+                              gc.ttlseconds = 14400,
+                              num_replicas = 9,
+                              num_voters = 5,
+                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              voter_constraints = '{+region=ca-central-1: 2}',
+                              lease_preferences = '[[+region=ca-central-1]]'
 
 
 # REGIONAL IN zone config extensions.
@@ -96,27 +96,27 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
 ----
 DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING
-                            range_min_bytes = 134217728,
-                            range_max_bytes = 536870912,
-                            gc.ttlseconds = 90000,
-                            num_replicas = 9,
-                            num_voters = 5,
-                            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                            voter_constraints = '{+region=ca-central-1: 2}',
-                            lease_preferences = '[[+region=ca-central-1], [+region=ap-southeast-2]]'
+                              range_min_bytes = 134217728,
+                              range_max_bytes = 536870912,
+                              gc.ttlseconds = 14400,
+                              num_replicas = 9,
+                              num_voters = 5,
+                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              voter_constraints = '{+region=ca-central-1: 2}',
+                              lease_preferences = '[[+region=ca-central-1], [+region=ap-southeast-2]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE tbl
 ----
 DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING
-                            range_min_bytes = 134217728,
-                            range_max_bytes = 536870912,
-                            gc.ttlseconds = 90000,
-                            num_replicas = 9,
-                            num_voters = 5,
-                            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                            voter_constraints = '{+region=ca-central-1: 2}',
-                            lease_preferences = '[[+region=ca-central-1], [+region=ap-southeast-2]]'
+                              range_min_bytes = 134217728,
+                              range_max_bytes = 536870912,
+                              gc.ttlseconds = 14400,
+                              num_replicas = 9,
+                              num_voters = 5,
+                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              voter_constraints = '{+region=ca-central-1: 2}',
+                              lease_preferences = '[[+region=ca-central-1], [+region=ap-southeast-2]]'
 
 statement ok
 ALTER TABLE tbl SET LOCALITY REGIONAL IN "ca-central-1"
@@ -125,14 +125,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE tbl
 ----
 TABLE tbl  ALTER TABLE tbl CONFIGURE ZONE USING
-           range_min_bytes = 134217728,
-           range_max_bytes = 536870912,
-           gc.ttlseconds = 90000,
-           num_replicas = 9,
-           num_voters = 5,
-           constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-           voter_constraints = '{+region=ca-central-1: 2}',
-           lease_preferences = '[[+region=ca-central-1], [+region=ap-southeast-2]]'
+             range_min_bytes = 134217728,
+             range_max_bytes = 536870912,
+             gc.ttlseconds = 14400,
+             num_replicas = 9,
+             num_voters = 5,
+             constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+             voter_constraints = '{+region=ca-central-1: 2}',
+             lease_preferences = '[[+region=ca-central-1], [+region=ap-southeast-2]]'
 
 statement ok
 ALTER TABLE tbl SET LOCALITY REGIONAL IN "ap-southeast-2"
@@ -141,14 +141,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE tbl
 ----
 TABLE tbl  ALTER TABLE tbl CONFIGURE ZONE USING
-           range_min_bytes = 134217728,
-           range_max_bytes = 536870912,
-           gc.ttlseconds = 90000,
-           num_replicas = 9,
-           num_voters = 5,
-           constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-           voter_constraints = '{+region=ap-southeast-2: 2}',
-           lease_preferences = '[[+region=ap-southeast-2], [+region=us-east-1]]'
+             range_min_bytes = 134217728,
+             range_max_bytes = 536870912,
+             gc.ttlseconds = 14400,
+             num_replicas = 9,
+             num_voters = 5,
+             constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+             voter_constraints = '{+region=ap-southeast-2: 2}',
+             lease_preferences = '[[+region=ap-southeast-2], [+region=us-east-1]]'
 
 statement ok
 ALTER TABLE tbl SET LOCALITY REGIONAL IN "us-east-1"
@@ -157,14 +157,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE tbl
 ----
 TABLE tbl  ALTER TABLE tbl CONFIGURE ZONE USING
-           range_min_bytes = 134217728,
-           range_max_bytes = 536870912,
-           gc.ttlseconds = 90000,
-           num_replicas = 9,
-           num_voters = 5,
-           constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-           voter_constraints = '{+region=us-east-1: 2}',
-           lease_preferences = '[[+region=us-east-1]]'
+             range_min_bytes = 134217728,
+             range_max_bytes = 536870912,
+             gc.ttlseconds = 14400,
+             num_replicas = 9,
+             num_voters = 5,
+             constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+             voter_constraints = '{+region=us-east-1: 2}',
+             lease_preferences = '[[+region=us-east-1]]'
 
 # GLOBAL zone config extensions.
 
@@ -175,15 +175,15 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE tbl
 ----
 TABLE tbl  ALTER TABLE tbl CONFIGURE ZONE USING
-           range_min_bytes = 134217728,
-           range_max_bytes = 536870912,
-           gc.ttlseconds = 90000,
-           global_reads = true,
-           num_replicas = 5,
-           num_voters = 5,
-           constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-           voter_constraints = '{+region=ca-central-1: 2}',
-           lease_preferences = '[[+region=ca-central-1]]'
+             range_min_bytes = 134217728,
+             range_max_bytes = 536870912,
+             gc.ttlseconds = 14400,
+             global_reads = true,
+             num_replicas = 5,
+             num_voters = 5,
+             constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+             voter_constraints = '{+region=ca-central-1: 2}',
+             lease_preferences = '[[+region=ca-central-1]]'
 
 
 statement ok
@@ -196,28 +196,28 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
 ----
 DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING
-                            range_min_bytes = 134217728,
-                            range_max_bytes = 536870912,
-                            gc.ttlseconds = 90000,
-                            num_replicas = 9,
-                            num_voters = 5,
-                            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                            voter_constraints = '{+region=ca-central-1: 2}',
-                            lease_preferences = '[[+region=ca-central-1], [+region=ap-southeast-2]]'
+                              range_min_bytes = 134217728,
+                              range_max_bytes = 536870912,
+                              gc.ttlseconds = 14400,
+                              num_replicas = 9,
+                              num_voters = 5,
+                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              voter_constraints = '{+region=ca-central-1: 2}',
+                              lease_preferences = '[[+region=ca-central-1], [+region=ap-southeast-2]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE tbl
 ----
 TABLE tbl  ALTER TABLE tbl CONFIGURE ZONE USING
-           range_min_bytes = 134217728,
-           range_max_bytes = 536870912,
-           gc.ttlseconds = 90000,
-           global_reads = true,
-           num_replicas = 6,
-           num_voters = 6,
-           constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-           voter_constraints = '{+region=ca-central-1: 2}',
-           lease_preferences = '[[+region=ca-central-1], [+region=ap-southeast-2], [+region=us-east-1]]'
+             range_min_bytes = 134217728,
+             range_max_bytes = 536870912,
+             gc.ttlseconds = 14400,
+             global_reads = true,
+             num_replicas = 6,
+             num_voters = 6,
+             constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+             voter_constraints = '{+region=ca-central-1: 2}',
+             lease_preferences = '[[+region=ca-central-1], [+region=ap-southeast-2], [+region=us-east-1]]'
 
 statement ok
 ALTER DATABASE "mr-zone-configs" ALTER LOCALITY GLOBAL CONFIGURE ZONE DISCARD
@@ -226,28 +226,28 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
 ----
 DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING
-                            range_min_bytes = 134217728,
-                            range_max_bytes = 536870912,
-                            gc.ttlseconds = 90000,
-                            num_replicas = 9,
-                            num_voters = 5,
-                            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                            voter_constraints = '{+region=ca-central-1: 2}',
-                            lease_preferences = '[[+region=ca-central-1], [+region=ap-southeast-2]]'
+                              range_min_bytes = 134217728,
+                              range_max_bytes = 536870912,
+                              gc.ttlseconds = 14400,
+                              num_replicas = 9,
+                              num_voters = 5,
+                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              voter_constraints = '{+region=ca-central-1: 2}',
+                              lease_preferences = '[[+region=ca-central-1], [+region=ap-southeast-2]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE tbl
 ----
 TABLE tbl  ALTER TABLE tbl CONFIGURE ZONE USING
-           range_min_bytes = 134217728,
-           range_max_bytes = 536870912,
-           gc.ttlseconds = 90000,
-           global_reads = true,
-           num_replicas = 5,
-           num_voters = 5,
-           constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-           voter_constraints = '{+region=ca-central-1: 2}',
-           lease_preferences = '[[+region=ca-central-1]]'
+             range_min_bytes = 134217728,
+             range_max_bytes = 536870912,
+             gc.ttlseconds = 14400,
+             global_reads = true,
+             num_replicas = 5,
+             num_voters = 5,
+             constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+             voter_constraints = '{+region=ca-central-1: 2}',
+             lease_preferences = '[[+region=ca-central-1]]'
 
 subtest conflicting_zone_config_extension
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs
@@ -45,12 +45,12 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE global_table
 ----
 RANGE default  ALTER RANGE default CONFIGURE ZONE USING
-               range_min_bytes = 134217728,
-               range_max_bytes = 536870912,
-               gc.ttlseconds = 90000,
-               num_replicas = 3,
-               constraints = '[]',
-               lease_preferences = '[]'
+                 range_min_bytes = 134217728,
+                 range_max_bytes = 536870912,
+                 gc.ttlseconds = 14400,
+                 num_replicas = 3,
+                 constraints = '[]',
+                 lease_preferences = '[]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE global_table_custom_gc_ttl
@@ -72,12 +72,12 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE gc_ttl_predefined_db
 ----
 RANGE default  ALTER RANGE default CONFIGURE ZONE USING
-               range_min_bytes = 134217728,
-               range_max_bytes = 536870912,
-               gc.ttlseconds = 90000,
-               num_replicas = 3,
-               constraints = '[]',
-               lease_preferences = '[]'
+                 range_min_bytes = 134217728,
+                 range_max_bytes = 536870912,
+                 gc.ttlseconds = 14400,
+                 num_replicas = 3,
+                 constraints = '[]',
+                 lease_preferences = '[]'
 
 statement ok
 ALTER DATABASE gc_ttl_predefined_db CONFIGURE ZONE USING gc.ttlseconds = 10;
@@ -757,12 +757,12 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
 ----
 RANGE default  ALTER RANGE default CONFIGURE ZONE USING
-               range_min_bytes = 134217728,
-               range_max_bytes = 536870912,
-               gc.ttlseconds = 90000,
-               num_replicas = 3,
-               constraints = '[]',
-               lease_preferences = '[]'
+                 range_min_bytes = 134217728,
+                 range_max_bytes = 536870912,
+                 gc.ttlseconds = 14400,
+                 num_replicas = 3,
+                 constraints = '[]',
+                 lease_preferences = '[]'
 
 statement ok
 ALTER INDEX regional_by_row@regional_by_row_pkey CONFIGURE ZONE DISCARD
@@ -904,15 +904,15 @@ query TT
 SHOW ZONE CONFIGURATION FOR INDEX tbl1@tbl1_i_idx
 ----
 TABLE tbl1  ALTER TABLE tbl1 CONFIGURE ZONE USING
-            range_min_bytes = 134217728,
-            range_max_bytes = 536870912,
-            gc.ttlseconds = 90000,
-            global_reads = true,
-            num_replicas = 3,
-            num_voters = 3,
-            constraints = '{+region=us-east-1: 1}',
-            voter_constraints = '[+region=us-east-1]',
-            lease_preferences = '[[+region=us-east-1]]'
+              range_min_bytes = 134217728,
+              range_max_bytes = 536870912,
+              gc.ttlseconds = 14400,
+              global_reads = true,
+              num_replicas = 3,
+              num_voters = 3,
+              constraints = '{+region=us-east-1: 1}',
+              voter_constraints = '[+region=us-east-1]',
+              lease_preferences = '[[+region=us-east-1]]'
 
 # Confirm that the zone configuration was wiped above by changing the locality
 # again, this time without an override.
@@ -1086,14 +1086,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR INDEX tbl3@tbl3_i_idx
 ----
 DATABASE initial_multiregion_db  ALTER DATABASE initial_multiregion_db CONFIGURE ZONE USING
-                                 range_min_bytes = 134217728,
-                                 range_max_bytes = 536870912,
-                                 gc.ttlseconds = 90000,
-                                 num_replicas = 3,
-                                 num_voters = 3,
-                                 constraints = '{+region=us-east-1: 1}',
-                                 voter_constraints = '[+region=us-east-1]',
-                                 lease_preferences = '[[+region=us-east-1]]'
+                                   range_min_bytes = 134217728,
+                                   range_max_bytes = 536870912,
+                                   gc.ttlseconds = 14400,
+                                   num_replicas = 3,
+                                   num_voters = 3,
+                                   constraints = '{+region=us-east-1: 1}',
+                                   voter_constraints = '[+region=us-east-1]',
+                                   lease_preferences = '[[+region=us-east-1]]'
 
 # DISCARDing a partition's zone configuration on a RBR table should fail.
 statement error attempting to discard the zone configuration of a multi-region entity
@@ -1138,14 +1138,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE tbl3
 ----
 DATABASE initial_multiregion_db  ALTER DATABASE initial_multiregion_db CONFIGURE ZONE USING
-                                 range_min_bytes = 134217728,
-                                 range_max_bytes = 536870912,
-                                 gc.ttlseconds = 90000,
-                                 num_replicas = 3,
-                                 num_voters = 3,
-                                 constraints = '{+region=us-east-1: 1}',
-                                 voter_constraints = '[+region=us-east-1]',
-                                 lease_preferences = '[[+region=us-east-1]]'
+                                   range_min_bytes = 134217728,
+                                   range_max_bytes = 536870912,
+                                   gc.ttlseconds = 14400,
+                                   num_replicas = 3,
+                                   num_voters = 3,
+                                   constraints = '{+region=us-east-1: 1}',
+                                   voter_constraints = '[+region=us-east-1]',
+                                   lease_preferences = '[[+region=us-east-1]]'
 
 statement ok
 DROP TABLE tbl3
@@ -1193,14 +1193,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR INDEX tbl4@tbl4_i_idx
 ----
 DATABASE initial_multiregion_db  ALTER DATABASE initial_multiregion_db CONFIGURE ZONE USING
-                                 range_min_bytes = 134217728,
-                                 range_max_bytes = 536870912,
-                                 gc.ttlseconds = 90000,
-                                 num_replicas = 3,
-                                 num_voters = 3,
-                                 constraints = '{+region=us-east-1: 1}',
-                                 voter_constraints = '[+region=us-east-1]',
-                                 lease_preferences = '[[+region=us-east-1]]'
+                                   range_min_bytes = 134217728,
+                                   range_max_bytes = 536870912,
+                                   gc.ttlseconds = 14400,
+                                   num_replicas = 3,
+                                   num_voters = 3,
+                                   constraints = '{+region=us-east-1: 1}',
+                                   voter_constraints = '[+region=us-east-1]',
+                                   lease_preferences = '[[+region=us-east-1]]'
 
 statement ok
 ALTER TABLE tbl4 CONFIGURE ZONE USING gc.ttlseconds=10
@@ -1234,14 +1234,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE tbl4
 ----
 DATABASE initial_multiregion_db  ALTER DATABASE initial_multiregion_db CONFIGURE ZONE USING
-                                 range_min_bytes = 134217728,
-                                 range_max_bytes = 536870912,
-                                 gc.ttlseconds = 90000,
-                                 num_replicas = 3,
-                                 num_voters = 3,
-                                 constraints = '{+region=us-east-1: 1}',
-                                 voter_constraints = '[+region=us-east-1]',
-                                 lease_preferences = '[[+region=us-east-1]]'
+                                   range_min_bytes = 134217728,
+                                   range_max_bytes = 536870912,
+                                   gc.ttlseconds = 14400,
+                                   num_replicas = 3,
+                                   num_voters = 3,
+                                   constraints = '{+region=us-east-1: 1}',
+                                   voter_constraints = '[+region=us-east-1]',
+                                   lease_preferences = '[[+region=us-east-1]]'
 
 # Test all cases where DISCARD is used to remove a zone configuration from a
 # REGIONAL BY TABLE IN REGION <region> table.
@@ -1286,14 +1286,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR INDEX tbl5@tbl5_i_idx
 ----
 TABLE tbl5  ALTER TABLE tbl5 CONFIGURE ZONE USING
-            range_min_bytes = 134217728,
-            range_max_bytes = 536870912,
-            gc.ttlseconds = 90000,
-            num_replicas = 3,
-            num_voters = 3,
-            constraints = '{+region=us-east-1: 1}',
-            voter_constraints = '[+region=us-east-1]',
-            lease_preferences = '[[+region=us-east-1]]'
+              range_min_bytes = 134217728,
+              range_max_bytes = 536870912,
+              gc.ttlseconds = 14400,
+              num_replicas = 3,
+              num_voters = 3,
+              constraints = '{+region=us-east-1: 1}',
+              voter_constraints = '[+region=us-east-1]',
+              lease_preferences = '[[+region=us-east-1]]'
 
 statement ok
 ALTER TABLE tbl5 CONFIGURE ZONE USING gc.ttlseconds=10
@@ -1332,14 +1332,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE tbl5
 ----
 DATABASE initial_multiregion_db  ALTER DATABASE initial_multiregion_db CONFIGURE ZONE USING
-                                 range_min_bytes = 134217728,
-                                 range_max_bytes = 536870912,
-                                 gc.ttlseconds = 90000,
-                                 num_replicas = 3,
-                                 num_voters = 3,
-                                 constraints = '{+region=us-east-1: 1}',
-                                 voter_constraints = '[+region=us-east-1]',
-                                 lease_preferences = '[[+region=us-east-1]]'
+                                   range_min_bytes = 134217728,
+                                   range_max_bytes = 536870912,
+                                   gc.ttlseconds = 14400,
+                                   num_replicas = 3,
+                                   num_voters = 3,
+                                   constraints = '{+region=us-east-1: 1}',
+                                   voter_constraints = '[+region=us-east-1]',
+                                   lease_preferences = '[[+region=us-east-1]]'
 
 statement ok
 DROP TABLE tbl5
@@ -1389,15 +1389,15 @@ query TT
 SHOW ZONE CONFIGURATION FOR INDEX tbl6@tbl6_i_idx
 ----
 TABLE tbl6  ALTER TABLE tbl6 CONFIGURE ZONE USING
-            range_min_bytes = 134217728,
-            range_max_bytes = 536870912,
-            gc.ttlseconds = 90000,
-            global_reads = true,
-            num_replicas = 3,
-            num_voters = 3,
-            constraints = '{+region=us-east-1: 1}',
-            voter_constraints = '[+region=us-east-1]',
-            lease_preferences = '[[+region=us-east-1]]'
+              range_min_bytes = 134217728,
+              range_max_bytes = 536870912,
+              gc.ttlseconds = 14400,
+              global_reads = true,
+              num_replicas = 3,
+              num_voters = 3,
+              constraints = '{+region=us-east-1: 1}',
+              voter_constraints = '[+region=us-east-1]',
+              lease_preferences = '[[+region=us-east-1]]'
 
 statement ok
 ALTER TABLE tbl6 CONFIGURE ZONE USING gc.ttlseconds=10
@@ -1438,14 +1438,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE tbl6
 ----
 DATABASE initial_multiregion_db  ALTER DATABASE initial_multiregion_db CONFIGURE ZONE USING
-                                 range_min_bytes = 134217728,
-                                 range_max_bytes = 536870912,
-                                 gc.ttlseconds = 90000,
-                                 num_replicas = 3,
-                                 num_voters = 3,
-                                 constraints = '{+region=us-east-1: 1}',
-                                 voter_constraints = '[+region=us-east-1]',
-                                 lease_preferences = '[[+region=us-east-1]]'
+                                   range_min_bytes = 134217728,
+                                   range_max_bytes = 536870912,
+                                   gc.ttlseconds = 14400,
+                                   num_replicas = 3,
+                                   num_voters = 3,
+                                   constraints = '{+region=us-east-1: 1}',
+                                   voter_constraints = '[+region=us-east-1]',
+                                   lease_preferences = '[[+region=us-east-1]]'
 
 statement ok
 DROP TABLE tbl6
@@ -1483,14 +1483,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "us-east-1" of INDEX tbl8@tbl8_pkey
 ----
 PARTITION "us-east-1" OF INDEX tbl8@tbl8_pkey  ALTER PARTITION "us-east-1" OF INDEX tbl8@tbl8_pkey CONFIGURE ZONE USING
-                                             range_min_bytes = 134217728,
-                                             range_max_bytes = 536870912,
-                                             gc.ttlseconds = 90000,
-                                             num_replicas = 3,
-                                             num_voters = 3,
-                                             constraints = '{+region=us-east-1: 1}',
-                                             voter_constraints = '[+region=us-east-1]',
-                                             lease_preferences = '[[+region=us-east-1]]'
+                                                 range_min_bytes = 134217728,
+                                                 range_max_bytes = 536870912,
+                                                 gc.ttlseconds = 14400,
+                                                 num_replicas = 3,
+                                                 num_voters = 3,
+                                                 constraints = '{+region=us-east-1: 1}',
+                                                 voter_constraints = '[+region=us-east-1]',
+                                                 lease_preferences = '[[+region=us-east-1]]'
 
 statement ok
 SET override_multi_region_zone_config = true;
@@ -1501,14 +1501,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "us-east-1" of INDEX tbl8@tbl8_pkey
 ----
 DATABASE initial_multiregion_db  ALTER DATABASE initial_multiregion_db CONFIGURE ZONE USING
-                                 range_min_bytes = 134217728,
-                                 range_max_bytes = 536870912,
-                                 gc.ttlseconds = 90000,
-                                 num_replicas = 3,
-                                 num_voters = 3,
-                                 constraints = '{+region=us-east-1: 1}',
-                                 voter_constraints = '[+region=us-east-1]',
-                                 lease_preferences = '[[+region=us-east-1]]'
+                                   range_min_bytes = 134217728,
+                                   range_max_bytes = 536870912,
+                                   gc.ttlseconds = 14400,
+                                   num_replicas = 3,
+                                   num_voters = 3,
+                                   constraints = '{+region=us-east-1: 1}',
+                                   voter_constraints = '[+region=us-east-1]',
+                                   lease_preferences = '[[+region=us-east-1]]'
 
 statement error missing zone configuration for partition "us-east-1" of tbl8@tbl8_pkey
 SELECT crdb_internal.validate_multi_region_zone_configs()
@@ -1523,14 +1523,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "us-east-1" of INDEX tbl8@tbl8_pkey
 ----
 PARTITION "us-east-1" OF INDEX tbl8@tbl8_pkey  ALTER PARTITION "us-east-1" OF INDEX tbl8@tbl8_pkey CONFIGURE ZONE USING
-                                             range_min_bytes = 134217728,
-                                             range_max_bytes = 536870912,
-                                             gc.ttlseconds = 90000,
-                                             num_replicas = 3,
-                                             num_voters = 3,
-                                             constraints = '{+region=us-east-1: 1}',
-                                             voter_constraints = '[+region=us-east-1]',
-                                             lease_preferences = '[[+region=us-east-1]]'
+                                                 range_min_bytes = 134217728,
+                                                 range_max_bytes = 536870912,
+                                                 gc.ttlseconds = 14400,
+                                                 num_replicas = 3,
+                                                 num_voters = 3,
+                                                 constraints = '{+region=us-east-1: 1}',
+                                                 voter_constraints = '[+region=us-east-1]',
+                                                 lease_preferences = '[[+region=us-east-1]]'
 
 statement ok
 SELECT crdb_internal.validate_multi_region_zone_configs()
@@ -1635,14 +1635,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE tbl10
 ----
 DATABASE initial_multiregion_db  ALTER DATABASE initial_multiregion_db CONFIGURE ZONE USING
-                                 range_min_bytes = 134217728,
-                                 range_max_bytes = 536870912,
-                                 gc.ttlseconds = 90000,
-                                 num_replicas = 3,
-                                 num_voters = 3,
-                                 constraints = '{+region=us-east-1: 1}',
-                                 voter_constraints = '[+region=us-east-1]',
-                                 lease_preferences = '[[+region=us-east-1]]'
+                                   range_min_bytes = 134217728,
+                                   range_max_bytes = 536870912,
+                                   gc.ttlseconds = 14400,
+                                   num_replicas = 3,
+                                   num_voters = 3,
+                                   constraints = '{+region=us-east-1: 1}',
+                                   voter_constraints = '[+region=us-east-1]',
+                                   lease_preferences = '[[+region=us-east-1]]'
 
 statement error zone configuration for table tbl10 contains incorrectly configured field "num_voters"
 SELECT crdb_internal.validate_multi_region_zone_configs()
@@ -1657,14 +1657,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE tbl10
 ----
 TABLE tbl10  ALTER TABLE tbl10 CONFIGURE ZONE USING
-             range_min_bytes = 134217728,
-             range_max_bytes = 536870912,
-             gc.ttlseconds = 90000,
-             num_replicas = 3,
-             num_voters = 3,
-             constraints = '{+region=us-east-1: 1}',
-             voter_constraints = '[+region=us-east-1]',
-             lease_preferences = '[[+region=us-east-1]]'
+               range_min_bytes = 134217728,
+               range_max_bytes = 536870912,
+               gc.ttlseconds = 14400,
+               num_replicas = 3,
+               num_voters = 3,
+               constraints = '{+region=us-east-1: 1}',
+               voter_constraints = '[+region=us-east-1]',
+               lease_preferences = '[[+region=us-east-1]]'
 
 statement ok
 SELECT crdb_internal.validate_multi_region_zone_configs()
@@ -1678,14 +1678,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE tbl10
 ----
 TABLE tbl10  ALTER TABLE tbl10 CONFIGURE ZONE USING
-             range_min_bytes = 134217728,
-             range_max_bytes = 536870912,
-             gc.ttlseconds = 90000,
-             num_replicas = 5,
-             num_voters = 3,
-             constraints = '{+region=us-east-1: 1}',
-             voter_constraints = '[+region=us-east-1]',
-             lease_preferences = '[[+region=us-east-1]]'
+               range_min_bytes = 134217728,
+               range_max_bytes = 536870912,
+               gc.ttlseconds = 14400,
+               num_replicas = 5,
+               num_voters = 3,
+               constraints = '{+region=us-east-1: 1}',
+               voter_constraints = '[+region=us-east-1]',
+               lease_preferences = '[[+region=us-east-1]]'
 
 statement ok
 SELECT crdb_internal.reset_multi_region_zone_configs_for_table($tbl10_id)
@@ -1694,14 +1694,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE tbl10
 ----
 TABLE tbl10  ALTER TABLE tbl10 CONFIGURE ZONE USING
-             range_min_bytes = 134217728,
-             range_max_bytes = 536870912,
-             gc.ttlseconds = 90000,
-             num_replicas = 3,
-             num_voters = 3,
-             constraints = '{+region=us-east-1: 1}',
-             voter_constraints = '[+region=us-east-1]',
-             lease_preferences = '[[+region=us-east-1]]'
+               range_min_bytes = 134217728,
+               range_max_bytes = 536870912,
+               gc.ttlseconds = 14400,
+               num_replicas = 3,
+               num_voters = 3,
+               constraints = '{+region=us-east-1: 1}',
+               voter_constraints = '[+region=us-east-1]',
+               lease_preferences = '[[+region=us-east-1]]'
 
 # Ensure that built-in no-ops on non-multi-region tables.
 statement ok
@@ -1724,12 +1724,12 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE tbl11
 ----
 TABLE tbl11  ALTER TABLE tbl11 CONFIGURE ZONE USING
-             range_min_bytes = 134217728,
-             range_max_bytes = 536870912,
-             gc.ttlseconds = 90000,
-             num_replicas = 10,
-             constraints = '[]',
-             lease_preferences = '[]'
+               range_min_bytes = 134217728,
+               range_max_bytes = 536870912,
+               gc.ttlseconds = 14400,
+               num_replicas = 10,
+               constraints = '[]',
+               lease_preferences = '[]'
 
 let $tbl11_id
 select table_id from crdb_internal.tables where name = 'tbl11'
@@ -1741,12 +1741,12 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE tbl11
 ----
 TABLE tbl11  ALTER TABLE tbl11 CONFIGURE ZONE USING
-             range_min_bytes = 134217728,
-             range_max_bytes = 536870912,
-             gc.ttlseconds = 90000,
-             num_replicas = 10,
-             constraints = '[]',
-             lease_preferences = '[]'
+               range_min_bytes = 134217728,
+               range_max_bytes = 536870912,
+               gc.ttlseconds = 14400,
+               num_replicas = 10,
+               constraints = '[]',
+               lease_preferences = '[]'
 
 query error pq: crdb_internal\.reset_multi_region_zone_configs_for_table\(\): error resolving referenced table ID 1: relation "\[1\]" does not exist
 SELECT crdb_internal.reset_multi_region_zone_configs_for_table(1)
@@ -1762,15 +1762,15 @@ USE "rebuild_zc_db"
 query TT
 SHOW ZONE CONFIGURATION FOR DATABASE "rebuild_zc_db"
 ----
-DATABASE rebuild_zc_db ALTER DATABASE rebuild_zc_db CONFIGURE ZONE USING
- range_min_bytes = 134217728,
- range_max_bytes = 536870912,
- gc.ttlseconds = 90000,
- num_replicas = 5,
- num_voters = 3,
- constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
- voter_constraints = '[+region=ca-central-1]',
- lease_preferences = '[[+region=ca-central-1]]'
+DATABASE rebuild_zc_db  ALTER DATABASE rebuild_zc_db CONFIGURE ZONE USING
+                          range_min_bytes = 134217728,
+                          range_max_bytes = 536870912,
+                          gc.ttlseconds = 14400,
+                          num_replicas = 5,
+                          num_voters = 3,
+                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                          voter_constraints = '[+region=ca-central-1]',
+                          lease_preferences = '[[+region=ca-central-1]]'
 
 
 statement ok
@@ -1781,15 +1781,15 @@ SET override_multi_region_zone_config = false
 query TT
 SHOW ZONE CONFIGURATION FOR DATABASE "rebuild_zc_db"
 ----
-DATABASE rebuild_zc_db ALTER DATABASE rebuild_zc_db CONFIGURE ZONE USING
- range_min_bytes = 134217728,
- range_max_bytes = 536870912,
- gc.ttlseconds = 90000,
- num_replicas = 10,
- num_voters = 3,
- constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
- voter_constraints = '[+region=ca-central-1]',
- lease_preferences = '[[+region=ca-central-1]]'
+DATABASE rebuild_zc_db  ALTER DATABASE rebuild_zc_db CONFIGURE ZONE USING
+                          range_min_bytes = 134217728,
+                          range_max_bytes = 536870912,
+                          gc.ttlseconds = 14400,
+                          num_replicas = 10,
+                          num_voters = 3,
+                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                          voter_constraints = '[+region=ca-central-1]',
+                          lease_preferences = '[[+region=ca-central-1]]'
 
 let $rebuild_db_id
 select id from crdb_internal.databases where name = 'rebuild_zc_db'
@@ -1800,15 +1800,15 @@ SELECT crdb_internal.reset_multi_region_zone_configs_for_database($rebuild_db_id
 query TT
 SHOW ZONE CONFIGURATION FOR DATABASE "rebuild_zc_db"
 ----
-DATABASE rebuild_zc_db ALTER DATABASE rebuild_zc_db CONFIGURE ZONE USING
- range_min_bytes = 134217728,
- range_max_bytes = 536870912,
- gc.ttlseconds = 90000,
- num_replicas = 5,
- num_voters = 3,
- constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
- voter_constraints = '[+region=ca-central-1]',
- lease_preferences = '[[+region=ca-central-1]]'
+DATABASE rebuild_zc_db  ALTER DATABASE rebuild_zc_db CONFIGURE ZONE USING
+                          range_min_bytes = 134217728,
+                          range_max_bytes = 536870912,
+                          gc.ttlseconds = 14400,
+                          num_replicas = 5,
+                          num_voters = 3,
+                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                          voter_constraints = '[+region=ca-central-1]',
+                          lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 SELECT crdb_internal.validate_multi_region_zone_configs()
@@ -1821,13 +1821,13 @@ SET override_multi_region_zone_config = false
 query TT
 SHOW ZONE CONFIGURATION FOR DATABASE "rebuild_zc_db"
 ----
-RANGE default ALTER RANGE default CONFIGURE ZONE USING
- range_min_bytes = 134217728,
- range_max_bytes = 536870912,
- gc.ttlseconds = 90000,
- num_replicas = 3,
- constraints = '[]',
- lease_preferences = '[]'
+RANGE default  ALTER RANGE default CONFIGURE ZONE USING
+                 range_min_bytes = 134217728,
+                 range_max_bytes = 536870912,
+                 gc.ttlseconds = 14400,
+                 num_replicas = 3,
+                 constraints = '[]',
+                 lease_preferences = '[]'
 
 statement ok
 SELECT crdb_internal.reset_multi_region_zone_configs_for_database($rebuild_db_id)
@@ -1835,15 +1835,15 @@ SELECT crdb_internal.reset_multi_region_zone_configs_for_database($rebuild_db_id
 query TT
 SHOW ZONE CONFIGURATION FOR DATABASE "rebuild_zc_db"
 ----
-DATABASE rebuild_zc_db ALTER DATABASE rebuild_zc_db CONFIGURE ZONE USING
- range_min_bytes = 134217728,
- range_max_bytes = 536870912,
- gc.ttlseconds = 90000,
- num_replicas = 5,
- num_voters = 3,
- constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
- voter_constraints = '[+region=ca-central-1]',
- lease_preferences = '[[+region=ca-central-1]]'
+DATABASE rebuild_zc_db  ALTER DATABASE rebuild_zc_db CONFIGURE ZONE USING
+                          range_min_bytes = 134217728,
+                          range_max_bytes = 536870912,
+                          gc.ttlseconds = 14400,
+                          num_replicas = 5,
+                          num_voters = 3,
+                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                          voter_constraints = '[+region=ca-central-1]',
+                          lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 SELECT crdb_internal.validate_multi_region_zone_configs()

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs_long_regions
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_configs_long_regions
@@ -24,11 +24,11 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE "mr-zone-configs"
 ----
 DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING
-                            range_min_bytes = 134217728,
-                            range_max_bytes = 536870912,
-                            gc.ttlseconds = 90000,
-                            num_replicas = 5,
-                            num_voters = 3,
-                            constraints = '{+region=veryveryveryveryveryveryverylongregion1: 1, +region=veryveryveryveryveryveryverylongregion2: 1, +region=veryveryveryveryveryveryverylongregion3: 1}',
-                            voter_constraints = '[+region=veryveryveryveryveryveryverylongregion1]',
-                            lease_preferences = '[[+region=veryveryveryveryveryveryverylongregion1]]'
+                              range_min_bytes = 134217728,
+                              range_max_bytes = 536870912,
+                              gc.ttlseconds = 14400,
+                              num_replicas = 5,
+                              num_voters = 3,
+                              constraints = '{+region=veryveryveryveryveryveryverylongregion1: 1, +region=veryveryveryveryveryveryverylongregion2: 1, +region=veryveryveryveryveryveryverylongregion3: 1}',
+                              voter_constraints = '[+region=veryveryveryveryveryveryverylongregion1]',
+                              lease_preferences = '[[+region=veryveryveryveryveryveryverylongregion1]]'

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning
@@ -1000,31 +1000,31 @@ query TTTTTTTTT
 SHOW PARTITIONS FROM DATABASE d_show_partitions
 ----
 d_show_partitions  t  p1  NULL  x  t@t_pkey  (1)  NULL  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[]',
-lease_preferences = '[]'
+                                                        range_max_bytes = 536870912,
+                                                        gc.ttlseconds = 14400,
+                                                        num_replicas = 3,
+                                                        constraints = '[]',
+                                                        lease_preferences = '[]'
 
 query TTTTTTTTT
 SHOW PARTITIONS FROM TABLE d_show_partitions.t
 ----
 d_show_partitions  t  p1  NULL  x  t@t_pkey  (1)  NULL  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[]',
-lease_preferences = '[]'
+                                                        range_max_bytes = 536870912,
+                                                        gc.ttlseconds = 14400,
+                                                        num_replicas = 3,
+                                                        constraints = '[]',
+                                                        lease_preferences = '[]'
 
 query TTTTTTTTT
 SHOW PARTITIONS FROM INDEX d_show_partitions.t@t_pkey
 ----
 d_show_partitions  t  p1  NULL  x  t@t_pkey  (1)  NULL  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[]',
-lease_preferences = '[]'
+                                                        range_max_bytes = 536870912,
+                                                        gc.ttlseconds = 14400,
+                                                        num_replicas = 3,
+                                                        constraints = '[]',
+                                                        lease_preferences = '[]'
 
 statement ok
 CREATE DATABASE "show partitions"
@@ -1036,31 +1036,31 @@ query TTTTTTTTT
 SHOW PARTITIONS FROM DATABASE "show partitions"
 ----
 show partitions  t  p1  NULL  x  t@t_pkey  (1)  NULL  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[]',
-lease_preferences = '[]'
+                                                      range_max_bytes = 536870912,
+                                                      gc.ttlseconds = 14400,
+                                                      num_replicas = 3,
+                                                      constraints = '[]',
+                                                      lease_preferences = '[]'
 
 query TTTTTTTTT
 SHOW PARTITIONS FROM TABLE "show partitions".t
 ----
 show partitions  t  p1  NULL  x  t@t_pkey  (1)  NULL  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[]',
-lease_preferences = '[]'
+                                                      range_max_bytes = 536870912,
+                                                      gc.ttlseconds = 14400,
+                                                      num_replicas = 3,
+                                                      constraints = '[]',
+                                                      lease_preferences = '[]'
 
 query TTTTTTTTT
 SHOW PARTITIONS FROM INDEX "show partitions".t@t_pkey
 ----
 show partitions  t  p1  NULL  x  t@t_pkey  (1)  NULL  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[]',
-lease_preferences = '[]'
+                                                      range_max_bytes = 536870912,
+                                                      gc.ttlseconds = 14400,
+                                                      num_replicas = 3,
+                                                      constraints = '[]',
+                                                      lease_preferences = '[]'
 
 statement ok
 CREATE DATABASE """"
@@ -1072,31 +1072,31 @@ query TTTTTTTTT
 SHOW PARTITIONS FROM DATABASE """"
 ----
 "  t  p1  NULL  x  t@t_pkey  (1)  NULL  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[]',
-lease_preferences = '[]'
+                                        range_max_bytes = 536870912,
+                                        gc.ttlseconds = 14400,
+                                        num_replicas = 3,
+                                        constraints = '[]',
+                                        lease_preferences = '[]'
 
 query TTTTTTTTT
 SHOW PARTITIONS FROM TABLE """".t
 ----
 "  t  p1  NULL  x  t@t_pkey  (1)  NULL  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[]',
-lease_preferences = '[]'
+                                        range_max_bytes = 536870912,
+                                        gc.ttlseconds = 14400,
+                                        num_replicas = 3,
+                                        constraints = '[]',
+                                        lease_preferences = '[]'
 
 query TTTTTTTTT
 SHOW PARTITIONS FROM INDEX """".t@t_pkey
 ----
 "  t  p1  NULL  x  t@t_pkey  (1)  NULL  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[]',
-lease_preferences = '[]'
+                                        range_max_bytes = 536870912,
+                                        gc.ttlseconds = 14400,
+                                        num_replicas = 3,
+                                        constraints = '[]',
+                                        lease_preferences = '[]'
 
 query T
 SELECT feature_name FROM crdb_internal.feature_usage WHERE feature_name='sql.show.partitions' AND usage_count > 0
@@ -1114,11 +1114,11 @@ query TTTTTTTTT
 SHOW PARTITIONS FROM TABLE t_inherit
 ----
 test  t_inherit  p1  NULL  x  t_inherit@t_inherit_pkey  (1)  NULL  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[]',
-lease_preferences = '[]'
+                                                                   range_max_bytes = 536870912,
+                                                                   gc.ttlseconds = 14400,
+                                                                   num_replicas = 3,
+                                                                   constraints = '[]',
+                                                                   lease_preferences = '[]'
 
 statement ok
 ALTER PARTITION p1 of TABLE t_inherit CONFIGURE ZONE USING num_replicas=5
@@ -1127,11 +1127,11 @@ query TTTTTTTTT
 SHOW PARTITIONS FROM TABLE t_inherit
 ----
 test  t_inherit  p1  NULL  x  t_inherit@t_inherit_pkey  (1)  num_replicas = 5  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 5,
-constraints = '[]',
-lease_preferences = '[]'
+                                                                               range_max_bytes = 536870912,
+                                                                               gc.ttlseconds = 14400,
+                                                                               num_replicas = 5,
+                                                                               constraints = '[]',
+                                                                               lease_preferences = '[]'
 
 statement ok
 CREATE TABLE t_inherit_range (x INT PRIMARY KEY)
@@ -1143,11 +1143,11 @@ query TTTTTTTTT
 SHOW PARTITIONS FROM TABLE t_inherit_range
 ----
 test  t_inherit_range  p1  NULL  x  t_inherit_range@t_inherit_range_pkey  (1) TO (2)  NULL  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-constraints = '[]',
-lease_preferences = '[]'
+                                                                                            range_max_bytes = 536870912,
+                                                                                            gc.ttlseconds = 14400,
+                                                                                            num_replicas = 3,
+                                                                                            constraints = '[]',
+                                                                                            lease_preferences = '[]'
 
 statement ok
 ALTER PARTITION p1 of TABLE t_inherit_range CONFIGURE ZONE USING num_replicas=5
@@ -1156,11 +1156,11 @@ query TTTTTTTTT
 SHOW PARTITIONS FROM TABLE t_inherit_range
 ----
 test  t_inherit_range  p1  NULL  x  t_inherit_range@t_inherit_range_pkey  (1) TO (2)  num_replicas = 5  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 5,
-constraints = '[]',
-lease_preferences = '[]'
+                                                                                                        range_max_bytes = 536870912,
+                                                                                                        gc.ttlseconds = 14400,
+                                                                                                        num_replicas = 5,
+                                                                                                        constraints = '[]',
+                                                                                                        lease_preferences = '[]'
 
 statement ok
 CREATE TABLE partition_by_nothing (

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -132,14 +132,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_table_explicit_crdb_region_column
 ----
 DATABASE multi_region_test_db  ALTER DATABASE multi_region_test_db CONFIGURE ZONE USING
-                               range_min_bytes = 134217728,
-                               range_max_bytes = 536870912,
-                               gc.ttlseconds = 90000,
-                               num_replicas = 5,
-                               num_voters = 5,
-                               constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                               voter_constraints = '{+region=ca-central-1: 2}',
-                               lease_preferences = '[[+region=ca-central-1]]'
+                                 range_min_bytes = 134217728,
+                                 range_max_bytes = 536870912,
+                                 gc.ttlseconds = 14400,
+                                 num_replicas = 5,
+                                 num_voters = 5,
+                                 constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                 voter_constraints = '{+region=ca-central-1: 2}',
+                                 lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 CREATE TABLE regional_by_row_table (
@@ -236,14 +236,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_table
 ----
 DATABASE multi_region_test_db  ALTER DATABASE multi_region_test_db CONFIGURE ZONE USING
-                               range_min_bytes = 134217728,
-                               range_max_bytes = 536870912,
-                               gc.ttlseconds = 90000,
-                               num_replicas = 5,
-                               num_voters = 5,
-                               constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                               voter_constraints = '{+region=ca-central-1: 2}',
-                               lease_preferences = '[[+region=ca-central-1]]'
+                                 range_min_bytes = 134217728,
+                                 range_max_bytes = 536870912,
+                                 gc.ttlseconds = 14400,
+                                 num_replicas = 5,
+                                 num_voters = 5,
+                                 constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                 voter_constraints = '{+region=ca-central-1: 2}',
+                                 lease_preferences = '[[+region=ca-central-1]]'
 
 query TTB colnames
 SELECT index_name, column_name, implicit FROM crdb_internal.index_columns
@@ -545,22 +545,9 @@ query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "ap-southeast-2" OF INDEX regional_by_row_table@regional_by_row_table_pkey
 ----
 PARTITION "ap-southeast-2" OF INDEX regional_by_row_table@regional_by_row_table_pkey  ALTER PARTITION "ap-southeast-2" OF INDEX regional_by_row_table@regional_by_row_table_pkey CONFIGURE ZONE USING
-                                                                                      range_min_bytes = 134217728,
-                                                                                      range_max_bytes = 536870912,
-                                                                                      gc.ttlseconds = 90000,
-                                                                                      num_replicas = 5,
-                                                                                      num_voters = 5,
-                                                                                      constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                                                                      voter_constraints = '{+region=ap-southeast-2: 2}',
-                                                                                      lease_preferences = '[[+region=ap-southeast-2]]'
-
-query TT
-SHOW ZONE CONFIGURATION FOR PARTITION "ap-southeast-2" OF INDEX regional_by_row_table@regional_by_row_table_pk_key
-----
-PARTITION "ap-southeast-2" OF INDEX regional_by_row_table@regional_by_row_table_pk_key  ALTER PARTITION "ap-southeast-2" OF INDEX regional_by_row_table@regional_by_row_table_pk_key CONFIGURE ZONE USING
                                                                                         range_min_bytes = 134217728,
                                                                                         range_max_bytes = 536870912,
-                                                                                        gc.ttlseconds = 90000,
+                                                                                        gc.ttlseconds = 14400,
                                                                                         num_replicas = 5,
                                                                                         num_voters = 5,
                                                                                         constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
@@ -568,17 +555,30 @@ PARTITION "ap-southeast-2" OF INDEX regional_by_row_table@regional_by_row_table_
                                                                                         lease_preferences = '[[+region=ap-southeast-2]]'
 
 query TT
+SHOW ZONE CONFIGURATION FOR PARTITION "ap-southeast-2" OF INDEX regional_by_row_table@regional_by_row_table_pk_key
+----
+PARTITION "ap-southeast-2" OF INDEX regional_by_row_table@regional_by_row_table_pk_key  ALTER PARTITION "ap-southeast-2" OF INDEX regional_by_row_table@regional_by_row_table_pk_key CONFIGURE ZONE USING
+                                                                                          range_min_bytes = 134217728,
+                                                                                          range_max_bytes = 536870912,
+                                                                                          gc.ttlseconds = 14400,
+                                                                                          num_replicas = 5,
+                                                                                          num_voters = 5,
+                                                                                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                                                          voter_constraints = '{+region=ap-southeast-2: 2}',
+                                                                                          lease_preferences = '[[+region=ap-southeast-2]]'
+
+query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "ap-southeast-2" OF INDEX regional_by_row_table@unique_b_a
 ----
 PARTITION "ap-southeast-2" OF INDEX regional_by_row_table@unique_b_a  ALTER PARTITION "ap-southeast-2" OF INDEX regional_by_row_table@unique_b_a CONFIGURE ZONE USING
-                                                                      range_min_bytes = 134217728,
-                                                                      range_max_bytes = 536870912,
-                                                                      gc.ttlseconds = 90000,
-                                                                      num_replicas = 5,
-                                                                      num_voters = 5,
-                                                                      constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                                                      voter_constraints = '{+region=ap-southeast-2: 2}',
-                                                                      lease_preferences = '[[+region=ap-southeast-2]]'
+                                                                        range_min_bytes = 134217728,
+                                                                        range_max_bytes = 536870912,
+                                                                        gc.ttlseconds = 14400,
+                                                                        num_replicas = 5,
+                                                                        num_voters = 5,
+                                                                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                                        voter_constraints = '{+region=ap-southeast-2: 2}',
+                                                                        lease_preferences = '[[+region=ap-southeast-2]]'
 
 statement ok
 CREATE TABLE regional_by_row_table_pk_defined_separately (
@@ -673,14 +673,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_table_as
 ----
 DATABASE multi_region_test_db  ALTER DATABASE multi_region_test_db CONFIGURE ZONE USING
-                               range_min_bytes = 134217728,
-                               range_max_bytes = 536870912,
-                               gc.ttlseconds = 90000,
-                               num_replicas = 5,
-                               num_voters = 5,
-                               constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                               voter_constraints = '{+region=ca-central-1: 2}',
-                               lease_preferences = '[[+region=ca-central-1]]'
+                                 range_min_bytes = 134217728,
+                                 range_max_bytes = 536870912,
+                                 gc.ttlseconds = 14400,
+                                 num_replicas = 5,
+                                 num_voters = 5,
+                                 constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                 voter_constraints = '{+region=ca-central-1: 2}',
+                                 lease_preferences = '[[+region=ca-central-1]]'
 
 query TI
 INSERT INTO regional_by_row_table_as (pk) VALUES (1), (10), (20)
@@ -717,14 +717,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE t_regional_by_row PARTITION "us-east-1"
 ----
 PARTITION "us-east-1" OF TABLE t_regional_by_row  ALTER PARTITION "us-east-1" OF TABLE t_regional_by_row CONFIGURE ZONE USING
-                                                  range_min_bytes = 134217728,
-                                                  range_max_bytes = 536870912,
-                                                  gc.ttlseconds = 90000,
-                                                  num_replicas = 5,
-                                                  num_voters = 5,
-                                                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                                  voter_constraints = '{+region=us-east-1: 2}',
-                                                  lease_preferences = '[[+region=us-east-1]]'
+                                                    range_min_bytes = 134217728,
+                                                    range_max_bytes = 536870912,
+                                                    gc.ttlseconds = 14400,
+                                                    num_replicas = 5,
+                                                    num_voters = 5,
+                                                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                    voter_constraints = '{+region=us-east-1: 2}',
+                                                    lease_preferences = '[[+region=us-east-1]]'
 
 query TTT
 SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE t_regional_by_row]
@@ -758,14 +758,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE t_regional_by_row
 ----
 DATABASE alter_survive_db  ALTER DATABASE alter_survive_db CONFIGURE ZONE USING
-                           range_min_bytes = 134217728,
-                           range_max_bytes = 536870912,
-                           gc.ttlseconds = 90000,
-                           num_replicas = 5,
-                           num_voters = 5,
-                           constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                           voter_constraints = '{+region=us-east-1: 2}',
-                           lease_preferences = '[[+region=us-east-1]]'
+                             range_min_bytes = 134217728,
+                             range_max_bytes = 536870912,
+                             gc.ttlseconds = 14400,
+                             num_replicas = 5,
+                             num_voters = 5,
+                             constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                             voter_constraints = '{+region=us-east-1: 2}',
+                             lease_preferences = '[[+region=us-east-1]]'
 
 statement ok
 ALTER DATABASE alter_survive_db SURVIVE ZONE FAILURE
@@ -774,14 +774,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE t_regional_by_row PARTITION "us-east-1"
 ----
 PARTITION "us-east-1" OF TABLE t_regional_by_row  ALTER PARTITION "us-east-1" OF TABLE t_regional_by_row CONFIGURE ZONE USING
-                                                  range_min_bytes = 134217728,
-                                                  range_max_bytes = 536870912,
-                                                  gc.ttlseconds = 90000,
-                                                  num_replicas = 5,
-                                                  num_voters = 3,
-                                                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                                  voter_constraints = '[+region=us-east-1]',
-                                                  lease_preferences = '[[+region=us-east-1]]'
+                                                    range_min_bytes = 134217728,
+                                                    range_max_bytes = 536870912,
+                                                    gc.ttlseconds = 14400,
+                                                    num_replicas = 5,
+                                                    num_voters = 3,
+                                                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                    voter_constraints = '[+region=us-east-1]',
+                                                    lease_preferences = '[[+region=us-east-1]]'
 
 # Test setting non-multi-region fields on tables behaves as appropriate.
 statement ok
@@ -924,14 +924,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row
 ----
 DATABASE add_regions  ALTER DATABASE add_regions CONFIGURE ZONE USING
-                      range_min_bytes = 134217728,
-                      range_max_bytes = 536870912,
-                      gc.ttlseconds = 90000,
-                      num_replicas = 3,
-                      num_voters = 3,
-                      constraints = '{+region=ca-central-1: 1}',
-                      voter_constraints = '[+region=ca-central-1]',
-                      lease_preferences = '[[+region=ca-central-1]]'
+                        range_min_bytes = 134217728,
+                        range_max_bytes = 536870912,
+                        gc.ttlseconds = 14400,
+                        num_replicas = 3,
+                        num_voters = 3,
+                        constraints = '{+region=ca-central-1: 1}',
+                        voter_constraints = '[+region=ca-central-1]',
+                        lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW CREATE TABLE regional_by_row_as
@@ -960,14 +960,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_as
 ----
 DATABASE add_regions  ALTER DATABASE add_regions CONFIGURE ZONE USING
-                      range_min_bytes = 134217728,
-                      range_max_bytes = 536870912,
-                      gc.ttlseconds = 90000,
-                      num_replicas = 3,
-                      num_voters = 3,
-                      constraints = '{+region=ca-central-1: 1}',
-                      voter_constraints = '[+region=ca-central-1]',
-                      lease_preferences = '[[+region=ca-central-1]]'
+                        range_min_bytes = 134217728,
+                        range_max_bytes = 536870912,
+                        gc.ttlseconds = 14400,
+                        num_replicas = 3,
+                        num_voters = 3,
+                        constraints = '{+region=ca-central-1: 1}',
+                        voter_constraints = '[+region=ca-central-1]',
+                        lease_preferences = '[[+region=ca-central-1]]'
 
 # Next, add a region. We expect this thing to succeed and add a partition +
 # zone config corresponding to the regions to both the regional by row tables.
@@ -1010,14 +1010,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row
 ----
 DATABASE add_regions  ALTER DATABASE add_regions CONFIGURE ZONE USING
-                      range_min_bytes = 134217728,
-                      range_max_bytes = 536870912,
-                      gc.ttlseconds = 90000,
-                      num_replicas = 4,
-                      num_voters = 3,
-                      constraints = '{+region=ca-central-1: 1, +region=us-east-1: 1}',
-                      voter_constraints = '[+region=ca-central-1]',
-                      lease_preferences = '[[+region=ca-central-1]]'
+                        range_min_bytes = 134217728,
+                        range_max_bytes = 536870912,
+                        gc.ttlseconds = 14400,
+                        num_replicas = 4,
+                        num_voters = 3,
+                        constraints = '{+region=ca-central-1: 1, +region=us-east-1: 1}',
+                        voter_constraints = '[+region=ca-central-1]',
+                        lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW CREATE TABLE regional_by_row_as
@@ -1053,14 +1053,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_as
 ----
 DATABASE add_regions  ALTER DATABASE add_regions CONFIGURE ZONE USING
-                      range_min_bytes = 134217728,
-                      range_max_bytes = 536870912,
-                      gc.ttlseconds = 90000,
-                      num_replicas = 4,
-                      num_voters = 3,
-                      constraints = '{+region=ca-central-1: 1, +region=us-east-1: 1}',
-                      voter_constraints = '[+region=ca-central-1]',
-                      lease_preferences = '[[+region=ca-central-1]]'
+                        range_min_bytes = 134217728,
+                        range_max_bytes = 536870912,
+                        gc.ttlseconds = 14400,
+                        num_replicas = 4,
+                        num_voters = 3,
+                        constraints = '{+region=ca-central-1: 1, +region=us-east-1: 1}',
+                        voter_constraints = '[+region=ca-central-1]',
+                        lease_preferences = '[[+region=ca-central-1]]'
 
 # Do the same thing as above, except with a different region.
 statement ok
@@ -1106,14 +1106,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row
 ----
 DATABASE add_regions  ALTER DATABASE add_regions CONFIGURE ZONE USING
-                      range_min_bytes = 134217728,
-                      range_max_bytes = 536870912,
-                      gc.ttlseconds = 90000,
-                      num_replicas = 5,
-                      num_voters = 3,
-                      constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                      voter_constraints = '[+region=ca-central-1]',
-                      lease_preferences = '[[+region=ca-central-1]]'
+                        range_min_bytes = 134217728,
+                        range_max_bytes = 536870912,
+                        gc.ttlseconds = 14400,
+                        num_replicas = 5,
+                        num_voters = 3,
+                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                        voter_constraints = '[+region=ca-central-1]',
+                        lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW CREATE TABLE regional_by_row_as
@@ -1154,14 +1154,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_as
 ----
 DATABASE add_regions  ALTER DATABASE add_regions CONFIGURE ZONE USING
-                      range_min_bytes = 134217728,
-                      range_max_bytes = 536870912,
-                      gc.ttlseconds = 90000,
-                      num_replicas = 5,
-                      num_voters = 3,
-                      constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                      voter_constraints = '[+region=ca-central-1]',
-                      lease_preferences = '[[+region=ca-central-1]]'
+                        range_min_bytes = 134217728,
+                        range_max_bytes = 536870912,
+                        gc.ttlseconds = 14400,
+                        num_replicas = 5,
+                        num_voters = 3,
+                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                        voter_constraints = '[+region=ca-central-1]',
+                        lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 CREATE DATABASE add_regions_in_txn WITH PRIMARY REGION "ca-central-1";
@@ -1232,14 +1232,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row
 ----
 DATABASE add_regions_in_txn  ALTER DATABASE add_regions_in_txn CONFIGURE ZONE USING
-                             range_min_bytes = 134217728,
-                             range_max_bytes = 536870912,
-                             gc.ttlseconds = 90000,
-                             num_replicas = 5,
-                             num_voters = 3,
-                             constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                             voter_constraints = '[+region=ca-central-1]',
-                             lease_preferences = '[[+region=ca-central-1]]'
+                               range_min_bytes = 134217728,
+                               range_max_bytes = 536870912,
+                               gc.ttlseconds = 14400,
+                               num_replicas = 5,
+                               num_voters = 3,
+                               constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                               voter_constraints = '[+region=ca-central-1]',
+                               lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 CREATE TABLE regional_by_row_like (LIKE regional_by_row)
@@ -1332,14 +1332,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_as
 ----
 DATABASE add_regions_in_txn  ALTER DATABASE add_regions_in_txn CONFIGURE ZONE USING
-                             range_min_bytes = 134217728,
-                             range_max_bytes = 536870912,
-                             gc.ttlseconds = 90000,
-                             num_replicas = 5,
-                             num_voters = 3,
-                             constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                             voter_constraints = '[+region=ca-central-1]',
-                             lease_preferences = '[[+region=ca-central-1]]'
+                               range_min_bytes = 134217728,
+                               range_max_bytes = 536870912,
+                               gc.ttlseconds = 14400,
+                               num_replicas = 5,
+                               num_voters = 3,
+                               constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                               voter_constraints = '[+region=ca-central-1]',
+                               lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 CREATE TABLE regional_by_row_unique_in_column (
@@ -1445,14 +1445,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row
 ----
 DATABASE drop_regions  ALTER DATABASE drop_regions CONFIGURE ZONE USING
-                       range_min_bytes = 134217728,
-                       range_max_bytes = 536870912,
-                       gc.ttlseconds = 90000,
-                       num_replicas = 4,
-                       num_voters = 3,
-                       constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1}',
-                       voter_constraints = '[+region=ca-central-1]',
-                       lease_preferences = '[[+region=ca-central-1]]'
+                         range_min_bytes = 134217728,
+                         range_max_bytes = 536870912,
+                         gc.ttlseconds = 14400,
+                         num_replicas = 4,
+                         num_voters = 3,
+                         constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1}',
+                         voter_constraints = '[+region=ca-central-1]',
+                         lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW CREATE TABLE regional_by_row
@@ -1487,14 +1487,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_as
 ----
 DATABASE drop_regions  ALTER DATABASE drop_regions CONFIGURE ZONE USING
-                       range_min_bytes = 134217728,
-                       range_max_bytes = 536870912,
-                       gc.ttlseconds = 90000,
-                       num_replicas = 4,
-                       num_voters = 3,
-                       constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1}',
-                       voter_constraints = '[+region=ca-central-1]',
-                       lease_preferences = '[[+region=ca-central-1]]'
+                         range_min_bytes = 134217728,
+                         range_max_bytes = 536870912,
+                         gc.ttlseconds = 14400,
+                         num_replicas = 4,
+                         num_voters = 3,
+                         constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1}',
+                         voter_constraints = '[+region=ca-central-1]',
+                         lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW CREATE TABLE regional_by_row_as
@@ -1536,14 +1536,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row
 ----
 DATABASE drop_regions  ALTER DATABASE drop_regions CONFIGURE ZONE USING
-                       range_min_bytes = 134217728,
-                       range_max_bytes = 536870912,
-                       gc.ttlseconds = 90000,
-                       num_replicas = 4,
-                       num_voters = 3,
-                       constraints = '{+region=ca-central-1: 1, +region=us-east-1: 1}',
-                       voter_constraints = '[+region=ca-central-1]',
-                       lease_preferences = '[[+region=ca-central-1]]'
+                         range_min_bytes = 134217728,
+                         range_max_bytes = 536870912,
+                         gc.ttlseconds = 14400,
+                         num_replicas = 4,
+                         num_voters = 3,
+                         constraints = '{+region=ca-central-1: 1, +region=us-east-1: 1}',
+                         voter_constraints = '[+region=ca-central-1]',
+                         lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW CREATE TABLE regional_by_row
@@ -1578,14 +1578,14 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_as
 ----
 DATABASE drop_regions  ALTER DATABASE drop_regions CONFIGURE ZONE USING
-                       range_min_bytes = 134217728,
-                       range_max_bytes = 536870912,
-                       gc.ttlseconds = 90000,
-                       num_replicas = 4,
-                       num_voters = 3,
-                       constraints = '{+region=ca-central-1: 1, +region=us-east-1: 1}',
-                       voter_constraints = '[+region=ca-central-1]',
-                       lease_preferences = '[[+region=ca-central-1]]'
+                         range_min_bytes = 134217728,
+                         range_max_bytes = 536870912,
+                         gc.ttlseconds = 14400,
+                         num_replicas = 4,
+                         num_voters = 3,
+                         constraints = '{+region=ca-central-1: 1, +region=us-east-1: 1}',
+                         voter_constraints = '[+region=ca-central-1]',
+                         lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW CREATE TABLE regional_by_row_as
@@ -1618,27 +1618,27 @@ query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row
 ----
 DATABASE drop_regions  ALTER DATABASE drop_regions CONFIGURE ZONE USING
-                       range_min_bytes = 134217728,
-                       range_max_bytes = 536870912,
-                       gc.ttlseconds = 90000,
-                       num_replicas = 3,
-                       num_voters = 3,
-                       constraints = '{+region=ca-central-1: 1}',
-                       voter_constraints = '[+region=ca-central-1]',
-                       lease_preferences = '[[+region=ca-central-1]]'
+                         range_min_bytes = 134217728,
+                         range_max_bytes = 536870912,
+                         gc.ttlseconds = 14400,
+                         num_replicas = 3,
+                         num_voters = 3,
+                         constraints = '{+region=ca-central-1: 1}',
+                         voter_constraints = '[+region=ca-central-1]',
+                         lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_as
 ----
 DATABASE drop_regions  ALTER DATABASE drop_regions CONFIGURE ZONE USING
-                       range_min_bytes = 134217728,
-                       range_max_bytes = 536870912,
-                       gc.ttlseconds = 90000,
-                       num_replicas = 3,
-                       num_voters = 3,
-                       constraints = '{+region=ca-central-1: 1}',
-                       voter_constraints = '[+region=ca-central-1]',
-                       lease_preferences = '[[+region=ca-central-1]]'
+                         range_min_bytes = 134217728,
+                         range_max_bytes = 536870912,
+                         gc.ttlseconds = 14400,
+                         num_replicas = 3,
+                         num_voters = 3,
+                         constraints = '{+region=ca-central-1: 1}',
+                         voter_constraints = '[+region=ca-central-1]',
+                         lease_preferences = '[[+region=ca-central-1]]'
 
 query TTT
 SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row_as]

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_placement_restricted
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_placement_restricted
@@ -18,29 +18,29 @@ SELECT partition_name, full_zone_config FROM [SHOW PARTITIONS FROM TABLE test]
 ORDER BY partition_name
 ----
 ap-southeast-2  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 5,
-num_voters = 3,
-constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-voter_constraints = '[+region=ap-southeast-2]',
-lease_preferences = '[[+region=ap-southeast-2]]'
-ca-central-1                                      range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 5,
-num_voters = 3,
-constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-voter_constraints = '[+region=ca-central-1]',
-lease_preferences = '[[+region=ca-central-1]]'
-us-east-1                                       range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 5,
-num_voters = 3,
-constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-voter_constraints = '[+region=us-east-1]',
-lease_preferences = '[[+region=us-east-1]]'
+                range_max_bytes = 536870912,
+                gc.ttlseconds = 14400,
+                num_replicas = 5,
+                num_voters = 3,
+                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                voter_constraints = '[+region=ap-southeast-2]',
+                lease_preferences = '[[+region=ap-southeast-2]]'
+ca-central-1    range_min_bytes = 134217728,
+                range_max_bytes = 536870912,
+                gc.ttlseconds = 14400,
+                num_replicas = 5,
+                num_voters = 3,
+                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                voter_constraints = '[+region=ca-central-1]',
+                lease_preferences = '[[+region=ca-central-1]]'
+us-east-1       range_min_bytes = 134217728,
+                range_max_bytes = 536870912,
+                gc.ttlseconds = 14400,
+                num_replicas = 5,
+                num_voters = 3,
+                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                voter_constraints = '[+region=us-east-1]',
+                lease_preferences = '[[+region=us-east-1]]'
 
 # Alter to RESTRICTED and see that we have no non-voter constraints.
 statement ok
@@ -51,29 +51,29 @@ SELECT partition_name, full_zone_config FROM [SHOW PARTITIONS FROM TABLE test]
 ORDER BY partition_name
 ----
 ap-southeast-2  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-num_voters = 3,
-constraints = '[]',
-voter_constraints = '[+region=ap-southeast-2]',
-lease_preferences = '[[+region=ap-southeast-2]]'
-ca-central-1                                      range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-num_voters = 3,
-constraints = '[]',
-voter_constraints = '[+region=ca-central-1]',
-lease_preferences = '[[+region=ca-central-1]]'
-us-east-1                                       range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-num_voters = 3,
-constraints = '[]',
-voter_constraints = '[+region=us-east-1]',
-lease_preferences = '[[+region=us-east-1]]'
+                range_max_bytes = 536870912,
+                gc.ttlseconds = 14400,
+                num_replicas = 3,
+                num_voters = 3,
+                constraints = '[]',
+                voter_constraints = '[+region=ap-southeast-2]',
+                lease_preferences = '[[+region=ap-southeast-2]]'
+ca-central-1    range_min_bytes = 134217728,
+                range_max_bytes = 536870912,
+                gc.ttlseconds = 14400,
+                num_replicas = 3,
+                num_voters = 3,
+                constraints = '[]',
+                voter_constraints = '[+region=ca-central-1]',
+                lease_preferences = '[[+region=ca-central-1]]'
+us-east-1       range_min_bytes = 134217728,
+                range_max_bytes = 536870912,
+                gc.ttlseconds = 14400,
+                num_replicas = 3,
+                num_voters = 3,
+                constraints = '[]',
+                voter_constraints = '[+region=us-east-1]',
+                lease_preferences = '[[+region=us-east-1]]'
 
 # Make sure placement restricted doesn't invalidate zone configs.
 statement ok
@@ -87,21 +87,21 @@ SELECT partition_name, full_zone_config FROM [SHOW PARTITIONS FROM TABLE test]
 ORDER BY partition_name
 ----
 ap-southeast-2  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-num_voters = 3,
-constraints = '[]',
-voter_constraints = '[+region=ap-southeast-2]',
-lease_preferences = '[[+region=ap-southeast-2]]'
-ca-central-1                                      range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-num_voters = 3,
-constraints = '[]',
-voter_constraints = '[+region=ca-central-1]',
-lease_preferences = '[[+region=ca-central-1]]'
+                range_max_bytes = 536870912,
+                gc.ttlseconds = 14400,
+                num_replicas = 3,
+                num_voters = 3,
+                constraints = '[]',
+                voter_constraints = '[+region=ap-southeast-2]',
+                lease_preferences = '[[+region=ap-southeast-2]]'
+ca-central-1    range_min_bytes = 134217728,
+                range_max_bytes = 536870912,
+                gc.ttlseconds = 14400,
+                num_replicas = 3,
+                num_voters = 3,
+                constraints = '[]',
+                voter_constraints = '[+region=ca-central-1]',
+                lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 ALTER DATABASE testdb ADD REGION "us-east-1"
@@ -111,29 +111,29 @@ SELECT partition_name, full_zone_config FROM [SHOW PARTITIONS FROM TABLE test]
 ORDER BY partition_name
 ----
 ap-southeast-2  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-num_voters = 3,
-constraints = '[]',
-voter_constraints = '[+region=ap-southeast-2]',
-lease_preferences = '[[+region=ap-southeast-2]]'
-ca-central-1                                      range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-num_voters = 3,
-constraints = '[]',
-voter_constraints = '[+region=ca-central-1]',
-lease_preferences = '[[+region=ca-central-1]]'
-us-east-1                                       range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 3,
-num_voters = 3,
-constraints = '[]',
-voter_constraints = '[+region=us-east-1]',
-lease_preferences = '[[+region=us-east-1]]'
+                range_max_bytes = 536870912,
+                gc.ttlseconds = 14400,
+                num_replicas = 3,
+                num_voters = 3,
+                constraints = '[]',
+                voter_constraints = '[+region=ap-southeast-2]',
+                lease_preferences = '[[+region=ap-southeast-2]]'
+ca-central-1    range_min_bytes = 134217728,
+                range_max_bytes = 536870912,
+                gc.ttlseconds = 14400,
+                num_replicas = 3,
+                num_voters = 3,
+                constraints = '[]',
+                voter_constraints = '[+region=ca-central-1]',
+                lease_preferences = '[[+region=ca-central-1]]'
+us-east-1       range_min_bytes = 134217728,
+                range_max_bytes = 536870912,
+                gc.ttlseconds = 14400,
+                num_replicas = 3,
+                num_voters = 3,
+                constraints = '[]',
+                voter_constraints = '[+region=us-east-1]',
+                lease_preferences = '[[+region=us-east-1]]'
 
 # Alter to DEFAULT and see that our constraints are back.
 statement ok
@@ -149,26 +149,26 @@ SELECT partition_name, full_zone_config FROM [SHOW PARTITIONS FROM TABLE test]
 ORDER BY partition_name
 ----
 ap-southeast-2  range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 5,
-num_voters = 3,
-constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-voter_constraints = '[+region=ap-southeast-2]',
-lease_preferences = '[[+region=ap-southeast-2]]'
-ca-central-1                                      range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 5,
-num_voters = 3,
-constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-voter_constraints = '[+region=ca-central-1]',
-lease_preferences = '[[+region=ca-central-1]]'
-us-east-1                                       range_min_bytes = 134217728,
-range_max_bytes = 536870912,
-gc.ttlseconds = 90000,
-num_replicas = 5,
-num_voters = 3,
-constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-voter_constraints = '[+region=us-east-1]',
-lease_preferences = '[[+region=us-east-1]]'
+                range_max_bytes = 536870912,
+                gc.ttlseconds = 14400,
+                num_replicas = 5,
+                num_voters = 3,
+                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                voter_constraints = '[+region=ap-southeast-2]',
+                lease_preferences = '[[+region=ap-southeast-2]]'
+ca-central-1    range_min_bytes = 134217728,
+                range_max_bytes = 536870912,
+                gc.ttlseconds = 14400,
+                num_replicas = 5,
+                num_voters = 3,
+                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                voter_constraints = '[+region=ca-central-1]',
+                lease_preferences = '[[+region=ca-central-1]]'
+us-east-1       range_min_bytes = 134217728,
+                range_max_bytes = 536870912,
+                gc.ttlseconds = 14400,
+                num_replicas = 5,
+                num_voters = 3,
+                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                voter_constraints = '[+region=us-east-1]',
+                lease_preferences = '[[+region=us-east-1]]'

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_table_placement_restricted
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_table_placement_restricted
@@ -20,27 +20,27 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE test
 ----
 DATABASE testdb  ALTER DATABASE testdb CONFIGURE ZONE USING
-                 range_min_bytes = 134217728,
-                 range_max_bytes = 536870912,
-                 gc.ttlseconds = 90000,
-                 num_replicas = 5,
-                 num_voters = 3,
-                 constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                 voter_constraints = '[+region=ca-central-1]',
-                 lease_preferences = '[[+region=ca-central-1]]'
+                   range_min_bytes = 134217728,
+                   range_max_bytes = 536870912,
+                   gc.ttlseconds = 14400,
+                   num_replicas = 5,
+                   num_voters = 3,
+                   constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                   voter_constraints = '[+region=ca-central-1]',
+                   lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE test_explicit_region
 ----
 TABLE test_explicit_region  ALTER TABLE test_explicit_region CONFIGURE ZONE USING
-                            range_min_bytes = 134217728,
-                            range_max_bytes = 536870912,
-                            gc.ttlseconds = 90000,
-                            num_replicas = 5,
-                            num_voters = 3,
-                            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                            voter_constraints = '[+region=ap-southeast-2]',
-                            lease_preferences = '[[+region=ap-southeast-2]]'
+                              range_min_bytes = 134217728,
+                              range_max_bytes = 536870912,
+                              gc.ttlseconds = 14400,
+                              num_replicas = 5,
+                              num_voters = 3,
+                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              voter_constraints = '[+region=ap-southeast-2]',
+                              lease_preferences = '[[+region=ap-southeast-2]]'
 
 # Alter to RESTRICTED and see that we have no non-voter constraints.
 statement ok
@@ -50,27 +50,27 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE test
 ----
 DATABASE testdb  ALTER DATABASE testdb CONFIGURE ZONE USING
-                 range_min_bytes = 134217728,
-                 range_max_bytes = 536870912,
-                 gc.ttlseconds = 90000,
-                 num_replicas = 3,
-                 num_voters = 3,
-                 constraints = '[]',
-                 voter_constraints = '[+region=ca-central-1]',
-                 lease_preferences = '[[+region=ca-central-1]]'
+                   range_min_bytes = 134217728,
+                   range_max_bytes = 536870912,
+                   gc.ttlseconds = 14400,
+                   num_replicas = 3,
+                   num_voters = 3,
+                   constraints = '[]',
+                   voter_constraints = '[+region=ca-central-1]',
+                   lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE test_explicit_region
 ----
 TABLE test_explicit_region  ALTER TABLE test_explicit_region CONFIGURE ZONE USING
-                            range_min_bytes = 134217728,
-                            range_max_bytes = 536870912,
-                            gc.ttlseconds = 90000,
-                            num_replicas = 3,
-                            num_voters = 3,
-                            constraints = '[]',
-                            voter_constraints = '[+region=ap-southeast-2]',
-                            lease_preferences = '[[+region=ap-southeast-2]]'
+                              range_min_bytes = 134217728,
+                              range_max_bytes = 536870912,
+                              gc.ttlseconds = 14400,
+                              num_replicas = 3,
+                              num_voters = 3,
+                              constraints = '[]',
+                              voter_constraints = '[+region=ap-southeast-2]',
+                              lease_preferences = '[[+region=ap-southeast-2]]'
 
 # Make sure placement restricted doesn't invalidate zone configs.
 statement ok
@@ -85,27 +85,27 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE test
 ----
 DATABASE testdb  ALTER DATABASE testdb CONFIGURE ZONE USING
-                 range_min_bytes = 134217728,
-                 range_max_bytes = 536870912,
-                 gc.ttlseconds = 90000,
-                 num_replicas = 3,
-                 num_voters = 3,
-                 constraints = '[]',
-                 voter_constraints = '[+region=ca-central-1]',
-                 lease_preferences = '[[+region=ca-central-1]]'
+                   range_min_bytes = 134217728,
+                   range_max_bytes = 536870912,
+                   gc.ttlseconds = 14400,
+                   num_replicas = 3,
+                   num_voters = 3,
+                   constraints = '[]',
+                   voter_constraints = '[+region=ca-central-1]',
+                   lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE test_explicit_region
 ----
 TABLE test_explicit_region  ALTER TABLE test_explicit_region CONFIGURE ZONE USING
-                            range_min_bytes = 134217728,
-                            range_max_bytes = 536870912,
-                            gc.ttlseconds = 90000,
-                            num_replicas = 3,
-                            num_voters = 3,
-                            constraints = '[]',
-                            voter_constraints = '[+region=ap-southeast-2]',
-                            lease_preferences = '[[+region=ap-southeast-2]]'
+                              range_min_bytes = 134217728,
+                              range_max_bytes = 536870912,
+                              gc.ttlseconds = 14400,
+                              num_replicas = 3,
+                              num_voters = 3,
+                              constraints = '[]',
+                              voter_constraints = '[+region=ap-southeast-2]',
+                              lease_preferences = '[[+region=ap-southeast-2]]'
 
 statement ok
 ALTER DATABASE testdb ADD REGION "us-east-1"
@@ -114,27 +114,27 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE test
 ----
 DATABASE testdb  ALTER DATABASE testdb CONFIGURE ZONE USING
-                 range_min_bytes = 134217728,
-                 range_max_bytes = 536870912,
-                 gc.ttlseconds = 90000,
-                 num_replicas = 3,
-                 num_voters = 3,
-                 constraints = '[]',
-                 voter_constraints = '[+region=ca-central-1]',
-                 lease_preferences = '[[+region=ca-central-1]]'
+                   range_min_bytes = 134217728,
+                   range_max_bytes = 536870912,
+                   gc.ttlseconds = 14400,
+                   num_replicas = 3,
+                   num_voters = 3,
+                   constraints = '[]',
+                   voter_constraints = '[+region=ca-central-1]',
+                   lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE test_explicit_region
 ----
 TABLE test_explicit_region  ALTER TABLE test_explicit_region CONFIGURE ZONE USING
-                            range_min_bytes = 134217728,
-                            range_max_bytes = 536870912,
-                            gc.ttlseconds = 90000,
-                            num_replicas = 3,
-                            num_voters = 3,
-                            constraints = '[]',
-                            voter_constraints = '[+region=ap-southeast-2]',
-                            lease_preferences = '[[+region=ap-southeast-2]]'
+                              range_min_bytes = 134217728,
+                              range_max_bytes = 536870912,
+                              gc.ttlseconds = 14400,
+                              num_replicas = 3,
+                              num_voters = 3,
+                              constraints = '[]',
+                              voter_constraints = '[+region=ap-southeast-2]',
+                              lease_preferences = '[[+region=ap-southeast-2]]'
 
 # Change primary region to ensure zone config is rebuilt on table changes.
 statement ok
@@ -144,14 +144,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE test
 ----
 DATABASE testdb  ALTER DATABASE testdb CONFIGURE ZONE USING
-                 range_min_bytes = 134217728,
-                 range_max_bytes = 536870912,
-                 gc.ttlseconds = 90000,
-                 num_replicas = 3,
-                 num_voters = 3,
-                 constraints = '[]',
-                 voter_constraints = '[+region=ap-southeast-2]',
-                 lease_preferences = '[[+region=ap-southeast-2]]'
+                   range_min_bytes = 134217728,
+                   range_max_bytes = 536870912,
+                   gc.ttlseconds = 14400,
+                   num_replicas = 3,
+                   num_voters = 3,
+                   constraints = '[]',
+                   voter_constraints = '[+region=ap-southeast-2]',
+                   lease_preferences = '[[+region=ap-southeast-2]]'
 
 # Alter to DEFAULT and see that our constraints are back.
 statement ok
@@ -161,27 +161,27 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE test
 ----
 DATABASE testdb  ALTER DATABASE testdb CONFIGURE ZONE USING
-                 range_min_bytes = 134217728,
-                 range_max_bytes = 536870912,
-                 gc.ttlseconds = 90000,
-                 num_replicas = 5,
-                 num_voters = 3,
-                 constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                 voter_constraints = '[+region=ap-southeast-2]',
-                 lease_preferences = '[[+region=ap-southeast-2]]'
+                   range_min_bytes = 134217728,
+                   range_max_bytes = 536870912,
+                   gc.ttlseconds = 14400,
+                   num_replicas = 5,
+                   num_voters = 3,
+                   constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                   voter_constraints = '[+region=ap-southeast-2]',
+                   lease_preferences = '[[+region=ap-southeast-2]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE test_explicit_region
 ----
 TABLE test_explicit_region  ALTER TABLE test_explicit_region CONFIGURE ZONE USING
-                            range_min_bytes = 134217728,
-                            range_max_bytes = 536870912,
-                            gc.ttlseconds = 90000,
-                            num_replicas = 5,
-                            num_voters = 3,
-                            constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                            voter_constraints = '[+region=ap-southeast-2]',
-                            lease_preferences = '[[+region=ap-southeast-2]]'
+                              range_min_bytes = 134217728,
+                              range_max_bytes = 536870912,
+                              gc.ttlseconds = 14400,
+                              num_replicas = 5,
+                              num_voters = 3,
+                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                              voter_constraints = '[+region=ap-southeast-2]',
+                              lease_preferences = '[[+region=ap-southeast-2]]'
 
 # Check that coming back from placement restricted results in a valid zone
 # config.

--- a/pkg/ccl/logictestccl/testdata/logic_test/secondary_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/secondary_region
@@ -25,14 +25,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE no_list;
 ----
 DATABASE no_list  ALTER DATABASE no_list CONFIGURE ZONE USING
-                  range_min_bytes = 134217728,
-                  range_max_bytes = 536870912,
-                  gc.ttlseconds = 90000,
-                  num_replicas = 4,
-                  num_voters = 3,
-                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1}',
-                  voter_constraints = '[+region=ap-southeast-2]',
-                  lease_preferences = '[[+region=ap-southeast-2], [+region=ca-central-1]]'
+                    range_min_bytes = 134217728,
+                    range_max_bytes = 536870912,
+                    gc.ttlseconds = 14400,
+                    num_replicas = 4,
+                    num_voters = 3,
+                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1}',
+                    voter_constraints = '[+region=ap-southeast-2]',
+                    lease_preferences = '[[+region=ap-southeast-2], [+region=ca-central-1]]'
 
 statement ok
 CREATE DATABASE db PRIMARY REGION "ap-southeast-2" REGIONS "ca-central-1" SECONDARY REGION "ca-central-1"
@@ -42,14 +42,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE db;
 ----
 DATABASE db  ALTER DATABASE db CONFIGURE ZONE USING
-             range_min_bytes = 134217728,
-             range_max_bytes = 536870912,
-             gc.ttlseconds = 90000,
-             num_replicas = 4,
-             num_voters = 3,
-             constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1}',
-             voter_constraints = '[+region=ap-southeast-2]',
-             lease_preferences = '[[+region=ap-southeast-2], [+region=ca-central-1]]'
+               range_min_bytes = 134217728,
+               range_max_bytes = 536870912,
+               gc.ttlseconds = 14400,
+               num_replicas = 4,
+               num_voters = 3,
+               constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1}',
+               voter_constraints = '[+region=ap-southeast-2]',
+               lease_preferences = '[[+region=ap-southeast-2], [+region=ca-central-1]]'
 
 # Secondary region cannot be the current primary region.
 statement error the secondary region cannot be the same as the current primary region
@@ -92,94 +92,94 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE db;
 ----
 DATABASE db  ALTER DATABASE db CONFIGURE ZONE USING
-             range_min_bytes = 134217728,
-             range_max_bytes = 536870912,
-             gc.ttlseconds = 90000,
-             num_replicas = 5,
-             num_voters = 3,
-             constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-             voter_constraints = '[+region=ap-southeast-2]',
-             lease_preferences = '[[+region=ap-southeast-2], [+region=ca-central-1]]'
+               range_min_bytes = 134217728,
+               range_max_bytes = 536870912,
+               gc.ttlseconds = 14400,
+               num_replicas = 5,
+               num_voters = 3,
+               constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+               voter_constraints = '[+region=ap-southeast-2]',
+               lease_preferences = '[[+region=ap-southeast-2], [+region=ca-central-1]]'
 
 # Verify that the zone configuration on the table is expected.
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE db.rbt_in_primary
 ----
 TABLE db.public.rbt_in_primary  ALTER TABLE db.public.rbt_in_primary CONFIGURE ZONE USING
-                                range_min_bytes = 134217728,
-                                range_max_bytes = 536870912,
-                                gc.ttlseconds = 90000,
-                                num_replicas = 5,
-                                num_voters = 3,
-                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                voter_constraints = '[+region=ap-southeast-2]',
-                                lease_preferences = '[[+region=ap-southeast-2], [+region=ca-central-1]]'
+                                  range_min_bytes = 134217728,
+                                  range_max_bytes = 536870912,
+                                  gc.ttlseconds = 14400,
+                                  num_replicas = 5,
+                                  num_voters = 3,
+                                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                  voter_constraints = '[+region=ap-southeast-2]',
+                                  lease_preferences = '[[+region=ap-southeast-2], [+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE db.rbt_in_us_east
 ----
 TABLE db.public.rbt_in_us_east  ALTER TABLE db.public.rbt_in_us_east CONFIGURE ZONE USING
-                                range_min_bytes = 134217728,
-                                range_max_bytes = 536870912,
-                                gc.ttlseconds = 90000,
-                                num_replicas = 5,
-                                num_voters = 3,
-                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                voter_constraints = '[+region=us-east-1]',
-                                lease_preferences = '[[+region=us-east-1], [+region=ca-central-1]]'
+                                  range_min_bytes = 134217728,
+                                  range_max_bytes = 536870912,
+                                  gc.ttlseconds = 14400,
+                                  num_replicas = 5,
+                                  num_voters = 3,
+                                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                  voter_constraints = '[+region=us-east-1]',
+                                  lease_preferences = '[[+region=us-east-1], [+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE db.rbt_in_ca_central
 ----
 TABLE db.public.rbt_in_ca_central  ALTER TABLE db.public.rbt_in_ca_central CONFIGURE ZONE USING
-                                   range_min_bytes = 134217728,
-                                   range_max_bytes = 536870912,
-                                   gc.ttlseconds = 90000,
-                                   num_replicas = 5,
-                                   num_voters = 3,
-                                   constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                   voter_constraints = '[+region=ca-central-1]',
-                                   lease_preferences = '[[+region=ca-central-1]]'
+                                     range_min_bytes = 134217728,
+                                     range_max_bytes = 536870912,
+                                     gc.ttlseconds = 14400,
+                                     num_replicas = 5,
+                                     num_voters = 3,
+                                     constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                     voter_constraints = '[+region=ca-central-1]',
+                                     lease_preferences = '[[+region=ca-central-1]]'
 
 # Verify that the zone configuration on a partition is expected.
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "us-east-1" OF TABLE db.rbr
 ----
 PARTITION "us-east-1" OF TABLE db.public.rbr  ALTER PARTITION "us-east-1" OF TABLE db.public.rbr CONFIGURE ZONE USING
-                                              range_min_bytes = 134217728,
-                                              range_max_bytes = 536870912,
-                                              gc.ttlseconds = 90000,
-                                              num_replicas = 5,
-                                              num_voters = 3,
-                                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                              voter_constraints = '[+region=us-east-1]',
-                                              lease_preferences = '[[+region=us-east-1], [+region=ca-central-1]]'
+                                                range_min_bytes = 134217728,
+                                                range_max_bytes = 536870912,
+                                                gc.ttlseconds = 14400,
+                                                num_replicas = 5,
+                                                num_voters = 3,
+                                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                voter_constraints = '[+region=us-east-1]',
+                                                lease_preferences = '[[+region=us-east-1], [+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "ap-southeast-2" OF TABLE db.rbr
 ----
 PARTITION "ap-southeast-2" OF TABLE db.public.rbr  ALTER PARTITION "ap-southeast-2" OF TABLE db.public.rbr CONFIGURE ZONE USING
-                                                   range_min_bytes = 134217728,
-                                                   range_max_bytes = 536870912,
-                                                   gc.ttlseconds = 90000,
-                                                   num_replicas = 5,
-                                                   num_voters = 3,
-                                                   constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                                   voter_constraints = '[+region=ap-southeast-2]',
-                                                   lease_preferences = '[[+region=ap-southeast-2], [+region=ca-central-1]]'
+                                                     range_min_bytes = 134217728,
+                                                     range_max_bytes = 536870912,
+                                                     gc.ttlseconds = 14400,
+                                                     num_replicas = 5,
+                                                     num_voters = 3,
+                                                     constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                     voter_constraints = '[+region=ap-southeast-2]',
+                                                     lease_preferences = '[[+region=ap-southeast-2], [+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "ca-central-1" OF TABLE db.rbr
 ----
 PARTITION "ca-central-1" OF TABLE db.public.rbr  ALTER PARTITION "ca-central-1" OF TABLE db.public.rbr CONFIGURE ZONE USING
-                                                 range_min_bytes = 134217728,
-                                                 range_max_bytes = 536870912,
-                                                 gc.ttlseconds = 90000,
-                                                 num_replicas = 5,
-                                                 num_voters = 3,
-                                                 constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                                 voter_constraints = '[+region=ca-central-1]',
-                                                 lease_preferences = '[[+region=ca-central-1]]'
+                                                   range_min_bytes = 134217728,
+                                                   range_max_bytes = 536870912,
+                                                   gc.ttlseconds = 14400,
+                                                   num_replicas = 5,
+                                                   num_voters = 3,
+                                                   constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                   voter_constraints = '[+region=ca-central-1]',
+                                                   lease_preferences = '[[+region=ca-central-1]]'
 
 
 statement ok
@@ -194,94 +194,94 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE db;
 ----
 DATABASE db  ALTER DATABASE db CONFIGURE ZONE USING
-             range_min_bytes = 134217728,
-             range_max_bytes = 536870912,
-             gc.ttlseconds = 90000,
-             num_replicas = 5,
-             num_voters = 5,
-             constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-             voter_constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2}',
-             lease_preferences = '[[+region=ap-southeast-2], [+region=ca-central-1]]'
+               range_min_bytes = 134217728,
+               range_max_bytes = 536870912,
+               gc.ttlseconds = 14400,
+               num_replicas = 5,
+               num_voters = 5,
+               constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+               voter_constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2}',
+               lease_preferences = '[[+region=ap-southeast-2], [+region=ca-central-1]]'
 
 # Verify that the zone configuration on the table is expected.
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE db.rbt_in_primary
 ----
 TABLE db.public.rbt_in_primary  ALTER TABLE db.public.rbt_in_primary CONFIGURE ZONE USING
-                                range_min_bytes = 134217728,
-                                range_max_bytes = 536870912,
-                                gc.ttlseconds = 90000,
-                                num_replicas = 5,
-                                num_voters = 5,
-                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                voter_constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2}',
-                                lease_preferences = '[[+region=ap-southeast-2], [+region=ca-central-1]]'
+                                  range_min_bytes = 134217728,
+                                  range_max_bytes = 536870912,
+                                  gc.ttlseconds = 14400,
+                                  num_replicas = 5,
+                                  num_voters = 5,
+                                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                  voter_constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2}',
+                                  lease_preferences = '[[+region=ap-southeast-2], [+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE db.rbt_in_us_east
 ----
 TABLE db.public.rbt_in_us_east  ALTER TABLE db.public.rbt_in_us_east CONFIGURE ZONE USING
-                                range_min_bytes = 134217728,
-                                range_max_bytes = 536870912,
-                                gc.ttlseconds = 90000,
-                                num_replicas = 5,
-                                num_voters = 5,
-                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                voter_constraints = '{+region=ca-central-1: 2, +region=us-east-1: 2}',
-                                lease_preferences = '[[+region=us-east-1], [+region=ca-central-1]]'
+                                  range_min_bytes = 134217728,
+                                  range_max_bytes = 536870912,
+                                  gc.ttlseconds = 14400,
+                                  num_replicas = 5,
+                                  num_voters = 5,
+                                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                  voter_constraints = '{+region=ca-central-1: 2, +region=us-east-1: 2}',
+                                  lease_preferences = '[[+region=us-east-1], [+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE db.rbt_in_ca_central
 ----
 TABLE db.public.rbt_in_ca_central  ALTER TABLE db.public.rbt_in_ca_central CONFIGURE ZONE USING
-                                   range_min_bytes = 134217728,
-                                   range_max_bytes = 536870912,
-                                   gc.ttlseconds = 90000,
-                                   num_replicas = 5,
-                                   num_voters = 5,
-                                   constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                   voter_constraints = '{+region=ca-central-1: 2}',
-                                   lease_preferences = '[[+region=ca-central-1]]'
+                                     range_min_bytes = 134217728,
+                                     range_max_bytes = 536870912,
+                                     gc.ttlseconds = 14400,
+                                     num_replicas = 5,
+                                     num_voters = 5,
+                                     constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                     voter_constraints = '{+region=ca-central-1: 2}',
+                                     lease_preferences = '[[+region=ca-central-1]]'
 
 # Verify that the zone configuration on a partition is expected.
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "us-east-1" OF TABLE db.rbr
 ----
 PARTITION "us-east-1" OF TABLE db.public.rbr  ALTER PARTITION "us-east-1" OF TABLE db.public.rbr CONFIGURE ZONE USING
-                                              range_min_bytes = 134217728,
-                                              range_max_bytes = 536870912,
-                                              gc.ttlseconds = 90000,
-                                              num_replicas = 5,
-                                              num_voters = 5,
-                                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                              voter_constraints = '{+region=ca-central-1: 2, +region=us-east-1: 2}',
-                                              lease_preferences = '[[+region=us-east-1], [+region=ca-central-1]]'
+                                                range_min_bytes = 134217728,
+                                                range_max_bytes = 536870912,
+                                                gc.ttlseconds = 14400,
+                                                num_replicas = 5,
+                                                num_voters = 5,
+                                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                voter_constraints = '{+region=ca-central-1: 2, +region=us-east-1: 2}',
+                                                lease_preferences = '[[+region=us-east-1], [+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "ap-southeast-2" OF TABLE db.rbr
 ----
 PARTITION "ap-southeast-2" OF TABLE db.public.rbr  ALTER PARTITION "ap-southeast-2" OF TABLE db.public.rbr CONFIGURE ZONE USING
-                                                   range_min_bytes = 134217728,
-                                                   range_max_bytes = 536870912,
-                                                   gc.ttlseconds = 90000,
-                                                   num_replicas = 5,
-                                                   num_voters = 5,
-                                                   constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                                   voter_constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2}',
-                                                   lease_preferences = '[[+region=ap-southeast-2], [+region=ca-central-1]]'
+                                                     range_min_bytes = 134217728,
+                                                     range_max_bytes = 536870912,
+                                                     gc.ttlseconds = 14400,
+                                                     num_replicas = 5,
+                                                     num_voters = 5,
+                                                     constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                     voter_constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2}',
+                                                     lease_preferences = '[[+region=ap-southeast-2], [+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "ca-central-1" OF TABLE db.rbr
 ----
 PARTITION "ca-central-1" OF TABLE db.public.rbr  ALTER PARTITION "ca-central-1" OF TABLE db.public.rbr CONFIGURE ZONE USING
-                                                 range_min_bytes = 134217728,
-                                                 range_max_bytes = 536870912,
-                                                 gc.ttlseconds = 90000,
-                                                 num_replicas = 5,
-                                                 num_voters = 5,
-                                                 constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                                 voter_constraints = '{+region=ca-central-1: 2}',
-                                                 lease_preferences = '[[+region=ca-central-1]]'
+                                                   range_min_bytes = 134217728,
+                                                   range_max_bytes = 536870912,
+                                                   gc.ttlseconds = 14400,
+                                                   num_replicas = 5,
+                                                   num_voters = 5,
+                                                   constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                   voter_constraints = '{+region=ca-central-1: 2}',
+                                                   lease_preferences = '[[+region=ca-central-1]]'
 
 # Update DATABASE db ADD REGION "us-central-1";
 
@@ -289,14 +289,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR DATABASE db;
 ----
 DATABASE db  ALTER DATABASE db CONFIGURE ZONE USING
-             range_min_bytes = 134217728,
-             range_max_bytes = 536870912,
-             gc.ttlseconds = 90000,
-             num_replicas = 5,
-             num_voters = 5,
-             constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-             voter_constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2}',
-             lease_preferences = '[[+region=ap-southeast-2], [+region=ca-central-1]]'
+               range_min_bytes = 134217728,
+               range_max_bytes = 536870912,
+               gc.ttlseconds = 14400,
+               num_replicas = 5,
+               num_voters = 5,
+               constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+               voter_constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2}',
+               lease_preferences = '[[+region=ap-southeast-2], [+region=ca-central-1]]'
 
 # Verify that the zone configuration on the table is expected.
 # The number of replicas should be 7.
@@ -308,67 +308,67 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE db.rbt_in_us_east
 ----
 TABLE db.public.rbt_in_us_east  ALTER TABLE db.public.rbt_in_us_east CONFIGURE ZONE USING
-                                range_min_bytes = 134217728,
-                                range_max_bytes = 536870912,
-                                gc.ttlseconds = 90000,
-                                num_replicas = 5,
-                                num_voters = 5,
-                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                voter_constraints = '{+region=ca-central-1: 2, +region=us-east-1: 2}',
-                                lease_preferences = '[[+region=us-east-1], [+region=ca-central-1]]'
+                                  range_min_bytes = 134217728,
+                                  range_max_bytes = 536870912,
+                                  gc.ttlseconds = 14400,
+                                  num_replicas = 5,
+                                  num_voters = 5,
+                                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                  voter_constraints = '{+region=ca-central-1: 2, +region=us-east-1: 2}',
+                                  lease_preferences = '[[+region=us-east-1], [+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE db.rbt_in_ca_central
 ----
 TABLE db.public.rbt_in_ca_central  ALTER TABLE db.public.rbt_in_ca_central CONFIGURE ZONE USING
-                                   range_min_bytes = 134217728,
-                                   range_max_bytes = 536870912,
-                                   gc.ttlseconds = 90000,
-                                   num_replicas = 5,
-                                   num_voters = 5,
-                                   constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                   voter_constraints = '{+region=ca-central-1: 2}',
-                                   lease_preferences = '[[+region=ca-central-1]]'
+                                     range_min_bytes = 134217728,
+                                     range_max_bytes = 536870912,
+                                     gc.ttlseconds = 14400,
+                                     num_replicas = 5,
+                                     num_voters = 5,
+                                     constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                     voter_constraints = '{+region=ca-central-1: 2}',
+                                     lease_preferences = '[[+region=ca-central-1]]'
 
 # Verify that the zone configuration on a partition is expected.
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "us-east-1" OF TABLE db.rbr
 ----
 PARTITION "us-east-1" OF TABLE db.public.rbr  ALTER PARTITION "us-east-1" OF TABLE db.public.rbr CONFIGURE ZONE USING
-                                              range_min_bytes = 134217728,
-                                              range_max_bytes = 536870912,
-                                              gc.ttlseconds = 90000,
-                                              num_replicas = 5,
-                                              num_voters = 5,
-                                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                              voter_constraints = '{+region=ca-central-1: 2, +region=us-east-1: 2}',
-                                              lease_preferences = '[[+region=us-east-1], [+region=ca-central-1]]'
+                                                range_min_bytes = 134217728,
+                                                range_max_bytes = 536870912,
+                                                gc.ttlseconds = 14400,
+                                                num_replicas = 5,
+                                                num_voters = 5,
+                                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                voter_constraints = '{+region=ca-central-1: 2, +region=us-east-1: 2}',
+                                                lease_preferences = '[[+region=us-east-1], [+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "ap-southeast-2" OF TABLE db.rbr
 ----
 PARTITION "ap-southeast-2" OF TABLE db.public.rbr  ALTER PARTITION "ap-southeast-2" OF TABLE db.public.rbr CONFIGURE ZONE USING
-                                                   range_min_bytes = 134217728,
-                                                   range_max_bytes = 536870912,
-                                                   gc.ttlseconds = 90000,
-                                                   num_replicas = 5,
-                                                   num_voters = 5,
-                                                   constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                                   voter_constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2}',
-                                                   lease_preferences = '[[+region=ap-southeast-2], [+region=ca-central-1]]'
+                                                     range_min_bytes = 134217728,
+                                                     range_max_bytes = 536870912,
+                                                     gc.ttlseconds = 14400,
+                                                     num_replicas = 5,
+                                                     num_voters = 5,
+                                                     constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                     voter_constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2}',
+                                                     lease_preferences = '[[+region=ap-southeast-2], [+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "ca-central-1" OF TABLE db.rbr
 ----
 PARTITION "ca-central-1" OF TABLE db.public.rbr  ALTER PARTITION "ca-central-1" OF TABLE db.public.rbr CONFIGURE ZONE USING
-                                                 range_min_bytes = 134217728,
-                                                 range_max_bytes = 536870912,
-                                                 gc.ttlseconds = 90000,
-                                                 num_replicas = 5,
-                                                 num_voters = 5,
-                                                 constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                                 voter_constraints = '{+region=ca-central-1: 2}',
-                                                 lease_preferences = '[[+region=ca-central-1]]'
+                                                   range_min_bytes = 134217728,
+                                                   range_max_bytes = 536870912,
+                                                   gc.ttlseconds = 14400,
+                                                   num_replicas = 5,
+                                                   num_voters = 5,
+                                                   constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                   voter_constraints = '{+region=ca-central-1: 2}',
+                                                   lease_preferences = '[[+region=ca-central-1]]'
 
 
 statement error database must be multi-region to support a secondary region
@@ -393,40 +393,40 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE db.rbt_in_us_east
 ----
 TABLE db.public.rbt_in_us_east  ALTER TABLE db.public.rbt_in_us_east CONFIGURE ZONE USING
-                                range_min_bytes = 134217728,
-                                range_max_bytes = 536870912,
-                                gc.ttlseconds = 90000,
-                                num_replicas = 5,
-                                num_voters = 5,
-                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                voter_constraints = '{+region=us-east-1: 2}',
-                                lease_preferences = '[[+region=us-east-1]]'
+                                  range_min_bytes = 134217728,
+                                  range_max_bytes = 536870912,
+                                  gc.ttlseconds = 14400,
+                                  num_replicas = 5,
+                                  num_voters = 5,
+                                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                  voter_constraints = '{+region=us-east-1: 2}',
+                                  lease_preferences = '[[+region=us-east-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "ap-southeast-2" OF TABLE db.rbr
 ----
 PARTITION "ap-southeast-2" OF TABLE db.public.rbr  ALTER PARTITION "ap-southeast-2" OF TABLE db.public.rbr CONFIGURE ZONE USING
-                                                   range_min_bytes = 134217728,
-                                                   range_max_bytes = 536870912,
-                                                   gc.ttlseconds = 90000,
-                                                   num_replicas = 5,
-                                                   num_voters = 5,
-                                                   constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                                   voter_constraints = '{+region=ap-southeast-2: 2}',
-                                                   lease_preferences = '[[+region=ap-southeast-2]]'
+                                                     range_min_bytes = 134217728,
+                                                     range_max_bytes = 536870912,
+                                                     gc.ttlseconds = 14400,
+                                                     num_replicas = 5,
+                                                     num_voters = 5,
+                                                     constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                     voter_constraints = '{+region=ap-southeast-2: 2}',
+                                                     lease_preferences = '[[+region=ap-southeast-2]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "ca-central-1" OF TABLE db.rbr
 ----
 PARTITION "ca-central-1" OF TABLE db.public.rbr  ALTER PARTITION "ca-central-1" OF TABLE db.public.rbr CONFIGURE ZONE USING
-                                                 range_min_bytes = 134217728,
-                                                 range_max_bytes = 536870912,
-                                                 gc.ttlseconds = 90000,
-                                                 num_replicas = 5,
-                                                 num_voters = 5,
-                                                 constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                                 voter_constraints = '{+region=ca-central-1: 2}',
-                                                 lease_preferences = '[[+region=ca-central-1]]'
+                                                   range_min_bytes = 134217728,
+                                                   range_max_bytes = 536870912,
+                                                   gc.ttlseconds = 14400,
+                                                   num_replicas = 5,
+                                                   num_voters = 5,
+                                                   constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                   voter_constraints = '{+region=ca-central-1: 2}',
+                                                   lease_preferences = '[[+region=ca-central-1]]'
 
 
 # Verify super region interactions

--- a/pkg/ccl/logictestccl/testdata/logic_test/super_regions
+++ b/pkg/ccl/logictestccl/testdata/logic_test/super_regions
@@ -46,41 +46,41 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE mr1.rbt;
 ----
 TABLE mr1.public.rbt  ALTER TABLE mr1.public.rbt CONFIGURE ZONE USING
-                      range_min_bytes = 134217728,
-                      range_max_bytes = 536870912,
-                      gc.ttlseconds = 90000,
-                      num_replicas = 3,
-                      num_voters = 3,
-                      constraints = '{+region=us-east-1: 1}',
-                      voter_constraints = '[+region=us-east-1]',
-                      lease_preferences = '[[+region=us-east-1]]'
+                        range_min_bytes = 134217728,
+                        range_max_bytes = 536870912,
+                        gc.ttlseconds = 14400,
+                        num_replicas = 3,
+                        num_voters = 3,
+                        constraints = '{+region=us-east-1: 1}',
+                        voter_constraints = '[+region=us-east-1]',
+                        lease_preferences = '[[+region=us-east-1]]'
 
 # mr1.rbr should only have its subzones changed.
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE mr1.rbr
 ----
 DATABASE mr1  ALTER DATABASE mr1 CONFIGURE ZONE USING
-              range_min_bytes = 134217728,
-              range_max_bytes = 536870912,
-              gc.ttlseconds = 90000,
-              num_replicas = 3,
-              num_voters = 3,
-              constraints = '{+region=us-east-1: 1}',
-              voter_constraints = '[+region=us-east-1]',
-              lease_preferences = '[[+region=us-east-1]]'
+                range_min_bytes = 134217728,
+                range_max_bytes = 536870912,
+                gc.ttlseconds = 14400,
+                num_replicas = 3,
+                num_voters = 3,
+                constraints = '{+region=us-east-1: 1}',
+                voter_constraints = '[+region=us-east-1]',
+                lease_preferences = '[[+region=us-east-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "us-east-1" OF TABLE mr1.rbr
 ----
 PARTITION "us-east-1" OF TABLE mr1.public.rbr  ALTER PARTITION "us-east-1" OF TABLE mr1.public.rbr CONFIGURE ZONE USING
-                                               range_min_bytes = 134217728,
-                                               range_max_bytes = 536870912,
-                                               gc.ttlseconds = 90000,
-                                               num_replicas = 3,
-                                               num_voters = 3,
-                                               constraints = '{+region=us-east-1: 1}',
-                                               voter_constraints = '[+region=us-east-1]',
-                                               lease_preferences = '[[+region=us-east-1]]'
+                                                 range_min_bytes = 134217728,
+                                                 range_max_bytes = 536870912,
+                                                 gc.ttlseconds = 14400,
+                                                 num_replicas = 3,
+                                                 num_voters = 3,
+                                                 constraints = '{+region=us-east-1: 1}',
+                                                 voter_constraints = '[+region=us-east-1]',
+                                                 lease_preferences = '[[+region=us-east-1]]'
 
 statement ok
 use mr1;
@@ -119,119 +119,119 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE mr2.t_rt_us_east_1
 ----
 TABLE mr2.public.t_rt_us_east_1  ALTER TABLE mr2.public.t_rt_us_east_1 CONFIGURE ZONE USING
-                                 range_min_bytes = 134217728,
-                                 range_max_bytes = 536870912,
-                                 gc.ttlseconds = 90000,
-                                 num_replicas = 4,
-                                 num_voters = 3,
-                                 constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
-                                 voter_constraints = '[+region=us-east-1]',
-                                 lease_preferences = '[[+region=us-east-1]]'
+                                   range_min_bytes = 134217728,
+                                   range_max_bytes = 536870912,
+                                   gc.ttlseconds = 14400,
+                                   num_replicas = 4,
+                                   num_voters = 3,
+                                   constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                                   voter_constraints = '[+region=us-east-1]',
+                                   lease_preferences = '[[+region=us-east-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE mr2.t_rt_primary_region
 ----
 TABLE mr2.public.t_rt_primary_region  ALTER TABLE mr2.public.t_rt_primary_region CONFIGURE ZONE USING
-                                      range_min_bytes = 134217728,
-                                      range_max_bytes = 536870912,
-                                      gc.ttlseconds = 90000,
-                                      num_replicas = 4,
-                                      num_voters = 3,
-                                      constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
-                                      voter_constraints = '[+region=us-east-1]',
-                                      lease_preferences = '[[+region=us-east-1]]'
+                                        range_min_bytes = 134217728,
+                                        range_max_bytes = 536870912,
+                                        gc.ttlseconds = 14400,
+                                        num_replicas = 4,
+                                        num_voters = 3,
+                                        constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                                        voter_constraints = '[+region=us-east-1]',
+                                        lease_preferences = '[[+region=us-east-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE mr2.t_rt
 ----
 TABLE mr2.public.t_rt  ALTER TABLE mr2.public.t_rt CONFIGURE ZONE USING
-                       range_min_bytes = 134217728,
-                       range_max_bytes = 536870912,
-                       gc.ttlseconds = 90000,
-                       num_replicas = 4,
-                       num_voters = 3,
-                       constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
-                       voter_constraints = '[+region=ap-southeast-2]',
-                       lease_preferences = '[[+region=ap-southeast-2]]'
+                         range_min_bytes = 134217728,
+                         range_max_bytes = 536870912,
+                         gc.ttlseconds = 14400,
+                         num_replicas = 4,
+                         num_voters = 3,
+                         constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                         voter_constraints = '[+region=ap-southeast-2]',
+                         lease_preferences = '[[+region=ap-southeast-2]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE mr2.t_rt_with_idx
 ----
 TABLE mr2.public.t_rt_with_idx  ALTER TABLE mr2.public.t_rt_with_idx CONFIGURE ZONE USING
-                                range_min_bytes = 134217728,
-                                range_max_bytes = 536870912,
-                                gc.ttlseconds = 90000,
-                                num_replicas = 4,
-                                num_voters = 3,
-                                constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
-                                voter_constraints = '[+region=ap-southeast-2]',
-                                lease_preferences = '[[+region=ap-southeast-2]]'
+                                  range_min_bytes = 134217728,
+                                  range_max_bytes = 536870912,
+                                  gc.ttlseconds = 14400,
+                                  num_replicas = 4,
+                                  num_voters = 3,
+                                  constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                                  voter_constraints = '[+region=ap-southeast-2]',
+                                  lease_preferences = '[[+region=ap-southeast-2]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR INDEX mr2.t_rt_with_idx@idx
 ----
 TABLE mr2.public.t_rt_with_idx  ALTER TABLE mr2.public.t_rt_with_idx CONFIGURE ZONE USING
-                                range_min_bytes = 134217728,
-                                range_max_bytes = 536870912,
-                                gc.ttlseconds = 90000,
-                                num_replicas = 4,
-                                num_voters = 3,
-                                constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
-                                voter_constraints = '[+region=ap-southeast-2]',
-                                lease_preferences = '[[+region=ap-southeast-2]]'
+                                  range_min_bytes = 134217728,
+                                  range_max_bytes = 536870912,
+                                  gc.ttlseconds = 14400,
+                                  num_replicas = 4,
+                                  num_voters = 3,
+                                  constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                                  voter_constraints = '[+region=ap-southeast-2]',
+                                  lease_preferences = '[[+region=ap-southeast-2]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "us-east-1" OF TABLE mr2.t_rbr;
 ----
 PARTITION "us-east-1" OF TABLE mr2.public.t_rbr  ALTER PARTITION "us-east-1" OF TABLE mr2.public.t_rbr CONFIGURE ZONE USING
-                                                 range_min_bytes = 134217728,
-                                                 range_max_bytes = 536870912,
-                                                 gc.ttlseconds = 90000,
-                                                 num_replicas = 4,
-                                                 num_voters = 3,
-                                                 constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
-                                                 voter_constraints = '[+region=us-east-1]',
-                                                 lease_preferences = '[[+region=us-east-1]]'
+                                                   range_min_bytes = 134217728,
+                                                   range_max_bytes = 536870912,
+                                                   gc.ttlseconds = 14400,
+                                                   num_replicas = 4,
+                                                   num_voters = 3,
+                                                   constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                                                   voter_constraints = '[+region=us-east-1]',
+                                                   lease_preferences = '[[+region=us-east-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "ap-southeast-2" OF TABLE mr2.t_rbr_with_idx;
 ----
 PARTITION "ap-southeast-2" OF TABLE mr2.public.t_rbr_with_idx  ALTER PARTITION "ap-southeast-2" OF TABLE mr2.public.t_rbr_with_idx CONFIGURE ZONE USING
-                                                               range_min_bytes = 134217728,
-                                                               range_max_bytes = 536870912,
-                                                               gc.ttlseconds = 90000,
-                                                               num_replicas = 4,
-                                                               num_voters = 3,
-                                                               constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
-                                                               voter_constraints = '[+region=ap-southeast-2]',
-                                                               lease_preferences = '[[+region=ap-southeast-2]]'
+                                                                 range_min_bytes = 134217728,
+                                                                 range_max_bytes = 536870912,
+                                                                 gc.ttlseconds = 14400,
+                                                                 num_replicas = 4,
+                                                                 num_voters = 3,
+                                                                 constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                                                                 voter_constraints = '[+region=ap-southeast-2]',
+                                                                 lease_preferences = '[[+region=ap-southeast-2]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "ca-central-1" OF TABLE mr2.t_rbr_with_idx;
 ----
 PARTITION "ca-central-1" OF TABLE mr2.public.t_rbr_with_idx  ALTER PARTITION "ca-central-1" OF TABLE mr2.public.t_rbr_with_idx CONFIGURE ZONE USING
-                                                             range_min_bytes = 134217728,
-                                                             range_max_bytes = 536870912,
-                                                             gc.ttlseconds = 90000,
-                                                             num_replicas = 5,
-                                                             num_voters = 3,
-                                                             constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                                             voter_constraints = '[+region=ca-central-1]',
-                                                             lease_preferences = '[[+region=ca-central-1]]'
+                                                               range_min_bytes = 134217728,
+                                                               range_max_bytes = 536870912,
+                                                               gc.ttlseconds = 14400,
+                                                               num_replicas = 5,
+                                                               num_voters = 3,
+                                                               constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                               voter_constraints = '[+region=ca-central-1]',
+                                                               lease_preferences = '[[+region=ca-central-1]]'
 
 # Check that indexes also have the updated zone configs.
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "ap-southeast-2" OF INDEX mr2.t_rbr_with_idx@idx
 ----
 PARTITION "ap-southeast-2" OF INDEX mr2.public.t_rbr_with_idx@idx  ALTER PARTITION "ap-southeast-2" OF INDEX mr2.public.t_rbr_with_idx@idx CONFIGURE ZONE USING
-                                                                   range_min_bytes = 134217728,
-                                                                   range_max_bytes = 536870912,
-                                                                   gc.ttlseconds = 90000,
-                                                                   num_replicas = 4,
-                                                                   num_voters = 3,
-                                                                   constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
-                                                                   voter_constraints = '[+region=ap-southeast-2]',
-                                                                   lease_preferences = '[[+region=ap-southeast-2]]'
+                                                                     range_min_bytes = 134217728,
+                                                                     range_max_bytes = 536870912,
+                                                                     gc.ttlseconds = 14400,
+                                                                     num_replicas = 4,
+                                                                     num_voters = 3,
+                                                                     constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                                                                     voter_constraints = '[+region=ap-southeast-2]',
+                                                                     lease_preferences = '[[+region=ap-southeast-2]]'
 
 # Create new tables and ensure they adhere to the super region zone configs.
 statement ok
@@ -250,93 +250,93 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE mr2.t_rt2
 ----
 TABLE mr2.public.t_rt2  ALTER TABLE mr2.public.t_rt2 CONFIGURE ZONE USING
-                        range_min_bytes = 134217728,
-                        range_max_bytes = 536870912,
-                        gc.ttlseconds = 90000,
-                        num_replicas = 4,
-                        num_voters = 3,
-                        constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
-                        voter_constraints = '[+region=ap-southeast-2]',
-                        lease_preferences = '[[+region=ap-southeast-2]]'
+                          range_min_bytes = 134217728,
+                          range_max_bytes = 536870912,
+                          gc.ttlseconds = 14400,
+                          num_replicas = 4,
+                          num_voters = 3,
+                          constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                          voter_constraints = '[+region=ap-southeast-2]',
+                          lease_preferences = '[[+region=ap-southeast-2]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE mr2.t_rt_with_idx2
 ----
 TABLE mr2.public.t_rt_with_idx2  ALTER TABLE mr2.public.t_rt_with_idx2 CONFIGURE ZONE USING
-                                 range_min_bytes = 134217728,
-                                 range_max_bytes = 536870912,
-                                 gc.ttlseconds = 90000,
-                                 num_replicas = 4,
-                                 num_voters = 3,
-                                 constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
-                                 voter_constraints = '[+region=ap-southeast-2]',
-                                 lease_preferences = '[[+region=ap-southeast-2]]'
+                                   range_min_bytes = 134217728,
+                                   range_max_bytes = 536870912,
+                                   gc.ttlseconds = 14400,
+                                   num_replicas = 4,
+                                   num_voters = 3,
+                                   constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                                   voter_constraints = '[+region=ap-southeast-2]',
+                                   lease_preferences = '[[+region=ap-southeast-2]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR INDEX mr2.t_rt_with_idx2@idx
 ----
 TABLE mr2.public.t_rt_with_idx2  ALTER TABLE mr2.public.t_rt_with_idx2 CONFIGURE ZONE USING
-                                 range_min_bytes = 134217728,
-                                 range_max_bytes = 536870912,
-                                 gc.ttlseconds = 90000,
-                                 num_replicas = 4,
-                                 num_voters = 3,
-                                 constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
-                                 voter_constraints = '[+region=ap-southeast-2]',
-                                 lease_preferences = '[[+region=ap-southeast-2]]'
+                                   range_min_bytes = 134217728,
+                                   range_max_bytes = 536870912,
+                                   gc.ttlseconds = 14400,
+                                   num_replicas = 4,
+                                   num_voters = 3,
+                                   constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                                   voter_constraints = '[+region=ap-southeast-2]',
+                                   lease_preferences = '[[+region=ap-southeast-2]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "us-east-1" OF TABLE mr2.t_rbr2;
 ----
 PARTITION "us-east-1" OF TABLE mr2.public.t_rbr2  ALTER PARTITION "us-east-1" OF TABLE mr2.public.t_rbr2 CONFIGURE ZONE USING
-                                                  range_min_bytes = 134217728,
-                                                  range_max_bytes = 536870912,
-                                                  gc.ttlseconds = 90000,
-                                                  num_replicas = 4,
-                                                  num_voters = 3,
-                                                  constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
-                                                  voter_constraints = '[+region=us-east-1]',
-                                                  lease_preferences = '[[+region=us-east-1]]'
+                                                    range_min_bytes = 134217728,
+                                                    range_max_bytes = 536870912,
+                                                    gc.ttlseconds = 14400,
+                                                    num_replicas = 4,
+                                                    num_voters = 3,
+                                                    constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                                                    voter_constraints = '[+region=us-east-1]',
+                                                    lease_preferences = '[[+region=us-east-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "ap-southeast-2" OF TABLE mr2.t_rbr_with_idx2;
 ----
 PARTITION "ap-southeast-2" OF TABLE mr2.public.t_rbr_with_idx2  ALTER PARTITION "ap-southeast-2" OF TABLE mr2.public.t_rbr_with_idx2 CONFIGURE ZONE USING
-                                                                range_min_bytes = 134217728,
-                                                                range_max_bytes = 536870912,
-                                                                gc.ttlseconds = 90000,
-                                                                num_replicas = 4,
-                                                                num_voters = 3,
-                                                                constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
-                                                                voter_constraints = '[+region=ap-southeast-2]',
-                                                                lease_preferences = '[[+region=ap-southeast-2]]'
+                                                                  range_min_bytes = 134217728,
+                                                                  range_max_bytes = 536870912,
+                                                                  gc.ttlseconds = 14400,
+                                                                  num_replicas = 4,
+                                                                  num_voters = 3,
+                                                                  constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                                                                  voter_constraints = '[+region=ap-southeast-2]',
+                                                                  lease_preferences = '[[+region=ap-southeast-2]]'
 
 # Check that indexes also have the updated zone configs.
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "ap-southeast-2" OF INDEX mr2.t_rbr_with_idx2@idx
 ----
 PARTITION "ap-southeast-2" OF INDEX mr2.public.t_rbr_with_idx2@idx  ALTER PARTITION "ap-southeast-2" OF INDEX mr2.public.t_rbr_with_idx2@idx CONFIGURE ZONE USING
-                                                                    range_min_bytes = 134217728,
-                                                                    range_max_bytes = 536870912,
-                                                                    gc.ttlseconds = 90000,
-                                                                    num_replicas = 4,
-                                                                    num_voters = 3,
-                                                                    constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
-                                                                    voter_constraints = '[+region=ap-southeast-2]',
-                                                                    lease_preferences = '[[+region=ap-southeast-2]]'
+                                                                      range_min_bytes = 134217728,
+                                                                      range_max_bytes = 536870912,
+                                                                      gc.ttlseconds = 14400,
+                                                                      num_replicas = 4,
+                                                                      num_voters = 3,
+                                                                      constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                                                                      voter_constraints = '[+region=ap-southeast-2]',
+                                                                      lease_preferences = '[[+region=ap-southeast-2]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "us-east-1" OF INDEX mr2.t_rbr_with_idx2@idx
 ----
 PARTITION "us-east-1" OF INDEX mr2.public.t_rbr_with_idx2@idx  ALTER PARTITION "us-east-1" OF INDEX mr2.public.t_rbr_with_idx2@idx CONFIGURE ZONE USING
-                                                               range_min_bytes = 134217728,
-                                                               range_max_bytes = 536870912,
-                                                               gc.ttlseconds = 90000,
-                                                               num_replicas = 4,
-                                                               num_voters = 3,
-                                                               constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
-                                                               voter_constraints = '[+region=us-east-1]',
-                                                               lease_preferences = '[[+region=us-east-1]]'
+                                                                 range_min_bytes = 134217728,
+                                                                 range_max_bytes = 536870912,
+                                                                 gc.ttlseconds = 14400,
+                                                                 num_replicas = 4,
+                                                                 num_voters = 3,
+                                                                 constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                                                                 voter_constraints = '[+region=us-east-1]',
+                                                                 lease_preferences = '[[+region=us-east-1]]'
 
 # "ca-central-1" is not part of any super region so replicas should be placed in
 # all 3 regions.
@@ -344,14 +344,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "ca-central-1" OF INDEX mr2.t_rbr_with_idx2@idx
 ----
 PARTITION "ca-central-1" OF INDEX mr2.public.t_rbr_with_idx2@idx  ALTER PARTITION "ca-central-1" OF INDEX mr2.public.t_rbr_with_idx2@idx CONFIGURE ZONE USING
-                                                                  range_min_bytes = 134217728,
-                                                                  range_max_bytes = 536870912,
-                                                                  gc.ttlseconds = 90000,
-                                                                  num_replicas = 5,
-                                                                  num_voters = 3,
-                                                                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                                                  voter_constraints = '[+region=ca-central-1]',
-                                                                  lease_preferences = '[[+region=ca-central-1]]'
+                                                                    range_min_bytes = 134217728,
+                                                                    range_max_bytes = 536870912,
+                                                                    gc.ttlseconds = 14400,
+                                                                    num_replicas = 5,
+                                                                    num_voters = 3,
+                                                                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                                    voter_constraints = '[+region=ca-central-1]',
+                                                                    lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 CREATE TABLE mr2.t_rt_ca_central_1() LOCALITY REGIONAL BY TABLE IN "ca-central-1";
@@ -360,14 +360,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE mr2.t_rt_ca_central_1;
 ----
 TABLE mr2.public.t_rt_ca_central_1  ALTER TABLE mr2.public.t_rt_ca_central_1 CONFIGURE ZONE USING
-                                    range_min_bytes = 134217728,
-                                    range_max_bytes = 536870912,
-                                    gc.ttlseconds = 90000,
-                                    num_replicas = 5,
-                                    num_voters = 3,
-                                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                    voter_constraints = '[+region=ca-central-1]',
-                                    lease_preferences = '[[+region=ca-central-1]]'
+                                      range_min_bytes = 134217728,
+                                      range_max_bytes = 536870912,
+                                      gc.ttlseconds = 14400,
+                                      num_replicas = 5,
+                                      num_voters = 3,
+                                      constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                      voter_constraints = '[+region=ca-central-1]',
+                                      lease_preferences = '[[+region=ca-central-1]]'
 
 # Now let's create a super region with only "ca-central-1" and ensure
 # mr2.t_rt_ca_central_1's zone configs are updated to only be part of
@@ -379,14 +379,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE mr2.t_rt_ca_central_1;
 ----
 TABLE mr2.public.t_rt_ca_central_1  ALTER TABLE mr2.public.t_rt_ca_central_1 CONFIGURE ZONE USING
-                                    range_min_bytes = 134217728,
-                                    range_max_bytes = 536870912,
-                                    gc.ttlseconds = 90000,
-                                    num_replicas = 3,
-                                    num_voters = 3,
-                                    constraints = '{+region=ca-central-1: 1}',
-                                    voter_constraints = '[+region=ca-central-1]',
-                                    lease_preferences = '[[+region=ca-central-1]]'
+                                      range_min_bytes = 134217728,
+                                      range_max_bytes = 536870912,
+                                      gc.ttlseconds = 14400,
+                                      num_replicas = 3,
+                                      num_voters = 3,
+                                      constraints = '{+region=ca-central-1: 1}',
+                                      voter_constraints = '[+region=ca-central-1]',
+                                      lease_preferences = '[[+region=ca-central-1]]'
 
 # Ensure regional by row table partitions have the correct zone configs
 # when there are multiple super regions defined.
@@ -407,66 +407,66 @@ query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "us-east-1" OF TABLE mr3.rt
 ----
 PARTITION "us-east-1" OF TABLE mr3.public.rt  ALTER PARTITION "us-east-1" OF TABLE mr3.public.rt CONFIGURE ZONE USING
-                                              range_min_bytes = 134217728,
-                                              range_max_bytes = 536870912,
-                                              gc.ttlseconds = 90000,
-                                              num_replicas = 4,
-                                              num_voters = 3,
-                                              constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
-                                              voter_constraints = '[+region=us-east-1]',
-                                              lease_preferences = '[[+region=us-east-1]]'
+                                                range_min_bytes = 134217728,
+                                                range_max_bytes = 536870912,
+                                                gc.ttlseconds = 14400,
+                                                num_replicas = 4,
+                                                num_voters = 3,
+                                                constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                                                voter_constraints = '[+region=us-east-1]',
+                                                lease_preferences = '[[+region=us-east-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "ap-southeast-2" OF TABLE mr3.rt
 ----
 PARTITION "ap-southeast-2" OF TABLE mr3.public.rt  ALTER PARTITION "ap-southeast-2" OF TABLE mr3.public.rt CONFIGURE ZONE USING
-                                                   range_min_bytes = 134217728,
-                                                   range_max_bytes = 536870912,
-                                                   gc.ttlseconds = 90000,
-                                                   num_replicas = 4,
-                                                   num_voters = 3,
-                                                   constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
-                                                   voter_constraints = '[+region=ap-southeast-2]',
-                                                   lease_preferences = '[[+region=ap-southeast-2]]'
+                                                     range_min_bytes = 134217728,
+                                                     range_max_bytes = 536870912,
+                                                     gc.ttlseconds = 14400,
+                                                     num_replicas = 4,
+                                                     num_voters = 3,
+                                                     constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                                                     voter_constraints = '[+region=ap-southeast-2]',
+                                                     lease_preferences = '[[+region=ap-southeast-2]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "ca-central-1" OF TABLE mr3.rt
 ----
 PARTITION "ca-central-1" OF TABLE mr3.public.rt  ALTER PARTITION "ca-central-1" OF TABLE mr3.public.rt CONFIGURE ZONE USING
-                                                 range_min_bytes = 134217728,
-                                                 range_max_bytes = 536870912,
-                                                 gc.ttlseconds = 90000,
-                                                 num_replicas = 5,
-                                                 num_voters = 3,
-                                                 constraints = '{+region=ca-central-1: 1, +region=us-central-1: 1, +region=us-west-1: 1}',
-                                                 voter_constraints = '[+region=ca-central-1]',
-                                                 lease_preferences = '[[+region=ca-central-1]]'
+                                                   range_min_bytes = 134217728,
+                                                   range_max_bytes = 536870912,
+                                                   gc.ttlseconds = 14400,
+                                                   num_replicas = 5,
+                                                   num_voters = 3,
+                                                   constraints = '{+region=ca-central-1: 1, +region=us-central-1: 1, +region=us-west-1: 1}',
+                                                   voter_constraints = '[+region=ca-central-1]',
+                                                   lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "us-west-1" OF TABLE mr3.rt
 ----
 PARTITION "us-west-1" OF TABLE mr3.public.rt  ALTER PARTITION "us-west-1" OF TABLE mr3.public.rt CONFIGURE ZONE USING
-                                              range_min_bytes = 134217728,
-                                              range_max_bytes = 536870912,
-                                              gc.ttlseconds = 90000,
-                                              num_replicas = 5,
-                                              num_voters = 3,
-                                              constraints = '{+region=ca-central-1: 1, +region=us-central-1: 1, +region=us-west-1: 1}',
-                                              voter_constraints = '[+region=us-west-1]',
-                                              lease_preferences = '[[+region=us-west-1]]'
+                                                range_min_bytes = 134217728,
+                                                range_max_bytes = 536870912,
+                                                gc.ttlseconds = 14400,
+                                                num_replicas = 5,
+                                                num_voters = 3,
+                                                constraints = '{+region=ca-central-1: 1, +region=us-central-1: 1, +region=us-west-1: 1}',
+                                                voter_constraints = '[+region=us-west-1]',
+                                                lease_preferences = '[[+region=us-west-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "us-central-1" OF TABLE mr3.rt
 ----
 PARTITION "us-central-1" OF TABLE mr3.public.rt  ALTER PARTITION "us-central-1" OF TABLE mr3.public.rt CONFIGURE ZONE USING
-                                                 range_min_bytes = 134217728,
-                                                 range_max_bytes = 536870912,
-                                                 gc.ttlseconds = 90000,
-                                                 num_replicas = 5,
-                                                 num_voters = 3,
-                                                 constraints = '{+region=ca-central-1: 1, +region=us-central-1: 1, +region=us-west-1: 1}',
-                                                 voter_constraints = '[+region=us-central-1]',
-                                                 lease_preferences = '[[+region=us-central-1]]'
+                                                   range_min_bytes = 134217728,
+                                                   range_max_bytes = 536870912,
+                                                   gc.ttlseconds = 14400,
+                                                   num_replicas = 5,
+                                                   num_voters = 3,
+                                                   constraints = '{+region=ca-central-1: 1, +region=us-central-1: 1, +region=us-west-1: 1}',
+                                                   voter_constraints = '[+region=us-central-1]',
+                                                   lease_preferences = '[[+region=us-central-1]]'
 
 statement ok
 ALTER DATABASE mr3 DROP SUPER REGION "r2"
@@ -475,40 +475,40 @@ query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "ca-central-1" OF TABLE mr3.rt
 ----
 PARTITION "ca-central-1" OF TABLE mr3.public.rt  ALTER PARTITION "ca-central-1" OF TABLE mr3.public.rt CONFIGURE ZONE USING
-                                                 range_min_bytes = 134217728,
-                                                 range_max_bytes = 536870912,
-                                                 gc.ttlseconds = 90000,
-                                                 num_replicas = 7,
-                                                 num_voters = 3,
-                                                 constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-central-1: 1, +region=us-east-1: 1, +region=us-west-1: 1}',
-                                                 voter_constraints = '[+region=ca-central-1]',
-                                                 lease_preferences = '[[+region=ca-central-1]]'
+                                                   range_min_bytes = 134217728,
+                                                   range_max_bytes = 536870912,
+                                                   gc.ttlseconds = 14400,
+                                                   num_replicas = 7,
+                                                   num_voters = 3,
+                                                   constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-central-1: 1, +region=us-east-1: 1, +region=us-west-1: 1}',
+                                                   voter_constraints = '[+region=ca-central-1]',
+                                                   lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "us-west-1" OF TABLE mr3.rt
 ----
 PARTITION "us-west-1" OF TABLE mr3.public.rt  ALTER PARTITION "us-west-1" OF TABLE mr3.public.rt CONFIGURE ZONE USING
-                                              range_min_bytes = 134217728,
-                                              range_max_bytes = 536870912,
-                                              gc.ttlseconds = 90000,
-                                              num_replicas = 7,
-                                              num_voters = 3,
-                                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-central-1: 1, +region=us-east-1: 1, +region=us-west-1: 1}',
-                                              voter_constraints = '[+region=us-west-1]',
-                                              lease_preferences = '[[+region=us-west-1]]'
+                                                range_min_bytes = 134217728,
+                                                range_max_bytes = 536870912,
+                                                gc.ttlseconds = 14400,
+                                                num_replicas = 7,
+                                                num_voters = 3,
+                                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-central-1: 1, +region=us-east-1: 1, +region=us-west-1: 1}',
+                                                voter_constraints = '[+region=us-west-1]',
+                                                lease_preferences = '[[+region=us-west-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "us-central-1" OF TABLE mr3.rt
 ----
 PARTITION "us-central-1" OF TABLE mr3.public.rt  ALTER PARTITION "us-central-1" OF TABLE mr3.public.rt CONFIGURE ZONE USING
-                                                 range_min_bytes = 134217728,
-                                                 range_max_bytes = 536870912,
-                                                 gc.ttlseconds = 90000,
-                                                 num_replicas = 7,
-                                                 num_voters = 3,
-                                                 constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-central-1: 1, +region=us-east-1: 1, +region=us-west-1: 1}',
-                                                 voter_constraints = '[+region=us-central-1]',
-                                                 lease_preferences = '[[+region=us-central-1]]'
+                                                   range_min_bytes = 134217728,
+                                                   range_max_bytes = 536870912,
+                                                   gc.ttlseconds = 14400,
+                                                   num_replicas = 7,
+                                                   num_voters = 3,
+                                                   constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-central-1: 1, +region=us-east-1: 1, +region=us-west-1: 1}',
+                                                   voter_constraints = '[+region=us-central-1]',
+                                                   lease_preferences = '[[+region=us-central-1]]'
 
 # Test cases for survive region failure.
 
@@ -533,27 +533,27 @@ query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "us-central-1" OF TABLE mr3.rt
 ----
 PARTITION "us-central-1" OF TABLE mr3.public.rt  ALTER PARTITION "us-central-1" OF TABLE mr3.public.rt CONFIGURE ZONE USING
-                                                 range_min_bytes = 134217728,
-                                                 range_max_bytes = 536870912,
-                                                 gc.ttlseconds = 90000,
-                                                 num_replicas = 5,
-                                                 num_voters = 5,
-                                                 constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-central-1: 1}',
-                                                 voter_constraints = '{+region=us-central-1: 2}',
-                                                 lease_preferences = '[[+region=us-central-1]]'
+                                                   range_min_bytes = 134217728,
+                                                   range_max_bytes = 536870912,
+                                                   gc.ttlseconds = 14400,
+                                                   num_replicas = 5,
+                                                   num_voters = 5,
+                                                   constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-central-1: 1}',
+                                                   voter_constraints = '{+region=us-central-1: 2}',
+                                                   lease_preferences = '[[+region=us-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "ap-southeast-2" OF TABLE mr3.rt
 ----
 PARTITION "ap-southeast-2" OF TABLE mr3.public.rt  ALTER PARTITION "ap-southeast-2" OF TABLE mr3.public.rt CONFIGURE ZONE USING
-                                                   range_min_bytes = 134217728,
-                                                   range_max_bytes = 536870912,
-                                                   gc.ttlseconds = 90000,
-                                                   num_replicas = 5,
-                                                   num_voters = 5,
-                                                   constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-central-1: 1}',
-                                                   voter_constraints = '{+region=ap-southeast-2: 2}',
-                                                   lease_preferences = '[[+region=ap-southeast-2]]'
+                                                     range_min_bytes = 134217728,
+                                                     range_max_bytes = 536870912,
+                                                     gc.ttlseconds = 14400,
+                                                     num_replicas = 5,
+                                                     num_voters = 5,
+                                                     constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-central-1: 1}',
+                                                     voter_constraints = '{+region=ap-southeast-2: 2}',
+                                                     lease_preferences = '[[+region=ap-southeast-2]]'
 
 # Test region failure with 5 regions in a super region.
 # 5 regions is the minimum number of regions we need to have more than
@@ -566,27 +566,27 @@ query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "us-central-1" OF TABLE mr3.rt
 ----
 PARTITION "us-central-1" OF TABLE mr3.public.rt  ALTER PARTITION "us-central-1" OF TABLE mr3.public.rt CONFIGURE ZONE USING
-                                                 range_min_bytes = 134217728,
-                                                 range_max_bytes = 536870912,
-                                                 gc.ttlseconds = 90000,
-                                                 num_replicas = 6,
-                                                 num_voters = 5,
-                                                 constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-central-1: 1, +region=us-east-1: 1, +region=us-west-1: 1}',
-                                                 voter_constraints = '{+region=us-central-1: 2}',
-                                                 lease_preferences = '[[+region=us-central-1]]'
+                                                   range_min_bytes = 134217728,
+                                                   range_max_bytes = 536870912,
+                                                   gc.ttlseconds = 14400,
+                                                   num_replicas = 6,
+                                                   num_voters = 5,
+                                                   constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-central-1: 1, +region=us-east-1: 1, +region=us-west-1: 1}',
+                                                   voter_constraints = '{+region=us-central-1: 2}',
+                                                   lease_preferences = '[[+region=us-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "ap-southeast-2" OF TABLE mr3.rt
 ----
 PARTITION "ap-southeast-2" OF TABLE mr3.public.rt  ALTER PARTITION "ap-southeast-2" OF TABLE mr3.public.rt CONFIGURE ZONE USING
-                                                   range_min_bytes = 134217728,
-                                                   range_max_bytes = 536870912,
-                                                   gc.ttlseconds = 90000,
-                                                   num_replicas = 6,
-                                                   num_voters = 5,
-                                                   constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-central-1: 1, +region=us-east-1: 1, +region=us-west-1: 1}',
-                                                   voter_constraints = '{+region=ap-southeast-2: 2}',
-                                                   lease_preferences = '[[+region=ap-southeast-2]]'
+                                                     range_min_bytes = 134217728,
+                                                     range_max_bytes = 536870912,
+                                                     gc.ttlseconds = 14400,
+                                                     num_replicas = 6,
+                                                     num_voters = 5,
+                                                     constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-central-1: 1, +region=us-east-1: 1, +region=us-west-1: 1}',
+                                                     voter_constraints = '{+region=ap-southeast-2: 2}',
+                                                     lease_preferences = '[[+region=ap-southeast-2]]'
 
 # a user should not be able to drop a region that is a member of a super region.
 statement error pq: region us-east-1 is part of super region test
@@ -621,14 +621,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE db3.t
 ----
 TABLE db3.public.t  ALTER TABLE db3.public.t CONFIGURE ZONE USING
-                    range_min_bytes = 134217728,
-                    range_max_bytes = 536870912,
-                    gc.ttlseconds = 90000,
-                    num_replicas = 4,
-                    num_voters = 3,
-                    constraints = '{+region=ca-central-1: 1, +region=us-west-1: 1}',
-                    voter_constraints = '[+region=ca-central-1]',
-                    lease_preferences = '[[+region=ca-central-1]]'
+                      range_min_bytes = 134217728,
+                      range_max_bytes = 536870912,
+                      gc.ttlseconds = 14400,
+                      num_replicas = 4,
+                      num_voters = 3,
+                      constraints = '{+region=ca-central-1: 1, +region=us-west-1: 1}',
+                      voter_constraints = '[+region=ca-central-1]',
+                      lease_preferences = '[[+region=ca-central-1]]'
 
 # ALTER PRIMARY REGION to "us-west-1" does not block because the primary
 # region does not change super regions.
@@ -653,14 +653,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE db3.t
 ----
 TABLE db3.public.t  ALTER TABLE db3.public.t CONFIGURE ZONE USING
-                    range_min_bytes = 134217728,
-                    range_max_bytes = 536870912,
-                    gc.ttlseconds = 90000,
-                    num_replicas = 3,
-                    num_voters = 3,
-                    constraints = '{+region=us-east-1: 1}',
-                    voter_constraints = '[+region=us-east-1]',
-                    lease_preferences = '[[+region=us-east-1]]'
+                      range_min_bytes = 134217728,
+                      range_max_bytes = 536870912,
+                      gc.ttlseconds = 14400,
+                      num_replicas = 3,
+                      num_voters = 3,
+                      constraints = '{+region=us-east-1: 1}',
+                      voter_constraints = '[+region=us-east-1]',
+                      lease_preferences = '[[+region=us-east-1]]'
 
 # Alter primary region to "us-west-1" such that db3.t is no longer in a
 # super region.
@@ -675,14 +675,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE db3.t
 ----
 TABLE db3.public.t  ALTER TABLE db3.public.t CONFIGURE ZONE USING
-                    range_min_bytes = 134217728,
-                    range_max_bytes = 536870912,
-                    gc.ttlseconds = 90000,
-                    num_replicas = 4,
-                    num_voters = 3,
-                    constraints = '{+region=ca-central-1: 1, +region=us-west-1: 1}',
-                    voter_constraints = '[+region=us-west-1]',
-                    lease_preferences = '[[+region=us-west-1]]'
+                      range_min_bytes = 134217728,
+                      range_max_bytes = 536870912,
+                      gc.ttlseconds = 14400,
+                      num_replicas = 4,
+                      num_voters = 3,
+                      constraints = '{+region=ca-central-1: 1, +region=us-west-1: 1}',
+                      voter_constraints = '[+region=us-west-1]',
+                      lease_preferences = '[[+region=us-west-1]]'
 
 # ALTER SUPER REGION test cases.
 
@@ -710,14 +710,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE db3.t
 ----
 TABLE db3.public.t  ALTER TABLE db3.public.t CONFIGURE ZONE USING
-                    range_min_bytes = 134217728,
-                    range_max_bytes = 536870912,
-                    gc.ttlseconds = 90000,
-                    num_replicas = 5,
-                    num_voters = 3,
-                    constraints = '{+region=ca-central-1: 1, +region=us-east-1: 1, +region=us-west-1: 1}',
-                    voter_constraints = '[+region=us-west-1]',
-                    lease_preferences = '[[+region=us-west-1]]'
+                      range_min_bytes = 134217728,
+                      range_max_bytes = 536870912,
+                      gc.ttlseconds = 14400,
+                      num_replicas = 5,
+                      num_voters = 3,
+                      constraints = '{+region=ca-central-1: 1, +region=us-east-1: 1, +region=us-west-1: 1}',
+                      voter_constraints = '[+region=us-west-1]',
+                      lease_preferences = '[[+region=us-west-1]]'
 
 statement ok
 ALTER DATABASE db3 ALTER SUPER REGION "test1" VALUES "us-west-1";
@@ -726,14 +726,14 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE db3.t
 ----
 TABLE db3.public.t  ALTER TABLE db3.public.t CONFIGURE ZONE USING
-                    range_min_bytes = 134217728,
-                    range_max_bytes = 536870912,
-                    gc.ttlseconds = 90000,
-                    num_replicas = 3,
-                    num_voters = 3,
-                    constraints = '{+region=us-west-1: 1}',
-                    voter_constraints = '[+region=us-west-1]',
-                    lease_preferences = '[[+region=us-west-1]]'
+                      range_min_bytes = 134217728,
+                      range_max_bytes = 536870912,
+                      gc.ttlseconds = 14400,
+                      num_replicas = 3,
+                      num_voters = 3,
+                      constraints = '{+region=us-west-1: 1}',
+                      voter_constraints = '[+region=us-west-1]',
+                      lease_preferences = '[[+region=us-west-1]]'
 
 query ITTT
 SELECT id, database_name, super_region_name, regions FROM crdb_internal.super_regions

--- a/pkg/ccl/logictestccl/testdata/logic_test/super_regions_backup
+++ b/pkg/ccl/logictestccl/testdata/logic_test/super_regions_backup
@@ -35,40 +35,40 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE mr1.t;
 ----
 DATABASE mr1  ALTER DATABASE mr1 CONFIGURE ZONE USING
-              range_min_bytes = 134217728,
-              range_max_bytes = 536870912,
-              gc.ttlseconds = 90000,
-              num_replicas = 5,
-              num_voters = 3,
-              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-              voter_constraints = '[+region=ca-central-1]',
-              lease_preferences = '[[+region=ca-central-1]]'
+                range_min_bytes = 134217728,
+                range_max_bytes = 536870912,
+                gc.ttlseconds = 14400,
+                num_replicas = 5,
+                num_voters = 3,
+                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                voter_constraints = '[+region=ca-central-1]',
+                lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE mr1.t2
 ----
 DATABASE mr1  ALTER DATABASE mr1 CONFIGURE ZONE USING
-              range_min_bytes = 134217728,
-              range_max_bytes = 536870912,
-              gc.ttlseconds = 90000,
-              num_replicas = 5,
-              num_voters = 3,
-              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-              voter_constraints = '[+region=ca-central-1]',
-              lease_preferences = '[[+region=ca-central-1]]'
+                range_min_bytes = 134217728,
+                range_max_bytes = 536870912,
+                gc.ttlseconds = 14400,
+                num_replicas = 5,
+                num_voters = 3,
+                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                voter_constraints = '[+region=ca-central-1]',
+                lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "us-east-1" OF TABLE mr1.t2
 ----
 PARTITION "us-east-1" OF TABLE mr1.public.t2  ALTER PARTITION "us-east-1" OF TABLE mr1.public.t2 CONFIGURE ZONE USING
-                                              range_min_bytes = 134217728,
-                                              range_max_bytes = 536870912,
-                                              gc.ttlseconds = 90000,
-                                              num_replicas = 4,
-                                              num_voters = 3,
-                                              constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
-                                              voter_constraints = '[+region=us-east-1]',
-                                              lease_preferences = '[[+region=us-east-1]]'
+                                                range_min_bytes = 134217728,
+                                                range_max_bytes = 536870912,
+                                                gc.ttlseconds = 14400,
+                                                num_replicas = 4,
+                                                num_voters = 3,
+                                                constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                                                voter_constraints = '[+region=us-east-1]',
+                                                lease_preferences = '[[+region=us-east-1]]'
 
 statement ok
 DROP TABLE mr1.t;
@@ -86,37 +86,37 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE mr1.t;
 ----
 DATABASE mr1  ALTER DATABASE mr1 CONFIGURE ZONE USING
-              range_min_bytes = 134217728,
-              range_max_bytes = 536870912,
-              gc.ttlseconds = 90000,
-              num_replicas = 5,
-              num_voters = 3,
-              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-              voter_constraints = '[+region=ca-central-1]',
-              lease_preferences = '[[+region=ca-central-1]]'
+                range_min_bytes = 134217728,
+                range_max_bytes = 536870912,
+                gc.ttlseconds = 14400,
+                num_replicas = 5,
+                num_voters = 3,
+                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                voter_constraints = '[+region=ca-central-1]',
+                lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "us-east-1" OF TABLE mr1.t2
 ----
 PARTITION "us-east-1" OF TABLE mr1.public.t2  ALTER PARTITION "us-east-1" OF TABLE mr1.public.t2 CONFIGURE ZONE USING
-                                              range_min_bytes = 134217728,
-                                              range_max_bytes = 536870912,
-                                              gc.ttlseconds = 90000,
-                                              num_replicas = 4,
-                                              num_voters = 3,
-                                              constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
-                                              voter_constraints = '[+region=us-east-1]',
-                                              lease_preferences = '[[+region=us-east-1]]'
+                                                range_min_bytes = 134217728,
+                                                range_max_bytes = 536870912,
+                                                gc.ttlseconds = 14400,
+                                                num_replicas = 4,
+                                                num_voters = 3,
+                                                constraints = '{+region=ap-southeast-2: 1, +region=us-east-1: 1}',
+                                                voter_constraints = '[+region=us-east-1]',
+                                                lease_preferences = '[[+region=us-east-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE mr1.t2
 ----
 DATABASE mr1  ALTER DATABASE mr1 CONFIGURE ZONE USING
-              range_min_bytes = 134217728,
-              range_max_bytes = 536870912,
-              gc.ttlseconds = 90000,
-              num_replicas = 5,
-              num_voters = 3,
-              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-              voter_constraints = '[+region=ca-central-1]',
-              lease_preferences = '[[+region=ca-central-1]]'
+                range_min_bytes = 134217728,
+                range_max_bytes = 536870912,
+                gc.ttlseconds = 14400,
+                num_replicas = 5,
+                num_voters = 3,
+                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                voter_constraints = '[+region=ca-central-1]',
+                lease_preferences = '[[+region=ca-central-1]]'

--- a/pkg/ccl/logictestccl/testdata/logic_test/zone
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone
@@ -524,12 +524,12 @@ query TT
 SHOW ZONE CONFIGURATION FOR PARTITION x1 OF TABLE t35756
 ----
 RANGE default  ALTER RANGE default CONFIGURE ZONE USING
-               range_min_bytes = 134217728,
-               range_max_bytes = 536870912,
-               gc.ttlseconds = 90000,
-               num_replicas = 3,
-               constraints = '[]',
-               lease_preferences = '[]'
+                 range_min_bytes = 134217728,
+                 range_max_bytes = 536870912,
+                 gc.ttlseconds = 14400,
+                 num_replicas = 3,
+                 constraints = '[]',
+                 lease_preferences = '[]'
 
 # Regression test for #38391: verify that altering an index's partition really
 # modifies the partition.
@@ -1165,13 +1165,13 @@ query TT
 SHOW ZONE CONFIGURATION FOR TABLE global
 ----
 TABLE global  ALTER TABLE global CONFIGURE ZONE USING
-              range_min_bytes = 134217728,
-              range_max_bytes = 536870912,
-              gc.ttlseconds = 90000,
-              global_reads = true,
-              num_replicas = 7,
-              constraints = '[]',
-              lease_preferences = '[]'
+                range_min_bytes = 134217728,
+                range_max_bytes = 536870912,
+                gc.ttlseconds = 14400,
+                global_reads = true,
+                num_replicas = 7,
+                constraints = '[]',
+                lease_preferences = '[]'
 
 # Ensure the global_reads field has correct inheritance semantics for index
 # subzones.
@@ -1186,13 +1186,13 @@ query TT
 SHOW ZONE CONFIGURATION FOR INDEX i_69647
 ----
 TABLE test.public.t_69647  ALTER TABLE test.public.t_69647 CONFIGURE ZONE USING
-                           range_min_bytes = 134217728,
-                           range_max_bytes = 536870912,
-                           gc.ttlseconds = 90000,
-                           global_reads = true,
-                           num_replicas = 7,
-                           constraints = '[]',
-                           lease_preferences = '[]'
+                             range_min_bytes = 134217728,
+                             range_max_bytes = 536870912,
+                             gc.ttlseconds = 14400,
+                             global_reads = true,
+                             num_replicas = 7,
+                             constraints = '[]',
+                             lease_preferences = '[]'
 
 statement ok
 ALTER INDEX i_69647 CONFIGURE ZONE USING num_replicas=5
@@ -1201,13 +1201,13 @@ query TT
 SHOW ZONE CONFIGURATION FOR INDEX i_69647
 ----
 INDEX test.public.t_69647@i_69647  ALTER INDEX test.public.t_69647@i_69647 CONFIGURE ZONE USING
-                                   range_min_bytes = 134217728,
-                                   range_max_bytes = 536870912,
-                                   gc.ttlseconds = 90000,
-                                   global_reads = true,
-                                   num_replicas = 5,
-                                   constraints = '[]',
-                                   lease_preferences = '[]'
+                                     range_min_bytes = 134217728,
+                                     range_max_bytes = 536870912,
+                                     gc.ttlseconds = 14400,
+                                     global_reads = true,
+                                     num_replicas = 5,
+                                     constraints = '[]',
+                                     lease_preferences = '[]'
 
 statement ok
 ALTER INDEX i_69647 CONFIGURE ZONE USING global_reads = false
@@ -1216,13 +1216,13 @@ query TT
 SHOW ZONE CONFIGURATION FOR INDEX i_69647
 ----
 INDEX test.public.t_69647@i_69647  ALTER INDEX test.public.t_69647@i_69647 CONFIGURE ZONE USING
-                                   range_min_bytes = 134217728,
-                                   range_max_bytes = 536870912,
-                                   gc.ttlseconds = 90000,
-                                   global_reads = false,
-                                   num_replicas = 5,
-                                   constraints = '[]',
-                                   lease_preferences = '[]'
+                                     range_min_bytes = 134217728,
+                                     range_max_bytes = 536870912,
+                                     gc.ttlseconds = 14400,
+                                     global_reads = false,
+                                     num_replicas = 5,
+                                     constraints = '[]',
+                                     lease_preferences = '[]'
 
 
 # Same test as above, but this time for partitions instead of indexes.
@@ -1234,10 +1234,10 @@ query TT
 SHOW ZONE CONFIGURATION FOR PARTITION "one" OF TABLE t_69647
 ----
 PARTITION one OF TABLE t_69647  ALTER PARTITION one OF TABLE t_69647 CONFIGURE ZONE USING
-                                range_min_bytes = 134217728,
-                                range_max_bytes = 536870912,
-                                gc.ttlseconds = 90000,
-                                global_reads = true,
-                                num_replicas = 3,
-                                constraints = '[]',
-                                lease_preferences = '[]'
+                                  range_min_bytes = 134217728,
+                                  range_max_bytes = 536870912,
+                                  gc.ttlseconds = 14400,
+                                  global_reads = true,
+                                  num_replicas = 3,
+                                  constraints = '[]',
+                                  lease_preferences = '[]'

--- a/pkg/ccl/multiregionccl/region_test.go
+++ b/pkg/ccl/multiregionccl/region_test.go
@@ -424,7 +424,7 @@ func TestSettingPlacementAmidstAddDrop(t *testing.T) {
 ALTER TABLE db.public.global CONFIGURE ZONE USING
 	range_min_bytes = 134217728,
 	range_max_bytes = 536870912,
-	gc.ttlseconds = 90000,
+	gc.ttlseconds = 14400,
 	global_reads = true,
 	num_replicas = 5,
 	num_voters = 3,
@@ -440,7 +440,7 @@ ALTER TABLE db.public.global CONFIGURE ZONE USING
 ALTER TABLE db.public.global CONFIGURE ZONE USING
 	range_min_bytes = 134217728,
 	range_max_bytes = 536870912,
-	gc.ttlseconds = 90000,
+	gc.ttlseconds = 14400,
 	global_reads = true,
 	num_replicas = 3,
 	num_voters = 3,

--- a/pkg/ccl/multiregionccl/regional_by_row_test.go
+++ b/pkg/ccl/multiregionccl/regional_by_row_test.go
@@ -62,7 +62,7 @@ func TestAlterTableLocalityRegionalByRowCorrectZoneConfigBeforeBackfill(t *testi
 					ExpectedSQL: `ALTER DATABASE t CONFIGURE ZONE USING
 	range_min_bytes = 134217728,
 	range_max_bytes = 536870912,
-	gc.ttlseconds = 90000,
+	gc.ttlseconds = 14400,
 	num_replicas = 3,
 	num_voters = 3,
 	constraints = '{+region=ajstorm-1: 1}',
@@ -75,7 +75,7 @@ func TestAlterTableLocalityRegionalByRowCorrectZoneConfigBeforeBackfill(t *testi
 					ExpectedSQL: `ALTER PARTITION "ajstorm-1" OF INDEX t.public.test@new_primary_key CONFIGURE ZONE USING
 	range_min_bytes = 134217728,
 	range_max_bytes = 536870912,
-	gc.ttlseconds = 90000,
+	gc.ttlseconds = 14400,
 	num_replicas = 3,
 	num_voters = 3,
 	constraints = '{+region=ajstorm-1: 1}',
@@ -95,7 +95,7 @@ func TestAlterTableLocalityRegionalByRowCorrectZoneConfigBeforeBackfill(t *testi
 					ExpectedSQL: `ALTER TABLE t.public.test CONFIGURE ZONE USING
 	range_min_bytes = 134217728,
 	range_max_bytes = 536870912,
-	gc.ttlseconds = 90000,
+	gc.ttlseconds = 14400,
 	global_reads = true,
 	num_replicas = 3,
 	num_voters = 3,
@@ -109,7 +109,7 @@ func TestAlterTableLocalityRegionalByRowCorrectZoneConfigBeforeBackfill(t *testi
 					ExpectedSQL: `ALTER PARTITION "ajstorm-1" OF INDEX t.public.test@new_primary_key CONFIGURE ZONE USING
 	range_min_bytes = 134217728,
 	range_max_bytes = 536870912,
-	gc.ttlseconds = 90000,
+	gc.ttlseconds = 14400,
 	global_reads = true,
 	num_replicas = 3,
 	num_voters = 3,
@@ -130,7 +130,7 @@ func TestAlterTableLocalityRegionalByRowCorrectZoneConfigBeforeBackfill(t *testi
 					ExpectedSQL: `ALTER DATABASE t CONFIGURE ZONE USING
 	range_min_bytes = 134217728,
 	range_max_bytes = 536870912,
-	gc.ttlseconds = 90000,
+	gc.ttlseconds = 14400,
 	num_replicas = 3,
 	num_voters = 3,
 	constraints = '{+region=ajstorm-1: 1}',
@@ -150,7 +150,7 @@ func TestAlterTableLocalityRegionalByRowCorrectZoneConfigBeforeBackfill(t *testi
 					ExpectedSQL: `ALTER DATABASE t CONFIGURE ZONE USING
 	range_min_bytes = 134217728,
 	range_max_bytes = 536870912,
-	gc.ttlseconds = 90000,
+	gc.ttlseconds = 14400,
 	num_replicas = 3,
 	num_voters = 3,
 	constraints = '{+region=ajstorm-1: 1}',

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/multitenant/range_tenants
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/multitenant/range_tenants
@@ -11,9 +11,9 @@ mutations discard
 initialize tenant=10
 ----
 
-# Muck with the RANGE TENANTS zone config; lower the GC TTL to 4h.
+# Muck with the RANGE TENANTS zone config; lower the GC TTL to 5h.
 exec-sql
-ALTER RANGE TENANTS CONFIGURE ZONE USING gc.ttlseconds = 14400;
+ALTER RANGE TENANTS CONFIGURE ZONE USING gc.ttlseconds = 18000;
 ----
 
 query-sql
@@ -22,7 +22,7 @@ SHOW ZONE CONFIGURATION FOR RANGE TENANTS;
 RANGE tenants ALTER RANGE tenants CONFIGURE ZONE USING
 	range_min_bytes = 134217728,
 	range_max_bytes = 536870912,
-	gc.ttlseconds = 14400,
+	gc.ttlseconds = 18000,
 	num_replicas = 3,
 	constraints = '[]',
 	lease_preferences = '[]'
@@ -45,7 +45,7 @@ state offset=47
 /Table/5{2-3}                              database system (host)
 /Table/5{3-4}                              database system (host)
 /Tenant/10{-\x00}                          database system (tenant)
-/Tenant/11{-\x00}                          ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11{-\x00}                          ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
 
 # Start the reconciliation loop for the tenant=10. It should have the vanilla
 # RANGE DEFAULT. Check against the underlying KV state, the SQL view of the
@@ -104,7 +104,7 @@ state offset=47
 /Tenant/10/Table/5{1-2}                    database system (tenant)
 /Tenant/10/Table/5{2-3}                    database system (tenant)
 /Tenant/10/Table/5{3-4}                    database system (tenant)
-/Tenant/11{-\x00}                          ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11{-\x00}                          ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
 
 query-sql tenant=10
 SHOW ZONE CONFIGURATION FOR RANGE DEFAULT
@@ -112,7 +112,7 @@ SHOW ZONE CONFIGURATION FOR RANGE DEFAULT
 RANGE default ALTER RANGE default CONFIGURE ZONE USING
 	range_min_bytes = 134217728,
 	range_max_bytes = 536870912,
-	gc.ttlseconds = 90000,
+	gc.ttlseconds = 14400,
 	num_replicas = 3,
 	constraints = '[]',
 	lease_preferences = '[]'
@@ -153,45 +153,45 @@ state offset=81
 /Tenant/10/Table/5{3-4}                    database system (tenant)
 /Tenant/10/Table/10{6-7}                   range default
 /Tenant/10/Table/10{7-8}                   range default
-/Tenant/11{-/Table/4}                      ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/Table/{4-5}                     ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/Table/{5-6}                     ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/Table/{6-7}                     ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/Table/{7-8}                     ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/Table/1{1-2}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/Table/1{2-3}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/Table/1{3-4}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/Table/1{4-5}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/Table/1{5-6}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/Table/{19-20}                   ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/Table/2{0-1}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/Table/2{1-2}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/Table/2{3-4}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/Table/2{4-5}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/Table/2{5-6}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/Table/2{6-7}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/Table/2{7-8}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/Table/2{8-9}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/NamespaceTable/{30-Max}         ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/{NamespaceTable/Max-Table/32}   ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/Table/3{2-3}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/Table/3{3-4}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/Table/3{4-5}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/Table/3{5-6}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/Table/3{6-7}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/Table/3{7-8}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/Table/{39-40}                   ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/Table/4{0-1}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/Table/4{1-2}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/Table/4{2-3}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/Table/4{3-4}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/Table/4{4-5}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/Table/4{6-7}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/Table/4{8-9}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/Table/5{0-1}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/Table/5{1-2}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/Table/5{2-3}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
-/Tenant/11/Table/5{3-4}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11{-/Table/4}                      ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/{4-5}                     ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/{5-6}                     ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/{6-7}                     ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/{7-8}                     ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/1{1-2}                    ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/1{2-3}                    ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/1{3-4}                    ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/1{4-5}                    ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/1{5-6}                    ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/{19-20}                   ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/2{0-1}                    ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/2{1-2}                    ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/2{3-4}                    ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/2{4-5}                    ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/2{5-6}                    ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/2{6-7}                    ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/2{7-8}                    ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/2{8-9}                    ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/NamespaceTable/{30-Max}         ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/{NamespaceTable/Max-Table/32}   ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/3{2-3}                    ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/3{3-4}                    ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/3{4-5}                    ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/3{5-6}                    ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/3{6-7}                    ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/3{7-8}                    ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/{39-40}                   ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/4{0-1}                    ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/4{1-2}                    ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/4{2-3}                    ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/4{3-4}                    ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/4{4-5}                    ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/4{6-7}                    ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/4{8-9}                    ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/5{0-1}                    ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/5{1-2}                    ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/5{2-3}                    ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/5{3-4}                    ttl_seconds=18000 ignore_strict_gc=true rangefeed_enabled=true
 
 query-sql tenant=11
 SHOW ZONE CONFIGURATION FOR RANGE DEFAULT
@@ -199,7 +199,7 @@ SHOW ZONE CONFIGURATION FOR RANGE DEFAULT
 RANGE default ALTER RANGE default CONFIGURE ZONE USING
 	range_min_bytes = 134217728,
 	range_max_bytes = 536870912,
-	gc.ttlseconds = 14400,
+	gc.ttlseconds = 18000,
 	num_replicas = 3,
 	constraints = '[]',
 	lease_preferences = '[]'
@@ -212,5 +212,5 @@ CREATE TABLE db.t2();
 
 mutations tenant=11
 ----
-upsert /Tenant/11/Table/10{6-7}            ttl_seconds=14400
-upsert /Tenant/11/Table/10{7-8}            ttl_seconds=14400
+upsert /Tenant/11/Table/10{6-7}            ttl_seconds=18000
+upsert /Tenant/11/Table/10{7-8}            ttl_seconds=18000

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/indexes
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/indexes
@@ -16,7 +16,7 @@ SHOW ZONE CONFIGURATION FOR DATABASE db
 DATABASE db ALTER DATABASE db CONFIGURE ZONE USING
 	range_min_bytes = 134217728,
 	range_max_bytes = 536870912,
-	gc.ttlseconds = 90000,
+	gc.ttlseconds = 14400,
 	num_replicas = 7,
 	constraints = '[]',
 	lease_preferences = '[]'
@@ -27,7 +27,7 @@ SHOW ZONE CONFIGURATION FOR TABLE db.t
 DATABASE db ALTER DATABASE db CONFIGURE ZONE USING
 	range_min_bytes = 134217728,
 	range_max_bytes = 536870912,
-	gc.ttlseconds = 90000,
+	gc.ttlseconds = 14400,
 	num_replicas = 7,
 	constraints = '[]',
 	lease_preferences = '[]'
@@ -38,7 +38,7 @@ SHOW ZONE CONFIGURATION FOR INDEX db.t@idx
 INDEX db.public.t@idx ALTER INDEX db.public.t@idx CONFIGURE ZONE USING
 	range_min_bytes = 134217728,
 	range_max_bytes = 536870912,
-	gc.ttlseconds = 90000,
+	gc.ttlseconds = 14400,
 	num_replicas = 7,
 	num_voters = 5,
 	constraints = '[]',

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partitions_primary_index
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/partitions_primary_index
@@ -19,7 +19,7 @@ SHOW ZONE CONFIGURATION FOR DATABASE db
 DATABASE db ALTER DATABASE db CONFIGURE ZONE USING
 	range_min_bytes = 134217728,
 	range_max_bytes = 536870912,
-	gc.ttlseconds = 90000,
+	gc.ttlseconds = 14400,
 	num_replicas = 7,
 	constraints = '[]',
 	lease_preferences = '[]'
@@ -30,7 +30,7 @@ SHOW ZONE CONFIGURATION FOR TABLE db.t
 TABLE db.public.t ALTER TABLE db.public.t CONFIGURE ZONE USING
 	range_min_bytes = 134217728,
 	range_max_bytes = 536870912,
-	gc.ttlseconds = 90000,
+	gc.ttlseconds = 14400,
 	num_replicas = 7,
 	num_voters = 5,
 	constraints = '[]',
@@ -43,7 +43,7 @@ SHOW ZONE CONFIGURATION FOR PARTITION one_two OF TABLE db.t
 TABLE db.public.t ALTER TABLE db.public.t CONFIGURE ZONE USING
 	range_min_bytes = 134217728,
 	range_max_bytes = 536870912,
-	gc.ttlseconds = 90000,
+	gc.ttlseconds = 14400,
 	num_replicas = 7,
 	num_voters = 5,
 	constraints = '[]',

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/indexes
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/indexes
@@ -16,7 +16,7 @@ SHOW ZONE CONFIGURATION FOR DATABASE db
 DATABASE db ALTER DATABASE db CONFIGURE ZONE USING
 	range_min_bytes = 134217728,
 	range_max_bytes = 536870912,
-	gc.ttlseconds = 90000,
+	gc.ttlseconds = 14400,
 	num_replicas = 7,
 	constraints = '[]',
 	lease_preferences = '[]'
@@ -27,7 +27,7 @@ SHOW ZONE CONFIGURATION FOR TABLE db.t
 DATABASE db ALTER DATABASE db CONFIGURE ZONE USING
 	range_min_bytes = 134217728,
 	range_max_bytes = 536870912,
-	gc.ttlseconds = 90000,
+	gc.ttlseconds = 14400,
 	num_replicas = 7,
 	constraints = '[]',
 	lease_preferences = '[]'
@@ -38,7 +38,7 @@ SHOW ZONE CONFIGURATION FOR INDEX db.t@idx
 INDEX db.public.t@idx ALTER INDEX db.public.t@idx CONFIGURE ZONE USING
 	range_min_bytes = 134217728,
 	range_max_bytes = 536870912,
-	gc.ttlseconds = 90000,
+	gc.ttlseconds = 14400,
 	num_replicas = 7,
 	num_voters = 5,
 	constraints = '[]',

--- a/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/partitions_primary_index
+++ b/pkg/ccl/spanconfigccl/spanconfigsqltranslatorccl/testdata/tenant/partitions_primary_index
@@ -19,7 +19,7 @@ SHOW ZONE CONFIGURATION FOR DATABASE db
 DATABASE db ALTER DATABASE db CONFIGURE ZONE USING
 	range_min_bytes = 134217728,
 	range_max_bytes = 536870912,
-	gc.ttlseconds = 90000,
+	gc.ttlseconds = 14400,
 	num_replicas = 7,
 	constraints = '[]',
 	lease_preferences = '[]'
@@ -30,7 +30,7 @@ SHOW ZONE CONFIGURATION FOR TABLE db.t
 TABLE db.public.t ALTER TABLE db.public.t CONFIGURE ZONE USING
 	range_min_bytes = 134217728,
 	range_max_bytes = 536870912,
-	gc.ttlseconds = 90000,
+	gc.ttlseconds = 14400,
 	num_replicas = 7,
 	num_voters = 5,
 	constraints = '[]',
@@ -43,7 +43,7 @@ SHOW ZONE CONFIGURATION FOR PARTITION one_two OF TABLE db.t
 TABLE db.public.t ALTER TABLE db.public.t CONFIGURE ZONE USING
 	range_min_bytes = 134217728,
 	range_max_bytes = 536870912,
-	gc.ttlseconds = 90000,
+	gc.ttlseconds = 14400,
 	num_replicas = 7,
 	num_voters = 5,
 	constraints = '[]',

--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -110,6 +110,24 @@ func runVersionUpgrade(ctx context.Context, t test.Test, c cluster.Cluster) {
 		require.NoError(t, err)
 	}
 
+	checkPinnedGCTTLStep := func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
+		// TODO(irfansharif): This can be removed when the predecessor version
+		// in this test is v23.1, where the default is 4h. This test was only to
+		// make sure that existing clusters that upgrade to 23.1 retained their
+		// existing GC TTL.
+		t.L().Printf("checking if GC TTL is pinned to 25h")
+		var ttlSeconds int
+		query := `
+	SELECT
+		(crdb_internal.pb_to_json('cockroach.config.zonepb.ZoneConfig', raw_config_protobuf)->'gc'->'ttlSeconds')::INT
+	FROM crdb_internal.zones
+	WHERE target = 'RANGE default'
+	LIMIT 1
+`
+		require.NoError(t, u.conn(ctx, t, 1).QueryRowContext(ctx, query).Scan(&ttlSeconds))
+		require.Equal(t, 24*60*60, ttlSeconds) // NB: 24h is what's used in the fixture
+	}
+
 	// The steps below start a cluster at predecessorVersion (from a fixture),
 	// then start an upgrade that is rolled back, and finally start and finalize
 	// the upgrade. Between each step, we run the feature tests defined in
@@ -182,6 +200,7 @@ func runVersionUpgrade(ctx context.Context, t test.Test, c cluster.Cluster) {
 		testFeaturesStep,
 		// schemaChangeStep,
 		backupStep,
+		checkPinnedGCTTLStep,
 	)
 
 	u.run(ctx, t)

--- a/pkg/config/zonepb/zone.go
+++ b/pkg/config/zonepb/zone.go
@@ -235,15 +235,7 @@ func DefaultZoneConfig() ZoneConfig {
 		RangeMinBytes: proto.Int64(128 << 20), // 128 MB
 		RangeMaxBytes: proto.Int64(512 << 20), // 512 MB
 		GC: &GCPolicy{
-			// Use 25 hours instead of the previous 24 to make users successful by
-			// default. Users desiring to take incremental backups every 24h may
-			// incorrectly assume that the previous default 24h was sufficient to do
-			// that. But the equation for incremental backups is:
-			// 	GC TTLSeconds >= (desired backup interval) + (time to perform incremental backup)
-			// We think most new users' incremental backups will complete within an
-			// hour, and larger clusters will have more experienced operators and will
-			// understand how to change these settings if needed.
-			TTLSeconds: 25 * 60 * 60,
+			TTLSeconds: 4 * 60 * 60, // 4 hrs
 		},
 		// The default zone is supposed to have empty VoterConstraints.
 		NullVoterConstraintsIsEmpty: true,

--- a/pkg/roachpb/span_config.go
+++ b/pkg/roachpb/span_config.go
@@ -157,7 +157,7 @@ func TestingDefaultSpanConfig() SpanConfig {
 		RangeMinBytes: 128 << 20, // 128 MB
 		RangeMaxBytes: 512 << 20, // 512 MB
 		GCPolicy: GCPolicy{
-			TTLSeconds: 25 * 60 * 60,
+			TTLSeconds: 4 * 60 * 60, // 4 hrs
 		},
 		NumReplicas: 3,
 	}

--- a/pkg/sql/catalog/internal/catkv/testdata/testdata
+++ b/pkg/sql/catalog/internal/catkv/testdata/testdata
@@ -134,7 +134,7 @@ get_by_ids id=0
 ----
 catalog:
   "000":
-    zone: gc.ttlseconds=90000
+    zone: gc.ttlseconds=14400
 trace:
 - Get /Table/3/1/0/2/1
 - Scan /Table/24/1/0/0
@@ -219,11 +219,11 @@ scan_all
 ----
 catalog:
   "000":
-    zone: gc.ttlseconds=90000
+    zone: gc.ttlseconds=14400
   "001":
     descriptor: database
     namespace: (0, 0, "system")
-    zone: gc.ttlseconds=90000
+    zone: gc.ttlseconds=14400
   "003":
     descriptor: relation
     namespace: (1, 29, "descriptor")
@@ -260,7 +260,7 @@ catalog:
   "016":
     zone: gc.ttlseconds=3600
   "017":
-    zone: gc.ttlseconds=90000
+    zone: gc.ttlseconds=14400
   "019":
     descriptor: relation
     namespace: (1, 29, "web_sessions")

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -490,7 +490,7 @@ SELECT zone_id, target FROM crdb_internal.zones ORDER BY 1
 query T
 SELECT quote_literal(raw_config_yaml) FROM crdb_internal.zones WHERE zone_id = 0
 ----
-e'range_min_bytes: 134217728\nrange_max_bytes: 536870912\ngc:\n  ttlseconds: 90000\nglobal_reads: null\nnum_replicas: 3\nnum_voters: null\nconstraints: []\nvoter_constraints: []\nlease_preferences: []\n'
+e'range_min_bytes: 134217728\nrange_max_bytes: 536870912\ngc:\n  ttlseconds: 14400\nglobal_reads: null\nnum_replicas: 3\nnum_voters: null\nconstraints: []\nvoter_constraints: []\nlease_preferences: []\n'
 
 query T
 SELECT raw_config_sql FROM crdb_internal.zones WHERE zone_id = 0
@@ -498,7 +498,7 @@ SELECT raw_config_sql FROM crdb_internal.zones WHERE zone_id = 0
 ALTER RANGE default CONFIGURE ZONE USING
   range_min_bytes = 134217728,
   range_max_bytes = 536870912,
-  gc.ttlseconds = 90000,
+  gc.ttlseconds = 14400,
   num_replicas = 3,
   constraints = '[]',
   lease_preferences = '[]'

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal_catalog
@@ -526,10 +526,10 @@ SELECT * FROM "".crdb_internal.kv_catalog_namespace
 query IT
 SELECT * FROM "".crdb_internal.kv_catalog_zones
 ----
-0    {"gc": {"ttlSeconds": 90000}, "nullVoterConstraintsIsEmpty": true, "numReplicas": 3, "rangeMaxBytes": "536870912", "rangeMinBytes": "134217728"}
-1    {"gc": {"ttlSeconds": 90000}, "nullVoterConstraintsIsEmpty": true, "numReplicas": 5, "rangeMaxBytes": "536870912", "rangeMinBytes": "134217728"}
+0    {"gc": {"ttlSeconds": 14400}, "nullVoterConstraintsIsEmpty": true, "numReplicas": 3, "rangeMaxBytes": "536870912", "rangeMinBytes": "134217728"}
+1    {"gc": {"ttlSeconds": 14400}, "nullVoterConstraintsIsEmpty": true, "numReplicas": 5, "rangeMaxBytes": "536870912", "rangeMinBytes": "134217728"}
 16   {"gc": {"ttlSeconds": 3600}, "nullVoterConstraintsIsEmpty": true, "numReplicas": 5, "rangeMaxBytes": "536870912", "rangeMinBytes": "134217728"}
-17   {"gc": {"ttlSeconds": 90000}, "nullVoterConstraintsIsEmpty": true, "numReplicas": 5, "rangeMaxBytes": "536870912", "rangeMinBytes": "134217728"}
+17   {"gc": {"ttlSeconds": 14400}, "nullVoterConstraintsIsEmpty": true, "numReplicas": 5, "rangeMaxBytes": "536870912", "rangeMinBytes": "134217728"}
 22   {"gc": {"ttlSeconds": 600}, "nullVoterConstraintsIsEmpty": true, "numReplicas": 5, "rangeMaxBytes": "536870912", "rangeMinBytes": "134217728"}
 25   {"gc": {"ttlSeconds": 600}}
 27   {"gc": {"ttlSeconds": 600}}

--- a/pkg/sql/logictest/testdata/logic_test/tenant_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/tenant_builtins
@@ -179,12 +179,12 @@ query TT
 SHOW ZONE CONFIGURATION FOR RANGE tenants
 ----
 RANGE default  ALTER RANGE default CONFIGURE ZONE USING
-               range_min_bytes = 134217728,
-               range_max_bytes = 536870912,
-               gc.ttlseconds = 90000,
-               num_replicas = 3,
-               constraints = '[]',
-               lease_preferences = '[]'
+                 range_min_bytes = 134217728,
+                 range_max_bytes = 536870912,
+                 gc.ttlseconds = 14400,
+                 num_replicas = 3,
+                 constraints = '[]',
+                 lease_preferences = '[]'
 
 statement ok
 ALTER RANGE tenants CONFIGURE ZONE USING gc.ttlseconds = 1

--- a/pkg/sql/logictest/testdata/logic_test/zone_config
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config
@@ -10,12 +10,12 @@ query IT
 SELECT zone_id, raw_config_sql FROM [SHOW ZONE CONFIGURATION FOR RANGE default]
 ----
 0  ALTER RANGE default CONFIGURE ZONE USING
-   range_min_bytes = 134217728,
-   range_max_bytes = 536870912,
-   gc.ttlseconds = 90000,
-   num_replicas = 1,
-   constraints = '[]',
-   lease_preferences = '[]'
+     range_min_bytes = 134217728,
+     range_max_bytes = 536870912,
+     gc.ttlseconds = 14400,
+     num_replicas = 1,
+     constraints = '[]',
+     lease_preferences = '[]'
 
 # Check that we can reset the default zone config to defaults.
 
@@ -26,12 +26,12 @@ query IT
 SELECT zone_id, raw_config_sql FROM [SHOW ZONE CONFIGURATION FOR RANGE default]
 ----
 0  ALTER RANGE default CONFIGURE ZONE USING
-   range_min_bytes = 134217728,
-   range_max_bytes = 536870912,
-   gc.ttlseconds = 90000,
-   num_replicas = 3,
-   constraints = '[]',
-   lease_preferences = '[]'
+     range_min_bytes = 134217728,
+     range_max_bytes = 536870912,
+     gc.ttlseconds = 14400,
+     num_replicas = 3,
+     constraints = '[]',
+     lease_preferences = '[]'
 
 # Make an override for the tests below
 
@@ -47,12 +47,12 @@ query IT
 SELECT zone_id, raw_config_sql FROM [SHOW ZONE CONFIGURATION FOR TABLE a]
 ----
 0  ALTER RANGE default CONFIGURE ZONE USING
-   range_min_bytes = 1234567,
-   range_max_bytes = 536870912,
-   gc.ttlseconds = 90000,
-   num_replicas = 3,
-   constraints = '[]',
-   lease_preferences = '[]'
+     range_min_bytes = 1234567,
+     range_max_bytes = 536870912,
+     gc.ttlseconds = 14400,
+     num_replicas = 3,
+     constraints = '[]',
+     lease_preferences = '[]'
 
 # Once USING DEFAULT has been used, we get the default config
 # but with our own zone config ID.
@@ -64,12 +64,12 @@ query IT
 SELECT zone_id, raw_config_sql FROM [SHOW ZONE CONFIGURATION FOR TABLE a]
 ----
 106  ALTER TABLE a CONFIGURE ZONE USING
-     range_min_bytes = 1234567,
-     range_max_bytes = 536870912,
-     gc.ttlseconds = 90000,
-     num_replicas = 3,
-     constraints = '[]',
-     lease_preferences = '[]'
+       range_min_bytes = 1234567,
+       range_max_bytes = 536870912,
+       gc.ttlseconds = 14400,
+       num_replicas = 3,
+       constraints = '[]',
+       lease_preferences = '[]'
 
 # Check that configurations can be adjusted with USING.
 statement ok
@@ -187,12 +187,12 @@ query IT
 SELECT zone_id, raw_config_sql FROM [SHOW ZONE CONFIGURATION FOR TABLE a]
 ----
 106  ALTER TABLE a CONFIGURE ZONE USING
-     range_min_bytes = 1234567,
-     range_max_bytes = 536870912,
-     gc.ttlseconds = 90000,
-     num_replicas = 3,
-     constraints = '[]',
-     lease_preferences = '[]'
+       range_min_bytes = 1234567,
+       range_max_bytes = 536870912,
+       gc.ttlseconds = 14400,
+       num_replicas = 3,
+       constraints = '[]',
+       lease_preferences = '[]'
 
 # Check that we can drop a configuration to get back to inherinting
 # the defaults.
@@ -231,12 +231,12 @@ query IT
 SELECT zone_id, raw_config_sql FROM [SHOW ZONE CONFIGURATION FOR TABLE a]
 ----
 106  ALTER TABLE a CONFIGURE ZONE USING
-     range_min_bytes = 1234567,
-     range_max_bytes = 536870912,
-     gc.ttlseconds = 90000,
-     num_replicas = 3,
-     constraints = '[]',
-     lease_preferences = '[]'
+       range_min_bytes = 1234567,
+       range_max_bytes = 536870912,
+       gc.ttlseconds = 14400,
+       num_replicas = 3,
+       constraints = '[]',
+       lease_preferences = '[]'
 
 statement ok
 ALTER TABLE a CONFIGURE ZONE USING num_voters = 1;
@@ -245,14 +245,14 @@ query IT
 SELECT zone_id, raw_config_sql FROM [SHOW ZONE CONFIGURATION FOR TABLE a]
 ----
 106  ALTER TABLE a CONFIGURE ZONE USING
-     range_min_bytes = 1234567,
-     range_max_bytes = 536870912,
-     gc.ttlseconds = 90000,
-     num_replicas = 3,
-     num_voters = 1,
-     constraints = '[]',
-     voter_constraints = '[]',
-     lease_preferences = '[]'
+       range_min_bytes = 1234567,
+       range_max_bytes = 536870912,
+       gc.ttlseconds = 14400,
+       num_replicas = 3,
+       num_voters = 1,
+       constraints = '[]',
+       voter_constraints = '[]',
+       lease_preferences = '[]'
 
 # 3. Sanity check that `voter_constraints` can be reset.
 statement ok
@@ -265,14 +265,14 @@ query IT
 SELECT zone_id, raw_config_sql FROM [SHOW ZONE CONFIGURATION FOR TABLE a]
 ----
 106  ALTER TABLE a CONFIGURE ZONE USING
-     range_min_bytes = 1234567,
-     range_max_bytes = 536870912,
-     gc.ttlseconds = 90000,
-     num_replicas = 3,
-     num_voters = 1,
-     constraints = '[]',
-     voter_constraints = '{+region=test: 1}',
-     lease_preferences = '[]'
+       range_min_bytes = 1234567,
+       range_max_bytes = 536870912,
+       gc.ttlseconds = 14400,
+       num_replicas = 3,
+       num_voters = 1,
+       constraints = '[]',
+       voter_constraints = '{+region=test: 1}',
+       lease_preferences = '[]'
 
 # Different error based on if the test is being run in the system tenant or
 # a secondary tenant.

--- a/pkg/sql/logictest/testdata/logic_test/zone_config_system_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config_system_tenant
@@ -104,7 +104,7 @@ SELECT crdb_internal.pb_to_json('cockroach.roachpb.SpanConfig', config)
 FROM system.span_configurations
 WHERE end_key > (SELECT crdb_internal.table_span($t_id)[1])
 ----
-{"gcPolicy": {"ttlSeconds": 90000}, "numReplicas": 3, "rangeMaxBytes": "16777216", "rangeMinBytes": "1048576"}
+{"gcPolicy": {"ttlSeconds": 14400}, "numReplicas": 3, "rangeMaxBytes": "16777216", "rangeMinBytes": "1048576"}
 
 statement ok
 CREATE TABLE db2.t2 (i INT PRIMARY KEY);


### PR DESCRIPTION
Fixes #89233.

Release note (general change): The GC TTL previously defaulted to 25h. This value was configurable using `ALTER RANGE DEFAULT CONFIGURE ZONE USING gc.ttlseconds = <whatever>`, but also possible to scope to specific schema objects using `ALTER {DATABASE,TABLE,INDEX} CONFIGURE ZONE USING ...`. This value determine how long overwritten values were retained. The `RANGE DEFAULT` value is now lowered to 4h but only for freshly created clusters. When existing clusters upgrade onto this release, we will respect whatever value they were using before the upgrade for all their schema objects. This will be 25h if the GC TTL was never altered, or some specific value if set explicitly. Full cluster backups taken on earlier version clusters, when restored to clusters that started off at v23.1, will use the GC TTL recorded in the backup image.

We've found the 25h value to translate to higher-than-necessary storage costs, especially for workloads where rows are deleted frequently. It can also make for costlier reads with respect to CPU since we currently have to scan over overwritten values to get to the one of interest. Finally, we've also observed cluster instability due to large unsplittable ranges that have accumulated an excessive amount of MVCC garbage. We chose a default of 25h originally to accommodate daily incremental backups with revision history. But with the introduction of scheduled backups introduced in 22.2, we no longer need a large GC TTL. Scheduled backups "chain together" and prevent garbage collection of relevant data to ensure coverage of revision history across backups, decoupling it from whatever value is used for GC TTL. So we no longer need a 25h default, hence this change.

The GC TTL determines how far back AS OF SYSTEM TIME queries can go, which now if going past `now()-4h`, will start failing informatively. To support larger windows for AS OF SYSTEM TIME queries, users are encouraged to pick a more appropriate GC TTL and set it using `ALTER ... CONFIGURE ZONE using gc.ttlseconds = <whatever>`. The earlier considerations around storage use, read costs, and stability still apply.

Release note (backward-incompatible change): See release note above. Technically this is not a backwards-incompatible change since we're only changing the default value that new clusters are initialized with -- existing clusters will remain unaffected. But it might be worth highlighting this change more prominently to our users for added scrutiny.