### PR TITLE
Revert "sql: add replication start time to `SHOW TENANT WITH REPLICATION STATUS`

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/replication_stream_e2e_test.go
@@ -907,18 +907,17 @@ func TestTenantStreamingShowTenant(t *testing.T) {
 	replicationDetails := details.Details().(jobspb.StreamIngestionDetails)
 
 	var (
-		id                   int
-		dest                 string
-		status               string
-		source               string
-		sourceUri            string
-		jobId                int
-		maxReplTime          time.Time
-		protectedTime        time.Time
-		replicationStartTime time.Time
+		id            int
+		dest          string
+		status        string
+		source        string
+		sourceUri     string
+		jobId         int
+		maxReplTime   time.Time
+		protectedTime time.Time
 	)
 	row := c.DestSysSQL.QueryRow(t, fmt.Sprintf("SHOW TENANT %s WITH REPLICATION STATUS", args.DestTenantName))
-	row.Scan(&id, &dest, &status, &source, &sourceUri, &jobId, &maxReplTime, &protectedTime, &replicationStartTime)
+	row.Scan(&id, &dest, &status, &source, &sourceUri, &jobId, &maxReplTime, &protectedTime)
 	require.Equal(t, 2, id)
 	require.Equal(t, "destination", dest)
 	require.Equal(t, "REPLICATING", status)
@@ -929,6 +928,4 @@ func TestTenantStreamingShowTenant(t *testing.T) {
 	require.Less(t, protectedTime, timeutil.Now())
 	require.GreaterOrEqual(t, maxReplTime, highWatermark.GoTime())
 	require.GreaterOrEqual(t, protectedTime, replicationDetails.ReplicationStartTime.GoTime())
-	require.Equal(t, replicationStartTime.UnixMicro(),
-		timeutil.Unix(0, replicationDetails.ReplicationStartTime.WallTime).UnixMicro())
 }

--- a/pkg/sql/catalog/colinfo/result_columns.go
+++ b/pkg/sql/catalog/colinfo/result_columns.go
@@ -293,7 +293,6 @@ var TenantColumnsWithReplication = ResultColumns{
 	// The protected timestamp on the destination cluster, meaning we cannot
 	// cutover to before this time.
 	{Name: "retained_time", Typ: types.Timestamp},
-	{Name: "replication_start_time", Typ: types.Timestamp},
 }
 
 // RangesNoLeases is the schema for crdb_internal.ranges_no_leases.

--- a/pkg/sql/show_tenant.go
+++ b/pkg/sql/show_tenant.go
@@ -201,7 +201,6 @@ func (n *showTenantNode) Values() tree.Datums {
 	replicationJobId := tree.NewDInt(tree.DInt(n.tenantInfo.TenantReplicationJobID))
 	replicatedTimestamp := tree.DNull
 	retainedTimestamp := tree.DNull
-	replicationStartTimestamp := tree.DNull
 
 	if n.replicationInfo != nil {
 		sourceTenantName = tree.NewDString(string(n.replicationInfo.IngestionDetails.SourceTenantName))
@@ -213,8 +212,6 @@ func (n *showTenantNode) Values() tree.Datums {
 		}
 		// The protected timestamp on the destination cluster.
 		retainedTimestamp, _ = tree.MakeDTimestamp(timeutil.Unix(0, n.protectedTimestamp.WallTime), time.Nanosecond)
-		replicationStartTimestamp, _ = tree.MakeDTimestamp(
-			timeutil.Unix(0, n.replicationInfo.IngestionDetails.ReplicationStartTime.WallTime), time.Nanosecond)
 	}
 
 	return tree.Datums{
@@ -226,7 +223,6 @@ func (n *showTenantNode) Values() tree.Datums {
 		replicationJobId,
 		replicatedTimestamp,
 		retainedTimestamp,
-		replicationStartTimestamp,
 	}
 }
 


### PR DESCRIPTION
This reverts commit 3833eedeb596216320837e69c59218bb5b89d74a. We decided that showing the `start_time` to the user is not useful. We already show the replicated_time and retention_time that is sufficient to pick a cutover time and fingerprint start time.

Fixes: #93447