### PR TITLE
release-22.2: ccl/sqlproxyccl: fix status code and hint reporting

### DIFF
--- a/pkg/ccl/sqlproxyccl/authentication_test.go
+++ b/pkg/ccl/sqlproxyccl/authentication_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/throttler"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/cockroachdb/errors"
 	"github.com/jackc/pgproto3/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -120,7 +119,7 @@ func TestAuthenticateThrottled(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, msg, &pgproto3.ErrorResponse{
 			Severity: "FATAL",
-			Code:     "08004",
+			Code:     "08C00",
 			Message:  "codeProxyRefusedConnection: connection attempt throttled",
 			Hint:     throttledErrorHint,
 		})
@@ -188,9 +187,7 @@ func TestAuthenticateError(t *testing.T) {
 
 	_, err := authenticate(srv, cli, nil /* proxyBackendKeyData */, nilThrottleHook)
 	require.Error(t, err)
-	codeErr := (*codeError)(nil)
-	require.True(t, errors.As(err, &codeErr))
-	require.Equal(t, codeAuthFailed, codeErr.code)
+	require.Equal(t, codeAuthFailed, getErrorCode(err))
 }
 
 func TestAuthenticateUnexpectedMessage(t *testing.T) {
@@ -212,9 +209,7 @@ func TestAuthenticateUnexpectedMessage(t *testing.T) {
 	srv.Close()
 
 	require.Error(t, err)
-	codeErr := (*codeError)(nil)
-	require.True(t, errors.As(err, &codeErr))
-	require.Equal(t, codeBackendDisconnected, codeErr.code)
+	require.Equal(t, codeBackendDisconnected, getErrorCode(err))
 }
 
 func TestReadTokenAuthResult(t *testing.T) {
@@ -230,9 +225,7 @@ func TestReadTokenAuthResult(t *testing.T) {
 
 		_, err := readTokenAuthResult(cli)
 		require.Error(t, err)
-		codeErr := (*codeError)(nil)
-		require.True(t, errors.As(err, &codeErr))
-		require.Equal(t, codeBackendDisconnected, codeErr.code)
+		require.Equal(t, codeBackendDisconnected, getErrorCode(err))
 	})
 
 	t.Run("error_response", func(t *testing.T) {
@@ -245,9 +238,7 @@ func TestReadTokenAuthResult(t *testing.T) {
 
 		_, err := readTokenAuthResult(cli)
 		require.Error(t, err)
-		codeErr := (*codeError)(nil)
-		require.True(t, errors.As(err, &codeErr))
-		require.Equal(t, codeAuthFailed, codeErr.code)
+		require.Equal(t, codeAuthFailed, getErrorCode(err))
 	})
 
 	t.Run("successful", func(t *testing.T) {

--- a/pkg/ccl/sqlproxyccl/connector_test.go
+++ b/pkg/ccl/sqlproxyccl/connector_test.go
@@ -795,7 +795,7 @@ func TestConnector_dialSQLServer(t *testing.T) {
 				require.Equal(t, c.StartupMsg, msg)
 				require.Equal(t, "127.0.0.2:4567", serverAddress)
 				require.Nil(t, tlsConfig)
-				return nil, newErrorf(codeBackendDown, "bar")
+				return nil, withCode(errors.New("bar"), codeBackendDown)
 			},
 		)()
 		sa := balancer.NewServerAssignment(tenantID, tracker, nil, "127.0.0.2:4567")

--- a/pkg/ccl/sqlproxyccl/error_source.go
+++ b/pkg/ccl/sqlproxyccl/error_source.go
@@ -22,19 +22,19 @@ type errorSourceConn struct {
 	writeErrMarker error
 }
 
-// errClientWrite indicates the error occured when attempting to write to the
+// errClientWrite indicates the error occurred when attempting to write to the
 // client connection.
 var errClientWrite = errors.New("client write error")
 
-// errClientRead indicates the error occured when attempting to read from the
+// errClientRead indicates the error occurred when attempting to read from the
 // client connection.
 var errClientRead = errors.New("client read error")
 
-// errServerWrite indicates the error occured when attempting to write to the
+// errServerWrite indicates the error occurred when attempting to write to the
 // sql server.
 var errServerWrite = errors.New("server write error")
 
-// errServerRead indicates the error occured when attempting to read from the
+// errServerRead indicates the error occurred when attempting to read from the
 // sql server.
 var errServerRead = errors.New("server read error")
 
@@ -44,13 +44,13 @@ var errServerRead = errors.New("server read error")
 func wrapConnectionError(err error) error {
 	switch {
 	case errors.Is(err, errClientRead):
-		return newErrorf(codeClientReadFailed, "unable to read from client: %s", err)
+		return withCode(errors.Wrap(err, "unable to read from client"), codeClientReadFailed)
 	case errors.Is(err, errClientWrite):
-		return newErrorf(codeClientWriteFailed, "unable to write to client: %s", err)
+		return withCode(errors.Wrap(err, "unable to write to client"), codeClientWriteFailed)
 	case errors.Is(err, errServerRead):
-		return newErrorf(codeBackendReadFailed, "unable to read from sql server: %s", err)
+		return withCode(errors.Wrap(err, "unable to read from sql server"), codeBackendReadFailed)
 	case errors.Is(err, errServerWrite):
-		return newErrorf(codeBackendWriteFailed, "unable to write to sql server: %s", err)
+		return withCode(errors.Wrap(err, "unable to write to sql server"), codeBackendWriteFailed)
 	}
 	return nil
 }

--- a/pkg/ccl/sqlproxyccl/error_source_test.go
+++ b/pkg/ccl/sqlproxyccl/error_source_test.go
@@ -24,11 +24,11 @@ type fakeConn struct {
 	writeError error
 }
 
-func (conn *fakeConn) Read(b []byte) (n int, err error) {
+func (conn *fakeConn) Read(_ []byte) (n int, err error) {
 	return conn.size, conn.readError
 }
 
-func (conn *fakeConn) Write(b []byte) (n int, err error) {
+func (conn *fakeConn) Write(_ []byte) (n int, err error) {
 	return conn.size, conn.writeError
 }
 
@@ -43,17 +43,11 @@ func TestWrapConnectionError(t *testing.T) {
 		{errClientWrite, codeClientWriteFailed},
 		{errServerRead, codeBackendReadFailed},
 		{errServerWrite, codeBackendWriteFailed},
-		{errors.New("some random error"), 0},
+		{errors.New("some random error"), codeNone},
 	}
 	for _, tc := range tests {
-		var code errorCode
 		err := wrapConnectionError(errors.Mark(errors.New("some inner error"), tc.marker))
-		if err != nil {
-			codeErr := &codeError{}
-			require.True(t, errors.As(err, &codeErr))
-			code = codeErr.code
-		}
-		require.Equal(t, code, tc.code)
+		require.Equal(t, tc.code, getErrorCode(err))
 	}
 }
 

--- a/pkg/ccl/sqlproxyccl/errorcode_string.go
+++ b/pkg/ccl/sqlproxyccl/errorcode_string.go
@@ -8,6 +8,7 @@ func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
+	_ = x[codeNone-0]
 	_ = x[codeAuthFailed-1]
 	_ = x[codeBackendReadFailed-2]
 	_ = x[codeBackendWriteFailed-3]
@@ -25,14 +26,13 @@ func _() {
 	_ = x[codeUnavailable-15]
 }
 
-const _errorCode_name = "codeAuthFailedcodeBackendReadFailedcodeBackendWriteFailedcodeClientReadFailedcodeClientWriteFailedcodeUnexpectedInsecureStartupMessagecodeUnexpectedStartupMessagecodeParamsRoutingFailedcodeBackendDowncodeBackendRefusedTLScodeBackendDisconnectedcodeClientDisconnectedcodeProxyRefusedConnectioncodeExpiredClientConnectioncodeUnavailable"
+const _errorCode_name = "codeNonecodeAuthFailedcodeBackendReadFailedcodeBackendWriteFailedcodeClientReadFailedcodeClientWriteFailedcodeUnexpectedInsecureStartupMessagecodeUnexpectedStartupMessagecodeParamsRoutingFailedcodeBackendDowncodeBackendRefusedTLScodeBackendDisconnectedcodeClientDisconnectedcodeProxyRefusedConnectioncodeExpiredClientConnectioncodeUnavailable"
 
-var _errorCode_index = [...]uint16{0, 14, 35, 57, 77, 98, 134, 162, 185, 200, 221, 244, 266, 292, 319, 334}
+var _errorCode_index = [...]uint16{0, 8, 22, 43, 65, 85, 106, 142, 170, 193, 208, 229, 252, 274, 300, 327, 342}
 
 func (i errorCode) String() string {
-	i -= 1
 	if i < 0 || i >= errorCode(len(_errorCode_index)-1) {
-		return "errorCode(" + strconv.FormatInt(int64(i+1), 10) + ")"
+		return "errorCode(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _errorCode_name[_errorCode_index[i]:_errorCode_index[i+1]]
 }

--- a/pkg/ccl/sqlproxyccl/forwarder.go
+++ b/pkg/ccl/sqlproxyccl/forwarder.go
@@ -378,7 +378,9 @@ func wrapClientToServerError(err error) error {
 	if err := wrapConnectionError(err); err != nil {
 		return err
 	}
-	return newErrorf(codeClientDisconnected, "unexpected error copying from client to target server: %v", err)
+	return withCode(errors.Wrap(err,
+		"unexpected error copying from client to target server"),
+		codeClientDisconnected)
 }
 
 // wrapServerToClientError overrides server to client errors for external
@@ -396,7 +398,9 @@ func wrapServerToClientError(err error) error {
 	if err := wrapConnectionError(err); err != nil {
 		return err
 	}
-	return newErrorf(codeBackendDisconnected, "unexpected error copying from target server to client: %s", err)
+	return withCode(errors.Wrap(err,
+		"unexpected error copying from target server to client"),
+		codeBackendDisconnected)
 }
 
 // makeLogicalClockFn returns a function that implements a simple logical clock.

--- a/pkg/ccl/sqlproxyccl/forwarder_test.go
+++ b/pkg/ccl/sqlproxyccl/forwarder_test.go
@@ -452,14 +452,15 @@ func TestWrapClientToServerError(t *testing.T) {
 		{errors.Mark(errors.New("foo"), context.Canceled), nil},
 		{errors.Wrap(context.DeadlineExceeded, "foo"), nil},
 		// Forwarding errors.
-		{errors.New("foo"), newErrorf(
+		{errors.New("foo"), withCode(errors.New(
+			"unexpected error copying from client to target server: foo"),
 			codeClientDisconnected,
-			"unexpected error copying from client to target server: foo",
 		)},
-		{errors.Mark(errors.New("some write error"), errClientWrite), newErrorf(
-			codeClientWriteFailed,
-			"unable to write to client: some write error",
-		)},
+		{errors.Mark(errors.New("some write error"), errClientWrite),
+			withCode(errors.New(
+				"unable to write to client: some write error"),
+				codeClientWriteFailed,
+			)},
 	} {
 		err := wrapClientToServerError(tc.input)
 		if tc.output == nil {
@@ -484,14 +485,15 @@ func TestWrapServerToClientError(t *testing.T) {
 		{errors.Mark(errors.New("foo"), context.Canceled), nil},
 		{errors.Wrap(context.DeadlineExceeded, "foo"), nil},
 		// Forwarding errors.
-		{errors.New("foo"), newErrorf(
+		{errors.New("foo"), withCode(errors.New(
+			"unexpected error copying from target server to client: foo"),
 			codeBackendDisconnected,
-			"unexpected error copying from target server to client: foo",
 		)},
-		{errors.Mark(errors.New("some read error"), errServerRead), newErrorf(
-			codeBackendReadFailed,
-			"unable to read from sql server: some read error",
-		)},
+		{errors.Mark(errors.New("some read error"), errServerRead),
+			withCode(errors.New(
+				"unable to read from sql server: some read error"),
+				codeBackendReadFailed,
+			)},
 	} {
 		err := wrapServerToClientError(tc.input)
 		if tc.output == nil {

--- a/pkg/ccl/sqlproxyccl/metrics.go
+++ b/pkg/ccl/sqlproxyccl/metrics.go
@@ -11,7 +11,6 @@ package sqlproxyccl
 import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
-	"github.com/cockroachdb/errors"
 )
 
 // metrics contains pointers to the metrics for monitoring proxy operations.
@@ -257,25 +256,22 @@ func (metrics *metrics) updateForError(err error) {
 	if err == nil {
 		return
 	}
-	codeErr := (*codeError)(nil)
-	if errors.As(err, &codeErr) {
-		switch codeErr.code {
-		case codeExpiredClientConnection:
-			metrics.ExpiredClientConnCount.Inc(1)
-		case codeBackendDisconnected, codeBackendReadFailed, codeBackendWriteFailed:
-			metrics.BackendDisconnectCount.Inc(1)
-		case codeClientDisconnected, codeClientWriteFailed, codeClientReadFailed:
-			metrics.ClientDisconnectCount.Inc(1)
-		case codeProxyRefusedConnection:
-			metrics.RefusedConnCount.Inc(1)
-			metrics.BackendDownCount.Inc(1)
-		case codeParamsRoutingFailed, codeUnavailable:
-			metrics.RoutingErrCount.Inc(1)
-			metrics.BackendDownCount.Inc(1)
-		case codeBackendDown:
-			metrics.BackendDownCount.Inc(1)
-		case codeAuthFailed:
-			metrics.AuthFailedCount.Inc(1)
-		}
+	switch getErrorCode(err) {
+	case codeExpiredClientConnection:
+		metrics.ExpiredClientConnCount.Inc(1)
+	case codeBackendDisconnected, codeBackendReadFailed, codeBackendWriteFailed:
+		metrics.BackendDisconnectCount.Inc(1)
+	case codeClientDisconnected, codeClientWriteFailed, codeClientReadFailed:
+		metrics.ClientDisconnectCount.Inc(1)
+	case codeProxyRefusedConnection:
+		metrics.RefusedConnCount.Inc(1)
+		metrics.BackendDownCount.Inc(1)
+	case codeParamsRoutingFailed, codeUnavailable:
+		metrics.RoutingErrCount.Inc(1)
+		metrics.BackendDownCount.Inc(1)
+	case codeBackendDown:
+		metrics.BackendDownCount.Inc(1)
+	case codeAuthFailed:
+		metrics.AuthFailedCount.Inc(1)
 	}
 }

--- a/pkg/ccl/sqlproxyccl/metrics_test.go
+++ b/pkg/ccl/sqlproxyccl/metrics_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -50,7 +51,7 @@ func TestMetricsUpdateForError(t *testing.T) {
 			for _, counter := range tc.counters {
 				before = append(before, counter.Count())
 			}
-			m.updateForError(newErrorf(tc.code, "test error"))
+			m.updateForError(withCode(errors.New("test error"), tc.code))
 			for i, counter := range tc.counters {
 				require.Equal(t, counter.Count(), before[i]+1)
 			}

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"github.com/jackc/pgconn"
 	pgproto3 "github.com/jackc/pgproto3/v2"
 	pgx "github.com/jackc/pgx/v4"
 	"github.com/stretchr/testify/assert"
@@ -80,7 +81,7 @@ func TestLongDBName(t *testing.T) {
 		_ *pgproto3.StartupMessage, outgoingAddr string, _ *tls.Config,
 	) (net.Conn, error) {
 		require.Equal(t, outgoingAddr, "127.0.0.1:26257")
-		return nil, newErrorf(codeParamsRoutingFailed, "boom")
+		return nil, withCode(errors.New("boom"), codeParamsRoutingFailed)
 	})()
 
 	stopper := stop.NewStopper()
@@ -90,7 +91,7 @@ func TestLongDBName(t *testing.T) {
 
 	longDB := strings.Repeat("x", 70) // 63 is limit
 	pgurl := fmt.Sprintf("postgres://unused:unused@%s/%s?options=--cluster=tenant-cluster-28&sslmode=require", addr, longDB)
-	te.TestConnectErr(ctx, t, pgurl, codeParamsRoutingFailed, "boom")
+	_ = te.TestConnectErr(ctx, t, pgurl, codeParamsRoutingFailed, "boom")
 	require.Equal(t, int64(1), s.metrics.RoutingErrCount.Count())
 }
 
@@ -123,12 +124,12 @@ func TestBackendDownRetry(t *testing.T) {
 		if callCount >= 3 {
 			directoryServer.DeleteTenant(roachpb.MakeTenantID(28))
 		}
-		return nil, newErrorf(codeBackendDown, "SQL pod is down")
+		return nil, withCode(errors.New("SQL pod is down"), codeBackendDown)
 	})()
 
 	// Valid connection, but no backend server running.
 	pgurl := fmt.Sprintf("postgres://unused:unused@%s/db?options=--cluster=tenant-cluster-28&sslmode=require", addr)
-	te.TestConnectErr(ctx, t, pgurl, codeParamsRoutingFailed, "cluster tenant-cluster-28 not found")
+	_ = te.TestConnectErr(ctx, t, pgurl, codeParamsRoutingFailed, "cluster tenant-cluster-28 not found")
 	require.Equal(t, 3, callCount)
 }
 
@@ -152,7 +153,7 @@ func TestFailedConnection(t *testing.T) {
 	u := fmt.Sprintf("postgres://unused:unused@localhost:%s/", p)
 
 	// Unencrypted connections bounce.
-	te.TestConnectErr(
+	_ = te.TestConnectErr(
 		ctx, t, u+"?options=--cluster=tenant-cluster-28&sslmode=disable",
 		codeUnexpectedInsecureStartupMessage, "server requires encryption",
 	)
@@ -161,21 +162,21 @@ func TestFailedConnection(t *testing.T) {
 	sslModesUsingTLS := []string{"require", "allow"}
 	for i, sslmode := range sslModesUsingTLS {
 		// TenantID rejected as malformed.
-		te.TestConnectErr(
+		_ = te.TestConnectErr(
 			ctx, t, u+"?options=--cluster=dimdog&sslmode="+sslmode,
 			codeParamsRoutingFailed, "invalid cluster identifier 'dimdog'",
 		)
 		require.Equal(t, int64(1+(i*3)), s.metrics.RoutingErrCount.Count())
 
 		// No cluster name and TenantID.
-		te.TestConnectErr(
+		_ = te.TestConnectErr(
 			ctx, t, u+"?sslmode="+sslmode,
 			codeParamsRoutingFailed, "missing cluster identifier",
 		)
 		require.Equal(t, int64(2+(i*3)), s.metrics.RoutingErrCount.Count())
 
 		// Bad TenantID. Ensure that we don't leak any parsing errors.
-		te.TestConnectErr(
+		_ = te.TestConnectErr(
 			ctx, t, u+"?options=--cluster=tenant-cluster-foo3&sslmode="+sslmode,
 			codeParamsRoutingFailed, "invalid cluster identifier 'tenant-cluster-foo3'",
 		)
@@ -251,10 +252,10 @@ func TestProxyAgainstSecureCRDB(t *testing.T) {
 	require.NoError(t, err)
 
 	url := fmt.Sprintf("postgres://bob:wrong@%s/tenant-cluster-28.defaultdb?sslmode=require", addr)
-	te.TestConnectErr(ctx, t, url, 0, "failed SASL auth")
+	_ = te.TestConnectErr(ctx, t, url, 0, "failed SASL auth")
 
 	url = fmt.Sprintf("postgres://bob@%s/tenant-cluster-28.defaultdb?sslmode=require", addr)
-	te.TestConnectErr(ctx, t, url, 0, "failed SASL auth")
+	_ = te.TestConnectErr(ctx, t, url, 0, "failed SASL auth")
 
 	// SNI provides tenant ID.
 	url = fmt.Sprintf("postgres://bob:builder@tenant-cluster-28.blah:%s/defaultdb?sslmode=require", port)
@@ -265,7 +266,7 @@ func TestProxyAgainstSecureCRDB(t *testing.T) {
 
 	// SNI tried but doesn't parse to valid tenant ID and DB/Options not provided
 	url = fmt.Sprintf("postgres://bob:builder@tenant_cluster_28.blah:%s/defaultdb?sslmode=require", port)
-	te.TestConnectErr(ctx, t, url, codeParamsRoutingFailed, "missing cluster identifier")
+	_ = te.TestConnectErr(ctx, t, url, codeParamsRoutingFailed, "missing cluster identifier")
 
 	// Database provides valid ID
 	url = fmt.Sprintf("postgres://bob:builder@%s/tenant-cluster-28.defaultdb?sslmode=require", addr)
@@ -311,7 +312,7 @@ func TestProxyTLSConf(t *testing.T) {
 			_ *pgproto3.StartupMessage, _ string, tlsConf *tls.Config,
 		) (net.Conn, error) {
 			require.Nil(t, tlsConf)
-			return nil, newErrorf(codeParamsRoutingFailed, "boom")
+			return nil, withCode(errors.New("boom"), codeParamsRoutingFailed)
 		})()
 
 		stopper := stop.NewStopper()
@@ -322,7 +323,7 @@ func TestProxyTLSConf(t *testing.T) {
 		})
 
 		pgurl := fmt.Sprintf("postgres://unused:unused@%s/%s?options=--cluster=tenant-cluster-28&sslmode=require", addr, "defaultdb")
-		te.TestConnectErr(ctx, t, pgurl, codeParamsRoutingFailed, "boom")
+		_ = te.TestConnectErr(ctx, t, pgurl, codeParamsRoutingFailed, "boom")
 	})
 
 	t.Run("skip-verify", func(t *testing.T) {
@@ -334,7 +335,7 @@ func TestProxyTLSConf(t *testing.T) {
 			_ *pgproto3.StartupMessage, _ string, tlsConf *tls.Config,
 		) (net.Conn, error) {
 			require.True(t, tlsConf.InsecureSkipVerify)
-			return nil, newErrorf(codeParamsRoutingFailed, "boom")
+			return nil, withCode(errors.New("boom"), codeParamsRoutingFailed)
 		})()
 
 		stopper := stop.NewStopper()
@@ -346,7 +347,7 @@ func TestProxyTLSConf(t *testing.T) {
 		})
 
 		pgurl := fmt.Sprintf("postgres://unused:unused@%s/%s?options=--cluster=tenant-cluster-28&sslmode=require", addr, "defaultdb")
-		te.TestConnectErr(ctx, t, pgurl, codeParamsRoutingFailed, "boom")
+		_ = te.TestConnectErr(ctx, t, pgurl, codeParamsRoutingFailed, "boom")
 	})
 
 	t.Run("no-skip-verify", func(t *testing.T) {
@@ -362,7 +363,7 @@ func TestProxyTLSConf(t *testing.T) {
 
 			require.False(t, tlsConf.InsecureSkipVerify)
 			require.Equal(t, tlsConf.ServerName, outgoingHost)
-			return nil, newErrorf(codeParamsRoutingFailed, "boom")
+			return nil, withCode(errors.New("boom"), codeParamsRoutingFailed)
 		})()
 
 		stopper := stop.NewStopper()
@@ -374,7 +375,7 @@ func TestProxyTLSConf(t *testing.T) {
 		})
 
 		pgurl := fmt.Sprintf("postgres://unused:unused@%s/%s?options=--cluster=tenant-cluster-28&sslmode=require", addr, "defaultdb")
-		te.TestConnectErr(ctx, t, pgurl, codeParamsRoutingFailed, "boom")
+		_ = te.TestConnectErr(ctx, t, pgurl, codeParamsRoutingFailed, "boom")
 	})
 
 }
@@ -533,7 +534,7 @@ func TestInsecureProxy(t *testing.T) {
 	)
 
 	url := fmt.Sprintf("postgres://bob:wrong@%s?sslmode=disable&options=--cluster=tenant-cluster-28&sslmode=require", addr)
-	te.TestConnectErr(ctx, t, url, 0, "failed SASL auth")
+	_ = te.TestConnectErr(ctx, t, url, 0, "failed SASL auth")
 
 	url = fmt.Sprintf("postgres://bob:builder@%s/?sslmode=disable&options=--cluster=tenant-cluster-28&sslmode=require", addr)
 	te.TestConnect(ctx, t, url, func(conn *pgx.Conn) {
@@ -567,7 +568,39 @@ func TestErroneousFrontend(t *testing.T) {
 	// Generic message here as the Frontend's error is not codeError and
 	// by default we don't pass back error's text. The startup message doesn't
 	// get processed in this case.
-	te.TestConnectErr(ctx, t, url, 0, "internal server error")
+	_ = te.TestConnectErr(ctx, t, url, 0, "internal server error")
+}
+
+func TestErrorHint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	te := newTester()
+	defer te.Close()
+	hint := "how to fix this err"
+
+	defer testutils.TestingHook(&FrontendAdmit, func(
+		conn net.Conn, incomingTLSConfig *tls.Config,
+	) *FrontendAdmitInfo {
+		return &FrontendAdmitInfo{Conn: conn,
+			Err: withCode(
+				errors.WithHint(
+					errors.New(frontendError),
+					hint),
+				codeParamsRoutingFailed)}
+	})()
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	_, addr, _ := newProxyServer(ctx, t, stopper, &ProxyOptions{})
+
+	url := fmt.Sprintf("postgres://bob:builder@%s/?sslmode=disable&options=--cluster=tenant-cluster-28&sslmode=require", addr)
+
+	err := te.TestConnectErr(ctx, t, url, 0, "codeParamsRoutingFailed: Frontend error")
+	pgErr := (*pgconn.PgError)(nil)
+	require.True(t, errors.As(err, &pgErr))
+	require.Equal(t, hint, pgErr.Hint)
 }
 
 func TestErroneousBackend(t *testing.T) {
@@ -593,7 +626,7 @@ func TestErroneousBackend(t *testing.T) {
 	// Generic message here as the Backend's error is not codeError and
 	// by default we don't pass back error's text. The startup message has
 	// already been processed.
-	te.TestConnectErr(ctx, t, url, 0, "internal server error")
+	_ = te.TestConnectErr(ctx, t, url, 0, "internal server error")
 }
 
 func TestProxyRefuseConn(t *testing.T) {
@@ -607,7 +640,7 @@ func TestProxyRefuseConn(t *testing.T) {
 	defer testutils.TestingHook(&BackendDial, func(
 		msg *pgproto3.StartupMessage, outgoingAddress string, tlsConfig *tls.Config,
 	) (net.Conn, error) {
-		return nil, newErrorf(codeProxyRefusedConnection, "too many attempts")
+		return nil, withCode(errors.New("too many attempts"), codeProxyRefusedConnection)
 	})()
 
 	stopper := stop.NewStopper()
@@ -615,7 +648,7 @@ func TestProxyRefuseConn(t *testing.T) {
 	s, addr, _ := newSecureProxyServer(ctx, t, stopper, &ProxyOptions{})
 
 	url := fmt.Sprintf("postgres://root:admin@%s?sslmode=require&options=--cluster=tenant-cluster-28&sslmode=require", addr)
-	te.TestConnectErr(ctx, t, url, codeProxyRefusedConnection, "too many attempts")
+	_ = te.TestConnectErr(ctx, t, url, codeProxyRefusedConnection, "too many attempts")
 	require.Equal(t, int64(1), s.metrics.RefusedConnCount.Count())
 	require.Equal(t, int64(0), s.metrics.SuccessfulConnCount.Count())
 	require.Equal(t, int64(0), s.metrics.ConnectionLatency.TotalCount())
@@ -747,7 +780,7 @@ func TestDirectoryConnect(t *testing.T) {
 		url := fmt.Sprintf(
 			"postgres://root:admin@%s/?sslmode=disable&options=--cluster=tenant-cluster-%d",
 			addr, notFoundTenantID)
-		te.TestConnectErr(ctx, t, url, codeParamsRoutingFailed, "cluster tenant-cluster-99 not found")
+		_ = te.TestConnectErr(ctx, t, url, codeParamsRoutingFailed, "cluster tenant-cluster-99 not found")
 	})
 
 	t.Run("fail to connect to backend", func(t *testing.T) {
@@ -758,9 +791,9 @@ func TestDirectoryConnect(t *testing.T) {
 		) (net.Conn, error) {
 			countFailures++
 			if countFailures >= 3 {
-				return nil, newErrorf(codeBackendDisconnected, "backend disconnected")
+				return nil, withCode(errors.New("backend disconnected"), codeBackendDisconnected)
 			}
-			return nil, newErrorf(codeBackendDown, "backend down")
+			return nil, withCode(errors.New("backend down"), codeBackendDown)
 		})()
 
 		// Ensure that Directory.ReportFailure is being called correctly.
@@ -781,7 +814,7 @@ func TestDirectoryConnect(t *testing.T) {
 		})()
 
 		url := fmt.Sprintf("postgres://root:admin@%s/?sslmode=disable&options=--cluster=tenant-cluster-28", addr)
-		te.TestConnectErr(ctx, t, url, codeBackendDisconnected, "backend disconnected")
+		_ = te.TestConnectErr(ctx, t, url, codeBackendDisconnected, "backend disconnected")
 		require.Equal(t, 3, countFailures)
 		require.Equal(t, 2, countReports)
 	})
@@ -2051,7 +2084,7 @@ type tester struct {
 	mu struct {
 		syncutil.Mutex
 		authenticated bool
-		errToClient   *codeError
+		errToClient   error
 	}
 
 	restoreAuthenticate    func()
@@ -2077,8 +2110,8 @@ func newTester() *tester {
 	originalSendErrToClient := SendErrToClient
 	te.restoreSendErrToClient =
 		testutils.TestingHook(&SendErrToClient, func(conn net.Conn, err error) {
-			if codeErr := (*codeError)(nil); errors.As(err, &codeErr) {
-				te.setErrToClient(codeErr)
+			if getErrorCode(err) != codeNone {
+				te.setErrToClient(err)
 			}
 			originalSendErrToClient(conn, err)
 		})
@@ -2106,13 +2139,13 @@ func (te *tester) setAuthenticated(auth bool) {
 }
 
 // ErrToClient returns any error sent by the proxy to the client.
-func (te *tester) ErrToClient() *codeError {
+func (te *tester) ErrToClient() error {
 	te.mu.Lock()
 	defer te.mu.Unlock()
 	return te.mu.errToClient
 }
 
-func (te *tester) setErrToClient(codeErr *codeError) {
+func (te *tester) setErrToClient(codeErr error) {
 	te.mu.Lock()
 	defer te.mu.Unlock()
 	te.mu.errToClient = codeErr
@@ -2143,7 +2176,7 @@ func (te *tester) TestConnect(ctx context.Context, t *testing.T, url string, fn 
 // an error to occur and validates the error matches the provided information.
 func (te *tester) TestConnectErr(
 	ctx context.Context, t *testing.T, url string, expCode errorCode, expErr string,
-) {
+) error {
 	t.Helper()
 	te.setAuthenticated(false)
 	te.setErrToClient(nil)
@@ -2165,8 +2198,9 @@ func (te *tester) TestConnectErr(
 	require.False(t, te.Authenticated())
 	if expCode != 0 {
 		require.NotNil(t, te.ErrToClient())
-		require.Equal(t, expCode, te.ErrToClient().code)
+		require.Equal(t, expCode, getErrorCode(te.ErrToClient()))
 	}
+	return err
 }
 
 func newSecureProxyServer(

--- a/pkg/sql/pgwire/pgcode/codes.go
+++ b/pkg/sql/pgwire/pgcode/codes.go
@@ -380,6 +380,10 @@ var (
 	// internally on a connection between different Cockroach nodes.
 	InternalConnectionFailure = MakeCode("58C01")
 
+	// ProxyConnectionError is returned by the sqlproxyccl and it indicates a
+	// problem establishing the connection through the proxy.
+	ProxyConnectionError = MakeCode("08C00")
+
 	// Class XC - cockroach extension.
 	// CockroachDB distributed system related errors.
 


### PR DESCRIPTION
Backport 1/1 commits from #94030.

/cc @cockroachdb/release

---

The error with code that the proxy uses doesn't follow the same pattern as the rest of the repo code and as a result the hint that we add to the error was not being passed to the end user. This PR refactors the error to be in line with the rest of the code, refactors the hint that we use in case of missing routing info and adds a test to verify that it works.

Fixes #93474

Release note: None

Release justification: Fixes a customer reported bug that only affects
the sqlproxy.