### PR TITLE
delegate: simplify / speed up SHOW FUNCTIONS; redefine several pg builtins as UDFs; fix pg_proc virtual index

### DIFF
--- a/pkg/sql/delegate/show_functions.go
+++ b/pkg/sql/delegate/show_functions.go
@@ -55,8 +55,8 @@ func (d *delegator) delegateShowFunctions(n *tree.ShowFunctions) (tree.Statement
 	const getFunctionsQuery = `
 SELECT n.nspname as schema_name,
   p.proname as function_name,
-  pg_catalog.pg_get_function_result(p.oid) as result_data_type,
-  pg_catalog.pg_get_function_identity_arguments(p.oid) as argument_data_types,
+  p.prorettype::REGTYPE::TEXT as result_data_type,
+	COALESCE((SELECT trim('{}' FROM replace(array_agg(unnest(proargtypes)::REGTYPE::TEXT)::TEXT, ',', ', '))), '') as argument_data_types,
   CASE p.prokind
 	  WHEN 'a' THEN 'agg'
 	  WHEN 'w' THEN 'window'
@@ -72,6 +72,7 @@ FROM %[1]s.pg_catalog.pg_proc p
 LEFT JOIN %[1]s.pg_catalog.pg_namespace n ON n.oid = p.pronamespace
 WHERE true
 %[2]s
+GROUP BY 1, 2, 3, proargtypes, 5, 6
 ORDER BY 1, 2, 4;
 `
 	query := fmt.Sprintf(

--- a/pkg/sql/logictest/testdata/logic_test/pg_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pg_builtins
@@ -79,19 +79,25 @@ NULL
 statement ok
 CREATE TABLE is_visible(a int primary key);
 CREATE TYPE visible_type AS ENUM('a');
+CREATE FUNCTION visible_func() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
 CREATE SCHEMA other;
 CREATE TABLE other.not_visible(a int primary key);
 CREATE TYPE other.not_visible_type AS ENUM('b');
+CREATE FUNCTION other.not_visible_func() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
 CREATE DATABASE db2;
 SET DATABASE = db2;
 CREATE TABLE table_in_db2(a int primary key);
 CREATE TYPE type_in_db2 AS ENUM('c');
+CREATE FUNCTION func_in_db2() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
 
 let $table_in_db2_id
 SELECT c.oid FROM pg_class c WHERE c.relname = 'table_in_db2';
 
 let $type_in_db2_id
 SELECT t.oid FROM pg_type t WHERE t.typname = 'type_in_db2';
+
+let $func_in_db2_id
+SELECT p.oid FROM pg_proc p WHERE p.proname = 'func_in_db2';
 
 statement ok
 SET DATABASE = test;
@@ -150,6 +156,31 @@ SELECT pg_type_is_visible(NULL)
 ----
 NULL
 
+query TB rowsort
+SELECT p.proname, pg_function_is_visible(p.oid)
+FROM pg_proc p
+WHERE p.proname IN ('array_length', 'visible_func', 'not_visible_func')
+----
+array_length      true
+visible_func      true
+not_visible_func  false
+
+# Looking up a function in a different database should return NULL.
+query B
+SELECT pg_function_is_visible($func_in_db2_id)
+----
+NULL
+
+# Looking up a non-existent OID should return NULL.
+query B
+SELECT pg_function_is_visible(1010101010)
+----
+NULL
+
+query B
+SELECT pg_function_is_visible(NULL)
+----
+NULL
 
 query TT
 SELECT pg_get_partkeydef(1), pg_get_partkeydef(NULL)
@@ -174,11 +205,11 @@ WHERE c.relname IN ('is_updatable', 'is_updatable_view', 'pg_class')
 ORDER BY c.oid, a.attnum
 ----
 relname            attname              oid         attnum  pg_relation_is_updatable  pg_column_is_updatable
-is_updatable       a                    120         1       28                        true
-is_updatable       b                    120         2       28                        true
-is_updatable       c                    120         3       28                        false
-is_updatable_view  a                    121         1       0                         false
-is_updatable_view  b                    121         2       0                         false
+is_updatable       a                    123         1       28                        true
+is_updatable       b                    123         2       28                        true
+is_updatable       c                    123         3       28                        false
+is_updatable_view  a                    124         1       0                         false
+is_updatable_view  b                    124         2       0                         false
 pg_class           oid                  4294967117  1       0                         false
 pg_class           relname              4294967117  2       0                         false
 pg_class           relnamespace         4294967117  3       0                         false

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -174,6 +174,13 @@ FROM pg_catalog.pg_proc WHERE proname IN ('proc_f', 'proc_f_2');
 100119  proc_f    105  1546506610  14  true   true   false  i  2  25  25 20  {i,i}  {"",b}  SELECT 'hello';
 100121  proc_f_2  120  1546506610  14  false  false  false  v  1  25  25     {i}    NULL    SELECT 'hello';
 
+# Ensure that the pg_proc virtual index works properly.
+
+query TT
+SELECT oid, proname FROM pg_proc WHERE oid = 'sc.proc_f_2'::regproc
+----
+100121  proc_f_2
+
 statement ok
 USE defaultdb;
 

--- a/pkg/sql/opt/xform/testdata/external/liquibase
+++ b/pkg/sql/opt/xform/testdata/external/liquibase
@@ -161,137 +161,204 @@ ON ft.ftserver = fs.oid
 WHERE ((c.relkind = 'r'::CHAR) OR (c.relkind = 'f'::CHAR)) AND (n.nspname = 'public')
 ----
 project
- ├── columns: oid:1!null schemaname:31!null tablename:2!null relacl:26 tableowner:155 description:162 relkind:17!null cluster:106 hasoids:20!null hasindexes:13!null hasrules:22!null tablespace:37 param:27 hastriggers:23!null unlogged:15!null ftoptions:136 srvname:140 reltuples:10!null inhtable:163!null inhschemaname:79 inhtablename:50
- ├── stable
- ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37,155), (2)-->(1,10,13,15,17,20,22,23,26,27,37,155)
+ ├── columns: oid:1!null schemaname:31!null tablename:2!null relacl:26 tableowner:173 description:180 relkind:17!null cluster:106 hasoids:20!null hasindexes:13!null hasrules:22!null tablespace:37 param:27 hastriggers:23!null unlogged:15!null ftoptions:136 srvname:140 reltuples:10!null inhtable:181!null inhschemaname:79 inhtablename:50
+ ├── immutable
+ ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37)
  ├── group-by (hash)
- │    ├── columns: c.oid:1!null c.relname:2!null c.relowner:5!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 count_rows:154!null pg_catalog.pg_description.description:161 rownum:164!null
- │    ├── grouping columns: rownum:164!null
- │    ├── key: (164)
- │    ├── fd: ()-->(31), (1)-->(2,5,10,13,15,17,20,22,23,26,27,37), (2)-->(1,5,10,13,15,17,20,22,23,26,27,37), (164)-->(1,2,5,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,154,161)
+ │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 count_rows:154!null column172:172 pg_catalog.pg_description.description:179 rownum:183!null
+ │    ├── grouping columns: rownum:183!null
+ │    ├── immutable
+ │    ├── key: (183)
+ │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (183)-->(1,2,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,154,172,179)
  │    ├── right-join (hash)
- │    │    ├── columns: c.oid:1!null c.relname:2!null c.relowner:5!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 pg_inherits.inhparent:150 pg_catalog.pg_description.description:161 rownum:164!null
- │    │    ├── fd: ()-->(31), (1)-->(2,5,10,13,15,17,20,22,23,26,27,37), (2)-->(1,5,10,13,15,17,20,22,23,26,27,37), (164)-->(1,2,5,10,13,15,17,20,22,23,26,27,37,50,79,106,136,140,161)
+ │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 pg_inherits.inhparent:150 column172:172 pg_catalog.pg_description.description:179 rownum:183!null
+ │    │    ├── immutable
+ │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (183)-->(1,2,10,13,15,17,20,22,23,26,27,37,50,79,106,136,140,172,179)
  │    │    ├── scan pg_inherits
  │    │    │    └── columns: pg_inherits.inhparent:150!null
  │    │    ├── distinct-on
- │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relowner:5!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 pg_catalog.pg_description.description:161 rownum:164!null
- │    │    │    ├── grouping columns: rownum:164!null
- │    │    │    ├── key: (164)
- │    │    │    ├── fd: ()-->(31), (1)-->(2,5,10,13,15,17,20,22,23,26,27,37), (2)-->(1,5,10,13,15,17,20,22,23,26,27,37), (164)-->(1,2,5,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,161)
+ │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 column172:172 pg_catalog.pg_description.description:179 rownum:183!null
+ │    │    │    ├── grouping columns: rownum:183!null
+ │    │    │    ├── immutable
+ │    │    │    ├── key: (183)
+ │    │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (183)-->(1,2,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,172,179)
  │    │    │    ├── left-join (hash)
- │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 n2.oid:78 n2.nspname:79 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140 objoid:158 objsubid:160 pg_catalog.pg_description.description:161 rownum:164!null
- │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3), (36)-->(37), (37)-->(36), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (78)~~>(79), (79)~~>(78), (84)-->(85), (105)-->(106), (134)-->(135,136), (139)-->(140), (140)-->(139), (164)-->(1,2,5,8,10,13,15,17,20,22,23,26,27,36,37,44,45,49-51,78,79,84,85,91,105,106,134-136,139,140)
+ │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 column172:172 objoid:176 objsubid:178 pg_catalog.pg_description.description:179 rownum:183!null
+ │    │    │    │    ├── immutable
+ │    │    │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (183)-->(1,2,10,13,15,17,20,22,23,26,27,37,50,79,106,136,140,172)
  │    │    │    │    ├── ordinality
