### PR TITLE
ccl/changefeedccl: skip TestChangefeedPropagatesTerminalError

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -5513,6 +5513,7 @@ func TestChangefeedHandlesDrainingNodes(t *testing.T) {
 
 func TestChangefeedPropagatesTerminalError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 95057, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	opts := makeOptions()


### PR DESCRIPTION
Refs: #95057

Reason: flaky test

Generated by bin/skip-test.

Epic: None
Release note: None