### PR TITLE
backupccl: move alloc heavy Files field from manifest to SST

### DIFF
--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -140,15 +140,27 @@ func backup(
 	var lastCheckpoint time.Time
 
 	var completedSpans, completedIntroducedSpans []roachpb.Span
+	kmsEnv := backupencryption.MakeBackupKMSEnv(execCtx.ExecCfg().Settings,
+		&execCtx.ExecCfg().ExternalIODirConfig, execCtx.ExecCfg().DB, execCtx.User(),
+		execCtx.ExecCfg().InternalExecutor)
 	// TODO(benesch): verify these files, rather than accepting them as truth
 	// blindly.
 	// No concurrency yet, so these assignments are safe.
-	for _, file := range backupManifest.Files {
-		if file.StartTime.IsEmpty() && !file.EndTime.IsEmpty() {
-			completedIntroducedSpans = append(completedIntroducedSpans, file.Span)
+	it, err := makeBackupManifestFileIterator(ctx, execCtx.ExecCfg().DistSQLSrv.ExternalStorage,
+		*backupManifest, encryption, &kmsEnv)
+	if err != nil {
+		return roachpb.RowCount{}, err
+	}
+	defer it.close()
+	for f, hasNext := it.next(); hasNext; f, hasNext = it.next() {
+		if f.StartTime.IsEmpty() && !f.EndTime.IsEmpty() {
+			completedIntroducedSpans = append(completedIntroducedSpans, f.Span)
 		} else {
-			completedSpans = append(completedSpans, file.Span)
+			completedSpans = append(completedSpans, f.Span)
 		}
+	}
+	if it.err() != nil {
+		return roachpb.RowCount{}, it.err()
 	}
 
 	// Subtract out any completed spans.
@@ -171,10 +183,6 @@ func backup(
 	if err != nil {
 		return roachpb.RowCount{}, errors.Wrap(err, "failed to determine nodes on which to run")
 	}
-
-	kmsEnv := backupencryption.MakeBackupKMSEnv(execCtx.ExecCfg().Settings,
-		&execCtx.ExecCfg().ExternalIODirConfig, execCtx.ExecCfg().DB, execCtx.User(),
-		execCtx.ExecCfg().InternalExecutor)
 
 	backupSpecs, err := distBackupPlanSpecs(
 		ctx,
@@ -319,11 +327,28 @@ func backup(
 		}
 	}
 
-	resumerSpan.RecordStructured(&types.StringValue{Value: "writing backup manifest"})
+	// Write a `BACKUP_MANIFEST` file to support backups in mixed-version clusters
+	// with 22.2 nodes.
+	//
+	// TODO(adityamaru): We can stop writing `BACKUP_MANIFEST` in 23.2
+	// because a mixed-version cluster with 23.1 nodes will read the
+	// `BACKUP_METADATA` instead.
 	if err := backupinfo.WriteBackupManifest(ctx, defaultStore, backupbase.BackupManifestName,
 		encryption, &kmsEnv, backupManifest); err != nil {
 		return roachpb.RowCount{}, err
 	}
+
+	// Write a `BACKUP_METADATA` file along with SSTs for all the alloc heavy
+	// fields elided from the `BACKUP_MANIFEST`.
+	//
+	// TODO(adityamaru,rhu713): Once backup/restore switches from writing and
+	// reading backup manifests to `metadata.sst` we can stop writing the slim
+	// manifest.
+	if err := backupinfo.WriteFilesListMetadataWithSSTs(ctx, defaultStore, encryption,
+		&kmsEnv, backupManifest); err != nil {
+		return roachpb.RowCount{}, err
+	}
+
 	var tableStatistics []*stats.TableStatisticProto
 	for i := range backupManifest.Descriptors {
 		if tbl, _, _, _, _ := descpb.GetDescriptors(&backupManifest.Descriptors[i]); tbl != nil {
@@ -350,7 +375,6 @@ func backup(
 		Statistics: tableStatistics,
 	}
 
-	resumerSpan.RecordStructured(&types.StringValue{Value: "writing backup table statistics"})
 	if err := backupinfo.WriteTableStatistics(ctx, defaultStore, encryption, &kmsEnv, &statsTable); err != nil {
 		return roachpb.RowCount{}, err
 	}

--- a/pkg/ccl/backupccl/backupbase/constants.go
+++ b/pkg/ccl/backupccl/backupbase/constants.go
@@ -32,13 +32,25 @@ const (
 	// Also exported for testing backup inspection tooling.
 	DateBasedIntoFolderName = "/2006/01/02-150405.00"
 
-	// BackupManifestName is the file name used for serialized BackupManifest
-	// protos.
-	BackupManifestName = "BACKUP_MANIFEST"
-
 	// BackupOldManifestName is an old name for the serialized BackupManifest
 	// proto. It is used by 20.1 nodes and earlier.
+	//
+	// TODO(adityamaru): Remove this in 22.2 as part of disallowing backups
+	// from >1 major version in the past.
 	BackupOldManifestName = "BACKUP"
+
+	// BackupManifestName is the file name used for serialized BackupManifest
+	// protos.
+	//
+	// TODO(adityamaru): Remove in 23.2 since at that point all nodes will be
+	// writing a SlimBackupManifest instead.
+	BackupManifestName = "BACKUP_MANIFEST"
+
+	// BackupMetadataName is the file name used for serialized BackupManifest
+	// protos written by 23.1 nodes and later. This manifest has the alloc heavy
+	// Files repeated fields nil'ed out, and is used in conjunction with SSTs for
+	// each of those elided fields.
+	BackupMetadataName = "BACKUP_METADATA"
 
 	// DefaultIncrementalsSubdir is the default name of the subdirectory to which
 	// incremental backups will be written.

--- a/pkg/ccl/backupccl/backupinfo/manifest_handling.go
+++ b/pkg/ccl/backupccl/backupinfo/manifest_handling.go
@@ -153,21 +153,46 @@ func ReadBackupManifestFromStore(
 ) (backuppb.BackupManifest, int64, error) {
 	ctx, sp := tracing.ChildSpan(ctx, "backupinfo.ReadBackupManifestFromStore")
 	defer sp.Finish()
-	backupManifest, memSize, err := ReadBackupManifest(ctx, mem, exportStore, backupbase.BackupManifestName,
+
+	manifest, memSize, err := ReadBackupManifest(ctx, mem, exportStore, backupbase.BackupMetadataName,
 		encryption, kmsEnv)
 	if err != nil {
-		oldManifest, newMemSize, newErr := ReadBackupManifest(ctx, mem, exportStore, backupbase.BackupOldManifestName,
-			encryption, kmsEnv)
-		if newErr != nil {
+		if !errors.Is(err, cloud.ErrFileDoesNotExist) {
 			return backuppb.BackupManifest{}, 0, err
 		}
-		backupManifest = oldManifest
-		memSize = newMemSize
+
+		// If we did not find `BACKUP_METADATA` we look for the
+		// `BACKUP_MANIFEST` file as it is possible the backup was created by a
+		// pre-23.1 node.
+		backupManifest, backupManifestMemSize, backupManifestErr := ReadBackupManifest(ctx, mem, exportStore,
+			backupbase.BackupManifestName, encryption, kmsEnv)
+		if backupManifestErr != nil {
+			if !errors.Is(backupManifestErr, cloud.ErrFileDoesNotExist) {
+				return backuppb.BackupManifest{}, 0, err
+			}
+
+			// If we did not find a `BACKUP_MANIFEST` we look for a `BACKUP` file as
+			// it is possible the backup was created by a pre-20.1 node.
+			//
+			// TODO(adityamaru): Remove this logic once we disallow restores beyond
+			// the binary upgrade compatibility window.
+			oldBackupManifest, oldBackupManifestMemSize, oldBackupManifestErr := ReadBackupManifest(ctx, mem, exportStore,
+				backupbase.BackupOldManifestName, encryption, kmsEnv)
+			if oldBackupManifestErr != nil {
+				return backuppb.BackupManifest{}, 0, oldBackupManifestErr
+			} else {
+				// We found a `BACKUP` manifest file.
+				manifest = oldBackupManifest
+				memSize = oldBackupManifestMemSize
+			}
+		} else {
+			// We found a `BACKUP_MANIFEST` file.
+			manifest = backupManifest
+			memSize = backupManifestMemSize
+		}
 	}
-	backupManifest.Dir = exportStore.Conf()
-	// TODO(dan): Sanity check this BackupManifest: non-empty EndTime, non-empty
-	// Paths, and non-overlapping Spans and keyranges in Files.
-	return backupManifest, memSize, nil
+	manifest.Dir = exportStore.Conf()
+	return manifest, memSize, nil
 }
 
 // compressData compresses data buffer and returns compressed
@@ -527,6 +552,47 @@ func WriteBackupLock(
 	lockFileName := fmt.Sprintf("%s%s", BackupLockFilePrefix, strconv.FormatInt(int64(jobID), 10))
 
 	return cloud.WriteFile(ctx, defaultStore, lockFileName, bytes.NewReader([]byte("lock")))
+}
+
+// WriteFilesListMetadataWithSSTs writes a "slim" version of manifest
+// to `exportStore`. This version has the alloc heavy `Files` repeated field
+// nil'ed out, and written to an accompanying SST instead.
+func WriteFilesListMetadataWithSSTs(
+	ctx context.Context,
+	exportStore cloud.ExternalStorage,
+	encryption *jobspb.BackupEncryptionOptions,
+	kmsEnv cloud.KMSEnv,
+	manifest *backuppb.BackupManifest,
+) error {
+	if err := writeFilesListMetadata(ctx, exportStore, backupbase.BackupMetadataName, encryption,
+		kmsEnv, manifest); err != nil {
+		return errors.Wrap(err, "failed to write the backup metadata with external Files list")
+	}
+	return errors.Wrap(WriteFilesListSST(ctx, exportStore, encryption, kmsEnv, manifest,
+		BackupMetadataFilesListPath), "failed to write backup metadata Files SST")
+}
+
+// writeFilesListMetadata compresses and writes a slimmer version of the
+// BackupManifest `desc` to `exportStore` with the `Files` field of the proto
+// set to a bogus value that will error out on incorrect use.
+func writeFilesListMetadata(
+	ctx context.Context,
+	exportStore cloud.ExternalStorage,
+	filename string,
+	encryption *jobspb.BackupEncryptionOptions,
+	kmsEnv cloud.KMSEnv,
+	manifest *backuppb.BackupManifest,
+) error {
+	slimManifest := *manifest
+	// We write a bogus file entry to ensure that no call site incorrectly uses
+	// the `Files` field from the FilesListMetadata proto.
+	bogusFile := backuppb.BackupManifest_File{
+		Span: roachpb.Span{Key: keys.MinKey, EndKey: keys.MaxKey},
+		Path: "assertion: this placeholder legacy Files entry should never be opened",
+	}
+	slimManifest.Files = []backuppb.BackupManifest_File{bogusFile}
+	slimManifest.HasExternalFilesList = true
+	return WriteBackupManifest(ctx, exportStore, filename, encryption, kmsEnv, &slimManifest)
 }
 
 // WriteBackupManifest compresses and writes the passed in BackupManifest `desc`

--- a/pkg/ccl/backupccl/backuppb/backup.proto
+++ b/pkg/ccl/backupccl/backuppb/backup.proto
@@ -131,7 +131,14 @@ message BackupManifest {
   int32 descriptor_coverage = 22 [
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/tree.DescriptorCoverage"];
 
-  // NEXT ID: 27
+  // HasExternalFilesList is set to true if the backup manifest has its `Files`
+  // field nil'ed out and written as a supporting SST file instead.
+  //
+  // TODO(adityamaru): Delete when backwards compatibility with 22.2 is dropped
+  // since all backups in 23.1+ will write slim manifests.
+  bool has_external_files_list = 27;
+
+  // NEXT ID: 28
 }
 
 message BackupPartitionDescriptor{

--- a/pkg/ccl/backupccl/bench_covering_test.go
+++ b/pkg/ccl/backupccl/bench_covering_test.go
@@ -13,12 +13,17 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/stretchr/testify/require"
 )
 
 func BenchmarkCoverageChecks(b *testing.B) {
+	tc, _, _, cleanupFn := backupRestoreTestSetup(b, singleNode, 1, InitManualReplication)
+	defer cleanupFn()
+	execCfg := tc.Server(0).ExecutorConfig().(sql.ExecutorConfig)
+	ctx := context.Background()
 	r, _ := randutil.NewTestRand()
 
 	for _, numBackups := range []int{1, 7, 24, 24 * 4} {
@@ -27,14 +32,18 @@ func BenchmarkCoverageChecks(b *testing.B) {
 				b.Run(fmt.Sprintf("numSpans=%d", numSpans), func(b *testing.B) {
 					for _, baseFiles := range []int{0, 10, 100, 1000, 10000} {
 						b.Run(fmt.Sprintf("numFiles=%d", baseFiles), func(b *testing.B) {
-							ctx := context.Background()
-							backups := MockBackupChain(numBackups, numSpans, baseFiles, r)
-							b.ResetTimer()
+							for _, hasExternalFilesList := range []bool{true, false} {
+								b.Run(fmt.Sprintf("slim=%t", hasExternalFilesList), func(b *testing.B) {
+									backups, err := MockBackupChain(ctx, numBackups, numSpans, baseFiles, r, hasExternalFilesList, execCfg)
+									require.NoError(b, err)
+									b.ResetTimer()
 
-							for i := 0; i < b.N; i++ {
-								if err := checkCoverage(ctx, backups[numBackups-1].Spans, backups); err != nil {
-									b.Fatal(err)
-								}
+									for i := 0; i < b.N; i++ {
+										if err := checkCoverage(ctx, backups[numBackups-1].Spans, backups); err != nil {
+											b.Fatal(err)
+										}
+									}
+								})
 							}
 						})
 					}
@@ -45,6 +54,11 @@ func BenchmarkCoverageChecks(b *testing.B) {
 }
 
 func BenchmarkRestoreEntryCover(b *testing.B) {
+	tc, _, _, cleanupFn := backupRestoreTestSetup(b, singleNode, 1, InitManualReplication)
+	defer cleanupFn()
+	execCfg := tc.Server(0).ExecutorConfig().(sql.ExecutorConfig)
+
+	ctx := context.Background()
 	r, _ := randutil.NewTestRand()
 	for _, numBackups := range []int{1, 2, 24, 24 * 4} {
 		b.Run(fmt.Sprintf("numBackups=%d", numBackups), func(b *testing.B) {
@@ -52,18 +66,29 @@ func BenchmarkRestoreEntryCover(b *testing.B) {
 				b.Run(fmt.Sprintf("numFiles=%d", baseFiles), func(b *testing.B) {
 					for _, numSpans := range []int{10, 100} {
 						b.Run(fmt.Sprintf("numSpans=%d", numSpans), func(b *testing.B) {
-							ctx := context.Background()
-							backups := MockBackupChain(numBackups, numSpans, baseFiles, r)
-							b.ResetTimer()
-							for i := 0; i < b.N; i++ {
-								if err := checkCoverage(ctx, backups[numBackups-1].Spans, backups); err != nil {
-									b.Fatal(err)
-								}
-								introducedSpanFrontier, err := createIntroducedSpanFrontier(backups, hlc.Timestamp{})
-								require.NoError(b, err)
+							for _, hasExternalFilesList := range []bool{true, false} {
+								b.Run(fmt.Sprintf("hasExternalFilesList=%t", hasExternalFilesList),
+									func(b *testing.B) {
+										backups, err := MockBackupChain(ctx, numBackups, numSpans, baseFiles, r, hasExternalFilesList, execCfg)
+										require.NoError(b, err)
+										b.ResetTimer()
+										for i := 0; i < b.N; i++ {
+											if err := checkCoverage(ctx, backups[numBackups-1].Spans, backups); err != nil {
+												b.Fatal(err)
+											}
+											introducedSpanFrontier, err := createIntroducedSpanFrontier(backups, hlc.Timestamp{})
+											require.NoError(b, err)
 
-								cov := makeSimpleImportSpans(backups[numBackups-1].Spans, backups, nil, introducedSpanFrontier, nil, 0)
-								b.ReportMetric(float64(len(cov)), "coverSize")
+											layerToBackupManifestFileIterFactory, err := getBackupManifestFileIters(ctx, &execCfg,
+												backups, nil, nil)
+											require.NoError(b, err)
+											cov, err := makeSimpleImportSpans(backups[numBackups-1].Spans, backups,
+												layerToBackupManifestFileIterFactory, nil, introducedSpanFrontier,
+												nil, 0)
+											require.NoError(b, err)
+											b.ReportMetric(float64(len(cov)), "coverSize")
+										}
+									})
 							}
 						})
 					}

--- a/pkg/ccl/backupccl/restore_span_covering_test.go
+++ b/pkg/ccl/backupccl/restore_span_covering_test.go
@@ -9,15 +9,19 @@
 package backupccl
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backupinfo"
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backuppb"
+	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/cloud/cloudpb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -27,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	spanUtils "github.com/cockroachdb/cockroach/pkg/util/span"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -36,7 +41,13 @@ import (
 // reintroduces a span. On a random backup, one random span is dropped and
 // another is added. Incremental backups have half as many files as the base.
 // Files spans are ordered by start key but may overlap.
-func MockBackupChain(length, spans, baseFiles int, r *rand.Rand) []backuppb.BackupManifest {
+func MockBackupChain(
+	ctx context.Context,
+	length, spans, baseFiles int,
+	r *rand.Rand,
+	hasExternalFilesList bool,
+	execCfg sql.ExecutorConfig,
+) ([]backuppb.BackupManifest, error) {
 	backups := make([]backuppb.BackupManifest, length)
 	ts := hlc.Timestamp{WallTime: time.Second.Nanoseconds()}
 
@@ -51,6 +62,7 @@ func MockBackupChain(length, spans, baseFiles int, r *rand.Rand) []backuppb.Back
 	}
 
 	for i := range backups {
+		backups[i].HasExternalFilesList = hasExternalFilesList
 		backups[i].Spans = make(roachpb.Spans, spans)
 		backups[i].IntroducedSpans = make(roachpb.Spans, 0)
 		for j := range backups[i].Spans {
@@ -95,10 +107,28 @@ func MockBackupChain(length, spans, baseFiles int, r *rand.Rand) []backuppb.Back
 			backups[i].Files[f].Path = fmt.Sprintf("12345-b%d-f%d.sst", i, f)
 			backups[i].Files[f].EntryCounts.DataSize = 1 << 20
 		}
+
+		config := cloudpb.ExternalStorage{S3Config: &cloudpb.ExternalStorage_S3{}}
+		if backups[i].HasExternalFilesList {
+			// Write the Files to an SST and put them at a well known location.
+			es, err := execCfg.DistSQLSrv.ExternalStorageFromURI(ctx,
+				fmt.Sprintf("nodelocal://1/mock%s", timeutil.Now().String()), username.RootUserName())
+			if err != nil {
+				return nil, err
+			}
+			config = es.Conf()
+			manifestCopy := backups[i]
+			err = backupinfo.WriteFilesListSST(ctx, es, nil, nil, &manifestCopy,
+				backupinfo.BackupMetadataFilesListPath)
+			if err != nil {
+				return nil, err
+			}
+			backups[i].Files = nil
+		}
 		// A non-nil Dir more accurately models the footprint of produced coverings.
-		backups[i].Dir = cloudpb.ExternalStorage{S3Config: &cloudpb.ExternalStorage_S3{}}
+		backups[i].Dir = config
 	}
-	return backups
+	return backups, nil
 }
 
 // checkRestoreCovering verifies that a covering actually uses every span of
@@ -116,10 +146,12 @@ func MockBackupChain(length, spans, baseFiles int, r *rand.Rand) []backuppb.Back
 //
 // The function also verifies that a cover does not cross a span boundary.
 func checkRestoreCovering(
+	ctx context.Context,
 	backups []backuppb.BackupManifest,
 	spans roachpb.Spans,
 	cov []execinfrapb.RestoreSpanEntry,
 	merged bool,
+	storageFactory cloud.ExternalStorageFactory,
 ) error {
 	var expectedPartitions int
 	required := make(map[string]*roachpb.SpanGroup)
@@ -148,7 +180,13 @@ func checkRestoreCovering(
 				// for explanation.
 				continue
 			}
-			for _, f := range b.Files {
+			it, err := makeBackupManifestFileIterator(ctx, storageFactory, b,
+				nil, nil)
+			if err != nil {
+				return err
+			}
+			defer it.close()
+			for f, hasNext := it.next(); hasNext; f, hasNext = it.next() {
 				if sp := span.Intersect(f.Span); sp.Valid() {
 					if required[f.Path] == nil {
 						required[f.Path] = &roachpb.SpanGroup{}
@@ -159,6 +197,9 @@ func checkRestoreCovering(
 						expectedPartitions++
 					}
 				}
+			}
+			if it.err() != nil {
+				return it.err()
 			}
 		}
 	}
@@ -193,6 +234,9 @@ const noSpanTargetSize = 0
 
 func TestRestoreEntryCoverExample(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	tc, _, _, cleanupFn := backupRestoreTestSetup(t, singleNode, 1, InitManualReplication)
+	defer cleanupFn()
 
 	sp := func(start, end string) roachpb.Span {
 		return roachpb.Span{Key: roachpb.Key(start), EndKey: roachpb.Key(end)}
@@ -230,7 +274,13 @@ func TestRestoreEntryCoverExample(t *testing.T) {
 	emptySpanFrontier, err := spanUtils.MakeFrontier(roachpb.Span{})
 	require.NoError(t, err)
 
-	cover := makeSimpleImportSpans(spans, backups, nil, emptySpanFrontier, nil, noSpanTargetSize)
+	execCfg := tc.Server(0).ExecutorConfig().(sql.ExecutorConfig)
+	layerToBackupManifestFileIterFactory, err := getBackupManifestFileIters(ctx, &execCfg,
+		backups, nil, nil)
+	require.NoError(t, err)
+	cover, err := makeSimpleImportSpans(spans, backups, layerToBackupManifestFileIterFactory, nil,
+		emptySpanFrontier, nil, noSpanTargetSize)
+	require.NoError(t, err)
 	require.Equal(t, []execinfrapb.RestoreSpanEntry{
 		{Span: sp("a", "c"), Files: paths("1", "4", "6")},
 		{Span: sp("c", "e"), Files: paths("2", "4", "6")},
@@ -239,7 +289,9 @@ func TestRestoreEntryCoverExample(t *testing.T) {
 		{Span: sp("l", "m"), Files: paths("9")},
 	}, cover)
 
-	coverSized := makeSimpleImportSpans(spans, backups, nil, emptySpanFrontier, nil, 2<<20)
+	coverSized, err := makeSimpleImportSpans(spans, backups, layerToBackupManifestFileIterFactory,
+		nil, emptySpanFrontier, nil, 2<<20)
+	require.NoError(t, err)
 	require.Equal(t, []execinfrapb.RestoreSpanEntry{
 		{Span: sp("a", "f"), Files: paths("1", "2", "4", "6")},
 		{Span: sp("f", "i"), Files: paths("3", "5", "6", "8")},
@@ -251,8 +303,9 @@ func TestRestoreEntryCoverExample(t *testing.T) {
 	introducedSpanFrontier, err := createIntroducedSpanFrontier(backups, hlc.Timestamp{})
 	require.NoError(t, err)
 
-	coverIntroduced := makeSimpleImportSpans(spans, backups, nil, introducedSpanFrontier, nil,
+	coverIntroduced, err := makeSimpleImportSpans(spans, backups, layerToBackupManifestFileIterFactory, nil, introducedSpanFrontier, nil,
 		noSpanTargetSize)
+	require.NoError(t, err)
 	require.Equal(t, []execinfrapb.RestoreSpanEntry{
 		{Span: sp("a", "f"), Files: paths("6")},
 		{Span: sp("f", "i"), Files: paths("3", "5", "6", "8")},
@@ -330,10 +383,10 @@ func createMockManifest(
 func TestRestoreEntryCoverReIntroducedSpans(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	codec := keys.SystemSQLCodec
-	execCfg := &sql.ExecutorConfig{
-		Codec: codec,
-	}
+	ctx := context.Background()
+	tc, _, _, cleanupFn := backupRestoreTestSetup(t, singleNode, 1, InitManualReplication)
+	defer cleanupFn()
+	execCfg := tc.Server(0).ExecutorConfig().(sql.ExecutorConfig)
 
 	testCases := []struct {
 		name string
@@ -441,32 +494,37 @@ func TestRestoreEntryCoverReIntroducedSpans(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			backups := []backuppb.BackupManifest{
-				createMockManifest(t, execCfg, test.full, hlc.Timestamp{WallTime: int64(1)}, fullBackupPath),
-				createMockManifest(t, execCfg, test.inc, hlc.Timestamp{WallTime: int64(2)}, incBackupPath),
+				createMockManifest(t, &execCfg, test.full, hlc.Timestamp{WallTime: int64(1)}, fullBackupPath),
+				createMockManifest(t, &execCfg, test.inc, hlc.Timestamp{WallTime: int64(2)}, incBackupPath),
 			}
 
 			// Create the IntroducedSpans field for incremental backup.
 			incTables, reIntroducedTables := createMockTables(test.inc)
 
 			newSpans := filterSpans(backups[1].Spans, backups[0].Spans)
-			reIntroducedSpans, err := spansForAllTableIndexes(execCfg, reIntroducedTables, nil)
+			reIntroducedSpans, err := spansForAllTableIndexes(&execCfg, reIntroducedTables, nil)
 			require.NoError(t, err)
 			backups[1].IntroducedSpans = append(newSpans, reIntroducedSpans...)
 
-			restoreSpans := spansForAllRestoreTableIndexes(codec, incTables, nil, false)
+			restoreSpans := spansForAllRestoreTableIndexes(execCfg.Codec, incTables, nil, false)
 			require.Equal(t, test.expectedRestoreSpanCount, len(restoreSpans))
 
 			introducedSpanFrontier, err := createIntroducedSpanFrontier(backups, hlc.Timestamp{})
 			require.NoError(t, err)
 
-			cover := makeSimpleImportSpans(restoreSpans, backups, nil, introducedSpanFrontier, nil, 0)
+			layerToBackupManifestFileIterFactory, err := getBackupManifestFileIters(ctx,
+				&execCfg, backups, nil, nil)
+			require.NoError(t, err)
+			cover, err := makeSimpleImportSpans(restoreSpans, backups, layerToBackupManifestFileIterFactory,
+				nil, introducedSpanFrontier, nil, 0)
+			require.NoError(t, err)
 
 			for _, reIntroTable := range reIntroducedTables {
 				var coveredReIntroducedGroup roachpb.SpanGroup
 				for _, entry := range cover {
 					// If a restoreSpanEntry overlaps with re-introduced span,
 					// assert the entry only contains files from the incremental backup.
-					if reIntroTable.TableSpan(codec).Overlaps(entry.Span) {
+					if reIntroTable.TableSpan(execCfg.Codec).Overlaps(entry.Span) {
 						coveredReIntroducedGroup.Add(entry.Span)
 						for _, files := range entry.Files {
 							require.Equal(t, incBackupPath, files.Path)
@@ -474,7 +532,7 @@ func TestRestoreEntryCoverReIntroducedSpans(t *testing.T) {
 					}
 				}
 				// Assert that all re-introduced indexes are included in the restore
-				for _, reIntroIndexSpan := range reIntroTable.AllIndexSpans(codec) {
+				for _, reIntroIndexSpan := range reIntroTable.AllIndexSpans(execCfg.Codec) {
 					require.Equal(t, true, coveredReIntroducedGroup.Encloses(reIntroIndexSpan))
 				}
 			}
@@ -485,20 +543,35 @@ func TestRestoreEntryCoverReIntroducedSpans(t *testing.T) {
 func TestRestoreEntryCover(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	r, _ := randutil.NewTestRand()
+	ctx := context.Background()
+	tc, _, _, cleanupFn := backupRestoreTestSetup(t, singleNode, 1, InitManualReplication)
+	defer cleanupFn()
+	execCfg := tc.Server(0).ExecutorConfig().(sql.ExecutorConfig)
+
 	for _, numBackups := range []int{1, 2, 3, 5, 9, 10, 11, 12} {
 		for _, spans := range []int{1, 2, 3, 5, 9, 11, 12} {
 			for _, files := range []int{0, 1, 2, 3, 4, 10, 12, 50} {
-				backups := MockBackupChain(numBackups, spans, files, r)
+				for _, hasExternalFilesList := range []bool{true, false} {
+					backups, err := MockBackupChain(ctx, numBackups, spans, files, r, hasExternalFilesList, execCfg)
+					require.NoError(t, err)
 
-				for _, target := range []int64{0, 1, 4, 100, 1000} {
-					t.Run(fmt.Sprintf("numBackups=%d, numSpans=%d, numFiles=%d, merge=%d", numBackups, spans, files, target), func(t *testing.T) {
-						introducedSpanFrontier, err := createIntroducedSpanFrontier(backups, hlc.Timestamp{})
-						require.NoError(t, err)
-						cover := makeSimpleImportSpans(backups[numBackups-1].Spans, backups, nil,
-							introducedSpanFrontier, nil,
-							target<<20)
-						require.NoError(t, checkRestoreCovering(backups, backups[numBackups-1].Spans, cover, target != noSpanTargetSize))
-					})
+					for _, target := range []int64{0, 1, 4, 100, 1000} {
+						t.Run(fmt.Sprintf("numBackups=%d, numSpans=%d, numFiles=%d, merge=%d, slim=%t",
+							numBackups, spans, files, target, hasExternalFilesList), func(t *testing.T) {
+							introducedSpanFrontier, err := createIntroducedSpanFrontier(backups, hlc.Timestamp{})
+							require.NoError(t, err)
+
+							layerToBackupManifestFileIterFactory, err := getBackupManifestFileIters(ctx,
+								&execCfg, backups, nil, nil)
+							require.NoError(t, err)
+							cover, err := makeSimpleImportSpans(backups[numBackups-1].Spans, backups,
+								layerToBackupManifestFileIterFactory, nil, introducedSpanFrontier,
+								nil, target<<20)
+							require.NoError(t, err)
+							require.NoError(t, checkRestoreCovering(ctx, backups, backups[numBackups-1].Spans,
+								cover, target != noSpanTargetSize, execCfg.DistSQLSrv.ExternalStorage))
+						})
+					}
 				}
 			}
 		}

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -401,6 +401,8 @@ you must pass the 'encryption_info_dir' parameter that points to the directory o
 		)
 		info.collectionURI = dest[0]
 		info.subdir = computedSubdir
+		info.kmsEnv = &kmsEnv
+		info.enc = encryption
 
 		mkStore := p.ExecCfg().DistSQLSrv.ExternalStorageFromURI
 		incStores, cleanupFn, err := backupdest.MakeBackupDestinationStores(ctx, p.User(), mkStore,
@@ -459,9 +461,7 @@ you must pass the 'encryption_info_dir' parameter that points to the directory o
 			}
 		}
 		if _, ok := opts[backupOptCheckFiles]; ok {
-			fileSizes, err := checkBackupFiles(ctx, info,
-				p.ExecCfg().DistSQLSrv.ExternalStorageFromURI,
-				p.User())
+			fileSizes, err := checkBackupFiles(ctx, info, p.ExecCfg(), p.User(), encryption, &kmsEnv)
 			if err != nil {
 				return err
 			}
@@ -493,7 +493,7 @@ func getBackupInfoReader(p sql.PlanHookState, backup *tree.ShowBackup) backupInf
 		case tree.BackupRangeDetails:
 			shower = backupShowerRanges
 		case tree.BackupFileDetails:
-			shower = backupShowerFileSetup(backup.InCollection)
+			shower = backupShowerFileSetup(p, backup.InCollection)
 		case tree.BackupSchemaDetails:
 			shower = backupShowerDefault(p, true, backup.Options)
 		case tree.BackupValidateDetails:
@@ -511,8 +511,10 @@ func getBackupInfoReader(p sql.PlanHookState, backup *tree.ShowBackup) backupInf
 func checkBackupFiles(
 	ctx context.Context,
 	info backupInfo,
-	storeFactory cloud.ExternalStorageFromURIFactory,
+	execCfg *sql.ExecutorConfig,
 	user username.SQLUsername,
+	encryption *jobspb.BackupEncryptionOptions,
+	kmsEnv cloud.KMSEnv,
 ) ([][]int64, error) {
 	const maxMissingFiles = 10
 	missingFiles := make(map[string]struct{}, maxMissingFiles)
@@ -521,7 +523,7 @@ func checkBackupFiles(
 		// TODO (msbutler): Right now, checkLayer opens stores for each backup layer. In 22.2,
 		// once a backup chain cannot have mixed localities, only create stores for full backup
 		// and first incremental backup.
-		defaultStore, err := storeFactory(ctx, info.defaultURIs[layer], user)
+		defaultStore, err := execCfg.DistSQLSrv.ExternalStorageFromURI(ctx, info.defaultURIs[layer], user)
 		if err != nil {
 			return nil, err
 		}
@@ -562,7 +564,7 @@ func checkBackupFiles(
 		}
 
 		for locality, uri := range info.localityInfo[layer].URIsByOriginalLocalityKV {
-			store, err := storeFactory(ctx, uri, user)
+			store, err := execCfg.DistSQLSrv.ExternalStorageFromURI(ctx, uri, user)
 			if err != nil {
 				return nil, err
 			}
@@ -570,8 +572,14 @@ func checkBackupFiles(
 		}
 
 		// Check all backup SSTs.
-		fileSizes := make([]int64, len(info.manifests[layer].Files))
-		for i, f := range info.manifests[layer].Files {
+		fileSizes := make([]int64, 0)
+		it, err := makeBackupManifestFileIterator(ctx, execCfg.DistSQLSrv.ExternalStorage,
+			info.manifests[layer], encryption, kmsEnv)
+		if err != nil {
+			return nil, err
+		}
+		defer it.close()
+		for f, hasNext := it.next(); hasNext; f, hasNext = it.next() {
 			store := defaultStore
 			uri := info.defaultURIs[layer]
 			if _, ok := localityStores[f.LocalityKV]; ok {
@@ -590,7 +598,10 @@ func checkBackupFiles(
 				}
 				continue
 			}
-			fileSizes[i] = sz
+			fileSizes = append(fileSizes, sz)
+		}
+		if it.err() != nil {
+			return nil, it.err()
 		}
 
 		return fileSizes, nil
@@ -629,6 +640,7 @@ type backupInfo struct {
 	subdir        string
 	localityInfo  []jobspb.RestoreDetails_BackupLocalityInfo
 	enc           *jobspb.BackupEncryptionOptions
+	kmsEnv        cloud.KMSEnv
 	fileSizes     [][]int64
 }
 
@@ -694,7 +706,6 @@ func backupShowerDefault(p sql.PlanHookState, showSchemas bool, opts tree.KVOpti
 
 			var rows []tree.Datums
 			for layer, manifest := range info.manifests {
-				ctx, sp := tracing.ChildSpan(ctx, "backupccl.backupShowerDefault.fn.layer")
 				descriptors, err := backupinfo.BackupManifestDescriptors(&manifest)
 				if err != nil {
 					return nil, err
@@ -749,7 +760,8 @@ func backupShowerDefault(p sql.PlanHookState, showSchemas bool, opts tree.KVOpti
 				if len(info.fileSizes) > 0 {
 					fileSizes = info.fileSizes[layer]
 				}
-				tableSizes, err := getTableSizes(ctx, manifest.Files, fileSizes)
+
+				tableSizes, err := getTableSizes(ctx, p.ExecCfg().DistSQLSrv.ExternalStorage, info, manifest, fileSizes)
 				if err != nil {
 					return nil, err
 				}
@@ -917,7 +929,6 @@ func backupShowerDefault(p sql.PlanHookState, showSchemas bool, opts tree.KVOpti
 					}
 					rows = append(rows, row)
 				}
-				sp.Finish()
 			}
 			return rows, nil
 		},
@@ -932,16 +943,29 @@ type descriptorSize struct {
 // getLogicalSSTSize gets the total logical bytes stored in each SST. Note that a
 // BackupManifest_File identifies a span in an SST and there can be multiple
 // spans stored in an SST.
-func getLogicalSSTSize(ctx context.Context, files []backuppb.BackupManifest_File) map[string]int64 {
+func getLogicalSSTSize(
+	ctx context.Context,
+	storeFactory cloud.ExternalStorageFactory,
+	manifest backuppb.BackupManifest,
+	enc *jobspb.BackupEncryptionOptions,
+	kmsEnv cloud.KMSEnv,
+) (map[string]int64, error) {
 	ctx, span := tracing.ChildSpan(ctx, "backupccl.getLogicalSSTSize")
 	defer span.Finish()
-	_ = ctx
 
 	sstDataSize := make(map[string]int64)
-	for _, file := range files {
-		sstDataSize[file.Path] += file.EntryCounts.DataSize
+	it, err := makeBackupManifestFileIterator(ctx, storeFactory, manifest, enc, kmsEnv)
+	if err != nil {
+		return nil, err
 	}
-	return sstDataSize
+	defer it.close()
+	for f, hasNext := it.next(); hasNext; f, hasNext = it.next() {
+		sstDataSize[f.Path] += f.EntryCounts.DataSize
+	}
+	if it.err() != nil {
+		return nil, it.err()
+	}
+	return sstDataSize, nil
 }
 
 // approximateSpanPhysicalSize approximates the number of bytes written to disk for the span.
@@ -953,24 +977,39 @@ func approximateSpanPhysicalSize(
 
 // getTableSizes gathers row and size count for each table in the manifest
 func getTableSizes(
-	ctx context.Context, files []backuppb.BackupManifest_File, fileSizes []int64,
+	ctx context.Context,
+	storeFactory cloud.ExternalStorageFactory,
+	info backupInfo,
+	manifest backuppb.BackupManifest,
+	fileSizes []int64,
 ) (map[descpb.ID]descriptorSize, error) {
 	ctx, span := tracing.ChildSpan(ctx, "backupccl.getTableSizes")
 	defer span.Finish()
 
-	tableSizes := make(map[descpb.ID]descriptorSize)
-	if len(files) == 0 {
-		return tableSizes, nil
-	}
-	_, tenantID, err := keys.DecodeTenantPrefix(files[0].Span.Key)
+	logicalSSTSize, err := getLogicalSSTSize(ctx, storeFactory, manifest, info.enc, info.kmsEnv)
 	if err != nil {
 		return nil, err
 	}
-	showCodec := keys.MakeSQLCodec(tenantID)
 
-	logicalSSTSize := getLogicalSSTSize(ctx, files)
+	it, err := makeBackupManifestFileIterator(ctx, storeFactory, manifest, info.enc, info.kmsEnv)
+	if err != nil {
+		return nil, err
+	}
+	defer it.close()
+	tableSizes := make(map[descpb.ID]descriptorSize)
+	var tenantID roachpb.TenantID
+	var showCodec keys.SQLCodec
+	var idx int
+	for f, hasNext := it.next(); hasNext; f, hasNext = it.next() {
+		if !tenantID.IsSet() {
+			var err error
+			_, tenantID, err = keys.DecodeTenantPrefix(f.Span.Key)
+			if err != nil {
+				return nil, err
+			}
+			showCodec = keys.MakeSQLCodec(tenantID)
+		}
 
-	for i, file := range files {
 		// TODO(dan): This assumes each file in the backup only
 		// contains data from a single table, which is usually but
 		// not always correct. It does not account for a BACKUP that
@@ -980,18 +1019,23 @@ func getTableSizes(
 		// TODO(msbutler): after handling the todo above, understand whether
 		// we should return an error if a key does not have tableId. The lack
 		// of error handling let #77705 sneak by our unit tests.
-		_, tableID, err := showCodec.DecodeTablePrefix(file.Span.Key)
+		_, tableID, err := showCodec.DecodeTablePrefix(f.Span.Key)
 		if err != nil {
 			continue
 		}
 		s := tableSizes[descpb.ID(tableID)]
-		s.rowCount.Add(file.EntryCounts)
+		s.rowCount.Add(f.EntryCounts)
 		if len(fileSizes) > 0 {
-			s.fileSize += approximateSpanPhysicalSize(file.EntryCounts.DataSize, logicalSSTSize[file.Path],
-				fileSizes[i])
+			s.fileSize += approximateSpanPhysicalSize(f.EntryCounts.DataSize, logicalSSTSize[f.Path],
+				fileSizes[idx])
 		}
 		tableSizes[descpb.ID(tableID)] = s
+		idx++
 	}
+	if it.err() != nil {
+		return nil, it.err()
+	}
+
 	return tableSizes, nil
 }
 
@@ -1190,7 +1234,9 @@ var backupShowerDoctor = backupShower{
 	},
 }
 
-func backupShowerFileSetup(inCol tree.StringOrPlaceholderOptList) backupShower {
+func backupShowerFileSetup(
+	p sql.PlanHookState, inCol tree.StringOrPlaceholderOptList,
+) backupShower {
 	return backupShower{header: colinfo.ResultColumns{
 		{Name: "path", Typ: types.String},
 		{Name: "backup_type", Typ: types.String},
@@ -1224,8 +1270,20 @@ func backupShowerFileSetup(inCol tree.StringOrPlaceholderOptList) backupShower {
 					backupType = "incremental"
 				}
 
-				logicalSSTSize := getLogicalSSTSize(ctx, manifest.Files)
-				for j, file := range manifest.Files {
+				logicalSSTSize, err := getLogicalSSTSize(ctx, p.ExecCfg().DistSQLSrv.ExternalStorage, manifest,
+					info.enc, info.kmsEnv)
+				if err != nil {
+					return nil, err
+				}
+
+				it, err := makeBackupManifestFileIterator(ctx, p.ExecCfg().DistSQLSrv.ExternalStorage,
+					manifest, info.enc, info.kmsEnv)
+				if err != nil {
+					return nil, err
+				}
+				defer it.close()
+				var idx int
+				for file, hasNext := it.next(); hasNext; file, hasNext = it.next() {
 					filePath := file.Path
 					if inCol != nil {
 						filePath = path.Join(manifestDirs[i], filePath)
@@ -1240,7 +1298,7 @@ func backupShowerFileSetup(inCol tree.StringOrPlaceholderOptList) backupShower {
 					sz := int64(-1)
 					if len(info.fileSizes) > 0 {
 						sz = approximateSpanPhysicalSize(file.EntryCounts.DataSize,
-							logicalSSTSize[file.Path], info.fileSizes[i][j])
+							logicalSSTSize[file.Path], info.fileSizes[i][idx])
 					}
 					rows = append(rows, tree.Datums{
 						tree.NewDString(filePath),
@@ -1254,6 +1312,10 @@ func backupShowerFileSetup(inCol tree.StringOrPlaceholderOptList) backupShower {
 						tree.NewDString(locality),
 						tree.NewDInt(tree.DInt(sz)),
 					})
+					idx++
+				}
+				if it.err() != nil {
+					return nil, it.err()
 				}
 			}
 			return rows, nil


### PR DESCRIPTION
Repeated fields in a backup's manifest do not scale well as
the amount of backed up data, and the length of the incremental
chain of backup grows. This has been a problem we have been aware
of, and has motivated us to incrementally move all repeated fields
out of the manifest and into their standalone metadata SST files.
The advantage of this is that during incremental backups or restores
we do not need to perform large allocations when unmarshalling the
manifest, but instead stream results from the relevant SST as and
when we need them. In support issues such as
https://github.com/cockroachdb/cockroach/issues/93272 we have seen this
unmarshalling step results in OOMs thereby preventing further incremental
backups, or making the backups unrestoreable. Efforts for moving backup,
and restore to have all their metadata in SSTs and rely on streaming reads
and writes is ongoing but outside the scope of this patch.

This patch is meant to be a targetted fix with an eye for backports.
Past experimentation has shown us that the `Files` repeated field in the
manifest is the largest cause of bloated, unmarshalable manifests. This change
teaches backup to continue writing a manifest file, but a slimmer one
with the `Files` field nil'ed out. The values in the `Files` field are
instead written to an SST file that sits alongside the `SLIM_BACKUP_MANIFEST`.
To maintain mixed-version compatability with nodes that rely on a regular
manifest, we continue to write a `BACKUP_MANIFEST` alongside its slim version.
On the read path, we add an optimization that first reads the slim
manifest if present. This way we avoid unmarshalling the alloc heavy
`Files` field, and instead teach all the places in the code that need the
`Files` to reach out to the metadata SST and read the values one by one. To
support both the slim and not-so-slim manifests we introduce an interface
that iterates over the Files depending on the manifest passed to it.

To reiterate, this work is a subset of the improvements we will get
from moving all repeated fields to SSTs and is expected to be superseded
by those efforts when they come to fruition.

Fixes: https://github.com/cockroachdb/cockroach/issues/93272

Release note (performance improvement): long chains of incremental backups
and restore of such chains will now allocate less memory during the unmarshaling
of metadata