### PR TITLE
release-22.2: server: refactor database index recommendations for DatabaseDetails API

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -550,12 +550,12 @@ func (s *adminServer) databaseDetailsHelper(
 		if err != nil {
 			return nil, err
 		}
-		resp.Stats.NumIndexRecommendations, err = s.getNumDatabaseIndexRecommendations(ctx, req.Database, resp.TableNames)
+		dbIndexRecommendations, err := getDatabaseIndexRecommendations(ctx, req.Database, s.ie, s.st, s.server.sqlServer.execCfg)
 		if err != nil {
 			return nil, err
 		}
+		resp.Stats.NumIndexRecommendations = int32(len(dbIndexRecommendations))
 	}
-
 	return &resp, nil
 }
 
@@ -666,25 +666,6 @@ func (s *adminServer) getDatabaseStats(
 	})
 
 	return &stats, nil
-}
-
-func (s *adminServer) getNumDatabaseIndexRecommendations(
-	ctx context.Context, databaseName string, tableNames []string,
-) (int32, error) {
-	var numDatabaseIndexRecommendations int
-	idxUsageStatsProvider := s.server.sqlServer.pgServer.SQLServer.GetLocalIndexStatistics()
-	for _, tableName := range tableNames {
-		tableIndexStatsRequest := &serverpb.TableIndexStatsRequest{
-			Database: databaseName,
-			Table:    tableName,
-		}
-		tableIndexStatsResponse, err := getTableIndexUsageStats(ctx, tableIndexStatsRequest, idxUsageStatsProvider, s.ie, s.server.st, s.server.sqlServer.execCfg)
-		if err != nil {
-			return 0, err
-		}
-		numDatabaseIndexRecommendations += len(tableIndexStatsResponse.IndexRecommendations)
-	}
-	return int32(numDatabaseIndexRecommendations), nil
 }
 
 // getFullyQualifiedTableName, given a database name and a tableName that either

