### PR TITLE
streamingccl: check that rangefeeds are enabled early

### DIFF
--- a/pkg/ccl/streamingccl/streamproducer/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamproducer/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/kv",
         "//pkg/kv/kvclient/kvcoord",
         "//pkg/kv/kvclient/rangefeed",
+        "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/protectedts",
         "//pkg/kv/kvserver/protectedts/ptpb",
         "//pkg/repstream",


### PR DESCRIPTION
If rangefeeds aren't enabled on the source cluster, the user doesn't get any feedback about why the replicated time is not advancing.

Here, we check for it early to avoid this confusion.

Epic: none

Release note: None