### PR TITLE
admission: CPU slot adjustment and utilization metrics

### DIFF
--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -2024,6 +2024,7 @@ func TestLint(t *testing.T) {
 			"../../storage/enginepb",
 			"../../storage/pebbleiter",
 			"../../util",
+			"../../util/admission",
 			"../../util/hlc",
 			"../../util/intsets",
 		}

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -3733,6 +3733,21 @@ var charts = []sectionDescription{
 				},
 			},
 			{
+				Title: "Granter Slot Counters",
+				Metrics: []string{
+					"admission.granter.slot_adjuster_increments.kv",
+					"admission.granter.slot_adjuster_decrements.kv",
+				},
+			},
+			{
+				Title: "Granter Slot Durations",
+				Metrics: []string{
+					"admission.granter.slots_exhausted_duration.kv",
+					"admission.granter.cpu_load_short_period_duration.kv",
+					"admission.granter.cpu_load_long_period_duration.kv",
+				},
+			},
+			{
 				Title: "Elastic CPU Utilization",
 				Metrics: []string{
 					"admission.elastic_cpu.utilization",

--- a/pkg/util/admission/grant_coordinator.go
+++ b/pkg/util/admission/grant_coordinator.go
@@ -431,13 +431,17 @@ func makeRegularGrantCoordinator(
 	}
 
 	kvSlotAdjuster := &kvSlotAdjuster{
-		settings:                 st,
-		minCPUSlots:              opts.MinCPUSlots,
-		maxCPUSlots:              opts.MaxCPUSlots,
-		totalSlotsMetric:         metrics.KVTotalSlots,
-		totalModerateSlotsMetric: metrics.KVTotalModerateSlots,
-		moderateSlotsClamp:       opts.MaxCPUSlots,
-		runnableAlphaOverride:    opts.RunnableAlphaOverride,
+		settings:                         st,
+		minCPUSlots:                      opts.MinCPUSlots,
+		maxCPUSlots:                      opts.MaxCPUSlots,
+		moderateSlotsClamp:               opts.MaxCPUSlots,
+		runnableAlphaOverride:            opts.RunnableAlphaOverride,
+		totalSlotsMetric:                 metrics.KVTotalSlots,
+		totalModerateSlotsMetric:         metrics.KVTotalModerateSlots,
+		cpuLoadShortPeriodDurationMetric: metrics.KVCPULoadShortPeriodDuration,
+		cpuLoadLongPeriodDurationMetric:  metrics.KVCPULoadLongPeriodDuration,
+		slotAdjusterIncrementsMetric:     metrics.KVSlotAdjusterIncrements,
+		slotAdjusterDecrementsMetric:     metrics.KVSlotAdjusterDecrements,
 	}
 	coord := &GrantCoordinator{
 		ambientCtx:                    ambientCtx,
@@ -451,12 +455,13 @@ func makeRegularGrantCoordinator(
 	}
 
 	kvg := &slotGranter{
-		coord:                  coord,
-		workKind:               KVWork,
-		totalHighLoadSlots:     opts.MinCPUSlots,
-		totalModerateLoadSlots: opts.MinCPUSlots,
-		usedSlotsMetric:        metrics.KVUsedSlots,
-		usedSoftSlotsMetric:    metrics.KVUsedSoftSlots,
+		coord:                        coord,
+		workKind:                     KVWork,
+		totalHighLoadSlots:           opts.MinCPUSlots,
+		totalModerateLoadSlots:       opts.MinCPUSlots,
+		usedSlotsMetric:              metrics.KVUsedSlots,
+		usedSoftSlotsMetric:          metrics.KVUsedSoftSlots,
+		slotsExhaustedDurationMetric: metrics.KVSlotsExhaustedDuration,
 	}
 
 	kvSlotAdjuster.granter = kvg
@@ -946,13 +951,18 @@ func (coord *GrantCoordinator) SafeFormat(s redact.SafePrinter, verb rune) {
 
 // GrantCoordinatorMetrics are metrics associated with a GrantCoordinator.
 type GrantCoordinatorMetrics struct {
-	KVTotalSlots                *metric.Gauge
-	KVUsedSlots                 *metric.Gauge
-	KVTotalModerateSlots        *metric.Gauge
-	KVUsedSoftSlots             *metric.Gauge
-	KVIOTokensExhaustedDuration *metric.Counter
-	SQLLeafStartUsedSlots       *metric.Gauge
-	SQLRootStartUsedSlots       *metric.Gauge
+	KVTotalSlots                 *metric.Gauge
+	KVUsedSlots                  *metric.Gauge
+	KVTotalModerateSlots         *metric.Gauge
+	KVUsedSoftSlots              *metric.Gauge
+	KVSlotsExhaustedDuration     *metric.Counter
+	KVCPULoadShortPeriodDuration *metric.Counter
+	KVCPULoadLongPeriodDuration  *metric.Counter
+	KVSlotAdjusterIncrements     *metric.Counter
+	KVSlotAdjusterDecrements     *metric.Counter
+	KVIOTokensExhaustedDuration  *metric.Counter
+	SQLLeafStartUsedSlots        *metric.Gauge
+	SQLRootStartUsedSlots        *metric.Gauge
 }
 
 // MetricStruct implements the metric.Struct interface.
@@ -960,13 +970,20 @@ func (GrantCoordinatorMetrics) MetricStruct() {}
 
 func makeGrantCoordinatorMetrics() GrantCoordinatorMetrics {
 	m := GrantCoordinatorMetrics{
-		KVTotalSlots:                metric.NewGauge(totalSlots),
-		KVUsedSlots:                 metric.NewGauge(addName(workKindString(KVWork), usedSlots)),
-		KVTotalModerateSlots:        metric.NewGauge(totalModerateSlots),
-		KVUsedSoftSlots:             metric.NewGauge(usedSoftSlots),
-		KVIOTokensExhaustedDuration: metric.NewCounter(kvIOTokensExhaustedDuration),
-		SQLLeafStartUsedSlots:       metric.NewGauge(addName(workKindString(SQLStatementLeafStartWork), usedSlots)),
-		SQLRootStartUsedSlots:       metric.NewGauge(addName(workKindString(SQLStatementRootStartWork), usedSlots)),
+		KVTotalSlots: metric.NewGauge(totalSlots),
+		KVUsedSlots:  metric.NewGauge(addName(workKindString(KVWork), usedSlots)),
+		// TODO(sumeer): remove moderate load slots and soft slots code and
+		// metrics #88032.
+		KVTotalModerateSlots:         metric.NewGauge(totalModerateSlots),
+		KVUsedSoftSlots:              metric.NewGauge(usedSoftSlots),
+		KVSlotsExhaustedDuration:     metric.NewCounter(kvSlotsExhaustedDuration),
+		KVCPULoadShortPeriodDuration: metric.NewCounter(kvCPULoadShortPeriodDuration),
+		KVCPULoadLongPeriodDuration:  metric.NewCounter(kvCPULoadLongPeriodDuration),
+		KVSlotAdjusterIncrements:     metric.NewCounter(kvSlotAdjusterIncrements),
+		KVSlotAdjusterDecrements:     metric.NewCounter(kvSlotAdjusterDecrements),
+		KVIOTokensExhaustedDuration:  metric.NewCounter(kvIOTokensExhaustedDuration),
+		SQLLeafStartUsedSlots:        metric.NewGauge(addName(workKindString(SQLStatementLeafStartWork), usedSlots)),
+		SQLRootStartUsedSlots:        metric.NewGauge(addName(workKindString(SQLStatementRootStartWork), usedSlots)),
 	}
 	return m
 }

--- a/pkg/util/admission/granter.go
+++ b/pkg/util/admission/granter.go
@@ -102,6 +102,9 @@ type slotGranter struct {
 
 	usedSlotsMetric     *metric.Gauge
 	usedSoftSlotsMetric *metric.Gauge
+	// Non-nil for KV slots.
+	slotsExhaustedDurationMetric *metric.Counter
+	exhaustedStart               time.Time
 }
 
 var _ granterWithLockedCalls = &slotGranter{}
@@ -127,6 +130,9 @@ func (sg *slotGranter) tryGetLocked(count int64, _ int8) grantResult {
 	}
 	if sg.usedSlots < sg.totalHighLoadSlots || sg.skipSlotEnforcement {
 		sg.usedSlots++
+		if sg.usedSlots == sg.totalHighLoadSlots && sg.slotsExhaustedDurationMetric != nil {
+			sg.exhaustedStart = timeutil.Now()
+		}
 		sg.usedSlotsMetric.Update(int64(sg.usedSlots))
 		return grantSuccess
 	}
@@ -172,6 +178,11 @@ func (sg *slotGranter) returnGrantLocked(count int64, _ int8) {
 	if count != 1 {
 		panic(errors.AssertionFailedf("unexpected count: %d", count))
 	}
+	if sg.usedSlots == sg.totalHighLoadSlots && sg.slotsExhaustedDurationMetric != nil {
+		now := timeutil.Now()
+		exhaustedMicros := now.Sub(sg.exhaustedStart).Microseconds()
+		sg.slotsExhaustedDurationMetric.Inc(exhaustedMicros)
+	}
 	sg.usedSlots--
 	if sg.usedSlots < 0 {
 		panic(errors.AssertionFailedf("used slots is negative %d", sg.usedSlots))
@@ -190,6 +201,9 @@ func (sg *slotGranter) tookWithoutPermissionLocked(count int64, _ int8) {
 		panic(errors.AssertionFailedf("unexpected count: %d", count))
 	}
 	sg.usedSlots++
+	if sg.usedSlots == sg.totalHighLoadSlots && sg.slotsExhaustedDurationMetric != nil {
+		sg.exhaustedStart = timeutil.Now()
+	}
 	sg.usedSlotsMetric.Update(int64(sg.usedSlots))
 }
 
@@ -217,6 +231,32 @@ func (sg *slotGranter) tryGrantLocked(grantChainID grantChainID) grantResult {
 		}
 	}
 	return res
+}
+
+//gcassert:inline
+func (sg *slotGranter) setTotalHighLoadSlotsLocked(totalHighLoadSlots int) {
+	// Mid-stack inlining.
+	if totalHighLoadSlots == sg.totalHighLoadSlots {
+		return
+	}
+	sg.setTotalHighLoadSlotsLockedInternal(totalHighLoadSlots)
+}
+
+func (sg *slotGranter) setTotalHighLoadSlotsLockedInternal(totalHighLoadSlots int) {
+	if sg.slotsExhaustedDurationMetric != nil {
+		if totalHighLoadSlots > sg.totalHighLoadSlots {
+			if sg.totalHighLoadSlots <= sg.usedSlots && totalHighLoadSlots > sg.usedSlots {
+				now := timeutil.Now()
+				exhaustedMicros := now.Sub(sg.exhaustedStart).Microseconds()
+				sg.slotsExhaustedDurationMetric.Inc(exhaustedMicros)
+			}
+		} else if totalHighLoadSlots < sg.totalHighLoadSlots {
+			if sg.totalHighLoadSlots > sg.usedSlots && totalHighLoadSlots <= sg.usedSlots {
+				sg.exhaustedStart = timeutil.Now()
+			}
+		}
+	}
+	sg.totalHighLoadSlots = totalHighLoadSlots
 }
 
 // tokenGranter implements granterWithLockedCalls.
@@ -688,6 +728,42 @@ var (
 	usedSoftSlots = metric.Metadata{
 		Name:        "admission.granter.used_soft_slots.kv",
 		Help:        "Used soft slots",
+		Measurement: "Slots",
+		Unit:        metric.Unit_COUNT,
+	}
+	// NB: this metric is independent of whether slots enforcement is happening
+	// or not.
+	kvSlotsExhaustedDuration = metric.Metadata{
+		Name:        "admission.granter.slots_exhausted_duration.kv",
+		Help:        "Total duration when KV slots were exhausted, in micros",
+		Measurement: "Microseconds",
+		Unit:        metric.Unit_COUNT,
+	}
+	// We have a metric for both short and long period. These metrics use the
+	// period provided in CPULoad and not wall time. So if the sum of the rate
+	// of these two is < 1sec/sec, the CPULoad ticks are not happening at the
+	// expected frequency (this could happen due to CPU overload).
+	kvCPULoadShortPeriodDuration = metric.Metadata{
+		Name:        "admission.granter.cpu_load_short_period_duration.kv",
+		Help:        "Total duration when CPULoad was being called with a short period, in micros",
+		Measurement: "Microseconds",
+		Unit:        metric.Unit_COUNT,
+	}
+	kvCPULoadLongPeriodDuration = metric.Metadata{
+		Name:        "admission.granter.cpu_load_long_period_duration.kv",
+		Help:        "Total duration when CPULoad was being called with a long period, in micros",
+		Measurement: "Microseconds",
+		Unit:        metric.Unit_COUNT,
+	}
+	kvSlotAdjusterIncrements = metric.Metadata{
+		Name:        "admission.granter.slot_adjuster_increments.kv",
+		Help:        "Number of increments of the total KV slots",
+		Measurement: "Slots",
+		Unit:        metric.Unit_COUNT,
+	}
+	kvSlotAdjusterDecrements = metric.Metadata{
+		Name:        "admission.granter.slot_adjuster_decrements.kv",
+		Help:        "Number of decrements of the total KV slots",
 		Measurement: "Slots",
 		Unit:        metric.Unit_COUNT,
 	}

--- a/pkg/util/admission/granter_test.go
+++ b/pkg/util/admission/granter_test.go
@@ -228,7 +228,17 @@ func TestGranterBasic(t *testing.T) {
 				samplePeriod = 250 * time.Millisecond
 			}
 			coord.CPULoad(runnable, procs, samplePeriod)
-			return flushAndReset()
+			str := flushAndReset()
+			kvsa := coord.cpuLoadListener.(*kvSlotAdjuster)
+			microsToMillis := func(micros int64) int64 {
+				return micros * int64(time.Microsecond) / int64(time.Millisecond)
+			}
+			return fmt.Sprintf("%sSlotAdjuster metrics: slots: %d, duration (short, long) millis: (%d, %d), inc: %d, dec: %d\n",
+				str, kvsa.totalSlotsMetric.Value(),
+				microsToMillis(kvsa.cpuLoadShortPeriodDurationMetric.Count()),
+				microsToMillis(kvsa.cpuLoadLongPeriodDurationMetric.Count()),
+				kvsa.slotAdjusterIncrementsMetric.Count(), kvsa.slotAdjusterDecrementsMetric.Count(),
+			)
 
 		case "set-io-tokens":
 			var tokens int

--- a/pkg/util/admission/testdata/granter
+++ b/pkg/util/admission/testdata/granter
@@ -220,6 +220,7 @@ cpu-load runnable=0 procs=1
 GrantCoordinator:
 (chain: id: 4 active: false index: 1) kv: used: 2, high(moderate)-total: 2(0) moderate-clamp: 0 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: used: 1, total: 1
+SlotAdjuster metrics: slots: 2, duration (short, long) millis: (1, 0), inc: 1, dec: 0
 
 # Tokens don't get overfull. And kv slots increased to 3. This causes a grant
 # to sql-kv-response and the grant chain is again active.
@@ -229,6 +230,7 @@ sql-kv-response: granted in chain 4, and returning 1
 GrantCoordinator:
 (chain: id: 4 active: true index: 1) kv: used: 2, high(moderate)-total: 3(0) moderate-clamp: 0 sql-kv-response: avail: 1
 sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: used: 1, total: 1
+SlotAdjuster metrics: slots: 3, duration (short, long) millis: (2, 0), inc: 2, dec: 0
 
 # Overload and kv slots decreased. Forces termination of grant chain 4.
 cpu-load runnable=2 procs=1
@@ -236,6 +238,7 @@ cpu-load runnable=2 procs=1
 GrantCoordinator:
 (chain: id: 5 active: false index: 1) kv: used: 2, high(moderate)-total: 2(0) moderate-clamp: -1 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 1, total: 2 sql-root-start: used: 1, total: 1
+SlotAdjuster metrics: slots: 2, duration (short, long) millis: (3, 0), inc: 2, dec: 1
 
 # Grant chain 4 terminates.
 continue-grant-chain work=sql-kv-response
@@ -266,6 +269,7 @@ sql-leaf-start: granted in chain 5, and returning 1
 GrantCoordinator:
 (chain: id: 5 active: true index: 3) kv: used: 2, high(moderate)-total: 3(0) moderate-clamp: 0 sql-kv-response: avail: 0
 sql-sql-response: avail: 1 sql-leaf-start: used: 2, total: 2 sql-root-start: used: 1, total: 1
+SlotAdjuster metrics: slots: 3, duration (short, long) millis: (4, 0), inc: 3, dec: 1
 
 # There is now a free sql-root-start slot, which the grant chain will get to.
 return-grant work=sql-root-start
@@ -332,6 +336,7 @@ cpu-load runnable=20 procs=1 infrequent=true
 GrantCoordinator:
 (chain: id: 1 active: false index: 5) kv: used: 1, high(moderate)-total: 1(0) moderate-clamp: -19 sql-kv-response: avail: 1
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 2
+SlotAdjuster metrics: slots: 1, duration (short, long) millis: (0, 250), inc: 0, dec: 0
 
 # sql-kv-response can get a token.
 try-get work=sql-kv-response
@@ -626,6 +631,7 @@ cpu-load runnable=0 procs=4 clamp=100
 GrantCoordinator:
 (chain: id: 1 active: false index: 5) kv: used: 0, high(moderate)-total: 2(2) moderate-clamp: 100 used-soft: 1 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+SlotAdjuster metrics: slots: 2, duration (short, long) millis: (1, 0), inc: 1, dec: 0
 
 try-get-soft-slots slots=2
 ----
@@ -676,6 +682,7 @@ cpu-load runnable=4 procs=8 clamp=100
 GrantCoordinator:
 (chain: id: 1 active: false index: 5) kv: used: 2, high(moderate)-total: 3(2) moderate-clamp: 100 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+SlotAdjuster metrics: slots: 3, duration (short, long) millis: (2, 0), inc: 2, dec: 0
 
 try-get-soft-slots slots=2
 ----
@@ -689,6 +696,7 @@ cpu-load runnable=1 procs=8 clamp=100
 GrantCoordinator:
 (chain: id: 1 active: false index: 5) kv: used: 2, high(moderate)-total: 3(3) moderate-clamp: 100 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+SlotAdjuster metrics: slots: 3, duration (short, long) millis: (3, 0), inc: 2, dec: 0
 
 try-get-soft-slots slots=2
 ----
@@ -702,6 +710,7 @@ cpu-load runnable=3 procs=8 clamp=100
 GrantCoordinator:
 (chain: id: 1 active: false index: 5) kv: used: 2, high(moderate)-total: 4(3) moderate-clamp: 100 used-soft: 1 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+SlotAdjuster metrics: slots: 4, duration (short, long) millis: (4, 0), inc: 3, dec: 0
 
 return-grant work=kv
 ----
@@ -722,12 +731,14 @@ cpu-load runnable=2 procs=8 clamp=100
 GrantCoordinator:
 (chain: id: 1 active: false index: 5) kv: used: 1, high(moderate)-total: 4(4) moderate-clamp: 100 used-soft: 2 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+SlotAdjuster metrics: slots: 4, duration (short, long) millis: (5, 0), inc: 3, dec: 0
 
 cpu-load runnable=2 procs=8 clamp=100
 ----
 GrantCoordinator:
 (chain: id: 1 active: false index: 5) kv: used: 1, high(moderate)-total: 4(4) moderate-clamp: 100 used-soft: 2 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+SlotAdjuster metrics: slots: 4, duration (short, long) millis: (6, 0), inc: 3, dec: 0
 
 try-get-soft-slots slots=2
 ----
@@ -741,24 +752,28 @@ cpu-load runnable=2 procs=8 clamp=100
 GrantCoordinator:
 (chain: id: 1 active: false index: 5) kv: used: 1, high(moderate)-total: 5(5) moderate-clamp: 100 used-soft: 3 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+SlotAdjuster metrics: slots: 5, duration (short, long) millis: (7, 0), inc: 4, dec: 0
 
 cpu-load runnable=6 procs=8 clamp=100
 ----
 GrantCoordinator:
 (chain: id: 1 active: false index: 5) kv: used: 1, high(moderate)-total: 5(4) moderate-clamp: 100 used-soft: 3 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+SlotAdjuster metrics: slots: 5, duration (short, long) millis: (8, 0), inc: 4, dec: 0
 
 cpu-load runnable=6 procs=8 clamp=100
 ----
 GrantCoordinator:
 (chain: id: 1 active: false index: 5) kv: used: 1, high(moderate)-total: 5(3) moderate-clamp: 100 used-soft: 3 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+SlotAdjuster metrics: slots: 5, duration (short, long) millis: (9, 0), inc: 4, dec: 0
 
 cpu-load runnable=6 procs=8 clamp=100
 ----
 GrantCoordinator:
 (chain: id: 1 active: false index: 5) kv: used: 1, high(moderate)-total: 5(3) moderate-clamp: 100 used-soft: 3 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+SlotAdjuster metrics: slots: 5, duration (short, long) millis: (10, 0), inc: 4, dec: 0
 
 #####################################################################
 # Test soft slots is not higher than regular slots.
@@ -780,6 +795,7 @@ cpu-load runnable=2 procs=8 clamp=100
 GrantCoordinator:
 (chain: id: 1 active: false index: 5) kv: used: 0, high(moderate)-total: 2(2) moderate-clamp: 100 used-soft: 1 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+SlotAdjuster metrics: slots: 2, duration (short, long) millis: (1, 0), inc: 1, dec: 0
 
 try-get-soft-slots slots=1
 ----
@@ -793,6 +809,7 @@ cpu-load runnable=2 procs=8 clamp=100
 GrantCoordinator:
 (chain: id: 1 active: false index: 5) kv: used: 0, high(moderate)-total: 3(3) moderate-clamp: 100 used-soft: 2 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+SlotAdjuster metrics: slots: 3, duration (short, long) millis: (2, 0), inc: 2, dec: 0
 
 return-soft-slots slots=2
 ----
@@ -805,6 +822,7 @@ cpu-load runnable=10 procs=8 clamp=100
 GrantCoordinator:
 (chain: id: 1 active: false index: 5) kv: used: 0, high(moderate)-total: 3(3) moderate-clamp: 100 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+SlotAdjuster metrics: slots: 3, duration (short, long) millis: (3, 0), inc: 2, dec: 0
 
 try-get work=kv
 ----
@@ -832,6 +850,7 @@ cpu-load runnable=10 procs=8 clamp=100
 GrantCoordinator:
 (chain: id: 1 active: false index: 5) kv: used: 3, high(moderate)-total: 2(2) moderate-clamp: 100 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+SlotAdjuster metrics: slots: 2, duration (short, long) millis: (4, 0), inc: 2, dec: 1
 
 #####################################################################
 # Test clamping down on total moderate slots.
@@ -853,6 +872,7 @@ cpu-load runnable=0 procs=8
 GrantCoordinator:
 (chain: id: 1 active: false index: 5) kv: used: 0, high(moderate)-total: 2(2) moderate-clamp: 4 used-soft: 1 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+SlotAdjuster metrics: slots: 2, duration (short, long) millis: (1, 0), inc: 1, dec: 0
 
 try-get-soft-slots slots=1
 ----
@@ -866,6 +886,7 @@ cpu-load runnable=0 procs=2
 GrantCoordinator:
 (chain: id: 1 active: false index: 5) kv: used: 0, high(moderate)-total: 3(1) moderate-clamp: 1 used-soft: 2 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+SlotAdjuster metrics: slots: 3, duration (short, long) millis: (2, 0), inc: 2, dec: 0
 
 # The moderate slots clamp is set to -1, because 10/2-6=-1.
 cpu-load runnable=6 procs=10
@@ -873,6 +894,7 @@ cpu-load runnable=6 procs=10
 GrantCoordinator:
 (chain: id: 1 active: false index: 5) kv: used: 0, high(moderate)-total: 3(0) moderate-clamp: -1 used-soft: 2 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+SlotAdjuster metrics: slots: 3, duration (short, long) millis: (3, 0), inc: 2, dec: 0
 
 # Making sure total moderate slots is set to 0, and not a negative value.
 cpu-load runnable=6 procs=10
@@ -880,6 +902,7 @@ cpu-load runnable=6 procs=10
 GrantCoordinator:
 (chain: id: 1 active: false index: 5) kv: used: 0, high(moderate)-total: 3(0) moderate-clamp: -1 used-soft: 2 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+SlotAdjuster metrics: slots: 3, duration (short, long) millis: (4, 0), inc: 2, dec: 0
 
 #####################################################################
 # Make sure the moderate slots clamp has no effect when it is higher than the total moderate slots.
@@ -902,6 +925,7 @@ cpu-load runnable=0 procs=2 clamp=3
 GrantCoordinator:
 (chain: id: 1 active: false index: 5) kv: used: 0, high(moderate)-total: 2(2) moderate-clamp: 3 used-soft: 1 sql-kv-response: avail: 2
 sql-sql-response: avail: 1 sql-leaf-start: used: 0, total: 2 sql-root-start: used: 0, total: 1
+SlotAdjuster metrics: slots: 2, duration (short, long) millis: (1, 0), inc: 1, dec: 0
 
 init-grant-coordinator min-cpu=1 max-cpu=3 sql-kv-tokens=2 sql-sql-tokens=1 sql-leaf=2 sql-root=1 enabled-soft-slot-granting=false
 ----


### PR DESCRIPTION
Our existing metrics are gauges (total and used slots) which don't give us insight into what is happening at smaller time scales. This creates uncertainty when we observe admission queueing but the gauge samples show total slots consistenly greater than used slots. Additionally, if total slots is steady during queuing, it doesn't tell us whether that was because of roughly matching increments or decrements, or no increments/decrements.

The following metrics are added:
- admission.granter.slots_exhausted_duration.kv: cumulative duration when the slots were exhausted. This can give insight into how much exhaustion was occurring. It is insufficient to tell us whether 0.5sec/sec of exhaustion is due to a long 500ms of exhaustion and then non-exhaustion or alternating 1ms of exhaustion and non-exhaustion. But this is an improvement over what we have.
- admission.granter.slot_adjuster_{increments,decrements}.kv: Counts the increments and decrements of the total slots.
- admission.granter.cpu_load_{short,long}_period_duration.kv: cumulative duration of short and long ticks, as indicated by the period in the CPULoad callback. We don't expect long period ticks when admission control is active (and we explicitly disable enforcement during long period ticks), but it helps us eliminate some hypothesis during incidents (e.g. long period ticks alternating with short period ticks causing a slow down in how fast we increment slots). Additionally, the sum of the rate of these two, if significantly < 1, would indicate that CPULoad frequency is lower than expected, say due to CPU overload.

Fixes #92673

Epic: none

Release note: None