### PR TITLE
sql: add more copy error logging

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2422,6 +2422,9 @@ func (ex *connExecutor) execCopyIn(
 		if retErr == nil && !payloadHasError(retPayload) {
 			ex.incrementExecutedStmtCounter(cmd.Stmt)
 		}
+		if p, ok := retPayload.(payloadWithError); ok {
+			log.SqlExec.Errorf(ctx, "error executing %s: %+v", cmd, p.errorCause())
+		}
 		if retErr != nil {
 			log.SqlExec.Errorf(ctx, "error executing %s: %+v", cmd, retErr)
 		}


### PR DESCRIPTION
Release note (sql change): COPY now logs an error during the insert phase on the SQL_EXEC logging channel.

Informs: https://github.com/cockroachdb/cockroach/issues/90656

Release justification: important logging change (bug fix if you will)