### PR TITLE
sql: include offline tables in index resolving

### DIFF
--- a/pkg/sql/catalog/resolver/resolver.go
+++ b/pkg/sql/catalog/resolver/resolver.go
@@ -723,7 +723,7 @@ func findTableContainingIndex(
 		if err != nil {
 			return false, nil, nil, err
 		}
-		if candidateTbl == nil || !(candidateTbl.IsTable() || candidateTbl.MaterializedView()) || candidateTbl.Offline() {
+		if candidateTbl == nil || !(candidateTbl.IsTable() || candidateTbl.MaterializedView()) {
 			continue
 		}
 


### PR DESCRIPTION
Previously we exclude offline tables from index resolution, this caused some problem for `SHOW RANGES` which should be able to show offline table's ranges as well. This PR just make it not skipping offline tables.

Release note: None