### PR TITLE
codeowners: mark `pkg/sql/sqlstats` as owned by SQL O11y

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -61,6 +61,7 @@
 
 /pkg/sql/execstats/          @cockroachdb/sql-observability
 /pkg/sql/scheduledlogging/   @cockroachdb/sql-observability
+/pkg/sql/sqlstats/           @cockroachdb/sql-observability
 
 /pkg/sql/sem/tree/           @cockroachdb/sql-syntax-prs
 /pkg/sql/parser/             @cockroachdb/sql-syntax-prs


### PR DESCRIPTION
Informs: #94880.

Epic: None

Release note: None