### PR TITLE
roachtest: fix the follower read test

### DIFF
--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -477,7 +477,7 @@ func initFollowerReadsDB(
 		q1 := fmt.Sprintf(`
 			SELECT
 				%s, %s
-			FROM [SHOW RANGES FROM TABLE test]`, votersCol, nonVotersCol)
+			FROM [SHOW RANGES FROM TABLE test.test]`, votersCol, nonVotersCol)
 
 		var voters, nonVoters int
 		err := db.QueryRowContext(ctx, q1).Scan(&voters, &nonVoters)


### PR DESCRIPTION
Fixes #94225.
Fixes #94228.

The test does not have a current database set, so all table names need to be qualified.

Release note: None