### PR TITLE
server: tenant access to node diagnostics and metrics

### DIFF
--- a/pkg/ccl/kvccl/kvtenantccl/BUILD.bazel
+++ b/pkg/ccl/kvccl/kvtenantccl/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/server/serverpb",
         "//pkg/settings",
         "//pkg/spanconfig",
+        "//pkg/ts/tspb",
         "//pkg/util/contextutil",
         "//pkg/util/errorutil",
         "//pkg/util/grpcutil",

--- a/pkg/ccl/kvccl/kvtenantccl/connector.go
+++ b/pkg/ccl/kvccl/kvtenantccl/connector.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
+	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
@@ -98,6 +99,8 @@ type Connector struct {
 type client struct {
 	roachpb.InternalClient
 	serverpb.StatusClient
+	serverpb.AdminClient
+	tspb.TimeSeriesClient
 }
 
 // Connector is capable of providing information on each of the KV nodes in the
@@ -123,6 +126,13 @@ var _ config.SystemConfigProvider = (*Connector)(nil)
 // tenant within the cluster. This is necessary for things such as
 // debug zip and range reports.
 var _ serverpb.TenantStatusServer = (*Connector)(nil)
+
+// Connector is capable of finding debug information about the cluster
+// the tenant belongs to. This is necessary for proper functioning of
+// the DB Console in cases where the tenant has privileges allowing it
+// to access system-level information.
+var _ serverpb.TenantAdminServer = (*Connector)(nil)
+var _ tspb.TenantTimeSeriesServer = (*Connector)(nil)
 
 // Connector is capable of accessing span configurations for secondary tenants.
 var _ spanconfig.KVAccessor = (*Connector)(nil)
@@ -451,6 +461,17 @@ func (c *Connector) RangeLookup(
 	return nil, nil, ctx.Err()
 }
 
+// NodesUI implements the serverpb.TenantStatusServer interface
+func (c *Connector) NodesUI(
+	ctx context.Context, req *serverpb.NodesRequest,
+) (resp *serverpb.NodesResponseExternal, retErr error) {
+	retErr = c.withClient(ctx, func(ctx context.Context, client *client) (err error) {
+		resp, err = client.NodesUI(ctx, req)
+		return
+	})
+	return
+}
+
 // Regions implements the serverpb.TenantStatusServer interface
 func (c *Connector) Regions(
 	ctx context.Context, req *serverpb.RegionsRequest,
@@ -747,8 +768,10 @@ func (c *Connector) dialAddrs(ctx context.Context) (*client, error) {
 				continue
 			}
 			return &client{
-				InternalClient: roachpb.NewInternalClient(conn),
-				StatusClient:   serverpb.NewStatusClient(conn),
+				InternalClient:   roachpb.NewInternalClient(conn),
+				StatusClient:     serverpb.NewStatusClient(conn),
+				AdminClient:      serverpb.NewAdminClient(conn),
+				TimeSeriesClient: tspb.NewTimeSeriesClient(conn),
 			}, nil
 		}
 	}
@@ -777,4 +800,26 @@ func (c *Connector) tryForgetClient(ctx context.Context, client roachpb.Internal
 	if c.mu.client == client {
 		c.mu.client = nil
 	}
+}
+
+// Liveness implements the serverpb.TenantAdminServer interface
+func (c *Connector) Liveness(
+	ctx context.Context, req *serverpb.LivenessRequest,
+) (resp *serverpb.LivenessResponse, retErr error) {
+	retErr = c.withClient(ctx, func(ctx context.Context, client *client) (err error) {
+		resp, err = client.Liveness(ctx, req)
+		return
+	})
+	return
+}
+
+// Query implements the serverpb.TenantTimeSeriesServer interface
+func (c *Connector) Query(
+	ctx context.Context, req *tspb.TimeSeriesQueryRequest,
+) (resp *tspb.TimeSeriesQueryResponse, retErr error) {
+	retErr = c.withClient(ctx, func(ctx context.Context, client *client) (err error) {
+		resp, err = client.Query(ctx, req)
+		return
+	})
+	return
 }

