### PR TITLE
eval: improve some int to reg* casts

### DIFF
--- a/pkg/sql/faketreeeval/BUILD.bazel
+++ b/pkg/sql/faketreeeval/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/repstream/streampb",
         "//pkg/roachpb",
         "//pkg/security/username",
+        "//pkg/sql/catalog",
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/pgwire/pgcode",

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -167,6 +168,13 @@ func (smf *DummyStreamManagerFactory) GetStreamIngestManager(
 // errors.
 type DummyEvalPlanner struct {
 	Monitor *mon.BytesMonitor
+}
+
+// LookupTableByID is part of the Planner interface.
+func (ep *DummyEvalPlanner) LookupTableByID(
+	ctx context.Context, tableID descpb.ID,
+) (catalog.TableDescriptor, error) {
+	return nil, nil
 }
 
 // ResolveOIDFromString is part of the Planner interface.

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function_notenant
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function_notenant
@@ -158,7 +158,7 @@ SELECT crdb_internal.get_zone_config(crdb_internal.get_namespace_id(0, 'root_tes
 query T
 SELECT ($t_id)::regclass
 ----
-109
+t
 
 # reset state to default
 user root

--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -227,6 +227,12 @@ SELECT typname from pg_type where oid='typ'::regtype
 ----
 typ
 
+## Make sure that regtype classes don't error on missing OID.
+query O
+SELECT 293874923::regtype
+----
+293874923
+
 ## Regression for #16767 - ensure regclass casts use normalized table names
 
 statement ok

--- a/pkg/sql/sem/eval/BUILD.bazel
+++ b/pkg/sql/sem/eval/BUILD.bazel
@@ -50,6 +50,7 @@ go_library(
         "//pkg/server/telemetry",
         "//pkg/settings",
         "//pkg/settings/cluster",
+        "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/lex",
         "//pkg/sql/parser",

--- a/pkg/sql/sem/eval/cast.go
+++ b/pkg/sql/sem/eval/cast.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/geo"
 	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -998,20 +999,42 @@ func performIntToOidCast(
 		}
 		return tree.NewDOidWithTypeAndName(o, t, name), nil
 
+	case oid.T_regclass:
+		if v == 0 {
+			return tree.WrapAsZeroOid(t), nil
+		}
+		desc, err := res.LookupTableByID(ctx, descpb.ID(o))
+		if err != nil {
+			if pgerror.GetPGCode(err) == pgcode.UndefinedTable {
+				// If we couldn't find a match for the input id, unfortunately we need
+				// to scan the full pg_class table, since it contains indexes - and we
+				// don't reserve OIDs for indexes today, we simply construct them via
+				// a hash function.
+				return defaultPerformIntFromCast(ctx, res, t, o)
+			}
+			return nil, err
+		}
+		return tree.NewDOidWithTypeAndName(o, t, desc.GetName()), nil
+
 	default:
 		if v == 0 {
 			return tree.WrapAsZeroOid(t), nil
 		}
-
-		dOid, errSafeToIgnore, err := res.ResolveOIDFromOID(ctx, t, tree.NewDOid(o))
-		if err != nil {
-			if !errSafeToIgnore {
-				return nil, err
-			}
-			dOid = tree.NewDOidWithType(o, t)
-		}
-		return dOid, nil
+		return defaultPerformIntFromCast(ctx, res, t, o)
 	}
+}
+
+func defaultPerformIntFromCast(
+	ctx context.Context, res Planner, t *types.T, o oid.Oid,
+) (tree.Datum, error) {
+	dOid, errSafeToIgnore, err := res.ResolveOIDFromOID(ctx, t, tree.NewDOid(o))
+	if err != nil {
+		if !errSafeToIgnore {
+			return nil, err
+		}
+		dOid = tree.NewDOidWithType(o, t)
+	}
+	return dOid, nil
 }
 
 func roundDecimalToInt(d *apd.Decimal) (int64, error) {

--- a/pkg/sql/sem/eval/cast.go
+++ b/pkg/sql/sem/eval/cast.go
@@ -978,6 +978,9 @@ func performIntToOidCast(
 		} else if types.IsOIDUserDefinedType(o) {
 			typ, err := res.ResolveTypeByOID(ctx, o)
 			if err != nil {
+				if pgerror.GetPGCode(err) == pgcode.UndefinedObject {
+					return tree.NewDOidWithType(o, t), nil
+				}
 				return nil, err
 			}
 			name = typ.PGName()

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
@@ -60,6 +61,10 @@ type DatabaseCatalog interface {
 	// sets it on the returned TableName.
 	// It returns the ID of the resolved table, and an error if the table doesn't exist.
 	ResolveTableName(ctx context.Context, tn *tree.TableName) (tree.ID, error)
+
+	// LookupTableByID looks up a table, by the given descriptor ID. Based on the
+	// CommonLookupFlags, it could use or skip the Collection cache.
+	LookupTableByID(ctx context.Context, tableID descpb.ID) (catalog.TableDescriptor, error)
 
 	// SchemaExists looks up the schema with the given name and determines
 	// whether it exists.


### PR DESCRIPTION
See commits.

- add fastpath for int to regclass casts
- fix compat issue with int to regtype casts