### PR TITLE
kv/server: skip a bunch of flakey tests

### DIFF
--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -2765,7 +2765,7 @@ func TestTxnWaitQueueDependencyCycleWithRangeSplit(t *testing.T) {
 func TestStoreCapacityAfterSplit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-
+	skip.WithIssue(t, 92677)
 	ctx := context.Background()
 	manualClock := hlc.NewHybridManualClock()
 	tc := testcluster.StartTestCluster(t, 2,

--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -1504,7 +1504,7 @@ func TestLearnerAndJointConfigAdminMerge(t *testing.T) {
 func TestMergeQueueDoesNotInterruptReplicationChange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-
+	skip.WithIssue(t, 94951)
 	ctx := context.Background()
 	var activateSnapshotTestingKnob int64
 	blockSnapshot := make(chan struct{})

--- a/pkg/sql/logictest/testdata/logic_test/testserver_test_22.1_22.2
+++ b/pkg/sql/logictest/testdata/logic_test/testserver_test_22.1_22.2
@@ -1,4 +1,5 @@
 # LogicTest: cockroach-go-testserver-22.1-22.2
+skip 94871
 
 query I
 SELECT 1

--- a/pkg/sql/logictest/testdata/logic_test/testserver_upgrade_node
+++ b/pkg/sql/logictest/testdata/logic_test/testserver_upgrade_node
@@ -1,5 +1,7 @@
 # LogicTest: cockroach-go-testserver-22.2-master
 
+skip 94956
+
 query I
 SELECT 1
 ----


### PR DESCRIPTION
TestStoreCapacityAfterSplit, TestMergeQueueDoesNotInterruptReplicationChange,
testserver_test_22.1_22.2, testserver_upgrade_node.

Informs: #94871, #94951, #92677, https://github.com/cockroachdb/cockroach/issues/94956

Release note: None