### PR TITLE
release-22.2: xform: use ordering from LIMIT as a hint for streaming group-by

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3348,6 +3348,10 @@ func (m *sessionDataMutator) SetOptimizerUseImprovedDisjunctionStats(val bool) {
 	m.data.OptimizerUseImprovedDisjunctionStats = val
 }
 
+func (m *sessionDataMutator) SetOptimizerUseLimitOrderingForStreamingGroupBy(val bool) {
+	m.data.OptimizerUseLimitOrderingForStreamingGroupBy = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4760,6 +4760,7 @@ optimizer                                             on
 optimizer_use_forecasts                               on
 optimizer_use_histograms                              on
 optimizer_use_improved_disjunction_stats              off
+optimizer_use_limit_ordering_for_streaming_group_by   off
 optimizer_use_multicol_stats                          on
 optimizer_use_not_visible_indexes                     off
 override_multi_region_zone_config                     off

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2806,6 +2806,7 @@ opt_split_scan_limit                                  2048                NULL  
 optimizer_use_forecasts                               on                  NULL      NULL        NULL        string
 optimizer_use_histograms                              on                  NULL      NULL        NULL        string
 optimizer_use_improved_disjunction_stats              off                 NULL      NULL        NULL        string
+optimizer_use_limit_ordering_for_streaming_group_by   off                 NULL      NULL        NULL        string
 optimizer_use_multicol_stats                          on                  NULL      NULL        NULL        string
 optimizer_use_not_visible_indexes                     off                 NULL      NULL        NULL        string
 override_multi_region_zone_config                     off                 NULL      NULL        NULL        string
@@ -2943,6 +2944,7 @@ opt_split_scan_limit                                  2048                NULL  
 optimizer_use_forecasts                               on                  NULL  user     NULL      on                  on
 optimizer_use_histograms                              on                  NULL  user     NULL      on                  on
 optimizer_use_improved_disjunction_stats              off                 NULL  user     NULL      off                 off
+optimizer_use_limit_ordering_for_streaming_group_by   off                 NULL  user     NULL      off                 off
 optimizer_use_multicol_stats                          on                  NULL  user     NULL      on                  on
 optimizer_use_not_visible_indexes                     off                 NULL  user     NULL      off                 off
 override_multi_region_zone_config                     off                 NULL  user     NULL      off                 off
@@ -3078,6 +3080,7 @@ optimizer                                             NULL    NULL     NULL     
 optimizer_use_forecasts                               NULL    NULL     NULL     NULL        NULL
 optimizer_use_histograms                              NULL    NULL     NULL     NULL        NULL
 optimizer_use_improved_disjunction_stats              NULL    NULL     NULL     NULL        NULL
+optimizer_use_limit_ordering_for_streaming_group_by   NULL    NULL     NULL     NULL        NULL
 optimizer_use_multicol_stats                          NULL    NULL     NULL     NULL        NULL
 optimizer_use_not_visible_indexes                     NULL    NULL     NULL     NULL        NULL
 override_multi_region_zone_config                     NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -106,6 +106,7 @@ opt_split_scan_limit                                  2048
 optimizer_use_forecasts                               on
 optimizer_use_histograms                              on
 optimizer_use_improved_disjunction_stats              off
+optimizer_use_limit_ordering_for_streaming_group_by   off
 optimizer_use_multicol_stats                          on
 optimizer_use_not_visible_indexes                     off
 override_multi_region_zone_config                     off

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -159,6 +159,7 @@ type Memo struct {
 	enforceHomeRegion                      bool
 	variableInequalityLookupJoinEnabled    bool
 	useImprovedDisjunctionStats            bool
+	useLimitOrderingForStreamingGroupBy    bool
 
 	// curRank is the highest currently in-use scalar expression rank.
 	curRank opt.ScalarRank
@@ -213,6 +214,7 @@ func (m *Memo) Init(evalCtx *eval.Context) {
 		enforceHomeRegion:                      evalCtx.SessionData().EnforceHomeRegion,
 		variableInequalityLookupJoinEnabled:    evalCtx.SessionData().VariableInequalityLookupJoinEnabled,
 		useImprovedDisjunctionStats:            evalCtx.SessionData().OptimizerUseImprovedDisjunctionStats,
+		useLimitOrderingForStreamingGroupBy:    evalCtx.SessionData().OptimizerUseLimitOrderingForStreamingGroupBy,
 	}
 	m.metadata.Init()
 	m.logPropsBuilder.init(evalCtx, m)
@@ -350,7 +352,8 @@ func (m *Memo) IsStale(
 		m.testingOptimizerDisableRuleProbability != evalCtx.SessionData().TestingOptimizerDisableRuleProbability ||
 		m.enforceHomeRegion != evalCtx.SessionData().EnforceHomeRegion ||
 		m.variableInequalityLookupJoinEnabled != evalCtx.SessionData().VariableInequalityLookupJoinEnabled ||
-		m.useImprovedDisjunctionStats != evalCtx.SessionData().OptimizerUseImprovedDisjunctionStats {
+		m.useImprovedDisjunctionStats != evalCtx.SessionData().OptimizerUseImprovedDisjunctionStats ||
+		m.useLimitOrderingForStreamingGroupBy != evalCtx.SessionData().OptimizerUseLimitOrderingForStreamingGroupBy {
 		return true, nil
 	}
 

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -298,6 +298,12 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().VariableInequalityLookupJoinEnabled = false
 	notStale()
 
+	// Stale use limit ordering for streaming group by.
+	evalCtx.SessionData().OptimizerUseLimitOrderingForStreamingGroupBy = true
+	stale()
+	evalCtx.SessionData().OptimizerUseLimitOrderingForStreamingGroupBy = false
+	notStale()
+
 	// Stale testing_optimizer_random_seed.
 	evalCtx.SessionData().TestingOptimizerRandomSeed = 100
 	stale()

--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -182,6 +182,24 @@ func (f *Factory) DisableOptimizations() {
 	f.NotifyOnMatchedRule(func(opt.RuleName) bool { return false })
 }
 
+// DisableOptimizationRules disables a specific set of transformation rules.
+func (f *Factory) DisableOptimizationRules(disabledRules util.FastIntSet) {
+	f.NotifyOnMatchedRule(func(rule opt.RuleName) bool {
+		return !disabledRules.Contains(int(rule))
+	})
+}
+
+// DisableOptimizationRulesTemporarily disables a specific set transformation
+// rules during the execution of the given function fn. A MatchedRuleFunc
+// previously set by NotifyOnMatchedRule is not invoked during execution of fn,
+// but will be invoked for future rule matches after fn returns.
+func (f *Factory) DisableOptimizationRulesTemporarily(disabledRules util.FastIntSet, fn func()) {
+	originalMatchedRule := f.matchedRule
+	f.DisableOptimizationRules(disabledRules)
+	fn()
+	f.matchedRule = originalMatchedRule
+}
+
 // DisableOptimizationsTemporarily disables all transformation rules during the
 // execution of the given function fn. A MatchedRuleFunc previously set by
 // NotifyOnMatchedRule is not invoked during execution of fn, but will be

--- a/pkg/sql/opt/xform/groupby_funcs.go
+++ b/pkg/sql/opt/xform/groupby_funcs.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/ordering"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/errors"
 )
 
@@ -170,6 +171,129 @@ func (c *CustomFuncs) MakeProjectFromPassthroughAggs(
 		Projections: projections,
 		Passthrough: passthrough,
 	}, grp)
+}
+
+// GroupingColsClosureOverlappingOrdering determines if the specified `ordering`
+// columns overlaps with the closure of the grouping columns in `private` as
+// determined by the functional dependencies of the `input` relation to the
+// grouped aggregation. If found, this expanded set of `groupingCols` is
+// returned, plus the overlapping ordering columns `newOrdering`, along with
+// `ok`=true.
+func (c *CustomFuncs) GroupingColsClosureOverlappingOrdering(
+	input memo.RelExpr, private *memo.GroupingPrivate, ordering props.OrderingChoice,
+) (groupingCols opt.ColSet, newOrdering props.OrderingChoice, ok bool) {
+	if ordering.Any() {
+		// If the limit specifies no ordering, there is no ordering hint for us to
+		// use.
+		return opt.ColSet{}, props.OrderingChoice{}, false
+	}
+	groupingCols = private.GroupingCols
+	// If the result requires a specific ordering, use that as the ordering of the
+	// aggregation if possible.
+	// Find all columns determined by the grouping columns.
+	groupingColumnsClosure := input.Relational().FuncDeps.ComputeClosure(groupingCols)
+	// It is safe to add ordering columns present in the grouping column closure
+	// as grouping columns because the original grouping columns determine all
+	// other column values in the closure (within a group there is only one
+	// combined set of values for the other columns). Doing so allows the required
+	// ordering to be provided by the streaming group by and possibly remove the
+	// requirement for a TopK operator.
+	orderingColsInClosure := groupingColumnsClosure.Intersection(ordering.ColSet())
+	if orderingColsInClosure.Empty() {
+		// If we have no columns to add to the grouping, this rewrite has no effect.
+		return opt.ColSet{}, props.OrderingChoice{}, false
+	}
+	groupingCols = groupingCols.Union(orderingColsInClosure)
+	newOrdering, fullPrefix, found := getPrefixFromOrdering(ordering.ToOrdering(), private.Ordering, input,
+		func(id opt.ColumnID) bool { return groupingCols.Contains(id) })
+	if !found || !fullPrefix {
+		return opt.ColSet{}, props.OrderingChoice{}, false
+	}
+	return groupingCols, newOrdering, true
+}
+
+// GenerateStreamingGroupByLimitOrderingHint generates a LimitExpr with an input
+// which is a GroupBy or DistinctOn expression with an expanded set of
+// `groupingCols` which is an overlap of the closure of the original grouping
+// columns closure and the ordering in the `limitExpr` as determined by
+// `GroupingColsClosureOverlappingOrdering`, which also produces the
+// `newOrdering`. Argument `private` is expected to be a canonical group-by.
+func (c *CustomFuncs) GenerateStreamingGroupByLimitOrderingHint(
+	grp memo.RelExpr,
+	limitExpr *memo.LimitExpr,
+	aggregation memo.RelExpr,
+	input memo.RelExpr,
+	aggs memo.AggregationsExpr,
+	private *memo.GroupingPrivate,
+	groupingCols opt.ColSet,
+	newOrdering props.OrderingChoice,
+) {
+	newPrivate := *private
+	newPrivate.Ordering = newOrdering
+	newPrivate.GroupingCols = groupingCols
+
+	// Remove constant column aggregate expressions if they've been added to
+	// the grouping columns. The column should appear in one place or the other,
+	// but not both.
+	newAggs := make(memo.AggregationsExpr, 0, len(aggs))
+	for _, agg := range aggs {
+		if !groupingCols.Contains(agg.Col) {
+			newAggs = append(newAggs, agg)
+			continue
+		}
+		constAggExpr, ok := agg.Agg.(*memo.ConstAggExpr)
+		if !ok {
+			newAggs = append(newAggs, agg)
+			continue
+		}
+		variableExpr, ok := constAggExpr.Input.(*memo.VariableExpr)
+		if !ok {
+			newAggs = append(newAggs, agg)
+			continue
+		}
+		if variableExpr.Col != agg.Col {
+			// Column IDs expected to match to safely remove this aggregation.
+			return
+		}
+	}
+	// Output columns are the union of grouping columns with columns from the
+	// aggregate projection list. Verify this is built correctly.
+	outputCols := groupingCols.Copy()
+	for i := range newAggs {
+		outputCols.Add(newAggs[i].Col)
+	}
+	if !aggregation.Relational().OutputCols.Equals(outputCols) {
+		// If the output columns in the new aggregation don't match those in the
+		// original aggregation, give up on this optimization.
+		return
+	}
+
+	var newAggregation memo.RelExpr
+	constructAggregation := func() {
+		newAggregation =
+			c.e.f.DynamicConstruct(
+				aggregation.Op(),
+				input,
+				&newAggs,
+				&newPrivate,
+			).(memo.RelExpr)
+	}
+	var disabledRules util.FastIntSet
+	// The ReduceGroupingCols rule must be disabled to prevent the ordering
+	// columns from being removed from the grouping columns during operation
+	// construction. This rule already reduced the grouping columns on the initial
+	// construction. We are just adding back in any ordering columns which overlap
+	// with grouping columns in order to generate a better plan.
+	disabledRules.Add(int(opt.ReduceGroupingCols))
+
+	c.e.f.DisableOptimizationRulesTemporarily(disabledRules, constructAggregation)
+	newLimitExpr :=
+		&memo.LimitExpr{
+			Input:    newAggregation,
+			Limit:    limitExpr.Limit,
+			Ordering: limitExpr.Ordering,
+		}
+	grp.Memo().AddLimitToGroup(newLimitExpr, grp)
 }
 
 // GenerateStreamingGroupBy generates variants of a GroupBy, DistinctOn,

--- a/pkg/sql/opt/xform/groupby_funcs.go
+++ b/pkg/sql/opt/xform/groupby_funcs.go
@@ -228,6 +228,10 @@ func (c *CustomFuncs) GenerateStreamingGroupByLimitOrderingHint(
 	groupingCols opt.ColSet,
 	newOrdering props.OrderingChoice,
 ) {
+	if !c.e.evalCtx.SessionData().OptimizerUseLimitOrderingForStreamingGroupBy {
+		// This transformation rule is explicitly disabled.
+		return
+	}
 	newPrivate := *private
 	newPrivate.Ordering = newOrdering
 	newPrivate.GroupingCols = groupingCols

--- a/pkg/sql/opt/xform/rules/limit.opt
+++ b/pkg/sql/opt/xform/rules/limit.opt
@@ -184,3 +184,39 @@
 (TopK $input:* $private:*)
 =>
 (GeneratePartialOrderTopK $input $private)
+
+# GenerateStreamingGroupByLimitOrderingHint generates streaming group-by and
+# distinct-on aggregations with an ordering matching the ordering specified in
+# the Limit Op. The goal is to eliminate the need for a TopK operation.
+[GenerateStreamingGroupByLimitOrderingHint, Explore]
+(Limit
+    $aggregation:(GroupBy | DistinctOn
+        $input:*
+        $aggs:*
+        $private:* & (IsCanonicalGroupBy $private)
+    )
+    (Const $limit:* & (IsPositiveInt $limit))
+    $ordering:* &
+        (Let
+            (
+                $groupingCols
+                $newOrdering
+                $ok
+            ):(GroupingColsClosureOverlappingOrdering
+                $input
+                $private
+                $ordering
+            )
+            $ok
+        )
+)
+=>
+(GenerateStreamingGroupByLimitOrderingHint
+    (Root)
+    $aggregation
+    $input
+    $aggs
+    $private
+    $groupingCols
+    $newOrdering
+)

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -2737,7 +2737,7 @@ ALTER TABLE t93410_2 INJECT STATISTICS '[
 ----
 
 # A streaming group-by with no TopK operation should be generated.
-opt expect=GenerateStreamingGroupByLimitOrderingHint
+opt set=optimizer_use_limit_ordering_for_streaming_group_by=true expect=GenerateStreamingGroupByLimitOrderingHint
 SELECT
   DISTINCT
   t1.col1,
@@ -2860,7 +2860,7 @@ project
 
 # GenerateStreamingGroupByLimitOrderingHint should not fire if there is no
 # overlap between the grouping columns and order-by columns.
-opt expect-not=GenerateStreamingGroupByLimitOrderingHint
+opt set=optimizer_use_limit_ordering_for_streaming_group_by=true expect-not=GenerateStreamingGroupByLimitOrderingHint
 SELECT
   DISTINCT
   t2.col1,
@@ -2929,7 +2929,7 @@ top-k
            └── array_remove(array_agg:27, NULL) [as=col6s:28, outer=(27), immutable]
 
 # A distinct-on which satisfies the required ordering should be used.
-opt expect=GenerateStreamingGroupByLimitOrderingHint
+opt set=optimizer_use_limit_ordering_for_streaming_group_by=true expect=GenerateStreamingGroupByLimitOrderingHint
 SELECT
   DISTINCT ON (t1.col5, t1.col9) t2.col2
 FROM
@@ -2984,7 +2984,7 @@ limit
  └── 20
 
 # This should generate a partial streaming aggregation.
-opt expect=GenerateStreamingGroupByLimitOrderingHint
+opt set=optimizer_use_limit_ordering_for_streaming_group_by=true expect=GenerateStreamingGroupByLimitOrderingHint
 SELECT
   count(*)
 FROM

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -2578,3 +2578,469 @@ scalar-group-by
  └── aggregations
       └── const-agg [as=min:7, outer=(1)]
            └── a:1
+
+# Regression Test for #93410
+exec-ddl
+CREATE TABLE t93410 (
+        col1 INT NOT NULL,
+        col2 INT NOT NULL,
+        col3 INT NOT NULL,
+        col4 INT NOT NULL,
+        col5 INT NOT NULL,
+        col6 INT NOT NULL,
+        col7 INT NOT NULL,
+        col8 INT NOT NULL,
+        col9 INT NOT NULL,
+        col10 INT NOT NULL,
+        col11 INT NOT NULL,
+        col12 INT NULL,
+        col13 INT NULL,
+        col14 INT NOT NULL,
+        col15 INT NULL,
+        col16 INT,
+        CONSTRAINT "primary" PRIMARY KEY (col1 ASC, col2 ASC, col3 ASC, col4 ASC, col5 ASC),
+        CONSTRAINT fk_col1_ref_t93410 FOREIGN KEY (col1, col2, col3, col4, col12) REFERENCES t93410(col1, col2, col3, col4, col5) ON DELETE CASCADE,
+        UNIQUE INDEX t93410_col1_col2_col3_col5_key (col1 ASC, col2 ASC, col3 ASC, col5 ASC),
+        INDEX t93410_col13_idx (col13 ASC),
+        INDEX t93410_col1_col2_col13_col15_idx (col1 ASC, col2 ASC, col13 ASC, col15 ASC),
+        UNIQUE INDEX t93410_col1_col2_col5_col9_key (col1 ASC, col2 ASC, col5 ASC, col9 ASC),
+        UNIQUE INDEX t93410_col1_col2_col5_key (col1 ASC, col2 ASC, col5 ASC)
+)
+----
+
+exec-ddl
+CREATE TABLE t93410_2 (
+        col1 INT NOT NULL,
+        col2 INT NOT NULL,
+        col3 INT NOT NULL,
+        col4 INT NOT NULL,
+        col5 INT NOT NULL,
+        col6 INT NOT NULL,
+        CONSTRAINT "primary" PRIMARY KEY (col1 ASC, col2 ASC, col3 ASC, col5 ASC, col6 ASC),
+        CONSTRAINT fk_col1_ref_t93410 FOREIGN KEY (col1, col2, col3, col4, col5) REFERENCES t93410(col1, col2, col3, col4, col5) ON DELETE CASCADE,
+        INDEX t93410_2_col1_col2_col3_col4_col5_idx (col1 ASC, col2 ASC, col3 ASC, col4 ASC, col5 ASC)
+)
+----
+
+exec-ddl
+ALTER TABLE t93410 INJECT STATISTICS '[
+    {
+        "avg_size": 2,
+        "columns": [
+            "col1"
+        ],
+        "created_at": "2022-12-15 19:58:40.9211",
+        "distinct_count": 100000,
+        "histo_buckets": [
+            {
+                "distinct_range": 0,
+                "num_eq": 300002,
+                "num_range": 0,
+                "upper_bound": "1"
+            },
+            {
+                "distinct_range": 100000,
+                "num_eq": 0,
+                "num_range": 100000,
+                "upper_bound": "100000"
+            }
+        ],
+        "histo_col_type": "INT8",
+        "histo_version": 2,
+        "null_count": 0,
+        "row_count": 400001
+    },
+    {
+        "avg_size": 2,
+        "columns": [
+            "col2"
+        ],
+        "created_at": "2022-12-15 19:58:40.9211",
+        "distinct_count": 100000,
+        "histo_buckets": [
+            {
+                "distinct_range": 0,
+                "num_eq": 300002,
+                "num_range": 0,
+                "upper_bound": "1"
+            },
+            {
+                "distinct_range": 100000,
+                "num_eq": 0,
+                "num_range": 100000,
+                "upper_bound": "100000"
+            }
+        ],
+        "histo_col_type": "INT8",
+        "histo_version": 2,
+        "null_count": 0,
+        "row_count": 400001
+    }
+]';
+----
+
+exec-ddl
+ALTER TABLE t93410_2 INJECT STATISTICS '[
+    {
+        "avg_size": 2,
+        "columns": [
+            "col1"
+        ],
+        "created_at": "2022-12-15 19:58:40.9211",
+        "distinct_count": 100000,
+        "histo_buckets": [
+            {
+                "distinct_range": 0,
+                "num_eq": 300002,
+                "num_range": 0,
+                "upper_bound": "1"
+            },
+            {
+                "distinct_range": 100000,
+                "num_eq": 0,
+                "num_range": 100000,
+                "upper_bound": "100000"
+            }
+        ],
+        "histo_col_type": "INT8",
+        "histo_version": 2,
+        "null_count": 0,
+        "row_count": 400001
+    },
+    {
+        "avg_size": 2,
+        "columns": [
+            "col2"
+        ],
+        "created_at": "2022-12-15 19:58:40.9211",
+        "distinct_count": 100000,
+        "histo_buckets": [
+            {
+                "distinct_range": 0,
+                "num_eq": 300002,
+                "num_range": 0,
+                "upper_bound": "1"
+            },
+            {
+                "distinct_range": 100000,
+                "num_eq": 0,
+                "num_range": 100000,
+                "upper_bound": "100000"
+            }
+        ],
+        "histo_col_type": "INT8",
+        "histo_version": 2,
+        "null_count": 0,
+        "row_count": 400001
+    }
+]';
+----
+
+# A streaming group-by with no TopK operation should be generated.
+opt expect=GenerateStreamingGroupByLimitOrderingHint
+SELECT
+  DISTINCT
+  t1.col1,
+  t1.col2,
+  t1.col3,
+  t1.col4,
+  t1.col5,
+  t1.col6,
+  t1.col7,
+  t1.col8,
+  t1.col9,
+  t1.col10,
+  t1.col11,
+  t1.col12,
+  t1.col13,
+  t1.col14,
+  t1.col15,
+  t1.col16,
+  array_remove(array_agg(t2.col6), NULL) AS col6s
+FROM
+  t93410 AS t1
+  LEFT OUTER JOIN t93410_2
+      AS t2 USING (col1, col2, col3, col4, col5)
+WHERE
+  t1.col2 = 1
+  AND t1.col1 = 1
+GROUP BY
+  t1.col1,
+  t1.col2,
+  t1.col3,
+  t1.col4,
+  t1.col5
+ORDER BY
+  col9 DESC, t1.col5 DESC
+LIMIT 20
+----
+project
+ ├── columns: col1:1!null col2:2!null col3:3!null col4:4!null col5:5!null col6:6!null col7:7!null col8:8!null col9:9!null col10:10!null col11:11!null col12:12 col13:13 col14:14!null col15:15 col16:16 col6s:28
+ ├── cardinality: [0 - 20]
+ ├── immutable
+ ├── key: (5)
+ ├── fd: ()-->(1,2), (5)-->(3,4,6-16,28)
+ ├── ordering: -9,-5 opt(1,2) [actual: -9,-5]
+ ├── limit
+ │    ├── columns: t1.col1:1!null t1.col2:2!null t1.col3:3!null t1.col4:4!null t1.col5:5!null t1.col6:6!null col7:7!null col8:8!null col9:9!null col10:10!null col11:11!null col12:12 col13:13 col14:14!null col15:15 col16:16 array_agg:27
+ │    ├── internal-ordering: -9,-5 opt(1,2)
+ │    ├── cardinality: [0 - 20]
+ │    ├── key: (5)
+ │    ├── fd: ()-->(1,2), (5)-->(1-4,6-16,27)
+ │    ├── ordering: -9,-5 opt(1,2) [actual: -9,-5]
+ │    ├── group-by (streaming)
+ │    │    ├── columns: t1.col1:1!null t1.col2:2!null t1.col3:3!null t1.col4:4!null t1.col5:5!null t1.col6:6!null col7:7!null col8:8!null col9:9!null col10:10!null col11:11!null col12:12 col13:13 col14:14!null col15:15 col16:16 array_agg:27
+ │    │    ├── grouping columns: t1.col5:5!null col9:9!null
+ │    │    ├── internal-ordering: -9,-5 opt(1,2)
+ │    │    ├── key: (5)
+ │    │    ├── fd: ()-->(1,2), (5)-->(1-4,6-16,27)
+ │    │    ├── ordering: -9,-5 opt(1,2) [actual: -9,-5]
+ │    │    ├── limit hint: 20.00
+ │    │    ├── left-join (lookup t93410_2@t93410_2_col1_col2_col3_col4_col5_idx [as=t2])
+ │    │    │    ├── columns: t1.col1:1!null t1.col2:2!null t1.col3:3!null t1.col4:4!null t1.col5:5!null t1.col6:6!null col7:7!null col8:8!null col9:9!null col10:10!null col11:11!null col12:12 col13:13 col14:14!null col15:15 col16:16 t2.col1:19 t2.col2:20 t2.col3:21 t2.col4:22 t2.col5:23 t2.col6:24
+ │    │    │    ├── key columns: [1 2 3 4 5] = [19 20 21 22 23]
+ │    │    │    ├── key: (5,21,23,24)
+ │    │    │    ├── fd: ()-->(1,2), (5)-->(3,4,6-16), (21,23,24)-->(22), (5,21,23,24)-->(19,20)
+ │    │    │    ├── ordering: -9,-5 opt(1,2) [actual: -9,-5]
+ │    │    │    ├── limit hint: 20.00
+ │    │    │    ├── index-join t93410
+ │    │    │    │    ├── columns: t1.col1:1!null t1.col2:2!null t1.col3:3!null t1.col4:4!null t1.col5:5!null t1.col6:6!null col7:7!null col8:8!null col9:9!null col10:10!null col11:11!null col12:12 col13:13 col14:14!null col15:15 col16:16
+ │    │    │    │    ├── key: (5)
+ │    │    │    │    ├── fd: ()-->(1,2), (5)-->(3,4,6-16)
+ │    │    │    │    ├── ordering: -9,-5 opt(1,2) [actual: -9,-5]
+ │    │    │    │    ├── limit hint: 100.00
+ │    │    │    │    └── sort
+ │    │    │    │         ├── columns: t1.col1:1!null t1.col2:2!null t1.col3:3!null t1.col4:4!null t1.col5:5!null col9:9!null
+ │    │    │    │         ├── key: (5)
+ │    │    │    │         ├── fd: ()-->(1,2), (5)-->(3,4,9)
+ │    │    │    │         ├── ordering: -9,-5 opt(1,2) [actual: -9,-5]
+ │    │    │    │         ├── limit hint: 100.00
+ │    │    │    │         └── scan t93410@t93410_col1_col2_col5_col9_key [as=t1]
+ │    │    │    │              ├── columns: t1.col1:1!null t1.col2:2!null t1.col3:3!null t1.col4:4!null t1.col5:5!null col9:9!null
+ │    │    │    │              ├── constraint: /1/2/5/9: [/1/1 - /1/1]
+ │    │    │    │              ├── key: (5)
+ │    │    │    │              └── fd: ()-->(1,2), (5)-->(3,4,9)
+ │    │    │    └── filters
+ │    │    │         ├── t2.col2:20 = 1 [outer=(20), constraints=(/20: [/1 - /1]; tight), fd=()-->(20)]
+ │    │    │         └── t2.col1:19 = 1 [outer=(19), constraints=(/19: [/1 - /1]; tight), fd=()-->(19)]
+ │    │    └── aggregations
+ │    │         ├── array-agg [as=array_agg:27, outer=(24)]
+ │    │         │    └── t2.col6:24
+ │    │         ├── const-agg [as=t1.col1:1, outer=(1)]
+ │    │         │    └── t1.col1:1
+ │    │         ├── const-agg [as=t1.col2:2, outer=(2)]
+ │    │         │    └── t1.col2:2
+ │    │         ├── const-agg [as=t1.col3:3, outer=(3)]
+ │    │         │    └── t1.col3:3
+ │    │         ├── const-agg [as=t1.col4:4, outer=(4)]
+ │    │         │    └── t1.col4:4
+ │    │         ├── const-agg [as=t1.col6:6, outer=(6)]
+ │    │         │    └── t1.col6:6
+ │    │         ├── const-agg [as=col7:7, outer=(7)]
+ │    │         │    └── col7:7
+ │    │         ├── const-agg [as=col8:8, outer=(8)]
+ │    │         │    └── col8:8
+ │    │         ├── const-agg [as=col10:10, outer=(10)]
+ │    │         │    └── col10:10
+ │    │         ├── const-agg [as=col11:11, outer=(11)]
+ │    │         │    └── col11:11
+ │    │         ├── const-agg [as=col12:12, outer=(12)]
+ │    │         │    └── col12:12
+ │    │         ├── const-agg [as=col13:13, outer=(13)]
+ │    │         │    └── col13:13
+ │    │         ├── const-agg [as=col14:14, outer=(14)]
+ │    │         │    └── col14:14
+ │    │         ├── const-agg [as=col15:15, outer=(15)]
+ │    │         │    └── col15:15
+ │    │         └── const-agg [as=col16:16, outer=(16)]
+ │    │              └── col16:16
+ │    └── 20
+ └── projections
+      └── array_remove(array_agg:27, NULL) [as=col6s:28, outer=(27), immutable]
+
+# GenerateStreamingGroupByLimitOrderingHint should not fire if there is no
+# overlap between the grouping columns and order-by columns.
+opt expect-not=GenerateStreamingGroupByLimitOrderingHint
+SELECT
+  DISTINCT
+  t2.col1,
+  t2.col2,
+  t2.col3,
+  t2.col4,
+  t2.col5,
+  array_remove(array_agg(t1.col6), NULL) AS col6s
+FROM
+  t93410 AS t1
+  LEFT OUTER JOIN t93410_2
+      AS t2 USING (col1, col2, col3, col4, col5)
+WHERE
+  t1.col2 = 1
+  AND t1.col1 = 1
+GROUP BY
+  t2.col1,
+  t2.col2,
+  t2.col3,
+  t2.col4,
+  t2.col5
+ORDER BY
+  col6s DESC
+LIMIT 20
+----
+top-k
+ ├── columns: col1:19 col2:20 col3:21 col4:22 col5:23 col6s:28
+ ├── internal-ordering: -28
+ ├── k: 20
+ ├── cardinality: [0 - 20]
+ ├── immutable
+ ├── key: (19-23)
+ ├── fd: (19-23)-->(28)
+ ├── ordering: -28
+ └── project
+      ├── columns: col6s:28 t2.col1:19 t2.col2:20 t2.col3:21 t2.col4:22 t2.col5:23
+      ├── immutable
+      ├── key: (19-23)
+      ├── fd: (19-23)-->(28)
+      ├── group-by (hash)
+      │    ├── columns: t2.col1:19 t2.col2:20 t2.col3:21 t2.col4:22 t2.col5:23 array_agg:27!null
+      │    ├── grouping columns: t2.col1:19 t2.col2:20 t2.col3:21 t2.col4:22 t2.col5:23
+      │    ├── key: (19-23)
+      │    ├── fd: (19-23)-->(27)
+      │    ├── left-join (merge)
+      │    │    ├── columns: t1.col1:1!null t1.col2:2!null t1.col3:3!null t1.col4:4!null t1.col5:5!null t1.col6:6!null t2.col1:19 t2.col2:20 t2.col3:21 t2.col4:22 t2.col5:23
+      │    │    ├── left ordering: +3,+4,+5,+1,+2
+      │    │    ├── right ordering: +21,+22,+23,+19,+20
+      │    │    ├── fd: ()-->(1,2), (5)-->(3,4,6)
+      │    │    ├── scan t93410 [as=t1]
+      │    │    │    ├── columns: t1.col1:1!null t1.col2:2!null t1.col3:3!null t1.col4:4!null t1.col5:5!null t1.col6:6!null
+      │    │    │    ├── constraint: /1/2/3/4/5: [/1/1 - /1/1]
+      │    │    │    ├── key: (5)
+      │    │    │    ├── fd: ()-->(1,2), (5)-->(3,4,6)
+      │    │    │    └── ordering: +3,+4,+5 opt(1,2) [actual: +3,+4,+5]
+      │    │    ├── scan t93410_2@t93410_2_col1_col2_col3_col4_col5_idx [as=t2]
+      │    │    │    ├── columns: t2.col1:19!null t2.col2:20!null t2.col3:21!null t2.col4:22!null t2.col5:23!null
+      │    │    │    ├── constraint: /19/20/21/22/23/24: [/1/1 - /1/1]
+      │    │    │    ├── fd: ()-->(19,20)
+      │    │    │    └── ordering: +21,+22,+23 opt(19,20) [actual: +21,+22,+23]
+      │    │    └── filters (true)
+      │    └── aggregations
+      │         └── array-agg [as=array_agg:27, outer=(6)]
+      │              └── t1.col6:6
+      └── projections
+           └── array_remove(array_agg:27, NULL) [as=col6s:28, outer=(27), immutable]
+
+# A distinct-on which satisfies the required ordering should be used.
+opt expect=GenerateStreamingGroupByLimitOrderingHint
+SELECT
+  DISTINCT ON (t1.col5, t1.col9) t2.col2
+FROM
+  t93410 AS t1
+  LEFT OUTER JOIN t93410_2
+      AS t2 USING (col1, col2, col3, col4, col5)
+WHERE
+  t1.col2 = 1
+  AND t1.col1 = 1
+ORDER BY
+  col9 ASC, t1.col5 DESC
+LIMIT 20
+----
+limit
+ ├── columns: col2:20  [hidden: t1.col5:5!null col9:9!null]
+ ├── internal-ordering: +9,-5
+ ├── cardinality: [0 - 20]
+ ├── key: (5)
+ ├── fd: (5)-->(9,20)
+ ├── ordering: +9,-5
+ ├── distinct-on
+ │    ├── columns: t1.col5:5!null col9:9!null t2.col2:20
+ │    ├── grouping columns: t1.col5:5!null col9:9!null
+ │    ├── internal-ordering: +9,-5 opt(1,2)
+ │    ├── key: (5)
+ │    ├── fd: (5)-->(9,20)
+ │    ├── ordering: +9,-5
+ │    ├── limit hint: 20.00
+ │    ├── left-join (lookup t93410_2@t93410_2_col1_col2_col3_col4_col5_idx [as=t2])
+ │    │    ├── columns: t1.col1:1!null t1.col2:2!null t1.col3:3!null t1.col4:4!null t1.col5:5!null col9:9!null t2.col1:19 t2.col2:20 t2.col3:21 t2.col4:22 t2.col5:23
+ │    │    ├── key columns: [1 2 3 4 5] = [19 20 21 22 23]
+ │    │    ├── fd: ()-->(1,2), (5)-->(3,4,9)
+ │    │    ├── ordering: +9,-5 opt(1,2) [actual: +9,-5]
+ │    │    ├── limit hint: 24.00
+ │    │    ├── sort
+ │    │    │    ├── columns: t1.col1:1!null t1.col2:2!null t1.col3:3!null t1.col4:4!null t1.col5:5!null col9:9!null
+ │    │    │    ├── key: (5)
+ │    │    │    ├── fd: ()-->(1,2), (5)-->(3,4,9)
+ │    │    │    ├── ordering: +9,-5 opt(1,2) [actual: +9,-5]
+ │    │    │    ├── limit hint: 100.00
+ │    │    │    └── scan t93410@t93410_col1_col2_col5_col9_key [as=t1]
+ │    │    │         ├── columns: t1.col1:1!null t1.col2:2!null t1.col3:3!null t1.col4:4!null t1.col5:5!null col9:9!null
+ │    │    │         ├── constraint: /1/2/5/9: [/1/1 - /1/1]
+ │    │    │         ├── key: (5)
+ │    │    │         └── fd: ()-->(1,2), (5)-->(3,4,9)
+ │    │    └── filters
+ │    │         ├── t2.col2:20 = 1 [outer=(20), constraints=(/20: [/1 - /1]; tight), fd=()-->(20)]
+ │    │         └── t2.col1:19 = 1 [outer=(19), constraints=(/19: [/1 - /1]; tight), fd=()-->(19)]
+ │    └── aggregations
+ │         └── first-agg [as=t2.col2:20, outer=(20)]
+ │              └── t2.col2:20
+ └── 20
+
+# This should generate a partial streaming aggregation.
+opt expect=GenerateStreamingGroupByLimitOrderingHint
+SELECT
+  count(*)
+FROM
+  t93410 AS t1
+  LEFT OUTER JOIN t93410_2
+      AS t2 USING (col1, col2, col3, col4)
+WHERE
+  t1.col2 = 1
+GROUP BY
+  t1.col2,
+  t1.col3,
+  t1.col4
+ORDER BY
+  t1.col4 DESC
+LIMIT 20
+----
+project
+ ├── columns: count:27!null  [hidden: t1.col4:4!null]
+ ├── cardinality: [0 - 20]
+ ├── ordering: -4
+ └── limit
+      ├── columns: t1.col3:3!null t1.col4:4!null count_rows:27!null
+      ├── internal-ordering: -4
+      ├── cardinality: [0 - 20]
+      ├── key: (3,4)
+      ├── fd: (3,4)-->(27)
+      ├── ordering: -4
+      ├── group-by (partial streaming)
+      │    ├── columns: t1.col3:3!null t1.col4:4!null count_rows:27!null
+      │    ├── grouping columns: t1.col3:3!null t1.col4:4!null
+      │    ├── key: (3,4)
+      │    ├── fd: (3,4)-->(27)
+      │    ├── ordering: -4
+      │    ├── limit hint: 20.00
+      │    ├── left-join (lookup t93410_2@t93410_2_col1_col2_col3_col4_col5_idx [as=t2])
+      │    │    ├── columns: t1.col1:1!null t1.col2:2!null t1.col3:3!null t1.col4:4!null t2.col1:19 t2.col2:20 t2.col3:21 t2.col4:22
+      │    │    ├── key columns: [1 2 3 4] = [19 20 21 22]
+      │    │    ├── fd: ()-->(2)
+      │    │    ├── ordering: -4 opt(2) [actual: -4]
+      │    │    ├── limit hint: 20.00
+      │    │    ├── sort
+      │    │    │    ├── columns: t1.col1:1!null t1.col2:2!null t1.col3:3!null t1.col4:4!null
+      │    │    │    ├── fd: ()-->(2)
+      │    │    │    ├── ordering: -4 opt(2) [actual: -4]
+      │    │    │    ├── limit hint: 100.00
+      │    │    │    └── select
+      │    │    │         ├── columns: t1.col1:1!null t1.col2:2!null t1.col3:3!null t1.col4:4!null
+      │    │    │         ├── fd: ()-->(2)
+      │    │    │         ├── scan t93410@t93410_col1_col2_col3_col5_key [as=t1]
+      │    │    │         │    └── columns: t1.col1:1!null t1.col2:2!null t1.col3:3!null t1.col4:4!null
+      │    │    │         └── filters
+      │    │    │              └── t1.col2:2 = 1 [outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
+      │    │    └── filters
+      │    │         └── t2.col2:20 = 1 [outer=(20), constraints=(/20: [/1 - /1]; tight), fd=()-->(20)]
+      │    └── aggregations
+      │         └── count-rows [as=count_rows:27]
+      └── 20
+
+# End Regression Test for #93410

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -300,6 +300,13 @@ message LocalOnlySessionData {
   // filters.
   bool optimizer_use_improved_disjunction_stats = 86;
 
+  // OptimizerUseLimitOrderingForStreamingGroupBy enables the exploration rule
+  // which optimizes 'SELECT ... GROUP BY ... ORDER BY ... LIMIT n' queries.
+  // The rule uses the required ordering in the limit expression to inform an
+  // interesting ordering to require from the input to the group-by expression.
+  // This can potentially eliminate a top-k operation.
+  bool optimizer_use_limit_ordering_for_streaming_group_by = 88;
+
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //
   // be propagated to the remote nodes. If so, that parameter should live  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2331,6 +2331,23 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalFalse,
 	},
+
+	// CockroachDB extension.
+	`optimizer_use_limit_ordering_for_streaming_group_by`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`optimizer_use_limit_ordering_for_streaming_group_by`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("optimizer_use_limit_ordering_for_streaming_group_by", s)
+			if err != nil {
+				return err
+			}
+			m.SetOptimizerUseLimitOrderingForStreamingGroupBy(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().OptimizerUseLimitOrderingForStreamingGroupBy), nil
+		},
+		GlobalDefault: globalFalse,
+	},
 }
 
 // We want test coverage for this on and off so make it metamorphic.


