### PR TITLE
roachtest: replace ordinal column reference in transfer-leases

### DIFF
--- a/pkg/cmd/roachtest/tests/quit.go
+++ b/pkg/cmd/roachtest/tests/quit.go
@@ -181,7 +181,7 @@ func (q *quitTest) createRanges(ctx context.Context) {
 	db := q.c.Conn(ctx, q.t.L(), 1)
 	defer db.Close()
 	if _, err := db.ExecContext(ctx, fmt.Sprintf(`
-CREATE TABLE t(x, y, PRIMARY KEY(x)) AS SELECT @1, 1 FROM generate_series(1,%[1]d)`,
+CREATE TABLE t(x, y, PRIMARY KEY(x)) AS SELECT i, 1 FROM generate_series(1,%[1]d) g(i)`,
 		numRanges)); err != nil {
 		q.Fatal(err)
 	}


### PR DESCRIPTION
This commit fixes a broken roachtest caused by #93754.

Fixes #94058

Release note: None