### PR TITLE
workloadccl: skip TestDeterministicInitialData to avoid flakes

### DIFF
--- a/pkg/ccl/workloadccl/allccl/all_test.go
+++ b/pkg/ccl/workloadccl/allccl/all_test.go
@@ -253,6 +253,8 @@ func hashTableInitialData(
 func TestDeterministicInitialData(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	skip.WithIssue(t, 93958, "flaky test")
+
 	// There are other tests that run initial data generation under race, so we
 	// don't get anything from running this one under race as well.
 	skip.UnderRace(t, "uninteresting under race")


### PR DESCRIPTION
I'm skipping this test until I have time to debug the reason for the flake.

Informs #93958

Release note: None