### PR TITLE
sql: allow multiple UDFs with in-exact type parameters of the same family

### DIFF
--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -11,7 +11,6 @@
 package tree
 
 import (
-	"log"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -319,50 +318,6 @@ func (fd *ResolvedFunctionDefinition) MatchOverload(
 		return QualifiedOverload{}, errors.Errorf("function name %q is not unique", fd.Name)
 	}
 	return ret[0], nil
-}
-
-func checkIfMatchedOverloadAt(
-	paramTypes []*types.T, ql QualifiedOverload, schema string,
-) bool {
-
-	matchedParam := func(
-		paramTypes []*types.T, ql QualifiedOverload, ord int,
-	) bool {
-		if schema == ql.Schema && (paramTypes == nil || ql.params().Match(paramTypes)) {
-			for _, qlp := range ql.params().Types() {
-				log.Printf("\n qlp : %v, pty : %v \n", qlp.Width(), paramTypes[ord].Width())
-				if qlp.Width() == paramTypes[ord].Width() {
-					continue
-				} else {
-					return false
-				}
-			}
-			return true
-		}
-		return false
-	}
-
-	for k, pty := range paramTypes {
-		switch pty.Family() {
-		// should check all the types that's supported by udf
-		case types.IntFamily:
-		case types.FloatFamily:
-		case types.DateFamily:
-		case types.TimestampFamily:
-		case types.IntervalFamily:
-		case types.BytesFamily:
-		case types.TimestampTZFamily:
-		case types.CollatedStringFamily:
-		case types.INetFamily:
-			if matchedParam(paramTypes, ql, k) {
-				return true
-			}
-			return false
-		default:
-			return true
-		}
-	}
-	return false
 }
 
 func combineOverloads(a, b []QualifiedOverload) []QualifiedOverload {

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -277,7 +277,7 @@ func (fd *ResolvedFunctionDefinition) MatchOverload(
 	paramTypes []*types.T, explicitSchema string, searchPath SearchPath,
 ) (QualifiedOverload, error) {
 	matched := func(ol QualifiedOverload, schema string) bool {
-		return schema == ol.Schema && (paramTypes == nil || ol.params().Match(paramTypes))
+		return schema == ol.Schema && (paramTypes == nil || ol.params().MatchExact(paramTypes))
 	}
 
 	typeNames := func() string {

--- a/pkg/sql/sem/tree/function_definition_test.go
+++ b/pkg/sql/sem/tree/function_definition_test.go
@@ -111,6 +111,14 @@ func TestMatchOverload(t *testing.T) {
 				Schema:   "sc2",
 				Overload: &tree.Overload{Oid: 4, IsUDF: true, Types: tree.ParamTypes{tree.ParamType{Typ: types.Int}}},
 			},
+			{
+				Schema: "sc3",
+				Overload: &tree.Overload{Oid: 5, IsUDF: true,
+					Types: tree.ParamTypes{
+						tree.ParamType{Typ: types.Int2}, tree.ParamType{Typ: types.Int4},
+					},
+				},
+			},
 		},
 	}
 
@@ -179,6 +187,12 @@ func TestMatchOverload(t *testing.T) {
 			expectedOid:    4,
 		},
 		{
+			testName:    "multiple parameters exact match on same family type",
+			argTypes:    []*types.T{types.Int2, types.Int4},
+			path:        []string{"sc3", "sc3", "pg_catalog"},
+			expectedOid: 5,
+		},
+		{
 			testName:       "explicit schema not in search path not found",
 			argTypes:       []*types.T{types.Int},
 			explicitSchema: "sc3",
@@ -190,6 +204,12 @@ func TestMatchOverload(t *testing.T) {
 			argTypes:    []*types.T{types.String},
 			path:        []string{"sc2", "sc1", "pg_catalog"},
 			expectedErr: `function f\(string\) does not exist`,
+		},
+		{
+			testName:    "multiple parameters exact match on same family type not exists",
+			argTypes:    []*types.T{types.Int, types.Int4},
+			path:        []string{"sc3", "sc3", "pg_catalog"},
+			expectedErr: `function f\(int,int4\) does not exist: function undefined`,
 		},
 	}
 

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -2039,6 +2039,10 @@ func (t *T) EquivalentExact(other *T) bool {
 		if t.Width() != other.Width() {
 			return false
 		}
+	case CollatedStringFamily:
+		if t.Width() != other.Width() {
+			return false
+		}
 	}
 	return true
 }

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -1950,38 +1950,6 @@ func (t *T) Equivalent(other *T) bool {
 	}
 
 	switch t.Family() {
-	case IntFamily:
-		if t.Width() != other.Width() {
-			return false
-		}
-	case FloatFamily:
-		if t.Width() != other.Width() {
-			return false
-		}
-	case DateFamily:
-		if t.Width() != other.Width() {
-			return false
-		}
-	case TimestampFamily:
-		if t.Width() != other.Width() {
-			return false
-		}
-	case IntervalFamily:
-		if t.Width() != other.Width() {
-			return false
-		}
-	case BytesFamily:
-		if t.Width() != other.Width() {
-			return false
-		}
-	case TimestampTZFamily:
-		if t.Width() != other.Width() {
-			return false
-		}
-	case INetFamily:
-		if t.Width() != other.Width() {
-			return false
-		}
 	case CollatedStringFamily:
 		// CockroachDB differs from Postgres by comparing collation names
 		// case-insensitively and equating hyphens/underscores.
@@ -2027,6 +1995,51 @@ func (t *T) Equivalent(other *T) bool {
 		}
 	}
 
