### PR TITLE
server: fix log flushDaemon incorrectly ignores syncInterval

### DIFF
--- a/pkg/util/log/log_flush.go
+++ b/pkg/util/log/log_flush.go
@@ -69,12 +69,12 @@ const syncWarnDuration = 10 * time.Second
 // Syncs ensure that the OS commits the data to disk. Syncs are less
 // frequent because they can incur more significant I/O costs.
 func flushDaemon() {
-	syncCounter := 1
+	syncCounter := 0
 
 	// This doesn't need to be Stop()'d as the loop never escapes.
 	for range time.Tick(flushInterval) {
-		doSync := syncCounter == syncInterval
 		syncCounter = (syncCounter + 1) % syncInterval
+		doSync := syncCounter == 0
 
 		// Is flushing disabled?
 		logging.mu.Lock()


### PR DESCRIPTION
flushDaemon runs in background and invokes lockAndFlushAndMaybeSync at every flushInterval (default is 1 second). Every syncInterval (default is 30 seconds) it's supposed to set doSync so that the subsequent call to lockAndFlushAndMaybeSync will result in file.Sync in addition to Flush.

The faulty logic caused doSync to be always false; i.e., file.Sync was never issued and may have resulted in truncated server logs. This fix restores the intended behavior, thereby issuing file.Sync at every syncInterval.

Epic: none

Release note (bug fix): server logs are now correctly fsynced at every syncInterval