### PR TITLE
opt: permit mixed-type virtual index pushdown

### DIFF
--- a/pkg/sql/opt/idxconstraint/index_constraints.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints.go
@@ -135,6 +135,11 @@ func (c *indexConstraintCtx) makeStringPrefixSpan(
 // given type. We disallow mixed-type comparisons because it would result in
 // incorrect encodings (#4313).
 func (c *indexConstraintCtx) verifyType(offset int, typ *types.T) bool {
+	if c.md.TableMeta(c.md.ColumnMeta(c.columns[offset].ID()).Table).Table.IsVirtualTable() {
+		// Virtual indexes permit mixed-type constraints, because we don't need to
+		// actually produce encodings to compare values in virtual indexes.
+		return true
+	}
 	return typ.Family() == types.UnknownFamily || c.colType(offset).Equivalent(typ)
 }
 


### PR DESCRIPTION
Previously, the optimizer disallowed any mixed-type index pushdowns, regardless of the index's virtual status, because normally different datatypes are encoded differently and permitting mixed-type comparisons would cause issues because constraining indexes is normally done with type encodings.

However, virtual indexes work differently: the encoding is never used to actually constrain the index, since it's all done in memory.

As a result, we can permit mixed-type index constraints on virtual indexes.

Release note: None

Co-authored-by: rafiss <rafi@cockroachlabs.com>