+	return true
+}
+
+func (t *T) EquivalentExact(other *T) bool {
+	if t.Family() == AnyFamily || other.Family() == AnyFamily {
+		return true
+	}
+	if t.Family() != other.Family() {
+		return false
+	}
+
+	switch t.Family() {
+	case IntFamily:
+		if t.Width() != other.Width() {
+			return false
+		}
+	case FloatFamily:
+		if t.Width() != other.Width() {
+			return false
+		}
+	case DateFamily:
+		if t.Width() != other.Width() {
+			return false
+		}
+	case TimestampFamily:
+		if t.Width() != other.Width() {
+			return false
+		}
+	case IntervalFamily:
+		if t.Width() != other.Width() {
+			return false
+		}
+	case BytesFamily:
+		if t.Width() != other.Width() {
+			return false
+		}
+	case TimestampTZFamily:
+		if t.Width() != other.Width() {
+			return false
+		}
+	case INetFamily:
+		if t.Width() != other.Width() {
+			return false
+		}
+	}
 	return true
 }
 

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -1950,6 +1950,38 @@ func (t *T) Equivalent(other *T) bool {
 	}
 
 	switch t.Family() {
+	case IntFamily:
+		if t.Width() != other.Width() {
+			return false
+		}
+	case FloatFamily:
+		if t.Width() != other.Width() {
+			return false
+		}
+	case DateFamily:
+		if t.Width() != other.Width() {
+			return false
+		}
+	case TimestampFamily:
+		if t.Width() != other.Width() {
+			return false
+		}
+	case IntervalFamily:
+		if t.Width() != other.Width() {
+			return false
+		}
+	case BytesFamily:
+		if t.Width() != other.Width() {
+			return false
+		}
+	case TimestampTZFamily:
+		if t.Width() != other.Width() {
+			return false
+		}
+	case INetFamily:
+		if t.Width() != other.Width() {
+			return false
+		}
 	case CollatedStringFamily:
 		// CockroachDB differs from Postgres by comparing collation names
 		// case-insensitively and equating hyphens/underscores.
@@ -1957,6 +1989,10 @@ func (t *T) Equivalent(other *T) bool {
 			if !lex.LocaleNamesAreEqual(t.Locale(), other.Locale()) {
 				return false
 			}
+		}
+
+		if t.Width() != other.Width() {
+			return false
 		}
 
 	case TupleFamily:


### PR DESCRIPTION
This patch makes it possible for udf to check exact type matching for udf parameters #94146
Added TypeList.MatchExact to apply udf parameter check only.

Unit test for such family type parameter matching are provided

Release note: None