### PR TITLE
opt: disable SplitLimitedScanIntoUnionScans cost check by default

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3446,6 +3446,10 @@ func (m *sessionDataMutator) SetAllowOrdinalColumnReference(val bool) {
 	m.data.AllowOrdinalColumnReferences = val
 }
 
+func (m *sessionDataMutator) SetOptimizerDisableSplitLimitedScanCostCheck(val bool) {
+	m.data.OptimizerDisableSplitLimitedScanCostCheck = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -159,6 +159,7 @@ type Memo struct {
 	enforceHomeRegion                      bool
 	variableInequalityLookupJoinEnabled    bool
 	allowOrdinalColumnReferences           bool
+	disableSplitLimitedScanCostCheck       bool
 
 	// curRank is the highest currently in-use scalar expression rank.
 	curRank opt.ScalarRank
@@ -213,6 +214,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		enforceHomeRegion:                      evalCtx.SessionData().EnforceHomeRegion,
 		variableInequalityLookupJoinEnabled:    evalCtx.SessionData().VariableInequalityLookupJoinEnabled,
 		allowOrdinalColumnReferences:           evalCtx.SessionData().AllowOrdinalColumnReferences,
+		disableSplitLimitedScanCostCheck:       evalCtx.SessionData().OptimizerDisableSplitLimitedScanCostCheck,
 	}
 	m.metadata.Init()
 	m.logPropsBuilder.init(ctx, evalCtx, m)
@@ -350,7 +352,8 @@ func (m *Memo) IsStale(
 		m.testingOptimizerDisableRuleProbability != evalCtx.SessionData().TestingOptimizerDisableRuleProbability ||
 		m.enforceHomeRegion != evalCtx.SessionData().EnforceHomeRegion ||
 		m.variableInequalityLookupJoinEnabled != evalCtx.SessionData().VariableInequalityLookupJoinEnabled ||
-		m.allowOrdinalColumnReferences != evalCtx.SessionData().AllowOrdinalColumnReferences {
+		m.allowOrdinalColumnReferences != evalCtx.SessionData().AllowOrdinalColumnReferences ||
+		m.disableSplitLimitedScanCostCheck != evalCtx.SessionData().OptimizerDisableSplitLimitedScanCostCheck {
 		return true, nil
 	}
 

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -323,10 +323,16 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().TestingOptimizerDisableRuleProbability = 0
 	notStale()
 
-	// Stale testing_optimizer_disable_rule_probability.
+	// Stale allow_ordinal_column_references.
 	evalCtx.SessionData().AllowOrdinalColumnReferences = true
 	stale()
 	evalCtx.SessionData().AllowOrdinalColumnReferences = false
+	notStale()
+
+	// Stale disable_split_limited_scans_cost_check.
+	evalCtx.SessionData().OptimizerDisableSplitLimitedScanCostCheck = true
+	stale()
+	evalCtx.SessionData().OptimizerDisableSplitLimitedScanCostCheck = false
 	notStale()
 
 	// Stale data sources and schema. Create new catalog so that data sources are

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -292,6 +292,7 @@ func New(catalog cat.Catalog, sql string) *OptTester {
 	ot.evalCtx.SessionData().InsertFastPath = true
 	ot.evalCtx.SessionData().OptSplitScanLimit = tabledesc.MaxBucketAllowed
 	ot.evalCtx.SessionData().VariableInequalityLookupJoinEnabled = true
+	ot.evalCtx.SessionData().OptimizerDisableSplitLimitedScanCostCheck = true
 
 	return ot
 }

--- a/pkg/sql/opt/xform/general_funcs.go
+++ b/pkg/sql/opt/xform/general_funcs.go
@@ -501,7 +501,7 @@ func (c *CustomFuncs) splitScanIntoUnionScansOrSelects(
 		scanCount = maxScanCount
 	}
 	rowCount := scan.Relational().Statistics().RowCount
-	if limit > 0 {
+	if !c.e.evalCtx.SessionData().OptimizerDisableSplitLimitedScanCostCheck && limit > 0 {
 		nLogN := rowCount * math.Log2(rowCount)
 		if scan.Relational().Statistics().Available &&
 			float64(scanCount*randIOCostFactor+limit*seqIOCostFactor) >= nLogN {

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -1570,8 +1570,10 @@ scalar-group-by
            └── data1:6
 
 # No-op case because the same number of rows would be scanned by the split-up
-# scans as by the original.
-opt expect-not=SplitLimitedScanIntoUnionScans
+# scans as by the original, and the legacy cost check is enabled.
+# TODO(mgartner): Remove this test when the legacy cost check is removed
+# entirely in v23.2.
+opt set=disable_split_limited_scans_cost_check=false expect-not=SplitLimitedScanIntoUnionScans
 SELECT max(data1) FROM index_tab WHERE id > 0 AND id < 4
 ----
 scalar-group-by
@@ -1651,6 +1653,123 @@ scalar-group-by
  └── aggregations
       └── max [as=max:12, outer=(6)]
            └── data1:6
+
+# Regression test for #94385. SplitLimitedScansIntoUnionScans should fire when
+# the original scan is highly selective.
+exec-ddl
+CREATE TABLE t94385 (
+  crdb_region STRING,
+  id INT,
+  a INT,
+  b INT,
+  c INT,
+  PRIMARY KEY (crdb_region, id),
+  CHECK (crdb_region IN ('ca', 'us', 'eu')),
+  INDEX (crdb_region, a, b, c)
+)
+----
+
+exec-ddl
+ALTER TABLE t94385 INJECT STATISTICS '[
+  {
+    "columns": ["crdb_region"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000000,
+    "distinct_count": 3,
+    "histo_col_type": "string",
+    "histo_buckets": [
+      {"num_eq": 330000, "num_range": 0, "distinct_range": 0, "upper_bound": "ca"},
+      {"num_eq": 330000, "num_range": 0, "distinct_range": 0, "upper_bound": "eu"},
+      {"num_eq": 340000, "num_range": 0, "distinct_range": 0, "upper_bound": "us"}
+    ]
+  },
+  {
+    "columns": ["id"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000000,
+    "distinct_count": 1000000,
+    "histo_col_type": "int",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "0"},
+      {"num_eq": 1, "num_range": 9, "distinct_range": 9, "upper_bound": "10"},
+      {"num_eq": 1, "num_range": 999989, "distinct_range": 999989, "upper_bound": "1000000"}
+    ]
+  },
+  {
+    "columns": ["a"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000000,
+    "distinct_count": 1000,
+    "histo_col_type": "int",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "0"},
+      {"num_eq": 1000, "num_range": 9, "distinct_range": 9, "upper_bound": "10"},
+      {"num_eq": 1, "num_range": 998990, "distinct_range": 998990, "upper_bound": "1000"}
+    ]
+  },
+  {
+    "columns": ["b"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000000,
+    "distinct_count": 1000,
+    "histo_col_type": "int",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "0"},
+      {"num_eq": 1000, "num_range": 9, "distinct_range": 9, "upper_bound": "10"},
+      {"num_eq": 1, "num_range": 998990, "distinct_range": 998990, "upper_bound": "1000"}
+    ]
+  },
+  {
+    "columns": ["c"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000000,
+    "distinct_count": 1000,
+    "histo_col_type": "int",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "0"},
+      {"num_eq": 1000, "num_range": 9, "distinct_range": 9, "upper_bound": "10"},
+      {"num_eq": 1, "num_range": 998990, "distinct_range": 998990, "upper_bound": "1000"}
+    ]
+  }
+]'
+----
+
+opt expect=SplitLimitedScanIntoUnionScans format=hide-all
+SELECT * FROM t94385
+WHERE a = 10 AND b = 10 AND c = 10 AND id > 10
+ORDER BY id LIMIT 1
+----
+limit
+ ├── union-all
+ │    ├── union-all
+ │    │    ├── scan t94385@t94385_crdb_region_a_b_c_idx
+ │    │    │    ├── constraint: /8/10/11/12/9: [/'ca'/10/10/10/11 - /'ca'/10/10/10]
+ │    │    │    └── limit: 1
+ │    │    └── scan t94385@t94385_crdb_region_a_b_c_idx
+ │    │         ├── constraint: /15/17/18/19/16: [/'eu'/10/10/10/11 - /'eu'/10/10/10]
+ │    │         └── limit: 1
+ │    └── scan t94385@t94385_crdb_region_a_b_c_idx
+ │         ├── constraint: /22/24/25/26/23: [/'us'/10/10/10/11 - /'us'/10/10/10]
+ │         └── limit: 1
+ └── 1
+
+# It does not fire if the legacy cost check is performed, i.e.,
+# disable_split_limited_scans_cost_check=false.
+# TODO(mgartner): Remove this test when the legacy cost check is removed
+# entirely in v23.2.
+opt set=disable_split_limited_scans_cost_check=false expect-not=SplitLimitedScanIntoUnionScans format=hide-all
+SELECT * FROM t94385
+WHERE a = 10 AND b = 10 AND c = 10 AND id > 10
+ORDER BY id LIMIT 1
+----
+top-k
+ ├── k: 1
+ └── scan t94385@t94385_crdb_region_a_b_c_idx
+      └── constraint: /1/3/4/5/2
+           ├── [/'ca'/10/10/10/11 - /'ca'/10/10/10]
+           ├── [/'eu'/10/10/10/11 - /'eu'/10/10/10]
+           └── [/'us'/10/10/10/11 - /'us'/10/10/10]
+
 
 # ---------------------------------------------------
 # GenerateTopK

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -312,6 +312,11 @@ message LocalOnlySessionData {
   // AllowOrdinalColumnReferences indicates whether the deprecated ordinal
   // column reference syntax (e.g., `SELECT @1 FROM t`) is allowed.
   bool allow_ordinal_column_references = 85;
+  // OptimizerDisableSplitLimitedScanCostCheck disables the cost check in the
+  // exploration rules SplitLimitedScanIntoUnionScans and
+  // SplitLimitedSelectIntoUnionSelects when true. It defaults to true.
+  // TODO(mgartner): Remove this option in v23.2.
+  bool optimizer_disable_split_limited_scan_cost_check = 87;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2389,6 +2389,21 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalFalse,
 	},
+	`optimizer_disable_split_limited_scan_cost_check`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`optimzer_disable_split_limited_scan_cost_check`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("optimizer_disable_split_limited_scan_cost_check", s)
+			if err != nil {
+				return err
+			}
+			m.SetOptimizerDisableSplitLimitedScanCostCheck(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().OptimizerDisableSplitLimitedScanCostCheck), nil
+		},
+		GlobalDefault: globalTrue,
+	},
 }
 
 // We want test coverage for this on and off so make it metamorphic.


### PR DESCRIPTION
#### opt: disable SplitLimitedScanIntoUnionScans cost check by default

This commit disables the cost check in the exploration rules
`SplitLimitedScanIntoUnionScans` & `SplitLimitedSelectIntoUnionSelects`
by default. It has been disabled because it prevents the rule from
firing when the original scan is highly selective, e.g., a row count
less than one. There are a couple reasons it is too strict:

  1. `rowCount * log₂(rowCount)` is negative when `rowCount` is less
     than one.
  2. It is comparing two different units, rows and cost.

Instead of making poor cost estimations inside an exploration rule, this
commit disables the check by default, staying consistent with the design of
other optimizer rules, and leaving it up to the coster to determine if
the transformation is optimal.

The check can be re-enabled by setting the
`optimizer_disable_split_limited_scan_cost_check` session setting to
`false`. This setting defaults to `true`. The setting has been added so
that this change can be backported with the setting defaulted to
`false`.

Fixes #94385

Release note (performance improvement): The optimizer now pushes limits
into scans in more cases.