### PR TITLE
colfetcher: don't use the cFetcher's allocator for other stuff

### DIFF
--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -324,7 +324,9 @@ func (cf *cFetcher) resetBatch() {
 }
 
 // Init sets up the cFetcher based on the table args. Only columns present in
-// tableArgs.cols will be fetched.
+// tableArgs.spec will be fetched.
+//
+// Note: the allocator must **not** be shared with any other component.
 func (cf *cFetcher) Init(
 	allocator *colmem.Allocator, nextKVer storage.NextKVer, tableArgs *cFetcherTableArgs,
 ) error {

--- a/pkg/sql/row/kv_fetcher.go
+++ b/pkg/sql/row/kv_fetcher.go
@@ -42,7 +42,11 @@ type KVFetcher struct {
 var _ storage.NextKVer = &KVFetcher{}
 
 // newTxnKVFetcher creates a new txnKVFetcher.
+//
 // If acc is non-nil, this fetcher will track its fetches and must be Closed.
+// The fetcher only grows and shrinks the account according to its own use, so
+// the memory account can be shared by the caller with other components (as long
+// as there is no concurrency).
 func newTxnKVFetcher(
 	txn *kv.Txn,
 	bsHeader *roachpb.BoundedStalenessHeader,
@@ -102,7 +106,11 @@ func newTxnKVFetcher(
 }
 
 // NewKVFetcher creates a new KVFetcher.
+//
 // If acc is non-nil, this fetcher will track its fetches and must be Closed.
+// The fetcher only grows and shrinks the account according to its own use, so
+// the memory account can be shared by the caller with other components (as long
+// as there is no concurrency).
 func NewKVFetcher(
 	txn *kv.Txn,
 	bsHeader *roachpb.BoundedStalenessHeader,


### PR DESCRIPTION
This commit fixes a minor bug in how we were accounting for the copy of the spans in the ColBatchScan. In particular, the `cFetcher` (or, more precisely, the `colmem.SetAccountingHelper`) requires that the allocator is not shared with other components (so that we could quickly get the footprint of the batch). This was violated in a single spot and is now fixed. The impact of this oversight is very minor - the set accounting helper would overestimate the footprint of the batch, so it could be returning batches smaller than the limit. Thus, the fix doesn't need to be backported.

I also audited other users of the set accounting helper and didn't find any other violations.

Epic: None

Release note: None