### PR TITLE
release-22.2: norm: inline constants only when type of column to replace is equivalent

### DIFF
--- a/pkg/sql/opt/norm/inline_funcs.go
+++ b/pkg/sql/opt/norm/inline_funcs.go
@@ -322,11 +322,14 @@ func (c *CustomFuncs) CanInlineConstVar(f memo.FiltersExpr) bool {
 	// value.
 	var fixedCols opt.ColSet
 	for i := range f {
-		if ok, l, _ := c.extractVarEqualsConst(f[i].Condition); ok {
+		if ok, l, e := c.extractVarEqualsConst(f[i].Condition); ok {
 			colType := c.mem.Metadata().ColumnMeta(l.Col).Type
 			if colinfo.CanHaveCompositeKeyEncoding(colType) {
 				// TODO(justin): allow inlining if the check we're doing is oblivious
 				// to composite-ness.
+				continue
+			}
+			if !e.Typ.Equivalent(colType) {
 				continue
 			}
 			if !fixedCols.Contains(l.Col) {
@@ -361,6 +364,9 @@ func (c *CustomFuncs) InlineConstVar(f memo.FiltersExpr) memo.FiltersExpr {
 		if ok, v, e := c.extractVarEqualsConst(f[i].Condition); ok {
 			colType := c.mem.Metadata().ColumnMeta(v.Col).Type
 			if colinfo.CanHaveCompositeKeyEncoding(colType) {
+				continue
+			}
+			if !e.Typ.Equivalent(colType) {
 				continue
 			}
 			if _, ok := vals[v.Col]; !ok {

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -9770,3 +9770,117 @@ select
  │    └── columns: col2:3!null col3:4!null col4:5!null
  └── filters
       └── col2:3 < 4 [outer=(3), constraints=(/3: (/NULL - /3]; tight)]
+
+# Regression test for #85356
+exec-ddl
+CREATE TABLE t85356 (c0 DECIMAL(15,3));
+----
+
+# Inlining of DECIMAL 3/2 as INT column rowid is not allowed.
+opt expect-not=InlineConstVar
+SELECT * FROM t85356
+WHERE (CASE WHEN t85356.rowid < t85356.rowid THEN t85356.rowid ELSE 1 END) IN (t85356.rowid) AND NOT t85356.rowid!=3/2;
+----
+project
+ ├── columns: c0:1
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── select
+      ├── columns: c0:1 rowid:2!null
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      ├── fd: ()-->(1,2)
+      ├── scan t85356
+      │    ├── columns: c0:1 rowid:2!null
+      │    ├── key: (2)
+      │    └── fd: (2)-->(1)
+      └── filters
+           ├── rowid:2 = CASE WHEN (rowid:2 IS NOT DISTINCT FROM CAST(NULL AS INT8)) AND CAST(NULL AS BOOL) THEN rowid:2 ELSE 1 END [outer=(2), constraints=(/2: (/NULL - ])]
+           └── rowid:2 = 1.5000000000000000000 [outer=(2), constraints=(/2: (/NULL - ]), fd=()-->(2)]
+
+# Inlining of INT2 constant 2 as INT column rowid is allowed.
+opt expect=InlineConstVar
+SELECT * FROM t85356
+WHERE (CASE WHEN t85356.rowid < t85356.rowid THEN t85356.rowid ELSE 1 END) IN (t85356.rowid) AND NOT t85356.rowid!=2::INT2;
+----
+values
+ ├── columns: c0:1!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1)
+
+# Inlining of INTEGER 2 as DECIMAL column c0 is not allowed because
+# `CanHaveCompositeKeyEncoding` returns `true` for decimals.
+opt expect-not=InlineConstVar
+SELECT * FROM t85356
+WHERE (CASE WHEN t85356.c0 < t85356.c0 THEN t85356.c0 ELSE 1.1 END) IN (t85356.c0) AND NOT t85356.c0!=2;
+----
+select
+ ├── columns: c0:1!null
+ ├── immutable
+ ├── fd: ()-->(1)
+ ├── scan t85356
+ │    └── columns: c0:1
+ └── filters
+      ├── c0:1 = CASE WHEN (c0:1 IS NOT DISTINCT FROM CAST(NULL AS DECIMAL(15,3))) AND CAST(NULL AS BOOL) THEN c0:1 ELSE 1.100 END [outer=(1), immutable, constraints=(/1: (/NULL - ])]
+      └── c0:1 = 2 [outer=(1), immutable, constraints=(/1: [/2 - /2]; tight), fd=()-->(1)]
+
+exec-ddl
+CREATE TABLE t85356_2 (c0 TIMESTAMP, c1 DATE);
+----
+
+# Inlining of a DATE constant as a TIMESTAMP is allowed.
+opt expect=InlineConstVar
+SELECT * FROM t85356_2
+WHERE (CASE WHEN t85356_2.c0 < t85356_2.c0 THEN t85356_2.c0 ELSE '2000-01-01T02:00:00'::timestamp END) IN
+        (t85356_2.c0) AND NOT t85356_2.c0!='12/01/01'::date;
+----
+values
+ ├── columns: c0:1!null c1:2!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1,2)
+
+# The lossy CAST of timestamp to DATE is not allowed for inlining.
+opt expect-not=InlineConstVar
+SELECT * FROM t85356_2
+WHERE (CASE WHEN t85356_2.c1 < t85356_2.c1 THEN t85356_2.c1 ELSE '12/01/01'::date END) IN
+        (t85356_2.c1) AND NOT t85356_2.c1!='2000-01-01T02:00:00'::timestamp;
+----
+select
+ ├── columns: c0:1 c1:2!null
+ ├── immutable
+ ├── fd: ()-->(2)
+ ├── scan t85356_2
+ │    └── columns: c0:1 c1:2
+ └── filters
+      ├── c1:2 = CASE WHEN (c1:2 IS NOT DISTINCT FROM CAST(NULL AS DATE)) AND CAST(NULL AS BOOL) THEN c1:2 ELSE '2001-12-01' END [outer=(2), constraints=(/2: (/NULL - ])]
+      └── c1:2 = '2000-01-01 02:00:00' [outer=(2), immutable, constraints=(/2: (/NULL - ]), fd=()-->(2)]
+
+# A non-lossy CAST of timestamp to DATE is allowed for inlining.
+opt expect=InlineConstVar
+SELECT * FROM t85356_2
+WHERE (CASE WHEN t85356_2.c1 < t85356_2.c1 THEN t85356_2.c1 ELSE '12/01/01'::date END) IN
+        (t85356_2.c1) AND NOT t85356_2.c1!='2000-01-01T00:00:00'::timestamp;
+----
+values
+ ├── columns: c0:1!null c1:2!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1,2)
+
+# A statement which could actually return rows is inlined but correctly is not
+# simplified into a `norows` values expression.
+opt expect=InlineConstVar
+SELECT * FROM t85356_2
+WHERE (CASE WHEN t85356_2.c0 < t85356_2.c0 THEN t85356_2.c0 ELSE '12/01/01'::date::timestamp END) IN
+        (t85356_2.c0) AND NOT t85356_2.c0!='12/01/01'::date;
+----
+select
+ ├── columns: c0:1!null c1:2
+ ├── fd: ()-->(1)
+ ├── scan t85356_2
+ │    └── columns: c0:1 c1:2
+ └── filters
+      └── c0:1 = '2001-12-01 00:00:00' [outer=(1), constraints=(/1: [/'2001-12-01 00:00:00' - /'2001-12-01 00:00:00']; tight), fd=()-->(1)]


### PR DESCRIPTION
Backport 1/1 commits from #94791.

/cc @cockroachdb/release

---

Fixes #85356

A CASE expression which has a different THEN expression type than a constant
which it is replaced by via inlining hits an internal error, e.g.
`(CASE WHEN false THEN int_col ELSE 1 END) IN (int_col) AND int_col=3/2`

The `InlineConstVar` rule replaces the `int_col` in the THEN clause with `3/2`,
which is a decimal. When comparing `3/2` with `1` from the ELSE clause, we
fail a sanity check because these types are expected to be equivalent. Maybe
if type checking and adding of implicit casts were re-done after normalization,
this inlining would be OK. But since this doesn't happen, the fix is to skip
the inlining if the column to replace and the constant are of non-equivalent
types.

Release note (bug fix): This patch fixes an internal error occurring in CASE
expressions when a column present in a THEN or ELSE expression is of an
inequivalent type compared to that of a constant this column is compared
to in an equality predicate, e.g.,
  `(CASE WHEN false THEN int_col ELSE 1 END) IN (int_col) AND int_col=3/2`

Release Justification: Fixes potential unrecoverable panics from SELECT statements with CASE.