### PR TITLE
kvserver: document reproposals

### DIFF
--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -498,9 +498,13 @@ type Replica struct {
 		// Instead, the buffer internally holds a reference to mu and will use
 		// it appropriately.
 		proposalBuf propBuf
-		// proposals stores the Raft in-flight commands which originated at
-		// this Replica, i.e. all commands for which propose has been called,
-		// but which have not yet applied.
+
+		// proposals stores the Raft in-flight commands which originated at this
+		// Replica, i.e. all commands for which propose has been called, but which
+		// have not yet applied. A proposal is "pending" until it is "finalized",
+		// meaning that `finishApplication` has been invoked on the proposal (which
+		// informs the client that the proposal has now been applied, optionally
+		// with an error, which may be an AmbiguousResultError).
 		//
 		// The *ProposalData in the map are "owned" by it. Elements from the
 		// map must only be referenced while the Replica.mu is held, except
@@ -509,12 +513,146 @@ type Replica struct {
 		// underneath raft. See comments on ProposalData fields for synchronization
 		// requirements.
 		//
-		// Due to Raft reproposals, multiple in-flight Raft entries can have
-		// the same CmdIDKey, all corresponding to the same KV request. However,
-		// not all Raft entries with a given command ID will correspond directly
-		// to the *RaftCommand contained in its associated *ProposalData. This
-		// is because the *RaftCommand can be mutated during reproposals by
-		// Replica.tryReproposeWithNewLeaseIndex.
+		// Due to Raft reproposals, multiple in-flight Raft entries can have the
+		// same CmdIDKey. There are two kinds of reproposals:
+		//
+		// (1) the exact same entry is handed to raft (possibly despite already being
+		// present in the log), usually after a timeout[^1].
+		//
+		// (2)  an existing proposal is updated with a new MaxLeaseIndex and handed to
+		// raft, i.e. we're intentionally creating a duplicate. This exists because
+		// for pipelined proposals, the client's goroutine returns without waiting
+		// for the proposal to apply.[^2][^3] When (2) is carried out, the existing
+		// copies of the proposal in the log will be "Superseded", see below. Note
+		// that (2) will only be invoked for proposals that aren't currently in the
+		// proposals map any more because they're in the middle of being applied;
+		// as part of (2), they are re-added to the map.
+		//
+		// To understand reproposals, we need a broad overview of entry application,
+		// which is batched (i.e. may process multiple log entries to be applied in
+		// a batched fashion). In entry application, the following steps are taken:
+		//
+		// 1. retrieve all local proposals: iterate through the entries in order,
+		//    and look them up in the proposals map. For each "local" entry (i.e.
+		//    tracked in the map), remove it from the map (unless the proposal
+		//    is not superseded, see below) and attach the value to the entry.
+		// 2. for each entry:
+		//    - stage written and in-memory effects of the entry (some may apply as no-ops
+		//    if they fail below-raft checks such as the MaxLeaseIndex check)
+		//    - Assuming the MaxLeaseIndex is violated and additional constraints are
+		//    satisfied, carry out (2) from above. On success, we know now that there
+		//    will be a reproposal in the log that can successfully apply. We unbind
+		//    the local proposal (so we don't signal it) and apply the current entry
+		//    as a no-op.
+		// 3. carry out additional side effects of the entire batch (stats updates etc).
+		//
+		// A prerequisite for (2) is that there currently aren't any copies of the proposal
+		// in the log that may ultimately apply, or we risk doubly applying commands - a
+		// correctness bug. After (2), any copies of the entry present in the log will have
+		// a MaxLeaseIndex strictly less than that of the in-memory command, and will be
+		// Superseded() by it.
+		//
+		// We can always safely create an identical copy (i.e. (1)) because of the
+		// replay protection conferred by the MaxLeaseIndex - all but the first
+		// proposal (that reach consensus) will be rejected (i.e. apply as a no-op).
+		//
+		// Naively, one might hope that by invoking (2) upon applying an entry for
+		// a command that is rejected due to a MaxLeaseIndex one could achieve the
+		// invariant that there is only ever one unapplied copy of the entry in the
+		// log, and then the in-memory proposal could reflect the MaxLeaseIndex
+		// assigned to this unapplied copy at all times.
+		//
+		// Unfortunately, for various reasons, this invariant does not hold:
+		// - entry application isn't durable, so upon a restart, we might roll
+		//   back to a log position that yet has to catch up over multiple previous
+		//   incarnations of (2), i.e. we will see the same entry multiple times at
+		//   various MaxLeaseIndex values.
+		//   (This technically not a problem, since we're losing the in-memory proposal
+		//   during the restart anyway, but should be kept in mind anyway).
+		// - Raft proposal forwarding due to (1)-type reproposals could "in
+		//   principle" lead to an old copy of the entry appearing again in the
+		//   unapplied log, at least if we make the reasonable assumption that
+		//   forwarded proposals may arrive at the leader with arbitrary delays.
+		//
+		// As a result, we can't "just" invoke (2) when seeing a rejected command,
+		// we additionally have to verify that there isn't a more recent reproposal
+		// underway that could apply successfully and supersedes the one we're
+		// currently looking at.
+		// So we carry out (2) only if the MaxLeaseIndex of the in-mem proposal matches
+		// that of the current entry, and update the in-mem MaxLeaseIndex with the result
+		// of (2) if it did.
+		//
+		// An example follows. Consider the following situation (where N is some base
+		// index not relevant to the example) in which we have one inflight proposal which
+		// has been triplicated in the log (due to [^1]):
+		//
+		//     proposals[id] = p{Cmd{MaxLeaseIndex: 100, ...}}
+		//
+		//     ... (unrelated entries)
+		//     raftlog[N] = Cmd{MaxLeaseIndex: 100, ...}
+		//     ... (unrelated entries)
+		//     raftlog[N+12] = (same as N)
+		//     ... (unrelated entries)
+		//     raftlog[N+15] = (same as N)
+		//
+		// where we assume that the `MaxLeaseIndex` 100 is invalid, i.e. when we see
+		// the first copy of the command being applied, we've already applied some
+		// command with equal or higher `MaxLeaseIndex`. In a world without
+		// mechanism (2), `N` would be rejected, and would finalize the proposal
+		// (i.e. signal the client with an error and remove the entry from
+		// `proposals`). Later, `N+12` and `N+15` would similarly be rejected (but
+		// they wouldn't even be regarded as local proposals any more due to not
+		// being present in `proposals`).
+		//
+		// However, (2) exists and it will engage during application of `N`: realizing
+		// that the current copies of the entry are all going to be rejected, it will
+		// modify the proposal by assigning a new `MaxLeaseIndex` to it, and handing
+		// it to `(*Replica).propose` again (which hands it to the proposal buffer,
+		// which will at some point flush it, leading to re-insertion into the raft
+		// log and the `proposals` map). The result will be this picture:
+		//
+		//     proposals[id] = p{Cmd{MaxLeaseIndex: 192, ...}}   <-- modified
+		//
+		//     ... (unrelated entries)
+		//     raftlog[N] = Cmd{MaxLeaseIndex: 100, ...}         <-- applied (as no-op)
+		//     ... (unrelated entries)
+		//     raftlog[N+12] = (same as N)                       (superseded)
+		//     ... (unrelated entries)
+		//     raftlog[N+15] = (same as N)                       (superseded)
+		//     ... (unrelated entries)
+		//     raftlog[N+18] = Cmd{MaxLeaseIndex: 192, ...}      <-- modified
+		//
+		// `N+18` might (in fact, is likely to) apply successfully. As a result, when
+		// we consider `N+12` or `N+15` for application, we must *not* carry out (2)
+		// again, or we break replay protection. In other words, the `MaxLeaseIndex`
+		// of the command being applied must be compared with the `MaxLeaseIndex` of
+		// the command in the proposals map; only if they match do we know that this
+		// is the most recent (in MaxLeaseIndex order) copy of the command, and only
+		// then can (2) engage. In addition, an entry that doesn't pass this equality
+		// check must not signal the proposer and/or unlink from the proposals map (as a
+		// newer reproposal which might succeed is likely in the log)[^4].
+		//
+		// Another way of framing the above is that `proposals[id].Cmd.MaxLeaseIndex`
+		// actually tracks the maximum `MaxLeaseIndex` of all copies that may be present in
+		// the log.
+		//
+		// If (2) results in an error (for example, since the proposal now fails to
+		// respect the closed timestamp), that error will finalize the proposal and
+		// is returned to the client.
+		//
+		// [^1]: https://github.com/cockroachdb/cockroach/blob/59ce13b6052a99a0318e3dfe017908ff5630db30/pkg/kv/kvserver/replica_raft.go#L1224
+		// [^2]: https://github.com/cockroachdb/cockroach/blob/59ce13b6052a99a0318e3dfe017908ff5630db30/pkg/kv/kvserver/replica_application_result.go#L148
+		// [^3]: it's debatable how useful this below-raft reproposal mechanism is.
+		// It was introduced in https://github.com/cockroachdb/cockroach/pull/35261,
+		// and perhaps could be phased out again if we also did
+		// https://github.com/cockroachdb/cockroach/issues/21849. Historical
+		// evidence points to https://github.com/cockroachdb/cockroach/issues/28876
+		// as the motivation for introducing this mechanism, i.e. it was about
+		// reducing failure rates early in the life of a cluster when raft
+		// leaderships were being determined. Perhaps we could "simply" disable
+		// async writes unless leadership was stable instead, by blocking on the
+		// proposal anyway.
+		// [^4]: https://github.com/cockroachdb/cockroach/blob/ab6a8650621ae798377f12bbfc1eee2fbec95480/pkg/kv/kvserver/replica_application_decoder.go#L100-L114
 		proposals map[kvserverbase.CmdIDKey]*ProposalData
 		// Indicates that the replica is in the process of applying log entries.
 		// Updated to true in handleRaftReady before entries are removed from

--- a/pkg/kv/kvserver/replica_application_decoder.go
+++ b/pkg/kv/kvserver/replica_application_decoder.go
@@ -111,7 +111,8 @@ func (d *replicaDecoder) retrieveLocalProposals(ctx context.Context) (anyLocal b
 			// criterion. While such proposals can be reproposed, only the first
 			// instance that gets applied matters and so removing the command is
 			// always what we want to happen.
-			cmd.Cmd.MaxLeaseIndex == cmd.proposal.command.MaxLeaseIndex
+			!cmd.proposal.Supersedes(cmd.Cmd.MaxLeaseIndex)
+
 		if shouldRemove {
 			// Delete the proposal from the proposals map. There may be reproposals
 			// of the proposal in the pipeline, but those will all have the same max

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -220,30 +220,30 @@ func (sm *replicaStateMachine) ApplySideEffects(
 			sm.r.handleReadWriteLocalEvalResult(ctx, *cmd.localResult)
 		}
 
-		rejected := cmd.Rejected()
-		higherReproposalsExist := cmd.Cmd.MaxLeaseIndex != cmd.proposal.command.MaxLeaseIndex
-		if !rejected && higherReproposalsExist {
-			log.Fatalf(ctx, "finishing proposal with outstanding reproposal at a higher max lease index")
+		if higherReproposalsExist := cmd.proposal.Supersedes(cmd.Cmd.MaxLeaseIndex); higherReproposalsExist {
+			// If the command wasn't rejected, we just applied it and no higher
+			// reproposal must exist (since that one may also apply).
+			//
+			// If the command was rejected with ProposalRejectionPermanent, no higher
+			// reproposal should exist (after all, whoever made that reproposal should
+			// also have seen a permanent rejection).
+			//
+			// If it was rejected with ProposalRejectionIllegalLeaseIndex, then the
+			// subsequent call to tryReproposeWithNewLeaseIndex[^1] must have returned an
+			// error (or the proposal would not be IsLocal() now). But that call
+			// cannot return an error for a proposal that is already superseded
+			// initially.
+			//
+			// [^1]: see (*replicaDecoder).retrieveLocalProposals()
+			log.Fatalf(ctx, "finishing proposal with outstanding reproposal at a higher max lease index: %+v", cmd)
 		}
-		if !rejected && cmd.proposal.applied {
+		if !cmd.Rejected() && cmd.proposal.applied {
 			// If the command already applied then we shouldn't be "finishing" its
 			// application again because it should only be able to apply successfully
 			// once. We expect that when any reproposal for the same command attempts
 			// to apply it will be rejected by the below raft lease sequence or lease
 			// index check in checkForcedErr.
 			log.Fatalf(ctx, "command already applied: %+v; unexpected successful result", cmd)
-		}
-		// If any reproposals at a higher MaxLeaseIndex exist we know that they will
-		// never successfully apply, remove them from the map to avoid future
-		// reproposals. If there is no command referencing this proposal at a higher
-		// MaxLeaseIndex then it will already have been removed (see
-		// shouldRemove in replicaDecoder.retrieveLocalProposals()). It is possible
-		// that a later command in this batch referred to this proposal but it must
-		// have failed because it carried the same MaxLeaseIndex.
-		if higherReproposalsExist {
-			sm.r.mu.Lock()
-			delete(sm.r.mu.proposals, cmd.ID)
-			sm.r.mu.Unlock()
 		}
 		cmd.proposal.applied = true
 	}

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -126,6 +126,20 @@ type ProposalData struct {
 	tok TrackedRequestToken
 }
 
+// Supersedes takes the MaxLeaseIndex of a RaftCommand obtained from a log
+// entry. It returns true if the ProposalData tracks a different MaxIndex,
+// implying that the log entry has been reproposed under an updated
+// MaxLeaseIndex. This implies that the current log entry will have been
+// rejected and should not be reproposed.
+//
+// Note that some commands such as lease requests (but not transfers) don't use
+// MaxLeaseIndex. For these, false will be returned.
+//
+// See (*Replica).mu.proposals for a detailed explanation of reproposals.
+func (proposal *ProposalData) Supersedes(entryMaxLeaseIndex uint64) bool {
+	return proposal.command.MaxLeaseIndex != entryMaxLeaseIndex
+}
+
 // finishApplication is called when a command application has finished. The
 // method will be called downstream of Raft if the command required consensus,
 // but can be called upstream of Raft if the command did not and was never


### PR DESCRIPTION
Reproposals are a deep rabbit hole and an area in which past changes
were all related to subtle bugs. Write it all up and in particular make
some simplifications that ought to be possible if my understanding is
correct:

- have proposals always enter `(*Replica).propose` without a
  MaxLeaseIndex or prior encoded command set, i.e. `propose`
  behaves the same for reproposals as for first proposals.
- assert that after a failed call to tryReproposeWithNewLeaseIndex,
  the command is not in the proposals map, i.e. check absence of
  a leak.
- replace code that should be impossible to reach (and had me confused
  for a good amount of time) with an assertion.
- add long comment on `r.mu.proposals`.

This commit also moves `tryReproposeWithNewLeaseIndex` off `(*Replica)`,
which is possible due to recent changes[^1]. In doing so, I realized
there was a (small) data race (now fixed): when returning a
`NotLeaseholderError` from that method, we weren't acquiring `r.mu`. It
may have looked as though we were holding it already since we're
accessing `r.mu.propBuf`, however that field has special semantics - it
wraps `r.mu` and acquires it when needed.

[^1]: The "below raft" test mentioned in the previous comment was
changed in https://github.com/cockroachdb/cockroach/pull/93785 and
no longer causes a false positive.

Epic: CRDB-220
Release note: None
