### PR TITLE
ui: add recent statements to sql activity page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/index.ts
@@ -22,3 +22,4 @@ export * from "./sqlApi";
 export * from "./tracezApi";
 export * from "./databasesApi";
 export * from "./eventsApi";
+export * from "./recentExecutionsApi";

--- a/pkg/ui/workspaces/cluster-ui/src/api/recentExecutionsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/recentExecutionsApi.ts
@@ -1,0 +1,114 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import {
+  executeInternalSql,
+  LARGE_RESULT_SIZE,
+  SqlExecutionRequest,
+  sqlResultsAreEmpty,
+} from "./sqlApi";
+import moment from "moment";
+import { ExecutionStatus, RecentStatement } from "../recentExecutions";
+
+export type RecentStatementsColumns = {
+  stmt_id: string;
+  stmt_no_constants: string;
+  txn_id: string;
+  session_id: string;
+  query: string;
+  status: string;
+  start_time: string;
+  elapsed_time: string;
+  app_name: string;
+  database_name: string;
+  user_name: string;
+  client_address: string;
+  is_full_scan: string;
+  plan_gist: string;
+};
+
+const recentStatementsQuery = `
+  SELECT
+    stmt_id,
+    stmt_no_constants,
+    txn_id,
+    session_id,
+    query,
+    status,
+    start_time,
+    elapsed_time,
+    app_name,
+    database_name,
+    user_name,
+    client_address,
+    is_full_scan,
+    plan_gist
+  FROM crdb_internal.node_recent_statements
+`;
+
+export const recentStatementsRequest: SqlExecutionRequest = {
+  statements: [
+    {
+      sql: recentStatementsQuery,
+    },
+  ],
+  execute: true,
+  max_result_size: LARGE_RESULT_SIZE,
+};
+
+function stringToExecutionStatus(status: string): ExecutionStatus {
+  switch (status) {
+    case "PREPARING":
+      return "Preparing";
+    case "EXECUTING":
+      return "Executing";
+    case "CANCELED":
+      return "Canceled";
+    case "TIMED_OUT":
+      return "Timed Out";
+    case "COMPLETED":
+      return "Completed";
+    case "FAILED":
+      return "Failed";
+  }
+}
+
+// getRecentStatements makes requests over the SQL API and transforms
+// the corresponding SQL responses into recent statements.
+export async function getRecentStatements(): Promise<RecentStatement[]> {
+  return executeInternalSql<RecentStatementsColumns>(
+    recentStatementsRequest,
+  ).then(result => {
+    if (sqlResultsAreEmpty(result)) {
+      if (result.error) {
+        throw result.error;
+      }
+      return [];
+    }
+    const recentStatements: RecentStatement[] =
+      result.execution.txn_results[0].rows.map(row => ({
+        statementID: row.stmt_id,
+        stmtNoConstants: row.stmt_no_constants,
+        transactionID: row.txn_id,
+        sessionID: row.session_id,
+        query: row.query,
+        status: stringToExecutionStatus(row.status),
+        start: moment.utc(row.start_time),
+        elapsedTime: moment.duration(row.elapsed_time),
+        application: row.app_name,
+        database: row.database_name,
+        user: row.user_name,
+        clientAddress: row.client_address,
+        isFullScan: row.is_full_scan === "true",
+        planGist: row.plan_gist,
+      }));
+    return recentStatements;
+  });
+}

--- a/pkg/ui/workspaces/cluster-ui/src/recentExecutions/executionStatusIcon.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/recentExecutions/executionStatusIcon.module.scss
@@ -14,3 +14,23 @@
 .executing {
   fill: $colors--success;
 }
