### PR TITLE
workflow: Building protobuf-client for Cluster UI

### DIFF
--- a/.github/workflows/cluster-ui-release-next.yml
+++ b/.github/workflows/cluster-ui-release-next.yml
@@ -61,4 +61,4 @@ jobs:
 
     - name: Publish prerelease version
       if: steps.version-check.outputs.published == 'no'
-      run: npm publish --access public --tag next --dry-run
+      run: yarn publish --access public --tag next

--- a/.github/workflows/cluster-ui-release-next.yml
+++ b/.github/workflows/cluster-ui-release-next.yml
@@ -59,6 +59,13 @@ jobs:
         cp ../../../../_bazel/bin/pkg/ui/workspaces/db-console/src/js/protos.* ../db-console/src/js/
         yarn build
 
+    - name: Create version tag and push
+      if: steps.version-check.outputs.published == 'no'
+      run: |
+        TAGNAME="@cockroachlabs/cluster-ui@$(cat ./package.json | jq -r '.version')"
+        git tag $TAGNAME
+        git push origin $TAGNAME
+
     - name: Publish prerelease version
       if: steps.version-check.outputs.published == 'no'
       run: yarn publish --access public --tag next

--- a/.github/workflows/cluster-ui-release-next.yml
+++ b/.github/workflows/cluster-ui-release-next.yml
@@ -1,16 +1,16 @@
 name: Publish Cluster UI Pre-release
-on:
-  push:
-    branches:
-      - master
-    paths:
-      - 'pkg/ui/workspaces/cluster-ui/**/*.tsx?'
-      - 'pkg/ui/workspaces/cluster-ui/yarn.lock'
-      - 'pkg/ui/workspaces/cluster-ui/package.json'
+on: [workflow_dispatch]
+#  push:
+#    branches:
+#      - master
+#    paths:
+#      - 'pkg/ui/workspaces/cluster-ui/**/*.tsx?'
+#      - 'pkg/ui/workspaces/cluster-ui/yarn.lock'
+#      - 'pkg/ui/workspaces/cluster-ui/package.json'
+
 
 jobs:
   publish_cluster_ui:
-    if: github.repository == 'cockroachdb/cockroach'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -52,10 +52,14 @@ jobs:
         fi
 
     - name: Build Cluster UI
+      #if: steps.version-check.outputs.published == 'no'
       run: |
         yarn install --frozen-lockfile
-        bazel build //pkg/ui/workspaces/cluster-ui:cluster-ui
+        bazel build //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client
+        cp ../../../../_bazel/bin/pkg/ui/workspaces/db-console/src/js/protos.* ../db-console/src/js/
+        yarn build
 
     - name: Publish prerelease version
-      if: steps.version-check.outputs.published == 'no'
-      run: npm publish --access public --tag next --dry-run
+      #if: steps.version-check.outputs.published == 'no'
+      run: |
+        npm publish --access public --tag next --dry-run

--- a/.github/workflows/cluster-ui-release-next.yml
+++ b/.github/workflows/cluster-ui-release-next.yml
@@ -1,16 +1,16 @@
 name: Publish Cluster UI Pre-release
-on: [workflow_dispatch]
-#  push:
-#    branches:
-#      - master
-#    paths:
-#      - 'pkg/ui/workspaces/cluster-ui/**/*.tsx?'
-#      - 'pkg/ui/workspaces/cluster-ui/yarn.lock'
-#      - 'pkg/ui/workspaces/cluster-ui/package.json'
-
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'pkg/ui/workspaces/cluster-ui/**/*.tsx?'
+      - 'pkg/ui/workspaces/cluster-ui/yarn.lock'
+      - 'pkg/ui/workspaces/cluster-ui/package.json'
 
 jobs:
   publish_cluster_ui:
+    if: github.repository == 'cockroachdb/cockroach'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -52,7 +52,7 @@ jobs:
         fi
 
     - name: Build Cluster UI
-      #if: steps.version-check.outputs.published == 'no'
+      if: steps.version-check.outputs.published == 'no'
       run: |
         yarn install --frozen-lockfile
         bazel build //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client
@@ -60,6 +60,5 @@ jobs:
         yarn build
 
     - name: Publish prerelease version
-      #if: steps.version-check.outputs.published == 'no'
-      run: |
-        npm publish --access public --tag next --dry-run
+      if: steps.version-check.outputs.published == 'no'
+      run: npm publish --access public --tag next --dry-run

--- a/.github/workflows/cluster-ui-release.yml
+++ b/.github/workflows/cluster-ui-release.yml
@@ -1,6 +1,5 @@
 name: Publish Cluster UI Release
 on:
-  workflow_dispatch:
   push:
     branches:
       - 'release-*'
@@ -11,7 +10,7 @@ on:
 
 jobs:
   publish_cluster_ui:
