### PR TITLE
(only to verify CI for custom build, won't merge)sql: avoid hydration when looking up descriptor within hydration cache

### DIFF
--- a/pkg/sql/catalog/descs/descriptor.go
+++ b/pkg/sql/catalog/descs/descriptor.go
@@ -203,6 +203,7 @@ func getDescriptorsByID(
 	if err := tc.finalizeDescriptors(ctx, txn, flags, descs, vls); err != nil {
 		return err
 	}
+	// Hydration is skipped if "SkipHydration" flag is true.
 	if err := tc.hydrateDescriptors(ctx, txn, flags, descs); err != nil {
 		return err
 	}

--- a/pkg/sql/catalog/typedesc/table_implicit_record_type.go
+++ b/pkg/sql/catalog/typedesc/table_implicit_record_type.go
@@ -58,7 +58,7 @@ func CreateImplicitRecordTypeFromTableDesc(
 	typs := make([]*types.T, len(cols))
 	names := make([]string, len(cols))
 	for i, col := range cols {
-		if col.GetType().UserDefined() && !col.GetType().IsHydrated() {
+		if !ColumnIsHydrated(col) {
 			return nil, errors.AssertionFailedf("encountered unhydrated col %s while creating implicit record type from"+
 				" table %s", col.ColName(), descriptor.GetName())
 		}
@@ -109,6 +109,21 @@ func CreateImplicitRecordTypeFromTableDesc(
 			Version:    tablePrivs.Version,
 		},
 	}, nil
+}
+
+// TableIsHydrated checks if all visible columns of a table are hydrated.
+func TableIsHydrated(tbl catalog.TableDescriptor) bool {
+	for _, col := range tbl.VisibleColumns() {
+		if !ColumnIsHydrated(col) {
+			return false
+		}
+	}
+	return true
+}
+
+// ColumnIsHydrated checks if a column is type hydrated.
+func ColumnIsHydrated(col catalog.Column) bool {
+	return !col.GetType().UserDefined() || col.GetType().IsHydrated()
 }
 
 // GetName implements the Namespace interface.

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -2622,3 +2622,51 @@ subtest variadic
 # Variadic UDFS are not currently supported.
 statement error pgcode 0A000 unimplemented: this syntax\nHINT.*\n.*88947
 CREATE FUNCTION rec(VARIADIC arr INT[]) RETURNS INT LANGUAGE SQL AS '1'
+
+# Regression test for #93314
+subtest regression_93314
+
+statement ok
+CREATE TYPE e_93314 AS ENUM ('a', 'b');
+CREATE TABLE t_93314 (i INT, e e_93314);
+INSERT INTO t_93314 VALUES (1, 'a');
+
+statement ok
+CREATE OR REPLACE FUNCTION f_93314 () RETURNS t_93314 AS
+$$
+  SELECT i, e
+  FROM t_93314
+  ORDER BY i
+  LIMIT 1;
+$$ LANGUAGE SQL;
+
+query T
+SELECT f_93314();
+----
+(1,a)
+
+statement ok
+CREATE TABLE t_93314_alias (i INT, e _e_93314);
+INSERT INTO t_93314_alias VALUES (1, ARRAY['a', 'b']::_e_93314);
+
+statement ok
+CREATE OR REPLACE FUNCTION f_93314_alias () RETURNS t_93314_alias AS
+$$
+  SELECT i, e
+  FROM t_93314_alias
+  ORDER BY i
+  LIMIT 1;
+$$ LANGUAGE SQL;
+
+query T
+SELECT f_93314_alias();
+----
+(1,"{a,b}")
+
+query TTTTTBBBTITTTTT
+SELECT oid, proname, pronamespace, proowner, prolang, proleakproof, proisstrict, proretset, provolatile, pronargs, prorettype, proargtypes, proargmodes, proargnames, prosrc
+FROM pg_catalog.pg_proc WHERE proname IN ('f_93314', 'f_93314_alias')
+ORDER BY oid;
+----
+100250  f_93314        105  1546506610  14  false  false  false  v  0  100249  ·  {}  NULL  SELECT i, e FROM test.public.t_93314 ORDER BY i LIMIT 1;
+100252  f_93314_alias  105  1546506610  14  false  false  false  v  0  100251  ·  {}  NULL  SELECT i, e FROM test.public.t_93314_alias ORDER BY i LIMIT 1;

--- a/pkg/sql/sem/tree/name_resolution.go
+++ b/pkg/sql/sem/tree/name_resolution.go
@@ -177,6 +177,12 @@ type CommonLookupFlags struct {
 	// ParentID enforces that the resolved descriptor exist with this parent
 	// ID if non-zero.
 	ParentID catid.DescID
+	// SkipHydration enforce descriptor lookups to skip hydration. This can be set
+	// to true only when looking up descriptors when hydrating another group of
+	// descriptors. The purpose is to avoid potential infinite recursion loop when
+	// trying to hydrate a descriptor which would lead to hydration of another
+	// descriptor depends on it.
+	SkipHydration bool
 }
 
 // SchemaLookupFlags is the flag struct suitable for GetSchemaByName().


### PR DESCRIPTION
Fixes #93314

When creating a UDF whose signature uses implicit record type which has a column of user defined enum type, crdb crashes because of a type hydration deadloop. The reason is that when we try to hydrate the implicit record type, the enum type also needs to be hydrated, and the schema descriptor as well because we need a fully qualified type name which requires a schema lookup and we now have function signatures within schema descriptor which has the type information. Then to hydrate the schema descriptor, the function signature types need to hydrated (again!), such the deadloop happens.

This pr adds a new flag for descriptor lookup to explicitly avoid hydration when looking up descriptor that can't be used as a UDT, so that we can avoid the hydration deadloop when looking up schema descriptor for its name.

Release note (sql change): Previously, cockroach db would crash if user creates a UDF whose function signature includes a implicit record type (essentially a table) which has a column using a user defined enum type. This root cause was that there was  a hydration deadloop when looking up descriptors during hydration. This PR adds a new flag to avoid hydration in order to avoid the deadloop, users shouldn't feel differentce on using UDFs.