### PR TITLE
release-22.2: sql: cleanup independent error messages for missing users

### DIFF
--- a/pkg/cli/interactive_tests/test_password.tcl
+++ b/pkg/cli/interactive_tests/test_password.tcl
@@ -49,7 +49,7 @@ eexpect "Enter password: "
 send "123\r"
 eexpect "Enter it again: "
 send "123\r"
-eexpect "ERROR: role/user a;b does not exist"
+eexpect "ERROR: role/user \"a;b\" does not exist"
 eexpect root@
 
 send "\\password myuser\r"

--- a/pkg/sql/alter_role.go
+++ b/pkg/sql/alter_role.go
@@ -27,10 +27,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessioninit"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
-	"github.com/cockroachdb/errors"
 )
 
 // alterRoleNode represents an ALTER ROLE ... [WITH] OPTION... statement.
@@ -200,7 +200,7 @@ func (n *alterRoleNode) startExec(params runParams) error {
 		if n.ifExists {
 			return nil
 		}
-		return pgerror.Newf(pgcode.UndefinedObject, "role/user %s does not exist", n.roleName)
+		return sqlerrors.NewUndefinedUserError(n.roleName)
 	}
 
 	isAdmin, err := params.p.UserHasAdminRole(params.ctx, n.roleName)
@@ -561,7 +561,7 @@ func (n *alterRoleSetNode) getRoleName(
 		if n.ifExists {
 			return false, username.SQLUsername{}, nil
 		}
-		return false, username.SQLUsername{}, errors.Newf("role/user %s does not exist", n.roleName)
+		return false, username.SQLUsername{}, sqlerrors.NewUndefinedUserError(n.roleName)
 	}
 	isAdmin, err := params.p.UserHasAdminRole(params.ctx, n.roleName)
 	if err != nil {

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessioninit"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/syntheticprivilege"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -791,7 +792,7 @@ func (p *planner) checkCanAlterToNewOwner(
 		return err
 	}
 	if !roleExists {
-		return pgerror.Newf(pgcode.UndefinedObject, "role/user %q does not exist", newOwner)
+		return sqlerrors.NewUndefinedUserError(newOwner)
 	}
 
 	// If the user is a superuser, skip privilege checks.

--- a/pkg/sql/create_schema.go
+++ b/pkg/sql/create_schema.go
@@ -115,8 +115,7 @@ func CreateUserDefinedSchemaDescriptor(
 			return nil, nil, err
 		}
 		if !exists {
-			return nil, nil, pgerror.Newf(pgcode.UndefinedObject, "role/user %q does not exist",
-				n.AuthRole)
+			return nil, nil, sqlerrors.NewUndefinedUserError(authRole)
 		}
 		owner = authRole
 	}

--- a/pkg/sql/delegate/BUILD.bazel
+++ b/pkg/sql/delegate/BUILD.bazel
@@ -60,6 +60,7 @@ go_library(
         "//pkg/sql/sem/catconstants",
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
+        "//pkg/sql/sqlerrors",
         "//pkg/sql/sqltelemetry",
         "//pkg/sql/syntheticprivilege",
         "//pkg/util",

--- a/pkg/sql/delegate/show_grants.go
+++ b/pkg/sql/delegate/show_grants.go
@@ -21,9 +21,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/oidext"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
@@ -383,7 +382,7 @@ SELECT database_name,
 			return nil, err
 		}
 		if !userExists {
-			return nil, pgerror.Newf(pgcode.UndefinedObject, "role/user %q does not exist", user)
+			return nil, sqlerrors.NewUndefinedUserError(user)
 		}
 	}
 

--- a/pkg/sql/drop_role.go
+++ b/pkg/sql/drop_role.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessioninit"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/syntheticprivilege"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -385,7 +386,7 @@ func (n *DropRoleNode) startExec(params runParams) error {
 		}
 
 		if numUsersDeleted == 0 && !n.ifExists {
-			return errors.Errorf("role/user %s does not exist", normalizedUsername)
+			return sqlerrors.NewUndefinedUserError(normalizedUsername)
 		}
 
 		// Drop all role memberships involving the user/role.

