### PR TITLE
changefeedccl: Re-enable schema changes with CDC expressions

### DIFF
--- a/pkg/ccl/changefeedccl/cdceval/expr_eval.go
+++ b/pkg/ccl/changefeedccl/cdceval/expr_eval.go
@@ -283,11 +283,7 @@ func (e *familyEvaluator) preparePlan(
 			}
 
 			plan, err = sql.PlanCDCExpression(ctx, execCtx, e.norm.SelectStatementForFamily(), opts...)
-
-			if err != nil {
-				return err
-			}
-			return nil
+			return err
 		},
 	)
 	if err != nil {

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -877,10 +877,9 @@ func logSanitizedChangefeedDestination(ctx context.Context, destination string) 
 func validateDetailsAndOptions(
 	details jobspb.ChangefeedDetails, opts changefeedbase.StatementOptions,
 ) error {
-	if err := opts.ValidateForCreateChangefeed(); err != nil {
+	if err := opts.ValidateForCreateChangefeed(details.Select != ""); err != nil {
 		return err
 	}
-
 	if opts.HasEndTime() {
 		scanType, err := opts.GetInitialScanType()
 		if err != nil {

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -6861,8 +6861,7 @@ func TestChangefeedPredicateWithSchemaChange(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	skip.UnderRace(t, "takes too long under race")
-	// TODO(#85143): remove this skip.
-	skip.WithIssue(t, 85143)
+	defer TestingSetIncludeParquetMetadata()()
 
 	setupSQL := []string{
 		`CREATE TYPE status AS ENUM ('open', 'closed', 'inactive')`,
@@ -6879,8 +6878,8 @@ func TestChangefeedPredicateWithSchemaChange(t *testing.T) {
 		`INSERT INTO foo (a, b, c, e) VALUES (2, 'two', 'c string', 'open')`,
 	}
 	initialPayload := []string{
-		`foo: [1, "one"]->{"after": {"a": 1, "b": "one", "c": null, "e": "inactive"}}`,
-		`foo: [2, "two"]->{"after": {"a": 2, "b": "two", "c": "c string", "e": "open"}}`,
+		`foo: [1, "one"]->{"a": 1, "b": "one", "c": null, "e": "inactive"}`,
+		`foo: [2, "two"]->{"a": 2, "b": "two", "c": "c string", "e": "open"}`,
 	}
 
 	type testCase struct {
@@ -6975,7 +6974,7 @@ func TestChangefeedPredicateWithSchemaChange(t *testing.T) {
 			createFeedStmt: "CREATE CHANGEFEED AS SELECT a, b, c, e FROM foo",
 			initialPayload: initialPayload,
 			alterStmt:      "ALTER TABLE foo DROP COLUMN c",
-			expectErr:      `column "foo.c" does not exist`,
+			expectErr:      `column "c" does not exist`,
 		},
 		{
 			name:           "drop referenced column filter",
@@ -6984,7 +6983,7 @@ func TestChangefeedPredicateWithSchemaChange(t *testing.T) {
 				`foo: [2, "two"]->{"a": 2, "b": "two", "c": "c string", "e": "open"}`,
 			},
 			alterStmt: "ALTER TABLE foo DROP COLUMN c",
-			expectErr: `column "foo.c" does not exist`,
+			expectErr: `column "c" does not exist`,
 		},
 		{
 			name:           "rename referenced column projection",
@@ -6992,7 +6991,7 @@ func TestChangefeedPredicateWithSchemaChange(t *testing.T) {
 			initialPayload: initialPayload,
 			alterStmt:      "ALTER TABLE foo RENAME COLUMN c TO c_new",
 			afterAlterStmt: "INSERT INTO foo (a, b) VALUES (3, 'tres')",
-			expectErr:      `column "foo.c" does not exist`,
+			expectErr:      `column "c" does not exist`,
 		},
 		{
 			name:           "rename referenced column filter",
@@ -7002,7 +7001,7 @@ func TestChangefeedPredicateWithSchemaChange(t *testing.T) {
 			},
 			alterStmt:      "ALTER TABLE foo RENAME COLUMN c TO c_new",
 			afterAlterStmt: "INSERT INTO foo (a, b) VALUES (3, 'tres')",
-			expectErr:      `column "foo.c" does not exist`,
+			expectErr:      `column "c" does not exist`,
 		},
 		{
 			name:           "alter enum",
@@ -7018,7 +7017,7 @@ func TestChangefeedPredicateWithSchemaChange(t *testing.T) {
 			name:           "alter enum value fails",
 			createFeedStmt: "CREATE CHANGEFEED AS SELECT * FROM foo WHERE e = 'open'",
 			initialPayload: []string{
-				`foo: [2, "two"]->{"after": {"a": 2, "b": "two", "c": "c string", "e": "open"}}`,
+				`foo: [2, "two"]->{"a": 2, "b": "two", "c": "c string", "e": "open"}`,
 			},
 			alterStmt:      "ALTER TYPE status RENAME VALUE 'open' TO 'active'",
 			afterAlterStmt: "INSERT INTO foo (a, b, e) VALUES (3, 'tres', 'active')",
@@ -7036,6 +7035,39 @@ func TestChangefeedPredicateWithSchemaChange(t *testing.T) {
 			payload: []string{
 				`foo: [1, "one"]->{"e": "done", "prev_e": "inactive"}`,
 			},
+		},
+		{
+			// Alter and rename a column. The changefeed expression does not
+			// explicitly involve the column in question (c) -- so, schema change works
+			// fine. Note: we get 2 backfill events -- one for each logical change
+			// (rename column, then add column).
+			name:           "add and rename column",
+			createFeedStmt: "CREATE CHANGEFEED AS SELECT *, (cdc_prev).e as old_e FROM foo",
+			initialPayload: []string{
+				`foo: [1, "one"]->{"a": 1, "b": "one", "c": null, "e": "inactive", "old_e": null}`,
+				`foo: [2, "two"]->{"a": 2, "b": "two", "c": "c string", "e": "open", "old_e": null}`,
+			},
+			alterStmt: "ALTER TABLE foo RENAME COLUMN c to c_old, ADD COLUMN c int DEFAULT 42",
+			payload: []string{
+				`foo: [1, "one"]->{"a": 1, "b": "one", "c": 42, "c_old": null, "e": "inactive", "old_e": "inactive"}`,
+				`foo: [1, "one"]->{"a": 1, "b": "one", "c_old": null, "e": "inactive", "old_e": "inactive"}`,
+				`foo: [2, "two"]->{"a": 2, "b": "two", "c": 42, "c_old": "c string", "e": "open", "old_e": "open"}`,
+				`foo: [2, "two"]->{"a": 2, "b": "two", "c_old": "c string", "e": "open", "old_e": "open"}`,
+			},
+		},
+		{
+			// Alter and rename a column. The changefeed expression does
+			// explicitly involve the column in question (c) -- so we expect
+			// to get an error because as soon as the first rename goes through, column
+			// no longer exists.
+			name:           "add and rename column error",
+			createFeedStmt: "CREATE CHANGEFEED AS SELECT c, (cdc_prev).c AS prev_c FROM foo",
+			initialPayload: []string{
+				`foo: [1, "one"]->{"c": null, "prev_c": null}`,
+				`foo: [2, "two"]->{"c": "c string", "prev_c": null}`,
+			},
+			alterStmt: "ALTER TABLE foo RENAME COLUMN c to c_old, ADD COLUMN c int DEFAULT 42",
+			expectErr: `column "c" does not exist`,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/ccl/changefeedccl/changefeedbase/options_test.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options_test.go
@@ -21,22 +21,32 @@ func TestOptionsValidations(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	require.NoError(t, MakeDefaultOptions().ValidateForCreateChangefeed(),
+	require.NoError(t, MakeDefaultOptions().ValidateForCreateChangefeed(false),
+		"Default options should be valid")
+	require.NoError(t, MakeDefaultOptions().ValidateForCreateChangefeed(true),
 		"Default options should be valid")
 
 	tests := []struct {
-		input map[string]string
-		err   string
+		input     map[string]string
+		isPred    bool
+		expectErr string
 	}{
-		{map[string]string{"format": "txt"}, "unknown format"},
-		{map[string]string{"initial_scan": "", "no_initial_scan": ""}, "cannot specify both"},
+		{map[string]string{"format": "txt"}, false, "unknown format"},
+		{map[string]string{"initial_scan": "", "no_initial_scan": ""}, false, "cannot specify both"},
+		{map[string]string{"diff": "", "format": "parquet"}, false, "cannot specify both"},
+		{map[string]string{"format": "txt"}, true, "unknown format"},
+		{map[string]string{"initial_scan": "", "no_initial_scan": ""}, true, "cannot specify both"},
+		{map[string]string{"diff": "", "format": "parquet"}, true, ""},
 	}
 
 	for _, test := range tests {
 		o := MakeStatementOptions(test.input)
-		err := o.ValidateForCreateChangefeed()
-		require.Error(t, err, fmt.Sprintf("%v should not be valid", test.input))
-		require.Contains(t, err.Error(), test.err)
+		err := o.ValidateForCreateChangefeed(test.isPred)
+		if test.expectErr == "" {
+			require.NoError(t, err)
+		} else {
+			require.Error(t, err, fmt.Sprintf("%v should not be valid", test.input))
+			require.Contains(t, err.Error(), test.expectErr)
+		}
 	}
-
 }

--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -332,7 +332,7 @@ func runPlanInsidePlan(
 	planCtx.stmtType = recv.stmtType
 
 	params.p.extendedEvalCtx.ExecCfg.DistSQLPlanner.PlanAndRun(
-		ctx, evalCtx, planCtx, params.p.Txn(), plan.main, recv,
+		ctx, evalCtx, planCtx, params.p.Txn(), plan.main, recv, nil, /* finishedSetupFn */
 	)
 	return resultWriter.Err()
 }

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -757,8 +757,13 @@ type PlanningCtx struct {
 	infra *physicalplan.PhysicalInfrastructure
 
 	// isLocal is set to true if we're planning this query on a single node.
-	isLocal  bool
-	planner  *planner
+	isLocal bool
+	planner *planner
+
+	// usePlannerDescriptorsForLocalFlow may be set to true to force
+	// planner.Descriptors() use for local flows.
+	usePlannerDescriptorsForLocalFlow bool
+
 	stmtType tree.StatementReturnType
 	// planDepth is set to the current depth of the planNode tree. It's used to
 	// keep track of whether it's valid to run a root node in a special fast path

--- a/pkg/sql/distsql_plan_changefeed.go
+++ b/pkg/sql/distsql_plan_changefeed.go
@@ -191,10 +191,22 @@ func RunCDCEvaluation(
 		return err
 	}
 
-	// Execute.
+	// Execute the flow.  Force the use of planner descriptor cache when setting
+	// up this local flow.  This is necessary so that as soon as the local flow
+	// setup completes, and all descriptors have been resolved (including leases
+	// for user defined types), we can release those descriptors. If we don't,
+	// then the descriptor leases acquired will be held for the
+	// DefaultDescriptorLeaseDuration (5 minutes), blocking potential schema
+	// changes.
+	cdcPlan.PlanCtx.usePlannerDescriptorsForLocalFlow = true
 	p := cdcPlan.PlanCtx.planner
+	finishedSetupFn := func() {
+		p.Descriptors().ReleaseAll(ctx)
+	}
+
 	p.DistSQLPlanner().PlanAndRun(
-		ctx, &p.extendedEvalCtx, cdcPlan.PlanCtx, p.txn, cdcPlan.Plan, receiver)
+		ctx, &p.extendedEvalCtx, cdcPlan.PlanCtx, p.txn, cdcPlan.Plan, receiver, finishedSetupFn,
+	)
 	return nil
 }
 

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -181,7 +181,7 @@ func TestDistSQLRunningInAbortedTxn(t *testing.T) {
 		planCtx.stmtType = recv.stmtType
 
 		execCfg.DistSQLPlanner.PlanAndRun(
-			ctx, evalCtx, planCtx, txn, p.curPlan.main, recv,
+			ctx, evalCtx, planCtx, txn, p.curPlan.main, recv, nil, /* finishedSetupFn */
 		)
 		return rw.Err()
 	})

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -156,7 +156,7 @@ func (dsp *DistSQLPlanner) Exec(
 		distributionType)
 	planCtx.stmtType = recv.stmtType
 
-	dsp.PlanAndRun(ctx, evalCtx, planCtx, p.txn, p.curPlan.main, recv)
+	dsp.PlanAndRun(ctx, evalCtx, planCtx, p.txn, p.curPlan.main, recv, nil /* finishedSetupFn */)
 	return rw.Err()
 }
 


### PR DESCRIPTION
Stop requiring `schema_change_policy=stop` when running
changefeeds with predicates.

Fixes https://github.com/cockroachdb/cockroach/issues/84767
Epic: [CRDB-17161](https://cockroachlabs.atlassian.net/browse/CRDB-17161)

Release note (enterprise change): Changefeed transformations
(`CREATE CHANGEFEED ... AS SELECT ...`) no longer require
`schema_change_policy=stop` option.