- │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 n2.oid:78 n2.nspname:79 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140 rownum:164!null
- │    │    │    │    │    ├── key: (164)
- │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3), (36)-->(37), (37)-->(36), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (78)~~>(79), (79)~~>(78), (84)-->(85), (105)-->(106), (134)-->(135,136), (139)-->(140), (140)-->(139), (164)-->(1-3,5,8,10,13,15,17,20,22,23,26,27,30,31,36,37,44,45,49-51,78,79,84,85,91,105,106,134-136,139,140)
- │    │    │    │    │    └── left-join (lookup pg_namespace [as=n2])
- │    │    │    │    │         ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 n2.oid:78 n2.nspname:79 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
- │    │    │    │    │         ├── key columns: [51] = [78]
- │    │    │    │    │         ├── lookup columns are key
- │    │    │    │    │         ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3), (36)-->(37), (37)-->(36), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (78)~~>(79), (79)~~>(78), (84)-->(85), (105)-->(106), (134)-->(135,136), (139)-->(140), (140)-->(139)
- │    │    │    │    │         ├── right-join (hash)
- │    │    │    │    │         │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
- │    │    │    │    │         │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (84)-->(85), (1,84)-->(91,105,106), (105)-->(106), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
- │    │    │    │    │         │    ├── inner-join (hash)
- │    │    │    │    │         │    │    ├── columns: i.inhrelid:44!null i.inhparent:45!null c2.oid:49!null c2.relname:50!null c2.relnamespace:51!null
- │    │    │    │    │         │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
- │    │    │    │    │         │    │    ├── fd: (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45)
- │    │    │    │    │         │    │    ├── scan pg_inherits [as=i]
- │    │    │    │    │         │    │    │    └── columns: i.inhrelid:44!null i.inhparent:45!null
- │    │    │    │    │         │    │    ├── scan pg_class@pg_class_relname_nsp_index [as=c2]
- │    │    │    │    │         │    │    │    ├── columns: c2.oid:49!null c2.relname:50!null c2.relnamespace:51!null
- │    │    │    │    │         │    │    │    ├── key: (49)
- │    │    │    │    │         │    │    │    └── fd: (49)-->(50,51), (50,51)-->(49)
+ │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 column172:172 rownum:183!null
+ │    │    │    │    │    ├── immutable
+ │    │    │    │    │    ├── key: (183)
+ │    │    │    │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (183)-->(1,2,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,172)
+ │    │    │    │    │    └── project
+ │    │    │    │    │         ├── columns: column172:172 c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140
+ │    │    │    │    │         ├── immutable
+ │    │    │    │    │         ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37)
+ │    │    │    │    │         ├── distinct-on
+ │    │    │    │    │         │    ├── columns: c.oid:1!null c.relname:2!null c.relowner:5!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 rolname:158 rownum:182!null
+ │    │    │    │    │         │    ├── grouping columns: rownum:182!null
+ │    │    │    │    │         │    ├── key: (182)
+ │    │    │    │    │         │    ├── fd: ()-->(31), (1)-->(2,5,10,13,15,17,20,22,23,26,27,37), (2)-->(1,5,10,13,15,17,20,22,23,26,27,37), (182)-->(1,2,5,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,158)
+ │    │    │    │    │         │    ├── right-join (hash)
+ │    │    │    │    │         │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 n2.oid:78 n2.nspname:79 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140 pg_catalog.pg_roles.oid:157 rolname:158 rownum:182!null
+ │    │    │    │    │         │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3), (36)-->(37), (37)-->(36), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (78)~~>(79), (79)~~>(78), (84)-->(85), (105)-->(106), (134)-->(135,136), (139)-->(140), (140)-->(139), (182)-->(1,2,5,8,10,13,15,17,20,22,23,26,27,36,37,44,45,49-51,78,79,84,85,91,105,106,134-136,139,140)
+ │    │    │    │    │         │    │    ├── scan pg_roles
+ │    │    │    │    │         │    │    │    └── columns: pg_catalog.pg_roles.oid:157 rolname:158
+ │    │    │    │    │         │    │    ├── ordinality
+ │    │    │    │    │         │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 n2.oid:78 n2.nspname:79 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140 rownum:182!null
+ │    │    │    │    │         │    │    │    ├── key: (182)
+ │    │    │    │    │         │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3), (36)-->(37), (37)-->(36), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (78)~~>(79), (79)~~>(78), (84)-->(85), (105)-->(106), (134)-->(135,136), (139)-->(140), (140)-->(139), (182)-->(1-3,5,8,10,13,15,17,20,22,23,26,27,30,31,36,37,44,45,49-51,78,79,84,85,91,105,106,134-136,139,140)
+ │    │    │    │    │         │    │    │    └── left-join (lookup pg_namespace [as=n2])
+ │    │    │    │    │         │    │    │         ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 n2.oid:78 n2.nspname:79 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
+ │    │    │    │    │         │    │    │         ├── key columns: [51] = [78]
+ │    │    │    │    │         │    │    │         ├── lookup columns are key
+ │    │    │    │    │         │    │    │         ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3), (36)-->(37), (37)-->(36), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (78)~~>(79), (79)~~>(78), (84)-->(85), (105)-->(106), (134)-->(135,136), (139)-->(140), (140)-->(139)
+ │    │    │    │    │         │    │    │         ├── right-join (hash)
+ │    │    │    │    │         │    │    │         │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
+ │    │    │    │    │         │    │    │         │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (84)-->(85), (1,84)-->(91,105,106), (105)-->(106), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
+ │    │    │    │    │         │    │    │         │    ├── inner-join (hash)
+ │    │    │    │    │         │    │    │         │    │    ├── columns: i.inhrelid:44!null i.inhparent:45!null c2.oid:49!null c2.relname:50!null c2.relnamespace:51!null
+ │    │    │    │    │         │    │    │         │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │    │    │    │    │         │    │    │         │    │    ├── fd: (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45)
+ │    │    │    │    │         │    │    │         │    │    ├── scan pg_inherits [as=i]
+ │    │    │    │    │         │    │    │         │    │    │    └── columns: i.inhrelid:44!null i.inhparent:45!null
+ │    │    │    │    │         │    │    │         │    │    ├── scan pg_class@pg_class_relname_nsp_index [as=c2]
+ │    │    │    │    │         │    │    │         │    │    │    ├── columns: c2.oid:49!null c2.relname:50!null c2.relnamespace:51!null
+ │    │    │    │    │         │    │    │         │    │    │    ├── key: (49)
+ │    │    │    │    │         │    │    │         │    │    │    └── fd: (49)-->(50,51), (50,51)-->(49)
+ │    │    │    │    │         │    │    │         │    │    └── filters
+ │    │    │    │    │         │    │    │         │    │         └── i.inhparent:45 = c2.oid:49 [outer=(45,49), constraints=(/45: (/NULL - ]; /49: (/NULL - ]), fd=(45)==(49), (49)==(45)]
+ │    │    │    │    │         │    │    │         │    ├── left-join (lookup pg_class [as=ci])
+ │    │    │    │    │         │    │    │         │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
+ │    │    │    │    │         │    │    │         │    │    ├── key columns: [84] = [105]
+ │    │    │    │    │         │    │    │         │    │    ├── lookup columns are key
+ │    │    │    │    │         │    │    │         │    │    ├── key: (1,84)
+ │    │    │    │    │         │    │    │         │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (84)-->(85), (1,84)-->(36,37,91,105,106), (105)-->(106), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
+ │    │    │    │    │         │    │    │         │    │    ├── left-join (lookup pg_index [as=ind])
+ │    │    │    │    │         │    │    │         │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 indexrelid:84 indrelid:85 indisclustered:91 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
+ │    │    │    │    │         │    │    │         │    │    │    ├── key columns: [957] = [84]
+ │    │    │    │    │         │    │    │         │    │    │    ├── lookup columns are key
+ │    │    │    │    │         │    │    │         │    │    │    ├── second join in paired joiner
+ │    │    │    │    │         │    │    │         │    │    │    ├── key: (1,84)
+ │    │    │    │    │         │    │    │         │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (84)-->(85), (1,84)-->(36,37,91), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
+ │    │    │    │    │         │    │    │         │    │    │    ├── left-join (lookup pg_index@pg_index_indrelid_index [as=ind])
+ │    │    │    │    │         │    │    │         │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140 indexrelid:957 indrelid:958 continuation:978
+ │    │    │    │    │         │    │    │         │    │    │    │    ├── key columns: [1] = [958]
+ │    │    │    │    │         │    │    │         │    │    │    │    ├── first join in paired joiner; continuation column: continuation:978
+ │    │    │    │    │         │    │    │         │    │    │    │    ├── key: (1,957)
+ │    │    │    │    │         │    │    │         │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3), (957)-->(958,978)
+ │    │    │    │    │         │    │    │         │    │    │    │    ├── left-join (lookup pg_tablespace [as=t])
+ │    │    │    │    │         │    │    │         │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
+ │    │    │    │    │         │    │    │         │    │    │    │    │    ├── key columns: [8] = [36]
+ │    │    │    │    │         │    │    │         │    │    │    │    │    ├── lookup columns are key
+ │    │    │    │    │         │    │    │         │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │         │    │    │         │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
+ │    │    │    │    │         │    │    │         │    │    │    │    │    ├── left-join (lookup pg_foreign_server [as=fs])
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    ├── key columns: [135] = [139]
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    ├── lookup columns are key
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (3)==(30), (30)==(3)
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    ├── left-join (lookup pg_foreign_table [as=ft])
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null ftrelid:134 ftserver:135 ftoptions:136
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    ├── key columns: [1] = [134]
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    ├── lookup columns are key
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136), (3)==(30), (30)==(3)
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    ├── inner-join (hash)
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3)
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    ├── select
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── scan pg_class [as=c]
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    │    └── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    └── filters
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │         └── (c.relkind:17 = 'r') OR (c.relkind:17 = 'f') [outer=(17), constraints=(/17: [/'f' - /'f'] [/'r' - /'r']; tight)]
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    ├── scan pg_namespace@pg_namespace_nspname_index [as=n]
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── columns: n.oid:30!null n.nspname:31!null
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── constraint: /31: [/'public' - /'public']
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── key: ()
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    └── fd: ()-->(30,31)
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    └── filters
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │         └── n.oid:30 = c.relnamespace:3 [outer=(3,30), constraints=(/3: (/NULL - ]; /30: (/NULL - ]), fd=(3)==(30), (30)==(3)]
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    └── filters (true)
+ │    │    │    │    │         │    │    │         │    │    │    │    │    │    └── filters (true)
+ │    │    │    │    │         │    │    │         │    │    │    │    │    └── filters (true)
+ │    │    │    │    │         │    │    │         │    │    │    │    └── filters (true)
+ │    │    │    │    │         │    │    │         │    │    │    └── filters
+ │    │    │    │    │         │    │    │         │    │    │         └── indisclustered:91 [outer=(91), constraints=(/91: [/true - /true]; tight), fd=()-->(91)]
+ │    │    │    │    │         │    │    │         │    │    └── filters (true)
+ │    │    │    │    │         │    │    │         │    └── filters
+ │    │    │    │    │         │    │    │         │         └── i.inhrelid:44 = c.oid:1 [outer=(1,44), constraints=(/1: (/NULL - ]; /44: (/NULL - ]), fd=(1)==(44), (44)==(1)]
+ │    │    │    │    │         │    │    │         └── filters (true)
  │    │    │    │    │         │    │    └── filters
