### PR TITLE
opt: fix minor mistakes in legacy disjunction stats logic

### DIFF
--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -331,9 +331,9 @@ func TestMemoIsStale(t *testing.T) {
 	notStale()
 
 	// Stale optimizer_use_improve_disjunction_stats.
-	evalCtx.SessionData().AllowOrdinalColumnReferences = true
+	evalCtx.SessionData().OptimizerUseImprovedDisjunctionStats = true
 	stale()
-	evalCtx.SessionData().AllowOrdinalColumnReferences = false
+	evalCtx.SessionData().OptimizerUseImprovedDisjunctionStats = false
 	notStale()
 
 	// Stale data sources and schema. Create new catalog so that data sources are

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -3218,7 +3218,7 @@ func (sb *statisticsBuilder) applyFiltersItem(
 			disjunctionSelectivity := combineOredSelectivities(selectivities)
 			s.RowCount *= disjunctionSelectivity.AsFloat()
 			s.Selectivity.Multiply(disjunctionSelectivity)
-		} else {
+		} else if numUnappliedDisjuncts == 0 {
 			// The filters are one or more disjunctions and tight constraint
 			// sets could be built for each.
 			var tmpStats, unionStats props.Statistics
@@ -3239,6 +3239,8 @@ func (sb *statisticsBuilder) applyFiltersItem(
 			// unioned stats and the input stats.
 			s.Selectivity = props.MinSelectivity(s.Selectivity, unionStats.Selectivity)
 			s.RowCount = min(s.RowCount, unionStats.RowCount)
+		} else {
+			numUnappliedConjuncts++
 		}
 	} else {
 		numUnappliedConjuncts++


### PR DESCRIPTION
These subtle bugs were discovered while creating #94439, the backport
of #89358 and #94389 to v22.1. They have already been included in that
backport. The backport to v22.2 has not yet been created, and it will
include this commit.

Epic: None

Release note: None
