### PR TITLE
ui: clear tenant cookie when multitenant session expires

### DIFF
--- a/pkg/ui/workspaces/db-console/src/redux/cachedDataReducer.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/cachedDataReducer.ts
@@ -26,6 +26,7 @@ import { getLoginPage } from "src/redux/login";
 import { APIRequestFn } from "src/util/api";
 
 import { PayloadAction, WithRequest } from "src/interfaces/action";
+import { maybeClearTenantCookie } from "./cookies";
 
 export interface WithPaginationRequest {
   page_size: number;
@@ -278,6 +279,7 @@ export class CachedDataReducer<
             // codes.  However, at the moment that's all that the underlying
             // timeoutFetch offers.  Major changes to this plumbing are warranted.
             if (error.message === "Unauthorized") {
+              maybeClearTenantCookie();
               // TODO(couchand): This is an unpleasant dependency snuck in here...
               const { location } = createHashHistory();
               if (location && !location.pathname.startsWith("/login")) {

--- a/pkg/ui/workspaces/db-console/src/redux/cookies.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/cookies.ts
@@ -39,6 +39,17 @@ export const selectTenantsFromMultitenantSessionCookie = (): string[] => {
     : [];
 };
 
+// maybeClearTenantCookie clears the tenant cookie if there are multiple tenants
+// found in the multitenant-session cookie.
+export const maybeClearTenantCookie = () => {
+  const tenants = selectTenantsFromMultitenantSessionCookie();
+  // If in multi-tenant environment, we need to clear the tenant cookie so that
+  // we can do a multi-tenant logout.
+  if (tenants.length > 1) {
+    setCookie("tenant", "");
+  }
+};
+
 export const setCookie = (
   key: string,
   val: string,

--- a/pkg/ui/workspaces/db-console/src/redux/login.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/login.ts
@@ -20,10 +20,7 @@ import { cockroach } from "src/js/protos";
 import { getDataFromServer } from "src/util/dataFromServer";
 
 import UserLoginRequest = cockroach.server.serverpb.UserLoginRequest;
-import {
-  selectTenantsFromMultitenantSessionCookie,
-  setCookie,
-} from "./cookies";
+import { maybeClearTenantCookie } from "./cookies";
 
 const dataFromServer = getDataFromServer();
 
@@ -217,12 +214,7 @@ export function doLogout(): ThunkAction<
 > {
   return dispatch => {
     dispatch(logoutBeginAction);
-    const tenants = selectTenantsFromMultitenantSessionCookie();
-    // If in multi-tenant environment, we need to clear the tenant cookie so that
-    // we can do a multi-tenant logout.
-    if (tenants.length > 1) {
-      setCookie("tenant", "");
-    }
+    maybeClearTenantCookie();
     // Make request to log out, reloading the page whether it succeeds or not.
     // If there was a successful log out but the network dropped the response somehow,
     // you'll get the login page on reload. If The logout actually didn't work, you'll


### PR DESCRIPTION
This change adds a method to clear the tenant cookie when the multitenant-session cookie has more than one tenant. The method is called on logout and if an api returns a 401 unauthorized error. This is to ensure that in a multitenant cluster when the session expires and the user is redirected to the login page, they will be able to do a multitenant login.

Fixes: #92843

Release note (ui change): clear tenant cookie on an api returning 401 error in order to allow for multitenant login again.