### PR TITLE
optbuilder: do not CAST recursive CTE seed columns to output types

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/with
+++ b/pkg/sql/logictest/testdata/logic_test/with
@@ -733,18 +733,22 @@ INSERT INTO graph_node (id, parent) VALUES
   ('C', 'B'),
   ('D', 'C')
 
-query T rowsort
+# The recursive query seed column types must match the output columns types.
+query error pgcode 42804 recursive query \"nodes\" column 1 has type string in non-recursive term but type varchar overall
 WITH RECURSIVE nodes AS (
   SELECT 'A' AS id
   UNION ALL
   SELECT graph_node.id FROM graph_node JOIN nodes ON graph_node.parent = nodes.id
 )
 SELECT * FROM nodes
-----
-A
-B
-C
-D
+
+# The recursive query seed column types must match the output columns types.
+query error pgcode 42804 recursive query \"foo\" column 1 has type int in non-recursive term but type decimal overall
+WITH RECURSIVE foo(i) AS
+    (SELECT i FROM (VALUES(1),(2)) t(i)
+    UNION ALL
+    SELECT (i+1)::numeric(10,0) FROM foo WHERE i < 10)
+SELECT * FROM foo
 
 # Tests with correlated CTEs.
 statement ok

--- a/pkg/sql/opt/norm/testdata/rules/with
+++ b/pkg/sql/opt/norm/testdata/rules/with
@@ -1746,20 +1746,20 @@ project
 # Case with a window function.
 norm expect=TryAddLimitToRecursiveBranch
 WITH RECURSIVE cte (i, j) AS (
-  (SELECT 1, 2)
+  (SELECT 1, 2::numeric)
   UNION ALL
   (SELECT i+1, sum(i) OVER (ORDER BY j) FROM cte WHERE i <= 10)
 )
 SELECT i, j FROM cte;
 ----
 project
- ├── columns: i:10 j:11
+ ├── columns: i:9 j:10
  ├── cardinality: [1 - ]
  ├── immutable
  ├── recursive-c-t-e
  │    ├── columns: i:3 j:4
  │    ├── working table binding: &2
- │    ├── initial columns: "?column?":1 "?column?":9
+ │    ├── initial columns: "?column?":1 numeric:2
  │    ├── recursive columns: "?column?":8 sum:7
  │    ├── cardinality: [1 - ]
  │    ├── immutable
@@ -1769,10 +1769,10 @@ project
  │    │    ├── key: ()
  │    │    └── fd: ()-->(3,4)
  │    ├── values
- │    │    ├── columns: "?column?":1!null "?column?":9!null
+ │    │    ├── columns: "?column?":1!null numeric:2!null
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── key: ()
- │    │    ├── fd: ()-->(1,9)
+ │    │    ├── fd: ()-->(1,2)
  │    │    └── (1, 2)
  │    └── project
  │         ├── columns: "?column?":8!null sum:7
@@ -1805,8 +1805,8 @@ project
  │         └── projections
  │              └── i:5 + 1 [as="?column?":8, outer=(5), immutable]
  └── projections
-      ├── i:3 [as=i:10, outer=(3)]
-      └── j:4 [as=j:11, outer=(4)]
+      ├── i:3 [as=i:9, outer=(3)]
+      └── j:4 [as=j:10, outer=(4)]
 
 # Case with DistinctOn.
 norm expect=TryAddLimitToRecursiveBranch
@@ -1869,7 +1869,7 @@ norm expect=TryAddLimitToRecursiveBranch
 WITH RECURSIVE cte (i, j) AS (
   (SELECT 1, 2)
   UNION ALL
-  (SELECT i+1, sum(j) FROM cte WHERE i <= 10 GROUP BY i)
+  (SELECT i+1, sum(j)::int FROM cte WHERE i <= 10 GROUP BY i)
 )
 SELECT i, j FROM cte;
 ----
@@ -1880,8 +1880,8 @@ project
  ├── recursive-c-t-e
  │    ├── columns: i:3 j:4
  │    ├── working table binding: &2
- │    ├── initial columns: "?column?":1 "?column?":9
- │    ├── recursive columns: "?column?":8 sum:7
+ │    ├── initial columns: "?column?":1 "?column?":2
+ │    ├── recursive columns: "?column?":8 sum:9
  │    ├── cardinality: [1 - ]
  │    ├── immutable
  │    ├── fake-rel
