### PR TITLE
ui: add summary cards on explain plan details

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/plansTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/plansTable.tsx
@@ -183,7 +183,7 @@ function formatInsights(recommendations: string[]): string {
   return `${recommendations.length} Insights`;
 }
 
-function formatIndexes(indexes: string[], database: string): ReactNode {
+export function formatIndexes(indexes: string[], database: string): ReactNode {
   if (indexes.length == 0) {
     return <></>;
   }

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.module.scss
@@ -156,3 +156,7 @@
 .margin-header {
   margin-top: 10px;
 }
+
+.margin-left-neg {
+  margin-left: -11px !important;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -632,7 +632,7 @@ export class StatementDetails extends React.Component<
               />
             </Col>
           </Row>
-          <Row gutter={24}>
+          <Row gutter={24} className={cx("margin-left-neg")}>
             <Col className="gutter-row" span={12}>
               <SummaryCard id="first-card" className={cx("summary-card")}>
                 {!isTenant && (


### PR DESCRIPTION
Previously, we only displayed the information about each explain plan on its overview page, making it hard to see the details for the specific plan selected.
This commit adds the information on the Explan Plan Details page, under the plan itself.
The information added:
- Last Execution Time
- Average Execution Time
- Execution Count
- Average Rows Read
- Full Scan
- Distributed
- Vectorized
- Used Indexes (contains link to table and index details)

https://www.loom.com/share/19fa0f727f6547a5b6595aef29e7d56e

<img width="1687" alt="Screen Shot 2023-01-04 at 3 21 22 PM" src="https://user-images.githubusercontent.com/1017486/210642823-08d488f7-a6cb-4806-8586-69f11dcf1320.png">


Epic: None

Release note (ui change): Adds information about the selected plan to the Explain Plan tab under Statement Details.