### PR TITLE
ui: add empty sessions results placeholder, display all session status options in filter dropdown

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/queryFilter/filter.tsx
@@ -251,6 +251,7 @@ export const inactiveFiltersState: Required<Omit<Filters, "timeUnit">> = {
   sqlType: "",
   database: "",
   regions: "",
+  sessionStatus: "",
   nodes: "",
 };
 

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/emptySessionsTablePlaceholder.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/emptySessionsTablePlaceholder.tsx
@@ -1,0 +1,43 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { EmptyTable, EmptyTableProps } from "src/empty";
+import magnifyingGlassImg from "src/assets/emptyState/magnifying-glass.svg";
+import emptyTableResultsImg from "src/assets/emptyState/empty-table-results.svg";
+import { Anchor } from "src/anchor";
+import { sessionsTable } from "src/util";
+
+const footer = (
+  <Anchor href={sessionsTable} target="_blank">
+    Learn more about sessions.
+  </Anchor>
+);
+
+const emptySearchResults = {
+  title: "No sessions match your search.",
+  icon: magnifyingGlassImg,
+};
+
+export const EmptySessionsTablePlaceholder: React.FC<{
+  isEmptySearchResults: boolean;
+}> = props => {
+  const emptyPlaceholderProps: EmptyTableProps = props.isEmptySearchResults
+    ? emptySearchResults
+    : {
+        title: "No sessions currently running.",
+        message:
+          "Sessions show you which statements and transactions are running for the active session.",
+        icon: emptyTableResultsImg,
+        footer,
+      };
+
+  return <EmptyTable {...emptyPlaceholderProps} />;
+};

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
@@ -20,9 +20,7 @@ import {
 } from "./sessionsTable";
 import { RouteComponentProps } from "react-router-dom";
 import classNames from "classnames/bind";
-import { sessionsTable } from "src/util/docs";
 
-import emptyTableResultsIcon from "../assets/emptyState/empty-table-results.svg";
 import LoadingError from "../sqlActivity/errorComponent";
 import { Pagination } from "src/pagination";
 import {
@@ -32,8 +30,6 @@ import {
   ColumnDescriptor,
 } from "src/sortedtable";
 import { Loading } from "src/loading";
-import { Anchor } from "src/anchor";
-import { EmptyTable } from "src/empty";
 import {
   calculateActiveFilters,
   defaultFilters,
@@ -67,9 +63,12 @@ import {
   StatisticTableColumnKeys,
 } from "../statsTableUtil/statsTableUtil";
 import { TableStatistics } from "../tableStatistics";
+import { EmptySessionsTablePlaceholder } from "./emptySessionsTablePlaceholder";
 
 const statementsPageCx = classNames.bind(statementsPageStyles);
 const sessionsPageCx = classNames.bind(sessionPageStyles);
+
+const sessionStatusFilterOptions = ["Active", "Closed", "Idle"];
 
 export interface OwnProps {
   sessions: SessionInfo[];
@@ -120,14 +119,6 @@ function getSessionUsernameFilterOptions(sessions: SessionInfo[]): string[] {
   const uniqueUsernames = new Set(sessions.map(s => s.session.username));
 
   return Array.from(uniqueUsernames).sort();
-}
-
-function getSessionStatusFilterOptions(sessions: SessionInfo[]): string[] {
-  const uniqueStatuses = new Set(
-    sessions.map(s => getStatusString(s.session.status)),
-  );
-
-  return Array.from(uniqueStatuses).sort();
 }
 
 export class SessionsPage extends React.Component<
@@ -360,7 +351,7 @@ export class SessionsPage extends React.Component<
 
     const appNames = getSessionAppFilterOptions(sessionsData);
     const usernames = getSessionUsernameFilterOptions(sessionsData);
-    const sessionStatuses = getSessionStatusFilterOptions(sessionsData);
+    const sessionStatuses = sessionStatusFilterOptions;
     const columns = makeSessionsColumns(
       "session",
       this.terminateSessionRef,
@@ -427,14 +418,9 @@ export class SessionsPage extends React.Component<
             data={sessionsToDisplay}
             columns={displayColumns}
             renderNoResult={
-              <EmptyTable
-                title="No sessions are currently running"
-                icon={emptyTableResultsIcon}
-                message="Sessions show you which statements and transactions are running for the active session."
-                footer={
-                  <Anchor href={sessionsTable} target="_blank">
-                    Learn more about sessions
-                  </Anchor>
+              <EmptySessionsTablePlaceholder
+                isEmptySearchResults={
+                  activeFilters > 0 && sessionsToDisplay.length === 0
                 }
               />
             }


### PR DESCRIPTION
Epic: None

Previously, the sessions page's session status filter did not display
all session statuses (Active, Closed, Idle) and only displayed statuses
for which there was SessionData for. This commit adds all three session
status options and displays an empty results placeholder. This makes it
clear to the user that the results are empty because no sessions  match
the selected filter(s) rather than because there are no sessions
running.

Loom [demo](https://www.loom.com/share/fbece5545b6f4641acbee36323c5c079).

Release note (ui change): added all three session status options
(Active, Closed, Idle) and an empty results placeholder.