### PR TITLE
pgwire: support decoding binary regXXX types

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1631,9 +1631,9 @@ oid     typname                typnamespace  typowner    typlen  typbyval  typty
 21      int2                   4294967127    NULL        2       true      b
 22      int2vector             4294967127    NULL        -1      false     b
 23      int4                   4294967127    NULL        4       true      b
-24      regproc                4294967127    NULL        8       true      b
+24      regproc                4294967127    NULL        4       true      b
 25      text                   4294967127    NULL        -1      false     b
-26      oid                    4294967127    NULL        8       true      b
+26      oid                    4294967127    NULL        4       true      b
 30      oidvector              4294967127    NULL        -1      false     b
 700     float4                 4294967127    NULL        4       true      b
 701     float8                 4294967127    NULL        8       true      b
@@ -1676,9 +1676,9 @@ oid     typname                typnamespace  typowner    typlen  typbyval  typty
 1562    varbit                 4294967127    NULL        -1      false     b
 1563    _varbit                4294967127    NULL        -1      false     b
 1700    numeric                4294967127    NULL        -1      false     b
-2202    regprocedure           4294967127    NULL        8       true      b
-2205    regclass               4294967127    NULL        8       true      b
-2206    regtype                4294967127    NULL        8       true      b
+2202    regprocedure           4294967127    NULL        4       true      b
+2205    regclass               4294967127    NULL        4       true      b
+2206    regtype                4294967127    NULL        4       true      b
 2207    _regprocedure          4294967127    NULL        -1      false     b
 2210    _regclass              4294967127    NULL        -1      false     b
 2211    _regtype               4294967127    NULL        -1      false     b
@@ -1695,9 +1695,9 @@ oid     typname                typnamespace  typowner    typlen  typbyval  typty
 3645    _tsquery               4294967127    NULL        -1      false     b
 3802    jsonb                  4294967127    NULL        -1      false     b
 3807    _jsonb                 4294967127    NULL        -1      false     b
-4089    regnamespace           4294967127    NULL        8       true      b
+4089    regnamespace           4294967127    NULL        4       true      b
 4090    _regnamespace          4294967127    NULL        -1      false     b
-4096    regrole                4294967127    NULL        8       true      b
+4096    regrole                4294967127    NULL        4       true      b
 4097    _regrole               4294967127    NULL        -1      false     b
 90000   geometry               4294967127    NULL        -1      false     b
 90001   _geometry              4294967127    NULL        -1      false     b

--- a/pkg/sql/pgwire/pgwirebase/encoding.go
+++ b/pkg/sql/pgwire/pgwirebase/encoding.go
@@ -556,12 +556,6 @@ func DecodeDatum(
 			}
 			i := int64(binary.BigEndian.Uint64(b))
 			return tree.NewDInt(tree.DInt(i)), nil
-		case oid.T_oid:
-			if len(b) < 4 {
-				return nil, pgerror.Newf(pgcode.Syntax, "oid requires 4 bytes for binary format")
-			}
-			u := binary.BigEndian.Uint32(b)
-			return tree.NewDOid(oid.Oid(u)), nil
 		case oid.T_float4:
 			if len(b) < 4 {
 				return nil, pgerror.Newf(pgcode.Syntax, "float4 requires 4 bytes for binary format")
@@ -832,6 +826,17 @@ func DecodeDatum(
 			}
 			if typ.Family() == types.TupleFamily {
 				return decodeBinaryTuple(ctx, evalCtx, b)
+			}
+			if typ.Family() == types.OidFamily {
+				if len(b) < 4 {
+					return nil, pgerror.Newf(pgcode.ProtocolViolation, "oid requires 4 bytes for binary format")
+				}
+				u := binary.BigEndian.Uint32(b)
+				oidTyp := types.Oid
+				if t, ok := types.OidToType[id]; ok {
+					oidTyp = t
+				}
+				return tree.NewDOidWithType(oid.Oid(u), oidTyp), nil
 			}
 		}
 	default:

--- a/pkg/sql/pgwire/testdata/pgtest/oid
+++ b/pkg/sql/pgwire/testdata/pgtest/oid
@@ -1,0 +1,35 @@
+# [2205, 4089, 24, 2206, 26] are the OIDs for regclass, regnamespace, regproc, regtype, and oid.
+send
+Parse {"Query": "SELECT $1, $2, $3, $4, $5", "ParameterOIDs": [2205,4089,24,2206,26]}
+Describe {"ObjectType": "S"}
+Bind {"ParameterFormatCodes": [1,1,1,1,1], "Parameters": [{"binary":"01000029"},{"binary":"0100002a"},{"binary":"0100002b"},{"binary":"0100002c"},{"binary":"ffffffff"}]}
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[2205,4089,24,2206,26]}
+{"Type":"RowDescription","Fields":[{"Name":"?column?","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":2205,"DataTypeSize":4,"TypeModifier":-1,"Format":0},{"Name":"?column?","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":4089,"DataTypeSize":4,"TypeModifier":-1,"Format":0},{"Name":"?column?","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":24,"DataTypeSize":4,"TypeModifier":-1,"Format":0},{"Name":"?column?","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":2206,"DataTypeSize":4,"TypeModifier":-1,"Format":0},{"Name":"?column?","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":26,"DataTypeSize":4,"TypeModifier":-1,"Format":0}]}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"16777257"},{"text":"16777258"},{"text":"16777259"},{"text":"16777260"},{"text":"4294967295"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# [2205] is the OID for regclass.
+send
+Parse {"Query": "SELECT $1", "ParameterOIDs": [2205]}
+Bind {"ParameterFormatCodes": [1], "Parameters": [{"binary":"0029"}]}
+Execute
+Sync
+----
+
+until
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ErrorResponse","Code":"08P01"}
+{"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -5766,7 +5766,7 @@ var baseDatumTypeSizes = map[types.Family]struct {
 	types.JsonFamily:           {unsafe.Sizeof(DJSON{}), variableSize},
 	types.UuidFamily:           {unsafe.Sizeof(DUuid{}), fixedSize},
 	types.INetFamily:           {unsafe.Sizeof(DIPAddr{}), fixedSize},
-	types.OidFamily:            {unsafe.Sizeof(DInt(0)), fixedSize},
+	types.OidFamily:            {unsafe.Sizeof(DOid{}.Oid), fixedSize},
 	types.EnumFamily:           {unsafe.Sizeof(DEnum{}), variableSize},
 
 	types.VoidFamily: {sz: unsafe.Sizeof(DVoid{}), variable: fixedSize},


### PR DESCRIPTION
Fixes #94353

Epic: None

Release note (bug fix): support receiving regXXX type values in binary extended protocol