### PR TITLE
[release-22.2] storage: handle intents under ingested range key in CheckSSTConflicts

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -803,6 +803,18 @@ func TestEvalAddSSTable(t *testing.T) {
 			sst:        kvs{rangeKV("a", "b", 8, ""), pointKV("a", 7, "a8"), rangeKV("c", "d", 8, "")},
 			expect:     kvs{rangeKV("a", "b", 8, ""), pointKV("a", 7, "a8"), pointKV("a", 6, "d"), rangeKV("c", "d", 8, "")},
 		},
+		"DisallowConflicts allows sst and engine range keys with no points": {
+			noConflict: true,
+			data:       kvs{rangeKV("a", "b", 6, ""), rangeKV("e", "f", 6, "")},
+			sst:        kvs{rangeKV("a", "b", 8, ""), rangeKV("c", "d", 8, "")},
+			expect:     kvs{rangeKV("a", "b", 8, ""), rangeKV("a", "b", 6, ""), rangeKV("c", "d", 8, ""), rangeKV("e", "f", 6, "")},
+		},
+		"DisallowConflicts returns engine intents below sst range keys as write intent errors": {
+			noConflict: true,
+			data:       kvs{pointKV("b", intentTS, "intent")},
+			sst:        kvs{rangeKV("a", "c", intentTS+8, "")},
+			expectErr:  &roachpb.WriteIntentError{},
+		},
 		"DisallowConflicts disallows sst range keys below engine point key": {
 			noConflict: true,
 			data:       kvs{pointKV("a", 6, "d")},

--- a/pkg/storage/sst.go
+++ b/pkg/storage/sst.go
@@ -427,12 +427,28 @@ func CheckSSTConflicts(
 			sstBottomTombstone := sstRangeKeys.Versions[len(sstRangeKeys.Versions)-1]
 			sstTopTombstone := sstRangeKeys.Versions[0]
 			extKey := extIter.UnsafeKey()
-			extValue, ok, err := tryDecodeSimpleMVCCValue(extIter.UnsafeValue())
-			if !ok && err == nil {
-				extValue, err = decodeExtendedMVCCValue(extIter.UnsafeValue())
-			}
-			if err != nil {
-				return enginepb.MVCCStats{}, err
+			var extValue MVCCValue
+			if extKey.IsValue() {
+				var ok bool
+				extValue, ok, err = tryDecodeSimpleMVCCValue(extIter.UnsafeValue())
+				if !ok && err == nil {
+					extValue, err = decodeExtendedMVCCValue(extIter.UnsafeValue())
+				}
+				if err != nil {
+					return enginepb.MVCCStats{}, err
+				}
+			} else {
+				// extIter is at an intent. Save it to the intents list and Next().
+				var mvccMeta enginepb.MVCCMetadata
+				if err = extIter.ValueProto(&mvccMeta); err != nil {
+					return enginepb.MVCCStats{}, err
+				}
+				intents = append(intents, roachpb.MakeIntent(mvccMeta.Txn, extIter.Key().Key))
+				if int64(len(intents)) >= maxIntents {
+					return statsDiff, &roachpb.WriteIntentError{Intents: intents}
+				}
+				extIter.Next()
+				continue
 			}
 
 			if sstBottomTombstone.Timestamp.LessEq(extKey.Timestamp) {
@@ -981,11 +997,13 @@ func CheckSSTConflicts(
 					sstIter.SeekGE(MVCCKey{Key: extIter.UnsafeKey().Key})
 					sstOK, sstErr = sstIter.Valid()
 				}
-				if extChangedKeys && !sstChangedKeys {
-					extIter.SeekGE(MVCCKey{Key: sstIter.UnsafeKey().Key})
-					extOK, extErr = extIter.Valid()
-				}
-				if extChangedKeys && sstChangedKeys && !extOK && sstOK {
+				// Re-seek the ext iterator if the ext iterator changed keys and:
+				// 1) the SST iterator did not change keys, and we need to bring the ext
+				//    iterator back.
+				// 2) the ext iterator became invalid
+				// 3) both iterators changed keys and the sst iterator's key is further
+				//    ahead.
+				if extChangedKeys && (!sstChangedKeys || (!extOK && sstOK) || extIter.UnsafeKey().Key.Compare(sstIter.UnsafeKey().Key) < 0) {
 					extIter.SeekGE(MVCCKey{Key: sstIter.UnsafeKey().Key})
 					extOK, extErr = extIter.Valid()
 				}


### PR DESCRIPTION
Manual backport of #94395.

----

Previously, we were returning an obscure error around MVCCValueLenAndIsTombstone not being supported for interleaved intents if we encountered an intent in the engine. This change fixes that to return a more appropriate error.

This change also fixes a case where the engine iterator would unexpectedly land on a key < the sst iterator, violating an invariant in this function.

Fixes parts of #94141.

Release note: None

Epic: none