### PR TITLE
build: use llvm-nm in place of nm

### DIFF
--- a/build/.bazelbuilderversion
+++ b/build/.bazelbuilderversion
@@ -1,1 +1,1 @@
-cockroachdb/bazel:20221215-030250
+cockroachdb/bazel:20230103-211452

--- a/build/bazelbuilder/Dockerfile
+++ b/build/bazelbuilder/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update \
     gnupg2 \
     libncurses-dev \
     libtinfo-dev \
+    llvm \
     lsof \
     make \
     netbase \
@@ -107,6 +108,10 @@ RUN case ${TARGETPLATFORM} in \
  && echo "$SHASUM /tmp/bazelisk" | sha256sum -c - \
  && chmod +x /tmp/bazelisk \
  && mv /tmp/bazelisk /usr/bin/bazel
+
+# Replace the nm command with LLVM's version, llvm-nm, which knows how to read
+# binaries build for platforms others than Linux.
+RUN ln -sf /usr/bin/llvm-nm /usr/bin/nm
 
 RUN rm -rf /tmp/* /var/lib/apt/lists/*
 

--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image=cockroachdb/builder
-version=20221219-170552
+version=20230103-212639
 
 function init() {
   docker build --tag="${image}" "$(dirname "${0}")/builder"

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update \
     git \
     gnupg2 \
     libncurses-dev \
+    llvm \
     make \
     patch \
     patchelf \
@@ -197,6 +198,10 @@ RUN apt-get purge -y \
     rsync \
     texinfo \
  && apt-get autoremove -y
+
+# Replace the nm command with LLVM's version, llvm-nm, which knows how to read
+# binaries build for platforms others than Linux.
+RUN ln -sf /usr/bin/llvm-nm /usr/bin/nm
 
 RUN rm -rf /tmp/* /var/lib/apt/lists/*
 


### PR DESCRIPTION
Currently, the build containers contain the standard GNU version of `nm`. This version of the tool is sufficient for the current build, which does not need to directly interact with binaries cross compiled for platforms other than Linux.

When pulling in the latest version of `jemalloc` (`5.3.0`), builds for cross compiled for macOS requiring using `nm` to perform name mangling. As the GNU version of `nm` in the Linux build container does not know how to read Macho-O binaries, the name mangling does not occur, and the Cockroach binary will fail to link.

Use the version of `nm` that ships with LLVM (`llvm-nm`) in place of GNU `nm`. This version of `nm` can understand Macho-O binaries and perform the name mangling as intended, resolving the linking issue.

Touches #83289.

Informs #93045.

Release note: None.

Epic: CRDB-20293