### PR TITLE
sql: avoid hydration when looking up non-type descriptor within hydration cache

### DIFF
--- a/pkg/sql/catalog/descs/descriptor.go
+++ b/pkg/sql/catalog/descs/descriptor.go
@@ -339,6 +339,7 @@ func getDescriptorsByID(
 	if err := tc.finalizeDescriptors(ctx, txn, flags, descs, vls); err != nil {
 		return err
 	}
+	// Hydration is skipped if "SkipHydration" flag is true.
 	if err := tc.hydrateDescriptors(ctx, txn, flags, descs); err != nil {
 		return err
 	}

--- a/pkg/sql/catalog/descs/hydrate.go
+++ b/pkg/sql/catalog/descs/hydrate.go
@@ -52,7 +52,9 @@ import (
 func (tc *Collection) hydrateDescriptors(
 	ctx context.Context, txn *kv.Txn, flags tree.CommonLookupFlags, descs []catalog.Descriptor,
 ) error {
-
+	if flags.SkipHydration {
+		return nil
+	}
 	var hydratableMutableIndexes, hydratableImmutableIndexes intsets.Fast
 	for i, desc := range descs {
 		if desc == nil || !hydrateddesc.IsHydratable(desc) {
@@ -120,7 +122,7 @@ func makeMutableTypeLookupFunc(
 		}
 		mut.UpsertDescriptor(desc)
 	}
-	mutableLookupFunc := func(ctx context.Context, id descpb.ID) (catalog.Descriptor, error) {
+	mutableLookupFunc := func(ctx context.Context, id descpb.ID, skipHydration bool) (catalog.Descriptor, error) {
 		// This special case exists to deal with the desire to use enums in the
 		// system database, and the fact that the hydration contract is such that
 		// when we resolve types mutably, we resolve the mutable type descriptors
@@ -130,13 +132,21 @@ func makeMutableTypeLookupFunc(
 		// let the caller have the immutable copy.
 		if id == catconstants.PublicSchemaID {
 			return tc.GetImmutableDescriptorByID(ctx, txn, id, tree.CommonLookupFlags{
-				Required:    true,
-				AvoidLeased: true,
+				Required:      true,
+				AvoidLeased:   true,
+				SkipHydration: skipHydration,
 			})
 		}
-		return tc.GetMutableDescriptorByID(ctx, txn, id)
+		return tc.getDescriptorByID(ctx, txn, tree.CommonLookupFlags{
+			Required:       true,
+			AvoidLeased:    true,
+			RequireMutable: true,
+			IncludeOffline: true,
+			IncludeDropped: true,
+			SkipHydration:  skipHydration,
+		}, id)
 	}
-	return hydrateddesc.MakeTypeLookupFuncForHydration(mut.Catalog, mutableLookupFunc)
+	return hydrateddesc.MakeTypeLookupFuncForHydration(mut, mutableLookupFunc)
 }
 
 func makeImmutableTypeLookupFunc(
@@ -152,15 +162,16 @@ func makeImmutableTypeLookupFunc(
 		}
 		imm.UpsertDescriptor(desc)
 	}
-	immutableLookupFunc := func(ctx context.Context, id descpb.ID) (catalog.Descriptor, error) {
+	immutableLookupFunc := func(ctx context.Context, id descpb.ID, skipHydration bool) (catalog.Descriptor, error) {
 		return tc.GetImmutableDescriptorByID(ctx, txn, id, tree.CommonLookupFlags{
 			Required:       true,
 			AvoidLeased:    flags.AvoidLeased,
 			IncludeOffline: flags.IncludeOffline,
 			AvoidSynthetic: true,
+			SkipHydration:  skipHydration,
 		})
 	}
-	return hydrateddesc.MakeTypeLookupFuncForHydration(imm.Catalog, immutableLookupFunc)
+	return hydrateddesc.MakeTypeLookupFuncForHydration(imm, immutableLookupFunc)
 }
 
 // HydrateCatalog installs type metadata in the type.T objects present for all
@@ -169,10 +180,10 @@ func HydrateCatalog(ctx context.Context, c nstree.MutableCatalog) error {
 	ctx, sp := tracing.ChildSpan(ctx, "descs.HydrateCatalog")
 	defer sp.Finish()
 
-	fakeLookupFunc := func(_ context.Context, id descpb.ID) (catalog.Descriptor, error) {
+	fakeLookupFunc := func(_ context.Context, id descpb.ID, skipHydration bool) (catalog.Descriptor, error) {
 		return nil, catalog.WrapDescRefErr(id, catalog.ErrDescriptorNotFound)
 	}
-	typeLookupFunc := hydrateddesc.MakeTypeLookupFuncForHydration(c.Catalog, fakeLookupFunc)
+	typeLookupFunc := hydrateddesc.MakeTypeLookupFuncForHydration(c, fakeLookupFunc)
 	return c.ForEachDescriptor(func(desc catalog.Descriptor) error {
 		if !hydrateddesc.IsHydratable(desc) {
 			return nil

--- a/pkg/sql/catalog/hydrateddesc/hydrate.go
+++ b/pkg/sql/catalog/hydrateddesc/hydrate.go
@@ -25,7 +25,7 @@ import (
 
 // HydrationLookupFunc is the type of function required to look up type
 // descriptors and their parent schemas and databases when hydrating an object.
-type HydrationLookupFunc func(ctx context.Context, id descpb.ID) (catalog.Descriptor, error)
+type HydrationLookupFunc func(ctx context.Context, id descpb.ID, skipHydration bool) (catalog.Descriptor, error)
 
 // IsHydratable returns false iff the descriptor definitely does not require
 // hydration
@@ -64,12 +64,14 @@ func Hydrate(
 // looked up in the nstree.Catalog object before being looked up via the
 // HydrationLookupFunc.
 func MakeTypeLookupFuncForHydration(
-	c nstree.Catalog, lookupFn HydrationLookupFunc,
+	c nstree.MutableCatalog, lookupFn HydrationLookupFunc,
 ) typedesc.TypeLookupFunc {
-	return func(ctx context.Context, id descpb.ID) (tn tree.TypeName, typ catalog.TypeDescriptor, err error) {
+	var typeLookupFunc func(ctx context.Context, id descpb.ID) (tn tree.TypeName, typ catalog.TypeDescriptor, err error)
+
+	typeLookupFunc = func(ctx context.Context, id descpb.ID) (tn tree.TypeName, typ catalog.TypeDescriptor, err error) {
 		typDesc := c.LookupDescriptor(id)
 		if typDesc == nil {
-			typDesc, err = lookupFn(ctx, id)
+			typDesc, err = lookupFn(ctx, id, false /* skipHydration */)
 			if err != nil {
 				if errors.Is(err, catalog.ErrDescriptorNotFound) {
 					n := tree.Name(fmt.Sprintf("[%d]", id))
@@ -77,11 +79,18 @@ func MakeTypeLookupFuncForHydration(
 				}
 				return tree.TypeName{}, nil, err
 			}
+			c.UpsertDescriptor(typDesc)
 		}
 		switch t := typDesc.(type) {
 		case catalog.TypeDescriptor:
 			typ = t
 		case catalog.TableDescriptor:
+			if !typedesc.TableIsHydrated(t) {
+				if err := Hydrate(ctx, t, typeLookupFunc); err != nil {
+					return tree.TypeName{}, nil, err
+				}
+				c.UpsertDescriptor(t)
+			}
 			typ, err = typedesc.CreateImplicitRecordTypeFromTableDesc(t)
 		default:
 			typ, err = catalog.AsTypeDescriptor(typDesc)
@@ -91,7 +100,7 @@ func MakeTypeLookupFuncForHydration(
 		}
 		dbDesc := c.LookupDescriptor(typ.GetParentID())
 		if dbDesc == nil {
-			dbDesc, err = lookupFn(ctx, typ.GetParentID())
+			dbDesc, err = lookupFn(ctx, typ.GetParentID(), true /* skipHydration */)
 			if err != nil {
 				if errors.Is(err, catalog.ErrDescriptorNotFound) {
 					n := fmt.Sprintf("[%d]", typ.GetParentID())
@@ -99,13 +108,14 @@ func MakeTypeLookupFuncForHydration(
 				}
 				return tree.TypeName{}, nil, err
 			}
+			c.UpsertDescriptor(dbDesc)
 		}
 		if _, err = catalog.AsDatabaseDescriptor(dbDesc); err != nil {
 			return tree.TypeName{}, nil, err
 		}
 		scDesc := c.LookupDescriptor(typ.GetParentSchemaID())
 		if scDesc == nil {
-			scDesc, err = lookupFn(ctx, typ.GetParentSchemaID())
+			scDesc, err = lookupFn(ctx, typ.GetParentSchemaID(), true /* skipHydration */)
 			if err != nil {
 				if errors.Is(err, catalog.ErrDescriptorNotFound) {
 					n := fmt.Sprintf("[%d]", typ.GetParentSchemaID())
@@ -113,6 +123,7 @@ func MakeTypeLookupFuncForHydration(
 				}
 				return tree.TypeName{}, nil, err
 			}
+			c.UpsertDescriptor(scDesc)
 		}
 		if _, err = catalog.AsSchemaDescriptor(scDesc); err != nil {
 			return tree.TypeName{}, nil, err
@@ -120,4 +131,6 @@ func MakeTypeLookupFuncForHydration(
 		tn = tree.MakeQualifiedTypeName(dbDesc.GetName(), scDesc.GetName(), typ.GetName())
 		return tn, typ, nil
 	}
+
+	return typeLookupFunc
 }

--- a/pkg/sql/catalog/typedesc/table_implicit_record_type.go
+++ b/pkg/sql/catalog/typedesc/table_implicit_record_type.go
@@ -57,7 +57,7 @@ func CreateImplicitRecordTypeFromTableDesc(
 	typs := make([]*types.T, len(cols))
 	names := make([]string, len(cols))
 	for i, col := range cols {
-		if col.GetType().UserDefined() && !col.GetType().IsHydrated() {
+		if !ColumnIsHydrated(col) {
 			return nil, errors.AssertionFailedf("encountered unhydrated col %s while creating implicit record type from"+
 				" table %s", col.ColName(), descriptor.GetName())
 		}
@@ -109,6 +109,19 @@ func CreateImplicitRecordTypeFromTableDesc(
 			Version:    tablePrivs.Version,
 		},
 	}, nil
+}
+
+func TableIsHydrated(tbl catalog.TableDescriptor) bool {
+	for _, col := range tbl.VisibleColumns() {
+		if !ColumnIsHydrated(col) {
+			return false
+		}
+	}
+	return true
+}
+
+func ColumnIsHydrated(col catalog.Column) bool {
+	return !col.GetType().UserDefined() || col.GetType().IsHydrated()
 }
 
 // GetName implements the Namespace interface.

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -2635,3 +2635,82 @@ query I
 SELECT f93083()
 ----
 NULL
+
+# Regression test for #93314
+subtest regression_93314
+
+statement ok
+CREATE TYPE e_93314 AS ENUM ('a', 'b');
+CREATE TABLE t_93314 (i INT, e e_93314);
+INSERT INTO t_93314 VALUES (1, 'a');
+
+statement ok
+CREATE OR REPLACE FUNCTION f_93314 () RETURNS t_93314 AS
+$$
+  SELECT i, e
+  FROM t_93314
+  ORDER BY i
+  LIMIT 1;
+$$ LANGUAGE SQL;
+
+query T
+SELECT f_93314();
+----
+(1,a)
+
+statement ok
+CREATE TABLE t_93314_alias (i INT, e _e_93314);
+INSERT INTO t_93314_alias VALUES (1, ARRAY['a', 'b']::_e_93314);
+
+statement ok
+CREATE OR REPLACE FUNCTION f_93314_alias () RETURNS t_93314_alias AS
+$$
+  SELECT i, e
+  FROM t_93314_alias
+  ORDER BY i
+  LIMIT 1;
+$$ LANGUAGE SQL;
+
+query T
+SELECT f_93314_alias();
+----
+(1,"{a,b}")
+
+statement ok
+CREATE TYPE comp_93314 AS (a INT, b INT);
+CREATE TABLE t_93314_comp (a INT, c comp_93314, FAMILY (a, c));
+
+statement ok
+INSERT INTO t_93314_comp VALUES (1, (2,3));
+
+statement ok
+CREATE FUNCTION f_93314_comp() RETURNS comp_93314 AS
+$$
+  SELECT (1, 2);
+$$ LANGUAGE SQL;
+
+query T
+SELECT f_93314_comp()
+----
+(1,2)
+
+statement ok
+CREATE FUNCTION f_93314_comp_t() RETURNS t_93314_comp AS
+$$
+  SELECT a, c FROM t_93314_comp LIMIT 1;
+$$ LANGUAGE SQL;
+
+query T
+SELECT f_93314_comp_t()
+----
+(1,"(2,3)")
+
+query TTTTTBBBTITTTTT
+SELECT oid, proname, pronamespace, proowner, prolang, proleakproof, proisstrict, proretset, provolatile, pronargs, prorettype, proargtypes, proargmodes, proargnames, prosrc
+FROM pg_catalog.pg_proc WHERE proname IN ('f_93314', 'f_93314_alias', 'f_93314_comp', 'f_93314_comp_t')
+ORDER BY oid;
+----
+100251  f_93314        105  1546506610  14  false  false  false  v  0  100250  ·  {}  NULL  SELECT i, e FROM test.public.t_93314 ORDER BY i LIMIT 1;
+100253  f_93314_alias  105  1546506610  14  false  false  false  v  0  100252  ·  {}  NULL  SELECT i, e FROM test.public.t_93314_alias ORDER BY i LIMIT 1;
+100257  f_93314_comp    105  1546506610  14  false  false  false  v  0  100254  ·  {}  NULL  SELECT (1, 2);
+100258  f_93314_comp_t  105  1546506610  14  false  false  false  v  0  100256  ·  {}  NULL  SELECT a, c FROM test.public.t_93314_comp LIMIT 1;

--- a/pkg/sql/sem/tree/name_resolution.go
+++ b/pkg/sql/sem/tree/name_resolution.go
@@ -179,6 +179,12 @@ type CommonLookupFlags struct {
 	// ParentID enforces that the resolved descriptor exist with this parent
 	// ID if non-zero.
 	ParentID catid.DescID
+	// SkipHydration enforce descriptor lookups to skip hydration. This can be set
+	// to true only when looking up descriptors when hydrating another group of
+	// descriptors. The purpose is to avoid potential infinite recursion loop when
+	// trying to hydrate a descriptor which would lead to hydration of another
+	// descriptor depends on it.
+	SkipHydration bool
 }
 
 // SchemaLookupFlags is the flag struct suitable for GetSchemaByName().


### PR DESCRIPTION
Fixes #93314

When creating a UDF whose signature uses implicit record type which has a column of user defined enum type, crdb crashes because of a type hydration deadloop. The reason is that when we try to hydrate the implicit record type, the enum type also needs to be hydrated, and the schema descriptor as well because we need a fully qualified type name which requires a schema lookup and we now have function signatures within schema descriptor which has the type information. Then to hydrate the schema descriptor, the function signature types need to hydrated (again!), such the deadloop happens.

This pr adds a new flag for descriptor lookup to explicitly avoid hydration when looking up descriptor that can't be used as a UDT, so that we can avoid the hydration deadloop when looking up schema descriptor for its name.

Release note (sql change): Previously, cockroach db would crash if user creates a UDF whose function signature includes a implicit record type (essentially a table) which has a column using a user defined enum type. This root cause was that there was  a hydration deadloop when looking up descriptors during hydration. This PR adds a new flag to avoid hydration in order to avoid the deadloop, users shouldn't feel differentce on using UDFs.