### PR TITLE
logictest: unskip mixed version tests for ARM builds

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1822,9 +1822,6 @@ func (t *logicTest) setup(
 		if !bazel.BuiltWithBazel() {
 			skip.IgnoreLint(t.t(), "cockroach-go/testserver can only be uzed in bazel builds")
 		}
-		if runtime.GOARCH == "arm64" {
-			skip.IgnoreLint(t.t(), "Skip under ARM64. See https://github.com/cockroachdb/cockroach/issues/94658")
-		}
 		if cfg.NumNodes != 3 {
 			t.Fatal("cockroach-go testserver tests must use 3 nodes")
 		}


### PR DESCRIPTION
The arm builds now use the expected tarball name format and can be used in these tests.

This reverts commit df505daf1419968ed054d30f19f602101ebcb407.
Fixes: #94658
Epic: none
Release note: None