### PR TITLE
release-22.1: tree: correct mutation/DDL property for some opaque operators

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -1028,6 +1028,56 @@ SELECT nextval('a')
 statement error cannot execute setval\(\) in a read-only transaction
 SELECT setval('a', 2)
 
+statement error cannot execute CREATE ROLE in a read-only transaction
+CREATE ROLE my_user
+
+statement error cannot execute ALTER ROLE in a read-only transaction
+ALTER ROLE testuser SET default_int_size = 4
+
+statement error cannot execute DROP ROLE in a read-only transaction
+DROP ROLE testuser
+
+statement error cannot execute SET CLUSTER SETTING in a read-only transaction
+SET CLUSTER SETTING diagnostics.reporting.enabled = true
+
+statement error cannot execute GRANT in a read-only transaction
+GRANT admin TO testuser
+
+statement error cannot execute REVOKE in a read-only transaction
+REVOKE admin FROM testuser
+
+statement error cannot execute GRANT in a read-only transaction
+GRANT CONNECT ON DATABASE test TO testuser
+
+statement error cannot execute create_tenant\(\) in a read-only transaction
+SELECT crdb_internal.create_tenant(3)
+
+statement error cannot execute destroy_tenant\(\) in a read-only transaction
+SELECT crdb_internal.destroy_tenant(3)
+
+# SET session variable should work in a read-only txn.
+statement ok
+SET intervalstyle = 'postgres'
+
+statement ok
+SET SESSION CHARACTERISTICS AS TRANSACTION PRIORITY NORMAL
+
+statement ok
+SET SESSION AUTHORIZATION DEFAULT
+
+statement ok
+BEGIN
+
+# DECLARE and FETCH CURSOR should work in a read-only txn.
+statement ok
+DECLARE foo CURSOR FOR SELECT 1
+
+statement ok
+FETCH 1 foo
+
+statement ok
+COMMIT
+
 query T
 SHOW TRANSACTION STATUS
 ----

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -113,7 +113,7 @@ type canModifySchema interface {
 // CanModifySchema returns true if the statement can modify
 // the database schema.
 func CanModifySchema(stmt Statement) bool {
-	if stmt.StatementReturnType() == DDL {
+	if stmt.StatementReturnType() == DDL || stmt.StatementType() == TypeDDL {
 		return true
 	}
 	scm, ok := stmt.(canModifySchema)
@@ -122,12 +122,19 @@ func CanModifySchema(stmt Statement) bool {
 
 // CanWriteData returns true if the statement can modify data.
 func CanWriteData(stmt Statement) bool {
+	if stmt.StatementType() == TypeDCL {
+		// Commands like GRANT and REVOKE modify system tables.
+		return true
+	}
 	switch stmt.(type) {
 	// Normal write operations.
 	case *Insert, *Delete, *Update, *Truncate:
 		return true
 	// Import operations.
 	case *CopyFrom, *Import, *Restore:
+		return true
+	// Backup creates a job and allows you to write into userfiles.
+	case *Backup:
 		return true
 	// CockroachDB extensions.
 	case *Split, *Unsplit, *Relocate, *RelocateRange, *Scatter:
@@ -410,7 +417,7 @@ func (*AlterSequence) StatementTag() string { return "ALTER SEQUENCE" }
 func (*AlterRole) StatementReturnType() StatementReturnType { return Ack }
 
 // StatementType implements the Statement interface.
-func (*AlterRole) StatementType() StatementType { return TypeDDL }
+func (*AlterRole) StatementType() StatementType { return TypeDCL }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*AlterRole) StatementTag() string { return "ALTER ROLE" }
@@ -421,7 +428,7 @@ func (*AlterRole) hiddenFromShowQueries() {}
 func (*AlterRoleSet) StatementReturnType() StatementReturnType { return Ack }
 
 // StatementType implements the Statement interface.
-func (*AlterRoleSet) StatementType() StatementType { return TypeDDL }
+func (*AlterRoleSet) StatementType() StatementType { return TypeDCL }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*AlterRoleSet) StatementTag() string { return "ALTER ROLE" }
@@ -713,7 +720,7 @@ func (*CreateType) modifiesSchema() bool { return true }
 func (*CreateRole) StatementReturnType() StatementReturnType { return Ack }
 
 // StatementType implements the Statement interface.
-func (*CreateRole) StatementType() StatementType { return TypeDDL }
+func (*CreateRole) StatementType() StatementType { return TypeDCL }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*CreateRole) StatementTag() string { return "CREATE ROLE" }
@@ -775,7 +782,7 @@ func (*Discard) StatementTag() string { return "DISCARD" }
 func (n *DeclareCursor) StatementReturnType() StatementReturnType { return Ack }
 
 // StatementType implements the Statement interface.
-func (*DeclareCursor) StatementType() StatementType { return TypeDCL }
+func (*DeclareCursor) StatementType() StatementType { return TypeDML }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*DeclareCursor) StatementTag() string { return "DECLARE CURSOR" }
@@ -838,7 +845,7 @@ func (*DropSequence) StatementTag() string { return "DROP SEQUENCE" }
 func (*DropRole) StatementReturnType() StatementReturnType { return Ack }
 
 // StatementType implements the Statement interface.
-func (*DropRole) StatementType() StatementType { return TypeDDL }
+func (*DropRole) StatementType() StatementType { return TypeDCL }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*DropRole) StatementTag() string { return "DROP ROLE" }
@@ -1202,7 +1209,7 @@ func (*SelectClause) StatementTag() string { return "SELECT" }
 func (*SetVar) StatementReturnType() StatementReturnType { return Ack }
 
 // StatementType implements the Statement interface.
-func (*SetVar) StatementType() StatementType { return TypeDCL }
+func (*SetVar) StatementType() StatementType { return TypeDML }
 
 // StatementTag returns a short string identifying the type of statement.
 func (n *SetVar) StatementTag() string {
@@ -1225,7 +1232,7 @@ func (*SetClusterSetting) StatementTag() string { return "SET CLUSTER SETTING" }
 func (*SetTransaction) StatementReturnType() StatementReturnType { return Ack }
 
 // StatementType implements the Statement interface.
-func (*SetTransaction) StatementType() StatementType { return TypeDCL }
+func (*SetTransaction) StatementType() StatementType { return TypeTCL }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*SetTransaction) StatementTag() string { return "SET TRANSACTION" }
@@ -1255,7 +1262,7 @@ func (*SetZoneConfig) StatementTag() string { return "CONFIGURE ZONE" }
 func (*SetSessionAuthorizationDefault) StatementReturnType() StatementReturnType { return Ack }
 
 // StatementType implements the Statement interface.
-func (*SetSessionAuthorizationDefault) StatementType() StatementType { return TypeDCL }
+func (*SetSessionAuthorizationDefault) StatementType() StatementType { return TypeDML }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*SetSessionAuthorizationDefault) StatementTag() string { return "SET" }
@@ -1264,7 +1271,7 @@ func (*SetSessionAuthorizationDefault) StatementTag() string { return "SET" }
 func (*SetSessionCharacteristics) StatementReturnType() StatementReturnType { return Ack }
 
 // StatementType implements the Statement interface.
