### PR TITLE
server: use `raftSparseStatus` in replica metrics

### DIFF
--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1707,10 +1707,6 @@ func (r *Replica) hasOutstandingSnapshotInFlightToStore(storeID roachpb.StoreID)
 	return r.getSnapshotLogTruncationConstraints(storeID) > 0
 }
 
-func isRaftLeader(raftStatus *raft.Status) bool {
-	return raftStatus != nil && raftStatus.SoftState.RaftState == raft.StateLeader
-}
-
 // HasRaftLeader returns true if the raft group has a raft leader currently.
 func HasRaftLeader(raftStatus *raft.Status) bool {
 	return raftStatus != nil && raftStatus.SoftState.Lead != 0

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -9010,8 +9010,8 @@ func TestReplicaMetrics(t *testing.T) {
 		}
 		return m
 	}
-	status := func(lead uint64, progress map[uint64]tracker.Progress) *raft.Status {
-		status := &raft.Status{
+	status := func(lead uint64, progress map[uint64]tracker.Progress) *raftSparseStatus {
+		status := &raftSparseStatus{
 			Progress: progress,
 		}
 		// The commit index is set so that a progress.Match value of 1 is behind
@@ -9055,7 +9055,7 @@ func TestReplicaMetrics(t *testing.T) {
 		replicas    int32
 		storeID     roachpb.StoreID
 		desc        roachpb.RangeDescriptor
-		raftStatus  *raft.Status
+		raftStatus  *raftSparseStatus
 		liveness    livenesspb.IsLiveMap
 		raftLogSize int64
 		expected    ReplicaMetrics


### PR DESCRIPTION
`Replica.Metrics()` calls `raftStatusRLocked()`, periodically across all replicas, which is moderately expensive due to deep copies of fields we don't care about. This patch instead uses `raftSparseStatusRLocked()` which omits these fields.

Epic: none
Release note: None