### PR TITLE
release-22.2: kvserver: skip rq decom non-voters under deadlock

### DIFF
--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -424,6 +424,7 @@ func TestReplicateQueueDecommissioningNonVoters(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	skip.UnderRace(t, "takes a long time or times out under race")
+	skip.UnderDeadlockWithIssue(t, 94383)
 
 	ctx := context.Background()
 


### PR DESCRIPTION
Backport 1/1 commits from #94384.

resolves: #92726
resolves: #94383

/cc @cockroachdb/release

---

`TestReplicateQueueDecommissioningNonVoters` has been consistently failing on master when run with the `deadlock` test flag. The cause of the failure is the test timing out on a `require.Eventually(...)` clause. This timeout occurs in both subtests: `replace` and `remove`. This test failure doesn't appear legitimate w.r.t the logic being tested.

This patch skips `TestReplicateQueueDecommissioningNonVoters` under `deadlock`.

resolves #92193
informs #94383

Release note: None
Release justification: Skip flaky test under `deadlock` build.
