### PR TITLE
storage: fix `CheckSSTConflicts` handling of MVCC range keys

### DIFF
--- a/pkg/storage/sst.go
+++ b/pkg/storage/sst.go
@@ -794,15 +794,30 @@ func CheckSSTConflicts(
 				// Seeks on the engine are expensive. Try Next()ing if we're very close
 				// to the sst key (which we might be).
 				nextsUntilSeek := numNextsBeforeSeek
+				rangeKeyChanged := false
 				for extOK && extIter.UnsafeKey().Key.Compare(sstIter.UnsafeKey().Key) < 0 {
 					extIter.NextKey()
 					extOK, _ = extIter.Valid()
+					rangeKeyChanged = rangeKeyChanged || extIter.RangeKeyChanged()
 					nextsUntilSeek--
 					if nextsUntilSeek <= 0 {
 						break
 					}
 				}
-				if extOK && extIter.UnsafeKey().Key.Compare(sstIter.UnsafeKey().Key) < 0 {
+				// TODO(erikgrinaker): NextKey() may not trigger `RangeKeyChanged()`
+				// on an exhausted iterator, so we check the case where we stepped
+				// from an initial range key onto an exhausted iterator. See:
+				// https://github.com/cockroachdb/cockroach/issues/94041
+				rangeKeyChanged = rangeKeyChanged || (!extOK && !extPrevRangeKeys.IsEmpty())
+				// If we havent't reached the SST key yet, seek to it. Otherwise, if we
+				// stepped past it but the range key changed we have to seek back to it,
+				// since we could otherwise have missed a range key that overlapped
+				// the SST key.
+				extCmp := 1
+				if extOK {
+					extCmp = extIter.UnsafeKey().Key.Compare(sstIter.UnsafeKey().Key)
+				}
+				if extCmp < 0 || (extCmp > 0 && rangeKeyChanged) {
 					extIter.SeekGE(MVCCKey{Key: sstIter.UnsafeKey().Key})
 				}
 			}
@@ -834,7 +849,7 @@ func CheckSSTConflicts(
 		// Since we use range key masking, we can just Next() the ext iterator
 		// past its range key.
 		if sstTimestamp.IsSet() && extHasRange && !extHasPoint && !sstHasRange {
-			if vers, ok := extRangeKeys.FirstAtOrAbove(sstTimestamp); !ok || vers.Timestamp.Equal(sstTimestamp) {
+			if extRangeKeys.Newest().Less(sstTimestamp) {
 				// All range key versions are below the request timestamp. We can seek
 				// past the range key, as all SST points/ranges are going to be above
 				// this range key.
@@ -850,15 +865,30 @@ func CheckSSTConflicts(
 					// Seeks on the engine are expensive. Try Next()ing if we're very close
 					// to the sst key (which we might be).
 					nextsUntilSeek := numNextsBeforeSeek
+					rangeKeyChanged := false
 					for extOK && extIter.UnsafeKey().Key.Compare(sstIter.UnsafeKey().Key) < 0 {
 						extIter.NextKey()
 						extOK, _ = extIter.Valid()
+						rangeKeyChanged = rangeKeyChanged || extIter.RangeKeyChanged()
 						nextsUntilSeek--
 						if nextsUntilSeek <= 0 {
 							break
 						}
 					}
-					if extOK && extIter.UnsafeKey().Key.Compare(sstIter.UnsafeKey().Key) < 0 {
+					// TODO(erikgrinaker): NextKey() may not trigger `RangeKeyChanged()`
+					// on an exhausted iterator, so we check the case where we stepped
+					// from an initial range key onto an exhausted iterator. See:
+					// https://github.com/cockroachdb/cockroach/issues/94041
+					rangeKeyChanged = rangeKeyChanged || (!extOK && !extPrevRangeKeys.IsEmpty())
+					// If we havent't reached the SST key yet, seek to it. Otherwise, if we
+					// stepped past it but the range key changed we have to seek back to it,
+					// since we could otherwise have missed a range key that overlapped
+					// the SST key.
+					extCmp := 1
+					if extOK {
+						extCmp = extIter.UnsafeKey().Key.Compare(sstIter.UnsafeKey().Key)
+					}
+					if extCmp < 0 || (extCmp > 0 && rangeKeyChanged) {
 						extIter.SeekGE(MVCCKey{Key: sstIter.UnsafeKey().Key})
 					}
 				}


### PR DESCRIPTION
`CheckSSTConflicts` keeps an SST and engine iterator in sync while checking for conflicts. To avoid seek costs, it attempts to step the engine iterator in case the corresponding SST key is nearby. However, this stepping could step right past an MVCC range key overlapping the SST key, which would break conflict checks with MVCC range tombstones.

This patch seeks the engine iterator back to the SST key if we step past it and the range key changed.

Resolves #93968.

Release note (bug fix): When experimental MVCC range tombstones are enabled (they're disabled by default), a bulk ingestion (e.g. an import) could in some situations fail to properly check for conflicts with existing MVCC range tombstones. This could cause the ingestion to write below a recently written MVCC range tombstone, in turn losing the ingested data. This could only happen in rare circumstances where a bulk ingestion was applied concurrently with an import cancellation.