### PR TITLE
cli: stop adding extra newlines in two places

### DIFF
--- a/pkg/cli/clisqlexec/run_query.go
+++ b/pkg/cli/clisqlexec/run_query.go
@@ -167,10 +167,6 @@ func (sqlExecCtx *Context) maybeShowTimes(
 	// or SQL notices with the full timing string.
 	var stats strings.Builder
 
-	// Print a newline so that there is a visual separation between a notice and
-	// the timing information.
-	fmt.Fprintln(&stats)
-
 	// Suggested by Radu: for sub-second results, show simplified
 	// timings in milliseconds.
 	unit := "s"

--- a/pkg/cli/clisqlshell/editor_bubbline.go
+++ b/pkg/cli/clisqlshell/editor_bubbline.go
@@ -117,15 +117,9 @@ func (b *bubblineReader) setPrompt(prompt string) {
 }
 
 func (b *bubblineReader) getLine() (string, error) {
+	// bubbline's GetLine takes care of handling the newline from the input, so
+	// we don't need to check for one or add one if it's missing.
 	l, err := b.ins.GetLine()
-	if len(l) > 0 && l[len(l)-1] == '\n' {
-		// Strip the final newline.
-		l = l[:len(l)-1]
-	} else {
-		// There was no newline at the end of the input
-		// (e.g. Ctrl+C was entered). Force one.
-		fmt.Fprintln(b.wout)
-	}
 	if errors.Is(err, bubbline.ErrTerminated) {
 		// Bubbline returns this go error when it sees SIGTERM. Convert it
 		// back into a signal, so that the process exit code matches.


### PR DESCRIPTION
Epic: CRDB-22182
Fixes https://github.com/cockroachdb/cockroach/issues/94318

Before commit 1:
```
root@localhost:26257/defaultdb> set cluster setting sql.defaults.implicit_select_for_update.enabled = true;

NOTICE: setting global default sql.defaults.implicit_select_for_update.enabled is not recommended
HINT: use the `ALTER ROLE ... SET` syntax to control session variable defaults at a finer-grained level. See: https://www.cockroachlabs.com/docs/v23.1/alter-role.html#set-default-session-variable-values-for-a-role
SET CLUSTER SETTING


Time: 1ms total (execution 1ms / network 0ms)
```

After commit 1:
```
root@localhost:26257/defaultdb> set cluster setting sql.defaults.implicit_select_for_update.enabled = true;

NOTICE: setting global default sql.defaults.implicit_select_for_update.enabled is not recommended
HINT: use the `ALTER ROLE ... SET` syntax to control session variable defaults at a finer-grained level. See: https://www.cockroachlabs.com/docs/v23.1/alter-role.html#set-default-session-variable-values-for-a-role
SET CLUSTER SETTING

Time: 1ms total (execution 1ms / network 0ms)
```

---

Before commit 2:
```
root@localhost:26257/defaultdb> select 1;

  ?column?
------------
         1
(1 row)

Time: 1ms total (execution 0ms / network 0ms)
```

After commit 2:
```
root@localhost:26257/defaultdb> select 1;
  ?column?
------------
         1
(1 row)

Time: 1ms total (execution 0ms / network 0ms)
```

---

Release note: None