### PR TITLE
sql: add user-facing error for invalid job type in job_payload_type builtin

### DIFF
--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -505,7 +505,6 @@ var functions = func() map[tree.FunctionClass]map[oid.Oid][]function {
 			"crdb_internal.force_",
 			"crdb_internal.unsafe_",
 			"crdb_internal.create_join_token",
-			"crdb_internal.job_payload_type",
 			"crdb_internal.reset_multi_region_zone_configs_for_database",
 			"crdb_internal.reset_index_usage_stats",
 			"crdb_internal.start_replication_stream",

--- a/pkg/jobs/jobspb/wrap.go
+++ b/pkg/jobs/jobspb/wrap.go
@@ -68,8 +68,18 @@ var (
 	_ ProgressDetails = SchemaTelemetryProgress{}
 )
 
-// Type returns the payload's job type.
+// Type returns the payload's job type and panics if the type is invalid.
 func (p *Payload) Type() Type {
+	typ, err := DetailsType(p.Details)
+	if err != nil {
+		panic(err)
+	}
+	return typ
+}
+
+// CheckType returns the payload's job type with an error
+// if the type is invalid.
+func (p *Payload) CheckType() (Type, error) {
 	return DetailsType(p.Details)
 }
 
@@ -103,46 +113,46 @@ var AutomaticJobTypes = [...]Type{
 }
 
 // DetailsType returns the type for a payload detail.
-func DetailsType(d isPayload_Details) Type {
+func DetailsType(d isPayload_Details) (Type, error) {
 	switch d := d.(type) {
 	case *Payload_Backup:
-		return TypeBackup
+		return TypeBackup, nil
 	case *Payload_Restore:
-		return TypeRestore
+		return TypeRestore, nil
 	case *Payload_SchemaChange:
-		return TypeSchemaChange
+		return TypeSchemaChange, nil
 	case *Payload_Import:
-		return TypeImport
+		return TypeImport, nil
 	case *Payload_Changefeed:
-		return TypeChangefeed
+		return TypeChangefeed, nil
 	case *Payload_CreateStats:
 		createStatsName := d.CreateStats.Name
 		if createStatsName == AutoStatsName {
-			return TypeAutoCreateStats
+			return TypeAutoCreateStats, nil
 		}
-		return TypeCreateStats
+		return TypeCreateStats, nil
 	case *Payload_SchemaChangeGC:
-		return TypeSchemaChangeGC
+		return TypeSchemaChangeGC, nil
 	case *Payload_TypeSchemaChange:
-		return TypeTypeSchemaChange
+		return TypeTypeSchemaChange, nil
 	case *Payload_StreamIngestion:
-		return TypeStreamIngestion
+		return TypeStreamIngestion, nil
 	case *Payload_NewSchemaChange:
-		return TypeNewSchemaChange
+		return TypeNewSchemaChange, nil
 	case *Payload_Migration:
-		return TypeMigration
+		return TypeMigration, nil
 	case *Payload_AutoSpanConfigReconciliation:
-		return TypeAutoSpanConfigReconciliation
+		return TypeAutoSpanConfigReconciliation, nil
 	case *Payload_AutoSQLStatsCompaction:
-		return TypeAutoSQLStatsCompaction
+		return TypeAutoSQLStatsCompaction, nil
 	case *Payload_StreamReplication:
-		return TypeStreamReplication
+		return TypeStreamReplication, nil
 	case *Payload_RowLevelTTL:
-		return TypeRowLevelTTL
+		return TypeRowLevelTTL, nil
 	case *Payload_SchemaTelemetry:
-		return TypeAutoSchemaTelemetry
+		return TypeAutoSchemaTelemetry, nil
 	default:
-		panic(errors.AssertionFailedf("Payload.Type called on a payload with an unknown details type: %T", d))
+		return TypeUnspecified, errors.Newf("Payload.Type called on a payload with an unknown details type: %T", d)
 	}
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -3763,6 +3763,9 @@ SELECT parse_ident('ab.xyz()', false)
 query error string is not a valid identifier: \"ab.xyz\(\)\"
 SELECT parse_ident('ab.xyz()', true)
 
-# Test that we return an appropriate user-facing error message when trying to decode invalid bytes.
+# Test that we return appropriate user-facing errors when trying to decode invalid bytes.
 query error pgcode 22023 pq: crdb_internal.job_payload_type\(\): invalid protocol message: proto: wrong wireType = 1 for field Import
 select crdb_internal.job_payload_type('invalid'::BYTES);
+
+query error pgcode 22023 pq: crdb_internal.job_payload_type\(\): invalid type in job payload protocol message: Payload.Type called on a payload with an unknown details type: <nil>
+select crdb_internal.job_payload_type('');

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4092,7 +4092,11 @@ value if you rely on the HLC for accuracy.`,
 				if err := protoutil.Unmarshal(data, &msg); err != nil {
 					return nil, pgerror.Wrap(err, pgcode.InvalidParameterValue, "invalid protocol message")
 				}
-				return tree.NewDString(msg.Type().String()), nil
+				typ, err := msg.CheckType()
+				if err != nil {
+					return nil, pgerror.Wrap(err, pgcode.InvalidParameterValue, "invalid type in job payload protocol message")
+				}
+				return tree.NewDString(typ.String()), nil
 			}
 
 			return []tree.Overload{


### PR DESCRIPTION
### sql: add user-facing error for invalid job type in job_payload_type builtin

Previously, the `job_payload_type` builtin would return an internal error
if the payload could be unmarshalled, but the type could not be determined.
This changes ensures the builtin returns an appropriate user-facing error
in this case.

Epic: none
Fixes: https://github.com/cockroachdb/cockroach/issues/94680

Release note: None