### PR TITLE
release-22.2: server: clean up startAttemptUpgrade

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1659,9 +1659,15 @@ func (s *Server) PreStart(ctx context.Context) error {
 	s.ctSender.Run(ctx, state.nodeID)
 
 	// Attempt to upgrade cluster version now that the sql server has been
-	// started. At this point we know that all startupmigrations have successfully
-	// been run so it is safe to upgrade to the binary's current version.
-	s.startAttemptUpgrade(ctx)
+	// started. At this point we know that all startupmigrations and permanent
+	// upgrades have successfully been run so it is safe to upgrade to the
+	// binary's current version.
+	//
+	// NB: We run this under the startup ctx (not workersCtx) so as to ensure
+	// all the upgrade steps are traced, for use during troubleshooting.
+	if err := s.startAttemptUpgrade(ctx); err != nil {
+		return errors.Wrap(err, "cannot start upgrade task")
+	}
 
 	if err := s.node.tenantSettingsWatcher.Start(ctx, s.sqlServer.execCfg.SystemTableIDResolver); err != nil {
 		return errors.Wrap(err, "failed to initialize the tenant settings watcher")


### PR DESCRIPTION
Backport 1/1 commits from #91049.

/cc @cockroachdb/release

---

This avoids a log error when `preserve_downgrade_option` is set, and overall simplifies the control flow.
Fixes #90382. 

Release justification: improves troubleshootability