### PR TITLE
roachtest: use --data-loader=INSERT for ledger, roachmart

### DIFF
--- a/pkg/cmd/roachtest/tests/ledger.go
+++ b/pkg/cmd/roachtest/tests/ledger.go
@@ -46,7 +46,8 @@ func registerLedger(r registry.Registry) {
 				concurrency := ifLocal(c, "", " --concurrency="+fmt.Sprint(nodes*32))
 				duration := " --duration=" + ifLocal(c, "10s", "10m")
 
-				cmd := fmt.Sprintf("./workload run ledger --init --histograms="+t.PerfArtifactsDir()+"/stats.json"+
+				// See https://github.com/cockroachdb/cockroach/issues/94062 for the --data-loader.
+				cmd := fmt.Sprintf("./workload run ledger --init --data-loader=INSERT --histograms="+t.PerfArtifactsDir()+"/stats.json"+
 					concurrency+duration+" {pgurl%s}", gatewayNodes)
 				c.Run(ctx, loadNode, cmd)
 				return nil

--- a/pkg/cmd/roachtest/tests/roachmart.go
+++ b/pkg/cmd/roachtest/tests/roachmart.go
@@ -51,7 +51,8 @@ func registerRoachmart(r registry.Registry) {
 			}
 		}
 		t.Status("initializing workload")
-		roachmartRun(ctx, 0, "./workload", "init", "roachmart")
+		// See https://github.com/cockroachdb/cockroach/issues/94062 for the --data-loader.
+		roachmartRun(ctx, 0, "./workload", "init", "roachmart", "--data-loader=INSERT")
 
 		duration := " --duration=" + ifLocal(c, "10s", "10m")
 


### PR DESCRIPTION
A recent PR[^1] exposed a bug in `--data-loader=AUTO` (the default). It
tries to use the IMPORT data loader whenever the workload supports it,
but there is a prerequisite it can't check: whether the CRDB server had
that workload linked in. If this is not the case, `workload init` will
fail.

There's a more holistic fix here somewhere, but for now get the
roachtests back to passing.

[^1]: https://github.com/cockroachdb/cockroach/commit/df0ef24978c51fb0a183d1ac379c1c48b372235d
exposed

Fixes https://github.com/cockroachdb/cockroach/issues/94062.
Fixes https://github.com/cockroachdb/cockroach/issues/94070.

Epic: None
Release note: None