### PR TITLE
roachtest/cdc: fix missing workload in cdc ledger

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -1940,15 +1940,17 @@ type ledgerWorkload struct {
 }
 
 func (lw *ledgerWorkload) install(ctx context.Context, c cluster.Cluster) {
+	// TODO(#94136): remove --data-loader=INSERT
 	c.Run(ctx, lw.workloadNodes.RandNode(), fmt.Sprintf(
-		`./workload init ledger {pgurl%s}`,
+		`./workload init ledger --data-loader=INSERT {pgurl%s}`,
 		lw.sqlNodes.RandNode(),
 	))
 }
 
 func (lw *ledgerWorkload) run(ctx context.Context, c cluster.Cluster, workloadDuration string) {
+	// TODO(#94136): remove --data-loader=INSERT
 	c.Run(ctx, lw.workloadNodes, fmt.Sprintf(
-		`./workload run ledger --mix=balance=0,withdrawal=50,deposit=50,reversal=0 {pgurl%s} --duration=%s`,
+		`./workload run ledger --data-loader=INSERT --mix=balance=0,withdrawal=50,deposit=50,reversal=0 {pgurl%s} --duration=%s`,
 		lw.sqlNodes,
 		workloadDuration,
 	))


### PR DESCRIPTION
With https://github.com/cockroachdb/cockroach/commit/df0ef24978c51fb0a183d1ac379c1c48b372235d, the workload binary may not include the ledger workload. To fix this, this change specifies the `data-loader` for the workload. See https://github.com/cockroachdb/cockroach/issues/94136 for more info.

Informs: https://github.com/cockroachdb/cockroach/issues/94038
Epic: None