### PR TITLE
cli: print the node's rpc address for demo

### DIFF
--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -1449,6 +1449,9 @@ func (c *transientCluster) ListDemoNodes(w, ew io.Writer, justOne bool) {
 			continue
 		}
 
+		// Print the RPC address for the node.
+		fmt.Fprintln(w, "  (rpc)     ", s.ServingRPCAddr())
+
 		nodeID := s.NodeID()
 		if !justOne {
 			// We skip the node ID if we're in the top level introduction of


### PR DESCRIPTION
This change prints the RPC address for nodes in demo to help with other cli tooling, specifically, `debug zip`.

Epic: CRDB-18407

Release note: None