### PR TITLE
kvserver: add `Replica.isRaftLeader` fast path for ticks

### DIFF
--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -525,6 +525,18 @@ func (r *Replica) hasPendingProposalQuotaRLocked() bool {
 	return !r.mu.proposalQuota.Full()
 }
 
+// isRaftLeader returns true if this replica believes it is the current
+// Raft leader.
+//
+// NB: This can race with Raft ready processing, where the Raft group has
+// processed a leader change before updating the replica state in a separate
+// critical section. The caller should always verify this against the Raft
+// status where necessary.
+func (r *Replica) isRaftLeaderRLocked() bool {
+	// Defensively check replicaID != 0.
+	return r.replicaID != 0 && r.replicaID == r.mu.leaderID
+}
+
 var errRemoved = errors.New("replica removed")
 
 // stepRaftGroup calls Step on the replica's RawNode with the provided request's
@@ -1141,7 +1153,7 @@ func (r *Replica) tick(
 	//
 	// This is likely unintentional, and the leader should likely consider itself
 	// live even when quiesced.
-	if r.replicaID == r.mu.leaderID {
+	if r.isRaftLeaderRLocked() {
 		r.mu.lastUpdateTimes.update(r.replicaID, timeutil.Now())
 	}
 

--- a/pkg/kv/kvserver/replica_raft_overload.go
+++ b/pkg/kv/kvserver/replica_raft_overload.go
@@ -312,7 +312,7 @@ func (r *Replica) updatePausedFollowersLocked(ctx context.Context, ioThresholdMa
 		return
 	}
 
-	if r.replicaID != r.mu.leaderID {
+	if !r.isRaftLeaderRLocked() {
 		// Only the raft leader pauses followers. Followers never send meaningful
 		// amounts of data in raft messages, so pausing doesn't make sense on them.
 		return

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -9995,6 +9995,10 @@ func (q *testQuiescer) descRLocked() *roachpb.RangeDescriptor {
 	return &q.desc
 }
 
+func (q *testQuiescer) isRaftLeaderRLocked() bool {
+	return q.status != nil && q.status.RaftState == raft.StateLeader
+}
+
 func (q *testQuiescer) raftSparseStatusRLocked() *raftSparseStatus {
 	return q.status
 }


### PR DESCRIPTION
This patch adds `Replica.isRaftLeader()` which can very cheaply determine whether the replica believes itself to be the current Raft leader. This reduces the Raft tick cost by 30% by nearly eliminating the `maybeTransferRaftLeadershipToLeaseholderLocked` CPU time.

Touches #94592.
Touches #94609.

Epic: none
Release note: None