### PR TITLE
cli/demo: fix the port allocation

### DIFF
--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -80,10 +80,6 @@ type transientCluster struct {
 	tenantServers []serverutils.TestTenantInterface
 	defaultDB     string
 
-	httpFirstPort int
-	sqlFirstPort  int
-	rpcFirstPort  int
-
 	adminPassword string
 	adminUser     username.SQLUsername
 
@@ -203,26 +199,6 @@ func NewDemoCluster(
 		if err := c.generateCerts(ctx, c.demoDir); err != nil {
 			return c, err
 		}
-	}
-
-	c.httpFirstPort = c.demoCtx.HTTPPort
-	c.sqlFirstPort = c.demoCtx.SQLPort
-	// +100 is the offset we've chosen to recommend to separate the SQL
-	// port from the RPC port when we deprecated the use of merged
-	// ports.
-	c.rpcFirstPort = c.demoCtx.SQLPort + 100
-	if c.demoCtx.Multitenant {
-		// This allows the first secondary tenant server to get the
-		// desired ports (i.e., those configured by --http-port or
-		// --sql-port, or the default) without conflicting with the system
-		// tenant.
-		// Note: this logic can be removed once we use a single
-		// listener for HTTP and SQL.
-		if c.demoCtx.DisableServerController {
-			c.httpFirstPort += c.demoCtx.NumNodes
-		}
-		c.sqlFirstPort += c.demoCtx.NumNodes
-		c.rpcFirstPort += c.demoCtx.NumNodes
 	}
 
 	c.stickyEngineRegistry = server.NewStickyInMemEnginesRegistry()
@@ -449,8 +425,8 @@ func (c *transientCluster) Start(ctx context.Context) (err error) {
 					args.SSLCertsDir = c.demoDir
 					args.DisableTLSForHTTP = true
 					args.EnableDemoLoginEndpoint = true
-					args.StartingRPCAndSQLPort = c.demoCtx.SQLPort - secondaryTenantID + i
-					args.StartingHTTPPort = c.demoCtx.HTTPPort - secondaryTenantID + i
+					args.StartingRPCAndSQLPort = c.demoCtx.sqlPort(i, true) - secondaryTenantID
+					args.StartingHTTPPort = c.demoCtx.httpPort(i, true) - secondaryTenantID
 					args.Locality = c.demoCtx.Localities[i]
 				}
 
@@ -586,9 +562,6 @@ func (c *transientCluster) createAndAddNode(
 	}
 	args := c.demoCtx.testServerArgsForTransientCluster(
 		c.sockForServer(idx), idx, joinAddr, c.demoDir,
-		c.sqlFirstPort,
-		c.rpcFirstPort,
-		c.httpFirstPort,
 		c.stickyEngineRegistry,
 	)
 	if idx == 0 {
@@ -795,6 +768,65 @@ func (c *transientCluster) waitForSQLReadiness(
 	return nil
 }
 
+func (demoCtx *Context) sqlPort(serverIdx int, forSecondaryTenant bool) int {
+	if demoCtx.SQLPort == 0 || testingForceRandomizeDemoPorts {
+		return 0
+	}
+	if !demoCtx.Multitenant {
+		// No multitenancy: just one port per node.
+		return demoCtx.SQLPort + serverIdx
+	}
+	if forSecondaryTenant {
+		// The port number of the secondary tenant is always
+		// the "base" port number.
+		return demoCtx.SQLPort + serverIdx
+	}
+	// System tenant.
+
+	// Currently using a separate SQL listener. System tenant uses port number
+	// offset by NumNodes.
+	return demoCtx.SQLPort + serverIdx + demoCtx.NumNodes
+}
+
+func (demoCtx *Context) httpPort(serverIdx int, forSecondaryTenant bool) int {
+	if demoCtx.HTTPPort == 0 || testingForceRandomizeDemoPorts {
+		return 0
+	}
+	if !demoCtx.Multitenant {
+		// No multitenancy: just one port per node.
+		return demoCtx.HTTPPort + serverIdx
+	}
+	if forSecondaryTenant {
+		// The port number of the secondary tenant is always
+		// the "base" port number.
+		return demoCtx.HTTPPort + serverIdx
+	}
+	// System tenant.
+	if !demoCtx.DisableServerController {
+		// Using server controller: same port for app and system tenant.
+		return demoCtx.HTTPPort + serverIdx
+	}
+	// Not using server controller: http port is offset by number of nodes.
+	return demoCtx.HTTPPort + serverIdx + demoCtx.NumNodes
+}
+
+func (demoCtx *Context) rpcPort(serverIdx int, forSecondaryTenant bool) int {
+	if demoCtx.SQLPort == 0 || testingForceRandomizeDemoPorts {
+		return 0
+	}
+	// +100 is the offset we've chosen to recommend to separate the SQL
+	// port from the RPC port when we deprecated the use of merged
+	// ports.
+	if !demoCtx.Multitenant {
+		return demoCtx.SQLPort + serverIdx + 100
+	}
+	if forSecondaryTenant {
+		return demoCtx.SQLPort + serverIdx + 100
+	}
+	// System tenant.
+	return demoCtx.SQLPort + serverIdx + demoCtx.NumNodes + 100
+}
+
 // testServerArgsForTransientCluster creates the test arguments for
 // a necessary server in the demo cluster.
 func (demoCtx *Context) testServerArgsForTransientCluster(
@@ -802,7 +834,6 @@ func (demoCtx *Context) testServerArgsForTransientCluster(
 	serverIdx int,
 	joinAddr string,
 	demoDir string,
-	sqlBasePort, rpcBasePort, httpBasePort int,
 	stickyEngineRegistry server.StickyInMemEnginesRegistry,
 ) base.TestServerArgs {
 	// Assign a path to the store spec, to be saved.
@@ -841,23 +872,10 @@ func (demoCtx *Context) testServerArgsForTransientCluster(
 	// `make stress`. This is bound to not work with fixed ports.
 	// So by default we use :0 to auto-allocate ports.
 	args.Addr = "127.0.0.1:0"
-	if !testingForceRandomizeDemoPorts {
-		sqlPort := sqlBasePort + serverIdx
-		if sqlBasePort == 0 {
-			sqlPort = 0
-		}
-		rpcPort := rpcBasePort + serverIdx
-		if rpcBasePort == 0 {
-			rpcPort = 0
-		}
-		httpPort := httpBasePort + serverIdx
-		if httpBasePort == 0 {
-			httpPort = 0
-		}
+	if sqlPort := demoCtx.sqlPort(serverIdx, false /* forSecondaryTenant */); sqlPort != 0 {
+		rpcPort := demoCtx.rpcPort(serverIdx, false)
 		args.Addr = fmt.Sprintf("127.0.0.1:%d", rpcPort)
 		args.SQLAddr = fmt.Sprintf("127.0.0.1:%d", sqlPort)
-		args.HTTPAddr = fmt.Sprintf("127.0.0.1:%d", httpPort)
-
 		if !demoCtx.DisableServerController {
 			// The code in NewDemoCluster put the KV ports higher
 			// so we need to subtract the number of nodes to get
@@ -866,6 +884,9 @@ func (demoCtx *Context) testServerArgsForTransientCluster(
 			// uses 1-based indexing for servers.
 			args.SecondaryTenantPortOffset = -(demoCtx.NumNodes + 1)
 		}
+	}
+	if httpPort := demoCtx.httpPort(serverIdx, false /* forSecondaryTenant */); httpPort != 0 {
+		args.HTTPAddr = fmt.Sprintf("127.0.0.1:%d", httpPort)
 	}
 
 	if demoCtx.Localities != nil {
@@ -1074,7 +1095,7 @@ func (c *transientCluster) startServerInternal(
 		c.sockForServer(serverIdx),
 		serverIdx,
 		c.firstServer.ServingRPCAddr(), c.demoDir,
-		c.sqlFirstPort, c.rpcFirstPort, c.httpFirstPort, c.stickyEngineRegistry)
+		c.stickyEngineRegistry)
 	s, err := server.TestServerFactory.New(args)
 	if err != nil {
 		return 0, err
@@ -1707,7 +1728,7 @@ func (c *transientCluster) sockForServer(serverIdx int) unixSocketDetails {
 	if !c.useSockets {
 		return unixSocketDetails{}
 	}
-	port := strconv.Itoa(c.sqlFirstPort + serverIdx)
+	port := strconv.Itoa(c.demoCtx.sqlPort(serverIdx, false))
 	databaseName := c.defaultDB
 	if c.demoCtx.Multitenant {
 		// TODO(knz): for now, we only define the unix socket for the

--- a/pkg/cli/democluster/demo_cluster_test.go
+++ b/pkg/cli/democluster/demo_cluster_test.go
@@ -71,7 +71,7 @@ func TestTestServerArgsForTransientCluster(t *testing.T) {
 				PartOfCluster:             true,
 				JoinAddr:                  "127.0.0.1",
 				DisableTLSForHTTP:         true,
-				Addr:                      "127.0.0.1:7890",
+				Addr:                      "127.0.0.1:1334",
 				SQLAddr:                   "127.0.0.1:1234",
 				HTTPAddr:                  "127.0.0.1:4567",
 				SecondaryTenantPortOffset: -2,
@@ -95,7 +95,7 @@ func TestTestServerArgsForTransientCluster(t *testing.T) {
 				DisableDefaultTestTenant:  true,
 				PartOfCluster:             true,
 				JoinAddr:                  "127.0.0.1",
-				Addr:                      "127.0.0.1:7892",
+				Addr:                      "127.0.0.1:1336",
 				SQLAddr:                   "127.0.0.1:1236",
 				HTTPAddr:                  "127.0.0.1:4569",
 				SecondaryTenantPortOffset: -2,
@@ -118,8 +118,9 @@ func TestTestServerArgsForTransientCluster(t *testing.T) {
 			demoCtx := newDemoCtx()
 			demoCtx.SQLPoolMemorySize = tc.sqlPoolMemorySize
 			demoCtx.CacheSize = tc.cacheSize
-
-			actual := demoCtx.testServerArgsForTransientCluster(unixSocketDetails{}, tc.serverIdx, tc.joinAddr, "", 1234, 7890, 4567, stickyEnginesRegistry)
+			demoCtx.SQLPort = 1234
+			demoCtx.HTTPPort = 4567
+			actual := demoCtx.testServerArgsForTransientCluster(unixSocketDetails{}, tc.serverIdx, tc.joinAddr, "", stickyEnginesRegistry)
 			stopper := actual.Stopper
 			defer stopper.Stop(context.Background())
 
@@ -259,8 +260,8 @@ func TestTransientClusterMultitenant(t *testing.T) {
 
 	// This test is too slow to complete under the race detector, sometimes.
 	skip.UnderRace(t)
-	skip.UnderStress(t)
-	skip.WithIssue(t, 94862)
+
+	defer TestingForceRandomizeDemoPorts()()
 
 	demoCtx := newDemoCtx()
 	// Set up an empty 3-node cluster with tenants on each node.

--- a/pkg/cli/interactive_tests/test_demo_networking.tcl
+++ b/pkg/cli/interactive_tests/test_demo_networking.tcl
@@ -1,0 +1,237 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+set ::env(COCKROACH_INSECURE) "false"
+
+start_test "Check that default demo has fixed ports, no multitenancy"
+spawn $argv demo --empty --no-line-editor --multitenant=false --nodes 2
+eexpect "Welcome"
+eexpect "defaultdb>"
+send "\\demo ls\r"
+
+eexpect "node 1"
+eexpect "(webui)"
+eexpect ":8080/demologin"
+eexpect "(sql)"
+eexpect ":26257"
+eexpect "(rpc)"
+eexpect ":26357"
+
+eexpect "node 2"
+eexpect "(webui)"
+eexpect ":8081/demologin"
+eexpect "(sql)"
+eexpect ":26258"
+eexpect "(rpc)"
+eexpect ":26358"
+
+eexpect "defaultdb>"
+send "\\q\r"
+eexpect eof
+end_test
+
+start_test "Check that http port can be randomized, no multitenancy"
+spawn $argv demo --empty --no-line-editor --multitenant=false --nodes 2 --http-port 0
+eexpect "Welcome"
+eexpect "defaultdb>"
+send "\\demo ls\r"
+
+eexpect "node 1"
+eexpect "(webui)"
+eexpect "(sql)"
+eexpect ":26257"
+eexpect "(rpc)"
+eexpect ":26357"
+
+eexpect "node 2"
+eexpect "(webui)"
+eexpect "(sql)"
+eexpect ":26258"
+eexpect "(rpc)"
+eexpect ":26358"
+
+eexpect "defaultdb>"
+send "\\q\r"
+eexpect eof
+end_test
+
+start_test "Check that sql port can be randomized, no multitenancy"
+spawn $argv demo --empty --no-line-editor --multitenant=false --nodes 2 --sql-port 0
+eexpect "Welcome"
+eexpect "defaultdb>"
+send "\\demo ls\r"
+
+eexpect "node 1"
+eexpect "(webui)"
+eexpect ":8080/demologin"
+eexpect "(sql)"
+eexpect "(rpc)"
+
+eexpect "node 2"
+eexpect "(webui)"
+eexpect ":8081/demologin"
+eexpect "(sql)"
+eexpect "(rpc)"
+
+eexpect "defaultdb>"
+send "\\q\r"
+eexpect eof
+end_test
+
+start_test "Check that sql and http port can be randomized, no multitenancy"
+spawn $argv demo --empty --no-line-editor --multitenant=false --nodes 2 --sql-port 0 --http-port 0
+eexpect "Welcome"
+eexpect "defaultdb>"
+send "\\demo ls\r"
+
+eexpect "node 1"
+eexpect "(webui)"
+eexpect "(sql)"
+eexpect "(rpc)"
+
+eexpect "node 2"
+eexpect "(webui)"
+eexpect "(sql)"
+eexpect "(rpc)"
+
+eexpect "defaultdb>"
+send "\\q\r"
+eexpect eof
+end_test
+
+start_test "Check that default demo has fixed ports, w/ multitenancy"
+spawn $argv demo --empty --no-line-editor --multitenant=true --nodes 2
+eexpect "Welcome"
+eexpect "defaultdb>"
+send "\\demo ls\r"
+
+eexpect "node 1"
+eexpect "(webui)"
+eexpect ":8080/demologin"
+# app tenant
+eexpect "(sql)"
+eexpect ":26257"
+eexpect "(rpc)"
+eexpect ":26257"
+# system tenant
+eexpect "(sql)"
+eexpect ":26259"
+eexpect "(rpc)"
+eexpect ":26359"
+
+eexpect "node 2"
+eexpect "(webui)"
+eexpect ":8081/demologin"
+# app tenant
+eexpect "(sql)"
+eexpect ":26258"
+eexpect "(rpc)"
+eexpect ":26258"
+# system tenant
+eexpect "(sql)"
+eexpect ":26260"
+eexpect "(rpc)"
+eexpect ":26360"
+
+eexpect "defaultdb>"
+send "\\q\r"
+eexpect eof
+end_test
+
+start_test "Check that http port can be randomized, w/ multitenancy"
+spawn $argv demo --empty --no-line-editor --multitenant=true --nodes 2 --http-port 0
+eexpect "Welcome"
+eexpect "defaultdb>"
+send "\\demo ls\r"
+
+eexpect "node 1"
+eexpect "(webui)"
+# app tenant
+eexpect "(sql)"
+eexpect ":26257"
+eexpect "(rpc)"
+eexpect ":26257"
+# system tenant
+eexpect "(sql)"
+eexpect ":26259"
+eexpect "(rpc)"
+eexpect ":26359"
+
+eexpect "node 2"
+eexpect "(webui)"
+# app tenant
+eexpect "(sql)"
+eexpect ":26258"
+eexpect "(rpc)"
+eexpect ":26258"
+# system tenant
+eexpect "(sql)"
+eexpect ":26260"
+eexpect "(rpc)"
+eexpect ":26360"
+
+eexpect "defaultdb>"
+send "\\q\r"
+eexpect eof
+end_test
+
+start_test "Check that sql port can be randomized, w/ multitenancy"
+spawn $argv demo --empty --no-line-editor --multitenant=true --nodes 2 --sql-port 0
+eexpect "Welcome"
+eexpect "defaultdb>"
+send "\\demo ls\r"
+
+eexpect "node 1"
+eexpect "(webui)"
+eexpect ":8080/demologin"
+# app tenant
+eexpect "(sql)"
+eexpect "(rpc)"
+# system tenant
+eexpect "(sql)"
+eexpect "(rpc)"
+
+eexpect "node 2"
+eexpect "(webui)"
+eexpect ":8081/demologin"
+# app tenant
+eexpect "(sql)"
+eexpect "(rpc)"
+# system tenant
+eexpect "(sql)"
+eexpect "(rpc)"
+
+eexpect "defaultdb>"
+send "\\q\r"
+eexpect eof
+end_test
+
+start_test "Check that sql and http port can be randomized, w/ multitenancy"
+spawn $argv demo --empty --no-line-editor --multitenant=true --nodes 2 --sql-port 0 --http-port 0
+eexpect "Welcome"
+eexpect "defaultdb>"
+send "\\demo ls\r"
+
+eexpect "node 1"
+eexpect "(webui)"
+# app tenant
+eexpect "(sql)"
+eexpect "(rpc)"
+# system tenant
+eexpect "(sql)"
+eexpect "(rpc)"
+
+eexpect "node 2"
+eexpect "(webui)"
+# app tenant
+eexpect "(sql)"
+eexpect "(rpc)"
+# system tenant
+eexpect "(sql)"
+eexpect "(rpc)"
+
+eexpect "defaultdb>"
+send "\\q\r"
+eexpect eof
+end_test

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -929,6 +929,7 @@ func (ts *TestServer) StartTenant(
 		baseCfg.SSLCertsDir = params.SSLCertsDir
 	}
 	if params.StartingRPCAndSQLPort > 0 {
+		log.Infof(ctx, "computing tenant server sql/rpc addr from %d", params.StartingRPCAndSQLPort)
 		baseCfg.SplitListenSQL = false
 		addr, _, err := addrutil.SplitHostPort(baseCfg.Addr, strconv.Itoa(params.StartingRPCAndSQLPort))
 		if err != nil {
@@ -941,6 +942,7 @@ func (ts *TestServer) StartTenant(
 		baseCfg.SQLAdvertiseAddr = newAddr
 	}
 	if params.StartingHTTPPort > 0 {
+		log.Infof(ctx, "computing tenant server http addr from %d", params.StartingHTTPPort)
 		addr, _, err := addrutil.SplitHostPort(baseCfg.HTTPAddr, strconv.Itoa(params.StartingHTTPPort))
 		if err != nil {
 			return nil, err
@@ -950,6 +952,11 @@ func (ts *TestServer) StartTenant(
 		baseCfg.HTTPAdvertiseAddr = newAddr
 	}
 
+	log.Infof(ctx, "tenant server configuration (no controller): rpc %v/%v sql %v/%v http %v/%v",
+		baseCfg.Addr, baseCfg.AdvertiseAddr,
+		baseCfg.SQLAddr, baseCfg.SQLAdvertiseAddr,
+		baseCfg.HTTPAddr, baseCfg.HTTPAdvertiseAddr,
+	)
 	sw, err := NewTenantServer(
 		ctx,
 		stopper,


### PR DESCRIPTION
Fixes #94862.

Prior to this patch, we were unconditionally applying a port offset for secondary tenant servers, even when the port allocation for the KV node was randomized. This resulted in the demo cluster trying to reuse arbitrary TCP ports which may be already in use elsewhere in the system.

This patch fixes it by ensuring that tenant servers also use random allocation when the KV node ports were randomly allocated in the first place.

It also adds demo networking tests that verify this via the `--sql-port` / `--http-port` flags.

Release note: None