### PR TITLE
metrics: add tenant name to _status/vars output

### DIFF
--- a/pkg/cli/mt_start_sql.go
+++ b/pkg/cli/mt_start_sql.go
@@ -87,7 +87,14 @@ func runStartSQL(cmd *cobra.Command, args []string) error {
 		// always be non-nil, even if NewServer returns a nil pointer (and
 		// an error). The code below is dependent on the interface
 		// reference remaining nil in case of error.
-		s, err := server.NewTenantServer(ctx, stopper, serverCfg.BaseConfig, serverCfg.SQLConfig)
+		s, err := server.NewTenantServer(
+			ctx,
+			stopper,
+			serverCfg.BaseConfig,
+			serverCfg.SQLConfig,
+			nil, /* parentRecorder */
+			nil, /* tenantNameContainer */
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/roachpb/BUILD.bazel
+++ b/pkg/roachpb/BUILD.bazel
@@ -53,6 +53,7 @@ go_library(
         "//pkg/util/interval",
         "//pkg/util/log",
         "//pkg/util/protoutil",
+        "//pkg/util/syncutil",
         "//pkg/util/timetz",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_apd_v3//:apd",

--- a/pkg/roachpb/tenant.go
+++ b/pkg/roachpb/tenant.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 
 	"github.com/cockroachdb/cockroach/pkg/base/serverident"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -185,4 +186,31 @@ func (n TenantName) IsValid() error {
 			"Tenant names must start and end with a lowercase letter or digit, contain only lowercase letters, digits or hyphens, with a maximum of 100 characters.")
 	}
 	return nil
+}
+
+// TenantNameContainer is a shared object between the
+// server controller and the tenant server that holds
+// a reference to the current name of the tenant and
+// updates it if needed. This facilitates some
+// observability use cases where we need to tag data
+// by tenant name.
+type TenantNameContainer syncutil.AtomicString
+
+func NewTenantNameContainer(name TenantName) *TenantNameContainer {
+	t := &TenantNameContainer{}
+	t.Set(name)
+	return t
+}
+
+func (c *TenantNameContainer) Set(name TenantName) {
+	(*syncutil.AtomicString)(c).Set(string(name))
+}
+
+func (c *TenantNameContainer) Get() TenantName {
+	return TenantName(c.String())
+}
+
+// String implements the fmt.Stringer interface.
+func (c *TenantNameContainer) String() string {
+	return (*syncutil.AtomicString)(c).Get()
 }

--- a/pkg/server/server_controller.go
+++ b/pkg/server/server_controller.go
@@ -74,6 +74,15 @@ type serverEntry struct {
 	// server is the actual server.
 	server onDemandServer
 
+	// nameContainer holds a shared reference to the current
+	// name of the tenant within this serverEntry. If the
+	// tenant's name is updated, the `Set` method on
+	// nameContainer should be called in order to update
+	// any subscribers within the tenant. These are typically
+	// observability-related features that label data with
+	// the current tenant name.
+	nameContainer *roachpb.TenantNameContainer
+
 	// shouldStop indicates whether shutting down the controller
 	// should cause this server to stop. This is true for all
 	// servers except the one serving the system tenant.
@@ -125,7 +134,7 @@ type tenantCreator interface {
 	// can be checked with errors.Is.
 	//
 	// testArgs is used by tests to tweak the tenant server.
-	newTenant(ctx context.Context, tenantName roachpb.TenantName, index int, deregister func(),
+	newTenant(ctx context.Context, tenantNameContainer *roachpb.TenantNameContainer, index int, deregister func(),
 		testArgs base.TestSharedProcessTenantArgs,
 	) (onDemandServer, error)
 }
@@ -136,6 +145,7 @@ func newServerController(
 	st *cluster.Settings,
 	tenantCreator tenantCreator,
 	systemServer onDemandServer,
+	systemTenantNameContainer *roachpb.TenantNameContainer,
 ) *serverController {
 	c := &serverController{
 		st:            st,
@@ -144,8 +154,9 @@ func newServerController(
 	}
 	c.mu.servers = map[roachpb.TenantName]serverEntry{
 		catconstants.SystemTenantName: {
-			server:     systemServer,
-			shouldStop: false,
+			server:        systemServer,
+			shouldStop:    false,
+			nameContainer: systemTenantNameContainer,
 		},
 	}
 	parentStopper.AddCloser(c)
@@ -197,13 +208,15 @@ func (c *serverController) createServerLocked(
 	// Server does not exist yet: instantiate and start it.
 	c.mu.nextServerIdx++
 	idx := c.mu.nextServerIdx
-	s, err := c.tenantCreator.newTenant(ctx, tenantName, idx, deregisterFn, testArgs)
+	nameContainer := roachpb.NewTenantNameContainer(tenantName)
+	s, err := c.tenantCreator.newTenant(ctx, nameContainer, idx, deregisterFn, testArgs)
 	if err != nil {
 		return nil, err
 	}
 	c.mu.servers[tenantName] = serverEntry{
-		server:     s,
-		shouldStop: true,
+		server:        s,
+		shouldStop:    true,
+		nameContainer: nameContainer,
 	}
 	return s, nil
 }
@@ -605,12 +618,12 @@ var _ tenantCreator = &Server{}
 // newTenant implements the tenantCreator interface.
 func (s *Server) newTenant(
 	ctx context.Context,
-	tenantName roachpb.TenantName,
+	tenantNameContainer *roachpb.TenantNameContainer,
 	index int,
 	deregister func(),
 	testArgs base.TestSharedProcessTenantArgs,
 ) (onDemandServer, error) {
-	tenantID, err := s.getTenantID(ctx, tenantName)
+	tenantID, err := s.getTenantID(ctx, tenantNameContainer.Get())
 	if err != nil {
 		return nil, err
 	}
@@ -622,7 +635,7 @@ func (s *Server) newTenant(
 	// Apply the TestTenantArgs, if any.
 	baseCfg.TestingKnobs = testArgs.Knobs
 
-	tenantServer, err := s.startInMemoryTenantServerInternal(ctx, baseCfg, sqlCfg, tenantStopper)
+	tenantServer, err := s.startInMemoryTenantServerInternal(ctx, baseCfg, sqlCfg, tenantStopper, tenantNameContainer)
 	if err != nil {
 		// Abandon any work done so far.
 		tenantStopper.Stop(ctx)
@@ -742,7 +755,11 @@ func (s *Server) makeSharedProcessTenantConfig(
 // Note that even if an error is returned, tasks might have been started with
 // the stopper, so the caller needs to Stop() it.
 func (s *Server) startInMemoryTenantServerInternal(
-	ctx context.Context, baseCfg BaseConfig, sqlCfg SQLConfig, stopper *stop.Stopper,
+	ctx context.Context,
+	baseCfg BaseConfig,
+	sqlCfg SQLConfig,
+	stopper *stop.Stopper,
+	tenantNameContainer *roachpb.TenantNameContainer,
 ) (*SQLServerWrapper, error) {
 	ambientCtx := baseCfg.AmbientCtx
 	stopper.SetTracer(baseCfg.Tracer)
@@ -755,7 +772,7 @@ func (s *Server) startInMemoryTenantServerInternal(
 	log.Infof(startCtx, "starting tenant server")
 
 	// Now start the tenant proper.
-	tenantServer, err := NewTenantServer(startCtx, stopper, baseCfg, sqlCfg)
+	tenantServer, err := NewTenantServer(startCtx, stopper, baseCfg, sqlCfg, s.recorder, tenantNameContainer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/status/BUILD.bazel
+++ b/pkg/server/status/BUILD.bazel
@@ -132,11 +132,13 @@ go_test(
         "//pkg/base",
         "//pkg/build",
         "//pkg/roachpb",
+        "//pkg/rpc",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/server/status/statuspb",
         "//pkg/settings/cluster",
+        "//pkg/sql/sem/catconstants",
         "//pkg/testutils/serverutils",
         "//pkg/ts/tspb",
         "//pkg/util/hlc",
@@ -149,6 +151,7 @@ go_test(
         "//pkg/util/timeutil",
         "@com_github_kr_pretty//:pretty",
         "@com_github_shirou_gopsutil_v3//net",
+        "@com_github_stretchr_testify//require",
     ],
 )
 

--- a/pkg/server/status/recorder_test.go
+++ b/pkg/server/status/recorder_test.go
@@ -11,6 +11,7 @@
 package status
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"os"
@@ -23,8 +24,10 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/server/status/statuspb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -33,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/system"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/kr/pretty"
+	"github.com/stretchr/testify/require"
 )
 
 // byTimeAndName is a slice of tspb.TimeSeriesData.
@@ -97,6 +101,97 @@ func (fs fakeStore) Registry() *metric.Registry {
 	return fs.registry
 }
 
+func TestMetricsRecorderTenants(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	nodeDesc := roachpb.NodeDescriptor{
+		NodeID: roachpb.NodeID(1),
+	}
+	reg1 := metric.NewRegistry()
+	manual := timeutil.NewManualTime(timeutil.Unix(0, 100))
+	st := cluster.MakeTestingClusterSettings()
+	rpcCtx := &rpc.Context{
+		ContextOptions: rpc.ContextOptions{
+			TenantID: roachpb.SystemTenantID,
+		},
+	}
+	recorder := NewMetricsRecorder(
+		hlc.NewClock(manual, time.Nanosecond),
+		nil,
+		rpcCtx,
+		nil,
+		st,
+		roachpb.NewTenantNameContainer(catconstants.SystemTenantName),
+	)
+	recorder.AddNode(reg1, nodeDesc, 50, "foo:26257", "foo:26258", "foo:5432")
+
+	nodeDescTenant := roachpb.NodeDescriptor{
+		NodeID: roachpb.NodeID(1),
+	}
+	reg2 := metric.NewRegistry()
+	stTenant := cluster.MakeTestingClusterSettings()
+	id, err := roachpb.MakeTenantID(123)
+	require.NoError(t, err)
+	rpcCtxTenant := &rpc.Context{
+		ContextOptions: rpc.ContextOptions{
+			TenantID: id,
+		},
+	}
+
+	appNameContainer := roachpb.NewTenantNameContainer("application")
+	recorderTenant := NewMetricsRecorder(
+		hlc.NewClock(manual, time.Nanosecond),
+		nil,
+		rpcCtxTenant,
+		nil,
+		stTenant,
+		appNameContainer,
+	)
+	recorderTenant.AddNode(reg2, nodeDescTenant, 50, "foo:26257", "foo:26258", "foo:5432")
+
+	g := metric.NewGauge(metric.Metadata{Name: "some_metric"})
+	reg1.AddMetric(g)
+	g.Update(123)
+
+	g2 := metric.NewGauge(metric.Metadata{Name: "some_metric"})
+	reg2.AddMetric(g2)
+	g2.Update(456)
+
+	recorder.AddTenantRecorder(recorderTenant)
+
+	buf := bytes.NewBuffer([]byte{})
+	err = recorder.PrintAsText(buf)
+	require.NoError(t, err)
+
+	require.Contains(t, buf.String(), `some_metric{tenant="system"} 123`)
+	require.Contains(t, buf.String(), `some_metric{tenant="application"} 456`)
+
+	bufTenant := bytes.NewBuffer([]byte{})
+	err = recorderTenant.PrintAsText(bufTenant)
+	require.NoError(t, err)
+
+	require.NotContains(t, bufTenant.String(), `some_metric{tenant="system"} 123`)
+	require.Contains(t, bufTenant.String(), `some_metric{tenant="application"} 456`)
+
+	// Update app name in container and ensure
+	// output changes accordingly.
+	appNameContainer.Set("application2")
+
+	buf = bytes.NewBuffer([]byte{})
+	err = recorder.PrintAsText(buf)
+	require.NoError(t, err)
+
+	require.Contains(t, buf.String(), `some_metric{tenant="system"} 123`)
+	require.Contains(t, buf.String(), `some_metric{tenant="application2"} 456`)
+
+	bufTenant = bytes.NewBuffer([]byte{})
+	err = recorderTenant.PrintAsText(bufTenant)
+	require.NoError(t, err)
+
+	require.NotContains(t, bufTenant.String(), `some_metric{tenant="system"} 123`)
+	require.Contains(t, bufTenant.String(), `some_metric{tenant="application2"} 456`)
+
+}
+
 // TestMetricsRecorder verifies that the metrics recorder properly formats the
 // statistics from various registries, both for Time Series and for Status
 // Summaries.
@@ -143,7 +238,13 @@ func TestMetricsRecorder(t *testing.T) {
 	}
 	manual := timeutil.NewManualTime(timeutil.Unix(0, 100))
 	st := cluster.MakeTestingClusterSettings()
-	recorder := NewMetricsRecorder(hlc.NewClock(manual, time.Nanosecond), nil, nil, nil, st /* maxOffset */)
+	rpcCtx := &rpc.Context{
+		ContextOptions: rpc.ContextOptions{
+			TenantID: roachpb.SystemTenantID,
+		},
+	}
+
+	recorder := NewMetricsRecorder(hlc.NewClock(manual, time.Nanosecond), nil, rpcCtx, nil, st, roachpb.NewTenantNameContainer(""))
 	recorder.AddStore(store1)
 	recorder.AddStore(store2)
 	recorder.AddNode(reg1, nodeDesc, 50, "foo:26257", "foo:26258", "foo:5432")

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -1310,20 +1310,20 @@ func TestStatusVarsTxnMetrics(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !bytes.Contains(body, []byte("sql_txn_begin_count 1")) {
-		t.Errorf("expected `sql_txn_begin_count 1`, got: %s", body)
+	if !bytes.Contains(body, []byte("sql_txn_begin_count{tenant=\"system\"} 1")) {
+		t.Errorf("expected `sql_txn_begin_count{tenant=\"system\"} 1`, got: %s", body)
 	}
-	if !bytes.Contains(body, []byte("sql_restart_savepoint_count 1")) {
-		t.Errorf("expected `sql_restart_savepoint_count 1`, got: %s", body)
+	if !bytes.Contains(body, []byte("sql_restart_savepoint_count{tenant=\"system\"} 1")) {
+		t.Errorf("expected `sql_restart_savepoint_count{tenant=\"system\"} 1`, got: %s", body)
 	}
-	if !bytes.Contains(body, []byte("sql_restart_savepoint_release_count 1")) {
-		t.Errorf("expected `sql_restart_savepoint_release_count 1`, got: %s", body)
+	if !bytes.Contains(body, []byte("sql_restart_savepoint_release_count{tenant=\"system\"} 1")) {
+		t.Errorf("expected `sql_restart_savepoint_release_count{tenant=\"system\"} 1`, got: %s", body)
 	}
-	if !bytes.Contains(body, []byte("sql_txn_commit_count 1")) {
-		t.Errorf("expected `sql_txn_commit_count 1`, got: %s", body)
+	if !bytes.Contains(body, []byte("sql_txn_commit_count{tenant=\"system\"} 1")) {
+		t.Errorf("expected `sql_txn_commit_count{tenant=\"system\"} 1`, got: %s", body)
 	}
-	if !bytes.Contains(body, []byte("sql_txn_rollback_count 0")) {
-		t.Errorf("expected `sql_txn_rollback_count 0`, got: %s", body)
+	if !bytes.Contains(body, []byte("sql_txn_rollback_count{tenant=\"system\"} 0")) {
+		t.Errorf("expected `sql_txn_rollback_count{tenant=\"system\"} 0`, got: %s", body)
 	}
 }
 

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -1073,6 +1073,8 @@ func (ts *TestServer) StartTenant(
 		stopper,
 		baseCfg,
 		sqlCfg,
+		ts.recorder,
+		roachpb.NewTenantNameContainer(params.TenantName),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This commit adds a `tenant` prometheus label to each metrics output via the
`_status/vars` HTTP endpoint. The label is populated with either "system" or
the name of the tenant generating the metric. When queried from the system
tenant's HTTP port or handler, the result will now also contain metrics from
all in-process tenants on the same node.

When initializing a tenant, an optional "parent" metrics recorder is passed
down allowing the tenant's recorder to be registered with the parent. When we
query the parent it iterates over all child recorders (much like we already do
for stores) and outputs all of their metrics as well.

Example:
```
sql_txn_commit_count{tenant="system"} 0
sql_txn_commit_count{tenant="demo-tenant"} 0
```

Resolves: https://github.com/cockroachdb/cockroach/issues/94663
Epic: CRDB-18798

Release note (ops change): Metrics output via `_status/vars` now contain
`tenant` labels allowing the user to distinguish between metrics emitted by
the system tenant vs other app tenants identified by their IDs.

Co-authored-by: Alex Barganier <abarganier@cockroachlabs.com>
Co-authored-by: Aaditya Sondhi <aadityas@cockroachlabs.com>