### PR TITLE
changefeedccl: Bring changefeed transformations out of preview

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -297,4 +297,4 @@ trace.jaeger.agent	string		the address of a Jaeger agent to receive traces using
 trace.opentelemetry.collector	string		address of an OpenTelemetry trace collector to receive traces using the otel gRPC protocol, as <host>:<port>. If no port is specified, 4317 will be used.
 trace.span_registry.enabled	boolean	true	if set, ongoing traces can be seen at https://<ui>/#/debug/tracez
 trace.zipkin.collector	string		the address of a Zipkin instance to receive traces, as <host>:<port>. If no port is specified, 9411 will be used.
-version	version	1000022.2-28	set the active cluster version in the format '<major>.<minor>'
+version	version	1000022.2-30	set the active cluster version in the format '<major>.<minor>'

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -235,6 +235,6 @@
 <tr><td><div id="setting-trace-opentelemetry-collector" class="anchored"><code>trace.opentelemetry.collector</code></div></td><td>string</td><td><code></code></td><td>address of an OpenTelemetry trace collector to receive traces using the otel gRPC protocol, as &lt;host&gt;:&lt;port&gt;. If no port is specified, 4317 will be used.</td></tr>
 <tr><td><div id="setting-trace-span-registry-enabled" class="anchored"><code>trace.span_registry.enabled</code></div></td><td>boolean</td><td><code>true</code></td><td>if set, ongoing traces can be seen at https://&lt;ui&gt;/#/debug/tracez</td></tr>
 <tr><td><div id="setting-trace-zipkin-collector" class="anchored"><code>trace.zipkin.collector</code></div></td><td>string</td><td><code></code></td><td>the address of a Zipkin instance to receive traces, as &lt;host&gt;:&lt;port&gt;. If no port is specified, 9411 will be used.</td></tr>
-<tr><td><div id="setting-version" class="anchored"><code>version</code></div></td><td>version</td><td><code>1000022.2-28</code></td><td>set the active cluster version in the format &#39;&lt;major&gt;.&lt;minor&gt;&#39;</td></tr>
+<tr><td><div id="setting-version" class="anchored"><code>version</code></div></td><td>version</td><td><code>1000022.2-30</code></td><td>set the active cluster version in the format &#39;&lt;major&gt;.&lt;minor&gt;&#39;</td></tr>
 </tbody>
 </table>

