### PR TITLE
ui: initial implementation for paginating recent stmts response

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/recentExecutionsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/recentExecutionsApi.ts
@@ -1,0 +1,119 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import {
+  executeInternalSql, LARGE_RESULT_SIZE,
+  SqlExecutionRequest,
+  sqlResultsAreEmpty,
+} from "./sqlApi";
+import moment from "moment";
+import { ExecutionStatus, RecentStatement } from "../recentExecutions";
+
+export type RecentStatementsColumns = {
+  stmt_id: string,
+  stmt_no_constants: string,
+  txn_id: string,
+  session_id: string,
+  query: string,
+  status: string,
+  start_time: string,
+  elapsed_time: string,
+  app_name: string,
+  database_name: string,
+  user_name: string,
+  client_address: string,
+  is_full_scan: string,
+  plan_gist: string
+};
+
+const recentStatementsQuery = (id: string): string =>
+  `SELECT
+    stmt_id,
+    stmt_no_constants,
+    txn_id,
+    session_id,
+    query,
+    status,
+    start_time,
+    elapsed_time,
+    app_name,
+    database_name,
+    user_name,
+    client_address,
+    is_full_scan,
+    plan_gist
+  FROM crdb_internal.node_recent_statements
+  WHERE stmt_id > ${id}
+  ORDER BY stmt_id ASC
+  LIMIT 100`
+
+export type RecentStatementsRequestKey = { id: string };
+
+export const recentStatementsRequest = (id: string): SqlExecutionRequest => {
+  return {
+  statements: [
+    {
+      sql: recentStatementsQuery(id),
+    },
+  ],
+  execute: true,
+  max_result_size: LARGE_RESULT_SIZE,
+}
+};
+
+function stringToExecutionStatus(status: string): ExecutionStatus {
+  switch (status) {
+    case "PREPARING":
+      return "Preparing"
+    case "EXECUTING":
+      return "Executing"
+    case "CANCELED":
+      return "Canceled"
+    case "TIMED_OUT":
+      return "Timed Out"
+    case "COMPLETED":
+      return "Completed"
+    case "FAILED":
+      return "Failed"
+  }
+}
+
+
+export async function getRecentStatements(key: RecentStatementsRequestKey): Promise<RecentStatement[]> {
+  return executeInternalSql<RecentStatementsColumns>(recentStatementsRequest(key.id)).then(
+    result => {
+      if (sqlResultsAreEmpty(result)) {
+        if (result.error) {
+          throw result.error;
+        }
+        return [];
+      }
+      const recentStatements: RecentStatement[] = result.execution.txn_results[0].rows.map(
+        row => ({
+          statementID: row.stmt_id,
+          stmtNoConstants: row.stmt_no_constants,
+          transactionID: row.txn_id,
+          sessionID: row.session_id,
+          query: row.query,
+          status: stringToExecutionStatus(row.status),
+          start: moment.utc(row.start_time),
+          elapsedTime: moment.duration(row.elapsed_time),
+          application: row.app_name,
+          database: row.database_name,
+          user: row.user_name,
+          clientAddress: row.client_address,
+          isFullScan: row.is_full_scan === 'true',
+          planGist: row.plan_gist
+        })
+      );
+      return recentStatements
+    }
+  )
+}

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/recentStatementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/recentStatementDetails.tsx
@@ -35,6 +35,7 @@ import { Loading } from "../loading";
 import { Insights } from "./planDetails";
 import { getIdxRecommendationsFromExecution } from "../api/idxRecForStatementApi";
 import { SortSetting } from "../sortedtable";
