### PR TITLE
sql: fix legacy encoding path for composite types

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/composite_types
+++ b/pkg/sql/logictest/testdata/logic_test/composite_types
@@ -31,7 +31,7 @@ statement error could not identify column \"foo\"
 SELECT ((1, 2)::t).foo
 
 statement ok
-CREATE TABLE tab (a t)
+CREATE TABLE tab (a t, i int default 0)
 
 statement ok
 INSERT INTO tab VALUES (NULL), ((1, 2))

--- a/pkg/sql/rowenc/valueside/legacy.go
+++ b/pkg/sql/rowenc/valueside/legacy.go
@@ -169,6 +169,15 @@ func MarshalLegacy(colType *types.T, val tree.Datum) (roachpb.Value, error) {
 			r.SetBytes(b)
 			return r, nil
 		}
+	case types.TupleFamily:
+		if v, ok := val.(*tree.DTuple); ok {
+			b, err := encodeUntaggedTuple(v, nil /* appendTo */, 0 /* colID */, nil /* scratch */)
+			if err != nil {
+				return r, err
+			}
+			r.SetBytes(b)
+			return r, nil
+		}
 	case types.CollatedStringFamily:
 		if v, ok := val.(*tree.DCollatedString); ok {
 			if lex.LocaleNamesAreEqual(v.Locale, colType.Locale()) {
@@ -352,6 +361,13 @@ func UnmarshalLegacy(a *tree.DatumAlloc, typ *types.T, value roachpb.Value) (tre
 		}
 		datum, _, err := decodeArray(a, typ, v)
 		// TODO(yuzefovich): do we want to create a new object via tree.DatumAlloc?
+		return datum, err
+	case types.TupleFamily:
+		v, err := value.GetBytes()
+		if err != nil {
+			return nil, err
+		}
+		datum, _, err := decodeTuple(a, typ, v)
 		return datum, err
 	case types.JsonFamily:
 		v, err := value.GetBytes()


### PR DESCRIPTION
Previously, an error was returned when trying to encode a composite type into a single-value column family. This is corrected now.

cc @chengxiong-ruan 

Epic: CRDB-22358
Release note: None (no release with this issue)