- │    │    │    │    │         │    │         └── i.inhparent:45 = c2.oid:49 [outer=(45,49), constraints=(/45: (/NULL - ]; /49: (/NULL - ]), fd=(45)==(49), (49)==(45)]
- │    │    │    │    │         │    ├── left-join (lookup pg_class [as=ci])
- │    │    │    │    │         │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
- │    │    │    │    │         │    │    ├── key columns: [84] = [105]
- │    │    │    │    │         │    │    ├── lookup columns are key
- │    │    │    │    │         │    │    ├── key: (1,84)
- │    │    │    │    │         │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (84)-->(85), (1,84)-->(36,37,91,105,106), (105)-->(106), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
- │    │    │    │    │         │    │    ├── left-join (lookup pg_index [as=ind])
- │    │    │    │    │         │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 indexrelid:84 indrelid:85 indisclustered:91 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
- │    │    │    │    │         │    │    │    ├── key columns: [938] = [84]
- │    │    │    │    │         │    │    │    ├── lookup columns are key
- │    │    │    │    │         │    │    │    ├── second join in paired joiner
- │    │    │    │    │         │    │    │    ├── key: (1,84)
- │    │    │    │    │         │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (84)-->(85), (1,84)-->(36,37,91), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
- │    │    │    │    │         │    │    │    ├── left-join (lookup pg_index@pg_index_indrelid_index [as=ind])
- │    │    │    │    │         │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140 indexrelid:938 indrelid:939 continuation:959
- │    │    │    │    │         │    │    │    │    ├── key columns: [1] = [939]
- │    │    │    │    │         │    │    │    │    ├── first join in paired joiner; continuation column: continuation:959
- │    │    │    │    │         │    │    │    │    ├── key: (1,938)
- │    │    │    │    │         │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3), (938)-->(939,959)
- │    │    │    │    │         │    │    │    │    ├── left-join (lookup pg_tablespace [as=t])
- │    │    │    │    │         │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
- │    │    │    │    │         │    │    │    │    │    ├── key columns: [8] = [36]
- │    │    │    │    │         │    │    │    │    │    ├── lookup columns are key
- │    │    │    │    │         │    │    │    │    │    ├── key: (1)
- │    │    │    │    │         │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
- │    │    │    │    │         │    │    │    │    │    ├── left-join (lookup pg_foreign_server [as=fs])
- │    │    │    │    │         │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
- │    │    │    │    │         │    │    │    │    │    │    ├── key columns: [135] = [139]
- │    │    │    │    │         │    │    │    │    │    │    ├── lookup columns are key
- │    │    │    │    │         │    │    │    │    │    │    ├── key: (1)
- │    │    │    │    │         │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (3)==(30), (30)==(3)
- │    │    │    │    │         │    │    │    │    │    │    ├── left-join (lookup pg_foreign_table [as=ft])
- │    │    │    │    │         │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null ftrelid:134 ftserver:135 ftoptions:136
- │    │    │    │    │         │    │    │    │    │    │    │    ├── key columns: [1] = [134]
- │    │    │    │    │         │    │    │    │    │    │    │    ├── lookup columns are key
- │    │    │    │    │         │    │    │    │    │    │    │    ├── key: (1)
- │    │    │    │    │         │    │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136), (3)==(30), (30)==(3)
- │    │    │    │    │         │    │    │    │    │    │    │    ├── inner-join (hash)
- │    │    │    │    │         │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null
- │    │    │    │    │         │    │    │    │    │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
- │    │    │    │    │         │    │    │    │    │    │    │    │    ├── key: (1)
- │    │    │    │    │         │    │    │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3)
- │    │    │    │    │         │    │    │    │    │    │    │    │    ├── select
- │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27
- │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── key: (1)
- │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
- │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── scan pg_class [as=c]
- │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27
- │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    ├── key: (1)
- │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    └── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
- │    │    │    │    │         │    │    │    │    │    │    │    │    │    └── filters
- │    │    │    │    │         │    │    │    │    │    │    │    │    │         └── (c.relkind:17 = 'r') OR (c.relkind:17 = 'f') [outer=(17), constraints=(/17: [/'f' - /'f'] [/'r' - /'r']; tight)]
- │    │    │    │    │         │    │    │    │    │    │    │    │    ├── scan pg_namespace@pg_namespace_nspname_index [as=n]
- │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── columns: n.oid:30!null n.nspname:31!null
- │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── constraint: /31: [/'public' - /'public']
- │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
- │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── key: ()
- │    │    │    │    │         │    │    │    │    │    │    │    │    │    └── fd: ()-->(30,31)
- │    │    │    │    │         │    │    │    │    │    │    │    │    └── filters
- │    │    │    │    │         │    │    │    │    │    │    │    │         └── n.oid:30 = c.relnamespace:3 [outer=(3,30), constraints=(/3: (/NULL - ]; /30: (/NULL - ]), fd=(3)==(30), (30)==(3)]
- │    │    │    │    │         │    │    │    │    │    │    │    └── filters (true)
- │    │    │    │    │         │    │    │    │    │    │    └── filters (true)
- │    │    │    │    │         │    │    │    │    │    └── filters (true)
- │    │    │    │    │         │    │    │    │    └── filters (true)
- │    │    │    │    │         │    │    │    └── filters
- │    │    │    │    │         │    │    │         └── indisclustered:91 [outer=(91), constraints=(/91: [/true - /true]; tight), fd=()-->(91)]
- │    │    │    │    │         │    │    └── filters (true)
- │    │    │    │    │         │    └── filters
- │    │    │    │    │         │         └── i.inhrelid:44 = c.oid:1 [outer=(1,44), constraints=(/1: (/NULL - ]; /44: (/NULL - ]), fd=(1)==(44), (44)==(1)]
- │    │    │    │    │         └── filters (true)
+ │    │    │    │    │         │    │         └── pg_catalog.pg_roles.oid:157 = c.relowner:5 [outer=(5,157), constraints=(/5: (/NULL - ]; /157: (/NULL - ]), fd=(5)==(157), (157)==(5)]
+ │    │    │    │    │         │    └── aggregations
+ │    │    │    │    │         │         ├── const-agg [as=c.oid:1, outer=(1)]
+ │    │    │    │    │         │         │    └── c.oid:1
+ │    │    │    │    │         │         ├── const-agg [as=c.relname:2, outer=(2)]
+ │    │    │    │    │         │         │    └── c.relname:2
+ │    │    │    │    │         │         ├── const-agg [as=c.relowner:5, outer=(5)]
+ │    │    │    │    │         │         │    └── c.relowner:5
+ │    │    │    │    │         │         ├── const-agg [as=c.reltuples:10, outer=(10)]
+ │    │    │    │    │         │         │    └── c.reltuples:10
+ │    │    │    │    │         │         ├── const-agg [as=c.relhasindex:13, outer=(13)]
+ │    │    │    │    │         │         │    └── c.relhasindex:13
+ │    │    │    │    │         │         ├── const-agg [as=c.relpersistence:15, outer=(15)]
+ │    │    │    │    │         │         │    └── c.relpersistence:15
+ │    │    │    │    │         │         ├── const-agg [as=c.relkind:17, outer=(17)]
+ │    │    │    │    │         │         │    └── c.relkind:17
+ │    │    │    │    │         │         ├── const-agg [as=c.relhasoids:20, outer=(20)]
+ │    │    │    │    │         │         │    └── c.relhasoids:20
+ │    │    │    │    │         │         ├── const-agg [as=c.relhasrules:22, outer=(22)]
+ │    │    │    │    │         │         │    └── c.relhasrules:22
+ │    │    │    │    │         │         ├── const-agg [as=c.relhastriggers:23, outer=(23)]
+ │    │    │    │    │         │         │    └── c.relhastriggers:23
+ │    │    │    │    │         │         ├── const-agg [as=c.relacl:26, outer=(26)]
+ │    │    │    │    │         │         │    └── c.relacl:26
+ │    │    │    │    │         │         ├── const-agg [as=c.reloptions:27, outer=(27)]
+ │    │    │    │    │         │         │    └── c.reloptions:27
+ │    │    │    │    │         │         ├── const-agg [as=n.nspname:31, outer=(31)]
+ │    │    │    │    │         │         │    └── n.nspname:31
+ │    │    │    │    │         │         ├── const-agg [as=spcname:37, outer=(37)]
+ │    │    │    │    │         │         │    └── spcname:37
+ │    │    │    │    │         │         ├── const-agg [as=c2.relname:50, outer=(50)]
+ │    │    │    │    │         │         │    └── c2.relname:50
+ │    │    │    │    │         │         ├── const-agg [as=n2.nspname:79, outer=(79)]
+ │    │    │    │    │         │         │    └── n2.nspname:79
+ │    │    │    │    │         │         ├── const-agg [as=ci.relname:106, outer=(106)]
+ │    │    │    │    │         │         │    └── ci.relname:106
+ │    │    │    │    │         │         ├── const-agg [as=ftoptions:136, outer=(136)]
+ │    │    │    │    │         │         │    └── ftoptions:136
+ │    │    │    │    │         │         ├── const-agg [as=srvname:140, outer=(140)]
+ │    │    │    │    │         │         │    └── srvname:140
+ │    │    │    │    │         │         └── first-agg [as=rolname:158, outer=(158)]
+ │    │    │    │    │         │              └── rolname:158
+ │    │    │    │    │         └── projections
+ │    │    │    │    │              └── assignment-cast: STRING [as=column172:172, outer=(5,158), immutable]
+ │    │    │    │    │                   └── COALESCE(rolname:158, (('unknown (OID=' || c.relowner:5) || ')')::NAME)
  │    │    │    │    ├── select
- │    │    │    │    │    ├── columns: objoid:158 objsubid:160!null pg_catalog.pg_description.description:161
- │    │    │    │    │    ├── fd: ()-->(160)
+ │    │    │    │    │    ├── columns: objoid:176 objsubid:178!null pg_catalog.pg_description.description:179
+ │    │    │    │    │    ├── fd: ()-->(178)
  │    │    │    │    │    ├── scan pg_description
- │    │    │    │    │    │    └── columns: objoid:158 objsubid:160 pg_catalog.pg_description.description:161
+ │    │    │    │    │    │    └── columns: objoid:176 objsubid:178 pg_catalog.pg_description.description:179
  │    │    │    │    │    └── filters
- │    │    │    │    │         └── objsubid:160 = 0 [outer=(160), constraints=(/160: [/0 - /0]; tight), fd=()-->(160)]
+ │    │    │    │    │         └── objsubid:178 = 0 [outer=(178), constraints=(/178: [/0 - /0]; tight), fd=()-->(178)]
  │    │    │    │    └── filters
- │    │    │    │         └── objoid:158 = c.oid:1 [outer=(1,158), constraints=(/1: (/NULL - ]; /158: (/NULL - ]), fd=(1)==(158), (158)==(1)]
+ │    │    │    │         └── objoid:176 = c.oid:1 [outer=(1,176), constraints=(/1: (/NULL - ]; /176: (/NULL - ]), fd=(1)==(176), (176)==(1)]
  │    │    │    └── aggregations
  │    │    │         ├── const-agg [as=c.oid:1, outer=(1)]
  │    │    │         │    └── c.oid:1
  │    │    │         ├── const-agg [as=c.relname:2, outer=(2)]
  │    │    │         │    └── c.relname:2
