### PR TITLE
raftlog: remove "version" terminology from existing encodings

### DIFF
--- a/pkg/kv/kvserver/kvserverbase/BUILD.bazel
+++ b/pkg/kv/kvserver/kvserverbase/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
         "bulk_adder.go",
         "forced_error.go",
         "knobs.go",
-        "raftversion.go",
         "stores.go",
         "syncing_write.go",
     ],

--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -324,7 +324,7 @@ func LoadTerm(
 		// sideloaded entries here to keep the term fetching cheap.
 		// TODO(pavelkalinnikov): consider not caching here, after measuring if it
 		// makes any difference.
-		typ, err := raftlog.EncodingVersion(entry)
+		typ, err := raftlog.EncodingOf(entry)
 		if err != nil {
 			return 0, err
 		}
@@ -401,7 +401,7 @@ func LoadEntries(
 		}
 		expectedIndex++
 
-		typ, err := raftlog.EncodingVersion(ent)
+		typ, err := raftlog.EncodingOf(ent)
 		if err != nil {
 			return err
 		}

--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -328,7 +328,7 @@ func LoadTerm(
 		if err != nil {
 			return 0, err
 		}
-		if typ != raftlog.RaftVersionSideloaded {
+		if typ != raftlog.EntryEncodingSideloaded {
 			eCache.Add(rangeID, []raftpb.Entry{entry}, false /* truncate */)
 		}
 		return entry.Term, nil
@@ -405,7 +405,7 @@ func LoadEntries(
 		if err != nil {
 			return err
 		}
-		if typ == raftlog.RaftVersionSideloaded {
+		if typ == raftlog.EntryEncodingSideloaded {
 			newEnt, err := MaybeInlineSideloadedRaftCommand(
 				ctx, rangeID, ent, sideloaded, eCache,
 			)

--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftentry"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftlog"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -329,7 +328,7 @@ func LoadTerm(
 		if err != nil {
 			return 0, err
 		}
-		if typ != kvserverbase.RaftVersionSideloaded {
+		if typ != raftlog.RaftVersionSideloaded {
 			eCache.Add(rangeID, []raftpb.Entry{entry}, false /* truncate */)
 		}
 		return entry.Term, nil
@@ -406,7 +405,7 @@ func LoadEntries(
 		if err != nil {
 			return err
 		}
-		if typ == kvserverbase.RaftVersionSideloaded {
+		if typ == raftlog.RaftVersionSideloaded {
 			newEnt, err := MaybeInlineSideloadedRaftCommand(
 				ctx, rangeID, ent, sideloaded, eCache,
 			)

--- a/pkg/kv/kvserver/logstore/logstore_bench_test.go
+++ b/pkg/kv/kvserver/logstore/logstore_bench_test.go
@@ -17,8 +17,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftentry"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftlog"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
@@ -76,7 +76,7 @@ func runBenchmarkLogStore_StoreEntries(b *testing.B, bytes int64) {
 		Term:  1,
 		Index: 1,
 		Type:  raftpb.EntryNormal,
-		Data:  kvserverbase.EncodeRaftCommand(kvserverbase.RaftVersionStandardPrefixByte, "deadbeef", data),
+		Data:  raftlog.EncodeRaftCommand(raftlog.RaftVersionStandardPrefixByte, "deadbeef", data),
 	})
 	stats := &AppendStats{}
 

--- a/pkg/kv/kvserver/logstore/logstore_bench_test.go
+++ b/pkg/kv/kvserver/logstore/logstore_bench_test.go
@@ -76,7 +76,7 @@ func runBenchmarkLogStore_StoreEntries(b *testing.B, bytes int64) {
 		Term:  1,
 		Index: 1,
 		Type:  raftpb.EntryNormal,
-		Data:  raftlog.EncodeRaftCommand(raftlog.RaftVersionStandardPrefixByte, "deadbeef", data),
+		Data:  raftlog.EncodeRaftCommand(raftlog.EntryEncodingStandardPrefixByte, "deadbeef", data),
 	})
 	stats := &AppendStats{}
 

--- a/pkg/kv/kvserver/logstore/sideload.go
+++ b/pkg/kv/kvserver/logstore/sideload.go
@@ -86,7 +86,7 @@ func MaybeSideloadEntries(
 		if err != nil {
 			return nil, 0, 0, 0, err
 		}
-		if typ != raftlog.RaftVersionSideloaded {
+		if typ != raftlog.EntryEncodingSideloaded {
 			otherEntriesSize += int64(len(input[i].Data))
 			continue
 		}
@@ -124,7 +124,7 @@ func MaybeSideloadEntries(
 		// TODO(tbg): this should be supported by a method as well.
 		{
 			data := make([]byte, raftlog.RaftCommandPrefixLen+e.Cmd.Size())
-			raftlog.EncodeRaftCommandPrefix(data[:raftlog.RaftCommandPrefixLen], raftlog.RaftVersionSideloadedPrefixByte, e.ID)
+			raftlog.EncodeRaftCommandPrefix(data[:raftlog.RaftCommandPrefixLen], raftlog.EntryEncodingSideloadedPrefixByte, e.ID)
 			_, err := protoutil.MarshalTo(&e.Cmd, data[raftlog.RaftCommandPrefixLen:])
 			if err != nil {
 				return nil, 0, 0, 0, errors.Wrap(err, "while marshaling stripped sideloaded command")
@@ -165,7 +165,7 @@ func MaybeInlineSideloadedRaftCommand(
 	if err != nil {
 		return nil, err
 	}
-	if typ != raftlog.RaftVersionSideloaded {
+	if typ != raftlog.EntryEncodingSideloaded {
 		return nil, nil
 	}
 	log.Event(ctx, "inlining sideloaded SSTable")
@@ -213,7 +213,7 @@ func MaybeInlineSideloadedRaftCommand(
 	// the EntryEncoding.
 	{
 		data := make([]byte, raftlog.RaftCommandPrefixLen+e.Cmd.Size())
-		raftlog.EncodeRaftCommandPrefix(data[:raftlog.RaftCommandPrefixLen], raftlog.RaftVersionSideloadedPrefixByte, e.ID)
+		raftlog.EncodeRaftCommandPrefix(data[:raftlog.RaftCommandPrefixLen], raftlog.EntryEncodingSideloadedPrefixByte, e.ID)
 		_, err := protoutil.MarshalTo(&e.Cmd, data[raftlog.RaftCommandPrefixLen:])
 		if err != nil {
 			return nil, err
@@ -232,7 +232,7 @@ func AssertSideloadedRaftCommandInlined(ctx context.Context, ent *raftpb.Entry) 
 	if err != nil {
 		log.Fatalf(ctx, "%v", err)
 	}
-	if typ != raftlog.RaftVersionSideloaded {
+	if typ != raftlog.EntryEncodingSideloaded {
 		return
 	}
 

--- a/pkg/kv/kvserver/logstore/sideload.go
+++ b/pkg/kv/kvserver/logstore/sideload.go
@@ -210,7 +210,7 @@ func MaybeInlineSideloadedRaftCommand(
 	}
 	e.Cmd.ReplicatedEvalResult.AddSSTable.Data = sideloadedData
 	// TODO(tbg): there should be a helper that properly encodes a command, given
-	// the RaftCommandEncodingVersion.
+	// the EntryEncoding.
 	{
 		data := make([]byte, raftlog.RaftCommandPrefixLen+e.Cmd.Size())
 		raftlog.EncodeRaftCommandPrefix(data[:raftlog.RaftCommandPrefixLen], raftlog.RaftVersionSideloadedPrefixByte, e.ID)

--- a/pkg/kv/kvserver/logstore/sideload.go
+++ b/pkg/kv/kvserver/logstore/sideload.go
@@ -82,7 +82,7 @@ func MaybeSideloadEntries(
 ) {
 	var output []raftpb.Entry
 	for i := range input {
-		typ, err := raftlog.EncodingVersion(input[i])
+		typ, err := raftlog.EncodingOf(input[i])
 		if err != nil {
 			return nil, 0, 0, 0, err
 		}
@@ -161,7 +161,7 @@ func MaybeInlineSideloadedRaftCommand(
 	sideloaded SideloadStorage,
 	entryCache *raftentry.Cache,
 ) (*raftpb.Entry, error) {
-	typ, err := raftlog.EncodingVersion(ent)
+	typ, err := raftlog.EncodingOf(ent)
 	if err != nil {
 		return nil, err
 	}
@@ -228,7 +228,7 @@ func MaybeInlineSideloadedRaftCommand(
 // requires unmarshalling the raft command, so this assertion should be kept out
 // of performance critical paths.
 func AssertSideloadedRaftCommandInlined(ctx context.Context, ent *raftpb.Entry) {
-	typ, err := raftlog.EncodingVersion(*ent)
+	typ, err := raftlog.EncodingOf(*ent)
 	if err != nil {
 		log.Fatalf(ctx, "%v", err)
 	}

--- a/pkg/kv/kvserver/logstore/sideload.go
+++ b/pkg/kv/kvserver/logstore/sideload.go
@@ -13,7 +13,6 @@ package logstore
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftentry"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftlog"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -87,7 +86,7 @@ func MaybeSideloadEntries(
 		if err != nil {
 			return nil, 0, 0, 0, err
 		}
-		if typ != kvserverbase.RaftVersionSideloaded {
+		if typ != raftlog.RaftVersionSideloaded {
 			otherEntriesSize += int64(len(input[i].Data))
 			continue
 		}
@@ -124,9 +123,9 @@ func MaybeSideloadEntries(
 		//
 		// TODO(tbg): this should be supported by a method as well.
 		{
-			data := make([]byte, kvserverbase.RaftCommandPrefixLen+e.Cmd.Size())
-			kvserverbase.EncodeRaftCommandPrefix(data[:kvserverbase.RaftCommandPrefixLen], kvserverbase.RaftVersionSideloadedPrefixByte, e.ID)
-			_, err := protoutil.MarshalTo(&e.Cmd, data[kvserverbase.RaftCommandPrefixLen:])
+			data := make([]byte, raftlog.RaftCommandPrefixLen+e.Cmd.Size())
+			raftlog.EncodeRaftCommandPrefix(data[:raftlog.RaftCommandPrefixLen], raftlog.RaftVersionSideloadedPrefixByte, e.ID)
+			_, err := protoutil.MarshalTo(&e.Cmd, data[raftlog.RaftCommandPrefixLen:])
 			if err != nil {
 				return nil, 0, 0, 0, errors.Wrap(err, "while marshaling stripped sideloaded command")
 			}
@@ -166,7 +165,7 @@ func MaybeInlineSideloadedRaftCommand(
 	if err != nil {
 		return nil, err
 	}
-	if typ != kvserverbase.RaftVersionSideloaded {
+	if typ != raftlog.RaftVersionSideloaded {
 		return nil, nil
 	}
 	log.Event(ctx, "inlining sideloaded SSTable")
@@ -213,9 +212,9 @@ func MaybeInlineSideloadedRaftCommand(
 	// TODO(tbg): there should be a helper that properly encodes a command, given
 	// the RaftCommandEncodingVersion.
 	{
-		data := make([]byte, kvserverbase.RaftCommandPrefixLen+e.Cmd.Size())
-		kvserverbase.EncodeRaftCommandPrefix(data[:kvserverbase.RaftCommandPrefixLen], kvserverbase.RaftVersionSideloadedPrefixByte, e.ID)
-		_, err := protoutil.MarshalTo(&e.Cmd, data[kvserverbase.RaftCommandPrefixLen:])
+		data := make([]byte, raftlog.RaftCommandPrefixLen+e.Cmd.Size())
+		raftlog.EncodeRaftCommandPrefix(data[:raftlog.RaftCommandPrefixLen], raftlog.RaftVersionSideloadedPrefixByte, e.ID)
+		_, err := protoutil.MarshalTo(&e.Cmd, data[raftlog.RaftCommandPrefixLen:])
 		if err != nil {
 			return nil, err
 		}
@@ -233,7 +232,7 @@ func AssertSideloadedRaftCommandInlined(ctx context.Context, ent *raftpb.Entry) 
 	if err != nil {
 		log.Fatalf(ctx, "%v", err)
 	}
-	if typ != kvserverbase.RaftVersionSideloaded {
+	if typ != raftlog.RaftVersionSideloaded {
 		return
 	}
 

--- a/pkg/kv/kvserver/logstore/sideload_test.go
+++ b/pkg/kv/kvserver/logstore/sideload_test.go
@@ -358,7 +358,7 @@ func TestRaftSSTableSideloadingInline(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	v1, v2 := raftlog.RaftVersionStandardPrefixByte, raftlog.RaftVersionSideloadedPrefixByte
+	v1, v2 := raftlog.EntryEncodingStandardPrefixByte, raftlog.EntryEncodingSideloadedPrefixByte
 	rangeID := roachpb.RangeID(1)
 
 	type testCase struct {
@@ -480,11 +480,11 @@ func TestRaftSSTableSideloadingSideload(t *testing.T) {
 	addSSTStripped := addSST
 	addSSTStripped.Data = nil
 
-	entV1Reg := mkEnt(raftlog.RaftVersionStandardPrefixByte, 10, 99, nil)
-	entV1SST := mkEnt(raftlog.RaftVersionStandardPrefixByte, 11, 99, &addSST)
-	entV2Reg := mkEnt(raftlog.RaftVersionSideloadedPrefixByte, 12, 99, nil)
-	entV2SST := mkEnt(raftlog.RaftVersionSideloadedPrefixByte, 13, 99, &addSST)
-	entV2SSTStripped := mkEnt(raftlog.RaftVersionSideloadedPrefixByte, 13, 99, &addSSTStripped)
+	entV1Reg := mkEnt(raftlog.EntryEncodingStandardPrefixByte, 10, 99, nil)
+	entV1SST := mkEnt(raftlog.EntryEncodingStandardPrefixByte, 11, 99, &addSST)
+	entV2Reg := mkEnt(raftlog.EntryEncodingSideloadedPrefixByte, 12, 99, nil)
+	entV2SST := mkEnt(raftlog.EntryEncodingSideloadedPrefixByte, 13, 99, &addSST)
+	entV2SSTStripped := mkEnt(raftlog.EntryEncodingSideloadedPrefixByte, 13, 99, &addSSTStripped)
 
 	type tc struct {
 		name              string

--- a/pkg/kv/kvserver/logstore/sideload_test.go
+++ b/pkg/kv/kvserver/logstore/sideload_test.go
@@ -53,7 +53,7 @@ func mustEntryEq(t testing.TB, l, r raftpb.Entry) {
 func mkEnt(
 	v byte, index, term uint64, as *kvserverpb.ReplicatedEvalResult_AddSSTable,
 ) raftpb.Entry {
-	cmdIDKey := strings.Repeat("x", kvserverbase.RaftCommandIDLen)
+	cmdIDKey := strings.Repeat("x", raftlog.RaftCommandIDLen)
 	var cmd kvserverpb.RaftCommand
 	cmd.ReplicatedEvalResult.AddSSTable = as
 	b, err := protoutil.Marshal(&cmd)
@@ -62,7 +62,7 @@ func mkEnt(
 	}
 	var ent raftpb.Entry
 	ent.Index, ent.Term = index, term
-	ent.Data = kvserverbase.EncodeRaftCommand(v, kvserverbase.CmdIDKey(cmdIDKey), b)
+	ent.Data = raftlog.EncodeRaftCommand(v, kvserverbase.CmdIDKey(cmdIDKey), b)
 	return ent
 }
 
@@ -358,7 +358,7 @@ func TestRaftSSTableSideloadingInline(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	v1, v2 := kvserverbase.RaftVersionStandardPrefixByte, kvserverbase.RaftVersionSideloadedPrefixByte
+	v1, v2 := raftlog.RaftVersionStandardPrefixByte, raftlog.RaftVersionSideloadedPrefixByte
 	rangeID := roachpb.RangeID(1)
 
 	type testCase struct {
@@ -480,11 +480,11 @@ func TestRaftSSTableSideloadingSideload(t *testing.T) {
 	addSSTStripped := addSST
 	addSSTStripped.Data = nil
 
-	entV1Reg := mkEnt(kvserverbase.RaftVersionStandardPrefixByte, 10, 99, nil)
-	entV1SST := mkEnt(kvserverbase.RaftVersionStandardPrefixByte, 11, 99, &addSST)
-	entV2Reg := mkEnt(kvserverbase.RaftVersionSideloadedPrefixByte, 12, 99, nil)
-	entV2SST := mkEnt(kvserverbase.RaftVersionSideloadedPrefixByte, 13, 99, &addSST)
-	entV2SSTStripped := mkEnt(kvserverbase.RaftVersionSideloadedPrefixByte, 13, 99, &addSSTStripped)
+	entV1Reg := mkEnt(raftlog.RaftVersionStandardPrefixByte, 10, 99, nil)
+	entV1SST := mkEnt(raftlog.RaftVersionStandardPrefixByte, 11, 99, &addSST)
+	entV2Reg := mkEnt(raftlog.RaftVersionSideloadedPrefixByte, 12, 99, nil)
+	entV2SST := mkEnt(raftlog.RaftVersionSideloadedPrefixByte, 13, 99, &addSST)
+	entV2SSTStripped := mkEnt(raftlog.RaftVersionSideloadedPrefixByte, 13, 99, &addSSTStripped)
 
 	type tc struct {
 		name              string

--- a/pkg/kv/kvserver/loqrecovery/BUILD.bazel
+++ b/pkg/kv/kvserver/loqrecovery/BUILD.bazel
@@ -50,6 +50,7 @@ go_test(
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/kvserverpb",
         "//pkg/kv/kvserver/loqrecovery/loqrecoverypb",
+        "//pkg/kv/kvserver/raftlog",
         "//pkg/kv/kvserver/stateloader",
         "//pkg/roachpb",
         "//pkg/security/securityassets",

--- a/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
+++ b/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/loqrecovery/loqrecoverypb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftlog"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -363,8 +364,8 @@ func raftLogFromPendingDescriptorUpdate(
 	if err != nil {
 		t.Fatalf("failed to serialize raftCommand: %v", err)
 	}
-	data := kvserverbase.EncodeRaftCommand(
-		kvserverbase.RaftVersionStandardPrefixByte, kvserverbase.CmdIDKey(fmt.Sprintf("%08d", entryIndex)), out)
+	data := raftlog.EncodeRaftCommand(
+		raftlog.RaftVersionStandardPrefixByte, kvserverbase.CmdIDKey(fmt.Sprintf("%08d", entryIndex)), out)
 	ent := raftpb.Entry{
 		Term:  1,
 		Index: replica.RaftCommittedIndex + entryIndex,

--- a/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
+++ b/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
@@ -365,7 +365,7 @@ func raftLogFromPendingDescriptorUpdate(
 		t.Fatalf("failed to serialize raftCommand: %v", err)
 	}
 	data := raftlog.EncodeRaftCommand(
-		raftlog.RaftVersionStandardPrefixByte, kvserverbase.CmdIDKey(fmt.Sprintf("%08d", entryIndex)), out)
+		raftlog.EntryEncodingStandardPrefixByte, kvserverbase.CmdIDKey(fmt.Sprintf("%08d", entryIndex)), out)
 	ent := raftpb.Entry{
 		Term:  1,
 		Index: replica.RaftCommittedIndex + entryIndex,

--- a/pkg/kv/kvserver/raft.go
+++ b/pkg/kv/kvserver/raft.go
@@ -274,10 +274,10 @@ func extractIDs(ids []kvserverbase.CmdIDKey, ents []raftpb.Entry) []kvserverbase
 			continue
 		}
 		switch typ {
-		case kvserverbase.RaftVersionStandard, kvserverbase.RaftVersionSideloaded:
+		case raftlog.RaftVersionStandard, raftlog.RaftVersionSideloaded:
 			id, _ := raftlog.DecomposeRaftVersionStandardOrSideloaded(e.Data)
 			ids = append(ids, id)
-		case kvserverbase.RaftVersionConfChange, kvserverbase.RaftVersionConfChangeV2:
+		case raftlog.RaftVersionConfChange, raftlog.RaftVersionConfChangeV2:
 			// Configuration changes don't have the CmdIDKey easily accessible but are
 			// rare, so fully decode the entry.
 			ent, err := raftlog.NewEntry(e)

--- a/pkg/kv/kvserver/raft.go
+++ b/pkg/kv/kvserver/raft.go
@@ -221,7 +221,7 @@ func raftEntryFormatter(data []byte) string {
 	}
 	// NB: a raft.EntryFormatter is only invoked for EntryNormal (raft methods
 	// that call this take care of unwrapping the ConfChange), and since
-	// len(data)>0 it has to be RaftVersionStandard or RaftVersionSideloaded and
+	// len(data)>0 it has to be EntryEncodingStandard or EntryEncodingSideloaded and
 	// they are encoded identically.
 	cmdID, data := raftlog.DecomposeRaftVersionStandardOrSideloaded(data)
 	return fmt.Sprintf("[%x] [%d]", cmdID, len(data))
@@ -274,10 +274,10 @@ func extractIDs(ids []kvserverbase.CmdIDKey, ents []raftpb.Entry) []kvserverbase
 			continue
 		}
 		switch typ {
-		case raftlog.RaftVersionStandard, raftlog.RaftVersionSideloaded:
+		case raftlog.EntryEncodingStandard, raftlog.EntryEncodingSideloaded:
 			id, _ := raftlog.DecomposeRaftVersionStandardOrSideloaded(e.Data)
 			ids = append(ids, id)
-		case raftlog.RaftVersionConfChange, raftlog.RaftVersionConfChangeV2:
+		case raftlog.EntryEncodingRaftConfChange, raftlog.EntryEncodingRaftConfChangeV2:
 			// Configuration changes don't have the CmdIDKey easily accessible but are
 			// rare, so fully decode the entry.
 			ent, err := raftlog.NewEntry(e)

--- a/pkg/kv/kvserver/raft.go
+++ b/pkg/kv/kvserver/raft.go
@@ -269,7 +269,7 @@ func (r *Replica) traceMessageSends(msgs []raftpb.Message, event string) {
 // in ents to ids and returns the result.
 func extractIDs(ids []kvserverbase.CmdIDKey, ents []raftpb.Entry) []kvserverbase.CmdIDKey {
 	for _, e := range ents {
-		typ, err := raftlog.EncodingVersion(e)
+		typ, err := raftlog.EncodingOf(e)
 		if err != nil {
 			continue
 		}

--- a/pkg/kv/kvserver/raftlog/BUILD.bazel
+++ b/pkg/kv/kvserver/raftlog/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     name = "raftlog",
     srcs = [
         "command.go",
+        "encoding.go",
         "entry.go",
         "iterator.go",
     ],

--- a/pkg/kv/kvserver/raftlog/encoding.go
+++ b/pkg/kv/kvserver/raftlog/encoding.go
@@ -8,9 +8,13 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package kvserverbase
+package raftlog
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
+)
 
 // RaftCommandEncodingVersion versions CockroachDB's raft entries.
 // A raftpb.Entry's RaftCommandEncodingVersion is a function of the
@@ -77,7 +81,7 @@ const (
 )
 
 // EncodeRaftCommand encodes a raft command (including the versioning prefix).
-func EncodeRaftCommand(prefixByte byte, commandID CmdIDKey, command []byte) []byte {
+func EncodeRaftCommand(prefixByte byte, commandID kvserverbase.CmdIDKey, command []byte) []byte {
 	b := make([]byte, RaftCommandPrefixLen+len(command))
 	EncodeRaftCommandPrefix(b[:RaftCommandPrefixLen], prefixByte, commandID)
 	copy(b[RaftCommandPrefixLen:], command)
@@ -85,7 +89,7 @@ func EncodeRaftCommand(prefixByte byte, commandID CmdIDKey, command []byte) []by
 }
 
 // EncodeRaftCommandPrefix encodes the versioning prefix for a Raft command.
-func EncodeRaftCommandPrefix(b []byte, prefixByte byte, commandID CmdIDKey) {
+func EncodeRaftCommandPrefix(b []byte, prefixByte byte, commandID kvserverbase.CmdIDKey) {
 	if len(commandID) != RaftCommandIDLen {
 		panic(fmt.Sprintf("invalid command ID length; %d != %d", len(commandID), RaftCommandIDLen))
 	}

--- a/pkg/kv/kvserver/raftlog/encoding.go
+++ b/pkg/kv/kvserver/raftlog/encoding.go
@@ -16,13 +16,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 )
 
-// RaftCommandEncodingVersion versions CockroachDB's raft entries.
-// A raftpb.Entry's RaftCommandEncodingVersion is a function of the
-// Entry's raftpb.EntryType and, in some cases, the first byte of the
-// Entry's Data payload.
+// EntryEncoding enumerates the encodings used in CockroachDB for raftpb.Entry.
 //
-// TODO(tbg): rename to RaftCommandEncoding.
-type RaftCommandEncodingVersion byte
+// A raftpb.Entry's EntryEncoding is determined by the Entry's raftpb.EntryType
+// and, in some cases, the first byte of the Entry's Data payload.
+type EntryEncoding byte
 
 const (
 	// RaftVersionStandard is the default encoding for a CockroachDB raft log
@@ -32,7 +30,7 @@ const (
 	// or whose first byte matches RaftVersionStandardPrefixByte. The subsequent
 	// eight bytes represent a CmdIDKey. The remaining bytes represent a
 	// kvserverpb.RaftCommand.
-	RaftVersionStandard RaftCommandEncodingVersion = 0
+	RaftVersionStandard EntryEncoding = 0
 	// RaftVersionSideloaded indicates a proposal representing the result of a
 	// roachpb.AddSSTableRequest for which the payload (the SST) is stored outside
 	// the storage engine to improve storage performance.
@@ -45,21 +43,21 @@ const (
 	// which is an SST to be ingested (and which is present in memory but made
 	// durable via direct storage on the filesystem, bypassing the storage
 	// engine).
-	RaftVersionSideloaded RaftCommandEncodingVersion = 1
+	RaftVersionSideloaded EntryEncoding = 1
 	// RaftVersionEmptyEntry is an empty entry. These are used by raft after
 	// leader election. Since they hold no data, there is nothing in them to
 	// decode.
-	RaftVersionEmptyEntry RaftCommandEncodingVersion = 253
+	RaftVersionEmptyEntry EntryEncoding = 253
 	// RaftVersionConfChange is a raftpb.Entry whose raftpb.EntryType is
 	// raftpb.EntryConfChange. The Entry's Data field holds a raftpb.ConfChange
 	// whose Context field is a kvserverpb.ConfChangeContext whose Payload is a
 	// kvserverpb.RaftCommand. In particular, the CmdIDKey requires a round of
 	// protobuf unmarshaling.
-	RaftVersionConfChange RaftCommandEncodingVersion = 254
+	RaftVersionConfChange EntryEncoding = 254
 	// RaftVersionConfChangeV2 is analogous to RaftVersionConfChange, with
 	// the replacements raftpb.EntryConfChange{,V2} and raftpb.ConfChange{,V2}
 	// applied.
-	RaftVersionConfChangeV2 RaftCommandEncodingVersion = 255
+	RaftVersionConfChangeV2 EntryEncoding = 255
 )
 
 // TODO(tbg): when we have a good library for encoding entries, these should

--- a/pkg/kv/kvserver/raftlog/encoding.go
+++ b/pkg/kv/kvserver/raftlog/encoding.go
@@ -23,6 +23,9 @@ import (
 // and, in some cases, the first byte of the Entry's Data payload.
 type EntryEncoding byte
 
+// TODO(tbg): use auto-assigned consts (iota) for the encodings below, since
+// they aren't on the wire.
+
 const (
 	// EntryEncodingStandard is the default encoding for a CockroachDB raft log
 	// entry.

--- a/pkg/kv/kvserver/raftlog/encoding.go
+++ b/pkg/kv/kvserver/raftlog/encoding.go
@@ -16,7 +16,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 )
 
-// EntryEncoding enumerates the encodings used in CockroachDB for raftpb.Entry.
+// EntryEncoding enumerates the encodings used in CockroachDB for raftpb.Entry's
+// Data slice.
 //
 // A raftpb.Entry's EntryEncoding is determined by the Entry's raftpb.EntryType
 // and, in some cases, the first byte of the Entry's Data payload.
@@ -78,7 +79,8 @@ const (
 	EntryEncodingSideloadedPrefixByte = byte(1)
 )
 
-// EncodeRaftCommand encodes a raft command (including the versioning prefix).
+// EncodeRaftCommand encodes a raft command of type EntryEncodingStandard or
+// EntryEncodingSideloaded.
 func EncodeRaftCommand(prefixByte byte, commandID kvserverbase.CmdIDKey, command []byte) []byte {
 	b := make([]byte, RaftCommandPrefixLen+len(command))
 	EncodeRaftCommandPrefix(b[:RaftCommandPrefixLen], prefixByte, commandID)
@@ -86,7 +88,8 @@ func EncodeRaftCommand(prefixByte byte, commandID kvserverbase.CmdIDKey, command
 	return b
 }
 
-// EncodeRaftCommandPrefix encodes the versioning prefix for a Raft command.
+// EncodeRaftCommandPrefix encodes the prefix for a Raft command of type
+// EntryEncodingStandard or EntryEncodingSideloaded.
 func EncodeRaftCommandPrefix(b []byte, prefixByte byte, commandID kvserverbase.CmdIDKey) {
 	if len(commandID) != RaftCommandIDLen {
 		panic(fmt.Sprintf("invalid command ID length; %d != %d", len(commandID), RaftCommandIDLen))

--- a/pkg/kv/kvserver/raftlog/encoding.go
+++ b/pkg/kv/kvserver/raftlog/encoding.go
@@ -23,41 +23,41 @@ import (
 type EntryEncoding byte
 
 const (
-	// RaftVersionStandard is the default encoding for a CockroachDB raft log
+	// EntryEncodingStandard is the default encoding for a CockroachDB raft log
 	// entry.
 	//
 	// This is a raftpb.Entry of type EntryNormal whose Data slice is either empty
-	// or whose first byte matches RaftVersionStandardPrefixByte. The subsequent
+	// or whose first byte matches EntryEncodingStandardPrefixByte. The subsequent
 	// eight bytes represent a CmdIDKey. The remaining bytes represent a
 	// kvserverpb.RaftCommand.
-	RaftVersionStandard EntryEncoding = 0
-	// RaftVersionSideloaded indicates a proposal representing the result of a
+	EntryEncodingStandard EntryEncoding = 0
+	// EntryEncodingSideloaded indicates a proposal representing the result of a
 	// roachpb.AddSSTableRequest for which the payload (the SST) is stored outside
 	// the storage engine to improve storage performance.
 	//
 	// This is a raftpb.Entry of type EntryNormal whose data slice is either empty
-	// or whose first byte matches RaftVersionSideloadedPrefixByte. The subsequent
+	// or whose first byte matches EntryEncodingSideloadedPrefixByte. The subsequent
 	// eight bytes represent a CmdIDKey. The remaining bytes represent a
 	// kvserverpb.RaftCommand whose kvserverpb.ReplicatedEvalResult holds a
 	// nontrival kvserverpb.ReplicatedEvalResult_AddSSTable, the Data field of
 	// which is an SST to be ingested (and which is present in memory but made
 	// durable via direct storage on the filesystem, bypassing the storage
 	// engine).
-	RaftVersionSideloaded EntryEncoding = 1
-	// RaftVersionEmptyEntry is an empty entry. These are used by raft after
+	EntryEncodingSideloaded EntryEncoding = 1
+	// EntryEncodingEmpty is an empty entry. These are used by raft after
 	// leader election. Since they hold no data, there is nothing in them to
 	// decode.
-	RaftVersionEmptyEntry EntryEncoding = 253
-	// RaftVersionConfChange is a raftpb.Entry whose raftpb.EntryType is
+	EntryEncodingEmpty EntryEncoding = 253
+	// EntryEncodingRaftConfChange is a raftpb.Entry whose raftpb.EntryType is
 	// raftpb.EntryConfChange. The Entry's Data field holds a raftpb.ConfChange
 	// whose Context field is a kvserverpb.ConfChangeContext whose Payload is a
 	// kvserverpb.RaftCommand. In particular, the CmdIDKey requires a round of
 	// protobuf unmarshaling.
-	RaftVersionConfChange EntryEncoding = 254
-	// RaftVersionConfChangeV2 is analogous to RaftVersionConfChange, with
+	EntryEncodingRaftConfChange EntryEncoding = 254
+	// EntryEncodingRaftConfChangeV2 is analogous to EntryEncodingRaftConfChange, with
 	// the replacements raftpb.EntryConfChange{,V2} and raftpb.ConfChange{,V2}
 	// applied.
-	RaftVersionConfChangeV2 EntryEncoding = 255
+	EntryEncodingRaftConfChangeV2 EntryEncoding = 255
 )
 
 // TODO(tbg): when we have a good library for encoding entries, these should
@@ -66,16 +66,16 @@ const (
 	// RaftCommandIDLen is the length of a command ID.
 	RaftCommandIDLen = 8
 	// RaftCommandPrefixLen is the length of the prefix of raft entries that
-	// use the RaftVersionStandard or RaftVersionSideloaded encodings. The
+	// use the EntryEncodingStandard or EntryEncodingSideloaded encodings. The
 	// bytes after the prefix represent the kvserverpb.RaftCommand.
 	//
 	RaftCommandPrefixLen = 1 + RaftCommandIDLen
-	// RaftVersionStandardPrefixByte is the first byte of a raftpb.Entry's
-	// Data slice for an Entry of encoding RaftVersionStandard.
-	RaftVersionStandardPrefixByte = byte(0)
-	// RaftVersionSideloadedPrefixByte is the first byte of a raftpb.Entry's Data
-	// slice for an Entry of encoding RaftVersionSideloaded.
-	RaftVersionSideloadedPrefixByte = byte(1)
+	// EntryEncodingStandardPrefixByte is the first byte of a raftpb.Entry's
+	// Data slice for an Entry of encoding EntryEncodingStandard.
+	EntryEncodingStandardPrefixByte = byte(0)
+	// EntryEncodingSideloadedPrefixByte is the first byte of a raftpb.Entry's Data
+	// slice for an Entry of encoding EntryEncodingSideloaded.
+	EntryEncodingSideloadedPrefixByte = byte(1)
 )
 
 // EncodeRaftCommand encodes a raft command (including the versioning prefix).

--- a/pkg/kv/kvserver/raftlog/entry.go
+++ b/pkg/kv/kvserver/raftlog/entry.go
@@ -28,9 +28,8 @@ import (
 	"go.etcd.io/raft/v3/raftpb"
 )
 
-// EncodingVersion determines the RaftCommandEncodingVersion for a given
-// Entry.
-func EncodingVersion(ent raftpb.Entry) (RaftCommandEncodingVersion, error) {
+// EncodingVersion determines the EntryEncoding for a given Entry.
+func EncodingVersion(ent raftpb.Entry) (EntryEncoding, error) {
 	if len(ent.Data) == 0 {
 		// An empty command.
 		return RaftVersionEmptyEntry, nil

--- a/pkg/kv/kvserver/raftlog/entry.go
+++ b/pkg/kv/kvserver/raftlog/entry.go
@@ -28,8 +28,8 @@ import (
 	"go.etcd.io/raft/v3/raftpb"
 )
 
-// EncodingVersion determines the EntryEncoding for a given Entry.
-func EncodingVersion(ent raftpb.Entry) (EntryEncoding, error) {
+// EncodingOf determines the EntryEncoding for a given Entry.
+func EncodingOf(ent raftpb.Entry) (EntryEncoding, error) {
 	if len(ent.Data) == 0 {
 		// An empty command.
 		return EntryEncodingEmpty, nil
@@ -129,7 +129,7 @@ func raftEntryFromRawValue(b []byte) (raftpb.Entry, error) {
 }
 
 func (e *Entry) load() error {
-	typ, err := EncodingVersion(e.Entry)
+	typ, err := EncodingOf(e.Entry)
 	if err != nil {
 		return err
 	}

--- a/pkg/kv/kvserver/raftlog/entry.go
+++ b/pkg/kv/kvserver/raftlog/entry.go
@@ -32,24 +32,24 @@ import (
 func EncodingVersion(ent raftpb.Entry) (EntryEncoding, error) {
 	if len(ent.Data) == 0 {
 		// An empty command.
-		return RaftVersionEmptyEntry, nil
+		return EntryEncodingEmpty, nil
 	}
 
 	switch ent.Type {
 	case raftpb.EntryNormal:
 	case raftpb.EntryConfChange:
-		return RaftVersionConfChange, nil
+		return EntryEncodingRaftConfChange, nil
 	case raftpb.EntryConfChangeV2:
-		return RaftVersionConfChangeV2, nil
+		return EntryEncodingRaftConfChangeV2, nil
 	default:
 		return 0, errors.AssertionFailedf("unknown EntryType %d", ent.Type)
 	}
 
 	switch ent.Data[0] {
-	case RaftVersionStandardPrefixByte:
-		return RaftVersionStandard, nil
-	case RaftVersionSideloadedPrefixByte:
-		return RaftVersionSideloaded, nil
+	case EntryEncodingStandardPrefixByte:
+		return EntryEncodingStandard, nil
+	case EntryEncodingSideloadedPrefixByte:
+		return EntryEncodingSideloaded, nil
 	default:
 		return 0, errors.AssertionFailedf("unknown command encoding version %d", ent.Data[0])
 	}
@@ -57,8 +57,8 @@ func EncodingVersion(ent raftpb.Entry) (EntryEncoding, error) {
 
 // DecomposeRaftVersionStandardOrSideloaded extracts the CmdIDKey and the
 // marshaled kvserverpb.RaftCommand from a slice which is known to have come
-// from a raftpb.Entry of type kvserverbase.RaftVersionStandard or
-// kvserverbase.RaftVersionSideloaded (which, mod the prefix byte, share an
+// from a raftpb.Entry of type kvserverbase.EntryEncodingStandard or
+// kvserverbase.EntryEncodingSideloaded (which, mod the prefix byte, share an
 // encoding).
 func DecomposeRaftVersionStandardOrSideloaded(data []byte) (kvserverbase.CmdIDKey, []byte) {
 	return kvserverbase.CmdIDKey(data[1 : 1+RaftCommandIDLen]), data[1+RaftCommandIDLen:]
@@ -145,16 +145,16 @@ func (e *Entry) load() error {
 		AsV2() raftpb.ConfChangeV2
 	}
 	switch typ {
-	case RaftVersionStandard, RaftVersionSideloaded:
+	case EntryEncodingStandard, EntryEncodingSideloaded:
 		e.ID, raftCmdBytes = DecomposeRaftVersionStandardOrSideloaded(e.Entry.Data)
-	case RaftVersionEmptyEntry:
+	case EntryEncodingEmpty:
 		// Nothing to load, the empty raftpb.Entry is represented by a trivial
 		// Entry.
 		return nil
-	case RaftVersionConfChange:
+	case EntryEncodingRaftConfChange:
 		e.ConfChangeV1 = &raftpb.ConfChange{}
 		ccTarget = e.ConfChangeV1
-	case RaftVersionConfChangeV2:
+	case EntryEncodingRaftConfChangeV2:
 		e.ConfChangeV2 = &raftpb.ConfChangeV2{}
 		ccTarget = e.ConfChangeV2
 	default:

--- a/pkg/kv/kvserver/raftlog/entry.go
+++ b/pkg/kv/kvserver/raftlog/entry.go
@@ -30,27 +30,27 @@ import (
 
 // EncodingVersion determines the RaftCommandEncodingVersion for a given
 // Entry.
-func EncodingVersion(ent raftpb.Entry) (kvserverbase.RaftCommandEncodingVersion, error) {
+func EncodingVersion(ent raftpb.Entry) (RaftCommandEncodingVersion, error) {
 	if len(ent.Data) == 0 {
 		// An empty command.
-		return kvserverbase.RaftVersionEmptyEntry, nil
+		return RaftVersionEmptyEntry, nil
 	}
 
 	switch ent.Type {
 	case raftpb.EntryNormal:
 	case raftpb.EntryConfChange:
-		return kvserverbase.RaftVersionConfChange, nil
+		return RaftVersionConfChange, nil
 	case raftpb.EntryConfChangeV2:
-		return kvserverbase.RaftVersionConfChangeV2, nil
+		return RaftVersionConfChangeV2, nil
 	default:
 		return 0, errors.AssertionFailedf("unknown EntryType %d", ent.Type)
 	}
 
 	switch ent.Data[0] {
-	case kvserverbase.RaftVersionStandardPrefixByte:
-		return kvserverbase.RaftVersionStandard, nil
-	case kvserverbase.RaftVersionSideloadedPrefixByte:
-		return kvserverbase.RaftVersionSideloaded, nil
+	case RaftVersionStandardPrefixByte:
+		return RaftVersionStandard, nil
+	case RaftVersionSideloadedPrefixByte:
+		return RaftVersionSideloaded, nil
 	default:
 		return 0, errors.AssertionFailedf("unknown command encoding version %d", ent.Data[0])
 	}
@@ -62,7 +62,7 @@ func EncodingVersion(ent raftpb.Entry) (kvserverbase.RaftCommandEncodingVersion,
 // kvserverbase.RaftVersionSideloaded (which, mod the prefix byte, share an
 // encoding).
 func DecomposeRaftVersionStandardOrSideloaded(data []byte) (kvserverbase.CmdIDKey, []byte) {
-	return kvserverbase.CmdIDKey(data[1 : 1+kvserverbase.RaftCommandIDLen]), data[1+kvserverbase.RaftCommandIDLen:]
+	return kvserverbase.CmdIDKey(data[1 : 1+RaftCommandIDLen]), data[1+RaftCommandIDLen:]
 }
 
 // Entry contains data related to a raft log entry. This is the raftpb.Entry
@@ -146,16 +146,16 @@ func (e *Entry) load() error {
 		AsV2() raftpb.ConfChangeV2
 	}
 	switch typ {
-	case kvserverbase.RaftVersionStandard, kvserverbase.RaftVersionSideloaded:
+	case RaftVersionStandard, RaftVersionSideloaded:
 		e.ID, raftCmdBytes = DecomposeRaftVersionStandardOrSideloaded(e.Entry.Data)
-	case kvserverbase.RaftVersionEmptyEntry:
+	case RaftVersionEmptyEntry:
 		// Nothing to load, the empty raftpb.Entry is represented by a trivial
 		// Entry.
 		return nil
-	case kvserverbase.RaftVersionConfChange:
+	case RaftVersionConfChange:
 		e.ConfChangeV1 = &raftpb.ConfChange{}
 		ccTarget = e.ConfChangeV1
-	case kvserverbase.RaftVersionConfChangeV2:
+	case RaftVersionConfChangeV2:
 		e.ConfChangeV2 = &raftpb.ConfChangeV2{}
 		ccTarget = e.ConfChangeV2
 	default:

--- a/pkg/kv/kvserver/raftlog/entry.go
+++ b/pkg/kv/kvserver/raftlog/entry.go
@@ -57,8 +57,8 @@ func EncodingVersion(ent raftpb.Entry) (EntryEncoding, error) {
 
 // DecomposeRaftVersionStandardOrSideloaded extracts the CmdIDKey and the
 // marshaled kvserverpb.RaftCommand from a slice which is known to have come
-// from a raftpb.Entry of type kvserverbase.EntryEncodingStandard or
-// kvserverbase.EntryEncodingSideloaded (which, mod the prefix byte, share an
+// from a raftpb.Entry of type raftlog.EntryEncodingStandard or
+// raftlog.EntryEncodingSideloaded (which, mod the prefix byte, share an
 // encoding).
 func DecomposeRaftVersionStandardOrSideloaded(data []byte) (kvserverbase.CmdIDKey, []byte) {
 	return kvserverbase.CmdIDKey(data[1 : 1+RaftCommandIDLen]), data[1+RaftCommandIDLen:]

--- a/pkg/kv/kvserver/raftlog/entry_test.go
+++ b/pkg/kv/kvserver/raftlog/entry_test.go
@@ -14,7 +14,6 @@ package raftlog
 import (
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/raft/v3/raftpb"
 )
@@ -23,10 +22,10 @@ func TestLoadInvalidEntry(t *testing.T) {
 	invalidEnt := raftpb.Entry{
 		Term:  1,
 		Index: 1,
-		Data: kvserverbase.EncodeRaftCommand(
+		Data: EncodeRaftCommand(
 			// It would be nice to have an "even more invalid" command here but it
 			// turns out that DecodeRaftCommand "handles" errors via panic().
-			kvserverbase.RaftVersionStandardPrefixByte, "foobarzz", []byte("definitely not a protobuf"),
+			RaftVersionStandardPrefixByte, "foobarzz", []byte("definitely not a protobuf"),
 		),
 	}
 	ent, err := NewEntry(invalidEnt)

--- a/pkg/kv/kvserver/raftlog/entry_test.go
+++ b/pkg/kv/kvserver/raftlog/entry_test.go
@@ -25,7 +25,7 @@ func TestLoadInvalidEntry(t *testing.T) {
 		Data: EncodeRaftCommand(
 			// It would be nice to have an "even more invalid" command here but it
 			// turns out that DecodeRaftCommand "handles" errors via panic().
-			RaftVersionStandardPrefixByte, "foobarzz", []byte("definitely not a protobuf"),
+			EntryEncodingStandardPrefixByte, "foobarzz", []byte("definitely not a protobuf"),
 		),
 	}
 	ent, err := NewEntry(invalidEnt)

--- a/pkg/kv/kvserver/raftlog/iter_bench_test.go
+++ b/pkg/kv/kvserver/raftlog/iter_bench_test.go
@@ -16,7 +16,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -93,7 +92,7 @@ func mkBenchEnt(b *testing.B) (_ raftpb.Entry, metaB []byte) {
 	}
 	cmdB, err := protoutil.Marshal(cmd)
 	require.NoError(b, err)
-	data := kvserverbase.EncodeRaftCommand(kvserverbase.RaftVersionStandardPrefixByte, "cmd12345", cmdB)
+	data := EncodeRaftCommand(RaftVersionStandardPrefixByte, "cmd12345", cmdB)
 
 	ent := raftpb.Entry{
 		Term:  1,

--- a/pkg/kv/kvserver/raftlog/iter_bench_test.go
+++ b/pkg/kv/kvserver/raftlog/iter_bench_test.go
@@ -92,7 +92,7 @@ func mkBenchEnt(b *testing.B) (_ raftpb.Entry, metaB []byte) {
 	}
 	cmdB, err := protoutil.Marshal(cmd)
 	require.NoError(b, err)
-	data := EncodeRaftCommand(RaftVersionStandardPrefixByte, "cmd12345", cmdB)
+	data := EncodeRaftCommand(EntryEncodingStandardPrefixByte, "cmd12345", cmdB)
 
 	ent := raftpb.Entry{
 		Term:  1,

--- a/pkg/kv/kvserver/raftlog/iter_test.go
+++ b/pkg/kv/kvserver/raftlog/iter_test.go
@@ -44,11 +44,11 @@ func ents(inds ...uint64) []raftpb.Entry {
 		typ := raftpb.EntryType(ind % 3)
 		switch typ {
 		case raftpb.EntryNormal:
-			prefixByte := kvserverbase.RaftVersionStandardPrefixByte
+			prefixByte := RaftVersionStandardPrefixByte
 			if ind%2 == 0 {
-				prefixByte = kvserverbase.RaftVersionSideloadedPrefixByte
+				prefixByte = RaftVersionSideloadedPrefixByte
 			}
-			data = kvserverbase.EncodeRaftCommand(prefixByte, cmdID, b)
+			data = EncodeRaftCommand(prefixByte, cmdID, b)
 		case raftpb.EntryConfChangeV2:
 			c := kvserverpb.ConfChangeContext{
 				CommandID: string(cmdID),

--- a/pkg/kv/kvserver/raftlog/iter_test.go
+++ b/pkg/kv/kvserver/raftlog/iter_test.go
@@ -44,9 +44,9 @@ func ents(inds ...uint64) []raftpb.Entry {
 		typ := raftpb.EntryType(ind % 3)
 		switch typ {
 		case raftpb.EntryNormal:
-			prefixByte := RaftVersionStandardPrefixByte
+			prefixByte := EntryEncodingStandardPrefixByte
 			if ind%2 == 0 {
-				prefixByte = RaftVersionSideloadedPrefixByte
+				prefixByte = EntryEncodingSideloadedPrefixByte
 			}
 			data = EncodeRaftCommand(prefixByte, cmdID, b)
 		case raftpb.EntryConfChangeV2:

--- a/pkg/kv/kvserver/replica_proposal_buf_test.go
+++ b/pkg/kv/kvserver/replica_proposal_buf_test.go
@@ -303,7 +303,7 @@ func (pc proposalCreator) encodeProposal(p *ProposalData) []byte {
 	cmdLen := p.command.Size()
 	needed := raftlog.RaftCommandPrefixLen + cmdLen + kvserverpb.MaxRaftCommandFooterSize()
 	data := make([]byte, raftlog.RaftCommandPrefixLen, needed)
-	raftlog.EncodeRaftCommandPrefix(data, raftlog.RaftVersionStandardPrefixByte, p.idKey)
+	raftlog.EncodeRaftCommandPrefix(data, raftlog.EntryEncodingStandardPrefixByte, p.idKey)
 	data = data[:raftlog.RaftCommandPrefixLen+p.command.Size()]
 	if _, err := protoutil.MarshalTo(p.command, data[raftlog.RaftCommandPrefixLen:]); err != nil {
 		panic(err)

--- a/pkg/kv/kvserver/replica_proposal_buf_test.go
+++ b/pkg/kv/kvserver/replica_proposal_buf_test.go
@@ -301,11 +301,11 @@ func (pc proposalCreator) newProposal(ba *roachpb.BatchRequest) *ProposalData {
 
 func (pc proposalCreator) encodeProposal(p *ProposalData) []byte {
 	cmdLen := p.command.Size()
-	needed := kvserverbase.RaftCommandPrefixLen + cmdLen + kvserverpb.MaxRaftCommandFooterSize()
-	data := make([]byte, kvserverbase.RaftCommandPrefixLen, needed)
-	kvserverbase.EncodeRaftCommandPrefix(data, kvserverbase.RaftVersionStandardPrefixByte, p.idKey)
-	data = data[:kvserverbase.RaftCommandPrefixLen+p.command.Size()]
-	if _, err := protoutil.MarshalTo(p.command, data[kvserverbase.RaftCommandPrefixLen:]); err != nil {
+	needed := raftlog.RaftCommandPrefixLen + cmdLen + kvserverpb.MaxRaftCommandFooterSize()
+	data := make([]byte, raftlog.RaftCommandPrefixLen, needed)
+	raftlog.EncodeRaftCommandPrefix(data, raftlog.RaftVersionStandardPrefixByte, p.idKey)
+	data = data[:raftlog.RaftCommandPrefixLen+p.command.Size()]
+	if _, err := protoutil.MarshalTo(p.command, data[raftlog.RaftCommandPrefixLen:]); err != nil {
 		panic(err)
 	}
 	return data

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -344,7 +344,7 @@ func (r *Replica) propose(
 
 	// Determine the encoding style for the Raft command.
 	prefix := true
-	encodingPrefixByte := raftlog.RaftVersionStandardPrefixByte
+	encodingPrefixByte := raftlog.EntryEncodingStandardPrefixByte
 	if crt := p.command.ReplicatedEvalResult.ChangeReplicas; crt != nil {
 		// EndTxnRequest with a ChangeReplicasTrigger is special because Raft
 		// needs to understand it; it cannot simply be an opaque command. To
@@ -416,7 +416,7 @@ func (r *Replica) propose(
 		}
 	} else if p.command.ReplicatedEvalResult.AddSSTable != nil {
 		log.VEvent(p.ctx, 4, "sideloadable proposal detected")
-		encodingPrefixByte = raftlog.RaftVersionSideloadedPrefixByte
+		encodingPrefixByte = raftlog.EntryEncodingSideloadedPrefixByte
 		r.store.metrics.AddSSTableProposals.Inc(1)
 
 		if p.command.ReplicatedEvalResult.AddSSTable.Data == nil {

--- a/pkg/kv/kvserver/replica_raft_quiesce.go
+++ b/pkg/kv/kvserver/replica_raft_quiesce.go
@@ -87,7 +87,7 @@ func (r *Replica) maybeUnquiesceAndWakeLeaderLocked() bool {
 	r.store.unquiescedReplicas.Unlock()
 	r.maybeCampaignOnWakeLocked(ctx)
 	// Propose an empty command which will wake the leader.
-	data := raftlog.EncodeRaftCommand(raftlog.RaftVersionStandardPrefixByte, makeIDKey(), nil)
+	data := raftlog.EncodeRaftCommand(raftlog.EntryEncodingStandardPrefixByte, makeIDKey(), nil)
 	_ = r.mu.internalRaftGroup.Propose(data)
 	return true
 }

--- a/pkg/kv/kvserver/replica_raft_quiesce.go
+++ b/pkg/kv/kvserver/replica_raft_quiesce.go
@@ -14,8 +14,8 @@ import (
 	"context"
 	"sort"
 
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftlog"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -87,7 +87,7 @@ func (r *Replica) maybeUnquiesceAndWakeLeaderLocked() bool {
 	r.store.unquiescedReplicas.Unlock()
 	r.maybeCampaignOnWakeLocked(ctx)
 	// Propose an empty command which will wake the leader.
-	data := kvserverbase.EncodeRaftCommand(kvserverbase.RaftVersionStandardPrefixByte, makeIDKey(), nil)
+	data := raftlog.EncodeRaftCommand(raftlog.RaftVersionStandardPrefixByte, makeIDKey(), nil)
 	_ = r.mu.internalRaftGroup.Propose(data)
 	return true
 }

--- a/pkg/kv/kvserver/replica_sideload_test.go
+++ b/pkg/kv/kvserver/replica_sideload_test.go
@@ -199,7 +199,7 @@ func TestRaftSSTableSideloading(t *testing.T) {
 	var idx int
 	for idx = 0; idx < len(ents); idx++ {
 		// Get the SST back from the raft log.
-		if typ, _ := raftlog.EncodingVersion(ents[idx]); typ != raftlog.RaftVersionSideloaded {
+		if typ, _ := raftlog.EncodingVersion(ents[idx]); typ != raftlog.EntryEncodingSideloaded {
 			continue
 		}
 		ent, err := logstore.MaybeInlineSideloadedRaftCommand(ctx, tc.repl.RangeID, ents[idx], tc.repl.raftMu.sideloaded, tc.store.raftEntryCache)

--- a/pkg/kv/kvserver/replica_sideload_test.go
+++ b/pkg/kv/kvserver/replica_sideload_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftlog"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -200,7 +199,7 @@ func TestRaftSSTableSideloading(t *testing.T) {
 	var idx int
 	for idx = 0; idx < len(ents); idx++ {
 		// Get the SST back from the raft log.
-		if typ, _ := raftlog.EncodingVersion(ents[idx]); typ != kvserverbase.RaftVersionSideloaded {
+		if typ, _ := raftlog.EncodingVersion(ents[idx]); typ != raftlog.RaftVersionSideloaded {
 			continue
 		}
 		ent, err := logstore.MaybeInlineSideloadedRaftCommand(ctx, tc.repl.RangeID, ents[idx], tc.repl.raftMu.sideloaded, tc.store.raftEntryCache)

--- a/pkg/kv/kvserver/replica_sideload_test.go
+++ b/pkg/kv/kvserver/replica_sideload_test.go
@@ -199,7 +199,7 @@ func TestRaftSSTableSideloading(t *testing.T) {
 	var idx int
 	for idx = 0; idx < len(ents); idx++ {
 		// Get the SST back from the raft log.
-		if typ, _ := raftlog.EncodingVersion(ents[idx]); typ != raftlog.EntryEncodingSideloaded {
+		if typ, _ := raftlog.EncodingOf(ents[idx]); typ != raftlog.EntryEncodingSideloaded {
 			continue
 		}
 		ent, err := logstore.MaybeInlineSideloadedRaftCommand(ctx, tc.repl.RangeID, ents[idx], tc.repl.raftMu.sideloaded, tc.store.raftEntryCache)


### PR DESCRIPTION
We were confounding versioning with encodings. Fundamentally Pavel and I have agreed that we only need to talk about encodings at this level. We may at some point want to use a new encoding and phase out another one in return, but this would be facilitated by higher layers (cluster version toggles, migrations, etc) so at the logstore/entry level there is no need to talk about versioning.

This PR moves the encoding enum and associated code into `raftlog` and performs some renames and comment updates that remove references to "versions".

Epic: CRDB-220
Release note: None