--- a/pkg/sql/grant_revoke.go
+++ b/pkg/sql/grant_revoke.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
@@ -610,8 +611,7 @@ func (p *planner) validateRoles(
 	}
 	for i, grantee := range roles {
 		if _, ok := users[grantee]; !ok {
-			sqlName := tree.Name(roles[i].Normalized())
-			return errors.Errorf("user or role %s does not exist", &sqlName)
+			return sqlerrors.NewUndefinedUserError(roles[i])
 		}
 	}
 

--- a/pkg/sql/grant_role.go
+++ b/pkg/sql/grant_role.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/roleoption"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -107,18 +108,17 @@ func (p *planner) GrantRoleNode(ctx context.Context, n *tree.GrantRole) (*GrantR
 			for name := range roleoption.ByName {
 				if maybeOption == name {
 					return nil, errors.WithHintf(
-						pgerror.Newf(pgcode.UndefinedObject,
-							"role/user %s does not exist", r),
+						sqlerrors.NewUndefinedUserError(r),
 						"%s is a role option, try using ALTER ROLE to change a role's options.", maybeOption)
 				}
 			}
-			return nil, pgerror.Newf(pgcode.UndefinedObject, "role/user %s does not exist", r)
+			return nil, sqlerrors.NewUndefinedUserError(r)
 		}
 	}
 
 	for _, m := range inputMembers {
 		if _, ok := roles[m]; !ok {
-			return nil, pgerror.Newf(pgcode.UndefinedObject, "role/user %s does not exist", m)
+			return nil, sqlerrors.NewUndefinedUserError(m)
 		}
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_table
@@ -1,14 +1,14 @@
 # Should error when a role that does not exist is provided.
-statement error pq: user or role who does not exist
+statement error pq: role/user "who" does not exist
 ALTER DEFAULT PRIVILEGES FOR ROLE who GRANT SELECT ON TABLES to testuser
 
-statement error pq: user or role who does not exist
+statement error pq: role/user "who" does not exist
 ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES to who
 
-statement error pq: user or role who does not exist
+statement error pq: role/user "who" does not exist
 ALTER DEFAULT PRIVILEGES FOR ROLE testuser GRANT SELECT ON TABLES to who
 
-statement error pq: user or role who does not exist
+statement error pq: role/user "who" does not exist
 ALTER DEFAULT PRIVILEGES FOR ROLE testuser GRANT SELECT ON TABLES to testuser, who
 
 # Should not be able to use invalid privileges.
@@ -357,7 +357,7 @@ d              public       t12         root      ALL             true
 d              public       t12         testuser  ALL             true
 
 # Cannot specify PUBLIC as the target role.
-statement error pq: user or role public does not exist
+statement error pq: role/user "public" does not exist
 ALTER DEFAULT PRIVILEGES FOR ROLE public REVOKE SELECT ON TABLES FROM testuser2, testuser3
 
 # Can specify PUBLIC as a grantee.

--- a/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_with_grant_option
+++ b/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_with_grant_option
@@ -1,14 +1,14 @@
 # Should error when a role that does not exist is provided.
-statement error pq: user or role who does not exist
+statement error pq: role/user "who" does not exist
 ALTER DEFAULT PRIVILEGES FOR ROLE who GRANT SELECT ON TABLES to testuser WITH GRANT OPTION
 
-statement error pq: user or role who does not exist
+statement error pq: role/user "who" does not exist
 ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES to who WITH GRANT OPTION
 
-statement error pq: user or role who does not exist
+statement error pq: role/user "who" does not exist
 ALTER DEFAULT PRIVILEGES FOR ROLE testuser GRANT SELECT ON TABLES to who WITH GRANT OPTION
 
-statement error pq: user or role who does not exist
+statement error pq: role/user "who" does not exist
 ALTER DEFAULT PRIVILEGES FOR ROLE testuser GRANT SELECT ON TABLES to testuser, who WITH GRANT OPTION
 
 # Should not be able to use invalid privileges.

--- a/pkg/sql/logictest/testdata/logic_test/alter_role_set
+++ b/pkg/sql/logictest/testdata/logic_test/alter_role_set
@@ -73,7 +73,7 @@ statement ok
 ALTER ROLE test_set_role RESET application_name
 
 # Setting for a role that does not exist should error
-statement error fake_role does not exist
+statement error "fake_role" does not exist
 ALTER ROLE fake_role SET application_name = 'e';
 
 # Setting for a role that does not exist works with IF EXISTS,

--- a/pkg/sql/logictest/testdata/logic_test/drop_user
+++ b/pkg/sql/logictest/testdata/logic_test/drop_user
@@ -44,10 +44,10 @@ admin     ·        {}
 root      ·        {admin}
 testuser  ·        {}
 
-statement error user user1 does not exist
+statement error user "user1" does not exist
 DROP USER user1
 
-statement error user user1 does not exist
+statement error user "user1" does not exist
 DROP USER usER1
 
 statement ok
@@ -108,7 +108,7 @@ testuser  ·        {}
 user3     ·        {}
 user4     ·        {}
 
-statement error user user1 does not exist
+statement error user "user1" does not exist
 DROP USER user1,user3
 
 query TTT colnames

--- a/pkg/sql/logictest/testdata/logic_test/grant_database
+++ b/pkg/sql/logictest/testdata/logic_test/grant_database
@@ -18,7 +18,7 @@ REVOKE CONNECT ON DATABASE a FROM admin
 statement ok
 CREATE USER readwrite
 
-statement error pq: user or role "test-user" does not exist
+statement error pq: role/user "test-user" does not exist
 GRANT ALL ON DATABASE a TO readwrite, "test-user"
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -1858,7 +1858,7 @@ CREATE TABLE c.t (id INT PRIMARY KEY)
 statement ok
 SET DATABASE = "b"
 
-statement error pq: user or role vanilli does not exist
+statement error pgcode 42704 role/user "vanilli" does not exist
 GRANT ALL ON * TO Vanilli
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -74,7 +74,7 @@ admin     ·        {}
 root      ·        {admin}
 testuser  ·        {}
 
-statement error pq: role/user myrole does not exist
+statement error pq: role/user "myrole" does not exist
 DROP ROLE myrole
 
 statement ok
@@ -92,7 +92,7 @@ CREATE ROLE rolec
 statement ok
 CREATE ROLE roled
 
-statement error pq: role/user rolee does not exist
+statement error pq: role/user "rolee" does not exist
 DROP ROLE rolea, roleb, rolec, roled, rolee
 
 statement ok
@@ -140,10 +140,10 @@ role_name
 admin
 root
 
-statement error pq: role/user unknownuser does not exist
+statement error pq: role/user "unknownuser" does not exist
 GRANT testrole TO unknownuser
 
-statement error pq: role/user unknownrole does not exist
+statement error pq: role/user "unknownrole" does not exist
 GRANT unknownrole TO testuser
 
 # Test role "grant" and WITH ADMIN option.
@@ -502,10 +502,10 @@ REVOKE admin FROM root
 statement error pq: role/user root cannot be removed from role admin or lose the ADMIN OPTION
 REVOKE ADMIN OPTION FOR admin FROM root
 
-statement error pq: role/user unknownuser does not exist
+statement error pq: role/user "unknownuser" does not exist
 REVOKE ADMIN OPTION FOR admin FROM unknownuser
 
-statement error pq: role/user unknownrole does not exist
+statement error pq: role/user "unknownrole" does not exist
 REVOKE ADMIN OPTION FOR unknownrole FROM root
 
 statement error pgcode 42939 CURRENT_USER cannot be used as a role name here
@@ -843,16 +843,16 @@ DROP USER public
 statement error role name "public" is reserved
 DROP ROLE public
 
-statement error role/user public does not exist
+statement error role/user "public" does not exist
 GRANT public TO testuser
 
-statement error role/user public does not exist
+statement error role/user "public" does not exist
 GRANT admin TO public
 
-statement error role/user public does not exist
+statement error role/user "public" does not exist
 REVOKE public FROM testuser
 
-statement error role/user public does not exist
+statement error role/user "public" does not exist
 REVOKE admin FROM public
 
 # Test "WITH CREATEROLE" option
@@ -1018,7 +1018,7 @@ ALTER USER testuser3 WITH PASSWORD 'ilov3beefjerky'
 
 user root
 
-statement error pq: role/user rolek does not exist
+statement error pq: role/user "rolek" does not exist
 ALTER ROLE rolek CREATEROLE
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -37,6 +37,9 @@ CREATE SCHEMA information_schema
 statement error pq: unacceptable schema name \"pg_temp\"
 CREATE SCHEMA pg_temp
 
+statement error role/user "bob" does not exist
+CREATE SCHEMA sc AUTHORIZATION bob
+
 # Create some tables and types in a user defined schema, and resolve them.
 statement ok
 CREATE SCHEMA myschema;

--- a/pkg/sql/logictest/testdata/logic_test/user
+++ b/pkg/sql/logictest/testdata/logic_test/user
@@ -84,7 +84,7 @@ statement ok
 PREPARE chpw AS ALTER USER foo WITH PASSWORD $1;
   EXECUTE chpw('bar')
 
-statement error user blix does not exist
+statement error user "blix" does not exist
 PREPARE chpw2 AS ALTER USER blix WITH PASSWORD $1;
   EXECUTE chpw2('baz')
 

--- a/pkg/sql/reassign_owned_by.go
+++ b/pkg/sql/reassign_owned_by.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/errors"
 )
