### PR TITLE
release: pass GCS credentials to publish-provisional-artifacts

### DIFF
--- a/build/teamcity/internal/release/process/publish-cockroach-release.sh
+++ b/build/teamcity/internal/release/process/publish-cockroach-release.sh
@@ -185,6 +185,10 @@ if [[ -n "${PUBLISH_LATEST}" && -z "${PRE_RELEASE}" ]]; then
     BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e TC_BUILDTYPE_ID -e TC_BUILD_BRANCH=$build_name -e bucket=$bucket -e gcs_credentials -e gcs_bucket=$gcs_bucket" run_bazel << 'EOF'
 bazel build --config ci //pkg/cmd/publish-provisional-artifacts
 BAZEL_BIN=$(bazel info bazel-bin --config ci)
+export google_credentials="$gcs_credentials"
+source "build/teamcity-support.sh"  # For log_into_gcloud
+log_into_gcloud
+export GOOGLE_APPLICATION_CREDENTIALS="$PWD/.google-credentials.json"
 $BAZEL_BIN/pkg/cmd/publish-provisional-artifacts/publish-provisional-artifacts_/publish-provisional-artifacts -bless -release -bucket "$bucket" --gcs-bucket="$gcs_bucket"
 EOF
 


### PR DESCRIPTION
Previously, publish-provisional-artifacts requires `GOOGLE_APPLICATION_CREDENTIALS` environment variable when `--gcs-bucket` is passed. This was not the case for the case where we upload the latest binaries (`--bless`).

This PR adds required steps to set up and pass the credentials.

Epic: none
Release note: None