### PR TITLE
streamingccl: use latest details when updating PTS record 

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/testdata/alter_tenant
+++ b/pkg/ccl/streamingccl/streamingest/testdata/alter_tenant
@@ -1,6 +1,3 @@
-skip issue-num=94855
-----
-
 create-replication-clusters
 ----
 


### PR DESCRIPTION
Previously, this updated the PTS record using a payload struct that
was retrieved from a cached jobs.Job. That details struct might have
outdated values of other fields in the face of an `ALTER TENANT`
statement.

Now, we update the job using the most recent version of the payload
from the jobs updater.

Closes https://github.com/cockroachdb/cockroach/pull/94857

Release note: None