### PR TITLE
streamingccl: add WITH RETENTION option to CREATE TENANT

### DIFF
--- a/docs/generated/sql/bnf/create_tenant_stmt.bnf
+++ b/docs/generated/sql/bnf/create_tenant_stmt.bnf
@@ -1,3 +1,3 @@
 create_tenant_stmt ::=
 	'CREATE' 'TENANT' name
-	| 'CREATE' 'TENANT' name 'FROM' 'REPLICATION' 'OF' name 'ON' string_or_placeholder
+	| 'CREATE' 'TENANT' name 'FROM' 'REPLICATION' 'OF' name 'ON' string_or_placeholder opt_with_tenant_replication_options

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -588,7 +588,7 @@ create_external_connection_stmt ::=
 
 create_tenant_stmt ::=
 	'CREATE' 'TENANT' name
-	| 'CREATE' 'TENANT' name 'FROM' 'REPLICATION' 'OF' name 'ON' string_or_placeholder
+	| 'CREATE' 'TENANT' name 'FROM' 'REPLICATION' 'OF' name 'ON' string_or_placeholder opt_with_tenant_replication_options
 
 create_schedule_stmt ::=
 	create_schedule_for_changefeed_stmt
@@ -1299,6 +1299,7 @@ unreserved_keyword ::=
 	| 'RESTRICT'
 	| 'RESTRICTED'
 	| 'RESUME'
+	| 'RETENTION'
 	| 'RETRY'
 	| 'RETURN'
 	| 'RETURNS'
@@ -1735,6 +1736,11 @@ changefeed_target_expr ::=
 label_spec ::=
 	string_or_placeholder
 	| 'IF' 'NOT' 'EXISTS' string_or_placeholder
+
+opt_with_tenant_replication_options ::=
+	'WITH' tenant_replication_options_list
+	| 'WITH' 'OPTIONS' '(' tenant_replication_options_list ')'
+	| 
 
 create_schedule_for_changefeed_stmt ::=
 	'CREATE' 'SCHEDULE' schedule_label_spec 'FOR' 'CHANGEFEED' changefeed_targets changefeed_sink opt_with_options cron_expr opt_with_schedule_options
@@ -2457,6 +2463,9 @@ target_elem ::=
 	| a_expr
 	| '*'
 
+tenant_replication_options_list ::=
+	( tenant_replication_options ) ( ( ',' tenant_replication_options ) )*
+
 schedule_label_spec ::=
 	label_spec
 	| 
@@ -3029,6 +3038,9 @@ target_name ::=
 bare_col_label ::=
 	'identifier'
 	| bare_label_keywords
+
+tenant_replication_options ::=
+	'RETENTION' '=' string_or_placeholder
 
 common_table_expr ::=
 	table_alias_name opt_col_def_list_no_types 'AS' '(' preparable_stmt ')'

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1638,10 +1638,6 @@ type StreamingTestingKnobs struct {
 	// frontier specs generated for the replication job.
 	AfterReplicationFlowPlan func([]*execinfrapb.StreamIngestionDataSpec,
 		*execinfrapb.StreamIngestionFrontierSpec)
-
-	// OverrideReplicationTTLSeconds will override the default value of the
-	// `ReplicationTTLSeconds` field on the StreamIngestion job details.
-	OverrideReplicationTTLSeconds int
 }
 
 var _ base.ModuleTestingKnobs = &StreamingTestingKnobs{}

--- a/pkg/sql/parser/testdata/create_tenant
+++ b/pkg/sql/parser/testdata/create_tenant
@@ -29,3 +29,19 @@ CREATE TENANT "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON 'pgurl
 CREATE TENANT "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON ('pgurl') -- fully parenthesized
 CREATE TENANT "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON '_' -- literals removed
 CREATE TENANT _ FROM REPLICATION OF _ ON 'pgurl' -- identifiers removed
+
+parse
+CREATE TENANT "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON 'pgurl' WITH RETENTION = '36h'
+----
+CREATE TENANT "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON 'pgurl' WITH RETENTION = '36h'
+CREATE TENANT "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON ('pgurl') WITH RETENTION = ('36h') -- fully parenthesized
+CREATE TENANT "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON '_' WITH RETENTION = '_' -- literals removed
+CREATE TENANT _ FROM REPLICATION OF _ ON 'pgurl' WITH RETENTION = '36h' -- identifiers removed
+
+parse
+CREATE TENANT "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON 'pgurl' WITH OPTIONS (RETENTION = '36h')
+----
+CREATE TENANT "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON 'pgurl' WITH RETENTION = '36h' -- normalized!
+CREATE TENANT "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON ('pgurl') WITH RETENTION = ('36h') -- fully parenthesized
+CREATE TENANT "destination-hyphen" FROM REPLICATION OF "source-hyphen" ON '_' WITH RETENTION = '_' -- literals removed
+CREATE TENANT _ FROM REPLICATION OF _ ON 'pgurl' WITH RETENTION = '36h' -- identifiers removed


### PR DESCRIPTION
This adds an WITH RETENTION = 'duration' option to CREATE TENANT to allow the user to set the retention window at replication stream creation time.

A future commit will support updating this option via SET as well.

Informs: #93441

Release note: None