### PR DESCRIPTION
Backport 1/1 commits from #93858.

/cc @cockroachdb/release

---

Fixes #93410

A query with a grouped aggregation, a LIMIT and an ORDER BY may not always explore the best-cost query plan.

Due to the existence of unique constraints on a table, the set of grouping columns may be reduced during normalization via rule ReduceGroupingCols such that it no longer includes columns present in the ORDER BY clause. This eliminates possibly cheap plans from consideration, for example, if the input to the aggregation is a lookup join, it may be cheaper to sort the input to the lookup join on the ORDER BY columns if they overlap with the grouping columns, so that a streaming group-by with no TopK operator can be used, and a full scan of the inputs to the join is avoided.

This fix adds a new exploration rule which ensures that a grouped aggregation with a LIMIT and ORDER BY clause considers using streaming group-by with no TopK when possible.

Release note (bug fix): This patch fixes join queries involving tables with unique constraints using LIMIT, GROUP BY and ORDER BY clauses to ensure the optimizer considers streaming group-by with no TopK operation, when possible. This is often the most efficient query plan.

Release justification: low risk fix for missing exploration of streaming group-by, disabled by default

---
sql: add optimizer_use_limit_ordering_for_streaming_group_by session setting

This commit adds the `optimizer_use_limit_ordering_for_streaming_group_by`
session setting that defaults to `false`. When `true`, an exploration
rule which uses the ordering specified in a
`SELECT ... GROUP BY ... ORDER BY ... LIMIT n;` statement as an
interesting ordering to require from the input to the group-by
expression, possibly eliminating a top-k operation.  When `false`, the
exploration rule is disabled. This setting allows backport of the new
exploration rule without impacting query plans of running clusters.

Release note: None