### PR TITLE
release-22.2: ui: added common id URL parameter constant for jobs, schedules, insights

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
@@ -18,7 +18,7 @@ import "antd/lib/row/style";
 import { Button } from "src/button";
 import { Loading } from "src/loading";
 import { SqlBox, SqlBoxSize } from "src/sql";
-import { getMatchParamByName, executionIdAttr } from "src/util";
+import { getMatchParamByName, idAttr } from "src/util";
 import { StatementInsightEvent } from "../types";
 import { InsightsError } from "../insightsErrorComponent";
 import classNames from "classnames/bind";
@@ -98,7 +98,7 @@ export const StatementInsightDetails: React.FC<
     }
   };
 
-  const executionID = getMatchParamByName(match, executionIdAttr);
+  const executionID = getMatchParamByName(match, idAttr);
 
   useEffect(() => {
     if (insightEventDetails == null) {

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
@@ -47,7 +47,7 @@ import { CockroachCloudContext } from "../../contexts";
 import { InsightsError } from "../insightsErrorComponent";
 import { TransactionDetailsLink } from "../workloadInsights/util";
 import { TimeScale } from "../../timeScaleDropdown";
-import { executionIdAttr } from "src/util";
+import { idAttr } from "src/util";
 
 const tableCx = classNames.bind(insightTableStyles);
 
@@ -102,7 +102,7 @@ export const TransactionInsightDetails: React.FC<
     columnTitle: "insights",
   });
   const isCockroachCloud = useContext(CockroachCloudContext);
-  const executionID = getMatchParamByName(match, executionIdAttr);
+  const executionID = getMatchParamByName(match, idAttr);
   const noInsights = !insightEventDetails;
   useEffect(() => {
     if (noInsights) {
@@ -156,7 +156,7 @@ export const TransactionInsightDetails: React.FC<
         <h3
           className={commonStyles("base-heading", "no-margin-bottom")}
         >{`Transaction Execution ID: ${String(
-          getMatchParamByName(match, executionIdAttr),
+          getMatchParamByName(match, idAttr),
         )}`}</h3>
       </div>
       <section>

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetails.tsx
@@ -21,9 +21,12 @@ import { Button } from "src/button";
 import { Loading } from "src/loading";
 import { SqlBox, SqlBoxSize } from "src/sql";
 import { SummaryCard, SummaryCardItem } from "src/summaryCard";
-import { TimestampToMoment } from "src/util";
-import { DATE_FORMAT_24_UTC } from "src/util/format";
-import { getMatchParamByName } from "src/util/query";
+import {
+  TimestampToMoment,
+  idAttr,
+  DATE_FORMAT_24_UTC,
+  getMatchParamByName,
+} from "src/util";
 
 import { HighwaterTimestamp } from "src/jobs/util/highwaterTimestamp";
 import { JobStatusCell } from "src/jobs/util/jobStatusCell";
@@ -67,7 +70,7 @@ export class JobDetails extends React.Component<JobDetailsProps> {
 
     this.props.refreshJob(
       new cockroach.server.serverpb.JobRequest({
-        job_id: Long.fromString(getMatchParamByName(this.props.match, "id")),
+        job_id: Long.fromString(getMatchParamByName(this.props.match, idAttr)),
       }),
     );
   }
@@ -167,7 +170,7 @@ export class JobDetails extends React.Component<JobDetailsProps> {
             Jobs
           </Button>
           <h3 className={jobCx("page--header__title")}>{`Job ID: ${String(
-            getMatchParamByName(this.props.match, "id"),
+            getMatchParamByName(this.props.match, idAttr),
           )}`}</h3>
         </div>
         <section className={jobCx("section section--container")}>

--- a/pkg/ui/workspaces/cluster-ui/src/schedules/scheduleDetailsPage/scheduleDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/schedules/scheduleDetailsPage/scheduleDetails.tsx
@@ -20,8 +20,7 @@ import { Button } from "src/button";
 import { Loading } from "src/loading";
 import { SqlBox, SqlBoxSize } from "src/sql";
 import { SummaryCard, SummaryCardItem } from "src/summaryCard";
-import { DATE_FORMAT_24_UTC } from "src/util/format";
-import { getMatchParamByName } from "src/util/query";
+import { DATE_FORMAT_24_UTC, idAttr, getMatchParamByName } from "src/util";
 
 import { commonStyles } from "src/common";
 import summaryCardStyles from "src/summaryCard/summaryCard.module.scss";
@@ -47,7 +46,7 @@ export type ScheduleDetailsProps = ScheduleDetailsStateProps &
   RouteComponentProps<unknown>;
 
 export const ScheduleDetails: React.FC<ScheduleDetailsProps> = props => {
-  const idStr = getMatchParamByName(props.match, "id");
+  const idStr = getMatchParamByName(props.match, idAttr);
   const { refreshSchedule } = props;
   useEffect(() => {
     refreshSchedule(Long.fromString(idStr));

--- a/pkg/ui/workspaces/cluster-ui/src/selectors/common.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/selectors/common.ts
@@ -9,7 +9,7 @@
 // licenses/APL.txt.
 
 import { RouteComponentProps } from "react-router";
-import { getMatchParamByName, executionIdAttr } from "src/util";
+import { getMatchParamByName, executionIdAttr, idAttr } from "src/util";
 
 // The functions in this file are agnostic to the different shape of each
 // state in db-console and cluster-ui. This file contains selector functions
@@ -18,6 +18,15 @@ import { getMatchParamByName, executionIdAttr } from "src/util";
 // between db-console and cluster-ui.
 
 export const selectExecutionID = (
-  _state: unknown,
+  _state: any,
   props: RouteComponentProps,
-): string | null => getMatchParamByName(props.match, executionIdAttr);
+): string | null => {
+  return getMatchParamByName(props.match, executionIdAttr);
+};
+
+export const selectID = (
+  _state: any,
+  props: RouteComponentProps,
+): string | null => {
+  return getMatchParamByName(props.match, idAttr);
+};

--- a/pkg/ui/workspaces/cluster-ui/src/store/insightDetails/transactionInsightDetails/transactionInsightDetails.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insightDetails/transactionInsightDetails/transactionInsightDetails.selectors.ts
@@ -10,11 +10,11 @@
 
 import { createSelector } from "reselect";
 import { AppState } from "src/store/reducers";
-import { selectExecutionID } from "src/selectors/common";
+import { selectID } from "src/selectors/common";
 
 const selectTransactionInsightDetailsState = createSelector(
   (state: AppState) => state.adminUI.transactionInsightDetails.cachedData,
-  selectExecutionID,
+  selectID,
   (cachedTxnInsightDetails, execId) => {
     return cachedTxnInsightDetails.get(execId);
   },

--- a/pkg/ui/workspaces/cluster-ui/src/store/insights/statementInsights/statementInsights.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insights/statementInsights/statementInsights.selectors.ts
@@ -16,7 +16,7 @@ import {
   selectStatementInsightsCombiner,
   selectStatementInsightDetailsCombiner,
 } from "src/selectors/insightsCommon.selectors";
-import { selectExecutionID } from "src/selectors/common";
+import { selectID } from "src/selectors/common";
 export const selectStatementInsights = createSelector(
   (state: AppState) => state.adminUI.statementInsights?.data,
   selectStatementInsightsCombiner,
@@ -27,7 +27,7 @@ export const selectStatementInsightsError = (state: AppState) =>
 
 export const selectStatementInsightDetails = createSelector(
   selectStatementInsights,
-  selectExecutionID,
+  selectID,
   selectStatementInsightDetailsCombiner,
 );
 

--- a/pkg/ui/workspaces/cluster-ui/src/util/constants.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/constants.ts
@@ -33,6 +33,7 @@ export const indexNameAttr = "index_name";
 export const txnFingerprintIdAttr = "txn_fingerprint_id";
 export const unset = "(unset)";
 export const viewAttr = "view";
+export const idAttr = "id";
 
 export const REMOTE_DEBUGGING_ERROR_TEXT =
   "This information is not available due to the current value of the 'server.remote_debugging.mode' setting.";

--- a/pkg/ui/workspaces/db-console/src/app.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.tsx
@@ -36,6 +36,7 @@ import {
   tableNameAttr,
   txnFingerprintIdAttr,
   viewAttr,
+  idAttr,
 } from "src/util/constants";
 import NotFound from "src/views/app/components/errorMessage/notFound";
 import Layout from "src/views/app/containers/layout";
@@ -160,10 +161,13 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
                   {/* events & jobs */}
                   <Route path="/events" component={EventPage} />
                   <Route exact path="/jobs" component={JobsPage} />
-                  <Route path={"/jobs/:id"} component={JobDetails} />
+                  <Route path={`/jobs/:${idAttr}`} component={JobDetails} />
 
                   <Route exact path="/schedules" component={SchedulesPage} />
-                  <Route path={"/schedules/:id"} component={ScheduleDetails} />
+                  <Route
+                    path={`/schedules/:${idAttr}`}
+                    component={ScheduleDetails}
+                  />
 
                   {/* databases */}
                   <Route exact path="/databases" component={DatabasesPage} />
@@ -311,11 +315,11 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
                     component={InsightsOverviewPage}
                   />
                   <Route
-                    path={`/insights/transaction/:${executionIdAttr}`}
+                    path={`/insights/transaction/:${idAttr}`}
                     component={TransactionInsightDetailsPage}
                   />
                   <Route
-                    path={`/insights/statement/:${executionIdAttr}`}
+                    path={`/insights/statement/:${idAttr}`}
                     component={StatementInsightDetailsPage}
                   />
 

--- a/pkg/ui/workspaces/db-console/src/util/constants.ts
+++ b/pkg/ui/workspaces/db-console/src/util/constants.ts
@@ -35,4 +35,5 @@ export const {
   unset,
   viewAttr,
   REMOTE_DEBUGGING_ERROR_TEXT,
+  idAttr,
 } = util;

--- a/pkg/ui/workspaces/db-console/src/views/insights/insightsSelectors.ts
+++ b/pkg/ui/workspaces/db-console/src/views/insights/insightsSelectors.ts
@@ -19,7 +19,7 @@ import {
   SchemaInsightEventFilters,
   SortSetting,
   selectStatementInsightsCombiner,
-  selectExecutionID,
+  selectID,
   selectStatementInsightDetailsCombiner,
   selectTxnInsightsCombiner,
 } from "@cockroachlabs/cluster-ui";
@@ -47,7 +47,7 @@ export const selectTransactionInsights = createSelector(
 export const selectTransactionInsightDetails = createSelector(
   [
     (state: AdminUIState) => state.cachedData.transactionInsightDetails,
-    selectExecutionID,
+    selectID,
   ],
   (insight, insightId): api.TransactionInsightEventDetailsResponse => {
     if (!insight) {
@@ -59,7 +59,7 @@ export const selectTransactionInsightDetails = createSelector(
 
 export const selectTransactionInsightDetailsError = createSelector(
   (state: AdminUIState) => state.cachedData.transactionInsightDetails,
-  selectExecutionID,
+  selectID,
   (insight, insightId): Error | null => {
     if (!insight) {
       return null;
@@ -75,7 +75,7 @@ export const selectStatementInsights = createSelector(
 
 export const selectStatementInsightDetails = createSelector(
   selectStatementInsights,
-  selectExecutionID,
+  selectID,
   selectStatementInsightDetailsCombiner,
 );
 

--- a/pkg/ui/workspaces/db-console/src/views/jobs/jobDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/jobDetails.tsx
@@ -7,26 +7,25 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
-import { JobDetails, JobDetailsStateProps } from "@cockroachlabs/cluster-ui";
+import {
+  JobDetails,
+  JobDetailsStateProps,
+  selectID,
+} from "@cockroachlabs/cluster-ui";
 import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { createSelector } from "reselect";
 import { CachedDataReducerState, refreshJob } from "src/redux/apiReducers";
 import { AdminUIState } from "src/redux/state";
 import { JobResponseMessage } from "src/util/api";
-import { getMatchParamByName } from "src/util/query";
 
 const selectJobState = createSelector(
-  [
-    (state: AdminUIState) => state.cachedData.job,
-    (_state: AdminUIState, props: RouteComponentProps) => props,
-  ],
-  (job, props): CachedDataReducerState<JobResponseMessage> => {
-    const jobId = getMatchParamByName(props.match, "id");
+  [(state: AdminUIState) => state.cachedData.job, selectID],
+  (job, jobID): CachedDataReducerState<JobResponseMessage> => {
     if (!job) {
       return null;
     }
-    return job[jobId];
+    return job[jobID];
   },
 );
 

--- a/pkg/ui/workspaces/db-console/src/views/schedules/scheduleDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/schedules/scheduleDetails.tsx
@@ -11,25 +11,21 @@ import {
   api,
   ScheduleDetails,
   ScheduleDetailsStateProps,
+  selectID,
 } from "@cockroachlabs/cluster-ui";
 import { connect } from "react-redux";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { createSelector } from "reselect";
 import { CachedDataReducerState, refreshSchedule } from "src/redux/apiReducers";
 import { AdminUIState } from "src/redux/state";
-import { getMatchParamByName } from "src/util/query";
 
 const selectScheduleState = createSelector(
-  [
-    (state: AdminUIState) => state.cachedData.schedule,
-    (_state: AdminUIState, props: RouteComponentProps) => props,
-  ],
-  (schedule, props): CachedDataReducerState<api.Schedule> => {
-    const scheduleId = getMatchParamByName(props.match, "id");
+  [(state: AdminUIState) => state.cachedData.schedule, selectID],
+  (schedule, scheduleID): CachedDataReducerState<api.Schedule> => {
     if (!schedule) {
       return null;
     }
-    return schedule[scheduleId];
+    return schedule[scheduleID];
   },
 );
 


### PR DESCRIPTION
Backport 1/1 commits from #92932.

/cc @cockroachdb/release

---

This commit adds a common URL parameter constant and parameter selector for the jobs, schedules, and insights details pages.

Part of https://github.com/cockroachdb/cockroach/issues/87693.

Background thread: https://cockroachlabs.slack.com/archives/G01Q9D01NTU/p1670001751479989

Release note: None

Release justification: bug fix