### PR TITLE
server: ListTenants endpoint on system admin server

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -7446,3 +7446,59 @@ Support status: [reserved](#support-status)
 
 
 
+## ListTenants
+
+`GET /_admin/v1/tenants`
+
+ListTenants returns a list of active tenants in the cluster.
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+
+
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| tenants | [Tenant](#cockroach.server.serverpb.ListTenantsResponse-cockroach.server.serverpb.Tenant) | repeated |  | [reserved](#support-status) |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.ListTenantsResponse-cockroach.server.serverpb.Tenant"></a>
+#### Tenant
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| tenant_id | [cockroach.roachpb.TenantID](#cockroach.server.serverpb.ListTenantsResponse-cockroach.roachpb.TenantID) |  |  | [reserved](#support-status) |
+| tenant_name | [string](#cockroach.server.serverpb.ListTenantsResponse-string) |  |  | [reserved](#support-status) |
+| sql_addr | [string](#cockroach.server.serverpb.ListTenantsResponse-string) |  |  | [reserved](#support-status) |
+| rpc_addr | [string](#cockroach.server.serverpb.ListTenantsResponse-string) |  |  | [reserved](#support-status) |
+
+
+
+
+
+

--- a/pkg/ccl/serverccl/admin_test.go
+++ b/pkg/ccl/serverccl/admin_test.go
@@ -157,3 +157,36 @@ func TestAdminAPIJobs(t *testing.T) {
 
 	require.Equal(t, backups[0], jobRes)
 }
+
+func TestListTenants(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		DisableDefaultTestTenant: true,
+	})
+	defer s.Stopper().Stop(context.Background())
+
+	db := sqlutils.MakeSQLRunner(sqlDB)
+	db.Exec(t, "CREATE TENANT test;")
+
+	const path = "tenants"
+	var response serverpb.ListTenantsResponse
+
+	if err := getAdminJSONProto(s, path, &response); err != nil {
+		t.Fatalf("unexpected error: %v\n", err)
+	}
+
+	require.NotEmpty(t, response.Tenants)
+	appTenantFound := false
+	for _, tenant := range response.Tenants {
+		if tenant.TenantName == "test" {
+			appTenantFound = true
+		}
+		require.NotNil(t, tenant.TenantId)
+		require.NotEmpty(t, tenant.TenantName)
+		require.NotEmpty(t, tenant.RpcAddr)
+		require.NotEmpty(t, tenant.SqlAddr)
+	}
+	require.True(t, appTenantFound, "test tenant not found")
+}

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -4122,3 +4122,77 @@ func (s *adminServer) SetTraceRecordingType(
 	})
 	return &serverpb.SetTraceRecordingTypeResponse{}, nil
 }
+
+func (s *adminServer) RecoveryCollectReplicaInfo(
+	request *serverpb.RecoveryCollectReplicaInfoRequest,
+	server serverpb.Admin_RecoveryCollectReplicaInfoServer,
+) error {
+	return errors.AssertionFailedf("To be implemented by #93040")
+}
+
+func (s *adminServer) RecoveryCollectLocalReplicaInfo(
+	request *serverpb.RecoveryCollectLocalReplicaInfoRequest,
+	server serverpb.Admin_RecoveryCollectLocalReplicaInfoServer,
+) error {
+	return errors.AssertionFailedf("To be implemented by #93040")
+}
+
+func (s *adminServer) RecoveryStagePlan(
+	ctx context.Context, request *serverpb.RecoveryStagePlanRequest,
+) (*serverpb.RecoveryStagePlanResponse, error) {
+	return nil, errors.AssertionFailedf("To be implemented by #93044")
+}
+
+func (s *adminServer) RecoveryNodeStatus(
+	ctx context.Context, request *serverpb.RecoveryNodeStatusRequest,
+) (*serverpb.RecoveryNodeStatusResponse, error) {
+	return nil, errors.AssertionFailedf("To be implemented by #93043")
+}
+
+func (s *adminServer) RecoveryVerify(
+	ctx context.Context, request *serverpb.RecoveryVerifyRequest,
+) (*serverpb.RecoveryVerifyResponse, error) {
+	return nil, errors.AssertionFailedf("To be implemented by #93043")
+}
+
+// ListTenants returns a list of active tenants in the cluster. Calling this
+// function will start in-process tenants if they are not already running.
+func (s *systemAdminServer) ListTenants(
+	ctx context.Context, _ *serverpb.ListTenantsRequest,
+) (*serverpb.ListTenantsResponse, error) {
+	ie := s.internalExecutor
+	rowIter, err := ie.QueryIterator(ctx, "list-tenants", nil, /* txn */
+		`SELECT name FROM system.tenants WHERE active = true AND name IS NOT NULL`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rowIter.Close() }()
+
+	var tenantNames []roachpb.TenantName
+	var hasNext bool
+	for hasNext, err = rowIter.Next(ctx); hasNext && err == nil; hasNext, err = rowIter.Next(ctx) {
+		row := rowIter.Cur()
+		tenantName := tree.MustBeDString(row[0])
+		tenantNames = append(tenantNames, roachpb.TenantName(tenantName))
+	}
+
+	var tenantList []*serverpb.Tenant
+	for _, tenantName := range tenantNames {
+		server, err := s.server.serverController.getOrCreateServer(ctx, tenantName)
+		if err != nil {
+			log.Errorf(ctx, "unable to get or create a tenant server: %v", err)
+			continue
+		}
+		tenantID := server.getTenantID()
+		tenantList = append(tenantList, &serverpb.Tenant{
+			TenantId:   &tenantID,
+			TenantName: string(tenantName),
+			SqlAddr:    server.getSQLAddr(),
+			RpcAddr:    server.getRPCAddr(),
+		})
+	}
+
+	return &serverpb.ListTenantsResponse{
+		Tenants: tenantList,
+	}, nil
+}

--- a/pkg/server/server_controller.go
+++ b/pkg/server/server_controller.go
@@ -68,6 +68,15 @@ type onDemandServer interface {
 
 	// serveConn handles an incoming SQL connection.
 	serveConn(ctx context.Context, conn net.Conn, status pgwire.PreServeStatus) error
+
+	// getSQLAddr returns the SQL address for this server.
+	getSQLAddr() string
+
+	// getRPCAddr() returns the RPC address for this server.
+	getRPCAddr() string
+
+	// getTenantID returns the TenantID for this server.
+	getTenantID() roachpb.TenantID
 }
 
 type serverEntry struct {
@@ -682,6 +691,18 @@ func (t *tenantServerWrapper) serveConn(
 	return t.server.sqlServer.pgServer.ServeConn(pgCtx, conn, status)
 }
 
+func (t *tenantServerWrapper) getSQLAddr() string {
+	return t.server.sqlServer.cfg.SQLAdvertiseAddr
+}
+
+func (t *tenantServerWrapper) getRPCAddr() string {
+	return t.server.sqlServer.cfg.AdvertiseAddr
+}
+
+func (t *tenantServerWrapper) getTenantID() roachpb.TenantID {
+	return t.server.sqlCfg.TenantID
+}
+
 // systemServerWrapper implements the onDemandServer interface for Server.
 //
 // (We can imagine a future where the SQL service for the system
@@ -719,6 +740,18 @@ func (t *systemServerWrapper) serveConn(
 	pgCtx := t.server.sqlServer.AnnotateCtx(context.Background())
 	pgCtx = logtags.AddTags(pgCtx, logtags.FromContext(ctx))
 	return t.server.sqlServer.pgServer.ServeConn(pgCtx, conn, status)
+}
+
+func (s *systemServerWrapper) getSQLAddr() string {
+	return s.server.sqlServer.cfg.SQLAdvertiseAddr
+}
+
+func (s *systemServerWrapper) getRPCAddr() string {
+	return s.server.sqlServer.cfg.AdvertiseAddr
+}
+
+func (s *systemServerWrapper) getTenantID() roachpb.TenantID {
+	return s.server.cfg.TenantID
 }
 
 func (s *Server) makeSharedProcessTenantConfig(

--- a/pkg/server/serverpb/admin.proto
+++ b/pkg/server/serverpb/admin.proto
@@ -22,6 +22,7 @@ import "kv/kvserver/loqrecovery/loqrecoverypb/recovery.proto";
 import "kv/kvserver/kvserverpb/range_log.proto";
 import "roachpb/api.proto";
 import "roachpb/metadata.proto";
+import "roachpb/data.proto";
 import "ts/catalog/chart_catalog.proto";
 import "util/metric/metric.proto";
 import "gogoproto/gogo.proto";
@@ -1223,6 +1224,25 @@ service Admin {
   // decommissioned.
   rpc RecoveryVerify(RecoveryVerifyRequest) returns (RecoveryVerifyResponse) {}
 
+  // ListTenants returns a list of active tenants in the cluster.
+  rpc ListTenants(ListTenantsRequest) returns (ListTenantsResponse) {
+    option (google.api.http) = {
+      get: "/_admin/v1/tenants"
+    };
+  }
+}
+
+message ListTenantsRequest{}
+
+message ListTenantsResponse {
+  repeated Tenant tenants = 1;
+}
+
+message Tenant {
+  roachpb.TenantID tenant_id = 1;
+  string tenant_name = 2;
+  string sql_addr = 3;
+  string rpc_addr = 4;
 }
 
 message ListTracingSnapshotsRequest {}


### PR DESCRIPTION
This patch adds a new endpoint to the system admin server that returns a
list of active tenants in the cluster. It queries the `system.tenants`
table to enumerate a list of tenants and then it starts those tenants on
the host to be able to return SQL and RPC addresses for those tenants.

Fixes #95014.

Release note: None