### PR TITLE
ui: update cluster-ui to 23.1.0-prerelease.2

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "23.1.0-prerelease.1",
+  "version": "23.1.0-prerelease.2",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Just a quick bug fix and some cleanup in this one:

```
$ git log --format=%s --no-merges \
  @cockroachlabs/cluster-ui@23.1.0-prerelease.1..HEAD \
  pkg/ui/workspaces/cluster-ui \

ui: update cluster-ui to 23.1.0-prerelease.2
ui: refresh nodes on tenants
ui: remove unused nodeNames property
```

Epic: None
Release note: None
