### PR TITLE
sql: validate computed columns with constants while adding

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -1095,3 +1095,42 @@ FROM t88128
 ----
 b1    expected_b1  b2    expected_b2
 true  true         true  true
+
+# Regression tests for #81698 computed columns are not validated on existing data"
+subtest regression_81698
+
+statement ok
+CREATE TABLE t81698 (i INT PRIMARY KEY);
+
+statement ok
+CREATE TYPE greeting AS ENUM ('hello', 'howdy', 'hi');
+
+statement error pgcode 22001 pq: value too long for type VARCHAR\(2\)
+ALTER TABLE t81698 ADD COLUMN v2 VARCHAR(2) AS ('virtual') VIRTUAL;
+
+statement error pgcode 22001 pq: value too long for type VARCHAR\(2\)
+ALTER TABLE t81698 ADD COLUMN v2 VARCHAR(2) AS ('stored') STORED;
+
+statement error pgcode 22003 pq: integer out of range for type int2
+ALTER TABLE t81698 ADD COLUMN s3 INT2 AS (32768) STORED;
+
+statement error pgcode 22P02 pq: invalid input value for enum greeting: "none"
+ALTER TABLE t81698 ADD COLUMN w2 greeting AS ('none') STORED;
+
+statement error pgcode 22001 pq: value too long for type VARCHAR\(2\)
+CREATE TABLE t81698_2 (
+  i INT PRIMARY KEY,
+  v VARCHAR(2) AS ('virtual') VIRTUAL
+);
+
+statement error pgcode XXUUU pq: expected computed column expression to have type bool, but '32768' has type int
+CREATE TABLE t81698_2 (
+  i INT PRIMARY KEY,
+  s4 BOOL AS (32768) STORED
+);
+
+statement error pgcode 22P02 pq: invalid input value for enum greeting: "none"
+CREATE TABLE t81698_2 (
+  i INT PRIMARY KEY,
+  w2 greeting AS ('none') STORED
+);

--- a/pkg/sql/logictest/testdata/logic_test/virtual_columns
+++ b/pkg/sql/logictest/testdata/logic_test/virtual_columns
@@ -1311,9 +1311,7 @@ ALTER TABLE t_added ADD COLUMN i4n INT4 GENERATED ALWAYS AS (NULL) VIRTUAL;
 statement ok
 ALTER TABLE t_added ADD COLUMN dn DECIMAL(5, 2) GENERATED ALWAYS AS (NULL) VIRTUAL;
 
-# Note that we really should not be able to add this column as the expression
-# does not fit into the type. See #81698.
-statement ok
+statement error pgcode 22003 pq: type DECIMAL\(5,2\)\: value with precision 5, scale 2 must round to an absolute value less than 10\^3
 ALTER TABLE t_added ADD COLUMN d DECIMAL(5, 2) GENERATED ALWAYS AS (123456.000000::DECIMAL) VIRTUAL;
 
 statement ok
@@ -1342,7 +1340,6 @@ CREATE TABLE public.t_added (
   i INT8 NOT NULL,
   i4n INT4 NULL AS (NULL) VIRTUAL,
   dn DECIMAL(5,2) NULL AS (NULL) VIRTUAL,
-  d DECIMAL(5,2) NULL AS (123456.000000:::DECIMAL) VIRTUAL,
   i4 INT4 NULL AS (4:::INT8) VIRTUAL,
   i2 INT2 NULL AS (2:::INT8) VIRTUAL,
   CONSTRAINT t_added_pkey PRIMARY KEY (i ASC)

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_column.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_column.go
@@ -207,12 +207,14 @@ func alterTableAddColumn(
 	}
 	if desc.HasDefault() {
 		expression := b.WrapExpression(tbl.TableID, cdd.DefaultExpr)
+
 		spec.def = &scpb.ColumnDefaultExpression{
 			TableID:    tbl.TableID,
 			ColumnID:   spec.col.ColumnID,
 			Expression: *expression,
 		}
 		b.IncrementSchemaChangeAddColumnQualificationCounter("default_expr")
+
 	}
 	// We're checking to see if a user is trying add a non-nullable column without a default to a
 	// non-empty table by scanning the primary index span with a limit of 1 to see if any key exists.
@@ -256,6 +258,7 @@ func alterTableAddColumn(
 	default:
 		b.IncrementSchemaChangeAddColumnTypeCounter(spec.colType.Type.TelemetryName())
 	}
+
 }
 
 func columnNamesToIDs(b BuildCtx, tbl *scpb.Table) map[string]descpb.ColumnID {


### PR DESCRIPTION
Computed columns with constanst are not validated while adding them, this was causing
issues when data is inserted. Same validation mechanism as insert line
is implemented.
    
Resolves: #81698
Signed-off-by: Kivanc Bilen <kivanc_bilen@hotmail.com>