### PR TITLE
optbuilder: disable RANGE window mode with offsets and NULLS LAST

### DIFF
--- a/pkg/sql/opt/optbuilder/testdata/window
+++ b/pkg/sql/opt/optbuilder/testdata/window
@@ -1536,3 +1536,12 @@ sort
            │         └── v:3 IS NULL [as=rank_1_nulls_ordering_1_1:8]
            └── windows
                 └── rank [as=rank:7]
+
+# Regression test for an internal error with RANGE mode with offsets and NULLS
+# LAST.
+# TODO(yuzefovich): teach the execution engine to support this special case
+# (#94032).
+build
+SELECT avg(k) OVER (ORDER BY id NULLS LAST RANGE 0 PRECEDING) FROM nulls_last_test
+----
+error: NULLS LAST with RANGE mode with OFFSET is currently unsupported

--- a/pkg/sql/opt/optbuilder/window.go
+++ b/pkg/sql/opt/optbuilder/window.go
@@ -99,13 +99,15 @@ func (b *Builder) buildWindow(outScope *scope, inScope *scope) {
 		// Build appropriate partitions.
 		partitions[i] = b.buildWindowPartition(def.Partitions, i, w.def.Name, inScope, argScope)
 
-		// Build appropriate orderings.
-		ord := b.buildWindowOrdering(def.OrderBy, i, w.def.Name, inScope, argScope)
-		orderings[i].FromOrdering(ord)
-
+		var isRangeModeWithOffsets bool
 		if def.Frame != nil {
 			windowFrames[i] = *def.Frame
+			isRangeModeWithOffsets = windowFrames[i].Mode == treewindow.RANGE && def.Frame.Bounds.HasOffset()
 		}
+
+		// Build appropriate orderings.
+		ord := b.buildWindowOrdering(def.OrderBy, i, w.def.Name, inScope, argScope, isRangeModeWithOffsets)
+		orderings[i].FromOrdering(ord)
 
 		if w.Filter != nil {
 			col := b.buildFilterCol(w.Filter, i, w.def.Name, inScope, argScope)
@@ -269,7 +271,7 @@ func (b *Builder) buildAggregationAsWindow(
 
 		// Build appropriate orderings.
 		if !agg.isCommutative() {
-			ord := b.buildWindowOrdering(agg.OrderBy, i, agg.def.Name, fromScope, g.aggInScope)
+			ord := b.buildWindowOrdering(agg.OrderBy, i, agg.def.Name, fromScope, g.aggInScope, false /* isRangeModeWithOffsets */)
 			orderings[i].FromOrdering(ord)
 		}
 
@@ -414,7 +416,11 @@ func (b *Builder) buildWindowPartition(
 
 // buildWindowOrdering builds the appropriate orderings for window functions.
 func (b *Builder) buildWindowOrdering(
-	orderBy tree.OrderBy, windowIndex int, funcName string, inScope, outScope *scope,
+	orderBy tree.OrderBy,
+	windowIndex int,
+	funcName string,
+	inScope, outScope *scope,
+	isRangeModeWithOffsets bool,
 ) opt.Ordering {
 	ord := make(opt.Ordering, 0, len(orderBy))
 	for j, t := range orderBy {
@@ -428,6 +434,11 @@ func (b *Builder) buildWindowOrdering(
 				expr := tree.NewTypedIsNullExpr(e)
 				col := outScope.findExistingCol(expr, false /* allowSideEffects */)
 				if col == nil {
+					if isRangeModeWithOffsets {
+						// TODO(yuzefovich): teach the execution engine to
+						// support this special case (#94032).
+						panic(errors.New("NULLS LAST with RANGE mode with OFFSET is currently unsupported"))
+					}
 					// Use an anonymous name because the column cannot be referenced
 					// in other expressions.
 					colName := scopeColName("").WithMetadataName(


### PR DESCRIPTION
This commit makes it so that we return a regular error when building the window frame with RANGE mode with offsets when NULLS LAST ordering is requested. The execution engine assumes that exactly one column is included in the ordering for such a frame, and we recently fixed how we handle NULLS LAST (by projecting another column), so at the moment with such queries we encounter a scary-looking internal error, and now we'll get a regular error. Teaching the execution engine about this is not exactly trivial, so for now we'll just prohibit such queries.

Addresses: #94032.

Epic: None

Release note (bug fix): Previously, CockroachDB could encounter an internal error when evaluating window functions with RANGE window frame mode with OFFSET PRECEDING or OFFSET FOLLOWING boundary when ORDER BY clause has NULLS LAST option. This will now result in a regular error since the feature is marked as unsupported.