### PR TITLE
ci: use static license for local roachtest

### DIFF
--- a/build/teamcity/cockroach/ci/tests/local_roachtest.sh
+++ b/build/teamcity/cockroach/ci/tests/local_roachtest.sh
@@ -1,24 +1,13 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -exuo pipefail
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
 
 source "$dir/teamcity-support.sh"  # For $root
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
-tc_start_block "Prepare environment"
-# Grab a testing license good for one hour.
-COCKROACH_DEV_LICENSE=$(curl --retry 3 --retry-connrefused -f "https://register.cockroachdb.com/api/prodtest")
-tc_end_block "Prepare environment"
-
 tc_start_block "Run local roachtests"
-run_bazel env \
-    COCKROACH_DEV_LICENSE="${COCKROACH_DEV_LICENSE}" \
-    GITHUB_API_TOKEN="${GITHUB_API_TOKEN-}" \
-    BUILD_VCS_NUMBER="${BUILD_VCS_NUMBER-}" \
-    TC_BUILD_ID="${TC_BUILD_ID-}" \
-    TC_SERVER_URL="${TC_SERVER_URL-}" \
-    TC_BUILD_BRANCH="${TC_BUILD_BRANCH-}" \
-    build/teamcity/cockroach/ci/tests/local_roachtest_impl.sh
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e COCKROACH_DEV_LICENSE -e BUILD_VCS_NUMBER -e TC_BUILD_ID -e TC_BUILD_BRANCH" \
+  run_bazel build/teamcity/cockroach/ci/tests/local_roachtest_impl.sh
 tc_end_block "Run local roachtests"

--- a/build/teamcity/cockroach/ci/tests/local_roachtest_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/local_roachtest_impl.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -euox pipefail
 
 if [[ "$(uname -m)" =~ (arm64|aarch64)$ ]]; then
   export CROSSLINUX_CONFIG="crosslinuxarm"


### PR DESCRIPTION
Previously, we fetched the cockroach licence from the registration server before running the test. This added 2 flakiness factors to the tests:
* The registration server can de down and affect the test outcomes. We hit this issue last year.
* The licence is valid only for an hour. In case the tests take more than an hour, we fail.

This PR removes the fetch step and uses the corresponding environment variable from TeamCity.

Epic: None
Fixes: DEVINF-620
Release note: None