### PR TITLE
release-22.2: ci: in unit tests, pass in relevant env vars for posting github issues

### DIFF
--- a/build/teamcity/cockroach/ci/tests/unit_tests.sh
+++ b/build/teamcity/cockroach/ci/tests/unit_tests.sh
@@ -8,5 +8,5 @@ source "$dir/teamcity-support.sh"  # For $root
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
 tc_start_block "Run unit tests"
-run_bazel build/teamcity/cockroach/ci/tests/unit_tests_impl.sh
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e TC_BUILD_BRANCH -e GITHUB_API_TOKEN -e BUILD_VCS_NUMBER -e TC_BUILD_ID -e TC_SERVER_URL -e TC_BUILDTYPE_ID -e GITHUB_REPO" run_bazel build/teamcity/cockroach/ci/tests/unit_tests_impl.sh
 tc_end_block "Run unit tests"


### PR DESCRIPTION
Backport 1/1 commits from #94727.

/cc @cockroachdb/release

Release justification: test-only code change

---

Also add some extra logging in `bazci` to help diagnose this case.

Release note: None
Epic: none
