### PR TITLE
colexecjoin: clarify handling of INTERSECT ALL joins

### DIFF
--- a/pkg/sql/colexec/colexechash/hashtable.go
+++ b/pkg/sql/colexec/colexechash/hashtable.go
@@ -236,16 +236,20 @@ type HashTable struct {
 	// currently being probed.
 	Keys []coldata.Vec
 
-	// Same and Visited are only used when the HashTable contains non-distinct
-	// keys (in HashTableFullBuildMode mode).
-	//
 	// Same is a densely-packed list that stores the keyID of the next key in
 	// the hash table that has the same value as the current key. The HeadID of
 	// the key is the first key of that value found in the next linked list.
 	// This field will be lazily populated by the prober.
+	//
+	// Same is only used when the HashTable contains non-distinct keys (in
+	// HashTableFullBuildMode mode) and is probed via HashTableDefaultProbeMode
+	// mode.
 	Same []keyID
 	// Visited represents whether each of the corresponding keys have been
 	// touched by the prober.
+	//
+	// Visited is only used by the hash joiner when the HashTable contains
+	// non-distinct keys or when performing set-operation joins.
 	Visited []bool
 
 	// Vals stores columns of the build source that are specified in colsToStore

--- a/pkg/sql/colexec/colexechash/hashtable_full_deleting.eg.go
+++ b/pkg/sql/colexec/colexechash/hashtable_full_deleting.eg.go
@@ -6038,55 +6038,28 @@ func (ht *HashTable) Check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []
 			}
 		}
 	case HashTableDeletingProbeMode:
-		if ht.Same != nil {
-			toCheckSlice := ht.ProbeScratch.ToCheck
-			_ = toCheckSlice[nToCheck-1]
-			for toCheckPos := uint64(0); toCheckPos < nToCheck && nDiffers < nToCheck; toCheckPos++ {
-				//gcassert:bce
-				toCheck := toCheckSlice[toCheckPos]
-				if !ht.ProbeScratch.differs[toCheck] {
-					keyID := ht.ProbeScratch.ToCheckID[toCheck]
-					if !ht.Visited[keyID] {
-						ht.ProbeScratch.HeadID[toCheck] = keyID
-						ht.Visited[keyID] = true
-					} else {
-						if keyID != 0 {
-							//gcassert:bce
-							toCheckSlice[nDiffers] = toCheck
-							nDiffers++
-						}
-					}
+		toCheckSlice := ht.ProbeScratch.ToCheck
+		_ = toCheckSlice[nToCheck-1]
+		for toCheckPos := uint64(0); toCheckPos < nToCheck && nDiffers < nToCheck; toCheckPos++ {
+			//gcassert:bce
+			toCheck := toCheckSlice[toCheckPos]
+			if !ht.ProbeScratch.differs[toCheck] {
+				keyID := ht.ProbeScratch.ToCheckID[toCheck]
+				if !ht.Visited[keyID] {
+					ht.ProbeScratch.HeadID[toCheck] = keyID
+					ht.Visited[keyID] = true
 				} else {
-					ht.ProbeScratch.differs[toCheck] = false
-					//gcassert:bce
-					toCheckSlice[nDiffers] = toCheck
-					nDiffers++
-				}
-			}
-		} else {
-			toCheckSlice := ht.ProbeScratch.ToCheck
-			_ = toCheckSlice[nToCheck-1]
-			for toCheckPos := uint64(0); toCheckPos < nToCheck && nDiffers < nToCheck; toCheckPos++ {
-				//gcassert:bce
-				toCheck := toCheckSlice[toCheckPos]
-				if !ht.ProbeScratch.differs[toCheck] {
-					keyID := ht.ProbeScratch.ToCheckID[toCheck]
-					if !ht.Visited[keyID] {
-						ht.ProbeScratch.HeadID[toCheck] = keyID
-						ht.Visited[keyID] = true
-					} else {
-						if keyID != 0 {
-							//gcassert:bce
-							toCheckSlice[nDiffers] = toCheck
-							nDiffers++
-						}
+					if keyID != 0 {
+						//gcassert:bce
+						toCheckSlice[nDiffers] = toCheck
+						nDiffers++
 					}
-				} else {
-					ht.ProbeScratch.differs[toCheck] = false
-					//gcassert:bce
-					toCheckSlice[nDiffers] = toCheck
-					nDiffers++
 				}
+			} else {
+				ht.ProbeScratch.differs[toCheck] = false
+				//gcassert:bce
+				toCheckSlice[nDiffers] = toCheck
+				nDiffers++
 			}
 		}
 	default:

--- a/pkg/sql/colexec/colexechash/hashtable_tmpl.go
+++ b/pkg/sql/colexec/colexechash/hashtable_tmpl.go
@@ -594,11 +594,7 @@ func (ht *HashTable) Check(probeVecs []coldata.Vec, nToCheck uint64, probeSel []
 			_CHECK_BODY(false, false, false)
 		}
 	case HashTableDeletingProbeMode:
-		if ht.Same != nil {
-			_CHECK_BODY(true, true, false)
-		} else {
-			_CHECK_BODY(false, true, false)
-		}
+		_CHECK_BODY(false, true, false)
 	default:
 		colexecerror.InternalError(errors.AssertionFailedf("unsupported hash table probe mode"))
 	}


### PR DESCRIPTION
This commit clarifies how the INTERSECT ALL joins are handled by the
hash joiner. Previously, this type of join would be handled via the same
collection method as other non-outer joins with non-distinct keys.
However, there is a crucial difference - `Same` slice would always
remain unpopulated for INTERSECT ALL, so the collection method would be
reduced to a much simpler version. This is the case since for this type
of join we only need to include the left tuple once if it has a match
and there is no need to traverse the hash chain trying to find more
matches.

In fact, the collection method for INTERSECT ALL is very similar to that
of EXCEPT ALL with only a condition being negated, so this commit takes
advantage of this observation and refactors `collectLeftAnti` to also
power the INTERSECT ALL collection.

This makes the code easier to follow and also allows us to not
instantiate `Same` array for the INTERSECT ALL joins. Additionally, it
allows us to remove some duplicated code in the `Check` function which
was previously conditioned on `Same` being non-nil even though both
branches had exactly the same code. The dead code in `distinctCollect`
is also now removed.

Epic: None

Release note: None