### PR TITLE
storage: abstract away pebbleResults as an interface

### DIFF
--- a/pkg/storage/pebble_mvcc_scanner.go
+++ b/pkg/storage/pebble_mvcc_scanner.go
@@ -30,9 +30,6 @@ import (
 	"github.com/cockroachdb/pebble"
 )
 
-// Key value lengths take up 8 bytes (2 x Uint32).
-const kvLenSize = 8
-
 var maxItersBeforeSeek = util.ConstantWithMetamorphicTestRange(
 	"mvcc-max-iters-before-seek",
 	10, /* defaultValue */
@@ -50,6 +47,45 @@ const (
 	// MVCCDecodingRequired is used when timestamps are needed.
 	MVCCDecodingRequired
 )
+
+// results abstracts away a result set where pebbleMVCCScanner put()'s KVs into.
+type results interface {
+	// clear clears the results so that its memory could be GCed.
+	clear()
+	// sizeInfo returns several pieces of information about the current size of
+	// the results:
+	// - the number of KVs currently in the results,
+	// - the current memory footprint of the results in bytes,
+	// - the increment for how much the memory footprint of the results will
+	//   increase (in bytes) if a KV (with the corresponding lengths of the key
+	//   and the value parts) is put into it.
+	//
+	// Note that we chose to squash all these things into a single method rather
+	// than defining a separate method for each parameter out of performance
+	// considerations.
+	sizeInfo(lenKey, lenValue int) (numKeys, numBytes, numBytesInc int64)
+	// put adds a KV into the results. An error is returned if the memory
+	// reservation is denied by the memory account.
+	put(_ context.Context, key []byte, value []byte, memAccount *mon.BoundAccount, maxNewSize int) error
+	// continuesFirstRow returns true if the given key belongs to the same SQL
+	// row as the first KV pair in the result (or if the result is empty). If
+	// either key is not a valid SQL row key, returns false.
+	continuesFirstRow(key roachpb.Key) bool
+	// maybeTrimPartialLastRow removes the last KV pairs from the result that
+	// are part of the same SQL row as the given key, returning the earliest key
+	// removed.
+	maybeTrimPartialLastRow(key roachpb.Key) (roachpb.Key, error)
+	// lastRowHasFinalColumnFamily returns true if the last key in the result is
+	// the maximum column family ID of the row. If so, we know that the row is
+	// complete. However, the inverse is not true: the final column families of
+	// the row may be omitted, in which case the caller has to scan to the next
+	// key to find out whether the row is complete.
+	//
+	// lastRowHasFinalColumnFamily is only called after having called put() with
+	// no error at least once, meaning that at least one key is in the results.
+	// Also, this is only called when wholeRows option is enabled.
+	lastRowHasFinalColumnFamily(reverse bool) bool
+}
 
 // Struct to store MVCCScan / MVCCGet in the same binary format as that
 // expected by MVCCScanDecodeKeyValue.
@@ -86,10 +122,28 @@ type pebbleResults struct {
 	lastOffsetIdx      int
 }
 
+// clear implements the results interface.
 func (p *pebbleResults) clear() {
 	*p = pebbleResults{}
 }
 
+// Key value lengths take up 8 bytes (2 x Uint32).
+const pebbleResultsKVLenSize = 8
+
+func pebbleResultsKVSizeOf(lenKey, lenValue int) int {
+	return pebbleResultsKVLenSize + lenKey + lenValue
+}
+
+// sizeInfo implements the results interface.
+func (p *pebbleResults) sizeInfo(lenKey, lenValue int) (numKeys, numBytes, numBytesInc int64) {
+	numKeys = p.count
+	numBytes = p.bytes
+	numBytesInc = int64(pebbleResultsKVSizeOf(lenKey, lenValue))
+	return numKeys, numBytes, numBytesInc
+}
+
+// put implements the results interface.
+//
 // The repr that MVCCScan / MVCCGet expects to provide as output goes:
 // <valueLen:Uint32><keyLen:Uint32><Key><Value>
 // This function adds to repr in that format.
@@ -109,7 +163,7 @@ func (p *pebbleResults) put(
 	// needs capacity greater than maxSize, we allocate exactly the size needed.
 	lenKey := len(key)
 	lenValue := len(value)
-	lenToAdd := p.sizeOf(lenKey, lenValue)
+	lenToAdd := pebbleResultsKVSizeOf(lenKey, lenValue)
 	if len(p.repr)+lenToAdd > cap(p.repr) {
 		// Exponential increase by default, while ensuring that we respect
 		// - a hard lower bound of lenToAdd
@@ -157,8 +211,8 @@ func (p *pebbleResults) put(
 	p.repr = p.repr[:startIdx+lenToAdd]
 	binary.LittleEndian.PutUint32(p.repr[startIdx:], uint32(lenValue))
 	binary.LittleEndian.PutUint32(p.repr[startIdx+4:], uint32(lenKey))
-	copy(p.repr[startIdx+kvLenSize:], key)
-	copy(p.repr[startIdx+kvLenSize+lenKey:], value)
+	copy(p.repr[startIdx+pebbleResultsKVLenSize:], key)
+	copy(p.repr[startIdx+pebbleResultsKVLenSize+lenKey:], value)
 	p.count++
 	p.bytes += int64(lenToAdd)
 
@@ -176,13 +230,7 @@ func (p *pebbleResults) put(
 	return nil
 }
 
-func (p *pebbleResults) sizeOf(lenKey, lenValue int) int {
-	return kvLenSize + lenKey + lenValue
-}
-
-// continuesFirstRow returns true if the given key belongs to the same SQL row
-// as the first KV pair in the result (or if the result is empty). If either
-// key is not a valid SQL row key, returns false.
+// continuesFirstRow implements the results interface.
 func (p *pebbleResults) continuesFirstRow(key roachpb.Key) bool {
 	repr := p.repr
 	if len(p.bufs) > 0 {
@@ -199,16 +247,8 @@ func (p *pebbleResults) continuesFirstRow(key roachpb.Key) bool {
 	return bytes.Equal(rowPrefix, getRowPrefix(extractResultKey(repr)))
 }
 
-// lastRowHasFinalColumnFamily returns true if the last key in the result is the
-// maximum column family ID of the row (i.e. when it equals len(lastOffsets)-1).
-// If so, we know that the row is complete. However, the inverse is not true:
-// the final column families of the row may be omitted, in which case the caller
-// has to scan to the next key to find out whether the row is complete.
+// lastRowHasFinalColumnFamily implements the results interface.
 func (p *pebbleResults) lastRowHasFinalColumnFamily(reverse bool) bool {
-	if !p.lastOffsetsEnabled || p.count == 0 {
-		return false
-	}
-
 	lastOffsetIdx := p.lastOffsetIdx - 1 // p.lastOffsetIdx is where next offset would be stored
 	if lastOffsetIdx < 0 {
 		lastOffsetIdx = len(p.lastOffsets) - 1
@@ -226,9 +266,9 @@ func (p *pebbleResults) lastRowHasFinalColumnFamily(reverse bool) bool {
 	return int(colFamilyID) == len(p.lastOffsets)-1
 }
 
-// maybeTrimPartialLastRow removes the last KV pairs from the result that are part
-// of the same SQL row as the given key, returning the earliest key removed. The
-// row cannot be made up of more KV pairs than given by len(lastOffsets),
+// maybeTrimPartialLastRow implements the results interface.
+//
+// The row cannot be made up of more KV pairs than given by len(lastOffsets),
 // otherwise an error is returned. Must be called before finish().
 func (p *pebbleResults) maybeTrimPartialLastRow(nextKey roachpb.Key) (roachpb.Key, error) {
 	if !p.lastOffsetsEnabled || len(p.repr) == 0 {
@@ -343,9 +383,6 @@ type pebbleMVCCScanner struct {
 	// hitting a limit. Partial rows at the end of the result will be trimmed. If
 	// allowEmpty is false, and the partial row is the first row in the result,
 	// the row will instead be completed by fetching additional KV pairs.
-	//
-	// Requires init() to have been called with trackLastOffsets set to the
-	// maximum number of KV pairs in a row.
 	wholeRows bool
 	// Stop adding intents and abort scan once maxIntents threshold is reached.
 	// This limit is only applicable to consistent scans since they return
@@ -387,7 +424,7 @@ type pebbleMVCCScanner struct {
 	curRawValue    pebble.LazyValue
 	curRangeKeys   MVCCRangeKeyStack
 	savedRangeKeys MVCCRangeKeyStack
-	results        pebbleResults
+	results        results
 	intents        pebble.Batch
 	// mostRecentTS stores the largest timestamp observed that is equal to or
 	// above the scan timestamp. Only applicable if failOnMoreRecent is true. If
@@ -460,13 +497,10 @@ func (p *pebbleMVCCScanner) release() {
 // init sets bounds on the underlying pebble iterator, and initializes other
 // fields not set by the calling method.
 func (p *pebbleMVCCScanner) init(
-	txn *roachpb.Transaction, ui uncertainty.Interval, trackLastOffsets int,
+	txn *roachpb.Transaction, ui uncertainty.Interval, results results,
 ) {
 	p.itersBeforeSeek = maxItersBeforeSeek / 2
-	if trackLastOffsets > 0 {
-		p.results.lastOffsetsEnabled = true
-		p.results.lastOffsets = make([]int, trackLastOffsets)
-	}
+	p.results = results
 
 	if txn != nil {
 		p.txn = txn
@@ -540,7 +574,7 @@ func (p *pebbleMVCCScanner) advance() bool {
 func (p *pebbleMVCCScanner) scan(
 	ctx context.Context,
 ) (*roachpb.Span, roachpb.ResumeReason, int64, error) {
-	if p.wholeRows && !p.results.lastOffsetsEnabled {
+	if p.wholeRows && !p.results.(*pebbleResults).lastOffsetsEnabled {
 		return nil, 0, 0, errors.AssertionFailedf("cannot use wholeRows without trackLastOffsets")
 	}
 
@@ -1126,12 +1160,14 @@ func (p *pebbleMVCCScanner) add(
 		}
 	}
 
-	// Check if adding the key would exceed a limit.
-	if p.targetBytes > 0 && p.results.bytes+int64(p.results.sizeOf(len(rawKey), len(rawValue))) > p.targetBytes {
-		p.resumeReason = roachpb.RESUME_BYTE_LIMIT
-		p.resumeNextBytes = int64(p.results.sizeOf(len(rawKey), len(rawValue)))
+	numKeys, numBytes, numBytesInc := p.results.sizeInfo(len(rawKey), len(rawValue))
 
-	} else if p.maxKeys > 0 && p.results.count >= p.maxKeys {
+	// Check if adding the key would exceed a limit.
+	if p.targetBytes > 0 && numBytes+numBytesInc > p.targetBytes {
+		p.resumeReason = roachpb.RESUME_BYTE_LIMIT
+		p.resumeNextBytes = numBytesInc
+
+	} else if p.maxKeys > 0 && numKeys >= p.maxKeys {
 		p.resumeReason = roachpb.RESUME_KEY_LIMIT
 	}
 
@@ -1141,7 +1177,7 @@ func (p *pebbleMVCCScanner) add(
 		// then make sure we include the first key in the result. If wholeRows is
 		// enabled, then also make sure we complete the first SQL row.
 		if !p.allowEmpty &&
-			(p.results.count == 0 || (p.wholeRows && p.results.continuesFirstRow(key))) {
+			(numKeys == 0 || (p.wholeRows && p.results.continuesFirstRow(key))) {
 			p.resumeReason = 0
 			p.resumeNextBytes = 0
 			mustPutKey = true
@@ -1172,21 +1208,22 @@ func (p *pebbleMVCCScanner) add(
 	//   p.targetBytes >= p.results.bytes + lenToAdd
 	// so maxNewSize will be sufficient.
 	var maxNewSize int
-	if p.targetBytes > 0 && p.targetBytes > p.results.bytes && !mustPutKey {
+	if p.targetBytes > 0 && p.targetBytes > numBytes && !mustPutKey {
 		// INVARIANT: !mustPutKey => maxNewSize is sufficient for key-value
 		// pair.
-		maxNewSize = int(p.targetBytes - p.results.bytes)
+		maxNewSize = int(p.targetBytes - numBytes)
 	}
 	if err := p.results.put(ctx, rawKey, rawValue, p.memAccount, maxNewSize); err != nil {
 		p.err = errors.Wrapf(err, "scan with start key %s", p.start)
 		return false, false
 	}
+	numKeys++
 
 	// Check if we hit the key limit just now to avoid scanning further before
 	// checking the key limit above on the next iteration. This has a small cost
 	// (~0.5% for large scans), but avoids the potentially large cost of scanning
 	// lots of garbage before the next key -- especially when maxKeys is small.
-	if p.maxKeys > 0 && p.results.count >= p.maxKeys {
+	if p.maxKeys > 0 && numKeys >= p.maxKeys {
 		// If we're not allowed to return partial SQL rows, check whether the last
 		// KV pair in the result has the maximum column family ID of the row. If so,
 		// we can return early. However, if it doesn't then we can't know yet

--- a/pkg/storage/pebble_mvcc_scanner_test.go
+++ b/pkg/storage/pebble_mvcc_scanner_test.go
@@ -93,12 +93,13 @@ func TestMVCCScanWithManyVersionsAndSeparatedIntents(t *testing.T) {
 		tombstones:       false,
 		failOnMoreRecent: false,
 	}
-	mvccScanner.init(nil /* txn */, uncertainty.Interval{}, 0 /* trackLastOffsets */)
+	var results pebbleResults
+	mvccScanner.init(nil /* txn */, uncertainty.Interval{}, &results)
 	_, _, _, err = mvccScanner.scan(context.Background())
 	require.NoError(t, err)
 
-	kvData := mvccScanner.results.finish()
-	numKeys := mvccScanner.results.count
+	kvData := results.finish()
+	numKeys := results.count
 	require.Equal(t, 3, int(numKeys))
 	type kv struct {
 		k MVCCKey
@@ -152,12 +153,13 @@ func TestMVCCScanWithLargeKeyValue(t *testing.T) {
 		end:     roachpb.Key("e"),
 		ts:      ts,
 	}
-	mvccScanner.init(nil /* txn */, uncertainty.Interval{}, 0 /* trackLastOffsets */)
+	var results pebbleResults
+	mvccScanner.init(nil /* txn */, uncertainty.Interval{}, &results)
 	_, _, _, err := mvccScanner.scan(context.Background())
 	require.NoError(t, err)
 
-	kvData := mvccScanner.results.finish()
-	numKeys := mvccScanner.results.count
+	kvData := results.finish()
+	numKeys := results.count
 	require.Equal(t, 4, int(numKeys))
 	require.Equal(t, 4, len(kvData))
 	require.Equal(t, 25, len(kvData[0]))
@@ -229,7 +231,7 @@ func TestMVCCScanWithMemoryAccounting(t *testing.T) {
 		end:    makeKey(nil, 11),
 		ts:     hlc.Timestamp{WallTime: 50},
 	}
-	scanner.init(&txn1, ui1, 0 /* trackLastOffsets */)
+	scanner.init(&txn1, ui1, &pebbleResults{})
 	cleanup := scannerWithAccount(ctx, st, scanner, 6000)
 	resumeSpan, resumeReason, resumeNextBytes, err := scanner.scan(ctx)
 	require.Nil(t, resumeSpan)
@@ -245,7 +247,7 @@ func TestMVCCScanWithMemoryAccounting(t *testing.T) {
 		end:    makeKey(nil, 11),
 		ts:     hlc.Timestamp{WallTime: 50},
 	}
-	scanner.init(&txn1, ui1, 0 /* trackLastOffsets */)
+	scanner.init(&txn1, ui1, &pebbleResults{})
 	cleanup = scannerWithAccount(ctx, st, scanner, 6000)
 	resumeSpan, resumeReason, resumeNextBytes, err = scanner.scan(ctx)
 	require.Nil(t, resumeSpan)
@@ -265,7 +267,7 @@ func TestMVCCScanWithMemoryAccounting(t *testing.T) {
 			ts:           hlc.Timestamp{WallTime: 50},
 			inconsistent: inconsistent,
 		}
-		scanner.init(nil, uncertainty.Interval{}, 0 /* trackLastOffsets */)
+		scanner.init(nil, uncertainty.Interval{}, &pebbleResults{})
 		cleanup = scannerWithAccount(ctx, st, scanner, 100)
 		resumeSpan, resumeReason, resumeNextBytes, err = scanner.scan(ctx)
 		require.Nil(t, resumeSpan)


### PR DESCRIPTION
This commit introduces a `results` interface (currently only implemented by `pebbleResults`) and teaches the `pebbleMVCCScanner` to use it. This interface will get a new implementation for the KV projection pushdown work in a follow-up commit.

As expected, this results in a minor perf [hit](https://gist.github.com/yuzefovich/d423c3f480069a97d4ea9b8b591e2e56), but there is no way around it, so it seems acceptable.

Epic: CRDB-14837

Release note: None