### PR TITLE
sql: add optimizer_use_improved_disjunction_stats session setting

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3446,6 +3446,10 @@ func (m *sessionDataMutator) SetAllowOrdinalColumnReference(val bool) {
 	m.data.AllowOrdinalColumnReferences = val
 }
 
+func (m *sessionDataMutator) SetOptimizerUseImprovedDisjunctionStats(val bool) {
+	m.data.OptimizerUseImprovedDisjunctionStats = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4845,6 +4845,7 @@ opt_split_scan_limit                                  2048
 optimizer                                             on
 optimizer_use_forecasts                               on
 optimizer_use_histograms                              on
+optimizer_use_improved_disjunction_stats              on
 optimizer_use_multicol_stats                          on
 optimizer_use_not_visible_indexes                     off
 override_multi_region_zone_config                     off

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2850,6 +2850,7 @@ on_update_rehome_row_enabled                          on                  NULL  
 opt_split_scan_limit                                  2048                NULL      NULL        NULL        string
 optimizer_use_forecasts                               on                  NULL      NULL        NULL        string
 optimizer_use_histograms                              on                  NULL      NULL        NULL        string
+optimizer_use_improved_disjunction_stats              on                  NULL      NULL        NULL        string
 optimizer_use_multicol_stats                          on                  NULL      NULL        NULL        string
 optimizer_use_not_visible_indexes                     off                 NULL      NULL        NULL        string
 override_multi_region_zone_config                     off                 NULL      NULL        NULL        string
@@ -2991,6 +2992,7 @@ on_update_rehome_row_enabled                          on                  NULL  
 opt_split_scan_limit                                  2048                NULL  user     NULL      2048                2048
 optimizer_use_forecasts                               on                  NULL  user     NULL      on                  on
 optimizer_use_histograms                              on                  NULL  user     NULL      on                  on
+optimizer_use_improved_disjunction_stats              on                  NULL  user     NULL      on                  on
 optimizer_use_multicol_stats                          on                  NULL  user     NULL      on                  on
 optimizer_use_not_visible_indexes                     off                 NULL  user     NULL      off                 off
 override_multi_region_zone_config                     off                 NULL  user     NULL      off                 off
@@ -3130,6 +3132,7 @@ opt_split_scan_limit                                  NULL    NULL     NULL     
 optimizer                                             NULL    NULL     NULL     NULL        NULL
 optimizer_use_forecasts                               NULL    NULL     NULL     NULL        NULL
 optimizer_use_histograms                              NULL    NULL     NULL     NULL        NULL
+optimizer_use_improved_disjunction_stats              NULL    NULL     NULL     NULL        NULL
 optimizer_use_multicol_stats                          NULL    NULL     NULL     NULL        NULL
 optimizer_use_not_visible_indexes                     NULL    NULL     NULL     NULL        NULL
 override_multi_region_zone_config                     NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -108,6 +108,7 @@ on_update_rehome_row_enabled                          on
 opt_split_scan_limit                                  2048
 optimizer_use_forecasts                               on
 optimizer_use_histograms                              on
+optimizer_use_improved_disjunction_stats              on
 optimizer_use_multicol_stats                          on
 optimizer_use_not_visible_indexes                     off
 override_multi_region_zone_config                     off

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -159,6 +159,7 @@ type Memo struct {
 	enforceHomeRegion                      bool
 	variableInequalityLookupJoinEnabled    bool
 	allowOrdinalColumnReferences           bool
+	useImprovedDisjunctionStats            bool
 
 	// curRank is the highest currently in-use scalar expression rank.
 	curRank opt.ScalarRank
@@ -213,6 +214,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		enforceHomeRegion:                      evalCtx.SessionData().EnforceHomeRegion,
 		variableInequalityLookupJoinEnabled:    evalCtx.SessionData().VariableInequalityLookupJoinEnabled,
 		allowOrdinalColumnReferences:           evalCtx.SessionData().AllowOrdinalColumnReferences,
+		useImprovedDisjunctionStats:            evalCtx.SessionData().OptimizerUseImprovedDisjunctionStats,
 	}
 	m.metadata.Init()
 	m.logPropsBuilder.init(ctx, evalCtx, m)
@@ -350,7 +352,8 @@ func (m *Memo) IsStale(
 		m.testingOptimizerDisableRuleProbability != evalCtx.SessionData().TestingOptimizerDisableRuleProbability ||
 		m.enforceHomeRegion != evalCtx.SessionData().EnforceHomeRegion ||
 		m.variableInequalityLookupJoinEnabled != evalCtx.SessionData().VariableInequalityLookupJoinEnabled ||
-		m.allowOrdinalColumnReferences != evalCtx.SessionData().AllowOrdinalColumnReferences {
+		m.allowOrdinalColumnReferences != evalCtx.SessionData().AllowOrdinalColumnReferences ||
+		m.useImprovedDisjunctionStats != evalCtx.SessionData().OptimizerUseImprovedDisjunctionStats {
 		return true, nil
 	}
 

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -323,7 +323,13 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().TestingOptimizerDisableRuleProbability = 0
 	notStale()
 
-	// Stale testing_optimizer_disable_rule_probability.
+	// Stale allow_ordinal_column_references.
+	evalCtx.SessionData().AllowOrdinalColumnReferences = true
+	stale()
+	evalCtx.SessionData().AllowOrdinalColumnReferences = false
+	notStale()
+
+	// Stale optimizer_use_improve_disjunction_stats.
 	evalCtx.SessionData().AllowOrdinalColumnReferences = true
 	stale()
 	evalCtx.SessionData().AllowOrdinalColumnReferences = false

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -3193,30 +3193,53 @@ func (sb *statisticsBuilder) applyFiltersItem(
 			}
 		}
 	} else if constraintUnion, numUnappliedDisjuncts := sb.buildDisjunctionConstraints(filter); len(constraintUnion) > 0 {
-		// The filters are one or more disjuncts and tight constraint sets could be
-		// built for at least one disjunct. numUnappliedDisjuncts contains the count
-		// of disjuncts which are not tight constraints.
-		var tmpStats props.Statistics
+		if sb.evalCtx.SessionData().OptimizerUseImprovedDisjunctionStats {
+			// The filters are one or more disjuncts and tight constraint sets
+			// could be built for at least one disjunct. numUnappliedDisjuncts
+			// contains the count of disjuncts which are not tight constraints.
+			var tmpStats props.Statistics
 
-		selectivities := make([]props.Selectivity, 0, len(constraintUnion)+numUnappliedDisjuncts)
-		// Get the stats for each constraint set, apply the selectivity to a
-		// temporary stats struct, and combine the disjunct selectivities.
-		// union the selectivity and row counts.
-		for i := 0; i < len(constraintUnion); i++ {
-			tmpStats.CopyFrom(s)
-			sb.constrainExpr(e, constraintUnion[i], relProps, &tmpStats)
-			selectivities = append(selectivities, tmpStats.Selectivity)
-		}
-		defaultSelectivity := props.MakeSelectivity(unknownFilterSelectivity)
-		for i := 0; i < numUnappliedDisjuncts; i++ {
-			selectivities = append(selectivities, defaultSelectivity)
-		}
+			selectivities := make([]props.Selectivity, 0, len(constraintUnion)+numUnappliedDisjuncts)
+			// Get the stats for each constraint set, apply the selectivity to a
+			// temporary stats struct, and combine the disjunct selectivities.
+			// union the selectivity and row counts.
+			for i := 0; i < len(constraintUnion); i++ {
+				tmpStats.CopyFrom(s)
+				sb.constrainExpr(e, constraintUnion[i], relProps, &tmpStats)
+				selectivities = append(selectivities, tmpStats.Selectivity)
+			}
+			defaultSelectivity := props.MakeSelectivity(unknownFilterSelectivity)
+			for i := 0; i < numUnappliedDisjuncts; i++ {
+				selectivities = append(selectivities, defaultSelectivity)
+			}
 
-		// TODO(mgartner): Calculate and set the column statistics based on
-		// constraintUnion.
-		disjunctionSelectivity := combineOredSelectivities(selectivities)
-		s.RowCount *= disjunctionSelectivity.AsFloat()
-		s.Selectivity.Multiply(disjunctionSelectivity)
+			// TODO(mgartner): Calculate and set the column statistics based on
+			// constraintUnion.
+			disjunctionSelectivity := combineOredSelectivities(selectivities)
+			s.RowCount *= disjunctionSelectivity.AsFloat()
+			s.Selectivity.Multiply(disjunctionSelectivity)
+		} else {
+			// The filters are one or more disjunctions and tight constraint
+			// sets could be built for each.
+			var tmpStats, unionStats props.Statistics
+			unionStats.CopyFrom(s)
+
+			// Get the stats for each constraint set, apply the selectivity to a
+			// temporary stats struct, and union the selectivity and row counts.
+			sb.constrainExpr(e, constraintUnion[0], relProps, &unionStats)
+			for i := 1; i < len(constraintUnion); i++ {
+				tmpStats.CopyFrom(s)
+				sb.constrainExpr(e, constraintUnion[i], relProps, &tmpStats)
+				unionStats.UnionWith(&tmpStats)
+			}
+
+			// The stats are unioned naively; the selectivity may be greater
+			// than 1 and the row count may be greater than the row count of the
+			// input stats. We use the minimum selectivity and row count of the
+			// unioned stats and the input stats.
+			s.Selectivity = props.MinSelectivity(s.Selectivity, unionStats.Selectivity)
+			s.RowCount = min(s.RowCount, unionStats.RowCount)
+		}
 	} else {
 		numUnappliedConjuncts++
 	}

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -1301,7 +1301,7 @@ project
 
 # Sample testcase using exprgen.
 expr colstat=1 colstat=2
-(Select 
+(Select
   (FakeRel
     [
       (OutputCols [ (NewColumn "a" "int") (NewColumn "b" "int") (NewColumn "c" "int")] )
@@ -1310,15 +1310,15 @@ expr colstat=1 colstat=2
         {
           "columns": ["a"],
           "distinct_count": 100,
-          "null_count": 0, 
-          "row_count": 100, 
+          "null_count": 0,
+          "row_count": 100,
           "created_at": "2018-01-01 1:00:00.00000+00:00"
         },
         {
           "columns": ["b"],
           "distinct_count": 20,
-          "null_count": 5, 
-          "row_count": 100, 
+          "null_count": 5,
+          "row_count": 100,
           "created_at": "2018-01-01 1:00:00.00000+00:00"
         }
       ]`)
@@ -3762,6 +3762,27 @@ project
  └── select
       ├── columns: c0:1(int) c1:2(int)
       ├── stats: [rows=1.9]
+      ├── scan t00
+      │    ├── columns: c0:1(int) c1:2(int)
+      │    └── stats: [rows=10, distinct(1)=10, null(1)=0, distinct(2)=10, null(2)=0]
+      │        histogram(1)=  0  0  9  1
+      │                     <--- 0 --- 10
+      │        histogram(2)=  0  0  9  1
+      │                     <--- 0 --- 10
+      └── filters
+           └── (c0:1 = 1) OR (c1:2 = 3) [type=bool, outer=(1,2)]
+
+# The row counts are slightly different when using legacy disjunction stats
+# calculation.
+opt set=optimizer_use_improved_disjunction_stats=false
+SELECT c0 FROM t00 WHERE (c0 = 1) OR (c1 = 3)
+----
+project
+ ├── columns: c0:1(int)
+ ├── stats: [rows=2]
+ └── select
+      ├── columns: c0:1(int) c1:2(int)
+      ├── stats: [rows=2]
       ├── scan t00
       │    ├── columns: c0:1(int) c1:2(int)
       │    └── stats: [rows=10, distinct(1)=10, null(1)=0, distinct(2)=10, null(2)=0]

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -292,6 +292,7 @@ func New(catalog cat.Catalog, sql string) *OptTester {
 	ot.evalCtx.SessionData().InsertFastPath = true
 	ot.evalCtx.SessionData().OptSplitScanLimit = tabledesc.MaxBucketAllowed
 	ot.evalCtx.SessionData().VariableInequalityLookupJoinEnabled = true
+	ot.evalCtx.SessionData().OptimizerUseImprovedDisjunctionStats = true
 
 	return ot
 }

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -312,6 +312,10 @@ message LocalOnlySessionData {
   // AllowOrdinalColumnReferences indicates whether the deprecated ordinal
   // column reference syntax (e.g., `SELECT @1 FROM t`) is allowed.
   bool allow_ordinal_column_references = 85;
+  // OptimizerUseImprovedDisjunctionStats, when true, indicates that the
+  // optimizer should use improved statistics calculations for disjunctive
+  // filters.
+  bool optimizer_use_improved_disjunction_stats = 86;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2389,6 +2389,21 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalFalse,
 	},
+	`optimizer_use_improved_disjunction_stats`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`optimizer_use_improved_disjunction_stats`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("optimizer_use_improved_disjunction_stats", s)
+			if err != nil {
+				return err
+			}
+			m.SetOptimizerUseImprovedDisjunctionStats(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().OptimizerUseImprovedDisjunctionStats), nil
+		},
+		GlobalDefault: globalTrue,
+	},
 }
 
 // We want test coverage for this on and off so make it metamorphic.


### PR DESCRIPTION
This commit adds the `optimizer_use_improved_disjunction_stats` session
setting that defaults to `true`. When `true`, the improved disjunction
logic added in #89358 is performed. When `false`, the logic reverts to
the previous logic. This setting will allow use to backport the new
logic without impacting query plans of running clusters by defaulting
the setting to false.

Epic: None

Release note: None
