### PR TITLE
changefeedccl: Scope CDC expression using optimizer

### DIFF
--- a/pkg/ccl/changefeedccl/cdceval/expr_eval.go
+++ b/pkg/ccl/changefeedccl/cdceval/expr_eval.go
@@ -229,7 +229,10 @@ func (e *Evaluator) setupProjection(presentation colinfo.ResultColumns) {
 // event descriptor.
 func inputSpecForEventDescriptor(
 	ed *cdcevent.EventDescriptor,
-) (inputTypes []*types.T, inputCols catalog.TableColMap, _ error) {
+) ([]*types.T, catalog.TableColMap, error) {
+	numCols := len(ed.ResultColumns()) + len(colinfo.AllSystemColumnDescs)
+	inputTypes := make([]*types.T, 0, numCols)
+	var inputCols catalog.TableColMap
 	for i, c := range ed.ResultColumns() {
 		col, err := ed.TableDescriptor().FindColumnWithName(tree.Name(c.Name))
 		if err != nil {
@@ -238,6 +241,13 @@ func inputSpecForEventDescriptor(
 		inputCols.Set(col.GetID(), i)
 		inputTypes = append(inputTypes, c.Typ)
 	}
+
+	// Add system columns.
+	for _, sc := range colinfo.AllSystemColumnDescs {
+		inputCols.Set(sc.ID, inputCols.Len())
+		inputTypes = append(inputTypes, sc.Type)
+	}
+
 	return inputTypes, inputCols, nil
 }
 

--- a/pkg/ccl/changefeedccl/cdceval/expr_eval.go
+++ b/pkg/ccl/changefeedccl/cdceval/expr_eval.go
@@ -190,7 +190,7 @@ func (e *Evaluator) preparePlan(ctx context.Context, plan *sql.CDCExpressionPlan
 				e.rowEvalCtx.prevRowTuple = nil
 			}
 
-			p, err := sql.PlanCDCExpression(ctx, execCtx, e.norm.SelectStatement())
+			p, err := sql.PlanCDCExpression(ctx, execCtx, e.norm.SelectStatementForFamily())
 			if err != nil {
 				return err
 			}

--- a/pkg/ccl/changefeedccl/cdceval/expr_eval_test.go
+++ b/pkg/ccl/changefeedccl/cdceval/expr_eval_test.go
@@ -56,9 +56,10 @@ CREATE TABLE foo (
   e status DEFAULT 'inactive',
   f STRING,
   g STRING,
+  h STRING NOT VISIBLE,
   flag BOOL,
   PRIMARY KEY (b, a),
-  FAMILY main (a, b, e),
+  FAMILY main (a, b, e, h),
   FAMILY only_c (c),
   FAMILY f_g_fam(f, g, flag)
 )`)
@@ -315,7 +316,12 @@ CREATE TABLE foo (
 				"INSERT INTO foo (a, b, c) VALUES (42, 'prev_select', 'c value old')",
 				"UPSERT INTO foo (a, b, c) VALUES (42, 'prev_select', 'c value updated')",
 			},
-			stmt: "SELECT a, b, c, (CASE WHEN cdc_prev.c IS NULL THEN 'not there' ELSE cdc_prev.c END) AS old_c FROM foo",
+			stmt: `SELECT
+               a, b, c,
+               (CASE WHEN cdc_prev.c IS NULL THEN 'not there' ELSE cdc_prev.c END) AS old_c
+             FROM foo
+             WHERE cdc_prev.crdb_internal_mvcc_timestamp IS NULL OR
+                   cdc_prev.crdb_internal_mvcc_timestamp < crdb_internal_mvcc_timestamp`,
 			expectMainFamily: []decodeExpectation{
 				{
 					expectUnwatchedErr: true,
@@ -365,23 +371,31 @@ CREATE TABLE foo (
 				},
 			},
 		},
-		// TODO(yevgeniy): enable this test.
-		// This requires adding support to "fetch" those magic system columns from
-		// row fetcher, or replace them with a function call.
-		//{
-		//	testName:   "main/magic_column",
-		//	familyName: "main",
-		//	actions: []string{
-		//		"INSERT INTO foo (a, b) VALUES (1,  'hello')",
-		//	},
-		//	stmt: "SELECT a,  crdb_internal_mvcc_timestamp FROM foo",
-		//	expectMainFamily: []decodeExpectation{
-		//		{
-		//			keyValues: []string{"hello", "1"},
-		//			allValues: map[string]string{"a": "1", "crdb_internal_mvcc_timestamp": "xxx"},
-		//		},
-		//	},
-		//},
+		{
+			testName:   "main/system_and_hidden_columns",
+			familyName: "main",
+			actions: []string{
+				"INSERT INTO foo (a, b, h) VALUES (1,  'hello', 'invisible')",
+			},
+			stmt: "SELECT a, tableoid, h FROM foo WHERE crdb_internal_mvcc_timestamp = cdc_mvcc_timestamp()",
+			expectMainFamily: []decodeExpectation{
+				{
+					keyValues: []string{"hello", "1"},
+					allValues: map[string]string{
+						"a": "1", "tableoid": strconv.Itoa(int(desc.GetID())), "h": "invisible",
+					},
+				},
+			},
+		},
+		{
+			testName:   "main/system_and_hidden_columns_error",
+			familyName: "only_c",
+			actions: []string{
+				"INSERT INTO foo (a, b, h) VALUES (1,  'hello', 'invisible')",
+			},
+			stmt:      "SELECT a, tableoid, h FROM foo WHERE crdb_internal_mvcc_timestamp = cdc_mvcc_timestamp()",
+			expectErr: `column "foo.h" does not exist`,
+		},
 		// {
 		//  // TODO(yevgeniy): Test currently disable since session data is not serialized.
 		//  // Issue #90421
@@ -543,7 +557,7 @@ CREATE TABLE foo (
 					expect, tc.expectFGFamily = popExpectation(t, tc.expectFGFamily)
 				}
 
-				updatedRow, err := decodeRowErr(decoder, &v, false)
+				updatedRow, err := decodeRowErr(decoder, &v, cdcevent.CurrentRow)
 				if expect.expectUnwatchedErr {
 					require.ErrorIs(t, err, cdcevent.ErrUnwatchedFamily)
 					continue
@@ -551,7 +565,7 @@ CREATE TABLE foo (
 
 				require.NoError(t, err)
 				require.True(t, updatedRow.IsInitialized())
-				prevRow := decodeRow(t, decoder, &v, true)
+				prevRow := decodeRow(t, decoder, &v, cdcevent.PrevRow)
 				require.NoError(t, err)
 
 				require.Equal(t, expect.keyValues, slurpKeys(t, updatedRow),
@@ -639,22 +653,22 @@ func TestUnsupportedCDCFunctions(t *testing.T) {
 }
 
 func decodeRowErr(
-	decoder cdcevent.Decoder, v *roachpb.RangeFeedValue, prev bool,
+	decoder cdcevent.Decoder, v *roachpb.RangeFeedValue, rt cdcevent.RowType,
 ) (cdcevent.Row, error) {
 	keyVal := roachpb.KeyValue{Key: v.Key}
-	if prev {
+	if rt == cdcevent.PrevRow {
 		keyVal.Value = v.PrevValue
 	} else {
 		keyVal.Value = v.Value
 	}
 	const keyOnly = false
-	return decoder.DecodeKV(context.Background(), keyVal, v.Timestamp(), keyOnly)
+	return decoder.DecodeKV(context.Background(), keyVal, rt, v.Timestamp(), keyOnly)
 }
 
 func decodeRow(
-	t *testing.T, decoder cdcevent.Decoder, v *roachpb.RangeFeedValue, prev bool,
+	t *testing.T, decoder cdcevent.Decoder, v *roachpb.RangeFeedValue, rt cdcevent.RowType,
 ) cdcevent.Row {
-	r, err := decodeRowErr(decoder, v, prev)
+	r, err := decodeRowErr(decoder, v, rt)
 	require.NoError(t, err)
 	return r
 }

--- a/pkg/ccl/changefeedccl/cdceval/expr_eval_test.go
+++ b/pkg/ccl/changefeedccl/cdceval/expr_eval_test.go
@@ -571,6 +571,16 @@ CREATE TABLE foo (
 
 				require.Equal(t, expect.keyValues, slurpKeys(t, projection))
 				require.Equal(t, expect.allValues, slurpValues(t, projection))
+
+				// Repeat the same eval, pretending that versions changed.
+				// Event descriptor versions are cached, so updated and prev row share
+				// same descriptor; we have to jump through some hoops to update
+				// just one.
+				descriptorCopy := *updatedRow.EventDescriptor
+				descriptorCopy.Version++
+				updatedRow.EventDescriptor = &descriptorCopy
+				_, err = e.Eval(ctx, updatedRow, prevRow)
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/pkg/ccl/changefeedccl/cdceval/plan.go
+++ b/pkg/ccl/changefeedccl/cdceval/plan.go
@@ -51,7 +51,7 @@ func NormalizeExpression(
 			defer configSemaForCDC(execCtx.SemaCtx(), norm.desc)()
 			// Plan execution; this steps triggers optimizer, which
 			// performs various validation steps.
-			_, err := sql.PlanCDCExpression(ctx, execCtx, norm.SelectStatement())
+			_, err := sql.PlanCDCExpression(ctx, execCtx, norm.SelectStatementForFamily())
 			if err == nil {
 				return nil
 			}
@@ -91,8 +91,8 @@ func SpansForExpression(
 	if err := withPlanner(ctx, execCfg, user, schemaTS, sd,
 		func(ctx context.Context, execCtx sql.JobExecContext) error {
 			defer configSemaForCDC(execCtx.SemaCtx(), d)()
-
-			plan, err = sql.PlanCDCExpression(ctx, execCtx, &tree.Select{Select: sc})
+			norm := &NormalizedSelectClause{SelectClause: sc, desc: d}
+			plan, err = sql.PlanCDCExpression(ctx, execCtx, norm.SelectStatementForFamily())
 			if err == nil {
 				return nil
 			}

--- a/pkg/ccl/changefeedccl/cdceval/plan_test.go
+++ b/pkg/ccl/changefeedccl/cdceval/plan_test.go
@@ -86,7 +86,20 @@ FAMILY extra (extra)
 	mainColumns := colinfo.ResultColumns{
 		rc("a", types.Int), rc("status", statusT), rc("alt", altStatusT),
 	}
+	// mainColumns as tuple.
+	mainColumnsTuple := colinfo.ResultColumns{
+		rc("foo", types.MakeLabeledTuple(
+			[]*types.T{types.Int, statusT, altStatusT},
+			[]string{"a", "status", "alt"}),
+		)}
+
 	extraColumns := colinfo.ResultColumns{rc("a", types.Int), rc("extra", types.String)}
+	// extraColumns as tuple.
+	extraColumnsTuple := colinfo.ResultColumns{
+		rc("foo", types.MakeLabeledTuple(
+			[]*types.T{types.Int, types.String},
+			[]string{"a", "extra"}),
+		)}
 
 	checkPresentation := func(t *testing.T, expected, found colinfo.ResultColumns) {
 		t.Helper()
@@ -120,6 +133,13 @@ FAMILY extra (extra)
 			presentation: mainColumns,
 		},
 		{
+			name:         "full table - main tuple",
+			desc:         fooDesc,
+			stmt:         "SELECT foo FROM foo",
+			planSpans:    roachpb.Spans{primarySpan},
+			presentation: mainColumnsTuple,
+		},
+		{
 			name:         "full table - double star",
 			desc:         fooDesc,
 			stmt:         "SELECT *, * FROM foo",
@@ -127,12 +147,20 @@ FAMILY extra (extra)
 			presentation: append(mainColumns, mainColumns...),
 		},
 		{
-			name:         "full table  extra family",
+			name:         "full table extra family",
 			desc:         fooDesc,
 			targetFamily: "extra",
 			stmt:         "SELECT * FROM foo",
 			planSpans:    roachpb.Spans{primarySpan},
 			presentation: extraColumns,
+		},
+		{
+			name:         "full table extra family tuple",
+			desc:         fooDesc,
+			targetFamily: "extra",
+			stmt:         "SELECT foo FROM foo",
+			planSpans:    roachpb.Spans{primarySpan},
+			presentation: extraColumnsTuple,
 		},
 		{
 			name:         "expression scoped to column family",
@@ -185,11 +213,26 @@ FAMILY extra (extra)
 			presentation: mainColumns,
 		},
 		{
-			name:         "can cast to standard type",
+			name:         "cast to standard type",
 			desc:         fooDesc,
 			stmt:         "SELECT 'cast'::string AS a, 'type_annotation':::string AS b FROM foo AS bar",
 			planSpans:    roachpb.Spans{primarySpan},
 			presentation: colinfo.ResultColumns{rc("a", types.String), rc("b", types.String)},
+		},
+		{
+			name:         "cast to table-typed tuple main",
+			desc:         fooDesc,
+			stmt:         "SELECT foo FROM foo",
+			planSpans:    roachpb.Spans{primarySpan},
+			presentation: mainColumnsTuple,
+		},
+		{
+			name:         "cast to table-typed tuple extra",
+			desc:         fooDesc,
+			stmt:         "SELECT foo FROM foo",
+			targetFamily: "extra",
+			planSpans:    roachpb.Spans{primarySpan},
+			presentation: extraColumnsTuple,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -269,7 +312,7 @@ func normalizeAndPlan(
 		func(ctx context.Context, execCtx sql.JobExecContext) error {
 			defer configSemaForCDC(execCtx.SemaCtx(), d)()
 
-			plan, err = sql.PlanCDCExpression(ctx, execCtx, norm.SelectStatement())
+			plan, err = sql.PlanCDCExpression(ctx, execCtx, norm.SelectStatementForFamily())
 			return err
 		},
 	); err != nil {

--- a/pkg/ccl/changefeedccl/cdceval/validation.go
+++ b/pkg/ccl/changefeedccl/cdceval/validation.go
@@ -41,9 +41,25 @@ func (n *NormalizedSelectClause) RequiresPrev() bool {
 	return len(n.From.Tables) > 1
 }
 
-// SelectStatement returns tree.Select representing this object.
-func (n *NormalizedSelectClause) SelectStatement() *tree.Select {
-	return &tree.Select{Select: n.SelectClause}
+// SelectStatementForFamily returns tree.Select representing this object.
+func (n *NormalizedSelectClause) SelectStatementForFamily() *tree.Select {
+	if !n.desc.HasOtherFamilies {
+		return &tree.Select{Select: n.SelectClause}
+	}
+
+	// Configure index flags to restrict access to specific column family. To do
+	// this, we construct table expression with appropriate index flag. We want to
+	// make sure that when we do that, we do not mutate underlying select clause.
+	// This is done so that the same NormalizedSelectClause can be used to build
+	// expression evaluation for different table column families.
+	sc := *n.SelectClause
+	sc.From.Tables = append(tree.TableExprs(nil), n.SelectClause.From.Tables...)
+	sc.From.Tables[0] = &tree.AliasedTableExpr{
+		Expr:       n.SelectClause.From.Tables[0],
+		IndexFlags: &tree.IndexFlags{FamilyID: &n.desc.FamilyID},
+	}
+
+	return &tree.Select{Select: &sc}
 }
 
 // normalizeAndValidateSelectForTarget normalizes select expression and verifies
@@ -376,7 +392,7 @@ func normalizeSelectClause(
 	var norm *NormalizedSelectClause
 	switch t := stmt.(type) {
 	case *tree.SelectClause:
-		if err := scopeAndRewrite(t, desc, requiresPrev); err != nil {
+		if err := scopeAndRewrite(t, requiresPrev); err != nil {
 			return nil, err
 		}
 		norm = &NormalizedSelectClause{
@@ -451,24 +467,11 @@ func (c *checkColumnsVisitor) FindColumnFamilies(sc *tree.SelectClause) error {
 
 // scopeAndRewrite restricts this expression scope only to the columns
 // being accessed, and rewrites select clause as needed to reflect that.
-func scopeAndRewrite(
-	sc *tree.SelectClause, desc *cdcevent.EventDescriptor, requiresPrev bool,
-) error {
+func scopeAndRewrite(sc *tree.SelectClause, requiresPrev bool) error {
 	tables := append(tree.TableExprs(nil), sc.From.Tables...)
 	if len(tables) != 1 {
 		return errors.AssertionFailedf("expected single table")
 	}
-
-	table := tables[0]
-	if aliased, ok := table.(*tree.AliasedTableExpr); ok {
-		table = aliased.Expr
-	}
-	tableRef, ok := table.(*tree.TableRef)
-	if !ok {
-		return errors.AssertionFailedf("expected table reference, found %T", tables[0])
-	}
-
-	tables[0] = maybeScopeTable(desc, tableRef)
 
 	if requiresPrev {
 		// prevTupleTableExpr is a table expression to select contents of tuple
@@ -507,51 +510,4 @@ func scopeAndRewrite(
 
 	sc.From = tree.From{Tables: tables}
 	return nil
-}
-
-// maybeScopeTable returns possibly "scoped" table expression.
-// If event descriptor targets all columns, then table expression returned
-// unmodified. However, if the event descriptor targets a subset of columns,
-// then returns table expression restricted to targeted columns.
-func maybeScopeTable(ed *cdcevent.EventDescriptor, tableRef *tree.TableRef) tree.TableExpr {
-	// If the event descriptor targets all columns in the table, we can use
-	// table as is.
-	if ed.FamilyID == 0 && !ed.HasVirtual && !ed.HasOtherFamilies {
-		return tableRef
-	}
-
-	// If the event descriptor targets specific column family, we need to scope
-	// expression to select only the columns in the event descriptor.
-	// The code below is a bit of a mouth full.  Assuming that we were selecting from
-	// table named 'tbl', all we're doing here is turning
-	// from clause (FROM tbl) into something that looks like:
-	//  FROM (SELECT col1, col2, ... FROM [tableID AS t]) AS tbl
-	// Where col1, col2, ... are columns in the target column family, tableID is the table
-	// ID of the target table.
-	scopedTable := &tree.SelectClause{
-		From: tree.From{
-			Tables: tree.TableExprs{&tree.TableRef{
-				TableID: tableRef.TableID,
-				As:      tree.AliasClause{Alias: "t"},
-			}},
-		},
-		Exprs: func() (exprs tree.SelectExprs) {
-			exprs = make(tree.SelectExprs, len(ed.ResultColumns()))
-			for i, c := range ed.ResultColumns() {
-				exprs[i] = tree.SelectExpr{Expr: &tree.ColumnItem{ColumnName: tree.Name(c.Name)}}
-			}
-			return exprs
-		}(),
-	}
-
-	return &tree.AliasedTableExpr{
-		Expr: &tree.Subquery{
-			Select: &tree.ParenSelect{
-				Select: &tree.Select{
-					Select: scopedTable,
-				},
-			},
-		},
-		As: tableRef.As,
-	}
 }

--- a/pkg/ccl/changefeedccl/cdceval/validation_test.go
+++ b/pkg/ccl/changefeedccl/cdceval/validation_test.go
@@ -135,28 +135,28 @@ func TestNormalizeAndValidate(t *testing.T) {
 			name:         "can target one column family",
 			desc:         bazDesc,
 			stmt:         "SELECT a, b FROM baz",
-			expectStmt:   fmt.Sprintf("SELECT baz.a, baz.b FROM (SELECT a, b FROM [%d AS t]) AS baz", bazDesc.GetID()),
+			expectStmt:   fmt.Sprintf("SELECT baz.a, baz.b FROM [%d AS baz]", bazDesc.GetID()),
 			splitColFams: false,
 		},
 		{
 			name:         "SELECT a, b FROM bop",
 			desc:         bopDesc,
 			stmt:         "SELECT a, b FROM bop",
-			expectStmt:   fmt.Sprintf("SELECT bop.a, bop.b FROM (SELECT a, b FROM [%d AS t]) AS bop", bopDesc.GetID()),
+			expectStmt:   fmt.Sprintf("SELECT bop.a, bop.b FROM [%d AS bop]", bopDesc.GetID()),
 			splitColFams: false,
 		},
 		{
 			name:         "SELECT a, c FROM baz",
 			desc:         bazDesc,
 			stmt:         "SELECT a, c FROM baz",
-			expectStmt:   fmt.Sprintf("SELECT baz.a, baz.c FROM (SELECT a, c FROM [%d AS t]) AS baz", bazDesc.GetID()),
+			expectStmt:   fmt.Sprintf("SELECT baz.a, baz.c FROM [%d AS baz]", bazDesc.GetID()),
 			splitColFams: false,
 		},
 		{
 			name:         "SELECT b, b+1 AS c FROM baz",
 			desc:         bazDesc,
 			stmt:         "SELECT b, b+1 AS c FROM baz",
-			expectStmt:   fmt.Sprintf("SELECT baz.b, baz.b + 1 AS c FROM (SELECT a, b FROM [%d AS t]) AS baz", bazDesc.GetID()),
+			expectStmt:   fmt.Sprintf("SELECT baz.b, baz.b + 1 AS c FROM [%d AS baz]", bazDesc.GetID()),
 			splitColFams: false,
 		},
 		{
@@ -170,14 +170,14 @@ func TestNormalizeAndValidate(t *testing.T) {
 			name:         "SELECT B FROM baz",
 			desc:         bazDesc,
 			stmt:         "SELECT B FROM baz",
-			expectStmt:   fmt.Sprintf("SELECT baz.b FROM (SELECT a, b FROM [%d AS t]) AS baz", bazDesc.GetID()),
+			expectStmt:   fmt.Sprintf("SELECT baz.b FROM [%d AS baz]", bazDesc.GetID()),
 			splitColFams: false,
 		},
 		{
 			name:         "SELECT baz.b FROM baz",
 			desc:         bazDesc,
 			stmt:         "SELECT baz.b FROM baz",
-			expectStmt:   fmt.Sprintf("SELECT baz.b FROM (SELECT a, b FROM [%d AS t]) AS baz", bazDesc.GetID()),
+			expectStmt:   fmt.Sprintf("SELECT baz.b FROM [%d AS baz]", bazDesc.GetID()),
 			splitColFams: false,
 		},
 		{
@@ -185,7 +185,7 @@ func TestNormalizeAndValidate(t *testing.T) {
 			desc: bazDesc,
 			stmt: "SELECT baz.b, row_to_json(cdc_prev.*) FROM baz",
 			expectStmt: fmt.Sprintf("SELECT baz.b, row_to_json(cdc_prev.*) FROM "+
-				"(SELECT a, b FROM [%d AS t]) AS baz, "+
+				"[%d AS baz], "+
 				"(SELECT (crdb_internal.cdc_prev_row()).*) AS cdc_prev",
 				bazDesc.GetID()),
 			// Currently, accessing cdc_prev.* is treated in such a way as to require
@@ -212,7 +212,7 @@ func TestNormalizeAndValidate(t *testing.T) {
 			name:         "SELECT b::string = 'c' FROM baz",
 			desc:         bazDesc,
 			stmt:         "SELECT b::string = 'c' FROM baz",
-			expectStmt:   fmt.Sprintf("SELECT baz.b::STRING = 'c' FROM (SELECT a, b FROM [%d AS t]) AS baz", bazDesc.GetID()),
+			expectStmt:   fmt.Sprintf("SELECT baz.b::STRING = 'c' FROM [%d AS baz]", bazDesc.GetID()),
 			splitColFams: false,
 		},
 		{
@@ -226,7 +226,7 @@ func TestNormalizeAndValidate(t *testing.T) {
 			name:         "no explicit column references",
 			desc:         bazDesc,
 			stmt:         "SELECT pi() FROM baz",
-			expectStmt:   fmt.Sprintf("SELECT pi() FROM (SELECT a, b FROM [%d AS t]) AS baz", bazDesc.GetID()),
+			expectStmt:   fmt.Sprintf("SELECT pi() FROM [%d AS baz]", bazDesc.GetID()),
 			splitColFams: false,
 		},
 		{

--- a/pkg/ccl/changefeedccl/cdcevent/event_test.go
+++ b/pkg/ccl/changefeedccl/cdcevent/event_test.go
@@ -376,7 +376,7 @@ CREATE TABLE foo (
 					expect, tc.expectOnlyCFamily = tc.expectOnlyCFamily[0], tc.expectOnlyCFamily[1:]
 				}
 				updatedRow, err := decoder.DecodeKV(
-					ctx, roachpb.KeyValue{Key: v.Key, Value: v.Value}, v.Timestamp(), tc.keyOnly)
+					ctx, roachpb.KeyValue{Key: v.Key, Value: v.Value}, CurrentRow, v.Timestamp(), tc.keyOnly)
 
 				if expect.expectUnwatchedErr {
 					require.ErrorIs(t, err, ErrUnwatchedFamily)
@@ -393,7 +393,7 @@ CREATE TABLE foo (
 				}
 
 				prevRow, err := decoder.DecodeKV(
-					ctx, roachpb.KeyValue{Key: v.Key, Value: v.PrevValue}, v.Timestamp(), tc.keyOnly)
+					ctx, roachpb.KeyValue{Key: v.Key, Value: v.PrevValue}, PrevRow, v.Timestamp(), tc.keyOnly)
 				require.NoError(t, err)
 
 				// prevRow always has key columns initialized.
@@ -593,7 +593,7 @@ func TestEventColumnOrderingWithSchemaChanges(t *testing.T) {
 					expect, tc.expectECFamily = tc.expectECFamily[0], tc.expectECFamily[1:]
 				}
 				updatedRow, err := decoder.DecodeKV(
-					ctx, roachpb.KeyValue{Key: v.Key, Value: v.Value}, v.Timestamp(), false)
+					ctx, roachpb.KeyValue{Key: v.Key, Value: v.Value}, CurrentRow, v.Timestamp(), false)
 
 				if expect.expectUnwatchedErr {
 					require.ErrorIs(t, err, ErrUnwatchedFamily)

--- a/pkg/ccl/changefeedccl/cdcevent/rowfetcher_cache.go
+++ b/pkg/ccl/changefeedccl/cdcevent/rowfetcher_cache.go
@@ -177,7 +177,10 @@ var ErrUnwatchedFamily = errors.New("watched table but unwatched family")
 // RowFetcherForColumnFamily returns row.Fetcher for the specified column family.
 // Returns ErrUnwatchedFamily error if family is not watched.
 func (c *rowFetcherCache) RowFetcherForColumnFamily(
-	tableDesc catalog.TableDescriptor, family descpb.FamilyID, keyOnly bool,
+	tableDesc catalog.TableDescriptor,
+	family descpb.FamilyID,
+	sysCols []descpb.ColumnDescriptor,
+	keyOnly bool,
 ) (*row.Fetcher, *descpb.ColumnFamilyDescriptor, error) {
 	idVer := CacheKey{ID: tableDesc.GetID(), Version: tableDesc.GetVersion(), FamilyID: family}
 	if v, ok := c.fetchers.Get(idVer); ok {
@@ -233,6 +236,16 @@ func (c *rowFetcherCache) RowFetcherForColumnFamily(
 		&spec, c.codec, tableDesc, tableDesc.GetPrimaryIndex(), relevantColumns,
 	); err != nil {
 		return nil, nil, err
+	}
+
+	// Add system columns.
+	for _, sc := range sysCols {
+		spec.FetchedColumns = append(spec.FetchedColumns, fetchpb.IndexFetchSpec_Column{
+			ColumnID:      sc.ID,
+			Name:          sc.Name,
+			Type:          sc.Type,
+			IsNonNullable: !sc.Nullable,
+		})
 	}
 
 	if err := rf.Init(

--- a/pkg/ccl/changefeedccl/cdcevent/rowfetcher_test.go
+++ b/pkg/ccl/changefeedccl/cdcevent/rowfetcher_test.go
@@ -77,11 +77,11 @@ func TestRowFetcherCache(t *testing.T) {
 	}
 
 	// Ensure a cache hit using the same table descriptor, family, and targets.
-	rf, _, err := rfCache.RowFetcherForColumnFamily(tableDesc, cFamilyID, false)
+	rf, _, err := rfCache.RowFetcherForColumnFamily(tableDesc, cFamilyID, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}
-	rf2, _, err := rfCache.RowFetcherForColumnFamily(tableDesc, cFamilyID, false)
+	rf2, _, err := rfCache.RowFetcherForColumnFamily(tableDesc, cFamilyID, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -90,7 +90,7 @@ func TestRowFetcherCache(t *testing.T) {
 	// Changing a type in another column family does not cause a cache eviction.
 	sqlDB.Exec(t, `ALTER TYPE status ADD VALUE 'pending'`)
 	refreshDesc()
-	rf3, _, err := rfCache.RowFetcherForColumnFamily(tableDesc, cFamilyID, false)
+	rf3, _, err := rfCache.RowFetcherForColumnFamily(tableDesc, cFamilyID, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,7 +99,7 @@ func TestRowFetcherCache(t *testing.T) {
 	// Changing a type in the same column family does cause a cache eviction.
 	sqlDB.Exec(t, `ALTER TYPE priority ADD VALUE 'medium'`)
 	refreshDesc()
-	rf4, _, err := rfCache.RowFetcherForColumnFamily(tableDesc, cFamilyID, false)
+	rf4, _, err := rfCache.RowFetcherForColumnFamily(tableDesc, cFamilyID, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/ccl/changefeedccl/event_processing.go
+++ b/pkg/ccl/changefeedccl/event_processing.go
@@ -307,7 +307,7 @@ func (c *kvEventToRowConsumer) ConsumeEvent(ctx context.Context, ev kvevent.Even
 		prevSchemaTimestamp = schemaTimestamp.Prev()
 	}
 
-	updatedRow, err := c.decoder.DecodeKV(ctx, ev.KV(), schemaTimestamp, keyOnly)
+	updatedRow, err := c.decoder.DecodeKV(ctx, ev.KV(), cdcevent.CurrentRow, schemaTimestamp, keyOnly)
 	if err != nil {
 		// Column families are stored contiguously, so we'll get
 		// events for each one even if we're not watching them all.
@@ -322,7 +322,7 @@ func (c *kvEventToRowConsumer) ConsumeEvent(ctx context.Context, ev kvevent.Even
 		if !c.details.Opts.GetFilters().WithDiff {
 			return cdcevent.Row{}, nil
 		}
-		return c.decoder.DecodeKV(ctx, ev.PrevKeyValue(), prevSchemaTimestamp, keyOnly)
+		return c.decoder.DecodeKV(ctx, ev.PrevKeyValue(), cdcevent.PrevRow, prevSchemaTimestamp, keyOnly)
 	}()
 	if err != nil {
 		// Column families are stored contiguously, so we'll get

--- a/pkg/sql/distsql_plan_changefeed.go
+++ b/pkg/sql/distsql_plan_changefeed.go
@@ -394,6 +394,10 @@ func newFamilyTableDescriptor(
 		includeSet.Add(id)
 	}
 
+	// Add system columns -- those are always available.
+	includeSet.Add(colinfo.MVCCTimestampColumnID)
+	includeSet.Add(colinfo.TableOIDColumnID)
+
 	return &familyTableDescriptor{
 		TableDescriptor: original,
 		includeSet:      includeSet,
@@ -433,12 +437,6 @@ func (d *familyTableDescriptor) AllColumns() []catalog.Column {
 // only include columns referenced by the target column family.
 func (d *familyTableDescriptor) VisibleColumns() []catalog.Column {
 	return d.filterColumns(d.TableDescriptor.VisibleColumns())
-}
-
-// SystemColumns implements catalog.TableDescriptor interface.
-// TODO(yevgeniy): Support system columns
-func (d *familyTableDescriptor) SystemColumns() []catalog.Column {
-	return nil
 }
 
 // EnforcedUniqueConstraintsWithoutIndex implements catalog.TableDescriptor interface.

--- a/pkg/sql/distsql_plan_changefeed.go
+++ b/pkg/sql/distsql_plan_changefeed.go
@@ -18,14 +18,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/resolver"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/clusterunique"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -67,13 +66,18 @@ func PlanCDCExpression(
 	}, clusterunique.ID{} /* queryID */)
 
 	p.curPlan.init(&p.stmt, &p.instrumentation)
-	p.optPlanningCtx.init(p)
 	opc := &p.optPlanningCtx
+	opc.init(p)
 	opc.reset(ctx)
 
+	familyID, err := extractFamilyID(cdcExpr)
+	if err != nil {
+		return cdcPlan, err
+	}
 	cdcCat := &cdcOptCatalog{
-		optCatalog: opc.catalog.(*optCatalog),
-		semaCtx:    &p.semaCtx,
+		optCatalog:     opc.catalog.(*optCatalog),
+		targetFamilyID: familyID,
+		semaCtx:        &p.semaCtx,
 	}
 	opc.catalog = cdcCat
 
@@ -281,10 +285,25 @@ func (n *cdcValuesNode) Close(ctx context.Context) {
 
 type cdcOptCatalog struct {
 	*optCatalog
-	semaCtx *tree.SemaContext
+	targetFamilyID catid.FamilyID
+	semaCtx        *tree.SemaContext
 }
 
 var _ cat.Catalog = (*cdcOptCatalog)(nil)
+
+// extractFamilyID extracts family ID hint from CDCExpression.
+func extractFamilyID(stmt CDCExpression) (catid.FamilyID, error) {
+	sc, ok := stmt.Select.(*tree.SelectClause)
+	if !ok {
+		return 0, errors.AssertionFailedf("unexpected expression type %T", stmt.Select)
+	}
+	if t, ok := sc.From.Tables[0].(*tree.AliasedTableExpr); ok {
+		if t.IndexFlags != nil && t.IndexFlags.FamilyID != nil {
+			return *t.IndexFlags.FamilyID, nil
+		}
+	}
+	return 0, nil
+}
 
 // ResolveDataSource implements cat.Catalog interface.
 // We provide custom implementation to ensure that we return data source for
@@ -302,7 +321,7 @@ func (c *cdcOptCatalog) ResolveDataSource(
 		return nil, cat.DataSourceName{}, err
 	}
 
-	ds, err := c.newCDCDataSource(desc)
+	ds, err := c.newCDCDataSource(desc, c.targetFamilyID)
 	if err != nil {
 		return nil, cat.DataSourceName{}, err
 	}
@@ -319,7 +338,8 @@ func (c *cdcOptCatalog) ResolveDataSourceByID(
 	if err != nil {
 		return nil, false, err
 	}
-	ds, err := c.newCDCDataSource(desc)
+
+	ds, err := c.newCDCDataSource(desc, c.targetFamilyID)
 	if err != nil {
 		return nil, false, err
 	}
@@ -341,14 +361,132 @@ func (c *cdcOptCatalog) ResolveFunction(
 	return c.optCatalog.ResolveFunction(ctx, fnName, path)
 }
 
-// newCDCDataSource builds an optTable for the target cdc table.
-// The descriptor presented to the optimizer hides all but the primary index.
+// newCDCDataSource builds an optTable for the target cdc table and family.
+func (c *cdcOptCatalog) newCDCDataSource(
+	original catalog.TableDescriptor, familyID catid.FamilyID,
+) (cat.DataSource, error) {
+	d, err := newFamilyTableDescriptor(original, familyID)
+	if err != nil {
+		return nil, err
+	}
+	return newOptTable(d, c.codec(), nil /* stats */, emptyZoneConfig)
+}
+
+// familyTableDescriptor wraps underlying catalog.TableDescriptor,
+// but restricts access to a single column family.
+type familyTableDescriptor struct {
+	catalog.TableDescriptor
+	includeSet catalog.TableColSet
+}
+
+func newFamilyTableDescriptor(
+	original catalog.TableDescriptor, familyID catid.FamilyID,
+) (catalog.TableDescriptor, error) {
+	// Build the set of columns in the family, along with the primary
+	// key columns.
+	fam, err := original.FindFamilyByID(familyID)
+	if err != nil {
+		return nil, err
+	}
+
+	includeSet := original.GetPrimaryIndex().CollectKeyColumnIDs()
+	for _, id := range fam.ColumnIDs {
+		includeSet.Add(id)
+	}
+
+	return &familyTableDescriptor{
+		TableDescriptor: original,
+		includeSet:      includeSet,
+	}, nil
+}
+
+// DeletableNonPrimaryIndexes implements catalog.TableDescriptor interface.
+// CDC currently supports primary index only.
 // TODO(yevgeniy): We should be able to use secondary indexes provided
 // the CDC expression access only the columns available in that secondary index.
-func (c *cdcOptCatalog) newCDCDataSource(original catalog.TableDescriptor) (cat.DataSource, error) {
-	// Build descriptor with all indexes other than primary removed.
-	desc := protoutil.Clone(original.TableDesc()).(*descpb.TableDescriptor)
-	desc.Indexes = desc.Indexes[:0]
-	updated := tabledesc.NewBuilder(desc).BuildImmutableTable()
-	return newOptTable(updated, c.codec(), nil /* stats */, emptyZoneConfig)
+func (d *familyTableDescriptor) DeletableNonPrimaryIndexes() []catalog.Index {
+	return nil
+}
+
+// ActiveIndexes implements catalog.TableDescriptor.
+// Only primary index supported for now.
+func (d *familyTableDescriptor) ActiveIndexes() []catalog.Index {
+	return d.TableDescriptor.ActiveIndexes()[:1]
+}
+
+// DeletableColumns implements catalog.TableDescriptor interface.
+// This implementation filters out underlying descriptor DeletableColumns to
+// only include columns referenced by the target column family.
+func (d *familyTableDescriptor) DeletableColumns() []catalog.Column {
+	return d.filterColumns(d.TableDescriptor.DeletableColumns())
+}
+
+// AllColumns implements catalog.TableDescriptor interface.
+// This implementation filters out underlying descriptor AllColumns to
+// only include columns referenced by the target column family.
+func (d *familyTableDescriptor) AllColumns() []catalog.Column {
+	return d.filterColumns(d.TableDescriptor.AllColumns())
+}
+
+// VisibleColumns implements catalog.TableDescriptor interface.
+// This implementation filters out underlying descriptor AllColumns to
+// only include columns referenced by the target column family.
+func (d *familyTableDescriptor) VisibleColumns() []catalog.Column {
+	return d.filterColumns(d.TableDescriptor.VisibleColumns())
+}
+
+// SystemColumns implements catalog.TableDescriptor interface.
+// TODO(yevgeniy): Support system columns
+func (d *familyTableDescriptor) SystemColumns() []catalog.Column {
+	return nil
+}
+
+// EnforcedUniqueConstraintsWithoutIndex implements catalog.TableDescriptor interface.
+// This implementation filters out constraints that reference columns outside of
+// target column family.
+func (d *familyTableDescriptor) EnforcedUniqueConstraintsWithoutIndex() []catalog.UniqueWithoutIndexConstraint {
+	constraints := d.TableDescriptor.EnforcedUniqueConstraintsWithoutIndex()
+	filtered := make([]catalog.UniqueWithoutIndexConstraint, 0, len(constraints))
+	for _, c := range constraints {
+		if c.CollectKeyColumnIDs().SubsetOf(d.includeSet) {
+			filtered = append(filtered, c)
+		}
+	}
+	return filtered
+}
+
+// EnforcedCheckConstraints implements catalog.TableDescriptor interface.
+// This implementation filters out constraints that reference columns outside of
+// target column family.
+func (d *familyTableDescriptor) EnforcedCheckConstraints() []catalog.CheckConstraint {
+	constraints := d.TableDescriptor.EnforcedCheckConstraints()
+	filtered := make([]catalog.CheckConstraint, 0, len(constraints))
+	for _, c := range constraints {
+		if c.CollectReferencedColumnIDs().SubsetOf(d.includeSet) {
+			filtered = append(filtered, c)
+		}
+	}
+	return filtered
+}
+
+func (d *familyTableDescriptor) filterColumns(cols []catalog.Column) []catalog.Column {
+	filtered := make([]catalog.Column, 0, len(cols))
+	for _, col := range cols {
+		if d.includeSet.Contains(col.GetID()) {
+			filtered = append(filtered, &remappedOrdinalColumn{Column: col, ord: len(filtered)})
+		}
+	}
+	return filtered
+}
+
+// remappedOrdinalColumn wraps underlying catalog.Column
+// but changes its ordinal position.
+type remappedOrdinalColumn struct {
+	catalog.Column
+	ord int
+}
+
+// Ordinal implements catalog.Column interface.
+func (c *remappedOrdinalColumn) Ordinal() int {
+	return c.ord
 }

--- a/pkg/sql/distsql_plan_changefeed_test.go
+++ b/pkg/sql/distsql_plan_changefeed_test.go
@@ -12,6 +12,7 @@ package sql
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"testing"
 
@@ -57,8 +58,23 @@ func TestChangefeedLogicalPlan(t *testing.T) {
 	s, db, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.Background())
 
+	defer tree.TestingEnableFamilyIndexHint()()
+
 	sqlDB := sqlutils.MakeSQLRunner(db)
-	sqlDB.Exec(t, `CREATE TABLE foo (a INT, b int, c STRING, CONSTRAINT "pk" PRIMARY KEY (a, b), UNIQUE (c))`)
+	sqlDB.Exec(t, `
+CREATE TABLE foo (
+  a INT,
+  b int,
+  c STRING,
+  double_c STRING AS (concat(c, c)) VIRTUAL,  -- Virtual columns ignored for now, but adding to make sure.
+  extra STRING NOT NULL,
+  CONSTRAINT "pk" PRIMARY KEY (a, b),
+  UNIQUE (c),
+  UNIQUE (extra),
+  FAMILY main (a,b,c),
+  FAMILY extra (extra)
+)`)
+
 	sqlDB.Exec(t, `CREATE TABLE bar (a INT)`)
 	fooDesc := desctestutils.TestingGetTableDescriptor(
 		kvDB, keys.SystemSQLCodec, "defaultdb", "public", "foo")
@@ -82,12 +98,30 @@ func TestChangefeedLogicalPlan(t *testing.T) {
 	rc := func(n string, typ *types.T) colinfo.ResultColumn {
 		return colinfo.ResultColumn{Name: n, Typ: typ}
 	}
-	allColumns := colinfo.ResultColumns{
+	mainColumns := colinfo.ResultColumns{
 		rc("a", types.Int), rc("b", types.Int), rc("c", types.String),
 	}
+	// mainColumns as tuple.
+	mainColumnsTuple := colinfo.ResultColumns{
+		rc("foo", types.MakeLabeledTuple(
+			[]*types.T{types.Int, types.Int, types.String},
+			[]string{"a", "b", "c"}),
+		)}
+
+	extraColumns := colinfo.ResultColumns{
+		rc("a", types.Int), rc("b", types.Int), rc("extra", types.String),
+	}
+
+	// extraColumnsAs tuple.
+	extraColumnsTuple := colinfo.ResultColumns{
+		rc("foo", types.MakeLabeledTuple(
+			[]*types.T{types.Int, types.Int, types.String},
+			[]string{"a", "b", "extra"}),
+		)}
+
 	checkPresentation := func(t *testing.T, expected, found colinfo.ResultColumns) {
 		t.Helper()
-		require.Equal(t, len(expected), len(found))
+		require.Equal(t, len(expected), len(found), "e=%v f=%v", expected, found)
 		for i := 0; i < len(found); i++ {
 			require.Equal(t, expected[i].Name, found[i].Name, "e=%v f=%v", expected[i], found[i])
 			require.True(t, expected[i].Typ.Equal(found[i].Typ), "e=%v f=%v", expected[i], found[i])
@@ -103,7 +137,13 @@ func TestChangefeedLogicalPlan(t *testing.T) {
 		{
 			stmt:        "SELECT * FROM foo WHERE 5 > 1",
 			expectSpans: roachpb.Spans{primarySpan},
-			present:     allColumns,
+			present:     mainColumns,
+		},
+		{
+			// Star scoped to column family.
+			stmt:        "SELECT * FROM foo@{FAMILY=[1]} WHERE 5 > 1",
+			expectSpans: roachpb.Spans{primarySpan},
+			present:     extraColumns,
 		},
 		{
 			stmt:      "SELECT * FROM foo WHERE 0 != 0",
@@ -112,6 +152,27 @@ func TestChangefeedLogicalPlan(t *testing.T) {
 		{
 			stmt:      "SELECT * FROM foo WHERE a IS NULL",
 			expectErr: "does not match any rows",
+		},
+		{
+			stmt:      "SELECT * FROM foo@{FAMILY=[1]} WHERE extra IS NULL",
+			expectErr: "does not match any rows",
+		},
+		{
+			// Cannot reference extra column when targeting main column family.
+			stmt:      "SELECT * FROM foo WHERE extra IS NULL",
+			expectErr: `column "extra" does not exist`,
+		},
+		{
+			// Can access system columns.
+			stmt:        "SELECT *, tableoid FROM foo",
+			expectSpans: roachpb.Spans{primarySpan},
+			present:     append(mainColumns, rc("tableoid", colinfo.TableOIDColumnDesc.Type)),
+		},
+		{
+			// Can access system columns in extra family.
+			stmt:        "SELECT *, crdb_internal_mvcc_timestamp AS mvcc FROM foo@{FAMILY=[1]}",
+			expectSpans: roachpb.Spans{primarySpan},
+			present:     append(extraColumns, rc("mvcc", colinfo.MVCCTimestampColumnDesc.Type)),
 		},
 		{
 			stmt:      "SELECT * FROM foo, bar WHERE foo.a = bar.a",
@@ -127,12 +188,12 @@ func TestChangefeedLogicalPlan(t *testing.T) {
 		},
 		{
 			stmt:      "SELECT * FROM foo WHERE 5 > 1 UNION SELECT * FROM foo WHERE a < 1",
-			expectErr: "unexpected multiple primary index scan operations",
+			expectErr: "unexpected expression type",
 		},
 		{
 			stmt:        "SELECT * FROM foo WHERE a >=3 or a < 3",
 			expectSpans: roachpb.Spans{primarySpan},
-			present:     allColumns,
+			present:     mainColumns,
 		},
 		{
 			stmt:      "SELECT * FROM foo WHERE 5",
@@ -145,7 +206,7 @@ func TestChangefeedLogicalPlan(t *testing.T) {
 		{
 			stmt:        "SELECT * FROM foo WHERE true",
 			expectSpans: roachpb.Spans{primarySpan},
-			present:     allColumns,
+			present:     mainColumns,
 		},
 		{
 			stmt:      "SELECT * FROM foo WHERE false",
@@ -154,32 +215,32 @@ func TestChangefeedLogicalPlan(t *testing.T) {
 		{
 			stmt:        "SELECT * FROM foo WHERE a > 100",
 			expectSpans: roachpb.Spans{{Key: mkPkKey(t, fooID, 101), EndKey: pkEnd}},
-			present:     allColumns,
+			present:     mainColumns,
 		},
 		{
 			stmt:        "SELECT * FROM foo WHERE a < 100",
 			expectSpans: roachpb.Spans{{Key: pkStart, EndKey: mkPkKey(t, fooID, 100)}},
-			present:     allColumns,
+			present:     mainColumns,
 		},
 		{
 			stmt:        "SELECT * FROM foo WHERE a > 10 AND a > 5",
 			expectSpans: roachpb.Spans{{Key: mkPkKey(t, fooID, 11), EndKey: pkEnd}},
-			present:     allColumns,
+			present:     mainColumns,
 		},
 		{
 			stmt:        "SELECT * FROM foo WHERE a > 10 OR a > 5",
 			expectSpans: roachpb.Spans{{Key: mkPkKey(t, fooID, 6), EndKey: pkEnd}},
-			present:     allColumns,
+			present:     mainColumns,
 		},
 		{
 			stmt:        "SELECT * FROM foo WHERE a > 100 AND a <= 101",
 			expectSpans: roachpb.Spans{{Key: mkPkKey(t, fooID, 101), EndKey: mkPkKey(t, fooID, 102)}},
-			present:     allColumns,
+			present:     mainColumns,
 		},
 		{
 			stmt:        "SELECT * FROM foo WHERE a > 100 and a < 200",
 			expectSpans: roachpb.Spans{{Key: mkPkKey(t, fooID, 101), EndKey: mkPkKey(t, fooID, 200)}},
-			present:     allColumns,
+			present:     mainColumns,
 		},
 		{
 			stmt: "SELECT * FROM foo WHERE a > 100 or a <= 99",
@@ -187,25 +248,25 @@ func TestChangefeedLogicalPlan(t *testing.T) {
 				{Key: pkStart, EndKey: mkPkKey(t, fooID, 100)},
 				{Key: mkPkKey(t, fooID, 101), EndKey: pkEnd},
 			},
-			present: allColumns,
+			present: mainColumns,
 		},
 		{
 			stmt:        "SELECT * FROM foo WHERE a > 100 AND b > 11",
 			expectSpans: roachpb.Spans{{Key: mkPkKey(t, fooID, 101, 12), EndKey: pkEnd}},
-			present:     allColumns,
+			present:     mainColumns,
 		},
 		{
 			// Same as above, but with table alias -- we expect remaining expression to
 			// preserve the alias.
 			stmt:        "SELECT * FROM foo AS buz WHERE buz.a > 100 AND b > 11",
 			expectSpans: roachpb.Spans{{Key: mkPkKey(t, fooID, 101, 12), EndKey: pkEnd}},
-			present:     allColumns,
+			present:     mainColumns,
 		},
 		{
 			// Same as above, but w/ silly tautology, which should be removed.
 			stmt:        "SELECT * FROM defaultdb.public.foo WHERE (a > 3 OR a <= 3) AND a > 100 AND b > 11",
 			expectSpans: roachpb.Spans{{Key: mkPkKey(t, fooID, 101, 12), EndKey: pkEnd}},
-			present:     allColumns,
+			present:     mainColumns,
 		},
 		{
 			stmt: "SELECT * FROM foo WHERE a < 42 OR (a > 100 AND b > 11)",
@@ -213,7 +274,7 @@ func TestChangefeedLogicalPlan(t *testing.T) {
 				{Key: pkStart, EndKey: mkPkKey(t, fooID, 42)},
 				{Key: mkPkKey(t, fooID, 101, 12), EndKey: pkEnd},
 			},
-			present: allColumns,
+			present: mainColumns,
 		},
 		{
 			// Same as above, but now with tuples.
@@ -224,18 +285,18 @@ func TestChangefeedLogicalPlan(t *testing.T) {
 				// /Table/104/1/100/12 (i.e. a="100" and b="12" (because 100/12 lexicographically follows 100).
 				{Key: mkPkKey(t, fooID, 100, 12), EndKey: pkEnd},
 			},
-			present: allColumns,
+			present: mainColumns,
 		},
 		{
 			stmt:        "SELECT * FROM foo WHERE (a, b) > (2, 5)",
 			expectSpans: roachpb.Spans{{Key: mkPkKey(t, fooID, 2, 6), EndKey: pkEnd}},
-			present:     allColumns,
+			present:     mainColumns,
 		},
 		{
 			// Test that aliased table names work.
 			stmt:        "SELECT * FROM foo as buz WHERE (buz.a, buz.b) > (2, 5)",
 			expectSpans: roachpb.Spans{{Key: mkPkKey(t, fooID, 2, 6), EndKey: pkEnd}},
-			present:     allColumns,
+			present:     mainColumns,
 		},
 		{
 			// This test also uses qualified names for some fields.
@@ -245,14 +306,14 @@ func TestChangefeedLogicalPlan(t *testing.T) {
 				{Key: mkPkKey(t, fooID, 10), EndKey: mkPkKey(t, fooID, 10, 25)},
 				{Key: mkPkKey(t, fooID, 20), EndKey: mkPkKey(t, fooID, 20, 25)},
 			},
-			present: allColumns,
+			present: mainColumns,
 		},
 		{
 			// Currently, only primary index supported; so even when doing lookup
 			// on a non-primary index, we expect primary index to be scanned.
 			stmt:        "SELECT * FROM foo WHERE c = 'unique'",
 			expectSpans: roachpb.Spans{primarySpan},
-			present:     allColumns,
+			present:     mainColumns,
 		},
 		{
 			// Point lookup.
@@ -267,6 +328,32 @@ func TestChangefeedLogicalPlan(t *testing.T) {
 			stmt:        `SELECT * FROM (SELECT a, c FROM foo) AS foo`,
 			expectSpans: roachpb.Spans{primarySpan},
 			present:     colinfo.ResultColumns{rc("a", types.Int), rc("c", types.String)},
+		},
+		{
+			// Expression targets column C with unique index.
+			// However, we currently do not support any indexes other than primary.
+			// Verify that's the case.
+			stmt:        `SELECT a, c FROM foo WHERE c IN ('a', 'b', 'c')`,
+			expectSpans: roachpb.Spans{primarySpan},
+			present:     colinfo.ResultColumns{rc("a", types.Int), rc("c", types.String)},
+		},
+		{
+			// foo as a table-typed tuple; main column family.
+			stmt:        `SELECT foo FROM foo`,
+			expectSpans: roachpb.Spans{primarySpan},
+			present:     mainColumnsTuple,
+		},
+		{
+			// foo as a table-typed tuple; extra column family.
+			stmt:        `SELECT foo FROM foo@{FAMILY=[1]}`,
+			expectSpans: roachpb.Spans{primarySpan},
+			present:     extraColumnsTuple,
+		},
+		{
+			// foo as a table typed tuple (extra column family), but using table reference.
+			stmt:        fmt.Sprintf(`SELECT foo FROM [%d AS foo]@{FAMILY=[1]}`, fooDesc.GetID()),
+			expectSpans: roachpb.Spans{primarySpan},
+			present:     extraColumnsTuple,
 		},
 	} {
 		t.Run(tc.stmt, func(t *testing.T) {
@@ -337,7 +424,15 @@ func TestCdcExpressionExecution(t *testing.T) {
 	defer s.Stopper().Stop(context.Background())
 
 	sqlDB := sqlutils.MakeSQLRunner(db)
-	sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b INT, c STRING)`)
+	sqlDB.Exec(t, `CREATE TABLE foo (
+a INT PRIMARY KEY, b INT, c STRING, extra STRING,
+FAMILY main(a,b,c),
+-- We will target primary family in the foo table.
+-- The semantics around * expansion should be adopted to
+-- only reference columns in the main family.
+FAMILY extra (extra)
+)`)
+
 	fooDesc := desctestutils.TestingGetTableDescriptor(
 		kvDB, keys.SystemSQLCodec, "defaultdb", "public", "foo")
 

--- a/pkg/sql/distsql_plan_changefeed_test.go
+++ b/pkg/sql/distsql_plan_changefeed_test.go
@@ -355,6 +355,12 @@ CREATE TABLE foo (
 			expectSpans: roachpb.Spans{primarySpan},
 			present:     extraColumnsTuple,
 		},
+		{
+			// System columns
+			stmt:        `SELECT crdb_internal_mvcc_timestamp AS mvcc FROM foo`,
+			expectSpans: roachpb.Spans{primarySpan},
+			present:     colinfo.ResultColumns{rc("mvcc", colinfo.MVCCTimestampColumnType)},
+		},
 	} {
 		t.Run(tc.stmt, func(t *testing.T) {
 			stmt, err := parser.ParseOne(tc.stmt)

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -12173,6 +12173,12 @@ index_flags_param:
     /* SKIP DOC */
      $$.val = &tree.IndexFlags{ZigzagIndexIDs: []tree.IndexID{tree.IndexID($4.int64())}}
   }
+| FAMILY '=' '[' iconst64 ']'
+  {
+    /* SKIP DOC */
+    id := tree.FamilyID(uint32($4.int64()))
+     $$.val = &tree.IndexFlags{FamilyID: &id}
+  }
 
 index_flags_param_list:
   index_flags_param


### PR DESCRIPTION
Changefeed expressions are different from regular
`SELECT` statements in that they only target one column
family at a time.  That means, for example, that `*`
expands differently for CDC expression, and that expression
itself cannot reference columns outside of the target
column family.

Prior to this change, this logic was enforced by CDC
itself via `FROM` clause mangling, where `FROM tbl` would
be replaced with `FROM (SELECT c1, c2, ... FROM tbl) AS tbl`.

This approach worked okay; however, it is better
to teach optimizer about column family targetting needed by CDC.
The reason why it is better to have optimizer be responsible for
this is that name resolution and star expansion are very tricky
to get right.
In particular, prior to this PR, CDC expressions with table-typed
tuples (`CREATE CHANGEFEED ... AS SELECT rides FROM rides`)
did not work, since CDC was not smart enough to know
that the `rides` in the `SELECT` clause is a table-typed tuple.

This PR teaches optimizer how to handle CDC expressions, targeted
to a single column family.  This is accomplished by extending
SQL grammar for index flags so that target column family can be
specified:
`CREATE CHANGEFEED ... AS SELECT * FROM rides@{FAMILY=[0]}`
Then, the `catalog.TableDescriptor` presented to the optimizer
is wrapped so that only to the columns available in
the target column family are visible to the optimizer.

Informs https://github.com/cockroachdb/cockroach/issues/90442
Fixes https://github.com/cockroachdb/cockroach/issues/82461
Informs https://github.com/cockroachdb/cockroach/issues/90260
Epic: CRDB-17161

--
Second commit:

Support system columns in CDC expressions.
System columns, such as `crdb_internal_mvcc_timestamp` are exposed
to CDC expressions.  These columns are normally hidden,
but can be explicitly accessed:

```
CREATE CHANGEFEED ... AS
SELECT *, crdb_internal_mvcc_timestamp AS mvcc FROM rides
```

These system columns are also available in the `cdc_prev` tuple.
This makes it possible to e.g. determine the age of the event:

```
CREATE CHANGEFEED ... AS
SELECT
 crdb_internal_mvcc_timestamp - cdc_prev.crdb_internal.mvcc_timestamp AS age
FROM rides
```

Fixes https://github.com/cockroachdb/cockroach/issues/90442
Epic: CRDB-17161

Release note (enterprise change): Changefeed expressions support
system columns.

Release note (enterprise change): Improve changefeed expressions
code to rely on optimizer to evaluate star expansion.
