### PR TITLE
release 22.1: backupccl: delake multinode datadriven tests that set cluster settings

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/column-families
+++ b/pkg/ccl/backupccl/testdata/backup-restore/column-families
@@ -21,11 +21,15 @@ exec-sql
 ALTER TABLE cfs SPLIT AT SELECT a FROM cfs;
 ----
 
-exec-sql
--- Split the output files very small to catch output SSTs mid-row.
-SET CLUSTER SETTING bulkio.backup.file_size = '1';
-SET CLUSTER SETTING kv.bulk_sst.target_size = '1';
-SET CLUSTER SETTING bulkio.backup.merge_file_buffer_size = '1MiB';
+
+# Split the output files very small to catch output SSTs mid-row.
+set-cluster-setting setting=bulkio.backup.file_size value=1
+----
+
+set-cluster-setting setting=kv.bulk_sst.target_size value=1
+----
+
+set-cluster-setting setting=bulkio.backup.merge_file_buffer_size value=1MiB
 ----
 
 exec-sql

--- a/pkg/ccl/backupccl/testdata/backup-restore/multiregion
+++ b/pkg/ccl/backupccl/testdata/backup-restore/multiregion
@@ -92,8 +92,7 @@ exec-sql
 DROP DATABASE no_region_db_2;
 ----
 
-exec-sql
-SET CLUSTER SETTING sql.defaults.primary_region = 'non-existent-region';
+set-cluster-setting setting=sql.defaults.primary_region value=non-existent-region
 ----
 
 exec-sql
@@ -104,8 +103,7 @@ HINT: valid regions: eu-central-1, eu-north-1
 --
 set the default PRIMARY REGION to a region that exists (see SHOW REGIONS FROM CLUSTER) then using SET CLUSTER SETTING sql.defaults.primary_region = 'region'
 
-exec-sql
-SET CLUSTER SETTING sql.defaults.primary_region = 'eu-central-1';
+set-cluster-setting setting=sql.defaults.primary_region value=eu-central-1
 ----
 
 exec-sql
@@ -143,7 +141,7 @@ BACKUP DATABASE eu_central_db INTO 'nodelocal://1/eu_central_database_backup/';
 new-server name=s4 share-io-dir=s1 allow-implicit-access localities=eu-central-1,eu-north-1
 ----
 
-exec-sql
+set-cluster-setting setting=sql.defaults.primary_region value=eu-north-1
 SET CLUSTER SETTING sql.defaults.primary_region = 'eu-north-1';
 ----
 


### PR DESCRIPTION
The `SET CLUSTER SETTING` stmt propogrates the cluster setting to remote nodes asynchronously, but our data driven multinode tests incorrectly assumed that settings were propogated during stmt execution. This patch adds a new 'set-cluster-setting' dd cmd which will propogate the cluster setting to all nodes before the cmd returns.

Fixes #92808

Release note: none

Relase justification: test only change