### PR TITLE
storage: give range keys precedence on timestamp conflict in `pointSynthesizingIter`

### DIFF
--- a/pkg/storage/point_synthesizing_iter.go
+++ b/pkg/storage/point_synthesizing_iter.go
@@ -11,6 +11,7 @@
 package storage
 
 import (
+	"bytes"
 	"sort"
 	"sync"
 
@@ -106,6 +107,14 @@ type PointSynthesizingIter struct {
 	// atPoint is true if the synthesizing iterator is positioned on a real point
 	// key in the underlying iterator. See struct comment for details.
 	atPoint bool
+
+	// pointConflict is true if the current iterator position is on a point key
+	// with the same timestamp as the range key, in which case the range key takes
+	// precedence and the real point key should be skipped. This shouldn't happen
+	// if MVCC conflict checks work correctly, but we'll be defensive as this has
+	// been seen to happen in randomized tests. atPoint is always false if this is
+	// true.
+	pointConflict bool
 
 	// atRangeKeysPos is true if the underlying iterator is at rangeKeysPos.
 	atRangeKeysPos bool
@@ -336,8 +345,8 @@ func (i *PointSynthesizingIter) extendRangeKeysEnd() {
 }
 
 // updateAtPoint updates i.atPoint according to whether the synthesizing
-// iterator is positioned on the real point key in the underlying iterator.
-// Requires i.rangeKeys to have been positioned first.
+// iterator is positioned on the real point key in the underlying iterator, as
+// well as i.pointConflict. Requires i.rangeKeys to have been positioned first.
 func (i *PointSynthesizingIter) updateAtPoint() {
 	if !i.iterHasPoint {
 		i.atPoint = false
@@ -347,11 +356,13 @@ func (i *PointSynthesizingIter) updateAtPoint() {
 		i.atPoint = false
 	} else if !i.reverse {
 		i.atPoint = i.rangeKeysIdx >= i.rangeKeysEnd || !i.iterKey.Timestamp.IsSet() ||
-			i.rangeKeys[i.rangeKeysIdx].Timestamp.LessEq(i.iterKey.Timestamp)
+			i.rangeKeys[i.rangeKeysIdx].Timestamp.Less(i.iterKey.Timestamp)
 	} else {
 		i.atPoint = i.rangeKeysIdx < 0 || (i.iterKey.Timestamp.IsSet() &&
-			i.iterKey.Timestamp.LessEq(i.rangeKeys[i.rangeKeysIdx].Timestamp))
+			i.iterKey.Timestamp.Less(i.rangeKeys[i.rangeKeysIdx].Timestamp))
 	}
+	i.pointConflict = !i.atPoint && i.iterHasPoint && i.atRangeKeysPos &&
+		i.rangeKeys[i.rangeKeysIdx].Timestamp.Equal(i.iterKey.Timestamp)
 }
 
 // updatePosition updates the synthesizing iterator for the position of the
@@ -361,6 +372,7 @@ func (i *PointSynthesizingIter) updatePosition() {
 	if !i.iterHasRange {
 		// Fast path: no range keys, so just clear range keys and bail out.
 		i.atPoint = i.iterHasPoint
+		i.pointConflict = false
 		i.clearRangeKeys()
 
 	} else if !i.reverse {
@@ -445,6 +457,7 @@ func (i *PointSynthesizingIter) updateSeekGEPosition(seekKey MVCCKey) {
 	// Fast path: no range key, so just reset the iterator and bail out.
 	if !i.iterHasRange {
 		i.atPoint = i.iterHasPoint
+		i.pointConflict = false
 		i.clearRangeKeys()
 		return
 	}
@@ -500,6 +513,8 @@ func (i *PointSynthesizingIter) Next() {
 			return
 		} else if i.atPoint {
 			i.rangeKeysIdx++
+		} else if i.pointConflict {
+			// point key and range key are at same position
 		} else if _, err := i.iterNext(); err != nil {
 			return
 		}
@@ -511,6 +526,12 @@ func (i *PointSynthesizingIter) Next() {
 			return
 		}
 		i.extendRangeKeysEnd()
+	} else if i.pointConflict {
+		if _, err := i.iterNext(); err != nil {
+			return
+		}
+		i.extendRangeKeysEnd()
+		i.rangeKeysIdx++
 	} else {
 		i.rangeKeysIdx++
 	}
@@ -532,7 +553,7 @@ func (i *PointSynthesizingIter) NextKey() {
 	// implement, so we may as well.
 	if i.reverse {
 		i.reverse = false
-		if !i.atPoint {
+		if !i.atPoint && !i.pointConflict {
 			if _, err := i.iterNext(); err != nil {
 				return
 			}
@@ -562,6 +583,7 @@ func (i *PointSynthesizingIter) SeekLT(seekKey MVCCKey) {
 	// Fast path: no range key, so just reset the iterator and bail out.
 	if !i.iterHasRange {
 		i.atPoint = i.iterHasPoint
+		i.pointConflict = false
 		i.clearRangeKeys()
 		return
 	}
@@ -621,6 +643,8 @@ func (i *PointSynthesizingIter) Prev() {
 			return
 		} else if i.atPoint {
 			i.rangeKeysIdx--
+		} else if i.pointConflict {
+			// point key and range key are at same position
 		} else if _, err := i.iterPrev(); err != nil {
 			return
 		}
@@ -631,6 +655,11 @@ func (i *PointSynthesizingIter) Prev() {
 		if _, err := i.iterPrev(); err != nil {
 			return
 		}
+	} else if i.pointConflict {
+		if _, err := i.iterPrev(); err != nil {
+			return
+		}
+		i.rangeKeysIdx--
 	} else {
 		i.rangeKeysIdx--
 	}
@@ -849,12 +878,16 @@ func (i *PointSynthesizingIter) assertInvariants() error {
 	}
 
 	// When atPoint is true, the underlying iterator must be valid and on a point.
+	// pointConflict must be false.
 	if i.atPoint {
 		if ok, _ := i.iter.Valid(); !ok {
 			return errors.AssertionFailedf("atPoint with invalid iter")
 		}
 		if hasPoint, _ := i.iter.HasPointAndRange(); !hasPoint {
 			return errors.AssertionFailedf("atPoint at non-point position %s", i.iter.UnsafeKey())
+		}
+		if i.pointConflict {
+			return errors.AssertionFailedf("atPoint with pointConflict at %s", i.iter.UnsafeKey())
 		}
 	}
 
@@ -954,9 +987,38 @@ func (i *PointSynthesizingIter) assertInvariants() error {
 		}
 	}
 
+	// Check for an overlapping point/range key timestamp. In this case,
+	// pointConflict must be true, atPoint must be false, and UnsafeValue()
+	// must return the range key's value.
+	var rangeKeyConflict MVCCRangeKeyVersion
+	if i.atRangeKeysPos && i.rangeKeysIdx >= 0 && i.rangeKeysIdx < i.rangeKeysEnd &&
+		i.rangeKeys[i.rangeKeysIdx].Timestamp.Equal(i.iterKey.Timestamp) {
+		rangeKeyConflict = i.rangeKeys[i.rangeKeysIdx]
+	}
+	if rangeKeyConflict.Timestamp.IsSet() && !i.pointConflict {
+		return errors.AssertionFailedf(
+			"conflicting range key and point key without pointConflict at %s", i.iterKey)
+	}
+	if i.pointConflict {
+		if i.atPoint {
+			return errors.AssertionFailedf("pointConflict with atPoint at %s", i.iterKey)
+		}
+		if rangeKeyConflict.Timestamp.IsEmpty() {
+			return errors.AssertionFailedf("pointConflict with no matching range key at %s", i.iterKey)
+		}
+		if value, err := i.UnsafeValue(); err != nil {
+			return err
+		} else if !bytes.Equal(value, rangeKeyConflict.Value) {
+			return errors.AssertionFailedf("pointConflict not returning range key value at %s", i.iterKey)
+		}
+		// We don't need to check the relative positioning below, because
+		// we already checked it.
+		return nil
+	}
+
 	// Check the relative positioning as minimum and maximum iter keys (in MVCC
 	// order). We can assume that overlapping range keys and point keys don't have
-	// the same timestamp, since this is enforced by MVCC mutations.
+	// the same timestamp, since this was checked above.
 	var minKey, maxKey MVCCKey
 
 	// The iterator should never lag behind the range key position.

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_gets_ts_conflict
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_gets_ts_conflict
@@ -1,0 +1,257 @@
+# Tests MVCC gets where point/range keys have the same timestamp. This
+# shouldn't happen, but it's been seen to happen in randomized tests due to
+# faulty conflict checks.
+#
+#  T
+#  5                                                  o-----------o
+#  4                                          k4  l4  m4  n4
+#  3  a3 b3   oc3-d3--e3--f3--g3--h3--i3--j3--k3--l3--m3--n3--o3--op3 q3  r3
+#  2                  e2  f2  g2  h2
+#  1          o---------------o
+#     a   b   c   d   e   f   g   h   i   j   k   l   m   n   o   p   q   r
+run ok
+put k=e ts=2 v=e2
+put k=f ts=2 v=f2
+put k=g ts=2 v=g2
+put k=h ts=2 v=h2
+put k=a ts=3 v=a3
+put k=b ts=3 v=b3
+put k=c ts=3 v=c3
+put k=d ts=3 v=d3
+put k=e ts=3 v=e3
+put k=f ts=3 v=f3
+put k=g ts=3 v=g3
+put k=h ts=3 v=h3
+put k=i ts=3 v=i3
+put k=j ts=3 v=j3
+put k=k ts=3 v=k3
+put k=l ts=3 v=l3
+put k=m ts=3 v=m3
+put k=n ts=3 v=n3
+put k=o ts=3 v=o3
+put k=p ts=3 v=p3
+put k=q ts=3 v=q3
+put k=r ts=3 v=r3
+put k=k ts=4 v=k4
+put k=l ts=4 v=l4
+put k=m ts=4 v=m4
+put k=n ts=4 v=n4
+put_rangekey k=c end=g ts=1
+put_rangekey k=c end=p ts=3
+put_rangekey k=m end=p ts=5
+----
+>> at end:
+rangekey: {c-g}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {g-m}/[3.000000000,0=/<empty>]
+rangekey: {m-p}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+data: "a"/3.000000000,0 -> /BYTES/a3
+data: "b"/3.000000000,0 -> /BYTES/b3
+data: "c"/3.000000000,0 -> /BYTES/c3
+data: "d"/3.000000000,0 -> /BYTES/d3
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "e"/2.000000000,0 -> /BYTES/e2
+data: "f"/3.000000000,0 -> /BYTES/f3
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/3.000000000,0 -> /BYTES/g3
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/3.000000000,0 -> /BYTES/h3
+data: "h"/2.000000000,0 -> /BYTES/h2
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "j"/3.000000000,0 -> /BYTES/j3
+data: "k"/4.000000000,0 -> /BYTES/k4
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "l"/4.000000000,0 -> /BYTES/l4
+data: "l"/3.000000000,0 -> /BYTES/l3
+data: "m"/4.000000000,0 -> /BYTES/m4
+data: "m"/3.000000000,0 -> /BYTES/m3
+data: "n"/4.000000000,0 -> /BYTES/n4
+data: "n"/3.000000000,0 -> /BYTES/n3
+data: "o"/3.000000000,0 -> /BYTES/o3
+data: "p"/3.000000000,0 -> /BYTES/p3
+data: "q"/3.000000000,0 -> /BYTES/q3
+data: "r"/3.000000000,0 -> /BYTES/r3
+
+# Run non-tombstone gets at all keys.
+run ok
+get k=c ts=5
+----
+get: "c" -> <no data>
+
+# Run tombstone gets at all keys.
+run ok
+get k=a ts=5 tombstones
+get k=b ts=5 tombstones
+get k=c ts=5 tombstones
+get k=d ts=5 tombstones
+get k=e ts=5 tombstones
+get k=f ts=5 tombstones
+get k=g ts=5 tombstones
+get k=h ts=5 tombstones
+get k=i ts=5 tombstones
+get k=j ts=5 tombstones
+get k=k ts=5 tombstones
+get k=l ts=5 tombstones
+get k=m ts=5 tombstones
+get k=n ts=5 tombstones
+get k=o ts=5 tombstones
+get k=p ts=5 tombstones
+get k=q ts=5 tombstones
+get k=r ts=5 tombstones
+----
+get: "a" -> /BYTES/a3 @3.000000000,0
+get: "b" -> /BYTES/b3 @3.000000000,0
+get: "c" -> /<empty> @3.000000000,0
+get: "d" -> /<empty> @3.000000000,0
+get: "e" -> /<empty> @3.000000000,0
+get: "f" -> /<empty> @3.000000000,0
+get: "g" -> /<empty> @3.000000000,0
+get: "h" -> /<empty> @3.000000000,0
+get: "i" -> /<empty> @3.000000000,0
+get: "j" -> /<empty> @3.000000000,0
+get: "k" -> /BYTES/k4 @4.000000000,0
+get: "l" -> /BYTES/l4 @4.000000000,0
+get: "m" -> /<empty> @5.000000000,0
+get: "n" -> /<empty> @5.000000000,0
+get: "o" -> /<empty> @5.000000000,0
+get: "p" -> /BYTES/p3 @3.000000000,0
+get: "q" -> /BYTES/q3 @3.000000000,0
+get: "r" -> /BYTES/r3 @3.000000000,0
+
+# Run tombstone gets at all keys and timestamps.
+run ok
+get k=c ts=3 tombstones
+get k=c ts=2 tombstones
+get k=c ts=1 tombstones
+----
+get: "c" -> /<empty> @3.000000000,0
+get: "c" -> /<empty> @1.000000000,0
+get: "c" -> /<empty> @1.000000000,0
+
+run ok
+get k=d ts=3 tombstones
+get k=d ts=2 tombstones
+get k=d ts=1 tombstones
+----
+get: "d" -> /<empty> @3.000000000,0
+get: "d" -> /<empty> @1.000000000,0
+get: "d" -> /<empty> @1.000000000,0
+
+run ok
+get k=e ts=3 tombstones
+get k=e ts=2 tombstones
+get k=e ts=1 tombstones
+----
+get: "e" -> /<empty> @3.000000000,0
+get: "e" -> /BYTES/e2 @2.000000000,0
+get: "e" -> /<empty> @1.000000000,0
+
+run ok
+get k=f ts=3 tombstones
+get k=f ts=2 tombstones
+get k=f ts=1 tombstones
+----
+get: "f" -> /<empty> @3.000000000,0
+get: "f" -> /BYTES/f2 @2.000000000,0
+get: "f" -> /<empty> @1.000000000,0
+
+run ok
+get k=g ts=3 tombstones
+get k=g ts=2 tombstones
+get k=g ts=1 tombstones
+----
+get: "g" -> /<empty> @3.000000000,0
+get: "g" -> /BYTES/g2 @2.000000000,0
+get: "g" -> <no data>
+
+run ok
+get k=h ts=3 tombstones
+get k=h ts=2 tombstones
+get k=h ts=1 tombstones
+----
+get: "h" -> /<empty> @3.000000000,0
+get: "h" -> /BYTES/h2 @2.000000000,0
+get: "h" -> <no data>
+
+run ok
+get k=i ts=3 tombstones
+get k=i ts=2 tombstones
+get k=i ts=1 tombstones
+----
+get: "i" -> /<empty> @3.000000000,0
+get: "i" -> <no data>
+get: "i" -> <no data>
+
+run ok
+get k=j ts=3 tombstones
+get k=j ts=2 tombstones
+get k=j ts=1 tombstones
+----
+get: "j" -> /<empty> @3.000000000,0
+get: "j" -> <no data>
+get: "j" -> <no data>
+
+run ok
+get k=k ts=5 tombstones
+get k=k ts=4 tombstones
+get k=k ts=3 tombstones
+get k=k ts=2 tombstones
+----
+get: "k" -> /BYTES/k4 @4.000000000,0
+get: "k" -> /BYTES/k4 @4.000000000,0
+get: "k" -> /<empty> @3.000000000,0
+get: "k" -> <no data>
+
+run ok
+get k=l ts=5 tombstones
+get k=l ts=4 tombstones
+get k=l ts=3 tombstones
+get k=l ts=2 tombstones
+----
+get: "l" -> /BYTES/l4 @4.000000000,0
+get: "l" -> /BYTES/l4 @4.000000000,0
+get: "l" -> /<empty> @3.000000000,0
+get: "l" -> <no data>
+
+run ok
+get k=m ts=5 tombstones
+get k=m ts=4 tombstones
+get k=m ts=3 tombstones
+get k=m ts=2 tombstones
+----
+get: "m" -> /<empty> @5.000000000,0
+get: "m" -> /BYTES/m4 @4.000000000,0
+get: "m" -> /<empty> @3.000000000,0
+get: "m" -> <no data>
+
+run ok
+get k=n ts=5 tombstones
+get k=n ts=4 tombstones
+get k=n ts=3 tombstones
+get k=n ts=2 tombstones
+----
+get: "n" -> /<empty> @5.000000000,0
+get: "n" -> /BYTES/n4 @4.000000000,0
+get: "n" -> /<empty> @3.000000000,0
+get: "n" -> <no data>
+
+run ok
+get k=o ts=5 tombstones
+get k=o ts=4 tombstones
+get k=o ts=3 tombstones
+get k=o ts=2 tombstones
+----
+get: "o" -> /<empty> @5.000000000,0
+get: "o" -> /<empty> @3.000000000,0
+get: "o" -> /<empty> @3.000000000,0
+get: "o" -> <no data>
+
+run ok
+get k=p ts=5 tombstones
+get k=p ts=4 tombstones
+get k=p ts=3 tombstones
+get k=p ts=2 tombstones
+----
+get: "p" -> /BYTES/p3 @3.000000000,0
+get: "p" -> /BYTES/p3 @3.000000000,0
+get: "p" -> /BYTES/p3 @3.000000000,0
+get: "p" -> <no data>

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_iter_point_synthesis_ts_conflict
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_iter_point_synthesis_ts_conflict
@@ -1,0 +1,851 @@
+# Tests point synthesis where some point/range keys have the same timestamp.
+# This shouldn't happen, but it's been seen to happen in randomized tests due to
+# faulty conflict checks. In this case, the range key takes precedence.
+#
+#  T
+#  5                                                  o-----------o
+#  4                                          k4  l4  m4  n4
+#  3  a3 b3   oc3-d3--e3--f3--g3--h3--i3--j3--k3--l3--m3--n3--o3--op3 q3  r3
+#  2                  e2  f2  g2  h2
+#  1          o---------------o
+#     a   b   c   d   e   f   g   h   i   j   k   l   m   n   o   p   q   r
+run ok
+put k=e ts=2 v=e2
+put k=f ts=2 v=f2
+put k=g ts=2 v=g2
+put k=h ts=2 v=h2
+put k=a ts=3 v=a3
+put k=b ts=3 v=b3
+put k=c ts=3 v=c3
+put k=d ts=3 v=d3
+put k=e ts=3 v=e3
+put k=f ts=3 v=f3
+put k=g ts=3 v=g3
+put k=h ts=3 v=h3
+put k=i ts=3 v=i3
+put k=j ts=3 v=j3
+put k=k ts=3 v=k3
+put k=l ts=3 v=l3
+put k=m ts=3 v=m3
+put k=n ts=3 v=n3
+put k=o ts=3 v=o3
+put k=p ts=3 v=p3
+put k=q ts=3 v=q3
+put k=r ts=3 v=r3
+put k=k ts=4 v=k4
+put k=l ts=4 v=l4
+put k=m ts=4 v=m4
+put k=n ts=4 v=n4
+put_rangekey k=c end=g ts=1
+put_rangekey k=c end=p ts=3
+put_rangekey k=m end=p ts=5
+----
+>> at end:
+rangekey: {c-g}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {g-m}/[3.000000000,0=/<empty>]
+rangekey: {m-p}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+data: "a"/3.000000000,0 -> /BYTES/a3
+data: "b"/3.000000000,0 -> /BYTES/b3
+data: "c"/3.000000000,0 -> /BYTES/c3
+data: "d"/3.000000000,0 -> /BYTES/d3
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "e"/2.000000000,0 -> /BYTES/e2
+data: "f"/3.000000000,0 -> /BYTES/f3
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/3.000000000,0 -> /BYTES/g3
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/3.000000000,0 -> /BYTES/h3
+data: "h"/2.000000000,0 -> /BYTES/h2
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "j"/3.000000000,0 -> /BYTES/j3
+data: "k"/4.000000000,0 -> /BYTES/k4
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "l"/4.000000000,0 -> /BYTES/l4
+data: "l"/3.000000000,0 -> /BYTES/l3
+data: "m"/4.000000000,0 -> /BYTES/m4
+data: "m"/3.000000000,0 -> /BYTES/m3
+data: "n"/4.000000000,0 -> /BYTES/n4
+data: "n"/3.000000000,0 -> /BYTES/n3
+data: "o"/3.000000000,0 -> /BYTES/o3
+data: "p"/3.000000000,0 -> /BYTES/p3
+data: "q"/3.000000000,0 -> /BYTES/q3
+data: "r"/3.000000000,0 -> /BYTES/r3
+
+# Iterate across the entire span, forward and reverse.
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=a
+iter_scan
+----
+iter_seek_ge: "a"/3.000000000,0=/BYTES/a3
+iter_scan: "a"/3.000000000,0=/BYTES/a3
+iter_scan: "b"/3.000000000,0=/BYTES/b3
+iter_scan: "c"/3.000000000,0=/<empty>
+iter_scan: "c"/1.000000000,0=/<empty>
+iter_scan: "d"/3.000000000,0=/<empty>
+iter_scan: "e"/3.000000000,0=/<empty>
+iter_scan: "e"/2.000000000,0=/BYTES/e2
+iter_scan: "f"/3.000000000,0=/<empty>
+iter_scan: "f"/2.000000000,0=/BYTES/f2
+iter_scan: "g"/3.000000000,0=/<empty>
+iter_scan: "g"/2.000000000,0=/BYTES/g2
+iter_scan: "h"/3.000000000,0=/<empty>
+iter_scan: "h"/2.000000000,0=/BYTES/h2
+iter_scan: "i"/3.000000000,0=/<empty>
+iter_scan: "j"/3.000000000,0=/<empty>
+iter_scan: "k"/4.000000000,0=/BYTES/k4
+iter_scan: "k"/3.000000000,0=/<empty>
+iter_scan: "l"/4.000000000,0=/BYTES/l4
+iter_scan: "l"/3.000000000,0=/<empty>
+iter_scan: "m"/5.000000000,0=/<empty>
+iter_scan: "m"/4.000000000,0=/BYTES/m4
+iter_scan: "m"/3.000000000,0=/<empty>
+iter_scan: "n"/5.000000000,0=/<empty>
+iter_scan: "n"/4.000000000,0=/BYTES/n4
+iter_scan: "n"/3.000000000,0=/<empty>
+iter_scan: "o"/5.000000000,0=/<empty>
+iter_scan: "o"/3.000000000,0=/<empty>
+iter_scan: "p"/3.000000000,0=/BYTES/p3
+iter_scan: "q"/3.000000000,0=/BYTES/q3
+iter_scan: "r"/3.000000000,0=/BYTES/r3
+iter_scan: .
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=z
+iter_scan reverse
+----
+iter_seek_lt: "r"/3.000000000,0=/BYTES/r3
+iter_scan: "r"/3.000000000,0=/BYTES/r3
+iter_scan: "q"/3.000000000,0=/BYTES/q3
+iter_scan: "p"/3.000000000,0=/BYTES/p3
+iter_scan: "o"/3.000000000,0=/<empty>
+iter_scan: "o"/5.000000000,0=/<empty>
+iter_scan: "n"/3.000000000,0=/<empty>
+iter_scan: "n"/4.000000000,0=/BYTES/n4
+iter_scan: "n"/5.000000000,0=/<empty>
+iter_scan: "m"/3.000000000,0=/<empty>
+iter_scan: "m"/4.000000000,0=/BYTES/m4
+iter_scan: "m"/5.000000000,0=/<empty>
+iter_scan: "l"/3.000000000,0=/<empty>
+iter_scan: "l"/4.000000000,0=/BYTES/l4
+iter_scan: "k"/3.000000000,0=/<empty>
+iter_scan: "k"/4.000000000,0=/BYTES/k4
+iter_scan: "j"/3.000000000,0=/<empty>
+iter_scan: "i"/3.000000000,0=/<empty>
+iter_scan: "h"/2.000000000,0=/BYTES/h2
+iter_scan: "h"/3.000000000,0=/<empty>
+iter_scan: "g"/2.000000000,0=/BYTES/g2
+iter_scan: "g"/3.000000000,0=/<empty>
+iter_scan: "f"/2.000000000,0=/BYTES/f2
+iter_scan: "f"/3.000000000,0=/<empty>
+iter_scan: "e"/2.000000000,0=/BYTES/e2
+iter_scan: "e"/3.000000000,0=/<empty>
+iter_scan: "d"/3.000000000,0=/<empty>
+iter_scan: "c"/1.000000000,0=/<empty>
+iter_scan: "c"/3.000000000,0=/<empty>
+iter_scan: "b"/3.000000000,0=/BYTES/b3
+iter_scan: "a"/3.000000000,0=/BYTES/a3
+iter_scan: .
+
+# Iterate across the entire span using NextKey().
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=a
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+iter_next_key
+----
+iter_seek_ge: "a"/3.000000000,0=/BYTES/a3
+iter_next_key: "b"/3.000000000,0=/BYTES/b3
+iter_next_key: "c"/3.000000000,0=/<empty>
+iter_next_key: "d"/3.000000000,0=/<empty>
+iter_next_key: "e"/3.000000000,0=/<empty>
+iter_next_key: "f"/3.000000000,0=/<empty>
+iter_next_key: "g"/3.000000000,0=/<empty>
+iter_next_key: "h"/3.000000000,0=/<empty>
+iter_next_key: "i"/3.000000000,0=/<empty>
+iter_next_key: "j"/3.000000000,0=/<empty>
+iter_next_key: "k"/4.000000000,0=/BYTES/k4
+iter_next_key: "l"/4.000000000,0=/BYTES/l4
+iter_next_key: "m"/5.000000000,0=/<empty>
+iter_next_key: "n"/5.000000000,0=/<empty>
+iter_next_key: "o"/5.000000000,0=/<empty>
+iter_next_key: "p"/3.000000000,0=/BYTES/p3
+iter_next_key: "q"/3.000000000,0=/BYTES/q3
+iter_next_key: "r"/3.000000000,0=/BYTES/r3
+iter_next_key: .
+
+# Unversioned seeks.
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=a
+iter_seek_ge k=b
+iter_seek_ge k=c
+iter_seek_ge k=d
+iter_seek_ge k=e
+iter_seek_ge k=f
+----
+iter_seek_ge: "a"/3.000000000,0=/BYTES/a3
+iter_seek_ge: "b"/3.000000000,0=/BYTES/b3
+iter_seek_ge: "c"/3.000000000,0=/<empty>
+iter_seek_ge: "d"/3.000000000,0=/<empty>
+iter_seek_ge: "e"/3.000000000,0=/<empty>
+iter_seek_ge: "f"/3.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis prefix
+iter_seek_ge k=a
+iter_seek_ge k=b
+iter_seek_ge k=c
+iter_seek_ge k=d
+iter_seek_ge k=e
+iter_seek_ge k=f
+iter_seek_ge k=g
+iter_seek_ge k=h
+iter_seek_ge k=i
+iter_seek_ge k=j
+iter_seek_ge k=k
+iter_seek_ge k=l
+iter_seek_ge k=m
+iter_seek_ge k=n
+iter_seek_ge k=o
+iter_seek_ge k=p
+iter_seek_ge k=q
+iter_seek_ge k=r
+iter_seek_ge k=s
+----
+iter_seek_ge: "a"/3.000000000,0=/BYTES/a3
+iter_seek_ge: "b"/3.000000000,0=/BYTES/b3
+iter_seek_ge: "c"/3.000000000,0=/<empty>
+iter_seek_ge: "d"/3.000000000,0=/<empty>
+iter_seek_ge: "e"/3.000000000,0=/<empty>
+iter_seek_ge: "f"/3.000000000,0=/<empty>
+iter_seek_ge: "g"/3.000000000,0=/<empty>
+iter_seek_ge: "h"/3.000000000,0=/<empty>
+iter_seek_ge: "i"/3.000000000,0=/<empty>
+iter_seek_ge: "j"/3.000000000,0=/<empty>
+iter_seek_ge: "k"/4.000000000,0=/BYTES/k4
+iter_seek_ge: "l"/4.000000000,0=/BYTES/l4
+iter_seek_ge: "m"/5.000000000,0=/<empty>
+iter_seek_ge: "n"/5.000000000,0=/<empty>
+iter_seek_ge: "o"/5.000000000,0=/<empty>
+iter_seek_ge: "p"/3.000000000,0=/BYTES/p3
+iter_seek_ge: "q"/3.000000000,0=/BYTES/q3
+iter_seek_ge: "r"/3.000000000,0=/BYTES/r3
+iter_seek_ge: .
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=s
+iter_seek_lt k=r
+iter_seek_lt k=q
+iter_seek_lt k=p
+iter_seek_lt k=o
+iter_seek_lt k=n
+iter_seek_lt k=m
+iter_seek_lt k=l
+iter_seek_lt k=k
+iter_seek_lt k=j
+iter_seek_lt k=i
+iter_seek_lt k=h
+iter_seek_lt k=g
+iter_seek_lt k=f
+iter_seek_lt k=e
+iter_seek_lt k=d
+iter_seek_lt k=c
+iter_seek_lt k=b
+iter_seek_lt k=a
+----
+iter_seek_lt: "r"/3.000000000,0=/BYTES/r3
+iter_seek_lt: "q"/3.000000000,0=/BYTES/q3
+iter_seek_lt: "p"/3.000000000,0=/BYTES/p3
+iter_seek_lt: "o"/3.000000000,0=/<empty>
+iter_seek_lt: "n"/3.000000000,0=/<empty>
+iter_seek_lt: "m"/3.000000000,0=/<empty>
+iter_seek_lt: "l"/3.000000000,0=/<empty>
+iter_seek_lt: "k"/3.000000000,0=/<empty>
+iter_seek_lt: "j"/3.000000000,0=/<empty>
+iter_seek_lt: "i"/3.000000000,0=/<empty>
+iter_seek_lt: "h"/2.000000000,0=/BYTES/h2
+iter_seek_lt: "g"/2.000000000,0=/BYTES/g2
+iter_seek_lt: "f"/2.000000000,0=/BYTES/f2
+iter_seek_lt: "e"/2.000000000,0=/BYTES/e2
+iter_seek_lt: "d"/3.000000000,0=/<empty>
+iter_seek_lt: "c"/1.000000000,0=/<empty>
+iter_seek_lt: "b"/3.000000000,0=/BYTES/b3
+iter_seek_lt: "a"/3.000000000,0=/BYTES/a3
+iter_seek_lt: .
+
+# Versioned seeks.
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=c ts=4
+iter_seek_ge k=c ts=3
+iter_seek_ge k=c ts=2
+----
+iter_seek_ge: "c"/3.000000000,0=/<empty>
+iter_seek_ge: "c"/3.000000000,0=/<empty>
+iter_seek_ge: "c"/1.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=d ts=4
+iter_seek_ge k=d ts=3
+iter_seek_ge k=d ts=2
+----
+iter_seek_ge: "d"/3.000000000,0=/<empty>
+iter_seek_ge: "d"/3.000000000,0=/<empty>
+iter_seek_ge: "e"/3.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=e ts=4
+iter_seek_ge k=e ts=3
+iter_seek_ge k=e ts=2
+----
+iter_seek_ge: "e"/3.000000000,0=/<empty>
+iter_seek_ge: "e"/3.000000000,0=/<empty>
+iter_seek_ge: "e"/2.000000000,0=/BYTES/e2
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=f ts=4
+iter_seek_ge k=f ts=3
+iter_seek_ge k=f ts=2
+----
+iter_seek_ge: "f"/3.000000000,0=/<empty>
+iter_seek_ge: "f"/3.000000000,0=/<empty>
+iter_seek_ge: "f"/2.000000000,0=/BYTES/f2
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=g ts=4
+iter_seek_ge k=g ts=3
+iter_seek_ge k=g ts=2
+----
+iter_seek_ge: "g"/3.000000000,0=/<empty>
+iter_seek_ge: "g"/3.000000000,0=/<empty>
+iter_seek_ge: "g"/2.000000000,0=/BYTES/g2
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=h ts=4
+iter_seek_ge k=h ts=3
+iter_seek_ge k=h ts=2
+----
+iter_seek_ge: "h"/3.000000000,0=/<empty>
+iter_seek_ge: "h"/3.000000000,0=/<empty>
+iter_seek_ge: "h"/2.000000000,0=/BYTES/h2
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=i ts=4
+iter_seek_ge k=i ts=3
+iter_seek_ge k=i ts=2
+----
+iter_seek_ge: "i"/3.000000000,0=/<empty>
+iter_seek_ge: "i"/3.000000000,0=/<empty>
+iter_seek_ge: "j"/3.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=j ts=4
+iter_seek_ge k=j ts=3
+iter_seek_ge k=j ts=2
+----
+iter_seek_ge: "j"/3.000000000,0=/<empty>
+iter_seek_ge: "j"/3.000000000,0=/<empty>
+iter_seek_ge: "k"/4.000000000,0=/BYTES/k4
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=k ts=4
+iter_seek_ge k=k ts=3
+iter_seek_ge k=k ts=2
+----
+iter_seek_ge: "k"/4.000000000,0=/BYTES/k4
+iter_seek_ge: "k"/3.000000000,0=/<empty>
+iter_seek_ge: "l"/4.000000000,0=/BYTES/l4
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=l ts=4
+iter_seek_ge k=l ts=3
+iter_seek_ge k=l ts=2
+----
+iter_seek_ge: "l"/4.000000000,0=/BYTES/l4
+iter_seek_ge: "l"/3.000000000,0=/<empty>
+iter_seek_ge: "m"/5.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=m ts=5
+iter_seek_ge k=m ts=4
+iter_seek_ge k=m ts=3
+iter_seek_ge k=m ts=2
+----
+iter_seek_ge: "m"/5.000000000,0=/<empty>
+iter_seek_ge: "m"/4.000000000,0=/BYTES/m4
+iter_seek_ge: "m"/3.000000000,0=/<empty>
+iter_seek_ge: "n"/5.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=n ts=5
+iter_seek_ge k=n ts=4
+iter_seek_ge k=n ts=3
+iter_seek_ge k=n ts=2
+----
+iter_seek_ge: "n"/5.000000000,0=/<empty>
+iter_seek_ge: "n"/4.000000000,0=/BYTES/n4
+iter_seek_ge: "n"/3.000000000,0=/<empty>
+iter_seek_ge: "o"/5.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=o ts=5
+iter_seek_ge k=o ts=4
+iter_seek_ge k=o ts=3
+iter_seek_ge k=o ts=2
+----
+iter_seek_ge: "o"/5.000000000,0=/<empty>
+iter_seek_ge: "o"/3.000000000,0=/<empty>
+iter_seek_ge: "o"/3.000000000,0=/<empty>
+iter_seek_ge: "p"/3.000000000,0=/BYTES/p3
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=p ts=4
+iter_seek_ge k=p ts=3
+iter_seek_ge k=p ts=2
+----
+iter_seek_ge: "p"/3.000000000,0=/BYTES/p3
+iter_seek_ge: "p"/3.000000000,0=/BYTES/p3
+iter_seek_ge: "q"/3.000000000,0=/BYTES/q3
+
+# Versioned reverse seeks.
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=c ts=4
+iter_seek_lt k=c ts=3
+iter_seek_lt k=c ts=2
+iter_seek_lt k=c ts=1
+----
+iter_seek_lt: "b"/3.000000000,0=/BYTES/b3
+iter_seek_lt: "b"/3.000000000,0=/BYTES/b3
+iter_seek_lt: "c"/3.000000000,0=/<empty>
+iter_seek_lt: "c"/3.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=d ts=4
+iter_seek_lt k=d ts=3
+iter_seek_lt k=d ts=2
+iter_seek_lt k=d ts=1
+----
+iter_seek_lt: "c"/1.000000000,0=/<empty>
+iter_seek_lt: "c"/1.000000000,0=/<empty>
+iter_seek_lt: "d"/3.000000000,0=/<empty>
+iter_seek_lt: "d"/3.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=e ts=4
+iter_seek_lt k=e ts=3
+iter_seek_lt k=e ts=2
+iter_seek_lt k=e ts=1
+----
+iter_seek_lt: "d"/3.000000000,0=/<empty>
+iter_seek_lt: "d"/3.000000000,0=/<empty>
+iter_seek_lt: "e"/3.000000000,0=/<empty>
+iter_seek_lt: "e"/2.000000000,0=/BYTES/e2
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=f ts=4
+iter_seek_lt k=f ts=3
+iter_seek_lt k=f ts=2
+iter_seek_lt k=f ts=1
+----
+iter_seek_lt: "e"/2.000000000,0=/BYTES/e2
+iter_seek_lt: "e"/2.000000000,0=/BYTES/e2
+iter_seek_lt: "f"/3.000000000,0=/<empty>
+iter_seek_lt: "f"/2.000000000,0=/BYTES/f2
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=g ts=4
+iter_seek_lt k=g ts=3
+iter_seek_lt k=g ts=2
+iter_seek_lt k=g ts=1
+----
+iter_seek_lt: "f"/2.000000000,0=/BYTES/f2
+iter_seek_lt: "f"/2.000000000,0=/BYTES/f2
+iter_seek_lt: "g"/3.000000000,0=/<empty>
+iter_seek_lt: "g"/2.000000000,0=/BYTES/g2
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=h ts=4
+iter_seek_lt k=h ts=3
+iter_seek_lt k=h ts=2
+iter_seek_lt k=h ts=1
+----
+iter_seek_lt: "g"/2.000000000,0=/BYTES/g2
+iter_seek_lt: "g"/2.000000000,0=/BYTES/g2
+iter_seek_lt: "h"/3.000000000,0=/<empty>
+iter_seek_lt: "h"/2.000000000,0=/BYTES/h2
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=i ts=4
+iter_seek_lt k=i ts=3
+iter_seek_lt k=i ts=2
+iter_seek_lt k=i ts=1
+----
+iter_seek_lt: "h"/2.000000000,0=/BYTES/h2
+iter_seek_lt: "h"/2.000000000,0=/BYTES/h2
+iter_seek_lt: "i"/3.000000000,0=/<empty>
+iter_seek_lt: "i"/3.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=j ts=4
+iter_seek_lt k=j ts=3
+iter_seek_lt k=j ts=2
+iter_seek_lt k=j ts=1
+----
+iter_seek_lt: "i"/3.000000000,0=/<empty>
+iter_seek_lt: "i"/3.000000000,0=/<empty>
+iter_seek_lt: "j"/3.000000000,0=/<empty>
+iter_seek_lt: "j"/3.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=k ts=4
+iter_seek_lt k=k ts=3
+iter_seek_lt k=k ts=2
+iter_seek_lt k=k ts=1
+----
+iter_seek_lt: "j"/3.000000000,0=/<empty>
+iter_seek_lt: "k"/4.000000000,0=/BYTES/k4
+iter_seek_lt: "k"/3.000000000,0=/<empty>
+iter_seek_lt: "k"/3.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=l ts=4
+iter_seek_lt k=l ts=3
+iter_seek_lt k=l ts=2
+iter_seek_lt k=l ts=1
+----
+iter_seek_lt: "k"/3.000000000,0=/<empty>
+iter_seek_lt: "l"/4.000000000,0=/BYTES/l4
+iter_seek_lt: "l"/3.000000000,0=/<empty>
+iter_seek_lt: "l"/3.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=m ts=5
+iter_seek_lt k=m ts=4
+iter_seek_lt k=m ts=3
+iter_seek_lt k=m ts=2
+iter_seek_lt k=m ts=1
+----
+iter_seek_lt: "l"/3.000000000,0=/<empty>
+iter_seek_lt: "m"/5.000000000,0=/<empty>
+iter_seek_lt: "m"/4.000000000,0=/BYTES/m4
+iter_seek_lt: "m"/3.000000000,0=/<empty>
+iter_seek_lt: "m"/3.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=n ts=5
+iter_seek_lt k=n ts=4
+iter_seek_lt k=n ts=3
+iter_seek_lt k=n ts=2
+iter_seek_lt k=n ts=1
+----
+iter_seek_lt: "m"/3.000000000,0=/<empty>
+iter_seek_lt: "n"/5.000000000,0=/<empty>
+iter_seek_lt: "n"/4.000000000,0=/BYTES/n4
+iter_seek_lt: "n"/3.000000000,0=/<empty>
+iter_seek_lt: "n"/3.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=o ts=5
+iter_seek_lt k=o ts=4
+iter_seek_lt k=o ts=3
+iter_seek_lt k=o ts=2
+iter_seek_lt k=o ts=1
+----
+iter_seek_lt: "n"/3.000000000,0=/<empty>
+iter_seek_lt: "o"/5.000000000,0=/<empty>
+iter_seek_lt: "o"/5.000000000,0=/<empty>
+iter_seek_lt: "o"/3.000000000,0=/<empty>
+iter_seek_lt: "o"/3.000000000,0=/<empty>
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=p ts=4
+iter_seek_lt k=p ts=3
+iter_seek_lt k=p ts=2
+iter_seek_lt k=p ts=1
+----
+iter_seek_lt: "o"/3.000000000,0=/<empty>
+iter_seek_lt: "o"/3.000000000,0=/<empty>
+iter_seek_lt: "p"/3.000000000,0=/BYTES/p3
+iter_seek_lt: "p"/3.000000000,0=/BYTES/p3
+
+# Seeks with opposite scans.
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=e
+iter_scan reverse
+----
+iter_seek_ge: "e"/3.000000000,0=/<empty>
+iter_scan: "e"/3.000000000,0=/<empty>
+iter_scan: "d"/3.000000000,0=/<empty>
+iter_scan: "c"/1.000000000,0=/<empty>
+iter_scan: "c"/3.000000000,0=/<empty>
+iter_scan: "b"/3.000000000,0=/BYTES/b3
+iter_scan: "a"/3.000000000,0=/BYTES/a3
+iter_scan: .
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=i
+iter_scan reverse
+----
+iter_seek_ge: "i"/3.000000000,0=/<empty>
+iter_scan: "i"/3.000000000,0=/<empty>
+iter_scan: "h"/2.000000000,0=/BYTES/h2
+iter_scan: "h"/3.000000000,0=/<empty>
+iter_scan: "g"/2.000000000,0=/BYTES/g2
+iter_scan: "g"/3.000000000,0=/<empty>
+iter_scan: "f"/2.000000000,0=/BYTES/f2
+iter_scan: "f"/3.000000000,0=/<empty>
+iter_scan: "e"/2.000000000,0=/BYTES/e2
+iter_scan: "e"/3.000000000,0=/<empty>
+iter_scan: "d"/3.000000000,0=/<empty>
+iter_scan: "c"/1.000000000,0=/<empty>
+iter_scan: "c"/3.000000000,0=/<empty>
+iter_scan: "b"/3.000000000,0=/BYTES/b3
+iter_scan: "a"/3.000000000,0=/BYTES/a3
+iter_scan: .
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=n
+iter_scan reverse
+----
+iter_seek_ge: "n"/5.000000000,0=/<empty>
+iter_scan: "n"/5.000000000,0=/<empty>
+iter_scan: "m"/3.000000000,0=/<empty>
+iter_scan: "m"/4.000000000,0=/BYTES/m4
+iter_scan: "m"/5.000000000,0=/<empty>
+iter_scan: "l"/3.000000000,0=/<empty>
+iter_scan: "l"/4.000000000,0=/BYTES/l4
+iter_scan: "k"/3.000000000,0=/<empty>
+iter_scan: "k"/4.000000000,0=/BYTES/k4
+iter_scan: "j"/3.000000000,0=/<empty>
+iter_scan: "i"/3.000000000,0=/<empty>
+iter_scan: "h"/2.000000000,0=/BYTES/h2
+iter_scan: "h"/3.000000000,0=/<empty>
+iter_scan: "g"/2.000000000,0=/BYTES/g2
+iter_scan: "g"/3.000000000,0=/<empty>
+iter_scan: "f"/2.000000000,0=/BYTES/f2
+iter_scan: "f"/3.000000000,0=/<empty>
+iter_scan: "e"/2.000000000,0=/BYTES/e2
+iter_scan: "e"/3.000000000,0=/<empty>
+iter_scan: "d"/3.000000000,0=/<empty>
+iter_scan: "c"/1.000000000,0=/<empty>
+iter_scan: "c"/3.000000000,0=/<empty>
+iter_scan: "b"/3.000000000,0=/BYTES/b3
+iter_scan: "a"/3.000000000,0=/BYTES/a3
+iter_scan: .
+
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=e ts=2
+iter_scan reverse
+----
+iter_seek_ge: "e"/2.000000000,0=/BYTES/e2
+iter_scan: "e"/2.000000000,0=/BYTES/e2
+iter_scan: "e"/3.000000000,0=/<empty>
+iter_scan: "d"/3.000000000,0=/<empty>
+iter_scan: "c"/1.000000000,0=/<empty>
+iter_scan: "c"/3.000000000,0=/<empty>
+iter_scan: "b"/3.000000000,0=/BYTES/b3
+iter_scan: "a"/3.000000000,0=/BYTES/a3
+iter_scan: .
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_ge k=n ts=4
+iter_scan reverse
+----
+iter_seek_ge: "n"/4.000000000,0=/BYTES/n4
+iter_scan: "n"/4.000000000,0=/BYTES/n4
+iter_scan: "n"/5.000000000,0=/<empty>
+iter_scan: "m"/3.000000000,0=/<empty>
+iter_scan: "m"/4.000000000,0=/BYTES/m4
+iter_scan: "m"/5.000000000,0=/<empty>
+iter_scan: "l"/3.000000000,0=/<empty>
+iter_scan: "l"/4.000000000,0=/BYTES/l4
+iter_scan: "k"/3.000000000,0=/<empty>
+iter_scan: "k"/4.000000000,0=/BYTES/k4
+iter_scan: "j"/3.000000000,0=/<empty>
+iter_scan: "i"/3.000000000,0=/<empty>
+iter_scan: "h"/2.000000000,0=/BYTES/h2
+iter_scan: "h"/3.000000000,0=/<empty>
+iter_scan: "g"/2.000000000,0=/BYTES/g2
+iter_scan: "g"/3.000000000,0=/<empty>
+iter_scan: "f"/2.000000000,0=/BYTES/f2
+iter_scan: "f"/3.000000000,0=/<empty>
+iter_scan: "e"/2.000000000,0=/BYTES/e2
+iter_scan: "e"/3.000000000,0=/<empty>
+iter_scan: "d"/3.000000000,0=/<empty>
+iter_scan: "c"/1.000000000,0=/<empty>
+iter_scan: "c"/3.000000000,0=/<empty>
+iter_scan: "b"/3.000000000,0=/BYTES/b3
+iter_scan: "a"/3.000000000,0=/BYTES/a3
+iter_scan: .
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=e
+iter_scan
+----
+iter_seek_lt: "d"/3.000000000,0=/<empty>
+iter_scan: "d"/3.000000000,0=/<empty>
+iter_scan: "e"/3.000000000,0=/<empty>
+iter_scan: "e"/2.000000000,0=/BYTES/e2
+iter_scan: "f"/3.000000000,0=/<empty>
+iter_scan: "f"/2.000000000,0=/BYTES/f2
+iter_scan: "g"/3.000000000,0=/<empty>
+iter_scan: "g"/2.000000000,0=/BYTES/g2
+iter_scan: "h"/3.000000000,0=/<empty>
+iter_scan: "h"/2.000000000,0=/BYTES/h2
+iter_scan: "i"/3.000000000,0=/<empty>
+iter_scan: "j"/3.000000000,0=/<empty>
+iter_scan: "k"/4.000000000,0=/BYTES/k4
+iter_scan: "k"/3.000000000,0=/<empty>
+iter_scan: "l"/4.000000000,0=/BYTES/l4
+iter_scan: "l"/3.000000000,0=/<empty>
+iter_scan: "m"/5.000000000,0=/<empty>
+iter_scan: "m"/4.000000000,0=/BYTES/m4
+iter_scan: "m"/3.000000000,0=/<empty>
+iter_scan: "n"/5.000000000,0=/<empty>
+iter_scan: "n"/4.000000000,0=/BYTES/n4
+iter_scan: "n"/3.000000000,0=/<empty>
+iter_scan: "o"/5.000000000,0=/<empty>
+iter_scan: "o"/3.000000000,0=/<empty>
+iter_scan: "p"/3.000000000,0=/BYTES/p3
+iter_scan: "q"/3.000000000,0=/BYTES/q3
+iter_scan: "r"/3.000000000,0=/BYTES/r3
+iter_scan: .
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=j
+iter_scan
+----
+iter_seek_lt: "i"/3.000000000,0=/<empty>
+iter_scan: "i"/3.000000000,0=/<empty>
+iter_scan: "j"/3.000000000,0=/<empty>
+iter_scan: "k"/4.000000000,0=/BYTES/k4
+iter_scan: "k"/3.000000000,0=/<empty>
+iter_scan: "l"/4.000000000,0=/BYTES/l4
+iter_scan: "l"/3.000000000,0=/<empty>
+iter_scan: "m"/5.000000000,0=/<empty>
+iter_scan: "m"/4.000000000,0=/BYTES/m4
+iter_scan: "m"/3.000000000,0=/<empty>
+iter_scan: "n"/5.000000000,0=/<empty>
+iter_scan: "n"/4.000000000,0=/BYTES/n4
+iter_scan: "n"/3.000000000,0=/<empty>
+iter_scan: "o"/5.000000000,0=/<empty>
+iter_scan: "o"/3.000000000,0=/<empty>
+iter_scan: "p"/3.000000000,0=/BYTES/p3
+iter_scan: "q"/3.000000000,0=/BYTES/q3
+iter_scan: "r"/3.000000000,0=/BYTES/r3
+iter_scan: .
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=o
+iter_scan
+----
+iter_seek_lt: "n"/3.000000000,0=/<empty>
+iter_scan: "n"/3.000000000,0=/<empty>
+iter_scan: "o"/5.000000000,0=/<empty>
+iter_scan: "o"/3.000000000,0=/<empty>
+iter_scan: "p"/3.000000000,0=/BYTES/p3
+iter_scan: "q"/3.000000000,0=/BYTES/q3
+iter_scan: "r"/3.000000000,0=/BYTES/r3
+iter_scan: .
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=e ts=2
+iter_scan
+----
+iter_seek_lt: "e"/3.000000000,0=/<empty>
+iter_scan: "e"/3.000000000,0=/<empty>
+iter_scan: "e"/2.000000000,0=/BYTES/e2
+iter_scan: "f"/3.000000000,0=/<empty>
+iter_scan: "f"/2.000000000,0=/BYTES/f2
+iter_scan: "g"/3.000000000,0=/<empty>
+iter_scan: "g"/2.000000000,0=/BYTES/g2
+iter_scan: "h"/3.000000000,0=/<empty>
+iter_scan: "h"/2.000000000,0=/BYTES/h2
+iter_scan: "i"/3.000000000,0=/<empty>
+iter_scan: "j"/3.000000000,0=/<empty>
+iter_scan: "k"/4.000000000,0=/BYTES/k4
+iter_scan: "k"/3.000000000,0=/<empty>
+iter_scan: "l"/4.000000000,0=/BYTES/l4
+iter_scan: "l"/3.000000000,0=/<empty>
+iter_scan: "m"/5.000000000,0=/<empty>
+iter_scan: "m"/4.000000000,0=/BYTES/m4
+iter_scan: "m"/3.000000000,0=/<empty>
+iter_scan: "n"/5.000000000,0=/<empty>
+iter_scan: "n"/4.000000000,0=/BYTES/n4
+iter_scan: "n"/3.000000000,0=/<empty>
+iter_scan: "o"/5.000000000,0=/<empty>
+iter_scan: "o"/3.000000000,0=/<empty>
+iter_scan: "p"/3.000000000,0=/BYTES/p3
+iter_scan: "q"/3.000000000,0=/BYTES/q3
+iter_scan: "r"/3.000000000,0=/BYTES/r3
+iter_scan: .
+
+run ok
+iter_new types=pointsAndRanges pointSynthesis
+iter_seek_lt k=n ts=2
+iter_scan
+----
+iter_seek_lt: "n"/3.000000000,0=/<empty>
+iter_scan: "n"/3.000000000,0=/<empty>
+iter_scan: "o"/5.000000000,0=/<empty>
+iter_scan: "o"/3.000000000,0=/<empty>
+iter_scan: "p"/3.000000000,0=/BYTES/p3
+iter_scan: "q"/3.000000000,0=/BYTES/q3
+iter_scan: "r"/3.000000000,0=/BYTES/r3
+iter_scan: .

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_scans_ts_conflict
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_scans_ts_conflict
@@ -1,0 +1,406 @@
+# Tests MVCC scans where point/range keys have the same timestamp. This
+# shouldn't happen, but it's been seen to happen in randomized tests due to
+# faulty conflict checks.
+#
+#  T
+#  5                                                  o-----------o
+#  4                                          k4  l4  m4  n4
+#  3  a3 b3   oc3-d3--e3--f3--g3--h3--i3--j3--k3--l3--m3--n3--o3--op3 q3  r3
+#  2                  e2  f2  g2  h2
+#  1          o---------------o
+#     a   b   c   d   e   f   g   h   i   j   k   l   m   n   o   p   q   r
+run ok
+put k=e ts=2 v=e2
+put k=f ts=2 v=f2
+put k=g ts=2 v=g2
+put k=h ts=2 v=h2
+put k=a ts=3 v=a3
+put k=b ts=3 v=b3
+put k=c ts=3 v=c3
+put k=d ts=3 v=d3
+put k=e ts=3 v=e3
+put k=f ts=3 v=f3
+put k=g ts=3 v=g3
+put k=h ts=3 v=h3
+put k=i ts=3 v=i3
+put k=j ts=3 v=j3
+put k=k ts=3 v=k3
+put k=l ts=3 v=l3
+put k=m ts=3 v=m3
+put k=n ts=3 v=n3
+put k=o ts=3 v=o3
+put k=p ts=3 v=p3
+put k=q ts=3 v=q3
+put k=r ts=3 v=r3
+put k=k ts=4 v=k4
+put k=l ts=4 v=l4
+put k=m ts=4 v=m4
+put k=n ts=4 v=n4
+put_rangekey k=c end=g ts=1
+put_rangekey k=c end=p ts=3
+put_rangekey k=m end=p ts=5
+----
+>> at end:
+rangekey: {c-g}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {g-m}/[3.000000000,0=/<empty>]
+rangekey: {m-p}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+data: "a"/3.000000000,0 -> /BYTES/a3
+data: "b"/3.000000000,0 -> /BYTES/b3
+data: "c"/3.000000000,0 -> /BYTES/c3
+data: "d"/3.000000000,0 -> /BYTES/d3
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "e"/2.000000000,0 -> /BYTES/e2
+data: "f"/3.000000000,0 -> /BYTES/f3
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/3.000000000,0 -> /BYTES/g3
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/3.000000000,0 -> /BYTES/h3
+data: "h"/2.000000000,0 -> /BYTES/h2
+data: "i"/3.000000000,0 -> /BYTES/i3
+data: "j"/3.000000000,0 -> /BYTES/j3
+data: "k"/4.000000000,0 -> /BYTES/k4
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "l"/4.000000000,0 -> /BYTES/l4
+data: "l"/3.000000000,0 -> /BYTES/l3
+data: "m"/4.000000000,0 -> /BYTES/m4
+data: "m"/3.000000000,0 -> /BYTES/m3
+data: "n"/4.000000000,0 -> /BYTES/n4
+data: "n"/3.000000000,0 -> /BYTES/n3
+data: "o"/3.000000000,0 -> /BYTES/o3
+data: "p"/3.000000000,0 -> /BYTES/p3
+data: "q"/3.000000000,0 -> /BYTES/q3
+data: "r"/3.000000000,0 -> /BYTES/r3
+
+# Run non-tombstone scans at all timestamps.
+run ok
+scan k=a end=z ts=1
+----
+scan: "a"-"z" -> <no data>
+
+run ok
+scan k=a end=z ts=2
+----
+scan: "e" -> /BYTES/e2 @2.000000000,0
+scan: "f" -> /BYTES/f2 @2.000000000,0
+scan: "g" -> /BYTES/g2 @2.000000000,0
+scan: "h" -> /BYTES/h2 @2.000000000,0
+
+run ok
+scan k=a end=z ts=3
+----
+scan: "a" -> /BYTES/a3 @3.000000000,0
+scan: "b" -> /BYTES/b3 @3.000000000,0
+scan: "p" -> /BYTES/p3 @3.000000000,0
+scan: "q" -> /BYTES/q3 @3.000000000,0
+scan: "r" -> /BYTES/r3 @3.000000000,0
+
+run ok
+scan k=a end=z ts=4
+----
+scan: "a" -> /BYTES/a3 @3.000000000,0
+scan: "b" -> /BYTES/b3 @3.000000000,0
+scan: "k" -> /BYTES/k4 @4.000000000,0
+scan: "l" -> /BYTES/l4 @4.000000000,0
+scan: "m" -> /BYTES/m4 @4.000000000,0
+scan: "n" -> /BYTES/n4 @4.000000000,0
+scan: "p" -> /BYTES/p3 @3.000000000,0
+scan: "q" -> /BYTES/q3 @3.000000000,0
+scan: "r" -> /BYTES/r3 @3.000000000,0
+
+run ok
+scan k=a end=z ts=5
+----
+scan: "a" -> /BYTES/a3 @3.000000000,0
+scan: "b" -> /BYTES/b3 @3.000000000,0
+scan: "k" -> /BYTES/k4 @4.000000000,0
+scan: "l" -> /BYTES/l4 @4.000000000,0
+scan: "p" -> /BYTES/p3 @3.000000000,0
+scan: "q" -> /BYTES/q3 @3.000000000,0
+scan: "r" -> /BYTES/r3 @3.000000000,0
+
+# Run tombstone scans at all timestamps.
+run ok
+scan k=a end=z ts=1 tombstones
+----
+scan: "c" -> /<empty> @1.000000000,0
+
+run ok
+scan k=a end=z ts=2 tombstones
+----
+scan: "c" -> /<empty> @1.000000000,0
+scan: "e" -> /BYTES/e2 @2.000000000,0
+scan: "f" -> /BYTES/f2 @2.000000000,0
+scan: "g" -> /BYTES/g2 @2.000000000,0
+scan: "h" -> /BYTES/h2 @2.000000000,0
+
+run ok
+scan k=a end=z ts=3 tombstones
+----
+scan: "a" -> /BYTES/a3 @3.000000000,0
+scan: "b" -> /BYTES/b3 @3.000000000,0
+scan: "c" -> /<empty> @3.000000000,0
+scan: "d" -> /<empty> @3.000000000,0
+scan: "e" -> /<empty> @3.000000000,0
+scan: "f" -> /<empty> @3.000000000,0
+scan: "g" -> /<empty> @3.000000000,0
+scan: "h" -> /<empty> @3.000000000,0
+scan: "i" -> /<empty> @3.000000000,0
+scan: "j" -> /<empty> @3.000000000,0
+scan: "k" -> /<empty> @3.000000000,0
+scan: "l" -> /<empty> @3.000000000,0
+scan: "m" -> /<empty> @3.000000000,0
+scan: "n" -> /<empty> @3.000000000,0
+scan: "o" -> /<empty> @3.000000000,0
+scan: "p" -> /BYTES/p3 @3.000000000,0
+scan: "q" -> /BYTES/q3 @3.000000000,0
+scan: "r" -> /BYTES/r3 @3.000000000,0
+
+run ok
+scan k=a end=z ts=4 tombstones
+----
+scan: "a" -> /BYTES/a3 @3.000000000,0
+scan: "b" -> /BYTES/b3 @3.000000000,0
+scan: "c" -> /<empty> @3.000000000,0
+scan: "d" -> /<empty> @3.000000000,0
+scan: "e" -> /<empty> @3.000000000,0
+scan: "f" -> /<empty> @3.000000000,0
+scan: "g" -> /<empty> @3.000000000,0
+scan: "h" -> /<empty> @3.000000000,0
+scan: "i" -> /<empty> @3.000000000,0
+scan: "j" -> /<empty> @3.000000000,0
+scan: "k" -> /BYTES/k4 @4.000000000,0
+scan: "l" -> /BYTES/l4 @4.000000000,0
+scan: "m" -> /BYTES/m4 @4.000000000,0
+scan: "n" -> /BYTES/n4 @4.000000000,0
+scan: "o" -> /<empty> @3.000000000,0
+scan: "p" -> /BYTES/p3 @3.000000000,0
+scan: "q" -> /BYTES/q3 @3.000000000,0
+scan: "r" -> /BYTES/r3 @3.000000000,0
+
+run ok
+scan k=a end=z ts=5 tombstones
+----
+scan: "a" -> /BYTES/a3 @3.000000000,0
+scan: "b" -> /BYTES/b3 @3.000000000,0
+scan: "c" -> /<empty> @3.000000000,0
+scan: "d" -> /<empty> @3.000000000,0
+scan: "e" -> /<empty> @3.000000000,0
+scan: "f" -> /<empty> @3.000000000,0
+scan: "g" -> /<empty> @3.000000000,0
+scan: "h" -> /<empty> @3.000000000,0
+scan: "i" -> /<empty> @3.000000000,0
+scan: "j" -> /<empty> @3.000000000,0
+scan: "k" -> /BYTES/k4 @4.000000000,0
+scan: "l" -> /BYTES/l4 @4.000000000,0
+scan: "m" -> /<empty> @5.000000000,0
+scan: "n" -> /<empty> @5.000000000,0
+scan: "o" -> /<empty> @5.000000000,0
+scan: "p" -> /BYTES/p3 @3.000000000,0
+scan: "q" -> /BYTES/q3 @3.000000000,0
+scan: "r" -> /BYTES/r3 @3.000000000,0
+
+# Run bounded tombstone scans.
+run ok
+scan k=d end=i ts=3 tombstones
+----
+scan: "d" -> /<empty> @3.000000000,0
+scan: "e" -> /<empty> @3.000000000,0
+scan: "f" -> /<empty> @3.000000000,0
+scan: "g" -> /<empty> @3.000000000,0
+scan: "h" -> /<empty> @3.000000000,0
+
+run ok
+scan k=d end=i ts=2 tombstones
+----
+scan: "d" -> /<empty> @1.000000000,0
+scan: "e" -> /BYTES/e2 @2.000000000,0
+scan: "f" -> /BYTES/f2 @2.000000000,0
+scan: "g" -> /BYTES/g2 @2.000000000,0
+scan: "h" -> /BYTES/h2 @2.000000000,0
+
+run ok
+scan k=i end=o ts=3 tombstones
+----
+scan: "i" -> /<empty> @3.000000000,0
+scan: "j" -> /<empty> @3.000000000,0
+scan: "k" -> /<empty> @3.000000000,0
+scan: "l" -> /<empty> @3.000000000,0
+scan: "m" -> /<empty> @3.000000000,0
+scan: "n" -> /<empty> @3.000000000,0
+
+run ok
+scan k=i end=o ts=4 tombstones
+----
+scan: "i" -> /<empty> @3.000000000,0
+scan: "j" -> /<empty> @3.000000000,0
+scan: "k" -> /BYTES/k4 @4.000000000,0
+scan: "l" -> /BYTES/l4 @4.000000000,0
+scan: "m" -> /BYTES/m4 @4.000000000,0
+scan: "n" -> /BYTES/n4 @4.000000000,0
+
+# Run reverse non-tombstone scans at all timestamps.
+run ok
+scan k=a end=z ts=1 reverse
+----
+scan: "a"-"z" -> <no data>
+
+run ok
+scan k=a end=z ts=2 reverse
+----
+scan: "h" -> /BYTES/h2 @2.000000000,0
+scan: "g" -> /BYTES/g2 @2.000000000,0
+scan: "f" -> /BYTES/f2 @2.000000000,0
+scan: "e" -> /BYTES/e2 @2.000000000,0
+
+run ok
+scan k=a end=z ts=3 reverse
+----
+scan: "r" -> /BYTES/r3 @3.000000000,0
+scan: "q" -> /BYTES/q3 @3.000000000,0
+scan: "p" -> /BYTES/p3 @3.000000000,0
+scan: "b" -> /BYTES/b3 @3.000000000,0
+scan: "a" -> /BYTES/a3 @3.000000000,0
+
+run ok
+scan k=a end=z ts=4 reverse
+----
+scan: "r" -> /BYTES/r3 @3.000000000,0
+scan: "q" -> /BYTES/q3 @3.000000000,0
+scan: "p" -> /BYTES/p3 @3.000000000,0
+scan: "n" -> /BYTES/n4 @4.000000000,0
+scan: "m" -> /BYTES/m4 @4.000000000,0
+scan: "l" -> /BYTES/l4 @4.000000000,0
+scan: "k" -> /BYTES/k4 @4.000000000,0
+scan: "b" -> /BYTES/b3 @3.000000000,0
+scan: "a" -> /BYTES/a3 @3.000000000,0
+
+run ok
+scan k=a end=z ts=5 reverse
+----
+scan: "r" -> /BYTES/r3 @3.000000000,0
+scan: "q" -> /BYTES/q3 @3.000000000,0
+scan: "p" -> /BYTES/p3 @3.000000000,0
+scan: "l" -> /BYTES/l4 @4.000000000,0
+scan: "k" -> /BYTES/k4 @4.000000000,0
+scan: "b" -> /BYTES/b3 @3.000000000,0
+scan: "a" -> /BYTES/a3 @3.000000000,0
+
+# Run reverse tombstone scans at all timestamps.
+run ok
+scan k=a end=z ts=1 reverse tombstones
+----
+scan: "c" -> /<empty> @1.000000000,0
+
+run ok
+scan k=a end=z ts=2 reverse tombstones
+----
+scan: "h" -> /BYTES/h2 @2.000000000,0
+scan: "g" -> /BYTES/g2 @2.000000000,0
+scan: "f" -> /BYTES/f2 @2.000000000,0
+scan: "e" -> /BYTES/e2 @2.000000000,0
+scan: "c" -> /<empty> @1.000000000,0
+
+run ok
+scan k=a end=z ts=3 reverse tombstones
+----
+scan: "r" -> /BYTES/r3 @3.000000000,0
+scan: "q" -> /BYTES/q3 @3.000000000,0
+scan: "p" -> /BYTES/p3 @3.000000000,0
+scan: "o" -> /<empty> @3.000000000,0
+scan: "n" -> /<empty> @3.000000000,0
+scan: "m" -> /<empty> @3.000000000,0
+scan: "l" -> /<empty> @3.000000000,0
+scan: "k" -> /<empty> @3.000000000,0
+scan: "j" -> /<empty> @3.000000000,0
+scan: "i" -> /<empty> @3.000000000,0
+scan: "h" -> /<empty> @3.000000000,0
+scan: "g" -> /<empty> @3.000000000,0
+scan: "f" -> /<empty> @3.000000000,0
+scan: "e" -> /<empty> @3.000000000,0
+scan: "d" -> /<empty> @3.000000000,0
+scan: "c" -> /<empty> @3.000000000,0
+scan: "b" -> /BYTES/b3 @3.000000000,0
+scan: "a" -> /BYTES/a3 @3.000000000,0
+
+run ok
+scan k=a end=z ts=4 reverse tombstones
+----
+scan: "r" -> /BYTES/r3 @3.000000000,0
+scan: "q" -> /BYTES/q3 @3.000000000,0
+scan: "p" -> /BYTES/p3 @3.000000000,0
+scan: "o" -> /<empty> @3.000000000,0
+scan: "n" -> /BYTES/n4 @4.000000000,0
+scan: "m" -> /BYTES/m4 @4.000000000,0
+scan: "l" -> /BYTES/l4 @4.000000000,0
+scan: "k" -> /BYTES/k4 @4.000000000,0
+scan: "j" -> /<empty> @3.000000000,0
+scan: "i" -> /<empty> @3.000000000,0
+scan: "h" -> /<empty> @3.000000000,0
+scan: "g" -> /<empty> @3.000000000,0
+scan: "f" -> /<empty> @3.000000000,0
+scan: "e" -> /<empty> @3.000000000,0
+scan: "d" -> /<empty> @3.000000000,0
+scan: "c" -> /<empty> @3.000000000,0
+scan: "b" -> /BYTES/b3 @3.000000000,0
+scan: "a" -> /BYTES/a3 @3.000000000,0
+
+run ok
+scan k=a end=z ts=5 reverse tombstones
+----
+scan: "r" -> /BYTES/r3 @3.000000000,0
+scan: "q" -> /BYTES/q3 @3.000000000,0
+scan: "p" -> /BYTES/p3 @3.000000000,0
+scan: "o" -> /<empty> @5.000000000,0
+scan: "n" -> /<empty> @5.000000000,0
+scan: "m" -> /<empty> @5.000000000,0
+scan: "l" -> /BYTES/l4 @4.000000000,0
+scan: "k" -> /BYTES/k4 @4.000000000,0
+scan: "j" -> /<empty> @3.000000000,0
+scan: "i" -> /<empty> @3.000000000,0
+scan: "h" -> /<empty> @3.000000000,0
+scan: "g" -> /<empty> @3.000000000,0
+scan: "f" -> /<empty> @3.000000000,0
+scan: "e" -> /<empty> @3.000000000,0
+scan: "d" -> /<empty> @3.000000000,0
+scan: "c" -> /<empty> @3.000000000,0
+scan: "b" -> /BYTES/b3 @3.000000000,0
+scan: "a" -> /BYTES/a3 @3.000000000,0
+
+# Run bounded reverse tombstone scans.
+run ok
+scan k=d end=i ts=3 reverse tombstones
+----
+scan: "h" -> /<empty> @3.000000000,0
+scan: "g" -> /<empty> @3.000000000,0
+scan: "f" -> /<empty> @3.000000000,0
+scan: "e" -> /<empty> @3.000000000,0
+scan: "d" -> /<empty> @3.000000000,0
+
+run ok
+scan k=d end=i ts=2 reverse tombstones
+----
+scan: "h" -> /BYTES/h2 @2.000000000,0
+scan: "g" -> /BYTES/g2 @2.000000000,0
+scan: "f" -> /BYTES/f2 @2.000000000,0
+scan: "e" -> /BYTES/e2 @2.000000000,0
+scan: "d" -> /<empty> @1.000000000,0
+
+run ok
+scan k=i end=o ts=3 reverse tombstones
+----
+scan: "n" -> /<empty> @3.000000000,0
+scan: "m" -> /<empty> @3.000000000,0
+scan: "l" -> /<empty> @3.000000000,0
+scan: "k" -> /<empty> @3.000000000,0
+scan: "j" -> /<empty> @3.000000000,0
+scan: "i" -> /<empty> @3.000000000,0
+
+run ok
+scan k=i end=o ts=4 reverse tombstones
+----
+scan: "n" -> /BYTES/n4 @4.000000000,0
+scan: "m" -> /BYTES/m4 @4.000000000,0
+scan: "l" -> /BYTES/l4 @4.000000000,0
+scan: "k" -> /BYTES/k4 @4.000000000,0
+scan: "j" -> /<empty> @3.000000000,0
+scan: "i" -> /<empty> @3.000000000,0


### PR DESCRIPTION
It's possible for a range key and point key to exist at the same timestamp. This should be prevented by MVCC conflict checks, but we've seen bugs where this has happened. In these cases, we typically give the range keys precedence, such that the MVCC point keys are considered deleted by the MVCC range tombstone.

However, `pointSynthesizingIter` would emit both the real and synthetic point in this case, with the real point emitted before the synthetic point. This would typically cause `pebbleMVCCScanner` to emit the real (undeleted) point. However, other code such as MVCC garbage collection will give the range key precedence, meaning that we'll garbage collect visible data.

This patch changes `pointSynthesizingIter` to give synthetic points precedence in this case, and omit the real point entirely, for consistency with other code. No release note is included, since this can only happen with bugs in MVCC conflict checks, and those will be addressed separately.

This has negligible impact on performance:

```
name                                                                    old time/op    new time/op    delta
MVCCScan_Pebble/rows=1/versions=1/valueSize=8/numRangeKeys=0-24           5.73µs ± 0%    5.73µs ± 2%    ~     (p=0.190 n=4+5)
MVCCScan_Pebble/rows=1/versions=1/valueSize=8/numRangeKeys=1-24           10.3µs ± 1%    10.3µs ± 1%    ~     (p=0.690 n=5+5)
MVCCScan_Pebble/rows=1/versions=1/valueSize=8/numRangeKeys=100-24          148µs ± 1%     148µs ± 2%    ~     (p=1.000 n=5+5)
MVCCScan_Pebble/rows=1/versions=10/valueSize=8/numRangeKeys=0-24          21.3µs ± 2%    21.4µs ± 1%    ~     (p=1.000 n=5+5)
MVCCScan_Pebble/rows=1/versions=10/valueSize=8/numRangeKeys=1-24          28.9µs ± 1%    28.8µs ± 1%    ~     (p=0.690 n=5+5)
MVCCScan_Pebble/rows=1/versions=10/valueSize=8/numRangeKeys=100-24         124µs ± 2%     124µs ± 1%    ~     (p=0.841 n=5+5)
MVCCScan_Pebble/rows=100/versions=1/valueSize=8/numRangeKeys=0-24         36.0µs ± 4%    35.0µs ± 1%  -2.78%  (p=0.016 n=5+5)
MVCCScan_Pebble/rows=100/versions=1/valueSize=8/numRangeKeys=1-24         55.2µs ± 2%    54.9µs ± 1%    ~     (p=0.841 n=5+5)
MVCCScan_Pebble/rows=100/versions=1/valueSize=8/numRangeKeys=100-24        159µs ± 1%     159µs ± 1%    ~     (p=0.690 n=5+5)
MVCCScan_Pebble/rows=100/versions=10/valueSize=8/numRangeKeys=0-24         139µs ± 1%     140µs ± 2%    ~     (p=0.421 n=5+5)
MVCCScan_Pebble/rows=100/versions=10/valueSize=8/numRangeKeys=1-24         216µs ± 1%     218µs ± 1%    ~     (p=0.095 n=5+5)
MVCCScan_Pebble/rows=100/versions=10/valueSize=8/numRangeKeys=100-24       325µs ± 1%     328µs ± 1%    ~     (p=0.151 n=5+5)
MVCCScan_Pebble/rows=10000/versions=1/valueSize=8/numRangeKeys=0-24       2.42ms ± 1%    2.44ms ± 1%  +0.89%  (p=0.032 n=5+5)
MVCCScan_Pebble/rows=10000/versions=1/valueSize=8/numRangeKeys=1-24       3.89ms ± 0%    3.91ms ± 1%    ~     (p=0.222 n=5+5)
MVCCScan_Pebble/rows=10000/versions=1/valueSize=8/numRangeKeys=100-24     4.73ms ± 1%    4.77ms ± 1%    ~     (p=0.095 n=5+5)
MVCCScan_Pebble/rows=10000/versions=10/valueSize=8/numRangeKeys=0-24      10.6ms ± 1%    10.8ms ± 1%    ~     (p=0.095 n=5+5)
MVCCScan_Pebble/rows=10000/versions=10/valueSize=8/numRangeKeys=1-24      17.7ms ± 1%    18.1ms ± 2%  +1.78%  (p=0.016 n=5+5)
MVCCScan_Pebble/rows=10000/versions=10/valueSize=8/numRangeKeys=100-24    22.4ms ± 7%    21.6ms ± 9%    ~     (p=0.421 n=5+5)
```

Resolves #93965.
Touches #93968.

Release note: None