### PR TITLE
multitenant: make {EXPERIMENTAL_}RELOCATE compatible with secondary tenants

### DIFF
--- a/pkg/sql/multitenant_admin_function_test.go
+++ b/pkg/sql/multitenant_admin_function_test.go
@@ -37,8 +37,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const createTable = "CREATE TABLE t(i int PRIMARY KEY);"
-const rangeErrorMessage = "RangeIterator failed to seek"
+const (
+	createTable      = "CREATE TABLE t(i int PRIMARY KEY);"
+	systemRangeID    = "54"
+	secondaryRangeID = "55"
+	systemKey        = "/Table/53"
+	secondaryKey     = "/Tenant/10"
+)
 
 type testClusterCfg struct {
 	base.TestClusterArgs
@@ -282,40 +287,40 @@ func TestMultiTenantAdminFunction(t *testing.T) {
 		{
 			desc:                          "ALTER RANGE x RELOCATE LEASE",
 			query:                         "ALTER RANGE (SELECT min(range_id) FROM [SHOW RANGES FROM TABLE t]) RELOCATE LEASE TO 1;",
-			expectedSystemResult:          [][]string{{"54", "/Table/53", "ok"}},
+			expectedSystemResult:          [][]string{{systemRangeID, systemKey, "ok"}},
 			expectedSecondaryErrorMessage: errorutil.UnsupportedWithMultiTenancyMessage,
 		},
 		{
 			desc:                     "ALTER RANGE x RELOCATE LEASE SkipSQLSystemTenantCheck",
 			query:                    "ALTER RANGE (SELECT min(range_id) FROM [SHOW RANGES FROM TABLE t]) RELOCATE LEASE TO 1;",
-			expectedSystemResult:     [][]string{{"54", "/Table/53", "ok"}},
-			expectedSecondaryResult:  [][]string{{"55", "", rangeErrorMessage}},
+			expectedSystemResult:     [][]string{{systemRangeID, systemKey, "ok"}},
+			expectedSecondaryResult:  [][]string{{secondaryRangeID, secondaryKey, "request [1 AdmTransferLease] not permitted"}},
 			skipSQLSystemTenantCheck: true,
 		},
 		{
 			desc:                          "ALTER RANGE RELOCATE LEASE",
 			query:                         "ALTER RANGE RELOCATE LEASE TO 1 FOR (SELECT min(range_id) FROM [SHOW RANGES FROM TABLE t]);",
-			expectedSystemResult:          [][]string{{"54", "/Table/53", "ok"}},
+			expectedSystemResult:          [][]string{{systemRangeID, systemKey, "ok"}},
 			expectedSecondaryErrorMessage: errorutil.UnsupportedWithMultiTenancyMessage,
 		},
 		{
 			desc:                     "ALTER RANGE RELOCATE LEASE SkipSQLSystemTenantCheck",
 			query:                    "ALTER RANGE RELOCATE LEASE TO 1 FOR (SELECT min(range_id) FROM [SHOW RANGES FROM TABLE t]);",
-			expectedSystemResult:     [][]string{{"54", "/Table/53", "ok"}},
-			expectedSecondaryResult:  [][]string{{"55", "", rangeErrorMessage}},
+			expectedSystemResult:     [][]string{{systemRangeID, systemKey, "ok"}},
+			expectedSecondaryResult:  [][]string{{secondaryRangeID, secondaryKey, "request [1 AdmTransferLease] not permitted"}},
 			skipSQLSystemTenantCheck: true,
 		},
 		{
 			desc:                          "ALTER TABLE x EXPERIMENTAL_RELOCATE LEASE",
 			query:                         "ALTER TABLE t EXPERIMENTAL_RELOCATE LEASE SELECT 1, 1;",
-			expectedSystemResult:          [][]string{{"\xbd", "/Table/53"}},
+			expectedSystemResult:          [][]string{{"\xbd", systemKey}},
 			expectedSecondaryErrorMessage: errorutil.UnsupportedWithMultiTenancyMessage,
 		},
 		{
 			desc:                          "ALTER TABLE x EXPERIMENTAL_RELOCATE LEASE SkipSQLSystemTenantCheck",
 			query:                         "ALTER TABLE t EXPERIMENTAL_RELOCATE LEASE SELECT 1, 1;",
-			expectedSystemResult:          [][]string{{"\xbd", "/Table/53"}},
-			expectedSecondaryErrorMessage: rangeErrorMessage,
+			expectedSystemResult:          [][]string{{"\xbd", systemKey}},
+			expectedSecondaryErrorMessage: "request [1 AdmTransferLease] not permitted",
 			skipSQLSystemTenantCheck:      true,
 		},
 		{
@@ -372,7 +377,7 @@ func TestMultiTenantAdminFunction(t *testing.T) {
 		{
 			desc:                          "ALTER TABLE x SCATTER",
 			query:                         "ALTER TABLE t SCATTER;",
-			expectedSystemResult:          [][]string{{"\xbd", "/Table/53"}},
+			expectedSystemResult:          [][]string{{"\xbd", systemKey}},
 			expectedSecondaryErrorMessage: "request [1 AdmScatter] not permitted",
 		},
 		{
@@ -499,27 +504,27 @@ func TestRelocateVoters(t *testing.T) {
 		{
 			desc:                          "ALTER RANGE x RELOCATE VOTERS",
 			query:                         "ALTER RANGE (SELECT min(range_id) FROM [SHOW RANGES FROM TABLE t]) RELOCATE VOTERS FROM %[1]s TO %[2]s;",
-			expectedSystemResult:          [][]string{{"54", "/Table/53", "ok"}},
+			expectedSystemResult:          [][]string{{systemRangeID, systemKey, "ok"}},
 			expectedSecondaryErrorMessage: errorutil.UnsupportedWithMultiTenancyMessage,
 		},
 		{
 			desc:                     "ALTER RANGE x RELOCATE VOTERS SkipSQLSystemTenantCheck",
 			query:                    "ALTER RANGE (SELECT min(range_id) FROM [SHOW RANGES FROM TABLE t]) RELOCATE VOTERS FROM %[1]s TO %[2]s;",
-			expectedSystemResult:     [][]string{{"54", "/Table/53", "ok"}},
-			expectedSecondaryResult:  [][]string{{"55", "", rangeErrorMessage}},
+			expectedSystemResult:     [][]string{{systemRangeID, systemKey, "ok"}},
+			expectedSecondaryResult:  [][]string{{secondaryRangeID, secondaryKey, "request [1 AdmChangeReplicas] not permitted"}},
 			skipSQLSystemTenantCheck: true,
 		},
 		{
 			desc:                          "ALTER RANGE RELOCATE VOTERS",
 			query:                         "ALTER RANGE RELOCATE VOTERS FROM %[1]s TO %[2]s FOR (SELECT min(range_id) FROM [SHOW RANGES FROM TABLE t]);",
-			expectedSystemResult:          [][]string{{"54", "/Table/53", "ok"}},
+			expectedSystemResult:          [][]string{{systemRangeID, systemKey, "ok"}},
 			expectedSecondaryErrorMessage: errorutil.UnsupportedWithMultiTenancyMessage,
 		},
 		{
 			desc:                     "ALTER RANGE RELOCATE VOTERS SkipSQLSystemTenantCheck",
 			query:                    "ALTER RANGE RELOCATE VOTERS FROM %[1]s TO %[2]s FOR (SELECT min(range_id) FROM [SHOW RANGES FROM TABLE t]);",
-			expectedSystemResult:     [][]string{{"54", "/Table/53", "ok"}},
-			expectedSecondaryResult:  [][]string{{"55", "", rangeErrorMessage}},
+			expectedSystemResult:     [][]string{{systemRangeID, systemKey, "ok"}},
+			expectedSecondaryResult:  [][]string{{secondaryRangeID, secondaryKey, "request [1 AdmChangeReplicas] not permitted"}},
 			skipSQLSystemTenantCheck: true,
 		},
 	}
@@ -620,14 +625,14 @@ func TestExperimentalRelocateVoters(t *testing.T) {
 		{
 			desc:                          "ALTER TABLE x EXPERIMENTAL_RELOCATE VOTERS",
 			query:                         "ALTER TABLE t EXPERIMENTAL_RELOCATE VOTERS VALUES (ARRAY[%[1]s], 1);",
-			expectedSystemResult:          [][]string{{"\xbd", "/Table/53"}},
+			expectedSystemResult:          [][]string{{"\xbd", systemKey}},
 			expectedSecondaryErrorMessage: errorutil.UnsupportedWithMultiTenancyMessage,
 		},
 		{
 			desc:                          "ALTER TABLE x EXPERIMENTAL_RELOCATE VOTERS SkipSQLSystemTenantCheck",
 			query:                         "ALTER TABLE t EXPERIMENTAL_RELOCATE VOTERS VALUES (ARRAY[%[1]s], 1);",
-			expectedSystemResult:          [][]string{{"\xbd", "/Table/53"}},
-			expectedSecondaryErrorMessage: rangeErrorMessage,
+			expectedSystemResult:          [][]string{{"\xbd", systemKey}},
+			expectedSecondaryErrorMessage: "request [1 AdmRelocateRng] not permitted",
 			skipSQLSystemTenantCheck:      true,
 		},
 	}
@@ -726,27 +731,27 @@ func TestRelocateNonVoters(t *testing.T) {
 		{
 			desc:                          "ALTER RANGE x RELOCATE NONVOTERS",
 			query:                         "ALTER RANGE (SELECT min(range_id) FROM [SHOW RANGES FROM TABLE t]) RELOCATE NONVOTERS FROM %[1]s TO %[2]s;",
-			expectedSystemResult:          [][]string{{"54", "/Table/53", "ok"}},
+			expectedSystemResult:          [][]string{{systemRangeID, systemKey, "ok"}},
 			expectedSecondaryErrorMessage: errorutil.UnsupportedWithMultiTenancyMessage,
 		},
 		{
 			desc:                     "ALTER RANGE x RELOCATE NONVOTERS SkipSQLSystemTenantCheck",
 			query:                    "ALTER RANGE (SELECT min(range_id) FROM [SHOW RANGES FROM TABLE t]) RELOCATE NONVOTERS FROM %[1]s TO %[2]s;",
-			expectedSystemResult:     [][]string{{"54", "/Table/53", "ok"}},
-			expectedSecondaryResult:  [][]string{{"55", "", rangeErrorMessage}},
+			expectedSystemResult:     [][]string{{systemRangeID, systemKey, "ok"}},
+			expectedSecondaryResult:  [][]string{{secondaryRangeID, secondaryKey, "request [1 AdmChangeReplicas] not permitted"}},
 			skipSQLSystemTenantCheck: true,
 		},
 		{
 			desc:                          "ALTER RANGE RELOCATE NONVOTERS",
 			query:                         "ALTER RANGE RELOCATE NONVOTERS FROM %[1]s TO %[2]s FOR (SELECT min(range_id) FROM [SHOW RANGES FROM TABLE t]);",
-			expectedSystemResult:          [][]string{{"54", "/Table/53", "ok"}},
+			expectedSystemResult:          [][]string{{systemRangeID, systemKey, "ok"}},
 			expectedSecondaryErrorMessage: errorutil.UnsupportedWithMultiTenancyMessage,
 		},
 		{
 			desc:                     "ALTER RANGE RELOCATE NONVOTERS SkipSQLSystemTenantCheck",
 			query:                    "ALTER RANGE RELOCATE NONVOTERS FROM %[1]s TO %[2]s FOR (SELECT min(range_id) FROM [SHOW RANGES FROM TABLE t]);",
-			expectedSystemResult:     [][]string{{"54", "/Table/53", "ok"}},
-			expectedSecondaryResult:  [][]string{{"55", "", rangeErrorMessage}},
+			expectedSystemResult:     [][]string{{systemRangeID, systemKey, "ok"}},
+			expectedSecondaryResult:  [][]string{{secondaryRangeID, secondaryKey, "request [1 AdmChangeReplicas] not permitted"}},
 			skipSQLSystemTenantCheck: true,
 		},
 	}
@@ -844,14 +849,14 @@ func TestExperimentalRelocateNonVoters(t *testing.T) {
 		{
 			desc:                          "ALTER TABLE x EXPERIMENTAL_RELOCATE NONVOTERS",
 			query:                         "ALTER TABLE t EXPERIMENTAL_RELOCATE NONVOTERS VALUES (ARRAY[%[1]s], 1);",
-			expectedSystemResult:          [][]string{{"\xbd", "/Table/53"}},
+			expectedSystemResult:          [][]string{{"\xbd", systemKey}},
 			expectedSecondaryErrorMessage: errorutil.UnsupportedWithMultiTenancyMessage,
 		},
 		{
 			desc:                          "ALTER TABLE x EXPERIMENTAL_RELOCATE NONVOTERS SkipSQLSystemTenantCheck",
 			query:                         "ALTER TABLE t EXPERIMENTAL_RELOCATE NONVOTERS VALUES (ARRAY[%[1]s], 1);",
-			expectedSystemResult:          [][]string{{"\xbd", "/Table/53"}},
-			expectedSecondaryErrorMessage: rangeErrorMessage,
+			expectedSystemResult:          [][]string{{"\xbd", systemKey}},
+			expectedSecondaryErrorMessage: "request [1 AdmRelocateRng] not permitted",
 			skipSQLSystemTenantCheck:      true,
 		},
 	}

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1957,14 +1957,11 @@ func (ef *execFactory) ConstructAlterTableSplit(
 		return nil, err
 	}
 
-	knobs := ef.planner.ExecCfg().TenantTestingKnobs
 	return &splitNode{
 		tableDesc:      index.Table().(*optTable).desc,
 		index:          index.(*optIndex).idx,
 		rows:           input.(planNode),
 		expirationTime: expirationTime,
-		// Tests can override tenant split permissions to allow secondary tenants to split.
-		testAllowSplitAndScatter: knobs != nil && knobs.AllowSplitAndScatter,
 	}, nil
 }
 

--- a/pkg/sql/relocate_range.go
+++ b/pkg/sql/relocate_range.go
@@ -14,7 +14,6 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
-	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/paramparse"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -34,54 +33,59 @@ type relocateRange struct {
 // relocateRunState contains the run-time state of
 // relocateRange during local execution.
 type relocateRunState struct {
-	toStoreDesc   *roachpb.StoreDescriptor
-	fromStoreDesc *roachpb.StoreDescriptor
-	results       relocateResults
+	rangeDescMap map[roachpb.RangeID]roachpb.RangeDescriptor
+	toTarget     roachpb.ReplicationTarget
+	fromTarget   roachpb.ReplicationTarget
+	results      relocateResults
 }
 
 // relocateResults captures the results of the last relocate run
 type relocateResults struct {
 	rangeID   roachpb.RangeID
-	rangeDesc *roachpb.RangeDescriptor
+	rangeDesc roachpb.RangeDescriptor
 	err       error
 }
 
-// relocateRequest is an internal data structure that describes a relocation.
-type relocateRequest struct {
-	rangeID         roachpb.RangeID
-	subjectReplicas tree.RelocateSubject
-	toStoreDesc     *roachpb.StoreDescriptor
-	fromStoreDesc   *roachpb.StoreDescriptor
-}
+func (n *relocateRange) startExec(params runParams) (err error) {
+	execCfg := params.p.ExecCfg()
 
-func (n *relocateRange) startExec(params runParams) error {
-	toStoreID, err := paramparse.DatumAsInt(params.ctx, params.EvalContext(), "TO", n.toStoreID)
+	rangeDescIterator, err := execCfg.RangeDescIteratorFactory.NewIterator(params.ctx, execCfg.Codec.TenantSpan())
 	if err != nil {
 		return err
 	}
-	var fromStoreID int64
-	if n.subjectReplicas != tree.RelocateLease {
-		// The from expression is NULL if the target is LEASE.
-		fromStoreID, err = paramparse.DatumAsInt(params.ctx, params.EvalContext(), "FROM", n.fromStoreID)
+	rangeDescMap := make(map[roachpb.RangeID]roachpb.RangeDescriptor)
+	for rangeDescIterator.Valid() {
+		rangeDesc := rangeDescIterator.CurRangeDescriptor()
+		rangeDescMap[rangeDesc.RangeID] = rangeDesc
+		rangeDescIterator.Next()
+	}
+	n.run.rangeDescMap = rangeDescMap
+
+	typedExprToReplicationTarget := func(typedExpr tree.TypedExpr, name string) (target roachpb.ReplicationTarget, _ error) {
+		storeID, err := paramparse.DatumAsInt(params.ctx, params.EvalContext(), name, typedExpr)
 		if err != nil {
-			return err
+			return target, err
 		}
+		if storeID <= 0 {
+			return target, errors.Errorf("invalid target %s store ID %d for RELOCATE", name, typedExpr)
+		}
+		// Lookup all the store descriptors upfront, so we don't have to do it for each
+		// range we are working with.
+		storeDesc, err := params.ExecCfg().NodeDescs.GetStoreDescriptor(roachpb.StoreID(storeID))
+		if err != nil {
+			return target, err
+		}
+		target.NodeID = storeDesc.Node.NodeID
+		target.StoreID = storeDesc.StoreID
+		return target, nil
 	}
 
-	if toStoreID <= 0 {
-		return errors.Errorf("invalid target to store ID %d for RELOCATE", n.toStoreID)
-	}
-	if n.subjectReplicas != tree.RelocateLease && fromStoreID <= 0 {
-		return errors.Errorf("invalid target from store ID %d for RELOCATE", n.fromStoreID)
-	}
-	// Lookup all the store descriptors upfront, so we dont have to do it for each
-	// range we are working with.
-	n.run.toStoreDesc, err = params.ExecCfg().NodeDescs.GetStoreDescriptor(roachpb.StoreID(toStoreID))
+	n.run.toTarget, err = typedExprToReplicationTarget(n.toStoreID, "TO")
 	if err != nil {
 		return err
 	}
 	if n.subjectReplicas != tree.RelocateLease {
-		n.run.fromStoreDesc, err = params.ExecCfg().NodeDescs.GetStoreDescriptor(roachpb.StoreID(fromStoreID))
+		n.run.fromTarget, err = typedExprToReplicationTarget(n.fromStoreID, "FROM")
 		if err != nil {
 			return err
 		}
@@ -97,20 +101,15 @@ func (n *relocateRange) Next(params runParams) (bool, error) {
 	if datum == tree.DNull {
 		return true, nil
 	}
+
 	rangeID := roachpb.RangeID(tree.MustBeDInt(datum))
-
-	rangeDesc, err := relocate(params, relocateRequest{
-		rangeID:         rangeID,
-		subjectReplicas: n.subjectReplicas,
-		fromStoreDesc:   n.run.fromStoreDesc,
-		toStoreDesc:     n.run.toStoreDesc,
-	})
-
-	// record the results of the relocation run, so we can output it.
-	n.run.results = relocateResults{
-		rangeID:   rangeID,
-		rangeDesc: rangeDesc,
-		err:       err,
+	results := &n.run.results
+	results.rangeID = rangeID
+	if rangeDesc, found := n.run.rangeDescMap[rangeID]; found {
+		results.rangeDesc = rangeDesc
+		results.err = n.relocate(params, rangeDesc)
+	} else {
+		results.err = errors.Errorf("Descriptor for range %d is not found", rangeID)
 	}
 	return true, nil
 }
@@ -121,7 +120,7 @@ func (n *relocateRange) Values() tree.Datums {
 		result = n.run.results.err.Error()
 	}
 	pretty := ""
-	if n.run.results.rangeDesc != nil {
+	if n.run.results.rangeDesc.IsInitialized() {
 		pretty = keys.PrettyPrint(nil /* valDirs */, n.run.results.rangeDesc.StartKey.AsRawKey())
 	}
 	return tree.Datums{
@@ -135,78 +134,29 @@ func (n *relocateRange) Close(ctx context.Context) {
 	n.rows.Close(ctx)
 }
 
-func relocate(params runParams, req relocateRequest) (*roachpb.RangeDescriptor, error) {
-	rangeDesc, err := lookupRangeDescriptorByRangeID(params.ctx, params.extendedEvalCtx.ExecCfg.DB, req.rangeID)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error looking up range descriptor")
+func (n *relocateRange) relocate(params runParams, rangeDesc roachpb.RangeDescriptor) error {
+	execCfg := params.ExecCfg()
+
+	if n.subjectReplicas == tree.RelocateLease {
+		err := execCfg.DB.AdminTransferLease(params.ctx, rangeDesc.StartKey, n.run.toTarget.StoreID)
+		return err
 	}
 
-	if req.subjectReplicas == tree.RelocateLease {
-		err := params.p.ExecCfg().DB.AdminTransferLease(params.ctx, rangeDesc.StartKey, req.toStoreDesc.StoreID)
-		return rangeDesc, err
+	toChangeType := roachpb.ADD_VOTER
+	fromChangeType := roachpb.REMOVE_VOTER
+	if n.subjectReplicas == tree.RelocateNonVoters {
+		toChangeType = roachpb.ADD_NON_VOTER
+		fromChangeType = roachpb.REMOVE_NON_VOTER
 	}
-
-	toTarget := roachpb.ReplicationTarget{NodeID: req.toStoreDesc.Node.NodeID, StoreID: req.toStoreDesc.StoreID}
-	fromTarget := roachpb.ReplicationTarget{NodeID: req.fromStoreDesc.Node.NodeID, StoreID: req.fromStoreDesc.StoreID}
-	if req.subjectReplicas == tree.RelocateNonVoters {
-		_, err := params.p.ExecCfg().DB.AdminChangeReplicas(
-			params.ctx, rangeDesc.StartKey, *rangeDesc, []roachpb.ReplicationChange{
-				{ChangeType: roachpb.ADD_NON_VOTER, Target: toTarget},
-				{ChangeType: roachpb.REMOVE_NON_VOTER, Target: fromTarget},
-			},
-		)
-		return rangeDesc, err
-	}
-	_, err = params.p.ExecCfg().DB.AdminChangeReplicas(
-		params.ctx, rangeDesc.StartKey, *rangeDesc, []roachpb.ReplicationChange{
-			{ChangeType: roachpb.ADD_VOTER, Target: toTarget},
-			{ChangeType: roachpb.REMOVE_VOTER, Target: fromTarget},
+	_, err := execCfg.DB.AdminChangeReplicas(
+		params.ctx, rangeDesc.StartKey, rangeDesc, []roachpb.ReplicationChange{
+			{ChangeType: toChangeType, Target: n.run.toTarget},
+			{ChangeType: fromChangeType, Target: n.run.fromTarget},
 		},
 	)
-	// TODO(aayush): If the `AdminChangeReplicas`call failed because it found that
-	// the range was already in the process of being rebalanced, we currently fail
-	// the statement. We should consider instead force-removing these learners
-	// when `AdminChangeReplicas` calls are issued by SQL.
-	return rangeDesc, err
-}
-
-func lookupRangeDescriptorByRangeID(
-	ctx context.Context, db *kv.DB, rangeID roachpb.RangeID,
-) (*roachpb.RangeDescriptor, error) {
-	var descriptor roachpb.RangeDescriptor
-	sentinelErr := errors.Errorf("sentinel")
-	err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-		return txn.Iterate(ctx, keys.MetaMin, keys.MetaMax, 100,
-			func(rows []kv.KeyValue) error {
-				var desc roachpb.RangeDescriptor
-				for _, row := range rows {
-					err := row.ValueProto(&desc)
-					if err != nil {
-						return errors.Wrapf(err, "unable to unmarshal range descriptor from %s", row.Key)
-					}
-					// In small enough clusters it's possible for the same range
-					// descriptor to be stored in both meta1 and meta2. This
-					// happens when some range spans both the meta and the user
-					// keyspace. Consider when r1 is [/Min,
-					// /System/NodeLiveness); we'll store the range descriptor
-					// in both /Meta2/<r1.EndKey> and in /Meta1/KeyMax[1].
-					//
-					// [1]: See kvserver.rangeAddressing.
-					// For the purposes of this code, we just return the first range
-					// descriptor we find.
-					if desc.RangeID == rangeID {
-						descriptor = desc
-						return sentinelErr
-					}
-				}
-				return nil
-			})
-	})
-	if errors.Is(err, sentinelErr) {
-		return &descriptor, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-	return nil, errors.Errorf("Descriptor for range %d is not found", rangeID)
+	// TODO(aayush): If the `AdminChangeReplicas` call failed because it found that
+	//  the range was already in the process of being rebalanced, we currently fail
+	//  the statement. We should consider instead force-removing these learners
+	//  when `AdminChangeReplicas` calls are issued by SQL.
+	return err
 }


### PR DESCRIPTION
Informs #93452

Use the RangeDescIterator in {EXPERIMENTAL_}RELOCATE so that secondary tenants can use these commands.

Release note: None