### PR TITLE
release-22.1: sql: fix ALTER TABLE ... SET REGIONAL BY ROW and concurrent writes

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_alter_table_regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_alter_table_regional_by_row
@@ -1,0 +1,87 @@
+# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
+# LogicTest: multiregion-9node-3region-3azs
+
+# This file contains a regression test for ALTER TABLE ... REGIONAL BY ROW
+# that exercises writes which are concurrent with the index backfill of the
+# new primary index.
+
+statement ok
+CREATE DATABASE region_test_db PRIMARY REGION "ap-southeast-2" SURVIVE ZONE FAILURE;
+
+statement ok
+USE region_test_db;
+
+statement ok
+CREATE TABLE t (i INT8 NULL, INDEX (i));
+
+statement ok
+INSERT INTO t VALUES (1);
+
+# Shorten the job registry intervals to speed up the test.
+statement ok
+SET CLUSTER SETTING jobs.registry.interval.base = 0.01;
+
+statement ok
+SET CLUSTER SETTING jobs.debug.pausepoints = 'indexbackfill.before_flow';
+
+statement error job \d+ was paused before it completed with reason: pause point "indexbackfill.before_flow" hit
+ALTER TABLE t SET LOCALITY REGIONAL BY ROW
+
+statement ok
+INSERT INTO t VALUES (2);
+
+let $job_id
+SELECT job_id
+  FROM crdb_internal.jobs
+ WHERE DESCRIPTION LIKE '%SET LOCALITY REGIONAL BY ROW%'
+
+statement ok
+SET CLUSTER SETTING jobs.debug.pausepoints = DEFAULT;
+
+statement ok
+RESUME JOB $job_id
+
+query TT
+SELECT status, error FROM [SHOW JOB WHEN COMPLETE $job_id]
+----
+succeeded  ·
+
+query TI
+SELECT crdb_region, * FROM t
+----
+ap-southeast-2  1
+ap-southeast-2  2
+
+# Go the other way and make sure that that works.
+
+statement ok
+SET CLUSTER SETTING jobs.debug.pausepoints = 'indexbackfill.before_flow';
+
+statement error job \d+ was paused before it completed with reason: pause point "indexbackfill.before_flow" hit
+ALTER TABLE t SET LOCALITY REGIONAL BY TABLE
+
+statement ok
+INSERT INTO t VALUES (3);
+
+let $job_id
+SELECT job_id
+  FROM crdb_internal.jobs
+ WHERE DESCRIPTION LIKE '%SET LOCALITY REGIONAL BY TABLE%'
+
+statement ok
+SET CLUSTER SETTING jobs.debug.pausepoints = DEFAULT;
+
+statement ok
+RESUME JOB $job_id
+
+query TT
+SELECT status, error FROM [SHOW JOB WHEN COMPLETE $job_id]
+----
+succeeded  ·
+
+query I
+SELECT * FROM t
+----
+1
+2
+3

--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -339,7 +339,29 @@ func (p *planner) AlterPrimaryKey(
 		if err != nil {
 			return err
 		}
-		tabledesc.UpdateIndexPartitioning(newPrimaryIndexDesc, true /* isIndexPrimary */, newImplicitCols, newPartitioning)
+		tabledesc.UpdateIndexPartitioning(
+			newPrimaryIndexDesc, true, /* isIndexPrimary */
+			newImplicitCols, newPartitioning,
+		)
+
+		// We need to now also update the partitioning for the new temp primary
+		// index. If we didn't, it wouldn't be partitioned, and writes which
+		// were merged into the new primary index will be wrong.
+		//
+		// We know that the temp index will have the subsequent index ID.
+		// This is hacky, sure, but it's about as good of an invariant
+		// as most of this code relies upon for correctness. This code will
+		// all be replaced by code in the declarative schema changer before
+		// too long where we'll model this all correctly.
+		newTempPrimaryIndex, err := tableDesc.FindIndexWithID(newPrimaryIndexDesc.ID + 1)
+		if err != nil {
+			return errors.NewAssertionErrorWithWrappedErrf(err,
+				"failed to find newly created temporary index for backfill")
+		}
+		tabledesc.UpdateIndexPartitioning(
+			newTempPrimaryIndex.IndexDesc(), true, /* isIndexPrimary */
+			newImplicitCols, newPartitioning,
+		)
 	}
 
 	// Create a new index that indexes everything the old primary index


### PR DESCRIPTION
Backport 1/1 commits from #94151.

Release justification: fixes a bug at low risk

/cc @cockroachdb/release

---

Before this change, we'd add the temp index before we had properly set up the new primary index. The result was that the temp index had the wrong structure; it did not have the region column prefix. This leads to rows written during the merge stage also not having that prefix.

Fixes: #94148

Release note (bug fix): A bug was introduced in 22.1 such that tables which receive writes concurrent with portions of an ALTER TABLE ... SET LOCALITY REGIONAL BY ROW may fail with an error: `duplicate key value violates unique constraint "new_primary_key"`. This bug has been fixed.