--- a/pkg/ccl/changefeedccl/bench_test.go
+++ b/pkg/ccl/changefeedccl/bench_test.go
@@ -250,7 +250,7 @@ func createBenchmarkChangefeed(
 	execCfg := s.ExecutorConfig().(sql.ExecutorConfig)
 	eventConsumer, err := newKVEventToRowConsumer(ctx, &execCfg, sf, initialHighWater,
 		sink, encoder, makeChangefeedConfigFromJobDetails(details), execinfrapb.ChangeAggregatorSpec{},
-		TestingKnobs{}, nil, nil)
+		TestingKnobs{}, nil, nil, nil)
 
 	if err != nil {
 		return nil, nil, err

--- a/pkg/ccl/changefeedccl/cdceval/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/cdceval/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     name = "cdceval",
     srcs = [
         "cdc_prev.go",
+        "compat.go",
         "doc.go",
         "expr_eval.go",
         "func_resolver.go",
@@ -52,6 +53,7 @@ go_library(
 go_test(
     name = "cdceval_test",
     srcs = [
+        "compat_test.go",
         "expr_eval_test.go",
         "func_resolver_test.go",
         "functions_test.go",

--- a/pkg/ccl/changefeedccl/cdceval/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/cdceval/BUILD.bazel
@@ -42,6 +42,8 @@ go_library(
         "//pkg/sql/types",
         "//pkg/util/ctxgroup",
         "//pkg/util/hlc",
+        "//pkg/util/log",
+        "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_lib_pq//oid",
     ],

--- a/pkg/ccl/changefeedccl/cdceval/compat.go
+++ b/pkg/ccl/changefeedccl/cdceval/compat.go
@@ -1,0 +1,54 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package cdceval
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/errors"
+)
+
+// RewritePreviewExpression handles CDC expressions created on 22.2 clusters.
+// The expression is rewritten so that it will continue functioning in
+// post clusterversion.V23_1_ChangefeedExpressionProductionReady clusters.
+// This code may be removed once 23.2 released.
+func RewritePreviewExpression(oldExpr *tree.SelectClause) (*tree.SelectClause, error) {
+	stmt, err := tree.SimpleStmtVisit(oldExpr, func(expr tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
+		switch t := expr.(type) {
+		default:
+			return true, expr, nil
+		case *tree.FuncExpr:
+			// Old style cdc_prev() function returned JSONb object.
+			// Replace this call with a call to row_to_json((cdc_prev).*)
+			if n, ok := t.Func.FunctionReference.(*tree.UnresolvedName); ok && n.Parts[0] == "cdc_prev" {
+				rowToJSON := &tree.FuncExpr{
+					Func: tree.ResolvableFunctionReference{
+						FunctionReference: tree.FunDefs["row_to_json"],
+					},
+					Exprs: tree.Exprs{
+						&tree.TupleStar{Expr: tree.NewUnresolvedName("cdc_prev")},
+					},
+				}
+				return true, rowToJSON, nil
+			}
+		}
+		return true, expr, nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	newExpr, ok := stmt.(*tree.SelectClause)
+	if !ok {
+		// We started with *tree.SelectClause, so getting anything else would be surprising.
+		return nil, errors.AssertionFailedf("unexpected result type %T", stmt)
+	}
+
+	return newExpr, nil
+}

--- a/pkg/ccl/changefeedccl/cdceval/compat_test.go
+++ b/pkg/ccl/changefeedccl/cdceval/compat_test.go
@@ -1,0 +1,78 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package cdceval
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompatRewrite(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.Background())
+
+	sqlDB := sqlutils.MakeSQLRunner(db)
+	sqlDB.Exec(t, `CREATE TABLE foo (a int, b int, c int)`)
+	execCfg := s.ExecutorConfig().(sql.ExecutorConfig)
+	fooDesc := cdctest.GetHydratedTableDescriptor(t, s.ExecutorConfig(), "foo")
+	target := changefeedbase.Target{
+		TableID: fooDesc.GetID(),
+	}
+	fooRef := fmt.Sprintf("[%d AS foo]", fooDesc.GetID())
+
+	for _, tc := range []struct {
+		oldExpr string
+		newExpr string
+	}{
+		{
+			oldExpr: "SELECT * FROM defaultdb.public.FOO",
+			newExpr: "SELECT * FROM defaultdb.public.foo",
+		},
+		{
+			oldExpr: "SELECT f.a, f.b, f.c FROM foo AS f WHERE f.c IS NULL",
+			newExpr: "SELECT f.a, f.b, f.c FROM foo AS f WHERE f.c IS NULL",
+		},
+		{
+			oldExpr: "SELECT foo.*, cdc_prev() FROM " + fooRef,
+			newExpr: "SELECT foo.*, row_to_json((cdc_prev).*) FROM " + fooRef,
+		},
+		{
+			oldExpr: "SELECT foo.*, cdc_prev()->'field' FROM " + fooRef,
+			newExpr: "SELECT foo.*, row_to_json((cdc_prev).*)->'field' FROM " + fooRef,
+		},
+		{
+			oldExpr: "SELECT foo.*, cdc_prev() FROM " + fooRef + " WHERE cdc_prev()->>'field' = 'blah'",
+			newExpr: "SELECT foo.*, row_to_json((cdc_prev).*) FROM " + fooRef + " WHERE (row_to_json((cdc_prev).*)->>'field') = 'blah'",
+		},
+	} {
+		sc, err := ParseChangefeedExpression(tc.oldExpr)
+		require.NoError(t, err)
+		sc, err = RewritePreviewExpression(sc)
+		require.NoError(t, err)
+		require.Equal(t, tc.newExpr, AsStringUnredacted(sc))
+
+		// Parse and plan new expression to make sure it's sane.
+		_, err = newEvaluatorWithNormCheck(&execCfg, fooDesc, s.Clock().Now(), target, AsStringUnredacted(sc))
+		require.NoError(t, err)
+	}
+}

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -283,7 +283,7 @@ func (ca *changeAggregator) Start(ctx context.Context) {
 	ca.sink = &errorWrapperSink{wrapped: ca.sink}
 	ca.eventConsumer, ca.sink, err = newEventConsumer(
 		ctx, ca.flowCtx.Cfg, ca.spec, feed, ca.frontier.SpanFrontier(), kvFeedHighWater,
-		ca.sink, ca.metrics, ca.knobs)
+		ca.sink, ca.metrics, ca.sliMetrics, ca.knobs)
 
 	if err != nil {
 		// Early abort in the case that there is an error setting up the consumption.

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedvalidators"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/docs"
 	"github.com/cockroachdb/cockroach/pkg/featureflag"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
@@ -46,6 +47,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/asof"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -435,17 +437,17 @@ func createChangefeedJobRecord(
 		return nil, err
 	}
 	tolerances := opts.GetCanHandle()
+	sd := p.SessionData().Clone()
+	// Add non-local session data state (localization, etc).
+	sessiondata.MarshalNonLocal(p.SessionData(), &sd.SessionData)
 	details := jobspb.ChangefeedDetails{
 		Tables:               tables,
 		SinkURI:              sinkURI,
 		StatementTime:        statementTime,
 		EndTime:              endTime,
 		TargetSpecifications: targets,
-		SessionData:          p.SessionData().SessionData,
+		SessionData:          &sd.SessionData,
 	}
-
-	// Add non-local session data state (localization, etc).
-	sessiondata.MarshalNonLocal(p.SessionData(), &details.SessionData)
 
 	specs := AllTargets(details)
 	for _, desc := range targetDescs {
@@ -468,8 +470,24 @@ func createChangefeedJobRecord(
 			return nil, err
 		}
 		if withDiff {
+			if !p.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.V23_1_ChangefeedExpressionProductionReady) {
+				return nil,
+					pgerror.Newf(
+						pgcode.FeatureNotSupported,
+						"cannot create new changefeed with CDC expression <%s>, "+
+							"which requires access to cdc_prev until cluster upgrade to %s finalized.",
+						tree.AsString(normalized),
+						clusterversion.V23_1_ChangefeedExpressionProductionReady.String,
+					)
+			}
 			opts.ForceDiff()
+		} else if opts.IsSet(changefeedbase.OptDiff) {
+			opts.ClearDiff()
+			p.BufferClientNotice(ctx, pgnotice.Newf(
+				"turning off unused %s option (expression <%s> does not use cdc_prev)",
+				changefeedbase.OptDiff, tree.AsString(normalized)))
 		}
+
 		// TODO: Set the default envelope to row here when using a sink and format
 		// that support it.
 		opts.SetDefaultEnvelope(changefeedbase.OptEnvelopeBare)
@@ -1032,20 +1050,23 @@ func (b *changefeedResumer) resumeWithRetries(
 	var lastRunStatusUpdate time.Time
 
 	for r := getRetry(ctx); r.Next(); {
-		// startedCh is normally used to signal back to the creator of the job that
-		// the job has started; however, in this case nothing will ever receive
-		// on the channel, causing the changefeed flow to block. Replace it with
-		// a dummy channel.
-		startedCh := make(chan tree.Datums, 1)
+		err := maybeUpgradePreProductionReadyExpression(ctx, jobID, details, jobExec)
 
-		err := distChangefeedFlow(ctx, jobExec, jobID, details, progress, startedCh)
 		if err == nil {
-			return nil // Changefeed completed -- e.g. due to initial_scan=only mode.
-		}
+			// startedCh is normally used to signal back to the creator of the job that
+			// the job has started; however, in this case nothing will ever receive
+			// on the channel, causing the changefeed flow to block. Replace it with
+			// a dummy channel.
+			startedCh := make(chan tree.Datums, 1)
+			err = distChangefeedFlow(ctx, jobExec, jobID, details, progress, startedCh)
+			if err == nil {
+				return nil // Changefeed completed -- e.g. due to initial_scan=only mode.
+			}
 
-		if knobs, ok := execCfg.DistSQLSrv.TestingKnobs.Changefeed.(*TestingKnobs); ok {
-			if knobs != nil && knobs.HandleDistChangefeedError != nil {
-				err = knobs.HandleDistChangefeedError(err)
+			if knobs, ok := execCfg.DistSQLSrv.TestingKnobs.Changefeed.(*TestingKnobs); ok {
+				if knobs != nil && knobs.HandleDistChangefeedError != nil {
+					err = knobs.HandleDistChangefeedError(err)
+				}
 			}
 		}
 
@@ -1080,6 +1101,7 @@ func (b *changefeedResumer) resumeWithRetries(
 				jobID, progress.GetHighWater(), reloadErr)
 		} else {
 			progress = reloadedJob.Progress()
+			details = reloadedJob.Details().(jobspb.ChangefeedDetails)
 		}
 	}
 	return errors.Wrap(ctx.Err(), `ran out of retries`)
@@ -1300,4 +1322,89 @@ func failureTypeForStartupError(err error) changefeedbase.FailureType {
 		return tag
 	}
 	return changefeedbase.OnStartup
+}
+
+// maybeUpgradePreProductionReadyExpression updates job record for the
+// changefeed using CDC transformation, created prior to
+// clusterversion.V23_1_ChangefeedExpressionProductionReady. The update happens
+// once cluster version finalized.
+// Returns nil when nothing needs to be done.
+// Returns fatal error message, causing changefeed to fail, if automatic upgrade
+// cannot for some reason. Returns a transient error to cause job retry/reload
+// when expression was upgraded.
+func maybeUpgradePreProductionReadyExpression(
+	ctx context.Context,
+	jobID jobspb.JobID,
+	details jobspb.ChangefeedDetails,
+	jobExec sql.JobExecContext,
+) error {
+	if details.Select == "" {
+		// Not an expression based changefeed.  Nothing to do.
+		return nil
+	}
+
+	if details.SessionData != nil {
+		// Already production ready. Nothing to do.
+		return nil
+	}
+
+	if !jobExec.ExecCfg().Settings.Version.IsActive(
+		ctx, clusterversion.V23_1_ChangefeedExpressionProductionReady,
+	) {
+		// Can't upgrade job record yet -- wait until upgrade finalized.
+		return nil
+	}
+
+	// Expressions prior to
+	// clusterversion.V23_1_ChangefeedExpressionProductionReady were rewritten to
+	// fully qualify all columns/types.  Furthermore, those expressions couldn't
+	// use any functions that depend on session data.  Thus, it is safe to use
+	// minimal session data.
+	sd := sessiondatapb.SessionData{
+		Database:   "",
+		UserProto:  jobExec.User().EncodeProto(),
+		Internal:   true,
+		SearchPath: sessiondata.DefaultSearchPathForUser(jobExec.User()).GetPathArray(),
+	}
+	details.SessionData = &sd
+
+	const errUpgradeErrMsg = "error rewriting changefeed expression.  Please recreate failed changefeed manually."
+	oldExpression, err := cdceval.ParseChangefeedExpression(details.Select)
+	if err != nil {
+		// That's mighty surprising; There is nothing we can do.  Make sure
+		// we fail changefeed in this case.
+		return changefeedbase.WithTerminalError(errors.WithHint(err, errUpgradeErrMsg))
+	}
+	newExpression, err := cdceval.RewritePreviewExpression(oldExpression)
+	if err != nil {
+		// That's mighty surprising; There is nothing we can do.  Make sure
+		// we fail changefeed in this case.
+		return changefeedbase.WithTerminalError(errors.WithHint(err, errUpgradeErrMsg))
+	}
+	details.Select = cdceval.AsStringUnredacted(newExpression)
+
+	const useReadLock = false
+	if err := jobExec.ExecCfg().JobRegistry.UpdateJobWithTxn(ctx, jobID, nil, useReadLock,
+		func(txn *kv.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+			payload := md.Payload
+			payload.Details = jobspb.WrapPayloadDetails(details)
+			ju.UpdatePayload(payload)
+			return nil
+		},
+	); err != nil {
+		// Failed to update job record; try again.
+		return err
+	}
+
+	// Job record upgraded.  Return transient error to reload job record and retry.
+	if newExpression == oldExpression {
+		return errors.New("changefeed expression updated")
+	}
+
+	return errors.Newf("changefeed expression %s rewritten as %s. "+
+		"Note: changefeed expression accesses the previous state of the row via deprecated cdc_prev() "+
+		"function. The rewritten expression should continue to work, but is likely to be inefficient. "+
+		"Existing changefeed needs to be recreated using new syntax. "+
+		"Please see CDC documentation on the use of new cdc_prev tuple.",
+		tree.AsString(oldExpression), tree.AsString(newExpression))
 }

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -879,6 +879,12 @@ func (s StatementOptions) ForceDiff() {
 	s.cache.EncodingOptions = EncodingOptions{}
 }
 
+// ClearDiff clears diff option.
+func (s StatementOptions) ClearDiff() {
+	delete(s.m, OptDiff)
+	s.cache.EncodingOptions = EncodingOptions{}
+}
+
 // SetDefaultEnvelope sets the envelope if not already set.
 func (s StatementOptions) SetDefaultEnvelope(t EnvelopeType) {
 	if _, ok := s.m[OptEnvelope]; !ok {

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -396,6 +396,11 @@ const (
 	// system.sql_instances table.
 	V23_1AlterSystemSQLInstancesAddSQLAddr
 
+	// V23_1_ChangefeedExpressionProductionReady marks changefeed expressions (transformation)
+	// as production ready.  This gate functions as a signal to attempt to upgrade
+	// chagnefeeds created prior to this version.
+	V23_1_ChangefeedExpressionProductionReady
+
 	// *************************************************
 	// Step (1): Add new versions here.
 	// Do not add new versions to a patch release.
@@ -677,6 +682,10 @@ var rawVersionsSingleton = keyedVersions{
 	{
 		Key:     V23_1AlterSystemSQLInstancesAddSQLAddr,
 		Version: roachpb.Version{Major: 22, Minor: 2, Internal: 28},
+	},
+	{
+		Key:     V23_1_ChangefeedExpressionProductionReady,
+		Version: roachpb.Version{Major: 22, Minor: 2, Internal: 30},
 	},
 
 	// *************************************************

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -933,7 +933,7 @@ message ChangefeedDetails {
   repeated ChangefeedTargetSpecification target_specifications = 8 [(gogoproto.nullable) = false];
 
   string select = 10;
-  sessiondatapb.SessionData session_data = 11 [(gogoproto.nullable) = false];
+  sessiondatapb.SessionData session_data = 11;
   reserved 1, 2, 5;
   reserved "targets";
 }

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1402,6 +1402,12 @@ var charts = []sectionDescription{
 				},
 			},
 			{
+				Title: "Filtered Messages",
+				Metrics: []string{
+					"changefeed.filtered_messages",
+				},
+			},
+			{
 				Title: "Entries",
 				Metrics: []string{
 					"changefeed.buffer_entries.in",


### PR DESCRIPTION
Add a mechanism to migrate changefeed expressions
created in 22.2 clusters to be compatible with
recently introduced changes.

Old changefeed expressions are transparently rewritten,
and the changefeed job record automatically updated
once cluster upgrade has been finalized.

A warning message may be logged if the rewritten expression
is inefficient.

The automatic update might still fail.  The end users
are encourraged to closely monitor the health of the
changefeeds during the upgrade, and recreate any failed
changefeeds as needed.

Epic: [CRDB-17161](https://cockroachlabs.atlassian.net/browse/CRDB-17161)

Release note (enterprise change): Changefeed transformations
introduced in 22.2 release in preview mode are no longer
experimental.  This feature can now be considered
to be fully production ready.