### PR TITLE
storage: Add support for TargetBytes for EndTxn

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -523,6 +523,7 @@ func IsEndTxnTriggeringRetryError(
 }
 
 const lockResolutionBatchSize = 500
+const lockResolutionBatchByteSize = 4 << 20 // 4 MB.
 
 // resolveLocalLocks synchronously resolves any locks that are local to this
 // range in the same batch and returns those lock spans. The remainder are
@@ -541,17 +542,19 @@ func resolveLocalLocks(
 	evalCtx EvalContext,
 ) (resolvedLocks []roachpb.LockUpdate, externalLocks []roachpb.Span, _ error) {
 	var resolveAllowance int64 = lockResolutionBatchSize
+	var targetBytes int64 = lockResolutionBatchByteSize
 	if args.InternalCommitTrigger != nil {
 		// If this is a system transaction (such as a split or merge), don't
 		// enforce the resolve allowance. These transactions rely on having
 		// their locks resolved synchronously.
 		resolveAllowance = 0
+		targetBytes = 0
 	}
-	return resolveLocalLocksWithPagination(ctx, desc, readWriter, ms, args, txn, evalCtx, resolveAllowance)
+	return resolveLocalLocksWithPagination(ctx, desc, readWriter, ms, args, txn, evalCtx, resolveAllowance, targetBytes)
 }
 
