### PR TITLE
sqlsmith: add crdb_internal.job_payload_type to blocklist

### DIFF
--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -513,6 +513,9 @@ var functions = func() map[tree.FunctionClass]map[oid.Oid][]function {
 			"crdb_internal.revalidate_unique_constraint",
 			"crdb_internal.request_statement_bundle",
 			"crdb_internal.set_compaction_concurrency",
+			// crdb_internal.job_payload_type unmarshals a jobspb.Payload from
+			// raw bytes. Calling it with random values will produce an error.
+			"crdb_internal.job_payload_type",
 		} {
 			skip = skip || strings.Contains(def.Name, substr)
 		}


### PR DESCRIPTION
Previously, we would test the `crdb_internal.job_payload_type` builtin function with random values. Since this function unmarshals a `jobspb.Payload`, calling it with random bytes will always produce an error. We do not need to test this function under the smither.

Epic: none
Fixes: #93843

Release note: None