### PR TITLE
roachtest: change fingerprinting builtin in c2c roachtest

### DIFF
--- a/pkg/storage/fingerprint_writer.go
+++ b/pkg/storage/fingerprint_writer.go
@@ -191,7 +191,6 @@ func FingerprintRangekeys(
 ) (uint64, error) {
 	ctx, sp := tracing.ChildSpan(ctx, "storage.FingerprintRangekeys")
 	defer sp.Finish()
-	_ = ctx // ctx is currently unused, but this new ctx should be used below in the future.
 
 	if len(ssts) == 0 {
 		return 0, nil

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -1388,11 +1388,16 @@ func cmdExport(e *evalCtx) error {
 	var summary roachpb.BulkOpSummary
 	var resume storage.MVCCKey
 	var fingerprint uint64
+	var hasRangeKeys bool
 	var err error
 	if shouldFingerprint {
-		summary, resume, fingerprint, err = storage.MVCCExportFingerprint(e.ctx, e.st, r, opts, sstFile)
+		summary, resume, fingerprint, hasRangeKeys, err = storage.MVCCExportFingerprint(e.ctx, e.st, r,
+			opts, sstFile)
 		if err != nil {
 			return err
+		}
+		if !hasRangeKeys {
+			sstFile = &storage.MemFile{}
 		}
 		e.results.buf.Printf("export: %s", &summary)
 		e.results.buf.Print(" fingerprint=true")
@@ -1410,9 +1415,12 @@ func cmdExport(e *evalCtx) error {
 	e.results.buf.Printf("\n")
 
 	if shouldFingerprint {
+		var ssts [][]byte
+		if sstFile.Len() != 0 {
+			ssts = append(ssts, sstFile.Bytes())
+		}
 		// Fingerprint the rangekeys returned as a pebble SST.
-		rangekeyFingerprint, err := storage.FingerprintRangekeys(e.ctx, e.st, opts.FingerprintOptions,
-			[][]byte{sstFile.Bytes()})
+		rangekeyFingerprint, err := storage.FingerprintRangekeys(e.ctx, e.st, opts.FingerprintOptions, ssts)
 		if err != nil {
 			return err
 		}

--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -26,7 +26,6 @@ import (
 // SSTWriter writes SSTables.
 type SSTWriter struct {
 	fw *sstable.Writer
-	f  io.Writer
 	// DataSize tracks the total key and value bytes added so far.
 	DataSize int64
 	scratch  []byte
@@ -101,7 +100,6 @@ func MakeBackupSSTWriter(ctx context.Context, cs *cluster.Settings, f io.Writer)
 	opts.MergerName = "nullptr"
 	return SSTWriter{
 		fw:                sstable.NewWriter(noopSyncCloser{f}, opts),
-		f:                 f,
 		supportsRangeKeys: opts.TableFormat >= sstable.TableFormatPebblev2,
 	}
 }
@@ -115,7 +113,6 @@ func MakeIngestionSSTWriter(
 	opts := MakeIngestionWriterOptions(ctx, cs)
 	return SSTWriter{
 		fw:                sstable.NewWriter(f, opts),
-		f:                 f,
 		supportsRangeKeys: opts.TableFormat >= sstable.TableFormatPebblev2,
 	}
 }


### PR DESCRIPTION
If no rangekeys are encountered during
fingerprinting the underlying SSTWriter does not write
any data to the SST, but still produces a non-empty
SST file. This file contains an empty data block, properties and
a footer that amount to 795 bytes. Since the file does
not contain any rangekeys it is going to be thrown away
on the client side, and so ferrying this file in the
ExportResponse is wasteful.

Experiments on the c2c/kv0 roachtest showed that fingerprinting
a single range ~250MB would result in 600k+ empty files. This magnitude
of pagination was all attributable to the elastic CPU limiter that
preempts an ExportRequest if it is consuming more CPU than it
was allotted. 600k+ empty files meant that we were buffering close
to 500MB of ExportResponse_Files (600k * 790bytes) on the node
serving the ExportRequest. This was then shipped over grpc to the
client where we were opening a multi-mem iterator over these 600k+ empty
files causing a node with 15GiB RAM to OOM.

Since fingerprinting does not set a `TargetBytes` on the export requests
it sends, in a cluster with more than one ranage there could be several
requests concurrently buffering these empty files, resulting in an even
more pronounced memory blowup.

This change ensures that the MemFile is nil'ed out if there
are no rangekeys encountered during the fingerprinting.

This change also returns nil values for the `BulkOpSummary`
and `Span` field of the `ExportResponse` when generated as
part of fingerprinting. These fields are not used and show
up in memory profiles of the c2c/kv0 roachtest.

Release note: None

Informs: https://github.com/cockroachdb/cockroach/issues/93078