### PR TITLE
changefeedccl: fix initial-scan-only roachtest failure

### DIFF
--- a/pkg/cmd/roachtest/tests/latency_verifier.go
+++ b/pkg/cmd/roachtest/tests/latency_verifier.go
@@ -90,7 +90,7 @@ func (lv *latencyVerifier) noteHighwater(highwaterTime time.Time) {
 	}
 
 	latency := timeutil.Since(highwaterTime)
-	if latency < lv.targetSteadyLatency/2 {
+	if lv.targetSteadyLatency == 0 || latency < lv.targetSteadyLatency/2 {
 		lv.latencyBecameSteady = true
 	}
 	if !lv.latencyBecameSteady {


### PR DESCRIPTION
Resolves #92041

This does 3 small changes:
1. Fix the test failure, looks like it was just something that got missed in the last rebase of the initial PR
2. Make the prometheus configuration be stored even on SkipInit to avoid errors when the stats collection code attempts to run.
3. Move the test to use cloudstorage since its our fastest sink so it would better stress test the rest of the pipeline.

Release note: None