### PR TITLE
cloud/amazon: reuse aws kms clients

### DIFF
--- a/pkg/cloud/amazon/BUILD.bazel
+++ b/pkg/cloud/amazon/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/server/telemetry",
         "//pkg/settings",
         "//pkg/settings/cluster",
+        "//pkg/util",
         "//pkg/util/contextutil",
         "//pkg/util/envutil",
         "//pkg/util/ioctx",

--- a/pkg/cloud/amazon/aws_kms.go
+++ b/pkg/cloud/amazon/aws_kms.go
@@ -13,6 +13,7 @@ package amazon
 import (
 	"context"
 	"net/url"
+	"reflect"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -22,7 +23,10 @@ import (
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -43,6 +47,7 @@ func init() {
 }
 
 type kmsURIParams struct {
+	customerMasterKeyID   string
 	accessKey             string
 	secret                string
 	tempToken             string
@@ -51,6 +56,20 @@ type kmsURIParams struct {
 	auth                  string
 	roleProvider          roleProvider
 	delegateRoleProviders []roleProvider
+	verbose               bool
+}
+
+var reuseKMSSession = settings.RegisterBoolSetting(
+	settings.TenantWritable,
+	"cloudstorage.aws.reuse_kms_session.enabled",
+	"persist the last opened AWS KMS session and reuse it when opening a new session with the same arguments",
+	util.ConstantWithMetamorphicTestBool("aws-reuse-kms", true),
+)
+
+var kmsClientCache struct {
+	syncutil.Mutex
+	key kmsURIParams
+	kms *awsKMS
 }
 
 func resolveKMSURIParams(kmsURI cloud.ConsumeURL) (kmsURIParams, error) {
@@ -62,6 +81,7 @@ func resolveKMSURIParams(kmsURI cloud.ConsumeURL) (kmsURIParams, error) {
 	}
 
 	params := kmsURIParams{
+		customerMasterKeyID:   strings.TrimPrefix(kmsURI.Path, "/"),
 		accessKey:             kmsURI.ConsumeParam(AWSAccessKeyParam),
 		secret:                kmsURI.ConsumeParam(AWSSecretParam),
 		tempToken:             kmsURI.ConsumeParam(AWSTempTokenParam),
@@ -70,6 +90,7 @@ func resolveKMSURIParams(kmsURI cloud.ConsumeURL) (kmsURIParams, error) {
 		auth:                  kmsURI.ConsumeParam(cloud.AuthParam),
 		roleProvider:          assumeRoleProvider,
 		delegateRoleProviders: delegateProviders,
+		verbose:               log.V(2),
 	}
 
 	// Validate that all the passed in parameters are supported.
@@ -106,13 +127,14 @@ func MakeAWSKMS(ctx context.Context, uri string, env cloud.KMSEnv) (cloud.KMS, e
 	if err != nil {
 		return nil, err
 	}
+
 	region := kmsURIParams.region
 	awsConfig := &aws.Config{
 		Credentials: credentials.NewStaticCredentials(kmsURIParams.accessKey,
 			kmsURIParams.secret, kmsURIParams.tempToken),
 	}
 	awsConfig.Logger = newLogAdapter(ctx)
-	if log.V(2) {
+	if kmsURIParams.verbose {
 		awsConfig.LogLevel = awsVerboseLogging
 	}
 
@@ -205,10 +227,28 @@ func MakeAWSKMS(ctx context.Context, uri string, env cloud.KMSEnv) (cloud.KMS, e
 		return nil, errors.New("could not find the aws kms region")
 	}
 	sess.Config.Region = aws.String(region)
-	return &awsKMS{
+
+	reuse := reuseKMSSession.Get(&env.ClusterSettings().SV)
+	if reuse {
+		kmsClientCache.Lock()
+		defer kmsClientCache.Unlock()
+
+		if reflect.DeepEqual(kmsClientCache.key, kmsURIParams) {
+			return kmsClientCache.kms, nil
+		}
+	}
+
+	kms := &awsKMS{
 		kms:                 kms.New(sess),
-		customerMasterKeyID: strings.TrimPrefix(kmsURI.Path, "/"),
-	}, nil
+		customerMasterKeyID: kmsURIParams.customerMasterKeyID,
+	}
+
+	if reuse {
+		// We already have the cache lock from reading the cached client.
+		kmsClientCache.key = kmsURIParams
+		kmsClientCache.kms = kms
+	}
+	return kms, nil
 }
 
 // MasterKeyID implements the KMS interface.


### PR DESCRIPTION
This patch adds a setting to cache the last AWS KMS client and then reuse it if subsequent KMS client initializations use the same arguments. This should fix issues where backups with a long incremental chain fail with `NoCredentialProviders: no valid providers in chain` because we are initializing too many KMS clients and overwhelming the EC2 metadata service.

Release note (bug fix): Operations like BACKUP can now reuse a previously created AWS KMS client if the client was created with the same parameters. This addresses the NoCredentialProviders errors on EC2 with for backups with long incremental chains.