### PR TITLE
logictest: de-flake distsql_enum

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_enum
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_enum
@@ -44,48 +44,46 @@ ALTER TABLE t2 SPLIT AT VALUES(0),(10),(20);
 ALTER TABLE t1 EXPERIMENTAL_RELOCATE VALUES (ARRAY[1], 0), (ARRAY[2], 10), (ARRAY[3], 20);
 ALTER TABLE t2 EXPERIMENTAL_RELOCATE VALUES (ARRAY[1], 0), (ARRAY[2], 10), (ARRAY[3], 20);
 
-# Tickle stats to force lookup join
-statement ok
-ALTER TABLE t1 INJECT STATISTICS '[
-  {
-    "columns": ["x"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 10,
-    "distinct_count": 100
-  }
-]'
+query TTTI colnames
+SELECT start_key, end_key, replicas, lease_holder from [SHOW RANGES FROM TABLE t1 WITH DETAILS] ORDER BY lease_holder
+----
+start_key           end_key                 replicas  lease_holder
+<before:/Table/53>  …/1/0                   {1}       1
+…/1/0               …/1/10                  {1}       1
+…/1/10              …/1/20                  {2}       2
+…/1/20              <after:/Table/110/1/0>  {3}       3
 
-statement ok
-ALTER TABLE t2 INJECT STATISTICS '[
-  {
-    "columns": ["x"],
-    "created_at": "2018-01-01 1:00:00.00000+00:00",
-    "row_count": 10000,
-    "distinct_count": 10000
-  }
-]'
+query TTTI colnames
+SELECT start_key, end_key, replicas, lease_holder from [SHOW RANGES FROM TABLE t2 WITH DETAILS] ORDER BY lease_holder
+----
+start_key                 end_key       replicas  lease_holder
+…/1/0                     …/1/10        {1}       1
+…/1/10                    …/1/20        {2}       2
+<before:/Table/109/1/20>  …/1/0         {3}       3
+…/1/20                    <after:/Max>  {3}       3
 
-query T nodeidx=1,retry
+# Ensure that the join readers are planned on the remote nodes.
+query T
 EXPLAIN (VEC)
-SELECT x from t1 WHERE EXISTS (SELECT x FROM t2 WHERE t1.x=t2.x AND t2.y='hello')
+SELECT t1.x from t1 INNER LOOKUP JOIN t2 ON t1.x=t2.x WHERE t2.y='hello'
 ----
 │
 ├ Node 1
+│ └ *colexec.ParallelUnorderedSynchronizer
+│   ├ *rowexec.joinReader
+│   │ └ *colfetcher.ColBatchScan
+│   ├ *colrpc.Inbox
+│   └ *colrpc.Inbox
+├ Node 2
 │ └ *colrpc.Outbox
 │   └ *rowexec.joinReader
 │     └ *colfetcher.ColBatchScan
-├ Node 2
-│ └ *colexec.ParallelUnorderedSynchronizer
-│   ├ *colrpc.Inbox
-│   ├ *rowexec.joinReader
-│   │ └ *colfetcher.ColBatchScan
-│   └ *colrpc.Inbox
 └ Node 3
   └ *colrpc.Outbox
     └ *rowexec.joinReader
       └ *colfetcher.ColBatchScan
 
-query I nodeidx=1
-SELECT x from t1 WHERE EXISTS (SELECT x FROM t2 WHERE t1.x=t2.x AND t2.y='hello')
+query I
+SELECT t1.x from t1 INNER LOOKUP JOIN t2 ON t1.x=t2.x WHERE t2.y='hello'
 ----
 0


### PR DESCRIPTION
This commit de-flakes `distsql_enum` test. Previously, in a regression test we relied on injected table stats to get to the desired plan with a lookup join, but this commit switches to using the join hint to get there.

Fixes: #93895.

Release note: None