### PR TITLE
sql: deflake TestScrubFKConstraintFKMissing

### DIFF
--- a/pkg/sql/scrub_unique_constraint.go
+++ b/pkg/sql/scrub_unique_constraint.go
@@ -121,8 +121,7 @@ func (o *sqlUniqueConstraintCheckOperation) Start(params runParams) error {
 	}
 	asOf := ""
 	if o.asOf != hlc.MaxTimestamp {
-		asOf = fmt.Sprintf("AS OF SYSTEM TIME %[1]d",
-			o.asOf.WallTime)
+		asOf = fmt.Sprintf("AS OF SYSTEM TIME '%s'", o.asOf.AsOfSystemTime())
 	}
 	tableName := fmt.Sprintf("%s.%s", o.tableName.Catalog(), o.tableName.Table())
 	dup, _, err := duplicateRowQuery(o.tableDesc, o.cols, o.predicate, false /* limitResults */)


### PR DESCRIPTION
Fixes #93401.

This commit fixes a flake in `TestScrubFKConstraintFKMissing` where a query's AS OF SYSTEM TIME clause did not agree with its parent transaction's timestamp. The query constructed in `sqlUniqueConstraintCheckOperation.Start` was stripping off the logical portion of the transaction timestamp when constructing the AS OF SYSTEM TIME clause, meaning that if the transaction's timestamp had a non-zero logical portion, the query would fail.

Given that we're running this statement inside of an explicit transaction, I don't know why it needs an AS OF SYSTEM TIME clause at all, but I don't intend to pull on that. Perhaps it's run in an implicit transaction in some cases.

Release note: None