@@ -59,7 +60,7 @@ func (p *planner) ReassignOwnedBy(ctx context.Context, n *tree.ReassignOwnedBy) 
 			return nil, err
 		}
 		if !roleExists {
-			return nil, pgerror.Newf(pgcode.UndefinedObject, "role/user %q does not exist", oldRole)
+			return nil, sqlerrors.NewUndefinedUserError(oldRole)
 		}
 	}
 	newRole, err := decodeusername.FromRoleSpec(
@@ -70,7 +71,7 @@ func (p *planner) ReassignOwnedBy(ctx context.Context, n *tree.ReassignOwnedBy) 
 	}
 	roleExists, err := RoleExists(ctx, p.ExecCfg().InternalExecutor, p.Txn(), newRole)
 	if !roleExists {
-		return nil, pgerror.Newf(pgcode.UndefinedObject, "role/user %q does not exist", newRole)
+		return nil, sqlerrors.NewUndefinedUserError(newRole)
 	}
 	if err != nil {
 		return nil, err

--- a/pkg/sql/revoke_role.go
+++ b/pkg/sql/revoke_role.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
@@ -90,13 +91,13 @@ func (p *planner) RevokeRoleNode(ctx context.Context, n *tree.RevokeRole) (*Revo
 
 	for _, r := range inputRoles {
 		if _, ok := roles[r]; !ok {
-			return nil, pgerror.Newf(pgcode.UndefinedObject, "role/user %s does not exist", r)
+			return nil, sqlerrors.NewUndefinedUserError(r)
 		}
 	}
 
 	for _, m := range inputMembers {
 		if _, ok := roles[m]; !ok {
-			return nil, pgerror.Newf(pgcode.UndefinedObject, "role/user %s does not exist", m)
+			return nil, sqlerrors.NewUndefinedUserError(m)
 		}
 	}
 

--- a/pkg/sql/sqlerrors/BUILD.bazel
+++ b/pkg/sql/sqlerrors/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/roachpb",
+        "//pkg/security/username",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",

--- a/pkg/sql/sqlerrors/errors.go
+++ b/pkg/sql/sqlerrors/errors.go
@@ -13,6 +13,7 @@ package sqlerrors
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -275,6 +276,11 @@ func NewUniqueConstraintReferencedByForeignKeyError(
 		"%q is referenced by foreign key from table %q",
 		uniqueConstraintOrIndexToDrop, tableName,
 	)
+}
+
+// NewUndefinedUserError returns an undefined user error.
+func NewUndefinedUserError(user username.SQLUsername) error {
+	return pgerror.Newf(pgcode.UndefinedObject, "role/user %q does not exist", user)
 }
 
 // NewRangeUnavailableError creates an unavailable range error.


### PR DESCRIPTION
Backport 1/1 commits from #94677.

/cc @cockroachdb/release

Release justification: risk free cleanup of error messaging

---

The missing user error message has lots of different forms in the codebase. This unifies to the one, whilst also fixing some missing error codes.

Epic: none

Release note (bug fix): Previously, certain GRANT or REVOKE commands on a user which does not exist would error with the correct PG code. This is now fixed.

Release note (sql change): Error messages for missing users sometimes had different forms. This is now unified as `role/user "user" does not exist`.
