### PR TITLE
kvserver: use cheaper `raftSparseStatus` during replica ticks

### DIFF
--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -9979,7 +9979,7 @@ type testQuiescer struct {
 	desc            roachpb.RangeDescriptor
 	numProposals    int
 	pendingQuota    bool
-	status          *raft.Status
+	status          *raftSparseStatus
 	lastIndex       uint64
 	raftReady       bool
 	ownsValidLease  bool
@@ -9995,7 +9995,7 @@ func (q *testQuiescer) descRLocked() *roachpb.RangeDescriptor {
 	return &q.desc
 }
 
-func (q *testQuiescer) raftStatusRLocked() *raft.Status {
+func (q *testQuiescer) raftSparseStatusRLocked() *raftSparseStatus {
 	return q.status
 }
 
@@ -10053,7 +10053,7 @@ func TestShouldReplicaQuiesce(t *testing.T) {
 						{NodeID: 3, ReplicaID: 3},
 					},
 				},
-				status: &raft.Status{
+				status: &raftSparseStatus{
 					BasicStatus: raft.BasicStatus{
 						ID: 1,
 						HardState: raftpb.HardState{
@@ -10225,7 +10225,7 @@ func TestFollowerQuiesceOnNotify(t *testing.T) {
 	) {
 		t.Run("", func(t *testing.T) {
 			q := &testQuiescer{
-				status: &raft.Status{
+				status: &raftSparseStatus{
 					BasicStatus: raft.BasicStatus{
 						ID: 2,
 						HardState: raftpb.HardState{


### PR DESCRIPTION
In an idle cluster with many unquiesced replicas, 40% of the `Replica.tick` CPU time is spent on `raft.RawNode.Status()`, when considering quiescence and Raft leadership transfers. This status call incurs expensive deep copies of the `Config` and `Progress.Inflights` fields, but these fields are never used by the callers.

This patch instead introduces a `raftSparseStatus` without these expensive and unnecessary fields, which reduces the CPU cost of ticks by about 20%.

Touches #94592.
Touches #94609.

Epic: none
Release note: None