-    # if: github.repository == 'cockroachdb/cockroach'
+    if: github.repository == 'cockroachdb/cockroach'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -58,6 +57,7 @@ jobs:
       id: branch-name
 
     - name: Build Cluster UI
+      if: steps.version-check.outputs.published == 'no'
       run: |
         yarn install --frozen-lockfile
         bazel build //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client
@@ -65,5 +65,5 @@ jobs:
         yarn build
 
     - name: Publish patch version
-      # if: steps.version-check.outputs.published == 'no'
+      if: steps.version-check.outputs.published == 'no'
       run: npm publish --access public --tag ${{ steps.branch_name.outputs.branch }} --dry-run

--- a/.github/workflows/cluster-ui-release.yml
+++ b/.github/workflows/cluster-ui-release.yml
@@ -1,5 +1,6 @@
 name: Publish Cluster UI Release
 on:
+  workflow_dispatch:
   push:
     branches:
       - 'release-*'
@@ -10,7 +11,7 @@ on:
 
 jobs:
   publish_cluster_ui:
-    if: github.repository == 'cockroachdb/cockroach'
+    # if: github.repository == 'cockroachdb/cockroach'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -59,8 +60,10 @@ jobs:
     - name: Build Cluster UI
       run: |
         yarn install --frozen-lockfile
-        bazel build //pkg/ui/workspaces/cluster-ui:cluster-ui
+        bazel build //pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client
+        cp ../../../../_bazel/bin/pkg/ui/workspaces/db-console/src/js/protos.* ../db-console/src/js/
+        yarn build
 
     - name: Publish patch version
-      if: steps.version-check.outputs.published == 'no'
+      # if: steps.version-check.outputs.published == 'no'
       run: npm publish --access public --tag ${{ steps.branch_name.outputs.branch }} --dry-run

--- a/pkg/ui/README.md
+++ b/pkg/ui/README.md
@@ -1,6 +1,6 @@
 # DB Console
 
