### PR TITLE
storage: mark `CheckSSTConflicts` stats as estimates with range key masking

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -296,6 +296,15 @@ func TestEvalAddSSTable(t *testing.T) {
 			expectStatsEst: true,
 			expectErrRace:  `SST contains non-empty MVCC value header for key "a"/2.000000000,0`,
 		},
+		"SSTTimestampToRequestTimestamp with DisallowConflicts causes estimated stats with range key masking": {
+			reqTS:          5,
+			toReqTS:        2, // NB: 2 is below range key at 3, to test range key masking timestamp
+			noConflict:     true,
+			data:           kvs{rangeKV("a", "c", 3, ""), pointKV("b", 1, "b1")},
+			sst:            kvs{pointKV("b", 2, "sst")},
+			expect:         kvs{rangeKV("a", "c", 3, ""), pointKV("b", 5, "sst"), pointKV("b", 1, "b1")},
+			expectStatsEst: !storage.DisableCheckSSTRangeKeyMasking, // assert correct without masking
+		},
 
 		// DisallowConflicts
 		"DisallowConflicts allows above and beside": {


### PR DESCRIPTION
Note to self: the first commit here should be backported, but not the last since we need to look at the effects of stats estimates on e.g. MVCC GC.

---

**batcheval: use correct range key masking timestamp in `AddSSTable`**

When `AddSSTable` has both `SSTTimestampToRequestTimestamp` and `DisallowConflicts` set (or any of the other `Disallow` parameters), it can enable range key masking for `CheckSSTConflicts` to skip across garbage. However, it enabled range key masking at the original SST timestamp rather than the rewritten SST timestamp. This patch uses the correct SST timestamp.

This has no effect on correctness, but could have a marginal impact on performance in the unlikely event the original SST timestamp was far in the past.

Release note: None

**storage: mark `CheckSSTConflicts` stats as estimates with range key masking**

When `CheckSSTConflicts` uses range key masking to omit conflict checks for point garbage covered by MVCC range tombstones, it can't correctly adjust MVCC stats for the covered points. This patch therefore marks MVCC stats as estimates in these cases.

Touches #89222.
Touches #92254.
Epic: CRDB-20465.

Release note: None