### PR TITLE
release-22.2: changefeedccl: increase chaos roachtest latency limits

### DIFF
--- a/pkg/ccl/changefeedccl/retry.go
+++ b/pkg/ccl/changefeedccl/retry.go
@@ -12,11 +12,13 @@ import (
 	"context"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
-var useFastRetry = false
+var useFastRetry = envutil.EnvOrDefaultBool(
+	"COCKROACH_CHANGEFEED_TESTING_FAST_RETRY", false)
 
 // getRetry returns retry object for changefeed.
 func getRetry(ctx context.Context) Retry {
@@ -30,7 +32,7 @@ func getRetry(ctx context.Context) Retry {
 		opts = retry.Options{
 			InitialBackoff: 5 * time.Millisecond,
 			Multiplier:     2,
-			MaxBackoff:     250 * time.Minute,
+			MaxBackoff:     250 * time.Millisecond,
 		}
 	}
 

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -100,7 +100,10 @@ func cdcBasicTest(ctx context.Context, t test.Test, c cluster.Cluster, args cdcT
 	kafkaNode := c.Node(c.Spec().NodeCount)
 	c.Put(ctx, t.Cockroach(), "./cockroach")
 	c.Put(ctx, t.DeprecatedWorkload(), "./workload", workloadNode)
-	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), crdbNodes)
+
+	settings := install.MakeClusterSettings()
+	settings.Env = append(settings.Env, "COCKROACH_CHANGEFEED_TESTING_FAST_RETRY=true")
+	c.Start(ctx, t.L(), option.DefaultStartOpts(), settings, crdbNodes)
 
 	db := c.Conn(ctx, t.L(), 1)
 	defer stopFeeds(db)


### PR DESCRIPTION
Backport 1/1 commits from #93552 

/cc @cockroachdb/release 

---

Resolves: #93238

Since our job-level retry MaxBackoff has increased from 10 seconds to 10 minutes, increase the chaos test latency limits.

Release note: None

Release justification: Roachtest fix