### PR TITLE
release-22.1: teamcity-trigger: reduce `COCKROACH_KVNEMESIS_STEPS` to 1000

### DIFF
--- a/pkg/cmd/teamcity-trigger/main.go
+++ b/pkg/cmd/teamcity-trigger/main.go
@@ -105,9 +105,9 @@ func runTC(queueBuild func(string, map[string]string)) {
 			// Disable -maxruns for kvnemesis. Run for the full 1h.
 			maxRuns = 0
 			if bazel.BuiltWithBazel() {
-				opts["env.EXTRA_BAZEL_FLAGS"] = "--test_env COCKROACH_KVNEMESIS_STEPS=10000"
+				opts["env.EXTRA_BAZEL_FLAGS"] = "--test_env COCKROACH_KVNEMESIS_STEPS=1000"
 			} else {
-				opts["env.COCKROACH_KVNEMESIS_STEPS"] = "10000"
+				opts["env.COCKROACH_KVNEMESIS_STEPS"] = "1000"
 			}
 		case baseImportPath + "sql/logictest", baseImportPath + "kv/kvserver":
 			// Stress heavy with reduced parallelism (to avoid overloading the

--- a/pkg/cmd/teamcity-trigger/main_test.go
+++ b/pkg/cmd/teamcity-trigger/main_test.go
@@ -64,20 +64,20 @@ func Example_runTC() {
 
 	// Output:
 	// github.com/cockroachdb/cockroach/pkg/kv/kvnemesis
-	//   env.COCKROACH_KVNEMESIS_STEPS: 10000
+	//   env.COCKROACH_KVNEMESIS_STEPS: 1000
 	//   env.GOFLAGS:     -parallel=4
 	//   env.STRESSFLAGS: -maxruns 0 -maxtime 1h0m0s -maxfails 1 -p 4
 	//   env.TESTTIMEOUT: 40m0s
 	//
 	// github.com/cockroachdb/cockroach/pkg/kv/kvnemesis
-	//   env.COCKROACH_KVNEMESIS_STEPS: 10000
+	//   env.COCKROACH_KVNEMESIS_STEPS: 1000
 	//   env.GOFLAGS:     -parallel=4
 	//   env.STRESSFLAGS: -maxruns 0 -maxtime 1h0m0s -maxfails 1 -p 4
 	//   env.TAGS:        deadlock
 	//   env.TESTTIMEOUT: 40m0s
 	//
 	// github.com/cockroachdb/cockroach/pkg/kv/kvnemesis
-	//   env.COCKROACH_KVNEMESIS_STEPS: 10000
+	//   env.COCKROACH_KVNEMESIS_STEPS: 1000
 	//   env.GOFLAGS:     -race -parallel=4
 	//   env.STRESSFLAGS: -maxruns 0 -maxtime 1h0m0s -maxfails 1 -p 1
 	//   env.TESTTIMEOUT: 40m0s


### PR DESCRIPTION
Backport 1/1 commits from #94065.

/cc @cockroachdb/release

Release justification: test improvement.

---

This patch reduces the number of KVNemesis iterations in nightly tests from 10000 to 1000. 10k-iteration failures are very hard to meaningfully debug. 1k iterations is arguably also hard to debug, but it's significantly more managable. Not to mention that kvnemesis runtime is quadratic in the number of steps, so this covers more ground in a 1-hour run.

Epic: none
Release note: None