### PR TITLE
release-22.2: sql: fall back to raw SQL for statement diagnostics bundle, and add errors.txt

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -472,6 +472,7 @@ func (ex *connExecutor) execStmtInOpenState(
 				ast,
 				sql,
 				res,
+				retPayload,
 				retErr,
 			)
 		}()

--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -126,6 +126,7 @@ func buildStatementBundle(
 	ctx context.Context,
 	db *kv.DB,
 	ie *InternalExecutor,
+	stmtRawSQL string,
 	plan *planTop,
 	planString string,
 	trace tracingpb.Recording,
@@ -134,7 +135,7 @@ func buildStatementBundle(
 	if plan == nil {
 		return diagnosticsBundle{collectionErr: errors.AssertionFailedf("execution terminated early")}
 	}
-	b := makeStmtBundleBuilder(db, ie, plan, trace, placeholders)
+	b := makeStmtBundleBuilder(db, ie, stmtRawSQL, plan, trace, placeholders)
 
 	b.addStatement()
 	b.addOptPlans()
@@ -187,6 +188,7 @@ type stmtBundleBuilder struct {
 	db *kv.DB
 	ie *InternalExecutor
 
+	stmt         string
 	plan         *planTop
 	trace        tracingpb.Recording
 	placeholders *tree.PlaceholderInfo
@@ -197,34 +199,43 @@ type stmtBundleBuilder struct {
 func makeStmtBundleBuilder(
 	db *kv.DB,
 	ie *InternalExecutor,
+	stmt string,
 	plan *planTop,
 	trace tracingpb.Recording,
 	placeholders *tree.PlaceholderInfo,
 ) stmtBundleBuilder {
-	b := stmtBundleBuilder{db: db, ie: ie, plan: plan, trace: trace, placeholders: placeholders}
+	b := stmtBundleBuilder{
+		db: db, ie: ie, stmt: stmt, plan: plan, trace: trace, placeholders: placeholders,
+	}
+	b.buildPrettyStatement()
 	b.z.Init()
 	return b
 }
 
-// addStatement adds the pretty-printed statement as file statement.txt.
-func (b *stmtBundleBuilder) addStatement() {
-	cfg := tree.DefaultPrettyCfg()
-	cfg.UseTabs = false
-	cfg.LineWidth = 100
-	cfg.TabWidth = 2
-	cfg.Simplify = true
-	cfg.Align = tree.PrettyNoAlign
-	cfg.JSONFmt = true
-	var output string
-	// If we hit an early error, stmt or stmt.AST might not be initialized yet.
-	switch {
-	case b.plan.stmt == nil:
-		output = "-- No Statement."
-	case b.plan.stmt.AST == nil:
-		output = "-- No AST."
-	default:
-		output = cfg.Pretty(b.plan.stmt.AST)
+// buildPrettyStatement saves the pretty-printed statement (without any
+// placeholder arguments).
+func (b *stmtBundleBuilder) buildPrettyStatement() {
+	// If we hit an early error, stmt or stmt.AST might not be initialized yet. In
+	// this case use the original statement SQL already in the stmtBundleBuilder.
+	if b.plan.stmt != nil && b.plan.stmt.AST != nil {
+		cfg := tree.DefaultPrettyCfg()
+		cfg.UseTabs = false
+		cfg.LineWidth = 100
+		cfg.TabWidth = 2
+		cfg.Simplify = true
+		cfg.Align = tree.PrettyNoAlign
+		cfg.JSONFmt = true
+		b.stmt = cfg.Pretty(b.plan.stmt.AST)
 	}
+	if b.stmt == "" {
+		b.stmt = "-- no statement"
+	}
+}
+
+// addStatement adds the pretty-printed statement in b.stmt as file
+// statement.txt.
+func (b *stmtBundleBuilder) addStatement() {
+	output := b.stmt
 
 	if b.placeholders != nil && len(b.placeholders.Values) != 0 {
 		var buf bytes.Buffer
@@ -324,25 +335,16 @@ func (b *stmtBundleBuilder) addTrace() {
 		b.z.AddFile("trace.json", traceJSONStr)
 	}
 
-	cfg := tree.DefaultPrettyCfg()
-	cfg.UseTabs = false
-	cfg.LineWidth = 100
-	cfg.TabWidth = 2
-	cfg.Simplify = true
-	cfg.Align = tree.PrettyNoAlign
-	cfg.JSONFmt = true
-	stmt := cfg.Pretty(b.plan.stmt.AST)
-
 	// The JSON is not very human-readable, so we include another format too.
-	b.z.AddFile("trace.txt", fmt.Sprintf("%s\n\n\n\n%s", stmt, b.trace.String()))
+	b.z.AddFile("trace.txt", fmt.Sprintf("%s\n\n\n\n%s", b.stmt, b.trace.String()))
 
 	// Note that we're going to include the non-anonymized statement in the trace.
 	// But then again, nothing in the trace is anonymized.
 	comment := fmt.Sprintf(`This is a trace for SQL statement: %s
 This trace can be imported into Jaeger for visualization. From the Jaeger Search screen, select the JSON File.
 Jaeger can be started using docker with: docker run -d --name jaeger -p 16686:16686 jaegertracing/all-in-one:1.17
-The UI can then be accessed at http://localhost:16686/search`, stmt)
-	jaegerJSON, err := b.trace.ToJaegerJSON(stmt, comment, "")
+The UI can then be accessed at http://localhost:16686/search`, b.stmt)
+	jaegerJSON, err := b.trace.ToJaegerJSON(b.stmt, comment, "")
 	if err != nil {
 		b.z.AddFile("trace-jaeger.txt", err.Error())
 	} else {

--- a/pkg/sql/explain_bundle_test.go
+++ b/pkg/sql/explain_bundle_test.go
@@ -98,7 +98,7 @@ CREATE TABLE s.a (a INT PRIMARY KEY);`)
 		// The bundle url is inside the error detail.
 		var pqErr *pq.Error
 		_ = errors.As(err, &pqErr)
-		checkBundle(t, fmt.Sprintf("%+v", pqErr.Detail), "", nil, base, plans, "distsql.html")
+		checkBundle(t, fmt.Sprintf("%+v", pqErr.Detail), "", nil, base, plans, "distsql.html errors.txt")
 	})
 
 	// #92920 Make sure schema and opt files are created.

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -391,9 +391,12 @@ func (ih *instrumentationHelper) Finish(
 			)
 			warnings = ob.GetWarnings()
 			bundle = buildStatementBundle(
-				ih.origCtx, cfg.DB, ie.(*InternalExecutor), &p.curPlan, ob.BuildString(), trace, placeholders,
+				ih.origCtx, cfg.DB, ie.(*InternalExecutor), stmtRawSQL, &p.curPlan, ob.BuildString(), trace,
+				placeholders,
 			)
-			bundle.insert(ctx, ih.fingerprint, ast, cfg.StmtDiagnosticsRecorder, ih.diagRequestID, ih.diagRequest)
+			bundle.insert(
+				ctx, ih.fingerprint, ast, cfg.StmtDiagnosticsRecorder, ih.diagRequestID, ih.diagRequest,
+			)
 			telemetry.Inc(sqltelemetry.StatementDiagnosticsCollectedCounter)
 		}
 		ih.stmtDiagnosticsRecorder.MaybeRemoveRequest(ih.diagRequestID, ih.diagRequest, execLatency)

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/stmtdiagnostics"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
+	"github.com/cockroachdb/cockroach/pkg/util/fsm"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
@@ -344,6 +345,7 @@ func (ih *instrumentationHelper) Finish(
 	ast tree.Statement,
 	stmtRawSQL string,
 	res RestrictedCommandResult,
+	retPayload fsm.EventPayload,
 	retErr error,
 ) error {
 	ctx := ih.origCtx
@@ -390,9 +392,13 @@ func (ih *instrumentationHelper) Finish(
 				queryLevelStats,
 			)
 			warnings = ob.GetWarnings()
+			var payloadErr error
+			if pwe, ok := retPayload.(payloadWithError); ok {
+				payloadErr = pwe.errorCause()
+			}
 			bundle = buildStatementBundle(
 				ih.origCtx, cfg.DB, ie.(*InternalExecutor), stmtRawSQL, &p.curPlan, ob.BuildString(), trace,
-				placeholders,
+				placeholders, res.Err(), payloadErr, retErr,
 			)
 			bundle.insert(
 				ctx, ih.fingerprint, ast, cfg.StmtDiagnosticsRecorder, ih.diagRequestID, ih.diagRequest,


### PR DESCRIPTION
Backport 2/2 commits from #94440.

/cc @cockroachdb/release

---

**sql: fall back to raw SQL for statement diagnostics bundle**

When gathering the statement for a statement diagnostics bundle, fall
back to using the raw SQL when we cannot pretty-print the statement AST,
which happens for statements that fail with certain errors.

(This also fixes a crash in addTrace, which was not handling these
error cases. It looks like this crash was partially fixed in #56768 but
not completely.)

Fixes: #94416 #56705

Epic: None

Release note (bug fix): Fix a crash that occurs on the gateway node when
collecting a statement diagnostics bundle (e.g. `EXPLAIN ANALYZE
(DEBUG)`) on a statement that fails with certain errors. This crash has
existed in various forms since the introduction of statement bundles in
v20.1.0.

**sql: add errors.txt to statement diagnostics bundles**

Add an errors.txt file to statement diagnostics bundles containing the
printed messages of various error objects.

Informs: #94416

Release note: None

---

Release justification: fix for high-severity bug in existing functionality.