### PR TITLE
kvserver: prevent race in Replica creation

### DIFF
--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -67,7 +67,7 @@ func (s *Store) FindTargetAndTransferLease(
 func (s *Store) AddReplica(repl *Replica) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if err := s.addReplicaToRangeMapLocked(repl); err != nil {
+	if err := s.addToReplicasByRangeIDLocked(repl); err != nil {
 		return err
 	}
 	if err := s.addToReplicasByKeyLocked(repl); err != nil {

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -70,7 +70,7 @@ func (s *Store) AddReplica(repl *Replica) error {
 	if err := s.addReplicaToRangeMapLocked(repl); err != nil {
 		return err
 	}
-	if err := s.addReplicaInternalLocked(repl); err != nil {
+	if err := s.addToReplicasByKeyLocked(repl); err != nil {
 		return err
 	}
 	s.metrics.ReplicaCount.Inc(1)

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -67,6 +67,9 @@ func (s *Store) FindTargetAndTransferLease(
 func (s *Store) AddReplica(repl *Replica) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if err := s.addReplicaToRangeMapLocked(repl); err != nil {
+		return err
+	}
 	if err := s.addReplicaInternalLocked(repl); err != nil {
 		return err
 	}

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1894,7 +1894,6 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 		// (Store).mu.
 		s.mu.Lock()
 		// TODO(pavelkalinnikov): hide these in Store's replica create functions.
-		// TODO(pavelkalinnikov): addToReplicasByRangeIDLocked needs a locked repl.mu.
 		err = s.addToReplicasByRangeIDLocked(rep)
 		if err == nil {
 			err = s.addToReplicasByKeyLocked(rep)

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1893,7 +1893,12 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 		// constraint (*Replica).raftMu < (*Store).mu. See the comment on
 		// (Store).mu.
 		s.mu.Lock()
-		err = s.addReplicaInternalLocked(rep)
+		// TODO(pavelkalinnikov): hide these in Store's replica create functions.
+		// TODO(pavelkalinnikov): addReplicaToRangeMapLocked needs a locked repl.mu.
+		err = s.addReplicaToRangeMapLocked(rep)
+		if err == nil {
+			err = s.addReplicaInternalLocked(rep)
+		}
 		s.mu.Unlock()
 		if err != nil {
 			return err

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -916,6 +916,9 @@ type Store struct {
 		// INVARIANT: Any ReplicaPlaceholder in this map is also in replicaPlaceholders.
 		// INVARIANT: Any Replica with Replica.IsInitialized()==true is also in replicasByRangeID.
 		replicasByKey *storeReplicaBTree
+		// creatingReplicas stores IDs of all ranges for which there is an ongoing
+		// attempt to create a replica.
+		creatingReplicas map[roachpb.RangeID]struct{}
 		// All *Replica objects for which Replica.IsInitialized is false.
 		//
 		// INVARIANT: any entry in this map is also in replicasByRangeID.
@@ -1290,6 +1293,7 @@ func NewStore(
 	s.mu.Lock()
 	s.mu.replicaPlaceholders = map[roachpb.RangeID]*ReplicaPlaceholder{}
 	s.mu.replicasByKey = newStoreReplicaBTree()
+	s.mu.creatingReplicas = map[roachpb.RangeID]struct{}{}
 	s.mu.uninitReplicas = map[roachpb.RangeID]*Replica{}
 	s.mu.Unlock()
 

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1897,7 +1897,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 		// TODO(pavelkalinnikov): addReplicaToRangeMapLocked needs a locked repl.mu.
 		err = s.addReplicaToRangeMapLocked(rep)
 		if err == nil {
-			err = s.addReplicaInternalLocked(rep)
+			err = s.addToReplicasByKeyLocked(rep)
 		}
 		s.mu.Unlock()
 		if err != nil {

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1894,8 +1894,8 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 		// (Store).mu.
 		s.mu.Lock()
 		// TODO(pavelkalinnikov): hide these in Store's replica create functions.
-		// TODO(pavelkalinnikov): addReplicaToRangeMapLocked needs a locked repl.mu.
-		err = s.addReplicaToRangeMapLocked(rep)
+		// TODO(pavelkalinnikov): addToReplicasByRangeIDLocked needs a locked repl.mu.
+		err = s.addToReplicasByRangeIDLocked(rep)
 		if err == nil {
 			err = s.addToReplicasByKeyLocked(rep)
 		}

--- a/pkg/kv/kvserver/store_create_replica.go
+++ b/pkg/kv/kvserver/store_create_replica.go
@@ -103,57 +103,59 @@ func (s *Store) tryGetReplica(
 	replicaID roachpb.ReplicaID,
 	creatingReplica *roachpb.ReplicaDescriptor,
 ) (*Replica, error) {
-	if repl, ok := s.mu.replicasByRangeID.Load(rangeID); ok {
-		repl.raftMu.Lock() // not unlocked on success
-		repl.mu.RLock()
+	repl, found := s.mu.replicasByRangeID.Load(rangeID)
+	if !found {
+		return nil, nil
+	}
 
-		// The current replica is removed, go back around.
-		if repl.mu.destroyStatus.Removed() {
-			repl.mu.RUnlock()
-			repl.raftMu.Unlock()
-			return nil, errRetry
-		}
+	repl.raftMu.Lock() // not unlocked on success
+	repl.mu.RLock()
 
-		// Drop messages from replicas we know to be too old.
-		if fromReplicaIsTooOldRLocked(repl, creatingReplica) {
-			repl.mu.RUnlock()
-			repl.raftMu.Unlock()
-			return nil, roachpb.NewReplicaTooOldError(creatingReplica.ReplicaID)
-		}
+	// The current replica is removed, go back around.
+	if repl.mu.destroyStatus.Removed() {
+		repl.mu.RUnlock()
+		repl.raftMu.Unlock()
+		return nil, errRetry
+	}
 
-		// The current replica needs to be removed, remove it and go back around.
-		if toTooOld := repl.replicaID < replicaID; toTooOld {
-			if shouldLog := log.V(1); shouldLog {
-				log.Infof(ctx, "found message for replica ID %d which is newer than %v",
-					replicaID, repl)
-			}
+	// Drop messages from replicas we know to be too old.
+	if fromReplicaIsTooOldRLocked(repl, creatingReplica) {
+		repl.mu.RUnlock()
+		repl.raftMu.Unlock()
+		return nil, roachpb.NewReplicaTooOldError(creatingReplica.ReplicaID)
+	}
 
-			repl.mu.RUnlock()
-			if err := s.removeReplicaRaftMuLocked(ctx, repl, replicaID, RemoveOptions{
-				DestroyData: true,
-			}); err != nil {
-				log.Fatalf(ctx, "failed to remove replica: %v", err)
-			}
-			repl.raftMu.Unlock()
-			return nil, errRetry
-		}
-		defer repl.mu.RUnlock()
-
-		if repl.replicaID > replicaID {
-			// The sender is behind and is sending to an old replica.
-			// We could silently drop this message but this way we'll inform the
-			// sender that they may no longer exist.
-			repl.raftMu.Unlock()
-			return nil, &roachpb.RaftGroupDeletedError{}
-		}
-		if repl.replicaID != replicaID {
-			// This case should have been caught by handleToReplicaTooOld.
-			log.Fatalf(ctx, "intended replica id %d unexpectedly does not match the current replica %v",
+	// The current replica needs to be removed, remove it and go back around.
+	if toTooOld := repl.replicaID < replicaID; toTooOld {
+		if shouldLog := log.V(1); shouldLog {
+			log.Infof(ctx, "found message for replica ID %d which is newer than %v",
 				replicaID, repl)
 		}
-		return repl, nil
+
+		repl.mu.RUnlock()
+		if err := s.removeReplicaRaftMuLocked(ctx, repl, replicaID, RemoveOptions{
+			DestroyData: true,
+		}); err != nil {
+			log.Fatalf(ctx, "failed to remove replica: %v", err)
+		}
+		repl.raftMu.Unlock()
+		return nil, errRetry
 	}
-	return nil, nil
+	defer repl.mu.RUnlock()
+
+	if repl.replicaID > replicaID {
+		// The sender is behind and is sending to an old replica.
+		// We could silently drop this message but this way we'll inform the
+		// sender that they may no longer exist.
+		repl.raftMu.Unlock()
+		return nil, &roachpb.RaftGroupDeletedError{}
+	}
+	if repl.replicaID != replicaID {
+		// This case should have been caught by handleToReplicaTooOld.
+		log.Fatalf(ctx, "intended replica id %d unexpectedly does not match the current replica %v",
+			replicaID, repl)
+	}
+	return repl, nil
 }
 
 // tryGetOrCreateReplica performs a single attempt at trying to lookup or

--- a/pkg/kv/kvserver/store_create_replica.go
+++ b/pkg/kv/kvserver/store_create_replica.go
@@ -217,7 +217,7 @@ func (s *Store) tryGetOrCreateReplica(
 		ctx, s.Engine(), tombstoneKey, hlc.Timestamp{}, &tombstone, storage.MVCCGetOptions{},
 	); err != nil {
 		return nil, false, err
-	} else if ok && replicaID != 0 && replicaID < tombstone.NextReplicaID {
+	} else if ok && replicaID < tombstone.NextReplicaID {
 		return nil, false, &roachpb.RaftGroupDeletedError{}
 	}
 

--- a/pkg/kv/kvserver/store_create_replica.go
+++ b/pkg/kv/kvserver/store_create_replica.go
@@ -335,7 +335,7 @@ func (s *Store) tryGetOrCreateReplica(
 	// key is unknown. The range will be added to replicasByKey later when a
 	// snapshot is applied.
 	// TODO(pavelkalinnikov): make this branch error-less.
-	if err := s.addReplicaToRangeMapLocked(repl); err != nil {
+	if err := s.addToReplicasByRangeIDLocked(repl); err != nil {
 		s.mu.Unlock()
 		repl.raftMu.Unlock()
 		return nil, false, err
@@ -400,8 +400,8 @@ func (s *Store) addPlaceholderLocked(placeholder *ReplicaPlaceholder) error {
 	return nil
 }
 
-// addReplicaToRangeMapLocked adds the replica to the replicas map.
-func (s *Store) addReplicaToRangeMapLocked(repl *Replica) error {
+// addToReplicasByRangeIDLocked adds the replica to the replicas map.
+func (s *Store) addToReplicasByRangeIDLocked(repl *Replica) error {
 	// It's ok for the replica to exist in the replicas map as long as it is the
 	// same replica object. This does not happen, to the best of our knowledge.
 	// TODO(pavelkalinnikov): consider asserting that existing == nil.

--- a/pkg/kv/kvserver/store_create_replica.go
+++ b/pkg/kv/kvserver/store_create_replica.go
@@ -361,12 +361,12 @@ func fromReplicaIsTooOldRLocked(toReplica *Replica, fromReplica *roachpb.Replica
 	return !found && fromReplica.ReplicaID < desc.NextReplicaID
 }
 
-// addReplicaInternalLocked adds the replica to the replicasByKey btree. The
+// addToReplicasByKeyLocked adds the replica to the replicasByKey btree. The
 // replica must already be in replicasByRangeID. Requires that Store.mu is held.
 //
 // Returns an error if a different replica with the same range ID, or an
 // overlapping replica or placeholder exists in this Store.
-func (s *Store) addReplicaInternalLocked(repl *Replica) error {
+func (s *Store) addToReplicasByKeyLocked(repl *Replica) error {
 	if !repl.IsInitialized() {
 		return errors.Errorf("attempted to add uninitialized replica %s", repl)
 	}
@@ -375,11 +375,11 @@ func (s *Store) addReplicaInternalLocked(repl *Replica) error {
 	}
 
 	if it := s.getOverlappingKeyRangeLocked(repl.Desc()); it.item != nil {
-		return errors.Errorf("%s: cannot addReplicaInternalLocked; range %s has overlapping range %s", s, repl, it.Desc())
+		return errors.Errorf("%s: cannot addToReplicasByKeyLocked; range %s has overlapping range %s", s, repl, it.Desc())
 	}
 
 	if it := s.mu.replicasByKey.ReplaceOrInsertReplica(context.Background(), repl); it.item != nil {
-		return errors.Errorf("%s: cannot addReplicaInternalLocked; range for key %v already exists in replicasByKey btree", s,
+		return errors.Errorf("%s: cannot addToReplicasByKeyLocked; range for key %v already exists in replicasByKey btree", s,
 			it.item.key())
 	}
 

--- a/pkg/kv/kvserver/store_create_replica.go
+++ b/pkg/kv/kvserver/store_create_replica.go
@@ -409,15 +409,6 @@ func (s *Store) addToReplicasByRangeIDLocked(repl *Replica) error {
 		repl.RangeID, repl); loaded && existing != repl {
 		return errors.Errorf("%s: replica already exists", repl)
 	}
-	// Check whether the replica is unquiesced but not in the map. This
-	// can happen during splits and merges, where the uninitialized (but
-	// also unquiesced) replica is removed from the unquiesced replica
-	// map in advance of this method being called.
-	if !repl.mu.quiescent {
-		s.unquiescedReplicas.Lock()
-		s.unquiescedReplicas.m[repl.RangeID] = struct{}{}
-		s.unquiescedReplicas.Unlock()
-	}
 	return nil
 }
 

--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -342,7 +342,7 @@ func (s *Store) SplitRange(
 		// assumption that distribution across all tracked load stats is
 		// identical.
 		leftRepl.loadStats.Split(rightRepl.loadStats)
-		if err := s.addReplicaInternalLocked(rightRepl); err != nil {
+		if err := s.addToReplicasByKeyLocked(rightRepl); err != nil {
 			return errors.Wrapf(err, "unable to add replica %v", rightRepl)
 		}
 


### PR DESCRIPTION
Previously, `getOrCreateReplica`:
- Creates a half-baked / "unloaded" `Replica` with `newUnloadedReplica`
- Inserts it to `replicasByRangeID`
- Leaves only the `Replica`'s locks acquired
- Finalizes / "loads" the `Replica`

This leaves a window of time during which the not properly created `Replica` is accessible via `Store` (in a limited way though, since its locks are still held). This makes space for a number of potential bugs.

After this commit:
- An uninitialized `Replica` is fully created
- Then it's inserted to the replicas map
- This is done with no regression in performance (in fact, there is a bonus)

As a result, the `Replica` is never accessible via `Store` until it's properly created.

Bonuses:
- `RangeTombstone` is read only once per replica creation (previously twice).
- The concept of unloaded replicas is now easily removable, because the replica creation code is consolidated, and is not interleaved with `Store` operations.

Informs #94911
Release note: none