### PR TITLE
sql/logic: deflake upsert test for `generated as identity` column

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -1345,12 +1345,31 @@ ORDER BY a
 statement ok
 INSERT INTO generated_as_id_t (a) VALUES (1) ON CONFLICT (a) DO UPDATE SET b=DEFAULT;
 
-query III rowsort
-SELECT * FROM generated_as_id_t ORDER BY a
+# `SELECT * FROM generated_as_id_t` now should give
+# 1  5  1
+# 2  2  2
+# 3  3  3
+# Do this fancy query to deal with the fact that transaction restarts on the
+# insert may change the sequence values used for columns b and c. This query
+# just ensures that they have the expected offset from each other.
+
+query III
+  SELECT a,
+         b - b_row2 AS b,
+         c - c_row2 AS c
+    FROM generated_as_id_t,
+         (
+              SELECT b AS b_row2,
+                     c AS c_row2
+                FROM generated_as_id_t
+            ORDER BY b
+               LIMIT 1
+         )
+ORDER BY a
 ----
-1  5  1
-2  2  2
-3  3  3
+1  3  -1
+2  0  0
+3  1  1
 
 subtest explicit_arbiter_indexes
 


### PR DESCRIPTION
See [this flake in teamcity.](https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_UnitTests_BazelUnitTests/8230155?showRootCauses=true&expandBuildChangesSection=true&expandBuildProblemsSection=true&expandBuildTestsSection=true)

fixes #93297

Epic: none

Release note: None