- │    │    │         ├── const-agg [as=c.relowner:5, outer=(5)]
- │    │    │         │    └── c.relowner:5
  │    │    │         ├── const-agg [as=c.reltuples:10, outer=(10)]
  │    │    │         │    └── c.reltuples:10
  │    │    │         ├── const-agg [as=c.relhasindex:13, outer=(13)]
@@ -324,8 +391,10 @@ project
  │    │    │         │    └── ftoptions:136
  │    │    │         ├── const-agg [as=srvname:140, outer=(140)]
  │    │    │         │    └── srvname:140
- │    │    │         └── first-agg [as=pg_catalog.pg_description.description:161, outer=(161)]
- │    │    │              └── pg_catalog.pg_description.description:161
+ │    │    │         ├── const-agg [as=column172:172, outer=(172)]
+ │    │    │         │    └── column172:172
+ │    │    │         └── first-agg [as=pg_catalog.pg_description.description:179, outer=(179)]
+ │    │    │              └── pg_catalog.pg_description.description:179
  │    │    └── filters
  │    │         └── pg_inherits.inhparent:150 = c.oid:1 [outer=(1,150), constraints=(/1: (/NULL - ]; /150: (/NULL - ]), fd=(1)==(150), (150)==(1)]
  │    └── aggregations
@@ -335,8 +404,6 @@ project
  │         │    └── c.oid:1
  │         ├── const-agg [as=c.relname:2, outer=(2)]
  │         │    └── c.relname:2
- │         ├── const-agg [as=c.relowner:5, outer=(5)]
- │         │    └── c.relowner:5
  │         ├── const-agg [as=c.reltuples:10, outer=(10)]
  │         │    └── c.reltuples:10
  │         ├── const-agg [as=c.relhasindex:13, outer=(13)]
@@ -369,9 +436,11 @@ project
  │         │    └── ftoptions:136
  │         ├── const-agg [as=srvname:140, outer=(140)]
  │         │    └── srvname:140
- │         └── const-agg [as=pg_catalog.pg_description.description:161, outer=(161)]
- │              └── pg_catalog.pg_description.description:161
+ │         ├── const-agg [as=column172:172, outer=(172)]
+ │         │    └── column172:172
+ │         └── const-agg [as=pg_catalog.pg_description.description:179, outer=(179)]
+ │              └── pg_catalog.pg_description.description:179
  └── projections
-      ├── pg_get_userbyid(c.relowner:5) [as=tableowner:155, outer=(5), stable]
-      ├── pg_catalog.pg_description.description:161 [as=description:162, outer=(161)]
-      └── count_rows:154 > 0 [as=inhtable:163, outer=(154)]
+      ├── column172:172 [as=tableowner:173, outer=(172)]
+      ├── pg_catalog.pg_description.description:179 [as=description:180, outer=(179)]
+      └── count_rows:154 > 0 [as=inhtable:181, outer=(154)]

--- a/pkg/sql/opt/xform/testdata/external/navicat
+++ b/pkg/sql/opt/xform/testdata/external/navicat
@@ -160,142 +160,209 @@ WHERE ((c.relkind = 'r'::CHAR) OR (c.relkind = 'f'::CHAR)) AND (n.nspname = 'pub
 ORDER BY schemaname, tablename
 ----
 sort
- ├── columns: oid:1!null schemaname:31!null tablename:2!null relacl:26 tableowner:155 description:162 relkind:17!null cluster:106 hasoids:20!null hasindexes:13!null hasrules:22!null tablespace:37 param:27 hastriggers:23!null unlogged:15!null ftoptions:136 srvname:140 reltuples:10!null inhtable:163!null inhschemaname:79 inhtablename:50
- ├── stable
- ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37,155), (2)-->(1,10,13,15,17,20,22,23,26,27,37,155)
+ ├── columns: oid:1!null schemaname:31!null tablename:2!null relacl:26 tableowner:173 description:180 relkind:17!null cluster:106 hasoids:20!null hasindexes:13!null hasrules:22!null tablespace:37 param:27 hastriggers:23!null unlogged:15!null ftoptions:136 srvname:140 reltuples:10!null inhtable:181!null inhschemaname:79 inhtablename:50
+ ├── immutable
+ ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37)
  ├── ordering: +2 opt(31) [actual: +2]
  └── project
-      ├── columns: tableowner:155 description:162 inhtable:163!null c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140
-      ├── stable
-      ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37,155), (2)-->(1,10,13,15,17,20,22,23,26,27,37,155)
+      ├── columns: tableowner:173 description:180 inhtable:181!null c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140
+      ├── immutable
+      ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37)
       ├── group-by (hash)
-      │    ├── columns: c.oid:1!null c.relname:2!null c.relowner:5!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 count_rows:154!null pg_catalog.pg_description.description:161 rownum:164!null
-      │    ├── grouping columns: rownum:164!null
-      │    ├── key: (164)
-      │    ├── fd: ()-->(31), (1)-->(2,5,10,13,15,17,20,22,23,26,27,37), (2)-->(1,5,10,13,15,17,20,22,23,26,27,37), (164)-->(1,2,5,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,154,161)
+      │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 count_rows:154!null column172:172 pg_catalog.pg_description.description:179 rownum:183!null
+      │    ├── grouping columns: rownum:183!null
+      │    ├── immutable
+      │    ├── key: (183)
+      │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (183)-->(1,2,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,154,172,179)
       │    ├── right-join (hash)
-      │    │    ├── columns: c.oid:1!null c.relname:2!null c.relowner:5!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 pg_inherits.inhparent:150 pg_catalog.pg_description.description:161 rownum:164!null
-      │    │    ├── fd: ()-->(31), (1)-->(2,5,10,13,15,17,20,22,23,26,27,37), (2)-->(1,5,10,13,15,17,20,22,23,26,27,37), (164)-->(1,2,5,10,13,15,17,20,22,23,26,27,37,50,79,106,136,140,161)
+      │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 pg_inherits.inhparent:150 column172:172 pg_catalog.pg_description.description:179 rownum:183!null
+      │    │    ├── immutable
+      │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (183)-->(1,2,10,13,15,17,20,22,23,26,27,37,50,79,106,136,140,172,179)
       │    │    ├── scan pg_inherits
       │    │    │    └── columns: pg_inherits.inhparent:150!null
       │    │    ├── distinct-on
-      │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relowner:5!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 pg_catalog.pg_description.description:161 rownum:164!null
-      │    │    │    ├── grouping columns: rownum:164!null
-      │    │    │    ├── key: (164)
-      │    │    │    ├── fd: ()-->(31), (1)-->(2,5,10,13,15,17,20,22,23,26,27,37), (2)-->(1,5,10,13,15,17,20,22,23,26,27,37), (164)-->(1,2,5,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,161)
+      │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 column172:172 pg_catalog.pg_description.description:179 rownum:183!null
+      │    │    │    ├── grouping columns: rownum:183!null
+      │    │    │    ├── immutable
+      │    │    │    ├── key: (183)
+      │    │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (183)-->(1,2,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,172,179)
       │    │    │    ├── left-join (hash)
-      │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 n2.oid:78 n2.nspname:79 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140 objoid:158 objsubid:160 pg_catalog.pg_description.description:161 rownum:164!null
-      │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3), (36)-->(37), (37)-->(36), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (78)~~>(79), (79)~~>(78), (84)-->(85), (105)-->(106), (134)-->(135,136), (139)-->(140), (140)-->(139), (164)-->(1,2,5,8,10,13,15,17,20,22,23,26,27,36,37,44,45,49-51,78,79,84,85,91,105,106,134-136,139,140)
+      │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 column172:172 objoid:176 objsubid:178 pg_catalog.pg_description.description:179 rownum:183!null
+      │    │    │    │    ├── immutable
+      │    │    │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (183)-->(1,2,10,13,15,17,20,22,23,26,27,37,50,79,106,136,140,172)
       │    │    │    │    ├── ordinality
