### PR TITLE
roachtest: use fresh virtualenv for python tests

### DIFF
--- a/pkg/cmd/roachtest/tests/asyncpg.go
+++ b/pkg/cmd/roachtest/tests/asyncpg.go
@@ -91,7 +91,7 @@ func registerAsyncpg(r registry.Registry) {
 		}
 
 		if err := repeatRunE(
-			ctx, t, c, node, "create virtualenv", `virtualenv venv`,
+			ctx, t, c, node, "create virtualenv", `virtualenv --clear venv`,
 		); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cmd/roachtest/tests/django.go
+++ b/pkg/cmd/roachtest/tests/django.go
@@ -94,7 +94,7 @@ func registerDjango(r registry.Registry) {
 		}
 
 		if err := repeatRunE(
-			ctx, t, c, node, "create virtualenv", `virtualenv venv`,
+			ctx, t, c, node, "create virtualenv", `virtualenv --clear venv`,
 		); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cmd/roachtest/tests/sqlalchemy.go
+++ b/pkg/cmd/roachtest/tests/sqlalchemy.go
@@ -93,7 +93,7 @@ func runSQLAlchemy(ctx context.Context, t test.Test, c cluster.Cluster) {
 	}
 
 	if err := repeatRunE(
-		ctx, t, c, node, "create virtualenv", `virtualenv venv`,
+		ctx, t, c, node, "create virtualenv", `virtualenv --clear venv`,
 	); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/91351
backport fixes https://github.com/cockroachdb/cockroach/issues/91347 and https://github.com/cockroachdb/cockroach/issues/91343

The sqlalchemy tests were failing because the wrong depenencies were in the virtualenv leftover from a previous test run.

Release note: None