### PR TITLE
storage: Add support for TargetBytes for resolve intent + range cmd

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_resolve_intent.go
+++ b/pkg/kv/kvserver/batcheval/cmd_resolve_intent.go
@@ -93,10 +93,17 @@ func ResolveIntent(
 		// The observation was from the wrong node. Ignore.
 		update.ClockWhilePending = roachpb.ObservedTimestamp{}
 	}
-	ok, _, _, err := storage.MVCCResolveWriteIntent(ctx, readWriter, ms, update,
-		storage.MVCCResolveWriteIntentOptions{})
+	ok, numBytes, resumeSpan, err := storage.MVCCResolveWriteIntent(ctx, readWriter, ms, update,
+		storage.MVCCResolveWriteIntentOptions{TargetBytes: h.TargetBytes})
 	if err != nil {
 		return result.Result{}, err
+	}
+	reply := resp.(*roachpb.ResolveIntentResponse)
+	reply.NumBytes = numBytes
+	if resumeSpan != nil {
+		reply.ResumeSpan = resumeSpan
+		reply.ResumeReason = roachpb.RESUME_BYTE_LIMIT
+		return result.Result{}, nil
 	}
 
 	var res result.Result

--- a/pkg/kv/kvserver/batcheval/cmd_resolve_intent_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_resolve_intent_test.go
@@ -272,6 +272,211 @@ func TestResolveIntentAfterPartialRollback(t *testing.T) {
 	})
 }
 
