### PR TITLE
split: init replica lb splitter with global rand

### DIFF
--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -13,7 +13,6 @@ package kvserver
 import (
 	"bytes"
 	"context"
-	"math/rand"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -96,8 +95,7 @@ func newUnloadedReplica(
 	r.mu.stateLoader = stateloader.Make(desc.RangeID)
 	r.mu.quiescent = true
 	r.mu.conf = store.cfg.DefaultSpanConfig
-	randSource := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
-	split.Init(&r.loadBasedSplitter, store.cfg.Settings, randSource, func() float64 {
+	split.Init(&r.loadBasedSplitter, store.cfg.Settings, split.GlobalRandSource(), func() float64 {
 		return float64(SplitByLoadQPSThreshold.Get(&store.cfg.Settings.SV))
 	}, func() time.Duration {
 		return kvserverbase.SplitByLoadMergeDelay.Get(&store.cfg.Settings.SV)

--- a/pkg/kv/kvserver/split/decider.go
+++ b/pkg/kv/kvserver/split/decider.go
@@ -15,6 +15,7 @@ package split
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -62,6 +63,27 @@ type RandSource interface {
 	// Intn returns, as an int, a non-negative pseudo-random number in the
 	// half-open interval [0,n).
 	Intn(n int) int
+}
+
+// globalRandSource implements the RandSource interface.
+type globalRandSource struct{}
+
+// Float64 returns, as a float64, a pseudo-random number in the half-open
+// interval [0.0,1.0) from the RandSource.
+func (g globalRandSource) Float64() float64 {
+	return rand.Float64()
+}
+
+// Intn returns, as an int, a non-negative pseudo-random number in the
+// half-open interval [0,n).
+func (g globalRandSource) Intn(n int) int {
+	return rand.Intn(n)
+}
+
+// GlobalRandSource returns an implementation of the RandSource interface that
+// redirects calls to the global rand.
+func GlobalRandSource() RandSource {
+	return globalRandSource{}
 }
 
 var enableUnweightedLBSplitFinder = settings.RegisterBoolSetting(


### PR DESCRIPTION
In https://github.com/cockroachdb/cockroach/pull/93838 we started initializing a new seeded rand for use in the load
based splitter's reservoir sampling algorithm. Previously, the splitter
was initialized using the global rand.

`rand.Source` heap allocates on init approximately 4kb. When initialized
per-replica, this is problematic as nodes scale to large replica counts.

This patch replaces initializing a new random source per-replica with
using the global rand instead.

This removes the heap allocation. This is shown below running 
`kv/splits/nodes=3/quiesce=true` (not at identical replica counts in the test,
 the proportions are the important part).

before:

![image](https://user-images.githubusercontent.com/39606633/210825416-a940904f-47c9-4271-9692-11b40be927f4.png)

after:

![image](https://user-images.githubusercontent.com/39606633/210825742-fc62ea6c-2125-44fe-ac07-984c22986089.png)

resolves: https://github.com/cockroachdb/cockroach/issues/94752
resolves: https://github.com/cockroachdb/cockroach/issues/94737

Release note: None