### PR TITLE
release-22.2: codeowners: mark `pkg/sql/sqlstats` as owned by SQL O11y

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,6 +51,7 @@
 /pkg/sql/delegate/*job*.go   @cockroachdb/jobs-prs
 
 /pkg/sql/execstats/          @cockroachdb/sql-observability
+/pkg/sql/sqlstats/           @cockroachdb/sql-observability
 
 /pkg/sql/sem/tree/           @cockroachdb/sql-syntax-prs
 /pkg/sql/parser/             @cockroachdb/sql-syntax-prs


### PR DESCRIPTION
Backport 1/1 commits from #94928.

/cc @cockroachdb/release

---

Informs: #94880.

Epic: None

Release note: None

Release justification: testing only change.