-      │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 n2.oid:78 n2.nspname:79 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140 rownum:164!null
-      │    │    │    │    │    ├── key: (164)
-      │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3), (36)-->(37), (37)-->(36), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (78)~~>(79), (79)~~>(78), (84)-->(85), (105)-->(106), (134)-->(135,136), (139)-->(140), (140)-->(139), (164)-->(1-3,5,8,10,13,15,17,20,22,23,26,27,30,31,36,37,44,45,49-51,78,79,84,85,91,105,106,134-136,139,140)
-      │    │    │    │    │    └── left-join (lookup pg_namespace [as=n2])
-      │    │    │    │    │         ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 n2.oid:78 n2.nspname:79 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
-      │    │    │    │    │         ├── key columns: [51] = [78]
-      │    │    │    │    │         ├── lookup columns are key
-      │    │    │    │    │         ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3), (36)-->(37), (37)-->(36), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (78)~~>(79), (79)~~>(78), (84)-->(85), (105)-->(106), (134)-->(135,136), (139)-->(140), (140)-->(139)
-      │    │    │    │    │         ├── right-join (hash)
-      │    │    │    │    │         │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
-      │    │    │    │    │         │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (84)-->(85), (1,84)-->(91,105,106), (105)-->(106), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
-      │    │    │    │    │         │    ├── inner-join (hash)
-      │    │    │    │    │         │    │    ├── columns: i.inhrelid:44!null i.inhparent:45!null c2.oid:49!null c2.relname:50!null c2.relnamespace:51!null
-      │    │    │    │    │         │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
-      │    │    │    │    │         │    │    ├── fd: (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45)
-      │    │    │    │    │         │    │    ├── scan pg_inherits [as=i]
-      │    │    │    │    │         │    │    │    └── columns: i.inhrelid:44!null i.inhparent:45!null
-      │    │    │    │    │         │    │    ├── scan pg_class@pg_class_relname_nsp_index [as=c2]
-      │    │    │    │    │         │    │    │    ├── columns: c2.oid:49!null c2.relname:50!null c2.relnamespace:51!null
-      │    │    │    │    │         │    │    │    ├── key: (49)
-      │    │    │    │    │         │    │    │    └── fd: (49)-->(50,51), (50,51)-->(49)
+      │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 column172:172 rownum:183!null
+      │    │    │    │    │    ├── immutable
+      │    │    │    │    │    ├── key: (183)
+      │    │    │    │    │    ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37), (183)-->(1,2,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,172)
+      │    │    │    │    │    └── project
+      │    │    │    │    │         ├── columns: column172:172 c.oid:1!null c.relname:2!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140
+      │    │    │    │    │         ├── immutable
+      │    │    │    │    │         ├── fd: ()-->(31), (1)-->(2,10,13,15,17,20,22,23,26,27,37), (2)-->(1,10,13,15,17,20,22,23,26,27,37)
+      │    │    │    │    │         ├── distinct-on
+      │    │    │    │    │         │    ├── columns: c.oid:1!null c.relname:2!null c.relowner:5!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.nspname:31!null spcname:37 c2.relname:50 n2.nspname:79 ci.relname:106 ftoptions:136 srvname:140 rolname:158 rownum:182!null
+      │    │    │    │    │         │    ├── grouping columns: rownum:182!null
+      │    │    │    │    │         │    ├── key: (182)
+      │    │    │    │    │         │    ├── fd: ()-->(31), (1)-->(2,5,10,13,15,17,20,22,23,26,27,37), (2)-->(1,5,10,13,15,17,20,22,23,26,27,37), (182)-->(1,2,5,10,13,15,17,20,22,23,26,27,31,37,50,79,106,136,140,158)
+      │    │    │    │    │         │    ├── right-join (hash)
+      │    │    │    │    │         │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 n2.oid:78 n2.nspname:79 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140 pg_catalog.pg_roles.oid:157 rolname:158 rownum:182!null
+      │    │    │    │    │         │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3), (36)-->(37), (37)-->(36), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (78)~~>(79), (79)~~>(78), (84)-->(85), (105)-->(106), (134)-->(135,136), (139)-->(140), (140)-->(139), (182)-->(1,2,5,8,10,13,15,17,20,22,23,26,27,36,37,44,45,49-51,78,79,84,85,91,105,106,134-136,139,140)
+      │    │    │    │    │         │    │    ├── scan pg_roles
+      │    │    │    │    │         │    │    │    └── columns: pg_catalog.pg_roles.oid:157 rolname:158
+      │    │    │    │    │         │    │    ├── ordinality
+      │    │    │    │    │         │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 n2.oid:78 n2.nspname:79 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140 rownum:182!null
+      │    │    │    │    │         │    │    │    ├── key: (182)
+      │    │    │    │    │         │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3), (36)-->(37), (37)-->(36), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (78)~~>(79), (79)~~>(78), (84)-->(85), (105)-->(106), (134)-->(135,136), (139)-->(140), (140)-->(139), (182)-->(1-3,5,8,10,13,15,17,20,22,23,26,27,30,31,36,37,44,45,49-51,78,79,84,85,91,105,106,134-136,139,140)
+      │    │    │    │    │         │    │    │    └── left-join (lookup pg_namespace [as=n2])
+      │    │    │    │    │         │    │    │         ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 n2.oid:78 n2.nspname:79 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
+      │    │    │    │    │         │    │    │         ├── key columns: [51] = [78]
+      │    │    │    │    │         │    │    │         ├── lookup columns are key
+      │    │    │    │    │         │    │    │         ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3), (36)-->(37), (37)-->(36), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (78)~~>(79), (79)~~>(78), (84)-->(85), (105)-->(106), (134)-->(135,136), (139)-->(140), (140)-->(139)
+      │    │    │    │    │         │    │    │         ├── right-join (hash)
+      │    │    │    │    │         │    │    │         │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 i.inhrelid:44 i.inhparent:45 c2.oid:49 c2.relname:50 c2.relnamespace:51 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
+      │    │    │    │    │         │    │    │         │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (84)-->(85), (1,84)-->(91,105,106), (105)-->(106), (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
+      │    │    │    │    │         │    │    │         │    ├── inner-join (hash)
+      │    │    │    │    │         │    │    │         │    │    ├── columns: i.inhrelid:44!null i.inhparent:45!null c2.oid:49!null c2.relname:50!null c2.relnamespace:51!null
+      │    │    │    │    │         │    │    │         │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+      │    │    │    │    │         │    │    │         │    │    ├── fd: (49)-->(50,51), (50,51)-->(49), (45)==(49), (49)==(45)
+      │    │    │    │    │         │    │    │         │    │    ├── scan pg_inherits [as=i]
+      │    │    │    │    │         │    │    │         │    │    │    └── columns: i.inhrelid:44!null i.inhparent:45!null
+      │    │    │    │    │         │    │    │         │    │    ├── scan pg_class@pg_class_relname_nsp_index [as=c2]
+      │    │    │    │    │         │    │    │         │    │    │    ├── columns: c2.oid:49!null c2.relname:50!null c2.relnamespace:51!null
+      │    │    │    │    │         │    │    │         │    │    │    ├── key: (49)
+      │    │    │    │    │         │    │    │         │    │    │    └── fd: (49)-->(50,51), (50,51)-->(49)
+      │    │    │    │    │         │    │    │         │    │    └── filters
+      │    │    │    │    │         │    │    │         │    │         └── i.inhparent:45 = c2.oid:49 [outer=(45,49), constraints=(/45: (/NULL - ]; /49: (/NULL - ]), fd=(45)==(49), (49)==(45)]
+      │    │    │    │    │         │    │    │         │    ├── left-join (lookup pg_class [as=ci])
+      │    │    │    │    │         │    │    │         │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
+      │    │    │    │    │         │    │    │         │    │    ├── key columns: [84] = [105]
+      │    │    │    │    │         │    │    │         │    │    ├── lookup columns are key
+      │    │    │    │    │         │    │    │         │    │    ├── key: (1,84)
+      │    │    │    │    │         │    │    │         │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (84)-->(85), (1,84)-->(36,37,91,105,106), (105)-->(106), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
+      │    │    │    │    │         │    │    │         │    │    ├── left-join (lookup pg_index [as=ind])
+      │    │    │    │    │         │    │    │         │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 indexrelid:84 indrelid:85 indisclustered:91 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
+      │    │    │    │    │         │    │    │         │    │    │    ├── key columns: [957] = [84]
+      │    │    │    │    │         │    │    │         │    │    │    ├── lookup columns are key
+      │    │    │    │    │         │    │    │         │    │    │    ├── second join in paired joiner
+      │    │    │    │    │         │    │    │         │    │    │    ├── key: (1,84)
+      │    │    │    │    │         │    │    │         │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (84)-->(85), (1,84)-->(36,37,91), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
+      │    │    │    │    │         │    │    │         │    │    │    ├── left-join (lookup pg_index@pg_index_indrelid_index [as=ind])
+      │    │    │    │    │         │    │    │         │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140 indexrelid:957 indrelid:958 continuation:978
+      │    │    │    │    │         │    │    │         │    │    │    │    ├── key columns: [1] = [958]
+      │    │    │    │    │         │    │    │         │    │    │    │    ├── first join in paired joiner; continuation column: continuation:978
+      │    │    │    │    │         │    │    │         │    │    │    │    ├── key: (1,957)
+      │    │    │    │    │         │    │    │         │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3), (957)-->(958,978)
+      │    │    │    │    │         │    │    │         │    │    │    │    ├── left-join (lookup pg_tablespace [as=t])
+      │    │    │    │    │         │    │    │         │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
+      │    │    │    │    │         │    │    │         │    │    │    │    │    ├── key columns: [8] = [36]
+      │    │    │    │    │         │    │    │         │    │    │    │    │    ├── lookup columns are key
+      │    │    │    │    │         │    │    │         │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │         │    │    │         │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
+      │    │    │    │    │         │    │    │         │    │    │    │    │    ├── left-join (lookup pg_foreign_server [as=fs])
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    ├── key columns: [135] = [139]
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    ├── lookup columns are key
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (3)==(30), (30)==(3)
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    ├── left-join (lookup pg_foreign_table [as=ft])
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null ftrelid:134 ftserver:135 ftoptions:136
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    ├── key columns: [1] = [134]
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    ├── lookup columns are key
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136), (3)==(30), (30)==(3)
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    ├── inner-join (hash)
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3)
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    ├── select
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── scan pg_class [as=c]
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    │    └── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │         └── (c.relkind:17 = 'r') OR (c.relkind:17 = 'f') [outer=(17), constraints=(/17: [/'f' - /'f'] [/'r' - /'r']; tight)]
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    ├── scan pg_namespace@pg_namespace_nspname_index [as=n]
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── columns: n.oid:30!null n.nspname:31!null
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── constraint: /31: [/'public' - /'public']
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    ├── key: ()
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    │    └── fd: ()-->(30,31)
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    │         └── n.oid:30 = c.relnamespace:3 [outer=(3,30), constraints=(/3: (/NULL - ]; /30: (/NULL - ]), fd=(3)==(30), (30)==(3)]
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    │    └── filters (true)
+      │    │    │    │    │         │    │    │         │    │    │    │    │    │    └── filters (true)
+      │    │    │    │    │         │    │    │         │    │    │    │    │    └── filters (true)
+      │    │    │    │    │         │    │    │         │    │    │    │    └── filters (true)
+      │    │    │    │    │         │    │    │         │    │    │    └── filters
+      │    │    │    │    │         │    │    │         │    │    │         └── indisclustered:91 [outer=(91), constraints=(/91: [/true - /true]; tight), fd=()-->(91)]
+      │    │    │    │    │         │    │    │         │    │    └── filters (true)
+      │    │    │    │    │         │    │    │         │    └── filters
+      │    │    │    │    │         │    │    │         │         └── i.inhrelid:44 = c.oid:1 [outer=(1,44), constraints=(/1: (/NULL - ]; /44: (/NULL - ]), fd=(1)==(44), (44)==(1)]
+      │    │    │    │    │         │    │    │         └── filters (true)
       │    │    │    │    │         │    │    └── filters
