### PR TITLE
ui: refresh nodes on tenants

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
@@ -106,8 +106,8 @@ export class SessionDetails extends React.Component<SessionDetailsProps> {
   };
 
   componentDidMount(): void {
+    this.props.refreshNodes();
     if (!this.props.isTenant) {
-      this.props.refreshNodes();
       this.props.refreshNodesLiveness();
     }
     this.props.refreshSessions();

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetailsConnected.tsx
@@ -29,7 +29,9 @@ import { TimeScale } from "src/timeScaleDropdown";
 export const SessionDetailsPageConnected = withRouter(
   connect(
     (state: AppState, props: RouteComponentProps) => ({
-      nodeNames: nodeDisplayNameByIDSelector(state),
+      nodeNames: selectIsTenant(state)
+        ? {}
+        : nodeDisplayNameByIDSelector(state),
       session: selectSession(state, props),
       sessionError: state.adminUI.sessions.lastError,
       uiConfig: selectSessionDetailsUiConfig(state),

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -268,8 +268,8 @@ export class StatementDetails extends React.Component<
       this.props.location,
     );
     this.props.refreshUserSQLRoles();
+    this.props.refreshNodes();
     if (!this.props.isTenant) {
-      this.props.refreshNodes();
       this.props.refreshNodesLiveness();
       if (!this.props.hasViewActivityRedactedRole) {
         this.props.refreshStatementDiagnosticsRequests();
@@ -291,8 +291,8 @@ export class StatementDetails extends React.Component<
       );
     }
 
+    this.props.refreshNodes();
     if (!this.props.isTenant) {
-      this.props.refreshNodes();
       this.props.refreshNodesLiveness();
       if (!this.props.hasViewActivityRedactedRole) {
         this.props.refreshStatementDiagnosticsRequests();

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -343,8 +343,8 @@ export class StatementsPage extends React.Component<
     }
 
     this.props.refreshUserSQLRoles();
+    this.props.refreshNodes();
     if (!this.props.isTenant) {
-      this.props.refreshNodes();
       if (!this.props.hasViewActivityRedactedRole) {
         this.props.refreshStatementDiagnosticsRequests();
       }
@@ -385,8 +385,8 @@ export class StatementsPage extends React.Component<
 
   componentDidUpdate = (): void => {
     this.updateQueryParams();
+    this.props.refreshNodes();
     if (!this.props.isTenant) {
-      this.props.refreshNodes();
       if (!this.props.hasViewActivityRedactedRole) {
         this.props.refreshStatementDiagnosticsRequests();
       }

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -197,16 +197,12 @@ export class TransactionDetails extends React.Component<
   componentDidMount(): void {
     this.refreshData("");
     this.props.refreshUserSQLRoles();
-    if (!this.props.isTenant) {
-      this.props.refreshNodes();
-    }
+    this.props.refreshNodes();
   }
 
   componentDidUpdate(prevProps: TransactionDetailsProps): void {
     this.getTransactionStateInfo(prevProps.transactionFingerprintId);
-    if (!this.props.isTenant) {
-      this.props.refreshNodes();
-    }
+    this.props.refreshNodes();
   }
 
   onChangeSortSetting = (ss: SortSetting): void => {

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -237,9 +237,7 @@ export class TransactionsPage extends React.Component<
       );
     }
 
-    if (!this.props.isTenant) {
-      this.props.refreshNodes();
-    }
+    this.props.refreshNodes();
   }
 
   componentWillUnmount(): void {
@@ -280,9 +278,7 @@ export class TransactionsPage extends React.Component<
 
   componentDidUpdate(): void {
     this.updateQueryParams();
-    if (!this.props.isTenant) {
-      this.props.refreshNodes();
-    }
+    this.props.refreshNodes();
   }
 
   onChangeSortSetting = (ss: SortSetting): void => {


### PR DESCRIPTION
Part of #89949

Now that we can show meaningful region information for tenants, we need to actually trigger the fetching of that information.

Release note: None