### PR TITLE
release-22.1: sql: propagate session_id into subqueries

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1529,6 +1529,7 @@ func (ex *connExecutor) execWithDistSQLEngine(
 			ex.resetEvalCtx(&factoryEvalCtx, planner.txn, planner.ExtendedEvalContext().StmtTimestamp)
 			factoryEvalCtx.Placeholders = &planner.semaCtx.Placeholders
 			factoryEvalCtx.Annotations = &planner.semaCtx.Annotations
+			factoryEvalCtx.SessionID = planner.ExtendedEvalContext().SessionID
 			// Query diagnostics can change the Context; make sure we are using the
 			// same one.
 			// TODO(radu): consider removing this if/when #46164 is addressed.

--- a/pkg/sql/logictest/testdata/logic_test/subquery
+++ b/pkg/sql/logictest/testdata/logic_test/subquery
@@ -550,3 +550,13 @@ WHERE
   t.oid
   NOT IN (SELECT (ARRAY[704, 11676, 10005, 3912, 11765, 59410, 11397])[i] FROM generate_series(1, 376) AS i)
 ----
+
+# Regression test for SHOW session_id in a subquery.
+# See https://github.com/cockroachdb/cockroach/issues/93739
+let $session_id
+SHOW session_id
+
+query B
+select lower((select session_id from [show session_id])) = lower('$session_id')
+----
+true

--- a/pkg/sql/run_control_test.go
+++ b/pkg/sql/run_control_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltestutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
@@ -398,6 +399,18 @@ func TestCancelIfExists(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestCancelWithSubquery(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	params, _ := tests.CreateTestServerParams()
+	s, conn, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(context.Background())
+
+	_, err := conn.Exec("CANCEL SESSION (SELECT session_id FROM [SHOW session_id]);")
+	require.EqualError(t, err, "driver: bad connection")
 }
 
 func TestIdleInSessionTimeout(t *testing.T) {


### PR DESCRIPTION
Backport 1/1 commits from #93748.

/cc @cockroachdb/release

---

fixes https://github.com/cockroachdb/cockroach/issues/93739

Release note (bug fix): Fixed a bug where the session_id session variable would not be properly set if used from a subquery,
