### PR TITLE
norm: fix folding binary and comparison operators with NULLs

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -1301,3 +1301,32 @@ vectorized: true
       estimated row count: 1,000 (missing stats)
       table: t0@t0_pkey
       spans: FULL SCAN
+
+# Regression tests for not checking whether arguments to a binary op are
+# non-NULL when folding (#94264).
+query T
+EXPLAIN SELECT 2-(9223372036854775807+436256318) < (CASE WHEN false THEN -1 END)
+----
+distribution: local
+vectorized: true
+·
+• values
+  size: 1 column, 1 row
+
+query T
+EXPLAIN SELECT (9223372036854775807+436256318)-2 < (CASE WHEN false THEN -1 END)
+----
+distribution: local
+vectorized: true
+·
+• values
+  size: 1 column, 1 row
+
+query T
+EXPLAIN SELECT (9223372036854775807+436256318)+2 < (CASE WHEN false THEN -1 END)
+----
+distribution: local
+vectorized: true
+·
+• values
+  size: 1 column, 1 row

--- a/pkg/sql/opt/norm/fold_constants_funcs.go
+++ b/pkg/sql/opt/norm/fold_constants_funcs.go
@@ -294,7 +294,13 @@ func (c *CustomFuncs) FoldBinary(
 	}
 
 	lDatum, rDatum := memo.ExtractConstDatum(left), memo.ExtractConstDatum(right)
-	result, err := eval.BinaryOp(c.f.ctx, c.f.evalCtx, o.EvalOp, lDatum, rDatum)
+	var result tree.Datum
+	var err error
+	if !o.CalledOnNullInput && (lDatum == tree.DNull || rDatum == tree.DNull) {
+		result = tree.DNull
+	} else {
+		result, err = eval.BinaryOp(c.f.ctx, c.f.evalCtx, o.EvalOp, lDatum, rDatum)
+	}
 	if err != nil {
 		return nil, false
 	}
@@ -511,7 +517,13 @@ func (c *CustomFuncs) FoldComparison(
 		lDatum, rDatum = rDatum, lDatum
 	}
 
-	result, err := eval.BinaryOp(c.f.ctx, c.f.evalCtx, o.EvalOp, lDatum, rDatum)
+	var result tree.Datum
+	var err error
+	if !o.CalledOnNullInput && (lDatum == tree.DNull || rDatum == tree.DNull) {
+		result = tree.DNull
+	} else {
+		result, err = eval.BinaryOp(c.f.ctx, c.f.evalCtx, o.EvalOp, lDatum, rDatum)
+	}
 	if err != nil {
 		return nil, false
 	}

