### PR TITLE
release-22.1: server: fixes nodes list on databases page

### DIFF
--- a/pkg/ccl/multiregionccl/BUILD.bazel
+++ b/pkg/ccl/multiregionccl/BUILD.bazel
@@ -53,6 +53,7 @@ go_test(
         "//pkg/security",
         "//pkg/security/securitytest",
         "//pkg/server",
+        "//pkg/server/serverpb",
         "//pkg/sql",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",

--- a/pkg/ccl/multiregionccl/multiregionccltestutils/testutils.go
+++ b/pkg/ccl/multiregionccl/multiregionccltestutils/testutils.go
@@ -61,25 +61,28 @@ func WithUseDatabase(db string) MultiRegionTestClusterParamsOption {
 func TestingCreateMultiRegionCluster(
 	t testing.TB, numServers int, knobs base.TestingKnobs, opts ...MultiRegionTestClusterParamsOption,
 ) (*testcluster.TestCluster, *gosql.DB, func()) {
-	regionNames := make(map[string]int, numServers)
+	regionNames := make([]string, numServers)
 	for i := 0; i < numServers; i++ {
 		// "us-east1", "us-east2"...
-		regionNames[fmt.Sprintf("us-east%d", i+1)] = 1
+		regionNames[i] = fmt.Sprintf("us-east%d", i+1)
 	}
 
 	return TestingCreateMultiRegionClusterWithRegionList(
 		t,
 		regionNames,
+		1, /* serversPerRegion */
 		knobs,
 		opts...)
 }
 
-// TestingCreateMultiRegionClusterWithRegionList creates a test cluster with numServers number
-// of nodes and the provided testing knobs applied to each of the nodes. Every
-// node is placed in its own locality, named "us-east1", "us-east2", and so on.
+// TestingCreateMultiRegionClusterWithRegionList creates a test cluster with
+// serversPerRegion number of nodes in each of the provided regions and the
+// provided testing knobs applied to each of the nodes. Every node is placed in
+// its own locality, named according to the given region names.
 func TestingCreateMultiRegionClusterWithRegionList(
 	t testing.TB,
-	regionToNumServers map[string]int,
+	regionNames []string,
+	serversPerRegion int,
 	knobs base.TestingKnobs,
 	opts ...MultiRegionTestClusterParamsOption,
 ) (*testcluster.TestCluster, *gosql.DB, func()) {
@@ -91,19 +94,12 @@ func TestingCreateMultiRegionClusterWithRegionList(
 	}
 
 	totalServerCount := 0
-	for region, numServers := range regionToNumServers {
-		for i := 0; i < numServers; i++ {
+	for _, region := range regionNames {
+		for i := 0; i < serversPerRegion; i++ {
 			serverArgs[totalServerCount] = base.TestServerArgs{
 				Knobs:         knobs,
 				ExternalIODir: params.baseDir,
 				UseDatabase:   params.useDatabase,
-				// Disabling this due to failures in the rtt_analysis tests. Ideally
-				// we could disable multi-tenancy just for those tests, but this function
-				// is used to create the MR cluster for all test cases. For
-				// bonus points, the code to re-enable this should also provide more
-				// flexibility in disabling the default test tenant by callers of this
-				// function. Re-enablement is tracked with #76378.
-				DisableDefaultTestTenant: true,
 				Locality: roachpb.Locality{
 					Tiers: []roachpb.Tier{{Key: "region", Value: region}},
 				},

--- a/pkg/ccl/multiregionccl/multiregionccltestutils/testutils.go
+++ b/pkg/ccl/multiregionccl/multiregionccltestutils/testutils.go
@@ -61,30 +61,58 @@ func WithUseDatabase(db string) MultiRegionTestClusterParamsOption {
 func TestingCreateMultiRegionCluster(
 	t testing.TB, numServers int, knobs base.TestingKnobs, opts ...MultiRegionTestClusterParamsOption,
 ) (*testcluster.TestCluster, *gosql.DB, func()) {
-	serverArgs := make(map[int]base.TestServerArgs)
-	regionNames := make([]string, numServers)
+	regionNames := make(map[string]int, numServers)
 	for i := 0; i < numServers; i++ {
 		// "us-east1", "us-east2"...
-		regionNames[i] = fmt.Sprintf("us-east%d", i+1)
+		regionNames[fmt.Sprintf("us-east%d", i+1)] = 1
 	}
+
+	return TestingCreateMultiRegionClusterWithRegionList(
+		t,
+		regionNames,
+		knobs,
+		opts...)
+}
+
+// TestingCreateMultiRegionClusterWithRegionList creates a test cluster with numServers number
+// of nodes and the provided testing knobs applied to each of the nodes. Every
+// node is placed in its own locality, named "us-east1", "us-east2", and so on.
+func TestingCreateMultiRegionClusterWithRegionList(
+	t testing.TB,
+	regionToNumServers map[string]int,
+	knobs base.TestingKnobs,
+	opts ...MultiRegionTestClusterParamsOption,
+) (*testcluster.TestCluster, *gosql.DB, func()) {
+	serverArgs := make(map[int]base.TestServerArgs)
 
 	params := &multiRegionTestClusterParams{}
 	for _, opt := range opts {
 		opt(params)
 	}
 
-	for i := 0; i < numServers; i++ {
-		serverArgs[i] = base.TestServerArgs{
-			Knobs:         knobs,
-			ExternalIODir: params.baseDir,
-			UseDatabase:   params.useDatabase,
-			Locality: roachpb.Locality{
-				Tiers: []roachpb.Tier{{Key: "region", Value: regionNames[i]}},
-			},
+	totalServerCount := 0
+	for region, numServers := range regionToNumServers {
+		for i := 0; i < numServers; i++ {
+			serverArgs[totalServerCount] = base.TestServerArgs{
+				Knobs:         knobs,
+				ExternalIODir: params.baseDir,
+				UseDatabase:   params.useDatabase,
+				// Disabling this due to failures in the rtt_analysis tests. Ideally
+				// we could disable multi-tenancy just for those tests, but this function
+				// is used to create the MR cluster for all test cases. For
+				// bonus points, the code to re-enable this should also provide more
+				// flexibility in disabling the default test tenant by callers of this
+				// function. Re-enablement is tracked with #76378.
+				DisableDefaultTestTenant: true,
+				Locality: roachpb.Locality{
+					Tiers: []roachpb.Tier{{Key: "region", Value: region}},
+				},
+			}
+			totalServerCount++
 		}
 	}
 
-	tc := testcluster.StartTestCluster(t, numServers, base.TestClusterArgs{
+	tc := testcluster.StartTestCluster(t, totalServerCount, base.TestClusterArgs{
 		ReplicationMode:   params.replicationMode,
 		ServerArgsPerNode: serverArgs,
 	})

--- a/pkg/ccl/multiregionccl/region_test.go
+++ b/pkg/ccl/multiregionccl/region_test.go
@@ -45,13 +45,10 @@ func TestMultiRegionDatabaseStats(t *testing.T) {
 	ctx := context.Background()
 	knobs := base.TestingKnobs{}
 
-	regionToNumServers := make(map[string]int, 6)
-	regionToNumServers["us-east"] = 3
-	regionToNumServers["us-west"] = 3
-
 	tc, db, cleanup := multiregionccltestutils.TestingCreateMultiRegionClusterWithRegionList(
 		t,
-		regionToNumServers, /* numServers */
+		[]string{"us-east", "us-west"},
+		3, /* serversPerRegion */
 		knobs,
 		multiregionccltestutils.WithUseDatabase("d"),
 	)


### PR DESCRIPTION
Backport 1/1 commits from #91130.

/cc @cockroachdb/release

---

The previous scan was returning the results for
multiple databases instead of just the specified
one. This caused the node list to show the incorrect 
nodes. It is fixed by using the new kvcoord.DistSender
which is a higher abstraction designed to handle
multi-tenant scenarios, and properly filtering the
range to just the specified span.

closes: #81674

Release justification: Bug fixes and low-risk updates
to new functionality.

Release note (bug fix): Fixes a bug which resulted 
in the regions listed for databases and tables
including an incorrect list of regions due to the 
logic including information about tables which 
are adjacent in the keyspace.
