### PR TITLE
sql: add a SHOW TENANTS command

### DIFF
--- a/docs/generated/sql/bnf/show_tenant_stmt.bnf
+++ b/docs/generated/sql/bnf/show_tenant_stmt.bnf
@@ -1,3 +1,4 @@
 show_tenant_stmt ::=
-	'SHOW' 'TENANT' d_expr
+	'SHOW' 'TENANTS'
+	| 'SHOW' 'TENANT' d_expr
 	| 'SHOW' 'TENANT' d_expr 'WITH' 'REPLICATION' 'STATUS'

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -921,7 +921,8 @@ show_tables_stmt ::=
 	| 'SHOW' 'TABLES' with_comment
 
 show_tenant_stmt ::=
-	'SHOW' 'TENANT' d_expr
+	'SHOW' 'TENANTS'
+	| 'SHOW' 'TENANT' d_expr
 	| 'SHOW' 'TENANT' d_expr 'WITH' 'REPLICATION' 'STATUS'
 
 show_trace_stmt ::=
@@ -1380,6 +1381,7 @@ unreserved_keyword ::=
 	| 'TEMPLATE'
 	| 'TEMPORARY'
 	| 'TENANT'
+	| 'TENANTS'
 	| 'TESTING_RELOCATE'
 	| 'TEXT'
 	| 'TIES'

