### PR TITLE
storage: introduce a noopSyncCloserFlusher

### DIFF
--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -57,6 +57,34 @@ func (noopSyncCloser) Close() error {
 	return nil
 }
 
+type flusher interface {
+	Flush() error
+}
+
+// noopSyncCloserFlusher is like noopSyncCloser but also implements the flusher
+// interface.
+type noopSyncCloserFlusher struct {
+	io.Writer
+}
+
+func (noopSyncCloserFlusher) Sync() error {
+	return nil
+}
+
+func (noopSyncCloserFlusher) Close() error {
+	return nil
+}
+
+func (n noopSyncCloserFlusher) Flush() error {
+	f, ok := n.Writer.(flusher)
+	if !ok {
+		return errors.AssertionFailedf(
+			"Writer in the noopSyncCloserFlusher does not implement flusher")
+	}
+
+	return f.Flush()
+}
+
 // MakeIngestionWriterOptions returns writer options suitable for writing SSTs
 // that will subsequently be ingested (e.g. with AddSSTable).
 func MakeIngestionWriterOptions(ctx context.Context, cs *cluster.Settings) sstable.WriterOptions {
@@ -93,8 +121,15 @@ func MakeBackupSSTWriter(ctx context.Context, cs *cluster.Settings, f io.Writer)
 	opts.BlockSize = 128 << 10
 
 	opts.MergerName = "nullptr"
+
+	var fw writeCloseSyncer
+	if _, ok := f.(flusher); ok {
+		fw = noopSyncCloserFlusher{f}
+	} else {
+		fw = noopSyncCloser{f}
+	}
 	return SSTWriter{
-		fw:                sstable.NewWriter(noopSyncCloser{f}, opts),
+		fw:                sstable.NewWriter(fw, opts),
 		f:                 f,
 		supportsRangeKeys: opts.TableFormat >= sstable.TableFormatPebblev2,
 	}


### PR DESCRIPTION
Previously, a BackupSSTWriter would wrap the passed
io.Writer in a noopSyncCloser before creating an SST
writer. A storage.MemFile implements the Flush method
so as to be considered flusher when creating an sstable
in pebble. This signals to the sstwriter that it does not
need to wrap the file with a bufio.Writer to buffer writes.
Since a noopSyncCloser does not implement the flusher interface,
the underlying MemFile is no longer considered a flusher.

This patch fixes that by introducing a noopSyncCloserFlusher
that implements the Flush method and is used to wrap the io.Writer
when it is itself a flusher.

Release note: None

Epic: none