### PR TITLE
release-22.2: util/stop: finish task span before Stop() returns

### DIFF
--- a/pkg/util/stop/stopper.go
+++ b/pkg/util/stop/stopper.go
@@ -478,8 +478,8 @@ func (s *Stopper) RunAsyncTaskEx(ctx context.Context, opt TaskOpts, f func(conte
 	// Call f on another goroutine.
 	taskStarted = true // Another goroutine now takes ownership of the alloc, if any.
 	go func() {
-		defer sp.Finish()
 		defer s.runPostlude()
+		defer sp.Finish()
 		defer s.recover(ctx)
 		if alloc != nil {
 			defer alloc.Release()


### PR DESCRIPTION
Backport 1/1 commits from #92338.

/cc @cockroachdb/release

---

Before this patch, a task's span was finished after the stopper considered the task to be finished. This was a problem for a test who wanted to assume that, once stopper.Stop() returns, all task spans are finished - which is a reasonable contract to expect. This patch reorders the span finish accordingly.

Fixes #83886

Release note: None
Epic: None

Release justification: minor bugfix affecting tracing