-      │    │    │    │    │         │    │         └── i.inhparent:45 = c2.oid:49 [outer=(45,49), constraints=(/45: (/NULL - ]; /49: (/NULL - ]), fd=(45)==(49), (49)==(45)]
-      │    │    │    │    │         │    ├── left-join (lookup pg_class [as=ci])
-      │    │    │    │    │         │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 indexrelid:84 indrelid:85 indisclustered:91 ci.oid:105 ci.relname:106 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
-      │    │    │    │    │         │    │    ├── key columns: [84] = [105]
-      │    │    │    │    │         │    │    ├── lookup columns are key
-      │    │    │    │    │         │    │    ├── key: (1,84)
-      │    │    │    │    │         │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (84)-->(85), (1,84)-->(36,37,91,105,106), (105)-->(106), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
-      │    │    │    │    │         │    │    ├── left-join (lookup pg_index [as=ind])
-      │    │    │    │    │         │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 indexrelid:84 indrelid:85 indisclustered:91 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
-      │    │    │    │    │         │    │    │    ├── key columns: [938] = [84]
-      │    │    │    │    │         │    │    │    ├── lookup columns are key
-      │    │    │    │    │         │    │    │    ├── second join in paired joiner
-      │    │    │    │    │         │    │    │    ├── key: (1,84)
-      │    │    │    │    │         │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (84)-->(85), (1,84)-->(36,37,91), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
-      │    │    │    │    │         │    │    │    ├── left-join (lookup pg_index@pg_index_indrelid_index [as=ind])
-      │    │    │    │    │         │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140 indexrelid:938 indrelid:939 continuation:959
-      │    │    │    │    │         │    │    │    │    ├── key columns: [1] = [939]
-      │    │    │    │    │         │    │    │    │    ├── first join in paired joiner; continuation column: continuation:959
-      │    │    │    │    │         │    │    │    │    ├── key: (1,938)
-      │    │    │    │    │         │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3), (938)-->(939,959)
-      │    │    │    │    │         │    │    │    │    ├── left-join (lookup pg_tablespace [as=t])
-      │    │    │    │    │         │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null t.oid:36 spcname:37 ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
-      │    │    │    │    │         │    │    │    │    │    ├── key columns: [8] = [36]
-      │    │    │    │    │         │    │    │    │    │    ├── lookup columns are key
-      │    │    │    │    │         │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │         │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,36,37,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (36)-->(37), (37)-->(36), (3)==(30), (30)==(3)
-      │    │    │    │    │         │    │    │    │    │    ├── left-join (lookup pg_foreign_server [as=fs])
-      │    │    │    │    │         │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null ftrelid:134 ftserver:135 ftoptions:136 fs.oid:139 srvname:140
-      │    │    │    │    │         │    │    │    │    │    │    ├── key columns: [135] = [139]
-      │    │    │    │    │         │    │    │    │    │    │    ├── lookup columns are key
-      │    │    │    │    │         │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │         │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136,139,140), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136,139,140), (139)~~>(140), (140)~~>(139), (3)==(30), (30)==(3)
-      │    │    │    │    │         │    │    │    │    │    │    ├── left-join (lookup pg_foreign_table [as=ft])
-      │    │    │    │    │         │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null ftrelid:134 ftserver:135 ftoptions:136
-      │    │    │    │    │         │    │    │    │    │    │    │    ├── key columns: [1] = [134]
-      │    │    │    │    │         │    │    │    │    │    │    │    ├── lookup columns are key
-      │    │    │    │    │         │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │         │    │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27,134-136), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (134)-->(135,136), (3)==(30), (30)==(3)
-      │    │    │    │    │         │    │    │    │    │    │    │    ├── inner-join (hash)
-      │    │    │    │    │         │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27 n.oid:30!null n.nspname:31!null
-      │    │    │    │    │         │    │    │    │    │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
-      │    │    │    │    │         │    │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │         │    │    │    │    │    │    │    │    ├── fd: ()-->(3,30,31), (1)-->(2,5,8,10,13,15,17,20,22,23,26,27), (2)-->(1,5,8,10,13,15,17,20,22,23,26,27), (3)==(30), (30)==(3)
-      │    │    │    │    │         │    │    │    │    │    │    │    │    ├── select
-      │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27
-      │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
-      │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── scan pg_class [as=c]
-      │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    ├── columns: c.oid:1!null c.relname:2!null c.relnamespace:3!null c.relowner:5!null c.reltablespace:8!null c.reltuples:10!null c.relhasindex:13!null c.relpersistence:15!null c.relkind:17!null c.relhasoids:20!null c.relhasrules:22!null c.relhastriggers:23!null c.relacl:26 c.reloptions:27
-      │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    ├── key: (1)
-      │    │    │    │    │         │    │    │    │    │    │    │    │    │    │    └── fd: (1)-->(2,3,5,8,10,13,15,17,20,22,23,26,27), (2,3)-->(1,5,8,10,13,15,17,20,22,23,26,27)
-      │    │    │    │    │         │    │    │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │         │    │    │    │    │    │    │    │    │         └── (c.relkind:17 = 'r') OR (c.relkind:17 = 'f') [outer=(17), constraints=(/17: [/'f' - /'f'] [/'r' - /'r']; tight)]
-      │    │    │    │    │         │    │    │    │    │    │    │    │    ├── scan pg_namespace@pg_namespace_nspname_index [as=n]
-      │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── columns: n.oid:30!null n.nspname:31!null
-      │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── constraint: /31: [/'public' - /'public']
-      │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── cardinality: [0 - 1]
-      │    │    │    │    │         │    │    │    │    │    │    │    │    │    ├── key: ()
-      │    │    │    │    │         │    │    │    │    │    │    │    │    │    └── fd: ()-->(30,31)
-      │    │    │    │    │         │    │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │         │    │    │    │    │    │    │    │         └── n.oid:30 = c.relnamespace:3 [outer=(3,30), constraints=(/3: (/NULL - ]; /30: (/NULL - ]), fd=(3)==(30), (30)==(3)]
-      │    │    │    │    │         │    │    │    │    │    │    │    └── filters (true)
-      │    │    │    │    │         │    │    │    │    │    │    └── filters (true)
-      │    │    │    │    │         │    │    │    │    │    └── filters (true)
-      │    │    │    │    │         │    │    │    │    └── filters (true)
-      │    │    │    │    │         │    │    │    └── filters
-      │    │    │    │    │         │    │    │         └── indisclustered:91 [outer=(91), constraints=(/91: [/true - /true]; tight), fd=()-->(91)]
-      │    │    │    │    │         │    │    └── filters (true)
-      │    │    │    │    │         │    └── filters
-      │    │    │    │    │         │         └── i.inhrelid:44 = c.oid:1 [outer=(1,44), constraints=(/1: (/NULL - ]; /44: (/NULL - ]), fd=(1)==(44), (44)==(1)]
-      │    │    │    │    │         └── filters (true)
+      │    │    │    │    │         │    │         └── pg_catalog.pg_roles.oid:157 = c.relowner:5 [outer=(5,157), constraints=(/5: (/NULL - ]; /157: (/NULL - ]), fd=(5)==(157), (157)==(5)]
+      │    │    │    │    │         │    └── aggregations
+      │    │    │    │    │         │         ├── const-agg [as=c.oid:1, outer=(1)]
+      │    │    │    │    │         │         │    └── c.oid:1
+      │    │    │    │    │         │         ├── const-agg [as=c.relname:2, outer=(2)]
+      │    │    │    │    │         │         │    └── c.relname:2
+      │    │    │    │    │         │         ├── const-agg [as=c.relowner:5, outer=(5)]
+      │    │    │    │    │         │         │    └── c.relowner:5
+      │    │    │    │    │         │         ├── const-agg [as=c.reltuples:10, outer=(10)]
+      │    │    │    │    │         │         │    └── c.reltuples:10
+      │    │    │    │    │         │         ├── const-agg [as=c.relhasindex:13, outer=(13)]
+      │    │    │    │    │         │         │    └── c.relhasindex:13
+      │    │    │    │    │         │         ├── const-agg [as=c.relpersistence:15, outer=(15)]
+      │    │    │    │    │         │         │    └── c.relpersistence:15
+      │    │    │    │    │         │         ├── const-agg [as=c.relkind:17, outer=(17)]
+      │    │    │    │    │         │         │    └── c.relkind:17
+      │    │    │    │    │         │         ├── const-agg [as=c.relhasoids:20, outer=(20)]
+      │    │    │    │    │         │         │    └── c.relhasoids:20
+      │    │    │    │    │         │         ├── const-agg [as=c.relhasrules:22, outer=(22)]
+      │    │    │    │    │         │         │    └── c.relhasrules:22
+      │    │    │    │    │         │         ├── const-agg [as=c.relhastriggers:23, outer=(23)]
+      │    │    │    │    │         │         │    └── c.relhastriggers:23
+      │    │    │    │    │         │         ├── const-agg [as=c.relacl:26, outer=(26)]
+      │    │    │    │    │         │         │    └── c.relacl:26
+      │    │    │    │    │         │         ├── const-agg [as=c.reloptions:27, outer=(27)]
+      │    │    │    │    │         │         │    └── c.reloptions:27
+      │    │    │    │    │         │         ├── const-agg [as=n.nspname:31, outer=(31)]
+      │    │    │    │    │         │         │    └── n.nspname:31
+      │    │    │    │    │         │         ├── const-agg [as=spcname:37, outer=(37)]
+      │    │    │    │    │         │         │    └── spcname:37
+      │    │    │    │    │         │         ├── const-agg [as=c2.relname:50, outer=(50)]
+      │    │    │    │    │         │         │    └── c2.relname:50
+      │    │    │    │    │         │         ├── const-agg [as=n2.nspname:79, outer=(79)]
+      │    │    │    │    │         │         │    └── n2.nspname:79
+      │    │    │    │    │         │         ├── const-agg [as=ci.relname:106, outer=(106)]
+      │    │    │    │    │         │         │    └── ci.relname:106
+      │    │    │    │    │         │         ├── const-agg [as=ftoptions:136, outer=(136)]
+      │    │    │    │    │         │         │    └── ftoptions:136
+      │    │    │    │    │         │         ├── const-agg [as=srvname:140, outer=(140)]
+      │    │    │    │    │         │         │    └── srvname:140
+      │    │    │    │    │         │         └── first-agg [as=rolname:158, outer=(158)]
+      │    │    │    │    │         │              └── rolname:158
+      │    │    │    │    │         └── projections
+      │    │    │    │    │              └── assignment-cast: STRING [as=column172:172, outer=(5,158), immutable]
+      │    │    │    │    │                   └── COALESCE(rolname:158, (('unknown (OID=' || c.relowner:5) || ')')::NAME)
       │    │    │    │    ├── select
-      │    │    │    │    │    ├── columns: objoid:158 objsubid:160!null pg_catalog.pg_description.description:161
-      │    │    │    │    │    ├── fd: ()-->(160)
+      │    │    │    │    │    ├── columns: objoid:176 objsubid:178!null pg_catalog.pg_description.description:179
+      │    │    │    │    │    ├── fd: ()-->(178)
       │    │    │    │    │    ├── scan pg_description
-      │    │    │    │    │    │    └── columns: objoid:158 objsubid:160 pg_catalog.pg_description.description:161
+      │    │    │    │    │    │    └── columns: objoid:176 objsubid:178 pg_catalog.pg_description.description:179
       │    │    │    │    │    └── filters
-      │    │    │    │    │         └── objsubid:160 = 0 [outer=(160), constraints=(/160: [/0 - /0]; tight), fd=()-->(160)]
+      │    │    │    │    │         └── objsubid:178 = 0 [outer=(178), constraints=(/178: [/0 - /0]; tight), fd=()-->(178)]
       │    │    │    │    └── filters
