### PR TITLE
kvserver: distinguish between encoding type and prefix byte

### DIFF
--- a/pkg/kv/kvserver/logstore/logstore_bench_test.go
+++ b/pkg/kv/kvserver/logstore/logstore_bench_test.go
@@ -76,7 +76,7 @@ func runBenchmarkLogStore_StoreEntries(b *testing.B, bytes int64) {
 		Term:  1,
 		Index: 1,
 		Type:  raftpb.EntryNormal,
-		Data:  kvserverbase.EncodeRaftCommand(kvserverbase.RaftVersionStandard, "deadbeef", data),
+		Data:  kvserverbase.EncodeRaftCommand(kvserverbase.RaftVersionStandardPrefixByte, "deadbeef", data),
 	})
 	stats := &AppendStats{}
 

--- a/pkg/kv/kvserver/logstore/sideload.go
+++ b/pkg/kv/kvserver/logstore/sideload.go
@@ -125,7 +125,7 @@ func MaybeSideloadEntries(
 		// TODO(tbg): this should be supported by a method as well.
 		{
 			data := make([]byte, kvserverbase.RaftCommandPrefixLen+e.Cmd.Size())
-			kvserverbase.EncodeRaftCommandPrefix(data[:kvserverbase.RaftCommandPrefixLen], kvserverbase.RaftVersionSideloaded, e.ID)
+			kvserverbase.EncodeRaftCommandPrefix(data[:kvserverbase.RaftCommandPrefixLen], kvserverbase.RaftVersionSideloadedPrefixByte, e.ID)
 			_, err := protoutil.MarshalTo(&e.Cmd, data[kvserverbase.RaftCommandPrefixLen:])
 			if err != nil {
 				return nil, 0, 0, 0, errors.Wrap(err, "while marshaling stripped sideloaded command")
@@ -214,7 +214,7 @@ func MaybeInlineSideloadedRaftCommand(
 	// the RaftCommandEncodingVersion.
 	{
 		data := make([]byte, kvserverbase.RaftCommandPrefixLen+e.Cmd.Size())
-		kvserverbase.EncodeRaftCommandPrefix(data[:kvserverbase.RaftCommandPrefixLen], kvserverbase.RaftVersionSideloaded, e.ID)
+		kvserverbase.EncodeRaftCommandPrefix(data[:kvserverbase.RaftCommandPrefixLen], kvserverbase.RaftVersionSideloadedPrefixByte, e.ID)
 		_, err := protoutil.MarshalTo(&e.Cmd, data[kvserverbase.RaftCommandPrefixLen:])
 		if err != nil {
 			return nil, err

--- a/pkg/kv/kvserver/logstore/sideload_test.go
+++ b/pkg/kv/kvserver/logstore/sideload_test.go
@@ -51,9 +51,7 @@ func mustEntryEq(t testing.TB, l, r raftpb.Entry) {
 }
 
 func mkEnt(
-	v kvserverbase.RaftCommandEncodingVersion,
-	index, term uint64,
-	as *kvserverpb.ReplicatedEvalResult_AddSSTable,
+	v byte, index, term uint64, as *kvserverpb.ReplicatedEvalResult_AddSSTable,
 ) raftpb.Entry {
 	cmdIDKey := strings.Repeat("x", kvserverbase.RaftCommandIDLen)
 	var cmd kvserverpb.RaftCommand
@@ -360,7 +358,7 @@ func TestRaftSSTableSideloadingInline(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	v1, v2 := kvserverbase.RaftVersionStandard, kvserverbase.RaftVersionSideloaded
+	v1, v2 := kvserverbase.RaftVersionStandardPrefixByte, kvserverbase.RaftVersionSideloadedPrefixByte
 	rangeID := roachpb.RangeID(1)
 
 	type testCase struct {
@@ -482,11 +480,11 @@ func TestRaftSSTableSideloadingSideload(t *testing.T) {
 	addSSTStripped := addSST
 	addSSTStripped.Data = nil
 
-	entV1Reg := mkEnt(kvserverbase.RaftVersionStandard, 10, 99, nil)
-	entV1SST := mkEnt(kvserverbase.RaftVersionStandard, 11, 99, &addSST)
-	entV2Reg := mkEnt(kvserverbase.RaftVersionSideloaded, 12, 99, nil)
-	entV2SST := mkEnt(kvserverbase.RaftVersionSideloaded, 13, 99, &addSST)
-	entV2SSTStripped := mkEnt(kvserverbase.RaftVersionSideloaded, 13, 99, &addSSTStripped)
+	entV1Reg := mkEnt(kvserverbase.RaftVersionStandardPrefixByte, 10, 99, nil)
+	entV1SST := mkEnt(kvserverbase.RaftVersionStandardPrefixByte, 11, 99, &addSST)
+	entV2Reg := mkEnt(kvserverbase.RaftVersionSideloadedPrefixByte, 12, 99, nil)
+	entV2SST := mkEnt(kvserverbase.RaftVersionSideloadedPrefixByte, 13, 99, &addSST)
+	entV2SSTStripped := mkEnt(kvserverbase.RaftVersionSideloadedPrefixByte, 13, 99, &addSSTStripped)
 
 	type tc struct {
 		name              string

--- a/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
+++ b/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
@@ -364,7 +364,7 @@ func raftLogFromPendingDescriptorUpdate(
 		t.Fatalf("failed to serialize raftCommand: %v", err)
 	}
 	data := kvserverbase.EncodeRaftCommand(
-		kvserverbase.RaftVersionStandard, kvserverbase.CmdIDKey(fmt.Sprintf("%08d", entryIndex)), out)
+		kvserverbase.RaftVersionStandardPrefixByte, kvserverbase.CmdIDKey(fmt.Sprintf("%08d", entryIndex)), out)
 	ent := raftpb.Entry{
 		Term:  1,
 		Index: replica.RaftCommittedIndex + entryIndex,

--- a/pkg/kv/kvserver/raftlog/entry.go
+++ b/pkg/kv/kvserver/raftlog/entry.go
@@ -46,21 +46,21 @@ func EncodingVersion(ent raftpb.Entry) (kvserverbase.RaftCommandEncodingVersion,
 		return 0, errors.AssertionFailedf("unknown EntryType %d", ent.Type)
 	}
 
-	v := kvserverbase.RaftCommandEncodingVersion(ent.Data[0])
-	switch v {
-	case kvserverbase.RaftVersionStandard:
-	case kvserverbase.RaftVersionSideloaded:
+	switch ent.Data[0] {
+	case kvserverbase.RaftVersionStandardPrefixByte:
+		return kvserverbase.RaftVersionStandard, nil
+	case kvserverbase.RaftVersionSideloadedPrefixByte:
+		return kvserverbase.RaftVersionSideloaded, nil
 	default:
-		return 0, errors.AssertionFailedf("unknown command encoding version %d", v)
+		return 0, errors.AssertionFailedf("unknown command encoding version %d", ent.Data[0])
 	}
-
-	return v, nil
 }
 
-// DecomposeRaftVersionStandardOrSideloaded extracts the CmdIDKey and the marshaled
-// kvserverpb.RaftCommand from a slice which is known to have come from a
-// raftpb.Entry of type kvserverbase.RaftVersionStandard or
-// kvserverbase.RaftVersionSideloaded (which share an encoding).
+// DecomposeRaftVersionStandardOrSideloaded extracts the CmdIDKey and the
+// marshaled kvserverpb.RaftCommand from a slice which is known to have come
+// from a raftpb.Entry of type kvserverbase.RaftVersionStandard or
+// kvserverbase.RaftVersionSideloaded (which, mod the prefix byte, share an
+// encoding).
 func DecomposeRaftVersionStandardOrSideloaded(data []byte) (kvserverbase.CmdIDKey, []byte) {
 	return kvserverbase.CmdIDKey(data[1 : 1+kvserverbase.RaftCommandIDLen]), data[1+kvserverbase.RaftCommandIDLen:]
 }

--- a/pkg/kv/kvserver/raftlog/entry_test.go
+++ b/pkg/kv/kvserver/raftlog/entry_test.go
@@ -26,7 +26,7 @@ func TestLoadInvalidEntry(t *testing.T) {
 		Data: kvserverbase.EncodeRaftCommand(
 			// It would be nice to have an "even more invalid" command here but it
 			// turns out that DecodeRaftCommand "handles" errors via panic().
-			kvserverbase.RaftVersionStandard, "foobarzz", []byte("definitely not a protobuf"),
+			kvserverbase.RaftVersionStandardPrefixByte, "foobarzz", []byte("definitely not a protobuf"),
 		),
 	}
 	ent, err := NewEntry(invalidEnt)

--- a/pkg/kv/kvserver/raftlog/iter_bench_test.go
+++ b/pkg/kv/kvserver/raftlog/iter_bench_test.go
@@ -93,7 +93,7 @@ func mkBenchEnt(b *testing.B) (_ raftpb.Entry, metaB []byte) {
 	}
 	cmdB, err := protoutil.Marshal(cmd)
 	require.NoError(b, err)
-	data := kvserverbase.EncodeRaftCommand(kvserverbase.RaftVersionStandard, "cmd12345", cmdB)
+	data := kvserverbase.EncodeRaftCommand(kvserverbase.RaftVersionStandardPrefixByte, "cmd12345", cmdB)
 
 	ent := raftpb.Entry{
 		Term:  1,

--- a/pkg/kv/kvserver/raftlog/iter_test.go
+++ b/pkg/kv/kvserver/raftlog/iter_test.go
@@ -44,10 +44,11 @@ func ents(inds ...uint64) []raftpb.Entry {
 		typ := raftpb.EntryType(ind % 3)
 		switch typ {
 		case raftpb.EntryNormal:
-			data = kvserverbase.EncodeRaftCommand(
-				kvserverbase.RaftCommandEncodingVersion(ind%2),
-				cmdID,
-				b)
+			prefixByte := kvserverbase.RaftVersionStandardPrefixByte
+			if ind%2 == 0 {
+				prefixByte = kvserverbase.RaftVersionSideloadedPrefixByte
+			}
+			data = kvserverbase.EncodeRaftCommand(prefixByte, cmdID, b)
 		case raftpb.EntryConfChangeV2:
 			c := kvserverpb.ConfChangeContext{
 				CommandID: string(cmdID),

--- a/pkg/kv/kvserver/replica_proposal_buf_test.go
+++ b/pkg/kv/kvserver/replica_proposal_buf_test.go
@@ -303,7 +303,7 @@ func (pc proposalCreator) encodeProposal(p *ProposalData) []byte {
 	cmdLen := p.command.Size()
 	needed := kvserverbase.RaftCommandPrefixLen + cmdLen + kvserverpb.MaxRaftCommandFooterSize()
 	data := make([]byte, kvserverbase.RaftCommandPrefixLen, needed)
-	kvserverbase.EncodeRaftCommandPrefix(data, kvserverbase.RaftVersionStandard, p.idKey)
+	kvserverbase.EncodeRaftCommandPrefix(data, kvserverbase.RaftVersionStandardPrefixByte, p.idKey)
 	data = data[:kvserverbase.RaftCommandPrefixLen+p.command.Size()]
 	if _, err := protoutil.MarshalTo(p.command, data[kvserverbase.RaftCommandPrefixLen:]); err != nil {
 		panic(err)

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -343,7 +343,7 @@ func (r *Replica) propose(
 
 	// Determine the encoding style for the Raft command.
 	prefix := true
-	version := kvserverbase.RaftVersionStandard
+	encodingPrefixByte := kvserverbase.RaftVersionStandardPrefixByte
 	if crt := p.command.ReplicatedEvalResult.ChangeReplicas; crt != nil {
 		// EndTxnRequest with a ChangeReplicasTrigger is special because Raft
 		// needs to understand it; it cannot simply be an opaque command. To
@@ -415,7 +415,7 @@ func (r *Replica) propose(
 		}
 	} else if p.command.ReplicatedEvalResult.AddSSTable != nil {
 		log.VEvent(p.ctx, 4, "sideloadable proposal detected")
-		version = kvserverbase.RaftVersionSideloaded
+		encodingPrefixByte = kvserverbase.RaftVersionSideloadedPrefixByte
 		r.store.metrics.AddSSTableProposals.Inc(1)
 
 		if p.command.ReplicatedEvalResult.AddSSTable.Data == nil {
@@ -437,7 +437,7 @@ func (r *Replica) propose(
 	data := make([]byte, preLen, needed)
 	// Encode prefix with command ID, if necessary.
 	if prefix {
-		kvserverbase.EncodeRaftCommandPrefix(data, version, p.idKey)
+		kvserverbase.EncodeRaftCommandPrefix(data, encodingPrefixByte, p.idKey)
 	}
 	// Encode body of command.
 	data = data[:preLen+cmdLen]

--- a/pkg/kv/kvserver/replica_raft_quiesce.go
+++ b/pkg/kv/kvserver/replica_raft_quiesce.go
@@ -87,7 +87,7 @@ func (r *Replica) maybeUnquiesceAndWakeLeaderLocked() bool {
 	r.store.unquiescedReplicas.Unlock()
 	r.maybeCampaignOnWakeLocked(ctx)
 	// Propose an empty command which will wake the leader.
-	data := kvserverbase.EncodeRaftCommand(kvserverbase.RaftVersionStandard, makeIDKey(), nil)
+	data := kvserverbase.EncodeRaftCommand(kvserverbase.RaftVersionStandardPrefixByte, makeIDKey(), nil)
 	_ = r.mu.internalRaftGroup.Propose(data)
 	return true
 }


### PR DESCRIPTION
Now the logical encodings are independent of what's on the
wire. This separation will be more helpful once we have
better encapsulation of entry encoding.

This was discussed in https://github.com/cockroachdb/cockroach/pull/93711.

Epic: CRDB-220
Release note: None