### PR TITLE
sql: fix TestExplainMVCCSteps

### DIFF
--- a/pkg/sql/explain_test.go
+++ b/pkg/sql/explain_test.go
@@ -332,7 +332,6 @@ func TestExplainMVCCSteps(t *testing.T) {
 	skip.UnderMetamorphic(t,
 		"this test expects a precise number of scan requests, which is not upheld "+
 			"in the metamorphic configuration that edits the kv batch size.")
-	skip.WithIssue(t, 94881)
 	ctx := context.Background()
 	srv, godb, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: true})
 	defer srv.Stopper().Stop(ctx)
@@ -353,7 +352,7 @@ func TestExplainMVCCSteps(t *testing.T) {
 	// Update all rows.
 	r.Exec(t, "UPDATE ab SET b=b+1 WHERE true")
 
-	expectedSteps, expectedSeeks = 2000, 1
+	expectedSteps, expectedSeeks = 1000, 1
 	foundSteps, foundSeeks = getMVCCStats(t, r, scanQuery)
 
 	assert.Equal(t, expectedSteps, foundSteps)


### PR DESCRIPTION
Fix TestExplainMVCCSteps. This test was skipped under metamorphic. When run without metamorphism, it reliably failed due to #93723, which reduced the number of iterator external step operations from the number of MVCC versions to the number of keys.

Close #94881.

Epic: None
Release note: None