### PR TITLE
roachpb: use gogoproto-generated `RangeDescriptor.Equal()`

### DIFF
--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -11,7 +11,6 @@
 package roachpb
 
 import (
-	"bytes"
 	"fmt"
 	"sort"
 	"strconv"
@@ -143,44 +142,6 @@ func NewRangeDescriptor(rangeID RangeID, start, end RKey, replicas ReplicaSet) *
 	}
 	desc.SetReplicas(MakeReplicaSet(repls))
 	return desc
-}
-
-// Equal compares two descriptors for equality. This was copied over from the
-// gogoproto generated version in order to ignore deprecated fields.
-func (r *RangeDescriptor) Equal(other *RangeDescriptor) bool {
-	if other == nil {
-		return r == nil
-	}
-	if r == nil {
-		return false
-	}
-	if r.RangeID != other.RangeID {
-		return false
-	}
-	if r.Generation != other.Generation {
-		return false
-	}
-	if !bytes.Equal(r.StartKey, other.StartKey) {
-		return false
-	}
-	if !bytes.Equal(r.EndKey, other.EndKey) {
-		return false
-	}
-	if len(r.InternalReplicas) != len(other.InternalReplicas) {
-		return false
-	}
-	for i := range r.InternalReplicas {
-		if !r.InternalReplicas[i].Equal(&other.InternalReplicas[i]) {
-			return false
-		}
-	}
-	if r.NextReplicaID != other.NextReplicaID {
-		return false
-	}
-	if !r.StickyBit.Equal(other.StickyBit) {
-		return false
-	}
-	return true
 }
 
 // GetRangeID returns the RangeDescriptor's ID.

--- a/pkg/roachpb/metadata.proto
+++ b/pkg/roachpb/metadata.proto
@@ -161,20 +161,17 @@ message ReplicaIdent {
 // A range is described using an inclusive start key, a non-inclusive end key,
 // and a list of replicas where the range is stored.
 //
-// NOTE: Care must be taken when adding or removing fields from this proto
-// because we have code relies on the descriptor comparing Equal() after
-// round-tripping through a previous/next version node (i.e. in mixed-version
-// clusters). Note that we don't need to proto encoding to be stable since, when
-// doing CPuts we use the raw bytes we've read from the DB as the expected value
-// (instead of re-marshaling the proto), but unfortunately we also need the
-// Equal() method to work. Also note that we configure our protos to not
-// maintain unrecognized fields.
+// NOTE: Care must be taken when making changes to this proto because we have
+// code that relies on the descriptor comparing Equal() after round-tripping
+// through a previous/next version node (i.e. in mixed-version clusters). Note
+// that we don't need the proto encoding to be stable since, when doing CPuts we
+// use the raw bytes we've read from the DB as the expected value (instead of
+// re-marshaling the proto), but unfortunately we also need the Equal() method
+// to work. Also note that we configure our protos to not maintain unrecognized
+// fields.
 message RangeDescriptor {
   option (gogoproto.goproto_stringer) = false;
-  // We implement the Equal method by hand so that it can ignore deprecated
-  // fields. This can be reverted in 21.1 once the "previous version" no longer
-  // populates deprecated_generation_comparable.
-  option (gogoproto.equal) = false;
+  option (gogoproto.equal) = true;
   option (gogoproto.populate) = true;
 
   optional int64 range_id = 1 [(gogoproto.nullable) = false,


### PR DESCRIPTION
We previously had a custom `RangeDescriptor.Equal()` to maintain backwards compatibility with older versions. As of 22.2, this is no longer needed, and the custom variant was equivalent to the generated one. This patch therefore reverts to the generated variant.

Epic: none
Release note: None