### PR TITLE
teamcity-trigger: reduce `COCKROACH_KVNEMESIS_STEPS` to 1000

### DIFF
--- a/pkg/cmd/teamcity-trigger/main.go
+++ b/pkg/cmd/teamcity-trigger/main.go
@@ -140,7 +140,7 @@ func runTC(queueBuild func(string, map[string]string)) {
 		if testTarget == "//pkg/kv/kvnemesis:kvnemesis_test" {
 			// Disable -maxruns for kvnemesis. Run for the full 1h.
 			maxRuns = 0
-			opts["env.EXTRA_BAZEL_FLAGS"] = "--test_env COCKROACH_KVNEMESIS_STEPS=10000"
+			opts["env.EXTRA_BAZEL_FLAGS"] = "--test_env COCKROACH_KVNEMESIS_STEPS=1000"
 		}
 
 		if testTarget == "//pkg/sql/logictest:logictest_test" || testTarget == "//pkg/kv/kvserver:kvserver_test" {


### PR DESCRIPTION
This patch reduces the number of KVNemesis iterations in nightly tests from 10000 to 1000. 10k-iteration failures are very hard to meaningfully debug. 1k iterations is arguably also hard to debug, but it's significantly more managable. Not to mention that kvnemesis runtime is quadratic in the number of steps, so this covers more ground in a 1-hour run.

Epic: none
Release note: None