### PR TITLE
release-22.1: roachpb: fix nil/zero comparisons in `RangeDescriptor.Equal()`

### DIFF
--- a/pkg/roachpb/metadata.proto
+++ b/pkg/roachpb/metadata.proto
@@ -129,7 +129,7 @@ enum ReplicaType {
 // non-nullable if #38302 is guaranteed to be on all nodes (I.E. 20.1).
 message ReplicaDescriptor {
   option (gogoproto.goproto_stringer) = false;
-  option (gogoproto.equal) = true;
+  option (gogoproto.equal) = false;
   option (gogoproto.populate) = true;
 
   optional int32 node_id = 1 [(gogoproto.nullable) = false,


### PR DESCRIPTION
In acdf42ad, first released in 22.2, all `RangeDescriptor` and `ReplicaDescriptor` fields were made non-nullable.  This was considered safe, because we do not rely on the range descriptor encoding being stable (the prep work for this was done back in 20.1 via  ea720e3e), and we consider a `nil` value equivalent to the default zero value.

Unfortunately, `RangeDescriptor.Equal()` and `ReplicaDescriptor.Equal()` did not consider `nil` and zero values equal, unlike the rest of the code. In particular, this can prevent range config changes (e.g. moving replicas, up/downreplication, splits, merges, etc) because e.g. `execChangeReplicasTxn()` compares the caller's view of the range descriptor to its view of the canonical range descriptor stored in KV.

There are two primary scenarios where this can happen in mixed 22.1/22.2 clusters:

1. When a 22.1 leaseholder's in-memory range descriptor diverges from the canonical range descriptor in KV, because the latter was written by a 22.1 node coordinating a config change that was then committed by a past 22.2 leaseholder who propagated its view of the range descriptor to 22.1 replicas via Raft.

2. When a 22.2 node sends an `AdminChangeReplicas` request to a 22.1 leaseholder, e.g. via an `ALTER RANGE RELOCATE` statement. `AdminSplit`/`AdminMerge` are unaffected (except for 1), because they use the leaseholder's in-memory descriptor rather than the caller's.

This patch fixes `Equal()` to properly consider `nil` and zero values as equal.

Touches #94834.
Epic: none

Release note (bug fix): Fixed a 22.2 compatibility bug where, in a cluster with mixed 22.2/22.1 nodes, range replica changes (moving replicas, up/downreplication, splits, and merges) could sometimes fail on 22.1 leaseholders with an error of the form "change replicas of r47 failed: descriptor changed: [expected] != [actual]", without any apparent differences between the listed descriptors. This would not affect the upgrade itself, and either continuing to upgrade all nodes to 22.2 or rolling nodes back to 22.1 (possibly with an additional restart) will resolve the issue.

---

Release justification: ensures forwards compatibility with 22.2 in mixed-version clusters.

/cc @cockroachdb/release