### PR TITLE
sql: explicitly add partialPredicate and fullStatisticID columns to system.table_statistics family

### DIFF
--- a/pkg/upgrade/upgrades/alter_table_statistics_partial_predicate_and_id.go
+++ b/pkg/upgrade/upgrades/alter_table_statistics_partial_predicate_and_id.go
@@ -21,8 +21,10 @@ import (
 
 const addPartialStatisticsPredicateAndIDCol = `
 ALTER TABLE system.table_statistics
-ADD COLUMN IF NOT EXISTS "partialPredicate" STRING,
-ADD COLUMN IF NOT EXISTS "fullStatisticID" INT8`
+ADD COLUMN IF NOT EXISTS "partialPredicate" STRING
+FAMILY "fam_0_tableID_statisticID_name_columnIDs_createdAt_rowCount_distinctCount_nullCount_histogram",
+ADD COLUMN IF NOT EXISTS "fullStatisticID" INT8
+FAMILY "fam_0_tableID_statisticID_name_columnIDs_createdAt_rowCount_distinctCount_nullCount_histogram"`
 
 func alterSystemTableStatisticsAddPartialPredicateAndID(
 	ctx context.Context, cs clusterversion.ClusterVersion, d upgrade.TenantDeps,


### PR DESCRIPTION
Previously, the newly added migration
addPartialStatatisticsPredicateAndIDCol did not explicitly include the two new columns in the system.table_statistics column family. This caused a randomized test failure in systemschema/validate-after-version-upgrade. This commit adds them to the column family.

Epic: CRDB-19449

Resolves: #93850

Release note: None