### PR TITLE
ccl/sqlproxyccl: fix status code and hint reporting

### DIFF
--- a/pkg/ccl/sqlproxyccl/authentication_test.go
+++ b/pkg/ccl/sqlproxyccl/authentication_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/throttler"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/cockroachdb/errors"
 	"github.com/jackc/pgproto3/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -120,7 +119,7 @@ func TestAuthenticateThrottled(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, msg, &pgproto3.ErrorResponse{
 			Severity: "FATAL",
-			Code:     "08004",
+			Code:     "08C00",
 			Message:  "codeProxyRefusedConnection: connection attempt throttled",
 			Hint:     throttledErrorHint,
 		})
@@ -188,9 +187,7 @@ func TestAuthenticateError(t *testing.T) {
 
 	_, err := authenticate(srv, cli, nil /* proxyBackendKeyData */, nilThrottleHook)
 	require.Error(t, err)
-	codeErr := (*codeError)(nil)
-	require.True(t, errors.As(err, &codeErr))
-	require.Equal(t, codeAuthFailed, codeErr.code)
+	require.Equal(t, codeAuthFailed, getErrorCode(err))
 }
 
 func TestAuthenticateUnexpectedMessage(t *testing.T) {
@@ -212,9 +209,7 @@ func TestAuthenticateUnexpectedMessage(t *testing.T) {
 	srv.Close()
 
 	require.Error(t, err)
-	codeErr := (*codeError)(nil)
-	require.True(t, errors.As(err, &codeErr))
-	require.Equal(t, codeBackendDisconnected, codeErr.code)
+	require.Equal(t, codeBackendDisconnected, getErrorCode(err))
 }
 
 func TestReadTokenAuthResult(t *testing.T) {
@@ -230,9 +225,7 @@ func TestReadTokenAuthResult(t *testing.T) {
 
 		_, err := readTokenAuthResult(cli)
 		require.Error(t, err)
-		codeErr := (*codeError)(nil)
-		require.True(t, errors.As(err, &codeErr))
-		require.Equal(t, codeBackendDisconnected, codeErr.code)
+		require.Equal(t, codeBackendDisconnected, getErrorCode(err))
 	})
 
 	t.Run("error_response", func(t *testing.T) {
@@ -245,9 +238,7 @@ func TestReadTokenAuthResult(t *testing.T) {
 
 		_, err := readTokenAuthResult(cli)
 		require.Error(t, err)
-		codeErr := (*codeError)(nil)
-		require.True(t, errors.As(err, &codeErr))
-		require.Equal(t, codeAuthFailed, codeErr.code)
+		require.Equal(t, codeAuthFailed, getErrorCode(err))
 	})
 
 	t.Run("successful", func(t *testing.T) {

--- a/pkg/ccl/sqlproxyccl/backend_dialer_test.go
+++ b/pkg/ccl/sqlproxyccl/backend_dialer_test.go
@@ -81,7 +81,7 @@ func TestBackendDialTLS(t *testing.T) {
 		name     string
 		addr     string
 		tenantID uint64
-		err      bool
+		errCode  errorCode
 	}{{
 		name:     "tenant10",
 		addr:     sql10.SQLAddr(),
@@ -94,22 +94,22 @@ func TestBackendDialTLS(t *testing.T) {
 		name:     "tenant10To11",
 		addr:     sql11.SQLAddr(),
 		tenantID: 10,
-		err:      true,
+		errCode:  codeBackendDown,
 	}, {
 		name:     "tenant11To10",
 		addr:     sql10.SQLAddr(),
 		tenantID: 11,
-		err:      true,
+		errCode:  codeBackendDown,
 	}, {
 		name:     "tenant10ToStorage",
 		addr:     storageServer.ServingSQLAddr(),
 		tenantID: 10,
-		err:      true,
+		errCode:  codeBackendDown,
 	}, {
 		name:     "tenantWithNodeIDToStoage",
 		addr:     storageServer.ServingSQLAddr(),
 		tenantID: uint64(storageServer.NodeID()),
-		err:      true,
+		errCode:  codeBackendDown,
 	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -120,8 +120,8 @@ func TestBackendDialTLS(t *testing.T) {
 
 			conn, err := BackendDial(startupMsg, tc.addr, tenantConfig)
 
-			if tc.err {
-				require.Error(t, err)
+			if tc.errCode != codeNone {
+				require.Equal(t, tc.errCode, getErrorCode(err))
 			} else {
 				require.NoError(t, err)
 				require.NotNil(t, conn)

--- a/pkg/ccl/sqlproxyccl/connector.go
+++ b/pkg/ccl/sqlproxyccl/connector.go
@@ -25,7 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
-	pgproto3 "github.com/jackc/pgproto3/v2"
+	"github.com/jackc/pgproto3/v2"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -112,14 +112,14 @@ func (c *connector) OpenTenantConnWithToken(
 	}
 	defer func() {
 		if retErr != nil {
-			serverConn.Close()
+			_ = serverConn.Close()
 		}
 	}()
 
 	// When we use token-based authentication, we will still get the initial
 	// connection data messages (e.g. ParameterStatus and BackendKeyData).
 	// Since this method is only used during connection migration (i.e. proxy
-	// is connecting to the SQL pod), we'll discard all of the messages, and
+	// is connecting to the SQL pod), we'll discard all the messages, and
 	// only return once we've seen a ReadyForQuery message.
 	newBackendKeyData, err := readTokenAuthResult(serverConn)
 	if err != nil {
@@ -157,7 +157,7 @@ func (c *connector) OpenTenantConnWithAuth(
 	}
 	defer func() {
 		if retErr != nil {
-			serverConn.Close()
+			_ = serverConn.Close()
 		}
 	}()
 
@@ -274,7 +274,7 @@ func (c *connector) dialTenantCluster(
 	// err will never be nil here regardless of whether we retry infinitely or
 	// a bounded number of times. In our case, since we retry infinitely, the
 	// only possibility is when ctx's Done channel is closed (which implies that
-	// ctx.Err() != nil.
+	// ctx.Err() != nil).
 	//
 	// If the error is already marked, just return that.
 	if errors.IsAny(err, context.Canceled, context.DeadlineExceeded) {
@@ -318,13 +318,14 @@ func (c *connector) lookupAddr(ctx context.Context) (string, error) {
 
 	case status.Code(err) == codes.FailedPrecondition:
 		if st, ok := status.FromError(err); ok {
-			return "", newErrorf(codeUnavailable, "%v", st.Message())
+			return "", withCode(errors.Newf("%v", st.Message()), codeUnavailable)
 		}
-		return "", newErrorf(codeUnavailable, "unavailable")
+		return "", withCode(errors.New("unavailable"), codeUnavailable)
 
 	case status.Code(err) == codes.NotFound:
-		return "", newErrorf(codeParamsRoutingFailed,
-			"cluster %s-%d not found", c.ClusterName, c.TenantID.ToUint64())
+		return "", withCode(
+			errors.Newf("cluster %s-%d not found", c.ClusterName, c.TenantID.ToUint64()),
+			codeParamsRoutingFailed)
 
 	default:
 		return "", markAsRetriableConnectorError(err)
@@ -355,8 +356,7 @@ func (c *connector) dialSQLServer(
 
 	conn, err := BackendDial(c.StartupMsg, serverAssignment.Addr(), tlsConf)
 	if err != nil {
-		var codeErr *codeError
-		if errors.As(err, &codeErr) && codeErr.code == codeBackendDown {
+		if getErrorCode(err) == codeBackendDown {
 			return nil, markAsRetriableConnectorError(err)
 		}
 		return nil, err

--- a/pkg/ccl/sqlproxyccl/connector_test.go
+++ b/pkg/ccl/sqlproxyccl/connector_test.go
@@ -796,7 +796,7 @@ func TestConnector_dialSQLServer(t *testing.T) {
 				require.Equal(t, c.StartupMsg, msg)
 				require.Equal(t, "127.0.0.2:4567", serverAddress)
 				require.Nil(t, tlsConfig)
-				return nil, newErrorf(codeBackendDown, "bar")
+				return nil, withCode(errors.New("bar"), codeBackendDown)
 			},
 		)()
 		sa := balancer.NewServerAssignment(tenantID, tracker, nil, "127.0.0.2:4567")

--- a/pkg/ccl/sqlproxyccl/error_source.go
+++ b/pkg/ccl/sqlproxyccl/error_source.go
@@ -22,19 +22,19 @@ type errorSourceConn struct {
 	writeErrMarker error
 }
 
-// errClientWrite indicates the error occured when attempting to write to the
+// errClientWrite indicates the error occurred when attempting to write to the
 // client connection.
 var errClientWrite = errors.New("client write error")
 
-// errClientRead indicates the error occured when attempting to read from the
+// errClientRead indicates the error occurred when attempting to read from the
 // client connection.
 var errClientRead = errors.New("client read error")
 
-// errServerWrite indicates the error occured when attempting to write to the
+// errServerWrite indicates the error occurred when attempting to write to the
 // sql server.
 var errServerWrite = errors.New("server write error")
 
-// errServerRead indicates the error occured when attempting to read from the
+// errServerRead indicates the error occurred when attempting to read from the
 // sql server.
 var errServerRead = errors.New("server read error")
 
@@ -44,13 +44,13 @@ var errServerRead = errors.New("server read error")
 func wrapConnectionError(err error) error {
 	switch {
 	case errors.Is(err, errClientRead):
-		return newErrorf(codeClientReadFailed, "unable to read from client: %s", err)
+		return withCode(errors.Wrap(err, "unable to read from client"), codeClientReadFailed)
 	case errors.Is(err, errClientWrite):
-		return newErrorf(codeClientWriteFailed, "unable to write to client: %s", err)
+		return withCode(errors.Wrap(err, "unable to write to client"), codeClientWriteFailed)
 	case errors.Is(err, errServerRead):
-		return newErrorf(codeBackendReadFailed, "unable to read from sql server: %s", err)
+		return withCode(errors.Wrap(err, "unable to read from sql server"), codeBackendReadFailed)
 	case errors.Is(err, errServerWrite):
-		return newErrorf(codeBackendWriteFailed, "unable to write to sql server: %s", err)
+		return withCode(errors.Wrap(err, "unable to write to sql server"), codeBackendWriteFailed)
 	}
 	return nil
 }

--- a/pkg/ccl/sqlproxyccl/error_source_test.go
+++ b/pkg/ccl/sqlproxyccl/error_source_test.go
@@ -24,11 +24,11 @@ type fakeConn struct {
 	writeError error
 }
 
-func (conn *fakeConn) Read(b []byte) (n int, err error) {
+func (conn *fakeConn) Read(_ []byte) (n int, err error) {
 	return conn.size, conn.readError
 }
 
-func (conn *fakeConn) Write(b []byte) (n int, err error) {
+func (conn *fakeConn) Write(_ []byte) (n int, err error) {
 	return conn.size, conn.writeError
 }
 
@@ -43,17 +43,11 @@ func TestWrapConnectionError(t *testing.T) {
 		{errClientWrite, codeClientWriteFailed},
 		{errServerRead, codeBackendReadFailed},
 		{errServerWrite, codeBackendWriteFailed},
-		{errors.New("some random error"), 0},
+		{errors.New("some random error"), codeNone},
 	}
 	for _, tc := range tests {
-		var code errorCode
 		err := wrapConnectionError(errors.Mark(errors.New("some inner error"), tc.marker))
-		if err != nil {
-			codeErr := &codeError{}
-			require.True(t, errors.As(err, &codeErr))
-			code = codeErr.code
-		}
-		require.Equal(t, code, tc.code)
+		require.Equal(t, tc.code, getErrorCode(err))
 	}
 }
 

--- a/pkg/ccl/sqlproxyccl/errorcode_string.go
+++ b/pkg/ccl/sqlproxyccl/errorcode_string.go
@@ -8,6 +8,7 @@ func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
+	_ = x[codeNone-0]
 	_ = x[codeAuthFailed-1]
 	_ = x[codeBackendReadFailed-2]
 	_ = x[codeBackendWriteFailed-3]
@@ -25,14 +26,13 @@ func _() {
 	_ = x[codeUnavailable-15]
 }
 
-const _errorCode_name = "codeAuthFailedcodeBackendReadFailedcodeBackendWriteFailedcodeClientReadFailedcodeClientWriteFailedcodeUnexpectedInsecureStartupMessagecodeUnexpectedStartupMessagecodeParamsRoutingFailedcodeBackendDowncodeBackendRefusedTLScodeBackendDisconnectedcodeClientDisconnectedcodeProxyRefusedConnectioncodeExpiredClientConnectioncodeUnavailable"
+const _errorCode_name = "codeNonecodeAuthFailedcodeBackendReadFailedcodeBackendWriteFailedcodeClientReadFailedcodeClientWriteFailedcodeUnexpectedInsecureStartupMessagecodeUnexpectedStartupMessagecodeParamsRoutingFailedcodeBackendDowncodeBackendRefusedTLScodeBackendDisconnectedcodeClientDisconnectedcodeProxyRefusedConnectioncodeExpiredClientConnectioncodeUnavailable"
 
-var _errorCode_index = [...]uint16{0, 14, 35, 57, 77, 98, 134, 162, 185, 200, 221, 244, 266, 292, 319, 334}
+var _errorCode_index = [...]uint16{0, 8, 22, 43, 65, 85, 106, 142, 170, 193, 208, 229, 252, 274, 300, 327, 342}
 
 func (i errorCode) String() string {
-	i -= 1
 	if i < 0 || i >= errorCode(len(_errorCode_index)-1) {
-		return "errorCode(" + strconv.FormatInt(int64(i+1), 10) + ")"
+		return "errorCode(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _errorCode_name[_errorCode_index[i]:_errorCode_index[i+1]]
 }

--- a/pkg/ccl/sqlproxyccl/forwarder.go
+++ b/pkg/ccl/sqlproxyccl/forwarder.go
@@ -378,7 +378,9 @@ func wrapClientToServerError(err error) error {
 	if err := wrapConnectionError(err); err != nil {
 		return err
 	}
-	return newErrorf(codeClientDisconnected, "unexpected error copying from client to target server: %v", err)
+	return withCode(errors.Wrap(err,
+		"unexpected error copying from client to target server"),
+		codeClientDisconnected)
 }
 
 // wrapServerToClientError overrides server to client errors for external
@@ -396,7 +398,9 @@ func wrapServerToClientError(err error) error {
 	if err := wrapConnectionError(err); err != nil {
 		return err
 	}
-	return newErrorf(codeBackendDisconnected, "unexpected error copying from target server to client: %s", err)
+	return withCode(errors.Wrap(err,
+		"unexpected error copying from target server to client"),
+		codeBackendDisconnected)
 }
 
 // makeLogicalClockFn returns a function that implements a simple logical clock.

--- a/pkg/ccl/sqlproxyccl/forwarder_test.go
+++ b/pkg/ccl/sqlproxyccl/forwarder_test.go
@@ -452,14 +452,15 @@ func TestWrapClientToServerError(t *testing.T) {
 		{errors.Mark(errors.New("foo"), context.Canceled), nil},
 		{errors.Wrap(context.DeadlineExceeded, "foo"), nil},
 		// Forwarding errors.
-		{errors.New("foo"), newErrorf(
+		{errors.New("foo"), withCode(errors.New(
+			"unexpected error copying from client to target server: foo"),
 			codeClientDisconnected,
-			"unexpected error copying from client to target server: foo",
 		)},
-		{errors.Mark(errors.New("some write error"), errClientWrite), newErrorf(
-			codeClientWriteFailed,
-			"unable to write to client: some write error",
-		)},
+		{errors.Mark(errors.New("some write error"), errClientWrite),
+			withCode(errors.New(
+				"unable to write to client: some write error"),
+				codeClientWriteFailed,
+			)},
 	} {
 		err := wrapClientToServerError(tc.input)
 		if tc.output == nil {
@@ -484,14 +485,15 @@ func TestWrapServerToClientError(t *testing.T) {
 		{errors.Mark(errors.New("foo"), context.Canceled), nil},
 		{errors.Wrap(context.DeadlineExceeded, "foo"), nil},
 		// Forwarding errors.
-		{errors.New("foo"), newErrorf(
+		{errors.New("foo"), withCode(errors.New(
+			"unexpected error copying from target server to client: foo"),
 			codeBackendDisconnected,
-			"unexpected error copying from target server to client: foo",
 		)},
-		{errors.Mark(errors.New("some read error"), errServerRead), newErrorf(
-			codeBackendReadFailed,
-			"unable to read from sql server: some read error",
-		)},
+		{errors.Mark(errors.New("some read error"), errServerRead),
+			withCode(errors.New(
+				"unable to read from sql server: some read error"),
+				codeBackendReadFailed,
+			)},
 	} {
 		err := wrapServerToClientError(tc.input)
 		if tc.output == nil {

--- a/pkg/ccl/sqlproxyccl/frontend_admitter.go
+++ b/pkg/ccl/sqlproxyccl/frontend_admitter.go
@@ -12,6 +12,7 @@ import (
 	"crypto/tls"
 	"net"
 
+	"github.com/cockroachdb/errors"
 	"github.com/jackc/pgproto3/v2"
 )
 
@@ -49,8 +50,9 @@ var FrontendAdmit = func(
 	m, err := pgproto3.NewBackend(pgproto3.NewChunkReader(conn), conn).ReceiveStartupMessage()
 	if err != nil {
 		return &FrontendAdmitInfo{
-			Conn: conn, Err: newErrorf(codeClientReadFailed, "while receiving startup message"),
-		}
+			Conn: conn, Err: withCode(
+				errors.New("while receiving startup message"), codeClientReadFailed,
+			)}
 	}
 
 	// CancelRequest is unencrypted and unauthenticated, regardless of whether
@@ -75,12 +77,14 @@ var FrontendAdmit = func(
 	if incomingTLSConfig != nil {
 		if _, ok := m.(*pgproto3.SSLRequest); !ok {
 			code := codeUnexpectedInsecureStartupMessage
-			return &FrontendAdmitInfo{Conn: conn, Err: newErrorf(code, "unsupported startup message: %T", m)}
+			return &FrontendAdmitInfo{Conn: conn, Err: withCode(
+				errors.Newf("unsupported startup message: %T", m), code)}
 		}
 
 		_, err = conn.Write([]byte{pgAcceptSSLRequest})
 		if err != nil {
-			return &FrontendAdmitInfo{Conn: conn, Err: newErrorf(codeClientWriteFailed, "acking SSLRequest: %v", err)}
+			return &FrontendAdmitInfo{Conn: conn, Err: withCode(
+				errors.Wrap(err, "acking SSLRequest"), codeClientWriteFailed)}
 		}
 
 		cfg := incomingTLSConfig.Clone()
@@ -96,7 +100,8 @@ var FrontendAdmit = func(
 		if err != nil {
 			return &FrontendAdmitInfo{
 				Conn: conn,
-				Err:  newErrorf(codeClientReadFailed, "receiving post-TLS startup message: %v", err),
+				Err: withCode(errors.Wrap(err,
+					"receiving post-TLS startup message"), codeClientReadFailed),
 			}
 		}
 	}
@@ -109,11 +114,10 @@ var FrontendAdmit = func(
 		if _, ok := startup.Parameters[sessionRevivalTokenStartupParam]; ok {
 			return &FrontendAdmitInfo{
 				Conn: conn,
-				Err: newErrorf(
-					codeUnexpectedStartupMessage,
+				Err: withCode(errors.Newf(
 					"parameter %s is not allowed",
-					sessionRevivalTokenStartupParam,
-				),
+					sessionRevivalTokenStartupParam),
+					codeUnexpectedStartupMessage),
 			}
 		}
 		return &FrontendAdmitInfo{Conn: conn, Msg: startup, SniServerName: sniServerName}
@@ -122,6 +126,7 @@ var FrontendAdmit = func(
 	code := codeUnexpectedStartupMessage
 	return &FrontendAdmitInfo{
 		Conn: conn,
-		Err:  newErrorf(code, "unsupported post-TLS startup message: %T", m),
+		Err: withCode(errors.Newf(
+			"unsupported post-TLS startup message: %T", m), code),
 	}
 }

--- a/pkg/ccl/sqlproxyccl/metrics.go
+++ b/pkg/ccl/sqlproxyccl/metrics.go
@@ -11,7 +11,6 @@ package sqlproxyccl
 import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
-	"github.com/cockroachdb/errors"
 )
 
 // metrics contains pointers to the metrics for monitoring proxy operations.
@@ -257,25 +256,22 @@ func (metrics *metrics) updateForError(err error) {
 	if err == nil {
 		return
 	}
-	codeErr := (*codeError)(nil)
-	if errors.As(err, &codeErr) {
-		switch codeErr.code {
-		case codeExpiredClientConnection:
-			metrics.ExpiredClientConnCount.Inc(1)
-		case codeBackendDisconnected, codeBackendReadFailed, codeBackendWriteFailed:
-			metrics.BackendDisconnectCount.Inc(1)
-		case codeClientDisconnected, codeClientWriteFailed, codeClientReadFailed:
-			metrics.ClientDisconnectCount.Inc(1)
-		case codeProxyRefusedConnection:
-			metrics.RefusedConnCount.Inc(1)
-			metrics.BackendDownCount.Inc(1)
-		case codeParamsRoutingFailed, codeUnavailable:
-			metrics.RoutingErrCount.Inc(1)
-			metrics.BackendDownCount.Inc(1)
-		case codeBackendDown:
-			metrics.BackendDownCount.Inc(1)
-		case codeAuthFailed:
-			metrics.AuthFailedCount.Inc(1)
-		}
+	switch getErrorCode(err) {
+	case codeExpiredClientConnection:
+		metrics.ExpiredClientConnCount.Inc(1)
+	case codeBackendDisconnected, codeBackendReadFailed, codeBackendWriteFailed:
+		metrics.BackendDisconnectCount.Inc(1)
+	case codeClientDisconnected, codeClientWriteFailed, codeClientReadFailed:
+		metrics.ClientDisconnectCount.Inc(1)
+	case codeProxyRefusedConnection:
+		metrics.RefusedConnCount.Inc(1)
+		metrics.BackendDownCount.Inc(1)
+	case codeParamsRoutingFailed, codeUnavailable:
+		metrics.RoutingErrCount.Inc(1)
+		metrics.BackendDownCount.Inc(1)
+	case codeBackendDown:
+		metrics.BackendDownCount.Inc(1)
+	case codeAuthFailed:
+		metrics.AuthFailedCount.Inc(1)
 	}
 }

--- a/pkg/ccl/sqlproxyccl/metrics_test.go
+++ b/pkg/ccl/sqlproxyccl/metrics_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -50,7 +51,7 @@ func TestMetricsUpdateForError(t *testing.T) {
 			for _, counter := range tc.counters {
 				before = append(before, counter.Count())
 			}
-			m.updateForError(newErrorf(tc.code, "test error"))
+			m.updateForError(withCode(errors.New("test error"), tc.code))
 			for i, counter := range tc.counters {
 				require.Equal(t, counter.Count(), before[i]+1)
 			}

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"github.com/jackc/pgconn"
 	pgproto3 "github.com/jackc/pgproto3/v2"
 	pgx "github.com/jackc/pgx/v4"
 	"github.com/stretchr/testify/assert"
@@ -81,7 +82,7 @@ func TestLongDBName(t *testing.T) {
 		_ *pgproto3.StartupMessage, outgoingAddr string, _ *tls.Config,
 	) (net.Conn, error) {
 		require.Equal(t, outgoingAddr, "127.0.0.1:26257")
-		return nil, newErrorf(codeParamsRoutingFailed, "boom")
+		return nil, withCode(errors.New("boom"), codeParamsRoutingFailed)
 	})()
 
 	stopper := stop.NewStopper()
@@ -91,7 +92,7 @@ func TestLongDBName(t *testing.T) {
 
 	longDB := strings.Repeat("x", 70) // 63 is limit
 	pgurl := fmt.Sprintf("postgres://unused:unused@%s/%s?options=--cluster=tenant-cluster-28&sslmode=require", addr, longDB)
-	te.TestConnectErr(ctx, t, pgurl, codeParamsRoutingFailed, "boom")
+	_ = te.TestConnectErr(ctx, t, pgurl, codeParamsRoutingFailed, "boom")
 	require.Equal(t, int64(1), s.metrics.RoutingErrCount.Count())
 }
 
@@ -124,12 +125,12 @@ func TestBackendDownRetry(t *testing.T) {
 		if callCount >= 3 {
 			directoryServer.DeleteTenant(roachpb.MustMakeTenantID(28))
 		}
-		return nil, newErrorf(codeBackendDown, "SQL pod is down")
+		return nil, withCode(errors.New("SQL pod is down"), codeBackendDown)
 	})()
 
 	// Valid connection, but no backend server running.
 	pgurl := fmt.Sprintf("postgres://unused:unused@%s/db?options=--cluster=tenant-cluster-28&sslmode=require", addr)
-	te.TestConnectErr(ctx, t, pgurl, codeParamsRoutingFailed, "cluster tenant-cluster-28 not found")
+	_ = te.TestConnectErr(ctx, t, pgurl, codeParamsRoutingFailed, "cluster tenant-cluster-28 not found")
 	require.Equal(t, 3, callCount)
 }
 
@@ -153,7 +154,7 @@ func TestFailedConnection(t *testing.T) {
 	u := fmt.Sprintf("postgres://unused:unused@localhost:%s/", p)
 
 	// Unencrypted connections bounce.
-	te.TestConnectErr(
+	_ = te.TestConnectErr(
 		ctx, t, u+"?options=--cluster=tenant-cluster-28&sslmode=disable",
 		codeUnexpectedInsecureStartupMessage, "server requires encryption",
 	)
@@ -162,21 +163,21 @@ func TestFailedConnection(t *testing.T) {
 	sslModesUsingTLS := []string{"require", "allow"}
 	for i, sslmode := range sslModesUsingTLS {
 		// TenantID rejected as malformed.
-		te.TestConnectErr(
+		_ = te.TestConnectErr(
 			ctx, t, u+"?options=--cluster=dimdog&sslmode="+sslmode,
 			codeParamsRoutingFailed, "invalid cluster identifier 'dimdog'",
 		)
 		require.Equal(t, int64(1+(i*3)), s.metrics.RoutingErrCount.Count())
 
 		// No cluster name and TenantID.
-		te.TestConnectErr(
+		_ = te.TestConnectErr(
 			ctx, t, u+"?sslmode="+sslmode,
 			codeParamsRoutingFailed, "missing cluster identifier",
 		)
 		require.Equal(t, int64(2+(i*3)), s.metrics.RoutingErrCount.Count())
 
 		// Bad TenantID. Ensure that we don't leak any parsing errors.
-		te.TestConnectErr(
+		_ = te.TestConnectErr(
 			ctx, t, u+"?options=--cluster=tenant-cluster-foo3&sslmode="+sslmode,
 			codeParamsRoutingFailed, "invalid cluster identifier 'tenant-cluster-foo3'",
 		)
@@ -252,10 +253,10 @@ func TestProxyAgainstSecureCRDB(t *testing.T) {
 	require.NoError(t, err)
 
 	url := fmt.Sprintf("postgres://bob:wrong@%s/tenant-cluster-28.defaultdb?sslmode=require", addr)
-	te.TestConnectErr(ctx, t, url, 0, "failed SASL auth")
+	_ = te.TestConnectErr(ctx, t, url, 0, "failed SASL auth")
 
 	url = fmt.Sprintf("postgres://bob@%s/tenant-cluster-28.defaultdb?sslmode=require", addr)
-	te.TestConnectErr(ctx, t, url, 0, "failed SASL auth")
+	_ = te.TestConnectErr(ctx, t, url, 0, "failed SASL auth")
 
 	// SNI provides tenant ID.
 	url = fmt.Sprintf("postgres://bob:builder@tenant-cluster-28.blah:%s/defaultdb?sslmode=require", port)
@@ -266,7 +267,7 @@ func TestProxyAgainstSecureCRDB(t *testing.T) {
 
 	// SNI tried but doesn't parse to valid tenant ID and DB/Options not provided
 	url = fmt.Sprintf("postgres://bob:builder@tenant_cluster_28.blah:%s/defaultdb?sslmode=require", port)
-	te.TestConnectErr(ctx, t, url, codeParamsRoutingFailed, "missing cluster identifier")
+	_ = te.TestConnectErr(ctx, t, url, codeParamsRoutingFailed, "missing cluster identifier")
 
 	// Database provides valid ID
 	url = fmt.Sprintf("postgres://bob:builder@%s/tenant-cluster-28.defaultdb?sslmode=require", addr)
@@ -312,7 +313,7 @@ func TestProxyTLSConf(t *testing.T) {
 			_ *pgproto3.StartupMessage, _ string, tlsConf *tls.Config,
 		) (net.Conn, error) {
 			require.Nil(t, tlsConf)
-			return nil, newErrorf(codeParamsRoutingFailed, "boom")
+			return nil, withCode(errors.New("boom"), codeParamsRoutingFailed)
 		})()
 
 		stopper := stop.NewStopper()
@@ -323,7 +324,7 @@ func TestProxyTLSConf(t *testing.T) {
 		})
 
 		pgurl := fmt.Sprintf("postgres://unused:unused@%s/%s?options=--cluster=tenant-cluster-28&sslmode=require", addr, "defaultdb")
-		te.TestConnectErr(ctx, t, pgurl, codeParamsRoutingFailed, "boom")
+		_ = te.TestConnectErr(ctx, t, pgurl, codeParamsRoutingFailed, "boom")
 	})
 
 	t.Run("skip-verify", func(t *testing.T) {
@@ -335,7 +336,7 @@ func TestProxyTLSConf(t *testing.T) {
 			_ *pgproto3.StartupMessage, _ string, tlsConf *tls.Config,
 		) (net.Conn, error) {
 			require.True(t, tlsConf.InsecureSkipVerify)
-			return nil, newErrorf(codeParamsRoutingFailed, "boom")
+			return nil, withCode(errors.New("boom"), codeParamsRoutingFailed)
 		})()
 
 		stopper := stop.NewStopper()
@@ -347,7 +348,7 @@ func TestProxyTLSConf(t *testing.T) {
 		})
 
 		pgurl := fmt.Sprintf("postgres://unused:unused@%s/%s?options=--cluster=tenant-cluster-28&sslmode=require", addr, "defaultdb")
-		te.TestConnectErr(ctx, t, pgurl, codeParamsRoutingFailed, "boom")
+		_ = te.TestConnectErr(ctx, t, pgurl, codeParamsRoutingFailed, "boom")
 	})
 
 	t.Run("no-skip-verify", func(t *testing.T) {
@@ -363,7 +364,7 @@ func TestProxyTLSConf(t *testing.T) {
 
 			require.False(t, tlsConf.InsecureSkipVerify)
 			require.Equal(t, tlsConf.ServerName, outgoingHost)
-			return nil, newErrorf(codeParamsRoutingFailed, "boom")
+			return nil, withCode(errors.New("boom"), codeParamsRoutingFailed)
 		})()
 
 		stopper := stop.NewStopper()
@@ -375,7 +376,7 @@ func TestProxyTLSConf(t *testing.T) {
 		})
 
 		pgurl := fmt.Sprintf("postgres://unused:unused@%s/%s?options=--cluster=tenant-cluster-28&sslmode=require", addr, "defaultdb")
-		te.TestConnectErr(ctx, t, pgurl, codeParamsRoutingFailed, "boom")
+		_ = te.TestConnectErr(ctx, t, pgurl, codeParamsRoutingFailed, "boom")
 	})
 
 }
@@ -534,7 +535,7 @@ func TestInsecureProxy(t *testing.T) {
 	)
 
 	url := fmt.Sprintf("postgres://bob:wrong@%s?sslmode=disable&options=--cluster=tenant-cluster-28&sslmode=require", addr)
-	te.TestConnectErr(ctx, t, url, 0, "failed SASL auth")
+	_ = te.TestConnectErr(ctx, t, url, 0, "failed SASL auth")
 
 	url = fmt.Sprintf("postgres://bob:builder@%s/?sslmode=disable&options=--cluster=tenant-cluster-28&sslmode=require", addr)
 	te.TestConnect(ctx, t, url, func(conn *pgx.Conn) {
@@ -568,7 +569,39 @@ func TestErroneousFrontend(t *testing.T) {
 	// Generic message here as the Frontend's error is not codeError and
 	// by default we don't pass back error's text. The startup message doesn't
 	// get processed in this case.
-	te.TestConnectErr(ctx, t, url, 0, "internal server error")
+	_ = te.TestConnectErr(ctx, t, url, 0, "internal server error")
+}
+
+func TestErrorHint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	te := newTester()
+	defer te.Close()
+	hint := "how to fix this err"
+
+	defer testutils.TestingHook(&FrontendAdmit, func(
+		conn net.Conn, incomingTLSConfig *tls.Config,
+	) *FrontendAdmitInfo {
+		return &FrontendAdmitInfo{Conn: conn,
+			Err: withCode(
+				errors.WithHint(
+					errors.New(frontendError),
+					hint),
+				codeParamsRoutingFailed)}
+	})()
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	_, addr, _ := newProxyServer(ctx, t, stopper, &ProxyOptions{})
+
+	url := fmt.Sprintf("postgres://bob:builder@%s/?sslmode=disable&options=--cluster=tenant-cluster-28&sslmode=require", addr)
+
+	err := te.TestConnectErr(ctx, t, url, 0, "codeParamsRoutingFailed: Frontend error")
+	pgErr := (*pgconn.PgError)(nil)
+	require.True(t, errors.As(err, &pgErr))
+	require.Equal(t, hint, pgErr.Hint)
 }
 
 func TestErroneousBackend(t *testing.T) {
@@ -594,7 +627,7 @@ func TestErroneousBackend(t *testing.T) {
 	// Generic message here as the Backend's error is not codeError and
 	// by default we don't pass back error's text. The startup message has
 	// already been processed.
-	te.TestConnectErr(ctx, t, url, 0, "internal server error")
+	_ = te.TestConnectErr(ctx, t, url, 0, "internal server error")
 }
 
 func TestProxyRefuseConn(t *testing.T) {
@@ -608,7 +641,7 @@ func TestProxyRefuseConn(t *testing.T) {
 	defer testutils.TestingHook(&BackendDial, func(
 		msg *pgproto3.StartupMessage, outgoingAddress string, tlsConfig *tls.Config,
 	) (net.Conn, error) {
-		return nil, newErrorf(codeProxyRefusedConnection, "too many attempts")
+		return nil, withCode(errors.New("too many attempts"), codeProxyRefusedConnection)
 	})()
 
 	stopper := stop.NewStopper()
@@ -616,7 +649,7 @@ func TestProxyRefuseConn(t *testing.T) {
 	s, addr, _ := newSecureProxyServer(ctx, t, stopper, &ProxyOptions{})
 
 	url := fmt.Sprintf("postgres://root:admin@%s?sslmode=require&options=--cluster=tenant-cluster-28&sslmode=require", addr)
-	te.TestConnectErr(ctx, t, url, codeProxyRefusedConnection, "too many attempts")
+	_ = te.TestConnectErr(ctx, t, url, codeProxyRefusedConnection, "too many attempts")
 	require.Equal(t, int64(1), s.metrics.RefusedConnCount.Count())
 	require.Equal(t, int64(0), s.metrics.SuccessfulConnCount.Count())
 	require.Equal(t, int64(0), s.metrics.ConnectionLatency.TotalCount())
@@ -748,7 +781,7 @@ func TestDirectoryConnect(t *testing.T) {
 		url := fmt.Sprintf(
 			"postgres://root:admin@%s/?sslmode=disable&options=--cluster=tenant-cluster-%d",
 			addr, notFoundTenantID)
-		te.TestConnectErr(ctx, t, url, codeParamsRoutingFailed, "cluster tenant-cluster-99 not found")
+		_ = te.TestConnectErr(ctx, t, url, codeParamsRoutingFailed, "cluster tenant-cluster-99 not found")
 	})
 
 	t.Run("fail to connect to backend", func(t *testing.T) {
@@ -759,9 +792,9 @@ func TestDirectoryConnect(t *testing.T) {
 		) (net.Conn, error) {
 			countFailures++
 			if countFailures >= 3 {
-				return nil, newErrorf(codeBackendDisconnected, "backend disconnected")
+				return nil, withCode(errors.New("backend disconnected"), codeBackendDisconnected)
 			}
-			return nil, newErrorf(codeBackendDown, "backend down")
+			return nil, withCode(errors.New("backend down"), codeBackendDown)
 		})()
 
 		// Ensure that Directory.ReportFailure is being called correctly.
@@ -782,7 +815,7 @@ func TestDirectoryConnect(t *testing.T) {
 		})()
 
 		url := fmt.Sprintf("postgres://root:admin@%s/?sslmode=disable&options=--cluster=tenant-cluster-28", addr)
-		te.TestConnectErr(ctx, t, url, codeBackendDisconnected, "backend disconnected")
+		_ = te.TestConnectErr(ctx, t, url, codeBackendDisconnected, "backend disconnected")
 		require.Equal(t, 3, countFailures)
 		require.Equal(t, 2, countReports)
 	})
@@ -2052,7 +2085,7 @@ type tester struct {
 	mu struct {
 		syncutil.Mutex
 		authenticated bool
-		errToClient   *codeError
+		errToClient   error
 	}
 
 	restoreAuthenticate    func()
@@ -2078,8 +2111,8 @@ func newTester() *tester {
 	originalSendErrToClient := SendErrToClient
 	te.restoreSendErrToClient =
 		testutils.TestingHook(&SendErrToClient, func(conn net.Conn, err error) {
-			if codeErr := (*codeError)(nil); errors.As(err, &codeErr) {
-				te.setErrToClient(codeErr)
+			if getErrorCode(err) != codeNone {
+				te.setErrToClient(err)
 			}
 			originalSendErrToClient(conn, err)
 		})
@@ -2107,13 +2140,13 @@ func (te *tester) setAuthenticated(auth bool) {
 }
 
 // ErrToClient returns any error sent by the proxy to the client.
-func (te *tester) ErrToClient() *codeError {
+func (te *tester) ErrToClient() error {
 	te.mu.Lock()
 	defer te.mu.Unlock()
 	return te.mu.errToClient
 }
 
-func (te *tester) setErrToClient(codeErr *codeError) {
+func (te *tester) setErrToClient(codeErr error) {
 	te.mu.Lock()
 	defer te.mu.Unlock()
 	te.mu.errToClient = codeErr
@@ -2144,7 +2177,7 @@ func (te *tester) TestConnect(ctx context.Context, t *testing.T, url string, fn 
 // an error to occur and validates the error matches the provided information.
 func (te *tester) TestConnectErr(
 	ctx context.Context, t *testing.T, url string, expCode errorCode, expErr string,
-) {
+) error {
 	t.Helper()
 	te.setAuthenticated(false)
 	te.setErrToClient(nil)
@@ -2166,8 +2199,9 @@ func (te *tester) TestConnectErr(
 	require.False(t, te.Authenticated())
 	if expCode != 0 {
 		require.NotNil(t, te.ErrToClient())
-		require.Equal(t, expCode, te.ErrToClient().code)
+		require.Equal(t, expCode, getErrorCode(te.ErrToClient()))
 	}
+	return err
 }
 
 func newSecureProxyServer(

--- a/pkg/sql/pgwire/pgcode/codes.go
+++ b/pkg/sql/pgwire/pgcode/codes.go
@@ -380,6 +380,10 @@ var (
 	// internally on a connection between different Cockroach nodes.
 	InternalConnectionFailure = MakeCode("58C01")
 
+	// ProxyConnectionError is returned by the sqlproxyccl and it indicates a
+	// problem establishing the connection through the proxy.
+	ProxyConnectionError = MakeCode("08C00")
+
 	// Class XC - cockroach extension.
 	// CockroachDB distributed system related errors.
 


### PR DESCRIPTION
The error with code that the proxy uses doesn't follow the same pattern as the rest of the repo code and as a result the hint that we add to the error was not being passed to the end user. This PR refactors the error to be in line with the rest of the code, refactors the hint that we use in case of missing routing info and adds a test to verify that it works.

Fixes #93474

Release note: None