### PR TITLE
release-22.1: sql: Define more columns in `pg_catalog.pg_statistic_ext`

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -5700,7 +5700,14 @@ statement ok
 CREATE TABLE stxtbl(a INT, b INT, c INT);
 CREATE STATISTICS stxobj ON b, c FROM stxtbl;
 
-query TTOOTTT colnames
+statement ok
+CREATE SCHEMA test;
+CREATE TABLE test.stxtbl2(a INT, b INT, c INT);
+CREATE STATISTICS stxobj2 ON a, c FROM test.stxtbl2;
+CREATE TABLE stx(stx) AS SELECT generate_series(1,100);
+ANALYZE stx;
+
+query TTOOITT colnames
 SELECT
   relname,
   stxname,
@@ -5713,7 +5720,10 @@ FROM pg_statistic_ext
 JOIN pg_class ON pg_statistic_ext.stxrelid = pg_class.oid
 ----
 relname  stxname  stxnamespace  stxowner  stxstattarget  stxkeys  stxkind
-stxtbl   stxobj   NULL          NULL      NULL           {2,3}    NULL
+stxtbl   stxobj   2178432656    NULL      -1             {2,3}    {d}
+stxtbl2  stxobj2  568579403     NULL      -1             {1,3}    {d}
+stx      NULL     2178432656    NULL      -1             {2}      {d}
+stx      NULL     2178432656    NULL      -1             {1}      {d}
 
 # Test that pg_shadow doesn't include roles that can't login
 query B colnames
@@ -5880,3 +5890,4 @@ WHERE
     AND t.typname LIKE 'myt%';
 ----
 0
+

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catprivilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
@@ -3275,8 +3276,12 @@ var pgCatalogStatisticExtTable = virtualSchemaTable{
 	comment: `pg_statistic_ext has the statistics objects created with CREATE STATISTICS
 https://www.postgresql.org/docs/13/catalog-pg-statistic-ext.html`,
 	schema: vtable.PgCatalogStatisticExt,
-	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		query := `SELECT "statisticID", name, "tableID", "columnIDs" FROM system.table_statistics;`
+	populate: func(ctx context.Context, p *planner, db catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+
+		//  '{d}' refers to Postgres code for n-distinct statistics or multi-column
+		//  statistics.
+		query := `SELECT "tableID", name, "columnIDs", "statisticID", '{d}'::"char"[] FROM system.table_statistics;`
+
 		rows, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.QueryBuffered(
 			ctx, "read-statistics-objects", p.txn, query,
 		)
@@ -3284,21 +3289,37 @@ https://www.postgresql.org/docs/13/catalog-pg-statistic-ext.html`,
 			return err
 		}
 
+		h := makeOidHasher()
+		statTgt := tree.NewDInt(-1)
+
 		for _, row := range rows {
-			statisticsID := tree.MustBeDInt(row[0])
-			name := tree.MustBeDString(row[1])
-			tableID := tree.MustBeDInt(row[2])
-			columnIDs := tree.MustBeDArray(row[3])
+			tableID := tree.MustBeDInt(row[0])
+			columnIDs := tree.MustBeDArray(row[2])
+			statisticsID := tree.MustBeDInt(row[3])
+			statisticsKind := tree.MustBeDArray(row[4])
+
+			// The statisticsID is generated from unique_rowid() so it won't fit in a
+			// uint32.
+			h.writeUInt64(uint64(statisticsID))
+			statisticsOID := h.getOid()
+
+			tn, err := descs.GetTableNameByID(ctx, p.Txn(), p.Descriptors(), descpb.ID(tableID))
+			if err != nil {
+				return err
+			}
+
+			statSchema := db.GetSchemaID(tn.Schema())
+			schemaOid := h.NamespaceOid(statSchema, tn.SchemaName.String())
 
 			if err := addRow(
-				tree.NewDOid(statisticsID), // oid
-				tree.NewDOid(tableID),      // stxrelid
-				&name,                      // stxname
-				tree.DNull,                 // stxnamespace
-				tree.DNull,                 // stxowner
-				tree.DNull,                 // stxstattarget
-				columnIDs,                  // stxkeys
-				tree.DNull,                 // stxkind
+				statisticsOID,                // oid
+				tableOid(descpb.ID(tableID)), // stxrelid
+				row[1],                       // stxname
+				schemaOid,                    // stxnamespace
+				tree.DNull,                   // stxowner
+				statTgt,                      // stxstattarget
+				columnIDs,                    // stxkeys
+				statisticsKind,               // stxkind
 			); err != nil {
 				return err
 			}


### PR DESCRIPTION
Backport 1/1 commits from #93274.

/cc @cockroachdb/release

---

Fixes: #88108
Fixes: #93430

This commit makes sure the `stxnamespace`, `stxkind` and `stxstattarget` columns are defined in `pg_statistics_ext`.

Release note: The `stxnamespace`, `stxkind` and
`stxstattarget` columns are now defined in
`pg_statistics_ext`.  Also `pg_statistics_ext` 
no longer crashes when stxname is null.

Release justification: Bug fix