-func (*SetSessionCharacteristics) StatementType() StatementType { return TypeDCL }
+func (*SetSessionCharacteristics) StatementType() StatementType { return TypeDML }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*SetSessionCharacteristics) StatementTag() string { return "SET" }

--- a/pkg/sql/tenant.go
+++ b/pkg/sql/tenant.go
@@ -224,6 +224,9 @@ func updateTenantRecord(
 
 // CreateTenant implements the tree.TenantOperator interface.
 func (p *planner) CreateTenant(ctx context.Context, tenID uint64) error {
+	if p.EvalContext().TxnReadOnly {
+		return readOnlyError("create_tenant()")
+	}
 	info := &descpb.TenantInfoWithUsage{
 		TenantInfo: descpb.TenantInfo{
 			ID: tenID,
@@ -395,6 +398,9 @@ func clearTenant(ctx context.Context, execCfg *ExecutorConfig, info *descpb.Tena
 
 // DestroyTenant implements the tree.TenantOperator interface.
 func (p *planner) DestroyTenant(ctx context.Context, tenID uint64, synchronous bool) error {
+	if p.EvalContext().TxnReadOnly {
+		return readOnlyError("destroy_tenant()")
+	}
 	const op = "destroy"
 	if err := rejectIfCantCoordinateMultiTenancy(p.execCfg.Codec, op); err != nil {
 		return err


### PR DESCRIPTION
Backport 1/1 commits from #93991.

/cc @cockroachdb/release

Release justification: bug fix

---

fixes https://github.com/cockroachdb/cockroach/issues/91713

In ed733adfefd26cd326a7677e9650eff687c4dfe3, a framework was added to mark certain opaque operators as DDL or mutations.

This was enhanced in 06581b3dbd1e302dc3108155344de70188b4f856, but that change wasn't exhaustive since it marked some statements as read-only, even if they could perform DDL.

With the addition of `StatementType()` in
89621764d4c2d438d1781238f10e9ef27ef2c392, we can make this a little more correct.

This allows the check at
https://github.com/cockroachdb/cockroach/blob/48ef0d89e6179c0d348a5236ad308d81fa392f7c/pkg/sql/opt/exec/execbuilder/relational.go#L163 to work correctly, and reject operations that shouldn't be allowed when using a read-only transaction.

To explain each change:
- BACKUP can modify job state and write to userfiles, so shouldn't be allowed in read-only mode.
- SET commands are always allowed in read-only mode in order to match Postgres behavior, and since those changes are all in-memory and session setting modifications don't respect transactions anyway.
- The crdb_internal tenant functions modify system tables.
- GRANT, REVOKE, and many other privilege-related statements are "DCL" (data control language), and all modify system tables or descriptors.

Release note (bug fix): CREATE ROLE, DELETE ROLE, GRANT, and REVOKE statements no longer work when the transaction is in read-only mode.