--- a/pkg/server/index_usage_stats.go
+++ b/pkg/server/index_usage_stats.go
@@ -12,6 +12,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -20,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/idxusage"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/errors"
@@ -242,9 +244,6 @@ func getTableIndexUsageStats(
  		WHERE ti.descriptor_id = $::REGCLASS`,
 		tableID,
 	)
-
-	const expectedNumDatums = 7
-
 	it, err := ie.QueryIteratorEx(ctx, "index-usage-stats", nil,
 		sessiondata.InternalExecutorOverride{
 			User:     userName,
@@ -264,14 +263,7 @@ func getTableIndexUsageStats(
 	defer func() { err = errors.CombineErrors(err, it.Close()) }()
 
 	for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
-		var row tree.Datums
-		if row = it.Cur(); row == nil {
-			return nil, errors.New("unexpected null row")
-		}
-
-		if row.Len() != expectedNumDatums {
-			return nil, errors.Newf("expected %d columns, received %d", expectedNumDatums, row.Len())
-		}
+		row := it.Cur()
 
 		indexID := tree.MustBeDInt(row[0])
 		indexName := tree.MustBeDString(row[1])
@@ -310,7 +302,11 @@ func getTableIndexUsageStats(
 		}
 
 		statsRow := idxusage.IndexStatsRow{
-			Row:              idxStatsRow,
+			TableID:          idxStatsRow.Statistics.Key.TableID,
+			IndexID:          idxStatsRow.Statistics.Key.IndexID,
+			CreatedAt:        idxStatsRow.CreatedAt,
+			LastRead:         idxStatsRow.Statistics.Stats.LastRead,
+			IndexType:        idxStatsRow.IndexType,
 			UnusedIndexKnobs: execConfig.UnusedIndexRecommendationsKnobs,
 		}
 		recommendations := statsRow.GetRecommendationsFromIndexStats(req.Database, st)
@@ -358,4 +354,84 @@ func getTableIDFromDatabaseAndTableName(
 	}
 	tableID := tree.MustBeDOid(row[0]).Oid
 	return int(tableID), nil
+}
+
+func getDatabaseIndexRecommendations(
+	ctx context.Context,
+	dbName string,
+	ie *sql.InternalExecutor,
+	st *cluster.Settings,
+	execConfig *sql.ExecutorConfig,
+) ([]*serverpb.IndexRecommendation, error) {
+
+	// Omit fetching index recommendations for the 'system' database.
+	if dbName == catconstants.SystemDatabaseName {
+		return []*serverpb.IndexRecommendation{}, nil
+	}
+
+	userName, err := userFromContext(ctx)
+	if err != nil {
+		return []*serverpb.IndexRecommendation{}, err
+	}
+
+	query := fmt.Sprintf(`
+		SELECT
+			ti.descriptor_id as table_id,
+			ti.index_id,
+			ti.index_type,
+			last_read,
+			ti.created_at
+		FROM %[1]s.crdb_internal.index_usage_statistics AS us
+		 JOIN %[1]s.crdb_internal.table_indexes AS ti ON (us.index_id = ti.index_id AND us.table_id = ti.descriptor_id AND index_type = 'secondary')
+		 JOIN %[1]s.crdb_internal.tables AS t ON (ti.descriptor_id = t.table_id AND t.database_name != 'system');`, dbName)
+
+	it, err := ie.QueryIteratorEx(ctx, "db-index-recommendations", nil,
+		sessiondata.InternalExecutorOverride{
+			User:     userName,
+			Database: dbName,
+		}, query)
+
+	if err != nil {
+		return []*serverpb.IndexRecommendation{}, err
+	}
+
+	// We have to make sure to close the iterator since we might return from the
+	// for loop early (before Next() returns false).
+	defer func() { err = errors.CombineErrors(err, it.Close()) }()
+
+	var ok bool
+	var idxRecommendations []*serverpb.IndexRecommendation
+
+	for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
+		row := it.Cur()
+
+		tableID := tree.MustBeDInt(row[0])
+		indexID := tree.MustBeDInt(row[1])
+		indexType := tree.MustBeDString(row[2])
+		lastRead := time.Time{}
+		if row[3] != tree.DNull {
+			lastRead = tree.MustBeDTimestampTZ(row[3]).Time
+		}
+		var createdAt *time.Time
+		if row[4] != tree.DNull {
+			ts := tree.MustBeDTimestamp(row[4])
+			createdAt = &ts.Time
+		}
+
+		if err != nil {
+			return []*serverpb.IndexRecommendation{}, err
+		}
+
+		statsRow := idxusage.IndexStatsRow{
+			TableID:          roachpb.TableID(tableID),
+			IndexID:          roachpb.IndexID(indexID),
+			CreatedAt:        createdAt,
+			LastRead:         lastRead,
+			IndexType:        string(indexType),
+			UnusedIndexKnobs: execConfig.UnusedIndexRecommendationsKnobs,
+		}
+		recommendations := statsRow.GetRecommendationsFromIndexStats(dbName, st)
+		idxRecommendations = append(idxRecommendations, recommendations...)
+	}
+	return idxRecommendations, nil
 }

--- a/pkg/sql/idxusage/BUILD.bazel
+++ b/pkg/sql/idxusage/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/server/serverpb",
         "//pkg/settings",
         "//pkg/settings/cluster",
+        "//pkg/sql/sem/catconstants",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",


### PR DESCRIPTION
Backport 1/1 commits from #93937.

/cc @cockroachdb/release

---

Resolves: https://github.com/cockroachdb/cockroach/issues/93909

Previously, the DatabaseDetails API would fetch the index recommendations of the database by executing an expensive query for **each table of the database**, then coalesce the results of each table to get the database-level result. This was needlessly expensive and impractical, particularly so for large schemas. This change ensures that only a single query is executed **per database** to fetch its index recommendations.

-----

**SHORT DEMOS**
Short demos of the change in latency before/after running `demo` on db-console. Notably, `movr` is the only database that we check for index recommendations.

**Before**
https://www.loom.com/share/fc7ca49e4f9c46738831c23742112069

**After**
https://www.loom.com/share/be6e4711ca1d43409774995dece0673b

Noted Improvements:
- The latency on fetching stats for `movr` improves from ~250ms to ~60ms
- Not shown in the videos above but the number of query calls improves from 45 to 4.

Release note (performance improvement): Refactored the query logic when fetching database index recommendations for the DatabaseDetails API endpoint, greatly reducing the query time and cost, particularly for large schemas.

Release justification: Category 4: Low risk, high reward changes to existing functionality 