### PR TITLE
roachtest: query only primary index in SHOW RANGES

### DIFF
--- a/pkg/cmd/roachtest/tests/copy.go
+++ b/pkg/cmd/roachtest/tests/copy.go
@@ -71,7 +71,7 @@ func registerCopy(r registry.Registry) {
 
 			rangeCount := func() int {
 				var count int
-				const q = "SELECT count(*) FROM [SHOW RANGES FROM TABLE bank.bank]"
+				const q = "SELECT count(*) FROM [SHOW RANGES FROM INDEX bank.bank@primary]"
 				if err := db.QueryRow(q).Scan(&count); err != nil {
 					t.Fatalf("failed to get range count: %v", err)
 				}


### PR DESCRIPTION
The semantics of SHOW RANGES has changed in 5604feaf, it now includes ranges of the secondary indicies. This change fixes the query to only request ranges of the primary index, to support the original assertion.

Fixes #93703
Release note: None