### PR TITLE
allocator: correct node count calculations with overrides

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
@@ -836,11 +836,23 @@ func TestAllocatorExistingReplica(t *testing.T) {
 func TestAllocatorReplaceDecommissioningReplica(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	storeDescriptors := sameDCStores
+
+	getNumNodes := func() int {
+		numNodes := 0
+		for _, storeDesc := range storeDescriptors {
+			if storeDesc.Node.NodeID == roachpb.NodeID(3) {
+				continue
+			}
+			numNodes++
+		}
+		return numNodes
+	}
 
 	ctx := context.Background()
-	stopper, g, sp, a, _ := CreateTestAllocator(ctx, 1, false /* deterministic */)
+	stopper, g, sp, a, _ := CreateTestAllocator(ctx, getNumNodes(), false /* deterministic */)
 	defer stopper.Stop(ctx)
-	gossiputil.NewStoreGossiper(g).GossipStores(sameDCStores, t)
+	gossiputil.NewStoreGossiper(g).GossipStores(storeDescriptors, t)
 
 	// Override liveness of n3 to decommissioning so the only available target is s4.
 	oSp := storepool.NewOverrideStorePool(sp, func(nid roachpb.NodeID, now time.Time, timeUntilStoreDead time.Duration) livenesspb.NodeLivenessStatus {
@@ -849,7 +861,7 @@ func TestAllocatorReplaceDecommissioningReplica(t *testing.T) {
 		}
 
 		return sp.NodeLivenessFn(nid, now, timeUntilStoreDead)
-	})
+	}, getNumNodes)
 
 	result, _, err := a.AllocateVoter(
 		ctx,
@@ -6600,27 +6612,32 @@ func TestAllocatorComputeActionWithStorePoolRemoveDead(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
-	stopper, _, sp, a, _ := CreateTestAllocator(ctx, 10, false /* deterministic */)
-	defer stopper.Stop(ctx)
-
 	for i, tcase := range testCases {
-		// Mark all dead nodes as alive, so we can override later.
-		all := append(tcase.live, tcase.dead...)
-		mockStorePool(sp, all, nil, nil, nil, nil, nil)
-		oSp := storepool.NewOverrideStorePool(sp, func(nid roachpb.NodeID, now time.Time, timeUntilStoreDead time.Duration) livenesspb.NodeLivenessStatus {
-			for _, deadStoreID := range tcase.dead {
-				if nid == roachpb.NodeID(deadStoreID) {
-					return livenesspb.NodeLivenessStatus_DEAD
-				}
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			ctx := context.Background()
+			getNumNodes := func() int {
+				return len(tcase.live) + len(tcase.dead)
 			}
+			stopper, _, sp, a, _ := CreateTestAllocator(ctx, getNumNodes(), false /* deterministic */)
+			defer stopper.Stop(ctx)
 
-			return sp.NodeLivenessFn(nid, now, timeUntilStoreDead)
+			// Mark all dead nodes as alive, so we can override later.
+			all := append(tcase.live, tcase.dead...)
+			mockStorePool(sp, all, nil, nil, nil, nil, nil)
+			oSp := storepool.NewOverrideStorePool(sp, func(nid roachpb.NodeID, now time.Time, timeUntilStoreDead time.Duration) livenesspb.NodeLivenessStatus {
+				for _, deadStoreID := range tcase.dead {
+					if nid == roachpb.NodeID(deadStoreID) {
+						return livenesspb.NodeLivenessStatus_DEAD
+					}
+				}
+
+				return sp.NodeLivenessFn(nid, now, timeUntilStoreDead)
+			}, getNumNodes)
+			action, _ := a.ComputeAction(ctx, oSp, conf, &tcase.desc)
+			if tcase.expectedAction != action {
+				t.Errorf("Test case %d expected action %d, got action %d", i, tcase.expectedAction, action)
+			}
 		})
-		action, _ := a.ComputeAction(ctx, oSp, conf, &tcase.desc)
-		if tcase.expectedAction != action {
-			t.Errorf("Test case %d expected action %d, got action %d", i, tcase.expectedAction, action)
-		}
 	}
 }
 
@@ -7243,34 +7260,35 @@ func TestAllocatorComputeActionWithStorePoolDecommission(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
-	stopper, _, sp, a, _ := CreateTestAllocator(ctx, 10, false /* deterministic */)
-	defer stopper.Stop(ctx)
-
 	for i, tcase := range testCases {
-		// Mark all decommissioning and decommissioned nodes as alive, so we can override later.
-		all := append(tcase.live, tcase.decommissioning...)
-		all = append(all, tcase.decommissioned...)
-		overrideLivenessMap := make(map[roachpb.NodeID]livenesspb.NodeLivenessStatus)
-		for _, sID := range tcase.decommissioned {
-			overrideLivenessMap[roachpb.NodeID(sID)] = livenesspb.NodeLivenessStatus_DECOMMISSIONED
-		}
-		for _, sID := range tcase.decommissioning {
-			overrideLivenessMap[roachpb.NodeID(sID)] = livenesspb.NodeLivenessStatus_DECOMMISSIONING
-		}
-		mockStorePool(sp, all, nil, tcase.dead, nil, nil, nil)
-		oSp := storepool.NewOverrideStorePool(sp, func(nid roachpb.NodeID, now time.Time, timeUntilStoreDead time.Duration) livenesspb.NodeLivenessStatus {
-			if liveness, ok := overrideLivenessMap[nid]; ok {
-				return liveness
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			ctx := context.Background()
+			getNumNodes := func() int {
+				return len(tcase.live) + len(tcase.dead)
 			}
 
-			return sp.NodeLivenessFn(nid, now, timeUntilStoreDead)
+			stopper, _, sp, a, _ := CreateTestAllocator(ctx, getNumNodes(), false /* deterministic */)
+			defer stopper.Stop(ctx)
+
+			// Mark all decommissioning and decommissioned nodes as alive, so we can override later.
+			all := append(tcase.live, tcase.decommissioning...)
+			all = append(all, tcase.decommissioned...)
+			overrideLivenessMap := make(map[roachpb.NodeID]livenesspb.NodeLivenessStatus)
+			for _, sID := range tcase.decommissioned {
+				overrideLivenessMap[roachpb.NodeID(sID)] = livenesspb.NodeLivenessStatus_DECOMMISSIONED
+			}
+			for _, sID := range tcase.decommissioning {
+				overrideLivenessMap[roachpb.NodeID(sID)] = livenesspb.NodeLivenessStatus_DECOMMISSIONING
+			}
+			mockStorePool(sp, all, nil, tcase.dead, nil, nil, nil)
+			oSp := storepool.NewOverrideStorePool(sp,
+				storepool.OverrideNodeLivenessFunc(overrideLivenessMap, sp.NodeLivenessFn), getNumNodes,
+			)
+			action, _ := a.ComputeAction(ctx, oSp, tcase.conf, &tcase.desc)
+			if tcase.expectedAction != action {
+				t.Errorf("Test case %d expected action %s, got action %s", i, tcase.expectedAction, action)
+			}
 		})
-		action, _ := a.ComputeAction(ctx, oSp, tcase.conf, &tcase.desc)
-		if tcase.expectedAction != action {
-			t.Errorf("Test case %d expected action %s, got action %s", i, tcase.expectedAction, action)
-			continue
-		}
 	}
 }
 

--- a/pkg/kv/kvserver/allocator/storepool/override_store_pool.go
+++ b/pkg/kv/kvserver/allocator/storepool/override_store_pool.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -39,6 +40,7 @@ type OverrideStorePool struct {
 	sp *StorePool
 
 	overrideNodeLivenessFn NodeLivenessFunc
+	overrideNodeCountFn    NodeCountFunc
 }
 
 var _ AllocatorStorePool = &OverrideStorePool{}
@@ -58,13 +60,27 @@ func OverrideNodeLivenessFunc(
 	}
 }
 
+// OverrideNodeCountFunc constructs a NodeCountFunc based on a set of predefined
+// overrides. If any nodeID does not have an override, the real liveness is used
+// for the count for the number of nodes not decommissioning or decommissioned.
+func OverrideNodeCountFunc(
+	overrides map[roachpb.NodeID]livenesspb.NodeLivenessStatus, nodeLiveness *liveness.NodeLiveness,
+) NodeCountFunc {
+	return func() int {
+		return nodeLiveness.GetNodeCountWithOverrides(overrides)
+	}
+}
+
 // NewOverrideStorePool constructs an OverrideStorePool that can use its own
 // view of node liveness while falling through to an underlying store pool for
 // the state of peer stores.
-func NewOverrideStorePool(storePool *StorePool, nl NodeLivenessFunc) *OverrideStorePool {
+func NewOverrideStorePool(
+	storePool *StorePool, nl NodeLivenessFunc, nc NodeCountFunc,
+) *OverrideStorePool {
 	return &OverrideStorePool{
 		sp:                     storePool,
 		overrideNodeLivenessFn: nl,
+		overrideNodeCountFn:    nc,
 	}
 }
 
@@ -133,7 +149,7 @@ func (o *OverrideStorePool) LiveAndDeadReplicas(
 
 // ClusterNodeCount implements the AllocatorStorePool interface.
 func (o *OverrideStorePool) ClusterNodeCount() int {
-	return o.sp.ClusterNodeCount()
+	return o.overrideNodeCountFn()
 }
 
 // IsDeterministic implements the AllocatorStorePool interface.

--- a/pkg/kv/kvserver/allocator/storepool/override_store_pool_test.go
+++ b/pkg/kv/kvserver/allocator/storepool/override_store_pool_test.go
@@ -32,9 +32,11 @@ func TestOverrideStorePoolStatusString(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
+	const nodeCount = 5
+
 	stopper, g, _, testStorePool, mnl := CreateTestStorePool(ctx, st,
 		TestTimeUntilStoreDead, false, /* deterministic */
-		func() int { return 10 }, /* nodeCount */
+		func() int { return nodeCount }, /* nodeCount */
 		livenesspb.NodeLivenessStatus_DEAD)
 	defer stopper.Stop(ctx)
 	sg := gossiputil.NewStoreGossiper(g)
@@ -46,6 +48,15 @@ func TestOverrideStorePoolStatusString(t *testing.T) {
 		}
 
 		return mnl.NodeLivenessFunc(nid, now, timeUntilStoreDead)
+	}, func() int {
+		excluded := 0
+		for _, overriddenLiveness := range livenessOverrides {
+			if overriddenLiveness == livenesspb.NodeLivenessStatus_DECOMMISSIONING ||
+				overriddenLiveness == livenesspb.NodeLivenessStatus_DECOMMISSIONED {
+				excluded++
+			}
+		}
+		return nodeCount - excluded
 	})
 
 	stores := []*roachpb.StoreDescriptor{
@@ -102,9 +113,11 @@ func TestOverrideStorePoolDecommissioningReplicas(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
+	const nodeCount = 5
+
 	stopper, g, _, testStorePool, mnl := CreateTestStorePool(ctx, st,
 		TestTimeUntilStoreDead, false, /* deterministic */
-		func() int { return 10 }, /* nodeCount */
+		func() int { return nodeCount }, /* nodeCount */
 		livenesspb.NodeLivenessStatus_DEAD)
 	defer stopper.Stop(ctx)
 	sg := gossiputil.NewStoreGossiper(g)
@@ -116,6 +129,15 @@ func TestOverrideStorePoolDecommissioningReplicas(t *testing.T) {
 		}
 
 		return mnl.NodeLivenessFunc(nid, now, timeUntilStoreDead)
+	}, func() int {
+		excluded := 0
+		for _, overriddenLiveness := range livenessOverrides {
+			if overriddenLiveness == livenesspb.NodeLivenessStatus_DECOMMISSIONING ||
+				overriddenLiveness == livenesspb.NodeLivenessStatus_DECOMMISSIONED {
+				excluded++
+			}
+		}
+		return nodeCount - excluded
 	})
 
 	stores := []*roachpb.StoreDescriptor{
@@ -207,10 +229,12 @@ func TestOverrideStorePoolGetStoreList(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
+	const nodeCount = 8
+
 	// We're going to manually mark stores dead in this test.
 	stopper, g, _, testStorePool, mnl := CreateTestStorePool(ctx, st,
 		TestTimeUntilStoreDead, false, /* deterministic */
-		func() int { return 10 }, /* nodeCount */
+		func() int { return nodeCount }, /* nodeCount */
 		livenesspb.NodeLivenessStatus_DEAD)
 	defer stopper.Stop(ctx)
 	sg := gossiputil.NewStoreGossiper(g)
@@ -222,6 +246,15 @@ func TestOverrideStorePoolGetStoreList(t *testing.T) {
 		}
 
 		return mnl.NodeLivenessFunc(nid, now, timeUntilStoreDead)
+	}, func() int {
+		excluded := 0
+		for _, overriddenLiveness := range livenessOverrides {
+			if overriddenLiveness == livenesspb.NodeLivenessStatus_DECOMMISSIONING ||
+				overriddenLiveness == livenesspb.NodeLivenessStatus_DECOMMISSIONED {
+				excluded++
+			}
+		}
+		return nodeCount - excluded
 	})
 
 	constraints := []roachpb.ConstraintsConjunction{

--- a/pkg/kv/kvserver/liveness/liveness.go
+++ b/pkg/kv/kvserver/liveness/liveness.go
@@ -1528,6 +1528,27 @@ func (nl *NodeLiveness) GetNodeCount() int {
 	return count
 }
 
+// GetNodeCountWithOverrides returns a count of the number of nodes in the cluster,
+// including dead nodes, but excluding decommissioning or decommissioned nodes,
+// using the provided set of liveness overrides.
+func (nl *NodeLiveness) GetNodeCountWithOverrides(
+	overrides map[roachpb.NodeID]livenesspb.NodeLivenessStatus,
+) int {
+	nl.mu.RLock()
+	defer nl.mu.RUnlock()
+	var count int
+	for _, l := range nl.mu.nodes {
+		if l.Membership.Active() {
+			if overrideStatus, ok := overrides[l.NodeID]; !ok ||
+				(overrideStatus != livenesspb.NodeLivenessStatus_DECOMMISSIONING &&
+					overrideStatus != livenesspb.NodeLivenessStatus_DECOMMISSIONED) {
+				count++
+			}
+		}
+	}
+	return count
+}
+
 // TestingSetDrainingInternal is a testing helper to set the internal draining
 // state for a NodeLiveness instance.
 func (nl *NodeLiveness) TestingSetDrainingInternal(

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -3438,7 +3438,9 @@ func TestAllocatorCheckRange(t *testing.T) {
 		name               string
 		stores             []*roachpb.StoreDescriptor
 		existingReplicas   []roachpb.ReplicaDescriptor
+		zoneConfig         *zonepb.ZoneConfig
 		livenessOverrides  map[roachpb.NodeID]livenesspb.NodeLivenessStatus
+		baselineExpNoop    bool
 		expectedAction     allocatorimpl.AllocatorAction
 		expectValidTarget  bool
 		expectedLogMessage string
@@ -3519,6 +3521,25 @@ func TestAllocatorCheckRange(t *testing.T) {
 			expectAllocatorErr: true,
 			expectedErrStr:     "likely not enough nodes in cluster",
 		},
+		{
+			name:   "five to four nodes at RF five",
+			stores: noLocalityStores,
+			existingReplicas: []roachpb.ReplicaDescriptor{
+				{NodeID: 1, StoreID: 1, ReplicaID: 1},
+				{NodeID: 2, StoreID: 2, ReplicaID: 2},
+				{NodeID: 3, StoreID: 3, ReplicaID: 3},
+				{NodeID: 4, StoreID: 4, ReplicaID: 4},
+				{NodeID: 5, StoreID: 5, ReplicaID: 5},
+			},
+			zoneConfig: zonepb.DefaultSystemZoneConfigRef(),
+			livenessOverrides: map[roachpb.NodeID]livenesspb.NodeLivenessStatus{
+				3: livenesspb.NodeLivenessStatus_DECOMMISSIONING,
+			},
+			baselineExpNoop:   true,
+			expectedAction:    allocatorimpl.AllocatorRemoveDecommissioningVoter,
+			expectErr:         false,
+			expectValidTarget: false,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			// Setup store pool based on store descriptors and configure test store.
@@ -3539,6 +3560,12 @@ func TestAllocatorCheckRange(t *testing.T) {
 			cfg := TestStoreConfig(clock)
 			cfg.Gossip = g
 			cfg.StorePool = sp
+			if tc.zoneConfig != nil {
+				// TODO(sarkesian): This override is not great. It would be much
+				// preferable to provide a SpanConfig if possible. See comment in
+				// createTestStoreWithoutStart.
+				cfg.SystemConfigProvider.GetSystemConfig().DefaultZoneConfig = tc.zoneConfig
+			}
 
 			s := createTestStoreWithoutStart(ctx, t, stopper, testStoreOpts{createSystemRanges: true}, &cfg)
 
@@ -3552,7 +3579,31 @@ func TestAllocatorCheckRange(t *testing.T) {
 			var storePoolOverride storepool.AllocatorStorePool
 			if len(tc.livenessOverrides) > 0 {
 				livenessOverride := storepool.OverrideNodeLivenessFunc(tc.livenessOverrides, sp.NodeLivenessFn)
-				storePoolOverride = storepool.NewOverrideStorePool(sp, livenessOverride)
+				nodeCountOverride := func() int {
+					numDecomOverrides := 0
+					for _, livenessStatus := range tc.livenessOverrides {
+						if livenessStatus == livenesspb.NodeLivenessStatus_DECOMMISSIONING ||
+							livenessStatus == livenesspb.NodeLivenessStatus_DECOMMISSIONED {
+							numDecomOverrides++
+						}
+					}
+					return numNodes - numDecomOverrides
+				}
+				storePoolOverride = storepool.NewOverrideStorePool(sp, livenessOverride, nodeCountOverride)
+			}
+
+			// Check if our baseline action without overrides is a noop; i.e., the
+			// range is fully replicated as configured and needs no actions.
+			if tc.baselineExpNoop {
+				action, _, _, err := s.AllocatorCheckRange(ctx, desc,
+					false /* collectTraces */, nil, /* overrideStorePool */
+				)
+				require.NoError(t, err, "expected baseline check without error")
+				require.Containsf(t, []allocatorimpl.AllocatorAction{
+					allocatorimpl.AllocatorNoop,
+					allocatorimpl.AllocatorConsiderRebalance,
+				}, action, "expected baseline noop, got %s", action)
+				//require.Equalf(t, allocatorimpl.AllocatorNoop, action, "expected baseline noop, got %s", action)
 			}
 
 			// Execute actual allocator range repair check.

--- a/pkg/server/decommission.go
+++ b/pkg/server/decommission.go
@@ -223,7 +223,12 @@ func (s *Server) DecommissionPreCheck(
 	overrideNodeLivenessFn := storepool.OverrideNodeLivenessFunc(
 		decommissionCheckNodeIDs, existingStorePool.NodeLivenessFn,
 	)
-	overrideStorePool := storepool.NewOverrideStorePool(existingStorePool, overrideNodeLivenessFn)
+	overrideNodeCount := storepool.OverrideNodeCountFunc(
+		decommissionCheckNodeIDs, evalStore.GetStoreConfig().NodeLiveness,
+	)
+	overrideStorePool := storepool.NewOverrideStorePool(
+		existingStorePool, overrideNodeLivenessFn, overrideNodeCount,
+	)
 
 	// Define our replica filter to only look at the replicas on the checked nodes.
 	predHasDecommissioningReplica := func(rDesc roachpb.ReplicaDescriptor) bool {

--- a/pkg/server/decommission_test.go
+++ b/pkg/server/decommission_test.go
@@ -193,6 +193,78 @@ func TestDecommissionPreCheckEvaluation(t *testing.T) {
 	require.Lenf(t, result.rangesNotReady, 0, "unexpected number of unready ranges")
 }
 
+// TestDecommissionPreCheckOddToEven tests evaluation of decommission readiness
+// when moving from 5 nodes to 3, in which case ranges with RF of 5 should have
+// an effective RF of 3.
+func TestDecommissionPreCheckOddToEven(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Set up test cluster.
+	ctx := context.Background()
+	tc := serverutils.StartNewTestCluster(t, 5, base.TestClusterArgs{
+		ReplicationMode: base.ReplicationManual,
+	})
+	defer tc.Stopper().Stop(ctx)
+
+	firstSvr := tc.Server(0).(*TestServer)
+	db := tc.ServerConn(0)
+	runQueries := func(queries ...string) {
+		for _, q := range queries {
+			if _, err := db.Exec(q); err != nil {
+				t.Fatalf("error executing '%s': %s", q, err)
+			}
+		}
+	}
+
+	// Create database and tables.
+	ac := firstSvr.AmbientCtx()
+	ctx, span := ac.AnnotateCtxWithSpan(context.Background(), "test")
+	defer span.Finish()
+	setupQueries := []string{
+		"CREATE DATABASE test",
+		"CREATE TABLE test.tblA (val STRING)",
+		"INSERT INTO test.tblA VALUES ('testvalA')",
+	}
+	runQueries(setupQueries...)
+	alterQueries := []string{
+		"ALTER TABLE test.tblA CONFIGURE ZONE USING num_replicas = 5, " +
+			"range_max_bytes = 500000, range_min_bytes = 100",
+	}
+	runQueries(alterQueries...)
+	tblAID, err := firstSvr.admin.queryTableID(ctx, username.RootUserName(), "test", "tblA")
+	require.NoError(t, err)
+	startKeyTblA := keys.TODOSQLCodec.TablePrefix(uint32(tblAID))
+
+	// Split off range for tblA.
+	_, rDescA, err := firstSvr.SplitRange(startKeyTblA)
+	require.NoError(t, err)
+
+	// Ensure all nodes have the correct span configs for tblA.
+	waitForSpanConfig(t, tc, rDescA.StartKey, 500000)
+
+	// Transfer tblA to all nodes.
+	tc.AddVotersOrFatal(t, startKeyTblA, tc.Target(1), tc.Target(2), tc.Target(3), tc.Target(4))
+	tc.TransferRangeLeaseOrFatal(t, rDescA, tc.Target(1))
+
+	// Validate range distribution.
+	rDescA = tc.LookupRangeOrFatal(t, startKeyTblA)
+	require.Lenf(t, rDescA.Replicas().VoterAndNonVoterDescriptors(), 5, "expected 5 replicas, have %v", rDescA)
+
+	require.True(t, hasReplicaOnServers(tc, &rDescA, 0, 1, 2, 3, 4))
+
+	// Evaluate n5 decommission check.
+	decommissioningNodeIDs := []roachpb.NodeID{tc.Server(4).NodeID()}
+	result, err := firstSvr.DecommissionPreCheck(ctx, decommissioningNodeIDs,
+		true /* strictReadiness */, true /* collectTraces */, 10000, /* maxErrors */
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.rangesChecked, "unexpected number of ranges checked")
+	require.Equalf(t, 1, result.actionCounts[allocatorimpl.AllocatorRemoveDecommissioningVoter.String()],
+		"unexpected allocator actions, got %v", result.actionCounts)
+	require.Lenf(t, result.rangesNotReady, 0, "unexpected number of unready ranges")
+}
+
 // decommissionTsArgs returns a base.TestServerArgs for creating a test cluster
 // with per-store attributes using a single, in-memory store for each node.
 func decommissionTsArgs(region string, attrs ...string) base.TestServerArgs {


### PR DESCRIPTION
While we are correctly using the overrides set in the
`OverrideStorePool` for the purposes of the node liveness function, the
node count function did not properly incorporate the overrides
previously. This change rectifies that, using the preset overrides
specified at creation of the override store pool to calculate the number
of non-decommissioning, non-decommissioned nodes (alive or dead), as
viewed by the override store pool. This allows for correct calculation
of the number of needed voters, allowing us to correctly determine which
allocation action is needed for a range.

Depends on https://github.com/cockroachdb/cockroach/pull/93758.

Epic: [CRDB-20924](https://cockroachlabs.atlassian.net/browse/CRDB-20924)

Release note: None