### PR TITLE
colserde: optimize the arrow batch converter

### DIFF
--- a/pkg/col/coldata/bytes.go
+++ b/pkg/col/coldata/bytes.go
@@ -13,6 +13,7 @@ package coldata
 import (
 	"encoding/binary"
 	"fmt"
+	"reflect"
 	"strings"
 	"unsafe"
 
@@ -541,40 +542,103 @@ func (b *Bytes) String() string {
 	return builder.String()
 }
 
-// BytesFromArrowSerializationFormat takes an Arrow byte slice and accompanying
-// offsets and populates b.
-func BytesFromArrowSerializationFormat(b *Bytes, data []byte, offsets []int32) {
-	numElements := len(offsets) - 1
-	// TODO(yuzefovich): we can come up with better strategy here. For example,
-	// we could estimate the average size of values and possibly not inline all
-	// of them, or we could at least ensure that b.buffer is large enough to
-	// hold some guess on the non-inlined total footprint.
-	if cap(b.elements) < numElements {
-		b.elements = make([]element, numElements)
-		b.buffer = b.buffer[:0]
-	} else {
-		b.Reset()
-		b.elements = b.elements[:numElements]
-	}
-	for i := 0; i < numElements; i++ {
-		b.Set(i, data[offsets[i]:offsets[i+1]])
-	}
+// elementsAsBytes unsafely casts b.elements[:n] to []byte.
+func (b *Bytes) elementsAsBytes(n int) []byte {
+	var bytes []byte
+	elementsHeader := (*reflect.SliceHeader)(unsafe.Pointer(&b.elements))
+	bytesHeader := (*reflect.SliceHeader)(unsafe.Pointer(&bytes))
+	bytesHeader.Data = elementsHeader.Data
+	bytesHeader.Len = int(ElementSize) * n
+	bytesHeader.Cap = int(ElementSize) * n
+	return bytes
 }
 
-// ToArrowSerializationFormat returns a bytes slice and offsets that are
-// Arrow-compatible. n is the number of elements to serialize. The results will
-// be appended to the passed-in slices.
-func (b *Bytes) ToArrowSerializationFormat(
-	n int, dataScratch []byte, offsetsScratch []int32,
-) ([]byte, []int32) {
+var zeroInt32Slice []int32
+
+func init() {
+	zeroInt32Slice = make([]int32, BatchSize())
+}
+
+// Serialize converts b into the "arrow-like" (which is arrow-compatible)
+// format.
+//
+// We call this "arrow-like" because we're abusing the arrow format to get the
+// best speed, possibly at the cost of increased allocations (when Bytes vector
+// has been modified in-place many times via Sets at arbitrary positions with
+// values of different lengths).
+//
+// In particular, the arrow format represents bytes values via two slices - the
+// flat []byte buffer and the offsets where len(offsets) = n + 1 (where n is the
+// number of elements). ith element is then buffer[offsets[i]:offsets[i+1].
+// However, we squash b.elements (which is []element) and b.buffer to be stored
+// in that flat byte slice, and we only need two positions in offsets to
+// indicate the boundary between the two as well as the total data length. As a
+// result, we have the following representation (which defeats the spirit of the
+// arrow format but doesn't cause any issues anywhere):
+//
+//	 buffer = [<b.elements as []byte><b.buffer]
+//	offsets = [0, 0, ..., 0, len(<b.elements as []byte>), len(<b.elements as []byte>) + len(buffer)]
+//
+// Note: it is assumed that n is not larger than BatchSize().
+func (b *Bytes) Serialize(n int, dataScratch []byte, offsetsScratch []int32) ([]byte, []int32) {
+	if buildutil.CrdbTestBuild {
+		if n > BatchSize() {
+			colexecerror.InternalError(errors.AssertionFailedf(
+				"too many bytes elements to serialize: %d vs BatchSize() of %d", n, BatchSize(),
+			))
+		}
+	}
 	data := dataScratch[:0]
 	offsets := offsetsScratch[:0]
-	offsets = append(offsets, 0)
-	for _, e := range b.elements[:n] {
-		data = append(data, e.get(b)...)
+
+	// Handle the cases of 0 and 1 elements separately since then we cannot
+	// store two offsets that we need.
+	if n == 0 {
+		offsets = append(offsets, 0)
+		return data, offsets
+	} else if n == 1 {
+		data = append(data, b.Get(0)...)
+		offsets = append(offsets, 0)
 		offsets = append(offsets, int32(len(data)))
+		return data, offsets
 	}
+
+	// Copy over b.elements treated as []byte as well as b.buffer into data.
+	bytes := b.elementsAsBytes(n)
+	if cap(data) < len(bytes)+len(b.buffer) {
+		data = make([]byte, 0, len(bytes)+len(b.buffer))
+	}
+	data = append(data, bytes...)
+	data = append(data, b.buffer...)
+
+	// Now populate the offsets slice which conforms to the arrow format and has
+	// the correct length.
+	offsets = append(offsets, zeroInt32Slice[:n-1]...)
+	offsets = append(offsets, int32(len(bytes)))
+	offsets = append(offsets, int32(len(data)))
 	return data, offsets
+}
+
+// Deserialize updates b according to the "arrow-like" format that was produced
+// by Serialize.
+func (b *Bytes) Deserialize(data []byte, offsets []int32) {
+	n := len(offsets) - 1
+	if cap(b.elements) < n {
+		b.elements = make([]element, n)
+	} else {
+		b.elements = b.elements[:n]
+	}
+	b.buffer = b.buffer[:0]
+	if n == 0 {
+		return
+	} else if n == 1 {
+		b.elements[0] = element{}
+		b.Set(0, data)
+		return
+	}
+	bytes := b.elementsAsBytes(n)
+	copy(bytes, data)
+	b.buffer = append(b.buffer, data[len(bytes):]...)
 }
 
 // ProportionalSize calls the method of the same name on bytes-like vectors,

--- a/pkg/col/coldata/bytes_test.go
+++ b/pkg/col/coldata/bytes_test.go
@@ -534,7 +534,9 @@ func TestToArrowSerializationFormat(t *testing.T) {
 	}
 	wind := b.Window(startIdx, endIdx)
 
-	data, offsets := wind.ToArrowSerializationFormat(wind.Len())
+	var data []byte
+	var offsets []int32
+	data, offsets = wind.ToArrowSerializationFormat(wind.Len(), data, offsets)
 
 	require.Equal(t, wind.Len(), len(offsets)-1)
 	require.Equal(t, int32(0), offsets[0])

--- a/pkg/col/coldata/bytes_test.go
+++ b/pkg/col/coldata/bytes_test.go
@@ -510,12 +510,12 @@ func TestProportionalSize(t *testing.T) {
 
 const letters = "abcdefghijklmnopqrstuvwxyz"
 
-func TestToArrowSerializationFormat(t *testing.T) {
+func TestArrowConversion(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	rng, _ := randutil.NewTestRand()
 	nullChance := 0.2
-	maxStringLength := 10
+	maxStringLength := BytesMaxInlineLength * 2
 	numElements := 1 + rng.Intn(BatchSize())
 
 	b := NewBytes(numElements)
@@ -527,18 +527,23 @@ func TestToArrowSerializationFormat(t *testing.T) {
 		b.Set(i, element)
 	}
 
-	startIdx := rng.Intn(numElements)
-	endIdx := startIdx + rng.Intn(numElements-startIdx)
-	if endIdx == startIdx {
-		endIdx++
+	source := b
+	if rng.Float64() < 0.5 {
+		// Sometimes use a window into Bytes to increase test coverage.
+		startIdx := rng.Intn(numElements)
+		endIdx := startIdx + rng.Intn(numElements-startIdx)
+		if endIdx == startIdx {
+			endIdx++
+		}
+		source = b.Window(startIdx, endIdx)
 	}
-	wind := b.Window(startIdx, endIdx)
+	n := source.Len()
 
 	var data []byte
 	var offsets []int32
-	data, offsets = wind.ToArrowSerializationFormat(wind.Len(), data, offsets)
+	data, offsets = source.Serialize(n, data, offsets)
 
-	require.Equal(t, wind.Len(), len(offsets)-1)
+	require.Equal(t, n, len(offsets)-1)
 	require.Equal(t, int32(0), offsets[0])
 	require.Equal(t, len(data), int(offsets[len(offsets)-1]))
 
@@ -547,15 +552,26 @@ func TestToArrowSerializationFormat(t *testing.T) {
 		require.GreaterOrEqualf(t, offsets[i], offsets[i-1], "unexpectedly found decreasing offsets: %v", offsets)
 	}
 
+	converted := NewBytes(n)
+	if rng.Float64() < 0.5 {
+		// Make a copy sometimes to simulate data and offsets being sent across
+		// the wire.
+		data = append([]byte(nil), data...)
+		offsets = append([]int32(nil), offsets...)
+	}
+	converted.Deserialize(data, offsets)
 	// Verify that the data contains the correct values.
-	for i := 0; i < len(offsets)-1; i++ {
-		element := data[offsets[i]:offsets[i+1]]
-		if len(element) == 0 {
-			// Bytes.Get returns a nil []byte value for NULL values whereas the
-			// slicing above will make it a zero-length []byte value. Override
-			// the latter to the former.
-			element = nil
+	for i := 0; i < n; i++ {
+		expected, actual := source.Get(i), converted.Get(i)
+		// When values are NULL or zero-length, they can have different
+		// representations ([]byte{nil} and []byte{}), so we convert both to the
+		// former.
+		if len(expected) == 0 {
+			expected = nil
 		}
-		require.Equal(t, wind.Get(i), element)
+		if len(actual) == 0 {
+			actual = nil
+		}
+		require.Equal(t, expected, actual)
 	}
 }

--- a/pkg/col/coldatatestutils/random_testutils.go
+++ b/pkg/col/coldatatestutils/random_testutils.go
@@ -235,27 +235,19 @@ func setNull(rng *rand.Rand, vec coldata.Vec, i int) {
 }
 
 // RandomBatch returns a batch with a capacity of capacity and a number of
-// random elements equal to length (capacity if length is 0). The values will be
-// null with a probability of nullProbability.
+// random elements equal to length (capacity if length is 0).
+// Note: args.Vec and args.N are ignored.
 func RandomBatch(
-	allocator *colmem.Allocator,
-	rng *rand.Rand,
-	typs []*types.T,
-	capacity int,
-	length int,
-	nullProbability float64,
+	allocator *colmem.Allocator, args RandomVecArgs, typs []*types.T, capacity int, length int,
 ) coldata.Batch {
 	batch := allocator.NewMemBatchWithFixedCapacity(typs, capacity)
 	if length == 0 {
 		length = capacity
 	}
+	args.N = length
 	for _, colVec := range batch.ColVecs() {
-		RandomVec(RandomVecArgs{
-			Rand:            rng,
-			Vec:             colVec,
-			N:               length,
-			NullProbability: nullProbability,
-		})
+		args.Vec = colVec
+		RandomVec(args)
 	}
 	batch.SetLength(length)
 	return batch
@@ -294,7 +286,7 @@ func RandomBatchWithSel(
 	nullProbability float64,
 	selProbability float64,
 ) coldata.Batch {
-	batch := RandomBatch(allocator, rng, typs, n, 0 /* length */, nullProbability)
+	batch := RandomBatch(allocator, RandomVecArgs{Rand: rng, NullProbability: nullProbability}, typs, n, 0 /* length */)
 	if selProbability != 0 {
 		sel := RandomSel(rng, n, 1-selProbability)
 		batch.SetSelection(true)

--- a/pkg/col/colserde/BUILD.bazel
+++ b/pkg/col/colserde/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
     size = "small",
     srcs = [
         "arrowbatchconverter_test.go",
+        "conversion_test.go",
         "file_test.go",
         "main_test.go",
         "record_batch_test.go",

--- a/pkg/col/colserde/arrowbatchconverter.go
+++ b/pkg/col/colserde/arrowbatchconverter.go
@@ -47,14 +47,6 @@ const (
 type ArrowBatchConverter struct {
 	typs []*types.T
 
-	// builders are the set of builders that need to be kept around in order to
-	// construct arrow representations of certain types when they cannot be simply
-	// cast from our current data representation.
-	builders struct {
-		// boolBuilder builds arrow bool columns as a bitmap from a bool slice.
-		boolBuilder *array.BooleanBuilder
-	}
-
 	// TODO(yuzefovich): perform memory accounting for these slices.
 	scratch struct {
 		// arrowData is used as scratch space returned as the corresponding
@@ -83,7 +75,6 @@ func NewArrowBatchConverter(typs []*types.T, mode ConversionMode) (*ArrowBatchCo
 		// need to allocate them.
 		return c, nil
 	}
-	c.builders.boolBuilder = array.NewBooleanBuilder(memory.DefaultAllocator)
 	c.scratch.arrowData = make([]array.Data, len(typs))
 	c.scratch.buffers = make([][]*memory.Buffer, len(typs))
 	// Calculate the number of buffers needed for all types to be able to batch
@@ -133,37 +124,31 @@ func (c *ArrowBatchConverter) BatchToArrow(batch coldata.Batch) ([]array.Data, e
 			nulls.Truncate(batch.Length())
 		}
 
-		// Bools require special handling.
-		if typ.Family() == types.BoolFamily {
-			c.builders.boolBuilder.AppendValues(vec.Bool()[:n], nil /* valid */)
-			c.scratch.arrowData[vecIdx] = *c.builders.boolBuilder.NewBooleanArray().Data()
-			// Overwrite incorrect null bitmap (that has all values as "valid")
-			// with the actual null bitmap. Note that if we actually don't have
-			// any nulls, we use a bitmap with zero length for it in order to
-			// reduce the size of serialized representation.
-			var arrowBitmap []byte
-			if nulls != nil {
-				arrowBitmap = nulls.NullBitmap()
-			}
-			c.scratch.arrowData[vecIdx].Buffers()[0].Reset(arrowBitmap)
-			continue
-		}
-
 		var (
 			values       []byte
 			offsetsBytes []byte
 		)
 
-		if f := typeconv.TypeFamilyToCanonicalTypeFamily(typ.Family()); f == types.IntFamily || f == types.FloatFamily {
+		if f := typeconv.TypeFamilyToCanonicalTypeFamily(typ.Family()); f == types.IntFamily ||
+			f == types.FloatFamily || f == types.BoolFamily {
 			// For ints and floats we have a fast path where we cast the
-			// underlying slice directly to the arrow format.
+			// underlying slice directly to the arrow format. Bools are handled
+			// in a special manner by casting to []byte since []byte and []bool
+			// have exactly the same structure (only a single bit of each byte
+			// is addressable).
 			//
-			// dataHeader is the reflect.SliceHeader of the coldata.Vec's underlying
-			// data slice that we are casting to bytes.
+			// dataHeader is the reflect.SliceHeader of the coldata.Vec's
+			// underlying data slice that we are casting to bytes.
 			var dataHeader *reflect.SliceHeader
-			// datumSize is the size of one datum that we are casting to a byte slice.
+			// datumSize is the size of one datum that we are casting to a byte
+			// slice.
 			var datumSize int64
-			if f == types.IntFamily {
+			switch f {
+			case types.BoolFamily:
+				bools := vec.Bool()[:n]
+				dataHeader = (*reflect.SliceHeader)(unsafe.Pointer(&bools))
+				datumSize = 1
+			case types.IntFamily:
 				switch typ.Width() {
 				case 16:
 					ints := vec.Int16()[:n]
@@ -180,7 +165,7 @@ func (c *ArrowBatchConverter) BatchToArrow(batch coldata.Batch) ([]array.Data, e
 				default:
 					panic(fmt.Sprintf("unexpected int width: %d", typ.Width()))
 				}
-			} else {
+			case types.FloatFamily:
 				floats := vec.Float64()[:n]
 				dataHeader = (*reflect.SliceHeader)(unsafe.Pointer(&floats))
 				datumSize = memsize.Float64
@@ -365,43 +350,28 @@ func (c *ArrowBatchConverter) ArrowToBatch(
 		d := &data[i]
 
 		switch typeconv.TypeFamilyToCanonicalTypeFamily(typ.Family()) {
-		case types.BoolFamily:
-			boolArr := array.NewBooleanData(d)
-			vec.Nulls().SetNullBitmap(boolArr.NullBitmapBytes(), batchLength)
-			vecArr := vec.Bool()
-			for j := 0; j < boolArr.Len(); j++ {
-				vecArr[j] = boolArr.Value(j)
-			}
-
 		case types.BytesFamily:
-			deserializeArrowIntoBytes(d, vec.Nulls(), vec.Bytes(), batchLength)
+			valueBytes, offsets := getValueBytesAndOffsets(d, vec.Nulls(), batchLength)
+			coldata.BytesFromArrowSerializationFormat(vec.Bytes(), valueBytes, offsets)
 
 		case types.JsonFamily:
-			deserializeArrowIntoBytes(d, vec.Nulls(), &vec.JSON().Bytes, batchLength)
+			valueBytes, offsets := getValueBytesAndOffsets(d, vec.Nulls(), batchLength)
+			coldata.BytesFromArrowSerializationFormat(&vec.JSON().Bytes, valueBytes, offsets)
 
 		case types.DecimalFamily:
 			// TODO(yuzefovich): this serialization is quite inefficient - improve
 			// it.
-			bytesArr := array.NewBinaryData(d)
-			vec.Nulls().SetNullBitmap(bytesArr.NullBitmapBytes(), batchLength)
+			valueBytes, offsets := getValueBytesAndOffsets(d, vec.Nulls(), batchLength)
 			// We need to be paying attention to nulls values so that we don't
 			// try to unmarshal invalid values.
 			var nulls *coldata.Nulls
 			if vec.MaybeHasNulls() {
 				nulls = vec.Nulls()
 			}
-			bytes := bytesArr.ValueBytes()
-			if bytes == nil {
-				// All bytes values are empty, so the representation is solely with the
-				// offsets slice, so create an empty slice so that the conversion
-				// corresponds.
-				bytes = make([]byte, 0)
-			}
-			offsets := bytesArr.ValueOffsets()
 			vecArr := vec.Decimal()
 			for j := 0; j < len(offsets)-1; j++ {
 				if nulls == nil || !nulls.NullAt(j) {
-					if err := vecArr[j].UnmarshalText(bytes[offsets[j]:offsets[j+1]]); err != nil {
+					if err := vecArr[j].UnmarshalText(valueBytes[offsets[j]:offsets[j+1]]); err != nil {
 						return err
 					}
 				}
@@ -410,26 +380,17 @@ func (c *ArrowBatchConverter) ArrowToBatch(
 		case types.TimestampTZFamily:
 			// TODO(yuzefovich): this serialization is quite inefficient - improve
 			// it.
-			bytesArr := array.NewBinaryData(d)
-			vec.Nulls().SetNullBitmap(bytesArr.NullBitmapBytes(), batchLength)
+			valueBytes, offsets := getValueBytesAndOffsets(d, vec.Nulls(), batchLength)
 			// We need to be paying attention to nulls values so that we don't
 			// try to unmarshal invalid values.
 			var nulls *coldata.Nulls
 			if vec.MaybeHasNulls() {
 				nulls = vec.Nulls()
 			}
-			bytes := bytesArr.ValueBytes()
-			if bytes == nil {
-				// All bytes values are empty, so the representation is solely with the
-				// offsets slice, so create an empty slice so that the conversion
-				// corresponds.
-				bytes = make([]byte, 0)
-			}
-			offsets := bytesArr.ValueOffsets()
 			vecArr := vec.Timestamp()
 			for j := 0; j < len(offsets)-1; j++ {
 				if nulls == nil || !nulls.NullAt(j) {
-					if err := vecArr[j].UnmarshalBinary(bytes[offsets[j]:offsets[j+1]]); err != nil {
+					if err := vecArr[j].UnmarshalBinary(valueBytes[offsets[j]:offsets[j+1]]); err != nil {
 						return err
 					}
 				}
@@ -438,26 +399,17 @@ func (c *ArrowBatchConverter) ArrowToBatch(
 		case types.IntervalFamily:
 			// TODO(asubiotto): this serialization is quite inefficient compared to
 			//  the direct casts below. Improve it.
-			bytesArr := array.NewBinaryData(d)
-			vec.Nulls().SetNullBitmap(bytesArr.NullBitmapBytes(), batchLength)
+			valueBytes, offsets := getValueBytesAndOffsets(d, vec.Nulls(), batchLength)
 			// We need to be paying attention to nulls values so that we don't
 			// try to unmarshal invalid values.
 			var nulls *coldata.Nulls
 			if vec.MaybeHasNulls() {
 				nulls = vec.Nulls()
 			}
-			bytes := bytesArr.ValueBytes()
-			if bytes == nil {
-				// All bytes values are empty, so the representation is solely with the
-				// offsets slice, so create an empty slice so that the conversion
-				// corresponds.
-				bytes = make([]byte, 0)
-			}
-			offsets := bytesArr.ValueOffsets()
 			vecArr := vec.Interval()
 			for j := 0; j < len(offsets)-1; j++ {
 				if nulls == nil || !nulls.NullAt(j) {
-					intervalBytes := bytes[offsets[j]:offsets[j+1]]
+					intervalBytes := valueBytes[offsets[j]:offsets[j+1]]
 					var err error
 					vecArr[j], err = duration.Decode(
 						int64(binary.LittleEndian.Uint64(intervalBytes[0:memsize.Int64])),
@@ -471,41 +423,47 @@ func (c *ArrowBatchConverter) ArrowToBatch(
 			}
 
 		case typeconv.DatumVecCanonicalTypeFamily:
-			bytesArr := array.NewBinaryData(d)
-			vec.Nulls().SetNullBitmap(bytesArr.NullBitmapBytes(), batchLength)
+			valueBytes, offsets := getValueBytesAndOffsets(d, vec.Nulls(), batchLength)
 			// We need to be paying attention to nulls values so that we don't
 			// try to unmarshal invalid values.
 			var nulls *coldata.Nulls
 			if vec.MaybeHasNulls() {
 				nulls = vec.Nulls()
 			}
-			bytes := bytesArr.ValueBytes()
-			if bytes == nil {
-				// All bytes values are empty, so the representation is solely with the
-				// offsets slice, so create an empty slice so that the conversion
-				// corresponds.
-				bytes = make([]byte, 0)
-			}
-			offsets := bytesArr.ValueOffsets()
 			vecArr := vec.Datum()
 			for j := 0; j < len(offsets)-1; j++ {
 				if nulls == nil || !nulls.NullAt(j) {
-					if err := vecArr.UnmarshalTo(j, bytes[offsets[j]:offsets[j+1]]); err != nil {
+					if err := vecArr.UnmarshalTo(j, valueBytes[offsets[j]:offsets[j+1]]); err != nil {
 						return err
 					}
 				}
 			}
 
 		default:
-			// For integers and floats we can just directly cast the slice
-			// without performing the copy.
+			// For bools, integers, and floats we can just directly cast the
+			// slice without performing the copy.
 			//
 			// However, we have to be careful to set the capacity on each slice
 			// explicitly to protect memory regions that come after the slice
 			// from corruption in case the slice will be appended to in the
-			// future. See an example in deserializeArrowIntoBytes.
+			// future.
 			var col coldata.Column
 			switch typeconv.TypeFamilyToCanonicalTypeFamily(typ.Family()) {
+			case types.BoolFamily:
+				buffers := d.Buffers()
+				// Nulls are always stored in the first buffer whereas the
+				// second one is the byte representation of the boolean vector
+				// (where each byte corresponds to a single bool value), so we
+				// need to unsafely cast from []byte to []bool.
+				nullsBitmap, bytes := buffers[0].Bytes(), buffers[1].Bytes()
+				vec.Nulls().SetNullBitmap(nullsBitmap, batchLength)
+				bytesHeader := (*reflect.SliceHeader)(unsafe.Pointer(&bytes))
+				var bools coldata.Bools
+				boolsHeader := (*reflect.SliceHeader)(unsafe.Pointer(&bools))
+				boolsHeader.Data = bytesHeader.Data
+				boolsHeader.Len = batchLength
+				boolsHeader.Cap = batchLength
+				col = bools[:batchLength:batchLength]
 			case types.IntFamily:
 				switch typ.Width() {
 				case 16:
@@ -549,42 +507,23 @@ func (c *ArrowBatchConverter) ArrowToBatch(
 	return nil
 }
 
-// deserializeArrowIntoBytes deserializes some arrow data into the given
-// Bytes structure, adding any nulls to the given null bitmap.
-func deserializeArrowIntoBytes(
-	d *array.Data, nulls *coldata.Nulls, bytes *coldata.Bytes, batchLength int,
-) {
+// getValueBytesAndOffsets picks into d and returns two of the three buffers
+// (the values and the offsets). The remaining buffer that corresponds to the
+// null bitmap is not returned since the passed-in nulls are updated in place.
+func getValueBytesAndOffsets(
+	d *array.Data, nulls *coldata.Nulls, batchLength int,
+) ([]byte, []int32) {
 	bytesArr := array.NewBinaryData(d)
 	nulls.SetNullBitmap(bytesArr.NullBitmapBytes(), batchLength)
-	b := bytesArr.ValueBytes()
-	if b == nil {
+	valueBytes := bytesArr.ValueBytes()
+	if valueBytes == nil {
 		// All bytes values are empty, so the representation is solely with the
 		// offsets slice, so create an empty slice so that the conversion
 		// corresponds.
-		b = make([]byte, 0)
+		valueBytes = make([]byte, 0)
 	}
-	// Cap the data and offsets slices explicitly to protect against possible
-	// corruption of the memory region that is after the arrow data for this
-	// Bytes vector.
-	//
-	// Consider the following scenario: a batch with two Bytes vectors is
-	// serialized. Say
-	// - the first vector is {data:[foo], offsets:[0, 3]}
-	// - the second vector is {data:[bar], offsets:[0, 3]}.
-	// After serializing both of them we will have a flat buffer with something
-	// like:
-	//   buf = {1foo031bar03} (ones represent the lengths of each vector).
-	// Now, when the first vector is being deserialized, it's data slice will be
-	// something like:
-	//   data = [foo031bar03], len(data) = 3, cap(data) > 3.
-	// If we don't explicitly cap the slice and deserialize it into a Bytes
-	// vector, then later when we append to that vector, we will overwrite the
-	// data that is actually a part of the second serialized vector, thus,
-	// corrupting it (or the next batch).
 	offsets := bytesArr.ValueOffsets()
-	b = b[:len(b):len(b)]
-	offsets = offsets[:len(offsets):len(offsets)]
-	coldata.BytesFromArrowSerializationFormat(bytes, b, offsets)
+	return valueBytes, offsets[:batchLength+1]
 }
 
 // Release should be called once the converter is no longer needed so that its

--- a/pkg/col/colserde/arrowbatchconverter.go
+++ b/pkg/col/colserde/arrowbatchconverter.go
@@ -28,7 +28,7 @@ import (
 )
 
 // ArrowBatchConverter converts batches to arrow column data
-// ([]*array.Data) and back again.
+// ([]array.Data) and back again.
 type ArrowBatchConverter struct {
 	typs []*types.T
 
@@ -43,35 +43,47 @@ type ArrowBatchConverter struct {
 	scratch struct {
 		// arrowData is used as scratch space returned as the corresponding
 		// conversion result.
-		arrowData []*array.Data
-		// buffers is scratch space for exactly two buffers per element in
+		arrowData []array.Data
+		// buffers is scratch space for two or three buffers per element in
 		// arrowData.
 		buffers [][]*memory.Buffer
 	}
 }
 
-// NewArrowBatchConverter converts coldata.Batches to []*array.Data and back
+// NewArrowBatchConverter converts coldata.Batches to []array.Data and back
 // again according to the schema specified by typs. Converting data that does
 // not conform to typs results in undefined behavior.
 func NewArrowBatchConverter(typs []*types.T) (*ArrowBatchConverter, error) {
 	c := &ArrowBatchConverter{typs: typs}
 	c.builders.boolBuilder = array.NewBooleanBuilder(memory.DefaultAllocator)
-	c.scratch.arrowData = make([]*array.Data, len(typs))
+	c.scratch.arrowData = make([]array.Data, len(typs))
 	c.scratch.buffers = make([][]*memory.Buffer, len(typs))
-	for i := range c.scratch.buffers {
-		// Some types need only two buffers: one for the nulls, and one for the
-		// values, but others (i.e. Bytes) need an extra buffer for the
-		// offsets.
-		c.scratch.buffers[i] = make([]*memory.Buffer, 0, 3)
+	// Calculate the number of buffers needed for all types to be able to batch
+	// allocate them below.
+	var numBuffersTotal int
+	for _, t := range typs {
+		numBuffersTotal += numBuffersForType(t)
+	}
+	slicesOfBuffers := make([]*memory.Buffer, numBuffersTotal)
+	buffers := make([]memory.Buffer, numBuffersTotal)
+	var buffersIdx int
+	for i, t := range typs {
+		n := numBuffersForType(t)
+		c.scratch.buffers[i] = slicesOfBuffers[:n:n]
+		slicesOfBuffers = slicesOfBuffers[n:]
+		for j := range c.scratch.buffers[i] {
+			c.scratch.buffers[i][j] = &buffers[buffersIdx]
+			buffersIdx++
+		}
 	}
 	return c, nil
 }
 
 // BatchToArrow converts the first batch.Length elements of the batch into an
-// arrow []*array.Data. It is assumed that the batch is not larger than
-// coldata.BatchSize(). The returned []*array.Data may only be used until the
+// arrow []array.Data. It is assumed that the batch is not larger than
+// coldata.BatchSize(). The returned []array.Data may only be used until the
 // next call to BatchToArrow.
-func (c *ArrowBatchConverter) BatchToArrow(batch coldata.Batch) ([]*array.Data, error) {
+func (c *ArrowBatchConverter) BatchToArrow(batch coldata.Batch) ([]array.Data, error) {
 	if batch.Width() != len(c.typs) {
 		return nil, errors.AssertionFailedf("mismatched batch width and schema length: %d != %d", batch.Width(), len(c.typs))
 	}
@@ -89,7 +101,7 @@ func (c *ArrowBatchConverter) BatchToArrow(batch coldata.Batch) ([]*array.Data, 
 		// Bools require special handling.
 		if typ.Family() == types.BoolFamily {
 			c.builders.boolBuilder.AppendValues(vec.Bool()[:n], nil /* valid */)
-			c.scratch.arrowData[vecIdx] = c.builders.boolBuilder.NewBooleanArray().Data()
+			c.scratch.arrowData[vecIdx] = *c.builders.boolBuilder.NewBooleanArray().Data()
 			// Overwrite incorrect null bitmap (that has all values as "valid")
 			// with the actual null bitmap. Note that if we actually don't have
 			// any nulls, we use a bitmap with zero length for it in order to
@@ -98,7 +110,7 @@ func (c *ArrowBatchConverter) BatchToArrow(batch coldata.Batch) ([]*array.Data, 
 			if nulls != nil {
 				arrowBitmap = nulls.NullBitmap()
 			}
-			c.scratch.arrowData[vecIdx].Buffers()[0] = memory.NewBufferBytes(arrowBitmap)
+			c.scratch.arrowData[vecIdx].Buffers()[0].Reset(arrowBitmap)
 			continue
 		}
 
@@ -254,12 +266,13 @@ func (c *ArrowBatchConverter) BatchToArrow(batch coldata.Batch) ([]*array.Data, 
 
 		// Construct the underlying arrow buffers.
 		// WARNING: The ordering of construction is critical.
-		c.scratch.buffers[vecIdx] = c.scratch.buffers[vecIdx][:0]
-		c.scratch.buffers[vecIdx] = append(c.scratch.buffers[vecIdx], memory.NewBufferBytes(arrowBitmap))
+		c.scratch.buffers[vecIdx][0].Reset(arrowBitmap)
+		bufferIdx := 1
 		if offsetsBytes != nil {
-			c.scratch.buffers[vecIdx] = append(c.scratch.buffers[vecIdx], memory.NewBufferBytes(offsetsBytes))
+			c.scratch.buffers[vecIdx][1].Reset(offsetsBytes)
+			bufferIdx++
 		}
-		c.scratch.buffers[vecIdx] = append(c.scratch.buffers[vecIdx], memory.NewBufferBytes(values))
+		c.scratch.buffers[vecIdx][bufferIdx].Reset(values)
 
 		// Create the data from the buffers. It might be surprising that we don't
 		// set a type or a null count, but these fields are not used in the way that
@@ -267,7 +280,7 @@ func (c *ArrowBatchConverter) BatchToArrow(batch coldata.Batch) ([]*array.Data, 
 		// information is inferred from the ArrowBatchConverter schema, null count
 		// is an optimization we can use when working with nulls, and childData is
 		// only used for nested types like Lists, Structs, or Unions.
-		c.scratch.arrowData[vecIdx] = array.NewData(
+		c.scratch.arrowData[vecIdx].Reset(
 			nil /* dtype */, n, c.scratch.buffers[vecIdx], nil /* childData */, 0 /* nulls */, 0, /* offset */
 		)
 	}
@@ -285,9 +298,8 @@ func unsafeCastOffsetsArray(offsetsInt32 []int32, offsetsBytes *[]byte) {
 	bytesHeader.Cap = int32Header.Cap * int(memsize.Int32)
 }
 
-// ArrowToBatch converts []*array.Data to a coldata.Batch. There must not be
-// more than coldata.BatchSize() elements in data. It's safe to call ArrowToBatch
-// concurrently.
+// ArrowToBatch converts []array.Data to a coldata.Batch. There must not be
+// more than coldata.BatchSize() elements in data.
 //
 // The passed in batch is overwritten, but after this method returns it stays
 // valid as long as `data` stays valid. Callers can use this to control the
@@ -297,7 +309,7 @@ func unsafeCastOffsetsArray(offsetsInt32 []int32, offsetsBytes *[]byte) {
 // The passed in data is also mutated (we store nulls differently than arrow and
 // the adjustment is done in place).
 func (c *ArrowBatchConverter) ArrowToBatch(
-	data []*array.Data, batchLength int, b coldata.Batch,
+	data []array.Data, batchLength int, b coldata.Batch,
 ) error {
 	if len(data) != len(c.typs) {
 		return errors.Errorf("mismatched data and schema length: %d != %d", len(data), len(c.typs))
@@ -305,20 +317,15 @@ func (c *ArrowBatchConverter) ArrowToBatch(
 
 	for i, typ := range c.typs {
 		vec := b.ColVec(i)
-		d := data[i]
-
-		// Eagerly release our data references to make sure they can be collected
-		// as quickly as possible as we copy each (or simply reference each) by
-		// coldata.Vecs below.
-		data[i] = nil
+		d := &data[i]
 
 		switch typeconv.TypeFamilyToCanonicalTypeFamily(typ.Family()) {
 		case types.BoolFamily:
 			boolArr := array.NewBooleanData(d)
 			vec.Nulls().SetNullBitmap(boolArr.NullBitmapBytes(), batchLength)
 			vecArr := vec.Bool()
-			for i := 0; i < boolArr.Len(); i++ {
-				vecArr[i] = boolArr.Value(i)
+			for j := 0; j < boolArr.Len(); j++ {
+				vecArr[j] = boolArr.Value(j)
 			}
 
 		case types.BytesFamily:
@@ -347,9 +354,9 @@ func (c *ArrowBatchConverter) ArrowToBatch(
 			}
 			offsets := bytesArr.ValueOffsets()
 			vecArr := vec.Decimal()
-			for i := 0; i < len(offsets)-1; i++ {
-				if nulls == nil || !nulls.NullAt(i) {
-					if err := vecArr[i].UnmarshalText(bytes[offsets[i]:offsets[i+1]]); err != nil {
+			for j := 0; j < len(offsets)-1; j++ {
+				if nulls == nil || !nulls.NullAt(j) {
+					if err := vecArr[j].UnmarshalText(bytes[offsets[j]:offsets[j+1]]); err != nil {
 						return err
 					}
 				}
@@ -375,9 +382,9 @@ func (c *ArrowBatchConverter) ArrowToBatch(
 			}
 			offsets := bytesArr.ValueOffsets()
 			vecArr := vec.Timestamp()
-			for i := 0; i < len(offsets)-1; i++ {
-				if nulls == nil || !nulls.NullAt(i) {
-					if err := vecArr[i].UnmarshalBinary(bytes[offsets[i]:offsets[i+1]]); err != nil {
+			for j := 0; j < len(offsets)-1; j++ {
+				if nulls == nil || !nulls.NullAt(j) {
+					if err := vecArr[j].UnmarshalBinary(bytes[offsets[j]:offsets[j+1]]); err != nil {
 						return err
 					}
 				}
@@ -403,11 +410,11 @@ func (c *ArrowBatchConverter) ArrowToBatch(
 			}
 			offsets := bytesArr.ValueOffsets()
 			vecArr := vec.Interval()
-			for i := 0; i < len(offsets)-1; i++ {
-				if nulls == nil || !nulls.NullAt(i) {
-					intervalBytes := bytes[offsets[i]:offsets[i+1]]
+			for j := 0; j < len(offsets)-1; j++ {
+				if nulls == nil || !nulls.NullAt(j) {
+					intervalBytes := bytes[offsets[j]:offsets[j+1]]
 					var err error
-					vecArr[i], err = duration.Decode(
+					vecArr[j], err = duration.Decode(
 						int64(binary.LittleEndian.Uint64(intervalBytes[0:memsize.Int64])),
 						int64(binary.LittleEndian.Uint64(intervalBytes[memsize.Int64:memsize.Int64*2])),
 						int64(binary.LittleEndian.Uint64(intervalBytes[memsize.Int64*2:memsize.Int64*3])),
@@ -436,9 +443,9 @@ func (c *ArrowBatchConverter) ArrowToBatch(
 			}
 			offsets := bytesArr.ValueOffsets()
 			vecArr := vec.Datum()
-			for i := 0; i < len(offsets)-1; i++ {
-				if nulls == nil || !nulls.NullAt(i) {
-					if err := vecArr.UnmarshalTo(i, bytes[offsets[i]:offsets[i+1]]); err != nil {
+			for j := 0; j < len(offsets)-1; j++ {
+				if nulls == nil || !nulls.NullAt(j) {
+					if err := vecArr.UnmarshalTo(j, bytes[offsets[j]:offsets[j+1]]); err != nil {
 						return err
 					}
 				}
@@ -486,6 +493,11 @@ func (c *ArrowBatchConverter) ArrowToBatch(
 			}
 			vec.SetCol(col)
 		}
+
+		// Eagerly release our data references to make sure they can be
+		// collected as quickly as possible as we copy each (or simply reference
+		// each) by coldata.Vecs above.
+		data[i] = array.Data{}
 	}
 	b.SetSelection(false)
 	b.SetLength(batchLength)

--- a/pkg/col/colserde/arrowbatchconverter.go
+++ b/pkg/col/colserde/arrowbatchconverter.go
@@ -40,6 +40,7 @@ type ArrowBatchConverter struct {
 		boolBuilder *array.BooleanBuilder
 	}
 
+	// TODO(yuzefovich): perform memory accounting for these slices.
 	scratch struct {
 		// arrowData is used as scratch space returned as the corresponding
 		// conversion result.
@@ -47,6 +48,13 @@ type ArrowBatchConverter struct {
 		// buffers is scratch space for two or three buffers per element in
 		// arrowData.
 		buffers [][]*memory.Buffer
+		// values and offsets will only be populated if there is at least one
+		// type that needs three buffers. If populated, then vecIdx'th elements
+		// of the slices will store the values and offsets, respectively, of the
+		// last serialized representation of vecIdx'th vector which allows us to
+		// reuse the same memory across BatchToArrow calls.
+		values  [][]byte
+		offsets [][]int32
 	}
 }
 
@@ -55,14 +63,19 @@ type ArrowBatchConverter struct {
 // not conform to typs results in undefined behavior.
 func NewArrowBatchConverter(typs []*types.T) (*ArrowBatchConverter, error) {
 	c := &ArrowBatchConverter{typs: typs}
+	// TODO(yuzefovich): we can avoid all of the allocations below if the
+	// converter is only used in the arrow-to-batch direction.
 	c.builders.boolBuilder = array.NewBooleanBuilder(memory.DefaultAllocator)
 	c.scratch.arrowData = make([]array.Data, len(typs))
 	c.scratch.buffers = make([][]*memory.Buffer, len(typs))
 	// Calculate the number of buffers needed for all types to be able to batch
 	// allocate them below.
 	var numBuffersTotal int
+	var needOffsets bool
 	for _, t := range typs {
-		numBuffersTotal += numBuffersForType(t)
+		n := numBuffersForType(t)
+		numBuffersTotal += n
+		needOffsets = needOffsets || n == 3
 	}
 	slicesOfBuffers := make([]*memory.Buffer, numBuffersTotal)
 	buffers := make([]memory.Buffer, numBuffersTotal)
@@ -75,6 +88,10 @@ func NewArrowBatchConverter(typs []*types.T) (*ArrowBatchConverter, error) {
 			c.scratch.buffers[i][j] = &buffers[buffersIdx]
 			buffersIdx++
 		}
+	}
+	if needOffsets {
+		c.scratch.values = make([][]byte, len(typs))
+		c.scratch.offsets = make([][]int32, len(typs))
 	}
 	return c, nil
 }
@@ -157,22 +174,27 @@ func (c *ArrowBatchConverter) BatchToArrow(batch coldata.Batch) ([]array.Data, e
 			valuesHeader.Len = dataHeader.Len * int(datumSize)
 			valuesHeader.Cap = dataHeader.Cap * int(datumSize)
 		} else {
-			var offsets []int32
+			values = c.scratch.values[vecIdx][:0]
+			offsets := c.scratch.offsets[vecIdx][:0]
+			if cap(offsets) < n+1 {
+				offsets = make([]int32, 0, n+1)
+			}
 			switch f {
 			case types.BytesFamily:
-				values, offsets = vec.Bytes().ToArrowSerializationFormat(n)
+				values, offsets = vec.Bytes().ToArrowSerializationFormat(n, values, offsets)
 				unsafeCastOffsetsArray(offsets, &offsetsBytes)
 
 			case types.JsonFamily:
-				values, offsets = vec.JSON().Bytes.ToArrowSerializationFormat(n)
+				values, offsets = vec.JSON().Bytes.ToArrowSerializationFormat(n, values, offsets)
 				unsafeCastOffsetsArray(offsets, &offsetsBytes)
 
 			case types.DecimalFamily:
-				offsets = make([]int32, 0, n+1)
 				decimals := vec.Decimal()[:n]
-				// We don't know exactly how big a decimal will serialize to. Let's
-				// estimate 16 bytes.
-				values = make([]byte, 0, n*16)
+				// We don't know exactly how big a decimal will serialize to.
+				// Let's estimate 16 bytes.
+				if cap(values) < n*16 {
+					values = make([]byte, 0, n*16)
+				}
 				for i := range decimals {
 					offsets = append(offsets, int32(len(values)))
 					if nulls != nil && nulls.NullAt(i) {
@@ -186,12 +208,11 @@ func (c *ArrowBatchConverter) BatchToArrow(batch coldata.Batch) ([]array.Data, e
 				unsafeCastOffsetsArray(offsets, &offsetsBytes)
 
 			case types.IntervalFamily:
-				offsets = make([]int32, 0, n+1)
 				intervals := vec.Interval()[:n]
 				intervalSize := int(memsize.Int64) * 3
-				// TODO(jordan): we could right-size this values slice by counting up the
-				// number of nulls in the nulls bitmap first, and subtracting from n.
-				values = make([]byte, intervalSize*n)
+				if cap(values) < intervalSize*n {
+					values = make([]byte, intervalSize*n)
+				}
 				var curNonNullInterval int
 				for i := range intervals {
 					offsets = append(offsets, int32(curNonNullInterval*intervalSize))
@@ -213,11 +234,12 @@ func (c *ArrowBatchConverter) BatchToArrow(batch coldata.Batch) ([]array.Data, e
 				unsafeCastOffsetsArray(offsets, &offsetsBytes)
 
 			case types.TimestampTZFamily:
-				offsets = make([]int32, 0, n+1)
 				timestamps := vec.Timestamp()[:n]
 				// See implementation of time.MarshalBinary.
 				const timestampSize = 14
-				values = make([]byte, 0, n*timestampSize)
+				if cap(values) < n*timestampSize {
+					values = make([]byte, 0, n*timestampSize)
+				}
 				for i := range timestamps {
 					offsets = append(offsets, int32(len(values)))
 					if nulls != nil && nulls.NullAt(i) {
@@ -233,13 +255,14 @@ func (c *ArrowBatchConverter) BatchToArrow(batch coldata.Batch) ([]array.Data, e
 				unsafeCastOffsetsArray(offsets, &offsetsBytes)
 
 			case typeconv.DatumVecCanonicalTypeFamily:
-				offsets = make([]int32, 0, n+1)
 				datums := vec.Datum().Window(0 /* start */, n)
 				// Make a very very rough estimate of the number of bytes we'll have to
 				// allocate for the datums in this vector. This will likely be an
 				// undercount, but the estimate is better than nothing.
 				size, _ := tree.DatumTypeSize(typ)
-				values = make([]byte, 0, n*int(size))
+				if cap(values) < n*int(size) {
+					values = make([]byte, 0, n*int(size))
+				}
 				for i := 0; i < n; i++ {
 					offsets = append(offsets, int32(len(values)))
 					if nulls != nil && nulls.NullAt(i) {
@@ -257,6 +280,10 @@ func (c *ArrowBatchConverter) BatchToArrow(batch coldata.Batch) ([]array.Data, e
 			default:
 				panic(fmt.Sprintf("unsupported type for conversion to arrow data %s", typ))
 			}
+
+			// Store the serialized slices as scratch space for the next call.
+			c.scratch.values[vecIdx] = values
+			c.scratch.offsets[vecIdx] = offsets
 		}
 
 		var arrowBitmap []byte
@@ -540,4 +567,10 @@ func deserializeArrowIntoBytes(
 	b = b[:len(b):len(b)]
 	offsets = offsets[:len(offsets):len(offsets)]
 	coldata.BytesFromArrowSerializationFormat(bytes, b, offsets)
+}
+
+// Release should be called once the converter is no longer needed so that its
+// memory could be GCed.
+func (c *ArrowBatchConverter) Release() {
+	*c = ArrowBatchConverter{}
 }

--- a/pkg/col/colserde/arrowbatchconverter.go
+++ b/pkg/col/colserde/arrowbatchconverter.go
@@ -184,11 +184,11 @@ func (c *ArrowBatchConverter) BatchToArrow(batch coldata.Batch) ([]array.Data, e
 			}
 			switch f {
 			case types.BytesFamily:
-				values, offsets = vec.Bytes().ToArrowSerializationFormat(n, values, offsets)
+				values, offsets = vec.Bytes().Serialize(n, values, offsets)
 				unsafeCastOffsetsArray(offsets, &offsetsBytes)
 
 			case types.JsonFamily:
-				values, offsets = vec.JSON().Bytes.ToArrowSerializationFormat(n, values, offsets)
+				values, offsets = vec.JSON().Bytes.Serialize(n, values, offsets)
 				unsafeCastOffsetsArray(offsets, &offsetsBytes)
 
 			case types.DecimalFamily:
@@ -352,11 +352,11 @@ func (c *ArrowBatchConverter) ArrowToBatch(
 		switch typeconv.TypeFamilyToCanonicalTypeFamily(typ.Family()) {
 		case types.BytesFamily:
 			valueBytes, offsets := getValueBytesAndOffsets(d, vec.Nulls(), batchLength)
-			coldata.BytesFromArrowSerializationFormat(vec.Bytes(), valueBytes, offsets)
+			vec.Bytes().Deserialize(valueBytes, offsets)
 
 		case types.JsonFamily:
 			valueBytes, offsets := getValueBytesAndOffsets(d, vec.Nulls(), batchLength)
-			coldata.BytesFromArrowSerializationFormat(&vec.JSON().Bytes, valueBytes, offsets)
+			vec.JSON().Bytes.Deserialize(valueBytes, offsets)
 
 		case types.DecimalFamily:
 			// TODO(yuzefovich): this serialization is quite inefficient - improve

--- a/pkg/col/colserde/arrowbatchconverter.go
+++ b/pkg/col/colserde/arrowbatchconverter.go
@@ -27,6 +27,21 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// ConversionMode describes how ArrowBatchConverter will be utilized.
+type ConversionMode int
+
+const (
+	// BiDirectional indicates that both arrow-to-batch and batch-to-arrow
+	// conversions can happen.
+	BiDirectional ConversionMode = iota
+	// ArrowToBatchOnly indicates that only arrow-to-batch conversion can
+	// happen.
+	ArrowToBatchOnly
+	// BatchToArrowOnly indicates that only batch-to-arrow conversion can
+	// happen.
+	BatchToArrowOnly
+)
+
 // ArrowBatchConverter converts batches to arrow column data
 // ([]array.Data) and back again.
 type ArrowBatchConverter struct {
@@ -61,10 +76,13 @@ type ArrowBatchConverter struct {
 // NewArrowBatchConverter converts coldata.Batches to []array.Data and back
 // again according to the schema specified by typs. Converting data that does
 // not conform to typs results in undefined behavior.
-func NewArrowBatchConverter(typs []*types.T) (*ArrowBatchConverter, error) {
+func NewArrowBatchConverter(typs []*types.T, mode ConversionMode) (*ArrowBatchConverter, error) {
 	c := &ArrowBatchConverter{typs: typs}
-	// TODO(yuzefovich): we can avoid all of the allocations below if the
-	// converter is only used in the arrow-to-batch direction.
+	if mode == ArrowToBatchOnly {
+		// All the allocations below are only used in BatchToArrow, so we don't
+		// need to allocate them.
+		return c, nil
+	}
 	c.builders.boolBuilder = array.NewBooleanBuilder(memory.DefaultAllocator)
 	c.scratch.arrowData = make([]array.Data, len(typs))
 	c.scratch.buffers = make([][]*memory.Buffer, len(typs))

--- a/pkg/col/colserde/arrowbatchconverter_test.go
+++ b/pkg/col/colserde/arrowbatchconverter_test.go
@@ -47,7 +47,7 @@ func TestArrowBatchConverterRandom(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	typs, b := randomBatch(testAllocator)
-	c, err := colserde.NewArrowBatchConverter(typs)
+	c, err := colserde.NewArrowBatchConverter(typs, colserde.BiDirectional)
 	require.NoError(t, err)
 
 	// Make a copy of the original batch because the converter modifies and casts
@@ -100,7 +100,7 @@ func TestRecordBatchRoundtripThroughBytes(t *testing.T) {
 			typs, src = randomBatch(testAllocator)
 		}
 		dest := testAllocator.NewMemBatchWithMaxCapacity(typs)
-		c, err := colserde.NewArrowBatchConverter(typs)
+		c, err := colserde.NewArrowBatchConverter(typs, colserde.BiDirectional)
 		require.NoError(t, err)
 		r, err := colserde.NewRecordBatchSerializer(typs)
 		require.NoError(t, err)
@@ -219,7 +219,7 @@ func BenchmarkArrowBatchConverter(b *testing.B) {
 		b,
 		"BatchToArrow",
 		func(b *testing.B, batch coldata.Batch, typ *types.T) {
-			c, err := colserde.NewArrowBatchConverter([]*types.T{typ})
+			c, err := colserde.NewArrowBatchConverter([]*types.T{typ}, colserde.BiDirectional)
 			require.NoError(b, err)
 			var data []array.Data
 			b.ResetTimer()
@@ -235,7 +235,7 @@ func BenchmarkArrowBatchConverter(b *testing.B) {
 		},
 		"ArrowToBatch",
 		func(b *testing.B, batch coldata.Batch, typ *types.T) {
-			c, err := colserde.NewArrowBatchConverter([]*types.T{typ})
+			c, err := colserde.NewArrowBatchConverter([]*types.T{typ}, colserde.BiDirectional)
 			require.NoError(b, err)
 			data, err := c.BatchToArrow(batch)
 			dataCopy := make([]array.Data, len(data))

--- a/pkg/col/colserde/arrowbatchconverter_test.go
+++ b/pkg/col/colserde/arrowbatchconverter_test.go
@@ -77,7 +77,7 @@ func roundTripBatch(
 		return err
 	}
 
-	var arrowDataOut []*array.Data
+	var arrowDataOut []array.Data
 	batchLength, err := r.Deserialize(&arrowDataOut, buf.Bytes())
 	if err != nil {
 		return err
@@ -221,7 +221,7 @@ func BenchmarkArrowBatchConverter(b *testing.B) {
 		func(b *testing.B, batch coldata.Batch, typ *types.T) {
 			c, err := colserde.NewArrowBatchConverter([]*types.T{typ})
 			require.NoError(b, err)
-			var data []*array.Data
+			var data []array.Data
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				data, _ = c.BatchToArrow(batch)
@@ -238,7 +238,7 @@ func BenchmarkArrowBatchConverter(b *testing.B) {
 			c, err := colserde.NewArrowBatchConverter([]*types.T{typ})
 			require.NoError(b, err)
 			data, err := c.BatchToArrow(batch)
-			dataCopy := make([]*array.Data, len(data))
+			dataCopy := make([]array.Data, len(data))
 			require.NoError(b, err)
 			result := testAllocator.NewMemBatchWithMaxCapacity([]*types.T{typ})
 			b.ResetTimer()

--- a/pkg/col/colserde/conversion_test.go
+++ b/pkg/col/colserde/conversion_test.go
@@ -1,0 +1,98 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colserde_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/apache/arrow/go/arrow/array"
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/colserde"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkConversion(b *testing.B) {
+	createSerializer := func(typ *types.T) (*colserde.ArrowBatchConverter, *colserde.RecordBatchSerializer) {
+		c, err := colserde.NewArrowBatchConverter([]*types.T{typ})
+		require.NoError(b, err)
+		s, err := colserde.NewRecordBatchSerializer([]*types.T{typ})
+		require.NoError(b, err)
+		return c, s
+	}
+	runConversionBenchmarks(
+		b,
+		"Serialize",
+		func(b *testing.B, batch coldata.Batch, typ *types.T) {
+			c, s := createSerializer(typ)
+			var buf bytes.Buffer
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				data, _ := c.BatchToArrow(batch)
+				if len(data) != 1 {
+					b.Fatal("expected arrow batch of length 1")
+				}
+				if data[0].Len() != coldata.BatchSize() {
+					b.Fatal("unexpected number of elements")
+				}
+				buf.Reset()
+				_, _, err := s.Serialize(&buf, data, coldata.BatchSize())
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		},
+		"Deserialize",
+		func(b *testing.B, batch coldata.Batch, typ *types.T) {
+			var serialized []byte
+			{
+				c, s := createSerializer(typ)
+				var buf bytes.Buffer
+				data, _ := c.BatchToArrow(batch)
+				if len(data) != 1 {
+					b.Fatal("expected arrow batch of length 1")
+				}
+				if data[0].Len() != coldata.BatchSize() {
+					b.Fatal("unexpected number of elements")
+				}
+				_, _, err := s.Serialize(&buf, data, coldata.BatchSize())
+				if err != nil {
+					b.Fatal(err)
+				}
+				serialized = buf.Bytes()
+			}
+			c, err := colserde.NewArrowBatchConverter([]*types.T{typ})
+			require.NoError(b, err)
+			s, err := colserde.NewRecordBatchSerializer([]*types.T{typ})
+			require.NoError(b, err)
+			result := testAllocator.NewMemBatchWithMaxCapacity([]*types.T{typ})
+			var arrowScratch []*array.Data
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				arrowScratch = arrowScratch[:0]
+				batchLength, err := s.Deserialize(&arrowScratch, serialized)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if err = c.ArrowToBatch(arrowScratch, batchLength, result); err != nil {
+					b.Fatal(err)
+				}
+				if result.Width() != 1 {
+					b.Fatal("expected one column")
+				}
+				if result.Length() != coldata.BatchSize() {
+					b.Fatal("unexpected number of elements")
+				}
+			}
+		},
+	)
+}

--- a/pkg/col/colserde/conversion_test.go
+++ b/pkg/col/colserde/conversion_test.go
@@ -75,7 +75,7 @@ func BenchmarkConversion(b *testing.B) {
 			s, err := colserde.NewRecordBatchSerializer([]*types.T{typ})
 			require.NoError(b, err)
 			result := testAllocator.NewMemBatchWithMaxCapacity([]*types.T{typ})
-			var arrowScratch []*array.Data
+			var arrowScratch []array.Data
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				arrowScratch = arrowScratch[:0]

--- a/pkg/col/colserde/conversion_test.go
+++ b/pkg/col/colserde/conversion_test.go
@@ -23,7 +23,7 @@ import (
 
 func BenchmarkConversion(b *testing.B) {
 	createSerializer := func(typ *types.T) (*colserde.ArrowBatchConverter, *colserde.RecordBatchSerializer) {
-		c, err := colserde.NewArrowBatchConverter([]*types.T{typ})
+		c, err := colserde.NewArrowBatchConverter([]*types.T{typ}, colserde.BatchToArrowOnly)
 		require.NoError(b, err)
 		s, err := colserde.NewRecordBatchSerializer([]*types.T{typ})
 		require.NoError(b, err)
@@ -70,7 +70,7 @@ func BenchmarkConversion(b *testing.B) {
 				}
 				serialized = buf.Bytes()
 			}
-			c, err := colserde.NewArrowBatchConverter([]*types.T{typ})
+			c, err := colserde.NewArrowBatchConverter([]*types.T{typ}, colserde.ArrowToBatchOnly)
 			require.NoError(b, err)
 			s, err := colserde.NewRecordBatchSerializer([]*types.T{typ})
 			require.NoError(b, err)

--- a/pkg/col/colserde/file.go
+++ b/pkg/col/colserde/file.go
@@ -166,7 +166,7 @@ type FileDeserializer struct {
 	a    *ArrowBatchConverter
 	rb   *RecordBatchSerializer
 
-	arrowScratch []*array.Data
+	arrowScratch []array.Data
 }
 
 // NewFileDeserializerFromBytes constructs a FileDeserializer for an in-memory
@@ -214,7 +214,7 @@ func newFileDeserializer(
 	if d.rb, err = NewRecordBatchSerializer(typs); err != nil {
 		return nil, err
 	}
-	d.arrowScratch = make([]*array.Data, 0, len(typs))
+	d.arrowScratch = make([]array.Data, 0, len(typs))
 
 	return d, nil
 }

--- a/pkg/col/colserde/file.go
+++ b/pkg/col/colserde/file.go
@@ -152,6 +152,11 @@ func (s *FileSerializer) Finish() error {
 	return err
 }
 
+// Close releases the resources of the serializer.
+func (s *FileSerializer) Close() {
+	s.a.Release()
+}
+
 // FileDeserializer decodes columnar data batches from files encoded according
 // to the arrow spec.
 type FileDeserializer struct {
@@ -175,9 +180,9 @@ func NewFileDeserializerFromBytes(typs []*types.T, buf []byte) (*FileDeserialize
 	return newFileDeserializer(typs, buf, func() error { return nil })
 }
 
-// NewFileDeserializerFromPath constructs a FileDeserializer by reading it from
-// a file.
-func NewFileDeserializerFromPath(typs []*types.T, path string) (*FileDeserializer, error) {
+// NewTestFileDeserializerFromPath constructs a FileDeserializer by reading it
+// from a file. It is only used in tests.
+func NewTestFileDeserializerFromPath(typs []*types.T, path string) (*FileDeserializer, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, pgerror.Wrapf(err, pgcode.Io, `opening %s`, path)
@@ -221,6 +226,7 @@ func newFileDeserializer(
 
 // Close releases any resources held by this deserializer.
 func (d *FileDeserializer) Close() error {
+	d.a.Release()
 	return d.bufCloseFn()
 }
 

--- a/pkg/col/colserde/file.go
+++ b/pkg/col/colserde/file.go
@@ -56,7 +56,7 @@ type FileSerializer struct {
 // NewFileSerializer creates a FileSerializer for the given types. The caller is
 // responsible for closing the given writer.
 func NewFileSerializer(w io.Writer, typs []*types.T) (*FileSerializer, error) {
-	a, err := NewArrowBatchConverter(typs)
+	a, err := NewArrowBatchConverter(typs, BatchToArrowOnly)
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +213,7 @@ func newFileDeserializer(
 	}
 	d.typs = typs
 
-	if d.a, err = NewArrowBatchConverter(typs); err != nil {
+	if d.a, err = NewArrowBatchConverter(typs, ArrowToBatchOnly); err != nil {
 		return nil, err
 	}
 	if d.rb, err = NewRecordBatchSerializer(typs); err != nil {

--- a/pkg/col/colserde/file_test.go
+++ b/pkg/col/colserde/file_test.go
@@ -107,7 +107,7 @@ func TestFileRoundtrip(t *testing.T) {
 		for i := 0; i < 2; i++ {
 			func() {
 				roundtrip := testAllocator.NewMemBatchWithFixedCapacity(typs, b.Length())
-				d, err := colserde.NewFileDeserializerFromPath(typs, path)
+				d, err := colserde.NewTestFileDeserializerFromPath(typs, path)
 				require.NoError(t, err)
 				defer func() { require.NoError(t, d.Close()) }()
 				require.Equal(t, typs, d.Typs())

--- a/pkg/col/colserde/file_test.go
+++ b/pkg/col/colserde/file_test.go
@@ -65,7 +65,8 @@ func TestFileRoundtrip(t *testing.T) {
 				// batch) to make sure that the second serialized batch is
 				// unchanged.
 				length := rng.Intn(original.Length()) + 1
-				r := coldatatestutils.RandomBatch(testAllocator, rng, typs, length, length, rng.Float64())
+				args := coldatatestutils.RandomVecArgs{Rand: rng, NullProbability: rng.Float64()}
+				r := coldatatestutils.RandomBatch(testAllocator, args, typs, length, length)
 				for vecIdx, vec := range roundtrip.ColVecs() {
 					vec.Append(coldata.SliceArgs{
 						Src:       r.ColVec(vecIdx),

--- a/pkg/col/colserde/record_batch.go
+++ b/pkg/col/colserde/record_batch.go
@@ -32,6 +32,8 @@ const (
 
 // numBuffersForType returns how many buffers are used to represent an array of
 // the given type.
+//
+//gcassert:inline
 func numBuffersForType(t *types.T) int {
 	// Most types are represented by 3 memory.Buffers (because most types are
 	// serialized into flat bytes representation). One buffer for the null
@@ -96,7 +98,7 @@ func calculatePadding(numBytes int) int {
 // so users who wish to retain references to individual array.Data elements must
 // do so by making a copy elsewhere.
 func (s *RecordBatchSerializer) Serialize(
-	w io.Writer, data []*array.Data, headerLength int,
+	w io.Writer, data []array.Data, headerLength int,
 ) (metadataLen uint32, dataLen uint64, _ error) {
 	if len(data) != len(s.numBuffers) {
 		return 0, 0, errors.Errorf("mismatched schema length and number of columns: %d != %d", len(s.numBuffers), len(data))
@@ -216,7 +218,7 @@ func (s *RecordBatchSerializer) Serialize(
 			}
 		}
 		// Eagerly discard the buffer; we have no use for it any longer.
-		data[i] = nil
+		data[i] = array.Data{}
 	}
 
 	// Add body padding. The body also needs to be a multiple of 8 bytes.
@@ -230,7 +232,7 @@ func (s *RecordBatchSerializer) Serialize(
 // into data and returns the length of the batch. Deserializing a schema that
 // does not match the schema given in NewRecordBatchSerializer results in
 // undefined behavior.
-func (s *RecordBatchSerializer) Deserialize(data *[]*array.Data, bytes []byte) (int, error) {
+func (s *RecordBatchSerializer) Deserialize(data *[]array.Data, bytes []byte) (int, error) {
 	// Read the metadata by first reading its length.
 	metadataLen := int(binary.LittleEndian.Uint32(bytes[:metadataLengthNumBytes]))
 	metadata := arrowserde.GetRootAsMessage(
@@ -285,6 +287,7 @@ func (s *RecordBatchSerializer) Deserialize(data *[]*array.Data, bytes []byte) (
 
 		// Decode the message body by using the offset and length information in the
 		// message header.
+		// TODO(yuzefovich): reuse these buffers across Deserialize calls.
 		buffers := make([]*memory.Buffer, s.numBuffers[fieldIdx])
 		for i := 0; i < s.numBuffers[fieldIdx]; i++ {
 			header.Buffers(&buf, bufferIdx)
@@ -301,7 +304,7 @@ func (s *RecordBatchSerializer) Deserialize(data *[]*array.Data, bytes []byte) (
 
 		*data = append(
 			*data,
-			array.NewData(
+			*array.NewData(
 				nil, /* dType */
 				int(header.Length()),
 				buffers,

--- a/pkg/col/colserde/record_batch_test.go
+++ b/pkg/col/colserde/record_batch_test.go
@@ -346,7 +346,7 @@ func TestRecordBatchSerializerDeserializeMemoryEstimate(t *testing.T) {
 	}
 	src.SetLength(coldata.BatchSize())
 
-	c, err := colserde.NewArrowBatchConverter(typs)
+	c, err := colserde.NewArrowBatchConverter(typs, colserde.BiDirectional)
 	require.NoError(t, err)
 	r, err := colserde.NewRecordBatchSerializer(typs)
 	require.NoError(t, err)

--- a/pkg/sql/colcontainer/diskqueue.go
+++ b/pkg/sql/colcontainer/diskqueue.go
@@ -436,6 +436,7 @@ func (d *diskQueue) Close(ctx context.Context) error {
 		if err := d.writeFooterAndFlush(ctx); err != nil {
 			return err
 		}
+		d.serializer.Close()
 		d.serializer = nil
 	}
 	if err := d.closeFileDeserializer(); err != nil {

--- a/pkg/sql/colcontainer/diskqueue_test.go
+++ b/pkg/sql/colcontainer/diskqueue_test.go
@@ -232,7 +232,8 @@ func BenchmarkDiskQueue(b *testing.B) {
 
 	rng, _ := randutil.NewTestRand()
 	typs := []*types.T{types.Int}
-	batch := coldatatestutils.RandomBatch(testAllocator, rng, typs, coldata.BatchSize(), 0, 0)
+	args := coldatatestutils.RandomVecArgs{Rand: rng}
+	batch := coldatatestutils.RandomBatch(testAllocator, args, typs, coldata.BatchSize(), 0 /* length */)
 	op := colexecop.NewRepeatableBatchSource(testAllocator, batch, typs)
 	ctx := context.Background()
 	for i := 0; i < b.N; i++ {

--- a/pkg/sql/colexec/colexecutils/spilling_queue_test.go
+++ b/pkg/sql/colexec/colexecutils/spilling_queue_test.go
@@ -370,7 +370,8 @@ func TestSpillingQueueMemoryAccounting(t *testing.T) {
 
 			numInputBatches := int(spillingQueueInitialItemsLen)*(1+rng.Intn(4)) + rng.Intn(int(spillingQueueInitialItemsLen))
 			numDequeuedBatches := 0
-			batch := coldatatestutils.RandomBatch(testAllocator, rng, typs, coldata.BatchSize(), coldata.BatchSize(), 0.1 /* nullProbability */)
+			args := coldatatestutils.RandomVecArgs{Rand: rng, NullProbability: 0.1}
+			batch := coldatatestutils.RandomBatch(testAllocator, args, typs, coldata.BatchSize(), coldata.BatchSize())
 			batchSize := colmem.GetBatchMemSize(batch)
 			getExpectedMemUsage := func(numEnqueuedBatches int) int64 {
 				batchesAccountedFor := numEnqueuedBatches

--- a/pkg/sql/colexec/parallel_unordered_synchronizer_test.go
+++ b/pkg/sql/colexec/parallel_unordered_synchronizer_test.go
@@ -78,7 +78,8 @@ func TestParallelUnorderedSynchronizer(t *testing.T) {
 	inputs := make([]colexecargs.OpWithMetaInfo, numInputs)
 	for i := range inputs {
 		var source colexecop.Operator
-		batch := coldatatestutils.RandomBatch(testAllocator, rng, typs, coldata.BatchSize(), 0 /* length */, rng.Float64())
+		args := coldatatestutils.RandomVecArgs{Rand: rng, NullProbability: rng.Float64()}
+		batch := coldatatestutils.RandomBatch(testAllocator, args, typs, coldata.BatchSize(), 0 /* length */)
 		if i < numInputs-1 {
 			s := colexecop.NewRepeatableBatchSource(testAllocator, batch, typs)
 			s.ResetBatchesToReturn(numBatches)

--- a/pkg/sql/colexec/serial_unordered_synchronizer_test.go
+++ b/pkg/sql/colexec/serial_unordered_synchronizer_test.go
@@ -40,7 +40,8 @@ func TestSerialUnorderedSynchronizer(t *testing.T) {
 	typs := []*types.T{types.Int}
 	inputs := make([]colexecargs.OpWithMetaInfo, numInputs)
 	for i := range inputs {
-		batch := coldatatestutils.RandomBatch(testAllocator, rng, typs, coldata.BatchSize(), 0 /* length */, rng.Float64())
+		args := coldatatestutils.RandomVecArgs{Rand: rng, NullProbability: rng.Float64()}
+		batch := coldatatestutils.RandomBatch(testAllocator, args, typs, coldata.BatchSize(), 0 /* length */)
 		source := colexecop.NewRepeatableBatchSource(testAllocator, batch, typs)
 		source.ResetBatchesToReturn(numBatches)
 		inputIdx := i

--- a/pkg/sql/colexec/types_integration_test.go
+++ b/pkg/sql/colexec/types_integration_test.go
@@ -155,7 +155,7 @@ func (a *arrowTestOperator) Next() coldata.Batch {
 	if err != nil {
 		colexecerror.InternalError(err)
 	}
-	var arrowDataOut []*array.Data
+	var arrowDataOut []array.Data
 	batchLength, err := a.r.Deserialize(&arrowDataOut, buf.Bytes())
 	if err != nil {
 		colexecerror.InternalError(err)

--- a/pkg/sql/colexec/types_integration_test.go
+++ b/pkg/sql/colexec/types_integration_test.go
@@ -81,7 +81,7 @@ func TestSQLTypesIntegration(t *testing.T) {
 
 			columnarizer := NewBufferingColumnarizerForTests(testAllocator, flowCtx, 0 /* processorID */, source)
 
-			c, err := colserde.NewArrowBatchConverter(typs)
+			c, err := colserde.NewArrowBatchConverter(typs, colserde.BiDirectional)
 			require.NoError(t, err)
 			r, err := colserde.NewRecordBatchSerializer(typs)
 			require.NoError(t, err)

--- a/pkg/sql/colflow/colrpc/inbox.go
+++ b/pkg/sql/colflow/colrpc/inbox.go
@@ -123,7 +123,7 @@ type Inbox struct {
 	deserializationStopWatch *timeutil.StopWatch
 
 	scratch struct {
-		data []*array.Data
+		data []array.Data
 		b    coldata.Batch
 	}
 }
@@ -154,7 +154,7 @@ func NewInbox(
 		errCh:                    make(chan error, 1),
 		deserializationStopWatch: timeutil.NewStopWatch(),
 	}
-	i.scratch.data = make([]*array.Data, len(typs))
+	i.scratch.data = make([]array.Data, len(typs))
 	return i, nil
 }
 

--- a/pkg/sql/colflow/colrpc/inbox.go
+++ b/pkg/sql/colflow/colrpc/inbox.go
@@ -485,8 +485,10 @@ func (i *Inbox) DrainMeta() []execinfrapb.ProducerMetadata {
 	// Eagerly lose the reference to the metadata since it might be of
 	// non-trivial footprint.
 	i.bufferedMeta = nil
-	// We also no longer need the scratch batch.
+	// We also no longer need the scratch batch nor the arrow-to-batch
+	// converter.
 	i.scratch.b = nil
+	i.converter.Release()
 	// The allocator tracks the memory usage for a few things (the scratch batch
 	// as well as the metadata), and when this function returns, we no longer
 	// reference any of those, so we can release all of the allocations.

--- a/pkg/sql/colflow/colrpc/inbox.go
+++ b/pkg/sql/colflow/colrpc/inbox.go
@@ -134,7 +134,7 @@ var _ colexecop.Operator = &Inbox{}
 func NewInbox(
 	allocator *colmem.Allocator, typs []*types.T, streamID execinfrapb.StreamID,
 ) (*Inbox, error) {
-	c, err := colserde.NewArrowBatchConverter(typs)
+	c, err := colserde.NewArrowBatchConverter(typs, colserde.ArrowToBatchOnly)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/colflow/colrpc/inbox_test.go
+++ b/pkg/sql/colflow/colrpc/inbox_test.go
@@ -279,7 +279,7 @@ func TestInboxShutdown(t *testing.T) {
 					defer inboxMemAccount.Close(inboxCtx)
 					inbox, err := NewInbox(colmem.NewAllocator(inboxCtx, &inboxMemAccount, coldata.StandardColumnFactory), typs, execinfrapb.StreamID(0))
 					require.NoError(t, err)
-					c, err := colserde.NewArrowBatchConverter(typs)
+					c, err := colserde.NewArrowBatchConverter(typs, colserde.BatchToArrowOnly)
 					require.NoError(t, err)
 					r, err := colserde.NewRecordBatchSerializer(typs)
 					require.NoError(t, err)

--- a/pkg/sql/colflow/colrpc/inbox_test.go
+++ b/pkg/sql/colflow/colrpc/inbox_test.go
@@ -219,7 +219,8 @@ func TestInboxShutdown(t *testing.T) {
 		nextSleep          = time.Millisecond * time.Duration(rng.Intn(10))
 		runWithStreamSleep = time.Millisecond * time.Duration(rng.Intn(10))
 		typs               = []*types.T{types.Int}
-		batch              = coldatatestutils.RandomBatch(testAllocator, rng, typs, coldata.BatchSize(), 0 /* length */, rng.Float64())
+		args               = coldatatestutils.RandomVecArgs{Rand: rng, NullProbability: rng.Float64()}
+		batch              = coldatatestutils.RandomBatch(testAllocator, args, typs, coldata.BatchSize(), 0 /* length */)
 	)
 
 	// drainMetaScenario specifies when DrainMeta should be called in the Next

--- a/pkg/sql/colflow/colrpc/outbox.go
+++ b/pkg/sql/colflow/colrpc/outbox.go
@@ -89,7 +89,7 @@ func NewOutbox(
 	typs []*types.T,
 	getStats func(context.Context) []*execinfrapb.ComponentStats,
 ) (*Outbox, error) {
-	c, err := colserde.NewArrowBatchConverter(typs)
+	c, err := colserde.NewArrowBatchConverter(typs, colserde.BatchToArrowOnly)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/colflow/colrpc/outbox.go
+++ b/pkg/sql/colflow/colrpc/outbox.go
@@ -116,6 +116,7 @@ func NewOutbox(
 func (o *Outbox) close() {
 	o.scratch.buf = nil
 	o.scratch.msg = nil
+	o.converter.Release()
 	// Unset the input (which is a deselector operator) so that its output batch
 	// could be garbage collected. This allows us to release all memory
 	// registered with the allocator (the allocator is shared by the outbox and

--- a/pkg/sql/execinfra/version.go
+++ b/pkg/sql/execinfra/version.go
@@ -64,17 +64,20 @@ import "github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 //
 // ATTENTION: When updating these fields, add a brief description of what
 // changed to the version history below.
-const Version execinfrapb.DistSQLVersion = 70
+const Version execinfrapb.DistSQLVersion = 71
 
 // MinAcceptedVersion is the oldest version that the server is compatible with.
 // A server will not accept flows with older versions.
-const MinAcceptedVersion execinfrapb.DistSQLVersion = 70
+const MinAcceptedVersion execinfrapb.DistSQLVersion = 71
 
 /*
 
 **  VERSION HISTORY **
 
 Please add new entries at the top.
+
+- Version: 71 (MinAcceptedVersion: 71)
+  - On-wire representation of booleans in the Arrow format has changed.
 
 - Version: 70 (MinAcceptedVersion: 70)
   - HashGroupJoinerSpec has been introduced.

--- a/pkg/sql/execinfra/version.go
+++ b/pkg/sql/execinfra/version.go
@@ -77,7 +77,8 @@ const MinAcceptedVersion execinfrapb.DistSQLVersion = 71
 Please add new entries at the top.
 
 - Version: 71 (MinAcceptedVersion: 71)
-  - On-wire representation of booleans in the Arrow format has changed.
+  - On-wire representation of booleans and bytes-like values in the Arrow format
+    has changed.
 
 - Version: 70 (MinAcceptedVersion: 70)
   - HashGroupJoinerSpec has been introduced.

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -2000,6 +2000,7 @@ func TestLint(t *testing.T) {
 
 		gcassertPaths := []string{
 			"../../col/coldata",
+			"../../col/colserde",
 			"../../keys",
 			"../../kv/kvclient/rangecache",
 			"../../roachpb",


### PR DESCRIPTION
This PR contains several commits that optimize the arrow batch converter (mostly in the batch-to-arrow direction). Please see each commit for details.

The comparison of all benchmarks in `colserde` package between the second and the last commits is [here](https://gist.github.com/yuzefovich/97c514b772e5bf1bc63f584203e6deaf).

Epic: CRDB-14837