### PR TITLE
kvserver: don't load uninitialized replicas

### DIFF
--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -251,7 +251,8 @@ type Replica struct {
 		// Note that there are two StateLoaders, in raftMu and mu,
 		// depending on which lock is being held.
 		stateLoader stateloader.StateLoader
-		// on-disk storage for sideloaded SSTables. nil when there's no ReplicaID.
+		// on-disk storage for sideloaded SSTables. Always non-nil.
+		// TODO(pavelkalinnikov): remove sideloaded == nil checks.
 		sideloaded logstore.SideloadStorage
 		// stateMachine is used to apply committed raft entries.
 		stateMachine replicaStateMachine

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -91,6 +91,8 @@ func newUnloadedReplica(
 			TxnWaitKnobs:      store.TestingKnobs().TxnWaitKnobs,
 		}),
 	}
+	r.sideTransportClosedTimestamp.init(store.cfg.ClosedTimestampReceiver, desc.RangeID)
+
 	r.mu.pendingLeaseRequest = makePendingLeaseRequest(r)
 	r.mu.stateLoader = stateloader.Make(desc.RangeID)
 	r.mu.quiescent = true
@@ -228,8 +230,6 @@ func (r *Replica) loadRaftMuLockedReplicaMuLocked(desc *roachpb.RangeDescriptor)
 		r.store.engine,
 	)
 	r.assertStateRaftMuLockedReplicaMuRLocked(ctx, r.store.Engine())
-
-	r.sideTransportClosedTimestamp.init(r.store.cfg.ClosedTimestampReceiver, desc.RangeID)
 
 	return nil
 }

--- a/pkg/kv/kvserver/stateloader/BUILD.bazel
+++ b/pkg/kv/kvserver/stateloader/BUILD.bazel
@@ -25,7 +25,10 @@ go_library(
 go_test(
     name = "stateloader_test",
     size = "small",
-    srcs = ["initial_test.go"],
+    srcs = [
+        "initial_test.go",
+        "stateloader_test.go",
+    ],
     args = ["-test.timeout=55s"],
     embed = [":stateloader"],
     deps = [
@@ -34,6 +37,7 @@ go_test(
         "//pkg/testutils",
         "//pkg/util/leaktest",
         "//pkg/util/stop",
+        "@com_github_stretchr_testify//require",
         "@io_etcd_go_raft_v3//raftpb",
     ],
 )

--- a/pkg/kv/kvserver/stateloader/stateloader.go
+++ b/pkg/kv/kvserver/stateloader/stateloader.go
@@ -337,6 +337,20 @@ func (rsl StateLoader) SetVersion(
 		hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, version)
 }
 
+// UninitializedReplicaState returns the ReplicaState of an uninitialized
+// Replica with the given range ID. It is equivalent to StateLoader.Load from an
+// empty storage.
+func UninitializedReplicaState(rangeID roachpb.RangeID) kvserverpb.ReplicaState {
+	return kvserverpb.ReplicaState{
+		Desc:           &roachpb.RangeDescriptor{RangeID: rangeID},
+		Lease:          &roachpb.Lease{},
+		TruncatedState: &roachpb.RaftTruncatedState{},
+		GCThreshold:    &hlc.Timestamp{},
+		Stats:          &enginepb.MVCCStats{},
+		GCHint:         &roachpb.GCHint{},
+	}
+}
+
 // The rest is not technically part of ReplicaState.
 
 // SynthesizeRaftState creates a Raft state which synthesizes both a HardState

--- a/pkg/kv/kvserver/stateloader/stateloader_test.go
+++ b/pkg/kv/kvserver/stateloader/stateloader_test.go
@@ -1,0 +1,30 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package stateloader
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUninitializedReplicaState(t *testing.T) {
+	eng := storage.NewDefaultInMemForTesting()
+	defer eng.Close()
+	desc := roachpb.RangeDescriptor{RangeID: 123}
+	exp, err := Make(desc.RangeID).Load(context.Background(), eng, &desc)
+	require.NoError(t, err)
+	act := UninitializedReplicaState(desc.RangeID)
+	require.Equal(t, exp, act)
+}

--- a/pkg/kv/kvserver/store_create_replica.go
+++ b/pkg/kv/kvserver/store_create_replica.go
@@ -294,7 +294,8 @@ func (s *Store) tryGetOrCreateReplica(
 			return err
 		}
 
-		return repl.loadRaftMuLockedReplicaMuLocked(repl.descRLocked())
+		repl.assertStateRaftMuLockedReplicaMuRLocked(ctx, s.Engine())
+		return nil
 	}(); err != nil {
 		// Mark the replica as destroyed and remove it from the replicas maps to
 		// ensure nobody tries to use it.


### PR DESCRIPTION
This change stops using `loadRaftMuLockedReplicaMuLocked` when creating an uninitialized replica, to make it clearer what happens in this case. It turns out that what it did for uninitialized desc is equivalent to setting an empty `ReplicaState` and asserting the match between in-memory and on-disk state.

Informs #94912, #93898
Epic: CRDB-220
Release note: None