### PR TITLE
sql, server: implement adding to new recent transactions cache

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -259,6 +259,10 @@ sql.multiple_modifications_of_table.enabled	boolean	false	if true, allow stateme
 sql.multiregion.drop_primary_region.enabled	boolean	true	allows dropping the PRIMARY REGION of a database if it is the last region
 sql.notices.enabled	boolean	true	enable notices in the server/client protocol being sent
 sql.optimizer.uniqueness_checks_for_gen_random_uuid.enabled	boolean	false	if enabled, uniqueness checks may be planned for mutations of UUID columns updated with gen_random_uuid(); otherwise, uniqueness is assumed due to near-zero collision probability
+sql.recent.statements_cache.capacity	integer	20000	the maximum number of statements in the cache
+sql.recent.statements_cache.time_to_live	duration	1h0m0s	the maximum time to live
+sql.recent.transactions_cache.capacity	integer	20000	the maximum number of Transactions in the cache
+sql.recent.transactions_cache.time_to_live	duration	1h0m0s	the maximum time to live
 sql.schema.telemetry.recurrence	string	@weekly	cron-tab recurrence for SQL schema telemetry job
 sql.spatial.experimental_box2d_comparison_operators.enabled	boolean	false	enables the use of certain experimental box2d comparison operators
 sql.stats.automatic_collection.enabled	boolean	true	automatic statistics collection mode

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -195,6 +195,10 @@
 <tr><td><code>sql.multiregion.drop_primary_region.enabled</code></td><td>boolean</td><td><code>true</code></td><td>allows dropping the PRIMARY REGION of a database if it is the last region</td></tr>
 <tr><td><code>sql.notices.enabled</code></td><td>boolean</td><td><code>true</code></td><td>enable notices in the server/client protocol being sent</td></tr>
 <tr><td><code>sql.optimizer.uniqueness_checks_for_gen_random_uuid.enabled</code></td><td>boolean</td><td><code>false</code></td><td>if enabled, uniqueness checks may be planned for mutations of UUID columns updated with gen_random_uuid(); otherwise, uniqueness is assumed due to near-zero collision probability</td></tr>
+<tr><td><code>sql.recent.statements_cache.capacity</code></td><td>integer</td><td><code>20000</code></td><td>the maximum number of statements in the cache</td></tr>
+<tr><td><code>sql.recent.statements_cache.time_to_live</code></td><td>duration</td><td><code>1h0m0s</code></td><td>the maximum time to live</td></tr>
+<tr><td><code>sql.recent.transactions_cache.capacity</code></td><td>integer</td><td><code>20000</code></td><td>the maximum number of Transactions in the cache</td></tr>
+<tr><td><code>sql.recent.transactions_cache.time_to_live</code></td><td>duration</td><td><code>1h0m0s</code></td><td>the maximum time to live</td></tr>
 <tr><td><code>sql.schema.telemetry.recurrence</code></td><td>string</td><td><code>@weekly</code></td><td>cron-tab recurrence for SQL schema telemetry job</td></tr>
 <tr><td><code>sql.spatial.experimental_box2d_comparison_operators.enabled</code></td><td>boolean</td><td><code>false</code></td><td>enables the use of certain experimental box2d comparison operators</td></tr>
 <tr><td><code>sql.stats.automatic_collection.enabled</code></td><td>boolean</td><td><code>true</code></td><td>automatic statistics collection mode</td></tr>

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -75,6 +75,7 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/sql/importer" // register jobs/planHooks declared outside of pkg/sql
 	"github.com/cockroachdb/cockroach/pkg/sql/optionalnodeliveness"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire"
+	"github.com/cockroachdb/cockroach/pkg/sql/recent"
 	_ "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scjob" // register jobs declared outside of pkg/sql
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
@@ -794,6 +795,9 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	// Instantiate the SQL session registry.
 	sessionRegistry := sql.NewSessionRegistry()
 
+	// Instantiate the cache of recent statements.
+	recentTransactionsCache := recent.NewTransactionsCache(st, sqlMonitorAndMetrics.rootSQLMemoryMonitor, time.Now)
+
 	// Instantiate the cache of closed SQL sessions.
 	closedSessionCache := sql.NewClosedSessionCache(cfg.Settings, sqlMonitorAndMetrics.rootSQLMemoryMonitor, time.Now)
 
@@ -896,6 +900,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		sessionRegistry:          sessionRegistry,
 		closedSessionCache:       closedSessionCache,
 		remoteFlowRunner:         remoteFlowRunner,
+		recentTransactionsCache:  recentTransactionsCache,
 		circularInternalExecutor: internalExecutor,
 		internalExecutorFactory:  internalExecutorFactory,
 		circularJobRegistry:      jobRegistry,

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -84,6 +84,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire"
 	"github.com/cockroachdb/cockroach/pkg/sql/querycache"
 	"github.com/cockroachdb/cockroach/pkg/sql/rangeprober"
+	"github.com/cockroachdb/cockroach/pkg/sql/recent"
 	"github.com/cockroachdb/cockroach/pkg/sql/scheduledlogging"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scdeps"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec"
