### PR TITLE
sql: support subqueries in UDFs

### DIFF
--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -279,8 +279,9 @@ func runPlanInsidePlan(
 		// We currently don't support cases when both the "inner" and the
 		// "outer" plans have subqueries due to limitations of how we're
 		// propagating the results of the subqueries.
-		// TODO(mgartner): Fix error message for routines so that it doesn't say
-		// "apply joins".
+		// TODO(mgartner): We should be able to lift this restriction for
+		// apply-joins, similarly to how subqueries within UDFs are planned - as
+		// routines instead of subqueries.
 		if len(params.p.curPlan.subqueryPlans) != 0 {
 			return unimplemented.NewWithIssue(66447, `apply joins with subqueries in the "inner" and "outer" contexts are not supported`)
 		}

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -2615,9 +2615,27 @@ SELECT a, sub_max_odd() FROM sub_all WHERE a = sub_max_odd()
 ----
 5  5
 
-# TODO(mgartner): Allow queries with subqueries outside and inside a UDF.
-statement error pgcode 0A000 unimplemented: apply joins with subqueries in the "inner" and "outer" contexts are not supported
+# Subqueries inside and outside a UDF are supported.
+query I rowsort
 SELECT a FROM sub_all WHERE sub_max_odd() = (SELECT max(a) FROM sub_odd)
+----
+1
+2
+3
+4
+5
+6
+
+# UDF with subquery where ordering must be preserved.
+statement ok
+CREATE FUNCTION sub_max_odd_with_order_by() RETURNS INT LANGUAGE SQL AS $$
+  SELECT a FROM sub_all WHERE a = (SELECT a FROM sub_odd ORDER BY a DESC LIMIT 1)
+$$
+
+query I
+SELECT sub_max_odd_with_order_by()
+----
+5
 
 # UDF with a subquery correlated with an input parameter.
 statement ok
@@ -2763,7 +2781,7 @@ SELECT oid, proname, pronamespace, proowner, prolang, proleakproof, proisstrict,
 FROM pg_catalog.pg_proc WHERE proname IN ('f_93314', 'f_93314_alias', 'f_93314_comp', 'f_93314_comp_t')
 ORDER BY oid;
 ----
-100256  f_93314         105  1546506610  14  false  false  false  v  0  100255  ·  {}  NULL  SELECT i, e FROM test.public.t_93314 ORDER BY i LIMIT 1;
-100258  f_93314_alias   105  1546506610  14  false  false  false  v  0  100257  ·  {}  NULL  SELECT i, e FROM test.public.t_93314_alias ORDER BY i LIMIT 1;
-100262  f_93314_comp    105  1546506610  14  false  false  false  v  0  100259  ·  {}  NULL  SELECT (1, 2);
-100263  f_93314_comp_t  105  1546506610  14  false  false  false  v  0  100261  ·  {}  NULL  SELECT a, c FROM test.public.t_93314_comp LIMIT 1;
+100257  f_93314         105  1546506610  14  false  false  false  v  0  100256  ·  {}  NULL  SELECT i, e FROM test.public.t_93314 ORDER BY i LIMIT 1;
+100259  f_93314_alias   105  1546506610  14  false  false  false  v  0  100258  ·  {}  NULL  SELECT i, e FROM test.public.t_93314_alias ORDER BY i LIMIT 1;
+100263  f_93314_comp    105  1546506610  14  false  false  false  v  0  100260  ·  {}  NULL  SELECT (1, 2);
+100264  f_93314_comp_t  105  1546506610  14  false  false  false  v  0  100262  ·  {}  NULL  SELECT a, c FROM test.public.t_93314_comp LIMIT 1;

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -2596,9 +2596,62 @@ CREATE FUNCTION err() RETURNS INT LANGUAGE SQL AS 'SELECT other_udf()'
 
 subtest subqueries
 
-# UDFs with subqueries are not currently supported.
-statement error pgcode 0A000 unimplemented: subquery usage inside a function definition
-CREATE FUNCTION rec(i INT) RETURNS INT LANGUAGE SQL AS 'SELECT * FROM t WHERE a = (SELECT max(i) FROM s)'
+statement ok
+CREATE TABLE sub_all (a INT);
+INSERT INTO sub_all VALUES (1), (2), (3), (4), (5), (6)
+
+statement ok
+CREATE TABLE sub_odd (a INT);
+INSERT INTO sub_odd VALUES (1), (3), (5)
+
+# UDF with an uncorrelated subquery.
+statement ok
+CREATE FUNCTION sub_max_odd() RETURNS INT LANGUAGE SQL AS $$
+  SELECT a FROM sub_all WHERE a = (SELECT max(a) FROM sub_odd)
+$$
+
+query II
+SELECT a, sub_max_odd() FROM sub_all WHERE a = sub_max_odd()
+----
+5  5
+
+# TODO(mgartner): Allow queries with subqueries outside and inside a UDF.
+statement error pgcode 0A000 unimplemented: apply joins with subqueries in the "inner" and "outer" contexts are not supported
+SELECT a FROM sub_all WHERE sub_max_odd() = (SELECT max(a) FROM sub_odd)
+
+# UDF with a subquery correlated with an input parameter.
+statement ok
+CREATE FUNCTION sub_prev_odd(i INT) RETURNS INT LANGUAGE SQL AS $$
+  SELECT a FROM sub_all WHERE a = (SELECT max(a) FROM sub_odd WHERE a < i)
+$$
+
+query II rowsort
+SELECT a, sub_prev_odd(a) FROM sub_all
+----
+1  NULL
+2  1
+3  1
+4  3
+5  3
+6  5
+
+# UDF with a correlated subquery.
+statement ok
+CREATE FUNCTION sub_is_odd(i INT) RETURNS BOOL LANGUAGE SQL AS $$
+  SELECT true FROM sub_all
+  WHERE EXISTS (SELECT 1 FROM sub_odd where sub_odd.a = sub_all.a)
+    AND a = i
+$$
+
+query IB rowsort
+SELECT a, sub_is_odd(a) FROM sub_all WHERE sub_is_odd(a) OR sub_is_odd(a) IS NULL
+----
+1  true
+2  NULL
+3  true
+4  NULL
+5  true
+6  NULL
 
 
 subtest variadic
@@ -2710,7 +2763,7 @@ SELECT oid, proname, pronamespace, proowner, prolang, proleakproof, proisstrict,
 FROM pg_catalog.pg_proc WHERE proname IN ('f_93314', 'f_93314_alias', 'f_93314_comp', 'f_93314_comp_t')
 ORDER BY oid;
 ----
-100251  f_93314        105  1546506610  14  false  false  false  v  0  100250  ·  {}  NULL  SELECT i, e FROM test.public.t_93314 ORDER BY i LIMIT 1;
-100253  f_93314_alias  105  1546506610  14  false  false  false  v  0  100252  ·  {}  NULL  SELECT i, e FROM test.public.t_93314_alias ORDER BY i LIMIT 1;
-100257  f_93314_comp    105  1546506610  14  false  false  false  v  0  100254  ·  {}  NULL  SELECT (1, 2);
-100258  f_93314_comp_t  105  1546506610  14  false  false  false  v  0  100256  ·  {}  NULL  SELECT a, c FROM test.public.t_93314_comp LIMIT 1;
+100256  f_93314         105  1546506610  14  false  false  false  v  0  100255  ·  {}  NULL  SELECT i, e FROM test.public.t_93314 ORDER BY i LIMIT 1;
+100258  f_93314_alias   105  1546506610  14  false  false  false  v  0  100257  ·  {}  NULL  SELECT i, e FROM test.public.t_93314_alias ORDER BY i LIMIT 1;
+100262  f_93314_comp    105  1546506610  14  false  false  false  v  0  100259  ·  {}  NULL  SELECT (1, 2);
+100263  f_93314_comp_t  105  1546506610  14  false  false  false  v  0  100261  ·  {}  NULL  SELECT a, c FROM test.public.t_93314_comp LIMIT 1;

--- a/pkg/sql/opt/exec/execbuilder/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
         "//pkg/sql/sem/tree/treebin",
         "//pkg/sql/sem/tree/treecmp",
         "//pkg/sql/sem/tree/treewindow",
+        "//pkg/sql/sem/volatility",
         "//pkg/sql/sqltelemetry",
         "//pkg/sql/types",
         "//pkg/util",

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -102,6 +102,13 @@ type Builder struct {
 	// by scans. See forUpdateLocking.
 	forceForUpdateLocking bool
 
+	// planLazySubqueries is true if the builder should plan subqueries that are
+	// lazily evaluated as routines instead of a subquery which is evaluated
+	// eagerly before the main query. This is required in cases that cannot be
+	// handled by the subquery execution machinery, e.g., when building
+	// subqueries for statements inside a UDF.
+	planLazySubqueries bool
+
 	// -- output --
 
 	// IsDDL is set to true if the statement contains DDL.

--- a/pkg/sql/opt/exec/execbuilder/testdata/udf
+++ b/pkg/sql/opt/exec/execbuilder/testdata/udf
@@ -96,6 +96,57 @@ query T kvtrace
 SELECT fetch_a_of_2_strict(1, NULL::INT)
 ----
 
+
+subtest subqueries
+
+statement ok
+CREATE TABLE sub1 (a INT);
+CREATE TABLE sub2 (a INT);
+CREATE TABLE sub3 (a INT);
+
+statement ok
+CREATE FUNCTION sub_fn() RETURNS INT LANGUAGE SQL AS 'SELECT a FROM sub1 WHERE a = (SELECT max(a) FROM sub2)'
+
+# A query with a subquery and a subquery inside a UDF.
+query T
+EXPLAIN (VERBOSE) SELECT * FROM sub3 WHERE sub_fn() = 3 AND (SELECT max(a) FROM sub2) = a
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: (a)
+│
+├── • filter
+│   │ columns: (a)
+│   │ estimated row count: 110 (missing stats)
+│   │ filter: (sub_fn() = 3) AND (a = @S1)
+│   │
+│   └── • scan
+│         columns: (a)
+│         estimated row count: 1,000 (missing stats)
+│         table: sub3@sub3_pkey
+│         spans: FULL SCAN
+│
+└── • subquery
+    │ id: @S1
+    │ original sql: (SELECT max(a) FROM sub2)
+    │ exec mode: one row
+    │
+    └── • group (scalar)
+        │ columns: (max)
+        │ estimated row count: 1 (missing stats)
+        │ aggregate 0: max(a)
+        │
+        └── • scan
+              columns: (a)
+              estimated row count: 1,000 (missing stats)
+              table: sub2@sub2_pkey
+              spans: FULL SCAN
+
+
+subtest regressions
+
 # Regression test for #93210. Do not plan unnecessary assignment casts on the
 # return values of UDFs.
 statement ok

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -295,6 +295,7 @@ func (b *Builder) buildStmt(
 	if b.insideFuncDef {
 		switch stmt := stmt.(type) {
 		case *tree.Select:
+		case tree.SelectStatement:
 		default:
 			panic(unimplemented.Newf("user-defined functions", "%s usage inside a function definition", stmt.StatementTag()))
 		}

--- a/pkg/sql/opt/optbuilder/subquery.go
+++ b/pkg/sql/opt/optbuilder/subquery.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treecmp"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/errors"
 )
 
@@ -203,9 +202,6 @@ func (s *subquery) Eval(_ context.Context, _ tree.ExprEvaluator) (tree.Datum, er
 // It stores the resulting relational expression in s.node, and also updates
 // s.cols and s.ordering with the output columns and ordering of the subquery.
 func (s *subquery) buildSubquery(desiredTypes []*types.T) {
-	if s.scope.builder.insideFuncDef {
-		panic(unimplemented.New("user-defined functions", "subquery usage inside a function definition"))
-	}
 	if s.scope.replaceSRFs {
 		// We need to save and restore the previous value of the replaceSRFs field in
 		// case we are recursively called within a subquery context.

--- a/pkg/sql/routine.go
+++ b/pkg/sql/routine.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/volatility"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
@@ -51,7 +50,7 @@ func (p *planner) EvalRoutineExpr(
 	// Configure stepping for volatile routines so that mutations made by the
 	// invoking statement are visible to the routine.
 	txn := p.Txn()
-	if expr.Volatility == volatility.Volatile {
+	if expr.EnableStepping {
 		prevSteppingMode := txn.ConfigureStepping(ctx, kv.SteppingEnabled)
 		prevSeqNum := txn.GetLeafTxnInputState(ctx).ReadSeqNum
 		defer func() {
@@ -90,7 +89,7 @@ func (p *planner) EvalRoutineExpr(
 
 			// Place a sequence point before each statement in the routine for
 			// volatile functions.
-			if expr.Volatility == volatility.Volatile {
+			if expr.EnableStepping {
 				if err := txn.Step(ctx); err != nil {
 					return err
 				}


### PR DESCRIPTION
#### sql: replace tree.Routine's Volatility field with EnableStepping

The `Volatility` field of `tree.Routine` makes the struct specific to
UDF execution. The field has been replaced with `EnableStepping` to
generalize `tree.Routine`, allowing it to be used in the future as
machinery for other types of expressions, like subqueries.

Release note: None

#### sql: enable some types of UDFs with subqueries

Previously, UDFs with statements containing subqueries were not allowed.
This restriction has been lifted. In many cases, these UDFs will be
executed successfully. But they do not currently work in all cases,
e.g., when the statement invoking the UDF also has subqueries.

Release note: None

#### sql: support statements with subqueries inside and outside UDF body

Previously, statements with subqueries that invoked UDFs with their own
subqueries would error. This was due to a limitation in the subquery
execution machinery which only supports running subqueries for top-level
statements.

This commit works around this limitation by planning subqueries within
UDFs as lazily evaluated routines, which have their own machinery for
evaluation. Subqueries for the top-level statement are still planned as
eagerly evaluated subqueries for two reasons:

  1. These new routine-based subqueries do not cache their results, if
     they are uncorrelated, so they are not as performant.
  2. Queries with eager subqueries can be distributed while routines
     cannot be distributed.

Future work includes caching the results of these lazily evaluated
subqueries to improve performance (addressing (1) above). We should also
be able use the same routine-based machinery to evaluate correlated
subqueries and eliminate all decorrelation errors.

Informs #87291

Epic CRDB-19257

Release note (sql change): User-defined functions with subqueries in the
body of the function are now supported.