+
+.preparing {
+  fill: $colors--success;
+}
+
+.timed-out {
+  fill: $colors--warning;
+}
+
+.canceled {
+  fill: $colors--warning;
+}
+
+.failed {
+  fill: $colors--warning;
+}
+
+.completed {
+  fill: $colors--success;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/recentExecutions/recentStatementsSection.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/recentExecutions/recentStatementsSection.tsx
@@ -24,7 +24,7 @@ import {
   ISortedTablePagination,
   SortedTable,
   SortSetting,
-} from "../sortedtable/sortedtable";
+} from "../sortedtable";
 import {
   getColumnOptions,
   makeRecentStatementsColumns,
@@ -32,6 +32,7 @@ import {
 import { StatementViewType } from "src/statementsPage/statementPageTypes";
 import { calculateActiveFilters } from "src/queryFilter/filter";
 import { isSelectedColumn } from "src/columnsSelector/utils";
+import { Pagination } from "../pagination";
 
 const sortableTableCx = classNames.bind(sortableTableStyles);
 
@@ -46,6 +47,7 @@ type RecentStatementsSectionProps = {
   onChangeSortSetting: (sortSetting: SortSetting) => void;
   onClearFilters: () => void;
   onColumnsSelect: (columns: string[]) => void;
+  onChangePagination: (page: number) => void;
 };
 
 export const RecentStatementsSection: React.FC<
@@ -61,6 +63,7 @@ export const RecentStatementsSection: React.FC<
   onClearFilters,
   onChangeSortSetting,
   onColumnsSelect,
+  onChangePagination,
 }) => {
   const columns = useMemo(
     () => makeRecentStatementsColumns(isTenant),
@@ -78,35 +81,43 @@ export const RecentStatementsSection: React.FC<
   const activeFilters = calculateActiveFilters(filters);
 
   return (
-    <section className={sortableTableCx("cl-table-container")}>
-      <div>
-        <ColumnsSelector
-          options={tableColumns}
-          onSubmitColumns={onColumnsSelect}
-        />
-        <TableStatistics
-          pagination={pagination}
-          search={search}
-          totalCount={statements.length}
-          arrayItemName="statements"
-          activeFilters={activeFilters}
-          onClearFilters={onClearFilters}
-        />
-      </div>
-      <SortedTable
-        className="statements-table"
-        data={statements}
-        columns={shownColumns}
-        sortSetting={sortSetting}
-        onChangeSortSetting={onChangeSortSetting}
-        renderNoResult={
-          <EmptyStatementsPlaceholder
-            isEmptySearchResults={search?.length > 0 && statements.length > 0}
-            statementView={StatementViewType.ACTIVE}
+    <div>
+      <section className={sortableTableCx("cl-table-container")}>
+        <div>
+          <ColumnsSelector
+            options={tableColumns}
+            onSubmitColumns={onColumnsSelect}
           />
-        }
-        pagination={pagination}
+          <TableStatistics
+            pagination={pagination}
+            search={search}
+            totalCount={statements.length}
+            arrayItemName="statements"
+            activeFilters={activeFilters}
+            onClearFilters={onClearFilters}
+          />
+        </div>
+        <SortedTable
+          className="statements-table"
+          data={statements}
+          columns={shownColumns}
+          sortSetting={sortSetting}
+          onChangeSortSetting={onChangeSortSetting}
+          renderNoResult={
+            <EmptyStatementsPlaceholder
+              isEmptySearchResults={search?.length > 0 && statements.length > 0}
+              statementView={StatementViewType.ACTIVE}
+            />
+          }
+          pagination={pagination}
+        />
+      </section>
+      <Pagination
+        pageSize={pagination.pageSize}
+        current={pagination.current}
+        total={statements.length}
+        onChange={onChangePagination}
       />
-    </section>
+    </div>
   );
 };

--- a/pkg/ui/workspaces/cluster-ui/src/recentExecutions/statusIcon.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/recentExecutions/statusIcon.tsx
@@ -21,6 +21,8 @@ export type StatusIconProps = {
 };
 
 export const StatusIcon: React.FC<StatusIconProps> = ({ status }) => {
-  const statusClassName = status !== "Waiting" ? "executing" : "waiting";
+  // The className will be an ExecutionStatus with spaces converted to hyphens, and
+  // all letters in lowercase. eg: Timed Out -> timed-out.
+  const statusClassName = status.toLowerCase().replace(/\s/g, "-");
   return <CircleFilled className={cx("status-icon", statusClassName)} />;
 };

--- a/pkg/ui/workspaces/cluster-ui/src/recentExecutions/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/recentExecutions/types.ts
@@ -16,7 +16,14 @@ export type SessionsResponse =
   protos.cockroach.server.serverpb.ListSessionsResponse;
 export type ActiveStatementResponse =
   protos.cockroach.server.serverpb.ActiveQuery;
-export type ExecutionStatus = "Waiting" | "Executing" | "Preparing";
+export type ExecutionStatus =
+  | "Waiting"
+  | "Executing"
+  | "Preparing"
+  | "Timed Out"
+  | "Canceled"
+  | "Completed"
+  | "Failed";
 export type ExecutionType = "statement" | "transaction";
 
 export const ActiveStatementPhase =

--- a/pkg/ui/workspaces/cluster-ui/src/selectors/recentExecutions.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/selectors/recentExecutions.selectors.ts
@@ -11,7 +11,11 @@
 import { createSelector } from "reselect";
 import { RecentExecutions } from "src/recentExecutions/types";
 import { AppState } from "src/store";
-import { selectRecentExecutionsCombiner } from "src/selectors/recentExecutionsCommon.selectors";
+import {
+  selectRecentExecutionsCombiner,
+  selectHistoricalExecutionsCombiner,
+  selectActiveExecutionsCombiner,
+} from "src/selectors/recentExecutionsCommon.selectors";
 import { selectExecutionID } from "src/selectors/common";
 import {
   getRecentTransaction,
@@ -28,9 +32,24 @@ const selectSessions = (state: AppState) => state.adminUI.sessions?.data;
 const selectClusterLocks = (state: AppState) =>
   state.adminUI.clusterLocks?.data;
 
-export const selectRecentExecutions = createSelector(
+const selectHistoricalStatements = (state: AppState) =>
+  state.adminUI.recentStatements?.data;
+
+export const selectHistoricalExecutions = createSelector(
+  selectHistoricalStatements,
+  selectClusterLocks,
+  selectHistoricalExecutionsCombiner,
+);
+
+export const selectActiveExecutions = createSelector(
   selectSessions,
   selectClusterLocks,
+  selectActiveExecutionsCombiner,
+);
+
+export const selectRecentExecutions = createSelector(
+  selectHistoricalExecutions,
+  selectActiveExecutions,
   selectRecentExecutionsCombiner,
 );
 
@@ -39,7 +58,7 @@ export const selectRecentStatements = createSelector(
   (executions: RecentExecutions) => executions.statements,
 );
 
-export const selecteRecentStatement = createSelector(
+export const selectRecentStatement = createSelector(
   selectRecentStatements,
   selectExecutionID,
   getRecentStatement,
@@ -64,7 +83,7 @@ export const selectContentionDetailsForTransaction = createSelector(
 );
 
 const selectRecentTxnFromStmt = createSelector(
-  selecteRecentStatement,
+  selectRecentStatement,
   selectRecentTransactions,
   (stmt, transactions) => {
     return transactions.find(txn => txn.transactionID === stmt.transactionID);

--- a/pkg/ui/workspaces/cluster-ui/src/selectors/recentExecutionsCommon.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/selectors/recentExecutionsCommon.selectors.ts
@@ -8,8 +8,11 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { RouteComponentProps } from "react-router";
-import { RecentExecutions, SessionsResponse } from "src/recentExecutions/types";
+import {
+  RecentExecutions,
+  RecentStatement,
+  SessionsResponse,
+} from "src/recentExecutions/types";
 import { ClusterLocksResponse } from "src/api";
 import {
   getRecentExecutionsFromSessions,
@@ -20,7 +23,7 @@ import {
 // state in db-console and cluster-ui. This file contains selector functions
 // and combiners that can be reused across both packages.
 
-export const selectRecentExecutionsCombiner = (
+export const selectActiveExecutionsCombiner = (
   sessions: SessionsResponse | null,
   clusterLocks: ClusterLocksResponse | null,
 ): RecentExecutions => {
@@ -40,5 +43,44 @@ export const selectRecentExecutionsCombiner = (
       status: waitTimeByTxnID[t.transactionID] != null ? "Waiting" : t.status,
       timeSpentWaiting: waitTimeByTxnID[t.transactionID],
     })),
+  };
+};
+
+export const selectHistoricalExecutionsCombiner = (
+  recentStatements: RecentStatement[] | null,
+  clusterLocks: ClusterLocksResponse | null,
+): RecentExecutions => {
+  if (!recentStatements) return { statements: [], transactions: [] };
+
+  const waitTimeByTxnID = getWaitTimeByTxnIDFromLocks(clusterLocks);
+
+  return {
+    statements: recentStatements.map(s => ({
+      ...s,
+      status: waitTimeByTxnID[s.transactionID] != null ? "Waiting" : s.status,
+      timeSpentWaiting: waitTimeByTxnID[s.transactionID],
+    })),
+    // TODO(amy): implement recently completed transactions
+    transactions: [],
+  };
+};
+
+export const selectRecentExecutionsCombiner = (
+  recentlyCompletedExecutions: RecentExecutions | null,
+  activeExecutions: RecentExecutions | null,
+): RecentExecutions => {
+  if (!recentlyCompletedExecutions && !activeExecutions)
+    return { statements: [], transactions: [] };
+
+  return {
+    // Create a new set to remove duplicates
+    statements: [
+      ...new Set(
+        (activeExecutions.statements || []).concat(
+          recentlyCompletedExecutions.statements || [],
+        ),
+      ),
+    ],
+    transactions: activeExecutions.transactions || [],
   };
 };

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/recentStatementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/recentStatementDetails.tsx
@@ -46,6 +46,7 @@ export type RecentStatementDetailsStateProps = {
 
 export type RecentStatementDetailsDispatchProps = {
   refreshLiveWorkload: () => void;
+  refreshRecentStatements: () => void;
 };
 
 enum TabKeysEnum {
@@ -68,6 +69,7 @@ export const RecentStatementDetails: React.FC<RecentStatementDetailsProps> = ({
   statement,
   match,
   refreshLiveWorkload,
+  refreshRecentStatements,
 }) => {
   const history = useHistory();
   const executionID = getMatchParamByName(match, executionIdAttr);
@@ -88,6 +90,13 @@ export const RecentStatementDetails: React.FC<RecentStatementDetailsProps> = ({
       refreshLiveWorkload();
     }
   }, [refreshLiveWorkload, statement]);
+
+  useEffect(() => {
+    if (statement == null) {
+      // Refresh sessions if the statement was not found initially.
+      refreshRecentStatements();
+    }
+  }, [refreshRecentStatements, statement]);
 
   const onTabClick = (key: TabKeysEnum) => {
     if (

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/recentStatementDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/recentStatementDetailsConnected.tsx
@@ -12,6 +12,7 @@ import { RouteComponentProps, withRouter } from "react-router-dom";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
 import { actions as sessionsActions } from "src/store/sessions";
+import { actions as recentStatementsActions } from "src/store/recentExecutions/recentStatements";
 import { AppState } from "../store";
 import {
   RecentStatementDetails,
@@ -19,7 +20,7 @@ import {
 } from "./recentStatementDetails";
 import { RecentStatementDetailsStateProps } from ".";
 import {
-  selecteRecentStatement,
+  selectRecentStatement,
   selectContentionDetailsForStatement,
 } from "src/selectors/recentExecutions.selectors";
 import { selectIsTenant } from "src/store/uiConfig";
@@ -32,7 +33,7 @@ const mapStateToProps = (
 ): RecentStatementDetailsStateProps => {
   return {
     contentionDetails: selectContentionDetailsForStatement(state, props),
-    statement: selecteRecentStatement(state, props),
+    statement: selectRecentStatement(state, props),
     match: props.match,
     isTenant: selectIsTenant(state),
   };
@@ -42,6 +43,7 @@ const mapDispatchToProps = (
   dispatch: Dispatch,
 ): RecentStatementDetailsDispatchProps => ({
   refreshLiveWorkload: () => dispatch(sessionsActions.refresh()),
+  refreshRecentStatements: () => dispatch(recentStatementsActions.refresh()),
 });
 
 export const RecentStatementDetailsPageConnected = withRouter(

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/recentStatementsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/recentStatementsPage.selectors.ts
@@ -23,6 +23,7 @@ import {
 } from "src/selectors/recentExecutions.selectors";
 import { actions as localStorageActions } from "src/store/localStorage";
 import { actions as sessionsActions } from "src/store/sessions";
+import { actions as recentStatementsActions } from "src/store/recentExecutions/recentStatements";
 import { selectIsTenant } from "src/store/uiConfig";
 import { localStorageSelector } from "../store/utils/selectors";
 
@@ -62,6 +63,7 @@ export const mapDispatchToRecentStatementsPageProps = (
   dispatch: Dispatch,
 ): RecentStatementsViewDispatchProps => ({
   refreshLiveWorkload: () => dispatch(sessionsActions.refresh()),
+  refreshRecentStatements: () => dispatch(recentStatementsActions.refresh()),
   onColumnsSelect: columns => {
     dispatch(
       localStorageActions.update({

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageRoot.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageRoot.tsx
@@ -49,13 +49,13 @@ export const StatementsPageRoot = ({
     },
     {
       value: StatementViewType.ACTIVE,
-      label: "Active Executions",
+      label: "Recent Executions",
       description: (
         <span>
-          Active executions represent individual statement executions in
-          progress. Use active statement execution details, such as the
-          application or elapsed time, to understand and tune workload
-          performance.
+          Recent executions represent individual statement executions that are
+          in progress or recently completed, failed, or canceled. Use recent
+          statement execution details, such as the application or elapsed time,
+          to understand and tune workload performance.
           {/* TODO (xinhaoz) #78379 add 'Learn More' link to documentation page*/}
         </span>
       ),

--- a/pkg/ui/workspaces/cluster-ui/src/store/recentExecutions/recentStatements/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/recentExecutions/recentStatements/index.ts
@@ -1,0 +1,12 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+export * from "./recentStatements.reducer";
+export * from "./recentStatements.sagas";

--- a/pkg/ui/workspaces/cluster-ui/src/store/recentExecutions/recentStatements/recentStatements.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/recentExecutions/recentStatements/recentStatements.reducer.ts
@@ -1,0 +1,46 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { DOMAIN_NAME, noopReducer } from "../../utils";
+import { RecentStatement } from "../../../recentExecutions";
+
+export type RecentStatementsState = {
+  data: RecentStatement[];
+  lastError: Error;
+  valid: boolean;
+};
+
+const initialState: RecentStatementsState = {
+  data: null,
+  lastError: null,
+  valid: true,
+};
+
+const recentStatementsSlice = createSlice({
+  name: `${DOMAIN_NAME}/recentStatements`,
+  initialState,
+  reducers: {
+    received: (state, action: PayloadAction<RecentStatement[]>) => {
+      state.data = action.payload;
+      state.valid = true;
+      state.lastError = null;
+    },
+    failed: (state, action: PayloadAction<Error>) => {
+      state.valid = false;
+      state.lastError = action.payload;
+    },
+    // Define actions that don't change state.
+    refresh: noopReducer,
+    request: noopReducer,
+  },
+});
+
+export const { reducer, actions } = recentStatementsSlice;

--- a/pkg/ui/workspaces/cluster-ui/src/store/recentExecutions/recentStatements/recentStatements.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/recentExecutions/recentStatements/recentStatements.sagas.ts
@@ -1,0 +1,45 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import {
+  all,
+  AllEffect,
+  call,
+  ForkEffect,
+  put,
+  PutEffect,
+  SelectEffect,
+  takeLatest,
+} from "redux-saga/effects";
+
+import { actions } from "./recentStatements.reducer";
+import { getRecentStatements } from "src/api/recentExecutionsApi";
+
+export function* refreshRecentStatementsSaga(): Generator<
+  AllEffect<PutEffect> | SelectEffect | PutEffect
+> {
+  yield put(actions.request());
+}
+
+export function* requestRecentStatementsSaga(): any {
+  try {
+    const result = yield call(getRecentStatements);
+    yield put(actions.received(result));
+  } catch (e) {
+    yield put(actions.failed(e));
+  }
+}
+
+export function* recentStatementsSaga(): Generator<AllEffect<ForkEffect>> {
+  yield all([
+    takeLatest(actions.request, requestRecentStatementsSaga),
+    takeLatest(actions.refresh, refreshRecentStatementsSaga),
+  ]);
+}

--- a/pkg/ui/workspaces/cluster-ui/src/store/reducers.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/reducers.ts
@@ -10,7 +10,6 @@
 
 import { createAction, createReducer } from "@reduxjs/toolkit";
 import { combineReducers, createStore } from "redux";
-import { TxnInsightEvent } from "src/insights";
 import {
   ClusterLocksReqState,
   reducer as clusterLocks,
@@ -31,6 +30,10 @@ import {
   reducer as transactionInsights,
   TransactionInsightsState,
 } from "./insights/transactionInsights";
+import {
+  reducer as recentStatements,
+  RecentStatementsState,
+} from "./recentExecutions/recentStatements";
 import { JobState, reducer as job } from "./jobDetails";
 import { JobsState, reducer as jobs } from "./jobs";
 import { LivenessState, reducer as liveness } from "./liveness";
@@ -75,6 +78,7 @@ export type AdminUiState = {
   transactionInsightDetails: TransactionInsightDetailsCachedState;
   executionInsights: ExecutionInsightsState;
   schemaInsights: SchemaInsightsState;
+  recentStatements: RecentStatementsState;
 };
 
 export type AppState = {
@@ -99,6 +103,7 @@ export const reducers = combineReducers<AdminUiState>({
   job,
   clusterLocks,
   schemaInsights,
+  recentStatements,
 });
 
 export const rootActions = {

--- a/pkg/ui/workspaces/cluster-ui/src/store/sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sagas.ts
@@ -28,6 +28,7 @@ import { transactionInsightsSaga } from "./insights/transactionInsights";
 import { transactionInsightDetailsSaga } from "./insightDetails/transactionInsightDetails";
 import { statementInsightsSaga } from "./insights/statementInsights";
 import { schemaInsightsSaga } from "./schemaInsights";
+import { recentStatementsSaga } from "./recentExecutions/recentStatements";
 
 export function* sagas(cacheInvalidationPeriod?: number): SagaIterator {
   yield all([
@@ -48,5 +49,6 @@ export function* sagas(cacheInvalidationPeriod?: number): SagaIterator {
     fork(indexStatsSaga),
     fork(clusterLocksSaga),
     fork(schemaInsightsSaga),
+    fork(recentStatementsSaga),
   ]);
 }

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -15,6 +15,7 @@ import moment from "moment";
 import {
   api as clusterUiApi,
   util,
+  RecentStatement,
   TxnContentionInsightDetails,
   TxnContentionInsightEvent,
   TxnInsightEvent,
@@ -407,6 +408,26 @@ export const refreshLiveWorkload = (): ThunkAction<any, any, any, Action> => {
       refreshSessions(new SessionsRequest({ exclude_closed_sessions: true })),
     );
     dispatch(refreshClusterLocks());
+    dispatch(refreshRecentStatements());
+  };
+};
+
+const recentStatementsReducerObj = new CachedDataReducer(
+  clusterUiApi.getRecentStatements,
+  "recentStatements",
+  null,
+  moment.duration(30, "s"),
+);
+export const refreshRecentStatements = recentStatementsReducerObj.refresh;
+
+export const refreshRecentStatementsAction = (): ThunkAction<
+  any,
+  any,
+  any,
+  Action
+> => {
+  return (dispatch: ThunkDispatch<unknown, unknown, Action>) => {
+    dispatch(refreshRecentStatements());
   };
 };
 
@@ -551,6 +572,7 @@ export interface APIReducersState {
   userSQLRoles: CachedDataReducerState<api.UserSQLRolesResponseMessage>;
   hotRanges: PaginatedCachedDataReducerState<api.HotRangesV2ResponseMessage>;
   clusterLocks: CachedDataReducerState<clusterUiApi.ClusterLocksResponse>;
+  recentStatements: CachedDataReducerState<RecentStatement[]>;
   transactionInsights: CachedDataReducerState<TxnContentionInsightEvent[]>;
   transactionInsightDetails: KeyedCachedDataReducerState<TxnContentionInsightDetails>;
   executionInsights: CachedDataReducerState<TxnInsightEvent[]>;
@@ -600,6 +622,8 @@ export const apiReducersReducer = combineReducers<APIReducersState>({
   [userSQLRolesReducerObj.actionNamespace]: userSQLRolesReducerObj.reducer,
   [hotRangesReducerObj.actionNamespace]: hotRangesReducerObj.reducer,
   [clusterLocksReducerObj.actionNamespace]: clusterLocksReducerObj.reducer,
+  [recentStatementsReducerObj.actionNamespace]:
+    recentStatementsReducerObj.reducer,
   [transactionInsightsReducerObj.actionNamespace]:
     transactionInsightsReducerObj.reducer,
   [transactionInsightDetailsReducerObj.actionNamespace]:

--- a/pkg/ui/workspaces/db-console/src/selectors/recentExecutionsSelectors.ts
+++ b/pkg/ui/workspaces/db-console/src/selectors/recentExecutionsSelectors.ts
@@ -11,6 +11,8 @@
 import {
   RecentExecutions,
   selectRecentExecutionsCombiner,
+  selectActiveExecutionsCombiner,
+  selectHistoricalExecutionsCombiner,
   getRecentStatement,
   getRecentTransaction,
   getContentionDetailsFromLocksAndTxns,
@@ -26,9 +28,24 @@ const selectSessions = (state: AdminUIState) => state.cachedData.sessions?.data;
 const selectClusterLocks = (state: AdminUIState) =>
   state.cachedData.clusterLocks?.data;
 
-export const selectRecentExecutions = createSelector(
+const selectHistoricalStatements = (state: AdminUIState) =>
+  state.cachedData.recentStatements?.data;
+
+export const selectHistoricalExecutions = createSelector(
+  selectHistoricalStatements,
+  selectClusterLocks,
+  selectHistoricalExecutionsCombiner,
+);
+
+export const selectActiveExecutions = createSelector(
   selectSessions,
   selectClusterLocks,
+  selectActiveExecutionsCombiner,
+);
+
+export const selectRecentExecutions = createSelector(
+  selectHistoricalExecutions,
+  selectActiveExecutions,
   selectRecentExecutionsCombiner,
 );
 

--- a/pkg/ui/workspaces/db-console/src/views/statements/recentStatementDetailsConnected.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/recentStatementDetailsConnected.tsx
@@ -16,7 +16,10 @@ import {
 import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { AdminUIState } from "src/redux/state";
-import { refreshLiveWorkload } from "src/redux/apiReducers";
+import {
+  refreshLiveWorkload,
+  refreshRecentStatements,
+} from "src/redux/apiReducers";
 import {
   selectRecentStatement,
   selectContentionDetailsForStatement,
@@ -33,6 +36,6 @@ export default withRouter(
       statement: selectRecentStatement(state, props),
       contentionDetails: selectContentionDetailsForStatement(state, props),
     }),
-    { refreshLiveWorkload },
+    { refreshLiveWorkload, refreshRecentStatements },
   )(RecentStatementDetails),
 );

--- a/pkg/ui/workspaces/db-console/src/views/statements/recentStatementsSelectors.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/recentStatementsSelectors.tsx
@@ -12,9 +12,14 @@ import {
   RecentStatementFilters,
   defaultFilters,
   SortSetting,
+  RecentStatementsViewDispatchProps,
+  RecentStatementsViewStateProps,
 } from "@cockroachlabs/cluster-ui";
 import { selectRecentStatements, selectAppName } from "src/selectors";
-import { refreshLiveWorkload } from "src/redux/apiReducers";
+import {
+  refreshLiveWorkload,
+  refreshRecentStatementsAction,
+} from "src/redux/apiReducers";
 import { LocalSetting } from "src/redux/localsettings";
 import { AdminUIState } from "src/redux/state";
 
@@ -44,7 +49,9 @@ const sortSettingLocalSetting = new LocalSetting<AdminUIState, SortSetting>(
   { ascending: false, columnTitle: "startTime" },
 );
 
-export const mapStateToRecentStatementViewProps = (state: AdminUIState) => ({
+export const mapStateToRecentStatementViewProps = (
+  state: AdminUIState,
+): RecentStatementsViewStateProps => ({
   filters: filtersLocalSetting.selector(state),
   selectedColumns: selectedColumnsLocalSetting.selectorToArray(state),
   sortSetting: sortSettingLocalSetting.selector(state),
@@ -53,10 +60,11 @@ export const mapStateToRecentStatementViewProps = (state: AdminUIState) => ({
   internalAppNamePrefix: selectAppName(state),
 });
 
-export const recentStatementsViewActions = {
+export const recentStatementsViewActions: RecentStatementsViewDispatchProps = {
   onColumnsSelect: (columns: string[]) =>
     selectedColumnsLocalSetting.set(columns.join(",")),
   refreshLiveWorkload,
+  refreshRecentStatements: refreshRecentStatementsAction,
   onFiltersChange: (filters: RecentStatementFilters) =>
     filtersLocalSetting.set(filters),
   onSortChange: (ss: SortSetting) => sortSettingLocalSetting.set(ss),


### PR DESCRIPTION
This change implements reading from the recent_statements virtual tables using sql over http. It then adds the info from the tables to redux, and displays it on the SQL Activity Page under a Recent Executions tab.

This has only been tested on DB Console. Changed should be tested on CC Console when the new virtual tables are added to the staging cluster.

This PR must be merged after the recent statements cache and virtual tables PRs: #93270 and #94158.

Part Of #86955

Release note (ui change): Adds recent statements to the SQL Activity Page on DB Console.

![image](https://user-images.githubusercontent.com/54999459/209208964-33f13a5c-d064-41b8-8a60-58de6e076ae6.png)
