### PR TITLE
colserde: perform memory accounting for scratch slices in the converter

### DIFF
--- a/pkg/col/colserde/BUILD.bazel
+++ b/pkg/col/colserde/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
         "//pkg/util/duration",
+        "//pkg/util/mon",
         "@com_github_apache_arrow_go_arrow//array",
         "@com_github_apache_arrow_go_arrow//memory",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/col/colserde/file_test.go
+++ b/pkg/col/colserde/file_test.go
@@ -12,6 +12,7 @@ package colserde_test
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -30,6 +31,7 @@ func TestFileRoundtrip(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	typs, b := randomBatch(testAllocator)
 	rng, _ := randutil.NewTestRand()
+	ctx := context.Background()
 
 	t.Run(`mem`, func(t *testing.T) {
 		// Make copies of the original batch because the converter modifies and
@@ -38,12 +40,13 @@ func TestFileRoundtrip(t *testing.T) {
 		bCopy := coldatatestutils.CopyBatch(b, typs, testColumnFactory)
 
 		var buf bytes.Buffer
-		s, err := colserde.NewFileSerializer(&buf, typs)
+		s, err := colserde.NewFileSerializer(&buf, typs, testMemAcc)
 		require.NoError(t, err)
-		require.NoError(t, s.AppendBatch(b))
+		require.NoError(t, s.AppendBatch(ctx, b))
 		// Append the same batch again.
-		require.NoError(t, s.AppendBatch(bCopy))
+		require.NoError(t, s.AppendBatch(ctx, bCopy))
 		require.NoError(t, s.Finish())
+		s.Close(ctx)
 
 		// Parts of the deserialization modify things (null bitmaps) in place, so
 		// run it twice to make sure those modifications don't leak back to the
@@ -53,7 +56,7 @@ func TestFileRoundtrip(t *testing.T) {
 				roundtrip := testAllocator.NewMemBatchWithFixedCapacity(typs, b.Length())
 				d, err := colserde.NewFileDeserializerFromBytes(typs, buf.Bytes())
 				require.NoError(t, err)
-				defer func() { require.NoError(t, d.Close()) }()
+				defer func() { require.NoError(t, d.Close(ctx)) }()
 				require.Equal(t, typs, d.Typs())
 				require.Equal(t, 2, d.NumBatches())
 
@@ -95,10 +98,11 @@ func TestFileRoundtrip(t *testing.T) {
 		f, err := os.Create(path)
 		require.NoError(t, err)
 		defer func() { require.NoError(t, f.Close()) }()
-		s, err := colserde.NewFileSerializer(f, typs)
+		s, err := colserde.NewFileSerializer(f, typs, testMemAcc)
 		require.NoError(t, err)
-		require.NoError(t, s.AppendBatch(b))
+		require.NoError(t, s.AppendBatch(ctx, b))
 		require.NoError(t, s.Finish())
+		s.Close(ctx)
 		require.NoError(t, f.Sync())
 
 		// Parts of the deserialization modify things (null bitmaps) in place, so
@@ -109,7 +113,7 @@ func TestFileRoundtrip(t *testing.T) {
 				roundtrip := testAllocator.NewMemBatchWithFixedCapacity(typs, b.Length())
 				d, err := colserde.NewTestFileDeserializerFromPath(typs, path)
 				require.NoError(t, err)
-				defer func() { require.NoError(t, d.Close()) }()
+				defer func() { require.NoError(t, d.Close(ctx)) }()
 				require.Equal(t, typs, d.Typs())
 				require.Equal(t, 1, d.NumBatches())
 				require.NoError(t, d.GetBatch(0, roundtrip))
@@ -123,25 +127,26 @@ func TestFileRoundtrip(t *testing.T) {
 func TestFileIndexing(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	ctx := context.Background()
 	const numInts = 10
 	typs := []*types.T{types.Int}
 	batchSize := 1
 
 	var buf bytes.Buffer
-	s, err := colserde.NewFileSerializer(&buf, typs)
+	s, err := colserde.NewFileSerializer(&buf, typs, testMemAcc)
 	require.NoError(t, err)
 
 	for i := 0; i < numInts; i++ {
 		b := testAllocator.NewMemBatchWithFixedCapacity(typs, batchSize)
 		b.SetLength(batchSize)
 		b.ColVec(0).Int64()[0] = int64(i)
-		require.NoError(t, s.AppendBatch(b))
+		require.NoError(t, s.AppendBatch(ctx, b))
 	}
 	require.NoError(t, s.Finish())
 
 	d, err := colserde.NewFileDeserializerFromBytes(typs, buf.Bytes())
 	require.NoError(t, err)
-	defer func() { require.NoError(t, d.Close()) }()
+	defer func() { require.NoError(t, d.Close(ctx)) }()
 	require.Equal(t, typs, d.Typs())
 	require.Equal(t, numInts, d.NumBatches())
 	for batchIdx := numInts - 1; batchIdx >= 0; batchIdx-- {

--- a/pkg/col/colserde/record_batch_test.go
+++ b/pkg/col/colserde/record_batch_test.go
@@ -12,6 +12,7 @@ package colserde_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"fmt"
 	"math"
@@ -346,8 +347,9 @@ func TestRecordBatchSerializerDeserializeMemoryEstimate(t *testing.T) {
 	}
 	src.SetLength(coldata.BatchSize())
 
-	c, err := colserde.NewArrowBatchConverter(typs, colserde.BiDirectional)
+	c, err := colserde.NewArrowBatchConverter(typs, colserde.BiDirectional, testMemAcc)
 	require.NoError(t, err)
+	defer c.Release(context.Background())
 	r, err := colserde.NewRecordBatchSerializer(typs)
 	require.NoError(t, err)
 	require.NoError(t, roundTripBatch(src, dest, c, r))

--- a/pkg/sql/colcontainer/diskqueue.go
+++ b/pkg/sql/colcontainer/diskqueue.go
@@ -192,7 +192,8 @@ type diskQueue struct {
 	readFile                     fs.File
 	scratchDecompressedReadBytes []byte
 
-	diskAcc *mon.BoundAccount
+	diskAcc         *mon.BoundAccount
+	converterMemAcc *mon.BoundAccount
 }
 
 var _ RewindableQueue = &diskQueue{}
@@ -225,7 +226,7 @@ type RewindableQueue interface {
 	Queue
 	// Rewind resets the Queue so that it Dequeues all Enqueued batches from the
 	// start.
-	Rewind() error
+	Rewind(context.Context) error
 }
 
 const (
@@ -361,16 +362,24 @@ func (cfg *DiskQueueCfg) setDefaultBufferSizeBytesForCacheMode() {
 
 // NewDiskQueue creates a Queue that spills to disk.
 func NewDiskQueue(
-	ctx context.Context, typs []*types.T, cfg DiskQueueCfg, diskAcc *mon.BoundAccount,
+	ctx context.Context,
+	typs []*types.T,
+	cfg DiskQueueCfg,
+	diskAcc *mon.BoundAccount,
+	converterMemAcc *mon.BoundAccount,
 ) (Queue, error) {
-	return newDiskQueue(ctx, typs, cfg, diskAcc)
+	return newDiskQueue(ctx, typs, cfg, diskAcc, converterMemAcc)
 }
 
 // NewRewindableDiskQueue creates a RewindableQueue that spills to disk.
 func NewRewindableDiskQueue(
-	ctx context.Context, typs []*types.T, cfg DiskQueueCfg, diskAcc *mon.BoundAccount,
+	ctx context.Context,
+	typs []*types.T,
+	cfg DiskQueueCfg,
+	diskAcc *mon.BoundAccount,
+	converterMemAcc *mon.BoundAccount,
 ) (RewindableQueue, error) {
-	d, err := newDiskQueue(ctx, typs, cfg, diskAcc)
+	d, err := newDiskQueue(ctx, typs, cfg, diskAcc, converterMemAcc)
 	if err != nil {
 		return nil, err
 	}
@@ -379,7 +388,11 @@ func NewRewindableDiskQueue(
 }
 
 func newDiskQueue(
-	ctx context.Context, typs []*types.T, cfg DiskQueueCfg, diskAcc *mon.BoundAccount,
+	ctx context.Context,
+	typs []*types.T,
+	cfg DiskQueueCfg,
+	diskAcc *mon.BoundAccount,
+	converterMemAcc *mon.BoundAccount,
 ) (*diskQueue, error) {
 	if err := cfg.EnsureDefaults(); err != nil {
 		return nil, err
@@ -391,6 +404,7 @@ func newDiskQueue(
 		files:            make([]file, 0, 4),
 		writeBufferLimit: cfg.BufferSizeBytes / 3,
 		diskAcc:          diskAcc,
+		converterMemAcc:  converterMemAcc,
 	}
 	// Refer to the DiskQueueCacheMode comment for why this division of
 	// BufferSizeBytes.
@@ -414,9 +428,9 @@ func (d *diskQueue) CloseRead() error {
 	return nil
 }
 
-func (d *diskQueue) closeFileDeserializer() error {
+func (d *diskQueue) closeFileDeserializer(ctx context.Context) error {
 	if d.deserializerState.FileDeserializer != nil {
-		if err := d.deserializerState.Close(); err != nil {
+		if err := d.deserializerState.Close(ctx); err != nil {
 			return err
 		}
 	}
@@ -436,10 +450,10 @@ func (d *diskQueue) Close(ctx context.Context) error {
 		if err := d.writeFooterAndFlush(ctx); err != nil {
 			return err
 		}
-		d.serializer.Close()
+		d.serializer.Close(ctx)
 		d.serializer = nil
 	}
-	if err := d.closeFileDeserializer(); err != nil {
+	if err := d.closeFileDeserializer(ctx); err != nil {
 		return err
 	}
 	if d.writeFile != nil {
@@ -486,7 +500,7 @@ func (d *diskQueue) rotateFile(ctx context.Context) error {
 
 	if d.serializer == nil {
 		writer := &diskQueueWriter{testingKnobAlwaysCompress: d.cfg.TestingKnobs.AlwaysCompress, wrapped: f}
-		d.serializer, err = colserde.NewFileSerializer(writer, d.typs)
+		d.serializer, err = colserde.NewFileSerializer(writer, d.typs, d.converterMemAcc)
 		if err != nil {
 			return err
 		}
@@ -586,8 +600,9 @@ func (d *diskQueue) Enqueue(ctx context.Context, b coldata.Batch) error {
 		}
 		d.files[d.writeFileIdx].finishedWriting = true
 		d.writeFile = nil
-		// Done with the serializer. Not setting this will cause us to attempt to
-		// flush the serializer on Close.
+		// Done with the serializer - close it and set it to nil. Not setting
+		// this will cause us to attempt to flush the serializer on Close.
+		d.serializer.Close(ctx)
 		d.serializer = nil
 		// The write file will be closed in Close.
 		d.done = true
@@ -601,7 +616,7 @@ func (d *diskQueue) Enqueue(ctx context.Context, b coldata.Batch) error {
 		}
 		return nil
 	}
-	if err := d.serializer.AppendBatch(b); err != nil {
+	if err := d.serializer.AppendBatch(ctx, b); err != nil {
 		return err
 	}
 	d.numBufferedBatches++
@@ -722,7 +737,7 @@ func (d *diskQueue) maybeInitDeserializer(ctx context.Context) (bool, error) {
 	if d.deserializerState.NumBatches() == 0 {
 		// Zero batches to deserialize in this region. This shouldn't happen but we
 		// might as well handle it.
-		if err := d.closeFileDeserializer(); err != nil {
+		if err := d.closeFileDeserializer(ctx); err != nil {
 			return false, err
 		}
 		d.files[d.readFileIdx].curOffsetIdx++
@@ -758,7 +773,7 @@ func (d *diskQueue) Dequeue(ctx context.Context, b coldata.Batch) (bool, error) 
 	if d.deserializerState.FileDeserializer != nil && d.deserializerState.curBatch >= d.deserializerState.NumBatches() {
 		// Finished all the batches, set the deserializer to nil to initialize a new
 		// one to read the next region.
-		if err := d.closeFileDeserializer(); err != nil {
+		if err := d.closeFileDeserializer(ctx); err != nil {
 			return false, err
 		}
 		d.files[d.readFileIdx].curOffsetIdx++
@@ -785,8 +800,8 @@ func (d *diskQueue) Dequeue(ctx context.Context, b coldata.Batch) (bool, error) 
 }
 
 // Rewind is part of the RewindableQueue interface.
-func (d *diskQueue) Rewind() error {
-	if err := d.closeFileDeserializer(); err != nil {
+func (d *diskQueue) Rewind(ctx context.Context) error {
+	if err := d.closeFileDeserializer(ctx); err != nil {
 		return err
 	}
 	if err := d.CloseRead(); err != nil {

--- a/pkg/sql/colcontainer/diskqueue_test.go
+++ b/pkg/sql/colcontainer/diskqueue_test.go
@@ -93,9 +93,9 @@ func TestDiskQueue(t *testing.T) {
 						err error
 					)
 					if rewindable {
-						q, err = colcontainer.NewRewindableDiskQueue(ctx, typs, queueCfg, testDiskAcc)
+						q, err = colcontainer.NewRewindableDiskQueue(ctx, typs, queueCfg, testDiskAcc, testMemAcc)
 					} else {
-						q, err = colcontainer.NewDiskQueue(ctx, typs, queueCfg, testDiskAcc)
+						q, err = colcontainer.NewDiskQueue(ctx, typs, queueCfg, testDiskAcc, testMemAcc)
 					}
 					require.NoError(t, err)
 
@@ -154,7 +154,7 @@ func TestDiskQueue(t *testing.T) {
 						}
 
 						if rewindable {
-							require.NoError(t, q.(colcontainer.RewindableQueue).Rewind())
+							require.NoError(t, q.(colcontainer.RewindableQueue).Rewind(ctx))
 						}
 					}
 
@@ -186,7 +186,7 @@ func TestDiskQueueCloseOnErr(t *testing.T) {
 	defer diskAcc.Close(ctx)
 
 	typs := []*types.T{types.Int}
-	q, err := colcontainer.NewDiskQueue(ctx, typs, queueCfg, &diskAcc)
+	q, err := colcontainer.NewDiskQueue(ctx, typs, queueCfg, &diskAcc, testMemAcc)
 	require.NoError(t, err)
 
 	b := coldata.NewMemBatch(typs, coldata.StandardColumnFactory)
@@ -238,7 +238,7 @@ func BenchmarkDiskQueue(b *testing.B) {
 	ctx := context.Background()
 	for i := 0; i < b.N; i++ {
 		op.ResetBatchesToReturn(numBatches)
-		q, err := colcontainer.NewDiskQueue(ctx, typs, queueCfg, testDiskAcc)
+		q, err := colcontainer.NewDiskQueue(ctx, typs, queueCfg, testDiskAcc, testMemAcc)
 		require.NoError(b, err)
 		for {
 			batchToEnqueue := op.Next()

--- a/pkg/sql/colcontainer/partitionedqueue_test.go
+++ b/pkg/sql/colcontainer/partitionedqueue_test.go
@@ -113,7 +113,7 @@ func TestPartitionedDiskQueue(t *testing.T) {
 	queueCfg.FS = countingFS
 
 	t.Run("ReopenReadPartition", func(t *testing.T) {
-		p := colcontainer.NewPartitionedDiskQueue(typs, queueCfg, sem, colcontainer.PartitionerStrategyDefault, testDiskAcc)
+		p := colcontainer.NewPartitionedDiskQueue(typs, queueCfg, sem, colcontainer.PartitionerStrategyDefault, testDiskAcc, testMemAcc)
 
 		countingFS.assertOpenFDs(t, sem, 0, 0)
 		require.NoError(t, p.Enqueue(ctx, 0, batch))
@@ -177,7 +177,7 @@ func TestPartitionedDiskQueueSimulatedExternal(t *testing.T) {
 		// new partition being written to when closedForWrites from maxPartitions
 		// and writing the merged result to a single new partition.
 		sem := colexecop.NewTestingSemaphore(maxPartitions + 1)
-		p := colcontainer.NewPartitionedDiskQueue(typs, queueCfg, sem, colcontainer.PartitionerStrategyCloseOnNewPartition, testDiskAcc)
+		p := colcontainer.NewPartitionedDiskQueue(typs, queueCfg, sem, colcontainer.PartitionerStrategyCloseOnNewPartition, testDiskAcc, testMemAcc)
 
 		// Define sortRepartition to be able to call this helper function
 		// recursively.
@@ -256,7 +256,7 @@ func TestPartitionedDiskQueueSimulatedExternal(t *testing.T) {
 		// number of partitions partitioned to and 2 represents the file descriptors
 		// for the left and right side in the case of a repartition.
 		sem := colexecop.NewTestingSemaphore(maxPartitions + 2)
-		p := colcontainer.NewPartitionedDiskQueue(typs, queueCfg, sem, colcontainer.PartitionerStrategyDefault, testDiskAcc)
+		p := colcontainer.NewPartitionedDiskQueue(typs, queueCfg, sem, colcontainer.PartitionerStrategyDefault, testDiskAcc, testMemAcc)
 
 		// joinRepartition will perform the partitioning that happens during a hash
 		// join. expectedRepartitionReadFDs are the read file descriptors that are

--- a/pkg/sql/colexec/colexecdisk/external_distinct.go
+++ b/pkg/sql/colexec/colexecdisk/external_distinct.go
@@ -36,6 +36,7 @@ func NewExternalDistinct(
 	createDiskBackedSorter DiskBackedSorterConstructor,
 	inMemUnorderedDistinct colexecop.Operator,
 	diskAcc *mon.BoundAccount,
+	converterMemAcc *mon.BoundAccount,
 ) (colexecop.Operator, colexecop.Closer) {
 	distinctSpec := args.Spec.Core.Distinct
 	distinctCols := distinctSpec.DistinctColumns
@@ -99,6 +100,7 @@ func NewExternalDistinct(
 		inMemMainOpConstructor,
 		diskBackedFallbackOpConstructor,
 		diskAcc,
+		converterMemAcc,
 		numRequiredActivePartitions,
 	)
 	// The last thing we need to do is making sure that the output has the

--- a/pkg/sql/colexec/colexecdisk/external_hash_aggregator.go
+++ b/pkg/sql/colexec/colexecdisk/external_hash_aggregator.go
@@ -40,6 +40,7 @@ func NewExternalHashAggregator(
 	newHashAggArgs *colexecagg.NewHashAggregatorArgs,
 	createDiskBackedSorter DiskBackedSorterConstructor,
 	diskAcc *mon.BoundAccount,
+	converterMemAcc *mon.BoundAccount,
 	outputOrdering execinfrapb.Ordering,
 ) (colexecop.Operator, colexecop.Closer) {
 	inMemMainOpConstructor := func(partitionedInputs []*partitionerToOperator) colexecop.ResettableOperator {
@@ -77,6 +78,7 @@ func NewExternalHashAggregator(
 		inMemMainOpConstructor,
 		diskBackedFallbackOpConstructor,
 		diskAcc,
+		converterMemAcc,
 		ehaNumRequiredActivePartitions,
 	)
 	// The last thing we need to do is making sure that the output has the

--- a/pkg/sql/colexec/colexecdisk/external_hash_joiner.go
+++ b/pkg/sql/colexec/colexecdisk/external_hash_joiner.go
@@ -68,6 +68,7 @@ func NewExternalHashJoiner(
 	leftInput, rightInput colexecop.Operator,
 	createDiskBackedSorter DiskBackedSorterConstructor,
 	diskAcc *mon.BoundAccount,
+	converterMemAcc *mon.BoundAccount,
 ) colexecop.ClosableOperator {
 	// This memory limit will restrict the size of the batches output by the
 	// in-memory hash joiner in the main strategy as well as by the merge joiner
@@ -115,7 +116,7 @@ func NewExternalHashJoiner(
 		return colexecjoin.NewMergeJoinOp(
 			unlimitedAllocator, memoryLimit, args.DiskQueueCfg, fdSemaphore, spec.JoinType,
 			leftPartitionSorter, rightPartitionSorter, spec.Left.SourceTypes,
-			spec.Right.SourceTypes, leftOrdering, rightOrdering, diskAcc, flowCtx.EvalCtx,
+			spec.Right.SourceTypes, leftOrdering, rightOrdering, diskAcc, converterMemAcc, flowCtx.EvalCtx,
 		)
 	}
 	return newHashBasedPartitioner(
@@ -129,6 +130,7 @@ func NewExternalHashJoiner(
 		inMemMainOpConstructor,
 		diskBackedFallbackOpConstructor,
 		diskAcc,
+		converterMemAcc,
 		colexecop.ExternalHJMinPartitions,
 	)
 }

--- a/pkg/sql/colexec/colexecdisk/external_sort.go
+++ b/pkg/sql/colexec/colexecdisk/external_sort.go
@@ -235,6 +235,7 @@ func NewExternalSorter(
 	diskQueueCfg colcontainer.DiskQueueCfg,
 	fdSemaphore semaphore.Semaphore,
 	diskAcc *mon.BoundAccount,
+	converterMemAcc *mon.BoundAccount,
 	testingVecFDsToAcquire int,
 ) colexecop.Operator {
 	if diskQueueCfg.BufferSizeBytes > 0 && maxNumberPartitions == 0 {
@@ -303,7 +304,10 @@ func NewExternalSorter(
 		inMemSorter:              inMemSorter,
 		inMemSorterInput:         inputPartitioner.(*inputPartitioningOperator),
 		partitionerCreator: func() colcontainer.PartitionedQueue {
-			return colcontainer.NewPartitionedDiskQueue(inputTypes, diskQueueCfg, partitionedDiskQueueSemaphore, colcontainer.PartitionerStrategyCloseOnNewPartition, diskAcc)
+			return colcontainer.NewPartitionedDiskQueue(
+				inputTypes, diskQueueCfg, partitionedDiskQueueSemaphore,
+				colcontainer.PartitionerStrategyCloseOnNewPartition, diskAcc, converterMemAcc,
+			)
 		},
 		inputTypes:           inputTypes,
 		ordering:             ordering,

--- a/pkg/sql/colexec/colexecdisk/hash_based_partitioner.go
+++ b/pkg/sql/colexec/colexecdisk/hash_based_partitioner.go
@@ -228,6 +228,7 @@ func newHashBasedPartitioner(
 		fdSemaphore semaphore.Semaphore,
 	) colexecop.ResettableOperator,
 	diskAcc *mon.BoundAccount,
+	converterMemAcc *mon.BoundAccount,
 	numRequiredActivePartitions int,
 ) *hashBasedPartitioner {
 	// Make a copy of the DiskQueueCfg and set defaults for the partitioning
@@ -248,7 +249,8 @@ func newHashBasedPartitioner(
 	partitionedInputs := make([]*partitionerToOperator, numInputs)
 	for i := range inputs {
 		partitioners[i] = colcontainer.NewPartitionedDiskQueue(
-			inputTypes[i], diskQueueCfg, partitionedDiskQueueSemaphore, colcontainer.PartitionerStrategyDefault, diskAcc,
+			inputTypes[i], diskQueueCfg, partitionedDiskQueueSemaphore,
+			colcontainer.PartitionerStrategyDefault, diskAcc, converterMemAcc,
 		)
 		partitionedInputs[i] = newPartitionerToOperator(
 			unlimitedAllocator, inputTypes[i], partitioners[i],

--- a/pkg/sql/colexec/colexecjoin/crossjoiner.eg.go
+++ b/pkg/sql/colexec/colexecjoin/crossjoiner.eg.go
@@ -1699,7 +1699,7 @@ func (b *crossJoinerBase) buildFromRightInput(ctx context.Context, destStartIdx 
 				}
 				// We have fully processed all the batches from the right side,
 				// so we need to Rewind the queue.
-				if err := b.rightTuples.Rewind(); err != nil {
+				if err := b.rightTuples.Rewind(ctx); err != nil {
 					colexecerror.InternalError(err)
 				}
 				bs.currentBatch = nil

--- a/pkg/sql/colexec/colexecjoin/crossjoiner.go
+++ b/pkg/sql/colexec/colexecjoin/crossjoiner.go
@@ -39,6 +39,7 @@ func NewCrossJoiner(
 	leftTypes []*types.T,
 	rightTypes []*types.T,
 	diskAcc *mon.BoundAccount,
+	converterMemAcc *mon.BoundAccount,
 ) colexecop.ClosableOperator {
 	c := &crossJoiner{
 		crossJoinerBase: newCrossJoinerBase(
@@ -50,6 +51,7 @@ func NewCrossJoiner(
 			diskQueueCfg,
 			fdSemaphore,
 			diskAcc,
+			converterMemAcc,
 		),
 		TwoInputInitHelper: colexecop.MakeTwoInputInitHelper(left, right),
 		outputTypes:        joinType.MakeOutputTypes(leftTypes, rightTypes),
@@ -303,6 +305,7 @@ func newCrossJoinerBase(
 	cfg colcontainer.DiskQueueCfg,
 	fdSemaphore semaphore.Semaphore,
 	diskAcc *mon.BoundAccount,
+	converterMemAcc *mon.BoundAccount,
 ) *crossJoinerBase {
 	base := &crossJoinerBase{
 		joinType: joinType,
@@ -324,6 +327,7 @@ func newCrossJoinerBase(
 				DiskQueueCfg:       cfg,
 				FDSemaphore:        fdSemaphore,
 				DiskAcc:            diskAcc,
+				ConverterMemAcc:    converterMemAcc,
 			},
 		),
 	}

--- a/pkg/sql/colexec/colexecjoin/crossjoiner_tmpl.go
+++ b/pkg/sql/colexec/colexecjoin/crossjoiner_tmpl.go
@@ -294,7 +294,7 @@ func (b *crossJoinerBase) buildFromRightInput(ctx context.Context, destStartIdx 
 				}
 				// We have fully processed all the batches from the right side,
 				// so we need to Rewind the queue.
-				if err := b.rightTuples.Rewind(); err != nil {
+				if err := b.rightTuples.Rewind(ctx); err != nil {
 					colexecerror.InternalError(err)
 				}
 				bs.currentBatch = nil

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_test.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_test.go
@@ -101,7 +101,7 @@ func TestMergeJoinCrossProduct(t *testing.T) {
 		leftMJSource, rightMJSource, typs, typs,
 		[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 		[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
-		testDiskAcc, evalCtx,
+		testDiskAcc, testMemAcc, evalCtx,
 	)
 	mj.Init(ctx)
 	hj := NewHashJoiner(NewHashJoinerArgs{
@@ -195,7 +195,7 @@ func BenchmarkMergeJoiner(b *testing.B) {
 			descpb.InnerJoin, leftSource, rightSource, sourceTypes, sourceTypes,
 			[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 			[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
-			testDiskAcc,
+			testDiskAcc, testMemAcc,
 		)
 		return &mergeJoinInnerOp{mergeJoinBase: base}
 	}

--- a/pkg/sql/colexec/colexecutils/spilling_buffer.go
+++ b/pkg/sql/colexec/colexecutils/spilling_buffer.go
@@ -57,10 +57,11 @@ type SpillingBuffer struct {
 	// because it only provides a window into input data after disk spilling.
 	scratch coldata.Batch
 
-	diskQueueCfg colcontainer.DiskQueueCfg
-	diskQueue    colcontainer.RewindableQueue
-	fdSemaphore  semaphore.Semaphore
-	diskAcc      *mon.BoundAccount
+	diskQueueCfg    colcontainer.DiskQueueCfg
+	diskQueue       colcontainer.RewindableQueue
+	fdSemaphore     semaphore.Semaphore
+	diskAcc         *mon.BoundAccount
+	converterMemAcc *mon.BoundAccount
 
 	dequeueScratch            coldata.Batch
 	lastDequeuedBatchMemUsage int64
@@ -103,6 +104,7 @@ func NewSpillingBuffer(
 	fdSemaphore semaphore.Semaphore,
 	inputTypes []*types.T,
 	diskAcc *mon.BoundAccount,
+	converterMemAcc *mon.BoundAccount,
 	colIdxs ...int,
 ) *SpillingBuffer {
 	if colIdxs == nil {
@@ -136,6 +138,7 @@ func NewSpillingBuffer(
 		diskQueueCfg:       diskQueueCfg,
 		fdSemaphore:        fdSemaphore,
 		diskAcc:            diskAcc,
+		converterMemAcc:    converterMemAcc,
 	}
 }
 
@@ -179,7 +182,8 @@ func (b *SpillingBuffer) AppendTuples(
 			}
 		}
 		if b.diskQueue, err = colcontainer.NewRewindableDiskQueue(
-			ctx, b.storedTypes, b.diskQueueCfg, b.diskAcc); err != nil {
+			ctx, b.storedTypes, b.diskQueueCfg, b.diskAcc, b.converterMemAcc,
+		); err != nil {
 			colexecerror.InternalError(err)
 		}
 		log.VEvent(ctx, 1, "spilled to disk")
@@ -240,7 +244,7 @@ func (b *SpillingBuffer) GetVecWithTuple(
 		// The idx'th tuple is located before the current head of the queue, so we
 		// need to rewind. TODO(drewk): look for a more efficient way to handle
 		// spilling.
-		if err = b.diskQueue.Rewind(); err != nil {
+		if err = b.diskQueue.Rewind(ctx); err != nil {
 			colexecerror.InternalError(err)
 		}
 		b.numDequeued = 0

--- a/pkg/sql/colexec/colexecutils/spilling_buffer_test.go
+++ b/pkg/sql/colexec/colexecutils/spilling_buffer_test.go
@@ -120,7 +120,7 @@ func TestSpillingBuffer(t *testing.T) {
 		// Create buffer.
 		buf := NewSpillingBuffer(
 			spillingQueueUnlimitedAllocator, memoryLimit, queueCfg,
-			colexecop.NewTestingSemaphore(2), typs, testDiskAcc, colsToStore...,
+			colexecop.NewTestingSemaphore(2), typs, testDiskAcc, testMemAcc, colsToStore...,
 		)
 		if setInMemTuplesLimit {
 			buf.testingKnobs.maxTuplesStoredInMemory = numBatches * inputBatchSize / 2

--- a/pkg/sql/colexec/colexecutils/spilling_queue_test.go
+++ b/pkg/sql/colexec/colexecutils/spilling_queue_test.go
@@ -127,6 +127,7 @@ func TestSpillingQueue(t *testing.T) {
 						DiskQueueCfg:       queueCfg,
 						FDSemaphore:        colexecop.NewTestingSemaphore(2),
 						DiskAcc:            testDiskAcc,
+						ConverterMemAcc:    testMemAcc,
 					},
 				)
 			} else {
@@ -138,6 +139,7 @@ func TestSpillingQueue(t *testing.T) {
 						DiskQueueCfg:       queueCfg,
 						FDSemaphore:        colexecop.NewTestingSemaphore(2),
 						DiskAcc:            testDiskAcc,
+						ConverterMemAcc:    testMemAcc,
 					},
 				)
 			}
@@ -227,7 +229,7 @@ func TestSpillingQueue(t *testing.T) {
 				}
 
 				if rewindable {
-					require.NoError(t, q.Rewind())
+					require.NoError(t, q.Rewind(ctx))
 					numAlreadyDequeuedTuples = numDequeuedTuplesBeforeReading
 					dequeuedBatches = dequeuedBatches[:numDequeuedBatchesBeforeReading]
 					dequeuedBatchLengths = dequeuedBatchLengths[:numDequeuedBatchesBeforeReading]
@@ -294,6 +296,7 @@ func TestSpillingQueueDidntSpill(t *testing.T) {
 			DiskQueueCfg:       queueCfg,
 			FDSemaphore:        colexecop.NewTestingSemaphore(2),
 			DiskAcc:            testDiskAcc,
+			ConverterMemAcc:    testMemAcc,
 		},
 	)
 
@@ -360,6 +363,7 @@ func TestSpillingQueueMemoryAccounting(t *testing.T) {
 				DiskQueueCfg:       queueCfg,
 				FDSemaphore:        colexecop.NewTestingSemaphore(2),
 				DiskAcc:            testDiskAcc,
+				ConverterMemAcc:    testMemAcc,
 			}
 			var q *SpillingQueue
 			if rewindable {
@@ -464,6 +468,7 @@ func TestSpillingQueueMovingTailWhenSpilling(t *testing.T) {
 			DiskQueueCfg:       queueCfg,
 			FDSemaphore:        colexecop.NewTestingSemaphore(2),
 			DiskAcc:            testDiskAcc,
+			ConverterMemAcc:    testMemAcc,
 		}
 		q := NewSpillingQueue(newQueueArgs)
 

--- a/pkg/sql/colexec/colexecwindow/buffered_window.go
+++ b/pkg/sql/colexec/colexecwindow/buffered_window.go
@@ -41,14 +41,15 @@ func newBufferedWindowOperator(
 	queueCfg.SetCacheMode(colcontainer.DiskQueueCacheModeIntertwinedCalls)
 	return &bufferedWindowOp{
 		windowInitFields: windowInitFields{
-			OneInputNode: colexecop.NewOneInputNode(input),
-			allocator:    args.MainAllocator,
-			memoryLimit:  memoryLimit,
-			diskQueueCfg: queueCfg,
-			fdSemaphore:  args.FdSemaphore,
-			outputTypes:  outputTypes,
-			diskAcc:      args.DiskAcc,
-			outputColIdx: args.OutputColIdx,
+			OneInputNode:    colexecop.NewOneInputNode(input),
+			allocator:       args.MainAllocator,
+			memoryLimit:     memoryLimit,
+			diskQueueCfg:    queueCfg,
+			fdSemaphore:     args.FdSemaphore,
+			outputTypes:     outputTypes,
+			diskAcc:         args.DiskAcc,
+			converterMemAcc: args.ConverterMemAcc,
+			outputColIdx:    args.OutputColIdx,
 		},
 		windower: windower,
 	}
@@ -143,13 +144,14 @@ type windowInitFields struct {
 	colexecop.OneInputNode
 	colexecop.InitHelper
 
-	allocator    *colmem.Allocator
-	memoryLimit  int64
-	diskQueueCfg colcontainer.DiskQueueCfg
-	fdSemaphore  semaphore.Semaphore
-	outputTypes  []*types.T
-	diskAcc      *mon.BoundAccount
-	outputColIdx int
+	allocator       *colmem.Allocator
+	memoryLimit     int64
+	diskQueueCfg    colcontainer.DiskQueueCfg
+	fdSemaphore     semaphore.Semaphore
+	outputTypes     []*types.T
+	diskAcc         *mon.BoundAccount
+	converterMemAcc *mon.BoundAccount
+	outputColIdx    int
 }
 
 // bufferedWindowOp extracts common fields for the various window operators
@@ -207,6 +209,7 @@ func (b *bufferedWindowOp) Init(ctx context.Context) {
 			DiskQueueCfg:       b.diskQueueCfg,
 			FDSemaphore:        b.fdSemaphore,
 			DiskAcc:            b.diskAcc,
+			ConverterMemAcc:    b.converterMemAcc,
 		},
 	)
 	b.windower.startNewPartition()

--- a/pkg/sql/colexec/colexecwindow/count_rows_aggregator.go
+++ b/pkg/sql/colexec/colexecwindow/count_rows_aggregator.go
@@ -35,8 +35,9 @@ func NewCountRowsOperator(
 	framer := newWindowFramer(args.EvalCtx, frame, ordering, args.InputTypes, args.PeersColIdx)
 	colsToStore := framer.getColsToStore(nil /* oldColsToStore */)
 	buffer := colexecutils.NewSpillingBuffer(
-		args.BufferAllocator, bufferMemLimit, args.QueueCfg,
-		args.FdSemaphore, args.InputTypes, args.DiskAcc, colsToStore...)
+		args.BufferAllocator, bufferMemLimit, args.QueueCfg, args.FdSemaphore,
+		args.InputTypes, args.DiskAcc, args.ConverterMemAcc, colsToStore...,
+	)
 	windower := &countRowsWindowAggregator{
 		partitionSeekerBase: partitionSeekerBase{
 			partitionColIdx: args.PartitionColIdx,

--- a/pkg/sql/colexec/colexecwindow/first_last_nth_value_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/first_last_nth_value_tmpl.go
@@ -68,8 +68,9 @@ func New_UPPERCASE_NAMEOperator(
 	bufferMemLimit := int64(float64(args.MemoryLimit) * 0.10)
 	mainMemLimit := args.MemoryLimit - bufferMemLimit
 	buffer := colexecutils.NewSpillingBuffer(
-		args.BufferAllocator, bufferMemLimit, args.QueueCfg,
-		args.FdSemaphore, args.InputTypes, args.DiskAcc, colsToStore...)
+		args.BufferAllocator, bufferMemLimit, args.QueueCfg, args.FdSemaphore,
+		args.InputTypes, args.DiskAcc, args.ConverterMemAcc, colsToStore...,
+	)
 	base := _OP_NAMEBase{
 		partitionSeekerBase: partitionSeekerBase{
 			buffer:          buffer,

--- a/pkg/sql/colexec/colexecwindow/first_value.eg.go
+++ b/pkg/sql/colexec/colexecwindow/first_value.eg.go
@@ -43,8 +43,9 @@ func NewFirstValueOperator(
 	bufferMemLimit := int64(float64(args.MemoryLimit) * 0.10)
 	mainMemLimit := args.MemoryLimit - bufferMemLimit
 	buffer := colexecutils.NewSpillingBuffer(
-		args.BufferAllocator, bufferMemLimit, args.QueueCfg,
-		args.FdSemaphore, args.InputTypes, args.DiskAcc, colsToStore...)
+		args.BufferAllocator, bufferMemLimit, args.QueueCfg, args.FdSemaphore,
+		args.InputTypes, args.DiskAcc, args.ConverterMemAcc, colsToStore...,
+	)
 	base := firstValueBase{
 		partitionSeekerBase: partitionSeekerBase{
 			buffer:          buffer,

--- a/pkg/sql/colexec/colexecwindow/lag.eg.go
+++ b/pkg/sql/colexec/colexecwindow/lag.eg.go
@@ -36,8 +36,9 @@ func NewLagOperator(
 	bufferMemLimit := int64(float64(args.MemoryLimit) * 0.10)
 	mainMemLimit := args.MemoryLimit - bufferMemLimit
 	buffer := colexecutils.NewSpillingBuffer(
-		args.BufferAllocator, bufferMemLimit, args.QueueCfg,
-		args.FdSemaphore, args.InputTypes, args.DiskAcc, argIdx)
+		args.BufferAllocator, bufferMemLimit, args.QueueCfg, args.FdSemaphore,
+		args.InputTypes, args.DiskAcc, args.ConverterMemAcc, argIdx,
+	)
 	base := lagBase{
 		partitionSeekerBase: partitionSeekerBase{
 			buffer:          buffer,

--- a/pkg/sql/colexec/colexecwindow/last_value.eg.go
+++ b/pkg/sql/colexec/colexecwindow/last_value.eg.go
@@ -43,8 +43,9 @@ func NewLastValueOperator(
 	bufferMemLimit := int64(float64(args.MemoryLimit) * 0.10)
 	mainMemLimit := args.MemoryLimit - bufferMemLimit
 	buffer := colexecutils.NewSpillingBuffer(
-		args.BufferAllocator, bufferMemLimit, args.QueueCfg,
-		args.FdSemaphore, args.InputTypes, args.DiskAcc, colsToStore...)
+		args.BufferAllocator, bufferMemLimit, args.QueueCfg, args.FdSemaphore,
+		args.InputTypes, args.DiskAcc, args.ConverterMemAcc, colsToStore...,
+	)
 	base := lastValueBase{
 		partitionSeekerBase: partitionSeekerBase{
 			buffer:          buffer,

--- a/pkg/sql/colexec/colexecwindow/lead.eg.go
+++ b/pkg/sql/colexec/colexecwindow/lead.eg.go
@@ -36,8 +36,9 @@ func NewLeadOperator(
 	bufferMemLimit := int64(float64(args.MemoryLimit) * 0.10)
 	mainMemLimit := args.MemoryLimit - bufferMemLimit
 	buffer := colexecutils.NewSpillingBuffer(
-		args.BufferAllocator, bufferMemLimit, args.QueueCfg,
-		args.FdSemaphore, args.InputTypes, args.DiskAcc, argIdx)
+		args.BufferAllocator, bufferMemLimit, args.QueueCfg, args.FdSemaphore,
+		args.InputTypes, args.DiskAcc, args.ConverterMemAcc, argIdx,
+	)
 	base := leadBase{
 		partitionSeekerBase: partitionSeekerBase{
 			buffer:          buffer,

--- a/pkg/sql/colexec/colexecwindow/lead_lag_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/lead_lag_tmpl.go
@@ -58,8 +58,9 @@ func New_UPPERCASE_NAMEOperator(
 	bufferMemLimit := int64(float64(args.MemoryLimit) * 0.10)
 	mainMemLimit := args.MemoryLimit - bufferMemLimit
 	buffer := colexecutils.NewSpillingBuffer(
-		args.BufferAllocator, bufferMemLimit, args.QueueCfg,
-		args.FdSemaphore, args.InputTypes, args.DiskAcc, argIdx)
+		args.BufferAllocator, bufferMemLimit, args.QueueCfg, args.FdSemaphore,
+		args.InputTypes, args.DiskAcc, args.ConverterMemAcc, argIdx,
+	)
 	base := _OP_NAMEBase{
 		partitionSeekerBase: partitionSeekerBase{
 			buffer:          buffer,

--- a/pkg/sql/colexec/colexecwindow/nth_value.eg.go
+++ b/pkg/sql/colexec/colexecwindow/nth_value.eg.go
@@ -45,8 +45,9 @@ func NewNthValueOperator(
 	bufferMemLimit := int64(float64(args.MemoryLimit) * 0.10)
 	mainMemLimit := args.MemoryLimit - bufferMemLimit
 	buffer := colexecutils.NewSpillingBuffer(
-		args.BufferAllocator, bufferMemLimit, args.QueueCfg,
-		args.FdSemaphore, args.InputTypes, args.DiskAcc, colsToStore...)
+		args.BufferAllocator, bufferMemLimit, args.QueueCfg, args.FdSemaphore,
+		args.InputTypes, args.DiskAcc, args.ConverterMemAcc, colsToStore...,
+	)
 	base := nthValueBase{
 		partitionSeekerBase: partitionSeekerBase{
 			buffer:          buffer,

--- a/pkg/sql/colexec/colexecwindow/relative_rank.eg.go
+++ b/pkg/sql/colexec/colexecwindow/relative_rank.eg.go
@@ -55,11 +55,12 @@ func NewRelativeRankOperator(
 			partitionColIdx: args.PartitionColIdx,
 			peersColIdx:     args.PeersColIdx,
 		},
-		memoryLimit:  args.MemoryLimit,
-		diskQueueCfg: args.QueueCfg,
-		fdSemaphore:  args.FdSemaphore,
-		inputTypes:   args.InputTypes,
-		diskAcc:      args.DiskAcc,
+		memoryLimit:     args.MemoryLimit,
+		diskQueueCfg:    args.QueueCfg,
+		fdSemaphore:     args.FdSemaphore,
+		inputTypes:      args.InputTypes,
+		diskAcc:         args.DiskAcc,
+		converterMemAcc: args.ConverterMemAcc,
 	}
 	switch windowFn {
 	case execinfrapb.WindowerSpec_PERCENT_RANK:
@@ -132,7 +133,8 @@ type relativeRankInitFields struct {
 	fdSemaphore  semaphore.Semaphore
 	inputTypes   []*types.T
 
-	diskAcc *mon.BoundAccount
+	diskAcc         *mon.BoundAccount
+	converterMemAcc *mon.BoundAccount
 }
 
 type relativeRankSizesState struct {
@@ -190,6 +192,7 @@ func (r *percentRankNoPartitionOp) Init(ctx context.Context) {
 			DiskQueueCfg:       r.diskQueueCfg,
 			FDSemaphore:        r.fdSemaphore,
 			DiskAcc:            r.diskAcc,
+			ConverterMemAcc:    r.converterMemAcc,
 		},
 	)
 	r.output = r.allocator.NewMemBatchWithFixedCapacity(append(r.inputTypes, types.Float), coldata.BatchSize())
@@ -372,6 +375,7 @@ func (r *percentRankWithPartitionOp) Init(ctx context.Context) {
 			DiskQueueCfg:       r.diskQueueCfg,
 			FDSemaphore:        r.fdSemaphore,
 			DiskAcc:            r.diskAcc,
+			ConverterMemAcc:    r.converterMemAcc,
 		},
 	)
 	r.partitionsState.runningSizes = r.allocator.NewMemBatchWithFixedCapacity([]*types.T{types.Int}, coldata.BatchSize())
@@ -384,6 +388,7 @@ func (r *percentRankWithPartitionOp) Init(ctx context.Context) {
 			DiskQueueCfg:       r.diskQueueCfg,
 			FDSemaphore:        r.fdSemaphore,
 			DiskAcc:            r.diskAcc,
+			ConverterMemAcc:    r.converterMemAcc,
 		},
 	)
 	r.output = r.allocator.NewMemBatchWithFixedCapacity(append(r.inputTypes, types.Float), coldata.BatchSize())
@@ -657,6 +662,7 @@ func (r *cumeDistNoPartitionOp) Init(ctx context.Context) {
 			DiskQueueCfg:       r.diskQueueCfg,
 			FDSemaphore:        r.fdSemaphore,
 			DiskAcc:            r.diskAcc,
+			ConverterMemAcc:    r.converterMemAcc,
 		},
 	)
 	r.peerGroupsState.runningSizes = r.allocator.NewMemBatchWithFixedCapacity([]*types.T{types.Int}, coldata.BatchSize())
@@ -669,6 +675,7 @@ func (r *cumeDistNoPartitionOp) Init(ctx context.Context) {
 			DiskQueueCfg:       r.diskQueueCfg,
 			FDSemaphore:        r.fdSemaphore,
 			DiskAcc:            r.diskAcc,
+			ConverterMemAcc:    r.converterMemAcc,
 		},
 	)
 	r.output = r.allocator.NewMemBatchWithFixedCapacity(append(r.inputTypes, types.Float), coldata.BatchSize())
@@ -927,6 +934,7 @@ func (r *cumeDistWithPartitionOp) Init(ctx context.Context) {
 			DiskQueueCfg:       r.diskQueueCfg,
 			FDSemaphore:        r.fdSemaphore,
 			DiskAcc:            r.diskAcc,
+			ConverterMemAcc:    r.converterMemAcc,
 		},
 	)
 	r.partitionsState.runningSizes = r.allocator.NewMemBatchWithFixedCapacity([]*types.T{types.Int}, coldata.BatchSize())
@@ -939,6 +947,7 @@ func (r *cumeDistWithPartitionOp) Init(ctx context.Context) {
 			DiskQueueCfg:       r.diskQueueCfg,
 			FDSemaphore:        r.fdSemaphore,
 			DiskAcc:            r.diskAcc,
+			ConverterMemAcc:    r.converterMemAcc,
 		},
 	)
 	r.peerGroupsState.runningSizes = r.allocator.NewMemBatchWithFixedCapacity([]*types.T{types.Int}, coldata.BatchSize())
@@ -951,6 +960,7 @@ func (r *cumeDistWithPartitionOp) Init(ctx context.Context) {
 			DiskQueueCfg:       r.diskQueueCfg,
 			FDSemaphore:        r.fdSemaphore,
 			DiskAcc:            r.diskAcc,
+			ConverterMemAcc:    r.converterMemAcc,
 		},
 	)
 	r.output = r.allocator.NewMemBatchWithFixedCapacity(append(r.inputTypes, types.Float), coldata.BatchSize())

--- a/pkg/sql/colexec/colexecwindow/relative_rank_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/relative_rank_tmpl.go
@@ -65,11 +65,12 @@ func NewRelativeRankOperator(
 			partitionColIdx: args.PartitionColIdx,
 			peersColIdx:     args.PeersColIdx,
 		},
-		memoryLimit:  args.MemoryLimit,
-		diskQueueCfg: args.QueueCfg,
-		fdSemaphore:  args.FdSemaphore,
-		inputTypes:   args.InputTypes,
-		diskAcc:      args.DiskAcc,
+		memoryLimit:     args.MemoryLimit,
+		diskQueueCfg:    args.QueueCfg,
+		fdSemaphore:     args.FdSemaphore,
+		inputTypes:      args.InputTypes,
+		diskAcc:         args.DiskAcc,
+		converterMemAcc: args.ConverterMemAcc,
 	}
 	switch windowFn {
 	case execinfrapb.WindowerSpec_PERCENT_RANK:
@@ -210,7 +211,8 @@ type relativeRankInitFields struct {
 	fdSemaphore  semaphore.Semaphore
 	inputTypes   []*types.T
 
-	diskAcc *mon.BoundAccount
+	diskAcc         *mon.BoundAccount
+	converterMemAcc *mon.BoundAccount
 }
 
 type relativeRankSizesState struct {
@@ -286,6 +288,7 @@ func (r *_RELATIVE_RANK_STRINGOp) Init(ctx context.Context) {
 			DiskQueueCfg:       r.diskQueueCfg,
 			FDSemaphore:        r.fdSemaphore,
 			DiskAcc:            r.diskAcc,
+			ConverterMemAcc:    r.converterMemAcc,
 		},
 	)
 	r.partitionsState.runningSizes = r.allocator.NewMemBatchWithFixedCapacity([]*types.T{types.Int}, coldata.BatchSize())
@@ -300,6 +303,7 @@ func (r *_RELATIVE_RANK_STRINGOp) Init(ctx context.Context) {
 			DiskQueueCfg:       r.diskQueueCfg,
 			FDSemaphore:        r.fdSemaphore,
 			DiskAcc:            r.diskAcc,
+			ConverterMemAcc:    r.converterMemAcc,
 		},
 	)
 	r.peerGroupsState.runningSizes = r.allocator.NewMemBatchWithFixedCapacity([]*types.T{types.Int}, coldata.BatchSize())
@@ -313,6 +317,7 @@ func (r *_RELATIVE_RANK_STRINGOp) Init(ctx context.Context) {
 			DiskQueueCfg:       r.diskQueueCfg,
 			FDSemaphore:        r.fdSemaphore,
 			DiskAcc:            r.diskAcc,
+			ConverterMemAcc:    r.converterMemAcc,
 		},
 	)
 	r.output = r.allocator.NewMemBatchWithFixedCapacity(append(r.inputTypes, types.Float), coldata.BatchSize())

--- a/pkg/sql/colexec/colexecwindow/window_aggregator.eg.go
+++ b/pkg/sql/colexec/colexecwindow/window_aggregator.eg.go
@@ -64,8 +64,9 @@ func NewWindowAggregatorOperator(
 	framer := newWindowFramer(args.EvalCtx, frame, ordering, args.InputTypes, args.PeersColIdx)
 	colsToStore := framer.getColsToStore(append([]int{}, argIdxs...))
 	buffer := colexecutils.NewSpillingBuffer(
-		args.BufferAllocator, bufferMemLimit, args.QueueCfg,
-		args.FdSemaphore, args.InputTypes, args.DiskAcc, colsToStore...)
+		args.BufferAllocator, bufferMemLimit, args.QueueCfg, args.FdSemaphore,
+		args.InputTypes, args.DiskAcc, args.ConverterMemAcc, colsToStore...,
+	)
 	inputIdxs := make([]uint32, len(argIdxs))
 	for i := range inputIdxs {
 		// We will always store the arg columns first in the buffer.

--- a/pkg/sql/colexec/colexecwindow/window_aggregator_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/window_aggregator_tmpl.go
@@ -66,8 +66,9 @@ func NewWindowAggregatorOperator(
 	framer := newWindowFramer(args.EvalCtx, frame, ordering, args.InputTypes, args.PeersColIdx)
 	colsToStore := framer.getColsToStore(append([]int{}, argIdxs...))
 	buffer := colexecutils.NewSpillingBuffer(
-		args.BufferAllocator, bufferMemLimit, args.QueueCfg,
-		args.FdSemaphore, args.InputTypes, args.DiskAcc, colsToStore...)
+		args.BufferAllocator, bufferMemLimit, args.QueueCfg, args.FdSemaphore,
+		args.InputTypes, args.DiskAcc, args.ConverterMemAcc, colsToStore...,
+	)
 	inputIdxs := make([]uint32, len(argIdxs))
 	for i := range inputIdxs {
 		// We will always store the arg columns first in the buffer.

--- a/pkg/sql/colexec/colexecwindow/window_framer_test.go
+++ b/pkg/sql/colexec/colexecwindow/window_framer_test.go
@@ -294,7 +294,8 @@ func makeSortedPartition(testCfg *testConfig) (tree.Datums, *colexecutils.Spilli
 
 	partition := colexecutils.NewSpillingBuffer(
 		testCfg.allocator, testCfg.memLimit, testCfg.queueCfg,
-		colexecop.NewTestingSemaphore(2), []*types.T{testCfg.typ, types.Bool}, testDiskAcc,
+		colexecop.NewTestingSemaphore(2), []*types.T{testCfg.typ, types.Bool},
+		testDiskAcc, testMemAcc,
 	)
 	insertBatch := testCfg.allocator.NewMemBatchWithFixedCapacity(
 		[]*types.T{testCfg.typ, types.Bool},

--- a/pkg/sql/colexec/colexecwindow/window_functions_test.go
+++ b/pkg/sql/colexec/colexecwindow/window_functions_test.go
@@ -1160,6 +1160,7 @@ func BenchmarkWindowFunctions(b *testing.B) {
 			QueueCfg:        queueCfg,
 			FdSemaphore:     colexecop.NewTestingSemaphore(fdLimit),
 			DiskAcc:         testDiskAcc,
+			ConverterMemAcc: testMemAcc,
 			Input:           source,
 			InputTypes:      sourceTypes,
 			OutputColIdx:    outputIdx,

--- a/pkg/sql/colexec/colexecwindow/window_functions_util.go
+++ b/pkg/sql/colexec/colexecwindow/window_functions_util.go
@@ -34,6 +34,7 @@ type WindowArgs struct {
 	QueueCfg        colcontainer.DiskQueueCfg
 	FdSemaphore     semaphore.Semaphore
 	DiskAcc         *mon.BoundAccount
+	ConverterMemAcc *mon.BoundAccount
 	Input           colexecop.Operator
 	InputTypes      []*types.T
 	OutputColIdx    int

--- a/pkg/sql/colexec/hash_aggregator_test.go
+++ b/pkg/sql/colexec/hash_aggregator_test.go
@@ -514,6 +514,7 @@ func BenchmarkHashAggregatorInputTuplesTracking(b *testing.B) {
 								DiskQueueCfg:       queueCfg,
 								FDSemaphore:        &colexecop.TestingSemaphore{},
 								DiskAcc:            testDiskAcc,
+								ConverterMemAcc:    testMemAcc,
 							},
 						)
 					},
@@ -577,6 +578,7 @@ func BenchmarkHashAggregatorPartialOrder(b *testing.B) {
 				DiskQueueCfg:       queueCfg,
 				FDSemaphore:        &colexecop.TestingSemaphore{},
 				DiskAcc:            testDiskAcc,
+				ConverterMemAcc:    testMemAcc,
 			},
 		)
 	}

--- a/pkg/sql/colexec/mergejoiner_test.go
+++ b/pkg/sql/colexec/mergejoiner_test.go
@@ -1756,7 +1756,7 @@ func TestFullOuterMergeJoinWithMaximumNumberOfGroups(t *testing.T) {
 		leftSource, rightSource, typs, typs,
 		[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 		[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
-		testDiskAcc, &evalCtx,
+		testDiskAcc, testMemAcc, &evalCtx,
 	)
 	a.Init(ctx)
 	i, count, expVal := 0, 0, int64(0)
@@ -1826,7 +1826,7 @@ func TestMergeJoinerMultiBatch(t *testing.T) {
 					leftSource, rightSource, typs, typs,
 					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 					[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
-					testDiskAcc, &evalCtx,
+					testDiskAcc, testMemAcc, &evalCtx,
 				)
 				a.Init(ctx)
 				i := 0
@@ -1901,7 +1901,7 @@ func TestMergeJoinerMultiBatchRuns(t *testing.T) {
 						leftSource, rightSource, typs, typs,
 						[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}, {ColIdx: 1, Direction: execinfrapb.Ordering_Column_ASC}},
 						[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}, {ColIdx: 1, Direction: execinfrapb.Ordering_Column_ASC}},
-						testDiskAcc, &evalCtx,
+						testDiskAcc, testMemAcc, &evalCtx,
 					)
 					a.Init(ctx)
 					i := 0
@@ -2031,7 +2031,7 @@ func TestMergeJoinerRandomized(t *testing.T) {
 						leftSource, rightSource, typs, typs,
 						[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
 						[]execinfrapb.Ordering_Column{{ColIdx: 0, Direction: execinfrapb.Ordering_Column_ASC}},
-						testDiskAcc, &evalCtx,
+						testDiskAcc, testMemAcc, &evalCtx,
 					)
 					a.Init(ctx)
 					i := 0

--- a/pkg/sql/colflow/colrpc/BUILD.bazel
+++ b/pkg/sql/colflow/colrpc/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/util/cancelchecker",
         "//pkg/util/log",
         "//pkg/util/log/logcrash",
+        "//pkg/util/mon",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
         "@com_github_apache_arrow_go_arrow//array",

--- a/pkg/sql/colflow/colrpc/colrpc_test.go
+++ b/pkg/sql/colflow/colrpc/colrpc_test.go
@@ -275,9 +275,11 @@ func TestOutboxInbox(t *testing.T) {
 			)
 			outboxMemAcc := testMemMonitor.MakeBoundAccount()
 			defer outboxMemAcc.Close(outboxCtx)
+			outboxConverterMemAcc := testMemMonitor.MakeBoundAccount()
+			defer outboxConverterMemAcc.Close(ctx)
 			outbox, err := NewOutbox(
 				colmem.NewAllocator(outboxCtx, &outboxMemAcc, coldata.StandardColumnFactory),
-				colexecargs.OpWithMetaInfo{Root: input}, typs, nil, /* getStats */
+				&outboxConverterMemAcc, colexecargs.OpWithMetaInfo{Root: input}, typs, nil, /* getStats */
 			)
 			require.NoError(t, err)
 
@@ -520,7 +522,7 @@ func TestInboxHostCtxCancellation(t *testing.T) {
 	defer outboxMemAcc.Close(outboxHostCtx)
 	outbox, err := NewOutbox(
 		colmem.NewAllocator(outboxHostCtx, &outboxMemAcc, coldata.StandardColumnFactory),
-		colexecargs.OpWithMetaInfo{Root: outboxInput}, typs, nil, /* getStats */
+		testMemAcc, colexecargs.OpWithMetaInfo{Root: outboxInput}, typs, nil, /* getStats */
 	)
 	require.NoError(t, err)
 	var wg sync.WaitGroup
@@ -701,6 +703,7 @@ func TestOutboxInboxMetadataPropagation(t *testing.T) {
 			}
 			outbox, err := NewOutbox(
 				colmem.NewAllocator(ctx, &outboxMemAcc, coldata.StandardColumnFactory),
+				testMemAcc,
 				colexecargs.OpWithMetaInfo{
 					Root: input,
 					MetadataSources: []colexecop.MetadataSource{
@@ -796,7 +799,7 @@ func BenchmarkOutboxInbox(b *testing.B) {
 	defer outboxMemAcc.Close(ctx)
 	outbox, err := NewOutbox(
 		colmem.NewAllocator(ctx, &outboxMemAcc, coldata.StandardColumnFactory),
-		colexecargs.OpWithMetaInfo{Root: input}, typs, nil, /* getStats */
+		testMemAcc, colexecargs.OpWithMetaInfo{Root: input}, typs, nil, /* getStats */
 	)
 	require.NoError(b, err)
 
@@ -861,7 +864,7 @@ func TestOutboxStreamIDPropagation(t *testing.T) {
 	defer outboxMemAcc.Close(ctx)
 	outbox, err := NewOutbox(
 		colmem.NewAllocator(ctx, &outboxMemAcc, coldata.StandardColumnFactory),
-		colexecargs.OpWithMetaInfo{Root: input}, typs, nil, /* getStats */
+		testMemAcc, colexecargs.OpWithMetaInfo{Root: input}, typs, nil, /* getStats */
 	)
 	require.NoError(t, err)
 

--- a/pkg/sql/colflow/colrpc/inbox.go
+++ b/pkg/sql/colflow/colrpc/inbox.go
@@ -134,7 +134,7 @@ var _ colexecop.Operator = &Inbox{}
 func NewInbox(
 	allocator *colmem.Allocator, typs []*types.T, streamID execinfrapb.StreamID,
 ) (*Inbox, error) {
-	c, err := colserde.NewArrowBatchConverter(typs, colserde.ArrowToBatchOnly)
+	c, err := colserde.NewArrowBatchConverter(typs, colserde.ArrowToBatchOnly, nil /* acc */)
 	if err != nil {
 		return nil, err
 	}
@@ -488,7 +488,7 @@ func (i *Inbox) DrainMeta() []execinfrapb.ProducerMetadata {
 	// We also no longer need the scratch batch nor the arrow-to-batch
 	// converter.
 	i.scratch.b = nil
-	i.converter.Release()
+	i.converter.Release(i.Ctx)
 	// The allocator tracks the memory usage for a few things (the scratch batch
 	// as well as the metadata), and when this function returns, we no longer
 	// reference any of those, so we can release all of the allocations.

--- a/pkg/sql/colflow/colrpc/inbox_test.go
+++ b/pkg/sql/colflow/colrpc/inbox_test.go
@@ -279,7 +279,7 @@ func TestInboxShutdown(t *testing.T) {
 					defer inboxMemAccount.Close(inboxCtx)
 					inbox, err := NewInbox(colmem.NewAllocator(inboxCtx, &inboxMemAccount, coldata.StandardColumnFactory), typs, execinfrapb.StreamID(0))
 					require.NoError(t, err)
-					c, err := colserde.NewArrowBatchConverter(typs, colserde.BatchToArrowOnly)
+					c, err := colserde.NewArrowBatchConverter(typs, colserde.BatchToArrowOnly, testMemAcc)
 					require.NoError(t, err)
 					r, err := colserde.NewRecordBatchSerializer(typs)
 					require.NoError(t, err)
@@ -309,7 +309,8 @@ func TestInboxShutdown(t *testing.T) {
 									wg.Add(1)
 									go func() {
 										defer wg.Done()
-										arrowData, err := c.BatchToArrow(batch)
+										defer c.Release(context.Background())
+										arrowData, err := c.BatchToArrow(context.Background(), batch)
 										if err != nil {
 											errCh <- err
 											return

--- a/pkg/sql/colflow/stats_test.go
+++ b/pkg/sql/colflow/stats_test.go
@@ -122,7 +122,7 @@ func TestVectorizedStatsCollector(t *testing.T) {
 			[]*types.T{types.Int}, []*types.T{types.Int},
 			[]execinfrapb.Ordering_Column{{ColIdx: 0}},
 			[]execinfrapb.Ordering_Column{{ColIdx: 0}},
-			tu.testDiskAcc, tu.evalCtx,
+			tu.testDiskAcc, tu.testMemAcc, tu.evalCtx,
 		)
 		timeAdvancingMergeJoiner := &timeAdvancingOperator{
 			OneInputHelper: colexecop.MakeOneInputHelper(mergeJoiner),


### PR DESCRIPTION
This commit introduces the memory accounting for values and offsets
scratch slices that are being reused across `BatchToArrow` calls since
recently. This required a lot of plumbing to propagate the memory
account from all places. The converter is careful to only grow and
shrink the account by its own usage, so the same memory account can be
reused across multiple converters (as long as there is no concurrency
going on, and we only can have concurrency for hash router outputs, so
there we give each output a separate account).

An additional minor change is that now in `diskQueue.Enqueue` we
properly `Close` the `FileSerializer` before `nil`-ing it out. This
isn't a problem per se since it is the caller's responsibility to close
the account used by the serializer, but it's nice to properly release
the accounted for bytes.

Epic: None

Release note: None