### PR TITLE
kvserver: don't consider followers to have pending proposal quota

### DIFF
--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -520,7 +520,7 @@ func (r *Replica) hasPendingProposalsRLocked() bool {
 // unquiescing (leading to deadlock). See #46699.
 func (r *Replica) hasPendingProposalQuotaRLocked() bool {
 	if r.mu.proposalQuota == nil {
-		return true
+		return false
 	}
 	return !r.mu.proposalQuota.Full()
 }


### PR DESCRIPTION
`Replica.hasPendingProposalQuotaRLocked()` considered a replica with `proposalQuota == nil` to have pending proposal quota, which in turn prevented quiescence. This condition is only possible on followers, which won't be able to quiesce anyway since we explicitly check for leadership. This can be misleading in vmodule logs, which claim "not quiescing: replication quota outstanding" on all followers.

This patch instead considers followers to have no pending proposal quota, thus vmodule logs will emit the more accurate "not quiescing: not leader".

This may lead to higher CPU usage on followers, because we now fall through to a `raftStatusRLocked` check which is more expensive. This should be optimized separately.

Touches #94457.

Epic: none
Release note: None