### PR TITLE
ui: use aria-query@5.0.1

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -166,7 +166,7 @@
     "yargs-parser": "~13.1.2",
     "protobufjs": "6.8.6",
     "**/jest-environment-jsdom": "^27.5.1",
-    "aria-query": "file:../../yarn-vendor/aria-query-5.0.0-no-spaced-files.tgz",
+    "aria-query": "5.0.1",
     "esbuild": "0.14.43"
   }
 }

--- a/pkg/ui/workspaces/cluster-ui/yarn.lock
+++ b/pkg/ui/workspaces/cluster-ui/yarn.lock
@@ -4010,9 +4010,10 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-aria-query@^5.0.0, "aria-query@file:../../yarn-vendor/aria-query-5.0.0-no-spaced-files.tgz":
-  version "5.0.0"
-  resolved "file:../../yarn-vendor/aria-query-5.0.0-no-spaced-files.tgz#4f643d272248b0c3df08fee7317e761fe83e9498"
+aria-query@5.0.1, aria-query@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.0.1.tgz#7b540d2d255ada22d861a4ee97d1e3f083e93894"
+  integrity sha512-bb1lJcEgfLvrfoCL9yn9/KQnpjK+B3T/ASg8qkJtzvkDMOZyPgPn7EL1rmR13tadpdaPXfPqqqd/wbnLxZLbYw==
 
 arr-diff@^4.0.0:
   version "4.0.0"

--- a/pkg/ui/workspaces/db-console/package.json
+++ b/pkg/ui/workspaces/db-console/package.json
@@ -199,7 +199,7 @@
     "**/redux": "^4.1.0",
     "**/ua-parser-js": "0.7.24",
     "**/url-parse": "^1.4.3",
-    "aria-query": "file:../../yarn-vendor/aria-query-5.0.0-no-spaced-files.tgz",
+    "aria-query": "5.0.1",
     "core-js": "^2.6.12",
     "elliptic": "~6.5.3",
     "esbuild": "0.14.43",

--- a/pkg/ui/workspaces/db-console/yarn.lock
+++ b/pkg/ui/workspaces/db-console/yarn.lock
@@ -3902,9 +3902,10 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-aria-query@^5.0.0, "aria-query@file:../../yarn-vendor/aria-query-5.0.0-no-spaced-files.tgz":
-  version "5.0.0"
-  resolved "file:../../yarn-vendor/aria-query-5.0.0-no-spaced-files.tgz#4f643d272248b0c3df08fee7317e761fe83e9498"
+aria-query@5.0.1, aria-query@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.0.1.tgz#7b540d2d255ada22d861a4ee97d1e3f083e93894"
+  integrity sha512-bb1lJcEgfLvrfoCL9yn9/KQnpjK+B3T/ASg8qkJtzvkDMOZyPgPn7EL1rmR13tadpdaPXfPqqqd/wbnLxZLbYw==
 
 arr-diff@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Previously, we used a custom build of aria-query@5.0.0 that removed
spurious files that contained a space in their names. Those files were
removed in the upstream version published as 5.0.1, which contains no
other changes.

Epic: none
Release note: None