### PR TITLE
sql: stub implementation of EXPLAIN ANALYZE (DEBUG, REDACT)

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -398,7 +398,13 @@ func (ex *connExecutor) execStmtInOpenState(
 		switch e.Mode {
 		case tree.ExplainDebug:
 			telemetry.Inc(sqltelemetry.ExplainAnalyzeDebugUseCounter)
-			ih.SetOutputMode(explainAnalyzeDebugOutput, explain.Flags{})
+			flags := explain.MakeFlags(&e.ExplainOptions)
+			flags.Verbose = true
+			flags.ShowTypes = true
+			if ex.server.cfg.TestingKnobs.DeterministicExplain {
+				flags.Redact = explain.RedactAll
+			}
+			ih.SetOutputMode(explainAnalyzeDebugOutput, flags)
 
 		case tree.ExplainPlan:
 			telemetry.Inc(sqltelemetry.ExplainAnalyzeUseCounter)

--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec/explain"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -124,6 +125,7 @@ type diagnosticsBundle struct {
 // system.statement_diagnostics.
 func buildStatementBundle(
 	ctx context.Context,
+	explainFlags explain.Flags,
 	db *kv.DB,
 	ie *InternalExecutor,
 	stmtRawSQL string,
@@ -137,7 +139,7 @@ func buildStatementBundle(
 	if plan == nil {
 		return diagnosticsBundle{collectionErr: errors.AssertionFailedf("execution terminated early")}
 	}
-	b := makeStmtBundleBuilder(db, ie, stmtRawSQL, plan, trace, placeholders, sv)
+	b := makeStmtBundleBuilder(explainFlags, db, ie, stmtRawSQL, plan, trace, placeholders, sv)
 
 	b.addStatement()
 	b.addOptPlans(ctx)
@@ -188,6 +190,8 @@ func (bundle *diagnosticsBundle) insert(
 
 // stmtBundleBuilder is a helper for building a statement bundle.
 type stmtBundleBuilder struct {
+	flags explain.Flags
+
 	db *kv.DB
 	ie *InternalExecutor
 
@@ -201,6 +205,7 @@ type stmtBundleBuilder struct {
 }
 
 func makeStmtBundleBuilder(
+	flags explain.Flags,
 	db *kv.DB,
 	ie *InternalExecutor,
 	stmt string,
@@ -210,7 +215,8 @@ func makeStmtBundleBuilder(
 	sv *settings.Values,
 ) stmtBundleBuilder {
 	b := stmtBundleBuilder{
-		db: db, ie: ie, stmt: stmt, plan: plan, trace: trace, placeholders: placeholders, sv: sv,
+		flags: flags, db: db, ie: ie, stmt: stmt, plan: plan, trace: trace, placeholders: placeholders,
+		sv: sv,
 	}
 	b.buildPrettyStatement()
 	b.z.Init()
@@ -240,6 +246,10 @@ func (b *stmtBundleBuilder) buildPrettyStatement() {
 // addStatement adds the pretty-printed statement in b.stmt as file
 // statement.txt.
 func (b *stmtBundleBuilder) addStatement() {
+	if b.flags.RedactValues {
+		return
+	}
+
 	output := b.stmt
 
 	if b.placeholders != nil && len(b.placeholders.Values) != 0 {
@@ -258,6 +268,10 @@ func (b *stmtBundleBuilder) addStatement() {
 // addOptPlans adds the EXPLAIN (OPT) variants as files opt.txt, opt-v.txt,
 // opt-vv.txt.
 func (b *stmtBundleBuilder) addOptPlans(ctx context.Context) {
+	if b.flags.RedactValues {
+		return
+	}
+
 	if b.plan.mem == nil || b.plan.mem.RootExpr() == nil {
 		// No optimizer plans; an error must have occurred during planning.
 		b.z.AddFile("opt.txt", noPlan)
@@ -281,6 +295,10 @@ func (b *stmtBundleBuilder) addOptPlans(ctx context.Context) {
 
 // addExecPlan adds the EXPLAIN (VERBOSE) plan as file plan.txt.
 func (b *stmtBundleBuilder) addExecPlan(plan string) {
+	if b.flags.RedactValues {
+		return
+	}
+
 	if plan == "" {
 		plan = "no plan"
 	}
@@ -288,6 +306,10 @@ func (b *stmtBundleBuilder) addExecPlan(plan string) {
 }
 
 func (b *stmtBundleBuilder) addDistSQLDiagrams() {
+	if b.flags.RedactValues {
+		return
+	}
+
 	for i, d := range b.plan.distSQLFlowInfos {
 		d.diagram.AddSpans(b.trace)
 		_, url, err := d.diagram.ToURL()
@@ -333,6 +355,10 @@ func (b *stmtBundleBuilder) addExplainVec() {
 // trace (the default and the jaeger formats), the third one is a human-readable
 // representation.
 func (b *stmtBundleBuilder) addTrace() {
+	if b.flags.RedactValues {
+		return
+	}
+
 	traceJSONStr, err := tracing.TraceToJSON(b.trace)
 	if err != nil {
 		b.z.AddFile("trace.json", err.Error())
@@ -378,6 +404,11 @@ func (b *stmtBundleBuilder) addEnv(ctx context.Context) {
 	}
 
 	b.z.AddFile("env.sql", buf.String())
+
+	if b.flags.RedactValues {
+		b.z.AddFile("schema.sql", "-- schema redacted\n")
+		return
+	}
 
 	mem := b.plan.mem
 	if mem == nil {
@@ -448,6 +479,10 @@ func (b *stmtBundleBuilder) addEnv(ctx context.Context) {
 }
 
 func (b *stmtBundleBuilder) addErrors(queryErr, payloadErr, commErr error) {
+	if b.flags.RedactValues {
+		return
+	}
+
 	if queryErr == nil && payloadErr == nil && commErr == nil {
 		return
 	}

--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 const noPlan = "no plan"
@@ -208,27 +209,32 @@ func makeStmtBundleBuilder(
 	flags explain.Flags,
 	db *kv.DB,
 	ie *InternalExecutor,
-	stmt string,
+	stmtRawSQL string,
 	plan *planTop,
 	trace tracingpb.Recording,
 	placeholders *tree.PlaceholderInfo,
 	sv *settings.Values,
 ) stmtBundleBuilder {
 	b := stmtBundleBuilder{
-		flags: flags, db: db, ie: ie, stmt: stmt, plan: plan, trace: trace, placeholders: placeholders,
-		sv: sv,
+		flags: flags, db: db, ie: ie, plan: plan, trace: trace, placeholders: placeholders, sv: sv,
 	}
-	b.buildPrettyStatement()
+	b.buildPrettyStatement(stmtRawSQL)
 	b.z.Init()
 	return b
 }
 
 // buildPrettyStatement saves the pretty-printed statement (without any
 // placeholder arguments).
-func (b *stmtBundleBuilder) buildPrettyStatement() {
+func (b *stmtBundleBuilder) buildPrettyStatement(stmtRawSQL string) {
 	// If we hit an early error, stmt or stmt.AST might not be initialized yet. In
-	// this case use the original statement SQL already in the stmtBundleBuilder.
-	if b.plan.stmt != nil && b.plan.stmt.AST != nil {
+	// this case use the original raw SQL.
+	if b.plan.stmt == nil || b.plan.stmt.AST == nil {
+		b.stmt = stmtRawSQL
+		// If we're collecting a redacted bundle, redact the raw SQL completely.
+		if b.flags.RedactValues && b.stmt != "" {
+			b.stmt = string(redact.RedactedMarker())
+		}
+	} else {
 		cfg := tree.DefaultPrettyCfg()
 		cfg.UseTabs = false
 		cfg.LineWidth = 100
@@ -236,7 +242,14 @@ func (b *stmtBundleBuilder) buildPrettyStatement() {
 		cfg.Simplify = true
 		cfg.Align = tree.PrettyNoAlign
 		cfg.JSONFmt = true
+		cfg.ValueRedaction = b.flags.RedactValues
 		b.stmt = cfg.Pretty(b.plan.stmt.AST)
+
+		// If we had ValueRedaction set, Pretty surrounded all constants with
+		// redaction markers. We must call Redact to fully redact them.
+		if b.flags.RedactValues {
+			b.stmt = string(redact.RedactableString(b.stmt).Redact())
+		}
 	}
 	if b.stmt == "" {
 		b.stmt = "-- no statement"
@@ -246,10 +259,6 @@ func (b *stmtBundleBuilder) buildPrettyStatement() {
 // addStatement adds the pretty-printed statement in b.stmt as file
 // statement.txt.
 func (b *stmtBundleBuilder) addStatement() {
-	if b.flags.RedactValues {
-		return
-	}
-
 	output := b.stmt
 
 	if b.placeholders != nil && len(b.placeholders.Values) != 0 {
@@ -257,7 +266,11 @@ func (b *stmtBundleBuilder) addStatement() {
 		buf.WriteString(output)
 		buf.WriteString("\n\n-- Arguments:\n")
 		for i, v := range b.placeholders.Values {
-			fmt.Fprintf(&buf, "--  %s: %v\n", tree.PlaceholderIdx(i), v)
+			if b.flags.RedactValues {
+				fmt.Fprintf(&buf, "--  %s: %s\n", tree.PlaceholderIdx(i), redact.RedactedMarker())
+			} else {
+				fmt.Fprintf(&buf, "--  %s: %v\n", tree.PlaceholderIdx(i), v)
+			}
 		}
 		output = buf.String()
 	}

--- a/pkg/sql/explain_bundle_test.go
+++ b/pkg/sql/explain_bundle_test.go
@@ -300,7 +300,7 @@ CREATE TABLE users(id UUID DEFAULT gen_random_uuid() PRIMARY KEY, promo_id INT R
 					}
 				}
 				return nil
-			}, "env.sql schema.sql vec.txt vec-v.txt",
+			}, "env.sql schema.sql statement.sql vec.txt vec-v.txt",
 		)
 	})
 }

--- a/pkg/sql/opt/exec/explain/flags.go
+++ b/pkg/sql/opt/exec/explain/flags.go
@@ -12,7 +12,7 @@ package explain
 
 import "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 
-// Flags are modifiers for EXPLAIN (PLAN).
+// Flags are modifiers for EXPLAIN.
 type Flags struct {
 	// Verbose indicates that more metadata is shown, and plan columns and
 	// ordering are shown.
@@ -26,9 +26,12 @@ type Flags struct {
 	HideValues bool
 	// If OnlyShape is true, we hide fields that could be different between 2
 	// plans that otherwise have exactly the same shape, like estimated row count.
-	// This is used for EXPLAIN(SHAPE), which is used for the statement-bundle
+	// This is used for EXPLAIN (SHAPE), which is used for the statement-bundle
 	// debug tool.
 	OnlyShape bool
+	// RedactValues is similar to HideValues but indicates that we should use
+	// redaction markers instead of underscores. Used by EXPLAIN (REDACT).
+	RedactValues bool
 
 	// Redaction control (for testing purposes).
 	Redact RedactFlags
@@ -78,6 +81,11 @@ func MakeFlags(options *tree.ExplainOptions) Flags {
 		f.HideValues = true
 		f.OnlyShape = true
 		f.Redact = RedactAll
+	}
+	if options.Flags[tree.ExplainFlagRedact] {
+		// Confusingly, this doesn't use any of the RedactFlags, which have a
+		// different purpose.
+		f.RedactValues = true
 	}
 	return f
 }

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -60,6 +60,8 @@ type PrettyCfg struct {
 	// JSONFmt, when set, pretty-prints strings that are asserted or cast
 	// to JSON.
 	JSONFmt bool
+	// ValueRedaction, when set, surrounds literal values with redaction markers.
+	ValueRedaction bool
 }
 
 // DefaultPrettyCfg returns a PrettyCfg with the default
@@ -177,7 +179,10 @@ func (p *PrettyCfg) Doc(f NodeFormatter) pretty.Doc {
 }
 
 func (p *PrettyCfg) docAsString(f NodeFormatter) pretty.Doc {
-	const prettyFlags = FmtShowPasswords | FmtParsable
+	prettyFlags := FmtShowPasswords | FmtParsable
+	if p.ValueRedaction {
+		prettyFlags |= FmtMarkRedactionNode | FmtOmitNameRedaction
+	}
 	txt := AsStringWithFlags(f, prettyFlags)
 	return pretty.Text(strings.TrimSpace(txt))
 }


### PR DESCRIPTION
**sql: stub implementation of EXPLAIN ANALYZE (DEBUG, REDACT)**

Add a new explain flag, `REDACT`, which can be used to collect a
redacted statement bundle with `EXPLAIN ANALYZE (DEBUG, REDACT)`.
Initially this is the only variant of `EXPLAIN` that supports `REDACT`
but the possibility of other variants using `REDACT` is left open.

This first commit plumbs the redact flag into explain_bundle.go but does
not implement redaction for any of the files, instead simply omitting
files which could contain user data. Following commits will add
redaction support for each file.

Part of: #68570

Epic: CRDB-19756

Release note (sql change): Add a new `REDACT` flag to `EXPLAIN` which
causes constants, literal values, parameter values, and any other user
data to be redacted in explain output. Redacted statement diagnostics
bundles can now be collected with `EXPLAIN ANALYZE (DEBUG, REDACT)`.

**sql: add statement.sql to EXPLAIN ANALYZE (DEBUG, REDACT)**

Support redaction of statement.sql, and add it back to redacted
statement diagnostics bundles.

Part of: #68570

Epic: CRDB-19756

Release note: None