@@ -1890,17 +1890,17 @@ project
  │    │    ├── key: ()
  │    │    └── fd: ()-->(3,4)
  │    ├── values
- │    │    ├── columns: "?column?":1!null "?column?":9!null
+ │    │    ├── columns: "?column?":1!null "?column?":2!null
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── key: ()
- │    │    ├── fd: ()-->(1,9)
+ │    │    ├── fd: ()-->(1,2)
  │    │    └── (1, 2)
  │    └── project
- │         ├── columns: "?column?":8!null sum:7
+ │         ├── columns: "?column?":8!null sum:9
  │         ├── cardinality: [0 - 1]
  │         ├── immutable
  │         ├── key: ()
- │         ├── fd: ()-->(7,8)
+ │         ├── fd: ()-->(8,9)
  │         ├── group-by (streaming)
  │         │    ├── columns: i:5!null sum:7
  │         │    ├── cardinality: [0 - 1]
@@ -1927,7 +1927,8 @@ project
  │         │         └── const-agg [as=i:5, outer=(5)]
  │         │              └── i:5
  │         └── projections
- │              └── i:5 + 1 [as="?column?":8, outer=(5), immutable]
+ │              ├── i:5 + 1 [as="?column?":8, outer=(5), immutable]
+ │              └── sum:7::INT8 [as=sum:9, outer=(7), immutable]
  └── projections
       ├── i:3 [as=i:10, outer=(3)]
       └── j:4 [as=j:11, outer=(4)]
@@ -2476,7 +2477,7 @@ norm expect=TryAddLimitToRecursiveBranch
 WITH RECURSIVE cte (i, j) AS (
   (SELECT 1, 2)
   UNION ALL
-  (SELECT i+1, sum(x) FROM cte INNER JOIN xy ON j = y WHERE i <= 10 GROUP BY i)
+  (SELECT i+1, sum(x)::int FROM cte INNER JOIN xy ON j = y WHERE i <= 10 GROUP BY i)
 )
 SELECT i, j FROM cte;
 ----
@@ -2487,8 +2488,8 @@ project
  ├── recursive-c-t-e
  │    ├── columns: i:3 j:4
  │    ├── working table binding: &2
- │    ├── initial columns: "?column?":1 "?column?":13
- │    ├── recursive columns: "?column?":12 sum:11
+ │    ├── initial columns: "?column?":1 "?column?":2
+ │    ├── recursive columns: "?column?":12 sum:13
  │    ├── cardinality: [1 - ]
  │    ├── immutable
  │    ├── fake-rel
@@ -2497,17 +2498,17 @@ project
  │    │    ├── key: ()
  │    │    └── fd: ()-->(3,4)
  │    ├── values
- │    │    ├── columns: "?column?":1!null "?column?":13!null
+ │    │    ├── columns: "?column?":1!null "?column?":2!null
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── key: ()
- │    │    ├── fd: ()-->(1,13)
+ │    │    ├── fd: ()-->(1,2)
  │    │    └── (1, 2)
  │    └── project
- │         ├── columns: "?column?":12!null sum:11!null
+ │         ├── columns: "?column?":12!null sum:13!null
  │         ├── cardinality: [0 - 1]
  │         ├── immutable
  │         ├── key: ()
- │         ├── fd: ()-->(11,12)
+ │         ├── fd: ()-->(12,13)
  │         ├── group-by (streaming)
  │         │    ├── columns: i:5!null sum:11!null
  │         │    ├── cardinality: [0 - 1]
@@ -2545,7 +2546,8 @@ project
  │         │         └── const-agg [as=i:5, outer=(5)]
  │         │              └── i:5
  │         └── projections
- │              └── i:5 + 1 [as="?column?":12, outer=(5), immutable]
+ │              ├── i:5 + 1 [as="?column?":12, outer=(5), immutable]
+ │              └── sum:11::INT8 [as=sum:13, outer=(11), immutable]
  └── projections
       ├── i:3 [as=i:14, outer=(3)]
       └── j:4 [as=j:15, outer=(4)]

--- a/pkg/sql/opt/optbuilder/testdata/with
+++ b/pkg/sql/opt/optbuilder/testdata/with
@@ -1563,43 +1563,11 @@ with &2 (v)
            └── mapping:
                 └──  a:5 => a:8
 
