### PR TITLE
storage: fix `CheckSSTConflicts` intent conflict above MVCC range tombstone

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -330,6 +330,12 @@ func TestEvalAddSSTable(t *testing.T) {
 			sst:        kvs{pointKV("a", 3, "sst")},
 			expectErr:  &roachpb.WriteIntentError{},
 		},
+		"DisallowConflicts returns WriteIntentError below intent above range key": {
+			noConflict: true,
+			data:       kvs{pointKV("b", intentTS, "intent"), rangeKV("a", "d", 2, ""), pointKV("b", 1, "b1")},
+			sst:        kvs{pointKV("b", 3, "sst")},
+			expectErr:  &roachpb.WriteIntentError{},
+		},
 		"DisallowConflicts ignores intents in span": { // inconsistent with blind writes
 			noConflict: true,
 			data:       kvs{pointKV("b", intentTS, "intent")},
@@ -419,6 +425,12 @@ func TestEvalAddSSTable(t *testing.T) {
 			noShadow:  true,
 			data:      kvs{pointKV("a", intentTS, "intent")},
 			sst:       kvs{pointKV("a", 3, "sst")},
+			expectErr: &roachpb.WriteIntentError{},
+		},
+		"DisallowShadowing returns WriteIntentError below intent above range key": {
+			noShadow:  true,
+			data:      kvs{pointKV("b", intentTS, "intent"), rangeKV("a", "d", 2, ""), pointKV("b", 1, "b1")},
+			sst:       kvs{pointKV("b", 3, "sst")},
 			expectErr: &roachpb.WriteIntentError{},
 		},
 		"DisallowShadowing ignores intents in span": { // inconsistent with blind writes
@@ -541,6 +553,12 @@ func TestEvalAddSSTable(t *testing.T) {
 			noShadowBelow: 5,
 			data:          kvs{pointKV("a", intentTS, "intent")},
 			sst:           kvs{pointKV("a", 3, "sst")},
+			expectErr:     &roachpb.WriteIntentError{},
+		},
+		"DisallowShadowingBelow returns WriteIntentError below intent above range key": {
+			noShadowBelow: 5,
+			data:          kvs{pointKV("b", intentTS, "intent"), rangeKV("a", "d", 2, ""), pointKV("b", 1, "b1")},
+			sst:           kvs{pointKV("b", 3, "sst")},
 			expectErr:     &roachpb.WriteIntentError{},
 		},
 		"DisallowShadowingBelow ignores intents in span": { // inconsistent with blind writes

--- a/pkg/storage/mvcc_key.go
+++ b/pkg/storage/mvcc_key.go
@@ -594,6 +594,8 @@ func (s MVCCRangeKeyStack) CloneInto(c *MVCCRangeKeyStack) {
 }
 
 // Covers returns true if any range key in the stack covers the given point key.
+// A timestamp of 0 (i.e. an intent) is considered to be above all timestamps,
+// and thus not covered by any range key.
 func (s MVCCRangeKeyStack) Covers(k MVCCKey) bool {
 	return s.Versions.Covers(k.Timestamp) && s.Bounds.ContainsKey(k.Key)
 }
@@ -705,8 +707,10 @@ func (v MVCCRangeKeyVersions) CloneInto(c *MVCCRangeKeyVersions) {
 }
 
 // Covers returns true if any version in the stack is above the given timestamp.
+// A timestamp of 0 (i.e. an intent) is considered to be above all timestamps,
+// and thus not covered by any range key.
 func (v MVCCRangeKeyVersions) Covers(ts hlc.Timestamp) bool {
-	return !v.IsEmpty() && ts.LessEq(v[0].Timestamp)
+	return !v.IsEmpty() && !ts.IsEmpty() && ts.LessEq(v[0].Timestamp)
 }
 
 // Equal returns whether versions in the specified MVCCRangeKeyVersions match


### PR DESCRIPTION
`CheckSSTConflicts` could fail to handle a point key collision with an intent written above an MVCC range tombstone, because the intent was considered to be deleted by the MVCC range tombstone.

This patch makes `MVCCRangeKeyStack.Covered()` consider a timestamp of 0 (i.e. an intent) as being above all range keys, because intents must be above all range keys by definition. Otherwise, this condition in `CheckSSTConflicts` would consider the intent as a point key deleted by an MVCC range tombstone, and therefore ignored:

```go
extValueDeletedByRange := extHasRange && extHasPoint && extRangeKeys.Covers(extKey)
```

`AddSSTable` operations are only used on offline tables, so this won't affect transaction isolation for ongoing transactions. However, it is possible (but unlikely) for a committed but unresolved write intent left behind by a past transaction to not be considered for conflict handling, and for `AddSSTable` to write below it.

Resolves #93934.

Release note (bug fix): When experimental MVCC range tombstones are enabled (they're disabled by default), a bulk ingestion (e.g. an import) could fail to take a committed-but-unresolved write intent into account during conflict checks when written above an MVCC range tombstone. It was therefore possible in very rare circumstances for the ingestion to write a value below the timestamp of the committed intent, causing the ingested value to disappear.