### PR TITLE
[WIP, DNM] storage: correctly determine cases where intent history is…

### DIFF
--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -1782,7 +1782,7 @@ func ScanConflictingIntentsForDroppingLatchesEarly(
 			// either of these conditions is true, a corresponding scan over the MVCC
 			// key space will need access to the key's intent history in order to read
 			// the correct provisional value. So we set `needIntentHistory` to true.
-			if seq <= meta.Txn.Sequence || ts.LessEq(meta.Timestamp.ToTimestamp()) {
+			if seq <= meta.Txn.Sequence || ts.Less(meta.Timestamp.ToTimestamp()) {
 				needIntentHistory = true
 			}
 			continue


### PR DESCRIPTION
… required

Read-only requests that drop their latches early, before evaluation, scan the lock table to resolve conflicts in
`ScanConflictingIntentsForDroppingLatchesEarly`. A request needs to determine if it needs access to the intent history during the scan phase. Typically, this happens if the lock table scan uncovers an intent from the same transaction but at a higher sequence number. However, we may also find intents at lower sequence numbers but at higher timestamps (e.g, the intent was pushed by a conflicting transaction) -- these intents need to be read, and to correctly do that during the scan phase, we need access to the intent history.

Note that this only applies to intents at strictly higher timestamps. Previously, we would determine we needed access to the intent history even if the intent history was at the same timestamp as the read request. In practice, this is quite common, which ends up meaning that we default back to the intent interleaving iterator more often than we need to. This patch fixes this behaviour.

References #94337 -- see explanation for "what's the deal with `pg_sleep`.

Epic: none

Release note: None