### PR TITLE
ui: add list of fingerprints used by index

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -4746,6 +4746,8 @@ Response object returned by TableIndexStatsResponse.
 | index_type | [string](#cockroach.server.serverpb.TableIndexStatsResponse-string) |  | index_type is the type of the index i.e. primary, secondary. | [reserved](#support-status) |
 | create_statement | [string](#cockroach.server.serverpb.TableIndexStatsResponse-string) |  | create_statement is the SQL statement that would re-create the current index if executed. | [reserved](#support-status) |
 | created_at | [google.protobuf.Timestamp](#cockroach.server.serverpb.TableIndexStatsResponse-google.protobuf.Timestamp) |  | CreatedAt is an approximate timestamp at which the index was created. Note that it may not always be populated. | [reserved](#support-status) |
+| index_id | [string](#cockroach.server.serverpb.TableIndexStatsResponse-string) |  | index_id is the ID of the index. | [reserved](#support-status) |
+| table_id | [string](#cockroach.server.serverpb.TableIndexStatsResponse-string) |  | table_id is the ID of the table which the index belongs to. | [reserved](#support-status) |
 
 
 

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1802,7 +1802,10 @@ message TableIndexStatsResponse {
     // CreatedAt is an approximate timestamp at which the index was created.
     // Note that it may not always be populated.
     google.protobuf.Timestamp created_at = 5 [(gogoproto.stdtime) = true];
-
+    // index_id is the ID of the index.
+    string index_id = 6 [(gogoproto.customname) = "IndexID"];
+    // table_id is the ID of the table which the index belongs to.
+    string table_id = 7 [(gogoproto.customname) = "TableID"];
   }
 
   repeated ExtendedCollectedIndexUsageStatistics statistics = 1;

--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.module.scss
@@ -142,3 +142,13 @@
   margin-top: 20px;
 }
 
+.bottom-space {
+  margin-bottom: 40px;
+}
+
+.table-scroll {
+  width: calc(100% - -23px);
+  overflow-x: scroll;
+  padding-left: 0;
+}
+

--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.stories.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.stories.tsx
@@ -20,12 +20,16 @@ const withData: IndexDetailsPageProps = {
   databaseName: randomName(),
   tableName: randomName(),
   indexName: randomName(),
+  isTenant: false,
+  nodeRegions: {},
   details: {
     loading: false,
     loaded: true,
     createStatement: `
       CREATE UNIQUE INDEX "primary" ON system.public.database_role_settings USING btree (database_id ASC, role_name ASC)
     `,
+    tableID: "1",
+    indexID: "1",
     totalReads: 0,
     lastRead: moment("2021-10-21T22:00:00Z"),
     lastReset: moment("2021-12-02T07:12:00Z"),

--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
@@ -10,7 +10,11 @@
 
 import React from "react";
 import classNames from "classnames/bind";
-import { SortSetting } from "src/sortedtable";
+import {
+  ISortedTablePagination,
+  SortedTable,
+  SortSetting,
+} from "src/sortedtable";
 
 import styles from "./indexDetailsPage.module.scss";
 import { baseHeadingClasses } from "src/transactionsPage/transactionsPageClasses";
@@ -26,9 +30,31 @@ import { SummaryCard } from "../summaryCard";
 import moment, { Moment } from "moment";
 import { Heading } from "@cockroachlabs/ui-components";
 import { Anchor } from "../anchor";
-import { Count, DATE_FORMAT_24_UTC, performanceTuningRecipes } from "../util";
+import {
+  calculateTotalWorkload,
+  Count,
+  DATE_FORMAT_24_UTC,
+  performanceTuningRecipes,
+} from "../util";
+import {
+  getStatementsUsingIndex,
+  StatementsListRequestFromDetails,
+  StatementsUsingIndexRequest,
+} from "../api/indexDetailsApi";
+import {
+  AggregateStatistics,
+  makeStatementsColumns,
+  populateRegionNodeForStatements,
+} from "../statementsTable";
+import { UIConfigState } from "../store";
+import statementsStyles from "../statementsPage/statementsPage.module.scss";
+import { Pagination } from "../pagination";
+import { TableStatistics } from "../tableStatistics";
+import { EmptyStatementsPlaceholder } from "../statementsPage/emptyStatementsPlaceholder";
+import { StatementViewType } from "../statementsPage/statementPageTypes";
 
 const cx = classNames.bind(styles);
+const stmtCx = classNames.bind(statementsStyles);
 
 // We break out separate interfaces for some of the nested objects in our data
 // so that we can make (typed) test assertions on narrower slices of the data.
@@ -45,6 +71,8 @@ const cx = classNames.bind(styles);
 //     details: { // IndexDetails;
 //       loading: boolean;
 //       loaded: boolean;
+//       tableID: string;
+//       indexID: string;
 //       createStatement: string;
 //       totalReads: number;
 //       lastRead: Moment;
@@ -58,11 +86,16 @@ export interface IndexDetailsPageData {
   indexName: string;
   details: IndexDetails;
   breadcrumbItems: BreadcrumbItem[];
+  isTenant: UIConfigState["isTenant"];
+  hasViewActivityRedactedRole?: UIConfigState["hasViewActivityRedactedRole"];
+  nodeRegions: { [nodeId: string]: string };
 }
 
 interface IndexDetails {
   loading: boolean;
   loaded: boolean;
+  tableID: string;
+  indexID: string;
   createStatement: string;
   totalReads: number;
   lastRead: Moment;
@@ -87,7 +120,9 @@ export type IndexDetailsPageProps = IndexDetailsPageData &
   IndexDetailPageActions;
 
 interface IndexDetailsPageState {
-  sortSetting: SortSetting;
+  statements: AggregateStatistics[];
+  stmtSortSetting: SortSetting;
+  stmtPagination: ISortedTablePagination;
 }
 
 export class IndexDetailsPage extends React.Component<
@@ -98,9 +133,15 @@ export class IndexDetailsPage extends React.Component<
     super(props);
 
     this.state = {
-      sortSetting: {
+      stmtSortSetting: {
         ascending: true,
+        columnTitle: "statementTime",
       },
+      stmtPagination: {
+        pageSize: 10,
+        current: 1,
+      },
+      statements: [],
     };
   }
 
@@ -112,6 +153,17 @@ export class IndexDetailsPage extends React.Component<
     this.refresh();
   }
 
+  onChangeSortSetting = (ss: SortSetting): void => {
+    this.setState({
+      stmtSortSetting: ss,
+    });
+  };
+
+  onChangePage = (current: number): void => {
+    const { stmtPagination } = this.state;
+    this.setState({ stmtPagination: { ...stmtPagination, current } });
+  };
+
   private refresh() {
     if (this.props.refreshNodes != null) {
       this.props.refreshNodes();
@@ -122,6 +174,17 @@ export class IndexDetailsPage extends React.Component<
         this.props.tableName,
       );
     }
+
+    const req: StatementsUsingIndexRequest = StatementsListRequestFromDetails(
+      this.props.details.tableID,
+      this.props.details.indexID,
+      this.props.databaseName,
+      null,
+    );
+    getStatementsUsingIndex(req).then(res => {
+      populateRegionNodeForStatements(res, this.props.nodeRegions);
+      this.setState({ statements: res });
+    });
   }
 
   private getTimestampString(timestamp: Moment): string {
@@ -210,6 +273,10 @@ export class IndexDetailsPage extends React.Component<
   }
 
   render(): React.ReactElement {
+    const { statements, stmtSortSetting, stmtPagination } = this.state;
+    const { isTenant, hasViewActivityRedactedRole } = this.props;
+    const isEmptySearchResults = statements?.length > 0;
+
     return (
       <div className={cx("page-container")}>
         <div className="root table-area">
@@ -312,7 +379,7 @@ export class IndexDetailsPage extends React.Component<
             <Row gutter={18} className={cx("row-spaced")}>
               <Col className="gutter-row" span={18}>
                 <SummaryCard className={cx("summary-card--row")}>
-                  <Heading type="h5">Index recommendations</Heading>
+                  <Heading type="h5">Index Recommendations</Heading>
                   <table>
                     <tbody>
                       {this.renderIndexRecommendations(
@@ -320,6 +387,47 @@ export class IndexDetailsPage extends React.Component<
                       )}
                     </tbody>
                   </table>
+                </SummaryCard>
+              </Col>
+            </Row>
+            <Row gutter={24} className={cx("row-spaced", "bottom-space")}>
+              <Col className="gutter-row" span={24}>
+                <SummaryCard className={cx("summary-card--row")}>
+                  <Heading type="h5">Index Usage</Heading>
+                  <TableStatistics
+                    pagination={stmtPagination}
+                    totalCount={statements.length}
+                    arrayItemName={"statement fingerprints using this index"}
+                    activeFilters={0}
+                  />
+                  <SortedTable
+                    data={statements}
+                    columns={makeStatementsColumns(
+                      statements,
+                      [],
+                      calculateTotalWorkload(statements),
+                      "statement",
+                      isTenant,
+                      hasViewActivityRedactedRole,
+                    ).filter(c => !(isTenant && c.hideIfTenant))}
+                    className={stmtCx("statements-table")}
+                    tableWrapperClassName={cx("table-scroll")}
+                    sortSetting={stmtSortSetting}
+                    onChangeSortSetting={this.onChangeSortSetting}
+                    pagination={stmtPagination}
+                    renderNoResult={
+                      <EmptyStatementsPlaceholder
+                        isEmptySearchResults={isEmptySearchResults}
+                        statementView={StatementViewType.USING_INDEX}
+                      />
+                    }
+                  />
+                  <Pagination
+                    pageSize={stmtPagination.pageSize}
+                    current={stmtPagination.current}
+                    total={statements.length}
+                    onChange={this.onChangePage}
+                  />
                 </SummaryCard>
               </Col>
             </Row>

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/emptyStatementsPlaceholder.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/emptyStatementsPlaceholder.tsx
@@ -11,11 +11,10 @@
 import React from "react";
 import { EmptyTable, EmptyTableProps } from "src/empty";
 import { Anchor } from "src/anchor";
-import { statementsTable } from "src/util";
+import { statementsTable, tabAttr, viewAttr } from "src/util";
 import magnifyingGlassImg from "../assets/emptyState/magnifying-glass.svg";
 import emptyTableResultsImg from "../assets/emptyState/empty-table-results.svg";
 import { StatementViewType } from "./statementPageTypes";
-import { tabAttr, viewAttr } from "src/util";
 import { Link } from "react-router-dom";
 import { commonStyles } from "src/common";
 
@@ -46,6 +45,13 @@ function getMessage(type: StatementViewType): EmptyTableProps {
             View Statement Fingerprints to see historical statement statistics.
           </Link>
         ),
+      };
+    case StatementViewType.USING_INDEX:
+      return {
+        title:
+          "No SQL statements using this index in the selected time interval",
+        icon: emptyTableResultsImg,
+        footer,
       };
     case StatementViewType.FINGERPRINTS:
     default:

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementPageTypes.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementPageTypes.ts
@@ -11,4 +11,5 @@
 export enum StatementViewType {
   ACTIVE = "active",
   FINGERPRINTS = "fingerprints",
+  USING_INDEX = "using_index",
 }

--- a/pkg/ui/workspaces/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
@@ -353,8 +353,8 @@ export const statisticsTableTitles: StatisticTableTitleType = {
               </Anchor>
             </p>
             <p>
-              {` represents one or more SQL statements by replacing the literal values (e.g., numbers and strings) with 
-              underscores (_). To view additional details of a SQL statement fingerprint, click the fingerprint to 
+              {` represents one or more SQL statements by replacing the literal values (e.g., numbers and strings) with
+              underscores (_). To view additional details of a SQL statement fingerprint, click the fingerprint to
               open the Statement Details page.`}
             </p>
           </>
@@ -372,8 +372,8 @@ export const statisticsTableTitles: StatisticTableTitleType = {
         content={
           <>
             <p>
-              {`A transaction fingerprint represents one or more SQL transactions by replacing the literal values (e.g., numbers and strings) with 
-              underscores (_). To view additional details of a SQL transaction fingerprint, click the fingerprint to 
+              {`A transaction fingerprint represents one or more SQL transactions by replacing the literal values (e.g., numbers and strings) with
+              underscores (_). To view additional details of a SQL transaction fingerprint, click the fingerprint to
               open the Transaction Details page.`}
             </p>
           </>
@@ -656,7 +656,7 @@ export const statisticsTableTitles: StatisticTableTitleType = {
         content={
           <>
             <p>
-              {`Maximum memory used by a ${contentModifier} with this fingerprint${fingerprintModifier} at any time 
+              {`Maximum memory used by a ${contentModifier} with this fingerprint${fingerprintModifier} at any time
               during its execution within the specified time interval. `}
             </p>
             <p>

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -485,6 +485,7 @@ export class TransactionDetails extends React.Component<
                       className={cx("statements-table")}
                       sortSetting={sortSetting}
                       onChangeSortSetting={this.onChangeSortSetting}
+                      pagination={pagination}
                     />
                   </div>
                 </section>

--- a/pkg/ui/workspaces/cluster-ui/src/util/convert.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/convert.ts
@@ -162,3 +162,8 @@ export function makeTimestamp(unixTs: number): Timestamp {
     seconds: fromNumber(unixTs),
   });
 }
+
+export function stringToTimestamp(t: string): Timestamp {
+  const unix = new Date(t).getTime() / 1000;
+  return makeTimestamp(unix);
+}

--- a/pkg/ui/workspaces/db-console/src/views/databases/indexDetailsPage/redux.spec.ts
+++ b/pkg/ui/workspaces/db-console/src/views/databases/indexDetailsPage/redux.spec.ts
@@ -134,6 +134,8 @@ describe("Index Details Page", function () {
         databaseName: "DATABASE",
         tableName: "TABLE",
         indexName: "INDEX",
+        isTenant: false,
+        nodeRegions: {},
         details: {
           loading: false,
           loaded: false,
@@ -142,6 +144,8 @@ describe("Index Details Page", function () {
           lastRead: moment(),
           lastReset: moment(),
           indexRecommendations: [],
+          tableID: undefined,
+          indexID: undefined,
         },
         breadcrumbItems: null,
       },
@@ -182,9 +186,13 @@ describe("Index Details Page", function () {
       databaseName: "DATABASE",
       tableName: "TABLE",
       indexName: "INDEX",
+      isTenant: false,
+      nodeRegions: {},
       details: {
         loading: false,
         loaded: true,
+        tableID: "15",
+        indexID: "2",
         createStatement:
           "CREATE INDEX jobs_created_by_type_created_by_id_idx ON system.public.jobs USING btree (created_by_type ASC, created_by_id ASC) STORING (status)",
         totalReads: 2,


### PR DESCRIPTION
Part Of #93087

This commits adds on the Index Details page the list of fingerprints that were used by that index.

This first commit shows all statement fingerprints, follow PRs will add features such as: search, filter, time selection and listing Transactions.

<img width="1682" alt="Screen Shot 2023-01-06 at 5 00 59 PM" src="https://user-images.githubusercontent.com/1017486/211108300-896b6b6c-6c38-472e-acc3-093d79bbd432.png">

https://www.loom.com/share/7ac91cd489204808a381e8b995442d67

This PR also updates the ui-components package to include the fix on the Tooltip component.

Release note (ui change): Adds on the Index Details page a list of all statement fingerprints that used that index.