### PR TITLE
ci: fix unit_tests_impl.sh

### DIFF
--- a/build/teamcity/cockroach/ci/tests/unit_tests_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/unit_tests_impl.sh
@@ -2,6 +2,10 @@
 
 set -xeuo pipefail
 
+dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
+
+source "$dir/teamcity-support.sh"  # for 'tc_release_branch'
+
 bazel build //pkg/cmd/bazci --config=ci
 
 EXTRA_PARAMS=""


### PR DESCRIPTION
Previous PR forgot to source teamcity-support.sh
which defines tc_release_branch().

Epic: none

Release note: None