### PR TITLE
ui: Building protobuf-client for Cluster UI

### DIFF
--- a/.github/workflows/cluster-ui-release-next.yml
+++ b/.github/workflows/cluster-ui-release-next.yml
@@ -1,5 +1,6 @@
 name: Publish Cluster UI Pre-release
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
@@ -52,10 +53,14 @@ jobs:
         fi
 
     - name: Build Cluster UI
+      if: steps.version-check.outputs.published == 'no'
       run: |
         yarn install --frozen-lockfile
-        bazel build //pkg/ui/workspaces/cluster-ui:cluster-ui
+        bazel build //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client
+        cp _bazel/bin/pkg/ui/workspaces/db-console/src/js/protos.* pkg/ui/workspaces/db-console/src/js/
+        npm run build
 
     - name: Publish prerelease version
       if: steps.version-check.outputs.published == 'no'
-      run: npm publish --access public --tag next --dry-run
+      run: |
+        npm publish --access public --tag next --ignore-scripts --dry-run

--- a/pkg/ui/workspaces/cluster-ui/.npmignore
+++ b/pkg/ui/workspaces/cluster-ui/.npmignore
@@ -21,3 +21,6 @@ enzyme.setup.js
 # project configs
 *.config.js
 tsconfig.json
+
+# bazel module mappings
+*.module_mappings.json

--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -8,6 +8,9 @@
   },
   "main": "dist/js/main.js",
   "types": "dist/types/index.d.ts",
+  "files": [
+    "dist/"
+  ],
   "scripts": {
     "build": "npm-run-all -p build:typescript build:bundle",
     "build:bundle": "NODE_ENV=production webpack --display-error-details --mode=production",
@@ -18,7 +21,6 @@
     "clean": "rm -rf  ./dist/*",
     "lint": "eslint './src/**/*.{tsx,ts,js}' --format=codeframe",
     "lint:fix": "eslint './src/**/*.{tsx,ts,js}' --format=codeframe --fix",
-    "prepublishOnly": "npm-run-all clean build",
     "test": "jest --watch",
     "start": "npm-run-all -p build:watch tsc:watch",
     "storybook": "start-storybook -p 6006",


### PR DESCRIPTION
On dry-run publishing, there is an npm life-cycle script that will run (`prepublishOnly`). This script will clean and rebuild Cluster-ui using the Typscript compiler for type generation and Webpack for the bundle. This is currently failing due to a dependence on
@cockroachlabs/crdb-protobuf-client, which is has not explicitly built as a part of the workflow.

To resolve this issue, I am removing the `prepublishOnly` script as it was an additional build step that was implicitly run as a part of `npm publish`. Then I am adding a step to `Build Cluster UI` to build the protobuf client with Bazel. Then I am copying the built files out of the bazel directory into the package directory and building the Cluster UI bundle with npm.

Epic: CC-7999
See also: CC-7959

Release note: None