### PR TITLE
pgwire: accept the client-provided username during mappings

### DIFF
--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -340,7 +340,11 @@ func (c *conn) serveImpl(
 	logAuthn := !inTestWithoutSQL && c.authLogEnabled()
 
 	// We'll build an authPipe to communicate with the authentication process.
-	authPipe := newAuthPipe(c, logAuthn, authOpt, c.sessionArgs.User)
+	systemIdentity := c.sessionArgs.SystemIdentity
+	if systemIdentity.Undefined() {
+		systemIdentity = c.sessionArgs.User
+	}
+	authPipe := newAuthPipe(c, logAuthn, authOpt, systemIdentity)
 	var authenticator authenticatorIO = authPipe
 
 	// procCh is the channel on which we'll receive the termination signal from

--- a/pkg/sql/pgwire/conn_test.go
+++ b/pkg/sql/pgwire/conn_test.go
@@ -576,7 +576,8 @@ func getSessionArgs(
 		}
 
 		ctx := context.Background()
-		cp, err := parseClientProvidedSessionParameters(ctx, &buf, conn.RemoteAddr(), trustRemoteAddr, false /* acceptTenantName */)
+		cp, err := parseClientProvidedSessionParameters(ctx, &buf, conn.RemoteAddr(), trustRemoteAddr,
+			false /* acceptTenantName */, false /* acceptSystemIdentityOption */)
 		if err != nil {
 			return conn, sql.SessionArgs{}, err
 		}

--- a/pkg/sql/pgwire/pre_serve.go
+++ b/pkg/sql/pgwire/pre_serve.go
@@ -112,6 +112,10 @@ type PreServeConnHandler struct {
 	// special hba.conf directive?)
 	trustClientProvidedRemoteAddr syncutil.AtomicBool
 
+	// acceptSystemIdentityOption determines whether the system_identity
+	// option will be read from the client. This is used in tests.
+	acceptSystemIdentityOption syncutil.AtomicBool
+
 	// acceptTenantName determines whether this pre-serve handler will
 	// interpret a tenant name specification in the connection
 	// parameters.
@@ -375,7 +379,7 @@ func (s *PreServeConnHandler) PreServe(
 
 	// Load the client-provided session parameters.
 	st.clientParameters, err = parseClientProvidedSessionParameters(
-		ctx, &buf, conn.RemoteAddr(), s.trustClientProvidedRemoteAddr.Get(), s.acceptTenantName)
+		ctx, &buf, conn.RemoteAddr(), s.trustClientProvidedRemoteAddr.Get(), s.acceptTenantName, s.acceptSystemIdentityOption.Get())
 	if err != nil {
 		st.Reserved.Close(ctx)
 		return conn, st, s.sendErr(ctx, conn, err)

--- a/pkg/sql/pgwire/testdata/auth/identity_map
+++ b/pkg/sql/pgwire/testdata/auth/identity_map
@@ -21,7 +21,7 @@ host   all      all  all     cert-password map=testing
 set_identity_map
 testing testuser carl               # Exact remapping
 testing /(.*)@cockroachlabs.com \1  # Generalized domain mapping
-testing testuser another_carl       # Verify first-one-wins
+testing testuser another_carl       # Another candidate mapping
 testing will_be_carl carl           # Another user for password testing
 testing testuser2 carl              # Cert that doesn't correspond to a db user
 testing testuser@example.com carl   # Cert with a non-SQL principal baked in
@@ -39,7 +39,7 @@ host   all      all  all     cert-password map=testing
 # Original configuration:
 # testing testuser carl               # Exact remapping
 # testing /(.*)@cockroachlabs.com \1  # Generalized domain mapping
-# testing testuser another_carl       # Verify first-one-wins
+# testing testuser another_carl       # Another candidate mapping
 # testing will_be_carl carl           # Another user for password testing
 # testing testuser2 carl              # Cert that doesn't correspond to a db user
 # testing testuser@example.com carl   # Cert with a non-SQL principal baked in
@@ -127,7 +127,7 @@ subtest end
 # Connect as the magic "testuser" since that comes pre-equipped with a cert.
 subtest certificate_good
 
-connect user=testuser database=mydb
+connect user=carl database=mydb system_identity=testuser
 ----
 ok mydb
 
@@ -149,7 +149,7 @@ subtest end
 # database username.
 subtest cert_with_principal_not_in_users
 
-connect user=testuser2 database=mydb force_certs show_system_identity
+connect system_identity=testuser2 user=carl database=mydb force_certs show_system_identity
 ----
 ok mydb testuser2
 


### PR DESCRIPTION
Fixes #93637.
cc @andy-dulson.

The initial implementation of the `pg_ident` compatibility code was mistakenly assuming that the result of mapping the system identity should always overwrite/replace the client-provided username.

This was incorrect. As per
https://www.postgresql.org/docs/15/auth-username-maps.html

> There is no restriction regarding how many database users a given
> operating system user can correspond to, nor vice versa. Thus, entries
> in a map should be thought of as meaning “this operating system user
> is allowed to connect as this database user”, rather than implying
> that they are equivalent. The connection will be allowed **if there is
> any map entry that pairs the user name obtained from the external
> authentication system with the database user name that the user has
> requested to connect as.**

Release note (bug fix): when using identity maps (via
`server.identity_map.configuration`), authentication now correctly
verifies that the client-provided username matches at least one of the
mappings for the system identity. Previously, the client-provided
username was incorrectly ignored and authentication could fail if the
first candidate mapping did not result in a valid DB username.

Release note (backward-incompatible change): There was a bug
whereby, when `server.identity_map.configuration` was used,
CockroachDB did not verify the client-provided username against
the target mappings. This bug was fixed; however,
**this also means that the client must now provide a valid DB
username.** This requirement is compatible with PostgreSQL; it was not
previously required by CockroachDB but it is now.

(This note does not apply when identity maps are not in use.)