### PR TITLE
storage: Fix CI Failures Due To MVCCGet Assignment Mismatch

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_resolve_intent_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_resolve_intent_test.go
@@ -338,7 +338,7 @@ func TestResolveIntentWithTargetBytes(t *testing.T) {
 				numBytes := batch.Len()
 				require.Equal(t, numBytes, initialBytes)
 
-				_, _, err = storage.MVCCGet(ctx, batch, testKeys[0], ts, storage.MVCCGetOptions{})
+				_, err = storage.MVCCGet(ctx, batch, testKeys[0], ts, storage.MVCCGetOptions{})
 				require.Error(t, err)
 			}
 
@@ -365,10 +365,10 @@ func TestResolveIntentWithTargetBytes(t *testing.T) {
 				require.Greater(t, numBytes, initialBytes+1000)
 				require.Less(t, numBytes, initialBytes+1100)
 
-				value, _, err := storage.MVCCGet(ctx, batch, testKeys[0], ts, storage.MVCCGetOptions{})
+				valueRes, err := storage.MVCCGet(ctx, batch, testKeys[0], ts, storage.MVCCGetOptions{})
 				require.NoError(t, err)
-				require.Equal(t, values[0].RawBytes, value.RawBytes,
-					"the value %s in get result does not match the value %s in request", values[0].RawBytes, value.RawBytes)
+				require.Equal(t, values[0].RawBytes, valueRes.Value.RawBytes,
+					"the value %s in get result does not match the value %s in request", values[0].RawBytes, valueRes.Value.RawBytes)
 			}
 		} else {
 			// Resolve an intent range for testKeys[0], testKeys[1], ...,
@@ -404,7 +404,7 @@ func TestResolveIntentWithTargetBytes(t *testing.T) {
 				numBytes := batch.Len()
 				require.Equal(t, numBytes, initialBytes)
 
-				_, _, err = storage.MVCCGet(ctx, batch, testKeys[0], ts, storage.MVCCGetOptions{})
+				_, err = storage.MVCCGet(ctx, batch, testKeys[0], ts, storage.MVCCGetOptions{})
 				require.Error(t, err)
 			}
 
@@ -434,11 +434,11 @@ func TestResolveIntentWithTargetBytes(t *testing.T) {
 				require.Greater(t, numBytes, initialBytes+3000)
 				require.Less(t, numBytes, initialBytes+3300)
 
-				value, _, err := storage.MVCCGet(ctx, batch, testKeys[2], ts, storage.MVCCGetOptions{})
+				valueRes, err := storage.MVCCGet(ctx, batch, testKeys[2], ts, storage.MVCCGetOptions{})
 				require.NoError(t, err)
-				require.Equal(t, values[2].RawBytes, value.RawBytes,
-					"the value %s in get result does not match the value %s in request", values[2].RawBytes, value.RawBytes)
-				_, _, err = storage.MVCCGet(ctx, batch, testKeys[3], ts, storage.MVCCGetOptions{})
+				require.Equal(t, values[2].RawBytes, valueRes.Value.RawBytes,
+					"the value %s in get result does not match the value %s in request", values[2].RawBytes, valueRes.Value.RawBytes)
+				_, err = storage.MVCCGet(ctx, batch, testKeys[3], ts, storage.MVCCGetOptions{})
 				require.Error(t, err)
 			}
 
@@ -468,10 +468,10 @@ func TestResolveIntentWithTargetBytes(t *testing.T) {
 				require.Greater(t, numBytes, initialBytes+5000)
 				require.Less(t, numBytes, initialBytes+5500)
 
-				value, _, err := storage.MVCCGet(ctx, batch, testKeys[nKeys-1], ts, storage.MVCCGetOptions{})
+				valueRes, err := storage.MVCCGet(ctx, batch, testKeys[nKeys-1], ts, storage.MVCCGetOptions{})
 				require.NoError(t, err)
-				require.Equal(t, values[nKeys-1].RawBytes, value.RawBytes,
-					"the value %s in get result does not match the value %s in request", values[nKeys-1].RawBytes, value.RawBytes)
+				require.Equal(t, values[nKeys-1].RawBytes, valueRes.Value.RawBytes,
+					"the value %s in get result does not match the value %s in request", values[nKeys-1].RawBytes, valueRes.Value.RawBytes)
 			}
 		}
 	})


### PR DESCRIPTION
Informs: #77228

cmd_resolve_intent_test.go calls MVCCGet, which originally returned 3 values, but in #94698, returns 2 values (MVCCGetResult). Unfortunately, the PR containing changes to cmd_resolve_intent_test.go used the original MVCCGet with 3 return values and was merged at around the same time as the change to MVCCGet, and the changes to cmd_resolve_intent_test.go calling the original MVCCGet with 3 return values was merged, which causes CI failures after the change to MVCCGet from 3 to 2 return values was also merged as is.

Release note: None