+import {RecentStatementsRequestKey} from "../api";
 const cx = classNames.bind(styles);
 
 export type RecentStatementDetailsStateProps = {
@@ -46,6 +47,7 @@ export type RecentStatementDetailsStateProps = {
 
 export type RecentStatementDetailsDispatchProps = {
   refreshLiveWorkload: () => void;
+  refreshRecentStatements: (req: RecentStatementsRequestKey) => void;
 };
 
 enum TabKeysEnum {
@@ -68,6 +70,7 @@ export const RecentStatementDetails: React.FC<RecentStatementDetailsProps> = ({
   statement,
   match,
   refreshLiveWorkload,
+  refreshRecentStatements,
 }) => {
   const history = useHistory();
   const executionID = getMatchParamByName(match, executionIdAttr);
@@ -88,6 +91,15 @@ export const RecentStatementDetails: React.FC<RecentStatementDetailsProps> = ({
       refreshLiveWorkload();
     }
   }, [refreshLiveWorkload, statement]);
+
+  useEffect(() => {
+    if (statement == null) {
+      // Refresh sessions if the statement was not found initially.
+      refreshRecentStatements({
+        id: executionID,
+      });
+    }
+  }, [refreshRecentStatements, statement]);
 
   const onTabClick = (key: TabKeysEnum) => {
     if (

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/recentStatementDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/recentStatementDetailsConnected.tsx
@@ -12,6 +12,7 @@ import { RouteComponentProps, withRouter } from "react-router-dom";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
 import { actions as sessionsActions } from "src/store/sessions";
+import { actions as recentStatementsActions } from "src/store/recentExecutions/recentStatements";
 import { AppState } from "../store";
 import {
   RecentStatementDetails,
@@ -23,6 +24,7 @@ import {
   selectContentionDetailsForStatement,
 } from "src/selectors/recentExecutions.selectors";
 import { selectIsTenant } from "src/store/uiConfig";
+import {RecentStatementsRequestKey} from "../api";
 
 // For tenant cases, we don't show information about node, regions and
 // diagnostics.
@@ -42,6 +44,7 @@ const mapDispatchToProps = (
   dispatch: Dispatch,
 ): RecentStatementDetailsDispatchProps => ({
   refreshLiveWorkload: () => dispatch(sessionsActions.refresh()),
+  refreshRecentStatements: (req: RecentStatementsRequestKey) => dispatch(recentStatementsActions.refresh(req)),
 });
 
 export const RecentStatementDetailsPageConnected = withRouter(

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/recentStatementsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/recentStatementsPage.selectors.ts
@@ -23,8 +23,10 @@ import {
 } from "src/selectors/recentExecutions.selectors";
 import { actions as localStorageActions } from "src/store/localStorage";
 import { actions as sessionsActions } from "src/store/sessions";
+import { actions as recentStatementsActions } from "src/store/recentExecutions/recentStatements"
 import { selectIsTenant } from "src/store/uiConfig";
 import { localStorageSelector } from "../store/utils/selectors";
+import { RecentStatementsRequestKey } from "../api";
 
 export const selectSortSetting = (state: AppState): SortSetting =>
   localStorageSelector(state)["sortSetting/ActiveStatementsPage"];
@@ -62,6 +64,7 @@ export const mapDispatchToRecentStatementsPageProps = (
   dispatch: Dispatch,
 ): RecentStatementsViewDispatchProps => ({
   refreshLiveWorkload: () => dispatch(sessionsActions.refresh()),
+  refreshRecentStatements: (req: RecentStatementsRequestKey) => dispatch(recentStatementsActions.refresh(req)),
   onColumnsSelect: columns => {
     dispatch(
       localStorageActions.update({

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/recentStatementsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/recentStatementsView.tsx
@@ -29,14 +29,15 @@ import {
 import {
   calculateActiveFilters,
   getFullFiltersAsStringRecord,
-} from "../queryFilter/filter";
+} from "../queryFilter";
 import { RecentStatementsSection } from "../recentExecutions/recentStatementsSection";
-import { inactiveFiltersState } from "../queryFilter/filter";
+import { inactiveFiltersState } from "../queryFilter";
 import { queryByName, syncHistory } from "src/util/query";
 import { getTableSortFromURL } from "../sortedtable/getTableSortFromURL";
 import { getRecentStatementFiltersFromURL } from "src/queryFilter/utils";
 
 import styles from "./statementsPage.module.scss";
+import {RecentStatementsRequestKey} from "../api";
 
 const cx = classNames.bind(styles);
 
@@ -45,6 +46,7 @@ export type RecentStatementsViewDispatchProps = {
   onFiltersChange: (filters: RecentStatementFilters) => void;
   onSortChange: (ss: SortSetting) => void;
   refreshLiveWorkload: () => void;
+  refreshRecentStatements: (req: RecentStatementsRequestKey) => void;
 };
 
 export type RecentStatementsViewStateProps = {
@@ -65,6 +67,7 @@ export const RecentStatementsView: React.FC<RecentStatementsViewProps> = ({
   refreshLiveWorkload,
   onFiltersChange,
   onSortChange,
+  refreshRecentStatements,
   selectedColumns,
   sortSetting,
   statements,
@@ -92,6 +95,15 @@ export const RecentStatementsView: React.FC<RecentStatementsViewProps> = ({
   }, [refreshLiveWorkload]);
 
   useEffect(() => {
+    // Refresh every 10 seconds.
+    refreshRecentStatements({ id: "key"});
+    const interval = setInterval(refreshRecentStatements, 10 * 1000);
+    return () => {
+      clearInterval(interval);
+    };
+  }, [refreshRecentStatements]);
+
+  useEffect(() => {
     // We use this effect to sync settings defined on the URL (sort, filters),
     // with the redux store. The only time we do this is when the user navigates
     // to the page directly via the URL and specifies settings in the query string.
@@ -116,6 +128,7 @@ export const RecentStatementsView: React.FC<RecentStatementsViewProps> = ({
       {
         ascending: sortSetting.ascending.toString(),
         columnTitle: sortSetting.columnTitle,
+        page: pagination.current.toString(),
         [RECENT_STATEMENT_SEARCH_PARAM]: search,
         ...getFullFiltersAsStringRecord(filters),
       },
@@ -128,11 +141,19 @@ export const RecentStatementsView: React.FC<RecentStatementsViewProps> = ({
     sortSetting.ascending,
     sortSetting.columnTitle,
     search,
+    pagination,
   ]);
 
   const resetPagination = () => {
     setPagination({
       current: 1,
+      pageSize: 20,
+    });
+  };
+
+  const onPaginationChange = (page: number): void => {
+    setPagination({
+      current: page,
       pageSize: 20,
     });
   };
@@ -206,6 +227,7 @@ export const RecentStatementsView: React.FC<RecentStatementsViewProps> = ({
             onClearFilters={clearFilters}
             onChangeSortSetting={onSortClick}
             onColumnsSelect={onColumnsSelect}
+            onChangePagination={onPaginationChange}
             isTenant={isTenant}
           />
         </Loading>

--- a/pkg/ui/workspaces/cluster-ui/src/store/recentExecutions/recentStatements/recentStatements.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/recentExecutions/recentStatements/recentStatements.reducer.ts
@@ -1,0 +1,53 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import {DOMAIN_NAME, noopReducer} from "../../utils";
+import {RecentStatement} from "../../../recentExecutions";
+import {RecentStatementsRequestKey, TxnContentionInsightDetailsRequest} from "../../../api";
+
+export type RecentStatementsState = {
+  data: RecentStatement[];
+  lastError: Error;
+  valid: boolean;
+};
+
+const initialState: RecentStatementsState = {
+  data: null,
+  lastError: null,
+  valid: true,
+};
+
+const recentStatementsSlice = createSlice({
+  name: `${DOMAIN_NAME}/recentStatements`,
+  initialState,
+  reducers: {
+    received: (state, action: PayloadAction<RecentStatement[]>) => {
+      state.data = action.payload;
+      state.valid = true;
+      state.lastError = null;
+    },
+    failed: (state, action: PayloadAction<Error>) => {
+      state.valid = false;
+      state.lastError = action.payload;
+    },
+    // Define actions that don't change state.
+    refresh: (
+      _,
+      _action: PayloadAction<RecentStatementsRequestKey>,
+    ) => {},
+    request: (
+      _,
+      _action: PayloadAction<RecentStatementsRequestKey>,
+    ) => {},
+  },
+});
+
+export const { reducer, actions } = recentStatementsSlice;

--- a/pkg/ui/workspaces/cluster-ui/src/store/recentExecutions/recentStatements/recentStatements.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/recentExecutions/recentStatements/recentStatements.sagas.ts
@@ -1,0 +1,46 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import {
+  all,
+  AllEffect,
+  call,
+  ForkEffect,
+  put, takeLatest,
+} from "redux-saga/effects";
+
+import { actions } from "./recentStatements.reducer";
+import { getRecentStatements, RecentStatementsRequestKey } from "src/api/recentExecutionsApi";
+import { PayloadAction } from "@reduxjs/toolkit";
+
+export function* refreshRecentStatementsSaga() {
+  yield put(actions.request());
+}
+
+export function* requestRecentStatementsSaga(
+  action: PayloadAction<RecentStatementsRequestKey>
+): any {
+  try {
+    const result = yield call(
+      getRecentStatements,
+      action.payload,
+    );
+    yield put(actions.received(result));
+  } catch (e) {
+    yield put(actions.failed(e));
+  }
+}
+
+export function* recentStatementsSaga(): Generator<AllEffect<ForkEffect>> {
+  yield all([
+    takeLatest(actions.request, requestRecentStatementsSaga),
+    takeLatest(actions.refresh, refreshRecentStatementsSaga),
+  ]);
+}

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -15,6 +15,7 @@ import moment from "moment";
 import {
   api as clusterUiApi,
   util,
+  RecentStatement,
   TxnContentionInsightDetails,
   TxnContentionInsightEvent,
   TxnInsightEvent,
@@ -410,6 +411,27 @@ export const refreshLiveWorkload = (): ThunkAction<any, any, any, Action> => {
   };
 };
 
+export const recentStatementsRequestKey = (
+  req: clusterUiApi.RecentStatementsRequestKey,
+): string => `${req.id}`;
+
+const recentStatementsReducerObj = new KeyedCachedDataReducer(
+  clusterUiApi.getRecentStatements,
+  "recentStatements",
+  recentStatementsRequestKey,
+  null,
+  moment.duration(30, "s"),
+);
+export const refreshRecentStatements = recentStatementsReducerObj.refresh;
+
+export const refreshRecentStatementsAction = (
+  req: clusterUiApi.RecentStatementsRequestKey,
+  ): ThunkAction<any, any, any, Action> => {
+  return (dispatch: ThunkDispatch<unknown, unknown, Action>) => {
+    dispatch(refreshRecentStatements(req));
+  };
+};
+
 const transactionInsightsReducerObj = new CachedDataReducer(
   clusterUiApi.getTxnInsightEvents,
   "transactionInsights",
@@ -551,6 +573,7 @@ export interface APIReducersState {
   userSQLRoles: CachedDataReducerState<api.UserSQLRolesResponseMessage>;
   hotRanges: PaginatedCachedDataReducerState<api.HotRangesV2ResponseMessage>;
   clusterLocks: CachedDataReducerState<clusterUiApi.ClusterLocksResponse>;
+  recentStatements: KeyedCachedDataReducerState<RecentStatement[]>;
   transactionInsights: CachedDataReducerState<TxnContentionInsightEvent[]>;
   transactionInsightDetails: KeyedCachedDataReducerState<TxnContentionInsightDetails>;
   executionInsights: CachedDataReducerState<TxnInsightEvent[]>;
@@ -600,6 +623,7 @@ export const apiReducersReducer = combineReducers<APIReducersState>({
   [userSQLRolesReducerObj.actionNamespace]: userSQLRolesReducerObj.reducer,
   [hotRangesReducerObj.actionNamespace]: hotRangesReducerObj.reducer,
   [clusterLocksReducerObj.actionNamespace]: clusterLocksReducerObj.reducer,
+  [recentStatementsReducerObj.actionNamespace]: recentStatementsReducerObj.reducer,
   [transactionInsightsReducerObj.actionNamespace]:
     transactionInsightsReducerObj.reducer,
   [transactionInsightDetailsReducerObj.actionNamespace]:

--- a/pkg/ui/workspaces/db-console/src/selectors/recentExecutionsSelectors.ts
+++ b/pkg/ui/workspaces/db-console/src/selectors/recentExecutionsSelectors.ts
@@ -11,6 +11,8 @@
 import {
   RecentExecutions,
   selectRecentExecutionsCombiner,
+  selectActiveExecutionsCombiner,
+  selectHistoricalExecutionsCombiner,
   getRecentStatement,
   getRecentTransaction,
   getContentionDetailsFromLocksAndTxns,
@@ -26,11 +28,26 @@ const selectSessions = (state: AdminUIState) => state.cachedData.sessions?.data;
 const selectClusterLocks = (state: AdminUIState) =>
   state.cachedData.clusterLocks?.data;
 
-export const selectRecentExecutions = createSelector(
+const selectHistoricalStatements = (state: AdminUIState) =>
+  state.cachedData.recentStatements?.data?.data;
+
+export const selectHistoricalExecutions = createSelector(
+  selectHistoricalStatements,
+  selectClusterLocks,
+  selectHistoricalExecutionsCombiner,
+)
+
+export const selectActiveExecutions = createSelector(
   selectSessions,
   selectClusterLocks,
-  selectRecentExecutionsCombiner,
+  selectActiveExecutionsCombiner,
 );
+
+export const selectRecentExecutions = createSelector(
+  selectHistoricalExecutions,
+  selectActiveExecutions,
+  selectRecentExecutionsCombiner,
+)
 
 export const selectRecentStatements = createSelector(
   selectRecentExecutions,


### PR DESCRIPTION
This change is the beginning implementation/thoughts behind paginating query responses for recent statements.

Paginating this response is necessary for the future, because our current max response size does not allow us to display every statement inside the cache.

Part Of #86955

Release note: None