### PR TITLE
changefeedccl: Add `changefeed_creation_timestamp` function

### DIFF
--- a/pkg/ccl/changefeedccl/cdceval/expr_eval.go
+++ b/pkg/ccl/changefeedccl/cdceval/expr_eval.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -35,6 +36,7 @@ import (
 type Evaluator struct {
 	sc *tree.SelectClause
 
+	statementTS hlc.Timestamp
 	// Execution context.
 	execCfg     *sql.ExecutorConfig
 	user        username.SQLUsername
@@ -79,14 +81,16 @@ func NewEvaluator(
 	execCfg *sql.ExecutorConfig,
 	user username.SQLUsername,
 	sd sessiondatapb.SessionData,
-) (*Evaluator, error) {
+	statementTS hlc.Timestamp,
+) *Evaluator {
 	return &Evaluator{
 		sc:          sc,
 		execCfg:     execCfg,
 		user:        user,
 		sessionData: sd,
+		statementTS: statementTS,
 		familyEval:  make(map[descpb.FamilyID]*familyEvaluator, 1), // usually, just 1 family.
-	}, nil
+	}
 }
 
 // NewEvaluator constructs new familyEvaluator for changefeed expression.
@@ -96,6 +100,7 @@ func newFamilyEvaluator(
 	execCfg *sql.ExecutorConfig,
 	user username.SQLUsername,
 	sd sessiondatapb.SessionData,
+	statementTS hlc.Timestamp,
 ) *familyEvaluator {
 	e := familyEvaluator{
 		targetFamilyID: targetFamilyID,
@@ -107,7 +112,7 @@ func newFamilyEvaluator(
 		},
 		rowCh: make(chan tree.Datums, 1),
 	}
-
+	e.rowEvalCtx.startTime = statementTS
 	// Arrange to be notified when event does not match predicate.
 	predicateAsProjection(e.norm)
 
@@ -138,7 +143,7 @@ func (e *Evaluator) Eval(
 
 	fe, ok := e.familyEval[updatedRow.FamilyID]
 	if !ok {
-		fe = newFamilyEvaluator(e.sc, updatedRow.FamilyID, e.execCfg, e.user, e.sessionData)
+		fe = newFamilyEvaluator(e.sc, updatedRow.FamilyID, e.execCfg, e.user, e.sessionData, e.statementTS)
 		e.familyEval[updatedRow.FamilyID] = fe
 	}
 
@@ -468,6 +473,7 @@ func (e *familyEvaluator) closeErr() error {
 // rowEvalContext represents the context needed to evaluate row expressions.
 type rowEvalContext struct {
 	ctx        context.Context
+	startTime  hlc.Timestamp
 	updatedRow cdcevent.Row
 }
 

--- a/pkg/ccl/changefeedccl/cdceval/expr_eval_test.go
+++ b/pkg/ccl/changefeedccl/cdceval/expr_eval_test.go
@@ -781,7 +781,8 @@ func newEvaluatorWithNormCheck(
 		return nil, err
 	}
 
-	return NewEvaluator(norm.SelectClause, execCfg, username.RootUserName(), defaultDBSessionData)
+	return NewEvaluator(norm.SelectClause, execCfg, username.RootUserName(),
+		defaultDBSessionData, hlc.Timestamp{}), nil
 }
 
 var defaultDBSessionData = sessiondatapb.SessionData{

--- a/pkg/ccl/changefeedccl/event_processing.go
+++ b/pkg/ccl/changefeedccl/event_processing.go
@@ -290,7 +290,7 @@ func newEvaluator(
 		sd = *spec.Feed.SessionData
 	}
 
-	return cdceval.NewEvaluator(sc, cfg, spec.User(), sd)
+	return cdceval.NewEvaluator(sc, cfg, spec.User(), sd, spec.Feed.StatementTime), nil
 }
 
 func (c *kvEventToRowConsumer) topicForEvent(eventMeta cdcevent.Metadata) (TopicDescriptor, error) {

--- a/pkg/sql/distsql_plan_changefeed.go
+++ b/pkg/sql/distsql_plan_changefeed.go
@@ -95,13 +95,17 @@ func PlanCDCExpression(
 	if err != nil {
 		return cdcPlan, err
 	}
+
 	cdcCat := &cdcOptCatalog{
 		optCatalog:     opc.catalog.(*optCatalog),
 		cdcConfig:      cfg,
 		targetFamilyID: familyID,
 		semaCtx:        &p.semaCtx,
 	}
+
+	// Reset catalog to cdc specific implementation.
 	opc.catalog = cdcCat
+	opc.optimizer.Init(ctx, p.EvalContext(), opc.catalog)
 
 	memo, err := opc.buildExecMemo(ctx)
 	if err != nil {


### PR DESCRIPTION
Add `changefeed_create_timestamp` function, which returns changefeed creation timestamp.

Changefeed transformations restrict access to some of the standard functions, including `now()`.
Without such function, it is difficult to express
changefeeds that want to emit events restricted
by time.  This function makes it possible to do
this.  For example, to create a changefeed that
emits events from the `accounts` table that
`last_withdrawal` happen starting 12 hours ago,
one could do:

```
CREATE CHANGEFEED ... AS
SELECT * FROM accounts WHERE last_withdrawal >
changefeed_create_timestamp() - interval '12 hours'
```

Epic: CRDB-17161

Release note (enterprise change): Changefeed expressions support `changefeed_create_timestamp` function.