### PR TITLE
randgen: enforce at least 1 count element for generate_test_objects

### DIFF
--- a/pkg/sql/catalog/randgen/randgen.go
+++ b/pkg/sql/catalog/randgen/randgen.go
@@ -314,7 +314,7 @@ func (g *testSchemaGenerator) prepareCounts(
 	const reasonableMaxCount = 10000000
 	for _, sz := range counts {
 		// We cap the individual count to a maximum number for two purposes.
-		// One is that abnormally large values are likely indicative of
+		// One is that abnormally large values are likely indicative
 		// of a user mistake; in which case we want an informative error message
 		// instead of something related to memory usage.
 		// The second is that we want to avoid an overflow in the computation
@@ -328,8 +328,8 @@ func (g *testSchemaGenerator) prepareCounts(
 	g.gencfg.createDatabases = false
 	g.gencfg.createSchemas = false
 	g.gencfg.useGeneratedPublicSchema = false
-	if len(counts) > 3 {
-		panic(genError{errors.WithHint(pgerror.Newf(pgcode.Syntax, "too many counts"),
+	if len(counts) < 1 || len(counts) > 3 {
+		panic(genError{errors.WithHint(pgerror.Newf(pgcode.Syntax, "invalid count"),
 			"Must specify between 1 and 3 counts.")})
 	}
 	numNewDatabases := 0

--- a/pkg/sql/logictest/testdata/logic_test/gen_test_objects
+++ b/pkg/sql/logictest/testdata/logic_test/gen_test_objects
@@ -568,6 +568,14 @@ SELECT crdb_internal.generate_test_objects('{"names":"a.b.c","counts":[0,0,10000
 query error too many objects generated
 SELECT crdb_internal.generate_test_objects('{"names":"a.b.c","counts":[10000000,10000000,10000000]}'::jsonb)
 
+subtest invalid_count
+
+query error invalid count
+SELECT crdb_internal.generate_test_objects('foo', ARRAY[]::INT8[])
+
+query error invalid count
+SELECT crdb_internal.generate_test_objects('foo', ARRAY[1, 2, 3, 4, 5]::INT8[])
+
 subtest temp_schema
 
 # Force create the temp schema.


### PR DESCRIPTION
This was assumed but never checked leading to a crash if an empty array is passed as the "count" argument to
`crdb_internal.generate_test_objects`.

Fixes: #95144.

Release note: None