### PR TITLE
sql: allow cursor WITH HOLD inside of txn as long as it gets closed

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1153,7 +1153,9 @@ func (ex *connExecutor) close(ctx context.Context, closeType closeType) {
 			ctx, &ex.extraTxnState.prepStmtsNamespaceMemAcc,
 		)
 		ex.extraTxnState.prepStmtsNamespaceMemAcc.Close(ctx)
-		ex.extraTxnState.sqlCursors.closeAll()
+		if err := ex.extraTxnState.sqlCursors.closeAll(false /* errorOnWithHold */); err != nil {
+			log.Warningf(ctx, "error closing cursors: %v", err)
+		}
 	}
 
 	if ex.sessionTracing.Enabled() {
@@ -1728,7 +1730,9 @@ func (ex *connExecutor) resetExtraTxnState(ctx context.Context, ev txnEvent) {
 	}
 
 	// Close all cursors.
-	ex.extraTxnState.sqlCursors.closeAll()
+	if err := ex.extraTxnState.sqlCursors.closeAll(false /* errorOnWithHold */); err != nil {
+		log.Warningf(ctx, "error closing cursors: %v", err)
+	}
 
 	ex.extraTxnState.createdSequences = make(map[descpb.ID]struct{})
 

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -988,6 +988,10 @@ func (ex *connExecutor) commitSQLTransactionInternal(ctx context.Context) error 
 	ctx, sp := tracing.EnsureChildSpan(ctx, ex.server.cfg.AmbientCtx.Tracer, "commit sql txn")
 	defer sp.Finish()
 
+	if err := ex.extraTxnState.sqlCursors.closeAll(true /* errorOnWithHold */); err != nil {
+		return err
+	}
+
 	// We need to step the transaction before committing if it has stepping
 	// enabled. If it doesn't have stepping enabled, then we just set the
 	// stepping mode back to what it was.
@@ -1070,6 +1074,9 @@ func (ex *connExecutor) createJobs(ctx context.Context) error {
 func (ex *connExecutor) rollbackSQLTransaction(
 	ctx context.Context, stmt tree.Statement,
 ) (fsm.Event, fsm.EventPayload) {
+	if err := ex.extraTxnState.sqlCursors.closeAll(false /* errorOnWithHold */); err != nil {
+		return ex.makeErrEvent(err, stmt)
+	}
 	if err := ex.state.mu.txn.Rollback(ctx); err != nil {
 		log.Warningf(ctx, "txn rollback failed: %s", err)
 	}

--- a/pkg/sql/logictest/testdata/logic_test/cursor
+++ b/pkg/sql/logictest/testdata/logic_test/cursor
@@ -598,3 +598,48 @@ FETCH 1 a b;
 
 statement ok
 COMMIT;
+
+statement error DECLARE CURSOR WITH HOLD can only be used in transaction blocks
+DECLARE foo CURSOR WITH HOLD FOR SELECT 1
+
+statement ok
+BEGIN
+
+statement ok
+DECLARE foo CURSOR WITH HOLD FOR SELECT 1
+
+statement ok
+DECLARE bar CURSOR WITH HOLD FOR SELECT 2
+
+query I
+FETCH 1 foo
+----
+1
+
+statement ok
+CLOSE foo
+
+statement ok
+CLOSE bar
+
+statement ok
+COMMIT
+
+statement ok
+BEGIN
+
+statement ok
+DECLARE foo CURSOR WITH HOLD FOR SELECT 1
+
+statement error cursor foo WITH HOLD must be closed before committing
+COMMIT
+
+statement ok
+BEGIN
+
+statement ok
+DECLARE foo CURSOR WITH HOLD FOR SELECT 1
+
+# ROLLBACK is fine, since it renders the cursor unusable anyway.
+statement ok
+ROLLBACK

--- a/pkg/sql/sql_cursor.go
+++ b/pkg/sql/sql_cursor.go
@@ -31,9 +31,6 @@ import (
 // DeclareCursor implements the DECLARE statement.
 // See https://www.postgresql.org/docs/current/sql-declare.html for details.
 func (p *planner) DeclareCursor(ctx context.Context, s *tree.DeclareCursor) (planNode, error) {
-	if s.Hold {
-		return nil, unimplemented.NewWithIssue(77101, "DECLARE CURSOR WITH HOLD")
-	}
 	if s.Binary {
 		return nil, unimplemented.NewWithIssue(77099, "DECLARE BINARY CURSOR")
 	}
@@ -45,6 +42,9 @@ func (p *planner) DeclareCursor(ctx context.Context, s *tree.DeclareCursor) (pla
 		name: s.String(),
 		constructor: func(ctx context.Context, p *planner) (_ planNode, _ error) {
 			if p.extendedEvalCtx.TxnImplicit {
+				if s.Hold {
+					return nil, unimplemented.NewWithIssue(77101, "DECLARE CURSOR WITH HOLD can only be used in transaction blocks")
+				}
 				return nil, pgerror.Newf(pgcode.NoActiveSQLTransaction, "DECLARE CURSOR can only be used in transaction blocks")
 			}
 
@@ -99,6 +99,7 @@ func (p *planner) DeclareCursor(ctx context.Context, s *tree.DeclareCursor) (pla
 				txn:          p.txn,
 				statement:    statement,
 				created:      timeutil.Now(),
+				withHold:     s.Hold,
 			}
 			if err := p.sqlCursors.addCursor(s.Name, cursor); err != nil {
 				// This case shouldn't happen because cursor names are scoped to a session,
@@ -258,6 +259,7 @@ type sqlCursor struct {
 	statement  string
 	created    time.Time
 	curRow     int64
+	withHold   bool
 }
 
 // Next implements the InternalRows interface.
@@ -271,8 +273,10 @@ func (s *sqlCursor) Next(ctx context.Context) (bool, error) {
 
 // sqlCursors contains a set of active cursors for a session.
 type sqlCursors interface {
-	// closeAll closes all cursors in the set.
-	closeAll()
+	// closeAll closes all cursors in the set. If any of the cursors were
+	// created WITH HOLD, and the errorOnWithHold flag is true, an error is
+	// returned.
+	closeAll(errorOnWithHold bool) error
 	// closeCursor closes the named cursor, returning an error if that cursor
 	// didn't exist in the set.
 	closeCursor(tree.Name) error
@@ -291,11 +295,17 @@ type cursorMap struct {
 	cursors map[tree.Name]*sqlCursor
 }
 
-func (c *cursorMap) closeAll() {
-	for _, c := range c.cursors {
-		_ = c.Close()
+func (c *cursorMap) closeAll(errorOnWithHold bool) error {
+	for n, c := range c.cursors {
+		if c.withHold && errorOnWithHold {
+			return unimplemented.NewWithIssuef(77101, "cursor %s WITH HOLD must be closed before committing", n)
+		}
+		if err := c.Close(); err != nil {
+			return err
+		}
 	}
 	c.cursors = nil
+	return nil
 }
 
 func (c *cursorMap) closeCursor(s tree.Name) error {
@@ -333,8 +343,8 @@ type connExCursorAccessor struct {
 	ex *connExecutor
 }
 
-func (c connExCursorAccessor) closeAll() {
-	c.ex.extraTxnState.sqlCursors.closeAll()
+func (c connExCursorAccessor) closeAll(errorOnWithHold bool) error {
+	return c.ex.extraTxnState.sqlCursors.closeAll(errorOnWithHold)
 }
 
 func (c connExCursorAccessor) closeCursor(s tree.Name) error {


### PR DESCRIPTION
informs https://github.com/cockroachdb/cockroach/issues/77101

The `DECLARE foo CURSOR WITH HOLD ...` syntax is now supported in a limited fashion. Unlike PG's `WITH HOLD`, this version can only be executed in a transaction block still. If there are any open cursors that have `WITH HOLD` open at the time a transaction is commited, the COMMIT fails.

No release note, since there's not actually any new functionality.

Release note: None