### PR TITLE
flowinfra: fix gRPC stream leak

### DIFF
--- a/pkg/sql/flowinfra/outbox.go
+++ b/pkg/sql/flowinfra/outbox.go
@@ -406,6 +406,13 @@ func (m *Outbox) listenForDrainSignalFromConsumer(ctx context.Context) (<-chan d
 			switch {
 			case signal.DrainRequest != nil:
 				if shouldExit := sendDrainSignal(true, nil); shouldExit {
+					// Drain the stream, as per the gRPC contract.
+					for {
+						_, err := stream.Recv()
+						if err != nil {
+							break
+						}
+					}
 					return
 				}
 			case signal.Handshake != nil:


### PR DESCRIPTION
The outbox wasn't always properly handling the gRPC stream from the consumer. As per the gRPC contract hidden in [1], one can't simply walk away from a stream; it needs to make sure it's closed in one of a number of ways, otherwise gRPC leaks goroutines.
Taking that contract to heart, our stream tracing also leaks spans if the stream is not disposed of properly. We were not hitting this part, though, because the outbox uses a dubious context.TODO() when establishing the stream - so our tracing was inhibited. But I was doing what was supposed to be an innocuous change to create a client-side span for such a stream, only to hit it.

[1] https://pkg.go.dev/google.golang.org/grpc#ClientConn.NewStream

Release note: None
Epic: None