### PR TITLE
cli: fix references to `kvadmission.store.provisioned_bandwidth`

### DIFF
--- a/pkg/base/store_spec.go
+++ b/pkg/base/store_spec.go
@@ -368,7 +368,7 @@ var fractionRegex = regexp.MustCompile(`^([-]?([0-9]+\.[0-9]*|[0-9]*\.[0-9]+|[0-
 //   - provisioned-rate=disk-name=<disk-name>[:bandwidth=<bandwidth-bytes/s>] The
 //     provisioned-rate can be used for admission control for operations on the
 //     store. The bandwidth is optional, and if unspecified, a cluster setting
-//     (kv.store.admission.provisioned_bandwidth) will be used.
+//     (kvadmission.store.provisioned_bandwidth) will be used.
 //
 // Note that commas are forbidden within any field name or value.
 func NewStoreSpec(value string) (StoreSpec, error) {

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -967,7 +967,7 @@ memory that the store may consume, for example:
 Optionally, to configure admission control enforcement to prevent disk
 bandwidth saturation, the "provisioned-rate" field can be specified with
 the "disk-name" and an optional "bandwidth". The bandwidth is used to override
-the value of the cluster setting, kv.store.admission.provisioned_bandwidth.
+the value of the cluster setting, kvadmission.store.provisioned_bandwidth.
 For example:
 <PRE>
 


### PR DESCRIPTION
The cluster setting `kv.store.admission.provisioned_bandwidth` was renamed to `kvadmission.store.provisioned_bandwidth` in 3414b034b65, but it was still referred to by the old name in a few spots.

Epic: none
Release note: None