### PR TITLE
streamingccl: skip TestDataDriven/alter_tenant

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/datadriven_test.go
+++ b/pkg/ccl/streamingccl/streamingest/datadriven_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -71,6 +72,9 @@ import (
 // - query-sql as=<source-system | source-tenant | destination-system | destination-tenant>
 // Executes the specified SQL query as the specified tenant, and prints the
 // results.
+//
+// - skip issue-num=N
+// Skips the test.
 func TestDataDriven(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -85,6 +89,12 @@ func TestDataDriven(t *testing.T) {
 			}
 
 			switch d.Cmd {
+			case "skip":
+				var issue int
+				d.ScanArgs(t, "issue-num", &issue)
+				skip.WithIssue(t, issue)
+				return ""
+
 			case "create-replication-clusters":
 				args := replicationtestutils.DefaultTenantStreamingClustersArgs
 				var cleanup func()

--- a/pkg/ccl/streamingccl/streamingest/testdata/alter_tenant
+++ b/pkg/ccl/streamingccl/streamingest/testdata/alter_tenant
@@ -1,3 +1,6 @@
+skip issue-num=94855
+----
+
 create-replication-clusters
 ----
 
@@ -11,6 +14,6 @@ ALTER TENANT "destination" SET REPLICATION RETENTION = '42s'
 query-sql as=destination-system
 SELECT crdb_internal.pb_to_json('payload', payload)->'streamIngestion'->'replicationTtlSeconds' as retention_ttl_seconds
 FROM system.jobs
-WHERE id = (SELECT replication_job_id FROM [SHOW TENANT"destination" WITH REPLICATION STATUS])
+WHERE id = (SELECT replication_job_id FROM [SHOW TENANT "destination" WITH REPLICATION STATUS])
 ----
 42


### PR DESCRIPTION
This test is flakey. We will unskip it when #94855 is resolved.

Epic: none

Release note: None