### PR TITLE
sql/pgwire: support for decoding JSON[] OID by aliasing to JSONB[] OID

### DIFF
--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -417,11 +417,14 @@ func (ex *connExecutor) execBind(
 				} else {
 					typ, ok := types.OidToType[t]
 					if !ok {
+						// These special cases for json, json[] is here so we can
+						// support decoding parameters with oid=json/json[] without
+						// adding full support for these type.
+						// TODO(sql-exp): Remove this if we support JSON.
 						if t == oid.T_json {
-							// This special case is here so we can support decoding parameters
-							// with oid=json without adding full support for the JSON type.
-							// TODO(sql-exp): Remove this if we support JSON.
 							typ = types.Json
+						} else if t == oid.T__json {
+							typ = types.JSONArrayForDecodingOnly
 						} else {
 							var err error
 							typ, err = ex.planner.ResolveTypeByOID(ctx, t)

--- a/pkg/sql/logictest/testdata/logic_test/json
+++ b/pkg/sql/logictest/testdata/logic_test/json
@@ -209,7 +209,7 @@ SELECT * from foo where bar->'x' = '{}'
 query T
 SELECT array_agg(bar ORDER BY pk) FROM foo
 ----
-{"'{\"a\": \"b\"}'","'[1, 2, 3]'","\"hello\"",1.000,true,false,NULL,"'{\"x\": [1, 2, 3]}'","'{\"x\": {\"y\": \"z\"}}'"}
+{"{\"a\": \"b\"}","[1, 2, 3]","\"hello\"",1.000,true,false,NULL,"{\"x\": [1, 2, 3]}","{\"x\": {\"y\": \"z\"}}"}
 
 statement ok
 DELETE FROM foo

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -973,11 +973,16 @@ func (c *conn) handleParse(
 				sqlTypeHints[i] = nil
 				continue
 			}
+			// This special case for json, json[] is here so we can support decoding
+			// parameters with oid=json/json[] without adding full support for these
+			// type.
+			// TODO(sql-exp): Remove this if we support JSON.
 			if t == oid.T_json {
-				// This special case is here so we can support decoding parameters
-				// with oid=json without adding full support for the JSON type.
-				// TODO(sql-exp): Remove this if we support JSON.
 				sqlTypeHints[i] = types.Json
+				continue
+			}
+			if t == oid.T__json {
+				sqlTypeHints[i] = types.JSONArrayForDecodingOnly
 				continue
 			}
 			v, ok := types.OidToType[t]

--- a/pkg/sql/pgwire/testdata/pgtest/json
+++ b/pkg/sql/pgwire/testdata/pgtest/json
@@ -116,3 +116,68 @@ ReadyForQuery
 {"Type":"DataRow","Values":[{"binary":"017b226b6579223a202276616c227d"}]}
 {"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Test formatting for spaces between key and value in a json.
+# https://github.com/cockroachdb/cockroach/issues/95434.
+send
+Parse {"Query": "SELECT $1::JSON"}
+Bind {"ParameterFormatCodes": [0], "Parameters": [{"text":"{\"key\":    \"val\"}"}]}
+Describe {"ObjectType": "S"}
+Execute
+Sync
+----
+
+# PG's format output follows the input.
+until noncrdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[114]}
+{"Type":"RowDescription","Fields":[{"Name":"json","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":114,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"text":"{\"key\":    \"val\"}"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# CRDB has a fixed len of space between the key and value when formatting the json.
+until crdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[3802]}
+{"Type":"RowDescription","Fields":[{"Name":"jsonb","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":3802,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"text":"{\"key\": \"val\"}"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Parse {"Query": "SELECT $1::JSON"}
+Bind {"ParameterFormatCodes": [0], "Parameters": [{"text":"{\"key\":\"val\"}"}]}
+Describe {"ObjectType": "S"}
+Execute
+Sync
+----
+
+until noncrdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[114]}
+{"Type":"RowDescription","Fields":[{"Name":"json","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":114,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"text":"{\"key\":\"val\"}"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# CRDB has a fixed len of space between the key and value when formatting the json.
+until crdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[3802]}
+{"Type":"RowDescription","Fields":[{"Name":"jsonb","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":3802,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"text":"{\"key\": \"val\"}"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/pgwire/testdata/pgtest/json_array
+++ b/pkg/sql/pgwire/testdata/pgtest/json_array
@@ -518,3 +518,65 @@ ReadyForQuery
 {"Type":"DataRow","Values":[{"text":"{\"{\\\"a\\\": {\\\"b\\\": \\\"c\\\"}}\"}"}]}
 {"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
+
+# PG's binary stores the space between kv, while crdb does not.
+# https://github.com/cockroachdb/cockroach/issues/95434.
+send
+Parse {"Query": "SELECT $1::JSON[]", "ParameterOIDs":[199]}
+Bind {"ParameterFormatCodes": [0], "ResultFormatCodes": [1], "Parameters": [{"text":"{\"{\\\"a\\\":      {}}\"}"}]}
+Describe {"ObjectType": "S"}
+Execute
+Sync
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[199]}
+{"Type":"RowDescription","Fields":[{"Name":"jsonb","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":3807,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"binary":"000000010000000000000eda00000001000000010000000a017b2261223a207b7d7d"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+until noncrdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[199]}
+{"Type":"RowDescription","Fields":[{"Name":"json","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":199,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"binary":"00000001000000000000007200000001000000010000000e7b2261223a2020202020207b7d7d"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Parse {"Query": "SELECT $1::JSON[]", "ParameterOIDs":[199]}
+Bind {"ParameterFormatCodes": [0], "ResultFormatCodes": [1], "Parameters": [{"text":"{\"{\\\"a\\\":{}}\"}"}]}
+Describe {"ObjectType": "S"}
+Execute
+Sync
+----
+
+until noncrdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[199]}
+{"Type":"RowDescription","Fields":[{"Name":"json","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":199,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"binary":"0000000100000000000000720000000100000001000000087b2261223a7b7d7d"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[199]}
+{"Type":"RowDescription","Fields":[{"Name":"jsonb","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":3807,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"binary":"000000010000000000000eda00000001000000010000000a017b2261223a207b7d7d"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/pgwire/testdata/pgtest/json_array
+++ b/pkg/sql/pgwire/testdata/pgtest/json_array
@@ -1,4 +1,4 @@
-send
+send crdb_only
 Query {"String": "SELECT ARRAY['{\"a\":{}}']::JSON[]"}
 ----
 
@@ -6,14 +6,254 @@ Query {"String": "SELECT ARRAY['{\"a\":{}}']::JSON[]"}
 until crdb_only
 ReadyForQuery
 ----
-{"Type":"RowDescription","Fields":[{"Name":"array","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":199,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
-{"Type":"DataRow","Values":[{"text":"{\"{\\\"a\\\":{}}\"}"}]}
+{"Type":"RowDescription","Fields":[{"Name":"array","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":3807,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"text":"{\"{\\\"a\\\": {}}\"}"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+
+# Array value must be of `{}` form.
+send
+Parse {"Query": "SELECT $1::JSON[]"}
+Bind {"ParameterFormatCodes": [0], "ResultFormatCodes": [1], "Parameters": [{"text":""}]}
+Execute
+Sync
+----
+
+until
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ErrorResponse","Code":"22P02"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Test text output encoding for JSON array.
+send crdb_only
+Parse {"Query": "SELECT $1::JSON[]"}
+Bind {"ParameterFormatCodes": [0], "Parameters": [{"text":"{}"}]}
+Describe {"ObjectType": "S"}
+Execute
+Sync
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[3807]}
+{"Type":"RowDescription","Fields":[{"Name":"jsonb","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":3807,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"text":"{}"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send crdb_only
+Parse {"Query": "SELECT $1::JSON[]"}
+Bind {"ParameterFormatCodes": [0], "Parameters": [{"text":"{\"{\\\"a\\\": {}}\"}"}]}
+Describe {"ObjectType": "S"}
+Execute
+Sync
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[3807]}
+{"Type":"RowDescription","Fields":[{"Name":"jsonb","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":3807,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"text":"{\"{\\\"a\\\": {}}\"}"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Test binary output encoding for JSON array text.
+send
+Parse {"Query": "SELECT $1::JSON[]"}
+Bind {"ParameterFormatCodes": [0], "ResultFormatCodes": [1], "Parameters": [{"text":"{}"}]}
+Describe {"ObjectType": "S"}
+Execute
+Sync
+----
+
+# CRDB currently only supports decoding JSON values. Encoding will always be in
+# JSONB format.
+until crdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[3807]}
+{"Type":"RowDescription","Fields":[{"Name":"jsonb","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":3807,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"binary":"000000000000000000000eda"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+until noncrdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[199]}
+{"Type":"RowDescription","Fields":[{"Name":"json","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":199,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"binary":"000000000000000000000072"}]}
 {"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
 send
 Parse {"Query": "SELECT $1::JSON[]"}
-Bind {"ParameterFormatCodes": [0], "Parameters": [{"text":"{}"}]}
+Bind {"ParameterFormatCodes": [0], "ResultFormatCodes": [1], "Parameters": [{"text":"{\"{\\\"a\\\": {}}\"}"}]}
+Describe {"ObjectType": "S"}
+Execute
+Sync
+----
+
+# CRDB currently only supports decoding JSON values. Encoding will always be in
+# JSONB format.
+until crdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[3807]}
+{"Type":"RowDescription","Fields":[{"Name":"jsonb","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":3807,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"binary":"000000010000000000000eda00000001000000010000000a017b2261223a207b7d7d"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+until noncrdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[199]}
+{"Type":"RowDescription","Fields":[{"Name":"json","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":199,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"binary":"0000000100000000000000720000000100000001000000097b2261223a207b7d7d"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Check that we can handle JSON parameters.
+# Text to Text.
+send
+Parse {"Query": "SELECT $1::JSON[]", "ParameterOIDs": [199]}
+Describe {"ObjectType": "S"}
+Bind {"ParameterFormatCodes": [0], "Parameters": [{"text":"{\"{\\\"a\\\": {}}\"}"}]}
+Execute
+Sync
+----
+
+until noncrdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[199]}
+{"Type":"RowDescription","Fields":[{"Name":"json","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":199,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"{\"{\\\"a\\\": {}}\"}"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# CRDB currently only supports decoding JSON values. Encoding will always be in
+# JSONB format.
+until crdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[199]}
+{"Type":"RowDescription","Fields":[{"Name":"jsonb","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":3807,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"{\"{\\\"a\\\": {}}\"}"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Text to binary.
+send
+Parse {"Query": "SELECT $1::JSON[]", "ParameterOIDs":[199]}
+Bind {"ParameterFormatCodes": [0], "ResultFormatCodes": [1], "Parameters": [{"text":"{}"}]}
+Describe {"ObjectType": "S"}
+Execute
+Sync
+----
+
+# CRDB currently only supports decoding JSON values. Encoding will always be in
+# JSONB format.
+until crdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[199]}
+{"Type":"RowDescription","Fields":[{"Name":"jsonb","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":3807,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"binary":"000000000000000000000eda"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+until noncrdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[199]}
+{"Type":"RowDescription","Fields":[{"Name":"json","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":199,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"binary":"000000000000000000000072"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Parse {"Query": "SELECT $1::JSON[]", "ParameterOIDs":[199]}
+Bind {"ParameterFormatCodes": [0], "ResultFormatCodes": [1], "Parameters": [{"text":"{\"{\\\"a\\\": {}}\"}"}]}
+Describe {"ObjectType": "S"}
+Execute
+Sync
+----
+
+# CRDB currently only supports decoding JSON values. Encoding will always be in
+# JSONB format.
+until crdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[199]}
+{"Type":"RowDescription","Fields":[{"Name":"jsonb","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":3807,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"binary":"000000010000000000000eda00000001000000010000000a017b2261223a207b7d7d"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+until noncrdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[199]}
+{"Type":"RowDescription","Fields":[{"Name":"json","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":199,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"binary":"0000000100000000000000720000000100000001000000097b2261223a207b7d7d"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Binary to Text.
+# `000000000000000000000eda` is the binary representation of `{}` in
+# type JSONB[].
+send
+Parse {"Query": "SELECT $1::JSON[]", "ParameterOIDs":[199]}
+Bind {"ParameterFormatCodes": [1], "Parameters": [{"binary":"000000000000000000000eda"}]}
+Execute
+Sync
+----
+
+# PG returns 42804 (data type mismatch) while CRDB returns 08P01
+# (protocol violation), but both are acceptable.
+until mapError=(42804, 08P01)
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ErrorResponse","Code":"08P01"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Parse {"Query": "SELECT $1::JSONB[]", "ParameterOIDs":[3807]}
+Bind {"ParameterFormatCodes": [1], "Parameters": [{"binary":"000000000000000000000eda"}]}
 Execute
 Sync
 ----
@@ -27,8 +267,60 @@ ReadyForQuery
 {"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
+# `000000000000000000000072` is the binary representation of `{}` in
+# type JSON[].
 send
-Bind {"ParameterFormatCodes": [0], "ResultFormatCodes": [1], "Parameters": [{"text":"{}"}]}
+Parse {"Query": "SELECT $1::JSON[]", "ParameterOIDs":[199]}
+Describe {"ObjectType": "S"}
+Bind {"ParameterFormatCodes": [1], "Parameters": [{"binary":"000000000000000000000072"}]}
+Execute
+Sync
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[199]}
+{"Type":"RowDescription","Fields":[{"Name":"jsonb","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":3807,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"{}"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+until noncrdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[199]}
+{"Type":"RowDescription","Fields":[{"Name":"json","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":199,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"{}"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# `000000010000000000000eda00000001000000010000000a017b2261223a207b7d7d`
+# is the binary representation of `{\"{\\\"a\\\": {}}\"}` in type JSONB[].
+send
+Parse {"Query": "SELECT $1::JSON[]", "ParameterOIDs":[199]}
+Bind {"ParameterFormatCodes": [1], "Parameters": [{"binary":"000000010000000000000eda00000001000000010000000a017b2261223a207b7d7d"}]}
+Execute
+Sync
+----
+
+# PG returns 42804 (data type mismatch) while CRDB returns 08P01
+# (protocol violation), but both are acceptable.
+until mapError=(42804, 08P01)
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ErrorResponse","Code":"08P01"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Parse {"Query": "SELECT $1::JSONB[]", "ParameterOIDs":[3807]}
+Bind {"ParameterFormatCodes": [1], "Parameters": [{"binary":"000000010000000000000eda00000001000000010000000a017b2261223a207b7d7d"}]}
 Execute
 Sync
 ----
@@ -36,16 +328,171 @@ Sync
 until
 ReadyForQuery
 ----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"{\"{\\\"a\\\": {}}\"}"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# `0000000100000000000000720000000100000001000000097b2261223a207b7d7d`
+# is the binary representation of `{\"{\\\"a\\\": {}}\"}` in type JSON[].
+send
+Parse {"Query": "SELECT $1::JSON[]", "ParameterOIDs":[199]}
+Bind {"ParameterFormatCodes": [1], "Parameters": [{"binary":"0000000100000000000000720000000100000001000000097b2261223a207b7d7d"}]}
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"{\"{\\\"a\\\": {}}\"}"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Binary to Binary.
+# `000000000000000000000eda` is the binary representation of `{}` in
+# type JSONB[].
+send
+Parse {"Query": "SELECT $1::JSON[]", "ParameterOIDs":[199]}
+Bind {"ParameterFormatCodes": [1], "ResultFormatCodes": [1], "Parameters": [{"binary":"000000000000000000000eda"}]}
+Describe {"ObjectType": "S"}
+Execute
+Sync
+----
+
+# PG returns 42804 (data type mismatch) while CRDB returns 08P01
+# (protocol violation), but both are acceptable.
+until mapError=(42804, 08P01)
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ErrorResponse","Code":"08P01"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Parse {"Query": "SELECT $1::JSONB[]", "ParameterOIDs":[3807]}
+Bind {"ParameterFormatCodes": [1], "ResultFormatCodes": [1], "Parameters": [{"binary":"000000000000000000000eda"}]}
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"binary":"000000000000000000000eda"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# `000000000000000000000072` is the binary representation of `{}` in
+# type JSON[].
+send
+Parse {"Query": "SELECT $1::JSON[]", "ParameterOIDs":[199]}
+Describe {"ObjectType": "S"}
+Bind {"ParameterFormatCodes": [1], "ResultFormatCodes": [1], "Parameters": [{"binary":"000000000000000000000072"}]}
+Execute
+Sync
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[199]}
+{"Type":"RowDescription","Fields":[{"Name":"jsonb","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":3807,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
 {"Type":"BindComplete"}
 {"Type":"DataRow","Values":[{"binary":"000000000000000000000072"}]}
 {"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
-# Check if we can handle JSON parameters.
+until noncrdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[199]}
+{"Type":"RowDescription","Fields":[{"Name":"json","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":199,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"binary":"000000000000000000000072"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# `000000010000000000000eda00000001000000010000000a017b2261223a207b7d7d`
+# is the binary representation of `{\"{\\\"a\\\": {}}\"}` in type JSONB[].
+send
+Parse {"Query": "SELECT $1::JSON[]", "ParameterOIDs":[199]}
+Bind {"ParameterFormatCodes": [1], "ResultFormatCodes": [1], "Parameters": [{"binary":"000000010000000000000eda00000001000000010000000a017b2261223a207b7d7d"}]}
+Execute
+Sync
+----
+
+# PG returns 42804 (data type mismatch) while CRDB returns 08P01
+# (protocol violation), but both are acceptable.
+until mapError=(42804, 08P01)
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ErrorResponse","Code":"08P01"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Parse {"Query": "SELECT $1::JSONB[]", "ParameterOIDs":[3807]}
+Bind {"ParameterFormatCodes": [1], "ResultFormatCodes": [1], "Parameters": [{"binary":"000000010000000000000eda00000001000000010000000a017b2261223a207b7d7d"}]}
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"binary":"000000010000000000000eda00000001000000010000000a017b2261223a207b7d7d"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# `0000000100000000000000720000000100000001000000097b2261223a207b7d7d`
+# is the binary representation of `{\"{\\\"a\\\": {}}\"}` in type JSON[].
+send
+Parse {"Query": "SELECT $1::JSON[]", "ParameterOIDs":[199]}
+Bind {"ParameterFormatCodes": [1], "ResultFormatCodes": [1], "Parameters": [{"binary":"0000000100000000000000720000000100000001000000097b2261223a207b7d7d"}]}
+Describe {"ObjectType": "S"}
+Execute
+Sync
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[199]}
+{"Type":"RowDescription","Fields":[{"Name":"jsonb","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":3807,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"binary":"0000000100000000000000720000000100000001000000097b2261223a207b7d7d"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+until noncrdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[199]}
+{"Type":"RowDescription","Fields":[{"Name":"json","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":199,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"binary":"0000000100000000000000720000000100000001000000097b2261223a207b7d7d"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Test with nested JSON.
 send
 Parse {"Query": "SELECT $1::JSON[]", "ParameterOIDs": [199]}
 Describe {"ObjectType": "S"}
-Bind {"ParameterFormatCodes": [0], "Parameters": [{"text":"{\"{\\\"a\\\":{}}\"}"}]}
+Bind {"ParameterFormatCodes": [0], "Parameters": [{"text":"{\"{\\\"a\\\":{\\\"b\\\": \\\"c\\\"}}\"}"}]}
 Execute
 Sync
 ----
@@ -57,14 +504,17 @@ ReadyForQuery
 {"Type":"ParameterDescription","ParameterOIDs":[199]}
 {"Type":"RowDescription","Fields":[{"Name":"json","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":199,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
 {"Type":"BindComplete"}
-{"Type":"DataRow","Values":[{"text":"{\"{\\\"a\\\":{}}\"}"}]}
+{"Type":"DataRow","Values":[{"text":"{\"{\\\"a\\\":{\\\"b\\\": \\\"c\\\"}}\"}"}]}
 {"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
-# unknown oid type: 199
 until crdb_only
-ErrorResponse
 ReadyForQuery
 ----
-{"Type":"ErrorResponse","Code":"08P01"}
+{"Type":"ParseComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[199]}
+{"Type":"RowDescription","Fields":[{"Name":"jsonb","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":3807,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"{\"{\\\"a\\\": {\\\"b\\\": \\\"c\\\"}}\"}"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/pgwire/testdata/pgtest/json_array
+++ b/pkg/sql/pgwire/testdata/pgtest/json_array
@@ -1,0 +1,70 @@
+send
+Query {"String": "SELECT ARRAY['{\"a\":{}}']::JSON[]"}
+----
+
+# JSON[] is implicitly treated as JSONB[].
+until crdb_only
+ReadyForQuery
+----
+{"Type":"RowDescription","Fields":[{"Name":"array","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":199,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"text":"{\"{\\\"a\\\":{}}\"}"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Parse {"Query": "SELECT $1::JSON[]"}
+Bind {"ParameterFormatCodes": [0], "Parameters": [{"text":"{}"}]}
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"{}"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Bind {"ParameterFormatCodes": [0], "ResultFormatCodes": [1], "Parameters": [{"text":"{}"}]}
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"binary":"000000000000000000000072"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Check if we can handle JSON parameters.
+send
+Parse {"Query": "SELECT $1::JSON[]", "ParameterOIDs": [199]}
+Describe {"ObjectType": "S"}
+Bind {"ParameterFormatCodes": [0], "Parameters": [{"text":"{\"{\\\"a\\\":{}}\"}"}]}
+Execute
+Sync
+----
+
+until noncrdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[199]}
+{"Type":"RowDescription","Fields":[{"Name":"json","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":199,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"{\"{\\\"a\\\":{}}\"}"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# unknown oid type: 199
+until crdb_only
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ErrorResponse","Code":"08P01"}
+{"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4209,7 +4209,7 @@ value if you rely on the HLC for accuracy.`,
 	),
 	"crdb_internal.merge_statement_stats": makeBuiltin(arrayProps(),
 		tree.Overload{
-			Types:      tree.ParamTypes{{Name: "input", Typ: types.JSONArray}},
+			Types:      tree.ParamTypes{{Name: "input", Typ: types.JSONBArray}},
 			ReturnType: tree.FixedReturnType(types.Jsonb),
 			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				arr := tree.MustBeDArray(args[0])
@@ -4240,7 +4240,7 @@ value if you rely on the HLC for accuracy.`,
 	),
 	"crdb_internal.merge_transaction_stats": makeBuiltin(arrayProps(),
 		tree.Overload{
-			Types:      tree.ParamTypes{{Name: "input", Typ: types.JSONArray}},
+			Types:      tree.ParamTypes{{Name: "input", Typ: types.JSONBArray}},
 			ReturnType: tree.FixedReturnType(types.Jsonb),
 			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				arr := tree.MustBeDArray(args[0])
@@ -4274,7 +4274,7 @@ value if you rely on the HLC for accuracy.`,
 	),
 	"crdb_internal.merge_stats_metadata": makeBuiltin(arrayProps(),
 		tree.Overload{
-			Types:      tree.ParamTypes{{Name: "input", Typ: types.JSONArray}},
+			Types:      tree.ParamTypes{{Name: "input", Typ: types.JSONBArray}},
 			ReturnType: tree.FixedReturnType(types.Jsonb),
 			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				arr := tree.MustBeDArray(args[0])

--- a/pkg/sql/sem/tree/pgwire_encode.go
+++ b/pkg/sql/sem/tree/pgwire_encode.go
@@ -151,6 +151,10 @@ func (d *DArray) pgwireFormat(ctx *FmtCtx) {
 			floatTyp := d.ResolvedType().ArrayContents()
 			b := PgwireFormatFloat(nil /*buf*/, fl, ctx.dataConversionConfig, floatTyp)
 			ctx.WriteString(string(b))
+		case *DJSON:
+			flags := ctx.flags | fmtRawStrings
+			s := AsStringWithFlags(v, flags, FmtDataConversionConfig(ctx.dataConversionConfig))
+			pgwireFormatStringInArray(ctx, s)
 		default:
 			s := AsStringWithFlags(v, ctx.flags, FmtDataConversionConfig(ctx.dataConversionConfig))
 			pgwireFormatStringInArray(ctx, s)

--- a/pkg/sql/session_state.go
+++ b/pkg/sql/session_state.go
@@ -175,11 +175,17 @@ func (p *planner) DeserializeSessionState(
 					placeholderTypes[i] = nil
 					continue
 				}
+				// These special cases for json, json[] is here so we can
+				// support decoding parameters with oid=json/json[] without
+				// adding full support for these type.
+				// TODO(sql-exp): Remove this if we support JSON.
 				if t == oid.T_json {
-					// This special case is here so we can support decoding parameters
-					// with oid=json without adding full support for the JSON type.
 					// TODO(sql-exp): Remove this if we support JSON.
 					placeholderTypes[i] = types.Json
+					continue
+				}
+				if t == oid.T__json {
+					placeholderTypes[i] = types.JSONArrayForDecodingOnly
 					continue
 				}
 				v, ok := types.OidToType[t]

--- a/pkg/sql/types/oid.go
+++ b/pkg/sql/types/oid.go
@@ -238,7 +238,11 @@ func CalcArrayOid(elemTyp *T) oid.Oid {
 	// Map the OID of the array element type to the corresponding array OID.
 	// This should always be possible for all other OIDs (checked in oid.go
 	// init method).
-	o = oidToArrayOid[o]
+	if o == oid.T_json {
+		o = oid.T__json
+	} else {
+		o = oidToArrayOid[o]
+	}
 	if o == 0 {
 		panic(errors.AssertionFailedf("oid %d couldn't be mapped to array oid", o))
 	}

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -650,9 +650,15 @@ var (
 	AnyEnumArray = &T{InternalType: InternalType{
 		Family: ArrayFamily, ArrayContents: AnyEnum, Oid: oid.T_anyarray, Locale: &emptyLocale}}
 
-	// JSONArray is the type of an array value having JSON-typed elements.
-	JSONArray = &T{InternalType: InternalType{
+	// JSONBArray is the type of an array value having JSONB-typed elements.
+	JSONBArray = &T{InternalType: InternalType{
 		Family: ArrayFamily, ArrayContents: Jsonb, Oid: oid.T__jsonb, Locale: &emptyLocale}}
+
+	// JSONArrayForDecodingOnly is the type of an array value having JSON-typed elements.
+	// Note that this struct can only used for decoding an input as we don't fully
+	// support the json array yet.
+	JSONArrayForDecodingOnly = &T{InternalType: InternalType{
+		Family: ArrayFamily, ArrayContents: Json, Oid: oid.T__json, Locale: &emptyLocale}}
 
 	// Int2Vector is a type-alias for an array of Int2 values with a different
 	// OID (T_int2vector instead of T__int2). It is a special VECTOR type used
@@ -1366,11 +1372,15 @@ func (t *T) WithoutTypeModifiers() *T {
 
 	typ, ok := OidToType[t.Oid()]
 	if !ok {
+		// These special cases for json, json[] is here so we can
+		// support decoding parameters with oid=json/json[] without
+		// adding full support for these type.
+		// TODO(sql-exp): Remove this if we support JSON.
 		if t.Oid() == oid.T_json {
-			// This special case is here so we can support decoding parameters
-			// with oid=json without adding full support for the JSON type.
-			// TODO(sql-exp): Remove this if we support JSON.
 			return Jsonb
+		}
+		if t.Oid() == oid.T__json {
+			return JSONArrayForDecodingOnly
 		}
 		panic(errors.AssertionFailedf("unexpected OID: %d", t.Oid()))
 	}


### PR DESCRIPTION
Previously, with the parameter type oid (199) for JSON[], the pgwire parse message
will fail to be executed with a `unknown oid type: 199`. We now aliasing it
to the one for `JSONB[]`.

This PR also includes a test revealing https://github.com/cockroachdb/cockroach/issues/95434.

This commit follows the changes in https://github.com/cockroachdb/cockroach/pull/88379.

fixes #90839

Release note (sql change): The pgwire protocol implementation can
now accept arguments of the JSON[] type (oid=199). Previously, it could
only accept JSONB[] (oid=3804). Internally, JSON[] and JSONB[] values are
still identical, so this change only affects how the values are received
over the wire protocol.