### PR TITLE
release-22.2: cloud: buffer and put uploader for azure

### DIFF
--- a/pkg/ccl/backupccl/backup_cloud_test.go
+++ b/pkg/ccl/backupccl/backup_cloud_test.go
@@ -148,7 +148,39 @@ func TestCloudBackupRestoreGoogleCloudStorage(t *testing.T) {
 func TestCloudBackupRestoreAzure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	const numAccounts = 1000
+
+	uri := createAzureURI(t, "TestCloudBackupRestoreAzure")
+
+	ctx := context.Background()
+	tc, _, _, cleanupFn := backupRestoreTestSetup(t, 1, numAccounts, InitManualReplication)
+	defer cleanupFn()
+
+	backupAndRestore(ctx, t, tc, []string{uri.String()}, []string{uri.String()}, numAccounts)
+}
+
+// TestBackupRestoreAzureWithLegacyPut is like TestBackupRestoreAzure
+// but it uses the legacy buffer-and-put upload method.
+func TestCloudBackupRestoreAzureWithLegacyPut(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	const numAccounts = 1000
+
+	uri := createAzureURI(t, "TestCloudBackupRestoreAzureWithLegacyPut")
+
+	ctx := context.Background()
+	tc, db, _, cleanupFn := backupRestoreTestSetup(t, 1, numAccounts, InitManualReplication)
+	defer cleanupFn()
+	db.Exec(t, "SET CLUSTER SETTING cloudstorage.azure.buffer_and_put_uploads.enabled=true")
+	backupAndRestore(ctx, t, tc, []string{uri.String()}, []string{uri.String()}, numAccounts)
+}
+
+func createAzureURI(t *testing.T, prefix string) url.URL {
+	t.Helper()
 	accountName := os.Getenv("AZURE_ACCOUNT_NAME")
+	// NB: the Azure Account key must not be url encoded.
 	accountKey := os.Getenv("AZURE_ACCOUNT_KEY")
 	if accountName == "" || accountKey == "" {
 		skip.IgnoreLint(t, "AZURE_ACCOUNT_NAME and AZURE_ACCOUNT_KEY env vars must be set")
@@ -158,19 +190,11 @@ func TestCloudBackupRestoreAzure(t *testing.T) {
 		skip.IgnoreLint(t, "AZURE_CONTAINER env var must be set")
 	}
 
-	// TODO(dan): Actually invalidate the descriptor cache and delete this line.
-	defer lease.TestingDisableTableLeases()()
-	const numAccounts = 1000
-
-	ctx := context.Background()
-	tc, _, _, cleanupFn := backupRestoreTestSetup(t, 1, numAccounts, InitManualReplication)
-	defer cleanupFn()
-	prefix := fmt.Sprintf("TestBackupRestoreAzure-%d", timeutil.Now().UnixNano())
-	uri := url.URL{Scheme: "azure", Host: bucket, Path: prefix}
+	timestampedPrefix := fmt.Sprintf("%s-%d", prefix, timeutil.Now().UnixNano())
+	uri := url.URL{Scheme: "azure", Host: bucket, Path: timestampedPrefix}
 	values := uri.Query()
 	values.Add(azure.AzureAccountNameParam, accountName)
 	values.Add(azure.AzureAccountKeyParam, accountKey)
 	uri.RawQuery = values.Encode()
-
-	backupAndRestore(ctx, t, tc, []string{uri.String()}, []string{uri.String()}, numAccounts)
+	return uri
 }

--- a/pkg/cloud/azure/azure_storage.go
+++ b/pkg/cloud/azure/azure_storage.go
@@ -11,6 +11,7 @@
 package azure
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -51,6 +52,13 @@ const (
 
 	scheme                   = "azure"
 	externalConnectionScheme = "azure-storage"
+)
+
+var usePutBlob = settings.RegisterBoolSetting(
+	settings.TenantWritable,
+	"cloudstorage.azure.buffer_and_put_uploads.enabled",
+	"construct files in memory before uploading via PutBlob (may cause crashes due to memory usage)",
+	false,
 )
 
 func parseAzureURL(
@@ -151,6 +159,10 @@ func (s *azureStorage) Settings() *cluster.Settings {
 }
 
 func (s *azureStorage) Writer(ctx context.Context, basename string) (io.WriteCloser, error) {
+	if usePutBlob.Get(&s.settings.SV) {
+		return s.putUploader(ctx, basename)
+	}
+
 	ctx, sp := tracing.ChildSpan(ctx, "azure.Writer")
 	sp.RecordStructured(&types.StringValue{Value: fmt.Sprintf("azure.Writer: %s",
 		path.Join(s.prefix, basename))})
@@ -165,6 +177,39 @@ func (s *azureStorage) Writer(ctx context.Context, basename string) (io.WriteClo
 		)
 		return err
 	}), nil
+}
+
+type putBlobUploader struct {
+	ctx  context.Context
+	blob azblob.BlockBlobURL
+	b    *bytes.Buffer
+	sp   *tracing.Span
+}
+
+func (u *putBlobUploader) Write(p []byte) (int, error) {
+	return u.b.Write(p)
+}
+
+func (u *putBlobUploader) Close() error {
+	if u.b != nil {
+		defer u.sp.Finish()
+		r := bytes.NewReader(u.b.Bytes())
+		_, err := u.blob.Upload(u.ctx, r, azblob.BlobHTTPHeaders{}, azblob.Metadata{}, azblob.BlobAccessConditions{},
+			azblob.DefaultAccessTier, nil /* blobTagsMap */, azblob.ClientProvidedKeyOptions{})
+		u.b = nil
+		return err
+	}
+	return nil
+}
+
+func (s *azureStorage) putUploader(ctx context.Context, basename string) (io.WriteCloser, error) {
+	ctx, sp := tracing.ChildSpan(ctx, "azure.Writer")
+	return &putBlobUploader{
+		b:    bytes.NewBuffer(make([]byte, 0, 4<<20)),
+		ctx:  ctx,
+		sp:   sp,
+		blob: s.getBlob(basename),
+	}, nil
 }
 
 // ReadFile is shorthand for ReadFileAt with offset 0.


### PR DESCRIPTION
This implements a buffer-and-put uploader for Azure, similar to that which already exists for s3. The main purpose of this is to facilitate debugging of possible issues with our default multi-part upload process.

Epic: None

Release justification: Low risk optional behaviour to facilitate Azure debugging and mitigate azure upload performance regression.

Release note: None