### PR TITLE
release-22.1: workload: fix TPC-H generator to generate correct values for p_name and ps_supplycost

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -468,6 +468,7 @@ ALL_TESTS = [
     "//pkg/workload/histogram:histogram_test",
     "//pkg/workload/movr:movr_test",
     "//pkg/workload/tpcc:tpcc_test",
+    "//pkg/workload/tpch:tpch_test",
     "//pkg/workload/workloadimpl:workloadimpl_test",
     "//pkg/workload/workloadsql:workloadsql_test",
     "//pkg/workload/ycsb:ycsb_test",

--- a/pkg/ccl/workloadccl/allccl/all_test.go
+++ b/pkg/ccl/workloadccl/allccl/all_test.go
@@ -270,7 +270,7 @@ func TestDeterministicInitialData(t *testing.T) {
 		`sqlsmith`:   0xcbf29ce484222325,
 		`startrek`:   0xa0249fbdf612734c,
 		`tpcc`:       0xab32e4f5e899eb2f,
-		`tpch`:       0x72869878971e76ac,
+		`tpch`:       0xe013881749bb67e8,
 		`ycsb`:       0x1244ea1c29ef67f6,
 	}
 

--- a/pkg/ccl/workloadccl/allccl/all_test.go
+++ b/pkg/ccl/workloadccl/allccl/all_test.go
@@ -270,7 +270,7 @@ func TestDeterministicInitialData(t *testing.T) {
 		`sqlsmith`:   0xcbf29ce484222325,
 		`startrek`:   0xa0249fbdf612734c,
 		`tpcc`:       0xab32e4f5e899eb2f,
-		`tpch`:       0x65a1e18ddf4e59aa,
+		`tpch`:       0x72869878971e76ac,
 		`ycsb`:       0x1244ea1c29ef67f6,
 	}
 

--- a/pkg/workload/tpch/BUILD.bazel
+++ b/pkg/workload/tpch/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "tpch",
@@ -24,6 +24,18 @@ go_library(
         "//pkg/workload/histogram",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_spf13_pflag//:pflag",
+        "@org_golang_x_exp//rand",
+    ],
+)
+
+go_test(
+    name = "tpch_test",
+    srcs = ["random_test.go"],
+    embed = [":tpch"],
+    deps = [
+        "//pkg/util/bufalloc",
+        "//pkg/util/timeutil",
+        "@com_github_stretchr_testify//assert",
         "@org_golang_x_exp//rand",
     ],
 )

--- a/pkg/workload/tpch/generate.go
+++ b/pkg/workload/tpch/generate.go
@@ -213,7 +213,7 @@ func (w *tpch) tpchPartSuppInitialRowBatch(
 		// PS_AVAILQTY random value [1 .. 9,999].
 		availQtyCol[i] = int16(randInt(rng, 1, 9999))
 		// PS_SUPPLYCOST random value [1.00 .. 1,000.00].
-		supplyCostCol[i] = float64(randFloat(rng, 1, 1000, 100))
+		supplyCostCol[i] = float64(randFloat(rng, 100, 100000, 100))
 		// PS_COMMENT text string [49,198].
 		commentCol.Set(i, w.textPool.randString(rng, 49, 198))
 	}

--- a/pkg/workload/tpch/random.go
+++ b/pkg/workload/tpch/random.go
@@ -129,9 +129,8 @@ func randPartName(rng *rand.Rand, namePerm []int, a *bufalloc.ByteAllocator) []b
 	// do nPartNames iterations of rand.Perm, to get a random 5-subset of the
 	// indexes into randPartNames.
 	for i := 0; i < nPartNames; i++ {
-		j := rng.Intn(i + 1)
-		namePerm[i] = namePerm[j]
-		namePerm[j] = i
+		j := rng.Intn(len(namePerm))
+		namePerm[i], namePerm[j] = namePerm[j], namePerm[i]
 	}
 	var buf []byte
 	*a, buf = a.Alloc(maxPartNameLen*nPartNames+nPartNames, 0)

--- a/pkg/workload/tpch/random_test.go
+++ b/pkg/workload/tpch/random_test.go
@@ -1,0 +1,58 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tpch
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/exp/rand"
+)
+
+func TestRandPartName(t *testing.T) {
+	var a bufalloc.ByteAllocator
+	rng := rand.New(rand.NewSource(uint64(timeutil.Now().UnixNano())))
+	seen := make(map[string]int)
+	runOneRound := func() {
+		namePerm := make([]int, len(randPartNames))
+		for i := range namePerm {
+			namePerm[i] = i
+		}
+		res := randPartName(rng, namePerm, &a)
+		names := strings.Split(string(res), " ")
+		assert.Equal(t, len(names), nPartNames)
+		seenLocal := make(map[string]int)
+		for _, name := range names {
+			if _, ok := seenLocal[name]; ok {
+				t.Errorf("names in '%s' are not unique", res)
+			}
+			seenLocal[name]++
+			seen[name]++
+		}
+	}
+
+	// We can't guarantee much about the global distribution of names,
+	// but we should make sure that we're not always using the same 5
+	// names. Run up to 100 times before failing.
+	for i := 0; i < 100; i++ {
+		if len(seen) > 5 {
+			return
+		}
+		runOneRound()
+	}
+
+	if len(seen) <= 5 {
+		t.Errorf("only saw 5 names after calling randPartName 100 times")
+	}
+}

--- a/pkg/workload/tpch/random_test.go
+++ b/pkg/workload/tpch/random_test.go
@@ -45,14 +45,18 @@ func TestRandPartName(t *testing.T) {
 	// We can't guarantee much about the global distribution of names,
 	// but we should make sure that we're not always using the same 5
 	// names. Run up to 100 times before failing.
+	//
+	// NB: The odds of this flaking are extremely low. 92 choose 5 gives
+	// 4,9177,128 unique combinations. After 100 shuffles, the probability of
+	// seeing the same combination is astronomically low.
 	for i := 0; i < 100; i++ {
-		if len(seen) > 5 {
+		if len(seen) > nPartNames {
 			return
 		}
 		runOneRound()
 	}
 
-	if len(seen) <= 5 {
-		t.Errorf("only saw 5 names after calling randPartName 100 times")
+	if len(seen) <= nPartNames {
+		t.Errorf("only saw %d names after calling randPartName 100 times", nPartNames)
 	}
 }


### PR DESCRIPTION
Backport 2/2 commits from #93814.

/cc @cockroachdb/release

---

**workload: fix TPC-H generator to generate correct values for p_name**

The TPC-H generator creates values for `p_name` in the `part` table by selecting 5 elements from a list of words called `randPartNames`. It is supposed to select 5 random unique elements from the full list, but prior to this commit, it only selected a permutation of the first 5 elements. This commit fixes the logic and adds a unit test.

Epic: None
Release note: None

**workload: fix TPC-H generator value of ps_supplycost**

Prior to this commit, the TPC-H generator was generating
a value between 0 and 10 for `ps_supplycost` in the `partsupp`
table. However, the spec calls for a random value in the range 
`[1.00 .. 1,000.00]`. This commit fixes the oversight.

Epic: None
Release note: None

----

Release justification: benchmark-only change