### PR TITLE
backupccl: change restore/tpce roachtest names and run tests on aws

### DIFF
--- a/build/teamcity/util/roachtest_util.sh
+++ b/build/teamcity/util/roachtest_util.sh
@@ -66,7 +66,7 @@ case "${CLOUD}" in
     if [ -z "${TESTS}" ]; then
       # NB: anchor ycsb to beginning of line to avoid matching `zfs/ycsb/*` which
       # isn't supported on AWS at time of writing.
-      TESTS="awsdms|kv(0|95)|^ycsb|tpcc/(headroom/n4cpu16)|tpccbench/(nodes=3/cpu=16)|scbench/randomload/(nodes=3/ops=2000/conc=1)|backup/(KMS/AWS/n3cpu4)"
+      TESTS="awsdms|kv(0|95)|^ycsb|tpcc/(headroom/n4cpu16)|tpccbench/(nodes=3/cpu=16)|scbench/randomload/(nodes=3/ops=2000/conc=1)|backup/(KMS/AWS/n3cpu4)|restore/tpce"
     fi
     ;;
   *)

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -762,18 +762,12 @@ type hardwareSpecs struct {
 	volumeSize int
 }
 
-// String prints the hardware specs. If full==false, only non default specs are printed.
+// String prints the hardware specs. If full==true, verbose specs are printed.
 func (hw hardwareSpecs) String(full bool) string {
 	var builder strings.Builder
-	if full || hw.cloud != defaultHardware.cloud {
-		builder.WriteString("/" + hw.cloud)
-	}
-	if full || hw.nodes != defaultHardware.nodes {
-		builder.WriteString(fmt.Sprintf("/nodes=%d", hw.nodes))
-	}
-	if full || hw.cpus != defaultHardware.cpus {
-		builder.WriteString(fmt.Sprintf("/cpus=%d", hw.cpus))
-	}
+	builder.WriteString("/" + hw.cloud)
+	builder.WriteString(fmt.Sprintf("/nodes=%d", hw.nodes))
+	builder.WriteString(fmt.Sprintf("/cpus=%d", hw.cpus))
 	if full {
 		builder.WriteString(fmt.Sprintf("/volSize=%dGB", hw.volumeSize))
 	}


### PR DESCRIPTION
This patch does 3 small things:
1) Ensure the new restore/tpce roachtests run on the aws roachtest nightly test job.
2) Revise the roachtest names to display hardware specs. I.e.:
- restore/tpce/400GB -> restore/tpce/400GB/aws/nodes=10/cpu=8
- restore/tpce/400GB/gce -> restore/tpce/400GB/gce/nodes=10/cpu=8

This prevents the the following headache: invoking `roachtest run restore/tpce/400GB` would previously run both tests above because `restore/tpce/400GB` regex matched with both tests. Now, each test name should uniquely identify a single test.

Release note: None

Epic: None