--- a/pkg/ccl/streamingccl/streamingest/alter_replication_job_test.go
+++ b/pkg/ccl/streamingccl/streamingest/alter_replication_job_test.go
@@ -66,9 +66,9 @@ func TestAlterTenantPauseResume(t *testing.T) {
 
 	t.Run("pause-resume-tenant-with-no-replication", func(t *testing.T) {
 		c.DestSysSQL.Exec(t, `CREATE TENANT noreplication`)
-		c.DestSysSQL.ExpectErr(t, "tenant \"noreplication\" does not have an active replication job",
+		c.DestSysSQL.ExpectErr(t, `tenant "noreplication" does not have an active replication job`,
 			`ALTER TENANT $1 PAUSE REPLICATION`, "noreplication")
-		c.DestSysSQL.ExpectErr(t, "tenant \"noreplication\" does not have an active replication job",
+		c.DestSysSQL.ExpectErr(t, `tenant "noreplication" does not have an active replication job`,
 			`ALTER TENANT $1 RESUME REPLICATION`, "noreplication")
 	})
 

--- a/pkg/ccl/streamingccl/streamingest/testdata/simple
+++ b/pkg/ccl/streamingccl/streamingest/testdata/simple
@@ -25,6 +25,18 @@ exec-sql as=source-tenant
 IMPORT INTO d.x CSV DATA ('userfile:///dx/export*-n*.0.csv');
 ----
 
+query-sql as=source-system
+SHOW TENANTS
+----
+1 system ACTIVE
+10 source ACTIVE
+
+query-sql as=destination-system
+SHOW TENANTS
+----
+1 system ACTIVE
+2 destination REPLICATING
+
 let $ts as=source-system
 SELECT clock_timestamp()::timestamp::string
 ----

--- a/pkg/sql/logictest/testdata/logic_test/tenant
+++ b/pkg/sql/logictest/testdata/logic_test/tenant
@@ -52,7 +52,7 @@ id  name    status
 query ITT colnames
 SHOW TENANT "tenant-one"
 ----
-id  name          status
+id  name        status
 2   tenant-one  ACTIVE
 
 query ITT colnames
@@ -73,13 +73,22 @@ SHOW TENANT three
 id  name   status
 4   three  ACTIVE
 
+query ITT colnames
+SHOW TENANTS
+----
+id  name        status
+1   system      ACTIVE
+2   tenant-one  ACTIVE
+3   two         ACTIVE
+4   three       ACTIVE
+
 statement error tenant "seven" does not exist
 SHOW TENANT seven
 
-statement error tenant "tenant-one" does not have an active replication job
+query error pq: tenant "tenant-one" does not have an active replication job
 SHOW TENANT "tenant-one" WITH REPLICATION STATUS
 
-statement error tenant "two" does not have an active replication job
+query error pq: tenant "two" does not have an active replication job
 SHOW TENANT two WITH REPLICATION STATUS
 
 # Test creating a tenant with the same name as an existing tenant, but a unique
@@ -154,6 +163,9 @@ user testuser
 statement error only users with the admin role are allowed to destroy tenant
 DROP TENANT "not-allowed"
 
+statement error only users with the admin role are allowed to show tenant
+SHOW TENANTS
+
 user root
 
 subtest reclaim_name
@@ -187,3 +199,16 @@ statement ok
 CREATE TENANT "1";
 CREATE TENANT "a-b";
 CREATE TENANT "hello-100"
+
+query ITT colnames
+SHOW TENANTS
+----
+id   name             status
+1    system           ACTIVE
+2    tenant-one       ACTIVE
+3    two              ACTIVE
+4    three            ACTIVE
+8    to-be-reclaimed  ACTIVE
+9    1                ACTIVE
+10   a-b              ACTIVE
+11   hello-100        ACTIVE

--- a/pkg/sql/logictest/testdata/logic_test/tenant_from_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/tenant_from_tenant
@@ -6,5 +6,8 @@ CREATE TENANT nope
 statement error only the system tenant can show other tenants
 SHOW TENANT nope
 
+statement error only the system tenant can show other tenants
+SHOW TENANTS
+
 statement error only the system tenant can destroy other tenants
 DROP TENANT nope

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -5541,13 +5541,20 @@ backup_kms:
 
 // %Help: SHOW TENANT - display tenant information
 // %Category: Misc
-// %Text: SHOW TENANT <tenant_name> [WITH REPLICATION STATUS]
+// %Text:
+// SHOW TENANT <tenant_name> [WITH REPLICATION STATUS]
+// SHOW TENANTS
 show_tenant_stmt:
-  SHOW TENANT d_expr
+  SHOW TENANTS
+  {
+   $$.val = &tree.ShowTenant{
+     All: true,
+   }
+  }
+| SHOW TENANT d_expr
   {
    $$.val = &tree.ShowTenant{
      Name: $3.expr(),
-     WithReplication: false,
    }
   }
 | SHOW TENANT d_expr WITH REPLICATION STATUS
@@ -16028,6 +16035,7 @@ unreserved_keyword:
 | TEMPLATE
 | TEMPORARY
 | TENANT
+| TENANTS
 | TESTING_RELOCATE
 | TEXT
 | TIES

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -864,10 +864,16 @@ func (node *ShowTableStats) Format(ctx *FmtCtx) {
 type ShowTenant struct {
 	Name            Expr
 	WithReplication bool
+	All             bool
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowTenant) Format(ctx *FmtCtx) {
+	if node.All {
+		ctx.WriteString("SHOW TENANTS")
+		return
+	}
+
 	ctx.WriteString("SHOW TENANT ")
 	ctx.FormatNode(node.Name)
 

--- a/pkg/sql/show_tenant.go
+++ b/pkg/sql/show_tenant.go
@@ -41,38 +41,42 @@ const (
 	replicationUnknownFormat tenantStatus = "REPLICATION UNKNOWN (%s)"
 )
 
-type showTenantNode struct {
-	name               tree.TypedExpr
+type tenantValues struct {
 	tenantInfo         *descpb.TenantInfo
 	tenantStatus       tenantStatus
-	withReplication    bool
 	replicationInfo    *streampb.StreamIngestionStats
 	protectedTimestamp hlc.Timestamp
-	columns            colinfo.ResultColumns
-	done               bool
 }
 
+type showTenantNode struct {
+	withReplication bool
+	all             bool
+	columns         colinfo.ResultColumns
+	row             int
+	tenantIds       []roachpb.TenantID
+	tenantName      roachpb.TenantName
+	values          *tenantValues
+}
+
+// ShowTenant constructs a showTenantNode.
 func (p *planner) ShowTenant(ctx context.Context, n *tree.ShowTenant) (planNode, error) {
 	if err := p.RequireAdminRole(ctx, "show tenant"); err != nil {
 		return nil, err
 	}
-
 	if err := rejectIfCantCoordinateMultiTenancy(p.execCfg.Codec, "show"); err != nil {
 		return nil, err
 	}
 
-	var dummyHelper tree.IndexedVarHelper
-	strName := paramparse.UnresolvedNameToStrVal(n.Name)
-	typedName, err := p.analyzeExpr(
-		ctx, strName, nil, dummyHelper, types.String,
-		true, "SHOW TENANT ... WITH REPLICATION STATUS")
-	if err != nil {
-		return nil, err
-	}
-
 	node := &showTenantNode{
-		name:            typedName,
 		withReplication: n.WithReplication,
+		all:             n.All,
+	}
+	if !n.All {
+		name, err := p.parseTenantName(ctx, n.Name)
+		if err != nil {
+			return nil, err
+		}
+		node.tenantName = name
 	}
 	if n.WithReplication {
 		node.columns = colinfo.TenantColumnsWithReplication
@@ -83,8 +87,19 @@ func (p *planner) ShowTenant(ctx context.Context, n *tree.ShowTenant) (planNode,
 	return node, nil
 }
 
-func (n *showTenantNode) getTenantName(params runParams) (roachpb.TenantName, error) {
-	dName, err := eval.Expr(params.ctx, params.p.EvalContext(), n.name)
+func (p *planner) parseTenantName(
+	ctx context.Context, exprName tree.Expr,
+) (roachpb.TenantName, error) {
+	var dummyHelper tree.IndexedVarHelper
+	strName := paramparse.UnresolvedNameToStrVal(exprName)
+	var err error
+	typedName, err := p.analyzeExpr(
+		ctx, strName, nil, dummyHelper, types.String,
+		true, "SHOW TENANT ... WITH REPLICATION STATUS")
+	if err != nil {
+		return "", err
+	}
+	dName, err := eval.Expr(ctx, p.EvalContext(), typedName)
 	if err != nil {
 		return "", err
 	}
@@ -95,16 +110,31 @@ func (n *showTenantNode) getTenantName(params runParams) (roachpb.TenantName, er
 	return roachpb.TenantName(*name), nil
 }
 
-func (n *showTenantNode) initReplicationStats(params runParams, job *jobs.Job) error {
+func (n *showTenantNode) startExec(params runParams) error {
+	if n.all {
+		ids, err := GetAllNonDropTenantIDs(params.ctx, params.p.execCfg, params.p.Txn())
+		if err != nil {
+			return err
+		}
+		n.tenantIds = ids
+	}
+
+	return nil
+}
+
+func getReplicationStats(
+	params runParams, job *jobs.Job,
+) (*streampb.StreamIngestionStats, *hlc.Timestamp, error) {
 	mgr, err := params.p.EvalContext().StreamManagerFactory.GetStreamIngestManager(params.ctx)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 	details, ok := job.Details().(jobspb.StreamIngestionDetails)
 	if !ok {
-		return errors.Newf("job with id %d is not a stream ingestion job", job.ID())
+		return nil, nil, errors.Newf("job with id %d is not a stream ingestion job", job.ID())
 	}
 	stats, err := mgr.GetStreamIngestionStats(params.ctx, details, job.Progress())
+	var protectedTimestamp hlc.Timestamp
 	if err != nil {
 		// An error means we don't have stats but we can still present some info,
 		// therefore we don't fail here.
@@ -113,9 +143,8 @@ func (n *showTenantNode) initReplicationStats(params runParams, job *jobs.Job) e
 		log.Infof(params.ctx, "stream ingestion stats unavailable for tenant %q and job %d",
 			details.DestinationTenantName, job.ID())
 	} else {
-		n.replicationInfo = stats
 		if stats.IngestionDetails.ProtectedTimestampRecordID == nil {
-			// We don't have the protected timestamp record but we still want to show
+			// We don't have the protected timestamp record, but we still want to show
 			// the info we do have about tenant replication status, logging an error
 			// and continuing.
 			log.Warningf(params.ctx, "protected timestamp unavailable for tenant %q and job %d",
@@ -124,12 +153,15 @@ func (n *showTenantNode) initReplicationStats(params runParams, job *jobs.Job) e
 			ptp := params.p.execCfg.ProtectedTimestampProvider
 			record, err := ptp.GetRecord(params.ctx, params.p.Txn(), *stats.IngestionDetails.ProtectedTimestampRecordID)
 			if err != nil {
-				return err
+				// Protected timestamp might not be set yet, no need to fail.
+				log.Warningf(params.ctx, "protected timestamp unavailable for tenant %q and job %d: %v",
+					details.DestinationTenantName, job.ID(), err)
+				return stats, nil, nil
 			}
-			n.protectedTimestamp = record.Timestamp
+			protectedTimestamp = record.Timestamp
 		}
 	}
-	return nil
+	return stats, &protectedTimestamp, nil
 }
 
 func getTenantStatus(
@@ -156,63 +188,91 @@ func getTenantStatus(
 	}
 }
 
-func (n *showTenantNode) startExec(params runParams) error {
-	tenantName, err := n.getTenantName(params)
-	if err != nil {
-		return err
-	}
-	tenantRecord, err := GetTenantRecordByName(params.ctx, params.p.execCfg, params.p.Txn(), tenantName)
-	if err != nil {
-		return err
-	}
-	n.tenantInfo = tenantRecord
-	jobId := n.tenantInfo.TenantReplicationJobID
+func (n *showTenantNode) getTenantValues(
+	params runParams, tenantInfo *descpb.TenantInfo,
+) (*tenantValues, error) {
+	var values tenantValues
+	values.tenantInfo = tenantInfo
+	jobId := values.tenantInfo.TenantReplicationJobID
 	if jobId == 0 {
 		// No replication job, this is a non-replicating tenant.
 		if n.withReplication {
-			return errors.Newf("tenant %q does not have an active replication job", tenantName)
+			return nil, errors.Newf("tenant %q does not have an active replication job", tenantInfo.Name)
 		}
-		n.tenantStatus = tenantStatus(n.tenantInfo.State.String())
-		return nil
+		values.tenantStatus = tenantStatus(values.tenantInfo.State.String())
+		return &values, nil
 	}
 
-	switch n.tenantInfo.State {
+	switch values.tenantInfo.State {
 	case descpb.TenantInfo_ADD:
 		// There is a replication job, we need to get the job info and the
 		// replication stats in order to generate the exact tenant status.
 		registry := params.p.execCfg.JobRegistry
 		job, err := registry.LoadJobWithTxn(params.ctx, jobId, params.p.Txn())
 		if err != nil {
-			return err
+			log.Errorf(params.ctx, "cannot load job info for replicated tenant %q and job %d: %v",
+				tenantInfo.Name, jobId, err)
+			values.tenantStatus = tenantStatus(fmt.Sprintf(string(replicationUnknownFormat), err))
+			return &values, nil
 		}
-		if err := n.initReplicationStats(params, job); err != nil {
-			return err
+		stats, protectedTimestamp, err := getReplicationStats(params, job)
+		if err != nil {
+			log.Errorf(params.ctx, "cannot load replication stats for replicated tenant %q and job %d: %v",
+				tenantInfo.Name, jobId, err)
+			values.tenantStatus = tenantStatus(fmt.Sprintf(string(replicationUnknownFormat), err))
+			return &values, nil
+		}
+		values.replicationInfo = stats
+		if protectedTimestamp != nil {
+			values.protectedTimestamp = *protectedTimestamp
 		}
 
-		n.tenantStatus = getTenantStatus(job.Status(), n.replicationInfo)
+		values.tenantStatus = getTenantStatus(job.Status(), values.replicationInfo)
 	case descpb.TenantInfo_ACTIVE, descpb.TenantInfo_DROP:
-		n.tenantStatus = tenantStatus(n.tenantInfo.State.String())
+		values.tenantStatus = tenantStatus(values.tenantInfo.State.String())
 	default:
-		return errors.Newf("unknown tenant status %s", n.tenantInfo.State)
+		return nil, errors.Newf("tenant %q state is unknown: %s", tenantInfo.Name, values.tenantInfo.State.String())
 	}
-
-	return nil
+	return &values, nil
 }
 
-func (n *showTenantNode) Next(_ runParams) (bool, error) {
-	if n.done {
-		return false, nil
+func (n *showTenantNode) Next(params runParams) (bool, error) {
+	var tenantInfo *descpb.TenantInfo
+	if n.all {
+		if n.row >= len(n.tenantIds) {
+			return false, nil
+		}
+		var err error
+		tenantInfo, err = GetTenantRecordByID(params.ctx, params.p.execCfg, params.p.Txn(), n.tenantIds[n.row])
+		if err != nil {
+			return false, err
+		}
+	} else {
+		// We only have one tenant, return true once.
+		if n.row > 0 {
+			return false, nil
+		}
+		var err error
+		tenantInfo, err = GetTenantRecordByName(params.ctx, params.p.execCfg, params.p.Txn(), n.tenantName)
+		if err != nil {
+			return false, err
+		}
 	}
-	n.done = true
+	values, err := n.getTenantValues(params, tenantInfo)
+	if err != nil {
+		return false, err
+	}
+	n.values = values
+	n.row++
 	return true, nil
 }
 
 func (n *showTenantNode) Values() tree.Datums {
-	tenantId := tree.NewDInt(tree.DInt(n.tenantInfo.ID))
-	tenantName := tree.NewDString(string(n.tenantInfo.Name))
-	tenantStatus := tree.NewDString(string(n.tenantStatus))
+	v := n.values
+	tenantId := tree.NewDInt(tree.DInt(v.tenantInfo.ID))
+	tenantName := tree.NewDString(string(v.tenantInfo.Name))
+	tenantStatus := tree.NewDString(string(v.tenantStatus))
 	if !n.withReplication {
-		// This is a simple 'SHOW TENANT name'.
 		return tree.Datums{
 			tenantId,
 			tenantName,
@@ -223,16 +283,16 @@ func (n *showTenantNode) Values() tree.Datums {
 	// This is a 'SHOW TENANT name WITH REPLICATION STATUS' command.
 	sourceTenantName := tree.DNull
 	sourceClusterUri := tree.DNull
-	replicationJobId := tree.NewDInt(tree.DInt(n.tenantInfo.TenantReplicationJobID))
+	replicationJobId := tree.NewDInt(tree.DInt(v.tenantInfo.TenantReplicationJobID))
 	replicatedTimestamp := tree.DNull
 	retainedTimestamp := tree.DNull
 	cutoverTimestamp := tree.DNull
 
-	if n.replicationInfo != nil {
-		sourceTenantName = tree.NewDString(string(n.replicationInfo.IngestionDetails.SourceTenantName))
-		sourceClusterUri = tree.NewDString(n.replicationInfo.IngestionDetails.StreamAddress)
-		if n.replicationInfo.ReplicationLagInfo != nil {
-			minIngested := n.replicationInfo.ReplicationLagInfo.MinIngestedTimestamp
+	if v.replicationInfo != nil {
+		sourceTenantName = tree.NewDString(string(v.replicationInfo.IngestionDetails.SourceTenantName))
+		sourceClusterUri = tree.NewDString(v.replicationInfo.IngestionDetails.StreamAddress)
+		if v.replicationInfo.ReplicationLagInfo != nil {
+			minIngested := v.replicationInfo.ReplicationLagInfo.MinIngestedTimestamp
 			// The latest fully replicated time. Truncating to the nearest microsecond
 			// because if we don't, then MakeDTimestamp rounds to the nearest
 			// microsecond. In that case a user may want to cutover to a rounded-up
@@ -245,9 +305,9 @@ func (n *showTenantNode) Values() tree.Datums {
 		// window (retained to replicated) and not below it. We take a timestamp
 		// that is greater than the protected timestamp by a microsecond or less
 		// (it's not exactly ceil but close enough).
-		retainedCeil := n.protectedTimestamp.GoTime().Truncate(time.Microsecond).Add(time.Microsecond)
+		retainedCeil := v.protectedTimestamp.GoTime().Truncate(time.Microsecond).Add(time.Microsecond)
 		retainedTimestamp, _ = tree.MakeDTimestampTZ(retainedCeil, time.Nanosecond)
-		progress := n.replicationInfo.IngestionProgress
+		progress := v.replicationInfo.IngestionProgress
 		if progress != nil && !progress.CutoverTime.IsEmpty() {
 			cutoverTimestamp = eval.TimestampToDecimalDatum(progress.CutoverTime)
 		}

--- a/pkg/sql/tenant.go
+++ b/pkg/sql/tenant.go
@@ -201,6 +201,36 @@ func CreateTenantRecord(
 	)
 }
 
+// GetAllNonDropTenantIDs returns all tenants in the system table, excluding
+// those in the DROP state.
+func GetAllNonDropTenantIDs(
+	ctx context.Context, execCfg *ExecutorConfig, txn *kv.Txn,
+) ([]roachpb.TenantID, error) {
+	rows, err := execCfg.InternalExecutor.QueryBuffered(
+		ctx, "get-tenant-ids", txn, `
+		 SELECT id
+		 FROM system.tenants
+		 WHERE crdb_internal.pb_to_json('cockroach.sql.sqlbase.TenantInfo', info, true)->>'state' != 'DROP'
+		 ORDER BY id
+		 `)
+	if err != nil {
+		return nil, err
+	}
+
+	tenants := make([]roachpb.TenantID, 0, len(rows))
+	for _, tenant := range rows {
+		iTenantId := uint64(tree.MustBeDInt(tenant[0]))
+		tenantId, err := roachpb.MakeTenantID(iTenantId)
+		if err != nil {
+			return nil, errors.NewAssertionErrorWithWrappedErrf(
+				err, "stored tenant ID %d does not convert to TenantID", iTenantId)
+		}
+		tenants = append(tenants, tenantId)
+	}
+
+	return tenants, nil
+}
+
 // GetTenantRecordByName retrieves a tenant with the provided name from
 // system.tenants.
 func GetTenantRecordByName(

--- a/pkg/sql/tenant_test.go
+++ b/pkg/sql/tenant_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -59,4 +60,38 @@ SELECT id, active FROM system.tenants WHERE id = 10
 	tdb.Exec(t, "SELECT crdb_internal.destroy_tenant(10, true)")
 	tdb.CheckQueryResults(t, tenantStateQuery, [][]string{})
 	checkKVsExistForTenant(t, false /* shouldExist */)
+}
+
+func TestGetTenantIds(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+	execCfg := s.ExecutorConfig().(sql.ExecutorConfig)
+	tdb := sqlutils.MakeSQLRunner(sqlDB)
+
+	// Create 2 tenants in addition to the system tenant.
+	tdb.Exec(t, "CREATE TENANT t1")
+	tdb.Exec(t, "CREATE TENANT t2")
+
+	ids, err := sql.GetAllNonDropTenantIDs(ctx, &execCfg, nil)
+	require.NoError(t, err)
+	expectedIds := []roachpb.TenantID{
+		roachpb.MustMakeTenantID(1),
+		roachpb.MustMakeTenantID(2),
+		roachpb.MustMakeTenantID(3),
+	}
+	require.Equal(t, expectedIds, ids)
+
+	// Drop tenant 2.
+	tdb.Exec(t, "DROP TENANT t1")
+
+	ids, err = sql.GetAllNonDropTenantIDs(ctx, &execCfg, nil)
+	require.NoError(t, err)
+	expectedIds = []roachpb.TenantID{
+		roachpb.MustMakeTenantID(1),
+		roachpb.MustMakeTenantID(3),
+	}
+	require.Equal(t, expectedIds, ids)
 }


### PR DESCRIPTION
This command prints all available tenants and their status.
To get the status for replication (c2c) tenants we need to get the job info.

For example:
```
    root@127.0.0.1:26257/defaultdb> show tenants;
      id |   name   |                               status
    -----+----------+----------------------------------------------------------------------
       1 | system   | ACTIVE
       2 | src      | ACTIVE
       3 | dest     | REPLICATION PAUSED
       4 | dest2    | REPLICATION UNKNOWN (succeeded)
       6 | dest3    | REPLICATION UNKNOWN (job with ID 819888096954253313 does not exist)
      11 | dest4    | ACTIVE
      12 | dest5    | REPLICATING
      13 | dest6    | INITIALIZING REPLICATION
    (13 rows)

    Time: 67ms total (execution 67ms / network 0ms)
```

Fixes: #92641

Epic: CRDB-18749

Release note: None