### PR TITLE
sql: avoid panic for notices in internal executor

### DIFF
--- a/pkg/sql/conn_io.go
+++ b/pkg/sql/conn_io.go
@@ -935,12 +935,12 @@ func (r *streamingCommandResult) SetColumns(ctx context.Context, cols colinfo.Re
 
 // BufferParamStatusUpdate is part of the RestrictedCommandResult interface.
 func (r *streamingCommandResult) BufferParamStatusUpdate(key string, val string) {
-	panic("unimplemented")
+	// Unimplemented: the internal executor does not support status updated.
 }
 
 // BufferNotice is part of the RestrictedCommandResult interface.
 func (r *streamingCommandResult) BufferNotice(notice pgnotice.Notice) {
-	panic("unimplemented")
+	// Unimplemented: the internal executor does not support notices.
 }
 
 // ResetStmtType is part of the RestrictedCommandResult interface.

--- a/pkg/sql/logictest/testdata/logic_test/cursor
+++ b/pkg/sql/logictest/testdata/logic_test/cursor
@@ -643,3 +643,11 @@ DECLARE foo CURSOR WITH HOLD FOR SELECT 1
 # ROLLBACK is fine, since it renders the cursor unusable anyway.
 statement ok
 ROLLBACK
+
+# Regression test for using a SQL cursor that buffers a notice.
+# See https://github.com/cockroachdb/cockroach/issues/94344
+statement ok
+BEGIN;
+declare a cursor for select * from crdb_internal.gossip_network;
+FETCH 1 FROM a;
+COMMIT


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/94344

Release note (bug fix): Fixed a panic that could be caused when using a SQL cursor to access tables in the crdb_internal schema.