### PR TITLE
import: add logging to import cancellation

### DIFF
--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -1149,7 +1149,9 @@ func runBackupMVCCRangeTombstones(ctx context.Context, t test.Test, c cluster.Cl
 	require.NoError(t, err)
 	_, err = conn.Exec(`SET CLUSTER SETTING storage.mvcc.range_tombstones.enabled = 't'`)
 	require.NoError(t, err)
-
+	_, err = conn.Exec(`SET CLUSTER SETTING server.debug.default_vmodule = 'txn=2,sst_batcher=4,
+revert=2'`)
+	require.NoError(t, err)
 	// Wait for ranges to upreplicate.
 	require.NoError(t, WaitFor3XReplication(ctx, t, conn))
 

--- a/pkg/sql/gcjob/table_garbage_collection.go
+++ b/pkg/sql/gcjob/table_garbage_collection.go
@@ -258,6 +258,7 @@ func deleteAllSpanData(
 			})
 			log.VEventf(ctx, 2, "delete range %s - %s", lastKey, endKey)
 			if err := db.Run(ctx, &b); err != nil {
+				log.Errorf(ctx, "delete range %s - %s failed: %s", span.Key, span.EndKey, err.Error())
 				return errors.Wrapf(err, "delete range %s - %s", lastKey, endKey)
 			}
 			n = 0

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -1394,6 +1394,7 @@ func (r *importResumer) OnFailOrCancel(ctx context.Context, execCtx interface{},
 		ctx context.Context, txn *kv.Txn, descsCol *descs.Collection,
 	) error {
 		if err := r.dropTables(ctx, txn, descsCol, cfg); err != nil {
+			log.Errorf(ctx, "drop tables failed: %s", err.Error())
 			return err
 		}
 

--- a/pkg/sql/revert.go
+++ b/pkg/sql/revert.go
@@ -199,6 +199,7 @@ func DeleteTableWithPredicate(
 							delRangeRequest)
 
 						if err != nil {
+							log.Errorf(ctx, "delete range %s - %s failed: %s", span.Key, span.EndKey, err.String())
 							return errors.Wrapf(err.GoError(), "delete range %s - %s", span.Key, span.EndKey)
 						}
 						span = nil


### PR DESCRIPTION
In #94740, the backup/mvcc-range-tombstones roachtest failed because an import cancellation retried for opaque reasons. This patch adds more logging to potential retryable errors so the next time the thest fails, the logs will clearly state why.

Epic: none

Release note: none