### PR TITLE
sqlsmith: skip crdb_internal.job_payload_type in sqlsmith testing

### DIFF
--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -505,6 +505,7 @@ var functions = func() map[tree.FunctionClass]map[oid.Oid][]function {
 			"crdb_internal.force_",
 			"crdb_internal.unsafe_",
 			"crdb_internal.create_join_token",
+			"crdb_internal.job_payload_type",
 			"crdb_internal.reset_multi_region_zone_configs_for_database",
 			"crdb_internal.reset_index_usage_stats",
 			"crdb_internal.start_replication_stream",


### PR DESCRIPTION
crdb_internal.job_payload_type is a recently-added builtin function that
expects specific payload types. Most inputs generated by sqlsmith cause
the builtin to produce an unexpected error. This PR adds it to the
sqlsmith skip list until it can fail more gracefully.
    
Epic: none
Informs: #94680