### PR TITLE
sql: don't use streamer for local flows and non-default key locking

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -4366,13 +4366,15 @@ func (dsp *DistSQLPlanner) NewPlanningCtx(
 		onFlowCleanup: []func(){infra.Release},
 	}
 	if !distribute {
-		if planner == nil || dsp.spanResolver == nil || planner.curPlan.flags.IsSet(planFlagContainsMutation) {
+		if planner == nil || dsp.spanResolver == nil || planner.curPlan.flags.IsSet(planFlagContainsMutation) ||
+			planner.curPlan.flags.IsSet(planFlagContainsNonDefaultLocking) {
 			// Don't parallelize the scans if we have a local plan if
 			// - we don't have a planner which is the case when we are not on
 			// the main query path;
 			// - we don't have a span resolver (this can happen only in tests);
 			// - the plan contains a mutation operation - we currently don't
-			// support any parallelism when mutations are present.
+			// support any parallelism when mutations are present;
+			// - the plan uses non-default key locking strength (see #94290).
 			return planCtx
 		}
 		prohibitParallelization, hasScanNodeToParallelize := checkScanParallelizationIfLocal(ctx, &planner.curPlan.planComponents)

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -700,14 +700,26 @@ func (dsp *DistSQLPlanner) Run(
 			// given a LeafTxn. In order for that LeafTxn to be created later,
 			// during the flow setup, we need to populate leafInputState below,
 			// so we tell the localState that there is concurrency.
-			if execinfra.CanUseStreamer(dsp.st) {
-				for _, proc := range plan.Processors {
-					if jr := proc.Spec.Core.JoinReader; jr != nil {
-						// Both index and lookup joins, with and without
-						// ordering, are executed via the Streamer API that has
-						// concurrency.
-						localState.HasConcurrency = true
-						break
+
+			// At the moment, we disable the usage of the Streamer API for local
+			// plans when non-default key locking modes are requested on some of
+			// the processors. This is the case since the lock spans propagation
+			// doesn't happen for the leaf txns which can result in excessive
+			// contention for future reads (since the acquired locks are not
+			// cleaned up properly when the txn commits).
+			// TODO(yuzefovich): fix the propagation of the lock spans with the
+			// leaf txns and remove this check. See #94290.
+			containsNonDefaultLocking := planCtx.planner != nil && planCtx.planner.curPlan.flags.IsSet(planFlagContainsNonDefaultLocking)
+			if !containsNonDefaultLocking {
+				if execinfra.CanUseStreamer(dsp.st) {
+					for _, proc := range plan.Processors {
+						if jr := proc.Spec.Core.JoinReader; jr != nil {
+							// Both index and lookup joins, with and without
+							// ordering, are executed via the Streamer API that has
+							// concurrency.
+							localState.HasConcurrency = true
+							break
+						}
 					}
 				}
 			}

--- a/pkg/sql/logictest/testdata/logic_test/select_for_update
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_update
@@ -466,3 +466,22 @@ statement ok
 ROLLBACK
 
 user root
+
+# Regression test for not propagating lock spans with leaf txns (#94290).
+statement ok
+CREATE TABLE t94290 (a INT, b INT, c INT, PRIMARY KEY(a), UNIQUE INDEX(b));
+INSERT INTO t94290 VALUES (1,2,3);
+
+# If the lock spans are not propagated, then the second query would take almost
+# 5 seconds.
+statement ok
+SET statement_timeout = '2s';
+
+statement ok
+SELECT * FROM t94290 WHERE b = 2 FOR UPDATE;
+
+statement ok
+SELECT * FROM t94290 WHERE b = 2 FOR UPDATE;
+
+statement ok
+RESET statement_timeout;

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -134,6 +134,10 @@ type Builder struct {
 	// ContainsMutation is set to true if the whole plan contains any mutations.
 	ContainsMutation bool
 
+	// ContainsNonDefaultKeyLocking is set to true if at least one node in the
+	// plan uses non-default key locking strength.
+	ContainsNonDefaultKeyLocking bool
+
 	// MaxFullScanRows is the maximum number of rows scanned by a full scan, as
 	// estimated by the optimizer.
 	MaxFullScanRows float64

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -611,6 +611,7 @@ func (b *Builder) scanParams(
 	if b.forceForUpdateLocking {
 		locking = forUpdateLocking
 	}
+	b.ContainsNonDefaultKeyLocking = b.ContainsNonDefaultKeyLocking || locking.IsLocking()
 
 	// Raise error if row-level locking is part of a read-only transaction.
 	// TODO(nvanbenschoten): this check should be shared across all expressions
@@ -2004,6 +2005,7 @@ func (b *Builder) buildIndexJoin(join *memo.IndexJoinExpr) (execPlan, error) {
 	if b.forceForUpdateLocking {
 		locking = forUpdateLocking
 	}
+	b.ContainsNonDefaultKeyLocking = b.ContainsNonDefaultKeyLocking || locking.IsLocking()
 
 	res := execPlan{outputCols: output}
 	b.recordJoinAlgorithm(exec.IndexJoin)
@@ -2292,6 +2294,7 @@ func (b *Builder) buildLookupJoin(join *memo.LookupJoinExpr) (execPlan, error) {
 	if b.forceForUpdateLocking {
 		locking = forUpdateLocking
 	}
+	b.ContainsNonDefaultKeyLocking = b.ContainsNonDefaultKeyLocking || locking.IsLocking()
 
 	joinType := joinOpToJoinType(join.JoinType)
 	b.recordJoinType(joinType)
@@ -2518,6 +2521,7 @@ func (b *Builder) buildInvertedJoin(join *memo.InvertedJoinExpr) (execPlan, erro
 	if b.forceForUpdateLocking {
 		locking = forUpdateLocking
 	}
+	b.ContainsNonDefaultKeyLocking = b.ContainsNonDefaultKeyLocking || locking.IsLocking()
 
 	joinType := joinOpToJoinType(join.JoinType)
 	b.recordJoinType(joinType)
@@ -2592,6 +2596,7 @@ func (b *Builder) buildZigzagJoin(join *memo.ZigzagJoinExpr) (execPlan, error) {
 		leftLocking = forUpdateLocking
 		rightLocking = forUpdateLocking
 	}
+	b.ContainsNonDefaultKeyLocking = b.ContainsNonDefaultKeyLocking || leftLocking.IsLocking() || rightLocking.IsLocking()
 
 	allCols := joinOutputMap(leftColMap, rightColMap)
 

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -627,6 +627,10 @@ const (
 
 	// planFlagContainsMutation is set if the plan has any mutations.
 	planFlagContainsMutation
+
+	// planFlagContainsNonDefaultLocking is set if the plan has a node with
+	// non-default key locking strength.
+	planFlagContainsNonDefaultLocking
 )
 
 func (pf planFlags) IsSet(flag planFlags) bool {

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -693,6 +693,9 @@ func (opc *optPlanningCtx) runExecBuilder(
 	if bld.ContainsMutation {
 		planTop.flags.Set(planFlagContainsMutation)
 	}
+	if bld.ContainsNonDefaultKeyLocking {
+		planTop.flags.Set(planFlagContainsNonDefaultLocking)
+	}
 	if planTop.instrumentation.ShouldSaveMemo() {
 		planTop.mem = mem
 		planTop.catalog = opc.catalog


### PR DESCRIPTION
This commit makes it so that we don't use the streamer API when running
fully-local plans if some processors in that flow require non-default
key locking. This change allows us to fix a regression with `SELECT FOR
UPDATE` where the acquired locks by that stmt would not be properly
cleaned up on the txn commit (because we currently don't propagate lock
spans for leaf txns, and the streamer requires us to use the leaf txns).
The initial attempt to fix this propagation exposed an issue with
multi-tenant setups, so for now we choose to simply not use the streamer
in such cases.

Additionally, this commit disables the parallelization of local scans
when non-default key locking strength is found. The parallelization of
local scans also requires us to use the leaf txns, and it was introduced
in 21.2 version; however, we haven't had any user reports. Still, it
seems reasonable to update that code path with the recent learnings.

Addresses: #94290.
Addresses: #94400.

Epic: None

Release note (bug fix): Previously, CockroachDB could delay the release
of the locks acquired when evaluating SELECT FOR UPDATE statements in
some cases. This delay (up to 5s) could then block the future readers.
The bug was introduced in 22.2.0, and the temporary workaround without
upgrading to a release with this fix is to set undocumented cluster
setting `sql.distsql.use_streamer.enabled` to `false`.