### PR TITLE
settings: set correct min binary version in MakeTestingClusterSettings

### DIFF
--- a/pkg/settings/cluster/cluster_settings.go
+++ b/pkg/settings/cluster/cluster_settings.go
@@ -137,14 +137,14 @@ func MakeClusterSettings() *Settings {
 }
 
 // MakeTestingClusterSettings returns a Settings object that has its binary and
-// minimum supported versions set to the baked in binary version. It also
+// minimum supported versions set to the baked in testing versions. It also
 // initializes the cluster version setting to the binary version.
 //
 // It is typically used for testing or one-off situations in which a Settings
 // object is needed, but cluster settings don't play a crucial role.
 func MakeTestingClusterSettings() *Settings {
 	return MakeTestingClusterSettingsWithVersions(
-		clusterversion.TestingBinaryVersion, clusterversion.TestingBinaryVersion, true /* initializeVersion */)
+		clusterversion.TestingBinaryVersion, clusterversion.TestingBinaryMinSupportedVersion, true /* initializeVersion */)
 }
 
 // MakeTestingClusterSettingsWithVersions returns a Settings object that has its


### PR DESCRIPTION
Previously, MakeTestingClusterSettings initialized a handle with TestingBinaryVersion as both the binary version and minimum supported binary version. This change sets the minimum supported binary version to TestingBinaryMinSupportedVersion instead.

MakeTestingClusterSettings is meant to be used by tests that are not concerned with cluster settings, it is also the default settings object used when starting a test tenant SQL pod if `params.Settings` is not overriden. `TestingBinaryMinSupportVersion` seems like a better value to default to unless explicilty overriden.

Release note: None