### PR TITLE
tsdb: store metrics with tenant separation

### DIFF
--- a/pkg/cli/mt_start_sql.go
+++ b/pkg/cli/mt_start_sql.go
@@ -87,7 +87,7 @@ func runStartSQL(cmd *cobra.Command, args []string) error {
 		// always be non-nil, even if NewServer returns a nil pointer (and
 		// an error). The code below is dependent on the interface
 		// reference remaining nil in case of error.
-		s, err := server.NewTenantServer(ctx, stopper, serverCfg.BaseConfig, serverCfg.SQLConfig)
+		s, err := server.NewTenantServer(ctx, stopper, serverCfg.BaseConfig, serverCfg.SQLConfig, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/server/server_controller.go
+++ b/pkg/server/server_controller.go
@@ -698,7 +698,7 @@ func (s *Server) startInMemoryTenantServerInternal(
 	log.Infof(startCtx, "starting tenant server")
 
 	// Now start the tenant proper.
-	tenantServer, err = NewTenantServer(startCtx, stopper, baseCfg, sqlCfg)
+	tenantServer, err = NewTenantServer(startCtx, stopper, baseCfg, sqlCfg, s.recorder)
 	if err != nil {
 		return stopper, tenantServer, err
 	}

--- a/pkg/server/status/BUILD.bazel
+++ b/pkg/server/status/BUILD.bazel
@@ -132,6 +132,7 @@ go_test(
         "//pkg/base",
         "//pkg/build",
         "//pkg/roachpb",
+        "//pkg/rpc",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
@@ -149,6 +150,7 @@ go_test(
         "//pkg/util/timeutil",
         "@com_github_kr_pretty//:pretty",
         "@com_github_shirou_gopsutil_v3//net",
+        "@com_github_stretchr_testify//require",
     ],
 )
 

--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -128,6 +128,8 @@ type MetricsRecorder struct {
 		// independent.
 		storeRegistries map[roachpb.StoreID]*metric.Registry
 		stores          map[roachpb.StoreID]storeMetrics
+
+		tenantRecorders map[roachpb.TenantID]*MetricsRecorder
 	}
 
 	// prometheusExporter merges metrics into families and generates the
@@ -139,6 +141,9 @@ type MetricsRecorder struct {
 	// round-trip) that requires a mutex to be safe for concurrent usage. We
 	// therefore give it its own mutex to avoid blocking other methods.
 	writeSummaryMu syncutil.Mutex
+
+	// tenantID is the tenantID of the tenant this recorder is attached to.
+	tenantID roachpb.TenantID
 }
 
 // NewMetricsRecorder initializes a new MetricsRecorder object that uses the
@@ -159,9 +164,18 @@ func NewMetricsRecorder(
 	}
 	mr.mu.storeRegistries = make(map[roachpb.StoreID]*metric.Registry)
 	mr.mu.stores = make(map[roachpb.StoreID]storeMetrics)
+	mr.mu.tenantRecorders = make(map[roachpb.TenantID]*MetricsRecorder)
 	mr.prometheusExporter = metric.MakePrometheusExporter()
 	mr.clock = clock
+	mr.tenantID = rpcContext.TenantID
 	return mr
+}
+
+func (mr *MetricsRecorder) AddTenantRecorder(rec *MetricsRecorder) {
+	mr.mu.Lock()
+	defer mr.mu.Unlock()
+
+	mr.mu.tenantRecorders[rec.tenantID] = rec
 }
 
 // AddNode adds the Registry from an initialized node, along with its descriptor
@@ -192,6 +206,7 @@ func (mr *MetricsRecorder) AddNode(
 	nodeIDGauge := metric.NewGauge(metadata)
 	nodeIDGauge.Update(int64(desc.NodeID))
 	reg.AddMetric(nodeIDGauge)
+	reg.AddLabel("tenant_id", mr.tenantID.String())
 }
 
 // AddStore adds the Registry from the provided store as a store-level registry
@@ -249,6 +264,9 @@ func (mr *MetricsRecorder) ScrapeIntoPrometheus(pm *metric.PrometheusExporter) {
 	pm.ScrapeRegistry(mr.mu.nodeRegistry, includeChildMetrics)
 	for _, reg := range mr.mu.storeRegistries {
 		pm.ScrapeRegistry(reg, includeChildMetrics)
+	}
+	for _, ten := range mr.mu.tenantRecorders {
+		ten.ScrapeIntoPrometheus(pm)
 	}
 }
 

--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -315,7 +315,7 @@ func (mr *MetricsRecorder) GetTimeSeriesData() []tspb.TimeSeriesData {
 	now := mr.clock.PhysicalNow()
 	recorder := registryRecorder{
 		registry:       mr.mu.nodeRegistry,
-		format:         nodeTimeSeriesPrefix,
+		format:         fmt.Sprintf("%s.%s", mr.tenantID.String(), nodeTimeSeriesPrefix),
 		source:         strconv.FormatInt(int64(mr.mu.desc.NodeID), 10),
 		timestampNanos: now,
 	}
@@ -325,11 +325,14 @@ func (mr *MetricsRecorder) GetTimeSeriesData() []tspb.TimeSeriesData {
 	for storeID, r := range mr.mu.storeRegistries {
 		storeRecorder := registryRecorder{
 			registry:       r,
-			format:         storeTimeSeriesPrefix,
+			format:         fmt.Sprintf("%s.%s", mr.tenantID.String(), storeTimeSeriesPrefix),
 			source:         strconv.FormatInt(int64(storeID), 10),
 			timestampNanos: now,
 		}
 		storeRecorder.record(&data)
+	}
+	for _, childRec := range mr.mu.tenantRecorders {
+		data = append(data, childRec.GetTimeSeriesData()...)
 	}
 	atomic.CompareAndSwapInt64(&mr.lastDataCount, lastDataCount, int64(len(data)))
 	return data

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -986,6 +986,7 @@ func (ts *TestServer) StartTenant(
 		stopper,
 		baseCfg,
 		sqlCfg,
+		ts.recorder,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -38,6 +38,7 @@ export default function (props: GraphDashboardProps) {
             title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
             downsampleMax
+            includeTenants={true}
           />
         ))}
       </Axis>

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/metricQuery/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/metricQuery/index.tsx
@@ -98,6 +98,7 @@ export interface MetricProps {
   derivative?: TimeSeriesQueryDerivative;
   aggregator?: TimeSeriesQueryAggregator;
   downsampler?: TimeSeriesQueryAggregator;
+  includeTenants?: boolean;
 }
 
 /**


### PR DESCRIPTION
This patch updates the MetricRecorder to prefix
metric names with tenant identifiers in its
`GetTimeSeriesData()` implementation, which is
used by the TSDB to periodically collect timeseries
data to store within tsdb.

This alters the tsdb keys as such:
```
/System/tsd/123.cr.node.sql.copy.count/...
/System/tsd/345.cr.node.sql.copy.count/...
``

This allows queries to be made for metrics
that are specific to a single tenant by
providing the tenant ID in the key prefix
being queried.

Release note: none