### PR TITLE
sql,storage: some preliminary changes for KV projection pushdown

### DIFF
--- a/pkg/sql/colfetcher/BUILD.bazel
+++ b/pkg/sql/colfetcher/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/types",
+        "//pkg/storage",
         "//pkg/util",
         "//pkg/util/encoding",
         "//pkg/util/hlc",

--- a/pkg/sql/row/BUILD.bazel
+++ b/pkg/sql/row/BUILD.bazel
@@ -64,6 +64,7 @@ go_library(
         "//pkg/sql/span",
         "//pkg/sql/sqlerrors",
         "//pkg/sql/types",
+        "//pkg/storage",
         "//pkg/storage/enginepb",
         "//pkg/util",
         "//pkg/util/admission",

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -53,27 +53,33 @@ const DebugRowFetch = false
 // part of the output.
 const noOutputColumn = -1
 
-// kvBatchFetcherResponse contains a response from the KVBatchFetcher.
-type kvBatchFetcherResponse struct {
-	// moreKVs indicates whether this response contains some keys from the
+// KVBatchFetcherResponse contains a response from the KVBatchFetcher.
+type KVBatchFetcherResponse struct {
+	// MoreKVs indicates whether this response contains some keys from the
 	// fetch.
 	//
 	// If true, then the fetch might (or might not) be complete at this point -
-	// another call to nextBatch() is needed to find out. If false, then the
+	// another call to NextBatch() is needed to find out. If false, then the
 	// fetch has already been completed and this response doesn't have any
 	// fetched data.
-	moreKVs bool
-	// Only one of kvs and batchResponse will be set. Which one is set depends
-	// on the server version. Both must be handled by calling code.
 	//
-	// kvs, if set, is a slice of roachpb.KeyValue, the deserialized kv pairs
+	// Note that it is possible that MoreKVs is true when neither KVs nor
+	// BatchResponse is set. This can occur when there was nothing to fetch for
+	// a Scan or a ReverseScan request, so the caller should just skip over such
+	// a response.
+	MoreKVs bool
+	// Only one of KVs and BatchResponse will be set. Which one is set depends
+	// on the request type (KVs is used for Gets and BatchResponse for Scans and
+	// ReverseScans). Both must be handled by calling code.
+	//
+	// KVs, if set, is a slice of roachpb.KeyValue, the deserialized kv pairs
 	// that were fetched.
-	kvs []roachpb.KeyValue
-	// batchResponse, if set, is a packed byte slice containing the keys and
-	// values. An empty batchResponse indicates that nothing was fetched for the
+	KVs []roachpb.KeyValue
+	// BatchResponse, if set, is a packed byte slice containing the keys and
+	// values. An empty BatchResponse indicates that nothing was fetched for the
 	// corresponding ScanRequest, and the caller is expected to skip over the
 	// response.
-	batchResponse []byte
+	BatchResponse []byte
 	// spanID is the ID associated with the span that generated this response.
 	spanID int
 }
@@ -89,11 +95,22 @@ type KVBatchFetcher interface {
 		firstBatchKeyLimit rowinfra.KeyLimit,
 	) error
 
-	// nextBatch returns the next batch of rows. See kvBatchFetcherResponse for
+	// NextBatch returns the next batch of rows. See KVBatchFetcherResponse for
 	// details on what is returned.
-	nextBatch(ctx context.Context) (kvBatchFetcherResponse, error)
+	NextBatch(ctx context.Context) (KVBatchFetcherResponse, error)
 
-	close(ctx context.Context)
+	// GetBytesRead returns the number of bytes read by this fetcher. It is safe
+	// for concurrent use and is able to handle a case of uninitialized fetcher.
+	GetBytesRead() int64
+
+	// GetBatchRequestsIssued returns the number of BatchRequests issued by this
+	// fetcher throughout its lifetime. It is safe for concurrent use and is
+	// able to handle a case of uninitialized fetcher.
+	GetBatchRequestsIssued() int64
+
+	// Close releases the resources of this KVBatchFetcher. Must be called once
+	// the fetcher is no longer in use.
+	Close(ctx context.Context)
 }
 
 type tableInfo struct {
@@ -379,21 +396,22 @@ func (rf *Fetcher) Init(ctx context.Context, args FetcherInitArgs) error {
 		}
 		rf.kvFetcher = args.StreamingKVFetcher
 	} else if !args.WillUseKVProvider {
-		fetcherArgs := kvBatchFetcherArgs{
+		var batchRequestsIssued int64
+		fetcherArgs := newTxnKVFetcherArgs{
 			reverse:                    args.Reverse,
 			lockStrength:               args.LockStrength,
 			lockWaitPolicy:             args.LockWaitPolicy,
 			lockTimeout:                args.LockTimeout,
 			acc:                        rf.kvFetcherMemAcc,
 			forceProductionKVBatchSize: args.ForceProductionKVBatchSize,
+			batchRequestsIssued:        &batchRequestsIssued,
 		}
-		var batchRequestsIssued int64
 		if args.Txn != nil {
-			fetcherArgs.sendFn = makeKVBatchFetcherDefaultSendFunc(args.Txn, &batchRequestsIssued)
+			fetcherArgs.sendFn = makeTxnKVFetcherDefaultSendFunc(args.Txn, &batchRequestsIssued)
 			fetcherArgs.requestAdmissionHeader = args.Txn.AdmissionHeader()
 			fetcherArgs.responseAdmissionQ = args.Txn.DB().SQLKVResponseAdmissionQ
 		}
-		rf.kvFetcher = newKVFetcher(newKVBatchFetcher(fetcherArgs), &batchRequestsIssued)
+		rf.kvFetcher = newKVFetcher(newTxnKVFetcherInternal(fetcherArgs))
 	}
 
 	return nil
@@ -408,8 +426,12 @@ func (rf *Fetcher) Init(ctx context.Context, args FetcherInitArgs) error {
 //   - allowing the caller to update the Fetcher to use the new txn. In this case,
 //     the caller should be careful since reads performed under different txns
 //     do not provide consistent view of the data.
+//
+// Note that this resets the number of batch requests issued by the Fetcher.
+// Consider using GetBatchRequestsIssued if that information is needed.
 func (rf *Fetcher) SetTxn(txn *kv.Txn) error {
-	sendFn := makeKVBatchFetcherDefaultSendFunc(txn, rf.kvFetcher.atomics.batchRequestsIssued)
+	var batchRequestsIssued int64
+	sendFn := makeTxnKVFetcherDefaultSendFunc(txn, &batchRequestsIssued)
 	return rf.setTxnAndSendFn(txn, sendFn)
 }
 
@@ -611,10 +633,7 @@ func (rf *Fetcher) ConsumeKVProvider(ctx context.Context, f *KVProvider) error {
 	if rf.kvFetcher != nil {
 		rf.kvFetcher.Close(ctx)
 	}
-	// We won't actually perform any KV reads, so we don't need to track the
-	// number of batch requests issued - the case of the KVProvider is handled
-	// separately in GetBatchRequestsIssued().
-	rf.kvFetcher = newKVFetcher(f, nil /* batchRequestsIssued */)
+	rf.kvFetcher = newKVFetcher(f)
 	return rf.startScan(ctx)
 }
 
@@ -1261,13 +1280,16 @@ func (rf *Fetcher) Key() roachpb.Key {
 
 // GetBytesRead returns total number of bytes read by the underlying KVFetcher.
 func (rf *Fetcher) GetBytesRead() int64 {
+	if rf == nil || rf.kvFetcher == nil {
+		return 0
+	}
 	return rf.kvFetcher.GetBytesRead()
 }
 
 // GetBatchRequestsIssued returns total number of BatchRequests issued by the
 // underlying KVFetcher.
 func (rf *Fetcher) GetBatchRequestsIssued() int64 {
-	if rf == nil || rf.args.WillUseKVProvider {
+	if rf == nil || rf.kvFetcher == nil || rf.args.WillUseKVProvider {
 		return 0
 	}
 	return rf.kvFetcher.GetBatchRequestsIssued()

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/intsets"
@@ -170,7 +171,7 @@ type Fetcher struct {
 
 	// mvccDecodeStrategy controls whether or not MVCC timestamps should
 	// be decoded from KV's fetched.
-	mvccDecodeStrategy MVCCDecodingStrategy
+	mvccDecodeStrategy storage.MVCCDecodingStrategy
 
 	// -- Fields updated during a scan --
 
@@ -299,7 +300,7 @@ func (rf *Fetcher) Init(ctx context.Context, args FetcherInitArgs) error {
 			switch colinfo.GetSystemColumnKindFromColumnID(colID) {
 			case catpb.SystemColumnKind_MVCCTIMESTAMP:
 				table.timestampOutputIdx = idx
-				rf.mvccDecodeStrategy = MVCCDecodingRequired
+				rf.mvccDecodeStrategy = storage.MVCCDecodingRequired
 
 			case catpb.SystemColumnKind_TABLEOID:
 				table.oidOutputIdx = idx
@@ -652,11 +653,11 @@ func (rf *Fetcher) setNextKV(kv roachpb.KeyValue, needsCopy bool) {
 // nextKey retrieves the next key/value and sets kv/kvEnd. Returns whether the
 // key indicates a new row (as opposed to another family for the current row).
 func (rf *Fetcher) nextKey(ctx context.Context) (newRow bool, spanID int, _ error) {
-	ok, kv, spanID, finalReferenceToBatch, err := rf.kvFetcher.NextKV(ctx, rf.mvccDecodeStrategy)
+	ok, kv, spanID, needsCopy, err := rf.kvFetcher.nextKV(ctx, rf.mvccDecodeStrategy)
 	if err != nil {
 		return false, 0, ConvertFetchError(&rf.table.spec, err)
 	}
-	rf.setNextKV(kv, finalReferenceToBatch)
+	rf.setNextKV(kv, needsCopy)
 
 	if !ok {
 		// No more keys in the scan.

--- a/pkg/sql/row/fetcher_test.go
+++ b/pkg/sql/row/fetcher_test.go
@@ -711,6 +711,9 @@ func TestRowFetcherReset(t *testing.T) {
 	); err != nil {
 		t.Fatal(err)
 	}
+	// We need to nil out the kvFetchers since these are stored as pointers.
+	fetcher.kvFetcher = nil
+	resetFetcher.kvFetcher = nil
 
 	if !reflect.DeepEqual(resetFetcher, fetcher) {
 		t.Fatal("unequal before and after reset", resetFetcher, fetcher)

--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -12,6 +12,7 @@ package row
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 	"unsafe"
 
@@ -102,6 +103,7 @@ func (s *identifiableSpans) reset() {
 
 // txnKVFetcher handles retrieval of key/values.
 type txnKVFetcher struct {
+	kvBatchFetcherHelper
 	// "Constant" fields, provided by the caller.
 	sendFn sendFunc
 	// spans is the list of Spans that will be read by this KV Fetcher. If an
@@ -225,7 +227,7 @@ func (f *txnKVFetcher) getBatchKeyLimitForIdx(batchIdx int) rowinfra.KeyLimit {
 	}
 }
 
-func makeKVBatchFetcherDefaultSendFunc(txn *kv.Txn, batchRequestsIssued *int64) sendFunc {
+func makeTxnKVFetcherDefaultSendFunc(txn *kv.Txn, batchRequestsIssued *int64) sendFunc {
 	return func(
 		ctx context.Context,
 		ba *roachpb.BatchRequest,
@@ -239,7 +241,7 @@ func makeKVBatchFetcherDefaultSendFunc(txn *kv.Txn, batchRequestsIssued *int64) 
 	}
 }
 
-type kvBatchFetcherArgs struct {
+type newTxnKVFetcherArgs struct {
 	sendFn                     sendFunc
 	reverse                    bool
 	lockStrength               descpb.ScanLockingStrength
@@ -247,17 +249,18 @@ type kvBatchFetcherArgs struct {
 	lockTimeout                time.Duration
 	acc                        *mon.BoundAccount
 	forceProductionKVBatchSize bool
+	batchRequestsIssued        *int64
 	requestAdmissionHeader     roachpb.AdmissionHeader
 	responseAdmissionQ         *admission.WorkQueue
 }
 
-// newKVBatchFetcher initializes a KVBatchFetcher.
+// newTxnKVFetcherInternal initializes a txnKVFetcher.
 //
 // The passed-in memory account is owned by the fetcher throughout its lifetime
 // but is **not** closed - it is the caller's responsibility to close acc if it
 // is non-nil.
-func newKVBatchFetcher(args kvBatchFetcherArgs) *txnKVFetcher {
-	return &txnKVFetcher{
+func newTxnKVFetcherInternal(args newTxnKVFetcherArgs) *txnKVFetcher {
+	f := &txnKVFetcher{
 		sendFn:                     args.sendFn,
 		reverse:                    args.reverse,
 		lockStrength:               getKeyLockingStrength(args.lockStrength),
@@ -268,6 +271,8 @@ func newKVBatchFetcher(args kvBatchFetcherArgs) *txnKVFetcher {
 		requestAdmissionHeader:     args.requestAdmissionHeader,
 		responseAdmissionQ:         args.responseAdmissionQ,
 	}
+	f.kvBatchFetcherHelper.init(f.nextBatch, args.batchRequestsIssued)
+	return f
 }
 
 // setTxnAndSendFn updates the txnKVFetcher with the new txn and sendFn. txn and
@@ -508,8 +513,7 @@ func popBatch(batches [][]byte) (batch []byte, remainingBatches [][]byte) {
 	return batch, remainingBatches
 }
 
-// nextBatch implements the KVBatchFetcher interface.
-func (f *txnKVFetcher) nextBatch(ctx context.Context) (resp kvBatchFetcherResponse, err error) {
+func (f *txnKVFetcher) nextBatch(ctx context.Context) (resp KVBatchFetcherResponse, err error) {
 	// The purpose of this loop is to unpack the two-level batch structure that is
 	// returned from the KV layer.
 	//
@@ -524,9 +528,9 @@ func (f *txnKVFetcher) nextBatch(ctx context.Context) (resp kvBatchFetcherRespon
 		// list and return it.
 		var batchResp []byte
 		batchResp, f.remainingBatches = popBatch(f.remainingBatches)
-		return kvBatchFetcherResponse{
-			moreKVs:       true,
-			batchResponse: batchResp,
+		return KVBatchFetcherResponse{
+			MoreKVs:       true,
+			BatchResponse: batchResp,
 			spanID:        f.curSpanID,
 		}, nil
 	}
@@ -545,7 +549,7 @@ func (f *txnKVFetcher) nextBatch(ctx context.Context) (resp kvBatchFetcherRespon
 		// Check whether we need to resume scanning this span.
 		header := reply.Header()
 		if header.NumKeys > 0 && f.scratchSpans.Len() > 0 {
-			return kvBatchFetcherResponse{}, errors.Errorf(
+			return KVBatchFetcherResponse{}, errors.Errorf(
 				"span with results after resume span; it shouldn't happen given that "+
 					"we're only scanning non-overlapping spans. New spans: %s",
 				catalogkeys.PrettySpans(nil, f.spans.Spans, 0 /* skip */))
@@ -557,49 +561,49 @@ func (f *txnKVFetcher) nextBatch(ctx context.Context) (resp kvBatchFetcherRespon
 			f.scratchSpans.push(*resumeSpan, f.curSpanID)
 		}
 
-		ret := kvBatchFetcherResponse{
-			moreKVs: true,
+		ret := KVBatchFetcherResponse{
+			MoreKVs: true,
 			spanID:  f.curSpanID,
 		}
 
 		switch t := reply.(type) {
 		case *roachpb.ScanResponse:
 			if len(t.BatchResponses) > 0 {
-				ret.batchResponse, f.remainingBatches = popBatch(t.BatchResponses)
+				ret.BatchResponse, f.remainingBatches = popBatch(t.BatchResponses)
 			}
 			if len(t.Rows) > 0 {
-				return kvBatchFetcherResponse{}, errors.AssertionFailedf(
+				return KVBatchFetcherResponse{}, errors.AssertionFailedf(
 					"unexpectedly got a ScanResponse using KEY_VALUES response format",
 				)
 			}
 			if len(t.IntentRows) > 0 {
-				return kvBatchFetcherResponse{}, errors.AssertionFailedf(
+				return KVBatchFetcherResponse{}, errors.AssertionFailedf(
 					"unexpectedly got a ScanResponse with non-nil IntentRows",
 				)
 			}
-			// Note that ret.batchResponse might be nil when the ScanResponse is
+			// Note that ret.BatchResponse might be nil when the ScanResponse is
 			// empty, and the caller (the KVFetcher) will skip over it.
 			return ret, nil
 		case *roachpb.ReverseScanResponse:
 			if len(t.BatchResponses) > 0 {
-				ret.batchResponse, f.remainingBatches = popBatch(t.BatchResponses)
+				ret.BatchResponse, f.remainingBatches = popBatch(t.BatchResponses)
 			}
 			if len(t.Rows) > 0 {
-				return kvBatchFetcherResponse{}, errors.AssertionFailedf(
+				return KVBatchFetcherResponse{}, errors.AssertionFailedf(
 					"unexpectedly got a ScanResponse using KEY_VALUES response format",
 				)
 			}
 			if len(t.IntentRows) > 0 {
-				return kvBatchFetcherResponse{}, errors.AssertionFailedf(
+				return KVBatchFetcherResponse{}, errors.AssertionFailedf(
 					"unexpectedly got a ScanResponse with non-nil IntentRows",
 				)
 			}
-			// Note that ret.batchResponse might be nil when the ScanResponse is
+			// Note that ret.BatchResponse might be nil when the ScanResponse is
 			// empty, and the caller (the KVFetcher) will skip over it.
 			return ret, nil
 		case *roachpb.GetResponse:
 			if t.IntentValue != nil {
-				return kvBatchFetcherResponse{}, errors.AssertionFailedf("unexpectedly got an IntentValue back from a SQL GetRequest %v", *t.IntentValue)
+				return KVBatchFetcherResponse{}, errors.AssertionFailedf("unexpectedly got an IntentValue back from a SQL GetRequest %v", *t.IntentValue)
 			}
 			if t.Value == nil {
 				// Nothing found in this particular response, let's continue to the next
@@ -607,7 +611,7 @@ func (f *txnKVFetcher) nextBatch(ctx context.Context) (resp kvBatchFetcherRespon
 				continue
 			}
 			f.getResponseScratch[0] = roachpb.KeyValue{Key: origSpan.Key, Value: *t.Value}
-			ret.kvs = f.getResponseScratch[:]
+			ret.KVs = f.getResponseScratch[:]
 			return ret, nil
 		}
 	}
@@ -616,21 +620,21 @@ func (f *txnKVFetcher) nextBatch(ctx context.Context) (resp kvBatchFetcherRespon
 		if f.scratchSpans.Len() == 0 {
 			// If we are out of keys, we can return and we're finished with the
 			// fetch.
-			return kvBatchFetcherResponse{moreKVs: false}, nil
+			return KVBatchFetcherResponse{MoreKVs: false}, nil
 		}
 		// We have some resume spans.
 		f.spans = f.scratchSpans
 		if f.acc != nil {
 			newSpansMemUsage := f.spans.MemUsage()
 			if err := f.acc.Resize(ctx, f.spansAccountedFor, newSpansMemUsage); err != nil {
-				return kvBatchFetcherResponse{}, err
+				return KVBatchFetcherResponse{}, err
 			}
 			f.spansAccountedFor = newSpansMemUsage
 		}
 	}
 	// We have more work to do. Ask the KV layer to continue where it left off.
 	if err := f.fetch(ctx); err != nil {
-		return kvBatchFetcherResponse{}, err
+		return KVBatchFetcherResponse{}, err
 	}
 	// We've got more data to process, recurse and process it.
 	return f.nextBatch(ctx)
@@ -650,8 +654,8 @@ func (f *txnKVFetcher) reset(ctx context.Context) {
 	f.batchResponseAccountedFor, f.spansAccountedFor = 0, 0
 }
 
-// close releases the resources of this txnKVFetcher.
-func (f *txnKVFetcher) close(ctx context.Context) {
+// Close releases the resources of this txnKVFetcher.
+func (f *txnKVFetcher) Close(ctx context.Context) {
 	f.reset(ctx)
 }
 
@@ -736,4 +740,53 @@ func spansToRequests(
 		}
 	}
 	return reqs
+}
+
+// kvBatchFetcherHelper is a small helper that extracts common logic for
+// implementing some methods of the KVBatchFetcher interface related to
+// observability.
+type kvBatchFetcherHelper struct {
+	nextBatch func(context.Context) (KVBatchFetcherResponse, error)
+	atomics   struct {
+		bytesRead           int64
+		batchRequestsIssued *int64
+	}
+}
+
+func (h *kvBatchFetcherHelper) init(
+	nextBatch func(context.Context) (KVBatchFetcherResponse, error), batchRequestsIssued *int64,
+) {
+	h.nextBatch = nextBatch
+	h.atomics.batchRequestsIssued = batchRequestsIssued
+}
+
+// NextBatch implements the KVBatchFetcher interface.
+func (h *kvBatchFetcherHelper) NextBatch(ctx context.Context) (KVBatchFetcherResponse, error) {
+	resp, err := h.nextBatch(ctx)
+	if !resp.MoreKVs || err != nil {
+		return resp, err
+	}
+	nBytes := len(resp.BatchResponse)
+	for i := range resp.KVs {
+		nBytes += len(resp.KVs[i].Key)
+		nBytes += len(resp.KVs[i].Value.RawBytes)
+	}
+	atomic.AddInt64(&h.atomics.bytesRead, int64(nBytes))
+	return resp, nil
+}
+
+// GetBytesRead implements the KVBatchFetcher interface.
+func (h *kvBatchFetcherHelper) GetBytesRead() int64 {
+	if h == nil {
+		return 0
+	}
+	return atomic.LoadInt64(&h.atomics.bytesRead)
+}
+
+// GetBatchRequestsIssued implements the KVBatchFetcher interface.
+func (h *kvBatchFetcherHelper) GetBatchRequestsIssued() int64 {
+	if h == nil || h.atomics.batchRequestsIssued == nil {
+		return 0
+	}
+	return atomic.LoadInt64(h.atomics.batchRequestsIssued)
 }

--- a/pkg/sql/row/kv_batch_streamer.go
+++ b/pkg/sql/row/kv_batch_streamer.go
@@ -25,6 +25,7 @@ import (
 
 // txnKVStreamer handles retrieval of key/values.
 type txnKVStreamer struct {
+	kvBatchFetcherHelper
 	streamer   *kvstreamer.Streamer
 	keyLocking lock.Strength
 
@@ -49,13 +50,18 @@ var _ KVBatchFetcher = &txnKVStreamer{}
 
 // newTxnKVStreamer creates a new txnKVStreamer.
 func newTxnKVStreamer(
-	streamer *kvstreamer.Streamer, lockStrength descpb.ScanLockingStrength, acc *mon.BoundAccount,
+	streamer *kvstreamer.Streamer,
+	lockStrength descpb.ScanLockingStrength,
+	acc *mon.BoundAccount,
+	batchRequestsIssued *int64,
 ) KVBatchFetcher {
-	return &txnKVStreamer{
+	f := &txnKVStreamer{
 		streamer:   streamer,
 		keyLocking: getKeyLockingStrength(lockStrength),
 		acc:        acc,
 	}
+	f.kvBatchFetcherHelper.init(f.nextBatch, batchRequestsIssued)
+	return f
 }
 
 // SetupNextFetch implements the KVBatchFetcher interface.
@@ -113,10 +119,10 @@ func (f *txnKVStreamer) getSpanID(resultPosition int) int {
 // GetResponses).
 func (f *txnKVStreamer) proceedWithLastResult(
 	ctx context.Context,
-) (skip bool, _ kvBatchFetcherResponse, _ error) {
+) (skip bool, _ KVBatchFetcherResponse, _ error) {
 	result := f.lastResultState.Result
-	ret := kvBatchFetcherResponse{
-		moreKVs: true,
+	ret := KVBatchFetcherResponse{
+		MoreKVs: true,
 		spanID:  f.getSpanID(result.Position),
 	}
 	if get := result.GetResp; get != nil {
@@ -125,21 +131,21 @@ func (f *txnKVStreamer) proceedWithLastResult(
 		if get.Value == nil {
 			// Nothing found in this particular response, so we skip it.
 			f.releaseLastResult(ctx)
-			return true, kvBatchFetcherResponse{}, nil
+			return true, KVBatchFetcherResponse{}, nil
 		}
 		origSpan := f.spans[result.Position]
 		f.getResponseScratch[0] = roachpb.KeyValue{Key: origSpan.Key, Value: *get.Value}
-		ret.kvs = f.getResponseScratch[:]
+		ret.KVs = f.getResponseScratch[:]
 		return false, ret, nil
 	}
 	scan := result.ScanResp
 	if len(scan.BatchResponses) > 0 {
-		ret.batchResponse, f.lastResultState.remainingBatches = scan.BatchResponses[0], scan.BatchResponses[1:]
+		ret.BatchResponse, f.lastResultState.remainingBatches = scan.BatchResponses[0], scan.BatchResponses[1:]
 	}
 	// We're consciously ignoring scan.Rows argument since the Streamer
 	// guarantees to always produce Scan responses using BATCH_RESPONSE format.
 	//
-	// Note that ret.batchResponse might be nil when the ScanResponse is empty,
+	// Note that ret.BatchResponse might be nil when the ScanResponse is empty,
 	// and the caller (the KVFetcher) will skip over it.
 	return false, ret, nil
 }
@@ -149,15 +155,14 @@ func (f *txnKVStreamer) releaseLastResult(ctx context.Context) {
 	f.lastResultState.Result = kvstreamer.Result{}
 }
 
-// nextBatch implements the KVBatchFetcher interface.
-func (f *txnKVStreamer) nextBatch(ctx context.Context) (kvBatchFetcherResponse, error) {
+func (f *txnKVStreamer) nextBatch(ctx context.Context) (resp KVBatchFetcherResponse, _ error) {
 	// Check whether there are more batches in the current ScanResponse.
 	if len(f.lastResultState.remainingBatches) > 0 {
-		ret := kvBatchFetcherResponse{
-			moreKVs: true,
+		ret := KVBatchFetcherResponse{
+			MoreKVs: true,
 			spanID:  f.getSpanID(f.lastResultState.Result.Position),
 		}
-		ret.batchResponse, f.lastResultState.remainingBatches = f.lastResultState.remainingBatches[0], f.lastResultState.remainingBatches[1:]
+		ret.BatchResponse, f.lastResultState.remainingBatches = f.lastResultState.remainingBatches[0], f.lastResultState.remainingBatches[1:]
 		return ret, nil
 	}
 
@@ -188,7 +193,7 @@ func (f *txnKVStreamer) nextBatch(ctx context.Context) (kvBatchFetcherResponse, 
 	var err error
 	f.results, err = f.streamer.GetResults(ctx)
 	if len(f.results) == 0 || err != nil {
-		return kvBatchFetcherResponse{moreKVs: false}, err
+		return KVBatchFetcherResponse{MoreKVs: false}, err
 	}
 	return f.nextBatch(ctx)
 }
@@ -201,8 +206,8 @@ func (f *txnKVStreamer) reset(ctx context.Context) {
 	}
 }
 
-// close releases the resources of this txnKVStreamer.
-func (f *txnKVStreamer) close(ctx context.Context) {
+// Close releases the resources of this txnKVStreamer.
+func (f *txnKVStreamer) Close(ctx context.Context) {
 	f.reset(ctx)
 	f.streamer.Close(ctx)
 	*f = txnKVStreamer{}

--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "array_64bit.go",
         "ballast.go",
         "batch.go",
+        "col_mvcc.go",
         "disk_map.go",
         "doc.go",
         "engine.go",

--- a/pkg/storage/col_mvcc.go
+++ b/pkg/storage/col_mvcc.go
@@ -1,0 +1,41 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package storage
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+)
+
+// NextKVer can fetch a new KV from somewhere. If MVCCDecodingStrategy is set
+// to MVCCDecodingRequired, the returned KV will include a timestamp.
+type NextKVer interface {
+	// NextKV returns the next kv from this NextKVer. Returns false if there are
+	// no more kvs to fetch, the kv that was fetched, and any errors that may
+	// have occurred.
+	//
+	// needsCopy is set to true when the caller should copy the returned
+	// KeyValue. One example of when this happens is when the returned KV's byte
+	// slices are the last reference into a larger backing byte slice. In such a
+	// case, the next call to NextKV might potentially allocate a big chunk of
+	// new memory, and by copying the returned KeyValue into a small slice that
+	// the caller owns, we avoid retaining two large backing byte slices at
+	// once.
+	NextKV(context.Context, MVCCDecodingStrategy) (
+		ok bool, kv roachpb.KeyValue, needsCopy bool, err error,
+	)
+
+	// GetLastEncodedKey returns the key that was returned on the last NextKV()
+	// call. This method allows callers to access the key at different layers of
+	// abstraction.
+	GetLastEncodedKey() roachpb.Key
+}

--- a/pkg/storage/pebble_mvcc_scanner.go
+++ b/pkg/storage/pebble_mvcc_scanner.go
@@ -40,6 +40,17 @@ var maxItersBeforeSeek = util.ConstantWithMetamorphicTestRange(
 	3,  /* max */
 )
 
+// MVCCDecodingStrategy controls if and how the fetcher should decode MVCC
+// timestamps from returned KV's.
+type MVCCDecodingStrategy int
+
+const (
+	// MVCCDecodingNotRequired is used when timestamps aren't needed.
+	MVCCDecodingNotRequired MVCCDecodingStrategy = iota
+	// MVCCDecodingRequired is used when timestamps are needed.
+	MVCCDecodingRequired
+)
+
 // Struct to store MVCCScan / MVCCGet in the same binary format as that
 // expected by MVCCScanDecodeKeyValue.
 type pebbleResults struct {


### PR DESCRIPTION
This PR contains a couple of commits that are mostly mechanical changes in preparation of the KV pushdown work. Some microbenchmarks of this PR are [here](https://gist.github.com/yuzefovich/24d3238bc638cc1121fd345c68ca3d0b), and they show effectively no change in the scan speed.

Epic: CRDB-14837

Informs: #82323
Informs: #87610