--- a/pkg/sql/opt/norm/rules/comp.opt
+++ b/pkg/sql/opt/norm/rules/comp.opt
@@ -39,8 +39,8 @@
 #       normalize.go either. We can add once we've proved it's OK to do so.
 [NormalizeCmpPlusConst, Normalize]
 (Eq | Ge | Gt | Le | Lt
-    (Plus $leftLeft:^(ConstValue) $leftRight:(ConstValue))
-    $right:(ConstValue) &
+    (Plus $leftLeft:^(ConstValue) $leftRight:(Const))
+    $right:(Const) &
         (ArithmeticErrorsOnOverflow
             (TypeOf $right)
             (TypeOf $leftRight)
@@ -65,8 +65,8 @@
 # See NormalizeCmpPlusConst for more details.
 [NormalizeCmpMinusConst, Normalize]
 (Eq | Ge | Gt | Le | Lt
-    (Minus $leftLeft:^(ConstValue) $leftRight:(ConstValue))
-    $right:(ConstValue) &
+    (Minus $leftLeft:^(ConstValue) $leftRight:(Const))
+    $right:(Const) &
         (ArithmeticErrorsOnOverflow
             (TypeOf $right)
             (TypeOf $leftRight)
@@ -90,8 +90,8 @@
 # See NormalizeCmpPlusConst for more details.
 [NormalizeCmpConstMinus, Normalize]
 (Eq | Ge | Gt | Le | Lt
-    (Minus $leftLeft:(ConstValue) $leftRight:^(ConstValue))
-    $right:(ConstValue) &
+    (Minus $leftLeft:(Const) $leftRight:^(ConstValue))
+    $right:(Const) &
         (ArithmeticErrorsOnOverflow
             (TypeOf $leftLeft)
             (TypeOf $right)

--- a/pkg/sql/opt/norm/testdata/rules/bool
+++ b/pkg/sql/opt/norm/testdata/rules/bool
@@ -434,28 +434,11 @@ FROM
 WHERE
 	(NOT (t.g ~ t.g));
 ----
-project
- ├── columns: "?column?":2 g:1
- ├── cardinality: [0 - 1]
- ├── immutable
+values
+ ├── columns: "?column?":2!null g:1!null
+ ├── cardinality: [0 - 0]
  ├── key: ()
- ├── fd: ()-->(1,2)
- ├── select
- │    ├── columns: column1:1
- │    ├── cardinality: [0 - 1]
- │    ├── immutable
- │    ├── key: ()
- │    ├── fd: ()-->(1)
- │    ├── values
- │    │    ├── columns: column1:1
- │    │    ├── cardinality: [1 - 1]
- │    │    ├── key: ()
- │    │    ├── fd: ()-->(1)
- │    │    └── (NULL,)
- │    └── filters
- │         └── NOT (CAST(NULL AS GEOMETRY) ~ CAST(NULL AS GEOMETRY)) [immutable]
- └── projections
-      └── NULL [as="?column?":2]
+ └── fd: ()-->(1,2)
 
 # --------------------------------------------------
 # EliminateNot

--- a/pkg/sql/opt/norm/testdata/rules/comp
+++ b/pkg/sql/opt/norm/testdata/rules/comp
@@ -162,6 +162,18 @@ values
  ├── fd: ()-->(2)
  └── (true,)
 
+# Regression test for #94264. This rule should not apply when the argument to a
+# Plus or a Minus is NULL.
+norm expect-not=(NormalizeCmpPlusConst)
+SELECT (9223372036854775807+436256318)+2 < (CASE WHEN false THEN -1 END)
+----
+values
+ ├── columns: "?column?":1
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (NULL,)
+
 # --------------------------------------------------
 # NormalizeCmpMinusConst
 # --------------------------------------------------
@@ -218,6 +230,19 @@ values
  ├── key: ()
  ├── fd: ()-->(2)
  └── (true,)
+
+# Regression test for #94264. This rule should not apply when the argument to a
+# Plus or a Minus is NULL.
+norm expect-not=(NormalizeCmpMinusConst)
+SELECT (9223372036854775807+436256318)-2 < (CASE WHEN false THEN -1 END)
+----
+values
+ ├── columns: "?column?":1
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (NULL,)
+
 
 # --------------------------------------------------
 # NormalizeCmpConstMinus
@@ -280,6 +305,18 @@ select
  │    └── fd: (1)-->(2-6)
  └── filters
       └── ('2022-01-01' - s:4::TIME) >= '2022-01-01 01:00:00' [outer=(4), stable]
+
+# Regression test for #94264. This rule should not apply when the argument to a
+# Plus or a Minus is NULL.
+norm expect-not=(NormalizeCmpConstMinus)
+SELECT 2-(9223372036854775807+436256318) < (CASE WHEN false THEN -1 END)
+----
+values
+ ├── columns: "?column?":1
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (NULL,)
 
 # --------------------------------------------------
 # NormalizeTupleEquality


### PR DESCRIPTION
This commit fixes a recently introduced regression in
https://github.com/cockroachdb/cockroach/commit/3a635c65469041524b3289b20ff05cb7833677ae where we removed the non-null
check of arguments to binary and comparison operators prior to
evaluating them. That check is needed if `CalledOnNullInput` is set to
`false` for the corresponding operator - in all other places where we
`Eval` the operator we do have this non-null check. This commit updates
the applicable normalization rules that can fold operators to apply only
to `Const` expressions (excluding `ConstValue`s which include NULLS) as
well as adds the additional protection of having an explicit non-null
check.

However, this bug seems to occur rarely in practice - the original
reproduction requires that there is an integer out of range computation
prior to folding, and I couldn't really simplify that reproduction.
Thus, I decided to omit the release note.

Fixes: #94264.

Release note: None