### PR TITLE
security: add option to re-enable old cipher suites

### DIFF
--- a/pkg/security/BUILD.bazel
+++ b/pkg/security/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "pem.go",
         "permission_check.go",
         "tls.go",
+        "tls_ciphersuites.go",
         "tls_settings.go",
         "utils.go",
         "x509.go",

--- a/pkg/security/tls.go
+++ b/pkg/security/tls.go
@@ -48,6 +48,13 @@ func newServerTLSConfig(
 		cfg.ClientCAs = certPool
 	}
 
+	if settings.oldCipherSuitesEnabled() {
+		cfg.CipherSuites = append(
+			cfg.CipherSuites,
+			OldCipherSuites()...,
+		)
+	}
+
 	// Should we disable session resumption? This may break forward secrecy.
 	// cfg.SessionTicketsDisabled = true
 	return cfg, nil
@@ -62,6 +69,13 @@ func newUIServerTLSConfig(settings TLSSettings, certPEM, keyPEM []byte) (*tls.Co
 	cfg, err := newBaseTLSConfigWithCertificate(settings, certPEM, keyPEM, nil)
 	if err != nil {
 		return nil, err
+	}
+
+	if settings.oldCipherSuitesEnabled() {
+		cfg.CipherSuites = append(
+			cfg.CipherSuites,
+			OldCipherSuites()...,
+		)
 	}
 
 	// Should we disable session resumption? This may break forward secrecy.
@@ -118,41 +132,7 @@ func newBaseTLSConfig(settings TLSSettings, caPEM []byte) (*tls.Config, error) {
 
 		VerifyPeerCertificate: makeOCSPVerifier(settings),
 
-		// CipherSuites is a list of enabled TLS 1.2 cipher suites. The
-		// order of the list is ignored; prioritization of cipher suites
-		// follows hard-coded rules in the Go standard library[1]. Note
-		// that TLS 1.3 ciphersuites are not configurable.
-		//
-		// This is the subset of Go's default cipher suite list which are
-		// also marked as "recommended" by IETF[2] (As of June 1, 2022).
-		// Mozilla recommends the same list with some comments on
-		// rationale and compatibility[3]. These ciphers are recommended
-		// because they are the ones that provide forward secrecy and
-		// authenticated encryption (AEAD). Mozilla claims they are
-		// compatible with "nearly all" clients from the last five years.
-		//
-		// [1]: https://github.com/golang/go/blob/4aa1efed4853ea067d665a952eee77c52faac774/src/crypto/tls/cipher_suites.go#L215-L270
-		// [2]: https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-4
-		// [3]: https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
-		CipherSuites: []uint16{
-			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
-			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
-			// Note: the codec names
-			// TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
-			// and
-			// TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
-			// are merely aliases for the two above.
-			//
-			// NB: no need to add TLS 1.3 ciphers here. As per the
-			// documentation of CipherSuites, the TLS 1.3 ciphers are not
-			// configurable. Go's predefined list always applies. All TLS
-			// 1.3 ciphers meet the forward secrecy and authenticated
-			// encryption requirements mentioned above.
-		},
+		CipherSuites: RecommendedCipherSuites(),
 
 		MinVersion: tls.VersionTLS12,
 	}, nil

--- a/pkg/security/tls_ciphersuites.go
+++ b/pkg/security/tls_ciphersuites.go
@@ -1,0 +1,72 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package security
+
+import "crypto/tls"
+
+// RecommendedCipherSuites returns a list of enabled TLS 1.2 cipher
+// suites. The order of the list is ignored; prioritization of cipher
+// suites follows hard-coded rules in the Go standard library[1].
+//
+// Note that TLS 1.3 ciphersuites are not configurable.
+//
+// This is the subset of Go's default cipher suite list which are
+// also marked as "recommended" by IETF[2] (As of June 1, 2022).
+// Mozilla recommends the same list with some comments on
+// rationale and compatibility[3]. These ciphers are recommended
+// because they are the ones that provide forward secrecy and
+// authenticated encryption (AEAD). Mozilla claims they are
+// compatible with "nearly all" clients from the last five years.
+//
+// [1]: https://github.com/golang/go/blob/4aa1efed4853ea067d665a952eee77c52faac774/src/crypto/tls/cipher_suites.go#L215-L270
+// [2]: https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-4
+// [3]: https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
+func RecommendedCipherSuites() []uint16 {
+	return []uint16{
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+		// Note: the codec names
+		// TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+		// and
+		// TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+		// are merely aliases for the two above.
+		//
+		// NB: no need to add TLS 1.3 ciphers here. As per the
+		// documentation of CipherSuites, the TLS 1.3 ciphers are not
+		// configurable. Go's predefined list always applies. All TLS
+		// 1.3 ciphers meet the forward secrecy and authenticated
+		// encryption requirements mentioned above.
+	}
+}
+
+// OldCipherSuites returns a list of "old" cipher suites for TLS v1.2,
+// from the list created by Mozilla[1]. These are enabled with the
+// use of the COCKROACH_TLS_ENABLE_OLD_CIPHER_SUITES environment
+// variable, and should strictly be used when the software
+// CockroachDB is being used with cannot be upgraded.
+//
+// Cipher suites not included in the recommended lists referred to
+// in the RecommendedCipherSuites documentation but required for
+// backwards compatibility should be added here, so organizations
+// can opt into using deprecated cipher suites rather than opting
+// every CRDB cluster into a worse security stance.
+//
+// [1]: https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility
+func OldCipherSuites() []uint16 {
+	return []uint16{
+		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+	}
+}

--- a/pkg/security/tls_settings.go
+++ b/pkg/security/tls_settings.go
@@ -15,12 +15,18 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 )
 
 const (
 	ocspOff    = 0
 	ocspLax    = 1
 	ocspStrict = 2
+
+	// OldCipherSuitesEnabledEnv is the environment variable used to reenable
+	// use of old cipher suites for backwards compatibility with applications
+	// that do not support any of the recommended cipher suites.
+	OldCipherSuitesEnabledEnv = "COCKROACH_TLS_ENABLE_OLD_CIPHER_SUITES"
 )
 
 // TLSSettings allows for customization of TLS behavior. It's called