-This directory contains the client-side code for CockroachDB's web-based DB 
+This directory contains the client-side code for CockroachDB's web-based DB
 Console, which provides details about a cluster's performance and health. See the
 [DB Console docs](https://www.cockroachlabs.com/docs/stable/ui-overview.html)
 for an expanded overview.
@@ -11,7 +11,7 @@ To start developing the UI, be sure you're able to build and run a CockroachDB
 node. Instructions for this are located in the top-level README. Every Cockroach
 node serves the UI, by default on port 8080, but you can customize the port with
 the `--http-port` flag. If you've started a node with the default options,
-you'll be able to access the UI at <http://localhost:8080>. If you've started 
+you'll be able to access the UI at <http://localhost:8080>. If you've started
 a node using `demo`, the default port is 8081 and you'll be able to access the UI
 at <http://localhost:8081>.
 
@@ -73,7 +73,7 @@ run `./dev ui watch` in one shell and `./dev build` in another.
 Many page-level components have been extracted into a
 separate repository for sharing with other applications.
 You can read all about this division in the [README for the
-package](https://github.com/cockroachdb/ui/blob/master/packages/cluster-ui/README.md)
+package](https://github.com/cockroachdb/cockroach/blob/master/pkg/ui/workspaces/cluster-ui/README.md)
 which describes a dev workflow that fits well with this package.
 
 ### Clearing the local cache

--- a/pkg/ui/workspaces/cluster-ui/.npmignore
+++ b/pkg/ui/workspaces/cluster-ui/.npmignore
@@ -21,3 +21,6 @@ enzyme.setup.js
 # project configs
 *.config.js
 tsconfig.json
+
+# bazel module mappings
+*.module_mappings.json

--- a/pkg/ui/workspaces/cluster-ui/AUTHORS
+++ b/pkg/ui/workspaces/cluster-ui/AUTHORS
@@ -1,1 +1,4 @@
 David Hartunian <davidh@cockroachlabs.com>
+Marylia Gutierrez <marylia@cockroachlabs.com>
+Matthew Todd <todd@cockroachlabs.com> <matthew@matthewtodd.org>
+Nathan Stilwell <nathanstilwell@cockroachlabs.com>

--- a/pkg/ui/workspaces/cluster-ui/AUTHORS
+++ b/pkg/ui/workspaces/cluster-ui/AUTHORS
@@ -2,3 +2,4 @@ David Hartunian <davidh@cockroachlabs.com>
 Marylia Gutierrez <marylia@cockroachlabs.com>
 Matthew Todd <todd@cockroachlabs.com> <matthew@matthewtodd.org>
 Nathan Stilwell <nathanstilwell@cockroachlabs.com>
+Sean Barag <barag@cockroachlabs.com>

--- a/pkg/ui/workspaces/cluster-ui/README.md
+++ b/pkg/ui/workspaces/cluster-ui/README.md
@@ -94,7 +94,7 @@ backgroundColor<<connected>> RosyBrown
 
 ## Version alignment with CRDB releases
 
-`cluster-ui` is dependent on the API of CRDB through a dependency on protobuf clients.
+`cluster-ui` is dependent on the API of CRDB through a dependency on a protobuf client.
 Since the API can change in incompatible ways between major versions of the database,
 versions of cluster-ui are published following the version scheme of CockroachDB.
 
@@ -185,7 +185,17 @@ here: https://storybook.js.org/docs/react/api/csf in order to
 facilitate writing unit tests with the storybook components.
 
 ## Publishing Cluster UI package to npm
-WIP
+Publishing Cluster UI pre-release versions from the master branch to npm is done
+by a Github Action workflow called "Publish Cluster UI Pre-release". This workflow
+will publish to npm anytime a version of Cluster UI is merged to master that is
+unpublished (by comparing the version in the `package.json` to versions of
+`@cockroachlabs/cluster-ui` on npm). To change the version of Cluster UI, you can
+run the command `yarn bump` from `pkg/ui/workspaces/cluster-ui`.
+
+To publish a version from a release branch, a manual publish is still required.
+The steps below can be followed to manually publish to npm. Github Workflows are
+being worked on for release branches, and this README will be updated when they
+are available.
 
 ### 1. Change the version in package.json
 CockroachDB uses a form of [calver](https://calver.org/) versioning where the major part
@@ -262,10 +272,10 @@ Once you have authenticated, you are ready to publish to npm.
 
 Go into the `pkg/ui/cluster-ui` subfolder, as you'll be publishing the package
 as specified by that `package.json`.
-  
+
 Note: If you've already updated `version` in `package.json` to reflect the new version,
 you'll need to temporarily change this back to the older version (i.e. the version
-that's currently listed on npm). After running the command below, the script will then 
+that's currently listed on npm). After running the command below, the script will then
 automatically reverted back to the newer version.
 
 To publish the package, run the publish command,

--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -8,6 +8,10 @@
   },
   "main": "dist/js/main.js",
   "types": "dist/types/index.d.ts",
+  "files": [
+    "dist/",
+    "AUTHORS"
+  ],
   "scripts": {
     "build": "npm-run-all -p build:typescript build:bundle",
     "build:bundle": "NODE_ENV=production webpack --display-error-details --mode=production",
@@ -18,7 +22,6 @@
     "clean": "rm -rf  ./dist/*",
     "lint": "eslint './src/**/*.{tsx,ts,js}' --format=codeframe",
     "lint:fix": "eslint './src/**/*.{tsx,ts,js}' --format=codeframe --fix",
-    "prepublishOnly": "npm-run-all clean build",
     "test": "jest --watch",
     "start": "npm-run-all -p build:watch tsc:watch",
     "storybook": "start-storybook -p 6006",


### PR DESCRIPTION
On dry-run publishing, there is an npm life-cycle script that will run (`prepublishOnly`). This script will clean and rebuild Cluster-ui using the Typscript compiler for type generation and Webpack for the bundle. This is currently failing due to a dependence on @cockroachlabs/crdb-protobuf-client, which is has not explicitly built as a part of the workflow.

To resolve this issue, I am removing the `prepublishOnly` script as it was an additional build step that was implicitly run as a part of `npm publish`. Then I am adding a step to `Build Cluster UI` to build the  protobuf client with Bazel. Then I am copying the built files out of the bazel directory into the package directory and building the Cluster UI bundle with npm.

I have also added a "files" section to the package.json to managed the files that are added to the package when publishing. Previously the package would include everything in the directory filtered by the contents of `.npmignore`. Now the package will include "mandatory files" (`package.json` and `README.md`) and the files specified in the "files" array (`dist/` and `AUTHORS`). A diff was also taken of the produced package against the published package [on npm](https://www.npmjs.com/package/@cockroachlabs/cluster-ui/v/23.1.0-prerelease.2?activeTab=explore). In this example, `local` is the locally built Cluster UI `.tgz` package on master and `remote` is `@cockroachlabs/cluster-ui@23.1.0-prerelease.2` package. The difference in package.json is part of this pull request.

```
╔═══════════════════════════
║ code/test/cluster-ui-publish-test 
╚════  △ diff -rq local remote
Only in remote: .babelrc
Only in remote: .prettierignore
Only in remote: .yarnrc
Only in remote: BUILD.bazel
Only in local/dist/js: main.js.map
Files local/package.json and remote/package.json differ
Only in remote: tsconfig.linting.json
```

This workflow was tested on [my personal fork](https://github.com/nathanstilwell/cockroach). An example dry run against master can be found [here](https://github.com/nathanstilwell/cockroach/actions/runs/3751489293).

Epic: CC-7999
See also: CC-7959
