### PR TITLE
sql: Remove type annotations from `column_default` in `information_schema.columns`

### DIFF
--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -756,9 +756,9 @@ func TestAdminAPITableDetails(t *testing.T) {
 			// Verify columns.
 			expColumns := []serverpb.TableDetailsResponse_Column{
 				{Name: "nulls_allowed", Type: "INT8", Nullable: true, DefaultValue: ""},
-				{Name: "nulls_not_allowed", Type: "INT8", Nullable: false, DefaultValue: "1000:::INT8"},
-				{Name: "default2", Type: "INT8", Nullable: true, DefaultValue: "2:::INT8"},
-				{Name: "string_default", Type: "STRING", Nullable: true, DefaultValue: "'default_string':::STRING"},
+				{Name: "nulls_not_allowed", Type: "INT8", Nullable: false, DefaultValue: "1000"},
+				{Name: "default2", Type: "INT8", Nullable: true, DefaultValue: "2"},
+				{Name: "string_default", Type: "STRING", Nullable: true, DefaultValue: "default_string"},
 				{Name: "rowid", Type: "INT8", Nullable: false, DefaultValue: "unique_rowid()", Hidden: true},
 			}
 			testutils.SortStructs(expColumns, "Name")

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -441,7 +441,7 @@ https://www.postgresql.org/docs/9.5/infoschema-columns.html`,
 				colDefault := tree.DNull
 				if column.HasDefault() {
 					colExpr, err := schemaexpr.FormatExprForDisplay(
-						ctx, table, column.GetDefaultExpr(), &p.semaCtx, p.SessionData(), tree.FmtParsable,
+						ctx, table, column.GetDefaultExpr(), &p.semaCtx, p.SessionData(), tree.FmtPgwireText,
 					)
 					if err != nil {
 						return err

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -520,7 +520,7 @@ a            INT8       false        NULL            ·                      {tt
 q            DECIMAL    false        NULL            ·                      {tt_pkey}                    false
 r            DECIMAL    true         NULL            ·                      {tt_pkey}                    false
 s            DECIMAL    false        NULL            ·                      {tt_pkey,tt_s_key}           false
-t            DECIMAL    true         4.0:::DECIMAL   ·                      {tt_pkey,tt_t_key}           false
+t            DECIMAL    true         4.0             ·                      {tt_pkey,tt_t_key}           false
 
 # Default values can be added and changed after table creation.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -98,8 +98,8 @@ query TTBTTTB colnames
 SHOW COLUMNS FROM x
 ----
 column_name  data_type  is_nullable  column_default  generation_expression  indices   is_hidden
-a            INT8       true         3:::INT8        ·                      {x_pkey}  false
-b            INT8       true         7:::INT8        ·                      {x_pkey}  false
+a            INT8       true         3               ·                      {x_pkey}  false
+b            INT8       true         7               ·                      {x_pkey}  false
 c            INT8       true         NULL            a                      {x_pkey}  false
 d            INT8       true         NULL            a + b                  {x_pkey}  false
 rowid        INT8       false        unique_rowid()  ·                      {x_pkey}  true

--- a/pkg/sql/logictest/testdata/logic_test/default
+++ b/pkg/sql/logictest/testdata/logic_test/default
@@ -30,11 +30,11 @@ CREATE TABLE t (
 query TTBTTTB colnames
 SHOW COLUMNS FROM t
 ----
-column_name  data_type  is_nullable  column_default     generation_expression  indices   is_hidden
-a            INT8       false        42:::INT8          ·                      {t_pkey}  false
-b            TIMESTAMP  true         now():::TIMESTAMP  ·                      {t_pkey}  false
-c            FLOAT8     true         random()           ·                      {t_pkey}  false
-d            DATE       true         now():::DATE       ·                      {t_pkey}  false
+column_name  data_type  is_nullable  column_default  generation_expression  indices   is_hidden
+a            INT8       false        42              ·                      {t_pkey}  false
+b            TIMESTAMP  true         now()           ·                      {t_pkey}  false
+c            FLOAT8     true         random()        ·                      {t_pkey}  false
+d            DATE       true         now()           ·                      {t_pkey}  false
 
 statement ok
 COMMENT ON COLUMN t.a IS 'a'
@@ -42,11 +42,11 @@ COMMENT ON COLUMN t.a IS 'a'
 query TTBTTTBT colnames
 SHOW COLUMNS FROM t WITH COMMENT
 ----
-column_name  data_type  is_nullable  column_default     generation_expression  indices   is_hidden  comment
-a            INT8       false        42:::INT8          ·                      {t_pkey}  false      a
-b            TIMESTAMP  true         now():::TIMESTAMP  ·                      {t_pkey}  false      NULL
-c            FLOAT8     true         random()           ·                      {t_pkey}  false      NULL
-d            DATE       true         now():::DATE       ·                      {t_pkey}  false      NULL
+column_name  data_type  is_nullable  column_default  generation_expression  indices   is_hidden  comment
+a            INT8       false        42              ·                      {t_pkey}  false      a
+b            TIMESTAMP  true         now()           ·                      {t_pkey}  false      NULL
+c            FLOAT8     true         random()        ·                      {t_pkey}  false      NULL
+d            DATE       true         now()           ·                      {t_pkey}  false      NULL
 
 statement ok
 INSERT INTO t VALUES (DEFAULT, DEFAULT, DEFAULT, DEFAULT)

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -536,8 +536,8 @@ WHERE
 ORDER BY
   column_name
 ----
-y  'hello':::test.public.greeting
-z  'hello':::test.public.greeting IS OF (test.public.greeting, test.public.greeting)
+y  hello
+z  hello IS OF (test.public.greeting, test.public.greeting)
 
 # Test computed columns with enum values.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -2065,6 +2065,17 @@ DROP DATABASE constraint_db CASCADE
 
 ## information_schema.columns
 
+statement ok
+SET DATABASE = test;
+CREATE TABLE t2(a smallint DEFAULT 0);
+
+query TT colnames
+select data_type, column_default from information_schema.columns where table_name = 't2' and column_name = 'a';
+----
+data_type  column_default
+smallint   0
+
+
 query TTTTI colnames
 SELECT table_catalog, table_schema, table_name, column_name, ordinal_position
 FROM system.information_schema.columns
@@ -2329,8 +2340,8 @@ FROM information_schema.columns
 WHERE table_schema = 'public' AND table_name = 'with_defaults'
 ----
 table_name     column_name  column_default
-with_defaults  a            9:::INT8
-with_defaults  b            'default':::STRING
+with_defaults  a            9
+with_defaults  b            default
 with_defaults  c            NULL
 with_defaults  d            NULL
 with_defaults  rowid        unique_rowid()
@@ -4898,8 +4909,10 @@ ORDER BY 3,4
 table_catalog  table_schema  table_name  column_name  ordinal_position
 test           public        t1          a            1
 test           public        t1          b            2
+test           public        t2          a            1
 other_db       public        t2          c            1
 other_db       public        t2          d            2
+test           public        t2          rowid        2
 
 statement ok
 SET DATABASE = "";
@@ -4915,8 +4928,10 @@ ORDER BY 3,4
 table_catalog  table_schema  table_name  column_name  ordinal_position
 test           public        t1          a            1
 test           public        t1          b            2
+test           public        t2          a            1
 other_db       public        t2          c            1
 other_db       public        t2          d            2
+test           public        t2          rowid        2
 
 statement ok
 SET DATABASE = test

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -954,9 +954,9 @@ check_table  d_0               CHECK        CHECK ((d > 0))            true
 query TTBTTTB
 SHOW COLUMNS FROM check_table
 ----
-k  INT8  false  NULL      ·  {check_table_pkey}  false
-c  INT8  true   NULL      ·  {check_table_pkey}  false
-d  INT8  true   1:::INT8  ·  {check_table_pkey}  false
+k  INT8  false  NULL  ·  {check_table_pkey}  false
+c  INT8  true   NULL  ·  {check_table_pkey}  false
+d  INT8  true   1     ·  {check_table_pkey}  false
 
 statement ok
 DROP TABLE check_table

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -234,10 +234,10 @@ descriptor  BYTES  true   NULL  ·  {primary}  false
 query TTBTTTB
 SHOW COLUMNS FROM system.users
 ----
-username        STRING  false  NULL   ·  {primary,users_user_id_idx}  false
-hashedPassword  BYTES   true   NULL   ·  {primary}                    false
-isRole          BOOL    false  false  ·  {primary}                    false
-user_id         OID     false  NULL   ·  {primary,users_user_id_idx}  false
+username        STRING  false  NULL  ·  {primary,users_user_id_idx}  false
+hashedPassword  BYTES   true   NULL  ·  {primary}                    false
+isRole          BOOL    false  f     ·  {primary}                    false
+user_id         OID     false  NULL  ·  {primary,users_user_id_idx}  false
 
 query TTBTTTB
 SHOW COLUMNS FROM system.zones
@@ -284,27 +284,27 @@ lastUpdated  TIMESTAMP  false  NULL  ·  {primary}  false
 query TTBTTTB
 SHOW COLUMNS FROM system.jobs
 ----
-id                 INT8       false  unique_rowid()     ·  {jobs_created_by_type_created_by_id_idx,jobs_job_type_idx,jobs_run_stats_idx,jobs_status_created_idx,primary}  false
-status             STRING     false  NULL               ·  {jobs_created_by_type_created_by_id_idx,jobs_run_stats_idx,jobs_status_created_idx,primary}                    false
-created            TIMESTAMP  false  now():::TIMESTAMP  ·  {jobs_run_stats_idx,jobs_status_created_idx,primary}                                                           false
-payload            BYTES      false  NULL               ·  {primary}                                                                                                      false
-progress           BYTES      true   NULL               ·  {primary}                                                                                                      false
-created_by_type    STRING     true   NULL               ·  {jobs_created_by_type_created_by_id_idx,primary}                                                               false
-created_by_id      INT8       true   NULL               ·  {jobs_created_by_type_created_by_id_idx,primary}                                                               false
-claim_session_id   BYTES      true   NULL               ·  {jobs_run_stats_idx,primary}                                                                                   false
-claim_instance_id  INT8       true   NULL               ·  {jobs_run_stats_idx,primary}                                                                                   false
-num_runs           INT8       true   NULL               ·  {jobs_run_stats_idx,primary}                                                                                   false
-last_run           TIMESTAMP  true   NULL               ·  {jobs_run_stats_idx,primary}                                                                                   false
-job_type           STRING     true   NULL               ·  {jobs_job_type_idx,primary}                                                                                    false
+id                 INT8       false  unique_rowid()  ·  {jobs_created_by_type_created_by_id_idx,jobs_job_type_idx,jobs_run_stats_idx,jobs_status_created_idx,primary}  false
+status             STRING     false  NULL            ·  {jobs_created_by_type_created_by_id_idx,jobs_run_stats_idx,jobs_status_created_idx,primary}                    false
+created            TIMESTAMP  false  now()           ·  {jobs_run_stats_idx,jobs_status_created_idx,primary}                                                           false
+payload            BYTES      false  NULL            ·  {primary}                                                                                                      false
+progress           BYTES      true   NULL            ·  {primary}                                                                                                      false
+created_by_type    STRING     true   NULL            ·  {jobs_created_by_type_created_by_id_idx,primary}                                                               false
+created_by_id      INT8       true   NULL            ·  {jobs_created_by_type_created_by_id_idx,primary}                                                               false
+claim_session_id   BYTES      true   NULL            ·  {jobs_run_stats_idx,primary}                                                                                   false
+claim_instance_id  INT8       true   NULL            ·  {jobs_run_stats_idx,primary}                                                                                   false
+num_runs           INT8       true   NULL            ·  {jobs_run_stats_idx,primary}                                                                                   false
+last_run           TIMESTAMP  true   NULL            ·  {jobs_run_stats_idx,primary}                                                                                   false
+job_type           STRING     true   NULL            ·  {jobs_job_type_idx,primary}                                                                                    false
 
 
 query TTBTTTB
 SHOW COLUMNS FROM system.settings
 ----
-name         STRING     false  NULL               ·  {primary}  false
-value        STRING     false  NULL               ·  {primary}  false
-lastUpdated  TIMESTAMP  false  now():::TIMESTAMP  ·  {primary}  false
-valueType    STRING     true   NULL               ·  {primary}  false
+name         STRING     false  NULL   ·  {primary}  false
+value        STRING     false  NULL   ·  {primary}  false
+lastUpdated  TIMESTAMP  false  now()  ·  {primary}  false
+valueType    STRING     true   NULL   ·  {primary}  false
 
 query TTBTTTB
 SHOW COLUMNS FROM system.role_members


### PR DESCRIPTION
Informs: https://github.com/cockroachdb/cockroach/issues/87774

The type annotation on `column_default` caused confusion in postgres compatible apps. This change formats the `column_default` without the type annotation. It does not address the incorrect type annotation.

Release note (bug fix): The content of `column_default` in `information_schema.columns` no longer have type annotations.