### PR TITLE
c2c: fix roachtest typo

### DIFF
--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -374,6 +374,7 @@ func registerClusterToCluster(r registry.Registry) {
 			cutover:            5 * time.Minute,
 		},
 	} {
+		sp := sp
 		clusterOps := make([]spec.Option, 0)
 		clusterOps = append(clusterOps, spec.CPU(sp.cpus))
 		if sp.pdSize != 0 {


### PR DESCRIPTION
This patch fixes a bug where the TestSpec.Run closure captured incorrect test specs, resulting in  the c2c/tpcc test using the c2c/kv0 test specs.

Release note: None

Epic: None