### PR TITLE
tree: make typeCheckSameTypedPlaceholders return the type

### DIFF
--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -465,3 +465,55 @@ func TestTypeCheckCollatedString(t *testing.T) {
 	require.Equal(t, rightTyp.Family(), types.CollatedStringFamily)
 	require.Equal(t, rightTyp.Locale(), "en-US-u-ks-level2")
 }
+
+func TestTypeCheckCaseExprWithPlaceholders(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Typecheck without any restrictions.
+	ctx := context.Background()
+	semaCtx := tree.MakeSemaContext()
+	semaCtx.Properties.Require("", 0 /* flags */)
+
+	// Hint all int4 types.
+	placeholderTypes := []*types.T{types.Int4, types.Int4, types.Int4, types.Int4, types.Int4}
+	err := semaCtx.Placeholders.Init(len(placeholderTypes), placeholderTypes)
+	require.NoError(t, err)
+
+	expr, err := parser.ParseExpr("case when 1 < $1 then $2 else $3 end = $4")
+	require.NoError(t, err)
+	typed, err := tree.TypeCheck(ctx, expr, &semaCtx, types.Any)
+	require.NoError(t, err)
+
+	leftTyp := typed.(*tree.ComparisonExpr).Left.(tree.TypedExpr).ResolvedType()
+	require.Equal(t, types.Int4, leftTyp)
+}
+
+func TestTypeCheckCaseExprWithConstantsAndUnresolvedPlaceholders(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Typecheck without any restrictions.
+	ctx := context.Background()
+	semaCtx := tree.MakeSemaContext()
+	semaCtx.Properties.Require("", 0 /* flags */)
+
+	// Hint all int4 types, but leave one of the THEN branches unhinted.
+	placeholderTypes := []*types.T{types.Int4, types.Int4, types.Int4, nil, types.Int4}
+	err := semaCtx.Placeholders.Init(len(placeholderTypes), placeholderTypes)
+	require.NoError(t, err)
+
+	expr, err := parser.ParseExpr("case when 1 < $1 then $2 when 1 < $3 then $4 else 3 end = $5")
+	require.NoError(t, err)
+	typed, err := tree.TypeCheck(ctx, expr, &semaCtx, types.Any)
+	require.NoError(t, err)
+
+	leftTyp := typed.(*tree.ComparisonExpr).Left.(tree.TypedExpr).ResolvedType()
+	require.Equal(t, types.Int4, leftTyp)
+
+	for i := 0; i < len(placeholderTypes); i++ {
+		pTyp, _, err := semaCtx.Placeholders.Type(tree.PlaceholderIdx(i))
+		require.NoError(t, err)
+		require.Equal(t, types.Int4, pTyp)
+	}
+}


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/93245
backport fixes https://github.com/cockroachdb/cockroach/issues/93493

Previously, this function always returned the "desired" type that was passed in. This was insufficient in cases where the desired type was types.Any. Now, the function returns the actual type that the placeholders were resolved to.

Release note (bug fix): Fixed a bug that could prevent CASE expressions that used placeholder return values from type-checking correctly.