### PR TITLE
release-22.2: ui: revert TransactionInsightDetailsCachedState.cachedData object

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
@@ -101,7 +101,7 @@ export const StatementInsightDetails: React.FC<
   const executionID = getMatchParamByName(match, idAttr);
 
   useEffect(() => {
-    if (insightEventDetails == null) {
+    if (!insightEventDetails) {
       refreshStatementInsights();
     }
   }, [insightEventDetails, refreshStatementInsights]);
@@ -124,7 +124,7 @@ export const StatementInsightDetails: React.FC<
       </h3>
       <div>
         <Loading
-          loading={insightEventDetails == null}
+          loading={!insightEventDetails}
           page={"Transaction Insight details"}
           error={insightError}
           renderError={() => InsightsError()}

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
@@ -161,7 +161,7 @@ export const TransactionInsightDetails: React.FC<
       </div>
       <section>
         <Loading
-          loading={insightEventDetails == null}
+          loading={!insightDetails}
           page={"Transaction Insight details"}
           error={insightError}
           renderError={() => InsightsError()}

--- a/pkg/ui/workspaces/cluster-ui/src/store/insightDetails/transactionInsightDetails/transactionInsightDetails.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insightDetails/transactionInsightDetails/transactionInsightDetails.selectors.ts
@@ -16,16 +16,16 @@ const selectTransactionInsightDetailsState = createSelector(
   (state: AppState) => state.adminUI.transactionInsightDetails.cachedData,
   selectID,
   (cachedTxnInsightDetails, execId) => {
-    return cachedTxnInsightDetails.get(execId);
+    return cachedTxnInsightDetails[execId];
   },
 );
 
 export const selectTransactionInsightDetails = createSelector(
   selectTransactionInsightDetailsState,
-  state => state.data,
+  state => state?.data,
 );
 
 export const selectTransactionInsightDetailsError = createSelector(
   selectTransactionInsightDetailsState,
-  state => state.lastError,
+  state => state?.lastError,
 );


### PR DESCRIPTION
Partial backport commits from #92932.

See https://github.com/cockroachdb/cockroach/pull/94944#issuecomment-1377768985 for more background information.

---

This commit reverts the cachedData field of TransactionInsightDetailsCachedState from a map to an object.

Fixes #94380 in release-22.2.

Release note: None

Release justification: bug fix