@@ -31,6 +37,7 @@ type TLSSettings interface {
 	ocspEnabled() bool
 	ocspStrict() bool
 	ocspTimeout() time.Duration
+	oldCipherSuitesEnabled() bool
 }
 
 var ocspMode = settings.RegisterEnumSetting(
@@ -65,6 +72,10 @@ func (c clusterTLSSettings) ocspTimeout() time.Duration {
 	return ocspTimeout.Get(&c.settings.SV)
 }
 
+func (c clusterTLSSettings) oldCipherSuitesEnabled() bool {
+	return areOldCipherSuitesEnabled()
+}
+
 // ClusterTLSSettings creates a TLSSettings backed by the
 // given cluster settings.
 func ClusterTLSSettings(settings *cluster.Settings) TLSSettings {
@@ -87,4 +98,15 @@ func (CommandTLSSettings) ocspStrict() bool {
 
 func (CommandTLSSettings) ocspTimeout() time.Duration {
 	return 0
+}
+
+func (c CommandTLSSettings) oldCipherSuitesEnabled() bool {
+	return areOldCipherSuitesEnabled()
+}
+
+// areOldCipherSuites returns true if CRDB should enable the use of
+// old, no longer recommended TLS cipher suites for the sake of
+// compatibility.
+func areOldCipherSuitesEnabled() bool {
+	return envutil.EnvOrDefaultBool(OldCipherSuitesEnabledEnv, false)
 }

--- a/pkg/security/tls_test.go
+++ b/pkg/security/tls_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/security/certnames"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/stretchr/testify/require"
 )
@@ -25,19 +26,28 @@ func TestLoadTLSConfig(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	cm, err := security.NewCertificateManager(certnames.EmbeddedCertsDir, security.CommandTLSSettings{})
 	require.NoError(t, err)
-	config, err := cm.GetServerTLSConfig()
+	// We check that the UI Server tls.Config doesn't include the old cipher suites by default.
+	config, err := cm.GetUIServerTLSConfig()
+	require.NoError(t, err)
+	clientConfig, err := config.GetConfigForClient(&tls.ClientHelloInfo{})
 	require.NoError(t, err)
 	require.NotNil(t, config.GetConfigForClient)
-	config, err = config.GetConfigForClient(&tls.ClientHelloInfo{})
-	require.NoError(t, err)
-	if err != nil {
-		t.Fatalf("Failed to load TLS config: %v", err)
-	}
+	require.NotNil(t, clientConfig)
+	require.Equal(t, security.RecommendedCipherSuites(), clientConfig.CipherSuites)
 
-	if len(config.Certificates) != 1 {
-		t.Fatalf("config.Certificates should have 1 cert; found %d", len(config.Certificates))
+	// Next we check that the Server tls.Config is correctly generated.
+	config, err = cm.GetServerTLSConfig()
+	require.NoError(t, err)
+	require.NotNil(t, config.GetConfigForClient)
+
+	clientConfig, err = config.GetConfigForClient(&tls.ClientHelloInfo{})
+	require.NoError(t, err)
+	require.NotNil(t, clientConfig)
+	require.Equal(t, security.RecommendedCipherSuites(), clientConfig.CipherSuites)
+	if len(clientConfig.Certificates) != 1 {
+		t.Fatalf("clientConfig.Certificates should have 1 cert; found %d", len(clientConfig.Certificates))
 	}
-	cert := config.Certificates[0]
+	cert := clientConfig.Certificates[0]
 	asn1Data := cert.Certificate[0] // TODO Check len()
 
 	x509Cert, err := x509.ParseCertificate(asn1Data)
@@ -45,17 +55,48 @@ func TestLoadTLSConfig(t *testing.T) {
 		t.Fatalf("Couldn't parse test cert: %v", err)
 	}
 
-	if err = verifyX509Cert(x509Cert, "localhost", config.RootCAs); err != nil {
+	if err = verifyX509Cert(x509Cert, "localhost", clientConfig.RootCAs); err != nil {
 		t.Errorf("Couldn't verify test cert against server CA: %v", err)
 	}
 
-	if err = verifyX509Cert(x509Cert, "localhost", config.ClientCAs); err != nil {
+	if err = verifyX509Cert(x509Cert, "localhost", clientConfig.ClientCAs); err != nil {
 		t.Errorf("Couldn't verify test cert against client CA: %v", err)
 	}
 
-	if err = verifyX509Cert(x509Cert, "google.com", config.RootCAs); err == nil {
+	if err = verifyX509Cert(x509Cert, "google.com", clientConfig.RootCAs); err == nil {
 		t.Errorf("Verified test cert for wrong hostname")
 	}
+}
+
+func TestLoadTLSConfigWithOldCipherSuites(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	reset := envutil.TestSetEnv(t, security.OldCipherSuitesEnabledEnv, "true")
+	defer reset()
+
+	cm, err := security.NewCertificateManager(certnames.EmbeddedCertsDir, security.CommandTLSSettings{})
+	require.NoError(t, err)
+
+	recommendedAndOldCipherSuites := append(
+		security.RecommendedCipherSuites(),
+		security.OldCipherSuites()...,
+	)
+
+	// We check that the UI Server tls.Config now includes the old cipher suites after the existing cipher suites.
+	config, err := cm.GetUIServerTLSConfig()
+	require.NoError(t, err)
+	clientConfig, err := config.GetConfigForClient(&tls.ClientHelloInfo{})
+	require.NoError(t, err)
+	require.NotNil(t, clientConfig)
+	require.Equal(t, recommendedAndOldCipherSuites, clientConfig.CipherSuites)
+
+	// We check that the Server tls.Config now includes the old cipher suites after the existing cipher suites.
+	config, err = cm.GetServerTLSConfig()
+	require.NoError(t, err)
+	require.NotNil(t, config.GetConfigForClient)
+	clientConfig, err = config.GetConfigForClient(&tls.ClientHelloInfo{})
+	require.NoError(t, err)
+	require.NotNil(t, clientConfig)
+	require.Equal(t, recommendedAndOldCipherSuites, clientConfig.CipherSuites)
 }
 
 func verifyX509Cert(cert *x509.Certificate, dnsName string, roots *x509.CertPool) error {


### PR DESCRIPTION
In https://github.com/cockroachdb/cockroach/pull/82362 we updated the list of cipher suites to match the "recommended" cipher suites defined in RFC 8447. As noted in that PR, very old clients may fail to connect.

For systems using those very old clients, this PR adds a setting that can be used to re-enable the "old" cipher suites removed in that PR.

Release note (security update): adds option to re-enable "old" cipher suites for use with very old clients.