### PR TITLE
cli,server: enable `cockroach` on permissionless cwd

### DIFF
--- a/pkg/base/store_spec.go
+++ b/pkg/base/store_spec.go
@@ -406,11 +406,7 @@ func NewStoreSpec(value string) (StoreSpec, error) {
 
 		switch field {
 		case pathField:
-			var err error
-			ss.Path, err = GetAbsoluteStorePath(pathField, value)
-			if err != nil {
-				return StoreSpec{}, err
-			}
+			ss.Path = value
 		case "size":
 			var err error
 			var minBytesAllowed int64 = MinimumStoreSize

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -1123,6 +1123,22 @@ func extraStoreFlagInit(cmd *cobra.Command) error {
 	if fs.Changed(cliflags.Store.Name) {
 		serverCfg.Stores = storeSpecs
 	}
+	// Convert all the store paths to absolute paths. We want this to
+	// ensure canonical directories across invocations; and also to
+	// benefit from the check in GetAbsoluteStorePath() that the user
+	// didn't mistakenly assume a heading '~' would get translated by
+	// CockroachDB. (The shell should be responsible for that.)
+	for i, ss := range serverCfg.Stores.Specs {
+		if ss.InMemory {
+			continue
+		}
+		absPath, err := base.GetAbsoluteStorePath("path", ss.Path)
+		if err != nil {
+			return err
+		}
+		ss.Path = absPath
+		serverCfg.Stores.Specs[i] = ss
+	}
 	return nil
 }
 

--- a/pkg/cli/interactive_tests/test_zero_directory.tcl
+++ b/pkg/cli/interactive_tests/test_zero_directory.tcl
@@ -1,0 +1,44 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+spawn /bin/bash
+send "PS1=':''/# '\r"
+eexpect ":/# "
+
+# Extract the absolute path of the crdb binary.
+send "b=\$(cd \$(dirname $argv) && pwd)\r"
+eexpect ":/# "
+# Ditto for the current directory.
+send "ppwd=\$PWD\r"
+eexpect ":/# "
+
+# Make a "zero directory": a directory without permissions.
+send "rm -rf zerodir && mkdir zerodir && cd zerodir\r"
+eexpect ":/# "
+system "chmod 0 zerodir"
+send "trap \"chmod +rwx \$ppwd/zerodir || true\" EXIT SIGHUP SIGINT\r"
+eexpect ":/# "
+
+
+start_test "Check that cockroach version works in a zero directory."
+send "\$b/\$(basename $argv) version\r"
+eexpect "Build Tag"
+eexpect "Platform"
+eexpect "Build Type"
+eexpect ":/# "
+end_test
+
+start_test "Check that a server can be started in a zero directory."
+send "\$b/\$(basename $argv) start-single-node --insecure --store=path=\$ppwd/logs/cockroach-data\r"
+eexpect "CockroachDB node starting"
+send "\003"
+eexpect "interrupted"
+eexpect ":/# "
+end_test
+
+# Clean up.
+send "cd \$ppwd && chmod +rwx zerodir && rm -rf zerodir\r"
+eexpect ":/# "
+send "exit\r"
+eexpect eof

--- a/pkg/cli/start_test.go
+++ b/pkg/cli/start_test.go
@@ -128,8 +128,12 @@ func TestStartArgChecking(t *testing.T) {
 	for i, c := range testCases {
 		// Reset the context and insecure flag for every test case.
 		err := f.Parse(c.args)
-		if !testutils.IsError(err, c.expected) {
-			t.Errorf("%d: expected %q, but found %v", i, c.expected, err)
+		var err2 error
+		if err == nil {
+			err2 = extraStoreFlagInit(startCmd)
+		}
+		if !testutils.IsError(err, c.expected) && !testutils.IsError(err2, c.expected) {
+			t.Errorf("%d: expected %q, but found %v / %v", i, c.expected, err, err2)
 		}
 	}
 }

--- a/pkg/geo/geos/geos.go
+++ b/pkg/geo/geos/geos.go
@@ -15,6 +15,7 @@
 package geos
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"path/filepath"
@@ -124,10 +125,6 @@ func findLibraryDirectories(flagLibraryDirectoryValue string, crdbBinaryLoc stri
 	// Try path by trying to find all parenting paths and appending
 	// `lib/libgeos_c.<ext>` to the current working directory, as well
 	// as the directory in which the cockroach binary is initialized.
-	cwd, err := os.Getwd()
-	if err != nil {
-		panic(err)
-	}
 	locs := []string{}
 	if flagLibraryDirectoryValue != "" {
 		locs = append(locs, flagLibraryDirectoryValue)
@@ -149,12 +146,18 @@ func findLibraryDirectories(flagLibraryDirectoryValue string, crdbBinaryLoc stri
 		}
 	}
 	locs = append(
-		append(
-			locs,
-			findLibraryDirectoriesInParentingDirectories(crdbBinaryLoc)...,
-		),
-		findLibraryDirectoriesInParentingDirectories(cwd)...,
+		locs,
+		findLibraryDirectoriesInParentingDirectories(crdbBinaryLoc)...,
 	)
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: cannot retrieve cwd: %v", err)
+	} else {
+		locs = append(
+			locs,
+			findLibraryDirectoriesInParentingDirectories(cwd)...,
+		)
+	}
 	return locs
 }
 


### PR DESCRIPTION
Fixes #28888.
Informs zd#15320.

Prior to this patch, running any `cockroach` subcommand on a permissionless cwd would fail in two ways:

- because the computation for the default store path was attempting to access cwd to compute an absolute path.
- because the GEOS initialization was trying to find the dynamically loadable module relative to cwd.

This patch changes the former to delay initialization of the configuration until an actual server command is executed; and the latter to tolerate a permissionless cwd.

Release note (bug fix): It is now possible to run `cockroach version` and `cockroach start` (and possibly other sub-commands) when the user running the command does not have permission to access the current working directory.