### PR TITLE
sql: implement the `log_timezone` session variable

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4819,6 +4819,7 @@ lc_time                                               C.UTF-8
 locality                                              region=test,dc=dc1
 locality_optimized_partitioned_index_scan             on
 lock_timeout                                          0
+log_timezone                                          UTC
 max_identifier_length                                 128
 max_index_keys                                        32
 node_id                                               1

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2838,6 +2838,7 @@ lc_time                                               C.UTF-8             NULL  
 locality                                              region=test,dc=dc1  NULL      NULL        NULL        string
 locality_optimized_partitioned_index_scan             on                  NULL      NULL        NULL        string
 lock_timeout                                          0                   NULL      NULL        NULL        string
+log_timezone                                          UTC                 NULL      NULL        NULL        string
 max_identifier_length                                 128                 NULL      NULL        NULL        string
 max_index_keys                                        32                  NULL      NULL        NULL        string
 node_id                                               1                   NULL      NULL        NULL        string
@@ -2978,6 +2979,7 @@ lc_time                                               C.UTF-8             NULL  
 locality                                              region=test,dc=dc1  NULL  user     NULL      region=test,dc=dc1  region=test,dc=dc1
 locality_optimized_partitioned_index_scan             on                  NULL  user     NULL      on                  on
 lock_timeout                                          0                   NULL  user     NULL      0s                  0s
+log_timezone                                          UTC                 NULL  user     NULL      UTC                 UTC
 max_identifier_length                                 128                 NULL  user     NULL      128                 128
 max_index_keys                                        32                  NULL  user     NULL      32                  32
 node_id                                               1                   NULL  user     NULL      1                   1
@@ -3115,6 +3117,7 @@ lc_time                                               NULL    NULL     NULL     
 locality                                              NULL    NULL     NULL     NULL        NULL
 locality_optimized_partitioned_index_scan             NULL    NULL     NULL     NULL        NULL
 lock_timeout                                          NULL    NULL     NULL     NULL        NULL
+log_timezone                                          NULL    NULL     NULL     NULL        NULL
 max_identifier_length                                 NULL    NULL     NULL     NULL        NULL
 max_index_keys                                        NULL    NULL     NULL     NULL        NULL
 node_id                                               NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -277,12 +277,20 @@ SHOW server_version_num
 server_version_num
 130000
 
+query T
+SHOW log_timezone
+----
+UTC
+
 # Test read-only variables
 statement error parameter "max_index_keys" cannot be changed
 SET max_index_keys = 32
 
 statement error parameter "node_id" cannot be changed
 SET node_id = 123
+
+statement error invalid value for parameter "log_timezone"
+SET log_timezone = 'Australia/South'
 
 query TT
 SELECT name, value FROM system.settings WHERE name = 'testing.str'

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -99,6 +99,7 @@ lc_time                                               C.UTF-8
 locality                                              region=test,dc=dc1
 locality_optimized_partitioned_index_scan             on
 lock_timeout                                          0
+log_timezone                                          UTC
 max_identifier_length                                 128
 max_index_keys                                        32
 node_id                                               1

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -341,6 +341,10 @@ var varGen = map[string]sessionVar{
 		},
 	},
 
+	// See https://www.postgresql.org/docs/15/datatype-datetime.html.
+	// We always log in UTC.
+	`log_timezone`: makeCompatStringVar(`log_timezone`, `UTC`),
+
 	// This is only kept for backwards compatibility and no longer has any effect.
 	`datestyle_enabled`: makeBackwardsCompatBoolVar(
 		"datestyle_enabled", true,


### PR DESCRIPTION
Informs #84505

Release note (sql change): Add the `log_timezone` session variable, which is read only and always UTC.