### PR TITLE
kv: Test to measure slowdown after a node restart

### DIFF
--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -74,6 +74,7 @@ func RegisterTests(r registry.Registry) {
 	registerKVRangeLookups(r)
 	registerKVScalability(r)
 	registerKVSplits(r)
+	registerKVRestartImpact(r)
 	registerKnex(r)
 	registerLOQRecovery(r)
 	registerLargeRange(r)


### PR DESCRIPTION
After a node is down for a few minutes and then starts up again, there is a slowdown related to it catching up on Raft messages it missed while down. This can cause an IO Overload scenario and greatly impact performance on the cluster.

This adds a test for the issue, a separate PR will be created to enable this test and fix the issue.

Informs: #95159

Epic: none
Release note: None