-# Verify the addition of casts to the "initial" query.
+# Verify a missing explicit cast in the "initial" query errors out.
 build
 WITH RECURSIVE cte(x) AS (SELECT a FROM x UNION ALL SELECT x::FLOAT FROM cte WHERE x < 10) SELECT * FROM cte;
 ----
-with &2 (cte)
- ├── columns: x:10
- ├── recursive-c-t-e
- │    ├── columns: x:6
- │    ├── working table binding: &1
- │    ├── initial columns: a:9
- │    ├── recursive columns: x:8
- │    ├── fake-rel
- │    │    └── columns: x:6
- │    ├── project
- │    │    ├── columns: a:9
- │    │    ├── project
- │    │    │    ├── columns: x.a:1
- │    │    │    └── scan x
- │    │    │         └── columns: x.a:1 b:2 rowid:3!null crdb_internal_mvcc_timestamp:4 tableoid:5
- │    │    └── projections
- │    │         └── x.a:1::FLOAT8 [as=a:9]
- │    └── project
- │         ├── columns: x:8!null
- │         ├── select
- │         │    ├── columns: x:7!null
- │         │    ├── with-scan &1 (cte)
- │         │    │    ├── columns: x:7
- │         │    │    └── mapping:
- │         │    │         └──  x:6 => x:7
- │         │    └── filters
- │         │         └── x:7 < 10
- │         └── projections
- │              └── x:7::FLOAT8 [as=x:8]
- └── with-scan &2 (cte)
-      ├── columns: x:10
-      └── mapping:
-           └──  x:6 => x:10
+error (42804): recursive query "cte" column 1 has type int in non-recursive term but type float overall
 
 exec-ddl
 CREATE TABLE graph_node (
@@ -1608,7 +1576,7 @@ CREATE TABLE graph_node (
 )
 ----
 
-# The 'A' in the initial query needs a cast to VARCHAR(16).
+# Verify a missing explicit cast in the "initial" query errors out.
 build
 WITH RECURSIVE nodes AS (
   SELECT 'A' AS id
@@ -1617,41 +1585,7 @@ WITH RECURSIVE nodes AS (
 )
 SELECT * FROM nodes;
 ----
-with &2 (nodes)
- ├── columns: id:9
- ├── recursive-c-t-e
- │    ├── columns: id:2
- │    ├── working table binding: &1
- │    ├── initial columns: id:8
- │    ├── recursive columns: graph_node.id:3
- │    ├── fake-rel
- │    │    └── columns: id:2
- │    ├── project
- │    │    ├── columns: id:8!null
- │    │    ├── project
- │    │    │    ├── columns: id:1!null
- │    │    │    ├── values
- │    │    │    │    └── ()
- │    │    │    └── projections
- │    │    │         └── 'A' [as=id:1]
- │    │    └── projections
- │    │         └── id:1::VARCHAR(16) [as=id:8]
- │    └── project
- │         ├── columns: graph_node.id:3!null
- │         └── inner-join (hash)
- │              ├── columns: graph_node.id:3!null parent:4!null crdb_internal_mvcc_timestamp:5 tableoid:6 id:7!null
- │              ├── scan graph_node
- │              │    └── columns: graph_node.id:3!null parent:4 crdb_internal_mvcc_timestamp:5 tableoid:6
- │              ├── with-scan &1 (nodes)
- │              │    ├── columns: id:7
- │              │    └── mapping:
- │              │         └──  id:2 => id:7
- │              └── filters
- │                   └── parent:4 = id:7
- └── with-scan &2 (nodes)
-      ├── columns: id:9
-      └── mapping:
-           └──  id:2 => id:9
+error (42804): recursive query "nodes" column 1 has type string in non-recursive term but type varchar overall
 
 # Mutating WITHs not allowed at non-root positions.
 build


### PR DESCRIPTION
Fixes #93371

Given the query:
```
SET VECTORIZE=off;
WITH RECURSIVE foo(i) AS
    (SELECT i FROM (VALUES(1),(2)) t(i)
    UNION ALL
    SELECT (i+1)::numeric(10,0) FROM foo WHERE i < 10)
 SELECT * FROM foo;
```
column `i` is CAST to the output type of the UNION ALL due to #62808 in order to support more recursive CTEs without explicit CASTS in seed (initial) expressions:
https://github.com/cockroachdb/cockroach/blob/0eac48e70abbdd163d4617e50659321b99d678d4/pkg/sql/opt/optbuilder/with.go#L335-L337

Column `i` is assigned column id 3 in `WithScanPrivate.InCols` and the expression in `recursiveScope.cols[0].scalar` references it as follows:
```
recursiveScope.cols[0].scalar:
result = {opt.ScalarExpr | *memo.CastExpr}
 Input = {opt.ScalarExpr | *memo.PlusExpr}
  Left = {opt.ScalarExpr | *memo.VariableExpr}
   Col = {opt.ColumnID} 3
   Typ = {*types.T | 0x976b060}
    InternalType = {types.InternalType}
     Family = {types.Family} IntFamily (1)
...
    TypeMeta = {types.UserDefinedTypeMetadata}
   rank = {opt.ScalarRank} 5
  Right = {opt.ScalarExpr | *memo.ConstExpr}
   Value = {tree.Datum | *tree.DInt} 1
```
After the CAST is applied, column id 3 is initialized as:
```
initialScope.cols[0].scalar:
 result = {opt.ScalarExpr | *memo.CastExpr}
 Input = {opt.ScalarExpr | *memo.VariableExpr}
  Col = {opt.ColumnID} 1
  Typ = {*types.T | 0x976b060}
  rank = {opt.ScalarRank} 12
 Typ = {*types.T | 0xc0037f2780}
  InternalType = {types.InternalType}
   Family = {types.Family} DecimalFamily (3)
   Width = {int32} 0
   Precision = {int32} 10
```
During execution, an assertion fails where the input to the `PlusExpr` is expected to be an integer, but is a decimal:
```
tree.MustBeDInt (datum.go:722) github.com/cockroachdb/cockroach/pkg/sql/sem/tree
eval.(*evaluator).EvalPlusIntOp (binary_op.go:1325) github.com/cockroachdb/cockroach/pkg/sql/sem/eval
tree.(*PlusIntOp).Eval (eval_op_generated.go:761) github.com/cockroachdb/cockroach/pkg/sql/sem/tree
eval.(*evaluator).EvalBinaryExpr (expr.go:120) github.com/cockroachdb/cockroach/pkg/sql/sem/eval
tree.(*BinaryExpr).Eval (eval_expr_generated.go:86) github.com/cockroachdb/cockroach/pkg/sql/sem/tree
eval.(*evaluator).EvalCastExpr (expr.go:180) github.com/cockroachdb/cockroach/pkg/sql/sem/eval
tree.(*CastExpr).Eval (eval_expr_generated.go:96) github.com/cockroachdb/cockroach/pkg/sql/sem/tree
eval.Expr (expr.go:26) github.com/cockroachdb/cockroach/pkg/sql/sem/eval
execinfrapb.(*ExprHelper).Eval (expr.go:248) github.com/cockroachdb/cockroach/pkg/sql/execinfrapb
execinfra.(*ProcOutputHelper).ProcessRow (processorsbase.go:275) github.com/cockroachdb/cockroach/pkg/sql/execinfra
...
```
The left of the Plus is referring to the `IndexedVar` column at ordinal 0:
```
result = {*tree.BinaryExpr | 0xc0022e27c0}
 Operator = {treebin.BinaryOperator}
  Symbol = {treebin.BinaryOperatorSymbol} Plus (3)
  IsExplicitOperator = {bool} false
 Left = {tree.Expr | *tree.IndexedVar}
  Idx = {int} 0
  Used = {bool} true
  col = {tree.NodeFormatter | *colinfo.varFormatter}
  typeAnnotation = {tree.typeAnnotation}
 Right = {tree.Expr | *tree.DInt} 1
 typeAnnotation = {tree.typeAnnotation}
 Op = {*tree.BinOp | 0xc0001817a0}
 ```
which has been CAST as a decimal, as indicated above.

To fully support casting of seed expressions, that may require replacing
all occurences of those expressions in `recursiveScope` with the new
CASTed expressions, and possibly re-doing type checking to catch any
illegal casts, etc.

This issue is solved by reverting #62808 in order to maintain
compatibility with Postgres, which errors out this query.
Relaxing the requirement for explicit CASTs in recursive CTE seed
expressions could possibly be supported in the future, but more work is
required to substitute seed expressions present in the recursive branch
with the implicitly CASTed expressions and make sure type checking is
complete.

Release note(bug fix): This patch fixes recursive CTE expressions which
cause internal errors when explicit CASTs of initial expressions to
output types are missing.