### PR TITLE
kv: don't mutate raft snapshot when logging raft ready

### DIFF
--- a/pkg/kv/kvserver/raft.go
+++ b/pkg/kv/kvserver/raft.go
@@ -207,8 +207,8 @@ func raftDescribeMessage(m raftpb.Message, f raft.EntryFormatter) string {
 		}
 		fmt.Fprintf(&buf, "]")
 	}
-	if m.Snapshot != nil && !raft.IsEmptySnap(*m.Snapshot) {
-		snap := m.Snapshot
+	if m.Snapshot != nil {
+		snap := *m.Snapshot
 		snap.Data = nil
 		fmt.Fprintf(&buf, " Snapshot:%v", snap)
 	}


### PR DESCRIPTION
This commit fixes a subtle bug that we introduced in e532c65 when we picked up etcd/raft at 285e4437. With `Message.Snapshot` now a pointer, logic in `raftDescribeMessage` began unintentionally mutating the message's snapshot, instead of mutating a local copy.

This commit fixes the bug. We only hit this path when verbose raft logging is enabled, so I doubt anyone hit this issue in the two weeks that this issue has sat on master.

I confirmed that we did not make the same mistake anywhere else.

Release note: None
Epic: None