### PR TITLE
kvnemesis: ignore `SysBytes:10` MVCC stats discrepancy

### DIFF
--- a/pkg/kv/kvnemesis/env.go
+++ b/pkg/kv/kvnemesis/env.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	gosql "database/sql"
 	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/cockroachdb/cockroach-go/v2/crdb"
@@ -66,6 +67,22 @@ func (e *Env) CheckConsistency(ctx context.Context, span roachpb.Span) []error {
 		var key, status, detail string
 		if err := rows.Scan(&rangeID, &key, &status, &detail); err != nil {
 			return []error{err}
+		}
+		// TODO(erikgrinaker): There's a known issue that can result in a 10-byte
+		// discrepancy in SysBytes. This hasn't been investigated, but it's not
+		// critical so we ignore it for now. See:
+		// https://github.com/cockroachdb/cockroach/issues/93896
+		if status == roachpb.CheckConsistencyResponse_RANGE_CONSISTENT_STATS_INCORRECT.String() {
+			m := regexp.MustCompile(`.*\ndelta \(stats-computed\): \{(.*)\}`).FindStringSubmatch(detail)
+			if len(m) > 1 {
+				delta := m[1]
+				// Strip out LastUpdateNanos and all zero-valued fields.
+				delta = regexp.MustCompile(`LastUpdateNanos:\d+`).ReplaceAllString(delta, "")
+				delta = regexp.MustCompile(`\S+:0\b`).ReplaceAllString(delta, "")
+				if regexp.MustCompile(`^\s*SysBytes:10\s*$`).MatchString(delta) {
+					continue
+				}
+			}
 		}
 		switch status {
 		case roachpb.CheckConsistencyResponse_RANGE_INDETERMINATE.String():


### PR DESCRIPTION
Resolves #93890.
Touches #93896.
Touches #93312.
Touches #86542.

Epic: none
Release note: None