### PR TITLE
release-22.2: pgwire: support binary encoding of generic tuples

### DIFF
--- a/pkg/sql/pgwire/testdata/pgtest/tuple
+++ b/pkg/sql/pgwire/testdata/pgtest/tuple
@@ -235,3 +235,20 @@ ReadyForQuery
 {"Type":"ParseComplete"}
 {"Type":"ErrorResponse","Code":"42601","Message":"error in argument for $1: insufficient bytes reading element for binary format. elementIdx=0 bufferLength=12 bufferStartIdx=12 bufferEndIdx=13"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Test binary encoding of a generic tuple result.
+send crdb_only
+Parse {"Name": "tuple_array", "Query": "SELECT (1::int8,'foo'::text)::record, ARRAY[(1::int8,'foo'::text)::record, (1::int8,'foo'::text)::record]"}
+Bind {"PreparedStatement": "tuple_array", "ResultFormatCodes": [1, 1]}
+Execute
+Sync
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"binary":"00000002000000140000000800000000000000010000001900000003666f6f"},{"binary":"0000000100000000000008c900000002000000010000001f00000002000000140000000800000000000000010000001900000003666f6f0000001f00000002000000140000000800000000000000010000001900000003666f6f"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -685,9 +685,14 @@ func writeBinaryDatumNotNull(
 		b.putInt32(int32(len(v.D)))
 		tupleTypes := t.TupleContents()
 		for i, elem := range v.D {
-			oid := tupleTypes[i].Oid()
-			b.putInt32(int32(oid))
-			b.writeBinaryDatum(ctx, elem, sessionLoc, tupleTypes[i])
+			// Untyped tuples don't know the types of the tuple contents, so fallback
+			// to using the datum's type.
+			elemTyp := elem.ResolvedType()
+			if i < len(tupleTypes) && tupleTypes[i].Family() != types.AnyFamily {
+				elemTyp = tupleTypes[i]
+			}
+			b.putInt32(int32(elemTyp.Oid()))
+			b.writeBinaryDatum(ctx, elem, sessionLoc, elemTyp)
 		}
 
 		lengthToWrite := b.Len() - (initialLen + 4)


### PR DESCRIPTION
Backport 1/2 commits from #94405.

/cc @cockroachdb/release

Release justification: fix a panic

---

fixes https://github.com/cockroachdb/cockroach/issues/94356

Release note (bug fix): Record types can now be encoded with the binary
encoding of the Postgres wire protocol. Previously, trying to use this
encoding could case a panic in the database.

