### PR TITLE
backupccl: deflake TestClusterRestoreFailCleanup

### DIFF
--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -609,6 +609,12 @@ func TestClusterRestoreFailCleanup(t *testing.T) {
 	_, sqlDB, tempDir, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
 	defer cleanupFn()
 
+	// This test flakes due to
+	// https://github.com/cockroachdb/cockroach/issues/86806. Instead of skipping
+	// the test all together, setting the cluster setting to false which triggers
+	// the failure.
+	sqlDB.Exec(t, "SET CLUSTER SETTING kv.bulkio.write_metadata_sst.enabled=false")
+
 	// Setup the system systemTablesToVerify to ensure that they are copied to the new cluster.
 	// Populate system.users.
 	for i := 0; i < 1000; i++ {


### PR DESCRIPTION
This test occasionally flakes due to #86806. To prevent the flakiness, this patch manually sets the kv.bulkio.write_metadata_sst.enabled cluster setting to false. When #86806  gets addressed, this patch should be reverted.

Epic: None

Release note: None