### PR TITLE
server: introduce a cluster setting for soft memory limit feature of Go

### DIFF
--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -875,6 +875,13 @@ func makeTenantSQLServerArgs(
 
 	sessionRegistry := sql.NewSessionRegistry()
 
+	goMemLimitSetting.SetOnChange(&baseCfg.Settings.SV, func(context.Context) {
+		handleGoMemLimitChange(&baseCfg.Settings.SV)
+	})
+	// TODO(yuzefovich): come up with a reasonable non-zero default value for
+	// goMemLimitSetting based on cfg.MemoryPoolSize (and pebble cache size for
+	// system tenants) before 23.1 release is cut.
+
 	monitorAndMetrics := newRootSQLMemoryMonitor(monitorAndMetricsOptions{
 		memoryPoolSize:          sqlCfg.MemoryPoolSize,
 		histogramWindowInterval: baseCfg.HistogramWindowInterval(),


### PR DESCRIPTION
This commit introduces a new cluster setting `server.go_mem_limit` which allows us to change the soft memory limit of Go runtime on each node in the cluster (rather than having to provide the limit via the `GOMEMLIMIT` environment variable on a per-node basis). By default, this cluster setting is currently set to 0 meaning that the memory limit is disabled. I want to backport this change to 22.2 branch to ease the usage of this feature whereas on 23.1 a separate change will come up with a heuristic for the default value (based on `--max-sql-memory` and `--cache` sizes).

The cluster setting is currently not documented (i.e. it is marked as "private"). Also, it is marked as tenant read-only.

Epic: CC-8863

Release note: None