### PR TITLE
colexec: fix range stats operator with the selection vector

### DIFF
--- a/pkg/col/coldata/batch.go
+++ b/pkg/col/coldata/batch.go
@@ -47,6 +47,8 @@ type Batch interface {
 	// Selection, if not nil, returns the selection vector on this batch: a
 	// densely-packed list of the *increasing* indices in each column that have
 	// not been filtered out by a previous step.
+	// TODO(yuzefovich): consider ensuring that the length of the returned slice
+	// equals the length of the batch.
 	Selection() []int
 	// SetSelection sets whether this batch is using its selection vector or not.
 	SetSelection(bool)

--- a/pkg/sql/colexec/range_stats.go
+++ b/pkg/sql/colexec/range_stats.go
@@ -108,7 +108,7 @@ func (r *rangeStatsOperator) Next() coldata.Batch {
 					keysOutputIdx = append(keysOutputIdx, i)
 				}
 			} else {
-				for _, idx := range inSel {
+				for _, idx := range inSel[:batch.Length()] {
 					if inNulls.MaybeHasNulls() && inNulls.NullAt(idx) {
 						// Skip all NULL keys.
 						continue
@@ -127,6 +127,8 @@ func (r *rangeStatsOperator) Next() coldata.Batch {
 			// TODO(ajwerner): Reserve memory for the responses. We know they'll
 			// at least, on average, contain keys so it'll be 2x the size of the
 			// keys plus some constant multiple.
+			// TODO(yuzefovich): add unit tests that use the RunTests test
+			// harness.
 			res, err := r.fetcher.RangeStats(r.Ctx, keys...)
 			if err != nil {
 				colexecerror.ExpectedError(err)


### PR DESCRIPTION
Previously, if the input batch had a selection vector set, we could get an index out of bounds internal error because we would iterate up to the length of the selection vector which can exceed the length of the batch.

Note that in practice this should be very rare to hit - generally speaking, the selection vector has the same length as all of the vectors in the batch. I couldn't reproduce the problem when using `demo`, so there is no regression test. Introduction of unit tests that use powerful `RunTests` test harness (that might have caught this bug) is left as a TODO.

Fixes: #93806.
Epic: CRDB-22701

Release note (bug fix): CockroachDB could previously, in rare cases, encounter an internal error when evaluating `crdb_internal.range_stats` builtin (which powers `SHOW RANGES` command among other things). The bug was introduced in 22.2.0 and is now fixed.