@@ -303,6 +304,9 @@ type sqlServerArgs struct {
 	// Used to track the DistSQL flows currently running on this node but
 	// initiated on behalf of other nodes.
 	remoteFlowRunner *flowinfra.RemoteFlowRunner
+
+	// Used to store recent transactions.
+	recentTransactionsCache *recent.TransactionsCache
 
 	// KV depends on the internal executor, so we pass a pointer to an empty
 	// struct in this configuration, which newSQLServer fills.
@@ -882,6 +886,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		SQLStatusServer:           cfg.sqlStatusServer,
 		SessionRegistry:           cfg.sessionRegistry,
 		ClosedSessionCache:        cfg.closedSessionCache,
+		RecentTransactionsCache:   cfg.recentTransactionsCache,
 		ContentionRegistry:        contentionRegistry,
 		SQLLiveness:               cfg.sqlLivenessProvider,
 		JobRegistry:               jobRegistry,

--- a/pkg/server/serverpb/status.go
+++ b/pkg/server/serverpb/status.go
@@ -44,6 +44,8 @@ type SQLStatusServer interface {
 	LogFilesList(context.Context, *LogFilesListRequest) (*LogFilesListResponse, error)
 	LogFile(context.Context, *LogFileRequest) (*LogEntriesResponse, error)
 	Logs(context.Context, *LogsRequest) (*LogEntriesResponse, error)
+	ListRecentStatements(context.Context, *ListRecentStatementsRequest) (*ListRecentStatementsResponse, error)
+	ListRecentTransactions(context.Context, *ListRecentTransactionsRequest) (*ListRecentTransactionsResponse, error)
 }
 
 // OptionalNodesStatusServer is a StatusServer that is only optionally present

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -892,6 +892,10 @@ message ActiveQuery {
   enum Phase {
     PREPARING = 0;
     EXECUTING = 1;
+    CANCELED  = 2;
+    TIMED_OUT = 3;
+    COMPLETED = 4;
+    FAILED    = 5;
   }
   // phase stores the current phase of execution for this query.
   Phase phase = 5;
@@ -923,6 +927,19 @@ message ActiveQuery {
 
   // The database the statement was executed on.
   string database = 14;
+
+  // The ID for the session that the statement was executed on
+  // (uint128 represented as raw bytes).
+  bytes session_id = 15 [(gogoproto.customname) = "SessionID"];
+
+  // The application name for the session that the statement was executed on.
+  string app_name = 16;
+
+  // The user name for the session that the statement was executed on.
+  string username = 17;
+
+  // The client address for the session that the statement was executed on.
+  string client_address = 18;
 }
 
 // Request object for ListSessions and ListLocalSessions.
@@ -1246,7 +1263,7 @@ message ProblemRangesResponse {
     ];
     repeated int64 circuit_breaker_error_range_ids = 10 [
       (gogoproto.customname) = "CircuitBreakerErrorRangeIDs",
-      (gogoproto.casttype) = 
+      (gogoproto.casttype) =
           "github.com/cockroachdb/cockroach/pkg/roachpb.RangeID"
     ];
     repeated int64 paused_replica_ids = 11 [
@@ -1882,6 +1899,46 @@ message ListExecutionInsightsResponse {
   ];
 }
 
+message ListRecentStatementsRequest {
+  // node_id is a string so that "local" can be used to specify that no
+  // forwarding is necessary.
+  string node_id = 1 [
+    (gogoproto.customname) = "NodeID"
+  ];
+}
+
+message ListRecentStatementsResponse {
+  // statements is a list of recently completed statements.
+  repeated ActiveQuery statements = 1 [
+    (gogoproto.nullable) = false
+  ];
+
+  // errors holds any errors that occurred during fan-out calls to other nodes.
+  repeated errorspb.EncodedError errors = 2 [
+    (gogoproto.nullable) = false
+  ];
+}
+
+message ListRecentTransactionsRequest {
+  // node_id is a string so that "local" can be used to specify that no
+  // forwarding is necessary.
+  string node_id = 1 [
+    (gogoproto.customname) = "NodeID"
+  ];
+}
+
+message ListRecentTransactionsResponse {
+  // statements is a list of recently completed statements.
+  repeated TxnInfo transactions = 1 [
+    (gogoproto.nullable) = false
+  ];
+
+  // errors holds any errors that occurred during fan-out calls to other nodes.
+  repeated errorspb.EncodedError errors = 2 [
+    (gogoproto.nullable) = false
+  ];
+}
+
 service Status {
   // Certificates retrieves a copy of the TLS certificates.
   rpc Certificates(CertificatesRequest) returns (CertificatesResponse) {
@@ -2322,4 +2379,10 @@ service Status {
   // ListExecutionInsights returns potentially problematic statements cluster-wide,
   // along with actions we suggest the application developer might take to remedy them.
   rpc ListExecutionInsights(ListExecutionInsightsRequest) returns (ListExecutionInsightsResponse) {}
+
+  // ListRecentStatements returns a list of recently completed statements.
+  rpc ListRecentStatements(ListRecentStatementsRequest) returns (ListRecentStatementsResponse) {}
+
+  // ListRecentTransactions returns a list of recently completed transactions.
+  rpc ListRecentTransactions(ListRecentTransactionsRequest) returns (ListRecentTransactionsResponse) {}
 }

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -50,6 +50,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/optionalnodeliveness"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire"
+	"github.com/cockroachdb/cockroach/pkg/sql/recent"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlinstance"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
@@ -188,6 +189,9 @@ func NewTenantServer(
 	closedSessionCache := sql.NewClosedSessionCache(
 		baseCfg.Settings, args.monitorAndMetrics.rootSQLMemoryMonitor, time.Now)
 	args.closedSessionCache = closedSessionCache
+
+	args.recentTransactionsCache = recent.NewTransactionsCache(
+		baseCfg.Settings, args.monitorAndMetrics.rootSQLMemoryMonitor, time.Now)
 
 	// Instantiate the serverIterator to provide fanout to SQL instances. The
 	// serverIterator needs access to sqlServer which is assigned below once we

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/multitenant"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/multitenantcpu"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
@@ -312,6 +313,9 @@ func (ex *connExecutor) execStmtInOpenState(
 	ctx, cancelQuery = contextutil.WithCancel(ctx)
 	ex.addActiveQuery(parserStmt, pinfo, queryID, cancelQuery)
 
+	// Check if query is internal.
+	isInternal := ex.executorType == executorTypeInternal || ex.planner.isInternalPlanner
+
 	// Make sure that we always unregister the query. It also deals with
 	// overwriting res.Error to a more user-friendly message in case of query
 	// cancellation.
@@ -331,26 +335,40 @@ func (ex *connExecutor) execStmtInOpenState(
 			}
 		}
 
-		// Detect context cancelation and overwrite whatever error might have been
-		// set on the result before. The idea is that once the query's context is
-		// canceled, all sorts of actors can detect the cancelation and set all
-		// sorts of errors on the result. Rather than trying to impose discipline
-		// in that jungle, we just overwrite them all here with an error that's
-		// nicer to look at for the client.
-		if res != nil && ctx.Err() != nil && res.Err() != nil {
-			// Even in the cases where the error is a retryable error, we want to
-			// intercept the event and payload returned here to ensure that the query
-			// is not retried.
-			retEv = eventNonRetriableErr{
-				IsCommit: fsm.FromBool(isCommit(ast)),
-			}
-			res.SetError(cancelchecker.QueryCanceledError)
-			retPayload = eventNonRetriableErrPayload{err: cancelchecker.QueryCanceledError}
-		}
+		// Disconnect the query from the ActiveQueries structure.
+		// This will prevent concurrent access to the queryMeta
+		// from this point onwards.
+		qm := ex.removeActiveQuery(queryID, ast)
 
-		ex.removeActiveQuery(queryID, ast)
+		// As a starting point, indicate that the query has completed.
+		// This will be refined below.
+		qm.phase = serverpb.ActiveQuery_COMPLETED
+
+		if hasResultErr := res != nil && res.Err() != nil; hasResultErr {
+			// The query has failed execution. We'll distinguish further cases below.
+			qm.phase = serverpb.ActiveQuery_FAILED
+
+			// Detect context cancelation and overwrite whatever error might have been
+			// set on the result before. The idea is that once the query's context is
+			// canceled, all sorts of actors can detect the cancelation and set all
+			// sorts of errors on the result. Rather than trying to impose discipline
+			// in that jungle, we just overwrite them all here with an error that's
+			// nicer to look at for the client.
+			if ctx.Err() != nil {
+				// Even in the cases where the error is a retryable error, we want to
+				// intercept the event and payload returned here to ensure that the query
+				// is not retried.
+				retEv = eventNonRetriableErr{
+					IsCommit: fsm.FromBool(isCommit(ast)),
+				}
+				res.SetError(cancelchecker.QueryCanceledError)
+				retPayload = eventNonRetriableErrPayload{err: cancelchecker.QueryCanceledError}
+				qm.phase = serverpb.ActiveQuery_CANCELED
+			}
+		}
 		cancelQuery()
-		if ex.executorType != executorTypeInternal {
+
+		if !isInternal {
 			ex.metrics.EngineMetrics.SQLActiveStatements.Dec(1)
 		}
 
@@ -372,16 +390,52 @@ func (ex *connExecutor) execStmtInOpenState(
 			}
 			res.SetError(sqlerrors.QueryTimeoutError)
 			retPayload = eventNonRetriableErrPayload{err: sqlerrors.QueryTimeoutError}
+			qm.phase = serverpb.ActiveQuery_TIMED_OUT
 		} else if txnTimedOut {
 			retEv = eventNonRetriableErr{
 				IsCommit: fsm.FromBool(isCommit(ast)),
 			}
 			res.SetError(sqlerrors.TxnTimeoutError)
 			retPayload = eventNonRetriableErrPayload{err: sqlerrors.TxnTimeoutError}
+			qm.phase = serverpb.ActiveQuery_TIMED_OUT
+		}
+
+		if !isInternal && !qm.hidden {
+			sd := ex.sessionDataStack.Base()
+
+			remoteStr := "<admin>"
+			if sd.RemoteAddr != nil {
+				remoteStr = sd.RemoteAddr.String()
+			}
+
+			t := ex.state.mu.txn
+			var autoRetryReasonStr string
+
+			if ex.state.mu.autoRetryReason != nil {
+				autoRetryReasonStr = ex.state.mu.autoRetryReason.Error()
+			}
+			txnInfo := &serverpb.TxnInfo{
+				ID:                    t.ID(),
+				Start:                 ex.state.mu.txnStart,
+				ElapsedTime:           time.Since(ex.state.mu.txnStart),
+				NumStatementsExecuted: int32(ex.state.mu.stmtCount),
+				NumRetries:            int32(t.Epoch()),
+				NumAutoRetries:        ex.state.mu.autoRetryCounter,
+				TxnDescription:        t.String(),
+				Implicit:              ex.implicitTxn(),
+				AllocBytes:            ex.state.mon.AllocBytes(),
+				MaxAllocBytes:         ex.state.mon.MaximumBytes(),
+				IsHistorical:          ex.state.isHistorical,
+				ReadOnly:              ex.state.readOnly,
+				Priority:              ex.state.priority.String(),
+				QualityOfService:      sessiondatapb.ToQoSLevelString(t.AdmissionHeader().Priority),
+				LastAutoRetryReason:   autoRetryReasonStr,
+			}
+			ex.server.addRecentStatement(ex.Ctx(), *txnInfo, ex.sessionID, ex.applicationName, sd.SessionUser().Normalized(), remoteStr, queryID, qm, timeutil.Now())
 		}
 	}(ctx, res)
 
-	if ex.executorType != executorTypeInternal {
+	if !isInternal {
 		ex.metrics.EngineMetrics.SQLActiveStatements.Inc(1)
 	}
 
@@ -1189,7 +1243,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 			return nil, errors.AssertionFailedf("query %d not in registry", stmt.QueryID)
 		}
 		queryMeta.planGist = planner.instrumentation.planGist.String()
-		queryMeta.phase = executing
+		queryMeta.phase = serverpb.ActiveQuery_EXECUTING
 		queryMeta.database = planner.CurrentDatabase()
 		// TODO(yuzefovich): introduce ternary PlanDistribution into queryMeta.
 		queryMeta.isDistributed = distributePlan.WillDistribute()
@@ -1417,7 +1471,8 @@ func (ex *connExecutor) handleTxnRowsGuardrails(
 		SessionID: ex.sessionID.String(),
 		NumRows:   numRows,
 	}
-	if shouldErr && ex.executorType == executorTypeInternal {
+	isInternal := ex.executorType == executorTypeInternal || ex.planner.isInternalPlanner
+	if shouldErr && isInternal {
 		// Internal work should never err and always log if violating either
 		// limit.
 		shouldLog = true
@@ -1432,7 +1487,7 @@ func (ex *connExecutor) handleTxnRowsGuardrails(
 	if shouldLog {
 		commonSQLEventDetails := ex.planner.getCommonSQLEventDetails(defaultRedactionOptions)
 		var event logpb.EventPayload
-		if ex.executorType == executorTypeInternal {
+		if isInternal {
 			if isRead {
 				event = &eventpb.TxnRowsReadLimitInternal{
 					CommonSQLEventDetails:     commonSQLEventDetails,
@@ -2185,7 +2240,7 @@ func (ex *connExecutor) addActiveQuery(
 		start:         ex.phaseTimes.GetSessionPhaseTime(sessionphase.SessionQueryReceived),
 		stmt:          stmt,
 		placeholders:  placeholders,
-		phase:         preparing,
+		phase:         serverpb.ActiveQuery_PREPARING,
 		isDistributed: false,
 		isFullScan:    false,
 		cancelQuery:   cancelQuery,
@@ -2196,15 +2251,16 @@ func (ex *connExecutor) addActiveQuery(
 	ex.mu.ActiveQueries[queryID] = qm
 }
 
-func (ex *connExecutor) removeActiveQuery(queryID clusterunique.ID, ast tree.Statement) {
+func (ex *connExecutor) removeActiveQuery(queryID clusterunique.ID, ast tree.Statement) *queryMeta {
 	ex.mu.Lock()
 	defer ex.mu.Unlock()
-	_, ok := ex.mu.ActiveQueries[queryID]
+	qm, ok := ex.mu.ActiveQueries[queryID]
 	if !ok {
 		panic(errors.AssertionFailedf("query %d missing from ActiveQueries", queryID))
 	}
 	delete(ex.mu.ActiveQueries, queryID)
 	ex.mu.LastActiveQuery = ast
+	return qm
 }
 
 // handleAutoCommit commits the KV transaction if it hasn't been committed

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/sql/querycache"
+	"github.com/cockroachdb/cockroach/pkg/sql/recent"
 	"github.com/cockroachdb/cockroach/pkg/sql/stmtdiagnostics"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -294,8 +295,9 @@ func startConnExecutor(
 		SystemConfig: config.NewConstantSystemConfigProvider(
 			config.NewSystemConfig(zonepb.DefaultZoneConfigRef()),
 		),
-		SessionRegistry:    NewSessionRegistry(),
-		ClosedSessionCache: NewClosedSessionCache(st, pool, time.Now),
+		SessionRegistry:       NewSessionRegistry(),
+		ClosedSessionCache:    NewClosedSessionCache(st, pool, time.Now),
+		RecentTransactionsCache: recent.NewTransactionsCache(st, pool, time.Now),
 		NodeInfo: NodeInfo{
 			NodeID:           nodeID,
 			LogicalClusterID: func() uuid.UUID { return uuid.UUID{} },

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -17,12 +17,15 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"math"
 	"net"
 	"net/url"
 	"reflect"
 	"regexp"
 	"strings"
+	"sync/atomic"
 	"time"
+	"unicode/utf8"
 
 	"github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -78,6 +81,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirecancel"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/querycache"
+	"github.com/cockroachdb/cockroach/pkg/sql/recent"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/scheduledlogging"
@@ -1176,19 +1180,20 @@ type ExecutorConfig struct {
 	NodesStatusServer serverpb.OptionalNodesStatusServer
 	// SQLStatusServer gives access to a subset of the Status service and is
 	// available when not running as a system tenant.
-	SQLStatusServer    serverpb.SQLStatusServer
-	TenantStatusServer serverpb.TenantStatusServer
-	MetricsRecorder    nodeStatusGenerator
-	SessionRegistry    *SessionRegistry
-	ClosedSessionCache *ClosedSessionCache
-	SQLLiveness        sqlliveness.Liveness
-	JobRegistry        *jobs.Registry
-	VirtualSchemas     *VirtualSchemaHolder
-	DistSQLPlanner     *DistSQLPlanner
-	TableStatsCache    *stats.TableStatisticsCache
-	StatsRefresher     *stats.Refresher
-	InternalExecutor   *InternalExecutor
-	QueryCache         *querycache.C
+	SQLStatusServer         serverpb.SQLStatusServer
+	TenantStatusServer      serverpb.TenantStatusServer
+	MetricsRecorder         nodeStatusGenerator
+	SessionRegistry         *SessionRegistry
+	ClosedSessionCache      *ClosedSessionCache
+	RecentTransactionsCache *recent.TransactionsCache
+	SQLLiveness             sqlliveness.Liveness
+	JobRegistry             *jobs.Registry
+	VirtualSchemas          *VirtualSchemaHolder
+	DistSQLPlanner          *DistSQLPlanner
+	TableStatsCache         *stats.TableStatisticsCache
+	StatsRefresher          *stats.Refresher
+	InternalExecutor        *InternalExecutor
+	QueryCache              *querycache.C
 
 	SchemaChangerMetrics *SchemaChangerMetrics
 	FeatureFlagMetrics   *featureflag.DenialMetrics
@@ -1931,17 +1936,6 @@ func isSetTransaction(ast tree.Statement) bool {
 	return isSet
 }
 
-// queryPhase represents a phase during a query's execution.
-type queryPhase int
-
-const (
-	// The phase before start of execution (includes parsing, building a plan).
-	preparing queryPhase = 0
-
-	// Execution phase.
-	executing queryPhase = 1
-)
-
 // queryMeta stores metadata about a query. Stored as reference in
 // session.mu.ActiveQueries.
 type queryMeta struct {
@@ -1971,7 +1965,7 @@ type queryMeta struct {
 	isFullScan bool
 
 	// Current phase of execution of query.
-	phase queryPhase
+	phase serverpb.ActiveQuery_Phase
 
 	// Cancellation function for the context associated with this query's
 	// statement.
@@ -1995,6 +1989,66 @@ type queryMeta struct {
 // associated stmt context.
 func (q *queryMeta) cancel() {
 	q.cancelQuery()
+}
+
+// toActiveQuery translates the queryMeta to a serverpb.ActiveQuery.
+func (q *queryMeta) toActiveQuery(
+	stmtID clusterunique.ID,
+	sessionID clusterunique.ID,
+	appName atomic.Value,
+	username string,
+	clientAddr string,
+	parsed parser.Statement,
+	timeNow time.Time,
+) serverpb.ActiveQuery {
+	truncateSQL := func(sql string) string {
+		if len(sql) > MaxSQLBytes {
+			sql = sql[:MaxSQLBytes-utf8.RuneLen('…')]
+			// Ensure the resulting string is valid utf8.
+			for {
+				if r, _ := utf8.DecodeLastRuneInString(sql); r != utf8.RuneError {
+					break
+				}
+				sql = sql[:len(sql)-1]
+			}
+			sql += "…"
+		}
+		return sql
+	}
+
+	sqlNoConstants := truncateSQL(formatStatementHideConstants(parsed.AST))
+	nPlaceholders := 0
+	if q.placeholders != nil {
+		nPlaceholders = len(q.placeholders.Values)
+	}
+	placeholders := make([]string, nPlaceholders)
+	for i := range placeholders {
+		placeholders[i] = tree.AsStringWithFlags(q.placeholders.Values[i], tree.FmtSimple)
+	}
+	sql := truncateSQL(q.stmt.SQL)
+	progress := math.Float64frombits(atomic.LoadUint64(&q.progressAtomic))
+	queryStart := q.start.UTC()
+	activeQuery := serverpb.ActiveQuery{
+		TxnID:          q.txnID,
+		ID:             stmtID.String(),
+		Start:          queryStart,
+		ElapsedTime:    timeNow.Sub(queryStart),
+		Sql:            sql,
+		SqlNoConstants: sqlNoConstants,
+		SqlSummary:     formatStatementSummary(parsed.AST),
+		Placeholders:   placeholders,
+		IsDistributed:  q.isDistributed,
+		Phase:          q.phase,
+		Progress:       float32(progress),
+		IsFullScan:     q.isFullScan,
+		PlanGist:       q.planGist,
+		Database:       q.database,
+		SessionID:      sessionID.GetBytes(),
+		AppName:        appName.Load().(string),
+		Username:       username,
+		ClientAddress:  clientAddr,
+	}
+	return activeQuery
 }
 
 // SessionDefaults mirrors fields in Session, for restoring default

--- a/pkg/sql/logictest/testdata/logic_test/rename_atomic
+++ b/pkg/sql/logictest/testdata/logic_test/rename_atomic
@@ -140,3 +140,16 @@ BEGIN;
 DROP VIEW v;
 CREATE VIEW v AS SELECT 1;
 COMMIT
+
+# Check for correct caching behavior when scanning the namespace table.
+subtest regression_93002
+
+statement ok
+CREATE SCHEMA sc93002
+
+statement ok
+BEGIN;
+SHOW TABLES FROM sc93002;
+CREATE TABLE sc93002.t(a INT);
+DROP SCHEMA sc93002 CASCADE;
+COMMIT;

--- a/pkg/sql/recent/BUILD.bazel
+++ b/pkg/sql/recent/BUILD.bazel
@@ -1,0 +1,38 @@
+load("//build/bazelutil/unused_checker:unused.bzl", "get_x_data")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "recent",
+    srcs = [
+        "statements_cache.go",
+        "transactions_cache.go",
+    ],
+    importpath = "github.com/cockroachdb/cockroach/pkg/sql/recent",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/server/serverpb",
+        "//pkg/settings",
+        "//pkg/settings/cluster",
+        "//pkg/sql/clusterunique",
+        "//pkg/util/cache",
+        "//pkg/util/mon",
+        "//pkg/util/syncutil",
+    ],
+)
+
+go_test(
+    name = "recent_test",
+    size = "small",
+    srcs = ["statements_cache_test.go"],
+    args = ["-test.timeout=55s"],
+    embed = [":recent"],
+    deps = [
+        "//pkg/server/serverpb",
+        "//pkg/settings/cluster",
+        "//pkg/util/leaktest",
+        "//pkg/util/mon",
+        "@com_github_stretchr_testify//require",
+    ],
+)
+
+get_x_data(name = "get_x_data")

--- a/pkg/sql/recent/statements_cache.go
+++ b/pkg/sql/recent/statements_cache.go
@@ -1,0 +1,169 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package recent
+
+import (
+	"context"
+	"sync"
+	"time"
+	"unsafe"
+
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/clusterunique"
+	"github.com/cockroachdb/cockroach/pkg/util/cache"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+type timeSource func() time.Time
+
+// StatementsCacheCapacity is the cluster setting that controls the
+// maximum number of recent statements in the cache.
+var StatementsCacheCapacity = settings.RegisterIntSetting(
+	settings.TenantWritable,
+	"sql.recent.statements_cache.capacity",
+	"the maximum number of statements in the cache",
+	20000,
+	settings.NonNegativeIntWithMaximum(100000),
+).WithPublic()
+
+// StatementsCacheTimeToLive is the cluster setting that controls the
+// maximum time to live that a statement remains in the cache.
+var StatementsCacheTimeToLive = settings.RegisterDurationSetting(
+	settings.TenantWritable,
+	"sql.recent.statements_cache.time_to_live",
+	"the maximum time to live",
+	time.Hour,
+	settings.NonNegativeDurationWithMaximum(time.Hour*24),
+).WithPublic()
+
+// StatementsCache is a FIFO cache for recent statements.
+type StatementsCache struct {
+	st      *cluster.Settings
+	timeSrc timeSource
+
+	mu struct {
+		syncutil.RWMutex
+		acc  mon.BoundAccount
+		data *cache.UnorderedCache
+	}
+
+	mon        *mon.BytesMonitor
+	Size       int
+	numEntries int
+}
+
+// statementsNode represents the value for each cache entry.
+type statementsNode struct {
+	data      serverpb.ActiveQuery
+	timestamp time.Time
+}
+
+// statementsPool allows for the "reuse" of statementsNodes.
+// If there are available nodes in the pool, it returns those
+// previously allocated nodes. If there aren't, it returns a newly
+// created node. If a node is evicted, it is returned to the pool
+// to be used again. This prevents the de-allocation and reallocation
+// of nodes every time we add to the pool.
+var statementsPool = sync.Pool{
+	New: func() interface{} {
+		return new(statementsNode)
+	},
+}
+
+// NewStatementsCache initializes and returns a new StatementsCache.
+func NewStatementsCache(
+	st *cluster.Settings, parentMon *mon.BytesMonitor, timeSrc timeSource,
+) *StatementsCache {
+	monitor := mon.NewMonitorInheritWithLimit("recent-statements-cache", 0, parentMon)
+
+	c := &StatementsCache{st: st, timeSrc: timeSrc}
+
+	c.mu.data = cache.NewUnorderedCache(cache.Config{
+		Policy: cache.CacheFIFO,
+		ShouldEvict: func(size int, _, value interface{}) bool {
+			capacity := StatementsCacheCapacity.Get(&st.SV)
+			return int64(size) > capacity
+		},
+		OnEvicted: func(_, value interface{}) {
+			node := value.(*statementsNode)
+			size := int64(node.size())
+			statementsPool.Put(node)
+			c.mu.acc.Shrink(context.Background(), size)
+		},
+	})
+
+	c.mu.acc = monitor.MakeBoundAccount()
+	c.mon = monitor
+	c.mon.StartNoReserved(context.Background(), parentMon)
+	return c
+}
+
+// Add stores an ActiveQuery in the cache.
+func (rc *StatementsCache) Add(ctx context.Context, stmt serverpb.ActiveQuery) error {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+
+	// Get a blank statementsNode from the statementsPool
+	node := statementsPool.Get().(*statementsNode)
+	*node = statementsNode{
+		data:      stmt,
+		timestamp: rc.timeSrc(),
+	}
+
+	if err := rc.mu.acc.Grow(ctx, int64(node.size())); err != nil {
+		return err
+	}
+	rc.mu.data.Add(stmt.ID, node)
+	return nil
+}
+
+// IterateRecentStatements iterates through all the statements in
+// the cache, evicting those that have reached the TTL.
+func (rc *StatementsCache) IterateRecentStatements(
+	ctx context.Context, visitor func(context.Context, *serverpb.ActiveQuery),
+) {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+	toEvict := ""
+	rc.mu.data.Do(func(entry *cache.Entry) {
+		if toEvict != "" {
+			rc.mu.data.Del(toEvict)
+			toEvict = ""
+		}
+		node := entry.Value.(*statementsNode)
+		if rc.pastTTL(node.timestamp) {
+			// We keep track of the entry to evict so
+			// that we can evict on the next iteration.
+			// Evicting during this iteration does not
+			// work since the current entry is still needed
+			// during the next iteration to find the next entry.
+			toEvict = entry.Key.(string)
+		} else {
+			visitor(ctx, &node.data)
+		}
+	})
+}
+
+func (rc *StatementsCache) pastTTL(timestamp time.Time) bool {
+	ttl := StatementsCacheTimeToLive.Get(&rc.st.SV)
+	return rc.timeSrc().UnixNano()-timestamp.UnixNano() > ttl.Nanoseconds()
+}
+
+func (n *statementsNode) size() int {
+	size := 0
+	size += int(unsafe.Sizeof(clusterunique.ID{}))
+	size += n.data.Size()
+	size += int(unsafe.Sizeof(time.Time{}))
+	return size
+}

--- a/pkg/sql/recent/transactions_cache.go
+++ b/pkg/sql/recent/transactions_cache.go
@@ -1,0 +1,177 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source License, use
+// of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt
+
+package recent
+
+import (
+	"context"
+	"sync"
+	"time"
+	"unsafe"
+
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/clusterunique"
+	"github.com/cockroachdb/cockroach/pkg/util/cache"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+// TransactionsCacheCapacity is the cluster setting that controls the
+// maximum number of recent Transactions in the cache.
+var TransactionsCacheCapacity = settings.RegisterIntSetting(
+	settings.TenantWritable,
+	"sql.recent.transactions_cache.capacity",
+	"the maximum number of Transactions in the cache",
+	20000,
+	settings.NonNegativeIntWithMaximum(100000),
+).WithPublic()
+
+// TransactionsCacheTimeToLive is the cluster setting that controls the
+// maximum time to live that a statement remains in the cache.
+var TransactionsCacheTimeToLive = settings.RegisterDurationSetting(
+	settings.TenantWritable,
+	"sql.recent.transactions_cache.time_to_live",
+	"the maximum time to live",
+	time.Hour,
+	settings.NonNegativeDurationWithMaximum(time.Hour*24),
+).WithPublic()
+
+// TransactionsCache is a FIFO cache for recent transactions.
+type TransactionsCache struct {
+	st      *cluster.Settings
+	timeSrc timeSource
+
+	mu struct {
+		syncutil.RWMutex
+		acc  mon.BoundAccount
+		data *cache.UnorderedCache
+	}
+
+	mon *mon.BytesMonitor
+}
+
+// transactionsNode represents the value for each cache entry.
+type transactionsNode struct {
+	txn       serverpb.TxnInfo
+	stmts     StatementsCache
+	timestamp time.Time
+}
+
+// TransactionsPool allows for the "reuse" of TransactionsNodes.
+// If there are available nodes in the pool, it returns those
+// previously allocated nodes. If there aren't, it returns a newly
+// created node. If a node is evicted, it is returned to the pool
+// to be used again. This prevents the de-allocation and reallocation
+// of nodes every time we add to the pool.
+var transactionsPool = sync.Pool{
+	New: func() interface{} {
+		return new(transactionsNode)
+	},
+}
+
+// NewTransactionsCache initializes and returns a new TransactionsCache.
+func NewTransactionsCache(
+	st *cluster.Settings, parentMon *mon.BytesMonitor, timeSrc timeSource,
+) *TransactionsCache {
+	monitor := mon.NewMonitorInheritWithLimit("recent-transactions-cache", 0, parentMon)
+
+	c := &TransactionsCache{st: st, timeSrc: timeSrc}
+
+	c.mu.data = cache.NewUnorderedCache(cache.Config{
+		Policy: cache.CacheFIFO,
+		ShouldEvict: func(size int, _, value interface{}) bool {
+			capacity := TransactionsCacheCapacity.Get(&st.SV)
+			return int64(size) > capacity
+		},
+		OnEvicted: func(_, value interface{}) {
+			node := value.(*transactionsNode)
+			size := int64(node.size())
+			transactionsPool.Put(node)
+			c.mu.acc.Shrink(context.Background(), size)
+		},
+	})
+
+	c.mu.acc = monitor.MakeBoundAccount()
+	c.mon = monitor
+	c.mon.StartNoReserved(context.Background(), parentMon)
+	return c
+}
+
+// Add stores an ActiveQuery in the cache.
+func (rc *TransactionsCache) Add(
+	ctx context.Context, txn serverpb.TxnInfo, stmt serverpb.ActiveQuery,
+) error {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+
+	txnNode, ok := rc.mu.data.Get(txn.ID)
+	if ok {
+		_ = txnNode.(*transactionsNode).stmts.Add(ctx, stmt)
+	} else {
+		// Get a blank transactionsNode from the transactionsPool
+		node := transactionsPool.Get().(*transactionsNode)
+		*node = transactionsNode{
+			txn:       txn,
+			stmts:     *NewStatementsCache(rc.st, rc.mon, rc.timeSrc),
+			timestamp: rc.timeSrc(),
+		}
+		_ = node.stmts.Add(ctx, stmt)
+		rc.mu.data.Add(txn.ID, node)
+	}
+	// TODO: add bytes monitor
+	//if err := rc.mu.acc.Grow(ctx, int64(node.size())); err != nil {
+	//	return err
+	//}
+	return nil
+}
+
+// IterateRecentTransactions iterates through all the transactions in
+// the cache, evicting those that have reached the TTL.
+func (rc *TransactionsCache) IterateRecentTransactions(
+	ctx context.Context, visitor func(context.Context, *serverpb.TxnInfo, *StatementsCache),
+) {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+	toEvict := ""
+	rc.mu.data.Do(func(entry *cache.Entry) {
+		if toEvict != "" {
+			rc.mu.data.Del(toEvict)
+			toEvict = ""
+		}
+		node := entry.Value.(*transactionsNode)
+		if rc.pastTTL(node.timestamp) {
+			// TODO: fix eviction policy to be during ShouldEvict
+			// We keep track of the entry to evict so
+			// that we can evict on the next iteration.
+			// Evicting during this iteration does not
+			// work since the current entry is still needed
+			// during the next iteration to find the next entry.
+			toEvict = entry.Key.(string)
+		} else {
+			visitor(ctx, &node.txn, &node.stmts)
+		}
+	})
+}
+
+func (rc *TransactionsCache) pastTTL(timestamp time.Time) bool {
+	ttl := TransactionsCacheTimeToLive.Get(&rc.st.SV)
+	return rc.timeSrc().UnixNano()-timestamp.UnixNano() > ttl.Nanoseconds()
+}
+
+func (n *transactionsNode) size() int {
+	size := 0
+	size += int(unsafe.Sizeof(clusterunique.ID{}))
+	size += n.txn.Size()
+	// TODO: implement finding size of statements cache
+	//size += n.stmts.Size
+	size += int(unsafe.Sizeof(time.Time{}))
+	return size
+}

--- a/pkg/sql/sem/catconstants/constants.go
+++ b/pkg/sql/sem/catconstants/constants.go
@@ -104,6 +104,8 @@ const (
 	CrdbInternalClusterExecutionInsightsTableID
 	CrdbInternalClusterLocksTableID
 	CrdbInternalClusterQueriesTableID
+	CrdbInternalClusterRecentStatementsTableID
+	CrdbInternalClusterRecentTransactionsTableID
 	CrdbInternalClusterTransactionsTableID
 	CrdbInternalClusterSessionsTableID
 	CrdbInternalClusterSettingsTableID
@@ -132,6 +134,8 @@ const (
 	CrdbInternalLocalContentionEventsTableID
 	CrdbInternalLocalDistSQLFlowsTableID
 	CrdbInternalNodeExecutionInsightsTableID
+	CrdbInternalNodeRecentStatementsTableID
+	CrdbInternalNodeRecentTransactionsTableID
 	CrdbInternalLocalQueriesTableID
 	CrdbInternalLocalTransactionsTableID
 	CrdbInternalLocalSessionsTableID


### PR DESCRIPTION
This change implements a new RecentTransactionsCache that is used to store the recent transactions that were executed. This new cache "wraps around" the existing RecentStatements Cache, as each txn has a cache of stmts associated with it. The cache also has two new cluster settings that tune the capacity and time that a transaction lives in the cache.

This change also implements a new RecentTransactions API and new recent transactions virtual tables. The virtual tables are a WIP, as we still need to add all the necessary fields from TxnInfo.

Future work for implementing recent transactions includes:
- testing adding to the transactions cache
- fixing up the cache implementation to be consistent with the statements cache
- fixing and testing the GetRecentTransactions API that populates new recent transactions virtual tables
- surfacing information from the virtual tables onto the UI, this should be very similar to the UI implementation for statements

Part Of #86955

Release note: None