### PR TITLE
tree: correct mutation/DDL property for some opaque operators

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -1028,6 +1028,59 @@ SELECT nextval('a')
 statement error cannot execute setval\(\) in a read-only transaction
 SELECT setval('a', 2)
 
+statement error cannot execute CREATE ROLE in a read-only transaction
+CREATE ROLE my_user
+
+statement error cannot execute ALTER ROLE in a read-only transaction
+ALTER ROLE testuser SET default_int_size = 4
+
+statement error cannot execute DROP ROLE in a read-only transaction
+DROP ROLE testuser
+
+statement error cannot execute SET CLUSTER SETTING in a read-only transaction
+SET CLUSTER SETTING sql.auth.change_own_password.enabled = true
+
+statement error cannot execute GRANT in a read-only transaction
+GRANT admin TO testuser
+
+statement error cannot execute REVOKE in a read-only transaction
+REVOKE admin FROM testuser
+
+statement error cannot execute GRANT in a read-only transaction
+GRANT CONNECT ON DATABASE test TO testuser
+
+statement error cannot execute create_tenant\(\) in a read-only transaction
+SELECT crdb_internal.create_tenant(3)
+
+statement error cannot execute rename_tenant\(\) in a read-only transaction
+SELECT crdb_internal.rename_tenant(3, 'new')
+
+statement error cannot execute destroy_tenant\(\) in a read-only transaction
+SELECT crdb_internal.destroy_tenant(3)
+
+# SET session variable should work in a read-only txn.
+statement ok
+SET intervalstyle = 'postgres'
+
+statement ok
+SET SESSION CHARACTERISTICS AS TRANSACTION PRIORITY NORMAL
+
+statement ok
+SET SESSION AUTHORIZATION DEFAULT
+
+statement ok
+BEGIN
+
+# DECLARE and FETCH CURSOR should work in a read-only txn.
+statement ok
+DECLARE foo CURSOR FOR SELECT 1
+
+statement ok
+FETCH 1 foo
+
+statement ok
+COMMIT
+
 query T
 SHOW TRANSACTION STATUS
 ----

--- a/pkg/sql/tenant.go
+++ b/pkg/sql/tenant.go
@@ -321,6 +321,9 @@ func getAvailableTenantID(
 func (p *planner) CreateTenant(
 	ctx context.Context, name roachpb.TenantName,
 ) (roachpb.TenantID, error) {
+	if p.EvalContext().TxnReadOnly {
+		return roachpb.TenantID{}, readOnlyError("create_tenant()")
+	}
 	const op = "create tenant"
 	if err := p.RequireAdminRole(ctx, op); err != nil {
 		return roachpb.TenantID{}, err
@@ -343,6 +346,9 @@ func (p *planner) CreateTenant(
 func (p *planner) CreateTenantWithID(
 	ctx context.Context, tenantID uint64, tenantName roachpb.TenantName,
 ) error {
+	if p.EvalContext().TxnReadOnly {
+		return readOnlyError("create_tenant()")
+	}
 	if err := p.RequireAdminRole(ctx, "create tenant"); err != nil {
 		return err
 	}
@@ -552,6 +558,10 @@ func (p *planner) DestroyTenantByID(
 }
 
 func (p *planner) validateDestroyTenant(ctx context.Context) error {
+	if p.EvalContext().TxnReadOnly {
+		return readOnlyError("destroy_tenant()")
+	}
+
 	const op = "destroy"
 	if err := p.RequireAdminRole(ctx, "destroy tenant"); err != nil {
 		return err
@@ -794,6 +804,10 @@ func TestingUpdateTenantRecord(
 func (p *planner) RenameTenant(
 	ctx context.Context, tenantID uint64, tenantName roachpb.TenantName,
 ) error {
+	if p.EvalContext().TxnReadOnly {
+		return readOnlyError("rename_tenant()")
+	}
+
 	if err := tenantName.IsValid(); err != nil {
 		return pgerror.WithCandidateCode(err, pgcode.Syntax)
 	}


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/91713

In ed733adfefd26cd326a7677e9650eff687c4dfe3, a framework was added to mark certain opaque operators as DDL or mutations.

This was enhanced in 06581b3dbd1e302dc3108155344de70188b4f856, but that change wasn't exhaustive since it marked some statements as read-only, even if they could perform DDL.

With the addition of `StatementType()` in
89621764d4c2d438d1781238f10e9ef27ef2c392, we can make this a little more correct.

This allows the check at
https://github.com/cockroachdb/cockroach/blob/48ef0d89e6179c0d348a5236ad308d81fa392f7c/pkg/sql/opt/exec/execbuilder/relational.go#L163 to work correctly, and reject operations that shouldn't be allowed when using a read-only transaction.

To explain each change:
- BACKUP can modify job state and write to userfiles, so shouldn't be allowed in read-only mode.
- SET commands are always allowed in read-only mode in order to match Postgres behavior, and since those changes are all in-memory and session setting modifications don't respect transactions anyway.
- The crdb_internal tenant functions modify system tables.
- GRANT, REVOKE, and many other privilege-related statements are "DCL" (data control language), and all modify system tables or descriptors.

Release note (bug fix): CREATE ROLE, DELETE ROLE, GRANT, and REVOKE statements no longer work when the transaction is in read-only mode.