### PR TITLE
sql/stats: fix a few small bugs in histogram.adjustCounts

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/forecast
+++ b/pkg/sql/opt/exec/execbuilder/testdata/forecast
@@ -193,9 +193,9 @@ scan g
  ├── columns: a:1
  ├── constraint: /1: [/0 - /99]
  ├── cardinality: [0 - 100]
- ├── stats: [rows=12, distinct(1)=10, null(1)=0]
- │   histogram(1)=  0 1.3333 0 0.66667 0 0.66667 0 1.3333 0 1.3333 0 0.66667 0 0.66667 0 1.3333 0 1.3333 0 0.66667 0 0.66667 0 1.3333
- │                <---- 0 ------- 1 ------- 2 ------ 3 ------ 4 ------- 5 ------- 6 ------ 7 ------ 8 ------- 9 ------ 10 ------ 11 -
+ ├── stats: [rows=12, distinct(1)=12, null(1)=0]
+ │   histogram(1)=  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1  0  1   0  1
+ │                <--- 0 --- 1 --- 2 --- 3 --- 4 --- 5 --- 6 --- 7 --- 8 --- 9 --- 10 --- 11
  ├── cost: 21.13
  ├── key: (1)
  └── distribution: test
@@ -1015,7 +1015,7 @@ distribution: local
 vectorized: true
 ·
 • scan
-  estimated row count: 3 (22% of the table; stats collected <hidden> ago; using stats forecast)
+  estimated row count: 3 (25% of the table; stats collected <hidden> ago; using stats forecast)
   table: g@g_pkey
   spans: [/9 - ]
 
@@ -1025,10 +1025,10 @@ EXPLAIN (OPT, VERBOSE) SELECT * FROM g WHERE a > 8
 scan g
  ├── columns: a:1
  ├── constraint: /1: [/9 - ]
- ├── stats: [rows=2.666667, distinct(1)=2.33333, null(1)=0]
- │   histogram(1)=  0 0.66667 0 0.66667 0 1.3333
- │                <----- 9 ------ 10 ------ 11 -
- ├── cost: 16.7133333
+ ├── stats: [rows=3, distinct(1)=3, null(1)=0]
+ │   histogram(1)=  0  1  0  1   0  1
+ │                <--- 9 --- 10 --- 11
+ ├── cost: 17.05
  ├── key: (1)
  └── distribution: test
 
@@ -1218,7 +1218,7 @@ distribution: local
 vectorized: true
 ·
 • scan
-  estimated row count: 3 (22% of the table; stats collected <hidden> ago; using stats forecast)
+  estimated row count: 3 (25% of the table; stats collected <hidden> ago; using stats forecast)
   table: g@g_pkey
   spans: [/9 - ]
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/forecast1401
+++ b/pkg/sql/opt/exec/execbuilder/testdata/forecast1401
@@ -18444,7 +18444,7 @@ distribution: local
 vectorized: true
 ·
 • scan
-  estimated row count: 179,489,802 (2.7% of the table; stats collected <hidden> ago; using stats forecast)
+  estimated row count: 179,489,803 (2.7% of the table; stats collected <hidden> ago; using stats forecast)
   table: t1401@t1401_c_idx
   spans: [/'2022-01-25 21:17:27.216095+00:00' - ]
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_stats
@@ -282,10 +282,10 @@ EXPLAIN (OPT, VERBOSE) SELECT * FROM g WHERE b >= 10
 scan g
  ├── columns: b:1
  ├── constraint: /1: [/10 - ]
- ├── stats: [rows=8, distinct(1)=6.5, null(1)=0]
- │   histogram(1)=  0 0.5  0 1.5  0 1.5  0 0.5  0  1   0  1   0 0.5  0 1.5
- │                <--- 10 --- 11 --- 12 --- 13 --- 14 --- 15 --- 16 --- 17
- ├── cost: 22.1
+ ├── stats: [rows=7, distinct(1)=6, null(1)=0]
+ │   histogram(1)=  0  2   0  1   0  1   0  1   0  1   0  1
+ │                <--- 11 --- 12 --- 13 --- 14 --- 15 --- 17
+ ├── cost: 21.09
  ├── key: (1)
  └── distribution: test
 

