### PR TITLE
logstore: rm old sideloaded storage migration

### DIFF
--- a/pkg/kv/kvserver/logstore/sideload_disk.go
+++ b/pkg/kv/kvserver/logstore/sideload_disk.go
@@ -65,13 +65,13 @@ func NewDiskSideloadStorage(
 	baseDir string,
 	limiter *rate.Limiter,
 	eng storage.Engine,
-) (*DiskSideloadStorage, error) {
+) *DiskSideloadStorage {
 	return &DiskSideloadStorage{
 		dir:     sideloadedPath(baseDir, rangeID),
 		eng:     eng,
 		st:      st,
 		limiter: limiter,
-	}, nil
+	}
 }
 
 func (ss *DiskSideloadStorage) createDir() error {

--- a/pkg/kv/kvserver/logstore/sideload_test.go
+++ b/pkg/kv/kvserver/logstore/sideload_test.go
@@ -83,19 +83,16 @@ func TestSideloadingSideloadedStorage(t *testing.T) {
 	})
 }
 
-func newTestingSideloadStorage(t *testing.T, eng storage.Engine) *DiskSideloadStorage {
-	st := cluster.MakeTestingClusterSettings()
-	ss, err := NewDiskSideloadStorage(
-		st, 1, filepath.Join(eng.GetAuxiliaryDir(), "fake", "testing", "dir"),
-		rate.NewLimiter(rate.Inf, math.MaxInt64), eng,
-	)
-	require.NoError(t, err)
-	return ss
+func newTestingSideloadStorage(eng storage.Engine) *DiskSideloadStorage {
+	return NewDiskSideloadStorage(
+		cluster.MakeTestingClusterSettings(), 1,
+		filepath.Join(eng.GetAuxiliaryDir(), "fake", "testing", "dir"),
+		rate.NewLimiter(rate.Inf, math.MaxInt64), eng)
 }
 
 func testSideloadingSideloadedStorage(t *testing.T, eng storage.Engine) {
 	ctx := context.Background()
-	ss := newTestingSideloadStorage(t, eng)
+	ss := newTestingSideloadStorage(eng)
 
 	assertCreated := func(isCreated bool) {
 		t.Helper()
@@ -427,7 +424,7 @@ func TestRaftSSTableSideloadingInline(t *testing.T) {
 
 		eng := storage.NewDefaultInMemForTesting()
 		defer eng.Close()
-		ss := newTestingSideloadStorage(t, eng)
+		ss := newTestingSideloadStorage(eng)
 		ec := raftentry.NewCache(1024) // large enough
 		if test.setup != nil {
 			test.setup(ec, ss)
@@ -532,7 +529,7 @@ func TestRaftSSTableSideloadingSideload(t *testing.T) {
 			ctx := context.Background()
 			eng := storage.NewDefaultInMemForTesting()
 			defer eng.Close()
-			sideloaded := newTestingSideloadStorage(t, eng)
+			sideloaded := newTestingSideloadStorage(eng)
 			postEnts, numSideloaded, size, nonSideloadedSize, err := MaybeSideloadEntries(ctx, test.preEnts, sideloaded)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/kv/kvserver/logstore/sideload_test.go
+++ b/pkg/kv/kvserver/logstore/sideload_test.go
@@ -86,7 +86,7 @@ func TestSideloadingSideloadedStorage(t *testing.T) {
 func newTestingSideloadStorage(t *testing.T, eng storage.Engine) *DiskSideloadStorage {
 	st := cluster.MakeTestingClusterSettings()
 	ss, err := NewDiskSideloadStorage(
-		st, 1, 2, filepath.Join(eng.GetAuxiliaryDir(), "fake", "testing", "dir"),
+		st, 1, filepath.Join(eng.GetAuxiliaryDir(), "fake", "testing", "dir"),
 		rate.NewLimiter(rate.Inf, math.MaxInt64), eng,
 	)
 	require.NoError(t, err)

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -222,16 +222,13 @@ func (r *Replica) loadRaftMuLockedReplicaMuLocked(desc *roachpb.RangeDescriptor)
 		r.mu.minLeaseProposedTS = r.Clock().NowAsClockTimestamp()
 	}
 
-	ssBase := r.Engine().GetAuxiliaryDir()
-	if r.raftMu.sideloaded, err = logstore.NewDiskSideloadStorage(
+	r.raftMu.sideloaded = logstore.NewDiskSideloadStorage(
 		r.store.cfg.Settings,
 		desc.RangeID,
-		ssBase,
+		r.Engine().GetAuxiliaryDir(),
 		r.store.limiters.BulkIOWriteRate,
 		r.store.engine,
-	); err != nil {
-		return errors.Wrap(err, "while initializing sideloaded storage")
-	}
+	)
 	r.assertStateRaftMuLockedReplicaMuRLocked(ctx, r.store.Engine())
 
 	r.sideTransportClosedTimestamp.init(r.store.cfg.ClosedTimestampReceiver, desc.RangeID)

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -226,7 +226,6 @@ func (r *Replica) loadRaftMuLockedReplicaMuLocked(desc *roachpb.RangeDescriptor)
 	if r.raftMu.sideloaded, err = logstore.NewDiskSideloadStorage(
 		r.store.cfg.Settings,
 		desc.RangeID,
-		replicaID,
 		ssBase,
 		r.store.limiters.BulkIOWriteRate,
 		r.store.engine,


### PR DESCRIPTION
This change removes the sideloaded storage path migration introduced in #35035. It has been safe to remove this migration since v20.1.

This reduces the cost of a replica start-up, because it no longer needs to call into the file system when creating the sideloaded storage.

Fixes #94811
Epic: none
Release note: none