### PR TITLE
schemachanger: rename UpdateBackReferencesInSequences

### DIFF
--- a/pkg/sql/schemachanger/scexec/scmutationexec/references.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/references.go
@@ -159,6 +159,8 @@ func (m *visitor) RemoveBackReferenceInTypes(
 	return updateBackReferencesInTypes(ctx, m, op.TypeIDs, op.BackReferencedDescriptorID, catalog.DescriptorIDSet{})
 }
 
+// updateBackReferencesInTypes updates back references of `backReferencedDescID`
+// in types represented by `typeIDs`, given the
 func updateBackReferencesInTypes(
 	ctx context.Context,
 	m *visitor,
@@ -191,8 +193,8 @@ func updateBackReferencesInTypes(
 	return nil
 }
 
-func (m *visitor) UpdateBackReferencesInSequences(
-	ctx context.Context, op scop.UpdateBackReferencesInSequences,
+func (m *visitor) UpdateTableBackReferencesInSequences(
+	ctx context.Context, op scop.UpdateTableBackReferencesInSequences,
 ) error {
 	var forwardRefs catalog.DescriptorIDSet
 	if desc, err := m.s.GetDescriptor(ctx, op.BackReferencedTableID); err != nil {

--- a/pkg/sql/schemachanger/scop/mutation.go
+++ b/pkg/sql/schemachanger/scop/mutation.go
@@ -408,9 +408,9 @@ type RemoveBackReferenceInTypes struct {
 	TypeIDs                    []descpb.ID
 }
 
-// UpdateBackReferencesInSequences updates back references to a table expression
+// UpdateTableBackReferencesInSequences updates back references to a table expression
 // (in a column or a check constraint) in the specified sequences.
-type UpdateBackReferencesInSequences struct {
+type UpdateTableBackReferencesInSequences struct {
 	mutationOp
 	BackReferencedTableID  descpb.ID
 	BackReferencedColumnID descpb.ColumnID

--- a/pkg/sql/schemachanger/scop/mutation_visitor_generated.go
+++ b/pkg/sql/schemachanger/scop/mutation_visitor_generated.go
@@ -70,7 +70,7 @@ type MutationVisitor interface {
 	RemoveColumnOnUpdateExpression(context.Context, RemoveColumnOnUpdateExpression) error
 	UpdateTableBackReferencesInTypes(context.Context, UpdateTableBackReferencesInTypes) error
 	RemoveBackReferenceInTypes(context.Context, RemoveBackReferenceInTypes) error
-	UpdateBackReferencesInSequences(context.Context, UpdateBackReferencesInSequences) error
+	UpdateTableBackReferencesInSequences(context.Context, UpdateTableBackReferencesInSequences) error
 	RemoveViewBackReferencesInRelations(context.Context, RemoveViewBackReferencesInRelations) error
 	SetColumnName(context.Context, SetColumnName) error
 	SetIndexName(context.Context, SetIndexName) error
@@ -342,8 +342,8 @@ func (op RemoveBackReferenceInTypes) Visit(ctx context.Context, v MutationVisito
 }
 
 // Visit is part of the MutationOp interface.
-func (op UpdateBackReferencesInSequences) Visit(ctx context.Context, v MutationVisitor) error {
-	return v.UpdateBackReferencesInSequences(ctx, op)
+func (op UpdateTableBackReferencesInSequences) Visit(ctx context.Context, v MutationVisitor) error {
+	return v.UpdateTableBackReferencesInSequences(ctx, op)
 }
 
 // Visit is part of the MutationOp interface.

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_check_constraint.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_check_constraint.go
@@ -38,11 +38,11 @@ func init() {
 						BackReferencedTableID: this.TableID,
 					}
 				}),
-				emit(func(this *scpb.CheckConstraint) *scop.UpdateBackReferencesInSequences {
+				emit(func(this *scpb.CheckConstraint) *scop.UpdateTableBackReferencesInSequences {
 					if len(this.UsesSequenceIDs) == 0 {
 						return nil
 					}
-					return &scop.UpdateBackReferencesInSequences{
+					return &scop.UpdateTableBackReferencesInSequences{
 						SequenceIDs:           this.UsesSequenceIDs,
 						BackReferencedTableID: this.TableID,
 					}
@@ -94,11 +94,11 @@ func init() {
 						BackReferencedTableID: this.TableID,
 					}
 				}),
-				emit(func(this *scpb.CheckConstraint) *scop.UpdateBackReferencesInSequences {
+				emit(func(this *scpb.CheckConstraint) *scop.UpdateTableBackReferencesInSequences {
 					if len(this.UsesSequenceIDs) == 0 {
 						return nil
 					}
-					return &scop.UpdateBackReferencesInSequences{
+					return &scop.UpdateTableBackReferencesInSequences{
 						SequenceIDs:           this.UsesSequenceIDs,
 						BackReferencedTableID: this.TableID,
 					}

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_column_default_expression.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_column_default_expression.go
@@ -35,11 +35,11 @@ func init() {
 						BackReferencedTableID: this.TableID,
 					}
 				}),
-				emit(func(this *scpb.ColumnDefaultExpression) *scop.UpdateBackReferencesInSequences {
+				emit(func(this *scpb.ColumnDefaultExpression) *scop.UpdateTableBackReferencesInSequences {
 					if len(this.UsesSequenceIDs) == 0 {
 						return nil
 					}
-					return &scop.UpdateBackReferencesInSequences{
+					return &scop.UpdateTableBackReferencesInSequences{
 						SequenceIDs:            this.UsesSequenceIDs,
 						BackReferencedTableID:  this.TableID,
 						BackReferencedColumnID: this.ColumnID,
@@ -65,11 +65,11 @@ func init() {
 						BackReferencedTableID: this.TableID,
 					}
 				}),
-				emit(func(this *scpb.ColumnDefaultExpression) *scop.UpdateBackReferencesInSequences {
+				emit(func(this *scpb.ColumnDefaultExpression) *scop.UpdateTableBackReferencesInSequences {
 					if len(this.UsesSequenceIDs) == 0 {
 						return nil
 					}
-					return &scop.UpdateBackReferencesInSequences{
+					return &scop.UpdateTableBackReferencesInSequences{
 						SequenceIDs:            this.UsesSequenceIDs,
 						BackReferencedTableID:  this.TableID,
 						BackReferencedColumnID: this.ColumnID,

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_column_on_update_expression.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_column_on_update_expression.go
@@ -35,11 +35,11 @@ func init() {
 						BackReferencedTableID: this.TableID,
 					}
 				}),
-				emit(func(this *scpb.ColumnOnUpdateExpression) *scop.UpdateBackReferencesInSequences {
+				emit(func(this *scpb.ColumnOnUpdateExpression) *scop.UpdateTableBackReferencesInSequences {
 					if len(this.UsesSequenceIDs) == 0 {
 						return nil
 					}
-					return &scop.UpdateBackReferencesInSequences{
+					return &scop.UpdateTableBackReferencesInSequences{
 						SequenceIDs:            this.UsesSequenceIDs,
 						BackReferencedTableID:  this.TableID,
 						BackReferencedColumnID: this.ColumnID,
@@ -65,11 +65,11 @@ func init() {
 						BackReferencedTableID: this.TableID,
 					}
 				}),
-				emit(func(this *scpb.ColumnOnUpdateExpression) *scop.UpdateBackReferencesInSequences {
+				emit(func(this *scpb.ColumnOnUpdateExpression) *scop.UpdateTableBackReferencesInSequences {
 					if len(this.UsesSequenceIDs) == 0 {
 						return nil
 					}
-					return &scop.UpdateBackReferencesInSequences{
+					return &scop.UpdateTableBackReferencesInSequences{
 						SequenceIDs:            this.UsesSequenceIDs,
 						BackReferencedTableID:  this.TableID,
 						BackReferencedColumnID: this.ColumnID,

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_drop_column
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_drop_column
@@ -1427,7 +1427,7 @@ PostCommitNonRevertiblePhase stage 3 of 3 with 12 MutationType ops
     *scop.RemoveColumnDefaultExpression
       ColumnID: 3
       TableID: 107
-    *scop.UpdateBackReferencesInSequences
+    *scop.UpdateTableBackReferencesInSequences
       BackReferencedColumnID: 3
       BackReferencedTableID: 107
       SequenceIDs:

--- a/pkg/sql/schemachanger/scplan/testdata/drop_database
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_database
@@ -340,7 +340,7 @@ PreCommitPhase stage 1 of 1 with 98 MutationType ops
     *scop.RemoveColumnDefaultExpression
       ColumnID: 3
       TableID: 110
-    *scop.UpdateBackReferencesInSequences
+    *scop.UpdateTableBackReferencesInSequences
       BackReferencedColumnID: 3
       BackReferencedTableID: 110
       SequenceIDs:
@@ -356,7 +356,7 @@ PreCommitPhase stage 1 of 1 with 98 MutationType ops
     *scop.RemoveColumnDefaultExpression
       ColumnID: 3
       TableID: 109
-    *scop.UpdateBackReferencesInSequences
+    *scop.UpdateTableBackReferencesInSequences
       BackReferencedColumnID: 3
       BackReferencedTableID: 109
       SequenceIDs:

--- a/pkg/sql/schemachanger/scplan/testdata/drop_owned_by
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_owned_by
@@ -216,7 +216,7 @@ PreCommitPhase stage 1 of 1 with 63 MutationType ops
     *scop.RemoveColumnDefaultExpression
       ColumnID: 3
       TableID: 109
-    *scop.UpdateBackReferencesInSequences
+    *scop.UpdateTableBackReferencesInSequences
       BackReferencedColumnID: 3
       BackReferencedTableID: 109
       SequenceIDs:
@@ -232,7 +232,7 @@ PreCommitPhase stage 1 of 1 with 63 MutationType ops
     *scop.RemoveColumnDefaultExpression
       ColumnID: 3
       TableID: 108
-    *scop.UpdateBackReferencesInSequences
+    *scop.UpdateTableBackReferencesInSequences
       BackReferencedColumnID: 3
       BackReferencedTableID: 108
       SequenceIDs:

--- a/pkg/sql/schemachanger/scplan/testdata/drop_schema
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_schema
@@ -1295,7 +1295,7 @@ PreCommitPhase stage 1 of 1 with 74 MutationType ops
     *scop.RemoveColumnDefaultExpression
       ColumnID: 3
       TableID: 106
-    *scop.UpdateBackReferencesInSequences
+    *scop.UpdateTableBackReferencesInSequences
       BackReferencedColumnID: 3
       BackReferencedTableID: 106
       SequenceIDs:

--- a/pkg/sql/schemachanger/scplan/testdata/drop_sequence
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_sequence
@@ -109,7 +109,7 @@ PreCommitPhase stage 1 of 1 with 11 MutationType ops
     *scop.RemoveColumnDefaultExpression
       ColumnID: 2
       TableID: 105
-    *scop.UpdateBackReferencesInSequences
+    *scop.UpdateTableBackReferencesInSequences
       BackReferencedColumnID: 2
       BackReferencedTableID: 105
       SequenceIDs:
@@ -117,7 +117,7 @@ PreCommitPhase stage 1 of 1 with 11 MutationType ops
     *scop.RemoveColumnDefaultExpression
       ColumnID: 2
       TableID: 106
-    *scop.UpdateBackReferencesInSequences
+    *scop.UpdateTableBackReferencesInSequences
       BackReferencedColumnID: 2
       BackReferencedTableID: 106
       SequenceIDs:

--- a/pkg/sql/schemachanger/scplan/testdata/drop_table
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_table
@@ -151,7 +151,7 @@ PreCommitPhase stage 1 of 1 with 42 MutationType ops
     *scop.RemoveColumnDefaultExpression
       ColumnID: 5
       TableID: 109
-    *scop.UpdateBackReferencesInSequences
+    *scop.UpdateTableBackReferencesInSequences
       BackReferencedColumnID: 5
       BackReferencedTableID: 109
       SequenceIDs:

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_seq
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_seq
@@ -28,7 +28,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │              ├── SetColumnName {"ColumnID":2,"Name":"l","TableID":106}
  │              ├── SetAddedColumnType {"ColumnType":{"ColumnID":2,"TableID":106}}
  │              ├── AddColumnDefaultExpression {"Default":{"ColumnID":2,"TableID":106}}
- │              ├── UpdateBackReferencesInSequences {"BackReferencedColumnID":2,"BackReferencedTableID":106}
+ │              ├── UpdateTableBackReferencesInSequences {"BackReferencedColumnID":2,"BackReferencedTableID":106}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":2,"IndexID":2,"IsUnique":true,"SourceIndexID":1,"TableID":106,"TemporaryIndexID":3}}
  │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":2,"TableID":106}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_1_of_7
@@ -25,7 +25,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            └── 10 Mutation operations
                 ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
                 ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
-                ├── UpdateBackReferencesInSequences {"BackReferencedColumnID":2,"BackReferencedTableID":106}
+                ├── UpdateTableBackReferencesInSequences {"BackReferencedColumnID":2,"BackReferencedTableID":106}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_2_of_7
@@ -37,7 +37,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 106, IndexID: 3}
            └── 9 Mutation operations
                 ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
-                ├── UpdateBackReferencesInSequences {"BackReferencedColumnID":2,"BackReferencedTableID":106}
+                ├── UpdateTableBackReferencesInSequences {"BackReferencedColumnID":2,"BackReferencedTableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_3_of_7
@@ -37,7 +37,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 106, IndexID: 3}
            └── 9 Mutation operations
                 ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
-                ├── UpdateBackReferencesInSequences {"BackReferencedColumnID":2,"BackReferencedTableID":106}
+                ├── UpdateTableBackReferencesInSequences {"BackReferencedColumnID":2,"BackReferencedTableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_4_of_7
@@ -37,7 +37,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 106, IndexID: 3}
            └── 9 Mutation operations
                 ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
-                ├── UpdateBackReferencesInSequences {"BackReferencedColumnID":2,"BackReferencedTableID":106}
+                ├── UpdateTableBackReferencesInSequences {"BackReferencedColumnID":2,"BackReferencedTableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_5_of_7
@@ -38,7 +38,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 106, IndexID: 3}
            └── 10 Mutation operations
                 ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
-                ├── UpdateBackReferencesInSequences {"BackReferencedColumnID":2,"BackReferencedTableID":106}
+                ├── UpdateTableBackReferencesInSequences {"BackReferencedColumnID":2,"BackReferencedTableID":106}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_6_of_7
@@ -38,7 +38,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 106, IndexID: 3}
            └── 10 Mutation operations
                 ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
-                ├── UpdateBackReferencesInSequences {"BackReferencedColumnID":2,"BackReferencedTableID":106}
+                ├── UpdateTableBackReferencesInSequences {"BackReferencedColumnID":2,"BackReferencedTableID":106}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_7_of_7
@@ -38,7 +38,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 106, IndexID: 3}
            └── 10 Mutation operations
                 ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
-                ├── UpdateBackReferencesInSequences {"BackReferencedColumnID":2,"BackReferencedTableID":106}
+                ├── UpdateTableBackReferencesInSequences {"BackReferencedColumnID":2,"BackReferencedTableID":106}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_add_check_with_seq_and_udt
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_add_check_with_seq_and_udt
@@ -14,7 +14,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD CHEC
  │         └── 3 Mutation operations
  │              ├── MakeAbsentCheckConstraintWriteOnly
  │              ├── UpdateTableBackReferencesInTypes {"BackReferencedTableID":107}
- │              └── UpdateBackReferencesInSequences {"BackReferencedTableID":107}
+ │              └── UpdateTableBackReferencesInSequences {"BackReferencedTableID":107}
  ├── PreCommitPhase
  │    └── Stage 1 of 1 in PreCommitPhase
  │         └── 5 Mutation operations

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_add_check_with_seq_and_udt.rollback_1_of_2
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_add_check_with_seq_and_udt.rollback_1_of_2
@@ -15,7 +15,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
            └── 8 Mutation operations
                 ├── RemoveCheckConstraint {"ConstraintID":2,"TableID":107}
                 ├── UpdateTableBackReferencesInTypes {"BackReferencedTableID":107}
-                ├── UpdateBackReferencesInSequences {"BackReferencedTableID":107}
+                ├── UpdateTableBackReferencesInSequences {"BackReferencedTableID":107}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":105}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_add_check_with_seq_and_udt.rollback_2_of_2
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_add_check_with_seq_and_udt.rollback_2_of_2
@@ -15,7 +15,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
            └── 8 Mutation operations
                 ├── RemoveCheckConstraint {"ConstraintID":2,"TableID":107}
                 ├── UpdateTableBackReferencesInTypes {"BackReferencedTableID":107}
-                ├── UpdateBackReferencesInSequences {"BackReferencedTableID":107}
+                ├── UpdateTableBackReferencesInSequences {"BackReferencedTableID":107}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":105}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":106}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq
@@ -145,7 +145,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN l INT NOT NULL DEFAU
 │           │         - 107
 │           │       TableID: 106
 │           │
-│           ├── • UpdateBackReferencesInSequences
+│           ├── • UpdateTableBackReferencesInSequences
 │           │     BackReferencedColumnID: 2
 │           │     BackReferencedTableID: 106
 │           │     SequenceIDs:

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_1_of_7
@@ -120,7 +120,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             │     ColumnID: 2
             │     TableID: 106
             │
-            ├── • UpdateBackReferencesInSequences
+            ├── • UpdateTableBackReferencesInSequences
             │     BackReferencedColumnID: 2
             │     BackReferencedTableID: 106
             │     SequenceIDs:

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_2_of_7
@@ -193,7 +193,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
             │     ColumnID: 2
             │     TableID: 106
             │
-            ├── • UpdateBackReferencesInSequences
+            ├── • UpdateTableBackReferencesInSequences
             │     BackReferencedColumnID: 2
             │     BackReferencedTableID: 106
             │     SequenceIDs:

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_3_of_7
@@ -193,7 +193,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
             │     ColumnID: 2
             │     TableID: 106
             │
-            ├── • UpdateBackReferencesInSequences
+            ├── • UpdateTableBackReferencesInSequences
             │     BackReferencedColumnID: 2
             │     BackReferencedTableID: 106
             │     SequenceIDs:

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_4_of_7
@@ -193,7 +193,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
             │     ColumnID: 2
             │     TableID: 106
             │
-            ├── • UpdateBackReferencesInSequences
+            ├── • UpdateTableBackReferencesInSequences
             │     BackReferencedColumnID: 2
             │     BackReferencedTableID: 106
             │     SequenceIDs:

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_5_of_7
@@ -191,7 +191,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             │     ColumnID: 2
             │     TableID: 106
             │
-            ├── • UpdateBackReferencesInSequences
+            ├── • UpdateTableBackReferencesInSequences
             │     BackReferencedColumnID: 2
             │     BackReferencedTableID: 106
             │     SequenceIDs:

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_6_of_7
@@ -191,7 +191,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             │     ColumnID: 2
             │     TableID: 106
             │
-            ├── • UpdateBackReferencesInSequences
+            ├── • UpdateTableBackReferencesInSequences
             │     BackReferencedColumnID: 2
             │     BackReferencedTableID: 106
             │     SequenceIDs:

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_7_of_7
@@ -191,7 +191,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             │     ColumnID: 2
             │     TableID: 106
             │
-            ├── • UpdateBackReferencesInSequences
+            ├── • UpdateTableBackReferencesInSequences
             │     BackReferencedColumnID: 2
             │     BackReferencedTableID: 106
             │     SequenceIDs:

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_check_with_seq_and_udt
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_check_with_seq_and_udt
@@ -31,7 +31,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ADD CHECK (i > nextval('s') OR j::typ = 'a'
 │           │     - 105
 │           │     - 106
 │           │
-│           └── • UpdateBackReferencesInSequences
+│           └── • UpdateTableBackReferencesInSequences
 │                 BackReferencedTableID: 107
 │                 SequenceIDs:
 │                 - 104

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_check_with_seq_and_udt.rollback_1_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_check_with_seq_and_udt.rollback_1_of_2
@@ -36,7 +36,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 2;
             │     - 105
             │     - 106
             │
-            ├── • UpdateBackReferencesInSequences
+            ├── • UpdateTableBackReferencesInSequences
             │     BackReferencedTableID: 107
             │     SequenceIDs:
             │     - 104

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_check_with_seq_and_udt.rollback_2_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_check_with_seq_and_udt.rollback_2_of_2
@@ -36,7 +36,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 2;
             │     - 105
             │     - 106
             │
-            ├── • UpdateBackReferencesInSequences
+            ├── • UpdateTableBackReferencesInSequences
             │     BackReferencedTableID: 107
             │     SequenceIDs:
             │     - 104


### PR DESCRIPTION
Rename UpdateBackReferencesInSequences to
UpdateTableBackReferencesInSequences since it's fits more specifically for tables referencing sequences.

Epic: None
Release note: None