--- a/pkg/sql/stats/forecast.go
+++ b/pkg/sql/stats/forecast.go
@@ -46,20 +46,20 @@ const minGoodnessOfFit = 0.95
 
 // ForecastTableStatistics produces zero or more statistics forecasts based on
 // the given observed statistics. The observed statistics must be ordered by
-// collection time descending, with the latest collected statistics first. The
+// collection time descending, with the latest observed statistics first. The
 // observed statistics may be a mixture of statistics for different sets of
-// columns, but should not contain statistics for any old nonexistent columns.
+// columns.
 //
 // Whether a forecast is produced for a set of columns depends on how well the
 // observed statistics for that set of columns fit a linear regression model.
 // This means a forecast will not necessarily be produced for every set of
 // columns in the table. Any forecasts produced will have the same CreatedAt
-// time, which will be up to a week after the latest observed statistics (and
-// could be in the past, present, or future relative to the current time). Any
-// forecasts produced will not necessarily have the same RowCount or be
-// consistent with the other forecasts produced. (For example, DistinctCount in
-// the forecast for columns {a, b} could very well end up less than
-// DistinctCount in the forecast for column {a}.)
+// time, which will be after the latest observed statistics (and could be in the
+// past, present, or future relative to the current time). Any forecasts
+// produced will not necessarily have the same RowCount or be consistent with
+// the other forecasts produced. (For example, DistinctCount in the forecast for
+// columns {a, b} could very well end up less than DistinctCount in the forecast
+// for column {a}.)
 //
 // ForecastTableStatistics is deterministic: given the same observations it will
 // return the same forecasts.
@@ -116,7 +116,7 @@ func ForecastTableStatistics(ctx context.Context, observed []*TableStatistic) []
 // based on the given observed statistics. The observed statistics must all be
 // for the same set of columns, must not contain any inverted histograms, must
 // have a single observation per collection time, and must be ordered by
-// collection time descending with the latest collected statistics first. The
+// collection time descending with the latest observed statistics first. The
 // given time to forecast at can be in the past, present, or future.
 //
 // To create a forecast, we construct a linear regression model over time for

--- a/pkg/sql/stats/forecast_test.go
+++ b/pkg/sql/stats/forecast_test.go
@@ -577,6 +577,32 @@ func TestForecastColumnStatistics(t *testing.T) {
 				hist: testHistogram{{20, 0, 0, 50}, {20, 0, 0, 301}},
 			},
 		},
+		// Histogram, rounded counts.
+		{
+			observed: []*testStat{
+				{
+					at: 2, row: 13, dist: 7, null: 3, size: 1,
+					hist: testHistogram{{5, 0, 0, 100}, {0, 5, 5, 200}},
+				},
+				{
+					at: 4, row: 26, dist: 12, null: 6, size: 4,
+					hist: testHistogram{{10, 0, 0, 200}, {0, 10, 10, 300}},
+				},
+				{
+					at: 6, row: 39, dist: 17, null: 9, size: 7,
+					hist: testHistogram{{15, 0, 0, 300}, {0, 15, 15, 400}},
+				},
+				{
+					at: 8, row: 52, dist: 22, null: 12, size: 10,
+					hist: testHistogram{{20, 0, 0, 400}, {0, 20, 20, 500}},
+				},
+			},
+			at: 9,
+			forecast: &testStat{
+				at: 9, row: 59, dist: 25, null: 14, size: 12,
+				hist: testHistogram{{22, 0, 0, 450}, {0, 23, 23, 550}},
+			},
+		},
 	}
 	ctx := context.Background()
 	var fullStatID, partialStatID uint64