+// TestResolveIntentWithTargetBytes tests that ResolveIntent and
+// ResolveIntentRange respect the specified TargetBytes i.e. resolve the
+// correct set of intents, return the correct data in the response, and ensure
+// the underlying write batch is the expected size.
+func TestResolveIntentWithTargetBytes(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	ts := hlc.Timestamp{WallTime: 1}
+	bytes := []byte{'a', 'b', 'c', 'd', 'e'}
+	nKeys := len(bytes)
+	testKeys := make([]roachpb.Key, nKeys)
+	values := make([]roachpb.Value, nKeys)
+	for i, b := range bytes {
+		testKeys[i] = make([]byte, 1000)
+		for j := range testKeys[i] {
+			testKeys[i][j] = b
+		}
+		values[i] = roachpb.MakeValueFromBytes([]byte{b})
+	}
+	txn := roachpb.MakeTransaction("test", roachpb.Key("a"), 0, ts, 0, 1)
+
+	testutils.RunTrueAndFalse(t, "ranged", func(t *testing.T, ranged bool) {
+		db := storage.NewDefaultInMemForTesting()
+		defer db.Close()
+		batch := db.NewBatch()
+		defer batch.Close()
+		st := makeClusterSettingsUsingEngineIntentsSetting(db)
+
+		for i, testKey := range testKeys {
+			err := storage.MVCCPut(ctx, batch, nil, testKey, ts, hlc.ClockTimestamp{}, values[i], &txn)
+			require.NoError(t, err)
+		}
+		initialBytes := batch.Len()
+
+		if !ranged {
+			// Resolve a point intent for testKeys[0].
+			ri := roachpb.ResolveIntentRequest{
+				IntentTxn: txn.TxnMeta,
+				Status:    roachpb.COMMITTED,
+			}
+			ri.Key = testKeys[0]
+
+			{
+				// Case 1: TargetBytes = -1. In this case, we should not resolve any
+				// intents.
+				resp := &roachpb.ResolveIntentResponse{}
+				_, err := ResolveIntent(ctx, batch,
+					CommandArgs{
+						EvalCtx: (&MockEvalCtx{ClusterSettings: st}).EvalContext(),
+						Args:    &ri,
+						Header: roachpb.Header{
+							TargetBytes: -1,
+						},
+					},
+					resp,
+				)
+				require.NoError(t, err)
+				require.Equal(t, resp.NumBytes, int64(0))
+				require.Equal(t, resp.ResumeSpan.Key, testKeys[0])
+				require.Equal(t, resp.ResumeReason, roachpb.RESUME_BYTE_LIMIT)
+				require.NoError(t, err)
+				numBytes := batch.Len()
+				require.Equal(t, numBytes, initialBytes)
+
+				_, _, err = storage.MVCCGet(ctx, batch, testKeys[0], ts, storage.MVCCGetOptions{})
+				require.Error(t, err)
+			}
+
+			{
+				// Case 2: TargetBytes = 500. In this case, we should resolve the
+				// intent for testKeys[0].
+				resp := &roachpb.ResolveIntentResponse{}
+				_, err := ResolveIntent(ctx, batch,
+					CommandArgs{
+						EvalCtx: (&MockEvalCtx{ClusterSettings: st}).EvalContext(),
+						Args:    &ri,
+						Header: roachpb.Header{
+							TargetBytes: 500,
+						},
+					},
+					resp,
+				)
+				require.Greater(t, resp.NumBytes, int64(1000))
+				require.Less(t, resp.NumBytes, int64(1100))
+				require.Nil(t, resp.ResumeSpan)
+				require.Equal(t, resp.ResumeReason, roachpb.RESUME_UNKNOWN)
+				require.NoError(t, err)
+				numBytes := batch.Len()
+				require.Greater(t, numBytes, initialBytes+1000)
+				require.Less(t, numBytes, initialBytes+1100)
+
+				value, _, err := storage.MVCCGet(ctx, batch, testKeys[0], ts, storage.MVCCGetOptions{})
+				require.NoError(t, err)
+				require.Equal(t, values[0].RawBytes, value.RawBytes,
+					"the value %s in get result does not match the value %s in request", values[0].RawBytes, value.RawBytes)
+			}
+		} else {
+			// Resolve an intent range for testKeys[0], testKeys[1], ...,
+			// testKeys[4].
+			rir := roachpb.ResolveIntentRangeRequest{
+				IntentTxn: txn.TxnMeta,
+				Status:    roachpb.COMMITTED,
+			}
+			rir.Key = testKeys[0]
+			rir.EndKey = testKeys[nKeys-1].Next()
+
+			{
+				// Case 1: TargetBytes = -1. In this case, we should not resolve any
+				// intents.
+				respr := &roachpb.ResolveIntentRangeResponse{}
+				_, err := ResolveIntentRange(ctx, batch,
+					CommandArgs{
+						EvalCtx: (&MockEvalCtx{ClusterSettings: st}).EvalContext(),
+						Args:    &rir,
+						Header: roachpb.Header{
+							TargetBytes: -1,
+						},
+					},
+					respr,
+				)
+				require.NoError(t, err)
+				require.Equal(t, respr.NumKeys, int64(0))
+				require.Equal(t, respr.NumBytes, int64(0))
+				require.Equal(t, respr.ResumeSpan.Key, testKeys[0])
+				require.Equal(t, respr.ResumeSpan.EndKey, testKeys[nKeys-1].Next())
+				require.Equal(t, respr.ResumeReason, roachpb.RESUME_BYTE_LIMIT)
+				require.NoError(t, err)
+				numBytes := batch.Len()
+				require.Equal(t, numBytes, initialBytes)
+
+				_, _, err = storage.MVCCGet(ctx, batch, testKeys[0], ts, storage.MVCCGetOptions{})
+				require.Error(t, err)
+			}
+
+			{
+				// Case 2: TargetBytes = 2900. In this case, we should resolve the
+				// first 3 intents - testKey[0], testKeys[1], and testKeys[2] (since we
+				// resolve intents until we exceed the TargetBytes limit).
+				respr := &roachpb.ResolveIntentRangeResponse{}
+				_, err := ResolveIntentRange(ctx, batch,
+					CommandArgs{
+						EvalCtx: (&MockEvalCtx{ClusterSettings: st}).EvalContext(),
+						Args:    &rir,
+						Header: roachpb.Header{
+							TargetBytes: 2900,
+						},
+					},
+					respr,
+				)
+				require.Equal(t, respr.NumKeys, int64(3))
+				require.Greater(t, respr.NumBytes, int64(3000))
+				require.Less(t, respr.NumBytes, int64(3300))
+				require.Equal(t, respr.ResumeSpan.Key, testKeys[2].Next())
+				require.Equal(t, respr.ResumeSpan.EndKey, testKeys[nKeys-1].Next())
+				require.Equal(t, respr.ResumeReason, roachpb.RESUME_BYTE_LIMIT)
+				require.NoError(t, err)
+				numBytes := batch.Len()
+				require.Greater(t, numBytes, initialBytes+3000)
+				require.Less(t, numBytes, initialBytes+3300)
+
+				value, _, err := storage.MVCCGet(ctx, batch, testKeys[2], ts, storage.MVCCGetOptions{})
+				require.NoError(t, err)
+				require.Equal(t, values[2].RawBytes, value.RawBytes,
+					"the value %s in get result does not match the value %s in request", values[2].RawBytes, value.RawBytes)
+				_, _, err = storage.MVCCGet(ctx, batch, testKeys[3], ts, storage.MVCCGetOptions{})
+				require.Error(t, err)
+			}
+
+			{
+				// Case 3: TargetBytes = 1100 (on remaining intents - testKeys[3] and
+				// testKeys[4]). In this case, we should resolve the remaining
+				// intents - testKey[4] and testKeys[5] (since we resolve intents until
+				// we exceed the TargetBytes limit).
+				respr := &roachpb.ResolveIntentRangeResponse{}
+				_, err := ResolveIntentRange(ctx, batch,
+					CommandArgs{
+						EvalCtx: (&MockEvalCtx{ClusterSettings: st}).EvalContext(),
+						Args:    &rir,
+						Header: roachpb.Header{
+							TargetBytes: 1100,
+						},
+					},
+					respr,
+				)
+				require.Equal(t, respr.NumKeys, int64(2))
+				require.Greater(t, respr.NumBytes, int64(2000))
+				require.Less(t, respr.NumBytes, int64(2200))
+				require.Nil(t, respr.ResumeSpan)
+				require.Equal(t, respr.ResumeReason, roachpb.RESUME_UNKNOWN)
+				require.NoError(t, err)
+				numBytes := batch.Len()
+				require.Greater(t, numBytes, initialBytes+5000)
+				require.Less(t, numBytes, initialBytes+5500)
+
+				value, _, err := storage.MVCCGet(ctx, batch, testKeys[nKeys-1], ts, storage.MVCCGetOptions{})
+				require.NoError(t, err)
+				require.Equal(t, values[nKeys-1].RawBytes, value.RawBytes,
+					"the value %s in get result does not match the value %s in request", values[nKeys-1].RawBytes, value.RawBytes)
+			}
+		}
+	})
+}
+
 func makeClusterSettingsUsingEngineIntentsSetting(engine storage.Engine) *cluster.Settings {
 	version := clusterversion.TestingBinaryVersion
 	return cluster.MakeTestingClusterSettingsWithVersions(version, version, true)

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -701,6 +701,10 @@ func (s spanSetWriter) ShouldWriteLocalTimestamps(ctx context.Context) bool {
 	return s.w.ShouldWriteLocalTimestamps(ctx)
 }
 
+func (s spanSetWriter) BufferedSize() int {
+	return s.w.BufferedSize()
+}
+
 // ReadWriter is used outside of the spanset package internally, in ccl.
 type ReadWriter struct {
 	spanSetReader

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -2517,11 +2517,22 @@ message Header {
   // complications discussed in "Unordered requests". For now, that's a good
   // enough reason to disallow such batches.
   int64 max_span_request_keys = 8;
+  // TargetBytes will have different behaviour depending on the request type.
+  //
+  // Forward and Reverse Scans:
   // If set to a non-zero value, sets a target (in bytes) for how large the
-  // response may grow. This is only supported for (forward and reverse) scans
-  // and limits the number of rows scanned (and returned). The target will only
-  // be overshot when the first result is larger than the target, unless
+  // response may grow. For forward and reverse scans, TargetBytes limits the
+  // number of rows scanned (and returned). The target will only be overshot
+  // when the first result is larger than the target, unless
   // target_bytes_allow_empty is set. A suitable resume span will be returned.
+  //
+  // Resolve Intent and Resolve Intent Range:
+  // If set to a non-zero value, sets a target (in bytes) for how large the
+  // write batch from intent resolution may grow. For resolve intent and resolve
+  // intent range: TargetBytes limits the number of intents resolved. We will
+  // resolve intents until the number of bytes added to the write batch by
+  // intent resolution exceeds the TargetBytes limit. A suitable resume span
+  // will be returned.
   //
   // The semantics around overlapping requests, unordered requests, and
   // supported requests from max_span_request_keys apply to the target_bytes

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -826,6 +826,12 @@ type Writer interface {
 	// This method is temporary, to handle the transition from clusters where not
 	// all nodes understand local timestamps.
 	ShouldWriteLocalTimestamps(ctx context.Context) bool
+
+	// BufferedSize returns the size of the underlying buffered writes if the
+	// Writer implementation is buffered, and 0 if the Writer implementation is
+	// not buffered. Buffered writers are expected to always give a monotonically
+	// increasing size.
+	BufferedSize() int
 }
 
 // ReadWriter is the read/write interface to an engine's data.

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -927,6 +927,7 @@ func (opts *MVCCGetOptions) errOnIntents() bool {
 type MVCCResolveWriteIntentOptions struct {
 	// See the documentation for MVCCResolveWriteIntent for information on these
 	// parameters.
+	TargetBytes int64
 }
 
 // MVCCResolveWriteIntentRangeOptions bundles options for the
@@ -934,7 +935,8 @@ type MVCCResolveWriteIntentOptions struct {
 type MVCCResolveWriteIntentRangeOptions struct {
 	// See the documentation for MVCCResolveWriteIntentRange for information on
 	// these parameters.
-	MaxKeys int64
+	MaxKeys     int64
+	TargetBytes int64
 }
 
 // newMVCCIterator sets up a suitable iterator for high-level MVCC operations
@@ -3987,11 +3989,16 @@ func MVCCIterate(
 }
 
 // MVCCResolveWriteIntent either commits, aborts (rolls back), or moves forward
-// in time an extant write intent for a given txn according to commit parameter.
-// ResolveWriteIntent will skip write intents of other txns. It returns
-// whether or not an intent was found to resolve. Note that the numBytes and
-// resumeSpan return values are currently unused and serve as a placeholder in
-// refactoring, but will be used in the future.
+// in time an extant write intent for a given txn according to commit
+// parameter. ResolveWriteIntent will skip write intents of other txns.
+//
+// An opts.TargetBytes of < 0 means resolve nothing and returns the intent as
+// the resume span. If opts.TargetBytes >= 0, then resolve intent and resume
+// span is nil.
+//
+// Returns whether or not an intent was found to resolve, number of bytes added
+// to the write batch by intent resolution, and the resume span if the max
+// bytes limit was exceeded.
 //
 // Transaction epochs deserve a bit of explanation. The epoch for a
 // transaction is incremented on transaction retries. A transaction
@@ -4021,16 +4028,25 @@ func MVCCResolveWriteIntent(
 	if len(intent.EndKey) > 0 {
 		return false, 0, nil, errors.Errorf("can't resolve range intent as point intent")
 	}
+	if opts.TargetBytes < 0 {
+		return false, 0, &roachpb.Span{Key: intent.Key}, nil
+	}
 
 	iterAndBuf := GetBufUsingIter(rw.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
 		KeyTypes: IterKeyTypePointsAndRanges,
 		Prefix:   true,
 	}))
 	iterAndBuf.iter.SeekIntentGE(intent.Key, intent.Txn.ID)
+	// Production code will use a buffered writer, which makes the numBytes
+	// calculation accurate. Note that an inaccurate numBytes (e.g. 0 in the
+	// case of an unbuffered writer) does not affect any safety properties of
+	// the database.
+	beforeBytes := rw.BufferedSize()
 	ok, err = mvccResolveWriteIntent(ctx, rw, iterAndBuf.iter, ms, intent, iterAndBuf.buf)
+	numBytes = int64(rw.BufferedSize() - beforeBytes)
 	// Using defer would be more convenient, but it is measurably slower.
 	iterAndBuf.Cleanup()
-	return ok, 0, nil, err
+	return ok, numBytes, nil, err
 }
 
 // iterForKeyVersions provides a subset of the functionality of MVCCIterator.
@@ -4790,12 +4806,19 @@ func (b IterAndBuf) Cleanup() {
 
 // MVCCResolveWriteIntentRange commits or aborts (rolls back) the range of write
 // intents specified by start and end keys for a given txn.
-// ResolveWriteIntentRange will skip write intents of other txns. A max of zero
-// means unbounded. A max of -1 means resolve nothing and returns the entire
-// intent span as the resume span. Returns the number of intents resolved and a
-// resume span if the max keys limit was exceeded. Note that the numBytes and
-// resumeReason return values are currently unused and serve as a placeholder
-// in refactoring, but will be used in the future.
+// ResolveWriteIntentRange will skip write intents of other txns.
+//
+// An opts.MaxKeys of zero means unbounded. An opts.MaxKeys of < 0 means
+// resolve nothing and returns the entire intent span as the resume span. An
+// opts.TargetBytes of 0 means no byte limit. An opts.TargetBytes of < 0 means
+// resolve nothing and returns the entire intent span as the resume span. If
+// opts.TargetBytes > 0, then resolve intents in the range until the number of
+// bytes added to the write batch by intent resolution exceeds
+// opts.TargetBytes.
+//
+// Returns the number of intents resolved, number of bytes added to the write
+// batch by intent resolution, the resume span if the max keys or bytes limit
+// was exceeded, and the resume reason.
 func MVCCResolveWriteIntentRange(
 	ctx context.Context,
 	rw ReadWriter,
@@ -4808,9 +4831,16 @@ func MVCCResolveWriteIntentRange(
 	resumeReason roachpb.ResumeReason,
 	err error,
 ) {
-	if opts.MaxKeys < 0 {
+	keysExceeded := opts.MaxKeys < 0
+	bytesExceeded := opts.TargetBytes < 0
+	if keysExceeded || bytesExceeded {
 		resumeSpan := intent.Span // don't inline or `intent` would escape to heap
-		return 0, 0, &resumeSpan, roachpb.RESUME_KEY_LIMIT, nil
+		if keysExceeded {
+			resumeReason = roachpb.RESUME_KEY_LIMIT
+		} else if bytesExceeded {
+			resumeReason = roachpb.RESUME_BYTE_LIMIT
+		}
+		return 0, 0, &resumeSpan, resumeReason, nil
 	}
 	ltStart, _ := keys.LockTableSingleKey(intent.Key, nil)
 	ltEnd, _ := keys.LockTableSingleKey(intent.EndKey, nil)
@@ -4854,9 +4884,16 @@ func MVCCResolveWriteIntentRange(
 			// No more intents in the given range.
 			break
 		}
-		if opts.MaxKeys > 0 && numKeys == opts.MaxKeys {
+		keysExceeded = opts.MaxKeys > 0 && numKeys == opts.MaxKeys
+		bytesExceeded = opts.TargetBytes > 0 && numBytes >= opts.TargetBytes
+		if keysExceeded || bytesExceeded {
+			if keysExceeded {
+				resumeReason = roachpb.RESUME_KEY_LIMIT
+			} else if bytesExceeded {
+				resumeReason = roachpb.RESUME_BYTE_LIMIT
+			}
 			// We could also compute a tighter nextKey here if we wanted to.
-			return numKeys, 0, &roachpb.Span{Key: lastResolvedKey.Next(), EndKey: intentEndKey}, roachpb.RESUME_KEY_LIMIT, nil
+			return numKeys, numBytes, &roachpb.Span{Key: lastResolvedKey.Next(), EndKey: intentEndKey}, resumeReason, nil
 		}
 		// Parse the MVCCMetadata to see if it is a relevant intent.
 		meta := &putBuf.meta
@@ -4880,15 +4917,17 @@ func MVCCResolveWriteIntentRange(
 		// subsequent iteration to construct a resume span.
 		lastResolvedKey = append(lastResolvedKey[:0], sepIter.UnsafeKey().Key...)
 		intent.Key = lastResolvedKey
+		beforeBytes := rw.BufferedSize()
 		ok, err := mvccResolveWriteIntent(ctx, rw, sepIter, ms, intent, putBuf)
 		if err != nil {
 			log.Warningf(ctx, "failed to resolve intent for key %q: %+v", lastResolvedKey, err)
 		} else if ok {
 			numKeys++
 		}
+		numBytes += int64(rw.BufferedSize() - beforeBytes)
 		sepIter.nextEngineKey()
 	}
-	return numKeys, 0, nil, 0, nil
+	return numKeys, numBytes, nil, 0, nil
 }
 
 // MVCCGarbageCollect creates an iterator on the ReadWriter. In parallel

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1907,6 +1907,11 @@ func (p *Pebble) MinVersionIsAtLeastTargetVersion(target roachpb.Version) (bool,
 	return MinVersionIsAtLeastTargetVersion(p.unencryptedFS, p.path, target)
 }
 
+// BufferedSize implements the Engine interface.
+func (p *Pebble) BufferedSize() int {
+	return 0
+}
+
 type pebbleReadOnly struct {
 	parent *Pebble
 	// The iterator reuse optimization in pebbleReadOnly is for servicing a
@@ -2212,6 +2217,10 @@ func (p *pebbleReadOnly) LogLogicalOp(op MVCCLogicalOpType, details MVCCLogicalO
 }
 
 func (p *pebbleReadOnly) ShouldWriteLocalTimestamps(ctx context.Context) bool {
+	panic("not implemented")
+}
+
+func (p *pebbleReadOnly) BufferedSize() int {
 	panic("not implemented")
 }
 

--- a/pkg/storage/pebble_batch.go
+++ b/pkg/storage/pebble_batch.go
@@ -420,6 +420,11 @@ func (p *pebbleBatch) ClearMVCCRangeKey(rangeKey MVCCRangeKey) error {
 		rangeKey.StartKey, rangeKey.EndKey, EncodeMVCCTimestampSuffix(rangeKey.Timestamp))
 }
 
+// BufferedSize implements the Engine interface.
+func (p *pebbleBatch) BufferedSize() int {
+	return p.Len()
+}
+
 // PutMVCCRangeKey implements the Batch interface.
 func (p *pebbleBatch) PutMVCCRangeKey(rangeKey MVCCRangeKey, value MVCCValue) error {
 	// NB: all MVCC APIs currently assume all range keys are range tombstones.

--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -425,6 +425,11 @@ func (fw *SSTWriter) ShouldWriteLocalTimestamps(context.Context) bool {
 	return false
 }
 
+// BufferedSize implements the Writer interface.
+func (fw *SSTWriter) BufferedSize() int {
+	return 0
+}
+
 // MemFile is a file-like struct that buffers all data written to it in memory.
 // Implements the writeCloseSyncer interface and is intended for use with
 // SSTWriter.

--- a/pkg/storage/testdata/mvcc_histories/resolve_intent_pagination
+++ b/pkg/storage/testdata/mvcc_histories/resolve_intent_pagination
@@ -1,0 +1,127 @@
+# Test MaxKeys and TargetBytes for resolve intent and resolve intent range.
+
+# Put some test data.
+run ok
+with t=A
+  txn_begin ts=1
+  put k=a v=a
+  put k=b v=b
+  put k=c v=c
+  put k=dddddddddddddddddddddddddddddddddddddddddddddddddd v=d
+  put k=eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee v=e
+  put k=f v=f
+----
+>> at end:
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
+meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/1.000000000,0 -> /BYTES/a
+meta: "b"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "b"/1.000000000,0 -> /BYTES/b
+meta: "c"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "c"/1.000000000,0 -> /BYTES/c
+meta: "dddddddddddddddddddddddddddddddddddddddddddddddddd"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "dddddddddddddddddddddddddddddddddddddddddddddddddd"/1.000000000,0 -> /BYTES/d
+meta: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"/1.000000000,0 -> /BYTES/e
+meta: "f"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "f"/1.000000000,0 -> /BYTES/f
+
+# Resolve none since targetBytes < 0.
+run ok
+resolve_intent t=A k=c status=COMMITTED targetBytes=-1 batched
+----
+resolve_intent: batch after write is empty
+>> at end:
+meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/1.000000000,0 -> /BYTES/a
+meta: "b"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "b"/1.000000000,0 -> /BYTES/b
+meta: "c"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "c"/1.000000000,0 -> /BYTES/c
+meta: "dddddddddddddddddddddddddddddddddddddddddddddddddd"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "dddddddddddddddddddddddddddddddddddddddddddddddddd"/1.000000000,0 -> /BYTES/d
+meta: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"/1.000000000,0 -> /BYTES/e
+meta: "f"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "f"/1.000000000,0 -> /BYTES/f
+
+# Resolve intent "b".
+run ok
+resolve_intent t=A k=b status=COMMITTED targetBytes=1 batched
+----
+resolve_intent: batch after write is non-empty
+>> at end:
+meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/1.000000000,0 -> /BYTES/a
+data: "b"/1.000000000,0 -> /BYTES/b
+meta: "c"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "c"/1.000000000,0 -> /BYTES/c
+meta: "dddddddddddddddddddddddddddddddddddddddddddddddddd"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "dddddddddddddddddddddddddddddddddddddddddddddddddd"/1.000000000,0 -> /BYTES/d
+meta: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"/1.000000000,0 -> /BYTES/e
+meta: "f"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "f"/1.000000000,0 -> /BYTES/f
+
+# Resolve none since maxKeys < 0.
+run ok
+resolve_intent_range t=A k=a end=z status=COMMITTED maxKeys=-1 batched
+----
+resolve_intent_range: batch after write is empty
+>> at end:
+meta: "a"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/1.000000000,0 -> /BYTES/a
+data: "b"/1.000000000,0 -> /BYTES/b
+meta: "c"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "c"/1.000000000,0 -> /BYTES/c
+meta: "dddddddddddddddddddddddddddddddddddddddddddddddddd"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "dddddddddddddddddddddddddddddddddddddddddddddddddd"/1.000000000,0 -> /BYTES/d
+meta: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"/1.000000000,0 -> /BYTES/e
+meta: "f"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "f"/1.000000000,0 -> /BYTES/f
+
+# Resolve 2 intents "a" and "c".
+run ok
+resolve_intent_range t=A k=a end=z status=COMMITTED maxKeys=2 batched
+----
+resolve_intent_range: batch after write is non-empty
+>> at end:
+data: "a"/1.000000000,0 -> /BYTES/a
+data: "b"/1.000000000,0 -> /BYTES/b
+data: "c"/1.000000000,0 -> /BYTES/c
+meta: "dddddddddddddddddddddddddddddddddddddddddddddddddd"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "dddddddddddddddddddddddddddddddddddddddddddddddddd"/1.000000000,0 -> /BYTES/d
+meta: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"/1.000000000,0 -> /BYTES/e
+meta: "f"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "f"/1.000000000,0 -> /BYTES/f
+
+# Resolve none since targetBytes < 0.
+run ok
+resolve_intent_range t=A k=a end=z status=COMMITTED targetBytes=-1 batched
+----
+resolve_intent_range: batch after write is empty
+>> at end:
+data: "a"/1.000000000,0 -> /BYTES/a
+data: "b"/1.000000000,0 -> /BYTES/b
+data: "c"/1.000000000,0 -> /BYTES/c
+meta: "dddddddddddddddddddddddddddddddddddddddddddddddddd"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "dddddddddddddddddddddddddddddddddddddddddddddddddd"/1.000000000,0 -> /BYTES/d
+meta: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"/1.000000000,0 -> /BYTES/e
+meta: "f"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "f"/1.000000000,0 -> /BYTES/f
+
+run ok
+resolve_intent_range t=A k=a end=z status=COMMITTED targetBytes=99 batched
+----
+resolve_intent_range: batch after write is non-empty
+>> at end:
+data: "a"/1.000000000,0 -> /BYTES/a
+data: "b"/1.000000000,0 -> /BYTES/b
+data: "c"/1.000000000,0 -> /BYTES/c
+data: "dddddddddddddddddddddddddddddddddddddddddddddddddd"/1.000000000,0 -> /BYTES/d
+data: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"/1.000000000,0 -> /BYTES/e
+meta: "f"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "f"/1.000000000,0 -> /BYTES/f


### PR DESCRIPTION
Informs: https://github.com/cockroachdb/cockroach/issues/77228

Intent resolution batches are sequenced on raft and each batch can
consist of 100-200 intents. If an intent key or even value in some cases
are large, it is possible that resolving all intents in the batch would
result in a raft command size exceeding the max raft command size
kv.raft.command.max_size.

To address this, we add support for TargetBytes in resolve intent and
resolve intent range commands, allowing us to stop resolving intents in
the batch as soon as we exceed the TargetBytes max bytes limit.

Adding support for byte size pagination for intent resolver and
RequestBatcher is added in PR https://github.com/cockroachdb/cockroach/pull/92268.

This PR adds pagination for asynchronous intent resolution. A future PR
will add pagination for synchronous intent resolution (i.e. EndTxn).

Release note: None