--- a/pkg/ccl/serverccl/adminccl/tenant_admin_test.go
+++ b/pkg/ccl/serverccl/adminccl/tenant_admin_test.go
@@ -57,12 +57,7 @@ func testUnimplementedRPCs(ctx context.Context, t *testing.T, helper serverccl.T
 	client := http.GetClient()
 	baseURL := http.GetBaseURL()
 
-	resp, err := client.Get(baseURL + "/_admin/v1/liveness")
-	require.NoError(t, err)
-	defer resp.Body.Close()
-	require.Equal(t, 501, resp.StatusCode)
-
-	resp, err = client.Post(baseURL+"/_admin/v1/enqueue_range", "application/json", nil)
+	resp, err := client.Post(baseURL+"/_admin/v1/enqueue_range", "application/json", nil)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	require.Equal(t, 501, resp.StatusCode)

--- a/pkg/kv/kvclient/kvtenant/BUILD.bazel
+++ b/pkg/kv/kvclient/kvtenant/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/spanconfig",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
+        "//pkg/ts/tspb",
         "//pkg/util/log",
         "//pkg/util/rangedesc",
         "//pkg/util/retry",

--- a/pkg/kv/kvclient/kvtenant/connector.go
+++ b/pkg/kv/kvclient/kvtenant/connector.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/rangedesc"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -72,6 +73,15 @@ type Connector interface {
 	// used by the SQL system to query for debug information, such as tenant-specific
 	// range reports.
 	serverpb.TenantStatusServer
+
+	// TenantAdminServer is the subset of the serverpb.AdminInterface that is
+	// used by the SQL system to query for debug information, such as cluster-wide
+	// observability.
+	serverpb.TenantAdminServer
+
+	// TenantTimeSeriesServer is the subset of the tspb.TimeSeriesServer that is
+	// used by the SQL system to query for timeseries data.
+	tspb.TenantTimeSeriesServer
 
 	// TokenBucketProvider provides access to the tenant cost control token
 	// bucket.

--- a/pkg/rpc/auth_tenant.go
+++ b/pkg/rpc/auth_tenant.go
@@ -133,6 +133,15 @@ func (a tenantAuthorizer) authorize(
 	case "/cockroach.server.serverpb.Status/HotRangesV2":
 		return a.authHotRangesV2(tenID)
 
+	case "/cockroach.server.serverpb.Status/NodesUI":
+		return a.authCapability(tenID)
+
+	case "/cockroach.server.serverpb.Admin/Liveness":
+		return a.authCapability(tenID)
+
+	case "/cockroach.ts.tspb.TimeSeries/Query":
+		return a.authCapability(tenID)
+
 	default:
 		return authErrorf("unknown method %q", fullMethod)
 	}
@@ -253,6 +262,12 @@ func (a tenantAuthorizer) authTenant(id roachpb.TenantID) error {
 	if a.tenantID != id {
 		return authErrorf("request from tenant %s not permitted on tenant %s", id, a.tenantID)
 	}
+	return nil
+}
+
+// authCapability checks if the current tenant has the requested capability.
+func (a tenantAuthorizer) authCapability(id roachpb.TenantID) error {
+	// TODO(davidh): add capability-specific checks here that correspond to specific requests.
 	return nil
 }
 

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -2199,6 +2199,15 @@ func getLivenessResponse(
 	}, nil
 }
 
+func (s *adminServer) Liveness(
+	ctx context.Context, req *serverpb.LivenessRequest,
+) (*serverpb.LivenessResponse, error) {
+	ctx = propagateGatewayMetadata(ctx)
+	ctx = s.AnnotateCtx(ctx)
+
+	return s.sqlServer.tenantConnect.Liveness(ctx, req)
+}
+
 // Liveness returns the liveness state of all nodes on the cluster
 // based on a KV transaction. To reach all nodes in the cluster, consider
 // using (statusServer).NodesWithLiveness instead.

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -100,6 +100,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/syntheticprivilegecache"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
+	"github.com/cockroachdb/cockroach/pkg/ts"
 	"github.com/cockroachdb/cockroach/pkg/upgrade"
 	"github.com/cockroachdb/cockroach/pkg/upgrade/upgradebase"
 	"github.com/cockroachdb/cockroach/pkg/upgrade/upgradecluster"
