### PR TITLE
sql: fixes database list with special characters

### DIFF
--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -479,6 +479,7 @@ go_test(
         "//pkg/util/netutil",
         "//pkg/util/netutil/addr",
         "//pkg/util/protoutil",
+        "//pkg/util/randident",
         "//pkg/util/randutil",
         "//pkg/util/stop",
         "//pkg/util/syncutil",

--- a/pkg/server/index_usage_stats.go
+++ b/pkg/server/index_usage_stats.go
@@ -388,6 +388,7 @@ func getDatabaseIndexRecommendations(
 		return []*serverpb.IndexRecommendation{}, err
 	}
 
+	escDBName := tree.NameString(dbName)
 	query := fmt.Sprintf(`
 		SELECT
 			ti.descriptor_id as table_id,
@@ -397,7 +398,7 @@ func getDatabaseIndexRecommendations(
 			ti.created_at
 		FROM %[1]s.crdb_internal.index_usage_statistics AS us
 		 JOIN %[1]s.crdb_internal.table_indexes AS ti ON (us.index_id = ti.index_id AND us.table_id = ti.descriptor_id AND index_type = 'secondary')
-		 JOIN %[1]s.crdb_internal.tables AS t ON (ti.descriptor_id = t.table_id AND t.database_name != 'system');`, dbName)
+		 JOIN %[1]s.crdb_internal.tables AS t ON (ti.descriptor_id = t.table_id AND t.database_name != 'system');`, escDBName)
 
 	it, err := ie.QueryIteratorEx(ctx, "db-index-recommendations", nil,
 		sessiondata.InternalExecutorOverride{


### PR DESCRIPTION
The database name was not properly escaped which causes the
query to fail if the database name has a special character.
The endpoint still does not support names with `/`. This will
not be an issue since all ui is being converted to sql-over-http.

Example uri: `http://localhost:8080/_admin/v1/databases/my%20testdb`

part of: #94328

Release note (sql change): fixes databases list api when database name has special characters.