--- a/pkg/sql/stats/histogram.go
+++ b/pkg/sql/stats/histogram.go
@@ -365,9 +365,14 @@ func (h *histogram) adjustCounts(
 				if countable {
 					maxDistRange -= h.buckets[i].DistinctRange
 
-					// Set the increment proportional to the remaining number of
-					// distinct values in the bucket.
+					// Set the increment proportional to the remaining number of distinct
+					// values in the bucket.
 					inc = remDistinctCount * (maxDistRange / maxDistinctCountRange)
+					// If the bucket has DistinctRange > maxDistRange (a rare but possible
+					// occurence, see #93892) then inc will be negative. Prevent this.
+					if inc < 0 {
+						inc = 0
+					}
 				}
 
 				h.buckets[i].NumRange += inc
@@ -573,11 +578,13 @@ func (h *histogram) addOuterBuckets(
 		maxDistRange, countable := maxDistinctRange(compareCtx, lowerBound, upperBound)
 
 		inc := avgRemPerBucket
-		if countable && colType.Family() == types.EnumFamily {
-			// Set the increment proportional to the remaining number of
-			// distinct values in the bucket. This only really matters for
-			// enums.
+		if countable {
+			// Set the increment proportional to the remaining number of distinct
+			// values in the bucket.
 			inc = remDistinctCount * (maxDistRange / maxDistinctCountExtraBuckets)
+			if inc < 0 {
+				inc = 0
+			}
 		}
 
 		h.buckets[i].NumRange += inc

--- a/pkg/sql/stats/histogram.go
+++ b/pkg/sql/stats/histogram.go
@@ -314,6 +314,7 @@ func (h *histogram) adjustCounts(
 			h.buckets[i].DistinctRange = 0
 			h.buckets[i].NumEq *= adjustmentFactorNumEq
 		}
+		h.clampNonNegative()
 		h.removeZeroBuckets()
 		return
 	}
@@ -412,7 +413,23 @@ func (h *histogram) adjustCounts(
 		h.buckets[i].NumEq *= adjustmentFactorRowCount
 	}
 
+	h.clampNonNegative()
 	h.removeZeroBuckets()
+}
+
+// clampNonNegative sets any negative counts to zero.
+func (h *histogram) clampNonNegative() {
+	for i := 0; i < len(h.buckets); i++ {
+		if h.buckets[i].NumEq < 0 {
+			h.buckets[i].NumEq = 0
+		}
+		if h.buckets[i].NumRange < 0 {
+			h.buckets[i].NumRange = 0
+		}
+		if h.buckets[i].DistinctRange < 0 {
+			h.buckets[i].DistinctRange = 0
+		}
+	}
 }
 
 // removeZeroBuckets removes any extra zero buckets if we don't need them
@@ -424,8 +441,8 @@ func (h *histogram) removeZeroBuckets() {
 
 	var j int
 	for i := 0; i < len(h.buckets); i++ {
-		if h.buckets[i].NumEq <= 0 && h.buckets[i].NumRange <= 0 &&
-			(i == len(h.buckets)-1 || h.buckets[i+1].NumRange <= 0) {
+		if h.buckets[i].NumEq == 0 && h.buckets[i].NumRange == 0 && h.buckets[i].DistinctRange == 0 &&
+			(i == len(h.buckets)-1 || h.buckets[i+1].NumRange == 0 && h.buckets[i+1].DistinctRange == 0) {
 			continue
 		}
 		if j != i {

--- a/pkg/sql/stats/histogram_test.go
+++ b/pkg/sql/stats/histogram_test.go
@@ -800,6 +800,20 @@ func TestAdjustCounts(t *testing.T) {
 				{NumRange: 5, NumEq: 1.67, DistinctRange: 2.25, UpperBound: d(15)},
 			},
 		},
+		{ // Clamp negative counts to zero.
+			h: []cat.HistogramBucket{
+				{NumRange: 0, NumEq: 100, DistinctRange: 0, UpperBound: d(-80)},
+				{NumRange: 100, NumEq: -1, DistinctRange: 8, UpperBound: d(-70)},
+				{NumRange: -1, NumEq: 100, DistinctRange: -1, UpperBound: d(-60)},
+			},
+			rowCount:      298,
+			distinctCount: 9,
+			expected: []cat.HistogramBucket{
+				{NumRange: 0, NumEq: 100, DistinctRange: 0, UpperBound: d(-80)},
+				{NumRange: 100, NumEq: 0, DistinctRange: 8, UpperBound: d(-70)},
+				{NumRange: 0, NumEq: 100, DistinctRange: 0, UpperBound: d(-60)},
+			},
+		},
 	}
 
 	evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())

--- a/pkg/sql/stats/histogram_test.go
+++ b/pkg/sql/stats/histogram_test.go
@@ -753,6 +753,53 @@ func TestAdjustCounts(t *testing.T) {
 			distinctCount: 0,
 			expected:      []cat.HistogramBucket{},
 		},
+		{ // Add outer buckets.
+			h: []cat.HistogramBucket{
+				{NumRange: 0, NumEq: 1, DistinctRange: 0, UpperBound: d(-2)},
+				{NumRange: 1, NumEq: 1, DistinctRange: 1, UpperBound: d(0)},
+				{NumRange: 1, NumEq: 1, DistinctRange: 1, UpperBound: d(2)},
+			},
+			rowCount:      18,
+			distinctCount: 9,
+			expected: []cat.HistogramBucket{
+				{NumRange: 0, NumEq: 0, DistinctRange: 0, UpperBound: d(-9223372036854775808)},
+				{NumRange: 4, NumEq: 2, DistinctRange: 2, UpperBound: d(-2)},
+				{NumRange: 2, NumEq: 2, DistinctRange: 1, UpperBound: d(0)},
+				{NumRange: 2, NumEq: 2, DistinctRange: 1, UpperBound: d(2)},
+				{NumRange: 4, NumEq: 0, DistinctRange: 2, UpperBound: d(9223372036854775807)},
+			},
+		},
+		{ // Add outer buckets but do not fill in range of first outer bucket (which
+			// is then removed for being redundant.)
+			h: []cat.HistogramBucket{
+				{NumRange: 0, NumEq: 1, DistinctRange: 0, UpperBound: d(-9223372036854775807)},
+				{NumRange: 1, NumEq: 1, DistinctRange: 1, UpperBound: d(-9223372036854775805)},
+				{NumRange: 1, NumEq: 1, DistinctRange: 1, UpperBound: d(-9223372036854775803)},
+			},
+			rowCount:      11,
+			distinctCount: 6,
+			expected: []cat.HistogramBucket{
+				{NumRange: 0, NumEq: 2, DistinctRange: 0, UpperBound: d(-9223372036854775807)},
+				{NumRange: 2, NumEq: 2, DistinctRange: 1.2, UpperBound: d(-9223372036854775805)},
+				{NumRange: 2, NumEq: 2, DistinctRange: 1.2, UpperBound: d(-9223372036854775803)},
+				{NumRange: 1, NumEq: 0, DistinctRange: 0.6, UpperBound: d(9223372036854775807)},
+			},
+		},
+		{ // Avoid adding negative NumRange for zero-range buckets with NumRange = 0
+			// and DistinctRange > 0 (see #93892).
+			h: []cat.HistogramBucket{
+				{NumRange: 0, NumEq: 1, DistinctRange: 0, UpperBound: d(10)},
+				{NumRange: 0, NumEq: 1, DistinctRange: 1, UpperBound: d(11)},
+				{NumRange: 1, NumEq: 1, DistinctRange: 1, UpperBound: d(15)},
+			},
+			rowCount:      10,
+			distinctCount: 6,
+			expected: []cat.HistogramBucket{
+				{NumRange: 0, NumEq: 1.67, DistinctRange: 0, UpperBound: d(10)},
+				{NumRange: 0, NumEq: 1.67, DistinctRange: 0.75, UpperBound: d(11)},
+				{NumRange: 5, NumEq: 1.67, DistinctRange: 2.25, UpperBound: d(15)},
+			},
+		},
 	}
 
 	evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())

