### PR TITLE
roachtest: fix up ranges_no_leases fallout

### DIFF
--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -1295,10 +1295,11 @@ func (h *decommTestHelper) waitUpReplicated(
 		// Check to see that there are no ranges where the target node is
 		// not part of the replica set.
 		stmtReplicaCount := fmt.Sprintf(
-			"SELECT count(*) FROM crdb_internal.ranges "+
-				"WHERE array_position(replicas, %d) IS NULL and database_name = '%s';",
-			targetLogicalNodeID, database,
-		)
+			`SELECT count(*) FROM [ SHOW RANGES FROM DATABASE %s ] WHERE
+array_position(voting_replicas, %[2]d) IS NULL AND
+array_position(non_voting_replicas, %[2]d) IS NULL AND
+array_position(learner_replicas, %[2]d) IS NULL
+`, database, targetLogicalNodeID)
 		if err := db.QueryRow(stmtReplicaCount).Scan(&count); err != nil {
 			return err
 		}

--- a/pkg/cmd/roachtest/tests/indexes.go
+++ b/pkg/cmd/roachtest/tests/indexes.go
@@ -98,7 +98,7 @@ func registerNIndexes(r registry.Registry, secondaryIndexes int) {
 						var ok bool
 						if err := conn.QueryRowContext(ctx, `
 							SELECT lease_holder <= $1
-							FROM [SHOW RANGES FROM TABLE indexes WITH DETAILS]`,
+							FROM [SHOW RANGES FROM TABLE indexes.indexes WITH DETAILS]`,
 							nodes/3,
 						).Scan(&ok); err != nil {
 							return err

--- a/pkg/cmd/roachtest/tests/mvcc_gc.go
+++ b/pkg/cmd/roachtest/tests/mvcc_gc.go
@@ -398,8 +398,9 @@ func visitTableRanges(
 	ctx context.Context, t test.Test, conn *gosql.DB, m tableMetadata, f func(rangeID int) error,
 ) error {
 	t.Helper()
-	rows, err := conn.QueryContext(ctx, `select range_id from crdb_internal.ranges_no_leases where database_name = $1 and table_name = $2`,
-		m.databaseName, m.tableName)
+	rows, err := conn.QueryContext(
+		ctx, fmt.Sprintf(`SELECT range_id FROM [ SHOW RANGES FROM %s.%s ]`, m.databaseName, m.tableName),
+	)
 	if err != nil {
 		t.Fatalf("failed to run consistency check query on table: %s", err)
 	}

--- a/pkg/cmd/roachtest/tests/split.go
+++ b/pkg/cmd/roachtest/tests/split.go
@@ -334,8 +334,7 @@ func runLargeRangeSplits(ctx context.Context, t test.Test, c cluster.Cluster, si
 		// up until it has been split off.
 		const query = `
 select concat('r', range_id::string) as range, voting_replicas
-from crdb_internal.ranges_no_leases
-where database_name = 'bank' and cardinality(voting_replicas) >= $1;`
+from [ SHOW RANGES FROM DATABASE bank ] where cardinality(voting_replicas) >= $1;`
 		tBegin := timeutil.Now()
 		m.Go(func(ctx context.Context) error {
 			opts, ch := retryOpts()


### PR DESCRIPTION
- roachtest: use SHOW RANGES in splits test
- roachtest: fix mvcc_gc
- roachtest: fix decommission
- roachtest: fix indexes test

Epic: CRDB-18656
Release note: None
