### PR TITLE
bazel build : integrate new cross toolchain for ppc64le architecture

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -96,6 +96,14 @@ build:crosslinuxs390x '--workspace_status_command=./build/bazelutil/stamp.sh s39
 build:crosslinuxs390x --config=crosslinuxs390xbase
 build:crosslinuxs390xbase --platforms=//build/toolchains:cross_linux_s390x
 build:crosslinuxs390xbase --config=cross
+build:crosslinuxppc64le '--workspace_status_command=./build/bazelutil/stamp.sh ppc64le-redhat-linux-gnu'
+build:crosslinuxppc64le --config=crosslinuxppc64lebase
+build:crosslinuxppc64lebase --platforms=//build/toolchains:cross_linux_ppc64le
+build:crosslinuxppc64lebase --config=cross
+build:crosslinuxppc '--workspace_status_command=./build/bazelutil/stamp.sh ppc-redhat-linux-gnu'
+build:crosslinuxppc --config=crosslinuxppcbase
+build:crosslinuxppcbase --platforms=//build/toolchains:cross_linux_ppc
+build:crosslinuxppc --config=cross
 
 # devdarwinx86_64 is a legacy setting that implies `--config=dev`.
 build:devdarwinx86_64 --config=dev

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -607,6 +607,7 @@ register_toolchains(
     "//build/toolchains:cross_arm64_linux_toolchain",
     "//build/toolchains:cross_arm64_linux_arm_toolchain",
     "//build/toolchains:cross_arm64_s390x_toolchain",
+    "//build/toolchains:cross_ppc_linux_toolchain",
     "//build/toolchains:cross_arm64_windows_toolchain",
     "//build/toolchains:cross_arm64_macos_toolchain",
     "//build/toolchains:cross_arm64_macos_arm_toolchain",

--- a/build/builder/mkrelease.sh
+++ b/build/builder/mkrelease.sh
@@ -99,6 +99,24 @@ case "${1-}" in
       LDFLAGS="-static-libgcc -static-libstdc++ -lrt"
       SUFFIX=-linux-2.6.32-gnu-s390x
     ) ;;
+
+    ?(ppc64le-)linux?(-gnu))
+    # Manually set the correct values for configure checks that libkrb5 will not be
+    # able to perform because we are cross-compiling.
+    export krb5_cv_attr_constructor_destructor=yes
+    export ac_cv_func_regcomp=yes
+    export ac_cv_printf_positional=yes
+    args=(
+      XGOOS=linux
+      XGOARCH=ppc64le
+      XCMAKE_SYSTEM_NAME=Linux
+      TARGET_TRIPLE=ppc64le-redhat-linux-gnu
+      # -lrt is needed as clock_gettime is not part of glibc prior to 2.17.
+      # If we update to a newer glibc, the -lrt can be removed.
+      LDFLAGS="-static-libgcc -static-libstdc++ -lrt"
+      SUFFIX=-linux-2.6.32-gnu-ppc64le
+    ) ;;
+
   *)  die "unknown release configuration: $1" ;;
 esac
 

--- a/build/toolchains/BUILD.bazel
+++ b/build/toolchains/BUILD.bazel
@@ -159,6 +159,31 @@ toolchain(
 )
 
 toolchain(
+    name = "cross_ppc_linux_toolchain",
+    exec_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:ppc",
+    ],
+    target_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:ppc",
+    ],
+    target_settings = [
+        ":cross",
+    ],
+    toolchain = "@toolchain_cross_ppc-unknown-linux-gnu//:toolchain",
+    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+)
+
+platform(
+    name = "cross_linux_ppc",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:ppc",
+    ],
+)
+
+toolchain(
     name = "cross_arm64_linux_toolchain",
     exec_compatible_with = [
         "@platforms//os:linux",

--- a/build/toolchains/crosstool-ng/cc_toolchain_config.bzl.tmpl
+++ b/build/toolchains/crosstool-ng/cc_toolchain_config.bzl.tmpl
@@ -139,7 +139,7 @@ def _impl(ctx):
         ]
     else:
         linker_flags.append("-lstdc++")
-    if "%{target}" in ("x86_64-unknown-linux-gnu", "s390x-ibm-linux-gnu"):
+    if "%{target}" in ("x86_64-unknown-linux-gnu", "s390x-ibm-linux-gnu", "ppc64le-redhat-linux-gnu"):
         linker_flags.append("-lrt")
 
     default_linker_flags = feature(

--- a/build/toolchains/toolchainbuild/crosstool-ng/perform-build.sh
+++ b/build/toolchains/toolchainbuild/crosstool-ng/perform-build.sh
@@ -56,6 +56,7 @@ build_ctng x86_64-unknown-linux-gnu
 build_ctng x86_64-w64-mingw
 build_ctng aarch64-unknown-linux-gnueabi
 build_ctng s390x-ibm-linux-gnu
+build_ctng ppc64le-redhat-linux-gnu
 rm -rf src
 
 # Build & install the terminfo lib (incl. in ncurses) for the linux targets (x86, arm and s390x).
@@ -91,6 +92,7 @@ build_ncurses() {
 build_ncurses x86_64-unknown-linux-gnu
 build_ncurses aarch64-unknown-linux-gnu
 build_ncurses s390x-ibm-linux-gnu
+build_ncurses ppc64le-redhat-linux-gnu
 cd ..
 
 apt-get purge -y gcc g++ && apt-get autoremove -y
@@ -113,3 +115,4 @@ bundle /x-tools/x86_64-unknown-linux-gnu
 bundle /x-tools/aarch64-unknown-linux-gnu
 bundle /x-tools/s390x-ibm-linux-gnu
 bundle /x-tools/x86_64-w64-mingw32
+bundle /x-tools/ppc64le-redhat-linux-gnu

--- a/c-deps/BUILD.bazel
+++ b/c-deps/BUILD.bazel
@@ -25,6 +25,7 @@ configure_make(
         ],
         "@io_bazel_rules_go//go/platform:linux_amd64": ["--host=x86_64-unknown-linux-gnu"],
         "@io_bazel_rules_go//go/platform:linux_arm64": ["--host=aarch64-unknown-linux-gnu"],
+	"@io_bazel_rules_go//go/platform:linux_ppc64le": ["--host=ppc64le-redhat-linux-gnu"],
         "@io_bazel_rules_go//go/platform:linux_s390x": ["--host=s390x-unknown-linux-gnu"],
         # NB: Normally host detection is handled by configure, but the version
         # of jemalloc we have vendored is pretty ancient and can't handle some
@@ -218,6 +219,7 @@ configure_make(
     ] + select({
         "@io_bazel_rules_go//go/platform:linux_amd64": ["--host=x86_64-unknown-linux-gnu"],
         "@io_bazel_rules_go//go/platform:linux_arm64": ["--host=aarch64-unknown-linux-gnu"],
+	"@io_bazel_rules_go//go/platform:linux_ppc64le": ["--host=ppc64le-redhat-linux-gnu"],
         "@io_bazel_rules_go//go/platform:linux_s390x": ["--host=s390x-unknown-linux-gnu"],
         "//conditions:default": [],
     }),


### PR DESCRIPTION
1. For compilation we use go_local_sdk to pick up any custom changes. go_local_sdk( name = "go_sdk", path = "<path to $GODIR>", )
2. Add new toolchain configuration that run on ppc64le.
Epic: none
Release note: None