### PR TITLE
kvserver: allow rangefeeds with expiration-based leases

### DIFF
--- a/pkg/kv/kvserver/client_rangefeed_test.go
+++ b/pkg/kv/kvserver/client_rangefeed_test.go
@@ -272,3 +272,80 @@ func TestRangefeedIsRoutedToNonVoter(t *testing.T) {
 	require.Regexp(t, "context canceled", <-rangefeedErrChan)
 	require.Regexp(t, "attempting to create a RangeFeed over replica.*2NON_VOTER", getRecAndFinish().String())
 }
+
+// TestRangefeedWorksOnLivenessRange ensures that a rangefeed works as expected
+// on the liveness range, which uses an expiration-based lease.
+func TestRangefeedWorksOnLivenessRange(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	// Speed up node liveness heartbeats.
+	var raftCfg base.RaftConfig
+	raftCfg.SetDefaults()
+	raftCfg.RangeLeaseRaftElectionTimeoutMultiplier = 1
+
+	tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			RaftConfig: raftCfg,
+		},
+	})
+	defer tc.Stopper().Stop(ctx)
+
+	_, err := tc.ServerConn(0).Exec("SET CLUSTER SETTING kv.rangefeed.enabled = true")
+	require.NoError(t, err)
+	_, err = tc.ServerConn(0).Exec("SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'")
+	require.NoError(t, err)
+
+	db := tc.Server(0).DB()
+	ds := tc.Server(0).DistSenderI().(*kvcoord.DistSender)
+	tc.Server(0)
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	startTS := db.Clock().Now()
+	eventC := make(chan kvcoord.RangeFeedMessage)
+	errC := make(chan error, 1)
+	go func() {
+		errC <- ds.RangeFeed(ctx, []roachpb.Span{keys.NodeLivenessSpan}, startTS, false /* withDiff */, eventC)
+	}()
+
+	// Wait for a liveness update.
+	var livenessEvent roachpb.RangeFeedValue
+	timeoutC := time.After(10 * time.Second)
+	for {
+		select {
+		case event := <-eventC:
+			if event.Val == nil {
+				continue
+			}
+			require.Equal(t, keys.NodeLivenessSpan, event.RegisteredSpan)
+			require.NotZero(t, event.Val.Value.Timestamp)
+			livenessEvent = *event.Val
+		case err := <-errC:
+			t.Fatalf("rangefeed unexpectedly exited with err=%v", err)
+		case <-timeoutC:
+			t.Fatal("timed out waiting for checkpoint")
+		}
+		break
+	}
+
+	// Wait for a checkpoint after the liveness update.
+	for {
+		select {
+		case event := <-eventC:
+			if checkpoint := event.Checkpoint; checkpoint == nil {
+				continue
+			} else if checkpoint.ResolvedTS.Less(livenessEvent.Value.Timestamp) {
+				continue
+			}
+		case err := <-errC:
+			t.Fatalf("rangefeed unexpectedly exited with err=%v", err)
+		case <-timeoutC:
+			t.Fatal("timed out waiting for checkpoint")
+		}
+		break
+	}
+}

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1556,11 +1556,6 @@ func (r *Replica) checkExecutionCanProceedForRangeFeed(
 		return err
 	} else if err := r.checkTSAboveGCThresholdRLocked(ts, status, false /* isAdmin */); err != nil {
 		return err
-	} else if r.requiresExpiringLeaseRLocked() {
-		// Ensure that the range does not require an expiration-based lease. If it
-		// does, it will never get closed timestamp updates and the rangefeed will
-		// never be able to advance its resolved timestamp.
-		return errors.New("expiration-based leases are incompatible with rangefeeds")
 	}
 	return nil
 }


### PR DESCRIPTION
When closed timestamp were originally implemented (b0297b6b), they depended on the liveness epoch and thus couldn't be used with expiration-based leases. This dependency was removed with the introduction of non-blocking transactions (99a5df94), but we still rejected rangefeeds on ranges with expiration-based leases. This patch removes this stale restriction.

Note that this restriction was only in effect for ranges satisfying `Replica.requiresExpiringLeaseRLocked()`, which was hardcoded to the meta and liveness ranges. This is significant, since we recently changed lease transfers to temporarily use expiration-based leases (5b0bdc5c), and these could otherwise have inadvertently hit this restriction.

Touches #93903.

Epic: none
Release note: None