### PR TITLE
base: remove unused tenant arg

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -247,10 +247,6 @@ type TestTenantArgs struct {
 
 	TenantID roachpb.TenantID
 
-	// Existing, if true, indicates an existing tenant, rather than a new tenant
-	// to be created by StartTenant.
-	Existing bool
-
 	// DisableCreateTenant disables the explicit creation of a tenant when
 	// StartTenant is attempted. It's used in cases where we want to validate
 	// that a tenant doesn't start if it isn't existing.

--- a/pkg/ccl/multiregionccl/multiregion_system_table_test.go
+++ b/pkg/ccl/multiregionccl/multiregion_system_table_test.go
@@ -287,7 +287,6 @@ func TestTenantStartupWithMultiRegionEnum(t *testing.T) {
 	ten2, tSQL2 := serverutils.StartTenant(t, tc.Server(2), base.TestTenantArgs{
 		Settings: cs,
 		TenantID: tenID,
-		Existing: true,
 		Locality: roachpb.Locality{
 			Tiers: []roachpb.Tier{
 				{Key: "region", Value: "us-east3"},

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -2348,10 +2348,6 @@ func startTestTenantPods(
 	var tenants []serverutils.TestTenantInterface
 	for i := 0; i < count; i++ {
 		params := tests.CreateTestTenantParams(tenantID)
-		// The first SQL pod will create the tenant keyspace in the host.
-		if i != 0 {
-			params.Existing = true
-		}
 		params.TestingKnobs = knobs
 		tenant, tenantDB := serverutils.StartTenant(t, ts, params)
 		tenant.(*server.TestTenant).PGPreServer().TestingSetTrustClientProvidedRemoteAddr(true)


### PR DESCRIPTION
This parameter was never read.

Release note: None
Epic: None