-// resolveLocalLocksWithPagination is resolveLocalLocks but with a max key
-// limit.
+// resolveLocalLocksWithPagination is resolveLocalLocks but with a max key and
+// target bytes limit.
 func resolveLocalLocksWithPagination(
 	ctx context.Context,
 	desc *roachpb.RangeDescriptor,
@@ -561,6 +564,7 @@ func resolveLocalLocksWithPagination(
 	txn *roachpb.Transaction,
 	evalCtx EvalContext,
 	maxKeys int64,
+	targetBytes int64,
 ) (resolvedLocks []roachpb.LockUpdate, externalLocks []roachpb.Span, _ error) {
 	if mergeTrigger := args.InternalCommitTrigger.GetMergeTrigger(); mergeTrigger != nil {
 		// If this is a merge, then use the post-merge descriptor to determine
@@ -592,26 +596,33 @@ func resolveLocalLocksWithPagination(
 			//
 			// Note that the underlying pebbleIterator will still be reused
 			// since readWriter is a pebbleBatch in the typical case.
-			ok, _, _, err := storage.MVCCResolveWriteIntent(ctx, readWriter, ms, update,
-				storage.MVCCResolveWriteIntentOptions{})
+			ok, numBytes, resumeSpan, err := storage.MVCCResolveWriteIntent(ctx, readWriter, ms, update,
+				storage.MVCCResolveWriteIntentOptions{TargetBytes: targetBytes})
 			if err != nil {
 				return 0, 0, 0, errors.Wrapf(err, "resolving write intent at %s on end transaction [%s]", span, txn.Status)
 			}
 			if ok {
 				numKeys = 1
 			}
-			resolvedLocks = append(resolvedLocks, update)
-			// If requested, replace point tombstones with range tombstones.
-			if ok && evalCtx.EvalKnobs().UseRangeTombstonesForPointDeletes {
-				if err := storage.ReplacePointTombstonesWithRangeTombstones(
-					ctx, spanset.DisableReadWriterAssertions(readWriter),
-					ms, update.Key, update.EndKey); err != nil {
-					return 0, 0, 0, errors.Wrapf(err,
-						"replacing point tombstones with range tombstones for write intent at %s on end transaction [%s]",
-						span, txn.Status)
+			if resumeSpan != nil {
+				externalLocks = append(externalLocks, *resumeSpan)
+				resumeReason = kvpb.RESUME_BYTE_LIMIT
+			} else {
+				// !ok && resumeSpan == nil is a valid condition that means
+				// that no intent was found.
+				resolvedLocks = append(resolvedLocks, update)
+				// If requested, replace point tombstones with range tombstones.
+				if ok && evalCtx.EvalKnobs().UseRangeTombstonesForPointDeletes {
+					if err := storage.ReplacePointTombstonesWithRangeTombstones(
+						ctx, spanset.DisableReadWriterAssertions(readWriter),
+						ms, update.Key, update.EndKey); err != nil {
+						return 0, 0, 0, errors.Wrapf(err,
+							"replacing point tombstones with range tombstones for write intent at %s on end transaction [%s]",
+							span, txn.Status)
+					}
 				}
 			}
-			return numKeys, 0, 0, nil
+			return numKeys, numBytes, resumeReason, nil
 		}
 		// For update ranges, cut into parts inside and outside our key
 		// range. Resolve locally inside, delegate the rest. In particular,
@@ -620,8 +631,8 @@ func resolveLocalLocksWithPagination(
 		externalLocks = append(externalLocks, outSpans...)
 		if inSpan != nil {
 			update.Span = *inSpan
-			numKeys, _, resumeSpan, resumeReason, err := storage.MVCCResolveWriteIntentRange(ctx, readWriter, ms, update,
-				storage.MVCCResolveWriteIntentRangeOptions{MaxKeys: maxKeys})
+			numKeys, numBytes, resumeSpan, resumeReason, err := storage.MVCCResolveWriteIntentRange(ctx, readWriter, ms, update,
+				storage.MVCCResolveWriteIntentRangeOptions{MaxKeys: maxKeys, TargetBytes: targetBytes})
 			if err != nil {
 				return 0, 0, 0, errors.Wrapf(err, "resolving write intent range at %s on end transaction [%s]", span, txn.Status)
 			}
@@ -643,12 +654,12 @@ func resolveLocalLocksWithPagination(
 						span, txn.Status)
 				}
 			}
-			return numKeys, 0, resumeReason, nil
+			return numKeys, numBytes, resumeReason, nil
 		}
 		return 0, 0, 0, nil
 	}
 
-	numKeys, _, _, err := storage.MVCCPaginate(ctx, maxKeys, 0 /* targetBytes */, false /* allowEmpty */, f)
+	numKeys, _, _, err := storage.MVCCPaginate(ctx, maxKeys, targetBytes, false /* allowEmpty */, f)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction_test.go
@@ -12,6 +12,7 @@ package batcheval
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"testing"
 
@@ -1387,6 +1388,211 @@ func TestComputeSplitRangeKeyStatsDelta(t *testing.T) {
 			require.NoError(t, err)
 			msDelta.AgeTo(nowNanos)
 			require.Equal(t, tc.expect, msDelta)
+		})
+	}
+}
+
+// TestResolveLocalLocks tests resolveLocalLocks for point and ranged intents
+// as well as under a max key or max byte limit, ensuring the returned
+// resolvedLocks, externalLocks, and numBytes are as expected.
+func TestResolveLocalLocks(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	intToKey := func(i int) roachpb.Key {
+		return roachpb.Key(fmt.Sprintf("%01000d", i))
+	}
+	ceil := func(i int, j int) int {
+		return (i + j - 1) / j
+	}
+
+	const (
+		numKeys             = 20
+		keysPerRangedLock   = 4
+		maxKeys             = 11 // not divisible by keysPerRangedLock
+		targetBytes         = 11900
+		keysFromTargetBytes = 12 // divisible by keysPerRangedLock
+	)
+
+	pointLocks := make([]roachpb.Span, numKeys)
+	for i := range pointLocks {
+		pointLocks[i].Key = intToKey(i)
+	}
+	rangedLocks := make([]roachpb.Span, numKeys/keysPerRangedLock)
+	for i := range rangedLocks {
+		rangedLocks[i].Key = intToKey(i * keysPerRangedLock)
+		rangedLocks[i].EndKey = intToKey((i + 1) * keysPerRangedLock)
+	}
+
+	expectedResolvedLocksPointMaxKeys := make([]roachpb.Span, maxKeys)
+	for i := range expectedResolvedLocksPointMaxKeys {
+		expectedResolvedLocksPointMaxKeys[i].Key = intToKey(i)
+	}
+	expectedExternalLocksPointMaxKeys := make([]roachpb.Span, numKeys-maxKeys)
+	for i := range expectedExternalLocksPointMaxKeys {
+		expectedExternalLocksPointMaxKeys[i].Key = intToKey(i + maxKeys)
+	}
+
+	expectedResolvedLocksRangedMaxKeys := make([]roachpb.Span, ceil(maxKeys, keysPerRangedLock))
+	for i := range expectedResolvedLocksRangedMaxKeys {
+		expectedResolvedLocksRangedMaxKeys[i].Key = intToKey(i * keysPerRangedLock)
+		if i == len(expectedResolvedLocksRangedMaxKeys)-1 {
+			expectedResolvedLocksRangedMaxKeys[i].EndKey = intToKey(maxKeys - 1).Next()
+		} else {
+			expectedResolvedLocksRangedMaxKeys[i].EndKey = intToKey((i + 1) * keysPerRangedLock)
+		}
+	}
+	expectedExternalLocksRangedMaxKeys := make([]roachpb.Span, ceil(numKeys, keysPerRangedLock)-ceil(maxKeys, keysPerRangedLock)+1)
+	for i := range expectedExternalLocksRangedMaxKeys {
+		offset := maxKeys / keysPerRangedLock
+		if i == 0 {
+			expectedExternalLocksRangedMaxKeys[i].Key = intToKey(maxKeys - 1).Next()
+		} else {
+			expectedExternalLocksRangedMaxKeys[i].Key = intToKey((i + offset) * keysPerRangedLock)
+		}
+		expectedExternalLocksRangedMaxKeys[i].EndKey = intToKey((i + offset + 1) * keysPerRangedLock)
+	}
+
+	expectedResolvedLocksPointTargetBytes := make([]roachpb.Span, keysFromTargetBytes)
+	for i := range expectedResolvedLocksPointTargetBytes {
+		expectedResolvedLocksPointTargetBytes[i].Key = intToKey(i)
+	}
+	expectedExternalLocksPointTargetBytes := make([]roachpb.Span, numKeys-keysFromTargetBytes)
+	for i := range expectedExternalLocksPointTargetBytes {
+		expectedExternalLocksPointTargetBytes[i].Key = intToKey(i + keysFromTargetBytes)
+	}
+
+	expectedResolvedLocksRangedTargetBytes := make([]roachpb.Span, keysFromTargetBytes/keysPerRangedLock)
+	for i := range expectedResolvedLocksRangedTargetBytes {
+		expectedResolvedLocksRangedTargetBytes[i].Key = intToKey(i * keysPerRangedLock)
+		expectedResolvedLocksRangedTargetBytes[i].EndKey = intToKey((i + 1) * keysPerRangedLock)
+	}
+	expectedExternalLocksRangedTargetBytes := make([]roachpb.Span, ceil(numKeys, keysPerRangedLock)-keysFromTargetBytes/keysPerRangedLock)
+	for i := range expectedExternalLocksRangedTargetBytes {
+		offset := keysFromTargetBytes / keysPerRangedLock
+		expectedExternalLocksRangedTargetBytes[i].Key = intToKey((i + offset) * keysPerRangedLock)
+		expectedExternalLocksRangedTargetBytes[i].EndKey = intToKey((i + offset + 1) * keysPerRangedLock)
+	}
+
+	expectedResolvedLocksNoLimit := make([]roachpb.Span, numKeys)
+	for i := range expectedResolvedLocksNoLimit {
+		expectedResolvedLocksNoLimit[i].Key = intToKey(i)
+	}
+	expectedExternalLocksNoLimit := make([]roachpb.Span, 0)
+
+	testCases := []struct {
+		desc                  string
+		lockSpans             []roachpb.Span
+		resolveAllowance      int64
+		targetBytes           int64
+		expectedResolvedLocks []roachpb.Span
+		expectedExternalLocks []roachpb.Span
+	}{
+		// Point intent resolution with a max keys limit. 20 point intents, 11
+		// become resolved locks and 9 become external locks.
+		{
+			desc:                  "Point locks with max keys",
+			lockSpans:             pointLocks,
+			resolveAllowance:      maxKeys,
+			targetBytes:           0,
+			expectedResolvedLocks: expectedResolvedLocksPointMaxKeys,
+			expectedExternalLocks: expectedExternalLocksPointMaxKeys,
+		},
+		// Ranged intent resolution with a max keys limit. 5 ranged locks (each
+		// containing 4 keys), 3 become resolved locks (containing the first 2
+		// locks and part of the 3rd lock) and 3 become external locks (containing
+		// the remaining part of the 3rd lock and the last 2 locks). Note that the
+		// max key limit splits in between the 3rd lock, so the resolved locks will
+		// contain the first part of the 3rd lock span and the external locks will
+		// contain the remaining part of the 3rd lock span.
+		{
+			desc:                  "Ranged locks with max keys",
+			lockSpans:             rangedLocks,
+			resolveAllowance:      maxKeys,
+			targetBytes:           0,
+			expectedResolvedLocks: expectedResolvedLocksRangedMaxKeys,
+			expectedExternalLocks: expectedExternalLocksRangedMaxKeys,
+		},
+		// Point intent resolution with a target bytes limit. 20 point intents, 12
+		// become resolved locks and 8 become external locks.
+		{
+			desc:                  "Point span with target bytes",
+			lockSpans:             pointLocks,
+			resolveAllowance:      0,
+			targetBytes:           targetBytes,
+			expectedResolvedLocks: expectedResolvedLocksPointTargetBytes,
+			expectedExternalLocks: expectedExternalLocksPointTargetBytes,
+		},
+		// Ranged intent resolution with a target bytes limit. 5 ranged locks (each
+		// containing 4 keys), 3 become resolved locks (containing the first 3
+		// locks) and 2 become external locks (containing the last 2 locks). Note
+		// that the target byte limit does not split in between any locks, so the
+		// resolved and external locks do not contain part of a lock span for any
+		// lock.
+		{
+			desc:                  "Ranged span with target bytes",
+			lockSpans:             rangedLocks,
+			resolveAllowance:      0,
+			targetBytes:           targetBytes,
+			expectedResolvedLocks: expectedResolvedLocksRangedTargetBytes,
+			expectedExternalLocks: expectedExternalLocksRangedTargetBytes,
+		},
+		// Point intent resolution without any limit. 20 point intents, 20 become
+		// resolved locks and 0 become external locks.
+		{
+			desc:                  "No key or byte limit",
+			lockSpans:             pointLocks,
+			resolveAllowance:      0,
+			targetBytes:           0,
+			expectedResolvedLocks: expectedResolvedLocksNoLimit,
+			expectedExternalLocks: expectedExternalLocksNoLimit,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			db := storage.NewDefaultInMemForTesting()
+			defer db.Close()
+			batch := db.NewBatch()
+			defer batch.Close()
+
+			ts := hlc.Timestamp{WallTime: 1}
+			txn := roachpb.MakeTransaction("test", roachpb.Key("a"), 0, ts, 0, 1)
+			txn.Status = roachpb.COMMITTED
+
+			for i := 0; i < numKeys; i++ {
+				err := storage.MVCCPut(ctx, batch, nil, intToKey(i), ts, hlc.ClockTimestamp{}, roachpb.MakeValueFromString("a"), &txn)
+				require.NoError(t, err)
+			}
+			resolvedLocks, externalLocks, err := resolveLocalLocksWithPagination(
+				ctx,
+				&roachpb.RangeDescriptor{
+					StartKey: roachpb.RKeyMin,
+					EndKey:   roachpb.RKeyMax,
+				},
+				batch,
+				nil,
+				&kvpb.EndTxnRequest{
+					LockSpans:             tc.lockSpans,
+					InternalCommitTrigger: &roachpb.InternalCommitTrigger{},
+				},
+				&txn,
+				(&MockEvalCtx{}).EvalContext(),
+				tc.resolveAllowance,
+				tc.targetBytes,
+			)
+			require.NoError(t, err)
+			require.Equal(t, len(tc.expectedResolvedLocks), len(resolvedLocks))
+			for i, lock := range resolvedLocks {
+				require.Equal(t, tc.expectedResolvedLocks[i].Key, lock.Key)
+				require.Equal(t, tc.expectedResolvedLocks[i].EndKey, lock.EndKey)
+			}
+			require.Equal(t, len(tc.expectedExternalLocks), len(externalLocks))
+			for i, lock := range externalLocks {
+				require.Equal(t, tc.expectedExternalLocks[i].Key, lock.Key)
+				require.Equal(t, tc.expectedExternalLocks[i].EndKey, lock.EndKey)
+			}
 		})
 	}
 }

