### PR TITLE
tree: fix regression in type-checking arrays with placeholders

### DIFF
--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -2436,9 +2436,11 @@ func typeCheckSameTypedExprs(
 			case !constIdxs.Empty():
 				return typeCheckConstsAndPlaceholdersWithDesired(s, desired)
 			case !placeholderIdxs.Empty():
-				next, _ := placeholderIdxs.Next(0)
-				p := s.exprs[next].(*Placeholder)
-				return nil, nil, placeholderTypeAmbiguityError(p.Idx)
+				typ, err := typeCheckSameTypedPlaceholders(s, desired)
+				if err != nil {
+					return nil, nil, err
+				}
+				return typedExprs, typ, nil
 			default:
 				if desired != types.Any {
 					return typedExprs, desired, nil


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/94192

Release note (bug fix): Fixed a bug that could happen when type-checking an array expression that only contains NULLs and placeholder values. The bug was only present in v22.2.1.