### PR TITLE
kvserver: deflake TestRemovePlaceholderRace

### DIFF
--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -3002,11 +3002,11 @@ func TestRemovePlaceholderRace(t *testing.T) {
 			for {
 				chgs := roachpb.MakeReplicationChanges(action, tc.Target(1))
 				if _, err := repl.ChangeReplicas(ctx, repl.Desc(), kvserverpb.SnapshotRequest_REBALANCE, kvserverpb.ReasonUnknown, "", chgs); err != nil {
-					if kvserver.IsRetriableReplicationChangeError(err) {
+					if kvserver.IsRetriableReplicationChangeError(err) ||
+						kvserver.IsReplicationChangeInProgressError(err) {
 						continue
-					} else {
-						t.Fatal(err)
 					}
+					t.Fatal(err)
 				}
 				break
 			}


### PR DESCRIPTION
ChangeReplicas may return an error when there is an in-flight snapshot for a learner Replica. This is retriable error, so this commit makes the test to ignore it and retry.

Fixes #91121
Epic: none
Release note: none