### PR TITLE
streamingccl: don't resume job in TestTenantStreamingCutoverOnSourceFailure

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
@@ -583,9 +583,6 @@ func TestTenantStreamingCutoverOnSourceFailure(t *testing.T) {
 	c.DestSysSQL.Exec(c.T, `ALTER TENANT $1 COMPLETE REPLICATION TO SYSTEM TIME $2::string`,
 		c.Args.DestTenantName, cutoverTime.AsOfSystemTime())
 
-	// Resume ingestion.
-	c.DestSysSQL.Exec(t, fmt.Sprintf("RESUME JOB %d", ingestionJobID))
-
 	// Ingestion job should succeed despite source failure due to the successful cutover
 	jobutils.WaitForJobToSucceed(t, c.DestSysSQL, jobspb.JobID(ingestionJobID))
 }


### PR DESCRIPTION
    ALTER TENANT ... COMPLETE REPLICATION

resumes the job for the user, so there is no need to resume the job here. This does raise the question about whether or not it is the right behaviour to resume the job by default.

Fixes #94034

Release note: None