### PR TITLE
roachprod: include storage workload metadata on snapshot

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -1014,7 +1014,7 @@ var storageSnapshotCmd = &cobra.Command{
 		cluster := args[0]
 		name := args[1]
 		desc := args[2]
-		return roachprod.SnapshotVolume(roachprodLibraryLogger, cluster, name, desc)
+		return roachprod.SnapshotVolume(context.Background(), roachprodLibraryLogger, cluster, name, desc)
 	}),
 }
 

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -1265,14 +1265,22 @@ type snapshotOutput struct {
 	SnapshotID string    `json:"SnapshotId"`
 }
 
-func (p *Provider) SnapshotVolume(volume vm.Volume, name, description string) (string, error) {
+func (p *Provider) SnapshotVolume(
+	volume vm.Volume, name, description string, labels map[string]string,
+) (string, error) {
 	region := volume.Zone[:len(volume.Zone)-1]
+	labels["Name"] = name
+	var tags []string
+	for k, v := range labels {
+		tags = append(tags, fmt.Sprintf("{Key=%s,Value=%s}", k, v))
+	}
+
 	args := []string{
 		"ec2", "create-snapshot",
 		"--description", description,
 		"--region", region,
 		"--volume-id", volume.ProviderResourceID,
-		"--tag-specifications", "ResourceType=snapshot,Tags=[{Key=Name,Value=" + name + "}]",
+		"--tag-specifications", "ResourceType=snapshot,Tags=[" + strings.Join(tags, ",") + "]",
 	}
 
 	var so snapshotOutput

--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -91,7 +91,9 @@ type Provider struct {
 	}
 }
 
-func (p *Provider) SnapshotVolume(volume vm.Volume, name, description string) (string, error) {
+func (p *Provider) SnapshotVolume(
+	volume vm.Volume, name, description string, labels map[string]string,
+) (string, error) {
 	// TODO(leon): implement
 	panic("unimplemented")
 }

--- a/pkg/roachprod/vm/flagstub/flagstub.go
+++ b/pkg/roachprod/vm/flagstub/flagstub.go
@@ -32,7 +32,7 @@ type provider struct {
 	unimplemented string
 }
 
-func (p *provider) SnapshotVolume(vm.Volume, string, string) (string, error) {
+func (p *provider) SnapshotVolume(vm.Volume, string, string, map[string]string) (string, error) {
 	return "", errors.Newf("%s", p.unimplemented)
 }
 

--- a/pkg/roachprod/vm/local/local.go
+++ b/pkg/roachprod/vm/local/local.go
@@ -119,7 +119,9 @@ type Provider struct {
 	storage VMStorage
 }
 
-func (p *Provider) SnapshotVolume(volume vm.Volume, name, description string) (string, error) {
+func (p *Provider) SnapshotVolume(
+	volume vm.Volume, name, description string, labels map[string]string,
+) (string, error) {
 	return "", nil
 }
 

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -304,7 +304,7 @@ type Provider interface {
 
 	CreateVolume(vco VolumeCreateOpts) (Volume, error)
 	AttachVolumeToVM(volume Volume, vm *VM) (string, error)
-	SnapshotVolume(volume Volume, name, description string) (string, error)
+	SnapshotVolume(volume Volume, name, description string, labels map[string]string) (string, error)
 }
 
 // DeleteCluster is an optional capability for a Provider which can


### PR DESCRIPTION
Currently when a snapshot is taken of a volume that has been used for storage workload collection, the snapshot only contains the user provided information--name of the snapshot and description. Which could lead to data not being included about which cluster this ran on, machine type, crdb version, etc.

As a result, we encode this metadata in the labels / tags when we create a snapshot allowing the user to provide both a name and a description while also capturing metadata that can be used for searching and further reference. There are some limitations with the maximum length of the labels (aws key: 128 chars value: 256 chars; gcp: both 63 chars) and which characters are allowed to be used (gcp: lowercase, digits, _, -; aws: letters, digits, spaces, ., :, +, =, @, _, /, -)

Alternatively, the metadata could be encoded into the description field which would allow for more data to be saved at the cost of it being harder to search / filter.

Fixes: #94075

Release note: None