### PR TITLE
roachprod: disable ext4 reserved space

### DIFF
--- a/pkg/roachprod/vm/aws/support.go
+++ b/pkg/roachprod/vm/aws/support.go
@@ -76,6 +76,7 @@ elif [ "${#disks[@]}" -eq "1" ] || [ -n "$use_multiple_disks" ]; then
     mount -o ${mount_opts} ${disk} ${mountpoint}
     chmod 777 ${mountpoint}
     echo "${disk} ${mountpoint} ext4 ${mount_opts} 1 1" | tee -a /etc/fstab
+    tune2fs -m 0 ${disk}
   done
 else
   mountpoint="${mount_prefix}1"
@@ -87,6 +88,7 @@ else
   mount -o ${mount_opts} ${raiddisk} ${mountpoint}
   chmod 777 ${mountpoint}
   echo "${raiddisk} ${mountpoint} ext4 ${mount_opts} 1 1" | tee -a /etc/fstab
+  tune2fs -m 0 ${raiddisk}
 fi
 
 sudo apt-get install -qy chrony

--- a/pkg/roachprod/vm/azure/utils.go
+++ b/pkg/roachprod/vm/azure/utils.go
@@ -55,6 +55,7 @@ else
     sudo mount -o "${mount_opts}" "${disk}" "${mount}"
     echo "${disk} ${mount} ext4 ${mount_opts} 1 1" | sudo tee -a /etc/fstab
     ln -s "${mount}" "/mnt/$(basename $mount)"
+    tune2fs -m 0 ${disk}
   done
   chown {{.RemoteUser}} /data*
 fi

--- a/pkg/roachprod/vm/gce/utils.go
+++ b/pkg/roachprod/vm/gce/utils.go
@@ -99,6 +99,7 @@ elif [ "${#disks[@]}" -eq "1" ] || [ -n "$use_multiple_disks" ]; then
     mkfs.ext4 -q -F ${disk}
     mount -o ${mount_opts} ${disk} ${mountpoint}
     echo "${d} ${mountpoint} ext4 ${mount_opts} 1 1" | tee -a /etc/fstab
+    tune2fs -m 0 ${disk}
 {{ end }}
     chmod 777 ${mountpoint}
   done
@@ -115,6 +116,7 @@ else
   mkfs.ext4 -q -F ${raiddisk}
   mount -o ${mount_opts} ${raiddisk} ${mountpoint}
   echo "${raiddisk} ${mountpoint} ext4 ${mount_opts} 1 1" | tee -a /etc/fstab
+  tune2fs -m 0 ${raiddisk}
 {{ end }}
   chmod 777 ${mountpoint}
 fi


### PR DESCRIPTION
By default, ext4 reserves 5% of blocks for the root user. The main rationale for this historical default is to reserve space for (a) important root processes, and (b) de-fragmentation. However, when this concerns disks which are used to store SST files, there is seemingly no good reason for this wasted space. Furthermore, debugging an out-of-disk space event becomes more surprising without a direct knowledge of this default.

Consequently, it was decided in favor of removing this reserved space, but only for data disks. Please see the corresponding GH issue for more details.

Epic: none
Fixes: #93120

Release note: None