--- a/pkg/sql/stats/quantile_test.go
+++ b/pkg/sql/stats/quantile_test.go
@@ -596,6 +596,9 @@ func (th testHistogram) toHistogram() histogram {
 	}
 	h := histogram{buckets: make([]cat.HistogramBucket, len(th))}
 	for i := range th {
+		// Unlike in TableStatistic.setHistogramBuckets and
+		// histogram.toHistogramData, we do not round here so that we can test the
+		// rounding behavior of those functions.
 		h.buckets[i].NumEq = th[i].NumEq
 		h.buckets[i].NumRange = th[i].NumRange
 		h.buckets[i].DistinctRange = th[i].DistinctRange

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -13,6 +13,7 @@ package stats
 import (
 	"context"
 	"fmt"
+	"math"
 	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
@@ -717,6 +718,12 @@ func (tabStat *TableStatistic) setHistogramBuckets(hist histogram) {
 			NumEq:      float64(tabStat.NullCount),
 			UpperBound: tree.DNull,
 		}}, tabStat.Histogram...)
+	}
+	// Round NumEq and NumRange, as if this had come from HistogramData. (We also
+	// round these counts in histogram.toHistogramData.)
+	for i := 0; i < len(tabStat.Histogram); i++ {
+		tabStat.Histogram[i].NumEq = math.Round(tabStat.Histogram[i].NumEq)
+		tabStat.Histogram[i].NumRange = math.Round(tabStat.Histogram[i].NumRange)
 	}
 }
 


