### PR TITLE
storage: include range key stats in ScanStats

### DIFF
--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -1781,14 +1781,18 @@ func humanizePointCount(n uint64) redact.SafeString {
 func (s *ScanStats) SafeFormat(w redact.SafePrinter, _ rune) {
 	w.Printf("scan stats: stepped %d times (%d internal); seeked %d times (%d internal); "+
 		"block-bytes: (total %s, cached %s); "+
-		"points: (count %s, key-bytes %s, value-bytes %s, tombstoned: %s)",
+		"points: (count %s, key-bytes %s, value-bytes %s, tombstoned: %s) "+
+		"ranges: (count %s), (contained-points %s, skipped-points %s)",
 		s.NumInterfaceSteps, s.NumInternalSteps, s.NumInterfaceSeeks, s.NumInternalSeeks,
 		humanizeutil.IBytes(int64(s.BlockBytes)),
 		humanizeutil.IBytes(int64(s.BlockBytesInCache)),
 		humanizePointCount(s.PointCount),
 		humanizeutil.IBytes(int64(s.KeyBytes)),
 		humanizeutil.IBytes(int64(s.ValueBytes)),
-		humanizePointCount(s.PointsCoveredByRangeTombstones))
+		humanizePointCount(s.PointsCoveredByRangeTombstones),
+		humanizePointCount(s.RangeKeyCount),
+		humanizePointCount(s.RangeKeyContainedPoints),
+		humanizePointCount(s.RangeKeySkippedPoints))
 }
 
 // String implements fmt.Stringer.

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -3200,4 +3200,7 @@ message ScanStats {
   uint64 value_bytes = 8;
   uint64 point_count = 9;
   uint64 points_covered_by_range_tombstones = 10;
+  uint64 range_key_count = 11;
+  uint64 range_key_contained_points = 12;
+  uint64 range_key_skipped_points = 13;
 }

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -3557,6 +3557,9 @@ func recordIteratorStats(ctx context.Context, iter MVCCIterator) {
 		ValueBytes:                     stats.InternalStats.ValueBytes,
 		PointCount:                     stats.InternalStats.PointCount,
 		PointsCoveredByRangeTombstones: stats.InternalStats.PointsCoveredByRangeTombstones,
+		RangeKeyCount:                  uint64(stats.RangeKeyStats.Count),
+		RangeKeyContainedPoints:        uint64(stats.RangeKeyStats.ContainedPoints),
+		RangeKeySkippedPoints:          uint64(stats.RangeKeyStats.SkippedPoints),
 	})
 }
 


### PR DESCRIPTION
Include the new, low-level Pebble range key iterator stats (introduced in cockroachdb/pebble#1871) in roachpb.ScanStats.

Informs #77580.
Close #93326.

Epic: None
Release note: None