### PR TITLE
kvnemesis: keep artifacts only on failure

### DIFF
--- a/pkg/kv/kvnemesis/kvnemesis_test.go
+++ b/pkg/kv/kvnemesis/kvnemesis_test.go
@@ -108,10 +108,18 @@ type tBridge struct {
 }
 
 func newTBridge(t *testing.T) *tBridge {
+	// NB: we're not using t.TempDir() because we want these to survive
+	// on failure.
 	td, err := os.MkdirTemp("", "kvnemesis")
 	if err != nil {
 		td = os.TempDir()
 	}
+	t.Cleanup(func() {
+		if t.Failed() {
+			return
+		}
+		_ = os.RemoveAll(td)
+	})
 	t.Logf("kvnemesis logging to %s", td)
 	return &tBridge{
 		ti: t,


### PR DESCRIPTION
The nightly runs amassed lots of artifacts because they run many
invocations of kvnemesis in one go. We only need artifacts on failure.

Epic: none
Release note: None
