### PR TITLE
sql: add flag to allow resolving index on offline tables

### DIFF
--- a/pkg/sql/catalog/resolver/resolver_test.go
+++ b/pkg/sql/catalog/resolver/resolver_test.go
@@ -637,7 +637,7 @@ CREATE TABLE c (a INT, INDEX idx2(a));`,
 		for _, tc := range testCases {
 			t.Run(tc.testName, func(t *testing.T) {
 				_, prefix, tblDesc, idxDesc, err := resolver.ResolveIndex(
-					ctx, schemaResolver, tc.name, true, false)
+					ctx, schemaResolver, tc.name, tree.IndexLookupFlags{Required: true, RequireActiveIndex: false})
 				var res string
 				if err != nil {
 					res = fmt.Sprintf("error: %s", err.Error())
@@ -647,7 +647,7 @@ CREATE TABLE c (a INT, INDEX idx2(a));`,
 				require.Equal(t, tc.expected, res)
 
 				_, _, _, _, err = resolver.ResolveIndex(
-					ctx, schemaResolver, tc.name, false, false)
+					ctx, schemaResolver, tc.name, tree.IndexLookupFlags{Required: false, RequireActiveIndex: false})
 				if tc.errIfNotRequired {
 					require.Error(t, err)
 				} else {
@@ -660,7 +660,7 @@ CREATE TABLE c (a INT, INDEX idx2(a));`,
 	require.NoError(t, err)
 }
 
-func TestResolveIndexSkipOfflineTable(t *testing.T) {
+func TestResolveIndexWithOfflineTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -715,26 +715,48 @@ CREATE INDEX baz_idx ON baz (s);
 		require.Equal(t, "defaultdb", schemaResolver.CurrentDatabase())
 		require.Equal(t, []string{"$user", "public"}, schemaResolver.CurrentSearchPath().GetPathArray())
 
-		// Make sure that baz table is skipped so that index baz_idx cannot be found.
+		// Make sure that baz table is skipped when `IncludeOfflineTable` flag is
+		// false, so that index baz_idx cannot be found.
 		found, _, _, _, err := resolver.ResolveIndex(
 			ctx,
 			schemaResolver,
 			newTableIndexName("", "", "", "baz_idx"),
-			false,
-			false,
+			tree.IndexLookupFlags{
+				Required:            false,
+				RequireActiveIndex:  true,
+				IncludeOfflineTable: false,
+			},
 		)
 		require.NoError(t, err)
 		require.False(t, found)
 
-		// Make sure that baz table is skipped so that it does not error out when
-		// resolving index on other tables. Note that because table name is not
+		// Make sure that baz table is considered when `IncludeOfflineTable` flag is
+		// true, so that index baz_idx can be found.
+		found, _, _, _, err = resolver.ResolveIndex(
+			ctx,
+			schemaResolver,
+			newTableIndexName("", "", "", "baz_idx"),
+			tree.IndexLookupFlags{
+				Required:            true,
+				RequireActiveIndex:  false,
+				IncludeOfflineTable: true,
+			},
+		)
+		require.NoError(t, err)
+		require.True(t, found)
+
+		// Make sure that baz table is taken care of so that it does not error out
+		// when resolving index on other tables. Note that because table name is not
 		// given, all tables on current search path are searched.
 		found, _, _, _, err = resolver.ResolveIndex(
 			ctx,
 			schemaResolver,
 			newTableIndexName("", "", "", "foo_idx"),
-			false,
-			false,
+			tree.IndexLookupFlags{
+				Required:            true,
+				RequireActiveIndex:  true,
+				IncludeOfflineTable: false,
+			},
 		)
 		require.NoError(t, err)
 		require.True(t, found)

--- a/pkg/sql/opt/cat/catalog.go
+++ b/pkg/sql/opt/cat/catalog.go
@@ -62,6 +62,12 @@ type Flags struct {
 	// cases where we don't need them (like SHOW variants), to avoid polluting the
 	// stats cache.
 	NoTableStats bool
+
+	// IncludeOfflineTables considers offline tables (e.g. being imported). This is
+	// useful in cases where we are running a statement like `SHOW RANGES` for
+	// which we also want to show valid ranges when a table is being imported
+	// (offline).
+	IncludeOfflineTables bool
 }
 
 // Catalog is an interface to a database catalog, exposing only the information

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -262,8 +262,11 @@ func (oc *optCatalog) ResolveIndex(
 			ctx,
 			oc.planner,
 			name,
-			true, /* required */
-			true, /* requireActiveIndex */
+			tree.IndexLookupFlags{
+				Required:            true,
+				RequireActiveIndex:  true,
+				IncludeOfflineTable: flags.IncludeOfflineTables,
+			},
 		)
 	})
 	if err != nil {

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -715,7 +715,14 @@ func expandIndexName(
 		return tn, desc, nil
 	}
 
-	found, resolvedPrefix, tbl, _, err := resolver.ResolveIndex(ctx, p, index, requireTable, false /*requireActiveIndex*/)
+	found, resolvedPrefix, tbl, _, err := resolver.ResolveIndex(
+		ctx,
+		p,
+		index,
+		tree.IndexLookupFlags{
+			Required: requireTable,
+		},
+	)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -759,7 +766,11 @@ func (p *planner) getTableAndIndexImpl(
 	ctx context.Context, tableWithIndex *tree.TableIndexName, privilege privilege.Kind,
 ) (catalog.ResolvedObjectPrefix, *tabledesc.Mutable, catalog.Index, error) {
 	_, resolvedPrefix, tbl, idx, err := resolver.ResolveIndex(
-		ctx, p, tableWithIndex, true /* required */, true, /* requireActiveIndex */
+		ctx, p, tableWithIndex,
+		tree.IndexLookupFlags{
+			Required:           true,
+			RequireActiveIndex: true,
+		},
 	)
 	if err != nil {
 		return catalog.ResolvedObjectPrefix{}, nil, nil, err

--- a/pkg/sql/schemachanger/scdeps/build_deps.go
+++ b/pkg/sql/schemachanger/scdeps/build_deps.go
@@ -170,8 +170,9 @@ func (d *buildDeps) MayResolveIndex(
 	idx catalog.Index,
 ) {
 	found, prefix, tbl, idx, err := resolver.ResolveIndex(
-		ctx, d.schemaResolver, &tableIndexName, false /* required */, false, /* requireActiveIndex */
+		ctx, d.schemaResolver, &tableIndexName, tree.IndexLookupFlags{},
 	)
+
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/sql/sem/tree/name_resolution.go
+++ b/pkg/sql/sem/tree/name_resolution.go
@@ -270,3 +270,14 @@ func ObjectLookupFlagsWithRequiredTableKind(kind RequiredTableKind) ObjectLookup
 		DesiredTableDescKind: kind,
 	}
 }
+
+// IndexLookupFlags is the flag struct used for resolver.ResolveIndex() only.
+type IndexLookupFlags struct {
+	// Control if the lookup can return nil index without returning an error if
+	// the index does not exist.
+	Required bool
+	// Control if the lookup only considers active indexes.
+	RequireActiveIndex bool
+	// Control if the lookup considers offline tables.
+	IncludeOfflineTable bool
+}


### PR DESCRIPTION
Previously offline tables are always skipped when resolving an index. This pr adds an flag to allow offline tables to be considered. The main use case is for `SHOW RANGES` where index ranges of tables being imported (offline) should be shown.

Informs:  #94128.
Epic: CRDB-22701
Release note: None