### PR TITLE
kvserver: move proposal encoding to flush time

### DIFF
--- a/pkg/kv/kvserver/kvserverpb/proposer_kv.go
+++ b/pkg/kv/kvserver/kvserverpb/proposer_kv.go
@@ -11,26 +11,9 @@
 package kvserverpb
 
 import (
-	"math"
-
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
-
-var maxRaftCommandFooterSize = (&RaftCommandFooter{
-	MaxLeaseIndex: math.MaxUint64,
-	ClosedTimestamp: hlc.Timestamp{
-		WallTime:  math.MaxInt64,
-		Logical:   math.MaxInt32,
-		Synthetic: true,
-	},
-}).Size()
-
-// MaxRaftCommandFooterSize returns the maximum possible size of an encoded
-// RaftCommandFooter proto.
-func MaxRaftCommandFooterSize() int {
-	return maxRaftCommandFooterSize
-}
 
 // IsZero returns whether all fields are set to their zero value.
 func (r ReplicatedEvalResult) IsZero() bool {

--- a/pkg/kv/kvserver/kvserverpb/proposer_kv.proto
+++ b/pkg/kv/kvserver/kvserverpb/proposer_kv.proto
@@ -328,7 +328,7 @@ message RaftCommand {
   // this command before the closed timestamp was known and later extended the
   // marshaled representation with a footer containing the closed timestamp. Due
   // to a gogoproto quirk[^1] a zero hlc.Timestamp{} still gets put on the wire,
-  // which we wanted to avoid sincei t caused subtle bugs[^2]. None of this
+  // which we wanted to avoid since it caused subtle bugs[^2]. None of this
   // applies any more but changing a field from nullable to non-nullable can
   // have a migration concern, which would need to be investigated.
   //

--- a/pkg/kv/kvserver/kvserverpb/proposer_kv.proto
+++ b/pkg/kv/kvserver/kvserverpb/proposer_kv.proto
@@ -310,13 +310,6 @@ message RaftCommand {
   // been added after it, and on removal, the assignment counters must be
   // updated accordingly. Managing retry of proposals becomes trickier as
   // well as that uproots whatever ordering was originally envisioned.
-  //
-  // This field is set through MaxLeaseFooter hackery. Unlike with the
-  // ClosedTimestamp, which needs to be nullable in this proto (see comment),
-  // there are no nullability concerns with this field. This is because
-  // max_lease_index is a primitive type, so it does not get encoded when zero.
-  // This alone ensures that the field is not encoded twice in the combined
-  // RaftCommand+MaxLeaseFooter proto.
   uint64 max_lease_index = 4;
 
   // The closed timestamp carried by this command. Once a follower is told to
@@ -329,12 +322,23 @@ message RaftCommand {
   // update. If the value is not zero, the value is greater or equal to that of
   // the previous commands (and all before it).
   //
-  // This field is set through ClosedTimestampFooter hackery. The field is
-  // nullable so that it does not get encoded when empty. This prevents the
-  // field from being encoded twice in the combined
-  // RaftCommand+ClosedTimestampFooter proto (encoding it twice is not illegal
-  // as far as proto goes - the last value wins when decoding - but it is a
-  // problem for sideloading, which reduces the size of the proto).
+  // NB:
+  //
+  // The nullability of this field is historical in nature; we used to marshal
+  // this command before the closed timestamp was known and later extended the
+  // marshaled representation with a footer containing the closed timestamp. Due
+  // to a gogoproto quirk[^1] a zero hlc.Timestamp{} still gets put on the wire,
+  // which we wanted to avoid sincei t caused subtle bugs[^2]. None of this
+  // applies any more but changing a field from nullable to non-nullable can
+  // have a migration concern, which would need to be investigated.
+  //
+  // A negative effect of this nullability is an additional allocation on the
+  // leaseholder to populate this field, which is why we currently leave it
+  // unpopulated there[^3], except during marshaling.
+  //
+  // [^1]: https://github.com/cockroachdb/cockroach/issues/85312
+  // [^2]: https://github.com/cockroachdb/cockroach/pull/60992
+  // [^3]: See (*propBuf).FlushLockedWithRaftGroup().
   util.hlc.Timestamp closed_timestamp = 17;
 
   reserved 3;
@@ -359,19 +363,4 @@ message RaftCommand {
   map<string, string> trace_data = 16;
 
   reserved 1, 2, 10001 to 10014;
-}
-
-// RaftCommandFooter contains a subset of the fields in RaftCommand. It is used
-// to optimize a pattern where most of the fields in RaftCommand are marshaled
-// outside of a heavily contended critical section, except for the fields in the
-// footer, which are assigned and marshaled inside of the critical section and
-// appended to the marshaled byte buffer. This minimizes the memory allocation
-// and marshaling work performed under lock.
-message RaftCommandFooter {
-  uint64 max_lease_index = 4;
-  // NOTE: unlike in RaftCommand, there's no reason to make this field nullable
-  // and so we make it non-nullable in order to save allocations. This means
-  // that the field on a decoded RaftCommand will also never be nil, but we
-  // don't rely on that.
-  util.hlc.Timestamp closed_timestamp = 17 [(gogoproto.nullable) = false];
 }

--- a/pkg/kv/kvserver/kvserverpb/proposer_kv.proto
+++ b/pkg/kv/kvserver/kvserverpb/proposer_kv.proto
@@ -332,13 +332,8 @@ message RaftCommand {
   // applies any more but changing a field from nullable to non-nullable can
   // have a migration concern, which would need to be investigated.
   //
-  // A negative effect of this nullability is an additional allocation on the
-  // leaseholder to populate this field, which is why we currently leave it
-  // unpopulated there[^3], except during marshaling.
-  //
   // [^1]: https://github.com/cockroachdb/cockroach/issues/85312
   // [^2]: https://github.com/cockroachdb/cockroach/pull/60992
-  // [^3]: See (*propBuf).FlushLockedWithRaftGroup().
   util.hlc.Timestamp closed_timestamp = 17;
 
   reserved 3;

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -74,10 +74,6 @@ type ProposalData struct {
 	// reproposals its MaxLeaseIndex field is mutated.
 	command *kvserverpb.RaftCommand
 
-	// encodedCommand is the encoded Raft command, with an optional prefix
-	// containing the command ID.
-	encodedCommand []byte
-
 	// quotaAlloc is the allocation retrieved from the proposalQuota. Once a
 	// proposal has been passed to raft modifying this field requires holding the
 	// raftMu. Once the proposal comes out of Raft, ownerwhip of this quota is

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -74,6 +74,11 @@ type ProposalData struct {
 	// reproposals its MaxLeaseIndex field is mutated.
 	command *kvserverpb.RaftCommand
 
+	// preAlloc is an optional byte slice that is populated in (*Replica).propose
+	// to avoid shifting allocation work into propBuf's FlushLockedWithRaftGroup
+	// method. The buffer is sized to hold the fully encoded command.
+	preAlloc []byte
+
 	// quotaAlloc is the allocation retrieved from the proposalQuota. Once a
 	// proposal has been passed to raft modifying this field requires holding the
 	// raftMu. Once the proposal comes out of Raft, ownerwhip of this quota is

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -78,6 +78,10 @@ type ProposalData struct {
 	// to avoid shifting allocation work into propBuf's FlushLockedWithRaftGroup
 	// method. The buffer is sized to hold the fully encoded command.
 	preAlloc []byte
+	// closedTimestamp backs p.command.ClosedTimestamp to avoid an allocation.
+	// This is populated in (*propBuf).FlushLockedWithRaftGroup, together
+	// with p.command.MaxLeaseIndex.
+	closedTimestamp hlc.Timestamp
 
 	// quotaAlloc is the allocation retrieved from the proposalQuota. Once a
 	// proposal has been passed to raft modifying this field requires holding the

--- a/pkg/kv/kvserver/replica_proposal_buf_test.go
+++ b/pkg/kv/kvserver/replica_proposal_buf_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -295,20 +294,7 @@ func (pc proposalCreator) newProposal(ba *roachpb.BatchRequest) *ProposalData {
 		Request:     ba,
 		leaseStatus: pc.lease,
 	}
-	p.encodedCommand = pc.encodeProposal(p)
 	return p
-}
-
-func (pc proposalCreator) encodeProposal(p *ProposalData) []byte {
-	cmdLen := p.command.Size()
-	needed := raftlog.RaftCommandPrefixLen + cmdLen + kvserverpb.MaxRaftCommandFooterSize()
-	data := make([]byte, raftlog.RaftCommandPrefixLen, needed)
-	raftlog.EncodeRaftCommandPrefix(data, raftlog.EntryEncodingStandardPrefixByte, p.idKey)
-	data = data[:raftlog.RaftCommandPrefixLen+p.command.Size()]
-	if _, err := protoutil.MarshalTo(p.command, data[raftlog.RaftCommandPrefixLen:]); err != nil {
-		panic(err)
-	}
-	return data
 }
 
 // TestProposalBuffer tests the basic behavior of the Raft proposal buffer.

--- a/pkg/kv/kvserver/replica_proposal_buf_test.go
+++ b/pkg/kv/kvserver/replica_proposal_buf_test.go
@@ -294,6 +294,9 @@ func (pc proposalCreator) newProposal(ba *roachpb.BatchRequest) *ProposalData {
 		Request:     ba,
 		leaseStatus: pc.lease,
 	}
+	// Avoid tripping the assertion in `(*propBuf).FlushLockedWithRaftGroup` that
+	// makes sure that preallocation isn't too stingy or forgotten.
+	p.preAlloc = make([]byte, 1024+p.command.Size())
 	return p
 }
 

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -475,6 +475,10 @@ func maxCompletedProposalSize(cmd *kvserverpb.RaftCommand) int {
 // meaning we can drop both the checks[^reprop-check]. This is a nice conceptual
 // simplification, and may or may not help reduce complexity around reproposal
 // errors that I still need to fill my understanding for.
+// ^-- hmm - even if *we* don't repropose identical copies might raft create some
+// due to proposal forwarding? I don't think so - but only if *we* don't accidentally
+// forward messages multiple times (retries, etc). Forwarded proposals don't have an
+// index yet, for obvious reasons.
 //
 // [^pipeline]: https://github.com/cockroachdb/cockroach/pull/35261 - the TL;DR is that
 // we don't really expect to need this in steady state but it happened enough


### PR DESCRIPTION
Previously, the bulk of proposal encoding happened in
`(*Replica).propose` and a buffer representing a part of the encoding
(depending on whether this was a conf change or regular command) was
constructed. This partially encoded proposal would then be handed to the
proposal buffer, which, at flush time, would do "more encoding": it
would complete the marshaled RaftCommand bytes with a "footer"
containing the `MaxLeaseAppliedIndex` and the `ClosedTimestamp`, both of
which are known only at flush time, and would wrap the result in a conf
change proposal, if needed.

This split was awkward. The footer hackery was awkward. It was difficult
to package entry encoding up in a more appropriate subpackage such as
`logstorage`.

This commit moves the entirety of the encoding code away from
`(*Replica).propose` and instead does it when the proposal buffer
flushes. This lets us remove all of the "footer" hackery (since now
we know everything we need to marshal) and collects all of the encoding
in one place, where it will be easier to extract in a future PR.

Epic: CRDB-220
Release note: None