### PR TITLE
cli/demo: fix the startup reference to "tenant 1"

### DIFF
--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -266,9 +266,9 @@ func runDemoInternal(
 
 		if demoCtx.Multitenant {
 			cliCtx.PrintfUnlessEmbedded(`#
-# You are connected to tenant 1, but can connect to the system tenant with
-# \connect and the SQL url below.
-`)
+# You are connected to tenant %q, but can connect to the system tenant with
+# '\connect' and the SQL url printed via '\demo ls'.
+`, c.TenantName())
 		}
 
 		if demoCtx.SimulateLatency {

--- a/pkg/cli/democluster/api.go
+++ b/pkg/cli/democluster/api.go
@@ -56,6 +56,9 @@ type DemoCluster interface {
 
 	// SetSimulatedLatency is used to enable or disable simulated latency.
 	SetSimulatedLatency(on bool)
+
+	// TenantName returns the tenant name that the default connection is for.
+	TenantName() string
 }
 
 // EnableEnterprise is not implemented here in order to keep OSS/BSL builds successful.

--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -2042,3 +2042,10 @@ func fileExists(path string) (bool, error) {
 	}
 	return exists, err
 }
+
+func (c *transientCluster) TenantName() string {
+	if c.demoCtx.Multitenant {
+		return demoTenantName
+	}
+	return catconstants.SystemTenantName
+}

--- a/pkg/cli/interactive_tests/test_demo_multitenant.tcl
+++ b/pkg/cli/interactive_tests/test_demo_multitenant.tcl
@@ -7,6 +7,7 @@ start_test "Check --multitenant flag runs as expected"
 spawn $argv demo --no-line-editor --empty --nodes 3 --multitenant
 
 eexpect "Welcome"
+eexpect "You are connected to tenant \"demo-tenant\""
 eexpect "(sql)"
 eexpect "127.0.0.1:26257/defaultdb"
 eexpect "defaultdb>"


### PR DESCRIPTION
Fixes #95134.

The welcome message was referring to an inexistent tenant and the
wrong URL. This commit fixes it.

Release note: None
Epic: None