-      │    │    │    │         └── objoid:158 = c.oid:1 [outer=(1,158), constraints=(/1: (/NULL - ]; /158: (/NULL - ]), fd=(1)==(158), (158)==(1)]
+      │    │    │    │         └── objoid:176 = c.oid:1 [outer=(1,176), constraints=(/1: (/NULL - ]; /176: (/NULL - ]), fd=(1)==(176), (176)==(1)]
       │    │    │    └── aggregations
       │    │    │         ├── const-agg [as=c.oid:1, outer=(1)]
       │    │    │         │    └── c.oid:1
       │    │    │         ├── const-agg [as=c.relname:2, outer=(2)]
       │    │    │         │    └── c.relname:2
-      │    │    │         ├── const-agg [as=c.relowner:5, outer=(5)]
-      │    │    │         │    └── c.relowner:5
       │    │    │         ├── const-agg [as=c.reltuples:10, outer=(10)]
       │    │    │         │    └── c.reltuples:10
       │    │    │         ├── const-agg [as=c.relhasindex:13, outer=(13)]
@@ -328,8 +395,10 @@ sort
       │    │    │         │    └── ftoptions:136
       │    │    │         ├── const-agg [as=srvname:140, outer=(140)]
       │    │    │         │    └── srvname:140
-      │    │    │         └── first-agg [as=pg_catalog.pg_description.description:161, outer=(161)]
-      │    │    │              └── pg_catalog.pg_description.description:161
+      │    │    │         ├── const-agg [as=column172:172, outer=(172)]
+      │    │    │         │    └── column172:172
+      │    │    │         └── first-agg [as=pg_catalog.pg_description.description:179, outer=(179)]
+      │    │    │              └── pg_catalog.pg_description.description:179
       │    │    └── filters
       │    │         └── pg_inherits.inhparent:150 = c.oid:1 [outer=(1,150), constraints=(/1: (/NULL - ]; /150: (/NULL - ]), fd=(1)==(150), (150)==(1)]
       │    └── aggregations
@@ -339,8 +408,6 @@ sort
       │         │    └── c.oid:1
       │         ├── const-agg [as=c.relname:2, outer=(2)]
       │         │    └── c.relname:2
-      │         ├── const-agg [as=c.relowner:5, outer=(5)]
-      │         │    └── c.relowner:5
       │         ├── const-agg [as=c.reltuples:10, outer=(10)]
       │         │    └── c.reltuples:10
       │         ├── const-agg [as=c.relhasindex:13, outer=(13)]
@@ -373,9 +440,11 @@ sort
       │         │    └── ftoptions:136
       │         ├── const-agg [as=srvname:140, outer=(140)]
       │         │    └── srvname:140
-      │         └── const-agg [as=pg_catalog.pg_description.description:161, outer=(161)]
-      │              └── pg_catalog.pg_description.description:161
+      │         ├── const-agg [as=column172:172, outer=(172)]
+      │         │    └── column172:172
+      │         └── const-agg [as=pg_catalog.pg_description.description:179, outer=(179)]
+      │              └── pg_catalog.pg_description.description:179
       └── projections
-           ├── pg_get_userbyid(c.relowner:5) [as=tableowner:155, outer=(5), stable]
-           ├── pg_catalog.pg_description.description:161 [as=description:162, outer=(161)]
-           └── count_rows:154 > 0 [as=inhtable:163, outer=(154)]
+           ├── column172:172 [as=tableowner:173, outer=(172)]
+           ├── pg_catalog.pg_description.description:179 [as=description:180, outer=(179)]
+           └── count_rows:154 > 0 [as=inhtable:181, outer=(154)]

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -2575,21 +2575,16 @@ https://www.postgresql.org/docs/9.5/catalog-pg-proc.html`,
 				coid := tree.MustBeDOid(unwrappedConstraint)
 				ooid := coid.Oid
 
