### PR TITLE
tests: longer timeout for cluster commands in queryComparisonTest

### DIFF
--- a/pkg/cmd/roachtest/tests/query_comparison_util.go
+++ b/pkg/cmd/roachtest/tests/query_comparison_util.go
@@ -41,10 +41,19 @@ func runQueryComparison(
 	ctx context.Context, t test.Test, c cluster.Cluster, qct *queryComparisonTest,
 ) {
 	roundTimeout := 10 * time.Minute
+
+	// A cluster context with a slightly longer timeout than the test timeout is
+	// used so cluster creation or cleanup commands should never time out and
+	// result in "context deadline exceeded" Github issues being created.
+	var clusterCancel context.CancelFunc
+	var clusterCtx context.Context
+	clusterCtx, clusterCancel = context.WithTimeout(ctx, t.Spec().(*registry.TestSpec).Timeout-2*time.Minute)
+	defer clusterCancel()
+
 	// Run 10 minute iterations of query comparison in a loop for about the entire
 	// test, giving 5 minutes at the end to allow the test to shut down cleanly.
 	var cancel context.CancelFunc
-	ctx, cancel = context.WithTimeout(ctx, t.Spec().(*registry.TestSpec).Timeout-5*time.Minute)
+	ctx, cancel = context.WithTimeout(clusterCtx, t.Spec().(*registry.TestSpec).Timeout-5*time.Minute)
 	defer cancel()
 	done := ctx.Done()
 	shouldExit := func() bool {
@@ -56,13 +65,13 @@ func runQueryComparison(
 		}
 	}
 
-	c.Put(ctx, t.Cockroach(), "./cockroach")
+	c.Put(clusterCtx, t.Cockroach(), "./cockroach")
 
 	for i := 0; ; i++ {
-		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings())
 		if shouldExit() {
 			return
 		}
+		c.Start(clusterCtx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings())
 
 		runOneRoundQueryComparison(ctx, i, roundTimeout, t, c, qct)
 		// If this iteration was interrupted because the timeout of ctx has been
@@ -71,8 +80,8 @@ func runQueryComparison(
 		if shouldExit() {
 			return
 		}
-		c.Stop(ctx, t.L(), option.DefaultStopOpts())
-		c.Wipe(ctx)
+		c.Stop(clusterCtx, t.L(), option.DefaultStopOpts())
+		c.Wipe(clusterCtx)
 	}
 }
 


### PR DESCRIPTION
Fixes #92753

There is a timing window in the query comparison roachprod tests where a cluster start command could be issued, and then soon after have its context time out, leading to "context deadline exceeded" errors that result in a Github issue being automatically created.

This fixes the issue by using a slightly longer timeout for cluster commands than for the actual SQL tests. We always check the shorter timeout to see if we should exit before attempting a cluster start command, so the start command should not time out any more.

Release note: None