### PR TITLE
storage: fix `GCBytesAge` in `CheckSSTConflicts` for covered point tombstone

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -383,6 +383,13 @@ func TestEvalAddSSTable(t *testing.T) {
 			sst:        kvs{pointKV("a", 3, "sst")},
 			expectErr:  "inline values are unsupported",
 		},
+		// Regression test for https://github.com/cockroachdb/cockroach/issues/94053.
+		"DisallowConflicts MVCC stats with point tombstone below range tombstone": {
+			noConflict: true,
+			data:       kvs{rangeKV("a", "c", 3, ""), pointKV("b", 2, ""), pointKV("b", 1, "b1")},
+			sst:        kvs{pointKV("b", 5, "sst")},
+			expect:     kvs{rangeKV("a", "c", 3, ""), pointKV("b", 5, "sst"), pointKV("b", 2, ""), pointKV("b", 1, "b1")},
+		},
 
 		// DisallowShadowing
 		"DisallowShadowing errors above existing": {


### PR DESCRIPTION
When `CheckSSTConflicts` ingests a point key above a point tombstone covered by a range tombstone, it incorrectly considered the key to be deleted at the range tombstone, not at the point tombstone. This patch fixes this calculation.

Resolves #94053.

Release note: None