### PR TITLE
roachtest: fix helper to install go1.19.4

### DIFF
--- a/pkg/cmd/roachtest/tests/go_helpers.go
+++ b/pkg/cmd/roachtest/tests/go_helpers.go
@@ -49,7 +49,7 @@ func installGolang(
 	}
 	if err := repeatRunE(
 		ctx, t, c, node, "verify tarball", `sha256sum -c - <<EOF
-3ca65ff0606054b076c009d3bb3b8aba0032b75ac690de716be5c44ce57da052 /tmp/go.tgz
+c9c08f783325c4cf840a94333159cc937f05f75d36a8b307951d5bd959cf2ab8 /tmp/go.tgz
 EOF`,
 	); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/93972
fixes https://github.com/cockroachdb/cockroach/issues/93971
fixes https://github.com/cockroachdb/cockroach/issues/93970
fixes https://github.com/cockroachdb/cockroach/issues/93969
fixes https://github.com/cockroachdb/cockroach/issues/93963

The change in ce39332b015ffa650c20f89d6eb9a90abf042e8a accidentally used the checksum for the macos download instead of the linux download.

Release note: None