### PR TITLE
sql/importer: Fix BenchmarkConvertToKVs

### DIFF
--- a/pkg/sql/importer/bench_test.go
+++ b/pkg/sql/importer/bench_test.go
@@ -98,6 +98,7 @@ func benchmarkConvertToKVs(b *testing.B, g workload.Generator) {
 			evalCtx := &eval.Context{
 				SessionDataStack: sessiondata.NewStack(&sessiondata.SessionData{}),
 				Codec:            keys.SystemSQLCodec,
+				Settings:         cluster.MakeTestingClusterSettings(),
 			}
 			semaCtx := tree.MakeSemaContext()
 			return wc.Worker(ctx, evalCtx, &semaCtx)


### PR DESCRIPTION
Set `cluster.MakeTestingClusterSettings()` in `eval.Context` Settings for `BenchmarkConvertToKVs` to execute successfully.

Fixes: #95052

Release justification: test-only change.
Release note: None