-				name, overload, err := p.ResolveFunctionByOID(ctx, ooid)
-				if err != nil {
-					if errors.Is(err, tree.ErrFunctionUndefined) {
-						return false, nil //nolint:returnerrcheck
-					}
-					return false, err
-				}
-
 				if funcdesc.IsOIDUserDefinedFunc(ooid) {
-					fnDesc, err := p.Descriptors().ByID(p.Txn()).WithoutNonPublic().Get().Function(ctx, descpb.ID(overload.Oid))
+					fnDesc, err := p.Descriptors().ByID(p.Txn()).WithoutNonPublic().Get().Function(ctx, funcdesc.UserDefinedFunctionOIDToID(ooid))
 					if err != nil {
+						if errors.Is(err, tree.ErrFunctionUndefined) {
+							return false, nil //nolint:returnerrcheck
+						}
 						return false, err
 					}
 
-					scDesc, err := p.Descriptors().ByIDWithLeased(p.Txn()).WithoutNonPublic().Get().Schema(ctx, descpb.ID(ooid))
+					scDesc, err := p.Descriptors().ByIDWithLeased(p.Txn()).WithoutNonPublic().Get().Schema(ctx, fnDesc.GetParentSchemaID())
 					if err != nil {
 						return false, err
 					}
@@ -2604,7 +2599,15 @@ https://www.postgresql.org/docs/9.5/catalog-pg-proc.html`,
 					return true, nil
 
 				} else {
-					err := addPgProcBuiltinRow(name, addRow)
+					name, _, err := p.ResolveFunctionByOID(ctx, ooid)
+					if err != nil {
+						if errors.Is(err, tree.ErrFunctionUndefined) {
+							return false, nil //nolint:returnerrcheck
+						}
+						return false, err
+					}
+
+					err = addPgProcBuiltinRow(name, addRow)
 					if err != nil {
 						return false, err
 					}

--- a/pkg/sql/sem/builtins/BUILD.bazel
+++ b/pkg/sql/sem/builtins/BUILD.bazel
@@ -64,6 +64,7 @@ go_library(
         "//pkg/sql/lex",
         "//pkg/sql/lexbase",
         "//pkg/sql/memsize",
+        "//pkg/sql/oidext",
         "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -1397,7 +1397,7 @@ var builtinOidsArray = []string{
 	1417: `pg_typeof(val: anyelement) -> string`,
 	1418: `pg_collation_for(str: anyelement) -> string`,
 	1419: `pg_get_userbyid(role_oid: oid) -> string`,
-	1420: `pg_sequence_parameters(sequence_oid: oid) -> string`,
+	1420: `pg_sequence_parameters(sequence_oid: oid) -> tuple{int AS start_value, int AS minimum_value, int AS maxmimum_value, int AS increment, bool AS cycle_option, int AS cache_size, oid AS data_type}`,
 	1421: `format_type(type_oid: oid, typemod: int) -> string`,
 	1422: `col_description(table_oid: oid, column_number: int) -> string`,
 	1423: `obj_description(object_oid: oid) -> string`,

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
+	"github.com/cockroachdb/cockroach/pkg/sql/oidext"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -262,27 +263,16 @@ func makePGGetViewDef(paramTypes tree.ParamTypes) tree.Overload {
 	return tree.Overload{
 		Types:      paramTypes,
 		ReturnType: tree.FixedReturnType(types.String),
-		Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-			r, err := evalCtx.Planner.QueryRowEx(
-				ctx, "pg_get_viewdef",
-				sessiondata.NoSessionDataOverride,
-				`SELECT definition
- FROM pg_catalog.pg_views v
- JOIN pg_catalog.pg_class c ON c.relname=v.viewname
-WHERE c.oid=$1
-UNION ALL
-SELECT definition
- FROM pg_catalog.pg_matviews v
- JOIN pg_catalog.pg_class c ON c.relname=v.matviewname
-WHERE c.oid=$1`, args[0])
-			if err != nil {
-				return nil, err
-			}
-			if len(r) == 0 {
-				return tree.DNull, nil
-			}
-			return r[0], nil
-		},
+		IsUDF:      true,
+		Body: `SELECT definition
+		FROM pg_catalog.pg_views v
+		JOIN pg_catalog.pg_class c ON c.relname=v.viewname
+		WHERE c.oid=$1
+		UNION ALL
+		SELECT definition
+		FROM pg_catalog.pg_matviews v
+		JOIN pg_catalog.pg_class c ON c.relname=v.matviewname
+		WHERE c.oid=$1`,
 		Info:       "Returns the CREATE statement for an existing view.",
 		Volatility: volatility.Stable,
 	}
@@ -293,19 +283,8 @@ func makePGGetConstraintDef(paramTypes tree.ParamTypes) tree.Overload {
 	return tree.Overload{
 		Types:      paramTypes,
 		ReturnType: tree.FixedReturnType(types.String),
-		Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-			r, err := evalCtx.Planner.QueryRowEx(
-				ctx, "pg_get_constraintdef",
-				sessiondata.NoSessionDataOverride,
-				"SELECT condef FROM pg_catalog.pg_constraint WHERE oid=$1", args[0])
-			if err != nil {
-				return nil, err
-			}
-			if len(r) == 0 {
-				return nil, pgerror.Newf(pgcode.InvalidParameterValue, "unknown constraint (OID=%s)", args[0])
-			}
-			return r[0], nil
-		},
+		IsUDF:      true,
+		Body:       `SELECT condef FROM pg_catalog.pg_constraint WHERE oid=$1 LIMIT 1`,
 		Info:       notUsableInfo,
 		Volatility: volatility.Stable,
 	}
@@ -540,6 +519,19 @@ func makeToRegOverload(typ *types.T, helpText string) builtinDefinition {
 	)
 }
 
+// Format the array {type,othertype} as type, othertype.
+// If there are no args, output the empty string.
+const getFunctionArgStringQuery = `SELECT 
+										COALESCE(
+										    (SELECT trim('{}' FROM replace(
+										        array_agg(unnest(proargtypes)::REGTYPE::TEXT)::TEXT,
+										        ',', ', ')))
+										    , '')
+                    FROM pg_catalog.pg_proc
+                    WHERE oid=$1
+                    GROUP BY oid, proargtypes
+                    LIMIT 1`
+
 var pgBuiltins = map[string]builtinDefinition{
 	// See https://www.postgresql.org/docs/9.6/static/functions-info.html.
 	"pg_backend_pid": makeBuiltin(defProps(),
@@ -659,27 +651,15 @@ var pgBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ParamTypes{{Name: "func_oid", Typ: types.Oid}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				idToQuery := catid.DescID(tree.MustBeDOid(args[0]).Oid)
-				getFuncQuery := `SELECT prosrc FROM pg_proc WHERE oid=$1`
-				if catid.IsOIDUserDefined(oid.Oid(idToQuery)) {
-					getFuncQuery = `SELECT create_statement FROM crdb_internal.create_function_statements WHERE function_id=$1`
-					idToQuery = catid.UserDefinedOIDToID(oid.Oid(idToQuery))
-				}
-				results, err := evalCtx.Planner.QueryRowEx(
-					ctx, "pg_get_functiondef",
-					sessiondata.NoSessionDataOverride,
-					getFuncQuery,
-					idToQuery,
-				)
-				if err != nil {
-					return nil, err
-				}
-				if len(results) == 0 {
-					return tree.DNull, nil
-				}
-				return results[0], nil
-			},
+			IsUDF:      true,
+			Body: fmt.Sprintf(
+				`SELECT COALESCE(create_statement, prosrc)
+             FROM pg_catalog.pg_proc
+             LEFT JOIN crdb_internal.create_function_statements
+             ON schema_id=pronamespace
+             AND function_id=oid::int-%d
+             WHERE oid=$1
+             LIMIT 1`, oidext.CockroachPredefinedOIDMax),
 			Info: "For user-defined functions, returns the definition of the specified function. " +
 				"For builtin functions, returns the name of the function.",
 			Volatility: volatility.Stable,
@@ -691,39 +671,8 @@ var pgBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ParamTypes{{Name: "func_oid", Typ: types.Oid}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				funcOid := tree.MustBeDOid(args[0])
-				t, err := evalCtx.Planner.QueryRowEx(
-					ctx, "pg_get_function_arguments",
-					sessiondata.NoSessionDataOverride,
-					`SELECT array_agg(unnest(proargtypes)::REGTYPE::TEXT) FROM pg_proc WHERE oid=$1`, funcOid.Oid)
-				if err != nil {
-					return nil, err
-				}
-				if len(t) == 0 || t[0] == tree.DNull {
-					return tree.NewDString(""), nil
-				}
-				arr := tree.MustBeDArray(t[0])
-				var sb strings.Builder
-				for i, elem := range arr.Array {
-					if i > 0 {
-						sb.WriteString(", ")
-					}
-					if elem == tree.DNull {
-						// This shouldn't ever happen, but let's be safe about it.
-						sb.WriteString("NULL")
-						continue
-					}
-					str, ok := tree.AsDString(elem)
-					if !ok {
-						// This also shouldn't happen.
-						sb.WriteString(elem.String())
-						continue
-					}
-					sb.WriteString(string(str))
-				}
-				return tree.NewDString(sb.String()), nil
-			},
+			IsUDF:      true,
+			Body:       getFunctionArgStringQuery,
 			Info: "Returns the argument list (with defaults) necessary to identify a function, " +
 				"in the form it would need to appear in within CREATE FUNCTION.",
 			Volatility: volatility.Stable,
@@ -739,20 +688,12 @@ var pgBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ParamTypes{{Name: "func_oid", Typ: types.Oid}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				funcOid := tree.MustBeDOid(args[0])
-				t, err := evalCtx.Planner.QueryRowEx(
-					ctx, "pg_get_function_result",
-					sessiondata.NoSessionDataOverride,
-					`SELECT prorettype::REGTYPE::TEXT FROM pg_proc WHERE oid=$1`, funcOid.Oid)
-				if err != nil {
-					return nil, err
-				}
-				if len(t) == 0 {
-					return tree.NewDString(""), nil
-				}
-				return t[0], nil
-			},
+			IsUDF:      true,
+			Body: `SELECT t.typname
+             FROM pg_catalog.pg_proc p
+             JOIN pg_catalog.pg_type t
+             ON prorettype=t.oid
+             WHERE p.oid=$1 LIMIT 1`,
 			Info:       "Returns the types of the result of the specified function.",
 			Volatility: volatility.Stable,
 		},
@@ -767,39 +708,8 @@ var pgBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ParamTypes{{Name: "func_oid", Typ: types.Oid}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				funcOid := tree.MustBeDOid(args[0])
-				t, err := evalCtx.Planner.QueryRowEx(
-					ctx, "pg_get_function_identity_arguments",
-					sessiondata.NoSessionDataOverride,
-					`SELECT array_agg(unnest(proargtypes)::REGTYPE::TEXT) FROM pg_proc WHERE oid=$1`, funcOid.Oid)
-				if err != nil {
-					return nil, err
-				}
-				if len(t) == 0 || t[0] == tree.DNull {
-					return tree.NewDString(""), nil
-				}
-				arr := tree.MustBeDArray(t[0])
-				var sb strings.Builder
-				for i, elem := range arr.Array {
-					if i > 0 {
-						sb.WriteString(", ")
-					}
-					if elem == tree.DNull {
-						// This shouldn't ever happen, but let's be safe about it.
-						sb.WriteString("NULL")
-						continue
-					}
-					str, ok := tree.AsDString(elem)
-					if !ok {
-						// This also shouldn't happen.
-						sb.WriteString(elem.String())
-						continue
-					}
-					sb.WriteString(string(str))
-				}
-				return tree.NewDString(sb.String()), nil
-			},
+			IsUDF:      true,
+			Body:       getFunctionArgStringQuery,
 			Info: "Returns the argument list (without defaults) necessary to identify a function, " +
 				"in the form it would need to appear in within ALTER FUNCTION, for instance.",
 			Volatility: volatility.Stable,
@@ -963,20 +873,8 @@ var pgBuiltins = map[string]builtinDefinition{
 				{Name: "role_oid", Typ: types.Oid},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				oid := args[0]
-				t, err := evalCtx.Planner.QueryRowEx(
-					ctx, "pg_get_userbyid",
-					sessiondata.NoSessionDataOverride,
-					"SELECT rolname FROM pg_catalog.pg_roles WHERE oid=$1", oid)
-				if err != nil {
-					return nil, err
-				}
-				if len(t) == 0 {
-					return tree.NewDString(fmt.Sprintf("unknown (OID=%s)", args[0])), nil
-				}
-				return t[0], nil
-			},
+			IsUDF:      true,
+			Body:       `SELECT COALESCE((SELECT rolname FROM pg_catalog.pg_roles WHERE oid=$1 LIMIT 1), 'unknown (OID=' || $1 || ')')`,
 			Info:       notUsableInfo,
 			Volatility: volatility.Stable,
 		},
@@ -988,29 +886,16 @@ var pgBuiltins = map[string]builtinDefinition{
 		// at least one UI tool, so we provide an implementation for compatibility.
 		// The real implementation returns a record; we fake it by returning a
 		// comma-delimited string enclosed by parentheses.
-		// TODO(jordan): convert this to return a record type once we support that.
 		tree.Overload{
-			Types:      tree.ParamTypes{{Name: "sequence_oid", Typ: types.Oid}},
-			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				r, err := evalCtx.Planner.QueryRowEx(
-					ctx, "pg_sequence_parameters",
-					sessiondata.NoSessionDataOverride,
-					`SELECT seqstart, seqmin, seqmax, seqincrement, seqcycle, seqcache, seqtypid `+
-						`FROM pg_catalog.pg_sequence WHERE seqrelid=$1`, args[0])
-				if err != nil {
-					return nil, err
-				}
-				if len(r) == 0 {
-					return nil, pgerror.Newf(pgcode.UndefinedTable, "unknown sequence (OID=%s)", args[0])
-				}
-				seqstart, seqmin, seqmax, seqincrement, seqcycle, seqcache, seqtypid := r[0], r[1], r[2], r[3], r[4], r[5], r[6]
-				seqcycleStr := "t"
-				if seqcycle.(*tree.DBool) == tree.DBoolFalse {
-					seqcycleStr = "f"
-				}
-				return tree.NewDString(fmt.Sprintf("(%s,%s,%s,%s,%s,%s,%s)", seqstart, seqmin, seqmax, seqincrement, seqcycleStr, seqcache, seqtypid)), nil
-			},
+			Types: tree.ParamTypes{{Name: "sequence_oid", Typ: types.Oid}},
+			ReturnType: tree.FixedReturnType(types.MakeLabeledTuple(
+				[]*types.T{types.Int, types.Int, types.Int, types.Int, types.Bool, types.Int, types.Oid},
+				[]string{"start_value", "minimum_value", "maxmimum_value", "increment", "cycle_option", "cache_size", "data_type"},
+			)),
+			IsUDF: true,
+			Body: `SELECT COALESCE ((SELECT (seqstart, seqmin, seqmax, seqincrement, seqcycle, seqcache, seqtypid)
+             FROM pg_catalog.pg_sequence WHERE seqrelid=$1 LIMIT 1),
+             CASE WHEN crdb_internal.force_error('42P01', 'relation with OID ' || $1 || ' does not exist') > 0 THEN NULL ELSE NULL END)`,
 			Info:       notUsableInfo,
 			Volatility: volatility.Stable,
 		},
@@ -1209,8 +1094,8 @@ var pgBuiltins = map[string]builtinDefinition{
 			Types:      tree.ParamTypes{{Name: "oid", Typ: types.Oid}},
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Body: `SELECT n.nspname = any current_schemas(true)
-             FROM pg_proc p
-             INNER LOOKUP JOIN pg_namespace n
+             FROM pg_catalog.pg_proc p
+             INNER LOOKUP JOIN pg_catalog.pg_namespace n
              ON p.pronamespace = n.oid
              WHERE p.oid=$1 LIMIT 1`,
 			Info:       "Returns whether the function with the given OID belongs to one of the schemas on the search path.",
@@ -1226,8 +1111,8 @@ var pgBuiltins = map[string]builtinDefinition{
 			Types:      tree.ParamTypes{{Name: "oid", Typ: types.Oid}},
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Body: `SELECT n.nspname = any current_schemas(true)
-             FROM pg_class c
-             INNER LOOKUP JOIN pg_namespace n
+             FROM pg_catalog.pg_class c
+             INNER LOOKUP JOIN pg_catalog.pg_namespace n
              ON c.relnamespace = n.oid
              WHERE c.oid=$1 LIMIT 1`,
 			Info:       "Returns whether the table with the given OID belongs to one of the schemas on the search path.",
@@ -1247,8 +1132,8 @@ var pgBuiltins = map[string]builtinDefinition{
 			Types:      tree.ParamTypes{{Name: "oid", Typ: types.Oid}},
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Body: `SELECT n.nspname = any current_schemas(true)
-             FROM pg_type t
-             INNER LOOKUP JOIN pg_namespace n
+             FROM pg_catalog.pg_type t
+             INNER LOOKUP JOIN pg_catalog.pg_namespace n
              ON t.typnamespace = n.oid
              WHERE t.oid=$1 LIMIT 1`,
 			Info:       "Returns whether the type with the given OID belongs to one of the schemas on the search path.",


### PR DESCRIPTION
Epic: CRDB-23454
Closes #94746
Closes #94953

Remove a couple of unnecessary builtin function calls in SHOW FUNCTIONS.
The query used to take 50 seconds, now it takes less than a second.

Also, rewrite several pg compatibility builtins as UDFs for improved performance.

Also, fix the pg_proc oid virtual index which didn't work for user-defined functions.

Epic: None