### PR TITLE
coldata: fix recent flaky behavior

### DIFF
--- a/pkg/col/coldata/bytes.go
+++ b/pkg/col/coldata/bytes.go
@@ -556,7 +556,7 @@ func (b *Bytes) elementsAsBytes(n int) []byte {
 var zeroInt32Slice []int32
 
 func init() {
-	zeroInt32Slice = make([]int32, BatchSize())
+	zeroInt32Slice = make([]int32, MaxBatchSize)
 }
 
 // Serialize converts b into the "arrow-like" (which is arrow-compatible)
@@ -579,12 +579,12 @@ func init() {
 //	 buffer = [<b.elements as []byte><b.buffer]
 //	offsets = [0, 0, ..., 0, len(<b.elements as []byte>), len(<b.elements as []byte>) + len(buffer)]
 //
-// Note: it is assumed that n is not larger than BatchSize().
+// Note: it is assumed that n is not larger than MaxBatchSize.
 func (b *Bytes) Serialize(n int, dataScratch []byte, offsetsScratch []int32) ([]byte, []int32) {
 	if buildutil.CrdbTestBuild {
-		if n > BatchSize() {
+		if n > MaxBatchSize {
 			colexecerror.InternalError(errors.AssertionFailedf(
-				"too many bytes elements to serialize: %d vs BatchSize() of %d", n, BatchSize(),
+				"too many bytes elements to serialize: %d vs MaxBatchSize of %d", n, MaxBatchSize,
 			))
 		}
 	}


### PR DESCRIPTION
In a just merged b353d181559e82c4c329b2a327936ebda3bbdb4e when addressing the PR feedback I introduced a possibility of a crash in tests. In particular, this can occur if we choose to randomize `coldata.BatchSize` value larger than the default (or if the test explicitly overrides it). The problem is that `BatchSize()` can return different values in `init()` of `coldata` package and during the test runs, so we now use `MaxBatchSize` where applicable.

Epic: None

Release note: None