### PR TITLE
kvserver: add overfull no rebalance options metric

### DIFF
--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -44,18 +44,27 @@ var (
 		Measurement: "Range Rebalances",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaStoreRebalancerImbalancedOverfullOptionsExhausted = metric.Metadata{
+		Name: "rebalancing.state.imbalanced_overfull_options_exhausted",
+		Help: "Number of occurrences where this store was overfull but failed to " +
+			"shed load after exhausting available rebalance options",
+		Measurement: "Overfull Options Exhausted",
+		Unit:        metric.Unit_COUNT,
+	}
 )
 
 // StoreRebalancerMetrics is the set of metrics for the store-level rebalancer.
 type StoreRebalancerMetrics struct {
-	LeaseTransferCount  *metric.Counter
-	RangeRebalanceCount *metric.Counter
+	LeaseTransferCount                      *metric.Counter
+	RangeRebalanceCount                     *metric.Counter
+	ImbalancedStateOverfullOptionsExhausted *metric.Counter
 }
 
 func makeStoreRebalancerMetrics() StoreRebalancerMetrics {
 	return StoreRebalancerMetrics{
-		LeaseTransferCount:  metric.NewCounter(metaStoreRebalancerLeaseTransferCount),
-		RangeRebalanceCount: metric.NewCounter(metaStoreRebalancerRangeRebalanceCount),
+		LeaseTransferCount:                      metric.NewCounter(metaStoreRebalancerLeaseTransferCount),
+		RangeRebalanceCount:                     metric.NewCounter(metaStoreRebalancerRangeRebalanceCount),
+		ImbalancedStateOverfullOptionsExhausted: metric.NewCounter(metaStoreRebalancerImbalancedOverfullOptionsExhausted),
 	}
 }
 
@@ -558,6 +567,7 @@ func (sr *StoreRebalancer) TransferToRebalanceRanges(
 		log.KvDistribution.Infof(ctx,
 			"ran out of leases worth transferring and load %s is still above desired threshold %s",
 			rctx.LocalDesc.Capacity.Load(), rctx.maxThresholds)
+		sr.metrics.ImbalancedStateOverfullOptionsExhausted.Inc(1)
 		return false
 	}
 
@@ -579,6 +589,7 @@ func (sr *StoreRebalancer) LogRangeRebalanceOutcome(ctx context.Context, rctx *R
 		log.KvDistribution.Infof(ctx,
 			"ran out of replicas worth transferring and load %s is still above desired threshold %s; will check again soon",
 			rctx.LocalDesc.Capacity.Load(), rctx.maxThresholds)
+		sr.metrics.ImbalancedStateOverfullOptionsExhausted.Inc(1)
 	}
 
 	// We successfully rebalanced below or equal to the max threshold,

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -674,6 +674,17 @@ var charts = []sectionDescription{
 		},
 		Charts: []chartDescription{
 			{
+				Title:   "Rebalancing Exhausted Options",
+				Metrics: []string{"rebalancing.state.imbalanced_overfull_options_exhausted"},
+			},
+		},
+	},
+	{
+		Organization: [][]string{
+			{DistributionLayer, "Rebalancing"},
+		},
+		Charts: []chartDescription{
+			{
 				Title:   "QPS",
 				Metrics: []string{"rebalancing.queriespersecond"},
 			},


### PR DESCRIPTION
Previously, there was no metric indication that a store was unable to
reduces its load below a balance threshold due to exhausing potential
rebalance actions. This metric is desirable to determine when the action
space needs to be increased (by splitting etc) to balance load.

This patch adds this metric:

`rebalancing.rebalancing.state.imbalanced_overfull_options_exhausted`

Which maintains a counter, incremented each time the a store's
rebalancer is unable to reduce the load on the store below the overfull
threshold due to running out of available rebalance actions.

Part of: https://github.com/cockroachdb/cockroach/issues/90582

Release note: None