### PR DESCRIPTION
**sql/stats: fix remaining-distinct increment in histogram.adjustCounts**

In both `stats.(*histogram).adjustCounts` and
`stats.(*histogram).addOuterBuckets` we have logic to spread remaining
distinct-count among the ranges of histogram buckets by incrementing
NumRange and DistinctRange in each bucket. For countable types (e.g.
integers, enums, etc.) this logic takes into account the maximum number
of distinct values in the range of the current bucket (`maxDistRange`).

This commit fixes two small bugs in this logic:
1. In `addOuterBuckets` we were not using `maxDistRange` for all
   countable types, only for enums, causing us to sometimes create
   buckets with positive NumRange and DistinctRange where they should
   have been zero, for example in the open range (-9223372036854775808,
   -9223372036854775807).
2. In `adjustCounts` we could have a negative increment for buckets with
   zero `maxDistRange` and positive `DistinctRange`, which sometimes
   happens due to (1). Issue #93892 is an example of this happening.

Fixes: #93892

Release note: None

**sql/stats: round counts in TableStatistic.setHistogramBuckets**

`stats.(*TableStatistic).setHistogramBuckets` is used by both statistics
forecasting and partial statistics merging to copy a generated histogram
into a TableStatistic as if it came from a decoded `HistogramData`. The
TableStatistic is then used directly by the optimizer.

We were missing something, though: even though histograms have float64
NumEq and NumRange, these are always rounded to integers to fit in
`HistogramData`. This commit also rounds these fields in
`setHistogramBuckets` to match.

This would have indirectly fixed #93892 by helping the optimizer ignore
a near-zero NumRange in the first bucket.

Release note: None

**sql/stats: defensively clamp negative counts in histograms to zero**

In rare cases at the end of `stats.(*histogram).adjustCounts` we could
have histogram buckets with negative counts. I don't think this is
possible any more, but this commit adds a defensive clamp to zero to
ensure that every histogram count is non-negative.

`removeZeroBuckets` sort of anticipated this, treating negative counts
as zero. Unfortunately this allowed #93892 to happen by removing a
bucket preceding a bucket with negative NumRange. This commit also
changes `removeZeroBuckets` to strictly look for zero counts.

Release note: None

**sql/stats: edit function comment for ForecastTableStatistics**

In #88508 I removed the 1-week horizon from statistics forecasting, but
forgot to remove it from the comment above `ForecastTableStatistics`.

Release note: None