### PR TITLE
streamingccl: increase producer job timeout

### DIFF
--- a/pkg/ccl/streamingccl/settings.go
+++ b/pkg/ccl/streamingccl/settings.go
@@ -29,7 +29,7 @@ var StreamReplicationJobLivenessTimeout = settings.RegisterDurationSetting(
 	settings.TenantWritable,
 	"stream_replication.job_liveness_timeout",
 	"controls how long we wait for to kill an inactive producer job",
-	time.Minute,
+	3*24*time.Hour,
 )
 
 // StreamReplicationConsumerHeartbeatFrequency controls frequency the stream replication


### PR DESCRIPTION
This timeout is the upper bound for how long the destination cluster can be down before the stream won't be able to be restarted without manual job state surgery.

It seems in our interest that this be rather high.

Epic: None

Release note: None