### PR TITLE
release: fix download url for sentry panic

### DIFF
--- a/pkg/cmd/release/sentry.go
+++ b/pkg/cmd/release/sentry.go
@@ -21,7 +21,8 @@ func generatePanic(tag string) error {
 	// the call usually exits non-zero on panic, but we don't need to fail in that case, thus "|| true"
 	// TODO: do not hardcode the URL
 	script := fmt.Sprintf(`
-curl https://binaries.cockroachdb.com/cockroach-%s.linux-amd64.tgz | tar -xz
+set -exuo pipefail
+curl --fail --silent --show-error --output /dev/stdout --url https://storage.googleapis.com/cockroach-builds-artifacts-prod/cockroach-%s.linux-amd64.tgz | tar -xz
 ./cockroach-%s.linux-amd64/cockroach demo --insecure -e "select crdb_internal.force_panic('testing')" || true
 `, tag, tag)
 	cmd := exec.Command("bash", "-c", script)


### PR DESCRIPTION
Previously, we tried to download the cockroach nightly tarball from binaries.cockroachdb.com. However, the binary is not published there.

Fix the URL and add some bash magic to catch the download issues.

Epic: none
Release note: None