@@ -368,6 +369,9 @@ type sqlServerArgs struct {
 	// rangeDescIteratorFactory is used to construct iterators over range
 	// descriptors.
 	rangeDescIteratorFactory rangedesc.IteratorFactory
+
+	// tenantTimeSeriesServer is used to make TSDB queries by the DB Console.
+	tenantTimeSeriesServer *ts.TenantServer
 }
 
 type monitorAndMetrics struct {

--- a/pkg/server/serverpb/admin.go
+++ b/pkg/server/serverpb/admin.go
@@ -10,6 +10,8 @@
 
 package serverpb
 
+import context "context"
+
 // Add adds values from ots to ts.
 func (ts *TableStatsResponse) Add(ots *TableStatsResponse) {
 	ts.RangeCount += ots.RangeCount
@@ -35,4 +37,8 @@ func (ts *TableStatsResponse) Add(ots *TableStatsResponse) {
 			ts.NodeCount--
 		}
 	}
+}
+
+type TenantAdminServer interface {
+	Liveness(context.Context, *LivenessRequest) (*LivenessResponse, error)
 }

--- a/pkg/server/serverpb/status.go
+++ b/pkg/server/serverpb/status.go
@@ -81,6 +81,9 @@ type TenantStatusServer interface {
 	TenantRanges(context.Context, *TenantRangesRequest) (*TenantRangesResponse, error)
 	Regions(context.Context, *RegionsRequest) (*RegionsResponse, error)
 	HotRangesV2(context.Context, *HotRangesRequest) (*HotRangesResponseV2, error)
+
+	// NodesUI is used by DB Console.
+	NodesUI(context.Context, *NodesRequest) (*NodesResponseExternal, error)
 }
 
 // OptionalNodesStatusServer returns the wrapped NodesStatusServer, if it is

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1596,6 +1596,15 @@ func (s *systemStatusServer) Nodes(
 	return resp, nil
 }
 
+func (s *statusServer) NodesUI(
+	ctx context.Context, req *serverpb.NodesRequest,
+) (*serverpb.NodesResponseExternal, error) {
+	ctx = propagateGatewayMetadata(ctx)
+	ctx = s.AnnotateCtx(ctx)
+
+	return s.sqlServer.tenantConnect.NodesUI(ctx, req)
+}
+
 func (s *systemStatusServer) NodesUI(
 	ctx context.Context, req *serverpb.NodesRequest,
 ) (*serverpb.NodesResponseExternal, error) {

--- a/pkg/ts/BUILD.bazel
+++ b/pkg/ts/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
     deps = [
         "//pkg/keys",
         "//pkg/kv",
+        "//pkg/kv/kvclient/kvtenant",
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/allocator/storepool",
         "//pkg/roachpb",

--- a/pkg/ts/tspb/timeseries.go
+++ b/pkg/ts/tspb/timeseries.go
@@ -11,6 +11,7 @@
 package tspb
 
 import (
+	context "context"
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -105,4 +106,8 @@ func VerifySlabAndSampleDuration(slabDuration, sampleDuration int64) error {
 	}
 
 	return nil
+}
+
+type TenantTimeSeriesServer interface {
+	Query(context.Context, *TimeSeriesQueryRequest) (*TimeSeriesQueryResponse, error)
 }


### PR DESCRIPTION
Previously, tenants were unable to access cluster-level node information, and could not make timeseries queries. This is due to the fact that tenants do not have access to gossip data and cannot make aritrary KV requests. Any of these requests must go through the `kvtenant.Connector` interface which authorizes these requests and proxies them over gRPC to the KV server.

Future changes will gate these abilities behind Tenant privileges.

Epic: CRDB-12100

Resolves: #94967

Release note: None