### PR TITLE
sql: [poc] implement string::regclass as a UDF

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -255,7 +255,7 @@ SELECT relname from pg_class where oid='quotedCase'::regclass
 query T
 SELECT relname from pg_class where oid='"quotedCase"'::regclass
 ----
-quotedCase
+"quotedCase"
 
 query error pgcode 42704 type 'typquotedcase' does not exist
 SELECT typname from pg_type where oid='typQuotedCase'::regtype

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
@@ -686,20 +687,22 @@ https://www.postgresql.org/docs/9.5/catalog-pg-class.html`,
 		}
 		implicitTypOID := typedesc.TableIDToImplicitTypeOID(table.GetID())
 		namespaceOid := schemaOid(sc.GetID())
+		var buf bytes.Buffer
+		lexbase.EncodeRestrictedSQLIdent(&buf, table.GetName(), lexbase.EncNoFlags)
 		if err := addRow(
-			tableOid(table.GetID()),        // oid
-			tree.NewDName(table.GetName()), // relname
-			namespaceOid,                   // relnamespace
-			tree.NewDOid(implicitTypOID),   // reltype (PG creates a composite type in pg_type for each table)
-			oidZero,                        // reloftype (used for type tables, which is unsupported)
-			ownerOid,                       // relowner
-			relAm,                          // relam
-			oidZero,                        // relfilenode
-			oidZero,                        // reltablespace
-			tree.DNull,                     // relpages
-			tree.DNull,                     // reltuples
-			zeroVal,                        // relallvisible
-			oidZero,                        // reltoastrelid
+			tableOid(table.GetID()),      // oid
+			tree.NewDName(buf.String()),  // relname
+			namespaceOid,                 // relnamespace
+			tree.NewDOid(implicitTypOID), // reltype (PG creates a composite type in pg_type for each table)
+			oidZero,                      // reloftype (used for type tables, which is unsupported)
+			ownerOid,                     // relowner
+			relAm,                        // relam
+			oidZero,                      // relfilenode
+			oidZero,                      // reltablespace
+			tree.DNull,                   // relpages
+			tree.DNull,                   // reltuples
+			zeroVal,                      // relallvisible
+			oidZero,                      // reltoastrelid
 			tree.MakeDBool(tree.DBool(table.IsPhysicalTable())), // relhasindex
 			tree.DBoolFalse, // relisshared
 			relPersistence,  // relpersistence

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -7746,6 +7746,27 @@ expires until the statement bundle is collected`,
 			Volatility: volatility.Immutable,
 		},
 	),
+	"crdb_internal.split_ident": makeBuiltin(defProps(),
+		tree.Overload{
+			Types:      tree.ParamTypes{{Name: "input", Typ: types.String}},
+			ReturnType: tree.FixedReturnType(types.StringArray),
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
+				list, err := eval.SplitIdentifierList(string(tree.MustBeDString(args[0])))
+				if err != nil {
+					return nil, err
+				}
+				ret := tree.NewDArray(types.String)
+				for _, ident := range list {
+					if err := ret.Append(tree.NewDString(ident)); err != nil {
+						return nil, err
+					}
+				}
+				return ret, nil
+			},
+			Info:       "Splits an input identifier into its constituent parts",
+			Volatility: volatility.Immutable,
+		},
+	),
 }
 
 var lengthImpls = func(incBitOverload bool) builtinDefinition {

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2044,6 +2044,7 @@ var builtinOidsArray = []string{
 	2066: `crdb_internal.generate_test_objects(parameters: jsonb) -> jsonb`,
 	2067: `crdb_internal.gen_rand_ident(name_pattern: string, count: int) -> string`,
 	2068: `crdb_internal.gen_rand_ident(name_pattern: string, count: int, parameters: jsonb) -> string`,
+	2069: `crdb_internal.split_ident(input: string) -> string[]`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2045,6 +2045,7 @@ var builtinOidsArray = []string{
 	2067: `crdb_internal.gen_rand_ident(name_pattern: string, count: int) -> string`,
 	2068: `crdb_internal.gen_rand_ident(name_pattern: string, count: int, parameters: jsonb) -> string`,
 	2069: `crdb_internal.split_ident(input: string) -> string[]`,
+	2070: `regclass(text: string) -> regclass`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/eval/parse_doid.go
+++ b/pkg/sql/sem/eval/parse_doid.go
@@ -56,7 +56,7 @@ func ParseDOid(ctx context.Context, evalCtx *Context, s string, t *types.T) (*tr
 	case oid.T_regproc:
 		// To be compatible with postgres, we always treat the trimmed input string
 		// as a function name.
-		substrs, err := splitIdentifierList(strings.TrimSpace(s))
+		substrs, err := SplitIdentifierList(strings.TrimSpace(s))
 		if err != nil {
 			return nil, err
 		}
@@ -252,7 +252,7 @@ func indexNameToOID(ctx context.Context, evalCtx *Context, tn tree.TableName) (o
 
 // castStringToRegClassTableName normalizes a TableName from a string.
 func castStringToRegClassTableName(s string) (tree.TableName, error) {
-	components, err := splitIdentifierList(s)
+	components, err := SplitIdentifierList(s)
 	if err != nil {
 		return tree.TableName{}, err
 	}
@@ -279,10 +279,10 @@ func castStringToRegClassTableName(s string) (tree.TableName, error) {
 	return u.ToTableName(), nil
 }
 
-// splitIdentifierList splits identifiers to individual components, lower
+// SplitIdentifierList splits identifiers to individual components, lower
 // casing non-quoted identifiers and escaping quoted identifiers as appropriate.
 // It is based on PostgreSQL's SplitIdentifier.
-func splitIdentifierList(in string) ([]string, error) {
+func SplitIdentifierList(in string) ([]string, error) {
 	var pos int
 	var ret []string
 	const separator = '.'

--- a/pkg/sql/sem/eval/parse_doid_test.go
+++ b/pkg/sql/sem/eval/parse_doid_test.go
@@ -31,7 +31,7 @@ func TestSplitIdentifierList(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.in, func(t *testing.T) {
-			out, err := splitIdentifierList(tc.in)
+			out, err := SplitIdentifierList(tc.in)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, out)
 		})
@@ -48,7 +48,7 @@ func TestSplitIdentifierList(t *testing.T) {
 
 	for _, tc := range errorTestCases {
 		t.Run(tc.in, func(t *testing.T) {
-			_, err := splitIdentifierList(tc.in)
+			_, err := SplitIdentifierList(tc.in)
 			require.EqualError(t, err, tc.expectedError)
 		})
 	}


### PR DESCRIPTION
This is a proof of concept that implements the string::regclass cast as a UDF, instead of requiring the custom logic that we do today. This permits the optimizer to have its way and optimize queries using this cast as it sees fit, rather than having to do a row-by-row execution of the cast.

The proof of concept demonstrates the idea of the optbuilder looking at casts to see if there are matching builtin functions for those casts. If there are, it delegates the cast to that builtin, rather than planning a cast at all.

I'm not sure if this is the appropriate place to put such a check - perhaps it's a transformation instead? Either way, I think this is exciting. Here are some example plans:

```
demo@127.0.0.1:26257/defaultdb> explain(opt) select 'a'::regclass;                                                                                                                                                                                                                                info                                                                                                              ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  values
   └── tuple                                                                                                                                                                                                      └── subquery
             └── project                                                                                                                                                                                                    ├── limit
                  │    ├── right-join (cross)
                  │    │    ├── inner-join (hash)
                  │    │    │    ├── select
                  │    │    │    │    ├── scan pg_namespace [as=n]
                  │    │    │    │    └── filters
                  │    │    │    │         └── nspname IN ('pg_catalog', 'pg_extension', 'public')
                  │    │    │    ├── select
                  │    │    │    │    ├── scan pg_class [as=c]
                  │    │    │    │    └── filters
                  │    │    │    │         └── relname = 'a'
                  │    │    │    └── filters
                  │    │    │         └── relnamespace = n.oid
                  │    │    ├── values
                  │    │    │    └── ()
                  │    │    └── filters (true)
                  │    └── 1
                  └── projections
                       └── assignment-cast: REGCLASS
                            └── COALESCE(c.oid, CASE WHEN crdb_internal.force_error('42P01', 'relation "a" does not exist') = 0 THEN CAST(NULL AS OID) ELSE CAST(NULL AS OID) END)
(24 rows)

Time: 2ms total (execution 2ms / network 0ms)

demo@127.0.0.1:26257/defaultdb> explain(opt) select relname::regclass from pg_class where relnamespace = 'pg_catalog'::regnamespace;
                                                                                              info
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  project
   ├── distinct-on
   │    ├── right-join (hash)
   │    │    ├── inner-join (hash)
   │    │    │    ├── scan pg_class [as=c]
   │    │    │    ├── select
   │    │    │    │    ├── scan pg_namespace [as=n]
   │    │    │    │    └── filters
   │    │    │    │         └── nspname IN ('pg_catalog', 'pg_extension', 'public')
   │    │    │    └── filters
   │    │    │         └── c.relnamespace = n.oid
   │    │    ├── ordinality
   │    │    │    └── select
   │    │    │         ├── scan pg_class
   │    │    │         └── filters
   │    │    │              └── pg_class.relnamespace = pg_catalog
   │    │    └── filters
   │    │         └── c.relname = pg_class.relname
   │    └── aggregations
   │         ├── const-agg
   │         │    └── pg_class.relname
   │         └── first-agg
   │              └── c.oid
   └── projections
        └── assignment-cast: REGCLASS
             └── COALESCE(c.oid, CASE WHEN crdb_internal.force_error('42P01', ('relation "' || pg_class.relname) || '" does not exist') = 0 THEN CAST(NULL AS OID) ELSE CAST(NULL AS OID) END)
(26 rows)
```

Epic: None
Release note: None