### PR TITLE
storage: require valid iterator for `RangeKeyChanged`

### DIFF
--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -204,7 +204,9 @@ type SimpleMVCCIterator interface {
 	// https://github.com/cockroachdb/cockroach/blob/master/docs/tech-notes/mvcc-range-tombstones.md
 	RangeKeys() MVCCRangeKeyStack
 	// RangeKeyChanged returns true if the previous seek or step moved to a
-	// different range key (or none at all). This includes an exhausted iterator.
+	// different range key (or none at all). Requires a valid iterator, but an
+	// exhausted iterator is considered to have had no range keys when calling
+	// this after repositioning.
 	RangeKeyChanged() bool
 }
 

--- a/pkg/storage/point_synthesizing_iter.go
+++ b/pkg/storage/point_synthesizing_iter.go
@@ -264,12 +264,13 @@ func (i *PointSynthesizingIter) updateIter() (bool, error) {
 		i.iterKey = i.iter.UnsafeKey()
 		i.atRangeKeysPos = (i.prefix && i.iterHasRange) ||
 			(!i.prefix && i.iterKey.Key.Equal(i.rangeKeysPos))
+		i.rangeKeyChanged = i.rangeKeyChanged || i.iter.RangeKeyChanged()
 	} else {
 		i.iterHasPoint, i.iterHasRange = false, false
 		i.iterKey = MVCCKey{}
 		i.atRangeKeysPos = false
+		// recall previous i.rangeKeyChanged state
 	}
-	i.rangeKeyChanged = i.rangeKeyChanged || i.iter.RangeKeyChanged()
 	return i.iterValid, i.iterErr
 }
 

--- a/pkg/storage/sst.go
+++ b/pkg/storage/sst.go
@@ -820,16 +820,13 @@ func CheckSSTConflicts(
 				for extOK && extIter.UnsafeKey().Key.Compare(sstIter.UnsafeKey().Key) < 0 {
 					extIter.NextKey()
 					extOK, _ = extIter.Valid()
-					rangeKeyChanged = rangeKeyChanged || extIter.RangeKeyChanged()
+					rangeKeyChanged = rangeKeyChanged || (extOK && extIter.RangeKeyChanged())
 					nextsUntilSeek--
 					if nextsUntilSeek <= 0 {
 						break
 					}
 				}
-				// TODO(erikgrinaker): NextKey() may not trigger `RangeKeyChanged()`
-				// on an exhausted iterator, so we check the case where we stepped
-				// from an initial range key onto an exhausted iterator. See:
-				// https://github.com/cockroachdb/cockroach/issues/94041
+				// Handle moving from a range key to an exhausted iterator.
 				rangeKeyChanged = rangeKeyChanged || (!extOK && !extPrevRangeKeys.IsEmpty())
 				// If we havent't reached the SST key yet, seek to it. Otherwise, if we
 				// stepped past it but the range key changed we have to seek back to it,
@@ -899,16 +896,13 @@ func CheckSSTConflicts(
 					for extOK && extIter.UnsafeKey().Key.Compare(sstIter.UnsafeKey().Key) < 0 {
 						extIter.NextKey()
 						extOK, _ = extIter.Valid()
-						rangeKeyChanged = rangeKeyChanged || extIter.RangeKeyChanged()
+						rangeKeyChanged = rangeKeyChanged || (extOK && extIter.RangeKeyChanged())
 						nextsUntilSeek--
 						if nextsUntilSeek <= 0 {
 							break
 						}
 					}
-					// TODO(erikgrinaker): NextKey() may not trigger `RangeKeyChanged()`
-					// on an exhausted iterator, so we check the case where we stepped
-					// from an initial range key onto an exhausted iterator. See:
-					// https://github.com/cockroachdb/cockroach/issues/94041
+					// Handle moving from a range key to an exhausted iterator.
 					rangeKeyChanged = rangeKeyChanged || (!extOK && !extPrevRangeKeys.IsEmpty())
 					// If we havent't reached the SST key yet, seek to it. Otherwise, if we
 					// stepped past it but the range key changed we have to seek back to it,


### PR DESCRIPTION
This patch clarifies that `RangeKeyChanged` can only be called on a valid iterator, as well as the semantics when repositioning an exhausted iterator.

A couple of callers that violated this contract have been fixed, but these would not have caused correctness issues.

Touches #94040.
Touches #94041.
Touches https://github.com/cockroachdb/pebble/issues/2199.

Epic: none
Release note: None