### PR TITLE
cli/start: fix the selection of directories for temp storage and external I/O

### DIFF
--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -1139,6 +1139,26 @@ func extraStoreFlagInit(cmd *cobra.Command) error {
 		ss.Path = absPath
 		serverCfg.Stores.Specs[i] = ss
 	}
+
+	// Configure the external I/O directory.
+	if !fs.Changed(cliflags.ExternalIODir.Name) {
+		// Try to find a directory from the store configuration.
+		for _, ss := range serverCfg.Stores.Specs {
+			if ss.InMemory {
+				continue
+			}
+			startCtx.externalIODir = filepath.Join(ss.Path, "extern")
+			break
+		}
+	}
+	if startCtx.externalIODir != "" {
+		// Make the directory name absolute.
+		var err error
+		startCtx.externalIODir, err = base.GetAbsoluteStorePath(cliflags.ExternalIODir.Name, startCtx.externalIODir)
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/pkg/cli/interactive_tests/test_extern_dir.tcl
+++ b/pkg/cli/interactive_tests/test_extern_dir.tcl
@@ -9,16 +9,9 @@ spawn /bin/bash
 send "PS1=':''/# '\r"
 eexpect ":/# "
 
-start_test "Check that non-absolute external-io-dir rejected"
-
-send "$argv start-single-node --insecure --store=$storedir --external-io-dir=blah\r"
-eexpect "external-io-dir path must be absolute"
-
-end_test
-
 start_test "Check disabling external IO explicitly"
 
-send "$argv start-single-node --insecure --store=$storedir --external-io-dir=disabled\r"
+send "$argv start-single-node --insecure --store=$storedir --external-io-dir=''\r"
 eexpect "external I/O path:   <disabled>"
 interrupt
 eexpect "shutdown completed"
@@ -37,9 +30,9 @@ end_test
 start_test "Check implicit external I/O dir under store dir"
 
 send "$argv start-single-node --insecure --store=$storedir\r"
-eexpect "external I/O path:   $env(HOME)/$storedir/extern"
+eexpect "external I/O path:"
+eexpect "$storedir/extern"
 interrupt
 eexpect "shutdown completed"
 
 end_test
-

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -188,20 +188,6 @@ func initTraceDir(ctx context.Context, dir string) {
 	}
 }
 
-func initExternalIODir(ctx context.Context, firstStore base.StoreSpec) (string, error) {
-	externalIODir := startCtx.externalIODir
-	if externalIODir == "" && !firstStore.InMemory {
-		externalIODir = filepath.Join(firstStore.Path, "extern")
-	}
-	if externalIODir == "" || externalIODir == "disabled" {
-		return "", nil
-	}
-	if !filepath.IsAbs(externalIODir) {
-		return "", errors.Errorf("%s path must be absolute", cliflags.ExternalIODir.Name)
-	}
-	return externalIODir, nil
-}
-
 func initTempStorageConfig(
 	ctx context.Context, st *cluster.Settings, stopper *stop.Stopper, stores base.StoreSpecList,
 ) (base.TempStorageConfig, error) {
@@ -553,9 +539,7 @@ func runStartInternal(
 	st := serverCfg.BaseConfig.Settings
 
 	// Derive temporary/auxiliary directory specifications.
-	if st.ExternalIODir, err = initExternalIODir(ctx, serverCfg.Stores.Specs[0]); err != nil {
-		return err
-	}
+	st.ExternalIODir = startCtx.externalIODir
 
 	if serverCfg.SQLConfig.TempStorageConfig, err = initTempStorageConfig(
 		ctx, st, stopper, serverCfg.Stores,

--- a/pkg/cli/start_test.go
+++ b/pkg/cli/start_test.go
@@ -12,6 +12,8 @@ package cli
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -74,6 +76,57 @@ func TestInitInsecure(t *testing.T) {
 	}
 }
 
+func TestExternalIODirSpec(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Avoid leaking configuration changes after the tests end.
+	// In addition to the usual initCLIDefaults, we need to reset
+	// the serverCfg because --store modifies it in a way that
+	// initCLIDefaults does not restore.
+	defer func(save server.Config) { serverCfg = save }(serverCfg)
+	defer initCLIDefaults()
+
+	f := startCmd.Flags()
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	j := filepath.Join
+	defaultStoreDir := j(cwd, "cockroach-data")
+
+	testCases := []struct {
+		args     []string
+		expected string
+	}{
+		{[]string{}, j(defaultStoreDir, "extern")},
+		{[]string{`--store=type=mem,size=1G`}, ``},
+		{[]string{`--store=type=mem,size=1G`, `--store=path=foo`}, j(j(cwd, "foo"), "extern")},
+		{[]string{`--store=path=foo`, `--store=type=mem,size=1G`}, j(j(cwd, "foo"), "extern")},
+		{[]string{`--store=path=foo`, `--store=path=bar`}, j(j(cwd, "foo"), "extern")},
+		{[]string{`--external-io-dir=`}, ``},
+		{[]string{`--external-io-dir=foo`}, j(cwd, "foo")},
+		{[]string{`--external-io-dir=disabled`}, j(cwd, "disabled")},
+		{[]string{`--external-io-dir=`, `--store=path=foo`}, ``},
+	}
+	for i, c := range testCases {
+		// Reset the context and insecure flag for every test case.
+		initCLIDefaults()
+		if err := f.Parse(c.args); err != nil {
+			t.Error(err)
+			continue
+		}
+		if err := extraStoreFlagInit(startCmd); err != nil {
+			t.Error(err)
+			continue
+		}
+		if startCtx.externalIODir != c.expected {
+			t.Errorf("%d: expected:\n%q\ngot:\n%s", i, c.expected, startCtx.externalIODir)
+		}
+	}
+}
+
 func TestStartArgChecking(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -127,6 +180,7 @@ func TestStartArgChecking(t *testing.T) {
 	}
 	for i, c := range testCases {
 		// Reset the context and insecure flag for every test case.
+		initCLIDefaults()
 		err := f.Parse(c.args)
 		var err2 error
 		if err == nil {


### PR DESCRIPTION
Fixes #62357.

See the individual commits for details.