--- a/pkg/kv/kvserver/intentresolver/intent_resolver_integration_test.go
+++ b/pkg/kv/kvserver/intentresolver/intent_resolver_integration_test.go
@@ -162,6 +162,101 @@ func TestAsyncIntentResolutionByteSizePagination(t *testing.T) {
 	})
 }
 
+// TestEndTxnByteSizePagination tests that EndTxn has byte size pagination.
+// This is done by creating a transaction where the total bytes of the write
+// values exceeds the max raft command size and updating the transaction
+// timestamp to ensure the key values are written to the raft command during
+// intent resolution. EndTxn will synchronously resolve the intents and the
+// write batch size from intent resolution will exceed the max raft command
+// size resulting in an error and no intents will be resolved, unless byte size
+// pagination is implemented.
+func TestEndTxnByteSizePagination(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	// Start test cluster.
+	clusterArgs := base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				Store: &kvserver.StoreTestingKnobs{
+					IntentResolverKnobs: kvserverbase.IntentResolverTestingKnobs{
+						DisableAsyncIntentResolution: true,
+					},
+				},
+			},
+		},
+	}
+	tc := testcluster.StartTestCluster(t, 1, clusterArgs)
+	defer tc.Stopper().Stop(ctx)
+
+	db := tc.ServerConn(0)
+	const numIntents = 7
+
+	{
+		_, err := db.Exec("CREATE TABLE t (i INT PRIMARY KEY, j STRING)")
+		require.NoError(t, err)
+	}
+
+	// Set the max raft command size to 5MB.
+	st := tc.Servers[0].ClusterSettings()
+	st.Manual.Store(true)
+	kvserverbase.MaxCommandSize.Override(ctx, &st.SV, 5<<20)
+
+	{
+		// Insert kv pairs whose values exceed max raft command size = 5MB in
+		// total.
+		tx, err := db.Begin()
+		require.NoError(t, err)
+		for i := 0; i < numIntents-1; i++ {
+			_, err = tx.Exec(fmt.Sprintf("INSERT INTO t (i, j) VALUES (%d, '%01000000d')", i, i))
+			require.NoError(t, err)
+		}
+
+		// Create a later transaction that writes to key numIntents-1.
+		{
+			tx2, err := db.Begin()
+			require.NoError(t, err)
+			_, err = tx2.Exec(fmt.Sprintf("INSERT INTO t (i, j) VALUES (%d, '0')", numIntents-1))
+			require.NoError(t, err)
+			err = tx2.Commit()
+			require.NoError(t, err)
+		}
+
+		// Have the first transaction write to key numIntents-1, which will force
+		// the transaction to update its timestamp.
+		_, err = tx.Exec(fmt.Sprintf("UPDATE t SET j = '1' WHERE i = %d", numIntents-1))
+		require.NoError(t, err)
+
+		// Commit, which will call EndTxn and synchronously resolve the intents,
+		// and the write batch size from intent resolution will exceed the max raft
+		// command size resulting in an error and no intents will be resolved,
+		// unless byte size pagination is implemented. Below, we check that at
+		// least 1 intent has been resolved.
+		err = tx.Commit()
+		require.NoError(t, err)
+	}
+
+	// Get the store, start key, and end key of the range containing table t.
+	startKey, endKey, store := getRangeInfoForTable(ctx, t, db, tc.Servers, "t")
+
+	// Check that at least 1 intent has been resolved to ensure synchronous
+	// intent resolution did not exceed the max raft command size, which can only
+	// happen if byte size pagination was implemented.
+	testutils.SucceedsSoon(t, func() error {
+		result, err := storage.MVCCScan(ctx, store.TODOEngine(), startKey, endKey,
+			hlc.MaxTimestamp, storage.MVCCScanOptions{Inconsistent: true})
+		if err != nil {
+			return err
+		}
+		if intentCount := len(result.Intents); intentCount == numIntents {
+			return errors.Errorf("Expected fewer than %d unresolved intents, got %d", numIntents, intentCount)
+		}
+		return nil
+	})
+}
+
 // TestIntentResolutionUnavailableRange tests that InFlightBackpressureLimit
 // resolve intent batches for an unavailable range does not stall indefinitely
 // and times out, allowing other resolve intent requests and queries for


### PR DESCRIPTION
Fixes: #77228

Intent resolution batches are sequenced on raft and each batch can
consist of 100-200 intents. If an intent key or even value in some cases
are large, it is possible that resolving all intents in the batch would
result in a raft command size exceeding the max raft command size
kv.raft.command.max_size.

To address this, we add support for TargetBytes in resolve intent and
resolve intent range commands, allowing us to stop resolving intents in
the batch as soon as we exceed the TargetBytes max bytes limit.

This PR adds byte pagination for synchronous intent resolution (i.e.
EndTxn / End Transaction).

Release note: None