### PR TITLE
tree: fix panic when encoding tuple

### DIFF
--- a/pkg/sql/sem/tree/pgwire_encode.go
+++ b/pkg/sql/sem/tree/pgwire_encode.go
@@ -49,7 +49,10 @@ func (d *DTuple) pgwireFormat(ctx *FmtCtx) {
 	comma := ""
 	for i, v := range d.D {
 		ctx.WriteString(comma)
-		t := d.ResolvedType().TupleContents()[i]
+		t := v.ResolvedType()
+		if tc := d.ResolvedType().TupleContents(); i < len(tc) {
+			t = tc[i]
+		}
 		switch dv := UnwrapDOidWrapper(v).(type) {
 		case dNull:
 		case *DString:


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/95008

This adds a bounds check to avoid a panic.

Release note (bug fix): Fixed a crash that could happen when formatting a tuple with an unknown type.