### PR TITLE
kvcoord: propagate lock spans in LeafTxnFinalState

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner.go
@@ -275,9 +275,8 @@ func (tp *txnPipeliner) SendLocked(
 	// request (think ResumeSpan); even if the check passes, we might end up over
 	// budget.
 	rejectOverBudget := rejectTxnOverTrackedWritesBudget.Get(&tp.st.SV)
-	maxBytes := TrackedWritesMaxSize.Get(&tp.st.SV)
 	if rejectOverBudget {
-		if err := tp.maybeRejectOverBudget(ba, maxBytes); err != nil {
+		if err := tp.maybeRejectOverBudget(ba, TrackedWritesMaxSize.Get(&tp.st.SV)); err != nil {
 			return nil, kvpb.NewError(err)
 		}
 	}
@@ -300,7 +299,7 @@ func (tp *txnPipeliner) SendLocked(
 	// go over budget despite the earlier pre-emptive check, then we stay over
 	// budget. Further requests will be rejected if they attempt to take more
 	// locks.
-	tp.updateLockTracking(ctx, ba, br, pErr, maxBytes, !rejectOverBudget /* condenseLocksIfOverBudget */)
+	tp.updateLockTracking(ctx, ba, br, pErr, !rejectOverBudget /* condenseLocksIfOverBudget */)
 	if pErr != nil {
 		return nil, tp.adjustError(ctx, ba, pErr)
 	}
@@ -602,44 +601,19 @@ func (tp *txnPipeliner) updateLockTracking(
 	ba *kvpb.BatchRequest,
 	br *kvpb.BatchResponse,
 	pErr *kvpb.Error,
-	maxBytes int64,
 	condenseLocksIfOverBudget bool,
 ) {
 	tp.updateLockTrackingInner(ctx, ba, br, pErr)
 
-	// Deal with compacting the lock spans.
-
-	// Compute how many bytes are left for locks after accounting for the
-	// in-flight writes.
-	locksBudget := maxBytes - tp.ifWrites.byteSize()
-	// If we're below budget, there's nothing more to do.
-	if tp.lockFootprint.bytesSize() <= locksBudget {
-		return
-	}
-
-	// We're over budget. If condenseLocksIfOverBudget is set, we condense the
-	// lock spans. If not set, we defer the work to a future locking request where
-	// we're going to try to save space without condensing and perhaps reject the
-	// txn if we fail (see the estimateSize() call).
-
+	// Deal with compacting the lock spans unless condenseLocksIfOverBudget is
+	// not set. In such a case we defer the work to a future locking request
+	// where we're going to try to save space without condensing and perhaps
+	// reject the txn if we fail (see the estimateSize() call).
 	if !condenseLocksIfOverBudget {
 		return
 	}
 
-	// After adding new writes to the lock footprint, check whether we need to
-	// condense the set to stay below memory limits.
-	alreadyCondensed := tp.lockFootprint.condensed
-	condensed := tp.lockFootprint.maybeCondense(ctx, tp.riGen, locksBudget)
-	if condensed && !alreadyCondensed {
-		if tp.condensedIntentsEveryN.ShouldLog() || log.ExpensiveLogEnabled(ctx, 2) {
-			log.Warningf(ctx,
-				"a transaction has hit the intent tracking limit (kv.transaction.max_intents_bytes); "+
-					"is it a bulk operation? Intent cleanup will be slower. txn: %s ba: %s",
-				ba.Txn, ba.Summary())
-		}
-		tp.txnMetrics.TxnsWithCondensedIntents.Inc(1)
-		tp.txnMetrics.TxnsWithCondensedIntentsGauge.Inc(1)
-	}
+	tp.maybeCondenseLockFootprint(ctx, ba)
 }
 
 func (tp *txnPipeliner) updateLockTrackingInner(
@@ -735,6 +709,42 @@ func (tp *txnPipeliner) updateLockTrackingInner(
 	}
 }
 
+// maybeCondenseLockFootprint checks whether the lock footprint combined with
+// the in-flight writes exceed the maximum size (as determined by the
+// TrackedWritesMaxSize cluster setting) and attempts to condense the lock
+// footprint if so.
+//
+// ba is optional and only used when logging a warning in case the budget is
+// exceeded.
+func (tp *txnPipeliner) maybeCondenseLockFootprint(ctx context.Context, ba *kvpb.BatchRequest) {
+	maxBytes := TrackedWritesMaxSize.Get(&tp.st.SV)
+	// Compute how many bytes are left for locks after accounting for the
+	// in-flight writes.
+	locksBudget := maxBytes - tp.ifWrites.byteSize()
+	// If we're below budget, there's nothing more to do.
+	if tp.lockFootprint.bytesSize() <= locksBudget {
+		return
+	}
+
+	alreadyCondensed := tp.lockFootprint.condensed
+	condensed := tp.lockFootprint.maybeCondense(ctx, tp.riGen, locksBudget)
+	if condensed && !alreadyCondensed {
+		if tp.condensedIntentsEveryN.ShouldLog() || log.ExpensiveLogEnabled(ctx, 2) {
+			var sb redact.StringBuilder
+			sb.SafeString(
+				"a transaction has hit the intent tracking limit (kv.transaction.max_intents_bytes); " +
+					"is it a bulk operation? Intent cleanup will be slower.",
+			)
+			if ba != nil {
+				sb.Printf(" txn: %s ba: %s", ba.Txn, ba.Summary())
+			}
+			log.Warningf(ctx, "%s", sb.String())
+		}
+		tp.txnMetrics.TxnsWithCondensedIntents.Inc(1)
+		tp.txnMetrics.TxnsWithCondensedIntentsGauge.Inc(1)
+	}
+}
+
 func (tp *txnPipeliner) trackLocks(s roachpb.Span, _ lock.Durability) {
 	tp.lockFootprint.insert(s)
 }
@@ -806,10 +816,19 @@ func (tp *txnPipeliner) initializeLeaf(tis *roachpb.LeafTxnInputState) {
 }
 
 // populateLeafFinalState is part of the txnInterceptor interface.
-func (tp *txnPipeliner) populateLeafFinalState(*roachpb.LeafTxnFinalState) {}
+func (tp *txnPipeliner) populateLeafFinalState(tfs *roachpb.LeafTxnFinalState) {
+	// Copy mutable state so access is safe for the caller.
+	// TODO(yuzefovich): investigate whether this copy is actually needed.
+	lockSpans := tp.lockFootprint.asSlice()
+	tfs.LockSpans = make([]roachpb.Span, len(lockSpans))
+	copy(tfs.LockSpans, lockSpans)
+}
 
 // importLeafFinalState is part of the txnInterceptor interface.
-func (tp *txnPipeliner) importLeafFinalState(context.Context, *roachpb.LeafTxnFinalState) {}
+func (tp *txnPipeliner) importLeafFinalState(ctx context.Context, tfs *roachpb.LeafTxnFinalState) {
+	tp.lockFootprint.insert(tfs.LockSpans...)
+	tp.maybeCondenseLockFootprint(ctx, nil /* ba */)
+}
 
 // epochBumpedLocked implements the txnInterceptor interface.
 func (tp *txnPipeliner) epochBumpedLocked() {

--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -733,6 +733,7 @@ message LeafTxnFinalState {
   // budget.
   bool refresh_invalid = 7;
   reserved 8;
+  repeated Span lock_spans = 9 [(gogoproto.nullable) = false];
 }
 
 // RangeClosedTimestampPolicy represents the policy used by the leaseholder of a

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -4465,15 +4465,13 @@ func (dsp *DistSQLPlanner) NewPlanningCtxWithOracle(
 		onFlowCleanup: []func(){infra.Release},
 	}
 	if !distribute {
-		if planner == nil || dsp.spanResolver == nil || planner.curPlan.flags.IsSet(planFlagContainsMutation) ||
-			planner.curPlan.flags.IsSet(planFlagContainsNonDefaultLocking) {
+		if planner == nil || dsp.spanResolver == nil || planner.curPlan.flags.IsSet(planFlagContainsMutation) {
 			// Don't parallelize the scans if we have a local plan if
 			// - we don't have a planner which is the case when we are not on
 			// the main query path;
 			// - we don't have a span resolver (this can happen only in tests);
 			// - the plan contains a mutation operation - we currently don't
-			// support any parallelism when mutations are present;
-			// - the plan uses non-default key locking strength (see #94290).
+			// support any parallelism when mutations are present.
 			return planCtx
 		}
 		prohibitParallelization, hasScanNodeToParallelize := checkScanParallelizationIfLocal(ctx, &planner.curPlan.planComponents)

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -737,26 +737,14 @@ func (dsp *DistSQLPlanner) Run(
 			// given a LeafTxn. In order for that LeafTxn to be created later,
 			// during the flow setup, we need to populate leafInputState below,
 			// so we tell the localState that there is concurrency.
-
-			// At the moment, we disable the usage of the Streamer API for local
-			// plans when non-default key locking modes are requested on some of
-			// the processors. This is the case since the lock spans propagation
-			// doesn't happen for the leaf txns which can result in excessive
-			// contention for future reads (since the acquired locks are not
-			// cleaned up properly when the txn commits).
-			// TODO(yuzefovich): fix the propagation of the lock spans with the
-			// leaf txns and remove this check. See #94290.
-			containsNonDefaultLocking := planCtx.planner != nil && planCtx.planner.curPlan.flags.IsSet(planFlagContainsNonDefaultLocking)
-			if !containsNonDefaultLocking {
-				if execinfra.CanUseStreamer(dsp.st) {
-					for _, proc := range plan.Processors {
-						if jr := proc.Spec.Core.JoinReader; jr != nil {
-							// Both index and lookup joins, with and without
-							// ordering, are executed via the Streamer API that has
-							// concurrency.
-							localState.HasConcurrency = true
-							break
-						}
+			if execinfra.CanUseStreamer(dsp.st) {
+				for _, proc := range plan.Processors {
+					if jr := proc.Spec.Core.JoinReader; jr != nil {
+						// Both index and lookup joins, with and without
+						// ordering, are executed via the Streamer API that has
+						// concurrency.
+						localState.HasConcurrency = true
+						break
 					}
 				}
 			}

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -141,10 +141,6 @@ type Builder struct {
 	// ContainsMutation is set to true if the whole plan contains any mutations.
 	ContainsMutation bool
 
-	// ContainsNonDefaultKeyLocking is set to true if at least one node in the
-	// plan uses non-default key locking strength.
-	ContainsNonDefaultKeyLocking bool
-
 	// MaxFullScanRows is the maximum number of rows scanned by a full scan, as
 	// estimated by the optimizer.
 	MaxFullScanRows float64

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -613,7 +613,6 @@ func (b *Builder) scanParams(
 	if b.forceForUpdateLocking {
 		locking = forUpdateLocking
 	}
-	b.ContainsNonDefaultKeyLocking = b.ContainsNonDefaultKeyLocking || locking.IsLocking()
 
 	// Raise error if row-level locking is part of a read-only transaction.
 	// TODO(nvanbenschoten): this check should be shared across all expressions
@@ -2058,7 +2057,6 @@ func (b *Builder) buildIndexJoin(join *memo.IndexJoinExpr) (execPlan, error) {
 	if b.forceForUpdateLocking {
 		locking = forUpdateLocking
 	}
-	b.ContainsNonDefaultKeyLocking = b.ContainsNonDefaultKeyLocking || locking.IsLocking()
 
 	res := execPlan{outputCols: output}
 	b.recordJoinAlgorithm(exec.IndexJoin)
@@ -2353,7 +2351,6 @@ func (b *Builder) buildLookupJoin(join *memo.LookupJoinExpr) (execPlan, error) {
 	if b.forceForUpdateLocking {
 		locking = forUpdateLocking
 	}
-	b.ContainsNonDefaultKeyLocking = b.ContainsNonDefaultKeyLocking || locking.IsLocking()
 
 	joinType := joinOpToJoinType(join.JoinType)
 	b.recordJoinType(joinType)
@@ -2585,7 +2582,6 @@ func (b *Builder) buildInvertedJoin(join *memo.InvertedJoinExpr) (execPlan, erro
 	if b.forceForUpdateLocking {
 		locking = forUpdateLocking
 	}
-	b.ContainsNonDefaultKeyLocking = b.ContainsNonDefaultKeyLocking || locking.IsLocking()
 
 	joinType := joinOpToJoinType(join.JoinType)
 	b.recordJoinType(joinType)
@@ -2660,7 +2656,6 @@ func (b *Builder) buildZigzagJoin(join *memo.ZigzagJoinExpr) (execPlan, error) {
 		leftLocking = forUpdateLocking
 		rightLocking = forUpdateLocking
 	}
-	b.ContainsNonDefaultKeyLocking = b.ContainsNonDefaultKeyLocking || leftLocking.IsLocking() || rightLocking.IsLocking()
 
 	allCols := joinOutputMap(leftColMap, rightColMap)
 

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -628,10 +628,6 @@ const (
 
 	// planFlagContainsMutation is set if the plan has any mutations.
 	planFlagContainsMutation
-
-	// planFlagContainsNonDefaultLocking is set if the plan has a node with
-	// non-default key locking strength.
-	planFlagContainsNonDefaultLocking
 )
 
 func (pf planFlags) IsSet(flag planFlags) bool {

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -696,9 +696,6 @@ func (opc *optPlanningCtx) runExecBuilder(
 	if bld.ContainsMutation {
 		planTop.flags.Set(planFlagContainsMutation)
 	}
-	if bld.ContainsNonDefaultKeyLocking {
-		planTop.flags.Set(planFlagContainsNonDefaultLocking)
-	}
 	if planTop.instrumentation.ShouldSaveMemo() {
 		planTop.mem = mem
 		planTop.catalog = opc.catalog


### PR DESCRIPTION
This commit makes it so that we propagate the lock footprint of the leaf txns in `LeafTxnFinalState`. This is needed in order to disable the read-only fast path when committing the txn that acquired locks while using the leaf txn (which can happen, for example, if we use the streamer API). Without this propagation, previously the locks would only be released after the txn expiration duration (5s).

Addresses: #94290.

Epic: None.

Release note (bug fix): Previously, CockroachDB could delay the release of the locks acquired when evaluating SELECT FOR UPDATE statements in some cases. This delay (up to 5s) could then block the future readers. The bug was introduced in 22.2.0, and the temporary workaround without upgrading to a release with this fix is to set undocumented cluster setting `sql.distsql.use_streamer.enabled` to `false`.