### PR TITLE
sql: return appropriate error message for job_payload_type builtin

### DIFF
--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -513,9 +513,6 @@ var functions = func() map[tree.FunctionClass]map[oid.Oid][]function {
 			"crdb_internal.revalidate_unique_constraint",
 			"crdb_internal.request_statement_bundle",
 			"crdb_internal.set_compaction_concurrency",
-			// crdb_internal.job_payload_type unmarshals a jobspb.Payload from
-			// raw bytes. Calling it with random values will produce an error.
-			"crdb_internal.job_payload_type",
 		} {
 			skip = skip || strings.Contains(def.Name, substr)
 		}

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -3762,3 +3762,7 @@ SELECT parse_ident('ab.xyz()', false)
 
 query error string is not a valid identifier: \"ab.xyz\(\)\"
 SELECT parse_ident('ab.xyz()', true)
+
+# Test that we return an appropriate user-facing error message when trying to decode invalid bytes.
+query error pgcode 22023 pq: crdb_internal.job_payload_type\(\): invalid protocol message: proto: wrong wireType = 1 for field Import
+select crdb_internal.job_payload_type('invalid'::BYTES);

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4090,7 +4090,7 @@ value if you rely on the HLC for accuracy.`,
 			getJobPayloadType := func(data []byte) (tree.Datum, error) {
 				var msg jobspb.Payload
 				if err := protoutil.Unmarshal(data, &msg); err != nil {
-					return nil, err
+					return nil, pgerror.Wrap(err, pgcode.InvalidParameterValue, "invalid protocol message")
 				}
 				return tree.NewDString(msg.Type().String()), nil
 			}


### PR DESCRIPTION
Previously, decoding an invalid payload with the `job_payload_type` builtin would return an error message. This change makes it return an appropriate user-facing error message.

Epic: none

Release note: None