### PR TITLE
democluster: don't re-panic on shutdown

### DIFF
--- a/pkg/cli/democluster/session_persistence.go
+++ b/pkg/cli/democluster/session_persistence.go
@@ -96,7 +96,7 @@ func (c *transientCluster) doPersistence(
 		}
 	}
 
-	if c.servers[0].TestServer != nil {
+	if len(c.servers) > 0 && c.servers[0].TestServer != nil {
 		sqlAddr := c.servers[0].ServingSQLAddr()
 		host, port, _ := addr.SplitHostPort(sqlAddr, "")
 		u.WithNet(pgurl.NetTCP(host, port))


### PR DESCRIPTION
Add protection to a function called on cluster shutdown to not panic when the shutdown happens as a result of a previous panic and no servers had been created.
Other code in this function already seems to have had this protection.

Release note: None
Epic: None